### PR TITLE
fix(1443): a retarget round-trip says nothing, instead of saying A changed to A

### DIFF
--- a/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
+++ b/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
@@ -191,6 +191,55 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     expect(delivered).not.toContain(B);
   });
 
+  it("a ROUND TRIP says nothing — the child never left the target it is on (#1443)", async () => {
+    // Found by the independent review of 0.51.4. Whether to nudge was decided from
+    // the INCOMING pair, while the message was composed from the PRESERVED origin,
+    // so A→B→A produced staleTargetNudge(A, A): a real agent turn asserting the
+    // target changed from A to A, for a tab whose child was correct throughout.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const A = "http://127.0.0.1:8188";
+    const B = "https://pod-b.proxy.runpod.net";
+
+    manager.send("tab-round-trip", "render");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(A, B); // stranded on A
+    manager.retargetAllForMcpEnv(B, A); // …and back. Nothing moved for this tab.
+
+    backend.autoComplete = true;
+    backend.release();
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(backend.turnTexts.some((x) => x.includes("target changed"))).toBe(false);
+    expect(backend.turnTexts).not.toContain(staleTargetNudge(A, A));
+  });
+
+  it("a round trip does not strand the marker for a LATER real move", async () => {
+    // The round trip clears the marker; a genuine move afterwards must still report
+    // from where that turn actually is, not from a stale origin.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const A = "http://127.0.0.1:8188";
+    const B = "https://pod-b.proxy.runpod.net";
+    const C = "https://pod-c.proxy.runpod.net";
+
+    manager.send("tab-after-trip", "render");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(A, B);
+    manager.retargetAllForMcpEnv(B, A); // round trip: marker cleared
+    manager.retargetAllForMcpEnv(A, C); // a real move, from A
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.length >= 2);
+    expect(backend.turnTexts[backend.turnTexts.length - 1]).toBe(staleTargetNudge(A, C));
+  });
+
   it("a per-request nudge queued AFTER a retarget survives the NEXT retarget", async () => {
     // codex finding, one step removed from #164: the retarget marker has to be
     // cleared when a per-request nudge overwrites the queued value, or the next

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2251,19 +2251,33 @@ export class PanelAgentManager {
       }
       // The EARLIEST address this tab was stranded on is the true `from`.
       const origin = this.pendingRetargetFrom.get(tabId) ?? (from as string);
+      // #1443 — ASK THE QUESTION ABOUT THE PAIR THAT GETS REPORTED.
+      //
+      // Whether this call is a move was decided from the INCOMING from→to, which is
+      // the right question for the caller and the wrong one for this tab: the
+      // message is composed from its PRESERVED origin. A tab held mid-turn across
+      // A→B→A has origin A and to A — it never left A — and was told, in a real
+      // agent turn, that its target changed from A to A. A→B→C, the case preserving
+      // the origin exists for, is correct; this is its degenerate sibling.
+      const stranded = retargetIsWorthNudging(origin, to);
       // Recompose BEFORE applying, not after: if the tab went idle in between,
       // applyPendingRestarts delivers whatever is queued right now, and a stale
       // A→B message would go out while the child is being respawned onto C.
-      this.pendingMcpRestart.set(tabId, queuedIsRetarget ? staleTargetNudge(origin, to) : null);
+      this.pendingMcpRestart.set(
+        tabId,
+        queuedIsRetarget && stranded ? staleTargetNudge(origin, to) : null,
+      );
       const outcome = this.applyPendingRestarts(tabId);
-      if (outcome === "scheduled") {
+      if (outcome === "scheduled" && stranded) {
         // Mid-turn: the tab is stranded on `origin` until the turn ends. Record
         // the origin so a further retarget in the same turn keeps it, and queue
         // the message the deferred respawn will carry.
         this.pendingRetargetFrom.set(tabId, origin);
         this.pendingMcpRestart.set(tabId, staleTargetNudge(origin, to));
       } else {
-        // Applied (or no agent): nothing is stranded any more.
+        // Applied, no agent, or a ROUND TRIP that landed back on `origin`: either
+        // way this tab has nothing to be told. The respawn still happens — it is
+        // the same env, so it is harmless — but it goes out silently.
         this.pendingRetargetFrom.delete(tabId);
       }
       tallyRestart(tally, outcome);


### PR DESCRIPTION
Closes #1443.

Found by the independent review of 0.51.4 that release did not get. `retargetAllForMcpEnv` decides whether to nudge by comparing the INCOMING `from`→`to`, then composes the message from the tab's PRESERVED origin — so a tab held mid-turn across `A → B → A` is told its target changed from A to A, in a real agent turn.

The child never left A. The A→B→C case that motivated preserving the origin is correct; this is its degenerate sibling.

Draft while I check the other shapes that reach the same line.