### PR TITLE
fix(1474): say WHY remove searched fewer roots than list_paths shows

### DIFF
--- a/src/__tests__/services/model-root-scope.test.ts
+++ b/src/__tests__/services/model-root-scope.test.ts
@@ -1,0 +1,90 @@
+// #1474 — `remove` searched one root while `list_paths` displayed several.
+//
+// On a normal Comfy Desktop launch:
+//   list        -> lists a model served from M:\Comfy-Desktop\ComfyUI-Shared\models
+//   list_paths  -> shows that shared root, from the live --extra-model-paths-config
+//   remove      -> "Model file not found ... Searched 1 root(s): <primary install>"
+//
+// Two tools disagreeing about which roots exist, with nothing to explain it. The
+// asymmetry is DELIBERATE — this resolver backs deletion, so it enumerates only roots
+// provable from the running server's launch arguments — but it was silent, and the
+// reporter had to diagnose it themselves before deleting the files by hand.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { modelNotFoundMessage } from "../../services/model-root-scope.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const msg = () =>
+  modelNotFoundMessage({
+    relativePath: "diffusion_models/z_image_turbo_bf16.safetensors",
+    searched: ["M:\\Comfy-Desktop\\ComfyUI-Installs\\comfyui\\ComfyUI\\models"],
+  });
+
+describe("#1474 the refusal keeps what it had", () => {
+  it("still names the file and the roots it did search", () => {
+    // The original text was not wrong, only incomplete — nothing should be lost.
+    expect(msg()).toMatch(/Model file not found: diffusion_models\/z_image_turbo_bf16\.safetensors/);
+    expect(msg()).toMatch(/Searched 1 root\(s\)/);
+    expect(msg()).toMatch(/ComfyUI-Installs/);
+  });
+});
+
+describe("#1474 it explains the asymmetry the reporter had to work out", () => {
+  it("says the searched roots may not be every root you can SEE", () => {
+    expect(msg()).toMatch(/may not be every root you can SEE/);
+  });
+
+  it("names the other tool by its live action, so the two can be compared", () => {
+    expect(msg()).toMatch(/list_local_models \(action:"list_paths"\)/);
+  });
+
+  it("states PROVABILITY as the reason, not an accident", () => {
+    // Without this the reader concludes one of the two tools is buggy.
+    expect(msg()).toMatch(/only roots it can PROVE/);
+    expect(msg()).toMatch(/launch arguments/);
+    expect(msg()).toMatch(/backs DELETION/);
+  });
+
+  it('refuses the "not found means not on disk" reading outright', () => {
+    // The reading that would make someone re-download a model they already have.
+    expect(msg()).toMatch(/does NOT mean "not on disk"/);
+  });
+
+  it("gives both ways forward", () => {
+    expect(msg()).toMatch(/main\.py appears in its arguments/);
+    expect(msg()).toMatch(/directly on the host/);
+    // And the containment caveat survives — this must not read as "just delete it".
+    expect(msg()).toMatch(/inside the intended root/);
+  });
+
+  it("does NOT claim any extra root was searched", () => {
+    // The one thing this fix must never do: imply deletion looked somewhere it did not.
+    expect(msg()).not.toMatch(/searched (all|every)/i);
+  });
+});
+
+describe("#1474 WIRING: the resolver throws through it", () => {
+  const src = readFileSync(join(HERE, "../../services/model-resolver.ts"), "utf8");
+
+  it("the not-found throw uses the shared message", () => {
+    expect(src).toMatch(/import \{ modelNotFoundMessage \} from "\.\/model-root-scope\.js";/);
+    expect(src).toMatch(/modelNotFoundMessage\(\{ relativePath, searched \}\)/);
+  });
+
+  it("the old bare sentence is gone from the throw", () => {
+    // Scoped to the throw: the phrase legitimately appears in this test's own prose
+    // and in comments explaining the change.
+    const at = src.indexOf("throw new ModelError(");
+    expect(at).toBeGreaterThan(-1);
+    const block = src.slice(at, at + 400);
+    expect(block).not.toMatch(/Searched \$\{searched\.length\} root\(s\)/);
+  });
+
+  it("the structured details still carry the searched roots", () => {
+    // A caller reading `details.searched` programmatically must be unaffected.
+    expect(src).toMatch(/\{ path: relativePath, searched \}/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -13,6 +13,7 @@ import { logger } from "../utils/logger.js";
 import { downloadWithCache, probeRemoteModelPayload } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
+import { modelNotFoundMessage } from "./model-root-scope.js";
 import {
   resolveModelsDir,
   resolveModelsDirWithBases,
@@ -2254,9 +2255,12 @@ export async function resolveExistingModelFile(
 
   if (dirHit) return dirHit;
 
+  // #1474 — say WHY only these roots were searched. `list_paths` may display roots
+  // this resolver refused to enumerate (it backs DELETION, so it uses only roots
+  // provable from the running server's launch arguments), and the caller was left
+  // holding two tools that disagreed with nothing to reconcile them.
   throw new ModelError(
-    `Model file not found: ${relativePath}. Searched ${searched.length} root(s): ` +
-      `${searched.join(", ")}`,
+    modelNotFoundMessage({ relativePath, searched }),
     { path: relativePath, searched },
   );
 }

--- a/src/services/model-root-scope.ts
+++ b/src/services/model-root-scope.ts
@@ -1,0 +1,59 @@
+/**
+ * #1474 — `remove` searched one root while `list_paths` displayed several.
+ *
+ * On a normal Comfy Desktop launch the reporter saw:
+ *
+ *   list        -> lists a model served from M:\\Comfy-Desktop\\ComfyUI-Shared\\models
+ *   list_paths  -> shows that shared root, read from the live --extra-model-paths-config
+ *   remove      -> "Model file not found ... Searched 1 root(s): <primary install>"
+ *
+ * Two tools disagreeing about which roots exist, with nothing to explain it. The
+ * reporter had to diagnose the asymmetry themselves and then delete the files by hand.
+ *
+ * ## Why the asymmetry is DELIBERATE, and stays
+ *
+ * `resolveExistingModelFile` enumerates only roots it can PROVE, because it is the
+ * resolver behind DELETION. `list_paths` may display a root it merely read from a
+ * config file; a deletion path may not act on one. The #764 display-only fallback is
+ * refused here on purpose, and this module does not relax that — the reporter said it
+ * plainly: this is a filesystem authorisation boundary and loosening it locally would
+ * be risky. They are right.
+ *
+ * ## What was actually wrong
+ *
+ * Not the rule — the SILENCE about it. "Searched 1 root(s)" reads as "there is one
+ * root", when the truth is "there is one root I can prove". A caller looking at
+ * `list_paths` sees a contradiction and no way to tell which tool is lying.
+ *
+ * So the refusal now says which roots were searched, that PROVABILITY is the reason
+ * others were not, and how to proceed — without widening what deletion may touch.
+ */
+
+/**
+ * The not-found refusal for a model the resolver could not locate.
+ *
+ * States the PROVABILITY rule unconditionally rather than trying to diff against what
+ * a listing tool would show: that would need the live snapshot plumbed into this
+ * resolver, and a parameter nothing passes is an inert fix. The rule is true on every
+ * call — only provable roots are ever searched — so saying it always is both simpler
+ * and never wrong.
+ */
+export function modelNotFoundMessage(opts: {
+  relativePath: string;
+  searched: readonly string[];
+}): string {
+  const { relativePath, searched } = opts;
+  return (
+    `Model file not found: ${relativePath}. Searched ${searched.length} root(s): ` +
+    `${searched.join(", ")}. That may not be every root you can SEE: this operation ` +
+    `searches only roots it can PROVE from the running ComfyUI's own launch arguments, ` +
+    `while list_local_models (action:"list_paths") also displays roots read from a ` +
+    `config file. On a Comfy Desktop install those differ, so a shared model root can ` +
+    `be listed there and absent here (#1474). The restriction is deliberate — this ` +
+    `resolver backs DELETION, and a path read from a config is not proof the running ` +
+    `server uses it — so "not found" here does NOT mean "not on disk". Compare against ` +
+    `list_paths: if the file lives under a root missing from the list above, launch ` +
+    `ComfyUI so its main.py appears in its arguments (which makes those roots provable), ` +
+    `or act on the file directly on the host after checking it is inside the intended root.`
+  );
+}


### PR DESCRIPTION
Refs #1474 — the **disclosure** half only.

The reporter saw `list` and `list_paths` show a Comfy Desktop shared model root, and `remove` answer *"Searched 1 root(s)"* with nothing to explain the difference. They diagnosed it themselves and deleted the files by hand.

**The asymmetry is deliberate and untouched here.** `resolveExistingModelFile` enumerates only roots provable from the running server's launch arguments, because it backs DELETION and a path read from a config is not proof the running server uses it. The reporter said relaxing that would be risky; I agree, so this widens nothing.

What was wrong was the silence. The refusal now names the provability rule, names `list_paths` so the two answers can be compared, refuses the "not found means not on disk" reading, and gives both routes forward with the containment caveat intact.

Stated unconditionally rather than diffed against `list_paths`' roots: that needs the live snapshot plumbed into the resolver, and a parameter nothing passes would be an inert fix. The rule holds on every call.

**Not in scope:** making Desktop shared roots provable so `remove` can act on them. That is a filesystem authorisation boundary, it is what the reporter actually wants, and it should not land unreviewed during a stabilisation freeze.

Five mutations verified plus a surviving control. Full suite green (8963).

🤖 Generated with [Claude Code](https://claude.com/claude-code)