### PR TITLE
fix(1454): say that list_templates reflects what the server REGISTERS, not what is on disk

### DIFF
--- a/src/__tests__/services/template-index-scope.test.ts
+++ b/src/__tests__/services/template-index-scope.test.ts
@@ -1,0 +1,90 @@
+// #1454 — an incomplete template list read as a complete one.
+//
+// `list_templates` consults exactly one source: the connected ComfyUI's
+// `/api/workflow_templates`. That reports what packs REGISTER, and a pack can ship
+// example workflows on disk without registering them — the reporter had
+// `ComfyUI-LTXVideo/example_workflows/2.5/*.json` present while the pack did not
+// appear at all, and fell back to searching the filesystem by hand.
+//
+// Nothing in the reply said that was possible. `source_count: 4` reads as "there are
+// four", so a caller concludes the workflow does not exist rather than that this
+// index cannot see it.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  TEMPLATE_INDEX_SCOPE_NOTE,
+  templateIndexScopeNote,
+} from "../../services/template-index-scope.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("#1454 what the note says", () => {
+  it("names the authority the index actually reflects", () => {
+    // Without the mechanism this is just hedging, and a reader has no reason to
+    // believe a 53-template answer could be missing their pack.
+    // Case-insensitive: a control mutation lowercasing the word killed the strict
+    // form, which punishes rewording rather than protecting the claim.
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/registers/i);
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/\/api\/workflow_templates/);
+  });
+
+  it("refuses the 'absent means it has none' reading outright", () => {
+    // The exact wrong conclusion the reporter was pushed toward.
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/without registering them/i);
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/not evidence it has no templates/i);
+  });
+
+  it("names WHERE the invisible ones live, and how to use one", () => {
+    // A caveat with no next step is just doubt. This is the search the reporter had
+    // to work out unaided.
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/custom_nodes\/<pack>\/example_workflows/);
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).toMatch(/by path/);
+  });
+
+  it("does NOT claim to have scanned the disk", () => {
+    // It has not. Implying otherwise would be a worse defect than the one being
+    // fixed — a caller would treat a still-incomplete list as exhaustive.
+    expect(TEMPLATE_INDEX_SCOPE_NOTE).not.toMatch(/scanned|searched the disk|includes on-disk/i);
+  });
+
+  it("stays short enough to be read", () => {
+    // It rides on every successful listing; a paragraph is skipped, and a skipped
+    // caveat protects nobody.
+    expect(TEMPLATE_INDEX_SCOPE_NOTE.length).toBeLessThan(500);
+  });
+});
+
+describe("#1454 when it attaches", () => {
+  it("attaches to EVERY listing, not only an empty one", () => {
+    // Gating on emptiness would hide it in exactly the reported case: 4 sources,
+    // 53 templates, and the one they wanted absent. The gap is not "the list is
+    // empty", it is "the list is one authority's view".
+    expect(templateIndexScopeNote()).toBe(TEMPLATE_INDEX_SCOPE_NOTE);
+    expect(templateIndexScopeNote().length).toBeGreaterThan(0);
+  });
+});
+
+describe("#1454 WIRING: the reply carries it", () => {
+  const src = readFileSync(join(HERE, "../../tools/skills-access.ts"), "utf8");
+
+  it("list_templates emits index_scope alongside the counts", () => {
+    // The behavioural tests cannot see the reply shape, and a note nothing attaches
+    // is the defect this repo keeps paying for.
+    expect(src).toMatch(
+      /import \{ templateIndexScopeNote \} from "\.\.\/services\/template-index-scope\.js";/,
+    );
+    const at = src.indexOf("source_count: groups.length");
+    expect(at).toBeGreaterThan(-1);
+    expect(src.slice(at, at + 600)).toMatch(/index_scope: templateIndexScopeNote\(\)/);
+  });
+
+  it("the counts are still reported — the note adds, it does not replace", () => {
+    const at = src.indexOf("source_count: groups.length");
+    const block = src.slice(at, at + 600);
+    expect(block).toMatch(/template_count: total/);
+    expect(block).toMatch(/templates: index/);
+  });
+});

--- a/src/services/template-index-scope.ts
+++ b/src/services/template-index-scope.ts
@@ -1,0 +1,48 @@
+/**
+ * #1454 — an incomplete template list read as a complete one.
+ *
+ * `list_templates` consults exactly one source: the connected ComfyUI's
+ * `/api/workflow_templates`. That endpoint reports what packs REGISTER, and a pack
+ * can ship example workflows on disk without registering them — the reporter had
+ * `ComfyUI-LTXVideo/example_workflows/2.5/*.json` sitting there while the pack did
+ * not appear at all, and fell back to searching the filesystem by hand.
+ *
+ * Nothing in the reply said that was possible. `source_count: 4` reads as "there are
+ * four", so a caller concludes the workflow they want does not exist rather than
+ * that this index cannot see it.
+ *
+ * ## What this does NOT do
+ *
+ * It does not scan the disk. Merging a local `custom_nodes/*∕example_workflows` walk
+ * is the fuller fix and the one the reporter asked for, but it is new filesystem I/O
+ * on a read path, gated on the target being local, with its own dedup and ordering
+ * rules — a capability addition rather than a correction, and not a freeze-window
+ * change.
+ *
+ * What it corrects is the CLAIM. The tool cannot know whether the server registered
+ * everything, so it stops implying it did and names where the unregistered ones live.
+ * That converts an invisible gap into a visible one with a next step, which is the
+ * difference between the reporter's experience and a two-minute check.
+ */
+
+/** The note that must accompany every template index. Short on purpose: it rides on
+ *  every successful listing, and a paragraph there is skipped rather than read. */
+export const TEMPLATE_INDEX_SCOPE_NOTE =
+  `This index is what the connected ComfyUI REGISTERS via /api/workflow_templates. A pack ` +
+  `can ship example workflows on disk WITHOUT registering them — those are invisible here, ` +
+  `so an absent pack is not evidence it has no templates (#1454). If one you expect is ` +
+  `missing, look for custom_nodes/<pack>/example_workflows/**/*.json on the ComfyUI host ` +
+  `and load it with the workflow-loading tool by path.`;
+
+/**
+ * Should the scope note be attached?
+ *
+ * Always, on a successful listing — including a listing with sources in it. The gap is
+ * not "the list is empty", it is "the list is what one authority knows", and that is
+ * equally true when the endpoint answered with plenty. Gating it on an empty result
+ * would hide it in exactly the reporter's case: 4 sources, 53 templates, and the one
+ * they wanted absent.
+ */
+export function templateIndexScopeNote(): string {
+  return TEMPLATE_INDEX_SCOPE_NOTE;
+}

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -16,6 +16,7 @@ import {
 } from "../services/workflow-deps.js";
 import { generateSkillCached } from "../services/skill-cache.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
+import { templateIndexScopeNote } from "../services/template-index-scope.js";
 import {
   bodyPrefixOf,
   classifyNonJson,
@@ -588,7 +589,15 @@ async function listWorkflowTemplatesAction(): Promise<ToolText> {
       {
         type: "text" as const,
         text: JSON.stringify(
-          { source_count: groups.length, template_count: total, templates: index },
+          {
+            source_count: groups.length,
+            template_count: total,
+            // #1454 — the counts above describe what the SERVER registers, not what is
+            // installed. Said on every listing, not only an empty one: the reporter's
+            // had 4 sources and 53 templates, and the pack they wanted was still absent.
+            index_scope: templateIndexScopeNote(),
+            templates: index,
+          },
           null,
           2,
         ),


### PR DESCRIPTION
Claims #1454.

`list_packs action:"list_templates"` reads exactly one source — `${base}/api/workflow_templates` — and reports `source_count`/`template_count` with no indication that a pack shipping example workflows on disk can be absent from it. The reporter had `ComfyUI-LTXVideo/example_workflows/2.5/*.json` present and the pack simply did not appear, so they fell back to a filesystem search.

Measured on my rig (ComfyUI 0.32.0): the endpoint returns **22 sources**, and it is the only thing this action consults.

**Scope — disclosure, not a disk scan.** The reporter's suggested merge of a local `custom_nodes/*/example_workflows/**/*.json` scan is the fuller fix and it is a genuine capability addition: new filesystem I/O on a read path, gated on the target being local, with its own dedup rules. That is not a freeze-window change.

What is in scope is that an incomplete list currently reads as a complete one. `source_count: 4` looks like "there are four", and the tool has no way to know whether the server registered everything — so it should stop implying it did, and name where the unregistered ones live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)