### PR TITLE
fix(646): tell a dropped graph write to verify with a graph READ, not the render queue

### DIFF
--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -266,3 +266,50 @@ describe("#646 the verify clause names evidence that exists for the command", ()
     }
   });
 });
+
+describe("#646 a graph_ prefix does not mean the effect is on the canvas", () => {
+  it("graph_save_subgraph is verified with panel_list_subgraphs (codex review, P1)", () => {
+    // It writes to the blueprint LIBRARY. The graph is identical afterwards, so both
+    // graph readers show exactly what they showed before and cannot tell a save that
+    // landed from one that did not — the same shape of wrong answer this fix exists
+    // to remove, one branch further in.
+    const text = midCommandVerifyClause("graph_save_subgraph");
+    expect(text).toMatch(/panel_list_subgraphs/);
+    expect(text).not.toMatch(/panel_query_graph/);
+    expect(text).not.toMatch(/queue action:"list"/);
+    // And the reason a blind retry is bad here is specific: a name collision.
+    expect(text).toMatch(/collides on the name/);
+  });
+
+  it("graph_copy_nodes says nothing can check it — and to just re-issue", () => {
+    // The clipboard is not readable and the graph is unchanged, so no reader is
+    // evidence. This is the ONE interrupted write where retrying is correct: a second
+    // copy of the same nodes is the same clipboard.
+    const text = midCommandVerifyClause("graph_copy_nodes");
+    expect(text).toMatch(/clipboard is not readable/);
+    expect(text).toMatch(/Just re-issue it/);
+    expect(text).not.toMatch(/panel_query_graph/);
+    expect(text).not.toMatch(/panel_list_subgraphs/);
+  });
+
+  it("the two carve-outs are checked BEFORE the generic graph_ branch", () => {
+    // Ordering is the whole mechanism — both names start with "graph_", so a branch
+    // placed after the prefix test would never be reached.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../services/mid-command-remedy.ts"),
+      "utf8",
+    );
+    const lib = src.indexOf("LIBRARY_COMMANDS.has(cmd)");
+    const clip = src.indexOf("CLIPBOARD_COMMANDS.has(cmd)");
+    const generic = src.indexOf('cmd.startsWith("graph_")');
+    expect(lib).toBeGreaterThan(-1);
+    expect(clip).toBeGreaterThan(-1);
+    expect(lib).toBeLessThan(generic);
+    expect(clip).toBeLessThan(generic);
+  });
+
+  it("an ordinary content edit is unaffected by the carve-outs", () => {
+    expect(midCommandVerifyClause("graph_set_widget")).toMatch(/panel_query_graph/);
+    expect(midCommandVerifyClause("graph_add_subgraph")).toMatch(/panel_query_graph/);
+  });
+});

--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -15,6 +15,9 @@
 // is no way to withdraw the first.
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   isInteractiveCommand,
@@ -128,13 +131,19 @@ describe("the disconnect remedy fits what was interrupted (#952)", () => {
   });
 
   it("an unknown or malformed command is treated as NON-interactive", () => {
-    // Fail toward the existing behaviour: the queue/output advice is merely
-    // unhelpful for something else, while claiming "a card may be on screen"
-    // about a write would be false.
+    // Claiming "a card may be on screen" about a write would be false, so anything
+    // not on the interactive list must classify as non-interactive.
     for (const cmd of ["", "   ", "graph_add_node", "ask_user_extra"]) {
       expect(isInteractiveCommand(cmd), cmd).toBe(false);
     }
-    expect(midCommandVerifyClause("graph_add_node")).toMatch(/queue action:"list"/);
+    // This used to assert that graph_add_node got the queue/output advice, on the
+    // rationale that it was "merely unhelpful". #646 is the bill for that: the
+    // reporter's interrupted graph_set_widget sent them to the render queue, which
+    // cannot see a canvas edit — the same wrong-remedy defect #952 fixed for
+    // interactive cards, still live for graph writes. Unhelpful advice that names a
+    // specific tool does not read as unhelpful; it reads as the answer.
+    expect(midCommandVerifyClause("graph_add_node")).toMatch(/panel_query_graph/);
+    expect(midCommandVerifyClause("ask_user_extra")).toMatch(/Verify that it applied/);
   });
 });
 
@@ -150,5 +159,110 @@ describe("WIRING: the bridge uses it (#952)", () => {
     expect(src).not.toMatch(
       /OUTCOME UNKNOWN: the command was already sent, so the panel may have applied it/,
     );
+  });
+});
+
+
+// ===========================================================================
+// panel#646 — the check named has to be able to hold the answer.
+//
+// Every non-interactive command got the same sentence: check queue action:"list"
+// / get_image list_outputs. That is RENDER evidence. The reporter's interrupted
+// command was graph_set_widget, and neither of those can say whether a widget
+// edit landed — so an agent following the advice looks somewhere structurally
+// incapable of answering and ends up retrying blindly anyway, which is the exact
+// thing OUTCOME UNKNOWN exists to prevent.
+// ===========================================================================
+describe("#646 the verify clause names evidence that exists for the command", () => {
+  const GRAPH_WRITES = [
+    "graph_set_widget", // the reported one
+    "graph_edit_node",
+    "graph_connect",
+    "graph_add_node",
+    "graph_remove_node",
+    "graph_paste_nodes",
+    "graph_create_subgraph",
+  ];
+
+  it.each(GRAPH_WRITES)("%s is verified with a graph READ, not the render queue", (cmd) => {
+    const text = midCommandVerifyClause(cmd);
+    expect(text).toMatch(/panel_query_graph/);
+    expect(text).toMatch(/graph READ/);
+    // The render tools must NOT be offered here — that is the defect.
+    expect(text).not.toMatch(/queue action:"list"/);
+    expect(text).not.toMatch(/list_outputs/);
+  });
+
+  it("says why the read is safe to run immediately", () => {
+    // A caller who has just lost a socket needs to know the check itself is not
+    // another risky write. Idempotence is the reason it is a better check than
+    // anything the run path offers.
+    expect(midCommandVerifyClause("graph_set_widget")).toMatch(/idempotent/);
+  });
+
+  it("tells the caller NOT to re-issue when the read shows it applied", () => {
+    // Verifying and then retrying anyway is the double-apply this whole message
+    // exists to avoid, and the old text never closed that loop.
+    expect(midCommandVerifyClause("graph_edit_node")).toMatch(/do\s+NOT re-issue/i);
+  });
+
+  it("graph_run KEEPS the queue/output check — it was right for exactly one command", () => {
+    const text = midCommandVerifyClause("graph_run");
+    expect(text).toMatch(/queue action:"list"/);
+    expect(text).toMatch(/list_outputs/);
+    // And it says what a blind retry costs, which is the reason to check.
+    expect(text).toMatch(/GPU time|duplicate output/);
+    expect(text).not.toMatch(/panel_query_graph/);
+  });
+
+  it("a workflow mutator is verified with the workflow list, not a canvas read", () => {
+    // These change which workflows exist or are open — a graph read cannot see it.
+    for (const cmd of ["workflow_save", "workflow_save_as", "workflow_rename", "workflow_close"]) {
+      const text = midCommandVerifyClause(cmd);
+      expect(text).toMatch(/panel_list_workflows/);
+      expect(text).not.toMatch(/panel_query_graph/);
+      expect(text).not.toMatch(/queue action:"list"/);
+    }
+  });
+
+  it("an UNRECOGNISED command names no tool at all", () => {
+    // The defect was a confidently wrong check. The default branch is exactly
+    // where a guess would be wrong again, so it says to verify and stops.
+    const text = midCommandVerifyClause("some_future_command");
+    expect(text).toMatch(/Verify that it applied/);
+    expect(text).not.toMatch(/panel_query_graph|queue action:"list"|list_outputs|panel_list_workflows/);
+    // It still explains WHY, so "verify" is not a bare instruction.
+    expect(text).toMatch(/reached the panel/);
+  });
+
+  it("an interactive card is untouched by all of this", () => {
+    const text = midCommandVerifyClause("ask_user");
+    expect(text).toMatch(/will NOT reach you/);
+    expect(text).not.toMatch(/panel_query_graph/);
+  });
+
+  it("the full message still carries the OUTCOME UNKNOWN framing", () => {
+    const msg = midCommandDisconnectMessage({ short: "wf:12345", cmd: "graph_set_widget" });
+    expect(msg).toMatch(/OUTCOME UNKNOWN/);
+    expect(msg).toMatch(/panel_query_graph/);
+  });
+
+  it("the duplicated workflow-mutator list still matches ui-bridge's", () => {
+    // WORKFLOW_MUTATORS is duplicated because ui-bridge.ts imports this module, so
+    // importing its ACTIVE_WORKFLOW_MUTATORS back would be a cycle. A duplicate is
+    // only honest with a check on it: if ui-bridge gains a fifth mutator, this
+    // module would silently send it to the default branch.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../services/ui-bridge.ts"),
+      "utf8",
+    );
+    const block = src.slice(src.indexOf("const ACTIVE_WORKFLOW_MUTATORS"));
+    const names = (block.slice(0, block.indexOf("]")).match(/"(\w+)"/g) ?? []).map((s) =>
+      s.replace(/"/g, ""),
+    );
+    expect(names.length).toBeGreaterThan(0);
+    for (const n of names) {
+      expect(midCommandVerifyClause(n)).toMatch(/panel_list_workflows/);
+    }
   });
 });

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -35,15 +35,54 @@ export function isInteractiveCommand(cmd: string): boolean {
 /**
  * The "verify before retrying" clause, chosen by what the command actually did.
  *
- * Two kinds, because they have different evidence and different costs:
+ * The point of OUTCOME UNKNOWN is that the caller checks instead of retrying blind.
+ * That only works if the check named can actually hold the answer — and for a graph
+ * write it did not. Every non-interactive command got the same sentence:
  *
- *  • an INTERACTIVE card — nothing in the tool surface can observe it, and a
- *    the answer to it will NEVER arrive (the panel refuses to replay a reply of
- *    this kind across a reconnect), and a retry duplicates the card. Say all
- *    three, and give the route that works — which differs for a secret.
- *  • anything else — the existing queue/output check, which is real evidence for
- *    a run or a write.
+ *     Verify before retrying (e.g. check queue action:"list" /
+ *     get_image (action:"list_outputs"))
+ *
+ * which is RENDER evidence. panel#646's interrupted command was `graph_set_widget`.
+ * Neither the queue nor the output list can say whether a widget edit landed, so an
+ * agent following that advice looks somewhere structurally incapable of answering,
+ * learns nothing, and ends up exactly where the message was trying to keep it from:
+ * retry blindly or give up. The old doc here asserted the queue check was "real
+ * evidence for a run or a write". It is evidence for a run.
+ *
+ * So the kinds are separated by WHAT CAN BE OBSERVED:
+ *
+ *  • an INTERACTIVE card — nothing in the tool surface can observe it, the answer
+ *    will NEVER arrive, and a retry duplicates the card in front of a human.
+ *  • a RUN — the queue and the output list are exactly right, and stay.
+ *  • a GRAPH WRITE — read the graph back. A graph read is idempotent and safe to
+ *    run the instant a tab is connected, which makes it a better check than
+ *    anything the run path offers.
+ *  • a WORKFLOW mutator — the workflow list, not the graph: these change which
+ *    workflows exist or are open, which a canvas read does not see.
+ *  • anything else — say to verify without naming tools that may not apply.
+ *    Naming a plausible-but-wrong check is what this fix exists to remove; doing
+ *    it again in the default branch would be the same defect with a different tool.
+ *
+ * Classified by NAME here rather than by importing GRAPH_CMD_EFFECT, for two
+ * reasons: ui-bridge.ts imports this module, so reading its table would be a cycle;
+ * and that table answers a different question (does this need the workflow fence),
+ * which is not the same as what evidence exists for it afterwards.
  */
+/** The one command whose evidence really is the render queue (panel#646). */
+const RUN_COMMAND = "graph_run";
+
+/** The four active-workflow mutators. A canvas read cannot see these — they change
+ *  which workflows exist or are open, not what is on the current graph. Mirrors
+ *  ACTIVE_WORKFLOW_MUTATORS in ui-bridge.ts, which cannot be imported here (it
+ *  imports this module). Duplicated deliberately and kept honest by a test that
+ *  reads the ui-bridge source and compares the two. */
+const WORKFLOW_MUTATORS = new Set<string>([
+  "workflow_save",
+  "workflow_save_as",
+  "workflow_rename",
+  "workflow_close",
+]);
+
 export function midCommandVerifyClause(cmd: string): string {
   if (isInteractiveCommand(cmd)) {
     // WAITING IS NOT A RECOVERY, and an earlier draft of this said it was
@@ -72,9 +111,37 @@ export function midCommandVerifyClause(cmd: string): string {
       `user may see two. Tell them which one to answer.`
     );
   }
+  if (cmd === RUN_COMMAND) {
+    // The one command the original sentence was actually right about.
+    return (
+      `Verify before retrying (check queue action:"list" / get_image ` +
+      `(action:"list_outputs")) instead of re-issuing it blindly — a second run costs ` +
+      `GPU time and produces a duplicate output.`
+    );
+  }
+  if (WORKFLOW_MUTATORS.has(cmd)) {
+    return (
+      `Verify with panel_list_workflows before retrying — these change which workflows ` +
+      `exist or are open, which a canvas read does not see. Re-issuing blindly can save ` +
+      `or close a second time.`
+    );
+  }
+  if (cmd.startsWith("graph_")) {
+    return (
+      `Verify with a graph READ before retrying — panel_query_graph on the node(s) this ` +
+      `touched (or panel_graph_outline for a structural change) and compare against what ` +
+      `you asked for. A read is idempotent, so it is safe the moment a tab is connected, ` +
+      `and it is the only check that can see a canvas edit: the render queue and the ` +
+      `output list cannot (panel#646). If the read shows the change already applied, do ` +
+      `NOT re-issue it. If the command only moved the view or the selection, it changed ` +
+      `no graph content, so there is nothing to verify and nothing worth re-issuing.`
+    );
+  }
+  // Deliberately names no tool. The defect being fixed was a confidently wrong
+  // check; an unrecognised command is exactly where a guess would be wrong again.
   return (
-    `Verify before retrying (e.g. check queue action:"list" / get_image (action:"list_outputs")) ` +
-    `instead of re-issuing it blindly.`
+    `Verify that it applied before retrying, rather than re-issuing it blindly — the ` +
+    `command reached the panel, so a retry may apply it twice.`
   );
 }
 

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -56,9 +56,17 @@ export function isInteractiveCommand(cmd: string): boolean {
  *  • a RUN — the queue and the output list are exactly right, and stay.
  *  • a GRAPH WRITE — read the graph back. A graph read is idempotent and safe to
  *    run the instant a tab is connected, which makes it a better check than
- *    anything the run path offers.
+ *    anything the run path offers. This branch is LAST among the graph_* kinds:
+ *    the prefix alone does not mean the effect is on the canvas, and the two cases
+ *    above are the ones where it is not.
  *  • a WORKFLOW mutator — the workflow list, not the graph: these change which
  *    workflows exist or are open, which a canvas read does not see.
+ *  • a LIBRARY write (`graph_save_subgraph`) — panel_list_subgraphs. The graph is
+ *    identical after a blueprint save, so both graph readers show what they showed
+ *    before and prove nothing (codex review).
+ *  • a CLIPBOARD write (`graph_copy_nodes`) — nothing can read the clipboard, and
+ *    the graph is unchanged. This is the one interrupted write where re-issuing is
+ *    the right answer: a second copy of the same nodes is the same clipboard.
  *  • anything else — say to verify without naming tools that may not apply.
  *    Naming a plausible-but-wrong check is what this fix exists to remove; doing
  *    it again in the default branch would be the same defect with a different tool.
@@ -70,6 +78,20 @@ export function isInteractiveCommand(cmd: string): boolean {
  */
 /** The one command whose evidence really is the render queue (panel#646). */
 const RUN_COMMAND = "graph_run";
+
+/** Writes to the user's blueprint LIBRARY, not to the canvas (codex review, P1).
+ *  `graph_save_subgraph` publishes a subgraph as a reusable blueprint; the graph is
+ *  unchanged afterwards, so both graph readers show exactly what they showed before
+ *  and cannot tell a save that landed from one that did not. `panel_list_subgraphs`
+ *  is the reader that can. */
+const LIBRARY_COMMANDS = new Set<string>(["graph_save_subgraph"]);
+
+/** Writes the CLIPBOARD, which nothing in the tool surface can read (codex review).
+ *  Copying leaves the graph identical, so a canvas read is no evidence at all —
+ *  but unlike everything else here, re-issuing is harmless: a second copy of the
+ *  same nodes produces the same clipboard. That makes "just do it again" the
+ *  correct advice rather than a dangerous one. */
+const CLIPBOARD_COMMANDS = new Set<string>(["graph_copy_nodes"]);
 
 /** The four active-workflow mutators. A canvas read cannot see these — they change
  *  which workflows exist or are open, not what is on the current graph. Mirrors
@@ -124,6 +146,22 @@ export function midCommandVerifyClause(cmd: string): string {
       `Verify with panel_list_workflows before retrying — these change which workflows ` +
       `exist or are open, which a canvas read does not see. Re-issuing blindly can save ` +
       `or close a second time.`
+    );
+  }
+  if (LIBRARY_COMMANDS.has(cmd)) {
+    return (
+      `Verify with panel_list_subgraphs before retrying — this writes to the blueprint ` +
+      `LIBRARY, not to the canvas, so the graph is identical either way and a graph read ` +
+      `cannot tell a save that landed from one that did not. If the blueprint is already ` +
+      `there, do NOT re-issue it: a second save collides on the name.`
+    );
+  }
+  if (CLIPBOARD_COMMANDS.has(cmd)) {
+    return (
+      `Nothing in the tool surface can check that — the clipboard is not readable, and the ` +
+      `graph is unchanged either way, so neither graph reader is evidence. Just re-issue it: ` +
+      `unlike the other interrupted writes, copying the same nodes twice produces the same ` +
+      `clipboard, so a retry here costs nothing and settles it.`
     );
   }
   if (cmd.startsWith("graph_")) {


### PR DESCRIPTION
Claims artokun/comfyui-mcp-panel#646.

When a mutating panel command dies mid-flight the bridge correctly reports `OUTCOME UNKNOWN` and tells the caller to verify before retrying. For anything that is not an interactive card, the remedy it names is:

> `Verify before retrying (e.g. check queue action:"list" / get_image (action:"list_outputs"))`

Those are **render** checks. The reporter's interrupted command was `graph_set_widget`. The queue and the output list cannot answer whether a widget edit landed — so an agent that follows the advice looks in a place that structurally cannot hold the answer, concludes nothing, and is left exactly where it started: retry blindly or give up.

`midCommandVerifyClause`'s own doc asserts the queue/output check is "real evidence for a run **or a write**". It is evidence for a run.

Scope: name the verification that actually fits what was interrupted — a graph read for a graph write, the queue for a run — and stay honest where a read genuinely cannot settle it.

The reporter also asked for graph tools to be withheld until the socket is stable; that part IS enforced today (`tabCanMutateGraph` fails closed at the write dispatch sites), and I will say so when closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)