### PR TITLE
fix(1397): show the Manager's own error body, bounded, instead of a bare status line

### DIFF
--- a/src/__tests__/services/manager-403-reason.test.ts
+++ b/src/__tests__/services/manager-403-reason.test.ts
@@ -64,7 +64,11 @@ describe("#1089 Manager 403 names its own reason", () => {
     const src = readFileSync(new URL("../../services/node-management.ts", import.meta.url), "utf8");
     const i = src.indexOf("ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}");
     expect(i).toBeGreaterThan(-1);
-    const window = src.slice(i, i + 240);
+    // Widened from 240 for #1397, which appends managerBodyClause(text) and its
+    // rationale between the message head and the `details` object. The assertions
+    // below are unchanged — only the distance they scan, which was never the
+    // property being protected.
+    const window = src.slice(i, i + 900);
     expect(window).toMatch(/explainManagerForbidden\(res\.status, text\)/);
     // …and the raw body is still carried in details, so nothing is LOST by
     // summarising it in the message.

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -115,3 +115,57 @@ describe("#1397 WIRING: the non-2xx site actually appends it", () => {
     expect(src.slice(at, at + 700)).toMatch(/\{ url, status: res\.status, body: text \}/);
   });
 });
+
+describe("#1397 a credential never reaches the message", () => {
+  // The excerpt is an ARBITRARY upstream payload on a user-visible path, and a
+  // Manager failure is exactly where a credential shows up: a pack install that
+  // cannot clone echoes the git remote. The rule here is that a secret never appears
+  // in an error, so these are the shapes, not a list of key names — the next
+  // credential will not be on a list.
+
+  it("strips credentials from a git remote in a clone failure", () => {
+    const body =
+      "CalledProcessError: git clone https://octocat:ghp_ABCDEFG1234567890abcdef@github.com/o/r.git failed";
+    const out = managerBodyExcerpt(body);
+    expect(out).not.toMatch(/ghp_ABCDEFG1234567890abcdef/);
+    expect(out).not.toMatch(/octocat:/);
+    expect(out).toMatch(/\*\*\*:\*\*\*@github\.com/);
+    // The DIAGNOSIS survives the redaction — that is the whole point of the excerpt.
+    expect(out).toMatch(/CalledProcessError/);
+    expect(out).toMatch(/github\.com\/o\/r\.git/);
+  });
+
+  it("strips bearer/token headers echoed into a traceback", () => {
+    const out = managerBodyExcerpt('headers={"Authorization": "Bearer sk-live-ABCDEF1234567890"}');
+    expect(out).not.toMatch(/sk-live-ABCDEF1234567890/);
+    expect(out).toMatch(/Bearer \*\*\*/i);
+  });
+
+  it("strips token-ish query params and reprs", () => {
+    for (const body of [
+      "GET /manager/queue/task?api_key=ABCDEF1234567890 failed",
+      "config: {'civitai_token': 'ABCDEF1234567890'}",
+      'url=https://x/y?access_token=ABCDEF1234567890',
+    ]) {
+      const out = managerBodyExcerpt(body);
+      expect(out, body).not.toMatch(/ABCDEF1234567890/);
+      expect(out, body).toMatch(/\*\*\*/);
+    }
+  });
+
+  it("redacts BEFORE the cap, so truncation cannot preserve half a secret", () => {
+    // Order is load-bearing. Redacting after the slice would leave the first half of
+    // a credential that straddles the boundary — a partial secret is a leaked one.
+    const secret = "ghp_" + "Z".repeat(80);
+    const body = `${"filler ".repeat(90)}https://u:${secret}@h/r.git`;
+    const out = managerBodyExcerpt(body, 700);
+    expect(out).not.toMatch(/ghp_ZZZ/);
+  });
+
+  it("does not over-redact an ordinary exception", () => {
+    // Over-redaction makes the excerpt useless, and this exists to make an opaque
+    // failure readable. A normal traceback must come through intact.
+    const body = "ModuleNotFoundError: No module named 'openai_whisper' in /home/u/ComfyUI/custom_nodes/x";
+    expect(managerBodyExcerpt(body)).toBe(body);
+  });
+});

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -170,19 +170,27 @@ describe("#1397 a credential never reaches the message", () => {
     expect(out).not.toMatch(/ghp_ZZZ/);
   });
 
-  it("redacts an Authorization: Basic header - both halves of a credential at once", () => {
-    // Found by review: `basic` was the one scheme the alternation missed. It matters
-    // MORE than the others, not less - the base64 blob decodes to `user:password`, so
-    // leaking it leaks the account itself, not a token that can be rotated.
-    const secret = "QWxhZGRpbjpvcGVuc2VzYW1l";
-    const out = managerBodyExcerpt(
-      "HTTPError: 401 Client Error for url http://127.0.0.1:8188/api/manager/queue/install " +
-        "(sent Authorization: Basic " + secret + ")",
-    );
+  it("redacts Authorization: Basic at ANY length, including a 4-char credential", () => {
+    // `Basic YTpi` decodes to `a:b`. A shape/length discriminator missed exactly this
+    // (round 3 of review), which is why the rule keys on the HEADER context instead:
+    // once `Authorization: Basic` is present, whatever follows is the credential
+    // regardless of how short or how word-like it looks.
+    for (const secret of ["YTpi", "QWxhZGRpbjpvcGVuc2VzYW1l", "dXNlcjpwYXNzd29yZA"]) {
+      const out = managerBodyExcerpt(
+        "HTTPError: 401 Client Error for url http://127.0.0.1:8188/api/manager/queue " +
+          "(sent Authorization: Basic " + secret + ")",
+      );
+      expect(out).not.toContain(secret);
+      expect(out).toMatch(/Basic \*\*\*/i);
+      expect(out).toMatch(/401/); // the diagnosis survives
+    }
+  });
+
+  it("redacts a Proxy-Authorization Basic header too", () => {
+    const secret = "cHJveHl1c2VyOnB3";
+    const out = managerBodyExcerpt("502 from proxy (Proxy-Authorization: Basic " + secret + ")");
     expect(out).not.toContain(secret);
-    expect(out).toMatch(/Basic \*\*\*/);
-    // The diagnosis still survives - redaction must not cost the reason.
-    expect(out).toMatch(/401/);
+    expect(out).toMatch(/Basic \*\*\*/i);
   });
 
   it("truncation never ends on half a surrogate pair", () => {
@@ -211,6 +219,11 @@ describe("#1397 a credential never reaches the message", () => {
     const out = managerBodyExcerpt("ValueError: Basic configuration missing for Deno package");
     expect(out).toContain("Basic configuration missing");
     expect(out).not.toContain("***");
+    // Round 3: a long alphanumeric identifier is still ordinary prose, not a
+    // credential. The shape-based rule ate this one; the context-based rule cannot.
+    const out2 = managerBodyExcerpt("ValueError: Basic ConfigVersion2026 missing for Deno package");
+    expect(out2).toContain("ConfigVersion2026");
+    expect(out2).not.toContain("***");
   });
 
   it("redacts a Cookie / session value", () => {
@@ -231,6 +244,18 @@ describe("#1397 a credential never reaches the message", () => {
     const out = managerBodyExcerpt("RequestError: authorization=" + v + " rejected upstream");
     expect(out).not.toContain(v);
     expect(out).toMatch(/authorization=\*\*\*/);
+  });
+
+  it("redacts a git remote whose PASSWORD contains a colon", () => {
+    // Round 3 claimed `https://user:pa:ss@host` leaks because the pattern "rejects the
+    // second colon". Measured here rather than argued: the user part excludes `:` but
+    // the password part does not, so the match runs to the `@` and the whole
+    // credential goes. Keeping the case pinned so a future tightening of that charset
+    // cannot silently reintroduce the leak.
+    const out = managerBodyExcerpt("fatal: could not read from https://user:pa:ss@host/repo.git");
+    expect(out).not.toContain("pa:ss");
+    expect(out).toContain("***");
+    expect(out).toContain("host/repo.git");
   });
 
   it("does not over-redact an ordinary exception", () => {

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -170,6 +170,39 @@ describe("#1397 a credential never reaches the message", () => {
     expect(out).not.toMatch(/ghp_ZZZ/);
   });
 
+  it("redacts an Authorization: Basic header - both halves of a credential at once", () => {
+    // Found by review: `basic` was the one scheme the alternation missed. It matters
+    // MORE than the others, not less - the base64 blob decodes to `user:password`, so
+    // leaking it leaks the account itself, not a token that can be rotated.
+    const secret = "QWxhZGRpbjpvcGVuc2VzYW1l";
+    const out = managerBodyExcerpt(
+      "HTTPError: 401 Client Error for url http://127.0.0.1:8188/api/manager/queue/install " +
+        "(sent Authorization: Basic " + secret + ")",
+    );
+    expect(out).not.toContain(secret);
+    expect(out).toMatch(/Basic \*\*\*/);
+    // The diagnosis still survives - redaction must not cost the reason.
+    expect(out).toMatch(/401/);
+  });
+
+  it("truncation never ends on half a surrogate pair", () => {
+    // `limit` counts UTF-16 code units, so a cut can land BETWEEN the halves of an
+    // emoji. The orphan serialises to U+FFFD, and a body that was merely long then
+    // reads as corrupted - "the tool mangled it" rather than "it was truncated".
+    //
+    // Cut lands exactly mid-pair: (limit - 1) filler chars, then a 2-unit emoji.
+    const body = "a".repeat(MANAGER_BODY_EXCERPT_LIMIT - 1) + "\u{1F600}tail";
+    const out = managerBodyExcerpt(body);
+    expect(out).toMatch(/\[truncated\]$/);
+    expect(out).not.toContain("\uFFFD");
+    // No lone surrogate survives: iterating by code point, any leading surrogate must
+    // come paired (a whole pair iterates as a single 2-unit string).
+    for (const ch of out) {
+      const c = ch.charCodeAt(0);
+      if (c >= 0xd800 && c <= 0xdbff) expect(ch.length).toBe(2);
+    }
+  });
+
   it("does not over-redact an ordinary exception", () => {
     // Over-redaction makes the excerpt useless, and this exists to make an opaque
     // failure readable. A normal traceback must come through intact.

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -203,6 +203,36 @@ describe("#1397 a credential never reaches the message", () => {
     }
   });
 
+  it('does not redact the ORDINARY word "basic"', () => {
+    // Regression from round 1 of review: matching `basic` like `bearer` turned
+    // "Basic configuration missing for Deno package" into "Basic *** missing ...",
+    // deleting the diagnosis this excerpt exists to deliver. An English word is pure
+    // letters; a credential blob carries a digit or a base64-only character.
+    const out = managerBodyExcerpt("ValueError: Basic configuration missing for Deno package");
+    expect(out).toContain("Basic configuration missing");
+    expect(out).not.toContain("***");
+  });
+
+  it("redacts a Cookie / session value", () => {
+    // A live session in a proxy's 401 body is as reusable as the password that
+    // minted it.
+    const sid = "abcdefghijklmnopQRST9xY";
+    const out = managerBodyExcerpt("HTTPError: 401 for /api/manager/queue (Cookie: session=" + sid + ")");
+    expect(out).not.toContain(sid);
+    // Asserting the PROPERTY, not the shape: `Cookie:` consumes `session=<value>`
+    // greedily, so the redacted form is `Cookie: ***` rather than `session=***`.
+    // Pinning the exact form here would fail on a harmless rule reorder.
+    expect(out).toContain("***");
+    expect(out).toMatch(/401/);
+  });
+
+  it("redacts a bare authorization=<value> pair", () => {
+    const v = "AbcDef123456789xyz";
+    const out = managerBodyExcerpt("RequestError: authorization=" + v + " rejected upstream");
+    expect(out).not.toContain(v);
+    expect(out).toMatch(/authorization=\*\*\*/);
+  });
+
   it("does not over-redact an ordinary exception", () => {
     // Over-redaction makes the excerpt useless, and this exists to make an opaque
     // failure readable. A normal traceback must come through intact.

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -156,8 +156,16 @@ describe("#1397 a credential never reaches the message", () => {
   it("redacts BEFORE the cap, so truncation cannot preserve half a secret", () => {
     // Order is load-bearing. Redacting after the slice would leave the first half of
     // a credential that straddles the boundary — a partial secret is a leaked one.
-    const secret = "ghp_" + "Z".repeat(80);
-    const body = `${"filler ".repeat(90)}https://u:${secret}@h/r.git`;
+    // Written as ONE literal, not assembled from fragments: check:vocabulary refuses a
+    // string built at runtime because a tool name spelled that way is invisible to it
+    // and survives every rename. A fake credential trips the same rule, and the rule is
+    // right — the fix is to stop concatenating, not to loosen the gate.
+    const secret =
+      "ghp_ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
+    const filler =
+      "filler filler filler filler filler filler filler filler filler filler filler " +
+      "filler filler filler filler filler filler filler filler filler filler filler ";
+    const body = `${filler}https://u:${secret}@h/r.git`;
     const out = managerBodyExcerpt(body, 700);
     expect(out).not.toMatch(/ghp_ZZZ/);
   });

--- a/src/__tests__/services/manager-error-body.test.ts
+++ b/src/__tests__/services/manager-error-body.test.ts
@@ -1,0 +1,117 @@
+// #1397 — the ComfyUI-Manager error body was captured and never shown.
+//
+// panel_update_node failed with "an opaque serialized ComfyUI-Manager
+// QueueTaskItem/OperationType exception and no actionable traceback". The body was
+// never missing — managerFetch stores it in `details` as { url, status, body } — it
+// just never reached the message for any status but 403. The reader got
+// `ComfyUI-Manager API 500 Internal Server Error for /v2/manager/queue/task` while
+// the exception naming the real cause (a missing Python dependency, in the report)
+// sat one layer down.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MANAGER_BODY_EXCERPT_LIMIT,
+  managerBodyClause,
+  managerBodyExcerpt,
+} from "../../services/manager-error-body.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("#1397 the body reaches the message", () => {
+  it("carries a serialized Manager exception through", () => {
+    // The reported shape.
+    const body =
+      '{"error":"QueueTaskItem","detail":"OperationType.UPDATE failed: ' +
+      "ModuleNotFoundError: No module named 'openai_whisper'\"}";
+    const clause = managerBodyClause(body);
+    expect(clause).toMatch(/ComfyUI-Manager said:/);
+    expect(clause).toMatch(/QueueTaskItem/);
+    // The part that actually names the cause must survive.
+    expect(clause).toMatch(/No module named 'openai_whisper'/);
+  });
+
+  it("accepts an already-parsed body, not only a string", () => {
+    // managerFetch parses JSON on the success path; a caller decorating a non-2xx
+    // error may hold either shape, and a body that reads as "" because it was an
+    // object would reintroduce the defect for exactly the responses that carry most.
+    const clause = managerBodyClause({ error: "QueueTaskItem", detail: "boom" });
+    expect(clause).toMatch(/QueueTaskItem/);
+    expect(clause).toMatch(/boom/);
+  });
+
+  it("is empty for an empty or unreadable body, with no dangling separator", () => {
+    // The caller appends unconditionally. An unreadable body must cost detail in the
+    // text and never produce "ComfyUI-Manager said:" followed by nothing.
+    for (const empty of ["", "   ", "\n\t ", undefined, null]) {
+      expect(managerBodyClause(empty), JSON.stringify(empty)).toBe("");
+    }
+  });
+
+  it("never throws while decorating an error", () => {
+    // This runs on a path that is already reporting a failure. An error-path guard
+    // that becomes the error is strictly worse than the message it was improving.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => managerBodyClause(circular)).not.toThrow();
+    expect(managerBodyClause(circular)).toBe("");
+  });
+});
+
+describe("#1397 it is BOUNDED, and says when it truncated", () => {
+  it("caps a large traceback", () => {
+    // #664 is the precedent: a verbatim error payload once carried tensor-sized
+    // fields and 41k-token tracebacks into a reply. Unbounded here would trade an
+    // unreadable message for an unusable one.
+    const huge = "Traceback (most recent call last): " + "x".repeat(50_000);
+    const excerpt = managerBodyExcerpt(huge);
+    expect(excerpt.length).toBeLessThan(MANAGER_BODY_EXCERPT_LIMIT + 40);
+    // The HEAD is kept — a Python exception names its cause at the top.
+    expect(excerpt).toMatch(/^Traceback \(most recent call last\):/);
+  });
+
+  it("MARKS the truncation rather than cutting silently", () => {
+    // A silently cut traceback reads as a complete one, and the reader concludes the
+    // exception ended where the budget did.
+    expect(managerBodyExcerpt("y".repeat(5_000))).toMatch(/… \[truncated\]$/);
+    // And a body that fits is NOT marked.
+    expect(managerBodyExcerpt("short and complete")).toBe("short and complete");
+    expect(managerBodyExcerpt("short and complete")).not.toMatch(/truncated/);
+  });
+
+  it("collapses whitespace so a traceback stays one readable line", () => {
+    expect(managerBodyExcerpt("line one\n\n   line two\t\tline three")).toBe(
+      "line one line two line three",
+    );
+  });
+});
+
+describe("#1397 WIRING: the non-2xx site actually appends it", () => {
+  const src = readFileSync(join(HERE, "../../services/node-management.ts"), "utf8");
+
+  it("managerFetch's failure message carries the clause", () => {
+    // The behavioural tests cannot see the call site, and the defect WAS the call
+    // site: the helper is useless if the thrower still reports a bare status line.
+    expect(src).toMatch(/import \{ managerBodyClause \} from "\.\/manager-error-body\.js";/);
+    const at = src.indexOf("`ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`");
+    expect(at).toBeGreaterThan(-1);
+    expect(src.slice(at, at + 700)).toMatch(/managerBodyClause\(text\)/);
+  });
+
+  it("the 403 explanation is kept, not replaced", () => {
+    // explainManagerForbidden says something this excerpt cannot — that a 403 is
+    // Manager's security setting rather than a broken request. Losing it would trade
+    // one specific message for a generic one.
+    const at = src.indexOf("`ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`");
+    expect(src.slice(at, at + 700)).toMatch(/explainManagerForbidden\(res\.status, text\)/);
+  });
+
+  it("the body is still captured in details", () => {
+    // The excerpt is bounded, so `details.body` remains the complete record for
+    // anything that needs it. Dropping it would lose data to gain readability.
+    const at = src.indexOf("`ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`");
+    expect(src.slice(at, at + 700)).toMatch(/\{ url, status: res\.status, body: text \}/);
+  });
+});

--- a/src/services/manager-error-body.ts
+++ b/src/services/manager-error-body.ts
@@ -24,6 +24,33 @@
  * exception ended where the budget did.
  */
 
+/**
+ * Redact credential shapes before ANY of this body is shown.
+ *
+ * The excerpt is an ARBITRARY upstream payload reaching a user-visible error, and a
+ * Manager failure is exactly where a credential can appear: a pack install that
+ * fails to clone echoes the git remote, and a remote can carry
+ * `https://user:token@host/...`. The rule in this project is that a secret never
+ * appears in an error, a disclosure, a fixture or a commit — so this runs before the
+ * cap, not after, and the redaction is on the SHAPE rather than on a list of known
+ * key names, because the next credential will not be on the list.
+ *
+ * Deliberately narrow. Over-redaction makes the excerpt useless and this exists to
+ * make an opaque failure readable; each pattern below is a shape that is a secret
+ * essentially whenever it appears, not merely a word that often sits near one.
+ */
+function redactCredentials(text: string): string {
+  return (
+    text
+      // scheme://user:secret@host — the git-remote case, and the one most likely here.
+      .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1***:***@")
+      // Authorization-style bearer/token headers echoed into a traceback.
+      .replace(/\b(bearer|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
+      // token=… / api_key=… / access_token=… in a query string or a repr.
+      .replace(/\b([a-z_]*(?:token|secret|password|passwd|api[_-]?key))(["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/=-]{6,}/gi, "$1$2***")
+  );
+}
+
 /** Characters of the Manager's body carried into the message. Enough for a Python
  *  exception's type and message line — which is the part that names the cause —
  *  without importing a traceback. */
@@ -59,7 +86,10 @@ export function managerBodyExcerpt(
   // Collapse newlines and runs of whitespace: a traceback pasted verbatim into a
   // single-line error is harder to read than a dense one, and the caller may be
   // rendering this into a log line.
-  const flat = raw.replace(/\s+/g, " ").trim();
+  //
+  // Redaction runs BEFORE the cap. After it, a credential split across the truncation
+  // boundary would keep its first half — a partial secret is still a leaked one.
+  const flat = redactCredentials(raw.replace(/\s+/g, " ").trim());
   // No empty-string guard: an empty `flat` already falls through the ternary and is
   // returned as "". A mutation deleting one proved it changed nothing, and a line
   // that reads as a correctness gate while being dead is worse than its absence.

--- a/src/services/manager-error-body.ts
+++ b/src/services/manager-error-body.ts
@@ -45,15 +45,35 @@ function redactCredentials(text: string): string {
       // scheme://user:secret@host — the git-remote case, and the one most likely here.
       .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1***:***@")
       // Authorization-style headers echoed into a traceback.
+      .replace(/\b(bearer|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
+      // `Basic` needs its OWN rule, and a narrower one. It carries base64 of
+      // `user:password`, so a leak is both halves of a credential at once — but
+      // "basic" is also an ordinary English word, and matching it the same way as
+      // `bearer` turned "Basic configuration missing for Deno package" into
+      // "Basic *** missing for Deno package", destroying the diagnosis. (Review found
+      // that; it was a defect the first fix INTRODUCED.)
       //
-      // `basic` is here for a reason found by review: it carries base64 of
-      // `user:password`, so a leak here is BOTH halves of a credential at once — the
-      // worst single case in this function — and it was the one scheme the original
-      // alternation missed. It is also why the length floor is lower for it: a short
-      // base64 blob is still a whole password.
-      .replace(/\b(bearer|basic|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
+      // The discriminator is the SHAPE of what follows: base64 at credential length,
+      // required to carry a digit or a base64-only character. An English word is
+      // pure letters, so it cannot match; `user:password` base64 essentially always
+      // can at 16+ characters. A digitless all-alpha base64 blob would slip through —
+      // accepted, because the alternative is redacting ordinary prose, and this
+      // excerpt exists to make an opaque failure readable.
+      .replace(
+        /\b(basic)\s+(?=[A-Za-z0-9+/]{16,}={0,2}\b)(?=[A-Za-z0-9+/=]*[0-9+/=])[A-Za-z0-9+/]{16,}={0,2}/gi,
+        "$1 ***",
+      )
       // token=… / api_key=… / access_token=… in a query string or a repr.
-      .replace(/\b([a-z_]*(?:token|secret|password|passwd|api[_-]?key))(["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/=-]{6,}/gi, "$1$2***")
+      // `authorization`, `cookie` and `session` join the key list for the same reason
+      // the others are on it: each is a credential essentially whenever it carries a
+      // value. A `Cookie: session=…` in a proxy's 401 body is a live session — as
+      // reusable as the password that minted it.
+      // The negative lookahead keeps this rule off the SCHEME NAME. Without it,
+      // `Authorization: Bearer <tok>` — already reduced to `Bearer ***` by the rule
+      // above — matched again with "Bearer" itself as the value, giving `*** ***` and
+      // hiding WHICH auth scheme was in play. That is diagnostic information with no
+      // secret in it, and a caller debugging a 401 wants it.
+      .replace(/\b([a-z_]*(?:token|secret|password|passwd|api[_-]?key|authorization|cookie|session))(["']?\s*[=:]\s*["']?)(?!(?:bearer|basic|digest|negotiate)\b)[A-Za-z0-9._~+/=-]{6,}/gi, "$1$2***")
   );
 }
 

--- a/src/services/manager-error-body.ts
+++ b/src/services/manager-error-body.ts
@@ -44,8 +44,14 @@ function redactCredentials(text: string): string {
     text
       // scheme://user:secret@host — the git-remote case, and the one most likely here.
       .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1***:***@")
-      // Authorization-style bearer/token headers echoed into a traceback.
-      .replace(/\b(bearer|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
+      // Authorization-style headers echoed into a traceback.
+      //
+      // `basic` is here for a reason found by review: it carries base64 of
+      // `user:password`, so a leak here is BOTH halves of a credential at once — the
+      // worst single case in this function — and it was the one scheme the original
+      // alternation missed. It is also why the length floor is lower for it: a short
+      // base64 blob is still a whole password.
+      .replace(/\b(bearer|basic|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
       // token=… / api_key=… / access_token=… in a query string or a repr.
       .replace(/\b([a-z_]*(?:token|secret|password|passwd|api[_-]?key))(["']?\s*[=:]\s*["']?)[A-Za-z0-9._~+/=-]{6,}/gi, "$1$2***")
   );
@@ -93,7 +99,17 @@ export function managerBodyExcerpt(
   // No empty-string guard: an empty `flat` already falls through the ternary and is
   // returned as "". A mutation deleting one proved it changed nothing, and a line
   // that reads as a correctness gate while being dead is worse than its absence.
-  return flat.length > limit ? `${flat.slice(0, limit)}… [truncated]` : flat;
+  if (flat.length <= limit) return flat;
+  // `limit` counts UTF-16 code units, so the cut can land BETWEEN the two halves of a
+  // surrogate pair (an emoji, or CJK extension-B). The orphaned half is not a
+  // character: it serialises to U+FFFD, and a body that was merely long ends up
+  // looking corrupted — which reads as "the tool mangled it" rather than "it was
+  // truncated". Drop a trailing lone high surrogate so the excerpt always ends on a
+  // whole code point. Costs at most one character of an already-bounded excerpt.
+  let cut = flat.slice(0, limit);
+  const last = cut.charCodeAt(cut.length - 1);
+  if (last >= 0xd800 && last <= 0xdbff) cut = cut.slice(0, -1);
+  return `${cut}… [truncated]`;
 }
 
 /** The clause appended to a Manager failure message. Empty when the body is. */

--- a/src/services/manager-error-body.ts
+++ b/src/services/manager-error-body.ts
@@ -46,21 +46,20 @@ function redactCredentials(text: string): string {
       .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1***:***@")
       // Authorization-style headers echoed into a traceback.
       .replace(/\b(bearer|token|apikey|api_key)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***")
-      // `Basic` needs its OWN rule, and a narrower one. It carries base64 of
-      // `user:password`, so a leak is both halves of a credential at once — but
-      // "basic" is also an ordinary English word, and matching it the same way as
-      // `bearer` turned "Basic configuration missing for Deno package" into
-      // "Basic *** missing for Deno package", destroying the diagnosis. (Review found
-      // that; it was a defect the first fix INTRODUCED.)
+      // `Basic` needs its OWN rule, because it is the one scheme name that is also an
+      // ordinary English word. Two earlier attempts failed in opposite directions:
+      // matching it like `bearer` redacted "Basic configuration missing for Deno
+      // package"; keying on base64 SHAPE then missed short credentials (`Basic YTpi`
+      // is `a:b`) and still ate "Basic ConfigVersion2026". Both were defects the
+      // fixes themselves introduced.
       //
-      // The discriminator is the SHAPE of what follows: base64 at credential length,
-      // required to carry a digit or a base64-only character. An English word is
-      // pure letters, so it cannot match; `user:password` base64 essentially always
-      // can at 16+ characters. A digitless all-alpha base64 blob would slip through —
-      // accepted, because the alternative is redacting ordinary prose, and this
-      // excerpt exists to make an opaque failure readable.
+      // So discriminate on CONTEXT, not on the value: redact only where `basic`
+      // follows an `Authorization`/`Proxy-Authorization` header. Prose does not say
+      // "Authorization: Basic configuration". That admits ANY value, however short or
+      // however word-like, which is what the shape rule could never do safely — and a
+      // bare `Basic <blob>` with no header in sight stays readable.
       .replace(
-        /\b(basic)\s+(?=[A-Za-z0-9+/]{16,}={0,2}\b)(?=[A-Za-z0-9+/=]*[0-9+/=])[A-Za-z0-9+/]{16,}={0,2}/gi,
+        /\b((?:proxy-)?authoriz(?:ation|ed)?["']?\s*[=:]\s*["']?\s*basic)\s+\S+/gi,
         "$1 ***",
       )
       // token=… / api_key=… / access_token=… in a query string or a repr.

--- a/src/services/manager-error-body.ts
+++ b/src/services/manager-error-body.ts
@@ -1,0 +1,73 @@
+/**
+ * #1397 — the ComfyUI-Manager error body was captured and never shown.
+ *
+ * `panel_update_node` failed with "an opaque serialized ComfyUI-Manager
+ * QueueTaskItem/OperationType exception and no actionable traceback". The body was
+ * not missing: `managerFetch` stores it in the error's `details` as
+ * `{ url, status, body }`. It simply never reached the human-readable message for
+ * any status except 403. So the diagnosis existed, one layer down, and the reader
+ * got `ComfyUI-Manager API 500 Internal Server Error for /v2/manager/queue/task`.
+ *
+ * For a Manager TASK failure the body is the whole point — it is where the
+ * serialized Python exception, and often the actual cause (a missing dependency, in
+ * the report), is written.
+ *
+ * ## Why it is bounded rather than passed through
+ *
+ * A Manager exception body can be a full traceback, and this repo has already paid
+ * for a verbatim error payload: #664 carried tensor-sized `current_inputs` and
+ * 41k-token tracebacks into a reply. An unbounded passthrough here would trade an
+ * unreadable message for an unusable one.
+ *
+ * So: a head excerpt, whitespace-collapsed, with truncation MARKED. The mark matters
+ * — a silently cut traceback reads as a complete one, and someone would conclude the
+ * exception ended where the budget did.
+ */
+
+/** Characters of the Manager's body carried into the message. Enough for a Python
+ *  exception's type and message line — which is the part that names the cause —
+ *  without importing a traceback. */
+export const MANAGER_BODY_EXCERPT_LIMIT = 600;
+
+/**
+ * A one-line, bounded excerpt of a Manager error body, or "" when there is nothing
+ * worth showing.
+ *
+ * Returns "" for an empty/whitespace body so the caller can append unconditionally
+ * without producing a dangling separator — an unreadable body must cost detail in
+ * the text and never a wrong conclusion.
+ */
+export function managerBodyExcerpt(
+  body: unknown,
+  limit = MANAGER_BODY_EXCERPT_LIMIT,
+): string {
+  const raw =
+    typeof body === "string"
+      ? body
+      : body === undefined || body === null
+        ? ""
+        : (() => {
+            // A non-string body (already-parsed JSON) still carries the message.
+            // Never let this throw: it is decorating an error that is already being
+            // reported, and an error-path guard must not become the error.
+            try {
+              return JSON.stringify(body);
+            } catch {
+              return "";
+            }
+          })();
+  // Collapse newlines and runs of whitespace: a traceback pasted verbatim into a
+  // single-line error is harder to read than a dense one, and the caller may be
+  // rendering this into a log line.
+  const flat = raw.replace(/\s+/g, " ").trim();
+  // No empty-string guard: an empty `flat` already falls through the ternary and is
+  // returned as "". A mutation deleting one proved it changed nothing, and a line
+  // that reads as a correctness gate while being dead is worse than its absence.
+  return flat.length > limit ? `${flat.slice(0, limit)}… [truncated]` : flat;
+}
+
+/** The clause appended to a Manager failure message. Empty when the body is. */
+export function managerBodyClause(body: unknown, limit = MANAGER_BODY_EXCERPT_LIMIT): string {
+  const excerpt = managerBodyExcerpt(body, limit);
+  return excerpt ? ` ComfyUI-Manager said: ${excerpt}` : "";
+}

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -30,6 +30,7 @@ import {
 import { withPanelPinGuard } from "./panel-pin-guard.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { managerBodyClause } from "./manager-error-body.js";
 
 // ---------------------------------------------------------------------------
 // Custom-node management — ports `comfy-cli node install|update|reinstall|fix|
@@ -273,7 +274,13 @@ async function managerFetch<T>(
     const text = await res.text().catch(() => "");
     throw new NodeManagementError(
       `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}` +
-        explainManagerForbidden(res.status, text),
+        explainManagerForbidden(res.status, text) +
+        // #1397 — SHOW THE BODY. It was already being captured into `details` below
+        // and only surfaced for 403, so a task-queue failure reported a bare status
+        // line while the serialized exception naming the cause sat one layer down.
+        // Bounded and truncation-marked; see manager-error-body.ts for why a
+        // passthrough is not an option here.
+        managerBodyClause(text),
       { url, status: res.status, body: text },
     );
   }


### PR DESCRIPTION
Claims #1397.

`panel_update_node` failed with "an opaque serialized ComfyUI-Manager QueueTaskItem/OperationType exception and no actionable traceback".

**Mechanism.** `managerFetch` turns a non-2xx response into:

```
ComfyUI-Manager API <status> <statusText> for <path>
```

The response body **is** captured — into `details` as `{ url, status, body }` — but only reaches the human-readable message for a 403, via `explainManagerForbidden`. Every other status drops it from the text. For a task-queue failure that body is exactly the actionable part, so the diagnosis existed and was discarded one layer down.

**Scope.** Carry a bounded excerpt of the body into the message. Bounded is load-bearing: a Python traceback can be large, and this repo has already paid for an unbounded verbatim error (one carried 41k tokens of tensor-sized fields), so this caps and marks truncation rather than passing through.

Not in scope here: the reporter's second gap — an update against a pack already at the latest revision should say so rather than fail. That is a different path and wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)