### PR TITLE
fix(1458): stable_audio_3 emits SaveAudioMP3 without required quality, and defaults to a silent sampler pair

### DIFF
--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -175,7 +175,7 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"audio" — generate audio codes via the TextEncodeAceStepAudio1.5 LLM (ACE only, default: true).
 </ParamField>
 <ParamField path="audio_quality" type="enum">
-  action:"audio" — SaveAudioMP3 bitrate/quality (ACE only, one of 'V0'/'128k'/'320k', default: '320k').
+  action:"audio" — SaveAudioMP3 bitrate/quality (ACE and stable_audio_3, one of 'V0'/'128k'/'320k', default: '320k').
   Options: `V0`, `128k`, `320k`.
 </ParamField>
 <ParamField path="asset_id" type="string">

--- a/src/__tests__/services/stable-audio-3-template.test.ts
+++ b/src/__tests__/services/stable-audio-3-template.test.ts
@@ -1,7 +1,7 @@
 // #1458 — the bundled stable_audio_3 template had two independent defects.
 //
-// 1. `SaveAudioMP3` omitted the REQUIRED `quality` input, so every generate_audio
-//    call for this family was rejected before execution:
+// 1. `SaveAudioMP3` omitted the REQUIRED `quality` input, so every audio generation
+//    for this family was rejected before execution:
 //      400 prompt_outputs_failed_validation
 //      - SaveAudioMP3 (node 8): Required input is missing (quality)
 //    The ace_step_15 sibling in the same file always set it. One of two templates.
@@ -31,7 +31,8 @@ describe("#1458 bug 1: SaveAudioMP3 carries the required quality", () => {
   });
 
   it("honours a caller's audio_quality instead of dropping it", () => {
-    // `audio_quality` is a PUBLIC generate_audio parameter. This family ignored it
+    // `audio_quality` is a PUBLIC parameter of the audio generation tool. This
+    // family ignored it
     // AND emitted no quality at all, so a caller who set it was silently overridden
     // on top of every run failing — accepting a parameter and discarding it is its
     // own defect, and fixing only the omission would have left it in place.
@@ -81,7 +82,7 @@ describe("#1458 bug 2: the defaults do not render silence", () => {
   });
 });
 
-describe("#1458 WIRING: generate_audio passes audio_quality to THIS family", () => {
+describe("#1458 WIRING: the audio tool passes audio_quality to THIS family", () => {
   it("the stable_audio_3 dispatch forwards it, like the ace_step path", () => {
     // A mutation deleting this line SURVIVED the tests above, and rightly: they call
     // createWorkflow directly, so no amount of composer testing can see whether the

--- a/src/__tests__/services/stable-audio-3-template.test.ts
+++ b/src/__tests__/services/stable-audio-3-template.test.ts
@@ -1,0 +1,99 @@
+// #1458 — the bundled stable_audio_3 template had two independent defects.
+//
+// 1. `SaveAudioMP3` omitted the REQUIRED `quality` input, so every generate_audio
+//    call for this family was rejected before execution:
+//      400 prompt_outputs_failed_validation
+//      - SaveAudioMP3 (node 8): Required input is missing (quality)
+//    The ace_step_15 sibling in the same file always set it. One of two templates.
+//
+// 2. The shipped sampler/cfg defaults — lcm + cfg 7 — render DIGITAL SILENCE
+//    (mean -91 dB) while ComfyUI reports success. The reporter measured six
+//    combinations; that pair was the only silent one, and lcm at cfg 1 is fine, so
+//    it was specifically the pairing the template shipped. A correctly-sized,
+//    correctly-durated file of nothing, with nothing in the logs.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createWorkflow } from "../../services/workflow-composer.js";
+
+type Node = { class_type: string; inputs: Record<string, unknown> };
+const nodes = (wf: unknown) => Object.values((wf as Record<string, Node>) ?? {});
+const nodeOfType = (wf: unknown, type: string) =>
+  nodes(wf).find((n) => n?.class_type === type);
+
+describe("#1458 bug 1: SaveAudioMP3 carries the required quality", () => {
+  it("emits quality, so the prompt passes validation", () => {
+    const save = nodeOfType(createWorkflow("stable_audio_3", {}), "SaveAudioMP3");
+    expect(save, "the template must still save audio").toBeTruthy();
+    expect(save!.inputs.quality).toBe("320k");
+  });
+
+  it("honours a caller's audio_quality instead of dropping it", () => {
+    // `audio_quality` is a PUBLIC generate_audio parameter. This family ignored it
+    // AND emitted no quality at all, so a caller who set it was silently overridden
+    // on top of every run failing — accepting a parameter and discarding it is its
+    // own defect, and fixing only the omission would have left it in place.
+    const save = nodeOfType(
+      createWorkflow("stable_audio_3", { audio_quality: "128k" }),
+      "SaveAudioMP3",
+    );
+    expect(save!.inputs.quality).toBe("128k");
+  });
+
+  it("matches the ace_step_15 sibling, which was always right", () => {
+    const ace = nodeOfType(createWorkflow("ace_step_15", {}), "SaveAudioMP3");
+    const sa3 = nodeOfType(createWorkflow("stable_audio_3", {}), "SaveAudioMP3");
+    expect(ace!.inputs.quality).toBe(sa3!.inputs.quality);
+  });
+});
+
+describe("#1458 bug 2: the defaults do not render silence", () => {
+  const sampler = (wf: unknown) => {
+    const k = nodes(wf).find((n) => "sampler_name" in (n?.inputs ?? {}));
+    return k?.inputs as { sampler_name?: unknown; cfg?: unknown };
+  };
+
+  it("does NOT ship the lcm + cfg 7 pair", () => {
+    // The exact measured-silent combination. Asserted as a PAIR, because neither
+    // half is wrong alone — lcm at cfg 1 produces audio, and cfg 7 is fine with
+    // euler or dpmpp_2m. Only the pairing is.
+    const s = sampler(createWorkflow("stable_audio_3", {}));
+    expect(`${s.sampler_name}+${s.cfg}`).not.toBe("lcm+7");
+  });
+
+  it("defaults to dpmpp_2m", () => {
+    // Chosen over euler on the reporter's own measurement: at 42s, euler produced
+    // ~53.7 audible click artifacts/sec against ~0.8/sec for dpmpp_2m. Both avoid
+    // the silence; a default is judged on the long render, where nobody is watching.
+    const s = sampler(createWorkflow("stable_audio_3", {}));
+    expect(s.sampler_name).toBe("dpmpp_2m");
+  });
+
+  it("still lets a caller ask for lcm explicitly", () => {
+    // The fix is a DEFAULT, not a ban. lcm at a low cfg is a legitimate fast path
+    // and the reporter measured it working; refusing it would trade a bad default
+    // for a missing capability.
+    const s = sampler(createWorkflow("stable_audio_3", { sampler_name: "lcm", cfg: 1 }));
+    expect(s.sampler_name).toBe("lcm");
+    expect(s.cfg).toBe(1);
+  });
+});
+
+describe("#1458 WIRING: generate_audio passes audio_quality to THIS family", () => {
+  it("the stable_audio_3 dispatch forwards it, like the ace_step path", () => {
+    // A mutation deleting this line SURVIVED the tests above, and rightly: they call
+    // createWorkflow directly, so no amount of composer testing can see whether the
+    // caller forwards the parameter. The composer honouring audio_quality is useless
+    // if the dispatch never sends it — which is exactly the state this issue found.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../services/generate-audio.ts"),
+      "utf8",
+    );
+    const at = src.indexOf('createWorkflow("stable_audio_3"');
+    expect(at).toBeGreaterThan(-1);
+    const call = src.slice(at, src.indexOf("});", at));
+    expect(call).toMatch(/audio_quality: resolved\.audio_quality/);
+  });
+});

--- a/src/__tests__/services/stable-audio-3-template.test.ts
+++ b/src/__tests__/services/stable-audio-3-template.test.ts
@@ -98,3 +98,34 @@ describe("#1458 WIRING: the audio tool passes audio_quality to THIS family", () 
     expect(call).toMatch(/audio_quality: resolved\.audio_quality/);
   });
 });
+
+describe("#1458 the audio_quality description matches where it now applies", () => {
+  // The fix routed stable_audio_3's SaveAudioMP3 `quality` through the SAME
+  // `audio_quality` parameter the ACE family uses. The parameter's own description
+  // still said "ACE only", which tells a stable_audio_3 caller the knob does not apply
+  // to them - a wrong answer about the tool's own surface, which is the defect class
+  // this issue is an instance of. Caught by the review gate probing the enum chain.
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../tools/generate-image.ts"),
+    "utf8",
+  );
+  const line = src.split("\n").find((l) => l.includes("SaveAudioMP3 bitrate/quality"));
+
+  it("the description exists and names BOTH families", () => {
+    expect(line).toBeDefined();
+    expect(line).toMatch(/stable_audio_3/);
+    expect(line).toMatch(/ACE/);
+  });
+
+  it('no longer claims "ACE only"', () => {
+    expect(line).not.toMatch(/ACE only/);
+  });
+
+  it("still names the legal values, which the live node reports as V0/128k/320k", () => {
+    // Verified against the running server's /object_info/SaveAudioMP3:
+    //   quality: ["COMBO", {default: "V0", options: ["V0", "128k", "320k"]}]
+    // An enum that drifts from the node definition fails validation exactly the way
+    // the omitted input did.
+    for (const v of ["V0", "128k", "320k"]) expect(line).toContain(v);
+  });
+});

--- a/src/services/generate-audio.ts
+++ b/src/services/generate-audio.ts
@@ -182,8 +182,8 @@ export async function generateAudio(
     sampler_name: resolved.sampler as string | undefined,
     scheduler: resolved.scheduler as string | undefined,
     filename_prefix: resolved.filename_prefix as string | undefined,
-    // #1458 — passed through like the ace_step path. generate_audio ACCEPTS
-    // audio_quality; this family dropped it on the floor.
+    // #1458 — passed through like the ace_step path. The audio generation tool
+    // ACCEPTS audio_quality; this family dropped it on the floor.
     audio_quality: resolved.audio_quality as string | undefined,
   });
 

--- a/src/services/generate-audio.ts
+++ b/src/services/generate-audio.ts
@@ -182,6 +182,9 @@ export async function generateAudio(
     sampler_name: resolved.sampler as string | undefined,
     scheduler: resolved.scheduler as string | undefined,
     filename_prefix: resolved.filename_prefix as string | undefined,
+    // #1458 — passed through like the ace_step path. generate_audio ACCEPTS
+    // audio_quality; this family dropped it on the floor.
+    audio_quality: resolved.audio_quality as string | undefined,
   });
 
   const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -644,6 +644,10 @@ interface StableAudio3Txt2AudioParams {
   sampler_name?: string;
   scheduler?: string;
   filename_prefix?: string;
+  /** #1458 — mirrors the ace_step sibling. `audio_quality` is a PUBLIC generate_audio
+   *  parameter, and this family both ignored it and emitted no `quality` at all, so a
+   *  caller who set it had it silently dropped on top of every run failing validation. */
+  audio_quality?: string;
 }
 
 function buildAceStep15Txt2Audio(p: AceStep15Txt2AudioParams): WorkflowJSON {
@@ -759,9 +763,20 @@ function buildStableAudio3Txt2Audio(p: StableAudio3Txt2AudioParams): WorkflowJSO
   const seed = p.seed ?? Math.floor(Math.random() * 2 ** 48);
   const steps = p.steps ?? 50;
   const cfg = p.cfg ?? 7;
-  const sampler = p.sampler_name ?? "lcm";
+  // #1458 — NOT "lcm". lcm at cfg 7 renders DIGITAL SILENCE (mean -91 dB) while
+  // ComfyUI reports success: a correctly-sized, correctly-durated file of nothing,
+  // with nothing in the logs to say so. The reporter measured six combinations and
+  // that pair was the only silent one — lcm at cfg 1 is fine — so it was specifically
+  // the pairing this template shipped.
+  //
+  // dpmpp_2m rather than euler, also measured: at 42s euler produced ~53.7 audible
+  // click artifacts/sec against ~0.8/sec for dpmpp_2m. Both avoid the silence; only
+  // one stays clean as the render gets longer, and a default is judged on the long
+  // case because that is where nobody is watching.
+  const sampler = p.sampler_name ?? "dpmpp_2m";
   const scheduler = p.scheduler ?? "simple";
   const prefix = p.filename_prefix ?? "audio/stable_audio_3";
+  const audioQuality = p.audio_quality ?? "320k";
 
   return {
     "1": {
@@ -807,7 +822,11 @@ function buildStableAudio3Txt2Audio(p: StableAudio3Txt2AudioParams): WorkflowJSO
     },
     "8": {
       class_type: "SaveAudioMP3",
-      inputs: { audio: conn("7", 0), filename_prefix: prefix },
+      // #1458 — `quality` is REQUIRED on SaveAudioMP3. Omitting it made every
+      // generate_audio for this family fail validation before execution:
+      // "SaveAudioMP3 (node 8): Required input is missing (quality)". The ace_step
+      // builder above always set it; only this sibling did not.
+      inputs: { audio: conn("7", 0), filename_prefix: prefix, quality: audioQuality },
     },
   };
 }

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -644,9 +644,10 @@ interface StableAudio3Txt2AudioParams {
   sampler_name?: string;
   scheduler?: string;
   filename_prefix?: string;
-  /** #1458 — mirrors the ace_step sibling. `audio_quality` is a PUBLIC generate_audio
-   *  parameter, and this family both ignored it and emitted no `quality` at all, so a
-   *  caller who set it had it silently dropped on top of every run failing validation. */
+  /** #1458 — mirrors the ace_step sibling. `audio_quality` is a PUBLIC parameter of
+   *  the audio generation tool, and this family both ignored it and emitted no
+   *  `quality` at all, so a caller who set it had it silently dropped on top of every
+   *  run failing validation. */
   audio_quality?: string;
 }
 
@@ -823,7 +824,7 @@ function buildStableAudio3Txt2Audio(p: StableAudio3Txt2AudioParams): WorkflowJSO
     "8": {
       class_type: "SaveAudioMP3",
       // #1458 — `quality` is REQUIRED on SaveAudioMP3. Omitting it made every
-      // generate_audio for this family fail validation before execution:
+      // audio generation for this family fail validation before execution:
       // "SaveAudioMP3 (node 8): Required input is missing (quality)". The ace_step
       // builder above always set it; only this sibling did not.
       inputs: { audio: conn("7", 0), filename_prefix: prefix, quality: audioQuality },

--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -376,7 +376,11 @@ export function registerGenerateImageTool(server: McpServer): void {
       audio_quality: z
         .enum(["V0", "128k", "320k"])
         .optional()
-        .describe("action:\"audio\" — SaveAudioMP3 bitrate/quality (ACE only, one of 'V0'/'128k'/'320k', default: '320k')."),
+        // #1458 — NOT "ACE only" any more. Both audio families end in SaveAudioMP3, and
+        // stable_audio_3 now sets `quality` from this same parameter, so telling a
+        // stable_audio_3 caller the knob does not apply to them is exactly the wrong
+        // answer this issue is about.
+        .describe("action:\"audio\" — SaveAudioMP3 bitrate/quality (ACE and stable_audio_3, one of 'V0'/'128k'/'320k', default: '320k')."),
 
       // ── re-render an existing asset ───────────────────────────────────────
       asset_id: z


### PR DESCRIPTION
Claims #1458. Two independent defects in one bundled template, both confirmed at the source.

**Bug 1 — every `generate_audio` for this family is rejected before execution.** `buildStableAudio3Txt2Audio` emits `SaveAudioMP3` with `{ audio, filename_prefix }` and no `quality`, which is a required input:

```
400 prompt_outputs_failed_validation
- SaveAudioMP3 (node 8): Required input is missing (quality)
```

The ace_step builder in the same file gets it right (`quality: audioQuality`, defaulting `"320k"`), so this is an omission in one of two sibling templates rather than a missing concept.

**Bug 2 — the shipped defaults render digital silence and report success.** The template defaults to `sampler_name: "lcm"` with `cfg: 7`. The reporter measured six combinations; that pair was the only silent one, including `lcm` at cfg 1 which works:

| sampler | cfg | steps | result |
|---|---|---|---|
| lcm | 1.0 | 8 | audio, −17.1 dB |
| euler | 7.0 | 50 | audio, −16.6 dB |
| dpmpp_2m | 7.0 | 50 | audio, −17.0 dB |
| **lcm** | **7.0** | **50** | **SILENT, −91.0 dB** |

So it is specifically the pairing shipped as default. A silent render that ComfyUI reports as `success`, with nothing in the logs, is the worst shape this can take — the user gets a correctly-sized, correctly-durated file of nothing.

Scope: fix both. Choosing `dpmpp_2m` over `euler` on the reporter's own measurement — at 42s, `euler` produced ~53.7 audible click artifacts/sec versus ~0.8/sec for `dpmpp_2m`.

Not in scope: their third observation (raw output running 14–20 dB hot and clipping on write, resolved by `AudioAdjustVolume` at −20 dB). That is a real finding but it changes the graph shape rather than a default, and they flagged it as "possibly worth a separate look" — it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)