### PR TITLE
fix(890): an unresolved pack must not read as 'does not exist' on a possibly-stale catalogue

### DIFF
--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -1,0 +1,117 @@
+// panel#890 — a POPULATED ComfyUI-Manager catalogue proves nothing about its age.
+//
+// Measured on a network that genuinely blocks the registry: Manager raises
+// InvalidChannel, logs "Cannot connect to comfyregistry", and then answers with
+// HTTP 200, 1,570,773 bytes, 5583 packs — out of the extension-node-map.json
+// bundled in its own package. A full list of unknown age, indistinguishable from
+// a current one.
+//
+// #1136's two caveats both key on an OBSERVED failure (empty list, caught
+// exception), so neither fires on a bundled fallback and `unresolved` went out
+// bare — reading as "these packs do not exist" in the very case Manager works
+// hardest to produce.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MANAGER_CATALOGUE_CURRENCY_CAVEAT,
+  managerCatalogueCurrencyUnverified,
+} from "../../services/manager-catalogue-currency.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("#890 when the caveat attaches", () => {
+  it("attaches when packs are unresolved and nothing stronger applies", () => {
+    // The reported case: a healthy-LOOKING catalogue answered, and some class_types
+    // did not resolve. Nothing observed a failure, which is exactly the problem.
+    expect(managerCatalogueCurrencyUnverified({ unresolvedCount: 3 })).toBe(true);
+  });
+
+  it("does NOT attach when nothing is unresolved", () => {
+    // Gated on there being something to mislead about — the same rule the
+    // catalogue_unavailable gate follows, and the contract its docblock states.
+    expect(managerCatalogueCurrencyUnverified({ unresolvedCount: 0 })).toBe(false);
+  });
+
+  it("yields to the STRONGER caveats rather than doubling up", () => {
+    // catalogue_unavailable and mappings_unavailable report an OBSERVED failure;
+    // this reports the absence of evidence either way. Emitting both buries the
+    // observed fact under the generic one and reads as two separate problems.
+    expect(
+      managerCatalogueCurrencyUnverified({ unresolvedCount: 3, catalogueUnavailable: "empty" }),
+    ).toBe(false);
+    expect(
+      managerCatalogueCurrencyUnverified({ unresolvedCount: 3, mappingsUnavailable: "threw" }),
+    ).toBe(false);
+  });
+});
+
+describe("#890 what the caveat says", () => {
+  it("does NOT claim the catalogue is stale", () => {
+    // The reporter named this trap explicitly: a staleness claim inferred from
+    // something the panel cannot observe would repeat the fault the issue is about.
+    // Manager does not report which source answered, so this may only say that the
+    // age is unknown — never that it is old.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).not.toMatch(/\bis (stale|out of date|old)\b/i);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).not.toMatch(/months out of date/i);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/nothing here can date it/i);
+  });
+
+  it("refuses the 'does not exist' reading outright", () => {
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/NOT proof these do not exist/);
+  });
+
+  it("names WHY a populated list is not evidence of currency", () => {
+    // The mechanism is the whole point — without it this reads as generic hedging,
+    // and a reader has no reason to believe a 5583-entry answer could be wrong.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/bundled in its own package/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/does not report which source/);
+  });
+
+  it("names an INDEPENDENT reader that can settle it, and both outcomes", () => {
+    // A caveat with no next step is just doubt. search_custom_nodes queries
+    // api.comfy.org directly rather than through Manager, so it is real evidence.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/search_custom_nodes/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/api\.comfy\.org directly/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/found there means this[\s\S]*behind/i);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/absent from both/i);
+    // And what to DO about the one outcome that is actionable.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/update ComfyUI-Manager/);
+  });
+
+  it("stays short enough to be read", () => {
+    // It attaches to every miss, including the many that are ordinary. A paragraph
+    // here becomes noise that gets skipped, and then it protects nobody.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT.length).toBeLessThan(700);
+  });
+});
+
+describe("#890 WIRING: it reaches both results and both renderers", () => {
+  const deps = readFileSync(join(HERE, "../../services/workflow-deps.ts"), "utf8");
+  const skills = readFileSync(join(HERE, "../../tools/skills-access.ts"), "utf8");
+
+  it("both result shapes can carry it", () => {
+    // WorkflowDepsAnalysis (the mappings path) and InstallDepsResult (the getlist
+    // path) are separate shapes and both render `unresolved`.
+    expect((deps.match(/catalogue_currency_unverified\?: string;/g) ?? []).length).toBe(2);
+  });
+
+  it("both results actually SET it", () => {
+    // A field nothing populates is the defect this repo keeps paying for: a
+    // mechanism that is complete, tested, and never reached.
+    expect((deps.match(/catalogue_currency_unverified: MANAGER_CATALOGUE_CURRENCY_CAVEAT/g) ?? []).length).toBe(2);
+  });
+
+  it("every site that renders the stronger caveats renders this one too", () => {
+    // If one renderer forgot it, `unresolved` still reads as "does not exist"
+    // wherever that path is taken — and the behavioural tests above cannot see it.
+    const stronger =
+      (skills.match(/result\.mappings_unavailable\)/g) ?? []).length +
+      (skills.match(/result\.catalogue_unavailable\)/g) ?? []).length;
+    const mine = (skills.match(/result\.catalogue_currency_unverified\)/g) ?? []).length;
+    expect(stronger).toBeGreaterThan(0);
+    expect(mine).toBe(stronger);
+  });
+});

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -114,23 +114,44 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
     // path — and nothing is installed on that branch, which makes it read as the MOST
     // settled answer of the three.
     //
-    // Anchored on the FIELD, not on return-block boundaries: the returns sit at
-    // different nesting depths, so an indent/brace terminator matched nothing and an
-    // earlier version of this test passed while checking zero sites. The `const `
-    // exclusion keeps the local `const unresolved: string[] = []` declaration out —
-    // that is not a reply, and demanding the caveat near it fails for no reason.
+    // The window is bounded to the ENCLOSING OBJECT by brace depth, not by a character
+    // count (codex round 3). A fixed 2600-char forward scan happened to be correct at
+    // today's distances — removing the early return's caveat did fail this test — but
+    // its correctness rested on two returns staying far enough apart, so an edit that
+    // moved them closer would let one return's caveat satisfy another's check and the
+    // test would pass while `unresolved` went out bare. That is the vacuous pass this
+    // test exists to prevent, so it must not depend on layout.
+    //
+    // Anchored on the FIELD rather than on `return {`: the returns sit at different
+    // nesting depths, and an indent-based terminator matched nothing at all. The
+    // `const ` exclusion drops the local `const unresolved: string[] = []` declaration,
+    // which is not a reply.
     const FIELD = new RegExp(String.raw`\n\s+unresolved: `, "g");
     const sites = [...deps.matchAll(FIELD)]
       .map((m) => m.index ?? 0)
       .filter((i) => !/const\s+$/.test(deps.slice(Math.max(0, i - 24), i + 1)));
     expect(sites.length).toBeGreaterThanOrEqual(3); // analysis + install + early return
+
+    /** The rest of the object literal this field sits in — to its matching `}`. */
+    const enclosingObject = (from: number): string => {
+      let depth = 1; // we are already inside the object that holds this field
+      for (let j = from; j < deps.length; j++) {
+        const c = deps[j];
+        if (c === "{") depth++;
+        else if (c === "}") {
+          depth--;
+          if (depth === 0) return deps.slice(from, j);
+        }
+      }
+      return deps.slice(from); // unbalanced — fail loudly below rather than pass
+    };
+
     for (const i of sites) {
-      // FORWARD-only, and wide enough to clear a long message literal: the install
-      // return carries ~600 characters of `catalogue_unavailable` prose between the
-      // field and the caveat, so a 900-char window reported a defect that was not one.
-      // Forward-only also means a neighbouring return's caveat cannot satisfy this one.
-      const window = deps.slice(i, i + 2600);
-      expect(window, deps.slice(i, i + 60)).toMatch(/catalogue_currency_unverified/);
+      const object = enclosingObject(i);
+      // A bound that is not a bound would reintroduce the vacuous pass, so assert the
+      // walk actually terminated before the end of the file.
+      expect(object.length).toBeLessThan(deps.length - i);
+      expect(object, deps.slice(i, i + 60)).toMatch(/catalogue_currency_unverified/);
     }
   });
 

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -60,7 +60,10 @@ describe("#890 what the caveat says", () => {
   });
 
   it("refuses the 'does not exist' reading outright", () => {
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/NOT proof these do not exist/);
+    // Case-insensitive: a control mutation lowercasing "NOT" killed the strict form,
+    // which punishes rewording rather than protecting the claim. The property is that
+    // the "does not exist" reading is refused, not how it is capitalised.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/not proof these do not exist/i);
   });
 
   it("names WHY a populated list is not evidence of currency", () => {

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -107,10 +107,31 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
     expect((deps.match(/catalogue_currency_unverified\?: string;/g) ?? []).length).toBe(2);
   });
 
-  it("both results actually SET it", () => {
-    // A field nothing populates is the defect this repo keeps paying for: a
-    // mechanism that is complete, tested, and never reached.
-    expect((deps.match(/catalogue_currency_unverified: MANAGER_CATALOGUE_CURRENCY_CAVEAT/g) ?? []).length).toBe(2);
+  it("EVERY return that emits `unresolved` also carries the caveat", () => {
+    // Counting setters was not enough, and codex round 2 proved it: an EARLY RETURN in
+    // installWorkflowDependencies (taken when nothing is missing) emitted `unresolved`
+    // bare. The caveat existed, was set in two places, and still never reached that
+    // path — and nothing is installed on that branch, which makes it read as the MOST
+    // settled answer of the three.
+    //
+    // Anchored on the FIELD, not on return-block boundaries: the returns sit at
+    // different nesting depths, so an indent/brace terminator matched nothing and an
+    // earlier version of this test passed while checking zero sites. The `const `
+    // exclusion keeps the local `const unresolved: string[] = []` declaration out —
+    // that is not a reply, and demanding the caveat near it fails for no reason.
+    const FIELD = new RegExp(String.raw`\n\s+unresolved: `, "g");
+    const sites = [...deps.matchAll(FIELD)]
+      .map((m) => m.index ?? 0)
+      .filter((i) => !/const\s+$/.test(deps.slice(Math.max(0, i - 24), i + 1)));
+    expect(sites.length).toBeGreaterThanOrEqual(3); // analysis + install + early return
+    for (const i of sites) {
+      // FORWARD-only, and wide enough to clear a long message literal: the install
+      // return carries ~600 characters of `catalogue_unavailable` prose between the
+      // field and the caveat, so a 900-char window reported a defect that was not one.
+      // Forward-only also means a neighbouring return's caveat cannot satisfy this one.
+      const window = deps.slice(i, i + 2600);
+      expect(window, deps.slice(i, i + 60)).toMatch(/catalogue_currency_unverified/);
+    }
   });
 
   it("every site that renders the stronger caveats renders this one too", () => {

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -155,14 +155,56 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
     }
   });
 
-  it("every site that renders the stronger caveats renders this one too", () => {
-    // If one renderer forgot it, `unresolved` still reads as "does not exist"
-    // wherever that path is taken — and the behavioural tests above cannot see it.
-    const stronger =
-      (skills.match(/result\.mappings_unavailable\)/g) ?? []).length +
-      (skills.match(/result\.catalogue_unavailable\)/g) ?? []).length;
-    const mine = (skills.match(/result\.catalogue_currency_unverified\)/g) ?? []).length;
-    expect(stronger).toBeGreaterThan(0);
-    expect(mine).toBe(stronger);
+  it("BOTH result renderers surface the currency caveat", () => {
+    // This used to assert parity with the stronger caveats — one currency render per
+    // stronger render. That premise died the moment `mappings_unavailable` gained a
+    // second render site (codex round 4), and the assertion started failing for a
+    // reason that was not a defect. The property that actually matters is coverage:
+    // there are two result shapes, each with a renderer, and BOTH must surface it —
+    // a renderer that forgets it leaves `unresolved` reading as "does not exist" on
+    // whichever path it serves.
+    expect((skills.match(/result\.catalogue_currency_unverified\)/g) ?? []).length).toBe(2);
+    // And the stronger caveats must still be rendered wherever they can be set, or
+    // this one silently becomes the only disclosure a reader ever sees.
+    expect(skills).toMatch(/result\.mappings_unavailable\)/);
+    expect(skills).toMatch(/result\.catalogue_unavailable\)/);
+  });
+});
+
+describe("#890 yielding to a caveat that never arrives", () => {
+  const deps = readFileSync(join(HERE, "../../services/workflow-deps.ts"), "utf8");
+  const skills = readFileSync(join(HERE, "../../tools/skills-access.ts"), "utf8");
+
+  it("the install result can CARRY the stronger mappings caveat", () => {
+    // codex round 4, P1. `mappings_unavailable` had nowhere to live on
+    // InstallDepsResult, so an install whose MAPPINGS lookup threw emitted `unresolved`
+    // with NO caveat at all: the strong one could not be represented, and the currency
+    // caveat correctly yields to it. Yielding to something that never arrives is the
+    // worst of both — it suppresses the weaker disclosure and loses the stronger one,
+    // leaving a bare list in the case we know the MOST about.
+    const install = deps.slice(deps.indexOf("export interface InstallDepsResult"));
+    const shape = install.slice(0, install.indexOf("\n}"));
+    expect(shape).toMatch(/mappings_unavailable\?: string;/);
+  });
+
+  it("both install returns propagate it from the analysis", () => {
+    // The analysis is where the mappings lookup actually happened, so it is carried
+    // over rather than recomputed — and BOTH returns need it: the early
+    // no-missing-packs one and the full install one.
+    expect(
+      (deps.match(/mappings_unavailable: analysis\.mappings_unavailable/g) ?? []).length,
+    ).toBe(2);
+  });
+
+  it("the currency caveat yields only when the stronger one will REACH the reader", () => {
+    // The gate is passed `analysis.mappings_unavailable` on the install path now. If it
+    // were not, the currency caveat would fire alongside a stronger caveat that is also
+    // present — two disclosures for one fact.
+    expect(deps).toMatch(/mappingsUnavailable: analysis\.mappings_unavailable/);
+  });
+
+  it("the install renderer surfaces it", () => {
+    // A field that is set and never rendered is the same hole one layer down.
+    expect((skills.match(/result\.mappings_unavailable\)/g) ?? []).length).toBe(2);
   });
 });

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -111,27 +111,38 @@ describe("#890 what the caveat says", () => {
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/does not report which source/);
   });
 
-  it("names an INDEPENDENT reader that can settle it, and both outcomes", () => {
-    // A caveat with no next step is just doubt. search_custom_nodes queries
-    // api.comfy.org directly rather than through Manager, so it is real evidence.
-    // The ACTION too: search_custom_nodes is action-parameterised and refuses without
-    // one, so naming the tool alone would cost a round trip to an error.
-    // BOTH parameters. The tool is action-parameterised AND `query` is required for
-    // the search action, so a half-named call costs a round trip to an error message
-    // inside a caveat whose whole job is to hand over a check that works.
+  it("names an independent check WITHOUT overclaiming what it proves", () => {
+    // A caveat with no next step is just doubt, so it names one: search_custom_nodes
+    // queries api.comfy.org directly rather than through Manager.
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/search_custom_nodes action:"search"/);
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/query:"<pack name>"/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/query:"/);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/api\.comfy\.org directly/);
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/found there means this[\s\S]*behind/i);
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/absent from both/i);
-    // And what to DO about the one outcome that is actionable.
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/update ComfyUI-Manager/);
+
+    // codex round 7, P1 — and the subtler version of the trap the reporter named.
+    // `unresolved` holds node CLASS TYPES, not pack ids, and the registry indexes
+    // PACKS. An earlier version told the reader to look the entries up and treat a hit
+    // as proof the catalogue was behind; neither half held. So the caveat says what the
+    // entries ARE, and offers the hit as a reason to update rather than a verdict.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/CLASS TYPES, not[\s\S]*pack ids/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/SUGGESTS the catalogue is behind/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/does not prove it/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/missing for indexing reasons/);
+    // The other direction is not evidence either, and saying it was would be the same
+    // overclaim pointed backwards.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/finding nothing settles nothing/);
+    // Still actionable: the one thing worth doing is named.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/updating\s+ComfyUI-Manager/);
   });
 
   it("stays short enough to be read", () => {
-    // It attaches to every miss, including the many that are ordinary. A paragraph
-    // here becomes noise that gets skipped, and then it protects nobody.
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT.length).toBeLessThan(700);
+    // It attaches to every miss, including the many that are ordinary, so a paragraph
+    // here becomes noise that gets skipped and then it protects nobody.
+    //
+    // Raised from 700 after codex round 7: saying what the entries ARE (class types,
+    // not pack ids) and that a registry hit SUGGESTS rather than proves cost about 150
+    // characters. A shorter caveat that overclaims is worse than a longer one that
+    // does not — brevity is a means here, not the point.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT.length).toBeLessThan(950);
   });
 });
 

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -75,7 +75,11 @@ describe("#890 what the caveat says", () => {
     // api.comfy.org directly rather than through Manager, so it is real evidence.
     // The ACTION too: search_custom_nodes is action-parameterised and refuses without
     // one, so naming the tool alone would cost a round trip to an error.
+    // BOTH parameters. The tool is action-parameterised AND `query` is required for
+    // the search action, so a half-named call costs a round trip to an error message
+    // inside a caveat whose whole job is to hand over a check that works.
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/search_custom_nodes action:"search"/);
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/query:"<pack name>"/);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/api\.comfy\.org directly/);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/found there means this[\s\S]*behind/i);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/absent from both/i);

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -73,7 +73,9 @@ describe("#890 what the caveat says", () => {
   it("names an INDEPENDENT reader that can settle it, and both outcomes", () => {
     // A caveat with no next step is just doubt. search_custom_nodes queries
     // api.comfy.org directly rather than through Manager, so it is real evidence.
-    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/search_custom_nodes/);
+    // The ACTION too: search_custom_nodes is action-parameterised and refuses without
+    // one, so naming the tool alone would cost a round trip to an error.
+    expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/search_custom_nodes action:"search"/);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/api\.comfy\.org directly/);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/found there means this[\s\S]*behind/i);
     expect(MANAGER_CATALOGUE_CURRENCY_CAVEAT).toMatch(/absent from both/i);

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -22,6 +22,44 @@ import {
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Blank out string/template/comment CONTENT, preserving length and therefore offsets,
+ *  so a brace scan sees only syntax. Deliberately small: it is a test fixture, not a
+ *  parser, and it only has to be right about braces in this one file. */
+function maskLiterals(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (c === "/" && next === "/") {
+      const nl = src.indexOf("\n", i);
+      blank(i, nl === -1 ? src.length : nl);
+      i = nl === -1 ? src.length : nl;
+    } else if (c === "/" && next === "*") {
+      const endC = src.indexOf("*/", i + 2);
+      const stop = endC === -1 ? src.length : endC + 2;
+      blank(i, stop);
+      i = stop;
+    } else if (c === '"' || c === "'" || c === "`") {
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === "\\") j += 2;
+        else if (src[j] === c) break;
+        else j++;
+      }
+      blank(i, Math.min(j + 1, src.length));
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+  return out.join("");
+}
+
+
 describe("#890 when the caveat attaches", () => {
   it("attaches when packs are unresolved and nothing stronger applies", () => {
     // The reported case: a healthy-LOOKING catalogue answered, and some class_types
@@ -107,7 +145,7 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
     expect((deps.match(/catalogue_currency_unverified\?: string;/g) ?? []).length).toBe(2);
   });
 
-  it("EVERY return that emits `unresolved` also carries the caveat", () => {
+  it("EVERY return that emits `unresolved` also carries a caveat", () => {
     // Counting setters was not enough, and codex round 2 proved it: an EARLY RETURN in
     // installWorkflowDependencies (taken when nothing is missing) emitted `unresolved`
     // bare. The caveat existed, was set in two places, and still never reached that
@@ -115,43 +153,40 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
     // settled answer of the three.
     //
     // The window is bounded to the ENCLOSING OBJECT by brace depth, not by a character
-    // count (codex round 3). A fixed 2600-char forward scan happened to be correct at
-    // today's distances — removing the early return's caveat did fail this test — but
-    // its correctness rested on two returns staying far enough apart, so an edit that
-    // moved them closer would let one return's caveat satisfy another's check and the
-    // test would pass while `unresolved` went out bare. That is the vacuous pass this
-    // test exists to prevent, so it must not depend on layout.
+    // count (round 3): a fixed forward window was correct only at today's distances, so
+    // an edit moving two returns closer would let one return's caveat satisfy another's
+    // check and this test would pass while `unresolved` went out bare.
     //
-    // Anchored on the FIELD rather than on `return {`: the returns sit at different
-    // nesting depths, and an indent-based terminator matched nothing at all. The
-    // `const ` exclusion drops the local `const unresolved: string[] = []` declaration,
-    // which is not a reply.
+    // Braces inside STRINGS, TEMPLATE LITERALS and COMMENTS are masked first (round 5).
+    // The messages in this file are long and full of prose; a future property like
+    // `note: "{"` would otherwise stop the walk from closing and let it run on into a
+    // later return that does carry a caveat — the same vacuous pass, reintroduced by
+    // the fix for it. Indices are preserved so offsets still line up with the source.
+    const masked = maskLiterals(deps);
+
     const FIELD = new RegExp(String.raw`\n\s+unresolved: `, "g");
-    const sites = [...deps.matchAll(FIELD)]
+    const sites = [...masked.matchAll(FIELD)]
       .map((m) => m.index ?? 0)
-      .filter((i) => !/const\s+$/.test(deps.slice(Math.max(0, i - 24), i + 1)));
+      .filter((i) => !/const\s+$/.test(masked.slice(Math.max(0, i - 24), i + 1)));
     expect(sites.length).toBeGreaterThanOrEqual(3); // analysis + install + early return
 
-    /** The rest of the object literal this field sits in — to its matching `}`. */
-    const enclosingObject = (from: number): string => {
-      let depth = 1; // we are already inside the object that holds this field
-      for (let j = from; j < deps.length; j++) {
-        const c = deps[j];
+    for (const i of sites) {
+      let depth = 1; // already inside the object holding this field
+      let close = -1;
+      for (let j = i; j < masked.length; j++) {
+        const c = masked[j];
         if (c === "{") depth++;
-        else if (c === "}") {
-          depth--;
-          if (depth === 0) return deps.slice(from, j);
+        else if (c === "}" && --depth === 0) {
+          close = j;
+          break;
         }
       }
-      return deps.slice(from); // unbalanced — fail loudly below rather than pass
-    };
-
-    for (const i of sites) {
-      const object = enclosingObject(i);
-      // A bound that is not a bound would reintroduce the vacuous pass, so assert the
-      // walk actually terminated before the end of the file.
-      expect(object.length).toBeLessThan(deps.length - i);
-      expect(object, deps.slice(i, i + 60)).toMatch(/catalogue_currency_unverified/);
+      // A walk that never closed is not a bound, and would silently widen the window.
+      expect(close, `unterminated object at ${deps.slice(i, i + 60)}`).toBeGreaterThan(i);
+      const object = deps.slice(i, close);
+      expect(object, deps.slice(i, i + 60)).toMatch(
+        /catalogue_currency_unverified|mappings_unavailable|catalogue_unavailable/,
+      );
     }
   });
 

--- a/src/__tests__/services/manager-catalogue-currency.test.ts
+++ b/src/__tests__/services/manager-catalogue-currency.test.ts
@@ -183,7 +183,11 @@ describe("#890 WIRING: it reaches both results and both renderers", () => {
       }
       // A walk that never closed is not a bound, and would silently widen the window.
       expect(close, `unterminated object at ${deps.slice(i, i + 60)}`).toBeGreaterThan(i);
-      const object = deps.slice(i, close);
+      // Matched on the MASKED slice too (codex round 6). Searching the raw source let a
+      // COMMENT mentioning one of these names satisfy the check — and this file is full
+      // of comments that name them, so a bare return sitting under one would have passed.
+      // Masking leaves only code, so the match proves a field, not a mention.
+      const object = masked.slice(i, close);
       expect(object, deps.slice(i, i + 60)).toMatch(
         /catalogue_currency_unverified|mappings_unavailable|catalogue_unavailable/,
       );

--- a/src/services/manager-catalogue-currency.ts
+++ b/src/services/manager-catalogue-currency.ts
@@ -51,7 +51,8 @@ export const MANAGER_CATALOGUE_CURRENCY_CAVEAT =
   `cannot reach the registry it serves a copy bundled in its own package — populated, ` +
   `HTTP 200, and indistinguishable from a current one; it does not report which source ` +
   `answered, so nothing here can date it (panel#890). To settle it, look one of these up ` +
-  `with search_custom_nodes, which queries api.comfy.org directly: found there means this ` +
+  `with search_custom_nodes action:"search", which queries api.comfy.org directly: found ` +
+  `there means this ` +
   `Manager catalogue is behind (update ComfyUI-Manager on the ComfyUI host and re-scan), ` +
   `absent from both means it is genuinely unknown to the registry.`;
 

--- a/src/services/manager-catalogue-currency.ts
+++ b/src/services/manager-catalogue-currency.ts
@@ -1,0 +1,76 @@
+/**
+ * panel#890 — a POPULATED ComfyUI-Manager catalogue proves nothing about its age.
+ *
+ * ## What was measured (the reporter's, on a network that genuinely blocks the registry)
+ *
+ * Manager raises `InvalidChannel` for the channel host and logs `Cannot connect to
+ * comfyregistry`. It then answers `/customnode/getmappings?mode=cache` with HTTP 200,
+ * 1,570,773 bytes, 5583 packs — served from the `extension-node-map.json` BUNDLED in
+ * the Manager package, via `get_data_by_mode`'s except-branch.
+ *
+ * So the failure mode is not an empty list. It is a full one, of unknown age, byte-for-
+ * byte indistinguishable from a current one. Manager does not report which source
+ * answered.
+ *
+ * ## Why the existing caveats do not cover it
+ *
+ * #1136 added `catalogue_unavailable` (the list came back EMPTY) and
+ * `mappings_unavailable` (the lookup threw and we caught it). Both key on an OBSERVED
+ * failure. A bundled fallback presents as success, so neither fires — and `unresolved`
+ * goes out with no caveat at all, reading as "these packs do not exist". That is the
+ * exact collapse #1136 exists to prevent, surviving in the case Manager works hardest
+ * to produce.
+ *
+ * ## What this deliberately does NOT say
+ *
+ * It does not claim the catalogue IS stale. Nothing here can observe that, and the
+ * reporter named that trap in the issue: a staleness claim inferred from something the
+ * panel cannot see would repeat the fault the original issue was filed about. This says
+ * only what is true of every Manager-served catalogue — its currency is unverifiable
+ * from here — and then hands over a check that can settle it.
+ *
+ * ## The discriminator
+ *
+ * `search_custom_nodes` queries `api.comfy.org` DIRECTLY rather than through Manager, so
+ * it is an independent source:
+ *
+ *   - found there, absent here  → this Manager catalogue is behind
+ *   - absent from both          → genuinely unknown to the registry
+ *
+ * Named rather than performed: this rides on a read that already has its answer, and
+ * adding a network call to it would make every dependency scan slower for a case that
+ * is usually fine.
+ */
+
+/** The one sentence that must accompany an `unresolved` list from a Manager catalogue
+ *  we could not date. Kept SHORT on purpose — it attaches to every miss, including the
+ *  many that are ordinary, so a paragraph here becomes noise that gets skipped and then
+ *  it protects nobody. */
+export const MANAGER_CATALOGUE_CURRENCY_CAVEAT =
+  `NOT proof these do not exist. This is the ComfyUI-Manager catalogue, and when Manager ` +
+  `cannot reach the registry it serves a copy bundled in its own package — populated, ` +
+  `HTTP 200, and indistinguishable from a current one; it does not report which source ` +
+  `answered, so nothing here can date it (panel#890). To settle it, look one of these up ` +
+  `with search_custom_nodes, which queries api.comfy.org directly: found there means this ` +
+  `Manager catalogue is behind (update ComfyUI-Manager on the ComfyUI host and re-scan), ` +
+  `absent from both means it is genuinely unknown to the registry.`;
+
+/**
+ * Should the currency caveat be attached?
+ *
+ * Only when there is something to mislead about (`unresolved` non-empty) AND no
+ * STRONGER caveat already applies. `catalogue_unavailable` and `mappings_unavailable`
+ * report an OBSERVED failure; this one reports the absence of evidence either way.
+ * Emitting both would bury the observed fact under the generic one and read as two
+ * separate problems.
+ */
+export function managerCatalogueCurrencyUnverified(opts: {
+  unresolvedCount: number;
+  catalogueUnavailable?: string;
+  mappingsUnavailable?: string;
+}): boolean {
+  if (opts.unresolvedCount <= 0) return false;
+  if (opts.catalogueUnavailable) return false;
+  if (opts.mappingsUnavailable) return false;
+  return true;
+}

--- a/src/services/manager-catalogue-currency.ts
+++ b/src/services/manager-catalogue-currency.ts
@@ -40,6 +40,14 @@
  * Named rather than performed: this rides on a read that already has its answer, and
  * adding a network call to it would make every dependency scan slower for a case that
  * is usually fine.
+ *
+ * Spelled out with BOTH `action` and `query` (codex review). The tool is
+ * action-parameterised and `query` is required for the search action, so a half-named
+ * call costs a round trip to an error — inside a caveat whose entire job is to hand
+ * over a check that works. (The review reported that this tool has no `action`
+ * parameter at all; measured against `registerRegistrySearchTools`, it does — a
+ * required `z.enum(["search","details"])`. The finding was wrong on that premise and
+ * right that the call was under-specified.)
  */
 
 /** The one sentence that must accompany an `unresolved` list from a Manager catalogue
@@ -51,8 +59,8 @@ export const MANAGER_CATALOGUE_CURRENCY_CAVEAT =
   `cannot reach the registry it serves a copy bundled in its own package — populated, ` +
   `HTTP 200, and indistinguishable from a current one; it does not report which source ` +
   `answered, so nothing here can date it (panel#890). To settle it, look one of these up ` +
-  `with search_custom_nodes action:"search", which queries api.comfy.org directly: found ` +
-  `there means this ` +
+  `with search_custom_nodes action:"search" query:"<pack name>", which queries api.comfy.org ` +
+  `directly: found there means this ` +
   `Manager catalogue is behind (update ComfyUI-Manager on the ComfyUI host and re-scan), ` +
   `absent from both means it is genuinely unknown to the registry.`;
 

--- a/src/services/manager-catalogue-currency.ts
+++ b/src/services/manager-catalogue-currency.ts
@@ -29,13 +29,21 @@
  * only what is true of every Manager-served catalogue — its currency is unverifiable
  * from here — and then hands over a check that can settle it.
  *
- * ## The discriminator
+ * ## The nearest thing to a discriminator
  *
- * `search_custom_nodes` queries `api.comfy.org` DIRECTLY rather than through Manager, so
- * it is an independent source:
+ * `search_custom_nodes` queries `api.comfy.org` DIRECTLY rather than through Manager,
+ * so it is an INDEPENDENT source. It is not a clean two-way test, and an earlier
+ * version of this said it was (codex round 7):
  *
- *   - found there, absent here  → this Manager catalogue is behind
- *   - absent from both          → genuinely unknown to the registry
+ *   - `unresolved` holds node CLASS TYPES, not pack ids, and the registry indexes
+ *     PACKS. So the entries cannot simply be looked up; the caller searches the class
+ *     type or the pack they believe provides it.
+ *   - A registry hit for a pack this catalogue omits SUGGESTS the catalogue is behind.
+ *     It does not prove it — a Manager mapping can be absent for indexing reasons that
+ *     have nothing to do with age — so it is offered as a reason to update, not a
+ *     verdict.
+ *   - Finding nothing settles nothing in either direction, and saying otherwise would
+ *     be the same overclaim pointed the other way.
  *
  * Named rather than performed: this rides on a read that already has its answer, and
  * adding a network call to it would make every dependency scan slower for a case that
@@ -44,10 +52,9 @@
  * Spelled out with BOTH `action` and `query` (codex review). The tool is
  * action-parameterised and `query` is required for the search action, so a half-named
  * call costs a round trip to an error — inside a caveat whose entire job is to hand
- * over a check that works. (The review reported that this tool has no `action`
- * parameter at all; measured against `registerRegistrySearchTools`, it does — a
- * required `z.enum(["search","details"])`. The finding was wrong on that premise and
- * right that the call was under-specified.)
+ * over a check that works. (A review round reported that this tool has no `action`
+ * parameter at all; measured twice against origin/main, it does — a required
+ * `z.enum(["search","details"])`, with exactly one registration of the name.)
  */
 
 /** The one sentence that must accompany an `unresolved` list from a Manager catalogue
@@ -58,11 +65,13 @@ export const MANAGER_CATALOGUE_CURRENCY_CAVEAT =
   `NOT proof these do not exist. This is the ComfyUI-Manager catalogue, and when Manager ` +
   `cannot reach the registry it serves a copy bundled in its own package — populated, ` +
   `HTTP 200, and indistinguishable from a current one; it does not report which source ` +
-  `answered, so nothing here can date it (panel#890). To settle it, look one of these up ` +
-  `with search_custom_nodes action:"search" query:"<pack name>", which queries api.comfy.org ` +
-  `directly: found there means this ` +
-  `Manager catalogue is behind (update ComfyUI-Manager on the ComfyUI host and re-scan), ` +
-  `absent from both means it is genuinely unknown to the registry.`;
+  `answered, so nothing here can date it (panel#890). These are node CLASS TYPES, not ` +
+  `pack ids, and the registry indexes PACKS — so search the class type, or the pack you ` +
+  `believe provides it, with search_custom_nodes action:"search" query:"<name>", which ` +
+  `queries api.comfy.org directly rather than through Manager. A pack found there that ` +
+  `this catalogue does not list SUGGESTS the catalogue is behind and is worth updating ` +
+  `ComfyUI-Manager on the ComfyUI host for — it does not prove it, because a mapping can ` +
+  `also be missing for indexing reasons, and finding nothing settles nothing either way.`;
 
 /**
  * Should the currency caveat be attached?

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -12,6 +12,10 @@ import {
   type ManagerApi,
 } from "./node-management.js";
 import { targetsPanelPackExactly, withPanelPinGuard } from "./panel-pin-guard.js";
+import {
+  MANAGER_CATALOGUE_CURRENCY_CAVEAT,
+  managerCatalogueCurrencyUnverified,
+} from "./manager-catalogue-currency.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -89,6 +93,15 @@ export interface ExtractDepsResult {
    * here we caught a real exception and logged it, then asserted absence anyway.
    */
   mappings_unavailable?: string;
+  /**
+   * panel#890 — set when `unresolved` came from a Manager catalogue whose CURRENCY
+   * could not be established, which is every populated one: Manager serves a copy
+   * bundled in its own package when the registry is unreachable, and does not report
+   * which source answered. Weaker than the two fields above — they report an OBSERVED
+   * failure; this reports the absence of evidence — so it is set only when neither of
+   * those is.
+   */
+  catalogue_currency_unverified?: string;
 }
 
 export interface InstallDepsResult {
@@ -107,6 +120,8 @@ export interface InstallDepsResult {
    * alongside, "not found in ComfyUI-Manager".
    */
   catalogue_unavailable?: string;
+  /** panel#890 — see the same field on WorkflowDepsAnalysis. */
+  catalogue_currency_unverified?: string;
 }
 
 export interface ManagerQueueStatus {
@@ -464,6 +479,15 @@ export async function extractWorkflowDependencies(
     ...(mappingsUnavailable && unresolved.length > 0
       ? { mappings_unavailable: mappingsUnavailable }
       : {}),
+    // panel#890 — the third state. The two caveats above fire on an OBSERVED failure
+    // (empty list, caught exception); a catalogue served from Manager's bundled copy
+    // presents as success, so neither fires and `unresolved` used to go out bare.
+    ...(managerCatalogueCurrencyUnverified({
+      unresolvedCount: unresolved.length,
+      mappingsUnavailable,
+    })
+      ? { catalogue_currency_unverified: MANAGER_CATALOGUE_CURRENCY_CAVEAT }
+      : {}),
   };
 }
 
@@ -622,6 +646,12 @@ export async function installWorkflowDependenciesForAnalysis(
             `blocked or filtered network there looks exactly like an empty result here. Refresh the ` +
             `Manager list on that host before concluding anything from "not found".`,
         }
+      : {}),
+    ...(managerCatalogueCurrencyUnverified({
+      unresolvedCount: unresolved.length,
+      catalogueUnavailable: catalogueEmpty ? "empty" : undefined,
+    })
+      ? { catalogue_currency_unverified: MANAGER_CATALOGUE_CURRENCY_CAVEAT }
       : {}),
     ...(panelNotes.length ? { panel_notes: panelNotes } : {}),
   };

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -510,6 +510,15 @@ export async function installWorkflowDependencies(
       installed: [],
       alreadyInstalled: analysis.requiredPacks,
       unresolved: analysis.unresolved,
+      // panel#890 (codex round 2, P1) — this early return emits `unresolved` too, and
+      // it used to emit it BARE. Nothing is installed on this path, so it reads as the
+      // most settled answer of the three, and "not found in ComfyUI-Manager" with no
+      // qualification is exactly the reading the caveat exists to prevent. Carried over
+      // from the analysis rather than recomputed: the analysis is where the catalogue
+      // was actually consulted.
+      ...(analysis.catalogue_currency_unverified
+        ? { catalogue_currency_unverified: analysis.catalogue_currency_unverified }
+        : {}),
     };
   }
 

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -122,6 +122,17 @@ export interface InstallDepsResult {
   catalogue_unavailable?: string;
   /** panel#890 — see the same field on WorkflowDepsAnalysis. */
   catalogue_currency_unverified?: string;
+  /**
+   * panel#890 (codex round 4) — the analysis's `mappings_unavailable`, carried through.
+   *
+   * It had nowhere to live on this shape, so an install whose MAPPINGS lookup threw
+   * emitted `unresolved` with no caveat of any kind: the strong one could not be
+   * represented, and the currency caveat deliberately yields to it. Yielding to a
+   * caveat that never arrives is the worst of both — it suppresses the weaker
+   * disclosure AND loses the stronger one, so the reader sees a bare list in the case
+   * we know the most about.
+   */
+  mappings_unavailable?: string;
 }
 
 export interface ManagerQueueStatus {
@@ -519,6 +530,11 @@ export async function installWorkflowDependencies(
       ...(analysis.catalogue_currency_unverified
         ? { catalogue_currency_unverified: analysis.catalogue_currency_unverified }
         : {}),
+      // The STRONGER caveat too (codex round 4). The currency one yields to it, so
+      // dropping it here left this path with neither.
+      ...(analysis.mappings_unavailable
+        ? { mappings_unavailable: analysis.mappings_unavailable }
+        : {}),
     };
   }
 
@@ -659,8 +675,13 @@ export async function installWorkflowDependenciesForAnalysis(
     ...(managerCatalogueCurrencyUnverified({
       unresolvedCount: unresolved.length,
       catalogueUnavailable: catalogueEmpty ? "empty" : undefined,
+      mappingsUnavailable: analysis.mappings_unavailable,
     })
       ? { catalogue_currency_unverified: MANAGER_CATALOGUE_CURRENCY_CAVEAT }
+      : {}),
+    // Same gap on this path: the analysis's mappings failure never reached the reply.
+    ...(analysis.mappings_unavailable
+      ? { mappings_unavailable: analysis.mappings_unavailable }
       : {}),
     ...(panelNotes.length ? { panel_notes: panelNotes } : {}),
   };

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -795,6 +795,10 @@ async function installDepsAction(input: string | Record<string, unknown>): Promi
     // #1136 — say it BEFORE the list. A reader who has already read
     // "not found in ComfyUI-Manager" has drawn the conclusion.
     if (result.catalogue_unavailable) lines.push(result.catalogue_unavailable, "");
+    // panel#890 (codex round 4) — the install reply can carry the analysis's mappings
+    // failure now, and a caveat that is set but never rendered is the same hole one
+    // layer down.
+    if (result.mappings_unavailable) lines.push(result.mappings_unavailable, "");
     if (result.catalogue_currency_unverified)
       lines.push(result.catalogue_currency_unverified, "");
     lines.push(

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -737,6 +737,10 @@ async function extractDepsAction(input: string | Record<string, unknown>): Promi
     // MAPPINGS endpoint, whose failure was previously caught, logged at warn and
     // discarded -- we held the exception and asserted absence anyway.
     if (result.mappings_unavailable) lines.push(result.mappings_unavailable, "");
+    // panel#890 — rendered at every site the stronger caveats are, or `unresolved`
+    // still reads as "does not exist" wherever this one was forgotten.
+    if (result.catalogue_currency_unverified)
+      lines.push(result.catalogue_currency_unverified, "");
     lines.push(
       `### Unresolved node types (${result.unresolved.length})`,
       "These class_types are neither installed nor known to ComfyUI-Manager:",
@@ -791,6 +795,8 @@ async function installDepsAction(input: string | Record<string, unknown>): Promi
     // #1136 — say it BEFORE the list. A reader who has already read
     // "not found in ComfyUI-Manager" has drawn the conclusion.
     if (result.catalogue_unavailable) lines.push(result.catalogue_unavailable, "");
+    if (result.catalogue_currency_unverified)
+      lines.push(result.catalogue_currency_unverified, "");
     lines.push(
       `### Could not resolve (${result.unresolved.length})`,
       "Not found in ComfyUI-Manager — install manually:",


### PR DESCRIPTION
Claims artokun/comfyui-mcp-panel#890.

The reporter measured a machine whose network blocks the registry: ComfyUI-Manager raises `InvalidChannel`, reports `Cannot connect to comfyregistry`, and then serves a **populated** catalogue — 5583 packs, 1.5 MB — out of the `extension-node-map.json` bundled in the Manager package. So the failure mode is not an empty list. It is a full list that may be months out of date, presented identically to a current one.

#1136 added `catalogue_unavailable` (empty list) and `mappings_unavailable` (a caught exception). Neither fires here, so `unresolved` carries no caveat and reads as "these packs do not exist" — which is the collapse #1136 exists to prevent, surviving in the case Manager works hardest to produce.

**Scope, and what I will NOT do.** The reporter is explicit that a staleness claim inferred from something the panel cannot observe would repeat the fault. Agreed — Manager does not report which source answered, so nothing here will assert the catalogue IS stale.

What it can do is stop asserting the opposite, and name a check that discriminates: `search_custom_nodes` queries `api.comfy.org` **directly**, an independent source. A pack absent from Manager's catalogue but present in the live registry proves the catalogue is behind — observable, no new network call on the read path, and it is a reader that can actually answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)