### PR TITLE
fix(1477): refuse a download that would exhaust the cache volume

### DIFF
--- a/src/__tests__/services/download-volume.test.ts
+++ b/src/__tests__/services/download-volume.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -33,7 +33,7 @@ describe("#1477 freeBytesFor", () => {
   it("walks UP to an existing ancestor - the cache dir may not exist yet", async () => {
     // On a first run ~/.comfyui-mcp/cache does not exist and statfs throws ENOENT.
     // Without the walk, every fresh install would silently skip the space check.
-    const nested = join(homedir(), ".comfyui-mcp-does-not-exist", "cache", "deeper");
+    const nested = join(tmpdir(), "cmcp-not-created-yet", "cache", "deeper");
     const free = await freeBytesFor(nested);
     expect(typeof free).toBe("number");
     expect(free as number).toBeGreaterThan(0);
@@ -48,7 +48,7 @@ describe("#1477 checkCacheVolumeSpace refuses only when it is sure", () => {
   it("refuses a download the staging volume cannot possibly hold", async () => {
     const refusal = await checkCacheVolumeSpace({
       needBytes: 1e15, // a petabyte: larger than any volume on this machine
-      cacheDir: join(homedir(), ".comfyui-mcp", "cache"),
+      cacheDir: join(tmpdir(), "cmcp-space-probe", "cache"),
     });
     expect(refusal).toBeTruthy();
     expect(refusal).toMatch(/NOT downloaded/);

--- a/src/__tests__/services/download-volume.test.ts
+++ b/src/__tests__/services/download-volume.test.ts
@@ -224,3 +224,60 @@ describe("#1477 round 2: the reserve scales, and the message tells the truth on 
     expect(typeof free).toBe("number");
   });
 });
+
+describe("#1477 round 3: a partial on disk is never denied", () => {
+  it("does not claim nothing was downloaded when a RESTART will discard a partial", () => {
+    // Review found `resuming` and "a partial exists" conflated. When a server ignores
+    // our Range we restart rather than append, so `resuming` is false - and the old
+    // message then told a user with a 22 GB .partial that nothing had been downloaded.
+    const m = insufficientCacheSpaceMessage({
+      needBytes: 10 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 1 * GB,
+      resuming: false,
+      partialExists: true,
+    });
+    expect(m).not.toMatch(/Nothing was written/);
+    expect(m).toMatch(/partial download from an earlier attempt is still on disk/);
+  });
+
+  it("says the free-space figure does NOT assume the partial was reclaimed", () => {
+    // The space math is deliberately conservative; the message must not imply
+    // otherwise, or the number reads as wrong.
+    const m = insufficientCacheSpaceMessage({
+      needBytes: 10 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 1 * GB,
+      partialExists: true,
+    });
+    expect(m).toMatch(/does NOT assume it was\s+reclaimed/);
+  });
+
+  it("the destination clause uses the SAME reserve as the policy", () => {
+    // A 4 GiB destination with 2 GiB free and a 1.5 GiB download: the policy's 5%
+    // reserve (200 MiB) says it fits, so the message must not demand a flat 1 GiB and
+    // report it as too small.
+    const small = 4 * GB;
+    const m = insufficientCacheSpaceMessage({
+      needBytes: 1.5 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 0.2 * GB,
+      destDir: "E:/models",
+      destFree: 2 * GB,
+      destHeadroom: headroomFor(small),
+    });
+    expect(m).toMatch(/DESTINATION has room/);
+  });
+
+  it("still refuses to claim destination room when there genuinely is none", () => {
+    const m = insufficientCacheSpaceMessage({
+      needBytes: 10 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 0.2 * GB,
+      destDir: "E:/models",
+      destFree: 1 * GB,
+      destHeadroom: headroomFor(4 * GB),
+    });
+    expect(m).not.toMatch(/DESTINATION has room/);
+  });
+});

--- a/src/__tests__/services/download-volume.test.ts
+++ b/src/__tests__/services/download-volume.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  freeBytesFor,
+  checkCacheVolumeSpace,
+  insufficientCacheSpaceMessage,
+  VOLUME_HEADROOM_BYTES,
+} from "../../services/download-volume.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GB = 1024 ** 3;
+
+// Exercised against the REAL filesystem rather than a mocked `statfs`. The behaviour
+// that matters here IS the platform's: that statfs throws ENOENT for a path that does
+// not exist yet (so the walk up to an existing ancestor is load-bearing), and that a
+// missing drive letter cannot be measured at all. A mock would only assert my model of
+// those semantics, which is the thing most likely to be wrong.
+//
+// `MISSING_VOLUME` is a drive letter with no volume mounted; verified unmeasurable.
+const MISSING_VOLUME = "M:/models/diffusion_models";
+
+describe("#1477 freeBytesFor", () => {
+  it("reports free bytes for a real volume", async () => {
+    const free = await freeBytesFor(tmpdir());
+    expect(typeof free).toBe("number");
+    expect(free as number).toBeGreaterThan(0);
+  });
+
+  it("walks UP to an existing ancestor - the cache dir may not exist yet", async () => {
+    // On a first run ~/.comfyui-mcp/cache does not exist and statfs throws ENOENT.
+    // Without the walk, every fresh install would silently skip the space check.
+    const nested = join(homedir(), ".comfyui-mcp-does-not-exist", "cache", "deeper");
+    const free = await freeBytesFor(nested);
+    expect(typeof free).toBe("number");
+    expect(free as number).toBeGreaterThan(0);
+  });
+
+  it("returns null for a volume that cannot be measured", async () => {
+    expect(await freeBytesFor(MISSING_VOLUME)).toBeNull();
+  });
+});
+
+describe("#1477 checkCacheVolumeSpace refuses only when it is sure", () => {
+  it("refuses a download the staging volume cannot possibly hold", async () => {
+    const refusal = await checkCacheVolumeSpace({
+      needBytes: 1e15, // a petabyte: larger than any volume on this machine
+      cacheDir: join(homedir(), ".comfyui-mcp", "cache"),
+    });
+    expect(refusal).toBeTruthy();
+    expect(refusal).toMatch(/NOT downloaded/);
+  });
+
+  it("proceeds when the volume plainly has room", async () => {
+    expect(await checkCacheVolumeSpace({ needBytes: 1024, cacheDir: tmpdir() })).toBeNull();
+  });
+
+  it("FAILS SOFT when free space cannot be read", async () => {
+    // An unmeasurable volume must not become an unusable one: this exists to stop a
+    // known-bad write, never to invent a new way for a good one to be blocked.
+    expect(
+      await checkCacheVolumeSpace({ needBytes: 1e15, cacheDir: MISSING_VOLUME }),
+    ).toBeNull();
+  });
+
+  it("proceeds when the size is unknown - it must not guess", async () => {
+    for (const needBytes of [undefined, 0, Number.NaN]) {
+      expect(await checkCacheVolumeSpace({ needBytes, cacheDir: tmpdir() })).toBeNull();
+    }
+  });
+
+  it("keeps headroom rather than letting a volume land on exactly zero", async () => {
+    // Free space EQUAL to the download fits arithmetically and is still a bad outcome
+    // on a system drive - the page-file case this issue is about.
+    const free = (await freeBytesFor(tmpdir())) as number;
+    expect(free).toBeGreaterThan(2 * VOLUME_HEADROOM_BYTES);
+    // Exactly the free space: refused, because it would leave zero.
+    expect(await checkCacheVolumeSpace({ needBytes: free, cacheDir: tmpdir() })).toBeTruthy();
+    // Comfortably inside the headroom: allowed.
+    expect(
+      await checkCacheVolumeSpace({
+        needBytes: free - 2 * VOLUME_HEADROOM_BYTES,
+        cacheDir: tmpdir(),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("#1477 the refusal explains the split between staging and destination", () => {
+  const msg = (destFree: number | null) =>
+    insufficientCacheSpaceMessage({
+      needBytes: 32.29 * GB,
+      cacheDir: "C:/Users/x/.comfyui-mcp/cache",
+      cacheFree: 0.7 * GB,
+      destDir: "F:/ComfyUI/models/diffusion_models",
+      destFree,
+    });
+
+  it("names both numbers, so the contradiction is legible", () => {
+    expect(msg(1000 * GB)).toMatch(/32\.29 GB/);
+    expect(msg(1000 * GB)).toMatch(/0\.70 GB free/);
+  });
+
+  it('says the destination HAS room — the fact that makes this fixable', () => {
+    // Without this the reader concludes their disk is full and deletes things.
+    const m = msg(1000 * GB);
+    expect(m).toMatch(/DESTINATION has room/);
+    expect(m).toMatch(/not a "your disk is full" problem/);
+    expect(m).toMatch(/staged in the cache/);
+  });
+
+  it("does NOT claim the destination has room when it does not", () => {
+    const m = msg(1 * GB);
+    expect(m).not.toMatch(/DESTINATION has room/);
+    expect(m).toMatch(/destination volume does not have room either/);
+  });
+
+  it("names the lever", () => {
+    expect(msg(1000 * GB)).toMatch(/COMFYUI_DOWNLOAD_CACHE_DIR/);
+  });
+
+  it("says nothing was written, so no cleanup is implied", () => {
+    // The reporter was left with a 22.62 GB .partial. A refusal that happens before
+    // the first byte must say so, or the reader goes looking for one.
+    expect(msg(1000 * GB)).toMatch(/Nothing was written/);
+    expect(msg(1000 * GB)).toMatch(/before the\s+first byte/);
+  });
+});
+
+describe("#1477 WIRING: the streaming path refuses before opening a handle", () => {
+  const src = readFileSync(join(HERE, "../../services/download-cache.ts"), "utf8");
+
+  it("imports and calls the check", () => {
+    expect(src).toMatch(
+      /import \{ checkCacheVolumeSpace \} from "\.\/download-volume\.js";/,
+    );
+    expect(src).toMatch(/await checkCacheVolumeSpace\(\{/);
+  });
+
+  it("the check runs BEFORE the write stream is created", () => {
+    // Order is the whole point: a refusal after createWriteStream would already have
+    // opened (and on some paths truncated) the target.
+    const check = src.indexOf("await checkCacheVolumeSpace({");
+    const open = src.indexOf("createWriteStream(targetPath");
+    expect(check).toBeGreaterThan(-1);
+    expect(open).toBeGreaterThan(-1);
+    expect(check).toBeLessThan(open);
+  });
+
+  it("a refusal throws rather than being logged and ignored", () => {
+    expect(src).toMatch(/if \(refusal\) throw new ModelError\(refusal/);
+  });
+
+  it("a resume asks only for the REMAINING bytes", () => {
+    // On an append the already-written bytes are on disk; demanding the full size
+    // would refuse resumes that fit perfectly well.
+    expect(src).toMatch(/appendMode\s*\?\s*Math\.max\(\(rangeTotal \?\? 0\) - \(resumeFromBytes \|\| 0\), 0\)/);
+  });
+});

--- a/src/__tests__/services/download-volume.test.ts
+++ b/src/__tests__/services/download-volume.test.ts
@@ -7,6 +7,7 @@ import {
   freeBytesFor,
   checkCacheVolumeSpace,
   insufficientCacheSpaceMessage,
+  headroomFor,
   VOLUME_HEADROOM_BYTES,
 } from "../../services/download-volume.js";
 
@@ -156,6 +157,70 @@ describe("#1477 WIRING: the streaming path refuses before opening a handle", () 
   it("a resume asks only for the REMAINING bytes", () => {
     // On an append the already-written bytes are on disk; demanding the full size
     // would refuse resumes that fit perfectly well.
-    expect(src).toMatch(/appendMode\s*\?\s*Math\.max\(\(rangeTotal \?\? 0\) - \(resumeFromBytes \|\| 0\), 0\)/);
+    expect(src).toMatch(/rangeTotal - \(resumeFromBytes \|\| 0\)/);
+  });
+
+  it("a resume with NO Content-Range total still checks, via Content-Length", () => {
+    // Round 2 of review: when a 206 carries no Content-Range total, `rangeTotal` is
+    // null and the original arithmetic yielded 0 -- which SKIPPED the guard on exactly
+    // the resume path it was written to protect. Content-Length on a 206 is the
+    // remaining slice, so it is the right fallback.
+    expect(src).toMatch(/remainingFromRange \?\? \(lengthHeaderPre > 0 \? lengthHeaderPre : 0\)/);
+  });
+
+  it("tells the check it is a resume, so the message does not lie about the partial", () => {
+    expect(src).toMatch(/resuming: appendMode/);
+  });
+});
+
+describe("#1477 round 2: the reserve scales, and the message tells the truth on a resume", () => {
+  it("keeps a full 1 GiB on a large volume - the system-drive case", () => {
+    expect(headroomFor(232 * GB)).toBe(VOLUME_HEADROOM_BYTES);
+  });
+
+  it("does not make a SMALL volume unusable", () => {
+    // A flat 1 GiB reserve would refuse a 2 GB file on a 4 GB stick that fits.
+    const small = 4 * GB;
+    expect(headroomFor(small)).toBeLessThan(VOLUME_HEADROOM_BYTES);
+    expect(headroomFor(small)).toBe(Math.floor(small * 0.05));
+  });
+
+  it("falls back to the full reserve for a nonsense total", () => {
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(headroomFor(bad)).toBe(VOLUME_HEADROOM_BYTES);
+    }
+  });
+
+  it("does NOT claim nothing was downloaded when interrupting a resume", () => {
+    // The partial exists on disk. Telling the user otherwise invites them to delete
+    // something they could have reused.
+    const resumeMsg = insufficientCacheSpaceMessage({
+      needBytes: 10 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 1 * GB,
+      resuming: true,
+    });
+    expect(resumeMsg).not.toMatch(/Nothing was written/);
+    expect(resumeMsg).toMatch(/existing partial download is untouched/);
+    expect(resumeMsg).toMatch(/still resumable/);
+  });
+
+  it("still says nothing was written on a FRESH download", () => {
+    const freshMsg = insufficientCacheSpaceMessage({
+      needBytes: 10 * GB,
+      cacheDir: "C:/cache",
+      cacheFree: 1 * GB,
+    });
+    expect(freshMsg).toMatch(/Nothing was written/);
+    expect(freshMsg).not.toMatch(/still resumable/);
+  });
+
+  it("refuses to measure a volume whose statfs fails for a NON-missing-path reason", async () => {
+    // Climbing on any error could answer confidently about a different disk. Only
+    // ENOENT/ENOTDIR justify walking up. A path under an existing FILE yields ENOTDIR
+    // and is therefore allowed to climb; that is the deliberate exception.
+    const underAFile = join(HERE, "download-volume.test.ts", "nested", "cache");
+    const free = await freeBytesFor(underAFile);
+    expect(typeof free).toBe("number");
   });
 });

--- a/src/__tests__/services/download-volume.test.ts
+++ b/src/__tests__/services/download-volume.test.ts
@@ -20,8 +20,22 @@ const GB = 1024 ** 3;
 // missing drive letter cannot be measured at all. A mock would only assert my model of
 // those semantics, which is the thing most likely to be wrong.
 //
-// `MISSING_VOLUME` is a drive letter with no volume mounted; verified unmeasurable.
-const MISSING_VOLUME = "M:/models/diffusion_models";
+// An unmeasurable location has to be DISCOVERED, not assumed. The first cut hardcoded
+// "M:/" and CI failed on a Windows runner that actually has an M: drive — it returned
+// 92 GB and the test demanded null. Same class as pinning a platform in a process test:
+// a machine-specific fact baked into an assertion.
+//
+// So probe for a drive letter with nothing mounted, and if the machine has all of them
+// (or we are not on Windows, where a bare letter means nothing), skip rather than
+// assert something untrue. `null` here means "no unmeasurable path available".
+async function findUnmeasurablePath(): Promise<string | null> {
+  if (process.platform !== "win32") return null;
+  for (const letter of ["Z", "Y", "X", "W", "V", "Q"]) {
+    const candidate = `${letter}:/models/diffusion_models`;
+    if ((await freeBytesFor(candidate)) === null) return candidate;
+  }
+  return null;
+}
 
 describe("#1477 freeBytesFor", () => {
   it("reports free bytes for a real volume", async () => {
@@ -40,7 +54,9 @@ describe("#1477 freeBytesFor", () => {
   });
 
   it("returns null for a volume that cannot be measured", async () => {
-    expect(await freeBytesFor(MISSING_VOLUME)).toBeNull();
+    const missing = await findUnmeasurablePath();
+    if (missing === null) return; // every drive letter is mounted, or not Windows
+    expect(await freeBytesFor(missing)).toBeNull();
   });
 });
 
@@ -61,8 +77,10 @@ describe("#1477 checkCacheVolumeSpace refuses only when it is sure", () => {
   it("FAILS SOFT when free space cannot be read", async () => {
     // An unmeasurable volume must not become an unusable one: this exists to stop a
     // known-bad write, never to invent a new way for a good one to be blocked.
+    const missing = await findUnmeasurablePath();
+    if (missing === null) return;
     expect(
-      await checkCacheVolumeSpace({ needBytes: 1e15, cacheDir: MISSING_VOLUME }),
+      await checkCacheVolumeSpace({ needBytes: 1e15, cacheDir: missing }),
     ).toBeNull();
   });
 

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2090,12 +2090,21 @@ async function streamUrlToFile(
     const lengthHeaderPre = Number(res.headers.get("content-length") || 0);
     const fresh200TotalPre = Math.max(lengthHeaderPre > 0 ? lengthHeaderPre : 0, redirectSize ?? 0);
     // On a resume only the REMAINING bytes are written; the rest is already on disk.
+    //
+    // When the 206 carries no Content-Range total, `rangeTotal` is null and the old
+    // arithmetic produced 0 — silently SKIPPING the guard on exactly the resume path
+    // it was written to protect (review found this). Content-Length on a 206 is the
+    // remaining slice, which is precisely the quantity still to be written, so fall
+    // back to it rather than to nothing.
+    const remainingFromRange =
+      rangeTotal != null ? Math.max(rangeTotal - (resumeFromBytes || 0), 0) : undefined;
     const needBytes = appendMode
-      ? Math.max((rangeTotal ?? 0) - (resumeFromBytes || 0), 0)
+      ? (remainingFromRange ?? (lengthHeaderPre > 0 ? lengthHeaderPre : 0))
       : fresh200TotalPre;
     const refusal = await checkCacheVolumeSpace({
       needBytes,
       cacheDir: dirname(targetPath),
+      resuming: appendMode,
     });
     if (refusal) throw new ModelError(refusal, { path: targetPath });
   }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2104,7 +2104,11 @@ async function streamUrlToFile(
     const refusal = await checkCacheVolumeSpace({
       needBytes,
       cacheDir: dirname(targetPath),
+      // `resuming` is "we are APPENDING"; `partialExists` is "there are bytes on disk
+      // either way". Review found these conflated, so a restart after a server ignored
+      // our Range told the user nothing had been downloaded while a partial sat there.
       resuming: appendMode,
+      partialExists: (resumeFromBytes || 0) > 0,
     });
     if (refusal) throw new ModelError(refusal, { path: targetPath });
   }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -24,6 +24,7 @@ import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
+import { checkCacheVolumeSpace } from "./download-volume.js";
 import {
   abortableDelay,
   backoffDelayMs,
@@ -2071,6 +2072,32 @@ async function streamUrlToFile(
     // A resume was actually taken (validated 206 append). Record it so
     // download_model action:"status" can report the partial was reused, not discarded (#467).
     onResume?.({ outcome: "resumed", discardedBytes: 0, discarded: false });
+  }
+
+  // #1477 — REFUSE before the first byte when the staging volume cannot hold this.
+  //
+  // The whole file is staged in the download cache before it lands at its
+  // destination, and that cache lives under homedir() — on Windows, essentially
+  // always the system drive, while models are almost always on a big secondary
+  // volume. A 32 GB download to a volume with 1 TB free was written to one with
+  // 0.7 GB free, and took it to the edge of zero. Driving a system drive to zero
+  // risks the page file and general OS stability, so this failure does not stay
+  // confined to the download that caused it.
+  //
+  // Content-Length is already parsed here, so the check costs nothing. It fails
+  // SOFT: an unmeasurable volume must not become an unusable one.
+  {
+    const lengthHeaderPre = Number(res.headers.get("content-length") || 0);
+    const fresh200TotalPre = Math.max(lengthHeaderPre > 0 ? lengthHeaderPre : 0, redirectSize ?? 0);
+    // On a resume only the REMAINING bytes are written; the rest is already on disk.
+    const needBytes = appendMode
+      ? Math.max((rangeTotal ?? 0) - (resumeFromBytes || 0), 0)
+      : fresh200TotalPre;
+    const refusal = await checkCacheVolumeSpace({
+      needBytes,
+      cacheDir: dirname(targetPath),
+    });
+    if (refusal) throw new ModelError(refusal, { path: targetPath });
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);

--- a/src/services/download-volume.ts
+++ b/src/services/download-volume.ts
@@ -1,0 +1,144 @@
+/**
+ * #1477 — a download filled the SYSTEM drive and would have driven it to zero.
+ *
+ * `download_model` stages the whole file in the content-addressed cache before it
+ * lands at its destination, and the cache path comes only from `homedir()`:
+ *
+ *   const DEFAULT_CACHE_DIR = join(homedir(), ".comfyui-mcp", "cache");
+ *
+ * On Windows `homedir()` is essentially always the system drive, while ComfyUI models
+ * are almost always on a big secondary volume. The reporter's ComfyUI lives on `F:`
+ * with 1 TB free; `C:` had 0.7 GB free of 232 GB. A 32.29 GB download to the roomy
+ * volume was written to the full one, and the `.partial` reached 22.62 GB before it
+ * died.
+ *
+ * ## Why this is worse than a failed download
+ *
+ * Taking a Windows system drive to zero risks the page file and general OS stability,
+ * not just this transfer. The failure is not confined to the thing that failed.
+ *
+ * ## What this module does, and deliberately does not do
+ *
+ * It REFUSES up front when the staging volume cannot hold what we already know is
+ * coming — `Content-Length` is parsed before the first byte is written, so the check
+ * costs nothing and needs no new network work.
+ *
+ * It does NOT relocate the cache. Choosing a staging directory on the destination
+ * volume is the deeper fix the reporter also asks for, and it changes where files
+ * land, how the cache is addressed, and whether the final move is a rename or a copy.
+ * That deserves its own change. Refusing before the disk fills is the part that stops
+ * the harm, and it is the part that can be made safe now.
+ *
+ * Every check here FAILS SOFT. If free space cannot be measured, the download proceeds
+ * exactly as before: this exists to prevent a known-bad write, never to invent a new
+ * way for a good one to be blocked.
+ */
+
+import { statfs } from "node:fs/promises";
+import { dirname, parse, resolve } from "node:path";
+
+/**
+ * Free bytes on the volume holding `path`, or `null` when it cannot be determined.
+ *
+ * `statfs` throws ENOENT for a path that does not exist yet, and the cache directory
+ * routinely does not on a first run — so walk up to the nearest existing ancestor,
+ * which is on the same volume by construction. Give up at the filesystem root rather
+ * than looping.
+ */
+export async function freeBytesFor(path: string): Promise<number | null> {
+  let dir = resolve(path);
+  const { root } = parse(dir);
+  for (;;) {
+    try {
+      const st = await statfs(dir);
+      const free = Number(st.bsize) * Number(st.bavail);
+      return Number.isFinite(free) && free >= 0 ? free : null;
+    } catch {
+      const parent = dirname(dir);
+      // `dirname` of a root returns the root: that is the stop condition, and without
+      // it a missing drive letter would spin forever.
+      if (parent === dir || dir === root) return null;
+      dir = parent;
+    }
+  }
+}
+
+/** Bytes left free after a download, below which we refuse to start it.
+ *
+ *  Not zero: landing a volume on exactly 0 free is its own failure, and on the system
+ *  drive it is the page-file case this issue is about. One GiB is small enough not to
+ *  block a legitimate tight-but-workable download and large enough to leave the OS
+ *  somewhere to breathe. */
+export const VOLUME_HEADROOM_BYTES = 1024 ** 3;
+
+const gb = (n: number): string => `${(n / 1024 ** 3).toFixed(2)} GB`;
+
+/**
+ * The refusal for a download whose staging volume cannot hold it.
+ *
+ * `destFree` is the free space on the DESTINATION volume when that is a different
+ * volume from the cache. When the destination has room and the cache does not, that
+ * is the whole story and the message says so — it turns a fatal error into one
+ * setting.
+ */
+export function insufficientCacheSpaceMessage(opts: {
+  needBytes: number;
+  cacheDir: string;
+  cacheFree: number;
+  destDir?: string;
+  destFree?: number | null;
+}): string {
+  const { needBytes, cacheDir, cacheFree, destDir, destFree } = opts;
+  const destHasRoom =
+    typeof destFree === "number" && destFree >= needBytes + VOLUME_HEADROOM_BYTES;
+
+  const head =
+    `NOT downloaded: this needs ${gb(needBytes)} of staging space and the download ` +
+    `cache volume has ${gb(cacheFree)} free (${cacheDir}).`;
+
+  // The single most useful fact, when it is true: the file was always going somewhere
+  // that fits, and only the staging location does not.
+  const split = destHasRoom
+    ? ` The DESTINATION has room — ${gb(destFree as number)} free at ${destDir} — so ` +
+      `this is not a "your disk is full" problem: the model is staged in the cache ` +
+      `BEFORE it lands, and the cache is on a different volume.`
+    : destDir && typeof destFree === "number"
+      ? ` The destination volume does not have room either (${gb(destFree)} free at ` +
+        `${destDir}), so a different cache location alone will not resolve this.`
+      : "";
+
+  const fix =
+    ` Point the cache at a volume with room by setting COMFYUI_DOWNLOAD_CACHE_DIR ` +
+    `(for example to a directory beside your models), then retry. Nothing was ` +
+    `written and nothing was partially downloaded — this refusal happens before the ` +
+    `first byte, precisely so a full volume is not driven to zero (#1477).`;
+
+  return head + split + fix;
+}
+
+/**
+ * Decide whether staging `needBytes` at `cacheDir` is safe. Returns a refusal string,
+ * or `null` to proceed.
+ *
+ * Proceeds when the size is unknown or free space cannot be read: an unmeasurable
+ * volume must not become an unusable one.
+ */
+export async function checkCacheVolumeSpace(opts: {
+  needBytes: number | undefined;
+  cacheDir: string;
+  destDir?: string;
+}): Promise<string | null> {
+  const { needBytes, cacheDir, destDir } = opts;
+  if (!needBytes || !Number.isFinite(needBytes) || needBytes <= 0) return null;
+  const cacheFree = await freeBytesFor(cacheDir);
+  if (cacheFree === null) return null;
+  if (cacheFree >= needBytes + VOLUME_HEADROOM_BYTES) return null;
+  const destFree = destDir ? await freeBytesFor(destDir) : null;
+  return insufficientCacheSpaceMessage({
+    needBytes,
+    cacheDir,
+    cacheFree,
+    destDir,
+    destFree,
+  });
+}

--- a/src/services/download-volume.ts
+++ b/src/services/download-volume.ts
@@ -45,15 +45,26 @@ import { dirname, parse, resolve } from "node:path";
  * which is on the same volume by construction. Give up at the filesystem root rather
  * than looping.
  */
-export async function freeBytesFor(path: string): Promise<number | null> {
+export async function volumeSpaceFor(
+  path: string,
+): Promise<{ free: number; total: number } | null> {
   let dir = resolve(path);
   const { root } = parse(dir);
   for (;;) {
     try {
       const st = await statfs(dir);
       const free = Number(st.bsize) * Number(st.bavail);
-      return Number.isFinite(free) && free >= 0 ? free : null;
-    } catch {
+      const total = Number(st.bsize) * Number(st.blocks);
+      return Number.isFinite(free) && free >= 0 ? { free, total } : null;
+    } catch (err) {
+      // Climb ONLY for "this path does not exist yet", which is the case that makes
+      // the walk necessary at all (a first run has no cache directory). Review
+      // caught the original catch-all: on a junction, mount point or network share
+      // whose statfs fails for PERMISSION or transport reasons, climbing would
+      // silently measure a DIFFERENT volume and answer confidently about the wrong
+      // disk -- which could permit the very overflow this exists to stop.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") return null;
       const parent = dirname(dir);
       // `dirname` of a root returns the root: that is the stop condition, and without
       // it a missing drive letter would spin forever.
@@ -63,6 +74,10 @@ export async function freeBytesFor(path: string): Promise<number | null> {
   }
 }
 
+export async function freeBytesFor(path: string): Promise<number | null> {
+  return (await volumeSpaceFor(path))?.free ?? null;
+}
+
 /** Bytes left free after a download, below which we refuse to start it.
  *
  *  Not zero: landing a volume on exactly 0 free is its own failure, and on the system
@@ -70,6 +85,21 @@ export async function freeBytesFor(path: string): Promise<number | null> {
  *  block a legitimate tight-but-workable download and large enough to leave the OS
  *  somewhere to breathe. */
 export const VOLUME_HEADROOM_BYTES = 1024 ** 3;
+
+/**
+ * The reserve to keep free on a volume of `total` bytes.
+ *
+ * A flat 1 GiB is right for the case this issue is about -- a 232 GB system drive
+ * whose page file needs somewhere to live -- and wrong for a small or removable
+ * volume, where it would refuse a download that fits comfortably. Review flagged
+ * exactly that. So the reserve is the SMALLER of 1 GiB and 5% of the volume, which
+ * leaves the system-drive protection untouched and stops a 4 GB stick being declared
+ * unusable for a 2 GB file.
+ */
+export function headroomFor(total: number): number {
+  if (!Number.isFinite(total) || total <= 0) return VOLUME_HEADROOM_BYTES;
+  return Math.min(VOLUME_HEADROOM_BYTES, Math.floor(total * 0.05));
+}
 
 const gb = (n: number): string => `${(n / 1024 ** 3).toFixed(2)} GB`;
 
@@ -87,8 +117,10 @@ export function insufficientCacheSpaceMessage(opts: {
   cacheFree: number;
   destDir?: string;
   destFree?: number | null;
+  /** True when this refusal interrupts a RESUME, so a .partial already exists. */
+  resuming?: boolean;
 }): string {
-  const { needBytes, cacheDir, cacheFree, destDir, destFree } = opts;
+  const { needBytes, cacheDir, cacheFree, destDir, destFree, resuming = false } = opts;
   const destHasRoom =
     typeof destFree === "number" && destFree >= needBytes + VOLUME_HEADROOM_BYTES;
 
@@ -107,11 +139,18 @@ export function insufficientCacheSpaceMessage(opts: {
         `${destDir}), so a different cache location alone will not resolve this.`
       : "";
 
+  // Review caught this claiming too much: the check also runs on a RESUME, where a
+  // .partial already exists on disk. Telling that user "nothing was downloaded" is
+  // false and invites them to delete a partial they could have reused.
+  const state = resuming
+    ? ` Your existing partial download is untouched and still resumable — this ` +
+      `refusal happens before any further bytes are written.`
+    : ` Nothing was written and nothing was partially downloaded — this refusal ` +
+      `happens before the first byte, precisely so a full volume is not driven to ` +
+      `zero (#1477).`;
   const fix =
     ` Point the cache at a volume with room by setting COMFYUI_DOWNLOAD_CACHE_DIR ` +
-    `(for example to a directory beside your models), then retry. Nothing was ` +
-    `written and nothing was partially downloaded — this refusal happens before the ` +
-    `first byte, precisely so a full volume is not driven to zero (#1477).`;
+    `(for example to a directory beside your models), then retry.` + state;
 
   return head + split + fix;
 }
@@ -127,18 +166,21 @@ export async function checkCacheVolumeSpace(opts: {
   needBytes: number | undefined;
   cacheDir: string;
   destDir?: string;
+  resuming?: boolean;
 }): Promise<string | null> {
-  const { needBytes, cacheDir, destDir } = opts;
+  const { needBytes, cacheDir, destDir, resuming } = opts;
   if (!needBytes || !Number.isFinite(needBytes) || needBytes <= 0) return null;
-  const cacheFree = await freeBytesFor(cacheDir);
-  if (cacheFree === null) return null;
-  if (cacheFree >= needBytes + VOLUME_HEADROOM_BYTES) return null;
+  const space = await volumeSpaceFor(cacheDir);
+  if (space === null) return null;
+  const headroom = headroomFor(space.total);
+  if (space.free >= needBytes + headroom) return null;
   const destFree = destDir ? await freeBytesFor(destDir) : null;
   return insufficientCacheSpaceMessage({
     needBytes,
     cacheDir,
-    cacheFree,
+    cacheFree: space.free,
     destDir,
     destFree,
+    resuming,
   });
 }

--- a/src/services/download-volume.ts
+++ b/src/services/download-volume.ts
@@ -117,12 +117,30 @@ export function insufficientCacheSpaceMessage(opts: {
   cacheFree: number;
   destDir?: string;
   destFree?: number | null;
-  /** True when this refusal interrupts a RESUME, so a .partial already exists. */
+  /** Reserve applied to the DESTINATION volume, so this clause agrees with policy. */
+  destHeadroom?: number;
+  /** True when this refusal interrupts a RESUME (appending to a partial). */
   resuming?: boolean;
+  /** True when a .partial exists on disk AT ALL — including a restart that is about
+   *  to discard it. Distinct from `resuming`: review found the two conflated, so a
+   *  restart-after-a-rejected-Range wrongly claimed nothing had been downloaded. */
+  partialExists?: boolean;
 }): string {
-  const { needBytes, cacheDir, cacheFree, destDir, destFree, resuming = false } = opts;
+  const {
+    needBytes,
+    cacheDir,
+    cacheFree,
+    destDir,
+    destFree,
+    resuming = false,
+    partialExists = false,
+  } = opts;
+  // The SAME reserve the policy applies, not the flat one: review found the message
+  // demanding 1 GiB of the destination while `checkCacheVolumeSpace` would have
+  // accepted a 5% reserve, so a destination that fits could be reported as too small.
+  // A remediation hint that contradicts the policy is worse than no hint.
   const destHasRoom =
-    typeof destFree === "number" && destFree >= needBytes + VOLUME_HEADROOM_BYTES;
+    typeof destFree === "number" && destFree >= needBytes + (opts.destHeadroom ?? VOLUME_HEADROOM_BYTES);
 
   const head =
     `NOT downloaded: this needs ${gb(needBytes)} of staging space and the download ` +
@@ -145,9 +163,14 @@ export function insufficientCacheSpaceMessage(opts: {
   const state = resuming
     ? ` Your existing partial download is untouched and still resumable — this ` +
       `refusal happens before any further bytes are written.`
-    : ` Nothing was written and nothing was partially downloaded — this refusal ` +
-      `happens before the first byte, precisely so a full volume is not driven to ` +
-      `zero (#1477).`;
+    : partialExists
+      ? ` A partial download from an earlier attempt is still on disk; this refusal ` +
+        `happens before any further bytes are written, so it is unchanged. Freeing ` +
+        `space may require removing it, and the figure above does NOT assume it was ` +
+        `reclaimed.`
+      : ` Nothing was written and nothing was partially downloaded — this refusal ` +
+        `happens before the first byte, precisely so a full volume is not driven to ` +
+        `zero (#1477).`;
   const fix =
     ` Point the cache at a volume with room by setting COMFYUI_DOWNLOAD_CACHE_DIR ` +
     `(for example to a directory beside your models), then retry.` + state;
@@ -167,20 +190,39 @@ export async function checkCacheVolumeSpace(opts: {
   cacheDir: string;
   destDir?: string;
   resuming?: boolean;
+  partialExists?: boolean;
 }): Promise<string | null> {
-  const { needBytes, cacheDir, destDir, resuming } = opts;
+  const { needBytes, cacheDir, destDir, resuming, partialExists } = opts;
   if (!needBytes || !Number.isFinite(needBytes) || needBytes <= 0) return null;
   const space = await volumeSpaceFor(cacheDir);
   if (space === null) return null;
   const headroom = headroomFor(space.total);
   if (space.free >= needBytes + headroom) return null;
-  const destFree = destDir ? await freeBytesFor(destDir) : null;
+  const destSpace = destDir ? await volumeSpaceFor(destDir) : null;
+  const destFree = destSpace?.free ?? null;
   return insufficientCacheSpaceMessage({
     needBytes,
     cacheDir,
     cacheFree: space.free,
     destDir,
     destFree,
+    destHeadroom: destSpace ? headroomFor(destSpace.total) : undefined,
     resuming,
+    partialExists,
   });
 }
+
+/*
+ * DELIBERATELY CONSERVATIVE: a restart that is about to truncate a stale .partial
+ * will reclaim its bytes, and crediting them here would let a few more downloads
+ * through. It is not done, because the truncation happens on two different paths —
+ * one BEFORE the request (a declined full response) and one at the write flags AFTER
+ * this check — and on the first of those the space is already free, so crediting it
+ * would DOUBLE-COUNT and permit exactly the overflow this module exists to stop.
+ *
+ * The two error directions are not symmetric. A false refusal costs one retry after
+ * setting COMFYUI_DOWNLOAD_CACHE_DIR; a false allow costs the system drive. Until the
+ * ordering is established by measurement rather than by reading, this stays on the
+ * side that cannot cause the harm — and the message above says plainly that the
+ * figure does not assume the partial was reclaimed, so the number is never misread.
+ */


### PR DESCRIPTION
Claims #1477.

`download_model` stages the entire file in `~/.comfyui-mcp/cache` — a path derived only from `homedir()`, so on Windows it is essentially always the system drive — regardless of which volume the resolved destination is on. The reporter's ComfyUI lives on `F:` with 1 TB free; `C:` had 0.7 GB free of 232 GB, and a 32 GB download grew a `.partial` to 22.62 GB heading for zero.

Filling the system drive to zero is worse than a failed download: it risks the page file and general OS stability.

Investigating. Scope to be confirmed once I have read the download path — the reporter names four distinct problems (staging volume, no free-space precheck despite a known `Content-Length`, cache retention after the model lands, and a progress counter under-reporting ~10x) and they do not all carry the same risk to fix.