### PR TITLE
chore(release): 0.51.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.6] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- the injected steering tells a code-mode agent where its panel tools actually are (#1435)
+
+
 ## [0.51.5] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.5",
+  "version": "0.51.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.5",
+      "version": "0.51.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.5",
+  "version": "0.51.6",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.6 tag into protected main.

**0.51.6 — #1398**: the injected panel steering now tells a code-mode agent where its panel tools actually are (`mcp__panel__panel_graph_outline` in the `ALL_TOOLS` catalog), instead of naming only the bare `panel_*` spelling it cannot see.

#1353 fixed the same wording in the unknown-tool *message* (v0.50.104); the reporter had that fix and still hit this, because the steering is a different surface. Both now share one text.

Four codex rounds: three found real defects — a persona override silently dropping the guidance, three further reassignment sites (one firing at startup, which would have shipped the fix dead), and idempotence keyed on the tool name so a persona merely mentioning it got nothing. Round 4: **PASS**.