### PR TITLE
fix(1425): colon-qualified node ids stop being uneditable (and stop resolving to the wrong node)

### DIFF
--- a/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
+++ b/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
@@ -89,17 +89,37 @@ describe("#845(4): an id the tools printed is accepted back", () => {
     expect(sent[0].node_id).toBe(42);
   });
 
-  // A subgraph-qualified id is a REAL shape in newer ComfyUI. Coercing "5:12" to
-  // 5 would target the WRONG node — worse than refusing. Supporting it is a
-  // deliberate wire-contract change, not something to fall out of a parse.
-  it("refuses a subgraph-qualified id rather than truncating it", async () => {
+  // A subgraph-qualified id is a REAL shape in newer ComfyUI. #845 REFUSED it,
+  // because coercing "5:12" to 5 would target the WRONG node and refusing was the
+  // safe half of that trade. #1425 is the deliberate wire-contract change #845 said
+  // this would take: unpacking a subgraph leaves genuine ROOT nodes with these ids,
+  // the readers hand them out, and refusing left 18 of 21 nodes uneditable.
+  //
+  // The half that must NOT change is the one this test was really protecting: it is
+  // still never allowed to become 5.
+  it("accepts a subgraph-qualified id and forwards it VERBATIM", async () => {
     const res = await callTool("panel_select_nodes", { node_ids: ["5:12"] });
-    expect(res.isError).toBe(true);
-    expect(sent).toHaveLength(0);
+    expect(res.isError).toBeFalsy();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].node_ids).toEqual(["5:12"]);
+    // The trap #845 named, asserted directly rather than implied.
+    expect(sent[0].node_ids).not.toContain(5);
+  });
+
+  it("accepts a DEEP qualified id — nesting has no depth limit", async () => {
+    const res = await callTool("panel_select_nodes", { node_ids: ["120:113:78"] });
+    expect(res.isError).toBeFalsy();
+    expect(sent[0].node_ids).toEqual(["120:113:78"]);
+  });
+
+  it("still normalizes plain ids alongside qualified ones in the same call", async () => {
+    const res = await callTool("panel_select_nodes", { node_ids: ["4", "263:78", 7] });
+    expect(res.isError).toBeFalsy();
+    expect(sent[0].node_ids).toEqual([4, "263:78", 7]);
   });
 
   it("refuses other non-integer strings", async () => {
-    for (const bad of ["42px", "4.5", "", "abc"]) {
+    for (const bad of ["42px", "4.5", "", "abc", "1:", ":1", "1::2", "1:-2"]) {
       sent = [];
       const res = await callTool("panel_select_nodes", { node_ids: [bad] });
       expect(res.isError, bad).toBe(true);

--- a/src/__tests__/orchestrator/node-id.test.ts
+++ b/src/__tests__/orchestrator/node-id.test.ts
@@ -1,0 +1,79 @@
+// #1425 — subgraph-qualified node ids (`120:104`) are real ROOT-level ids left by
+// an unpacked subgraph. The readers hand them out; every WRITE tool refused them,
+// leaving 18 of 21 nodes uneditable in the reporter's workflow.
+//
+// The dangerous direction is NOT the refusal — it is the fix done halfway. #845
+// left a `Number.parseInt(v, 10)` on this path, so widening the pattern WITHOUT
+// changing the transform turns a loud refusal into a silent edit of node 263 when
+// the caller asked for 263:78. Every assertion about acceptance below is paired
+// with one about identity for that reason.
+
+import { describe, expect, it } from "vitest";
+import {
+  NODE_ID_MESSAGE,
+  isNodeIdString,
+  isQualifiedNodeId,
+  normalizeNodeId,
+} from "../../orchestrator/node-id.js";
+
+describe("#1425 which strings name a node", () => {
+  it("accepts the plain integer forms #845 already allowed", () => {
+    for (const v of ["42", "0", "-20", "007"]) expect(isNodeIdString(v)).toBe(true);
+  });
+
+  it("accepts subgraph-qualified ids at any depth", () => {
+    // The reporter's own ids: two- and three-segment forms from one workflow.
+    for (const v of ["120:104", "263:78", "120:113:78", "1:2:3:4"]) {
+      expect(isNodeIdString(v)).toBe(true);
+      expect(isQualifiedNodeId(v)).toBe(true);
+    }
+  });
+
+  it("still rejects what #845 rejected", () => {
+    for (const v of ["42px", "4.5", "", " ", "abc", "1:", ":1", "1::2", "1:2:", "1:-2", "1: 2"]) {
+      expect(isNodeIdString(v)).toBe(false);
+    }
+  });
+
+  it("a plain id is not a qualified one", () => {
+    expect(isQualifiedNodeId("42")).toBe(false);
+    expect(isQualifiedNodeId("-20")).toBe(false);
+  });
+
+  it("a leading negative is a boundary rail; an inner one is not a shape at all", () => {
+    // Rail ids (-10/-20) are real and the readers emit them, so `-20:3` has to
+    // survive; `1:-2` is not produced by anything and must not be invented here.
+    expect(isNodeIdString("-20:3")).toBe(true);
+    expect(isNodeIdString("1:-2")).toBe(false);
+  });
+});
+
+describe("#1425 what goes on the wire", () => {
+  it("a plain id still becomes the NUMBER the wire has always carried", () => {
+    expect(normalizeNodeId(42)).toBe(42);
+    expect(normalizeNodeId("42")).toBe(42);
+    expect(normalizeNodeId("-20")).toBe(-20);
+    expect(normalizeNodeId("007")).toBe(7);
+  });
+
+  it("a qualified id is passed through UNTOUCHED — parsing it is the bug", () => {
+    // The whole point: `Number.parseInt("263:78", 10)` is 263, a DIFFERENT node.
+    expect(normalizeNodeId("263:78")).toBe("263:78");
+    expect(normalizeNodeId("120:113:78")).toBe("120:113:78");
+    expect(Number.parseInt("263:78", 10)).toBe(263); // the trap, stated outright
+    expect(normalizeNodeId("263:78")).not.toBe(263);
+  });
+
+  it("never returns NaN — an unparseable id must not reach the panel as one", () => {
+    for (const v of ["42", "-20", "263:78", "120:113:78"]) {
+      const out = normalizeNodeId(v);
+      expect(typeof out === "number" ? Number.isNaN(out) : false).toBe(false);
+    }
+  });
+
+  it("the rejection message names the qualified shape", () => {
+    // A caller holding `263:78` needs to know whether it is unsupported or
+    // malformed; the old message ("must be an integer") answered neither.
+    expect(NODE_ID_MESSAGE).toContain("120:104");
+  });
+});

--- a/src/__tests__/orchestrator/node-id.test.ts
+++ b/src/__tests__/orchestrator/node-id.test.ts
@@ -9,8 +9,10 @@
 // with one about identity for that reason.
 
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import {
   NODE_ID_MESSAGE,
+  NODE_ID_PATTERN,
   isNodeIdString,
   isQualifiedNodeId,
   normalizeNodeId,
@@ -75,5 +77,24 @@ describe("#1425 what goes on the wire", () => {
     // A caller holding `263:78` needs to know whether it is unsupported or
     // malformed; the old message ("must be an integer") answered neither.
     expect(NODE_ID_MESSAGE).toContain("120:104");
+  });
+});
+
+describe("#1425 what the tool schema ADVERTISES", () => {
+  it("keeps a pattern on the wire schema — a refine would advertise nothing", () => {
+    // Validating through `.refine()` type-checks and passes every behavioural test
+    // above, while rendering as a bare {"type":"string"}: clients would be told
+    // LESS about a node id than the old integer-only rule told them. Measured, not
+    // assumed — this is the assertion that catches a switch back.
+    const schema = z.toJSONSchema(
+      z.object({ node_id: z.string().regex(NODE_ID_PATTERN, NODE_ID_MESSAGE) }),
+      { io: "input", unrepresentable: "any" },
+    ) as { properties: { node_id: { pattern?: string } } };
+    expect(schema.properties.node_id.pattern).toBeTruthy();
+    // And the advertised pattern must actually admit the shape this issue is about.
+    const advertised = new RegExp(schema.properties.node_id.pattern!);
+    expect(advertised.test("263:78")).toBe(true);
+    expect(advertised.test("42")).toBe(true);
+    expect(advertised.test("1:-2")).toBe(false);
   });
 });

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -1,0 +1,64 @@
+/**
+ * #1425 — the wire contract for a node id, including the SUBGRAPH-QUALIFIED shape.
+ *
+ * #845 made the tools accept back an id they had printed: the graph readers return
+ * ids as strings (`"42"`), so `"42"` and `42` both had to mean node 42. That change
+ * deliberately stopped short of `"5:12"`:
+ *
+ *   > a subgraph-qualified id is a real shape in newer ComfyUI, and silently
+ *   > truncating it to `5` would target the WRONG node rather than fail. If those
+ *   > need supporting, that is a separate, deliberate change to the wire contract.
+ *
+ * This is that change. Unpacking a subgraph leaves genuine ROOT-level nodes carrying
+ * ids like `120:104` and `120:113:78`; the readers list them and render them, and
+ * every write tool refused them — 18 of 21 nodes uneditable in the reporter's
+ * workflow. So the refusal was not protecting anything by then, it was just the
+ * conservative half of a trade whose other half never arrived.
+ *
+ * The two halves have to move TOGETHER. Widening the pattern alone would send
+ * `"263:78"` through `Number.parseInt(…, 10)` and yield `263` — turning a loud
+ * refusal into a silent edit of a DIFFERENT node, which is the exact outcome #845
+ * refused to risk. So a qualified id is never converted: it stays the string the
+ * reader printed, all the way to the panel.
+ */
+
+/** A plain integer id, the form the wire has always carried. */
+const PLAIN = /^-?\d+$/;
+
+/**
+ * A subgraph-qualified id: integer segments joined by colons (`120:104`,
+ * `120:113:78`). No depth limit — nesting is arbitrary, and a limit would fail the
+ * deep case in exactly the way this fixes the shallow one. Only the FIRST segment
+ * may be negative: a leading `-` marks the boundary-rail ids the readers emit, and
+ * a `-` inside a path would be a shape nothing produces.
+ */
+const QUALIFIED = /^-?\d+(?::\d+)+$/;
+
+/** Does this string name a node at all — either spelling? */
+export function isNodeIdString(v: string): boolean {
+  return PLAIN.test(v) || QUALIFIED.test(v);
+}
+
+/** True for the qualified form specifically (`"5:12"`), false for `"5"`. */
+export function isQualifiedNodeId(v: string): boolean {
+  return QUALIFIED.test(v);
+}
+
+/**
+ * Normalize an accepted id to what goes on the wire.
+ *
+ * A plain id becomes the NUMBER the panel has always received, so nothing about
+ * the existing surface changes. A qualified id is returned VERBATIM — parsing it
+ * is precisely the bug. Callers must therefore treat a node id as `number | string`
+ * rather than assuming the number.
+ */
+export function normalizeNodeId(v: number | string): number | string {
+  if (typeof v === "number") return v;
+  if (QUALIFIED.test(v)) return v;
+  return Number.parseInt(v, 10);
+}
+
+/** The message a rejected id gets. Names the qualified shape explicitly, because a
+ *  caller holding `263:78` needs to know whether it is unsupported or malformed. */
+export const NODE_ID_MESSAGE =
+  "a node id must be an integer (e.g. 42) or a subgraph-qualified id (e.g. 120:104)";

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -34,9 +34,19 @@ const PLAIN = /^-?\d+$/;
  */
 const QUALIFIED = /^-?\d+(?::\d+)+$/;
 
+/**
+ * Both spellings in ONE pattern, so it can be handed to `z.string().regex()`.
+ *
+ * That matters beyond tidiness: `.regex()` puts a `pattern` on the advertised MCP
+ * input schema, while `.refine()` renders as a bare `{"type":"string"}` (measured
+ * with zod 4's toJSONSchema). Validating through a refine would therefore have told
+ * every client LESS about a node id than the old integer-only rule did.
+ */
+export const NODE_ID_PATTERN = /^-?\d+(?::\d+)*$/;
+
 /** Does this string name a node at all — either spelling? */
 export function isNodeIdString(v: string): boolean {
-  return PLAIN.test(v) || QUALIFIED.test(v);
+  return NODE_ID_PATTERN.test(v);
 }
 
 /** True for the qualified form specifically (`"5:12"`), false for `"5"`. */

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -51,7 +51,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
-import { NODE_ID_MESSAGE, isNodeIdString, normalizeNodeId } from "./node-id.js";
+import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -7554,7 +7554,7 @@ const nodeId = () =>
   z
     .union([
       z.number().int(),
-      z.string().refine(isNodeIdString, NODE_ID_MESSAGE),
+      z.string().regex(NODE_ID_PATTERN, NODE_ID_MESSAGE),
     ])
     .transform(normalizeNodeId);
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -51,6 +51,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
+import { NODE_ID_MESSAGE, isNodeIdString, normalizeNodeId } from "./node-id.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -7539,17 +7540,23 @@ function validatePanelEditNodeArgs(args: Record<string, unknown>): string | null
  * Nothing about `"42"` is ambiguous. Accept both spellings and normalize to the
  * number the wire has always carried, so the round trip closes.
  *
- * DELIBERATELY STRICT about what counts as a node id: only an integer, or a
- * string that is exactly an integer. `"42px"`, `"4.5"`, `""` and `"5:12"` are
- * still rejected. The last one matters — a subgraph-qualified id is a real
- * shape in newer ComfyUI, and silently truncating it to `5` would target the
- * WRONG node rather than fail. If those need supporting, that is a separate,
- * deliberate change to the wire contract, not something to fall out of a coerce.
+ * STRICT about what counts as a node id: an integer, a string that is exactly an
+ * integer, or a subgraph-qualified id (`"120:104"`). `"42px"`, `"4.5"` and `""`
+ * are still rejected.
+ *
+ * #1425 added the qualified shape — the "separate, deliberate change to the wire
+ * contract" this comment used to defer. Unpacking a subgraph leaves genuine ROOT
+ * nodes carrying those ids, the readers hand them out, and every write tool
+ * refused them. Crucially the qualified form is NOT parsed to a number: see
+ * node-id.ts, where truncating `"263:78"` to `263` would edit the wrong node.
  */
 const nodeId = () =>
-  z.union([z.number().int(), z.string().regex(/^-?\d+$/, "a node id must be an integer")]).transform(
-    (v) => (typeof v === "number" ? v : Number.parseInt(v, 10)),
-  );
+  z
+    .union([
+      z.number().int(),
+      z.string().refine(isNodeIdString, NODE_ID_MESSAGE),
+    ])
+    .transform(normalizeNodeId);
 
 /**
  * #845 — which `panel_canvas` arguments the chosen action actually consumes.


### PR DESCRIPTION
Closes #1425.

Confirmed live on main — `src/orchestrator/panel-tools.ts:6935`:

```ts
const nodeId = () =>
  z.union([z.number().int(), z.string().regex(/^-?\d+$/, "a node id must be an integer")]).transform(
    (v) => (typeof v === "number" ? v : Number.parseInt(v, 10)),
  );
```

Root nodes left behind by an unpacked subgraph have ids like `263:78`. Read tools return them; every WRITE tool rejects them — 18 of 21 nodes uneditable in the reporter's workflow.

The reporter also spotted the second, worse half: widening the regex alone would make `Number.parseInt("263:78", 10)` yield `263` and silently edit **a different node**. So the transform has to stop collapsing these, not just the pattern.

Draft while I work out how far the string id has to travel.