### PR TITLE
chore(release): 0.51.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.8] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a panel message that arrives before boot finishes is no longer dropped (#1439)
+
+
 ## [0.51.7] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.7",
+  "version": "0.51.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.7",
+      "version": "0.51.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.7",
+  "version": "0.51.8",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.8 tag into protected main.

**0.51.8 — #1411**: a panel message sent while the orchestrator is still starting is no longer silently dropped.

The bridge accepts frames seconds before the orchestrator installs its handler; everything in that window used to hit an optional-call on a null handler and vanish — the user watches their own message appear in the transcript and nothing happens. Frames are now held and drained when the handler is installed, in arrival order, bounded by count AND bytes, with a per-pass budget so a self-feeding handler cannot wedge the event loop.

Live-verified in the real window: message sent at T+1.51s, orchestrator ready at T+2.50s, `delivered 2 of 2 panel frame(s) that arrived before the handler was installed`, then `spawning agent for tab`.

Five codex rounds — four found real P1s (re-entrant reordering, stranded frames on a nested handler swap, an unbounded synchronous drain, a live frame overtaking a queued one, and an uncancellable continuation). Round 5: PASS.