### PR TITLE
chore(release): 0.51.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.15] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- workflow navigation has a reader too — name it (#1459)
+
+
 ## [0.51.14] - 2026-08-12
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.14",
+  "version": "0.51.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.14",
+      "version": "0.51.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.14",
+  "version": "0.51.15",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles 0.51.15 into protected main.

Completes panel#646. `workflow_open` / `workflow_new` interrupted mid-command are now answered by the panel's OPEN RECEIPT (`last_open` in the workflow-list reply, #402) — which answers only for the command whose id equals its `rid` — rather than by an `active` pointer a backend reconnect can restore on its own.

Verified against the LIVE panel's registered command handler names: all 19 route to a reader that can observe their effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)