### PR TITLE
feat(#1452): add exact per-action tool allowlist

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -277,9 +277,11 @@ available, HTTP polling otherwise).
 ## Restricting the tool surface
 
 For a **hosted** deployment — a shared Open WebUI, a team frontend — the operator is not
-the person prompting. These variables withhold tools from the model entirely: a withheld
-tool is never registered, so it is absent from `tools/list`, absent from `call_tool`, and
-the model never learns it exists.
+the person prompting. The tool preset/allow/deny variables withhold tools from the model
+entirely: a withheld tool is never registered, so it is absent from `tools/list`, absent
+from `call_tool`, and the model never learns it exists. The action allow list is the
+narrower companion for a tool that must remain visible: the tool stays registered, but
+an unlisted action is rejected before its handler runs.
 
 <ParamField path="COMFYUI_MCP_TOOL_PRESET" type="string">
   `safe` — everything except tools that change the machine or the model library.
@@ -306,9 +308,27 @@ the model never learns it exists.
   `ALLOW=list_*` would re-admit `list_packs`, whose `install_deps` action installs and
   runs third-party code, and `ALLOW=*` would make every preset inert.
 </ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_ACTION_ALLOW" type="string">
+  Comma-separated, exact `tool:action` pairs. When set, every tool call carrying an
+  `action` field must match one of these pairs; action-bearing tools omitted from the
+  list cannot dispatch any action. This restricts consolidated tools whose names alone
+  no longer reveal their blast radius—for example, allow queue inspection and targeted
+  cancellation without also allowing queue edits or a global clear:
+
+  `queue:list,queue:status,queue:cancel,enqueue_workflow:enqueue`
+
+  Pair this with `COMFYUI_MCP_TOOL_ALLOW` to bound both dimensions. Rules are exact;
+  wildcards are rejected so a newly-added action cannot become allowed after an upgrade.
+</ParamField>
 
 ```bash A hosted deployment that cannot install or restart anything
 COMFYUI_MCP_TOOL_PRESET=safe npx comfyui-mcp@latest --http --host 0.0.0.0 --port 9100
+```
+
+```bash A generation operator that can inspect, enqueue, and cancel—but not install or clear queues
+COMFYUI_MCP_TOOL_ALLOW=get_system_stats,get_history,create_workflow,enqueue_workflow,queue \
+COMFYUI_MCP_TOOL_ACTION_ALLOW=get_system_stats:stats,get_system_stats:logs,get_system_stats:health,get_history:list,get_history:diagnose,create_workflow:create,create_workflow:modify,create_workflow:validate,create_workflow:node_info,enqueue_workflow:enqueue,queue:list,queue:status,queue:cancel \
+npx comfyui-mcp@latest
 ```
 
 <Warning>

--- a/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
+++ b/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
@@ -146,3 +146,42 @@ describe("panel-tools #754: strict schemas reject unknown argument keys", () => 
     expect(createBlock).toMatch(/strictPanelSchema\(d\.schema\)/);
   });
 });
+
+describe("panel-tools: action policy survives real MCP dispatch", () => {
+  let client: Client;
+  let server: McpServer;
+  const previous = process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+
+  beforeAll(async () => {
+    process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = "panel_canvas:fit";
+    server = new McpServer({ name: "panel-action-policy-test", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "panel-action-policy-test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+    if (previous === undefined) delete process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+    else process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = previous;
+  });
+
+  it("allows an exact pair and rejects another valid action before the handler", async () => {
+    const allowed = await client.callTool({
+      name: "panel_canvas",
+      arguments: { action: "fit" },
+    });
+    expect(allowed.isError).not.toBe(true);
+
+    const denied = await client.callTool({
+      name: "panel_canvas",
+      arguments: { action: "zoom", scale: 1.5 },
+    });
+    expect(denied.isError).toBe(true);
+    expect((denied.content as Array<{ text?: string }>)[0]?.text).toContain(
+      "panel_canvas:zoom",
+    );
+  });
+});

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -113,6 +113,17 @@ describe("panel-secrets (canonical .env store)", () => {
     expect((base as Record<string, string>).CIVITAI_API_TOKEN).toBeUndefined();
   });
 
+  it("forwards even an empty action policy so the child refuses it instead of opening up", () => {
+    const previous = process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+    try {
+      process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = "";
+      expect(buildComfyuiMcpEnv({}).COMFYUI_MCP_TOOL_ACTION_ALLOW).toBe("");
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+      else process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = previous;
+    }
+  });
+
   it("lets a saved secret OVERRIDE a base env default of the same key", () => {
     const base = { CIVITAI_API_TOKEN: "from-process-env" };
     setComfyuiSecret("CIVITAI_API_TOKEN", "from-panel");

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolveToolSurfacePolicy,
+  toolActionAllowed,
   toolAllowed,
   toolMatches,
   TOOL_PRESETS,
@@ -66,6 +67,14 @@ describe("the operator's policy is read from the environment (#873)", () => {
   it("reads deny, allow and a preset", () => {
     expect(resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_DENY: "a, b ,c" }).deny).toEqual(["a", "b", "c"]);
     expect(resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "x" }).allow).toEqual(["x"]);
+    expect(
+      resolveToolSurfacePolicy({
+        COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list, queue:status,queue:list",
+      }).actionAllow,
+    ).toEqual([
+      { tool: "queue", action: "list" },
+      { tool: "queue", action: "status" },
+    ]);
     const preset = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
     expect(preset.preset).toBe("safe");
     // The preset's patterns live in presetDeny, kept apart from an explicit DENY because
@@ -178,7 +187,12 @@ describe("allow wins, and is absolute (#873)", () => {
     // unset expands to "". Reading that as "no rules configured" produces the full
     // surface with no log — the identical failure the unknown-preset throw exists to
     // prevent, reached from a different direction.
-    for (const v of ["COMFYUI_MCP_TOOL_ALLOW", "COMFYUI_MCP_TOOL_DENY", "COMFYUI_MCP_TOOL_PRESET"]) {
+    for (const v of [
+      "COMFYUI_MCP_TOOL_ALLOW",
+      "COMFYUI_MCP_TOOL_DENY",
+      "COMFYUI_MCP_TOOL_PRESET",
+      "COMFYUI_MCP_TOOL_ACTION_ALLOW",
+    ]) {
       expect(() => resolveToolSurfacePolicy({ [v]: "" }), v).toThrow(/set but empty/);
       expect(() => resolveToolSurfacePolicy({ [v]: "  ,  " }), v).toThrow(/Refusing to start|set but empty/);
     }
@@ -191,6 +205,82 @@ describe("allow wins, and is absolute (#873)", () => {
     // Not a full glob — a mid-string wildcard is NOT silently honoured, because a rule
     // that matches more than it reads like is worse than one that matches nothing.
     expect(toolMatches("generate_image", "gen*image")).toBe(false);
+  });
+});
+
+describe("action-level allow lists fail closed", () => {
+  it("requires exact tool:action pairs and rejects wildcard or malformed rules", () => {
+    for (const value of ["queue:*", "queue", ":list", "queue:", "Queue:list", "queue:list:extra"]) {
+      expect(
+        () => resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ACTION_ALLOW: value }),
+        value,
+      ).toThrow(/invalid rule|Refusing to start/);
+    }
+  });
+
+  it("bounds every call that carries an action while leaving ordinary tools alone", () => {
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list,enqueue_workflow:enqueue",
+    });
+    expect(toolActionAllowed("queue", { action: "list" }, p)).toBe(true);
+    expect(toolActionAllowed("queue", { action: "clear" }, p)).toBe(false);
+    expect(toolActionAllowed("enqueue_workflow", { action: "rerun" }, p)).toBe(false);
+    expect(toolActionAllowed("get_system_stats", { action: "stats" }, p)).toBe(false);
+    expect(toolActionAllowed("panel_graph_outline", {}, p)).toBe(true);
+  });
+
+  it("blocks before the registered handler on the direct and catalog registration boundary", async () => {
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list",
+    });
+    let called = 0;
+    let registeredHandler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+    const registrar = {
+      tool: (...args: unknown[]) => {
+        registeredHandler = args[args.length - 1] as typeof registeredHandler;
+        return { name: args[0] };
+      },
+    };
+    const wrapped = withToolSurfaceFilter(registrar, p);
+    wrapped.tool("queue", "queue", {}, async () => {
+      called++;
+      return { content: [{ type: "text", text: "ran" }] };
+    });
+
+    const denied = (await registeredHandler?.({ action: "clear" })) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+    expect(denied.isError).toBe(true);
+    expect(denied.content?.[0]?.text).toContain('queue:clear');
+    expect(called).toBe(0);
+
+    await registeredHandler?.({ action: "list" });
+    expect(called).toBe(1);
+  });
+
+  it("also blocks a denied action in the real compact call_tool catalog", async () => {
+    const previous = process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+    process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = "queue:list";
+    try {
+      const { collectToolCatalog } = await import("../../tools/index.js");
+      const catalog = await collectToolCatalog();
+      const queue = catalog.get("queue");
+      expect(queue).toBeDefined();
+
+      // This would call ComfyUI's destructive queue-clear endpoint if the catalog
+      // route bypassed the wrapper. No fetch mock is installed deliberately: the test
+      // can only pass when policy denial happens before the real handler.
+      const denied = await queue!.handler({ action: "clear" });
+      expect(denied.isError).toBe(true);
+      expect(denied.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("queue:clear"),
+      });
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+      else process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = previous;
+    }
   });
 });
 
@@ -435,6 +525,7 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     const body = src.slice(at, at + 1400);
     expect(body).toContain("resolveToolSurfacePolicy()");
     expect(body).toContain("toolAllowed(d.name, policy)");
+    expect(body).toContain("toolActionPolicyError(d.name, args, policy)");
   });
 
   it("is applied to the OTHER panel registration path as well — createPanelMcpServer", async () => {
@@ -450,9 +541,10 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     const src = codeOnly(await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8"));
     const at = src.indexOf("export function createPanelMcpServer");
     expect(at).toBeGreaterThan(-1);
-    const body = src.slice(at, at + 1800);
+    const body = src.slice(at, at + 2600);
     expect(body).toContain("resolveToolSurfacePolicy()");
     expect(body).toContain("toolAllowed(d.name, policy)");
+    expect(body).toContain("toolActionPolicyError(d.name, args, policy)");
   });
 
   it("the policy reaches the SPAWNED comfyui child through the env builder BOTH lanes share", async () => {
@@ -469,7 +561,12 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     const at = src.indexOf("export function buildComfyuiMcpEnv");
     expect(at).toBeGreaterThan(-1);
     const body = src.slice(at, at + 3200);
-    for (const v of ["COMFYUI_MCP_TOOL_PRESET", "COMFYUI_MCP_TOOL_ALLOW", "COMFYUI_MCP_TOOL_DENY"]) {
+    for (const v of [
+      "COMFYUI_MCP_TOOL_PRESET",
+      "COMFYUI_MCP_TOOL_ALLOW",
+      "COMFYUI_MCP_TOOL_DENY",
+      "COMFYUI_MCP_TOOL_ACTION_ALLOW",
+    ]) {
       // Assert the ASSIGNMENT, not that the name appears somewhere. Checking only for the
       // name passed with the forwarding deleted, because the `process.env.X ?` guard on
       // the line above still mentions X — the test matched the condition and called it

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -229,6 +229,84 @@ describe("action-level allow lists fail closed", () => {
     expect(toolActionAllowed("panel_graph_outline", {}, p)).toBe(true);
   });
 
+  // THE OVER-PERMISSIVE DIRECTION IS THE ONLY ONE THAT MATTERS HERE.
+  //
+  // Every test above this point asserts that an ALLOWED action is allowed and that a
+  // plainly-different one is not. Neither can see the failures that actually ship: a
+  // compare that was loosened to `startsWith`, lowercased "to be forgiving", or split
+  // into two independent `.some()` calls. Each of those keeps every existing assertion
+  // green while widening the allowlist, so the near-misses get their own tests.
+  it("does not admit a near-miss tool or action name", () => {
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list",
+    });
+    expect(toolActionAllowed("queue", { action: "list" }, p)).toBe(true);
+
+    // PREFIX / EXTRA SEGMENT — `startsWith` in either position would pass these.
+    for (const action of ["list_all", "listall", "lis", "list ", " list", "list:extra"]) {
+      expect(toolActionAllowed("queue", { action }, p), `action ${JSON.stringify(action)}`).toBe(
+        false,
+      );
+    }
+    for (const tool of ["queue_admin", "queuex", "que", "my_queue", "enqueue"]) {
+      expect(toolActionAllowed(tool, { action: "list" }, p), `tool ${tool}`).toBe(false);
+    }
+
+    // CASE — the rule grammar rejects an uppercase RULE, but nothing there constrains
+    // the incoming CALL, which is the side an attacker controls.
+    for (const [tool, action] of [
+      ["queue", "LIST"],
+      ["queue", "List"],
+      ["QUEUE", "list"],
+      ["Queue", "List"],
+    ]) {
+      expect(toolActionAllowed(tool, { action }, p), `${tool}:${action}`).toBe(false);
+    }
+  });
+
+  it("does not let two separate rules be recombined into a pair nobody allowed", () => {
+    // The classic allowlist bug: `some(r => r.tool === name) && some(r => r.action === a)`
+    // reads correct, passes every single-rule test, and quietly permits the CROSS product.
+    // Here that would hand an operator who allowed queue INSPECTION a model download, and
+    // an operator who allowed a download the ability to CLEAR someone else's queue.
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list,download_model:download",
+    });
+    expect(toolActionAllowed("queue", { action: "list" }, p)).toBe(true);
+    expect(toolActionAllowed("download_model", { action: "download" }, p)).toBe(true);
+
+    expect(toolActionAllowed("queue", { action: "download" }, p)).toBe(false);
+    expect(toolActionAllowed("download_model", { action: "list" }, p)).toBe(false);
+  });
+
+  it("refuses an action that is present but not a string, instead of waving it through", () => {
+    // The one shape this function cannot classify. Resolving it as "no action here" is
+    // the permissive answer, and permissive is the direction that ships a hole.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list" });
+    for (const action of [["list"], { toString: () => "list" }, 1, true]) {
+      expect(toolActionAllowed("queue", { action }, p), JSON.stringify(action)).toBe(false);
+    }
+    // ABSENT is genuinely not an action call and stays governed by the tool-level policy.
+    expect(toolActionAllowed("queue", {}, p)).toBe(true);
+    expect(toolActionAllowed("queue", { action: undefined }, p)).toBe(true);
+    expect(toolActionAllowed("queue", { action: null }, p)).toBe(true);
+  });
+
+  it("an action list ALONE makes the policy active, or the whole gate is dead code", () => {
+    // `withToolSurfaceFilter` returns the registrar UNWRAPPED when `active` is false, so
+    // an operator who sets only COMFYUI_MCP_TOOL_ACTION_ALLOW would get a server that
+    // logs nothing and enforces nothing. Asserted directly because it is one `||` term
+    // away from being true, and losing it is invisible in every allowed/denied test.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list" });
+    expect(p.active).toBe(true);
+    expect(p.allow).toEqual([]);
+    expect(p.deny).toEqual([]);
+    expect(p.preset).toBeUndefined();
+
+    const registrar = { tool: (...args: unknown[]) => ({ name: args[0] }) };
+    expect(withToolSurfaceFilter(registrar, p)).not.toBe(registrar);
+  });
+
   it("blocks before the registered handler on the direct and catalog registration boundary", async () => {
     const p = resolveToolSurfacePolicy({
       COMFYUI_MCP_TOOL_ACTION_ALLOW: "queue:list",
@@ -276,6 +354,34 @@ describe("action-level allow lists fail closed", () => {
       expect(denied.content[0]).toMatchObject({
         type: "text",
         text: expect.stringContaining("queue:clear"),
+      });
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+      else process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = previous;
+    }
+  });
+
+  it("does not let a PREFIX near-miss through on the real catalog route either", async () => {
+    // `cancel` and `cancel_queued` are both real members of queue's action enum, so this
+    // near-miss survives schema validation and reaches the gate — which the synthetic
+    // names above cannot do. An operator allowing targeted `cancel` (one prompt_id) has
+    // not allowed `cancel_queued`, which drops the ENTIRE pending queue, someone else's
+    // work included. A `startsWith` compare admits it and every other test stays green.
+    const previous = process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;
+    process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW = "queue:cancel";
+    try {
+      const { collectToolCatalog } = await import("../../tools/index.js");
+      const catalog = await collectToolCatalog();
+      const queue = catalog.get("queue");
+      expect(queue).toBeDefined();
+
+      // No fetch mock, deliberately: reaching the handler means reaching ComfyUI, so this
+      // can only pass by being refused first.
+      const denied = await queue!.handler({ action: "cancel_queued" });
+      expect(denied.isError).toBe(true);
+      expect(denied.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("queue:cancel_queued"),
       });
     } finally {
       if (previous === undefined) delete process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26,7 +26,11 @@
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 // #873 — the operator's tool-surface policy also governs the panel surface.
-import { resolveToolSurfacePolicy, toolAllowed } from "../tools/tool-surface-filter.js";
+import {
+  resolveToolSurfacePolicy,
+  toolActionPolicyError,
+  toolAllowed,
+} from "../tools/tool-surface-filter.js";
 import { logger as toolPolicyLogger } from "../utils/logger.js";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
@@ -13509,10 +13513,13 @@ export function createPanelMcpServer(
     }
     return true;
   });
-  if (withheldSdk.length) {
+  if (withheldSdk.length || policy.actionAllow.length) {
     toolPolicyLogger.info(
       `[panel-tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
-        `${withheldSdk.length} panel tool(s) withheld from the in-process server`,
+        `${withheldSdk.length} panel tool(s) withheld from the in-process server` +
+        (policy.actionAllow.length
+          ? `; ${policy.actionAllow.length} exact tool action(s) allowed`
+          : ""),
     );
   }
   // The Anthropic SDK's tool() accepts (name, description, zodRawShape, cb). The
@@ -13534,7 +13541,8 @@ export function createPanelMcpServer(
       // rejected). The cast documents that the type is being widened past what
       // TS can express here, not past what the SDK actually accepts.
       strictPanelSchema(d.schema) as unknown as typeof d.schema,
-      (args: Record<string, unknown>) => d.handler(args, ctx),
+      async (args: Record<string, unknown>) =>
+        toolActionPolicyError(d.name, args, policy) ?? (await d.handler(args, ctx)),
     ),
   ) as unknown as SdkTool[];
   const server = createSdkMcpServer({
@@ -13582,19 +13590,24 @@ export function registerPanelTools(server: McpServer, ctx: PanelToolCtx): void {
         inputSchema: strictPanelSchema(d.schema),
       },
       (async (args: Record<string, unknown>) => {
+        const policyError = toolActionPolicyError(d.name, args, policy);
+        if (policyError) return policyError as never;
         const res = await d.handler(args ?? {}, ctx);
         // ToolResult is already the MCP CallToolResult shape (content[] + isError).
         return res as never;
       }) as never,
     );
   }
-  if (withheld.length) {
+  if (withheld.length || policy.actionAllow.length) {
     // Logged for the OPERATOR, never surfaced to the model — the point is that it does
     // not learn these exist. Silence here is how a policy that withholds the whole panel
     // becomes an afternoon of "why can't it see my canvas".
     toolPolicyLogger.info(
       `[panel-tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
-        `${withheld.length} panel tool(s) withheld`,
+        `${withheld.length} panel tool(s) withheld` +
+        (policy.actionAllow.length
+          ? `; ${policy.actionAllow.length} exact tool action(s) allowed`
+          : ""),
     );
   }
 }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -2282,6 +2282,9 @@ export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string,
     ...(process.env.COMFYUI_MCP_TOOL_DENY
       ? { COMFYUI_MCP_TOOL_DENY: process.env.COMFYUI_MCP_TOOL_DENY }
       : {}),
+    ...(process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW !== undefined
+      ? { COMFYUI_MCP_TOOL_ACTION_ALLOW: process.env.COMFYUI_MCP_TOOL_ACTION_ALLOW }
+      : {}),
     // KEY NAMES only — never values.
     ...(managed.length ? { [MANAGED_SECRET_KEYS_ENV]: managed.join(",") } : {}),
     ...secrets,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -177,7 +177,10 @@ export async function registerAllTools(server: McpServer): Promise<void> {
     logger.info(
       `[tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
         `${filtered.length} tool(s) withheld` +
-        (filtered.length ? `: ${filtered.slice(0, 12).join(", ")}${filtered.length > 12 ? ", …" : ""}` : ""),
+        (filtered.length ? `: ${filtered.slice(0, 12).join(", ")}${filtered.length > 12 ? ", …" : ""}` : "") +
+        (policy.actionAllow.length
+          ? `; ${policy.actionAllow.length} exact tool action(s) allowed`
+          : ""),
     );
   }
 }

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -245,10 +245,21 @@ export interface ToolSurfacePolicy {
   deny: string[];
   /** The preset's deny patterns, if a preset was named. */
   presetDeny: string[];
+  /**
+   * Exact `tool:action` pairs permitted when action-level restriction is active.
+   * An empty list means action-level restriction is inactive. When non-empty,
+   * every call carrying a string `action` must match one of these pairs.
+   */
+  actionAllow: ToolActionRule[];
   /** True when the operator configured anything at all. */
   active: boolean;
   /** The preset name, when one was named — for disclosure in logs. */
   preset?: string;
+}
+
+export interface ToolActionRule {
+  tool: string;
+  action: string;
 }
 
 /**
@@ -276,6 +287,35 @@ function splitList(raw: string | undefined, varName: string): string[] {
     );
   }
   return items;
+}
+
+/**
+ * Parse a fail-closed action allow list.
+ *
+ * Rules are exact `tool:action` pairs. Globs are deliberately unsupported: allowing
+ * `queue:*` would silently admit a newly-added destructive action after an upgrade,
+ * which is exactly the release-drift problem an allow list is meant to prevent.
+ */
+function splitActionAllow(raw: string | undefined): ToolActionRule[] {
+  const items = splitList(raw, "COMFYUI_MCP_TOOL_ACTION_ALLOW");
+  const rules: ToolActionRule[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const match = /^([a-z_][a-z0-9_]*):([a-z_][a-z0-9_]*)$/.exec(item);
+    if (!match) {
+      throw new Error(
+        `COMFYUI_MCP_TOOL_ACTION_ALLOW contains invalid rule "${item}". ` +
+          `Expected exact tool:action pairs such as "queue:list"; wildcards and empty ` +
+          `names are not allowed. Refusing to start because ignoring a malformed rule ` +
+          `could expose an action the operator meant to withhold.`,
+      );
+    }
+    const key = `${match[1]}:${match[2]}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rules.push({ tool: match[1], action: match[2] });
+  }
+  return rules;
 }
 
 /**
@@ -310,6 +350,7 @@ export function toolMatches(name: string, pattern: string): boolean {
 export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): ToolSurfacePolicy {
   const allow = splitList(env.COMFYUI_MCP_TOOL_ALLOW, "COMFYUI_MCP_TOOL_ALLOW");
   const denyRaw = splitList(env.COMFYUI_MCP_TOOL_DENY, "COMFYUI_MCP_TOOL_DENY");
+  const actionAllow = splitActionAllow(env.COMFYUI_MCP_TOOL_ACTION_ALLOW);
   const presetName = (env.COMFYUI_MCP_TOOL_PRESET ?? "").trim();
   if (env.COMFYUI_MCP_TOOL_PRESET !== undefined && presetName === "") {
     throw new Error(
@@ -333,8 +374,56 @@ export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): 
     allow,
     deny: denyRaw,
     presetDeny: preset ?? [],
-    active: allow.length > 0 || denyRaw.length > 0 || preset !== undefined,
+    actionAllow,
+    active:
+      allow.length > 0 ||
+      denyRaw.length > 0 ||
+      actionAllow.length > 0 ||
+      preset !== undefined,
     ...(preset ? { preset: presetName } : {}),
+  };
+}
+
+/**
+ * Decide whether one parsed tool invocation may dispatch.
+ *
+ * The policy is absolute for calls that carry `action`: once configured, an action on
+ * ANY tool must be named. Calls without an action field are unchanged and remain governed
+ * by the tool-level surface policy. This makes a partial list fail closed: forgetting
+ * `enqueue_workflow:rerun` disables reruns instead of leaving every rerun variant open.
+ */
+export function toolActionAllowed(
+  name: string,
+  args: unknown,
+  policy: ToolSurfacePolicy,
+): boolean {
+  if (policy.actionAllow.length === 0) return true;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return true;
+  const action = (args as Record<string, unknown>).action;
+  if (typeof action !== "string") return true;
+  return policy.actionAllow.some((rule) => rule.tool === name && rule.action === action);
+}
+
+export function toolActionPolicyError(
+  name: string,
+  args: unknown,
+  policy: ToolSurfacePolicy,
+): { content: Array<{ type: "text"; text: string }>; isError: true } | undefined {
+  if (toolActionAllowed(name, args, policy)) return undefined;
+  const action =
+    args && typeof args === "object"
+      ? String((args as Record<string, unknown>).action)
+      : "unknown";
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `Action "${name}:${action}" is withheld by ` +
+          "COMFYUI_MCP_TOOL_ACTION_ALLOW.",
+      },
+    ],
+    isError: true,
   };
 }
 
@@ -412,6 +501,15 @@ export function withToolSurfaceFilter<T extends object>(
       // Registration is skipped entirely. The SDK's `tool()` returns a handle some
       // callers chain on, so hand back something inert rather than undefined.
       return { name, disabled: true } as unknown;
+    }
+    const handler = args[args.length - 1];
+    if (name && typeof handler === "function" && policy.actionAllow.length > 0) {
+      const wrapped = async (...handlerArgs: unknown[]) => {
+        const policyError = toolActionPolicyError(name, handlerArgs[0], policy);
+        if (policyError) return policyError;
+        return await (handler as (...handlerArgs: unknown[]) => unknown)(...handlerArgs);
+      };
+      return orig(...args.slice(0, -1), wrapped);
     }
     return orig(...args);
   };

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -400,7 +400,25 @@ export function toolActionAllowed(
   if (policy.actionAllow.length === 0) return true;
   if (!args || typeof args !== "object" || Array.isArray(args)) return true;
   const action = (args as Record<string, unknown>).action;
-  if (typeof action !== "string") return true;
+  // ABSENT is not an action call. Those stay governed by the tool-level surface policy,
+  // which is the documented composition: bound the tools with ALLOW/PRESET, bound the
+  // actions with this list.
+  if (action === undefined || action === null) return true;
+  // PRESENT BUT NOT A STRING IS REFUSED, not waved through. Every one of the 34 live
+  // `action` fields is a REQUIRED `z.enum([...])` and both dispatch routes validate
+  // before the handler runs (the SDK on the direct route, an explicit safeParse in
+  // compact.ts), so nothing real reaches here with a non-string action — which is
+  // exactly why the branch has to be decided rather than defaulted. "Not a string" was
+  // returning ALLOWED, so the one shape this function cannot classify was resolved in
+  // the permissive direction, and it would stay that way if a future tool ever widened
+  // an action field or a caller reused this helper somewhere the schema is looser. An
+  // unclassifiable call is not an allowed call.
+  if (typeof action !== "string") return false;
+  // EXACT on BOTH halves, and both halves of the SAME rule. Matching `tool` against one
+  // rule and `action` against another would let `ALLOW=queue:list,download_model:download`
+  // admit `queue:download`; a prefix or case-insensitive compare would let `list_all`,
+  // `LIST` or `queue_admin` through. See the over-permissive tests, which are the only
+  // thing that can see any of those.
   return policy.actionAllow.some((rule) => rule.tool === name && rule.action === action);
 }
 


### PR DESCRIPTION
Refs #1452

> **Maintainer note — this is a FEATURE, and the repo is under a feature freeze (bug/stability only).**
> It is parked here in a reviewable state rather than queued for merge. Nothing below is a request to land it.

## What changed

- Add `COMFYUI_MCP_TOOL_ACTION_ALLOW` as an exact comma-separated `tool:action` allowlist.
- Reject malformed, empty, or wildcard rules at startup.
- Enforce the policy before handlers run across:
  - direct MCP tool registration
  - the compact `call_tool` catalog
  - the Claude in-process panel server
  - the Codex HTTP panel server
- Forward the policy to spawned ComfyUI MCP children, including an explicitly empty value so the child fails closed.
- Document how tool-level and action-level policy compose.

## Why

#873 / #1383 made tool names enforceable, but consolidated tools mix actions with very different blast radii. An operator currently cannot allow `queue:list` and targeted `queue:cancel` without also exposing `queue:edit` and global `queue:clear`.

The allowlist is exact and intentionally has no wildcard support. New actions introduced by a future release therefore remain denied until the operator names them explicitly.

Calls without an `action` field are unchanged and remain governed by the existing tool-level preset/allow/deny policy.

## Reachability

An allowlist that is implemented but never consulted is the failure mode worth checking before any other, so each route was pinned:

| Route | How it is reached | Evidence |
| --- | --- | --- |
| direct MCP registration | `registerAllTools` → `withToolSurfaceFilter` wraps `server.tool`, gating the handler | source assertion on the install line + handler-boundary test |
| compact `call_tool` | `collectToolCatalog` wraps `catalog.asRegistrar()`, so the catalog stores the *wrapped* handler that `call_tool` dispatches | real `collectToolCatalog()` dispatch, no fetch mock — reaching the handler would mean reaching ComfyUI |
| Codex HTTP panel | `registerPanelTools` calls `toolActionPolicyError` before the handler | real `McpServer` + `Client` over `InMemoryTransport` |
| Claude in-process panel | `createPanelMcpServer`, same | source assertion |

Default-deny holds: once `COMFYUI_MCP_TOOL_ACTION_ALLOW` is set, a call carrying a string `action` is refused unless a rule names that exact `tool:action`. A tool with no rule at all can dispatch no action.

## Over-permissive cases now covered

The direction that ships a hole is "permits more than intended", and a test that only proves the allowed action is allowed cannot see any of it. Added:

- **Prefix / extra segment** — `queue:list` must not admit `list_all`, `listall`, `lis`, `list:extra`, nor tools `queue_admin`, `queuex`, `my_queue`, `enqueue`.
- **Prefix near-miss on the real dispatch route** — `queue:cancel` must not admit `cancel_queued`. Both are genuine members of queue's action enum, so unlike a synthetic name this one survives schema validation and actually reaches the gate — and `cancel_queued` drops the entire pending queue, someone else's work included.
- **Case** — the rule grammar already rejects an uppercase *rule*, but nothing constrained the incoming *call*, which is the side a caller controls: `QUEUE:list`, `queue:LIST`, `Queue:List` are refused.
- **Cross-product** — `queue:list,download_model:download` must not admit `queue:download` or `download_model:list`. This is the classic allowlist bug (`some(tool) && some(action)`); it reads correct and passes every single-rule test.
- **Whitespace** — `" list"` / `"list "` are not `list`.
- **Policy activation** — an action list *alone* must make the policy active, or `withToolSurfaceFilter` returns the registrar unwrapped and the entire gate is dead code.

One behaviour was tightened rather than left defaulted: an `action` that is **present but not a string** was returning *allowed*, resolving the one shape the gate cannot classify in the permissive direction. It now refuses. An absent or `null` action is still allowed, since that is not an action call. All 34 live `action` fields are required `z.enum([...])` and both dispatch routes validate before the handler runs, so nothing real reaches that branch today — which is exactly why it needed deciding instead of defaulting.

## Validation

Re-run on Windows against current `main`:

- `origin/main` merged into the branch; no conflicts.
- `npm run lint` (tsc --noEmit) clean.
- `npm run check:vocabulary` and `npm run check:unknown-collapse` clean.
- Focused suites green: `tool-surface-filter`, `panel-tools-strict-schema`, `panel-secrets` — 200/200.
- **Mutation-tested**, because these tests are worth exactly what they can kill. Six widening mutations, six killed, **zero survivors**: prefix compare, case-insensitive compare, cross-product compare, non-string waved through, the action list no longer activating the policy, and the gate never installed on the registrar.
- Doc example audited against the live enums — every `tool:action` pair in it is real (`get_system_stats:stats|logs|health`, `get_history:list|diagnose`, `create_workflow:create|modify|validate|node_info`, `enqueue_workflow:enqueue`, `queue:list|status|cancel`). A wrong pair there would hand an operator a config that silently withholds something they meant to allow.

Full suite: **9,444 passed / 21 failed** across 12 files. Every one of the 21 is `Test timed out in 30000ms`, on a host that was running ~280 concurrent node processes (the run reported 4,019s transform and 9,710s import against 691s wall). All of them pass in isolation:

- `tool-surface-filter`, `vocabulary`, `vocabulary-handshake` — 320/320.
- `ui-bridge > names the versioned panel-sync remedy (#706)` — **91ms** isolated, and that file contains no reference to `tool-surface-filter`, `toolActionAllowed`, or `COMFYUI_MCP_TOOL_ACTION_ALLOW`.

No failure is attributable to this branch. Stating the limit of that claim plainly: the reason they are unrelated is machine load, so this is evidence about this host, not a green CI run. No CI checks are currently reported on this branch.

## Reviewer notes

- A refused action returns an error naming `COMFYUI_MCP_TOOL_ACTION_ALLOW`, so the model learns the mechanism exists. That is a deliberate departure from the #873 tool-level design, where a denied tool is *absent* so the model never learns of it — and it is unavoidable here, since the tool must stay registered for its allowed actions. Worth a conscious ruling rather than inheriting by accident.
- Setting only `COMFYUI_MCP_TOOL_ACTION_ALLOW` leaves every action-free tool fully reachable. The docs say to pair it with `COMFYUI_MCP_TOOL_ALLOW`, which is correct, but an operator who reads the variable name as a lockdown would be wrong.
