### PR TITLE
chore(release): 0.51.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.16] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- an unresolved pack must not read as 'does not exist' on a possibly-stale catalogue (#1463)
+
+
 ## [0.51.15] - 2026-08-12
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.15",
+  "version": "0.51.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.15",
+      "version": "0.51.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.15",
+  "version": "0.51.16",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles 0.51.16 into protected main.

panel#890 — measured on a network that blocks the registry: ComfyUI-Manager serves a **populated** 5583-pack catalogue out of the copy bundled in its own package, HTTP 200, indistinguishable from a current one. #1136's caveats both key on an observed failure (empty list, caught exception), so neither fires, and `unresolved` went out bare — reading as "these packs do not exist" in the case Manager works hardest to produce.

It carries `catalogue_currency_unverified` now, on all three result paths. It never claims the catalogue is stale — nothing here can observe that, and the reporter named that trap explicitly — and it points at `search_custom_nodes`, which queries `api.comfy.org` directly rather than through Manager, while being honest that a hit *suggests* rather than proves.

Eight review rounds. The ones that mattered: a third return path the wiring test structurally could not see, the stronger `mappings_unavailable` caveat having nowhere to live on the install shape (so the currency caveat yielded to something that never arrived), and the caveat itself overclaiming what a registry hit proves — `unresolved` holds node class types, not pack ids.

Verified against the shipped surface: every tool the caveat names is live vocabulary, and the call it prescribes (`action:"search"` with `query`) is valid against the registered schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)