### PR TITLE
chore(release): 0.51.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.10] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a retarget round-trip says nothing, instead of saying A changed to A (#1444)
+
+
 ## [0.51.9] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.9",
+  "version": "0.51.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.9",
+      "version": "0.51.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.9",
+  "version": "0.51.10",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.10 tag into protected main.

**0.51.10 — #1443**: a ComfyUI retarget round-trip (A→B→A) no longer tells a mid-turn agent that its target changed from A to A.

Found by the independent review that 0.51.4 did not get — it shipped on a self-review while the review tooling was failing. The guard was present and correct, and asked about the wrong pair: whether to nudge came from the incoming from→to, while the message was composed from the tab's preserved origin.

Verified on the built artifact: the round trip says nothing, and A→B→C still reports A→C.