### PR TITLE
chore(release): 0.51.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.11] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a relay fence stops assuming the panel is served from COMFYUI_URL (#1446)
+
+
 ## [0.51.10] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.10",
+  "version": "0.51.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.10",
+      "version": "0.51.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.10",
+  "version": "0.51.11",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.11 tag into protected main.

**0.51.11 — comfyui-mcp-panel#1065**: the "no server-observed Origin" refusal stops telling users to abandon the relay backend and to report a protocol gap that was closed in v0.50.67.

Two surfaces render that refusal; #1240 updated one and left the other. A user on 0.50.114 — a version that HAD the fix — followed the stale one, downgraded a working remote setup, and filed the report it asked for. Both surfaces now share one remedy.

The remedy states what the gate actually checks: PRESENCE, not agreement. The origin never has to match where the panel is served from — which is what makes the reporter's intentionally-different headless COMFYUI_URL fine. Relay and non-relay causes are named separately, because the predicate is generic and a blanket "set COMFYUI_URL" is a dead end for a non-browser caller.

Codex round 1 caught that my first fix was over-broad in a new direction; round 2: PASS.