### PR TITLE
fix(1401): a preserved fence that still matches is not 'graph tools will keep failing'

### DIFF
--- a/src/__tests__/orchestrator/fence-matching-uuid.test.ts
+++ b/src/__tests__/orchestrator/fence-matching-uuid.test.ts
@@ -89,11 +89,23 @@ describe("#1401 an uncorroborated uuid that MATCHES the fence", () => {
     expect(text).not.toContain("graph tools will keep failing");
   });
 
-  it("says the fence was not re-derived, but names it as the SAME instance", async () => {
+  it("says the fence was not re-derived, and names what that rules OUT", async () => {
     const { text } = await setCurrent();
     expect(text).toContain("NOT re-derived");
     expect(text).toContain(LIVE);
-    expect(text.toLowerCase()).toContain("same one this session is already fenced");
+    expect(text).toContain("matches the fence this session already holds");
+    expect(text).toContain("DIFFERENT workflow instance");
+  });
+
+  it("does NOT promise the graph tools work — that is what could not be confirmed", async () => {
+    // codex review: a matching uuid rules OUT "fenced to another instance"; it does
+    // not rule IN liveness, because a stale or background record can carry the right
+    // uuid and still not be the canvas in front of the user. Claiming health here
+    // would be the mirror image of the bug being fixed — turning "could not confirm"
+    // into "is fine" instead of into "is broken".
+    const { text } = await setCurrent();
+    expect(text).toContain("NOT a claim that graph tools work");
+    expect(text).not.toMatch(/likely to work|should work|will work/i);
   });
 
   it("prescribes a cheap probe FIRST, not a hard refresh", async () => {
@@ -155,6 +167,6 @@ describe("#1401 a reply that names NO identity keeps the hard wording", () => {
 
   it("does not claim the fence still matches", async () => {
     const { text } = await setCurrent();
-    expect(text.toLowerCase()).not.toContain("same one this session is already fenced");
+    expect(text).not.toContain("matches the fence this session already holds");
   });
 });

--- a/src/__tests__/orchestrator/fence-matching-uuid.test.ts
+++ b/src/__tests__/orchestrator/fence-matching-uuid.test.ts
@@ -1,0 +1,160 @@
+// #1401 — THE SAME UUID IS NOT THE SAME SITUATION.
+//
+// After a restart the panel answers `workflow_list` but marks its active record
+// UNCONFIRMED. Corroboration refuses to adopt through that, and it is right to:
+// a stale or mixed reply can carry ANOTHER canvas's perfectly valid uuid.
+//
+// What was wrong is the consequence asserted afterwards. The caller was told this
+// session is "STILL fenced to the previous workflow instance and graph tools will
+// keep failing", and sent to hard-refresh the tab — while the uuid the panel had
+// just reported was the SAME one the session was already fenced to. The reporter's
+// very next call was a panel_graph_outline that succeeded.
+//
+// So: the refusal does not move, nothing is adopted, and the fence is not written.
+// Only the DIAGNOSIS splits, on evidence that was already in hand and discarded.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const STALE = "11111111-1111-4111-8111-111111111111";
+const LIVE = "22222222-2222-4222-8222-222222222222";
+
+let listReplies: Array<Record<string, unknown>>;
+let listCalls: number;
+let stamp: string | undefined;
+let adopted: string | undefined;
+
+/** The reporter's shape: the panel answers, and says its own active record is NOT
+ *  confirmed — the post-restart reconciliation window. */
+function reconciling(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: false };
+}
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        const n = listCalls;
+        listCalls += 1;
+        return listReplies[Math.min(n, listReplies.length - 1)];
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      adopted = uuid; // must never fire on any path below
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function setCurrent(): Promise<{ res: ToolResult; text: string }> {
+  const ctx = makePanelToolCtx(bridge(), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+  if (!def) throw new Error("panel_set_workflow_target is not registered");
+  const res: ToolResult = await def.handler({ mode: "current" }, ctx);
+  return { res, text: (res.content[0] as { text: string }).text };
+}
+
+beforeEach(() => {
+  listCalls = 0;
+  adopted = undefined;
+});
+
+describe("#1401 an uncorroborated uuid that MATCHES the fence", () => {
+  beforeEach(() => {
+    stamp = LIVE; // the session is already fenced to the canvas the panel names
+    listReplies = [reconciling(LIVE)]; // never corroborates, however often re-read
+  });
+
+  it("does NOT claim graph tools will keep failing", async () => {
+    // The false statement the reporter acted on. Their next call worked.
+    const { text } = await setCurrent();
+    expect(text).not.toContain("graph tools will keep failing");
+  });
+
+  it("says the fence was not re-derived, but names it as the SAME instance", async () => {
+    const { text } = await setCurrent();
+    expect(text).toContain("NOT re-derived");
+    expect(text).toContain(LIVE);
+    expect(text.toLowerCase()).toContain("same one this session is already fenced");
+  });
+
+  it("prescribes a cheap probe FIRST, not a hard refresh", async () => {
+    // A hard refresh throws away the user's canvas state; it must not be the
+    // opening move for a case where the binding is probably fine.
+    const { text } = await setCurrent();
+    const probeAt = text.indexOf("panel_graph_outline");
+    const refreshAt = text.search(/hard[- ]refresh|refresh the ComfyUI tab|F5/i);
+    expect(probeAt, "the probe must be mentioned").toBeGreaterThan(-1);
+    if (refreshAt > -1) expect(probeAt).toBeLessThan(refreshAt);
+  });
+
+  it("still ADOPTS NOTHING — the fail-closed rule does not move", async () => {
+    await setCurrent();
+    expect(adopted, "no uncorroborated identity may be written").toBeUndefined();
+    expect(stamp).toBe(LIVE); // unchanged, because it already was LIVE
+  });
+
+  it("is still reported as a FAILURE, not as success", async () => {
+    // Softening the DIAGNOSIS must not soften the RESULT: the rebind genuinely
+    // did not happen, and the caller must still see an error rather than a
+    // reassuring success. (The failure path answers as an error result, not the
+    // JSON body the success path returns.)
+    const { res, text } = await setCurrent();
+    expect(res.isError).toBe(true);
+    expect(text).toContain("did NOT restore this session's graph binding");
+  });
+});
+
+describe("#1401 an uncorroborated uuid that DIFFERS keeps the hard wording", () => {
+  // The over-broad direction. If this softened too, the fix would be hiding a
+  // genuinely wedged session behind "probably fine" — worse than the bug.
+  beforeEach(() => {
+    stamp = STALE; // fenced to one canvas…
+    listReplies = [reconciling(LIVE)]; // …while the panel names a different one
+  });
+
+  it("still says graph tools will keep failing", async () => {
+    const { text } = await setCurrent();
+    expect(text).toContain("graph tools will keep failing");
+    expect(text).toContain(STALE);
+  });
+
+  it("still adopts nothing", async () => {
+    await setCurrent();
+    expect(adopted).toBeUndefined();
+    expect(stamp).toBe(STALE);
+  });
+});
+
+describe("#1401 a reply that names NO identity keeps the hard wording", () => {
+  // Nothing to compare means nothing is known: absence of evidence must not be
+  // rendered as the reassuring case.
+  beforeEach(() => {
+    stamp = STALE;
+    const active = { path: "workflows/a.json", routing_key: TAB }; // no workflow_uuid
+    listReplies = [{ active, workflows: [{ ...active, active: true }], active_confirmed: false }];
+  });
+
+  it("does not claim the fence still matches", async () => {
+    const { text } = await setCurrent();
+    expect(text.toLowerCase()).not.toContain("same one this session is already fenced");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4252,21 +4252,29 @@ function describeFenceRebind(
       // succeeded, after being told it would keep failing and to hard-refresh.
       //
       // So this splits on evidence rather than reporting the worst case for both:
-      // a MATCHING uuid means "not re-derived, probably still fine, try one"; a
-      // DIFFERENT or absent one keeps the original certain-failure wording.
+      // a MATCHING uuid rules OUT the fenced-to-another-instance case without ruling
+      // IN liveness (codex: a stale/background record can carry the right uuid), so it
+      // reports what is ruled out and sends the caller to the read that settles it; a
+      // DIFFERENT or absent uuid keeps the original certain-failure wording.
       const fenceStillMatches =
         r.status === "no_identity" && r.seenUuid !== undefined && r.seenUuid === r.before.uuid;
       if (fenceStillMatches) {
         return {
           binding: "not_recovered",
           note:
-            `${lead}. This session's fence was NOT re-derived — but the identity the panel ` +
-            `did report for the active canvas is the SAME one this session is already fenced ` +
-            `to (${r.before.uuid}), so it was not repointed at a different workflow and graph ` +
-            `tools are likely to work. TRY ONE (panel_graph_outline) before doing anything ` +
-            `heavier: if it succeeds, the fence was fine all along and this was a ` +
-            `reconciliation race, not a broken binding. Only if it fails with a ` +
-            `workflow-instance mismatch is the fence actually stale — then ${RELOAD_TAB_REMEDY}`,
+            `${lead}. This session's fence was NOT re-derived, and whether that reply describes ` +
+            `the LIVE canvas is exactly what could not be confirmed — a stale or background ` +
+            `record can carry the right uuid and still not be the canvas in front of the user, ` +
+            `so this is NOT a claim that graph tools work. What IS known is narrower and still ` +
+            `useful: the identity it reported matches the fence this session already holds ` +
+            `(${r.before.uuid}), so this is not the case where the session is fenced to a ` +
+            `DIFFERENT workflow instance — which is the one that keeps graph tools failing.` +
+            `
+
+WHAT TO DO: settle it with a graph read — call panel_graph_outline. That ` +
+            `answers the question this could not: if it succeeds, the binding was fine and this ` +
+            `was a reconciliation race. If it fails with a workflow-instance mismatch, the ` +
+            `reply was stale after all — then ${RELOAD_TAB_REMEDY}`,
         };
       }
       return r.before.uuid

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3514,6 +3514,11 @@ export type WorkflowFenceRebind =
        *  is wrong (an older build sends no open-workflow list), and telling that
        *  caller to try again in a moment is advice that can never come true. */
       rechecks?: { attempts: number; waitedMs: number; settles: boolean };
+      /** #1401 — the uuid the panel reported but could not corroborate. NOT
+       *  adopted, and never treated as the live identity; used only so the
+       *  message can stop asserting certain failure when it EQUALS the fence
+       *  this session already holds. */
+      seenUuid?: string;
     }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check).
@@ -3563,12 +3568,24 @@ function corroborateActiveForFence(
    *  the panel has finished confirming) settles; a SHAPE fact (this build does
    *  not send a `workflows` array; these records share no comparable identity
    *  field) does not, no matter how long anyone waits. */
-  | { ok: false; why: string; settles: boolean } {
+  /** `seenUuid` — the identity the panel REPORTED for the active canvas, when it
+   *  reported one at all. Deliberately kept on the FAILURE path (#1401): it must
+   *  never be adopted, but it is the only thing that can tell "we could not
+   *  confirm the canvas" apart from "the canvas is a different one". A caller
+   *  whose preserved fence equals this uuid is not broken, and telling them their
+   *  graph tools will keep failing sends them to a hard refresh for nothing. */
+  | { ok: false; why: string; settles: boolean; seenUuid?: string } {
   const active = parsed.active;
+  // Read once, up front, so every failure branch below can report it. Undefined
+  // whenever the record is missing, unreadable, or carries no usable uuid.
+  const seenUuid =
+    active && typeof active === "object"
+      ? responseWorkflowUuid(active as Record<string, unknown>)
+      : undefined;
   if (!active || typeof active !== "object") {
     // SETTLES: mid-restore the frontend genuinely has no active workflow yet —
     // that is #1184's finding in this reply's terms, and it is the window here.
-    return { ok: false, why: "the reply carried no active-workflow record", settles: true };
+    return { ok: false, seenUuid, why: "the reply carried no active-workflow record", settles: true };
   }
   // #514: the panel says so itself when its active record is not confirmed. An
   // explicit `false` is the panel telling us the value is untrustworthy — never
@@ -3579,6 +3596,7 @@ function corroborateActiveForFence(
     // and a moment later it says otherwise (#1292).
     return {
       ok: false,
+      seenUuid,
       why: "the panel reported its active workflow as UNCONFIRMED",
       settles: true,
     };
@@ -3592,6 +3610,7 @@ function corroborateActiveForFence(
   if (!Array.isArray(list)) {
     return {
       ok: false,
+      seenUuid,
       why: "the reply carried no open-workflow list to corroborate the active record against",
       settles: false,
     };
@@ -3599,6 +3618,7 @@ function corroborateActiveForFence(
   if (list.length === 0) {
     return {
       ok: false,
+      seenUuid,
       why: "the reply's open-workflow list was empty, so nothing corroborates the active record",
       settles: true,
     };
@@ -3613,6 +3633,7 @@ function corroborateActiveForFence(
     // SETTLES: a snapshot taken before the panel re-flagged its active tab.
     return {
       ok: false,
+      seenUuid,
       why: "no entry in the open-workflow list is marked active",
       settles: true,
     };
@@ -3622,6 +3643,7 @@ function corroborateActiveForFence(
     // uuid through, so it is refused rather than arbitrated.
     return {
       ok: false,
+      seenUuid,
       why: `${flaggedActive.length} entries in the open-workflow list are marked active (a mixed reply)`,
       // SETTLES: "mixed" IS the half-reconciled state, by definition.
       settles: true,
@@ -3634,6 +3656,7 @@ function corroborateActiveForFence(
   if (verdict === false) {
     return {
       ok: false,
+      seenUuid,
       why: "the active record and the entry marked active in the open-workflow list name DIFFERENT workflows (a stale or mixed reply)",
       // SETTLES: a stale half of the snapshot catches up.
       settles: true,
@@ -3642,6 +3665,7 @@ function corroborateActiveForFence(
   if (verdict !== true) {
     return {
       ok: false,
+      seenUuid,
       why: "the active record and the open-workflow list share no comparable identity field, so nothing corroborates it",
       // DOES NOT SETTLE: a field the records do not carry will not appear by
       // waiting — that is the reply's SHAPE, not its timing.
@@ -3831,6 +3855,7 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
       kind: "uncorroborated",
       why: corroborated.why,
       rechecks: { attempts, waitedMs, settles: corroborated.settles },
+      ...(corroborated.seenUuid ? { seenUuid: corroborated.seenUuid } : {}),
     };
   }
   const active = corroborated.active;
@@ -4215,6 +4240,33 @@ function describeFenceRebind(
             `its graph binding is healthy could NOT be determined. Routing is set. Treat graph ` +
             `tools as unconfirmed: if the next one fails with a workflow-instance mismatch, ` +
             `that is the answer.${remedy}`,
+        };
+      }
+      // #1401 — the SAME uuid is not the same situation.
+      //
+      // The gate is right to refuse an uncorroborated identity, and nothing here
+      // adopts one. What was wrong was the consequence asserted afterwards: when
+      // the identity the panel reported EQUALS the fence this session already
+      // holds, graph tools are not fenced to a different instance and generally
+      // keep working — the reporter's next call was a panel_graph_outline that
+      // succeeded, after being told it would keep failing and to hard-refresh.
+      //
+      // So this splits on evidence rather than reporting the worst case for both:
+      // a MATCHING uuid means "not re-derived, probably still fine, try one"; a
+      // DIFFERENT or absent one keeps the original certain-failure wording.
+      const fenceStillMatches =
+        r.status === "no_identity" && r.seenUuid !== undefined && r.seenUuid === r.before.uuid;
+      if (fenceStillMatches) {
+        return {
+          binding: "not_recovered",
+          note:
+            `${lead}. This session's fence was NOT re-derived — but the identity the panel ` +
+            `did report for the active canvas is the SAME one this session is already fenced ` +
+            `to (${r.before.uuid}), so it was not repointed at a different workflow and graph ` +
+            `tools are likely to work. TRY ONE (panel_graph_outline) before doing anything ` +
+            `heavier: if it succeeds, the fence was fine all along and this was a ` +
+            `reconciliation race, not a broken binding. Only if it fails with a ` +
+            `workflow-instance mismatch is the fence actually stale — then ${RELOAD_TAB_REMEDY}`,
         };
       }
       return r.before.uuid


### PR DESCRIPTION
Closes #1401.

Confirmed live on origin/main, `src/orchestrator/panel-tools.ts`:

```ts
`${lead}, so this session is STILL fenced to the previous workflow instance ` +
`(${r.before.uuid}) and graph tools will keep failing.${remedy}`
```

The gate is right to refuse to ADOPT an uncorroborated identity. What is wrong is the consequence it then asserts: when the preserved fence already matches the restored canvas, graph tools work fine — the reporter's `panel_graph_outline` succeeded immediately after being told it would keep failing, and being sent to press F5.

That is a "could not confirm" reported as "is broken" — the #796 class this repo already gates on.

Draft while I check what the recovery result actually knows about the observed UUID.