### PR TITLE
fix(646): workflow navigation has a reader too — name it

### DIFF
--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -315,7 +315,7 @@ describe("#646 a graph_ prefix does not mean the effect is on the canvas", () =>
 });
 
 describe("#646 workflow navigation has a reader too", () => {
-  it("workflow_open / workflow_new name panel_list_workflows", () => {
+  it("workflow_open / workflow_new name the OPEN RECEIPT, not `active`", () => {
     // Found by running the LIVE panel's registered command names through the
     // classifier after the fix merged: these two fell to the default branch, which
     // names no tool. Not wrong — but a reader that can answer exists, and naming it
@@ -324,12 +324,38 @@ describe("#646 workflow navigation has a reader too", () => {
     // navigation differently, but the EVIDENCE is the same.
     for (const cmd of ["workflow_open", "workflow_new"]) {
       const text = midCommandVerifyClause(cmd);
-      expect(text, cmd).toMatch(/panel_list_workflows/);
+      expect(text, cmd).toMatch(/last_open_receipt/);
+      // codex review, P1: the first attempt named panel_list_workflows and stopped
+      // there, on the reasoning that an opened workflow appears in it. The panel had
+      // already written the rebuttal — after a backend reconnect the frontend restores
+      // a tab BY ITSELF, so `active` matching your target is not proof your open ran.
+      // Naming that as the check would have been this module's own defect, for the one
+      // command class that already has a purpose-built correct mechanism.
+      expect(text, cmd).toMatch(/Do NOT conclude anything from `active`/);
+      // The instruction AND the reason. A mutation that kept "restores a tab by
+      // itself" but deleted what it explains survived an earlier version of this —
+      // and the causal half is the part that stops an agent reasoning its way back
+      // to `active` ("but it matched, so surely…").
+      expect(text, cmd).toMatch(/restores a tab by\s+itself/);
+      expect(text, cmd).toMatch(/without your command ever running/);
+      // A receipt is over-readable without the rule that scopes it.
+      expect(text, cmd).toMatch(/answers ONLY for the command whose id equals/);
       expect(text, cmd).not.toMatch(/panel_query_graph/);
       expect(text, cmd).not.toMatch(/queue action:"list"/);
     }
+    // All three applied states, because they demand different actions.
+    const open = midCommandVerifyClause("workflow_open");
+    expect(open).toMatch(/`applied:true`/);
+    expect(open).toMatch(/`applied:false`.*safe to re-issue/);
+    expect(open).toMatch(/must NOT be blindly retried/);
     // And the specific cost of a blind retry, which differs from the mutators'.
-    expect(midCommandVerifyClause("workflow_new")).toMatch(/two empty tabs/);
+    // Asserted as a PROPERTY — that the cost of a blind retry is stated, and stated
+    // for workflow_new specifically. A control mutation swapping "empty" for "blank"
+    // killed the literal form, which punishes rewording rather than protecting
+    // behaviour.
+    const nw = midCommandVerifyClause("workflow_new");
+    expect(nw).toMatch(/blind retry costs/);
+    expect(nw).toMatch(/second workflow_new/);
   });
 
   it("navigation is still NOT treated as an active-workflow mutator", () => {

--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -313,3 +313,36 @@ describe("#646 a graph_ prefix does not mean the effect is on the canvas", () =>
     expect(midCommandVerifyClause("graph_add_subgraph")).toMatch(/panel_query_graph/);
   });
 });
+
+describe("#646 workflow navigation has a reader too", () => {
+  it("workflow_open / workflow_new name panel_list_workflows", () => {
+    // Found by running the LIVE panel's registered command names through the
+    // classifier after the fix merged: these two fell to the default branch, which
+    // names no tool. Not wrong — but a reader that can answer exists, and naming it
+    // is what this module is for. An opened or newly created workflow appears in
+    // panel_list_workflows exactly as a saved or renamed one does; the fence treats
+    // navigation differently, but the EVIDENCE is the same.
+    for (const cmd of ["workflow_open", "workflow_new"]) {
+      const text = midCommandVerifyClause(cmd);
+      expect(text, cmd).toMatch(/panel_list_workflows/);
+      expect(text, cmd).not.toMatch(/panel_query_graph/);
+      expect(text, cmd).not.toMatch(/queue action:"list"/);
+    }
+    // And the specific cost of a blind retry, which differs from the mutators'.
+    expect(midCommandVerifyClause("workflow_new")).toMatch(/two empty tabs/);
+  });
+
+  it("navigation is still NOT treated as an active-workflow mutator", () => {
+    // The two sets stay separate: ui-bridge deliberately excludes navigation from
+    // ACTIVE_WORKFLOW_MUTATORS, and collapsing them here would blur a real
+    // distinction even though both happen to share a reader.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../services/mid-command-remedy.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(/const WORKFLOW_NAVIGATION = new Set/);
+    const mutators = src.slice(src.indexOf("const WORKFLOW_MUTATORS"));
+    const block = mutators.slice(0, mutators.indexOf("]"));
+    expect(block).not.toMatch(/workflow_open|workflow_new/);
+  });
+});

--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -324,7 +324,12 @@ describe("#646 workflow navigation has a reader too", () => {
     // navigation differently, but the EVIDENCE is the same.
     for (const cmd of ["workflow_open", "workflow_new"]) {
       const text = midCommandVerifyClause(cmd);
-      expect(text, cmd).toMatch(/last_open_receipt/);
+      // The REPLY KEY is `last_open`. codex round 2: the first version said
+      // `last_open_receipt`, which is the panel's local VARIABLE name and not a field
+      // any reply carries — a confidently named thing that does not exist, which is
+      // the defect this module was written to remove. Both directions asserted.
+      expect(text, cmd).toMatch(/`last_open`/);
+      expect(text, cmd).not.toMatch(/last_open_receipt/);
       // codex review, P1: the first attempt named panel_list_workflows and stopped
       // there, on the reasoning that an opened workflow appears in it. The panel had
       // already written the rebuttal — after a backend reconnect the frontend restores

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -112,9 +112,23 @@ const WORKFLOW_MUTATORS = new Set<string>([
  *  panel_list_workflows.
  *
  *  Found by running the LIVE panel's registered command names through this classifier
- *  after the fix merged — these two fell to the default branch, which names no tool at
- *  all. Not wrong, but a reader that can answer exists, and the point of this module is
- *  to name it. */
+ *  after the fix merged — these two fell to the default branch, which names no tool.
+ *
+ *  The first attempt sent them to `panel_list_workflows` on the reasoning that an opened
+ *  workflow appears there. Codex caught it, and the panel had already written the
+ *  rebuttal: `active` matching your target is NOT proof your open ran, because after a
+ *  backend reconnect the frontend restores a tab BY ITSELF (#433). Naming that reader
+ *  would have been the exact defect this module exists to remove — a confident check
+ *  that cannot answer — for the one command class that already has a purpose-built
+ *  correct mechanism.
+ *
+ *  That mechanism is the panel's OPEN RECEIPTS (#402): every workflow_open/workflow_new
+ *  that RAN is journaled with the selector it was asked for, the identity it resolved
+ *  to, and whether it applied. The latest one rides in the workflow-list reply as
+ *  `last_open_receipt`, and it answers ONLY for the command whose id equals its `rid` —
+ *  so an EARLIER successful open of the same file is not evidence about a later dropped
+ *  one. The message says both halves, because the receipt is over-readable without the
+ *  rule that comes with it. */
 const WORKFLOW_NAVIGATION = new Set<string>(["workflow_open", "workflow_new"]);
 
 export function midCommandVerifyClause(cmd: string): string {
@@ -155,9 +169,15 @@ export function midCommandVerifyClause(cmd: string): string {
   }
   if (WORKFLOW_NAVIGATION.has(cmd)) {
     return (
-      `Verify with panel_list_workflows before retrying — an opened or newly created ` +
-      `workflow appears there. If it is already open, do NOT re-issue it: a second ` +
-      `workflow_new leaves the user with two empty tabs.`
+      `Verify with panel_list_workflows and read its \`last_open_receipt\` — the panel's own ` +
+      `execution record for opens (#402). It answers ONLY for the command whose id equals ` +
+      `its \`rid\`: \`applied:true\` means it completed, \`applied:false\` means nothing was ` +
+      `applied and it is safe to re-issue, \`applied:"unknown"\` means it may have taken ` +
+      `effect and must NOT be blindly retried. Do NOT conclude anything from \`active\` ` +
+      `matching your target, and do not read an EARLIER receipt for the same file as ` +
+      `evidence about this one — after a backend reconnect the frontend restores a tab by ` +
+      `itself, which explains a matching \`active\` without your command ever running. A ` +
+      `blind retry costs: a second workflow_new leaves the user with two empty tabs.`
     );
   }
   if (WORKFLOW_MUTATORS.has(cmd)) {

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -105,6 +105,18 @@ const WORKFLOW_MUTATORS = new Set<string>([
   "workflow_close",
 ]);
 
+/** Workflow NAVIGATION/creation. Deliberately not in ACTIVE_WORKFLOW_MUTATORS — they
+ *  carry their own explicit or new target rather than mutating active content, so the
+ *  fence treats them differently. But the QUESTION HERE IS EVIDENCE, not fencing, and
+ *  the evidence is identical: an opened or newly created workflow shows up in
+ *  panel_list_workflows.
+ *
+ *  Found by running the LIVE panel's registered command names through this classifier
+ *  after the fix merged — these two fell to the default branch, which names no tool at
+ *  all. Not wrong, but a reader that can answer exists, and the point of this module is
+ *  to name it. */
+const WORKFLOW_NAVIGATION = new Set<string>(["workflow_open", "workflow_new"]);
+
 export function midCommandVerifyClause(cmd: string): string {
   if (isInteractiveCommand(cmd)) {
     // WAITING IS NOT A RECOVERY, and an earlier draft of this said it was
@@ -139,6 +151,13 @@ export function midCommandVerifyClause(cmd: string): string {
       `Verify before retrying (check queue action:"list" / get_image ` +
       `(action:"list_outputs")) instead of re-issuing it blindly — a second run costs ` +
       `GPU time and produces a duplicate output.`
+    );
+  }
+  if (WORKFLOW_NAVIGATION.has(cmd)) {
+    return (
+      `Verify with panel_list_workflows before retrying — an opened or newly created ` +
+      `workflow appears there. If it is already open, do NOT re-issue it: a second ` +
+      `workflow_new leaves the user with two empty tabs.`
     );
   }
   if (WORKFLOW_MUTATORS.has(cmd)) {

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -107,9 +107,9 @@ const WORKFLOW_MUTATORS = new Set<string>([
 
 /** Workflow NAVIGATION/creation. Deliberately not in ACTIVE_WORKFLOW_MUTATORS — they
  *  carry their own explicit or new target rather than mutating active content, so the
- *  fence treats them differently. But the QUESTION HERE IS EVIDENCE, not fencing, and
- *  the evidence is identical: an opened or newly created workflow shows up in
- *  panel_list_workflows.
+ *  fence treats them differently. The question HERE is evidence, not fencing — and the
+ *  evidence for these is NOT the workflow list itself, which is where the first attempt
+ *  went wrong.
  *
  *  Found by running the LIVE panel's registered command names through this classifier
  *  after the fix merged — these two fell to the default branch, which names no tool.
@@ -125,7 +125,10 @@ const WORKFLOW_MUTATORS = new Set<string>([
  *  That mechanism is the panel's OPEN RECEIPTS (#402): every workflow_open/workflow_new
  *  that RAN is journaled with the selector it was asked for, the identity it resolved
  *  to, and whether it applied. The latest one rides in the workflow-list reply as
- *  `last_open_receipt`, and it answers ONLY for the command whose id equals its `rid` —
+ *  `last_open` — that is the reply KEY; the panel's local variable is `lastOpenReceipt`,
+ *  and naming THAT is how the first version of this shipped a field no reply carries
+ *  (codex round 2), which is the very defect this module exists to remove. It answers
+ *  ONLY for the command whose id equals its `rid` —
  *  so an EARLIER successful open of the same file is not evidence about a later dropped
  *  one. The message says both halves, because the receipt is over-readable without the
  *  rule that comes with it. */
@@ -169,7 +172,7 @@ export function midCommandVerifyClause(cmd: string): string {
   }
   if (WORKFLOW_NAVIGATION.has(cmd)) {
     return (
-      `Verify with panel_list_workflows and read its \`last_open_receipt\` — the panel's own ` +
+      `Verify with panel_list_workflows and read its \`last_open\` — the panel's own ` +
       `execution record for opens (#402). It answers ONLY for the command whose id equals ` +
       `its \`rid\`: \`applied:true\` means it completed, \`applied:false\` means nothing was ` +
       `applied and it is safe to re-issue, \`applied:"unknown"\` means it may have taken ` +


### PR DESCRIPTION
Follow-up to #1457, found by **live verification**: I pulled the command handler names the running panel actually registers and ran all 19 through the shipped classifier. Every one routed to a reader that can see its effect — except `workflow_open` and `workflow_new`, which fell to the default branch.

That branch names no tool on purpose (naming a plausible-but-wrong check is the defect #1457 fixed). But `panel_list_workflows` genuinely can see an opened or newly created workflow, so there was a right answer available and it wasn't given.

They stay out of `WORKFLOW_MUTATORS` — ui-bridge excludes navigation from `ACTIVE_WORKFLOW_MUTATORS` for a real reason, and a test keeps the sets separate. Fencing and evidence are different questions that happen to share a reader here.

Mutations: disabling the branch, dropping `workflow_new`, and collapsing navigation into the mutator set all fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)