### PR TITLE
fix(236): compare the panel's tool vocabulary at the handshake, not at call time

### DIFF
--- a/scripts/export-vocabulary.mts
+++ b/scripts/export-vocabulary.mts
@@ -54,7 +54,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { computeVocabularyHash, DEAD_NAMES, MAX_TOOLS, TOOL_NAMES } from "../src/tools/vocabulary.js";
+import { assembleVocabularyHash, DEAD_NAMES, MAX_TOOLS, TOOL_NAMES } from "../src/tools/vocabulary.js";
 import { CALL_TOOL_WHITELIST } from "../src/orchestrator/call-tool-admission.js";
 import { buildPanelToolDefs } from "../src/orchestrator/panel-tools.js";
 
@@ -88,15 +88,13 @@ const dead = DEAD_NAMES.map((d) => ({ name: d.name, since: d.since, replacement:
 
 /** Identifies the VOCABULARY, not the build that produced it.
  *
- *  Computed by computeVocabularyHash() in src/tools/vocabulary.ts rather than
+ *  Computed by assembleVocabularyHash() in src/tools/vocabulary.ts rather than
  *  inline here, because the RUNTIME handshake compares against this value. Two
  *  copies of the rule would drift, and a drifted hash reports a mismatch that is
- *  not real — which is worse than having no check at all. */
-const vocabularyHash = computeVocabularyHash({
-  core,
-  panel: panelSorted,
-  dead: dead.map((d) => d.name),
-});
+ *  not real — which is worse than having no check at all. That applies to the
+ *  INPUT as much as to the digest, so the core/panel-sorted/dead assembly moved
+ *  in there with it; this file no longer decides what gets hashed (#236). */
+const vocabularyHash = assembleVocabularyHash(panel);
 
 const artefact = {
   $comment:

--- a/src/__tests__/tools/vocabulary-handshake.test.ts
+++ b/src/__tests__/tools/vocabulary-handshake.test.ts
@@ -154,7 +154,10 @@ describe("#236 the handshake is wired, not just implemented", () => {
     const start = ORCH.indexOf("// #236 — THE VOCABULARY HANDSHAKE");
     expect(start).toBeGreaterThan(-1);
     const block = ORCH.slice(start, start + 2400);
-    expect(block).toMatch(/if \(skew\.status === "mismatch"\)/);
+    // Matched as a PROPERTY: the gate tests for "mismatch" exactly. Pinning the whole
+    // `if (...)` broke when a dedup clause was added to the same condition — a real
+    // refactor, not a behaviour change.
+    expect(block).toMatch(/skew\.status === "mismatch"/);
     expect(block).not.toMatch(/status !== "match"/);
   });
 
@@ -186,45 +189,65 @@ describe("#236 the runtime hash agrees with the artefact the panel vendors", () 
   });
 });
 
-describe("#236 the dedup map is bounded", () => {
+describe("#236 the report is deduped by VOCABULARY, not by tab", () => {
   const ORCH = readFileSync(join(HERE, "../../orchestrator/index.ts"), "utf8");
 
-  it("evicts rather than growing for every tab id ever seen (codex review, P2)", () => {
-    // Tab ids are minted continually — every tmp: connection and every workflow
-    // switch produces a new one — so an uncapped module-level Map keyed by tab id
-    // retains an entry per tab forever, including long-disconnected ones.
-    expect(ORCH).toMatch(/MAX_LOGGED_VOCABULARY_SKEW = \d+/);
-    const start = ORCH.indexOf("loggedVocabularySkew.set(panelTab");
-    expect(start).toBeGreaterThan(-1);
-    const before = ORCH.slice(Math.max(0, start - 600), start);
-    expect(before).toMatch(/loggedVocabularySkew\.size >= MAX_LOGGED_VOCABULARY_SKEW/);
-    expect(before).toMatch(/loggedVocabularySkew\.delete\(oldest\)/);
+  it("keys on the hash so a reused wf: id cannot suppress a real mismatch", () => {
+    // Codex round 2, P2: with a per-tab key, a tab that warned and then closed left an
+    // entry that silenced the NEXT tab opening the same workflow — wf: ids are reused.
+    expect(ORCH).toMatch(/const loggedVocabularySkew = new Set<string>\(\);/);
+    expect(ORCH).toMatch(/loggedVocabularySkew\.has\(advertised!\)/);
+    // No tab id may be involved in the dedup decision at all.
+    expect(ORCH).not.toMatch(/loggedVocabularySkew\.(get|set)\(panelTab/);
+    expect(ORCH).not.toMatch(/loggedVocabularySkew\.delete\(panelTab\)/);
   });
 
-  it("eviction can only DUPLICATE a warning, never suppress one", () => {
-    // The safety argument, asserted so it cannot be quietly inverted into an
-    // eviction that drops mismatches instead of dedup entries.
-    const map = new Map<string, string>();
+  it("is bounded, and eviction can only DUPLICATE a report, never suppress one", () => {
+    expect(ORCH).toMatch(/MAX_LOGGED_VOCABULARY_SKEW = \d+/);
+    const at = ORCH.indexOf("loggedVocabularySkew.add(advertised!)");
+    expect(at).toBeGreaterThan(-1);
+    const before = ORCH.slice(Math.max(0, at - 600), at);
+    expect(before).toMatch(/loggedVocabularySkew\.size >= MAX_LOGGED_VOCABULARY_SKEW/);
+
+    // The safety argument, executed rather than asserted about, so it cannot be
+    // quietly inverted into an eviction that drops mismatches instead of entries.
+    const seen = new Set<string>();
     const CAP = 3;
-    const warned: string[] = [];
-    const seen = (tab: string, hash: string) => {
-      if (map.get(tab) === hash) return;
-      while (map.size >= CAP) {
-        const oldest = map.keys().next().value;
+    const reported: string[] = [];
+    const hello = (hash: string) => {
+      if (seen.has(hash)) return;
+      while (seen.size >= CAP) {
+        const oldest = seen.values().next().value;
         if (oldest === undefined) break;
-        map.delete(oldest);
+        seen.delete(oldest);
       }
-      map.set(tab, hash);
-      warned.push(tab);
+      seen.add(hash);
+      reported.push(hash);
     };
-    seen("a", "h1");
-    seen("a", "h1"); // deduped
-    expect(warned).toEqual(["a"]);
-    seen("b", "h1");
-    seen("c", "h1");
-    seen("d", "h1"); // evicts "a"
-    seen("a", "h1"); // "a" warns AGAIN — a duplicate, which is the safe direction
-    expect(warned).toEqual(["a", "b", "c", "d", "a"]);
-    expect(map.size).toBeLessThanOrEqual(CAP);
+    hello("h1");
+    hello("h1"); // same build, same news
+    expect(reported).toEqual(["h1"]);
+    hello("h2");
+    hello("h3");
+    hello("h4"); // evicts h1
+    hello("h1"); // reported AGAIN — a duplicate, which is the safe direction
+    expect(reported).toEqual(["h1", "h2", "h3", "h4", "h1"]);
+    expect(seen.size).toBeLessThanOrEqual(CAP);
+  });
+
+  it("two tabs sharing a reused workflow id both get the truth", () => {
+    // The concrete round-2 scenario, as behaviour: tab A (wf:123) warns and closes;
+    // tab B opens the same workflow with the same disagreeing build. Under the old
+    // per-tab key B was silenced by A's leftover entry. Keyed by hash, the question
+    // "have we said this yet" no longer depends on which tab is asking.
+    const seen = new Set<string>();
+    const report = (_tab: string, hash: string) => {
+      if (seen.has(hash)) return false;
+      seen.add(hash);
+      return true;
+    };
+    expect(report("wf:123", "H")).toBe(true); // tab A
+    expect(report("wf:123", "H")).toBe(false); // tab B — same build, already said
+    expect(report("wf:123", "H2")).toBe(true); // B updated to a DIFFERENT bad build
   });
 });

--- a/src/__tests__/tools/vocabulary-handshake.test.ts
+++ b/src/__tests__/tools/vocabulary-handshake.test.ts
@@ -185,3 +185,46 @@ describe("#236 the runtime hash agrees with the artefact the panel vendors", () 
     );
   });
 });
+
+describe("#236 the dedup map is bounded", () => {
+  const ORCH = readFileSync(join(HERE, "../../orchestrator/index.ts"), "utf8");
+
+  it("evicts rather than growing for every tab id ever seen (codex review, P2)", () => {
+    // Tab ids are minted continually — every tmp: connection and every workflow
+    // switch produces a new one — so an uncapped module-level Map keyed by tab id
+    // retains an entry per tab forever, including long-disconnected ones.
+    expect(ORCH).toMatch(/MAX_LOGGED_VOCABULARY_SKEW = \d+/);
+    const start = ORCH.indexOf("loggedVocabularySkew.set(panelTab");
+    expect(start).toBeGreaterThan(-1);
+    const before = ORCH.slice(Math.max(0, start - 600), start);
+    expect(before).toMatch(/loggedVocabularySkew\.size >= MAX_LOGGED_VOCABULARY_SKEW/);
+    expect(before).toMatch(/loggedVocabularySkew\.delete\(oldest\)/);
+  });
+
+  it("eviction can only DUPLICATE a warning, never suppress one", () => {
+    // The safety argument, asserted so it cannot be quietly inverted into an
+    // eviction that drops mismatches instead of dedup entries.
+    const map = new Map<string, string>();
+    const CAP = 3;
+    const warned: string[] = [];
+    const seen = (tab: string, hash: string) => {
+      if (map.get(tab) === hash) return;
+      while (map.size >= CAP) {
+        const oldest = map.keys().next().value;
+        if (oldest === undefined) break;
+        map.delete(oldest);
+      }
+      map.set(tab, hash);
+      warned.push(tab);
+    };
+    seen("a", "h1");
+    seen("a", "h1"); // deduped
+    expect(warned).toEqual(["a"]);
+    seen("b", "h1");
+    seen("c", "h1");
+    seen("d", "h1"); // evicts "a"
+    seen("a", "h1"); // "a" warns AGAIN — a duplicate, which is the safe direction
+    expect(warned).toEqual(["a", "b", "c", "d", "a"]);
+    expect(map.size).toBeLessThanOrEqual(CAP);
+  });
+});

--- a/src/__tests__/tools/vocabulary-handshake.test.ts
+++ b/src/__tests__/tools/vocabulary-handshake.test.ts
@@ -8,6 +8,9 @@
 // boundary. The skew then surfaces at CALL time as "unknown tool".
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   computeVocabularyHash,
   describeVocabularySkew,
@@ -100,5 +103,85 @@ describe("describeVocabularySkew", () => {
   it("explains that a resulting 'unknown tool' is the skew, not a broken panel", () => {
     const r = describeVocabularySkew(HASH, "ab".repeat(32));
     expect(r.status === "mismatch" && r.message).toMatch(/unknown tool/i);
+  });
+});
+
+
+// ===========================================================================
+// #236 — IS THE HANDSHAKE ACTUALLY PERFORMED?
+//
+// Everything above this line passed for months while the check did not exist.
+// `describeVocabularySkew` was called by nothing but these tests; the bridge
+// stored the panel's advertised hash on every hello under a comment promising
+// the comparison, and no code ever read the field. Green tests proved the
+// function WORKED. They could not, and did not, prove it RAN.
+//
+// So these assert reachability, which is the property that was actually missing.
+// ===========================================================================
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("#236 the handshake is wired, not just implemented", () => {
+  const ORCH = readFileSync(join(HERE, "../../orchestrator/index.ts"), "utf8");
+
+  it("the orchestrator's hello handler CALLS describeVocabularySkew", () => {
+    // A source assertion because the call sits inside the hello handler of a large
+    // side-effectful module — there is no seam to import and no return value to
+    // observe. Deleting the call is the mutation this exists to kill; behavioural
+    // tests of the describer cannot see it, which is exactly how it went missing.
+    expect(ORCH).toMatch(/import \{ assembleVocabularyHash, describeVocabularySkew \}/);
+    // Asserted as a PROPERTY — the call exists and is fed THIS server's hash — not
+    // as an exact expression. A control mutation that only reworded the argument
+    // (`serverVocabularyHash() + ""`) killed the strict form, which is a test that
+    // punishes rewording rather than protecting behaviour.
+    expect(ORCH).toMatch(/describeVocabularySkew\([\s\S]{0,160}serverVocabularyHash\(\)/);
+    // It must read the hash off THIS hello, not from anywhere it could go stale.
+    expect(ORCH).toMatch(/\(event as \{ vocabulary_hash\?: unknown \}\)\.vocabulary_hash/);
+  });
+
+  it("the check runs on the hello path, not lazily at first tool call", () => {
+    // "Detected at connection time" is the entire ask in #236. A comparison that
+    // happened on first USE would be the call-time surfacing the issue reported.
+    const hello = ORCH.slice(ORCH.indexOf("const helloPanelVer"));
+    const idx = hello.indexOf("describeVocabularySkew(");
+    expect(idx).toBeGreaterThan(-1);
+    expect(idx).toBeLessThan(4000); // same handler, not elsewhere in the file
+  });
+
+  it("only a MISMATCH warns — unknown and match stay silent", () => {
+    // The three-state discipline at the CALL SITE, not just in the describer:
+    // warning on `unknown` would fire at every user on a panel predating the
+    // handshake, whose vocabulary is very likely fine.
+    const start = ORCH.indexOf("// #236 — THE VOCABULARY HANDSHAKE");
+    expect(start).toBeGreaterThan(-1);
+    const block = ORCH.slice(start, start + 2400);
+    expect(block).toMatch(/if \(skew\.status === "mismatch"\)/);
+    expect(block).not.toMatch(/status !== "match"/);
+  });
+
+  it("the bridge no longer stores a hash nobody reads", () => {
+    const BRIDGE = readFileSync(join(HERE, "../../services/ui-bridge.ts"), "utf8");
+    // The dead field is gone WITH the comment that claimed it was compared. A false
+    // comment outlives the code it describes and costs the next reader the same
+    // investigation it cost this one.
+    expect(BRIDGE).not.toMatch(/panelVocabularyHash/);
+    expect(BRIDGE).not.toMatch(/detected at the handshake instead of at call time/);
+  });
+});
+
+describe("#236 the runtime hash agrees with the artefact the panel vendors", () => {
+  it("assembleVocabularyHash over the LIVE panel defs equals the exported hash", async () => {
+    // The decisive anti-drift check, and the reason the assembly moved into
+    // vocabulary.ts. If the runtime assembled its own copy of "core + panel sorted
+    // + dead", it would agree with the artefact right until one side changed — and
+    // then report a mismatch that is not real, which the module doc calls worse than
+    // having no check at all. This compares the two for real.
+    const { assembleVocabularyHash } = await import("../../tools/vocabulary.js");
+    const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+    const artefact = JSON.parse(
+      readFileSync(join(HERE, "../../../docs/design/tool-vocabulary.json"), "utf8"),
+    ) as { vocabularyHash: string };
+    expect(assembleVocabularyHash(buildPanelToolDefs().map((d) => d.name))).toBe(
+      artefact.vocabularyHash,
+    );
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -72,6 +72,17 @@ import { buildPanelToolDefs } from "./panel-tools.js";
  *  vocabulary is reported again — that is new information, not a repeat. */
 const loggedVocabularySkew = new Map<string, string>();
 
+/** Cap on the map above (codex review, P2). Tab ids are minted continually — every
+ *  `tmp:` connection and every workflow switch produces a new one — and a long-lived
+ *  server would otherwise retain one entry per tab that ever reported a skew, forever,
+ *  including tabs that disconnected hours ago.
+ *
+ *  Evicting the OLDEST is safe in the direction that matters: the only consequence of
+ *  dropping an entry is that a still-connected tab's unchanged mismatch gets logged a
+ *  second time. It can never SUPPRESS a warning, because entries only ever suppress.
+ *  A duplicated log line is the correct thing to risk here; a missed one is not. */
+const MAX_LOGGED_VOCABULARY_SKEW = 200;
+
 /** This server's vocabulary hash, computed once.
  *
  *  Memoised because it cannot change without a restart (the tool surface is fixed at
@@ -3453,6 +3464,13 @@ export async function runPanelOrchestrator(): Promise<void> {
         // a panel that UPDATES to a different (still disagreeing) vocabulary is.
         if (skew.status === "mismatch") {
           if (loggedVocabularySkew.get(panelTab) !== advertised) {
+            // Insertion-ordered, so the first key is the oldest. Evicted BEFORE the
+            // insert so the cap is a real bound rather than a bound-plus-one.
+            while (loggedVocabularySkew.size >= MAX_LOGGED_VOCABULARY_SKEW) {
+              const oldest = loggedVocabularySkew.keys().next().value;
+              if (oldest === undefined) break;
+              loggedVocabularySkew.delete(oldest);
+            }
             loggedVocabularySkew.set(panelTab, advertised!);
             logger.warn(`[panel-orchestrator] ${skew.message}`);
           }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -66,22 +66,29 @@ import { logger } from "../utils/logger.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
 
-/** Tab id → the panel vocabulary hash whose MISMATCH has already been logged (#236),
- *  so a reconnect loop does not repeat the same warning every few seconds. Keyed by
- *  the HASH, not just the tab, so a panel that updates to a DIFFERENT disagreeing
- *  vocabulary is reported again — that is new information, not a repeat. */
-const loggedVocabularySkew = new Map<string, string>();
-
-/** Cap on the map above (codex review, P2). Tab ids are minted continually — every
- *  `tmp:` connection and every workflow switch produces a new one — and a long-lived
- *  server would otherwise retain one entry per tab that ever reported a skew, forever,
- *  including tabs that disconnected hours ago.
+/** The panel vocabulary hashes whose MISMATCH has already been reported (#236).
  *
- *  Evicting the OLDEST is safe in the direction that matters: the only consequence of
- *  dropping an entry is that a still-connected tab's unchanged mismatch gets logged a
- *  second time. It can never SUPPRESS a warning, because entries only ever suppress.
- *  A duplicated log line is the correct thing to risk here; a missed one is not. */
-const MAX_LOGGED_VOCABULARY_SKEW = 200;
+ *  Keyed by the HASH ALONE, not by tab. Codex round 2 found that a per-tab key lets a
+ *  stale entry suppress a real mismatch: `wf:` ids are reused, so a tab that closes
+ *  after warning leaves an entry that silences the NEXT tab opening the same workflow.
+ *
+ *  Keying by hash is not a patch for that, it is the correct granularity. The fact
+ *  being reported — "the vocabulary this panel build vendored disagrees with this
+ *  server's" — is a property of the panel BUILD, not of a tab or a workflow. Saying it
+ *  once per distinct disagreeing vocabulary is exactly the news there is; saying it
+ *  once per tab was always repeating one fact under different labels.
+ *
+ *  It also bounds itself: a process sees one or two panel builds, so the set holds one
+ *  or two entries where the per-tab map grew with every id ever minted. */
+const loggedVocabularySkew = new Set<string>();
+
+/** A cap anyway (codex round 1, P2). Nothing legitimate mints hashes — a panel
+ *  advertises one per build — but this reads a value off the wire, and a broken or
+ *  hand-modified panel that sent a fresh hash every hello would otherwise grow the set
+ *  without limit. Oldest-first eviction, and the direction stays safe: an evicted entry
+ *  can only cause a mismatch to be reported a SECOND time, never suppress one, because
+ *  entries only ever suppress. */
+const MAX_LOGGED_VOCABULARY_SKEW = 64;
 
 /** This server's vocabulary hash, computed once.
  *
@@ -3459,28 +3466,26 @@ export async function runPanelOrchestrator(): Promise<void> {
           advertised,
           typeof helloPanelVer === "string" ? helloPanelVer : undefined,
         );
-        // Logged once per DISTINCT advertised hash per tab. A reconnect ping-pong
-        // repeats the same hello every few seconds and the same skew is not new news;
-        // a panel that UPDATES to a different (still disagreeing) vocabulary is.
-        if (skew.status === "mismatch") {
-          if (loggedVocabularySkew.get(panelTab) !== advertised) {
-            // Insertion-ordered, so the first key is the oldest. Evicted BEFORE the
-            // insert so the cap is a real bound rather than a bound-plus-one.
-            while (loggedVocabularySkew.size >= MAX_LOGGED_VOCABULARY_SKEW) {
-              const oldest = loggedVocabularySkew.keys().next().value;
-              if (oldest === undefined) break;
-              loggedVocabularySkew.delete(oldest);
-            }
-            loggedVocabularySkew.set(panelTab, advertised!);
-            logger.warn(`[panel-orchestrator] ${skew.message}`);
+        // Reported once per DISTINCT disagreeing vocabulary, for the whole process.
+        // A reconnect ping-pong repeats the same hello every few seconds and the same
+        // skew is not new news; a panel that UPDATES to a different (still disagreeing)
+        // vocabulary is, and its new hash reports again.
+        //
+        // There is deliberately NO "clear on match" here. Under the per-tab key a
+        // stale entry had to be cleared so a tab that came back into agreement and
+        // later regressed would report again; keyed by hash there is nothing stale to
+        // clear — a regression re-advertises the same disagreeing hash, and if it was
+        // already reported, that is genuinely the same news the user already has.
+        if (skew.status === "mismatch" && !loggedVocabularySkew.has(advertised!)) {
+          // Insertion-ordered, so the first entry is the oldest. Evicted BEFORE the
+          // add so the cap is a real bound rather than a bound-plus-one.
+          while (loggedVocabularySkew.size >= MAX_LOGGED_VOCABULARY_SKEW) {
+            const oldest = loggedVocabularySkew.values().next().value;
+            if (oldest === undefined) break;
+            loggedVocabularySkew.delete(oldest);
           }
-        } else {
-          // Cleared, so a panel that updates INTO agreement and later regresses is
-          // reported again instead of being suppressed by a stale entry. `unknown`
-          // clears it too: it is the absence of evidence, and holding a prior
-          // mismatch against a build that told us nothing would report a skew that
-          // this connection never proved.
-          loggedVocabularySkew.delete(panelTab);
+          loggedVocabularySkew.add(advertised!);
+          logger.warn(`[panel-orchestrator] ${skew.message}`);
         }
       }
       // #706 — an npm-orchestrator update can require a newer Registry panel.

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -63,6 +63,27 @@ import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
 import { logger } from "../utils/logger.js";
+import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
+import { buildPanelToolDefs } from "./panel-tools.js";
+
+/** Tab id → the panel vocabulary hash whose MISMATCH has already been logged (#236),
+ *  so a reconnect loop does not repeat the same warning every few seconds. Keyed by
+ *  the HASH, not just the tab, so a panel that updates to a DIFFERENT disagreeing
+ *  vocabulary is reported again — that is new information, not a repeat. */
+const loggedVocabularySkew = new Map<string, string>();
+
+/** This server's vocabulary hash, computed once.
+ *
+ *  Memoised because it cannot change without a restart (the tool surface is fixed at
+ *  build time) and buildPanelToolDefs() walks every panel tool definition — work that
+ *  has no business running on every hello, which is a hot path during a reconnect loop. */
+let cachedServerVocabularyHash: string | undefined;
+function serverVocabularyHash(): string {
+  cachedServerVocabularyHash ??= assembleVocabularyHash(
+    buildPanelToolDefs().map((d) => d.name),
+  );
+  return cachedServerVocabularyHash;
+}
 import {
   PanelAgentManager,
   fetchSupportedModels,
@@ -3404,6 +3425,45 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (typeof helloPanelVer === "string" && helloPanelVer && helloPanelVer !== latestPanelVersion) {
         latestPanelVersion = helloPanelVer;
         void refreshEnvCapabilities();
+      }
+      // #236 — THE VOCABULARY HANDSHAKE, at the handshake.
+      //
+      // `describeVocabularySkew` and the hash it compares have existed, fully
+      // unit-tested, since the #683 follow-up, and NOTHING called them: the bridge
+      // stored the panel's advertised hash on every hello under a comment promising
+      // this exact check, and no code read the field. A mechanism can be completely
+      // unreachable and still pass every test it has — the tests proved the function
+      // worked, never that it ran — so the call site below is asserted directly, by
+      // source, in vocabulary-handshake.test.ts.
+      //
+      // The comparison is done HERE rather than in the bridge because the server's own
+      // hash needs buildPanelToolDefs(), and panel-tools.ts imports ui-bridge.ts — the
+      // bridge cannot reach it without a cycle. The orchestrator already imports both.
+      const helloVocabHash = (event as { vocabulary_hash?: unknown }).vocabulary_hash;
+      {
+        const advertised =
+          typeof helloVocabHash === "string" && helloVocabHash ? helloVocabHash : undefined;
+        const skew = describeVocabularySkew(
+          serverVocabularyHash(),
+          advertised,
+          typeof helloPanelVer === "string" ? helloPanelVer : undefined,
+        );
+        // Logged once per DISTINCT advertised hash per tab. A reconnect ping-pong
+        // repeats the same hello every few seconds and the same skew is not new news;
+        // a panel that UPDATES to a different (still disagreeing) vocabulary is.
+        if (skew.status === "mismatch") {
+          if (loggedVocabularySkew.get(panelTab) !== advertised) {
+            loggedVocabularySkew.set(panelTab, advertised!);
+            logger.warn(`[panel-orchestrator] ${skew.message}`);
+          }
+        } else {
+          // Cleared, so a panel that updates INTO agreement and later regresses is
+          // reported again instead of being suppressed by a stale entry. `unknown`
+          // clears it too: it is the absence of evidence, and holding a prior
+          // mismatch against a build that told us nothing would report a skew that
+          // this connection never proved.
+          loggedVocabularySkew.delete(panelTab);
+        }
       }
       // #706 — an npm-orchestrator update can require a newer Registry panel.
       // The panel-sync service owns the ENTIRE safety decision: it re-reads the

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -146,11 +146,6 @@ interface Conn {
    *  (see makeUnknownCommandError) — the panel gained these bridge commands in
    *  0.11.4, so older builds reject graph_* / ui_* with a raw dispatch error. */
   panelVersion?: string;
-  /** The `vocabularyHash` of the tool vocabulary this panel build VENDORED, as sent
-   *  in its `hello`. Undefined when the panel did not advertise one — an older
-   *  build, which means UNVERIFIED, not disagreeing. Never inherited across a
-   *  hello: a reconnect may be a freshly updated build with a different copy. */
-  panelVocabularyHash?: string;
   /** True only when THIS hello actually CARRIED a `panel_version` (not inherited from
    *  a prior connection under the same tab id). `panelVersion` is deliberately
    *  inherited across a reconnect that omits the field (line ~849) so the reactive
@@ -2386,15 +2381,6 @@ export class UiBridge {
           panelVersionAdvertised:
             typeof (msg as { panel_version?: unknown }).panel_version === "string" &&
             !!(msg as { panel_version?: string }).panel_version,
-          // The vocabulary the panel VENDORED, so the skew that #683 exposed can be
-          // detected at the handshake instead of at call time as "unknown tool".
-          // Re-read from THIS hello and never inherited: a reconnect may be a freshly
-          // updated build carrying a different vendored copy, and inheriting would
-          // report the OLD build's agreement as if it were this one's.
-          panelVocabularyHash:
-            typeof (msg as { vocabulary_hash?: unknown }).vocabulary_hash === "string"
-              ? ((msg as { vocabulary_hash?: string }).vocabulary_hash || undefined)
-              : undefined,
           // #570 P0c — re-read from THIS hello, never inherited (a reconnect may be a newly
           // updated build). Strict === true so any non-true / absent value is non-enforcing.
           enforcesWorkflowStamp:

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -2168,6 +2168,37 @@ export function retiredToolMessage(name: string): string | undefined {
  * expression. Two copies of a hash rule drift, and a handshake that compares a
  * drifted hash reports a mismatch that is not real — worse than no check.
  */
+/**
+ * The hash of THIS server's vocabulary — the value the panel handshake compares
+ * against (#236).
+ *
+ * The panel tool names arrive as an argument rather than being imported, and that
+ * is load-bearing: `buildPanelToolDefs` lives in orchestrator/panel-tools.ts, which
+ * imports ui-bridge, which would make importing it here a cycle. Passing them in
+ * keeps this module free of the orchestrator entirely.
+ *
+ * ## Why the ASSEMBLY lives here and not at each call site
+ *
+ * `computeVocabularyHash` hashes whatever it is handed; deciding WHAT to hand it —
+ * core names, panel names SORTED, dead names — is a second rule, and it was
+ * previously written out only in scripts/export-vocabulary.mts. A runtime check
+ * that assembled its own copy would agree with the artefact right up until one of
+ * the two changed, and then report a mismatch that is not real. The doc on
+ * `computeVocabularyHash` says two copies of the hash rule must not exist; this is
+ * the same argument applied to its input, which is just as capable of drifting.
+ *
+ * So the exporter calls this too, and `vocabulary-handshake.test.ts` asserts the
+ * value it produces from the live panel defs equals the artefact's own
+ * `vocabularyHash` — the only check that can actually catch drift between them.
+ */
+export function assembleVocabularyHash(panelToolNames: readonly string[]): string {
+  return computeVocabularyHash({
+    core: [...TOOL_NAMES],
+    panel: [...panelToolNames].sort(),
+    dead: DEAD_NAMES.map((d) => d.name),
+  });
+}
+
 export function computeVocabularyHash(input: {
   core: readonly string[];
   panel: readonly string[];


### PR DESCRIPTION
Claims artokun/comfyui-mcp-panel#236.

**The reported bug is already fixed.** `graph_query` was rejected with a fabricated `≥0.11.4` minimum; it now carries its true one (0.7.0) via #619, and the #392/#236 proactive gates refuse pre-dispatch instead of round-tripping. That part will be closed with evidence.

**What is still real** is the structural half of the report — capability mismatch discovered at call time rather than at connect. There is a half-built mechanism for exactly that:

- `computeVocabularyHash()` exists in `src/tools/vocabulary.ts`, documented as "the primitive the panel handshake compares (#683 follow-up)".
- `ui-bridge.ts` reads `vocabulary_hash` off the hello into `panelVocabularyHash`, commented "so the skew that #683 exposed can be detected at the handshake instead of at call time as 'unknown tool'".
- **Nothing reads that field, and no panel sends it.** Both comments describe a check that does not exist.

Scope: make the comparison real, and keep it three-state — a panel that advertises no hash is `could not determine`, never `mismatch` (#796 class). Panel-side send lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)