### PR TITLE
fix(1411): a panel message that arrives before boot finishes is no longer dropped

### DIFF
--- a/src/__tests__/services/ui-bridge-preboot-queue.test.ts
+++ b/src/__tests__/services/ui-bridge-preboot-queue.test.ts
@@ -1,0 +1,200 @@
+// #1411 — A MESSAGE SENT BEFORE THE ORCHESTRATOR FINISHES STARTING IS NOT GONE.
+//
+// The bridge binds its port and accepts frames several seconds before the
+// orchestrator installs `onPanelMessage` (measured: listening at T+0.0s, ready at
+// T+3.7s). Every frame in that window used to be accepted, stamped, echoed into
+// the panel transcript, and then dropped by an optional-call on a null handler —
+// no queue, no ack, no error. The user watches their own message appear and
+// nothing happen, which reads as the agent ignoring them.
+//
+// A real panel reaches this window whenever the orchestrator restarts with the
+// sidebar open: a self-restart on rebuild, a crash restart, a machine waking.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { createServer } from "node:net";
+import { UiBridge } from "../../services/ui-bridge.js";
+import type { PanelEvent } from "../../services/ui-bridge.js";
+
+let bridge: UiBridge;
+
+beforeEach(() => {
+  bridge = new UiBridge(0); // no listen() — this is about the handler, not the port
+});
+
+afterEach(() => {
+  bridge.onPanelMessage = null;
+});
+
+/** The private dispatch the socket handlers call. Reached directly so the test is
+ *  about the queue rather than about WebSocket timing. */
+function deliver(ev: PanelEvent): void {
+  (bridge as unknown as { deliverPanelEvent: (e: PanelEvent) => void }).deliverPanelEvent(ev);
+}
+
+const msg = (text: string): PanelEvent =>
+  ({ type: "user_message", tab_id: "wf:a.json", text }) as unknown as PanelEvent;
+
+describe("#1411 frames that arrive before the handler exists", () => {
+  it("are DELIVERED once the handler is installed, not dropped", async () => {
+    deliver(msg("the message the user typed during boot"));
+    expect(bridge.preHandlerBacklog().held).toBe(1);
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => void seen.push((e as unknown as { text: string }).text);
+
+    expect(seen).toEqual(["the message the user typed during boot"]);
+    expect(bridge.preHandlerBacklog().held).toBe(0);
+  });
+
+  it("arrive in the order the panel SENT them — hello before message", async () => {
+    // Reordering would hand the orchestrator a message for a tab it has not been
+    // told about, which is a different bug than the one being fixed.
+    deliver({ type: "hello", tab_id: "wf:a.json" } as unknown as PanelEvent);
+    deliver(msg("first"));
+    deliver(msg("second"));
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => {
+      const ev = e as unknown as { type: string; text?: string };
+      seen.push(ev.type === "hello" ? "hello" : (ev.text ?? "?"));
+    };
+
+    expect(seen).toEqual(["hello", "first", "second"]);
+  });
+
+  it("are delivered ONCE — a second handler assignment does not replay them", async () => {
+    deliver(msg("only once"));
+    const first: string[] = [];
+    bridge.onPanelMessage = (e) => void first.push((e as unknown as { text: string }).text);
+    const second: string[] = [];
+    bridge.onPanelMessage = (e) => void second.push((e as unknown as { text: string }).text);
+
+    expect(first).toEqual(["only once"]);
+    expect(second).toEqual([]); // the queue was emptied by the first assignment
+  });
+
+  it("do not queue at all once a handler exists — delivery stays synchronous", async () => {
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => void seen.push((e as unknown as { text: string }).text);
+
+    deliver(msg("live"));
+
+    expect(seen).toEqual(["live"]);
+    expect(bridge.preHandlerBacklog().held).toBe(0);
+  });
+
+  it("setting the handler to null does not drop what is already held", async () => {
+    deliver(msg("held"));
+    bridge.onPanelMessage = null; // the cleanup pattern used across the suite
+    expect(bridge.preHandlerBacklog().held).toBe(1);
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => void seen.push((e as unknown as { text: string }).text);
+    expect(seen).toEqual(["held"]);
+  });
+
+  it("one frame that THROWS does not strand the frames behind it", async () => {
+    // The user's message must not be lost because an earlier hello blew up.
+    deliver({ type: "hello", tab_id: "wf:a.json" } as unknown as PanelEvent);
+    deliver(msg("must still arrive"));
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => {
+      const ev = e as unknown as { type: string; text?: string };
+      if (ev.type === "hello") throw new Error("hello handler blew up");
+      seen.push(ev.text ?? "?");
+    };
+
+    expect(seen).toEqual(["must still arrive"]);
+  });
+});
+
+describe("#1411 the queue is BOUNDED, and says so", () => {
+  it("refuses past the cap rather than growing without limit", async () => {
+    // Nothing guarantees a handler is ever installed; an unbounded buffer would be
+    // its own bug, quieter than the one being fixed.
+    for (let i = 0; i < 250; i++) deliver(msg(`m${i}`));
+
+    const { held, dropped } = bridge.preHandlerBacklog();
+    expect(held).toBe(200);
+    expect(dropped).toBe(50);
+  });
+
+  it("keeps the EARLIEST frames — the hello that identifies the tab is in them", async () => {
+    deliver({ type: "hello", tab_id: "wf:a.json" } as unknown as PanelEvent);
+    for (let i = 0; i < 250; i++) deliver(msg(`m${i}`));
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => {
+      const ev = e as unknown as { type: string; text?: string };
+      seen.push(ev.type === "hello" ? "hello" : (ev.text ?? "?"));
+    };
+
+    expect(seen[0]).toBe("hello");
+    expect(seen).toHaveLength(200);
+    expect(seen).not.toContain("m199"); // refused, because the cap was already reached
+  });
+
+  it("clears the refusal count once it has been reported", async () => {
+    for (let i = 0; i < 210; i++) deliver(msg(`m${i}`));
+    expect(bridge.preHandlerBacklog().dropped).toBe(10);
+
+    bridge.onPanelMessage = () => {};
+    expect(bridge.preHandlerBacklog().dropped).toBe(0);
+  });
+});
+
+/** A free port, the way the sibling suite finds one. */
+async function freePort(): Promise<number> {
+  return await new Promise((resolve) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as { port: number }).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+describe("#1411 over a REAL socket — the wiring, not just the queue", () => {
+  // The tests above reach deliverPanelEvent directly, so they would all still pass
+  // if the socket handlers went back to `this.onPanelMessage?.(…)` and dropped
+  // everything. This is the one that fails if they do.
+  it("a user_message sent BEFORE the handler is installed still arrives", async () => {
+    const port = await freePort();
+    const live = new UiBridge(port);
+    live.start();
+    expect(await live.whenReady()).toBe(true);
+    try {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((r) => sock.on("open", () => r()));
+
+      // Exactly the reported sequence: the panel connects and talks while the
+      // orchestrator is still starting, so NO handler exists yet.
+      sock.send(JSON.stringify({ type: "hello", tab_id: "wf:a.json", title: "a" }));
+      sock.send(JSON.stringify({ type: "user_message", tab_id: "wf:a.json", text: "hello?" }));
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(live.preHandlerBacklog().held).toBeGreaterThan(0);
+
+      // Boot finishes.
+      const seen: Array<{ type: string; text?: string }> = [];
+      live.onPanelMessage = (e) => void seen.push(e as unknown as { type: string; text?: string });
+
+      const user = seen.find((e) => e.type === "user_message");
+      expect(user, "the message the user typed during boot").toBeTruthy();
+      expect(user!.text).toBe("hello?");
+      // The hello matters as much: it is what tells the orchestrator this tab
+      // exists, and a message delivered for a tab it was never told about is a
+      // different bug. Its dispatch site is separate, so it needs its own
+      // assertion — without this, reverting only that site passes everything.
+      const hello = seen.find((e) => e.type === "hello");
+      expect(hello, "the hello that identifies the tab").toBeTruthy();
+      expect(seen.indexOf(hello!)).toBeLessThan(seen.indexOf(user!));
+      sock.close();
+    } finally {
+      live.onPanelMessage = null;
+      await live.stop?.();
+    }
+  });
+});

--- a/src/__tests__/services/ui-bridge-preboot-queue.test.ts
+++ b/src/__tests__/services/ui-bridge-preboot-queue.test.ts
@@ -191,6 +191,57 @@ describe("#1411 a self-feeding handler cannot wedge the event loop", () => {
   });
 });
 
+describe("#1411 nothing overtakes a frame that is still waiting (codex round 3)", () => {
+  it("a live frame arriving BEFORE the continuation lands behind the queued one", async () => {
+    // A,B are the backlog; handling A queues C, which the budget defers to the next
+    // tick. A socket frame D arriving in that gap must NOT be delivered around C —
+    // the panel sent C first, so A,B,D,C would be a reordering the queue exists to
+    // prevent.
+    deliver(msg("A"));
+    deliver(msg("B"));
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => {
+      const text = (e as unknown as { text: string }).text;
+      seen.push(text);
+      if (text === "A") deliver(msg("C"));
+    };
+    expect(seen).toEqual(["A", "B"]); // pass over, C still queued
+
+    deliver(msg("D")); // the socket keeps running while the continuation is pending
+    expect(seen).toEqual(["A", "B"]); // …and D did not jump the queue
+
+    for (let i = 0; i < 5 && bridge.preHandlerBacklog().held > 0; i++) await tick();
+    expect(seen).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("stop() cancels a pending continuation instead of firing after teardown", async () => {
+    const port = await freePort();
+    const live = new UiBridge(port);
+    live.start();
+    expect(await live.whenReady()).toBe(true);
+
+    const raw = live as unknown as { deliverPanelEvent: (e: PanelEvent) => void };
+    // A must be BACKLOG, not a live delivery: only a drain pass can leave work for
+    // a continuation, which is the thing being cancelled here.
+    raw.deliverPanelEvent(msg("A"));
+
+    const seen: string[] = [];
+    live.onPanelMessage = (e) => {
+      const text = (e as unknown as { text?: string }).text ?? "";
+      seen.push(text);
+      if (text === "A") raw.deliverPanelEvent(msg("after-stop")); // queued mid-drain
+    };
+    expect(seen).toEqual(["A"]);
+    expect(live.preHandlerBacklog().held).toBe(1); // waiting on the continuation
+
+    await live.stop();
+    for (let i = 0; i < 5; i++) await tick();
+
+    expect(seen).toEqual(["A"]); // the continuation was cancelled, not run after stop
+  });
+});
+
 describe("#1411 the queue is BOUNDED, and says so", () => {
   it("refuses past the cap rather than growing without limit", async () => {
     // Nothing guarantees a handler is ever installed; an unbounded buffer would be

--- a/src/__tests__/services/ui-bridge-preboot-queue.test.ts
+++ b/src/__tests__/services/ui-bridge-preboot-queue.test.ts
@@ -110,6 +110,49 @@ describe("#1411 frames that arrive before the handler exists", () => {
   });
 });
 
+describe("#1411 frames that arrive DURING the drain (codex review, P1)", () => {
+  it("land BEHIND what is still held, not in front of it", async () => {
+    // Handling A can synchronously cause C to arrive — a hello handler that pushes,
+    // a reply that loops back. Delivering C immediately would reorder A, B, C into
+    // A, C, B, which is the ordering guarantee this queue exists to provide.
+    deliver(msg("A"));
+    deliver(msg("B"));
+
+    const seen: string[] = [];
+    bridge.onPanelMessage = (e) => {
+      const text = (e as unknown as { text: string }).text;
+      seen.push(text);
+      if (text === "A") deliver(msg("C"));
+    };
+
+    expect(seen).toEqual(["A", "B", "C"]);
+    expect(bridge.preHandlerBacklog().held).toBe(0);
+  });
+
+  it("a handler that swaps ITSELF out mid-drain does not strand the next frame", async () => {
+    // The nested assignment's own drain is suppressed by the re-entry guard, so the
+    // outer loop has to be what finishes the job — otherwise the frame sits queued
+    // indefinitely, which is the original bug with extra steps.
+    deliver(msg("A"));
+
+    const seen: string[] = [];
+    const replacement = (e: unknown) =>
+      void seen.push(`second:${(e as { text: string }).text}`);
+    bridge.onPanelMessage = (e) => {
+      const text = (e as unknown as { text: string }).text;
+      seen.push(`first:${text}`);
+      if (text === "A") {
+        bridge.onPanelMessage = null;
+        deliver(msg("B")); // held: there is no handler at this instant
+        bridge.onPanelMessage = replacement as (ev: PanelEvent) => void;
+      }
+    };
+
+    expect(seen).toEqual(["first:A", "second:B"]);
+    expect(bridge.preHandlerBacklog().held).toBe(0);
+  });
+});
+
 describe("#1411 the queue is BOUNDED, and says so", () => {
   it("refuses past the cap rather than growing without limit", async () => {
     // Nothing guarantees a handler is ever installed; an unbounded buffer would be
@@ -134,6 +177,25 @@ describe("#1411 the queue is BOUNDED, and says so", () => {
     expect(seen[0]).toBe("hello");
     expect(seen).toHaveLength(200);
     expect(seen).not.toContain("m199"); // refused, because the cap was already reached
+  });
+
+  it("is bounded by BYTES too — a frame count is not a resource bound", async () => {
+    // codex review, P1: this is an INGRESS path that previously discarded, so
+    // retaining 200 arbitrarily large frames would be new memory exposure.
+    const big = "x".repeat(50_000);
+    for (let i = 0; i < 40; i++) deliver(msg(big)); // ~2 MB offered, well under 200 frames
+
+    const { held, dropped, bytes } = bridge.preHandlerBacklog();
+    expect(held).toBeLessThan(200); // refused on BYTES, before the count cap
+    expect(dropped).toBeGreaterThan(0);
+    expect(bytes).toBeLessThanOrEqual(1_000_000);
+  });
+
+  it("gives the bytes back as frames are delivered", async () => {
+    deliver(msg("x".repeat(1000)));
+    expect(bridge.preHandlerBacklog().bytes).toBeGreaterThan(900);
+    bridge.onPanelMessage = () => {};
+    expect(bridge.preHandlerBacklog().bytes).toBe(0);
   });
 
   it("clears the refusal count once it has been reported", async () => {

--- a/src/__tests__/services/ui-bridge-preboot-queue.test.ts
+++ b/src/__tests__/services/ui-bridge-preboot-queue.test.ts
@@ -215,6 +215,38 @@ describe("#1411 nothing overtakes a frame that is still waiting (codex round 3)"
     expect(seen).toEqual(["A", "B", "C", "D"]);
   });
 
+  it("a handler that calls stop() MID-DRAIN cannot leave a successor behind it", async () => {
+    // codex round 4, P1: cancellation alone is not enough. When the handler calls
+    // stop() while being drained, pendingDrain is still null at that moment, so
+    // nothing is there to cancel — and the pass then scheduled its successor
+    // afterwards, which ran after teardown.
+    const port = await freePort();
+    const live = new UiBridge(port);
+    live.start();
+    expect(await live.whenReady()).toBe(true);
+
+    const raw = live as unknown as { deliverPanelEvent: (e: PanelEvent) => void };
+    raw.deliverPanelEvent(msg("A"));
+
+    const seen: string[] = [];
+    live.onPanelMessage = (e) => {
+      const text = (e as unknown as { text?: string }).text ?? "";
+      seen.push(text);
+      if (text === "A") {
+        raw.deliverPanelEvent(msg("after-teardown")); // queued mid-drain
+        void live.stop(); // …and the bridge goes down in the same breath
+      }
+    };
+
+    // A frame that arrives after teardown has nowhere to go: it must not be held
+    // (a leak) and must not be delivered later (a lie about a dead bridge).
+    raw.deliverPanelEvent(msg("post-teardown"));
+    expect(live.preHandlerBacklog().held).toBe(0);
+
+    for (let i = 0; i < 5; i++) await tick();
+    expect(seen).toEqual(["A"]);
+  });
+
   it("stop() cancels a pending continuation instead of firing after teardown", async () => {
     const port = await freePort();
     const live = new UiBridge(port);

--- a/src/__tests__/services/ui-bridge-preboot-queue.test.ts
+++ b/src/__tests__/services/ui-bridge-preboot-queue.test.ts
@@ -32,6 +32,9 @@ function deliver(ev: PanelEvent): void {
   (bridge as unknown as { deliverPanelEvent: (e: PanelEvent) => void }).deliverPanelEvent(ev);
 }
 
+/** One turn of the event loop — where work produced DURING a drain is delivered. */
+const tick = () => new Promise<void>((r) => setImmediate(() => r()));
+
 const msg = (text: string): PanelEvent =>
   ({ type: "user_message", tab_id: "wf:a.json", text }) as unknown as PanelEvent;
 
@@ -125,6 +128,11 @@ describe("#1411 frames that arrive DURING the drain (codex review, P1)", () => {
       if (text === "A") deliver(msg("C"));
     };
 
+    // A and B were the pre-handler backlog, so they land synchronously. C was
+    // produced BY the drain, so it is delivered on a later tick — bounded work per
+    // pass (codex round 2), with the order preserved either way.
+    expect(seen).toEqual(["A", "B"]);
+    await tick();
     expect(seen).toEqual(["A", "B", "C"]);
     expect(bridge.preHandlerBacklog().held).toBe(0);
   });
@@ -148,7 +156,37 @@ describe("#1411 frames that arrive DURING the drain (codex review, P1)", () => {
       }
     };
 
+    expect(seen).toEqual(["first:A"]);
+    await tick(); // the replacement handler picks up what was queued mid-drain
     expect(seen).toEqual(["first:A", "second:B"]);
+    expect(bridge.preHandlerBacklog().held).toBe(0);
+  });
+});
+
+describe("#1411 a self-feeding handler cannot wedge the event loop", () => {
+  it("does bounded work per pass, and still delivers everything in order", async () => {
+    // codex round 2, P1: the drain loop can extend the queue it is draining, so an
+    // unbounded loop lets a handler that emits one frame per frame it handles spin
+    // forever — the assignment never returns and Node stops. The budget is the
+    // backlog present when the pass started; the rest is rescheduled, never dropped.
+    deliver(msg("seed"));
+
+    const seen: string[] = [];
+    let more = 5;
+    bridge.onPanelMessage = (e) => {
+      const text = (e as unknown as { text: string }).text;
+      seen.push(text);
+      if (more > 0) {
+        more -= 1;
+        deliver(msg(`echo${more}`));
+      }
+    };
+
+    // The synchronous pass delivered only the pre-existing backlog and RETURNED.
+    expect(seen).toEqual(["seed"]);
+    for (let i = 0; i < 10 && bridge.preHandlerBacklog().held > 0; i++) await tick();
+
+    expect(seen).toEqual(["seed", "echo4", "echo3", "echo2", "echo1", "echo0"]);
     expect(bridge.preHandlerBacklog().held).toBe(0);
   });
 });

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1676,8 +1676,116 @@ export class UiBridge {
   private readyPromise: Promise<boolean> | null = null;
   private readyResolve: ((ok: boolean) => void) | null = null;
 
-  /** Called for panel-initiated frames (no rid): user messages, hellos. */
-  onPanelMessage: ((event: PanelEvent) => void) | null = null;
+  /**
+   * Called for panel-initiated frames (no rid): user messages, hellos.
+   *
+   * #1411 — ASSIGNING THIS DRAINS WHATEVER ARRIVED BEFORE IT.
+   *
+   * The bridge binds its port and starts accepting frames several seconds before
+   * the orchestrator installs this handler (measured on the reporting machine:
+   * listening at T+0.0s, orchestrator ready at T+3.7s). Every frame in that window
+   * used to hit `this.onPanelMessage?.(…)` and vanish — accepted, stamped, echoed
+   * into the panel transcript, then dropped with no queue, no ack and no error. The
+   * user watches their own message appear and nothing happen, which reads as the
+   * agent ignoring them rather than as a fault.
+   *
+   * A panel reaches this window whenever the orchestrator restarts under an open
+   * sidebar: a self-restart on rebuild, a crash restart, a machine waking up.
+   */
+  private panelMessageHandler: ((event: PanelEvent) => void) | null = null;
+
+  get onPanelMessage(): ((event: PanelEvent) => void) | null {
+    return this.panelMessageHandler;
+  }
+
+  set onPanelMessage(fn: ((event: PanelEvent) => void) | null) {
+    this.panelMessageHandler = fn;
+    if (fn) this.drainPreHandlerFrames(fn);
+  }
+
+  /** Frames that arrived before the handler existed, in ARRIVAL ORDER — so the
+   *  handler sees the sequence the panel actually sent (its `hello` before its
+   *  first message), not a reordering invented by the queue. */
+  private preHandlerFrames: PanelEvent[] = [];
+  /** How many were refused once the cap was hit. Reported, never silent. */
+  private preHandlerDropped = 0;
+  private draining = false;
+
+  /**
+   * Bound on the pre-handler queue.
+   *
+   * The window is bounded by boot, so this is generous for the case it exists for.
+   * It is a cap rather than an unbounded buffer because nothing guarantees a
+   * handler is EVER installed — a bridge constructed without one (tests, a future
+   * embedder) would otherwise accumulate every frame for the life of the process.
+   * On overflow the EARLIEST frames are kept: the first of them is the `hello` that
+   * identifies the tab, and a message replayed without it is worth less than the
+   * message that was refused.
+   */
+  private static readonly MAX_PRE_HANDLER_FRAMES = 200;
+
+  /** Deliver a panel-initiated frame, or hold it until there is somewhere to
+   *  deliver it (#1411). Never drops silently. */
+  private deliverPanelEvent(event: PanelEvent): void {
+    const fn = this.panelMessageHandler;
+    if (fn) {
+      fn(event);
+      return;
+    }
+    if (this.preHandlerFrames.length >= UiBridge.MAX_PRE_HANDLER_FRAMES) {
+      this.preHandlerDropped += 1;
+      if (this.preHandlerDropped === 1) {
+        logger.warn(
+          `[ui-bridge] the panel-message handler is still not installed and ` +
+            `${UiBridge.MAX_PRE_HANDLER_FRAMES} frames are already held — further frames are ` +
+            `being REFUSED, not queued (#1411). Anything sent from here until the orchestrator ` +
+            `finishes starting is lost.`,
+        );
+      }
+      return;
+    }
+    this.preHandlerFrames.push(event);
+  }
+
+  /** Hand over everything held, in order, then report anything that was refused. */
+  private drainPreHandlerFrames(fn: (event: PanelEvent) => void): void {
+    if (this.draining) return; // a handler assigned FROM a handler must not re-enter
+    const held = this.preHandlerFrames;
+    if (held.length === 0 && this.preHandlerDropped === 0) return;
+    this.preHandlerFrames = [];
+    this.draining = true;
+    try {
+      logger.info(
+        `[ui-bridge] delivering ${held.length} panel frame(s) that arrived before the handler ` +
+          `was installed (#1411)`,
+      );
+      for (const event of held) {
+        try {
+          fn(event);
+        } catch (err) {
+          // One bad frame must not strand the rest — including the user's message.
+          logger.warn(
+            `[ui-bridge] a held frame threw while being delivered: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+    if (this.preHandlerDropped > 0) {
+      logger.warn(
+        `[ui-bridge] ${this.preHandlerDropped} panel frame(s) were REFUSED before the handler ` +
+          `was installed and are gone (#1411)`,
+      );
+      this.preHandlerDropped = 0;
+    }
+  }
+
+  /** Test seam: how many frames are held right now, and how many were refused. */
+  preHandlerBacklog(): { held: number; dropped: number } {
+    return { held: this.preHandlerFrames.length, dropped: this.preHandlerDropped };
+  }
 
   constructor(port = DEFAULT_BRIDGE_PORT, token: string | null = null, host = "127.0.0.1") {
     this.port = port;
@@ -2284,7 +2392,7 @@ export class UiBridge {
         // buffered items below — which belong to the PRIOR workflow — are NOT replayed into
         // the replacement (a wrong-conversation/media delivery). For a PROVEN reconnect it
         // drops nothing, so the replay/flush proceeds exactly as before, just after the ack.
-        this.onPanelMessage?.(msg as PanelEvent);
+        this.deliverPanelEvent(msg as PanelEvent);
         // Replay anything this tab's agent produced while the tab had no live connection
         // (its socket was re-helloed to another workflow). The panel swaps to this
         // workflow's thread synchronously, so they render + record into the RIGHT
@@ -2499,7 +2607,7 @@ export class UiBridge {
           msg.title = this.conns.get(effectiveTab)?.title;
           if (msg.type === "user_message") this.setLastActiveTab(effectiveTab);
         }
-        this.onPanelMessage?.(msg as PanelEvent);
+        this.deliverPanelEvent(msg as PanelEvent);
       }
     });
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1712,6 +1712,8 @@ export class UiBridge {
   private draining = false;
   private drainScheduled = false;
   private pendingDrain: ReturnType<typeof setImmediate> | null = null;
+  /** Set by stop(): no further continuation may be scheduled after teardown. */
+  private drainStopped = false;
 
   /**
    * Bounds on the pre-handler queue — COUNT and BYTES (codex review, P1).
@@ -1744,6 +1746,12 @@ export class UiBridge {
   /** Deliver a panel-initiated frame, or hold it until there is somewhere to
    *  deliver it (#1411). Never drops silently. */
   private deliverPanelEvent(event: PanelEvent): void {
+    // A stopped bridge dispatches NOTHING. Past teardown there is nowhere for a
+    // frame to go: delivering it pretends a dead bridge is live, and holding it is
+    // a leak nothing will ever drain. This has to precede the live-delivery path —
+    // sitting after it, a frame arriving post-stop was handed straight to a handler
+    // that was still installed.
+    if (this.drainStopped) return;
     const fn = this.panelMessageHandler;
     // The queue is the ordering authority whenever ANYTHING is still waiting on it
     // (codex rounds 1 and 3, both P1). Three conditions, one rule — deliver
@@ -1828,6 +1836,14 @@ export class UiBridge {
     // Anything still held — produced during this pass, or queued by a handler that
     // swapped itself out and back — is delivered on a later tick. Never dropped,
     // and never spun on: each pass does a bounded amount of synchronous work.
+    // The teardown race codex round 4 raised — a handler calling stop() mid-drain,
+    // leaving pendingDrain null at the moment stop() looks for it — is closed
+    // upstream of here rather than by a fourth condition on this line: stop() drops
+    // whatever is held, and deliverPanelEvent refuses anything after it, so by this
+    // point a stopped bridge has nothing left to schedule. A `!drainStopped` clause
+    // was tried and removed: mutation testing showed it could never change the
+    // outcome, and a guard that cannot fail reads as protection while providing
+    // none.
     if (this.preHandlerFrames.length > 0 && this.panelMessageHandler && !this.drainScheduled) {
       this.drainScheduled = true;
       const pending = setImmediate(() => {
@@ -1835,11 +1851,19 @@ export class UiBridge {
         this.drainScheduled = false;
         this.drainPreHandlerFrames();
       });
-      // UNREF'd (codex round 3, P1): a handler that emits a frame per delivery keeps
+      // UNREF'd (codex round 3, P1; re-examined round 4): a handler that emits a frame per delivery keeps
       // one continuation perpetually pending, and a referenced immediate would stop
       // a short-lived CLI — or a test — from ever exiting. Held so stop() can cancel
       // it: a bridge torn down inside the schedule-to-callback window must not run
       // it afterwards.
+      //
+      // The cost of unref is that a process which would otherwise exit does not wait
+      // for this. That is acceptable HERE and nowhere else in the queue: the budget
+      // is the whole backlog, so everything that arrived before the handler is
+      // delivered in the FIRST, synchronous pass. A continuation therefore only ever
+      // carries frames a handler produced while being drained — work whose consumer
+      // is going away too. The alternative, a referenced immediate, hangs the process
+      // forever on a self-feeding handler, which is strictly worse.
       pending.unref?.();
       this.pendingDrain = pending;
     }
@@ -4674,10 +4698,24 @@ export class UiBridge {
   }
 
   async stop(): Promise<void> {
+    // Fence FIRST, then cancel: a drain in flight must not schedule a successor
+    // behind this call (codex round 4, P1).
+    this.drainStopped = true;
     if (this.pendingDrain) {
       clearImmediate(this.pendingDrain);
       this.pendingDrain = null;
       this.drainScheduled = false;
+    }
+    if (this.preHandlerFrames.length > 0) {
+      // Held frames die with the bridge. That is the honest end state — there is
+      // nowhere left to deliver them — but it is never silent, because "the frame
+      // vanished and nothing said so" is the whole of #1411.
+      logger.warn(
+        `[ui-bridge] stopping with ${this.preHandlerFrames.length} panel frame(s) still held ` +
+          `and undelivered (#1411)`,
+      );
+      this.preHandlerFrames = [];
+      this.preHandlerBytes = 0;
     }
     for (const armed of this.tabGoneTimers.values()) clearTimeout(armed.timer);
     this.tabGoneTimers.clear();

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1710,6 +1710,7 @@ export class UiBridge {
   /** How many were refused once the cap was hit. Reported, never silent. */
   private preHandlerDropped = 0;
   private draining = false;
+  private drainScheduled = false;
 
   /**
    * Bounds on the pre-handler queue — COUNT and BYTES (codex review, P1).
@@ -1787,12 +1788,22 @@ export class UiBridge {
     const held = this.preHandlerFrames.length;
     this.draining = true;
     let delivered = 0;
+    // A BUDGET, because the loop body can extend the queue it is draining (codex
+    // round 2, P1): a handler that feeds one frame back per frame it handles would
+    // otherwise keep this synchronous loop non-empty forever and wedge the event
+    // loop — worse than the bug being fixed. The budget is the number of frames
+    // held when the drain STARTED, which is exactly the pre-handler backlog this
+    // exists to deliver; anything produced while draining is new work and is
+    // rescheduled below rather than dropped.
+    let budget = held;
     try {
       for (;;) {
         const handler = this.panelMessageHandler;
         // Cleared mid-drain: keep the rest HELD rather than dropping them — there
         // is nowhere to deliver them, which is the situation this queue exists for.
         if (!handler || this.preHandlerFrames.length === 0) break;
+        if (budget <= 0) break; // yield the rest to the next tick
+        budget -= 1;
         const event = this.preHandlerFrames.shift() as PanelEvent;
         this.preHandlerBytes = Math.max(0, this.preHandlerBytes - UiBridge.frameBytes(event));
         delivered += 1;
@@ -1808,6 +1819,16 @@ export class UiBridge {
       }
     } finally {
       this.draining = false;
+    }
+    // Anything still held — produced during this pass, or queued by a handler that
+    // swapped itself out and back — is delivered on a later tick. Never dropped,
+    // and never spun on: each pass does a bounded amount of synchronous work.
+    if (this.preHandlerFrames.length > 0 && this.panelMessageHandler && !this.drainScheduled) {
+      this.drainScheduled = true;
+      setImmediate(() => {
+        this.drainScheduled = false;
+        this.drainPreHandlerFrames();
+      });
     }
     if (delivered > 0) {
       logger.info(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1700,7 +1700,7 @@ export class UiBridge {
 
   set onPanelMessage(fn: ((event: PanelEvent) => void) | null) {
     this.panelMessageHandler = fn;
-    if (fn) this.drainPreHandlerFrames(fn);
+    if (fn) this.drainPreHandlerFrames();
   }
 
   /** Frames that arrived before the handler existed, in ARRIVAL ORDER — so the
@@ -1712,56 +1712,92 @@ export class UiBridge {
   private draining = false;
 
   /**
-   * Bound on the pre-handler queue.
+   * Bounds on the pre-handler queue — COUNT and BYTES (codex review, P1).
    *
-   * The window is bounded by boot, so this is generous for the case it exists for.
-   * It is a cap rather than an unbounded buffer because nothing guarantees a
-   * handler is EVER installed — a bridge constructed without one (tests, a future
-   * embedder) would otherwise accumulate every frame for the life of the process.
+   * The window is bounded by boot, so these are generous for the case they exist
+   * for. They are bounds rather than an unbounded buffer because nothing
+   * guarantees a handler is EVER installed, and because this is an INGRESS path
+   * that previously discarded: retaining 200 arbitrarily large frames would be new
+   * memory exposure, quieter than the bug being fixed. A frame count alone is not
+   * a resource bound.
+   *
    * On overflow the EARLIEST frames are kept: the first of them is the `hello` that
    * identifies the tab, and a message replayed without it is worth less than the
    * message that was refused.
    */
   private static readonly MAX_PRE_HANDLER_FRAMES = 200;
+  private static readonly MAX_PRE_HANDLER_BYTES = 1_000_000;
+  private preHandlerBytes = 0;
+
+  /** Rough wire size of a held frame. Only ever computed inside the pre-handler
+   *  window, which both bounds cap, so this cannot become a hot-path cost. */
+  private static frameBytes(event: PanelEvent): number {
+    try {
+      return JSON.stringify(event)?.length ?? 0;
+    } catch {
+      return 0; // unserialisable: counted as free rather than refused
+    }
+  }
 
   /** Deliver a panel-initiated frame, or hold it until there is somewhere to
    *  deliver it (#1411). Never drops silently. */
   private deliverPanelEvent(event: PanelEvent): void {
     const fn = this.panelMessageHandler;
-    if (fn) {
+    // While a drain is in flight the queue is still the ordering authority: a
+    // frame that arrives BECAUSE an earlier one is being handled must land BEHIND
+    // whatever is still held (codex review, P1). Delivering it now would reorder
+    // A, B, C into A, C, B.
+    if (fn && !this.draining) {
       fn(event);
       return;
     }
-    if (this.preHandlerFrames.length >= UiBridge.MAX_PRE_HANDLER_FRAMES) {
+    const bytes = UiBridge.frameBytes(event);
+    if (
+      this.preHandlerFrames.length >= UiBridge.MAX_PRE_HANDLER_FRAMES ||
+      this.preHandlerBytes + bytes > UiBridge.MAX_PRE_HANDLER_BYTES
+    ) {
       this.preHandlerDropped += 1;
       if (this.preHandlerDropped === 1) {
         logger.warn(
-          `[ui-bridge] the panel-message handler is still not installed and ` +
-            `${UiBridge.MAX_PRE_HANDLER_FRAMES} frames are already held — further frames are ` +
-            `being REFUSED, not queued (#1411). Anything sent from here until the orchestrator ` +
-            `finishes starting is lost.`,
+          `[ui-bridge] the panel-message handler is still not installed and the held-frame ` +
+            `budget is full (${this.preHandlerFrames.length} frames, ${this.preHandlerBytes} B) ` +
+            `— further frames are being REFUSED, not queued (#1411). Anything sent from here ` +
+            `until the orchestrator finishes starting is lost.`,
         );
       }
       return;
     }
+    this.preHandlerBytes += bytes;
     this.preHandlerFrames.push(event);
   }
 
-  /** Hand over everything held, in order, then report anything that was refused. */
-  private drainPreHandlerFrames(fn: (event: PanelEvent) => void): void {
+  /**
+   * Hand over everything held, in order, then report anything that was refused.
+   *
+   * A WORK LOOP, not a snapshot of the queue (codex review, P1). Two things can
+   * happen while a frame is being handled, and both are handled by re-reading the
+   * queue and the handler on every iteration rather than by capturing them once:
+   * a handler can cause another frame to arrive (it must go to the BACK), and a
+   * handler can swap itself out and back (its own drain is suppressed by
+   * `draining`, so this loop has to be the thing that finishes the job).
+   */
+  private drainPreHandlerFrames(): void {
     if (this.draining) return; // a handler assigned FROM a handler must not re-enter
-    const held = this.preHandlerFrames;
-    if (held.length === 0 && this.preHandlerDropped === 0) return;
-    this.preHandlerFrames = [];
+    if (this.preHandlerFrames.length === 0 && this.preHandlerDropped === 0) return;
+    const held = this.preHandlerFrames.length;
     this.draining = true;
+    let delivered = 0;
     try {
-      logger.info(
-        `[ui-bridge] delivering ${held.length} panel frame(s) that arrived before the handler ` +
-          `was installed (#1411)`,
-      );
-      for (const event of held) {
+      for (;;) {
+        const handler = this.panelMessageHandler;
+        // Cleared mid-drain: keep the rest HELD rather than dropping them — there
+        // is nowhere to deliver them, which is the situation this queue exists for.
+        if (!handler || this.preHandlerFrames.length === 0) break;
+        const event = this.preHandlerFrames.shift() as PanelEvent;
+        this.preHandlerBytes = Math.max(0, this.preHandlerBytes - UiBridge.frameBytes(event));
+        delivered += 1;
         try {
-          fn(event);
+          handler(event);
         } catch (err) {
           // One bad frame must not strand the rest — including the user's message.
           logger.warn(
@@ -1773,6 +1809,12 @@ export class UiBridge {
     } finally {
       this.draining = false;
     }
+    if (delivered > 0) {
+      logger.info(
+        `[ui-bridge] delivered ${delivered} of ${held} panel frame(s) that arrived before the ` +
+          `handler was installed (#1411)`,
+      );
+    }
     if (this.preHandlerDropped > 0) {
       logger.warn(
         `[ui-bridge] ${this.preHandlerDropped} panel frame(s) were REFUSED before the handler ` +
@@ -1783,8 +1825,12 @@ export class UiBridge {
   }
 
   /** Test seam: how many frames are held right now, and how many were refused. */
-  preHandlerBacklog(): { held: number; dropped: number } {
-    return { held: this.preHandlerFrames.length, dropped: this.preHandlerDropped };
+  preHandlerBacklog(): { held: number; dropped: number; bytes: number } {
+    return {
+      held: this.preHandlerFrames.length,
+      dropped: this.preHandlerDropped,
+      bytes: this.preHandlerBytes,
+    };
   }
 
   constructor(port = DEFAULT_BRIDGE_PORT, token: string | null = null, host = "127.0.0.1") {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1711,6 +1711,7 @@ export class UiBridge {
   private preHandlerDropped = 0;
   private draining = false;
   private drainScheduled = false;
+  private pendingDrain: ReturnType<typeof setImmediate> | null = null;
 
   /**
    * Bounds on the pre-handler queue — COUNT and BYTES (codex review, P1).
@@ -1744,11 +1745,15 @@ export class UiBridge {
    *  deliver it (#1411). Never drops silently. */
   private deliverPanelEvent(event: PanelEvent): void {
     const fn = this.panelMessageHandler;
-    // While a drain is in flight the queue is still the ordering authority: a
-    // frame that arrives BECAUSE an earlier one is being handled must land BEHIND
-    // whatever is still held (codex review, P1). Delivering it now would reorder
-    // A, B, C into A, C, B.
-    if (fn && !this.draining) {
+    // The queue is the ordering authority whenever ANYTHING is still waiting on it
+    // (codex rounds 1 and 3, both P1). Three conditions, one rule — deliver
+    // directly only when there is nothing ahead of this frame:
+    //   * a drain in flight: a frame produced BY a handler must land behind what is
+    //     still held, or A,B,C arrives as A,C,B;
+    //   * a scheduled continuation: a socket frame D arriving between the pass and
+    //     its setImmediate would otherwise overtake the C that is already queued;
+    //   * a non-empty queue at all: nothing may be delivered around held frames.
+    if (fn && !this.draining && !this.drainScheduled && this.preHandlerFrames.length === 0) {
       fn(event);
       return;
     }
@@ -1825,10 +1830,18 @@ export class UiBridge {
     // and never spun on: each pass does a bounded amount of synchronous work.
     if (this.preHandlerFrames.length > 0 && this.panelMessageHandler && !this.drainScheduled) {
       this.drainScheduled = true;
-      setImmediate(() => {
+      const pending = setImmediate(() => {
+        this.pendingDrain = null;
         this.drainScheduled = false;
         this.drainPreHandlerFrames();
       });
+      // UNREF'd (codex round 3, P1): a handler that emits a frame per delivery keeps
+      // one continuation perpetually pending, and a referenced immediate would stop
+      // a short-lived CLI — or a test — from ever exiting. Held so stop() can cancel
+      // it: a bridge torn down inside the schedule-to-callback window must not run
+      // it afterwards.
+      pending.unref?.();
+      this.pendingDrain = pending;
     }
     if (delivered > 0) {
       logger.info(
@@ -4661,6 +4674,11 @@ export class UiBridge {
   }
 
   async stop(): Promise<void> {
+    if (this.pendingDrain) {
+      clearImmediate(this.pendingDrain);
+      this.pendingDrain = null;
+      this.drainScheduled = false;
+    }
     for (const armed of this.tabGoneTimers.values()) clearTimeout(armed.timer);
     this.tabGoneTimers.clear();
     if (this.bindRetryTimer) {


### PR DESCRIPTION
Closes #1411.

Confirmed still live on origin/main — `src/services/ui-bridge.ts` has two `this.onPanelMessage?.(msg as PanelEvent)` sites (lines 2287, 2502), and the handler is assigned late in orchestrator boot. Between the port binding and that assignment, a `user_message` is accepted, stamped, echoed into the transcript, and then discarded: no queue, no acknowledgement, no error.

Measured window on this machine: bridge listening at T+0.0s, orchestrator "ready" at T+3.7s.

The failure mode is the bad kind — the user sees their message in the transcript and simply waits, so it reads as the agent ignoring them.

Draft while I work out the right bound on the queue: an unbounded pre-boot buffer is its own bug.