### PR TITLE
chore(release): 0.51.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.13] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- compare the panel's tool vocabulary at the handshake, not at call time (#1455)
+
+
 ## [0.51.12] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.12",
+  "version": "0.51.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.12",
+      "version": "0.51.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.12",
+  "version": "0.51.13",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles 0.51.13 into protected main.

Performs the panel vocabulary handshake instead of only implementing it (panel#236). `describeVocabularySkew()` and the hash it compares had existed, fully unit-tested, since the #683 follow-up, and nothing in the product ever called them — the bridge stored the panel's advertised hash on every hello, under a comment promising this exact check, for no reader at all.

Pairs with panel 0.14.14, the first build that sends the hash. Verified live: the two halves now compute the same value, so a real connect resolves to `match`.

The first live comparison found genuine drift (the panel's vendored copy was missing `panel_remove_widget`) — re-vendored in the panel repo before release so the pair agrees on arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)