### PR TITLE
fix(panel#1065): a relay fence stops assuming the panel is served from COMFYUI_URL

### DIFF
--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -24,7 +24,7 @@
 
 import { describe, expect, it } from "vitest";
 import { UiBridge } from "../../services/ui-bridge.js";
-import { unreachableReason, identityReason } from "../../orchestrator/fence-refusal.js";
+import { NO_ORIGIN_REMEDY, identityReason, unreachableReason } from "../../orchestrator/fence-refusal.js";
 import { workflowIdentityParts } from "../../orchestrator/session-store.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
@@ -172,8 +172,18 @@ describe("the refusal message names the gate and matches the remedy to it", () =
       ),
     );
 
-    expect(text).toMatch(/Refreshing the tab will NOT help/);
-    expect(text).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
+    // Its intent is unchanged: a structural gate must not be answered with a
+    // refresh. Its WORDING moved to the shared NO_ORIGIN_REMEDY (panel#1065),
+    // because the copy asserted here had gone stale — it still told the user to
+    // abandon the relay backend and to report a protocol gap that #1240 closed,
+    // which is how panel#1065 came to be filed, quoting this exact sentence.
+    expect(text).toMatch(/Refreshing the tab will not change it/i);
+    expect(text).toContain(NO_ORIGIN_REMEDY);
+    // The advice that cost a working setup must be gone, not merely reworded.
+    expect(text).not.toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
+    expect(text).not.toMatch(/forward the browser'?s handshake Origin/i);
+    // The real remedy has to be the one they are actually given.
+    expect(text).toMatch(/Set COMFYUI_URL to the URL the panel is served from/);
     // The generic remedy must be suppressed, not merely preceded.
     expect(text).not.toMatch(/Ask the user to manually refresh/);
   });

--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -177,13 +177,15 @@ describe("the refusal message names the gate and matches the remedy to it", () =
     // because the copy asserted here had gone stale — it still told the user to
     // abandon the relay backend and to report a protocol gap that #1240 closed,
     // which is how panel#1065 came to be filed, quoting this exact sentence.
-    expect(text).toMatch(/Refreshing the tab will not change it/i);
+    expect(text).toMatch(/Refreshing the tab will not change either case/i);
     expect(text).toContain(NO_ORIGIN_REMEDY);
     // The advice that cost a working setup must be gone, not merely reworded.
     expect(text).not.toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
     expect(text).not.toMatch(/forward the browser'?s handshake Origin/i);
-    // The real remedy has to be the one they are actually given.
-    expect(text).toMatch(/Set COMFYUI_URL to the URL the panel is served from/);
+    // The real remedy has to be the one they are actually given — and it has to be
+    // true for a NON-relay caller too, so it names both causes rather than one.
+    expect(text).toMatch(/On a RELAY connection/);
+    expect(text).toMatch(/On any other path/);
     // The generic remedy must be suppressed, not merely preceded.
     expect(text).not.toMatch(/Ask the user to manually refresh/);
   });

--- a/src/__tests__/orchestrator/no-origin-remedy.test.ts
+++ b/src/__tests__/orchestrator/no-origin-remedy.test.ts
@@ -24,8 +24,23 @@ import { NO_ORIGIN_REMEDY, identityReason } from "../../orchestrator/fence-refus
 const NO_ORIGIN = identityReason("tab-1", undefined, "not-a-uuid", "none" as never);
 
 describe("panel#1065 the no-origin remedy is the one that works", () => {
-  it("names the thing that actually supplies the origin", () => {
-    expect(NO_ORIGIN_REMEDY).toContain("Set COMFYUI_URL to the URL the panel is served from");
+  it("states what the gate actually checks — presence, never agreement", () => {
+    // Measured, not assumed: workflowIdentityParts requires an origin to EXIST and
+    // both call sites take only `.uuid`; `identity.origin` is never read again. This
+    // is what resolves the reporter's stated tension — their COMFYUI_URL
+    // "intentionally is not the browser panel origin", and it does not have to be.
+    expect(NO_ORIGIN_REMEDY).toContain("PRESENCE, not agreement");
+    expect(NO_ORIGIN_REMEDY).toContain("does not have ");
+    expect(NO_ORIGIN_REMEDY).toContain("to match where the panel is served from");
+  });
+
+  it("gives the RELAY cause and the non-relay cause separately", () => {
+    // codex review, P1: the predicate is generic. A blanket "set COMFYUI_URL" sends a
+    // direct/LAN/pairing or non-browser caller to a configuration change that cannot
+    // add a handshake Origin, and leaves them fenced with nothing left to try.
+    expect(NO_ORIGIN_REMEDY).toContain("On a RELAY connection");
+    expect(NO_ORIGIN_REMEDY).toContain("On any other path");
+    expect(NO_ORIGIN_REMEDY).toContain("never presented an Origin header");
   });
 
   it("does NOT tell the user to abandon the relay backend", () => {
@@ -33,7 +48,8 @@ describe("panel#1065 the no-origin remedy is the one that works", () => {
     // costs them a working remote setup and fixes nothing.
     expect(NO_ORIGIN_REMEDY).not.toMatch(/unset COMFYUI_MCP_TUNNEL_BACKEND/i);
     expect(NO_ORIGIN_REMEDY).not.toMatch(/rather than the relay backend/i);
-    expect(NO_ORIGIN_REMEDY).toContain("switching away from the relay backend is");
+    expect(NO_ORIGIN_REMEDY).toContain("you do not have ");
+    expect(NO_ORIGIN_REMEDY).toContain("to leave the relay backend");
   });
 
   it("does NOT ask for a report about a protocol gap that is closed", () => {

--- a/src/__tests__/orchestrator/no-origin-remedy.test.ts
+++ b/src/__tests__/orchestrator/no-origin-remedy.test.ts
@@ -1,0 +1,61 @@
+// comfyui-mcp-panel#1065 — A STALE REMEDY MANUFACTURED ITS OWN BUG REPORT.
+//
+// Two surfaces render the "this connection has no server-observed Origin" refusal:
+// fence-refusal.ts's identityReason(), and the `rejected` branch of
+// describeFenceRebind() in panel-tools.ts. #1077/#1240 gave the relay path the
+// origin it already knows from COMFYUI_URL and updated the FIRST one. The second
+// kept the pre-fix text, which told the user two wrong things:
+//
+//   * abandon the relay backend (unset COMFYUI_MCP_TUNNEL_BACKEND=relay), and
+//   * "report it: the relay protocol has to forward the browser's handshake Origin
+//     for this path to work at all".
+//
+// A user on 0.50.114 — a version that HAS the fix — did both, and panel#1065 quotes
+// that sentence back verbatim. They were told to downgrade a working setup on the
+// way, and the real remedy (set COMFYUI_URL) was never mentioned to them.
+//
+// So this file pins the property that failed, not just the wording: the two
+// surfaces say the SAME thing, because they are the same string.
+
+import { describe, expect, it } from "vitest";
+import { NO_ORIGIN_REMEDY, identityReason } from "../../orchestrator/fence-refusal.js";
+
+// (tabId, origin, workflowUuid, failure) — an ABSENT origin is the case here.
+const NO_ORIGIN = identityReason("tab-1", undefined, "not-a-uuid", "none" as never);
+
+describe("panel#1065 the no-origin remedy is the one that works", () => {
+  it("names the thing that actually supplies the origin", () => {
+    expect(NO_ORIGIN_REMEDY).toContain("Set COMFYUI_URL to the URL the panel is served from");
+  });
+
+  it("does NOT tell the user to abandon the relay backend", () => {
+    // #1240 gave the relay path its origin. Sending a user off it is advice that
+    // costs them a working remote setup and fixes nothing.
+    expect(NO_ORIGIN_REMEDY).not.toMatch(/unset COMFYUI_MCP_TUNNEL_BACKEND/i);
+    expect(NO_ORIGIN_REMEDY).not.toMatch(/rather than the relay backend/i);
+    expect(NO_ORIGIN_REMEDY).toContain("switching away from the relay backend is");
+  });
+
+  it("does NOT ask for a report about a protocol gap that is closed", () => {
+    // This is the sentence panel#1065 quotes. It must not be able to generate
+    // another one.
+    expect(NO_ORIGIN_REMEDY).not.toMatch(/forward the browser'?s handshake Origin/i);
+    expect(NO_ORIGIN_REMEDY).not.toMatch(/report it/i);
+  });
+
+  it("still says what keeps working, so the session is not read as dead", () => {
+    expect(NO_ORIGIN_REMEDY).toContain("Reads and non-graph tools keep working");
+  });
+});
+
+describe("panel#1065 the refusal that shows it", () => {
+  it("carries the shared remedy rather than a copy", () => {
+    expect(NO_ORIGIN).toContain("no server-observed Origin");
+    expect(NO_ORIGIN).toContain(NO_ORIGIN_REMEDY);
+  });
+
+  it("does not repeat the stale advice anywhere in the refusal", () => {
+    expect(NO_ORIGIN).not.toMatch(/forward the browser'?s handshake Origin/i);
+    expect(NO_ORIGIN).not.toMatch(/unset COMFYUI_MCP_TUNNEL_BACKEND/i);
+  });
+});

--- a/src/orchestrator/fence-refusal.ts
+++ b/src/orchestrator/fence-refusal.ts
@@ -51,6 +51,28 @@ export function noPanelTabReason(tabId: string): string {
  * BEFORE the structural no-Origin case, or it borrows a remedy that cannot help
  * it and is told its problem is permanent.
  */
+/**
+ * The remedy for "this connection has no server-observed Origin" (panel#1065).
+ *
+ * Shared, because it was NOT shared and the two copies drifted. #1077/#1240 gave
+ * the relay path the origin it already knows from COMFYUI_URL, and updated the
+ * refusal below to say so. The OTHER surface rendering this same refusal — the
+ * `rejected` branch of describeFenceRebind in panel-tools.ts — kept the pre-fix
+ * text, which told the user to abandon the relay backend and to "report it: the
+ * relay protocol has to forward the browser's handshake Origin for this path to
+ * work at all".
+ *
+ * A user on 0.50.114 — a version that HAS the fix — followed that instruction and
+ * filed panel#1065 quoting it back. The stale sentence manufactured its own bug
+ * report, and told someone to downgrade a working setup on the way.
+ */
+export const NO_ORIGIN_REMEDY =
+  `Set COMFYUI_URL to the URL the panel is served from — that is what supplies this ` +
+  `connection's origin, and it is what is missing or unparseable when this happens. ` +
+  `Refreshing the tab will not change it, and switching away from the relay backend is ` +
+  `no longer necessary: a relay session supplies the origin it already knows. Reads and ` +
+  `non-graph tools keep working meanwhile — they do not need the fence.`;
+
 export function identityReason(
   tabId: string,
   origin: string | undefined,
@@ -68,10 +90,9 @@ export function identityReason(
     // reader to change a backend that is no longer the reason (#1077).
     return (
       `this tab's connection carries no server-observed Origin, and the workflow identity is ` +
-      `bound to one — so the fence cannot be adopted for it. Refreshing the tab will not ` +
-      `change it. This means the connection reached the orchestrator by a path that neither ` +
-      `observed nor was told the panel's origin; if COMFYUI_URL is unset or unparseable for ` +
-      `this session, setting it to the URL the panel is served from is what supplies it.`
+      `bound to one — so the fence cannot be adopted for it. This means the connection reached ` +
+      `the orchestrator by a path that neither observed nor was told the panel's origin. ` +
+      NO_ORIGIN_REMEDY
     );
   }
   // #1255 — this used to end "a malformed uuid, or one bound to a different

--- a/src/orchestrator/fence-refusal.ts
+++ b/src/orchestrator/fence-refusal.ts
@@ -67,11 +67,26 @@ export function noPanelTabReason(tabId: string): string {
  * report, and told someone to downgrade a working setup on the way.
  */
 export const NO_ORIGIN_REMEDY =
-  `Set COMFYUI_URL to the URL the panel is served from — that is what supplies this ` +
-  `connection's origin, and it is what is missing or unparseable when this happens. ` +
-  `Refreshing the tab will not change it, and switching away from the relay backend is ` +
-  `no longer necessary: a relay session supplies the origin it already knows. Reads and ` +
-  `non-graph tools keep working meanwhile — they do not need the fence.`;
+  // The gate's OWN semantics come first, because they dissolve the fear the old
+  // wording created and the reporter's stated obstacle at once. Measured, not
+  // assumed: workflowIdentityParts requires an origin to EXIST, both call sites
+  // take only `.uuid`, and `identity.origin` is never read again — so the value
+  // is a scope, not a claim to be checked against the browser.
+  `What this gate checks is PRESENCE, not agreement: the identity needs SOME origin to be ` +
+  `scoped to, and nothing ever compares it against the browser's — so the value does not have ` +
+  `to match where the panel is served from. ` +
+  // Two causes, named separately (codex review, P1). The predicate that selects this
+  // remedy is generic, and a blanket "set COMFYUI_URL" sends a direct/LAN/pairing or
+  // non-browser caller to a change that CANNOT add a handshake origin, leaving them
+  // fenced with nothing left to try.
+  `On a RELAY connection the origin is derived from COMFYUI_URL, so an unset or unparseable ` +
+  `COMFYUI_URL is the usual cause and setting it to any valid URL supplies one; you do not have ` +
+  `to leave the relay backend, which has supplied its own origin since 0.50.67. ` +
+  `On any other path the connection never presented an Origin header at all — a non-browser ` +
+  `client, or a proxy that strips it — and what fixes that is reaching the orchestrator from the ` +
+  `browser panel itself. ` +
+  `Refreshing the tab will not change either case. Reads and non-graph tools keep working ` +
+  `meanwhile — they do not need the fence.`;
 
 export function identityReason(
   tabId: string,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -52,6 +52,7 @@ import type { UiBridge } from "../services/ui-bridge.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
 import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
+import { NO_ORIGIN_REMEDY } from "./fence-refusal.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -4090,11 +4091,12 @@ function describeFenceRebind(
             // the tab" — the reporter did that repeatedly, including closing and
             // reopening it, and it could never have worked.
             r.refusalReason && /no server-observed Origin/i.test(r.refusalReason)
-              ? `Refreshing the tab will NOT help — this one is structural. Reconnect over a ` +
-                `direct/loopback or cloudflared link rather than the relay backend (unset ` +
-                `COMFYUI_MCP_TUNNEL_BACKEND=relay), or continue with reads and non-graph tools, ` +
-                `which do not need the fence. Please also report it: the relay protocol has to ` +
-                `forward the browser's handshake Origin for this path to work at all.`
+              ? // panel#1065 — SHARED with fence-refusal.ts, because this copy went stale.
+                // It still described the world before #1240 gave the relay path its
+                // origin: it told the user to abandon the relay backend and to report
+                // a protocol gap that had already been closed. Someone did exactly
+                // that, on a version that had the fix.
+                NO_ORIGIN_REMEDY
               : RELOAD_TAB_REMEDY
           }`,
       };


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#1065.

The reporter is on 0.50.114 and the relay-origin fix (#1240) shipped in **v0.50.67**, so they had it — this is not a version gap.

`setupRelayBridge` supplies the fence origin as `relayIdentityOrigin(comfyuiUrl)`, on the stated premise that *"the Origin identifies WHERE THE PANEL PAGE IS SERVED FROM, and that is the ComfyUI URL"*. Their Environment line says exactly why that fails for them:

> Headless COMFYUI_URL is intentionally not the browser panel origin.

When the panel page is not served from `COMFYUI_URL`, the derived origin is not the browser's, so the identity stays unbindable and every mutation is fenced while reads work — their reported symptom precisely.

Draft while I establish what the relay path can know about the real origin, and whether taking it from the panel is safe on the one path that is NOT a single trust domain.