### PR TITLE
chore(release): 0.51.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.12] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- say how long the workflow switch has been holding (#1450)
+
+
 ## [0.51.11] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.11",
+  "version": "0.51.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.11",
+      "version": "0.51.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.11",
+  "version": "0.51.12",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.12 tag into protected main.

**0.51.12 — comfyui-mcp-panel#1097**: a workflow switch that never clears stops reading like one that will.

The panel refuses commands while it switches the canvas workflow, and the orchestrator retried once and then said "it normally clears in well under a second, so simply retry". For the reporter it never cleared — a load dialog or unsaved-changes prompt can hold a switch open indefinitely — and every refusal read identically to the momentary case, so nothing was ever in a position to notice the advice was not working.

It now times the run of refusals per tab and, past a few seconds and a second failed call, says how long it has been held, offers both explanations without asserting either, and says which one retrying can fix.

Five codex rounds; four found real defects, including two of mine in opposite directions on when a success may clear the evidence.