### PR TITLE
fix(1398): the injected steering tells a code-mode agent where its panel tools actually are

### DIFF
--- a/src/__tests__/orchestrator/deferred-panel-tools.test.ts
+++ b/src/__tests__/orchestrator/deferred-panel-tools.test.ts
@@ -1,0 +1,68 @@
+// #1398 — a code-mode agent was told, by the INJECTED steering, to look for tools it
+// could never see under that name. It scanned its direct declarations, found no bare
+// `panel_` name, concluded the live-canvas tools were missing, and started
+// investigating a rollback of the product — while the panel MCP endpoint was
+// answering tools/list with 91 tools and HTTP 200.
+//
+// #1353 fixed the message you get when you CALL a missing tool (v0.50.104). The
+// reporter had that fix; it is a different surface from the one they followed.
+//
+// These assert on the RENDERED strings, not on the source. A template literal whose
+// `${…}` silently failed to interpolate would type-check, build, and ship the
+// placeholder text to the agent — the exact failure this guidance exists to prevent,
+// and one no source-grep test can see.
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFERRED_PANEL_QUALIFIED_NAME,
+  DEFERRED_PANEL_TOOLS_NOTE,
+  DEFERRED_PANEL_TOOLS_STEERING,
+} from "../../deferred-panel-tools.js";
+import { PANEL_SYSTEM_APPEND } from "../../orchestrator/index.js";
+
+describe("#1398 the injected steering says where the tools actually are", () => {
+  it("names the prefixed spelling a deferred catalog holds", () => {
+    // Not "check your deferred tools" — the reporter's agent DID inspect its tools.
+    // What it needed was the spelling.
+    expect(PANEL_SYSTEM_APPEND).toContain("mcp__panel__panel_graph_outline");
+  });
+
+  it("names the catalog to search", () => {
+    expect(PANEL_SYSTEM_APPEND).toContain("ALL_TOOLS");
+  });
+
+  it("requires BOTH surfaces to be empty before absence may be concluded", () => {
+    expect(PANEL_SYSTEM_APPEND).toMatch(/BOTH your direct declarations and your\s+deferred catalog/);
+  });
+
+  it("tells the agent not to treat apparent absence as a product fault", () => {
+    // The reported harm was not the wrong belief — it was what the agent did next.
+    expect(PANEL_SYSTEM_APPEND.toLowerCase()).toContain("roll back");
+  });
+
+  it("INTERPOLATED — no un-rendered placeholder reaches the agent", () => {
+    // The assertion that catches the silent failure: `${DEFERRED_PANEL_TOOLS_STEERING}`
+    // inside a non-template string compiles and ships the literal text.
+    expect(PANEL_SYSTEM_APPEND).not.toContain("${");
+    expect(PANEL_SYSTEM_APPEND).toContain(DEFERRED_PANEL_TOOLS_STEERING);
+  });
+});
+
+describe("#1398 both surfaces share one source of truth", () => {
+  it("the steering is built from the same note the unknown-tool message uses", () => {
+    // Two surfaces phrasing this in their own words is how one ends up a version
+    // behind the other — which is exactly what #1398 reported after #1353.
+    expect(DEFERRED_PANEL_TOOLS_STEERING).toContain(DEFERRED_PANEL_TOOLS_NOTE);
+  });
+
+  it("the qualified name is assembled from the prefix, not written out twice", () => {
+    expect(DEFERRED_PANEL_QUALIFIED_NAME).toBe("mcp__panel__panel_graph_outline");
+    expect(DEFERRED_PANEL_TOOLS_NOTE).toContain(DEFERRED_PANEL_QUALIFIED_NAME);
+  });
+
+  it("the note distinguishes the two spellings rather than mentioning one", () => {
+    // "look for mcp__panel__panel_graph_outline" alone leaves a reader unsure whether
+    // the bare name was wrong or merely absent.
+    expect(DEFERRED_PANEL_TOOLS_NOTE).toContain("not `panel_graph_outline`");
+  });
+});

--- a/src/__tests__/orchestrator/deferred-panel-tools.test.ts
+++ b/src/__tests__/orchestrator/deferred-panel-tools.test.ts
@@ -167,8 +167,37 @@ describe("#1398 the install line itself", () => {
       "utf8",
     );
     expect(src).toContain("let panelSystemAppend = resolvePanelPersona();");
-    // And nothing else may resolve the persona behind its back.
+    // And nothing else may resolve the persona behind its back. Keyed on the
+    // FALLBACK, not the id string (codex round 2, P2): a bypass written as
+    // `resolvePrompt(PANEL_PERSONA_ID, PANEL_SYSTEM_APPEND)` passes an id-literal
+    // check while dropping the remedy. Any such call still has to name the fallback.
     const direct = src.match(/resolvePrompt\("panel\.persona"/g) ?? [];
     expect(direct).toHaveLength(1); // exactly one: inside resolvePanelPersona itself
+    // Matches ANY resolvePrompt whose fallback is the persona, whatever the id
+    // expression is — so `resolvePrompt(PANEL_PERSONA_ID, PANEL_SYSTEM_APPEND)` is
+    // caught too. (Comments and registerPrompt legitimately name the constant, so
+    // counting bare mentions would be brittle in the way codex warned about.)
+    const resolvers = src.match(/resolvePrompt\([^)]*PANEL_SYSTEM_APPEND/g) ?? [];
+    expect(resolvers).toHaveLength(1); // only resolvePanelPersona resolves the persona
+  });
+});
+
+describe("#1398 idempotence is keyed on the GUIDANCE, not the tool name", () => {
+  // codex round 2, P1. A persona that merely mentions the qualified name — a user
+  // override naming the tool, a translation keeping identifiers — used to be treated
+  // as already-fixed and received none of the actual guidance.
+  it("a persona that only MENTIONS the tool name still gets the guidance", () => {
+    const mentionsOnly = `Usa ${DEFERRED_PANEL_QUALIFIED_NAME} para leer el lienzo.`;
+    const out = withDeferredPanelToolsNote(mentionsOnly);
+    expect(out).not.toBe(mentionsOnly);
+    expect(out).toContain("ALL_TOOLS");
+    expect(out).toContain(DEFERRED_PANEL_TOOLS_STEERING);
+  });
+
+  it("a persona carrying the FULL steering is still returned untouched", () => {
+    const already = `preamble
+
+${DEFERRED_PANEL_TOOLS_STEERING}`;
+    expect(withDeferredPanelToolsNote(already)).toBe(already);
   });
 });

--- a/src/__tests__/orchestrator/deferred-panel-tools.test.ts
+++ b/src/__tests__/orchestrator/deferred-panel-tools.test.ts
@@ -177,7 +177,11 @@ describe("#1398 the install line itself", () => {
     // expression is — so `resolvePrompt(PANEL_PERSONA_ID, PANEL_SYSTEM_APPEND)` is
     // caught too. (Comments and registerPrompt legitimately name the constant, so
     // counting bare mentions would be brittle in the way codex warned about.)
-    const resolvers = src.match(/resolvePrompt\([^)]*PANEL_SYSTEM_APPEND/g) ?? [];
+    // `[^)]*` could not cross a nested `)` (codex round 3), so an equivalent
+    // refactor like `resolvePrompt(promptIdFor("panel.persona"), PANEL_SYSTEM_APPEND)`
+    // matched nothing and failed this guard for no reason. Bounded-span instead: it
+    // spans a nested call while still not running away across the file.
+    const resolvers = src.match(/resolvePrompt\([\s\S]{0,200}?PANEL_SYSTEM_APPEND/g) ?? [];
     expect(resolvers).toHaveLength(1); // only resolvePanelPersona resolves the persona
   });
 });

--- a/src/__tests__/orchestrator/deferred-panel-tools.test.ts
+++ b/src/__tests__/orchestrator/deferred-panel-tools.test.ts
@@ -12,13 +12,29 @@
 // placeholder text to the agent — the exact failure this guidance exists to prevent,
 // and one no source-grep test can see.
 
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+
+// Importing the orchestrator entry transitively reaches resolveLiveInterpreter, which
+// shells out to find the python actually serving the port on THIS machine — so these
+// tests would assert one thing where ComfyUI is running and another where it is not,
+// and CI could not tell us (#1290/#1263). Stubbed at its module boundary.
+vi.mock("../../services/live-interpreter.js", async () => ({
+  ...(await vi.importActual("../../services/live-interpreter.js")),
+  resolveLiveInterpreter: () => undefined,
+}));
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   DEFERRED_PANEL_QUALIFIED_NAME,
   DEFERRED_PANEL_TOOLS_NOTE,
   DEFERRED_PANEL_TOOLS_STEERING,
+  withDeferredPanelToolsNote,
 } from "../../deferred-panel-tools.js";
-import { PANEL_SYSTEM_APPEND } from "../../orchestrator/index.js";
+import { setPromptOverride } from "../../services/prompt-overrides.js";
+import { PANEL_SYSTEM_APPEND, resolvePanelPersona } from "../../orchestrator/index.js";
 
 describe("#1398 the injected steering says where the tools actually are", () => {
   it("names the prefixed spelling a deferred catalog holds", () => {
@@ -64,5 +80,95 @@ describe("#1398 both surfaces share one source of truth", () => {
     // "look for mcp__panel__panel_graph_outline" alone leaves a reader unsure whether
     // the bare name was wrong or merely absent.
     expect(DEFERRED_PANEL_TOOLS_NOTE).toContain("not `panel_graph_outline`");
+  });
+});
+
+describe("#1398 the guidance survives a persona OVERRIDE", () => {
+  // codex review, P1: the persona is resolved through resolvePrompt("panel.persona", …),
+  // so a locale translation or a user override replaces the WHOLE string — silently
+  // taking this guidance with it. A non-English deployment would then reproduce #1398
+  // with the fix apparently shipped, which is the hardest version of it to diagnose.
+  it("appends the note to an override that lacks it", () => {
+    const translated = "Eres el asistente autónomo integrado en el panel de ComfyUI.";
+    const out = withDeferredPanelToolsNote(translated);
+    expect(out).toContain(translated); // the override is preserved, not replaced
+    expect(out).toContain(DEFERRED_PANEL_QUALIFIED_NAME);
+    expect(out).toContain("ALL_TOOLS");
+  });
+
+  it("is IDEMPOTENT — a persona that already carries it is returned untouched", () => {
+    // Applied on every refresh, so a non-idempotent version would grow the prompt by
+    // a paragraph each time.
+    const once = withDeferredPanelToolsNote("a persona with no tool guidance at all");
+    const twice = withDeferredPanelToolsNote(once);
+    expect(twice).toBe(once);
+    expect(once.split("ALL_TOOLS").length - 1).toBe(1); // exactly one mention, not two
+  });
+
+  it("leaves the shipped default persona untouched", () => {
+    expect(withDeferredPanelToolsNote(PANEL_SYSTEM_APPEND)).toBe(PANEL_SYSTEM_APPEND);
+  });
+
+  it("an empty override still gets the guidance", () => {
+    expect(withDeferredPanelToolsNote("")).toContain(DEFERRED_PANEL_QUALIFIED_NAME);
+  });
+});
+
+describe("#1398 the guidance reaches the agent THROUGH the override path", () => {
+  // setPromptOverride is a read-modify-WRITE of ~/.comfyui-mcp/panel-prompts.json —
+  // the real one. Redirect it, or a test run edits the user's own persona override.
+  let dir = "";
+  let prev: string | undefined;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "cmcp-prompts-"));
+    prev = process.env.COMFYUI_MCP_PANEL_PROMPTS;
+    process.env.COMFYUI_MCP_PANEL_PROMPTS = join(dir, "panel-prompts.json");
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.COMFYUI_MCP_PANEL_PROMPTS;
+    else process.env.COMFYUI_MCP_PANEL_PROMPTS = prev;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The helper being correct proves nothing about it being CALLED. A mutation run
+  // showed exactly that: dropping the call at the resolution site left all twelve
+  // tests above green, so the wiring is asserted here on the real resolver.
+  it("a TRANSLATED persona override still carries the guidance", () => {
+    const translated = "Eres el asistente autónomo integrado en el panel lateral de ComfyUI.";
+    setPromptOverride("panel.persona", translated);
+    try {
+      const persona = resolvePanelPersona();
+      expect(persona).toContain(translated); // the translation is honoured…
+      expect(persona).toContain(DEFERRED_PANEL_QUALIFIED_NAME); // …and so is this
+      expect(persona).toContain("ALL_TOOLS");
+    } finally {
+      setPromptOverride("panel.persona", "");
+    }
+  });
+
+  it("with no override, the shipped persona is returned unchanged", () => {
+    setPromptOverride("panel.persona", "");
+    expect(resolvePanelPersona()).toBe(PANEL_SYSTEM_APPEND);
+  });
+});
+
+describe("#1398 the install line itself", () => {
+  // `panelSystemAppend` is a local inside runPanelOrchestrator(), so a call site that
+  // bypasses resolvePanelPersona() and calls resolvePrompt() directly is invisible to
+  // every behavioural test above — confirmed by a mutation run that left all 14 green
+  // while the guidance stopped reaching agents entirely.
+  //
+  // A source assertion is a weak instrument and is used here for the one thing it can
+  // do: notice the line being removed. It is verified the only way that means
+  // anything, by deleting the line and watching this fail.
+  it("runPanelOrchestrator builds the persona through resolvePanelPersona()", () => {
+    const src = readFileSync(
+      fileURLToPath(new URL("../../orchestrator/index.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(src).toContain("let panelSystemAppend = resolvePanelPersona();");
+    // And nothing else may resolve the persona behind its back.
+    const direct = src.match(/resolvePrompt\("panel\.persona"/g) ?? [];
+    expect(direct).toHaveLength(1); // exactly one: inside resolvePanelPersona itself
   });
 });

--- a/src/deferred-panel-tools.ts
+++ b/src/deferred-panel-tools.ts
@@ -57,3 +57,23 @@ export const DEFERRED_PANEL_TOOLS_STEERING =
   `deferred catalog hold nothing matching \`panel_\` may you say the live-canvas tools are ` +
   `unavailable — and never treat their apparent absence as a product fault to diagnose, ` +
   `downgrade, or roll back.`;
+
+/**
+ * Guarantee the guidance survives a persona OVERRIDE (codex review, #1398 P1).
+ *
+ * The default persona interpolates the steering, but the persona is resolved through
+ * `resolvePrompt("panel.persona", …)`: a locale translation or a user override
+ * replaces the WHOLE string, silently taking this with it — and a non-English or
+ * customized deployment then reproduces #1398 exactly, with the fix apparently
+ * shipped. The guidance is about the SPELLING of a tool name, which is the same in
+ * every language, so it belongs outside anything translatable.
+ *
+ * Idempotent: keyed on the qualified name, so the default persona (which already
+ * contains it) is returned untouched rather than carrying the paragraph twice.
+ */
+export function withDeferredPanelToolsNote(persona: string): string {
+  if (persona.includes(DEFERRED_PANEL_QUALIFIED_NAME)) return persona;
+  return `${persona}
+
+${DEFERRED_PANEL_TOOLS_STEERING}`;
+}

--- a/src/deferred-panel-tools.ts
+++ b/src/deferred-panel-tools.ts
@@ -1,0 +1,59 @@
+/**
+ * #1398 / #1353 — the one place that says where a code-mode agent's panel tools are.
+ *
+ * On a code-mode / deferred-tool client (the Codex backend) the panel tools are NOT
+ * declared directly. They live in the `ALL_TOOLS` catalog under an `mcp__panel__`
+ * prefix, so any instruction that says "look for a `panel_` tool" is followed
+ * literally, finds nothing among the direct declarations, and licenses exactly the
+ * wrong conclusion — while the panel MCP endpoint is answering `tools/list` with 91
+ * tools and HTTP 200.
+ *
+ * #1353 fixed the message a caller gets when it CALLS a missing tool. It did not
+ * fix the steering INJECTED into the system prompt, which is the surface the #1398
+ * reporter actually followed: their agent concluded the live-canvas tools were
+ * absent and went on to investigate rolling the product back two dozen versions.
+ *
+ * Two surfaces making the same claim in their own words is how one of them ends up
+ * a version behind the other. They share this text now, so a third can too.
+ */
+
+/** The tool a reader is most likely to look for first, in both spellings. */
+export const DEFERRED_PANEL_EXAMPLE = "panel_graph_outline";
+
+/**
+ * The prefixed name a deferred catalog actually holds. Built rather than written
+ * out so the prefix appears once: the namespace is `mcp__<server>__`, and the panel
+ * MCP server is registered as `panel` (see PANEL_NAMESPACE_RE in tools/compact.ts,
+ * which strips exactly this shape off an incoming call).
+ */
+export const DEFERRED_PANEL_PREFIX = "mcp__panel__";
+
+/** `mcp__panel__panel_graph_outline` — the string a search must match. */
+export const DEFERRED_PANEL_QUALIFIED_NAME = `${DEFERRED_PANEL_PREFIX}${DEFERRED_PANEL_EXAMPLE}`;
+
+/**
+ * The caveat, phrased to be dropped into a longer sentence about absence.
+ *
+ * Deliberately names BOTH the catalog and the exact string to look for. "Check your
+ * deferred tools" is not enough: the reporter's agent did inspect its tools, and the
+ * thing it needed was the spelling.
+ */
+export const DEFERRED_PANEL_TOOLS_NOTE =
+  `A code-mode/deferred-tool client (e.g. the Codex backend) does NOT declare these ` +
+  `directly — it lists them in its deferred catalog (\`ALL_TOOLS\`) under an MCP prefix, ` +
+  `so the name to look for is \`${DEFERRED_PANEL_QUALIFIED_NAME}\`, not ` +
+  `\`${DEFERRED_PANEL_EXAMPLE}\`. Search that catalog too, and if it is there, call it ` +
+  `through the nested tools namespace.`;
+
+/**
+ * The same caveat as a standalone instruction for the INJECTED steering, where it has
+ * to carry its own "before you conclude anything" framing rather than continuing a
+ * sentence about a specific failed call.
+ */
+export const DEFERRED_PANEL_TOOLS_STEERING =
+  `FINDING THESE TOOLS: if you cannot see a \`${DEFERRED_PANEL_EXAMPLE}\`-style name among ` +
+  `your directly declared tools, you have NOT established that the live-canvas tools are ` +
+  `missing. ${DEFERRED_PANEL_TOOLS_NOTE} Only when BOTH your direct declarations and your ` +
+  `deferred catalog hold nothing matching \`panel_\` may you say the live-canvas tools are ` +
+  `unavailable — and never treat their apparent absence as a product fault to diagnose, ` +
+  `downgrade, or roll back.`;

--- a/src/deferred-panel-tools.ts
+++ b/src/deferred-panel-tools.ts
@@ -68,11 +68,15 @@ export const DEFERRED_PANEL_TOOLS_STEERING =
  * shipped. The guidance is about the SPELLING of a tool name, which is the same in
  * every language, so it belongs outside anything translatable.
  *
- * Idempotent: keyed on the qualified name, so the default persona (which already
- * contains it) is returned untouched rather than carrying the paragraph twice.
+ * Idempotent, keyed on the WHOLE steering rather than on the tool name (codex round
+ * 2, P1). Keying on the name alone meant a persona that merely MENTIONS
+ * `mcp__panel__panel_graph_outline` — a user override naming the tool, a translation
+ * that keeps identifiers verbatim — was returned unchanged and never received the
+ * catalog, the namespace, or the do-not-diagnose-a-rollback part. That persona then
+ * reproduces #1398 while looking, to this function, like it already had the fix.
  */
 export function withDeferredPanelToolsNote(persona: string): string {
-  if (persona.includes(DEFERRED_PANEL_QUALIFIED_NAME)) return persona;
+  if (persona.includes(DEFERRED_PANEL_TOOLS_STEERING)) return persona;
   return `${persona}
 
 ${DEFERRED_PANEL_TOOLS_STEERING}`;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -76,6 +76,7 @@ import {
 } from "./panel-agent.js";
 import { promptText } from "./error-text.js";
 import { callToolAdmission } from "./call-tool-admission.js";
+import { DEFERRED_PANEL_TOOLS_STEERING } from "../deferred-panel-tools.js";
 import {
   createPanelMcpServer,
   makePanelToolCtx,
@@ -201,9 +202,14 @@ const MCP_VERSION_RUNNING = ((): string | undefined => {
   }
 })();
 
-const PANEL_SYSTEM_APPEND = `You are the autonomous assistant embedded directly in a ComfyUI sidebar panel. The person is working in ComfyUI and talks to you through that panel: their messages arrive as your prompts, and everything you write is shown to them in the panel chat. Write for that reader — lead with the result, keep replies short and concrete, and don't narrate routine internal steps.
+/** Exported for tests (#1398): the RENDERED persona is the only thing that proves
+ *  the deferred-catalog guidance actually reaches an agent — a template literal that
+ *  silently failed to interpolate would type-check, build, and ship the placeholder. */
+export const PANEL_SYSTEM_APPEND = `You are the autonomous assistant embedded directly in a ComfyUI sidebar panel. The person is working in ComfyUI and talks to you through that panel: their messages arrive as your prompts, and everything you write is shown to them in the panel chat. Write for that reader — lead with the result, keep replies short and concrete, and don't narrate routine internal steps.
 
 You can SEE and EDIT the workflow the user currently has open, via the panel_* tools (panel_graph_outline, panel_query_graph, panel_add_node, panel_connect, panel_set_widget, panel_run, panel_get_errors, panel_save_workflow, …). STRONGLY PREFER building on their live canvas: read it first (panel_graph_outline, then panel_query_graph for specifics), add/wire/configure nodes with the panel_* tools, then panel_run to queue it — so the user watches the work happen and the result loads in their own workflow with full Ctrl+Z undo. Only fall back to the headless generate_image/enqueue_workflow tools when the user explicitly wants a one-off they don't need on their canvas, or when no panel tab is connected (a panel_* call will error if so). On a LARGE graph (a loaded pack/template with dozens of nodes), do NOT dump the whole thing and scan it — and NEVER shell out to grep/jq/python over a saved workflow file. To UNDERSTAND the graph, call panel_graph_outline FIRST: a compact, dependency-ordered TEXT map (nodes topologically sorted source→sink, each with its key widgets and ← inputs / → outputs wiring, plus a groups index) made for you to read top-to-bottom. To PINPOINT and INSPECT specific nodes, use panel_query_graph: filter by types/title/widget predicates ('cfg>7'), traverse upstream_of/downstream_of a node, aggregate with group_by:'type', and read ONE node's exact slot/widget detail with {ids:[id], fields:'detail'} — output is token-bounded so it can never flood your context. panel_find_nodes remains for free-text search across all fields.
+
+${DEFERRED_PANEL_TOOLS_STEERING}
 
 PROMPT DIRECTOR AWARENESS. When the graph contains PromptDirector, PromptDirectorAuto, PromptDirectorContext, PromptProducer, or PromptDirectorResultCritic nodes, call panel_audit_prompt_director before declaring that the prompt/model/LoRA setup is correct or diagnosing a failed edit. The audit correlates live wiring and loader widgets with the nodes' resolved Model Explorer metadata, edit plan, LoRA compatibility/strengths, exact final prompt, warnings, and critic verdict. Surface concise, useful observations proactively (including when the configuration is coherent). Its recommendations are READ-ONLY proposals: ask before applying panel_set_widget/panel_connect changes unless the user already explicitly asked you to fix the workflow.
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -76,7 +76,10 @@ import {
 } from "./panel-agent.js";
 import { promptText } from "./error-text.js";
 import { callToolAdmission } from "./call-tool-admission.js";
-import { DEFERRED_PANEL_TOOLS_STEERING } from "../deferred-panel-tools.js";
+import {
+  DEFERRED_PANEL_TOOLS_STEERING,
+  withDeferredPanelToolsNote,
+} from "../deferred-panel-tools.js";
 import {
   createPanelMcpServer,
   makePanelToolCtx,
@@ -342,6 +345,20 @@ The panel tools cannot come back during this session — the tool set was fixed 
  * lies when the bind fails" is precisely the kind of thing that stays broken when
  * only the happy path is exercised.
  */
+/**
+ * The panel persona as an agent actually receives it (#1398).
+ *
+ * The deferred-catalog guidance is re-applied AFTER `resolvePrompt`, because a
+ * locale translation or a user persona override replaces the WHOLE string and would
+ * otherwise take it with them — reproducing #1398 in exactly the deployments least
+ * equipped to diagnose it (codex review, P1). Exported so that re-application is a
+ * TESTABLE unit: inlining it at the call site made dropping it invisible to every
+ * test, which a mutation run confirmed.
+ */
+export function resolvePanelPersona(): string {
+  return withDeferredPanelToolsNote(resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND));
+}
+
 export function panelToolsRetraction(backend: string, panelToolsAvailable: boolean): string {
   if (panelToolsAvailable) return "";
   // pi has no MCP client at all; PI_CAPABILITY_OVERRIDE already retracts strictly
@@ -1797,7 +1814,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // mirror-image lie: claiming to be a build we are not running.
   const mcpVersionRunning = MCP_VERSION_RUNNING;
   let latestPanelVersion: string | undefined;
-  let panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
+  let panelSystemAppend = resolvePanelPersona();
   // Set once the manager exists so a later refresh (after a ComfyUI restart) feeds
   // the freshly-gathered env into newly-spawned agents too — Claude reads
   // manager.opts.systemAppend at each spawn; Codex reads the closed-over
@@ -1819,7 +1836,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const caps = await gatherEnvCapabilities({ comfyuiUrl, comfyuiPath, backendId, mcpVersion: mcpVersionRunning, panelVersion: latestPanelVersion });
       if (gen !== envRefreshGen) return; // a newer refresh superseded us — drop this stale result
       envCaps = caps;
-      panelSystemAppend = buildPanelSystemAppend(resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND), envCaps);
+      panelSystemAppend = buildPanelSystemAppend(resolvePanelPersona(), envCaps);
       if (liveManager) liveManager.setSystemAppend(panelSystemAppend);
     } catch (err) {
       if (gen !== envRefreshGen) return; // superseded — let the newer refresh own the prompt
@@ -1830,7 +1847,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // non-default backend would rebuild a stale env block off the old caps,
       // disagreeing with the reset panelSystemAppend (#358 wiring).
       envCaps = undefined;
-      panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
+      panelSystemAppend = resolvePanelPersona();
       logger.debug(
         `[panel-orchestrator] env-capabilities probe failed (using static prompt): ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -1850,7 +1867,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       return panelSystemAppend;
     }
     return buildPanelSystemAppend(
-      resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND),
+      resolvePanelPersona(),
       { ...envCaps, backend, otherBackendAvailable },
     );
   };

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -1,3 +1,4 @@
+import { DEFERRED_PANEL_TOOLS_NOTE } from "../deferred-panel-tools.js";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -403,11 +404,9 @@ function panelNamespaceMessage(catalog: ToolCatalog, name: string): string {
     //
     // So the absence test has to name both the prefix and the deferred catalog before
     // it is allowed to conclude anything.
-    "BEFORE concluding they are absent: a code-mode/deferred-tool client (e.g. the Codex " +
-    "backend) does NOT declare these directly — it lists them in its deferred catalog " +
-    "(`ALL_TOOLS`) under an MCP prefix, so the name to look for is " +
-    "`mcp__panel__panel_graph_outline`, not `panel_graph_outline`. Search that catalog too, " +
-    "and if it is there, call it through the nested tools namespace. Only when BOTH the " +
+    // Shared with the INJECTED steering (#1398): two surfaces phrasing this in their
+    // own words is how one ends up a version behind the other.
+    `BEFORE concluding they are absent: ${DEFERRED_PANEL_TOOLS_NOTE} Only when BOTH the ` +
     "direct declarations and the deferred catalog have nothing matching `panel_` is there " +
     "no live-canvas route from here: read the " +
     "workflow from disk instead (get_workflow, whose list/get/analyze/query actions read saved files), " +


### PR DESCRIPTION
Closes #1398.

Confirmed live on origin/main. #1360 fixed the *unknown-tool message* (`src/tools/compact.ts` now names `mcp__panel__panel_graph_outline` and the `ALL_TOOLS` catalog) and shipped in **v0.50.104** — the reporter is on 0.50.110, so they had it.

But that is the message you get when you CALL a missing tool. The block the reporter actually followed is the steering INJECTED into the system prompt, and `git show origin/main:src/orchestrator/index.ts | grep ALL_TOOLS` returns nothing. So a code-mode agent reads the injected check, scans its direct declarations, finds no bare `panel_` name, and concludes the live-canvas tools are absent — this reporter's agent went on to investigate a version rollback.

Draft while I find every injected surface that makes this claim, rather than fixing only the one that was reported.