### PR TITLE
chore(release): 0.51.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.7] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a preserved fence that still matches is not 'graph tools will keep failing' (#1437)
+
+
 ## [0.51.6] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.6",
+  "version": "0.51.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.6",
+      "version": "0.51.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.6",
+  "version": "0.51.7",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.7 tag into protected main.

**0.51.7 — #1401**: after a restart, `panel_set_workflow_target({mode:"current"})` no longer asserts that graph tools "will keep failing" — and send the user to hard-refresh — when the uuid the panel reported is the same one the session's fence already holds.

The refusal to adopt an uncorroborated identity is unchanged and nothing is adopted. Only the diagnosis splits, on evidence that was already in hand and discarded.

Codex round 1 caught the mirror-image error in my first cut (claiming "likely to work" from an uncorroborated record); round 2: PASS.