### PR TITLE
fix(panel#1097): say how long the workflow switch has been holding

### DIFF
--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -28,7 +28,7 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
-import { resetSwitchHolds } from "../../orchestrator/switch-hold.js";
+import { resetSwitchHolds, switchHoldFor } from "../../orchestrator/switch-hold.js";
 
 const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
 
@@ -166,12 +166,43 @@ describe("panel#1097: a switch that never clears stops reading like one that wil
     await ctx.call({ cmd: "graph_outline" });
     await new Promise((r) => setTimeout(r, 3100));
 
-    // A command that lands clears the hold…
-    const okCtx = makePanelToolCtx(bridgeFailing(0), "tab-1");
+    // A command that was switch-refused and then SUCCEEDED on its retry clears the
+    // hold. (An unrelated success does not — it proves nothing about the switch.)
+    const okCtx = makePanelToolCtx(bridgeFailing(1), "tab-1");
     expect((await okCtx.call({ cmd: "graph_outline" })).isError).toBeFalsy();
 
     // …so the next refusal is a fresh, momentary one again.
     const after = textOf(await makePanelToolCtx(bridgeFailing(99), "tab-1").call({ cmd: "graph_outline" }));
     expect(after).not.toContain("HELD FOR");
   }, 15_000);
+});
+
+describe("panel#1097: the run belongs to the tab the command was DISPATCHED on", () => {
+  // codex rounds 1-2. ctx.tabId is mutable: ensureReachable rebinds a current-mode
+  // session onto whichever tab is live. Snapshotting it BEFORE that rebind filed
+  // tab B's refusal under tab A — so an unrelated A command could later reset a
+  // stuck B, and B's own age was never recorded.
+  it("records under the REBOUND tab, not the one the call started on", async () => {
+    // The tab must move BETWEEN the two attempts — that is the only ordering where
+    // the reassignment matters. If it has already moved before the first send, the
+    // pre-rebind and post-rebind reads are the same value and nothing is proven.
+    let reachable = "tab-1";
+    const bridge = {
+      send: async () => {
+        reachable = "tab-2"; // the session rebinds during the retry's ensureReachable
+        throw switchGuardError();
+      },
+      push: () => 1,
+      canReach: (id: string) => id === reachable,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: reachable, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => reachable,
+    } as unknown as PanelToolCtx["bridge"];
+
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    await ctx.call({ cmd: "graph_outline" });
+
+    expect(switchHoldFor("tab-2"), "the tab it was actually dispatched on").toBeTruthy();
+    expect(switchHoldFor("tab-1"), "the tab the call merely started on").toBeUndefined();
+  });
 });

--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -154,8 +154,11 @@ describe("panel#1097: a switch that never clears stops reading like one that wil
     const text = textOf(await ctx.call({ cmd: "graph_outline" }));
 
     expect(text).toContain("HELD FOR");
-    expect(text).toContain("waiting for a person");
-    expect(text).toContain("no number of retries will clear it");
+    // Both explanations, neither asserted (codex review) — elapsed time does not
+    // prove a modal, and a large graph or remote canvas can legitimately take this.
+    expect(text).toContain("it may still be loading");
+    expect(text).toContain("awaiting a person");
+    expect(text).toContain("Retrying clears the first and never the second");
   }, 15_000);
 
   it("a SUCCESS between refusals resets the run — the age is not cumulative", async () => {

--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -206,3 +206,36 @@ describe("panel#1097: the run belongs to the tab the command was DISPATCHED on",
     expect(switchHoldFor("tab-1"), "the tab the call merely started on").toBeUndefined();
   });
 });
+
+describe("panel#1097: only a SWITCH refusal that then succeeds clears the run", () => {
+  // codex round 3, P2: clearing after a transient-reconnect retry resets the
+  // evidence one step removed — reconnecting proves nothing about whether the
+  // canvas switch cleared, and a status read can reconnect while graph commands
+  // stay refused.
+  it("a reconnect-retry success leaves a switch run intact", async () => {
+    // Build a run first.
+    const stuck = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    await stuck.call({ cmd: "graph_outline" });
+    expect(switchHoldFor("tab-1")).toBeTruthy();
+
+    // A DIFFERENT failure kind that retries and succeeds.
+    let n = 0;
+    const reconnecting = {
+      send: async () => {
+        n += 1;
+        // A real transient-reconnect shape (isTransientReconnectError matches this).
+        if (n === 1) throw new Error("socket hang up");
+        return { ok: true, nodes: [] };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+    } as unknown as PanelToolCtx["bridge"];
+
+    const res = await makePanelToolCtx(reconnecting, "tab-1").call({ cmd: "graph_outline" });
+    expect(res.isError).toBeFalsy();
+    expect(switchHoldFor("tab-1"), "the switch run is not evidence about a reconnect").toBeTruthy();
+  });
+});

--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -28,6 +28,7 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
+import { resetSwitchHolds } from "../../orchestrator/switch-hold.js";
 
 const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
 
@@ -60,6 +61,7 @@ function bridgeFailing(failures: number, err: () => Error = switchGuardError) {
 
 beforeEach(() => {
   __panelToolsTestHooks.setRetrySettleMs(0); // the real wait is ~400ms
+  resetSwitchHolds(); // panel#1097 — the run is per tab and outlives one call
 });
 
 describe("#1027: a mid-switch refusal is retried, not surfaced", () => {
@@ -131,4 +133,42 @@ describe("#1027: the other refusals keep their own handling", () => {
     expect(res.isError).toBe(true);
     expect(attempts).toBe(1);
   });
+});
+
+describe("panel#1097: a switch that never clears stops reading like one that will", () => {
+  // The reporter retried into this refusal indefinitely. Every one of them said
+  // "it normally clears in well under a second, so simply retry", because nothing
+  // timed the RUN — so the tool could not notice its own advice failing.
+  it("says nothing extra while the hold is still momentary", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+    expect(text).toContain("still switching or reloading");
+    expect(text).not.toContain("HELD FOR");
+  });
+
+  it("reports the hold once a run of refusals contradicts that advice", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    // Each call refuses twice (initial + the one retry), so the run builds.
+    await ctx.call({ cmd: "graph_outline" });
+    await new Promise((r) => setTimeout(r, 3100)); // past the "worth saying" floor
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+
+    expect(text).toContain("HELD FOR");
+    expect(text).toContain("waiting for a person");
+    expect(text).toContain("no number of retries will clear it");
+  }, 15_000);
+
+  it("a SUCCESS between refusals resets the run — the age is not cumulative", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    await ctx.call({ cmd: "graph_outline" });
+    await new Promise((r) => setTimeout(r, 3100));
+
+    // A command that lands clears the hold…
+    const okCtx = makePanelToolCtx(bridgeFailing(0), "tab-1");
+    expect((await okCtx.call({ cmd: "graph_outline" })).isError).toBeFalsy();
+
+    // …so the next refusal is a fresh, momentary one again.
+    const after = textOf(await makePanelToolCtx(bridgeFailing(99), "tab-1").call({ cmd: "graph_outline" }));
+    expect(after).not.toContain("HELD FOR");
+  }, 15_000);
 });

--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -239,3 +239,29 @@ describe("panel#1097: only a SWITCH refusal that then succeeds clears the run", 
     expect(switchHoldFor("tab-1"), "the switch run is not evidence about a reconnect").toBeTruthy();
   });
 });
+
+describe("panel#1097: what a SUCCESS proves depends on the command", () => {
+  // Two rounds pulled opposite ways here. Clearing on every routed success let an
+  // unguarded read wipe the evidence while graph commands stayed refused (r2);
+  // clearing only on a switch-retry left a stale run for the next, unrelated
+  // switch to inherit (r4). The guard's domain is what both agree on.
+  it("an ordinary first-attempt graph success clears the run", async () => {
+    const stuck = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    await stuck.call({ cmd: "graph_outline" });
+    expect(switchHoldFor("tab-1")).toBeTruthy();
+
+    const healthy = makePanelToolCtx(bridgeFailing(0), "tab-1");
+    expect((await healthy.call({ cmd: "graph_outline" })).isError).toBeFalsy();
+    expect(switchHoldFor("tab-1"), "the switch is demonstrably over").toBeUndefined();
+  });
+
+  it("a NON-guard command's success does not — it was never refused", async () => {
+    const stuck = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    await stuck.call({ cmd: "graph_outline" });
+    expect(switchHoldFor("tab-1")).toBeTruthy();
+
+    const healthy = makePanelToolCtx(bridgeFailing(0), "tab-1");
+    expect((await healthy.call({ cmd: "panel_status" })).isError).toBeFalsy();
+    expect(switchHoldFor("tab-1"), "a status read proves nothing about the switch").toBeTruthy();
+  });
+});

--- a/src/__tests__/orchestrator/switch-hold.test.ts
+++ b/src/__tests__/orchestrator/switch-hold.test.ts
@@ -76,17 +76,41 @@ describe("panel#1097 what it says, and when it says nothing", () => {
     const held = recordSwitchHold("tab", T0 + 4000);
     const text = describeSwitchHold(held, T0 + 4000);
     expect(text).toContain("HELD FOR 4s");
-    expect(text).toContain("across 2 attempts");
+    expect(text).toContain("across 2 refusals");
   });
 
-  it("names the human-waiting cause, and that retrying cannot fix it", () => {
+  it("offers BOTH explanations and asserts neither", () => {
+    // codex review, P1: elapsed time does not prove a modal. A very large graph, a
+    // slow disk or a remote canvas can legitimately switch for longer than this,
+    // and telling that user the canvas is "not busy" and that retrying cannot work
+    // would be wrong in the one direction that costs them the fix.
     recordSwitchHold("tab", T0);
     const held = recordSwitchHold("tab", T0 + 240_000);
     const text = describeSwitchHold(held, T0 + 240_000);
     expect(text).toContain("HELD FOR 4m");
-    expect(text).toContain("waiting for a person");
+    expect(text).toContain("it may still be loading");
     expect(text).toMatch(/load dialog|unsaved-changes prompt/);
-    expect(text).toContain("no number of retries will clear it");
+    expect(text).toContain("Retrying clears the first and never the second");
+    // The verdicts that are not established by elapsed time.
+    expect(text).not.toContain("waiting for a person, not as busy");
+    expect(text).not.toContain("no number of retries will clear it");
+  });
+
+  it("counts REFUSALS, and says so — that is what it measures", () => {
+    // codex review, P2: "attempts" overstated it. The run counts terminal refusals,
+    // not routed sends, and with a ~400ms settle those differ by a factor of two.
+    recordSwitchHold("tab", T0);
+    const held = recordSwitchHold("tab", T0 + 5000);
+    expect(describeSwitchHold(held, T0 + 5000)).toContain("across 2 refusals");
+  });
+
+  it("evicts runs nobody has touched, so the map cannot grow forever", () => {
+    // codex review, P2: without eviction an entry survives per tab id for the life
+    // of the process, and a reused id inherits a stale age.
+    recordSwitchHold("old-tab", T0);
+    recordSwitchHold("new-tab", T0 + 11 * 60_000);
+    expect(switchHoldFor("old-tab")).toBeUndefined();
+    expect(switchHoldFor("new-tab")).toBeTruthy();
   });
 
   it("renders minutes past 90s and seconds below it", () => {

--- a/src/__tests__/orchestrator/switch-hold.test.ts
+++ b/src/__tests__/orchestrator/switch-hold.test.ts
@@ -27,9 +27,9 @@ beforeEach(() => resetSwitchHolds());
 
 describe("panel#1097 timing a run of switch refusals", () => {
   it("starts a run on the first refusal and counts the rest", () => {
-    expect(recordSwitchHold("tab", T0)).toEqual({ since: T0, count: 1 });
-    expect(recordSwitchHold("tab", T0 + 1000)).toEqual({ since: T0, count: 2 });
-    expect(recordSwitchHold("tab", T0 + 9000)).toEqual({ since: T0, count: 3 });
+    expect(recordSwitchHold("tab", T0)).toEqual({ since: T0, last: T0, count: 1 });
+    expect(recordSwitchHold("tab", T0 + 1000)).toEqual({ since: T0, last: T0 + 1000, count: 2 });
+    expect(recordSwitchHold("tab", T0 + 9000)).toEqual({ since: T0, last: T0 + 9000, count: 3 });
   });
 
   it("keeps runs per TAB — one stuck canvas must not age another's", () => {
@@ -45,12 +45,20 @@ describe("panel#1097 timing a run of switch refusals", () => {
     clearSwitchHold("tab");
     expect(switchHoldFor("tab")).toBeUndefined();
     // …and the fresh run is dated from now, not from the old start.
-    expect(recordSwitchHold("tab", T0 + 60_000)).toEqual({ since: T0 + 60_000, count: 1 });
+    expect(recordSwitchHold("tab", T0 + 60_000)).toEqual({
+      since: T0 + 60_000,
+      last: T0 + 60_000,
+      count: 1,
+    });
   });
 
   it("a backwards clock restarts the run rather than reporting a negative age", () => {
     recordSwitchHold("tab", T0);
-    expect(recordSwitchHold("tab", T0 - 5000)).toEqual({ since: T0 - 5000, count: 1 });
+    expect(recordSwitchHold("tab", T0 - 5000)).toEqual({
+      since: T0 - 5000,
+      last: T0 - 5000,
+      count: 1,
+    });
   });
 });
 
@@ -107,12 +115,24 @@ describe("panel#1097 what it says, and when it says nothing", () => {
   });
 
   it("evicts runs nobody has touched, so the map cannot grow forever", () => {
-    // codex review, P2: without eviction an entry survives per tab id for the life
+    // codex round 1, P2: without eviction an entry survives per tab id for the life
     // of the process, and a reused id inherits a stale age.
     recordSwitchHold("old-tab", T0);
     recordSwitchHold("new-tab", T0 + 11 * 60_000);
     expect(switchHoldFor("old-tab")).toBeUndefined();
     expect(switchHoldFor("new-tab")).toBeTruthy();
+  });
+
+  it("does NOT evict a hold that is still being retried — the most stuck case", () => {
+    // codex round 3, P2: eviction keyed on the run's START dropped a hold that had
+    // been retried for over ten minutes, resetting it to the momentary wording at
+    // exactly the moment it was most obviously stuck.
+    recordSwitchHold("stuck", T0);
+    for (let m = 1; m <= 15; m++) recordSwitchHold("stuck", T0 + m * 60_000);
+    const hold = switchHoldFor("stuck");
+    expect(hold, "still tracked after 15 minutes of retrying").toBeTruthy();
+    expect(hold?.since).toBe(T0); // and still aged from the START of the run
+    expect(describeSwitchHold(hold, T0 + 15 * 60_000)).toContain("HELD FOR 15m");
   });
 
   it("renders minutes past 90s and seconds below it", () => {

--- a/src/__tests__/orchestrator/switch-hold.test.ts
+++ b/src/__tests__/orchestrator/switch-hold.test.ts
@@ -76,7 +76,7 @@ describe("panel#1097 what it says, and when it says nothing", () => {
     const held = recordSwitchHold("tab", T0 + 4000);
     const text = describeSwitchHold(held, T0 + 4000);
     expect(text).toContain("HELD FOR 4s");
-    expect(text).toContain("across 2 refusals");
+    expect(text).toContain("across 2 failed calls");
   });
 
   it("offers BOTH explanations and asserts neither", () => {
@@ -96,12 +96,14 @@ describe("panel#1097 what it says, and when it says nothing", () => {
     expect(text).not.toContain("no number of retries will clear it");
   });
 
-  it("counts REFUSALS, and says so — that is what it measures", () => {
-    // codex review, P2: "attempts" overstated it. The run counts terminal refusals,
-    // not routed sends, and with a ~400ms settle those differ by a factor of two.
+  it("counts FAILED CALLS, and says so — that is what it measures", () => {
+    // codex rounds 1-2: "attempts" overstated it, and "refusals" understated what
+    // the panel saw. Each failed call refuses, settles, retries and refuses again,
+    // so the panel sees roughly twice this. "Failed calls" is the number this
+    // counts and the one a caller can compare against what they actually did.
     recordSwitchHold("tab", T0);
     const held = recordSwitchHold("tab", T0 + 5000);
-    expect(describeSwitchHold(held, T0 + 5000)).toContain("across 2 refusals");
+    expect(describeSwitchHold(held, T0 + 5000)).toContain("across 2 failed calls");
   });
 
   it("evicts runs nobody has touched, so the map cannot grow forever", () => {

--- a/src/__tests__/orchestrator/switch-hold.test.ts
+++ b/src/__tests__/orchestrator/switch-hold.test.ts
@@ -1,0 +1,103 @@
+// comfyui-mcp-panel#1097 — "SIMPLY RETRY" MUST STOP BEING SAID TO SOMEONE WHOSE
+// RETRIES ARE NOT WORKING.
+//
+// The panel refuses commands while it switches the canvas workflow, which is
+// right. The orchestrator retries once and then explains, ending with "it normally
+// clears in well under a second, so simply retry". For the reporter it never
+// cleared — a switch can be held open indefinitely by a load dialog or an
+// unsaved-changes prompt waiting on a person — and every refusal read identically
+// to the momentary case, so nothing ever noticed that the advice was not working.
+//
+// This times the RUN of refusals per tab. It decides nothing: no guard is
+// bypassed, no command is retried differently. It only lets the message tell the
+// two cases apart.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSwitchHold,
+  describeSwitchHold,
+  recordSwitchHold,
+  resetSwitchHolds,
+  switchHoldFor,
+} from "../../orchestrator/switch-hold.js";
+
+const T0 = 1_800_000_000_000;
+
+beforeEach(() => resetSwitchHolds());
+
+describe("panel#1097 timing a run of switch refusals", () => {
+  it("starts a run on the first refusal and counts the rest", () => {
+    expect(recordSwitchHold("tab", T0)).toEqual({ since: T0, count: 1 });
+    expect(recordSwitchHold("tab", T0 + 1000)).toEqual({ since: T0, count: 2 });
+    expect(recordSwitchHold("tab", T0 + 9000)).toEqual({ since: T0, count: 3 });
+  });
+
+  it("keeps runs per TAB — one stuck canvas must not age another's", () => {
+    recordSwitchHold("tab-a", T0);
+    recordSwitchHold("tab-b", T0 + 60_000);
+    expect(switchHoldFor("tab-a")?.since).toBe(T0);
+    expect(switchHoldFor("tab-b")?.since).toBe(T0 + 60_000);
+  });
+
+  it("a SUCCESS clears the run, so the next refusal starts fresh", () => {
+    recordSwitchHold("tab", T0);
+    recordSwitchHold("tab", T0 + 30_000);
+    clearSwitchHold("tab");
+    expect(switchHoldFor("tab")).toBeUndefined();
+    // …and the fresh run is dated from now, not from the old start.
+    expect(recordSwitchHold("tab", T0 + 60_000)).toEqual({ since: T0 + 60_000, count: 1 });
+  });
+
+  it("a backwards clock restarts the run rather than reporting a negative age", () => {
+    recordSwitchHold("tab", T0);
+    expect(recordSwitchHold("tab", T0 - 5000)).toEqual({ since: T0 - 5000, count: 1 });
+  });
+});
+
+describe("panel#1097 what it says, and when it says nothing", () => {
+  it("says NOTHING for the common momentary case", () => {
+    // The refusal is already correct for a switch that clears in under a second;
+    // adding a paragraph to it would be noise on the overwhelmingly common path.
+    const brief = recordSwitchHold("tab", T0);
+    expect(describeSwitchHold(brief, T0 + 200)).toBe("");
+    const secondQuick = recordSwitchHold("tab", T0 + 400);
+    expect(describeSwitchHold(secondQuick, T0 + 500)).toBe("");
+  });
+
+  it("says nothing on a FIRST refusal however old the clock claims it is", () => {
+    // One refusal is not a run — and "held for 9s across 1 attempt" would be
+    // describing a single call's own latency, not a stuck canvas.
+    const first = recordSwitchHold("tab", T0);
+    expect(describeSwitchHold(first, T0 + 90_000)).toBe("");
+  });
+
+  it("speaks up once the hold contradicts the advice being given", () => {
+    recordSwitchHold("tab", T0);
+    const held = recordSwitchHold("tab", T0 + 4000);
+    const text = describeSwitchHold(held, T0 + 4000);
+    expect(text).toContain("HELD FOR 4s");
+    expect(text).toContain("across 2 attempts");
+  });
+
+  it("names the human-waiting cause, and that retrying cannot fix it", () => {
+    recordSwitchHold("tab", T0);
+    const held = recordSwitchHold("tab", T0 + 240_000);
+    const text = describeSwitchHold(held, T0 + 240_000);
+    expect(text).toContain("HELD FOR 4m");
+    expect(text).toContain("waiting for a person");
+    expect(text).toMatch(/load dialog|unsaved-changes prompt/);
+    expect(text).toContain("no number of retries will clear it");
+  });
+
+  it("renders minutes past 90s and seconds below it", () => {
+    recordSwitchHold("tab", T0);
+    const a = recordSwitchHold("tab", T0 + 80_000);
+    expect(describeSwitchHold(a, T0 + 80_000)).toContain("HELD FOR 80s");
+    const b = recordSwitchHold("tab", T0 + 200_000);
+    expect(describeSwitchHold(b, T0 + 200_000)).toContain("HELD FOR 3m");
+  });
+
+  it("says nothing at all when there is no run", () => {
+    expect(describeSwitchHold(undefined, T0)).toBe("");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -56,6 +56,7 @@ import {
   clearSwitchHold,
   describeSwitchHold,
   recordSwitchHold,
+  successProvesSwitchCleared,
 } from "./switch-hold.js";
 import { NO_ORIGIN_REMEDY } from "./fence-refusal.js";
 
@@ -6183,7 +6184,13 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
-      return ok(await sendRouted(cmd, timeoutMs, observeRid));
+      const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid));
+      // panel#1097 — a guard-domain command that SUCCEEDS is the evidence that the
+      // switch is over, whichever attempt lands it. Without this an ordinary
+      // first-attempt success left the old run in place, and a later unrelated
+      // switch inherited its age and was announced as stuck at once (codex r4).
+      if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
+      return firstTry;
     } catch (err) {
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
       // transport (or replace it under a new tab id) the instant after we dispatch.
@@ -6213,7 +6220,12 @@ export function makePanelToolCtx(
           // (codex round 2); clearing after a transient-reconnect retry does the
           // same thing one step removed, because reconnecting proves nothing about
           // whether the switch cleared (codex round 3).
-          if (isWorkflowSwitchGuardRefusal(err)) clearSwitchHold(holdTab);
+          // Same rule on the retry path. A transient-RECONNECT retry that succeeds
+          // proves nothing about the switch (codex r3), so the command still has to
+          // be one the guard would have refused.
+          if (isWorkflowSwitchGuardRefusal(err) && successProvesSwitchCleared(cmd.cmd)) {
+            clearSwitchHold(holdTab);
+          }
           return retried;
         } catch (err2) {
           // #1027 — a switch STILL in progress is not a reconnect, and saying so

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6207,12 +6207,13 @@ export function makePanelToolCtx(
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
           const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
-          // Cleared HERE and nowhere else: this is the one path that knows a switch
-          // refusal preceded this success. Clearing on every routed success let an
-          // unguarded command (a status read) wipe the evidence while graph commands
-          // stayed refused, and left the retry path not clearing at all — so a later
-          // refusal inherited a stale age (codex round 2).
-          clearSwitchHold(holdTab);
+          // Cleared HERE and nowhere else, and only when the failure this retried
+          // was a SWITCH refusal. Clearing on every routed success let an unguarded
+          // status read wipe the evidence while graph commands stayed refused
+          // (codex round 2); clearing after a transient-reconnect retry does the
+          // same thing one step removed, because reconnecting proves nothing about
+          // whether the switch cleared (codex round 3).
+          if (isWorkflowSwitchGuardRefusal(err)) clearSwitchHold(holdTab);
           return retried;
         } catch (err2) {
           // #1027 — a switch STILL in progress is not a reconnect, and saying so

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6166,6 +6166,11 @@ export function makePanelToolCtx(
       dispatchedRid = rid;
       onDispatchedRid?.(rid);
     };
+    // panel#1097 — captured BEFORE any await, and used by BOTH the success and the
+    // refusal paths. `ctx.tabId` is mutable and ensureReachable can rebind this
+    // session onto another tab mid-flight, so reading it after the await can clear
+    // or age the WRONG tab's run (codex review).
+    const holdTab = ctx.tabId;
     try {
       // #436: a MUTATING graph edit must not fire into the "Connected: none"
       // window a ComfyUI restart/reload opens. A read survives that window (it is
@@ -6184,10 +6189,9 @@ export function makePanelToolCtx(
       }
       ensureReachable();
       const sent = ok(await sendRouted(cmd, timeoutMs, observeRid));
-      // panel#1097 — the switch cleared, so a LATER refusal starts a fresh run
-      // rather than inheriting this one's age. Without this the elapsed figure only
-      // ever grows, and a message built on it becomes as misleading as none.
-      clearSwitchHold(ctx.tabId);
+      // The switch cleared, so a LATER refusal starts a fresh run rather than
+      // inheriting this one's age — otherwise the figure only ever grows.
+      clearSwitchHold(holdTab);
       return sent;
     } catch (err) {
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
@@ -6214,7 +6218,7 @@ export function makePanelToolCtx(
             // panel#1097 — time the RUN of these refusals. "Simply retry" is right
             // for the fraction of a second this normally lasts and wrong for a
             // switch held open by a dialog, and the two were indistinguishable.
-            const held = describeSwitchHold(recordSwitchHold(ctx.tabId));
+            const held = describeSwitchHold(recordSwitchHold(holdTab));
             return fail(
               `${name} was NOT applied — nothing changed. The panel is still switching or ` +
                 `reloading the workflow on the canvas, which it refuses commands during so a ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6166,11 +6166,6 @@ export function makePanelToolCtx(
       dispatchedRid = rid;
       onDispatchedRid?.(rid);
     };
-    // panel#1097 — captured BEFORE any await, and used by BOTH the success and the
-    // refusal paths. `ctx.tabId` is mutable and ensureReachable can rebind this
-    // session onto another tab mid-flight, so reading it after the await can clear
-    // or age the WRONG tab's run (codex review).
-    const holdTab = ctx.tabId;
     try {
       // #436: a MUTATING graph edit must not fire into the "Connected: none"
       // window a ComfyUI restart/reload opens. A read survives that window (it is
@@ -6188,11 +6183,7 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
-      const sent = ok(await sendRouted(cmd, timeoutMs, observeRid));
-      // The switch cleared, so a LATER refusal starts a fresh run rather than
-      // inheriting this one's age — otherwise the figure only ever grows.
-      clearSwitchHold(holdTab);
-      return sent;
+      return ok(await sendRouted(cmd, timeoutMs, observeRid));
     } catch (err) {
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
       // transport (or replace it under a new tab id) the instant after we dispatch.
@@ -6205,10 +6196,24 @@ export function makePanelToolCtx(
       // is what retrySettleMs already waits. Still gated on RETRY-SAFE commands,
       // so a mutation is never re-issued on our own initiative.
       if (isRetrySafeCmd(cmd) && (isTransientReconnectError(err) || isWorkflowSwitchGuardRefusal(err))) {
+        // panel#1097 — declared out here so the refusal branch below can see it,
+        // and REASSIGNED after ensureReachable so it names the tab the command is
+        // actually dispatched on. Reading it before the rebind attributed a refusal
+        // from B to A; reading it after the await let a later rebind move it again
+        // (codex rounds 1 and 2).
+        let holdTab = ctx.tabId;
         try {
           await sleep(retrySettleMs());
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
-          return ok(await sendRouted(cmd, timeoutMs, observeRid));
+          holdTab = ctx.tabId;
+          const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
+          // Cleared HERE and nowhere else: this is the one path that knows a switch
+          // refusal preceded this success. Clearing on every routed success let an
+          // unguarded command (a status read) wipe the evidence while graph commands
+          // stayed refused, and left the retry path not clearing at all — so a later
+          // refusal inherited a stale age (codex round 2).
+          clearSwitchHold(holdTab);
+          return retried;
         } catch (err2) {
           // #1027 — a switch STILL in progress is not a reconnect, and saying so
           // would be the #1001 mistake again: the tab is connected and healthy,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -52,6 +52,11 @@ import type { UiBridge } from "../services/ui-bridge.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
 import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
+import {
+  clearSwitchHold,
+  describeSwitchHold,
+  recordSwitchHold,
+} from "./switch-hold.js";
 import { NO_ORIGIN_REMEDY } from "./fence-refusal.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
@@ -6178,7 +6183,12 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
-      return ok(await sendRouted(cmd, timeoutMs, observeRid));
+      const sent = ok(await sendRouted(cmd, timeoutMs, observeRid));
+      // panel#1097 — the switch cleared, so a LATER refusal starts a fresh run
+      // rather than inheriting this one's age. Without this the elapsed figure only
+      // ever grows, and a message built on it becomes as misleading as none.
+      clearSwitchHold(ctx.tabId);
+      return sent;
     } catch (err) {
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
       // transport (or replace it under a new tab id) the instant after we dispatch.
@@ -6201,6 +6211,10 @@ export function makePanelToolCtx(
           // it is simply mid-switch. Name the actual state and the actual wait.
           if (isWorkflowSwitchGuardRefusal(err2)) {
             const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
+            // panel#1097 — time the RUN of these refusals. "Simply retry" is right
+            // for the fraction of a second this normally lasts and wrong for a
+            // switch held open by a dialog, and the two were indistinguishable.
+            const held = describeSwitchHold(recordSwitchHold(ctx.tabId));
             return fail(
               `${name} was NOT applied — nothing changed. The panel is still switching or ` +
                 `reloading the workflow on the canvas, which it refuses commands during so a ` +
@@ -6208,7 +6222,8 @@ export function makePanelToolCtx(
                 `reconnect: it normally clears in well under a second, so simply retry. If a ` +
                 `switch appears stuck, check the canvas — a load dialog or an unsaved-changes ` +
                 `prompt can hold it open awaiting the user. ` +
-                `(${err2 instanceof Error ? err2.message : String(err2)})`,
+                `(${err2 instanceof Error ? err2.message : String(err2)})` +
+                held,
             );
           }
           // The retry also failed — surface an actionable reconnecting status rather

--- a/src/orchestrator/switch-hold.ts
+++ b/src/orchestrator/switch-hold.ts
@@ -124,3 +124,23 @@ export function describeSwitchHold(hold: Hold | undefined, now: number = Date.no
     `the first and never the second, so if it keeps growing, look at the canvas.`
   );
 }
+
+/**
+ * Is this command one the switch guard would refuse — i.e. does its success prove
+ * the switch has cleared?
+ *
+ * Two review rounds pulled in opposite directions and this is what they agree on.
+ * Clearing on EVERY routed success let an unguarded status read wipe the evidence
+ * while graph commands stayed refused (round 2). Clearing only on the retry of a
+ * switch refusal left a stale run behind after an ordinary first-attempt success,
+ * so a later, unrelated switch inherited its age and was announced as stuck
+ * immediately (round 4).
+ *
+ * The panel refuses "every graph and workflow executor" while switching — that is
+ * the domain, and the success of one of those is exactly the evidence that the
+ * switch is over.
+ */
+export function successProvesSwitchCleared(cmd: unknown): boolean {
+  const name = typeof cmd === "string" ? cmd : undefined;
+  return typeof name === "string" && /^(graph_|workflow_)/.test(name);
+}

--- a/src/orchestrator/switch-hold.ts
+++ b/src/orchestrator/switch-hold.ts
@@ -23,8 +23,12 @@
 
 /** A run of consecutive switch-guard refusals for one tab. */
 interface Hold {
-  /** When the FIRST refusal of this run was seen. */
+  /** When the FIRST refusal of this run was seen — what the age is measured from. */
   since: number;
+  /** When the LAST one was. Eviction keys on THIS: a hold that is still being
+   *  retried after ten minutes is the most stuck one there is, and evicting it by
+   *  start time would reset it to the momentary wording exactly then (codex). */
+  last: number;
   /** How many of those runs have ended in a terminal refusal. One per FAILED
    *  CALL, not per panel refusal: each call refuses, settles, retries and refuses
    *  again, so the panel sees roughly twice this (codex review). The message says
@@ -46,10 +50,10 @@ const MAX_HOLDS = 200;
 
 function evict(now: number): void {
   for (const [tab, hold] of holds) {
-    if (now - hold.since > HOLD_TTL_MS) holds.delete(tab);
+    if (now - hold.last > HOLD_TTL_MS) holds.delete(tab);
   }
   if (holds.size <= MAX_HOLDS) return;
-  const byAge = [...holds.entries()].sort((a, b) => a[1].since - b[1].since);
+  const byAge = [...holds.entries()].sort((a, b) => a[1].last - b[1].last);
   for (const [tab] of byAge.slice(0, holds.size - MAX_HOLDS)) holds.delete(tab);
 }
 
@@ -64,7 +68,9 @@ export function recordSwitchHold(tabId: string, now: number = Date.now()): Hold 
   // A clock that jumped backwards must not produce a negative age: restart the run
   // rather than report something that cannot be true.
   const next: Hold =
-    prev && now >= prev.since ? { since: prev.since, count: prev.count + 1 } : { since: now, count: 1 };
+    prev && now >= prev.since
+      ? { since: prev.since, last: now, count: prev.count + 1 }
+      : { since: now, last: now, count: 1 };
   holds.set(tabId, next);
   return next;
 }

--- a/src/orchestrator/switch-hold.ts
+++ b/src/orchestrator/switch-hold.ts
@@ -31,12 +31,31 @@ interface Hold {
 
 const holds = new Map<string, Hold>();
 
+/** A run nobody has touched for this long is over — the tab closed, rebound, or
+ *  simply moved on without a routed success to clear it. Without eviction this map
+ *  keeps an entry per tab id for the life of the process (codex review), and a
+ *  reused id would inherit a stale age. */
+const HOLD_TTL_MS = 10 * 60 * 1000;
+/** A hard ceiling for the pathological case (many short-lived tab ids). Oldest
+ *  runs go first: the freshest are the ones a message could still be built from. */
+const MAX_HOLDS = 200;
+
+function evict(now: number): void {
+  for (const [tab, hold] of holds) {
+    if (now - hold.since > HOLD_TTL_MS) holds.delete(tab);
+  }
+  if (holds.size <= MAX_HOLDS) return;
+  const byAge = [...holds.entries()].sort((a, b) => a[1].since - b[1].since);
+  for (const [tab] of byAge.slice(0, holds.size - MAX_HOLDS)) holds.delete(tab);
+}
+
 /**
  * Record a switch-guard refusal for `tabId` and return the run so far.
  *
  * `now` is injected so the wording is testable without faking a clock.
  */
 export function recordSwitchHold(tabId: string, now: number = Date.now()): Hold {
+  evict(now);
   const prev = holds.get(tabId);
   // A clock that jumped backwards must not produce a negative age: restart the run
   // rather than report something that cannot be true.
@@ -82,10 +101,16 @@ export function describeSwitchHold(hold: Hold | undefined, now: number = Date.no
   if (!Number.isFinite(ms) || ms < 3000 || hold.count < 2) return "";
   const secs = Math.round(ms / 1000);
   const howLong = secs < 90 ? `${secs}s` : `${Math.round(secs / 60)}m`;
+  // States the OBSERVATION and both explanations, never a verdict (codex review).
+  // Elapsed time does not prove a modal: a very large graph, a slow disk or a
+  // remote canvas can legitimately switch for longer than this, and telling that
+  // user the canvas is "not busy" and that retrying cannot work would be wrong in
+  // the one direction that costs them the thing that would have worked.
   return (
-    ` THIS HAS BEEN HELD FOR ${howLong} across ${hold.count} attempts, which is far longer than a ` +
-    `switch takes — treat the canvas as waiting for a person, not as busy. A load dialog, an ` +
-    `unsaved-changes prompt, or a modal on the ComfyUI tab will hold it open indefinitely, and no ` +
-    `number of retries will clear it.`
+    ` THIS HAS BEEN HELD FOR ${howLong} across ${hold.count} refusals, which is longer than a ` +
+    `switch usually takes. Two things look like this: it may still be loading — a very large ` +
+    `graph, a slow disk, a remote canvas — or it may be held open by something on the ComfyUI ` +
+    `tab awaiting a person, such as a load dialog or an unsaved-changes prompt. Retrying clears ` +
+    `the first and never the second, so if it keeps growing, look at the canvas.`
   );
 }

--- a/src/orchestrator/switch-hold.ts
+++ b/src/orchestrator/switch-hold.ts
@@ -1,0 +1,91 @@
+/**
+ * comfyui-mcp-panel#1097 — HOW LONG the panel has been refusing for.
+ *
+ * The panel refuses commands while it is switching or reloading the canvas
+ * workflow, which is right: a command that landed mid-switch could apply to the
+ * wrong graph. The orchestrator retries once and then explains, and it already
+ * names the stuck case — "a load dialog or an unsaved-changes prompt can hold it
+ * open awaiting the user".
+ *
+ * What it could not say is how long. A switch holding for 200ms and one holding
+ * for four minutes produced the identical refusal, ending in "it normally clears
+ * in well under a second, so simply retry". The reporter retried, and retried, and
+ * the tool never had a way to notice it was telling them to do something that was
+ * not working. "Never clears" was invisible to the only thing in a position to see
+ * it.
+ *
+ * The orchestrator sees every one of those refusals, so it can time the RUN of
+ * them per tab without the panel changing at all. Nothing here decides anything —
+ * no guard is bypassed and no command is retried differently. It only lets the
+ * message distinguish "wait a moment" from "this has been held for four minutes,
+ * go and look at the canvas".
+ */
+
+/** A run of consecutive switch-guard refusals for one tab. */
+interface Hold {
+  /** When the FIRST refusal of this run was seen. */
+  since: number;
+  /** How many have been seen since — a fast retry loop is worth naming too. */
+  count: number;
+}
+
+const holds = new Map<string, Hold>();
+
+/**
+ * Record a switch-guard refusal for `tabId` and return the run so far.
+ *
+ * `now` is injected so the wording is testable without faking a clock.
+ */
+export function recordSwitchHold(tabId: string, now: number = Date.now()): Hold {
+  const prev = holds.get(tabId);
+  // A clock that jumped backwards must not produce a negative age: restart the run
+  // rather than report something that cannot be true.
+  const next: Hold =
+    prev && now >= prev.since ? { since: prev.since, count: prev.count + 1 } : { since: now, count: 1 };
+  holds.set(tabId, next);
+  return next;
+}
+
+/**
+ * Forget a tab's run.
+ *
+ * Called when a command SUCCEEDS on that tab: the switch cleared, so the next
+ * refusal starts a fresh run rather than inheriting an age from an unrelated one.
+ * Without this the elapsed time would only ever grow, and a message built on it
+ * would eventually be as misleading as no message at all.
+ */
+export function clearSwitchHold(tabId: string): void {
+  holds.delete(tabId);
+}
+
+/** Test seam. */
+export function switchHoldFor(tabId: string): Hold | undefined {
+  return holds.get(tabId);
+}
+
+/** Test seam: drop all state between tests. */
+export function resetSwitchHolds(): void {
+  holds.clear();
+}
+
+/**
+ * How long a switch has been holding, in words, or "" when it is too brief to be
+ * worth saying — which is the common case and must not be cluttered.
+ *
+ * The threshold is deliberately low: the refusal itself claims a switch "normally
+ * clears in well under a second", so anything past a few seconds already
+ * contradicts that claim and is worth surfacing.
+ */
+export function describeSwitchHold(hold: Hold | undefined, now: number = Date.now()): string {
+  if (!hold) return "";
+  const ms = now - hold.since;
+  if (!Number.isFinite(ms) || ms < 3000 || hold.count < 2) return "";
+  const secs = Math.round(ms / 1000);
+  const howLong = secs < 90 ? `${secs}s` : `${Math.round(secs / 60)}m`;
+  return (
+    ` THIS HAS BEEN HELD FOR ${howLong} across ${hold.count} attempts, which is far longer than a ` +
+    `switch takes — treat the canvas as waiting for a person, not as busy. A load dialog, an ` +
+    `unsaved-changes prompt, or a modal on the ComfyUI tab will hold it open indefinitely, and no ` +
+    `number of retries will clear it.`
+  );
+}

--- a/src/orchestrator/switch-hold.ts
+++ b/src/orchestrator/switch-hold.ts
@@ -25,7 +25,11 @@
 interface Hold {
   /** When the FIRST refusal of this run was seen. */
   since: number;
-  /** How many have been seen since — a fast retry loop is worth naming too. */
+  /** How many of those runs have ended in a terminal refusal. One per FAILED
+   *  CALL, not per panel refusal: each call refuses, settles, retries and refuses
+   *  again, so the panel sees roughly twice this (codex review). The message says
+   *  "failed calls" because that is the number this counts and the one a caller
+   *  can compare against what they did. */
   count: number;
 }
 
@@ -107,7 +111,7 @@ export function describeSwitchHold(hold: Hold | undefined, now: number = Date.no
   // user the canvas is "not busy" and that retrying cannot work would be wrong in
   // the one direction that costs them the thing that would have worked.
   return (
-    ` THIS HAS BEEN HELD FOR ${howLong} across ${hold.count} refusals, which is longer than a ` +
+    ` THIS HAS BEEN HELD FOR ${howLong} across ${hold.count} failed calls, which is longer than a ` +
     `switch usually takes. Two things look like this: it may still be loading — a very large ` +
     `graph, a slow disk, a remote canvas — or it may be held open by something on the ComfyUI ` +
     `tab awaiting a person, such as a load dialog or an unsaved-changes prompt. Retrying clears ` +


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#1097.

The panel refuses commands while it is switching the canvas workflow — correctly, so a command cannot land on the wrong graph. The orchestrator retries once and then explains, and its message already hypothesises the stuck case: *"If a switch appears stuck, check the canvas — a load dialog or an unsaved-changes prompt can hold it open awaiting the user."*

What it does not say is **how long**. A switch that has been holding for 200ms and one that has been holding for four minutes produce the identical refusal, so the reporter's "never clears" was invisible to the tool telling them to "simply retry". That is the difference between advice that works and advice that loops.

Draft while I wire the elapsed time through — the orchestrator sees every refusal, so it can time the run of them without the panel changing at all.