### PR TITLE
chore(release): 0.51.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.14] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- tell a dropped graph write to verify with a graph READ, not the render queue (#1457)
+
+
 ## [0.51.13] - 2026-08-12
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.13",
+  "version": "0.51.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.13",
+      "version": "0.51.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.13",
+  "version": "0.51.14",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles 0.51.14 into protected main.

panel#646 — when a mutating panel command is written to the socket and the connection dies before a reply, the caller is told OUTCOME UNKNOWN and to verify before retrying. The check it named for every non-interactive command was the render queue and the output list. The reporter's interrupted command was `graph_set_widget`; neither tool can see a canvas edit.

The remedy is now chosen by what can be observed: `graph_run` keeps the queue check, a graph write gets a graph read, `graph_save_subgraph` gets `panel_list_subgraphs`, `graph_copy_nodes` says nothing can read the clipboard and to just re-issue, and an unrecognised command names no tool at all.

Verified against the LIVE panel's registered command handler names, pulled from the running ComfyUI: all 19 route to a reader that can see their effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)