### PR TITLE
chore(release): 0.51.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.9] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- an empty download listing stops reading as 'nothing is running' (#1441)
+
+
 ## [0.51.8] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.8",
+  "version": "0.51.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.8",
+      "version": "0.51.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.8",
+  "version": "0.51.9",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.9 tag into protected main.

**0.51.9 — #1420**: `download_model action:"status"` no longer answers a bare `No downloads are being tracked.` — a sentence a reporter read as proof, concluding ~24 GB of in-flight transfer was lost and telling their user so, while both jobs were streaming and were adopted intact minutes later.

Message-only; tracking behaviour is untouched. The reply now scopes its claim to this session's store, says it cannot distinguish the two states, names the staging behaviour that makes the obvious disk check agree with the wrong answer, and forbids the lost-data conclusion. Its remedies are route-aware and conditional, and it says outright that it is not an instruction to re-download — an empty listing is exactly the state in which an agent cannot tell whether re-issuing would be the corrupting second Manager dispatch (#1197). The sibling id/url-miss reply carries the same caveats so the two cannot disagree.

Five codex rounds; four found real defects, including advice of mine that could have destroyed a file.