### PR TITLE
chore(release): 0.51.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.18
+
+### Fixed
+
+- **A model download can no longer exhaust the system drive (#1477).** `download_model` stages
+  the whole file in the content-addressed cache before it lands, and that cache path came only
+  from `homedir()` -- on Windows essentially always the system drive, while models are almost
+  always on a big secondary volume. The reporter's ComfyUI lives on `F:` with 1 TB free; `C:`
+  had 0.7 GB free of 232 GB, and a 32.29 GB download grew a `.partial` to 22.62 GB heading for
+  zero. Taking a Windows system drive to zero risks the page file and general OS stability, so
+  the failure did not stay confined to the download that caused it.
+
+  `Content-Length` is already known before the first byte is written, and there was no
+  free-space check anywhere in the codebase. There is now: the download is REFUSED up front,
+  naming the space needed, the space available, the destination's free space when it is a
+  different volume, and `COMFYUI_DOWNLOAD_CACHE_DIR` as the lever. The reserve scales as
+  min(1 GiB, 5% of the volume) so a small or removable cache volume stays usable. Every check
+  fails soft: an unknown size or an unreadable volume proceeds exactly as before, because an
+  unmeasurable volume must not become an unusable one.
+
+  Not addressed here, and deliberately: relocating the cache to the destination volume, the
+  cached copies retained after a model lands, and the ~10x progress under-report -- all three
+  are recorded on the issue.
+
 ## 0.51.17
 
 ### Fixed
@@ -227,6 +251,14 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.51.18] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- refuse a download that would exhaust the cache volume (#1482)
+
 
 ## [0.51.17] - 2026-08-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.17",
+  "version": "0.51.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.17",
+      "version": "0.51.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.17",
+  "version": "0.51.18",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected main with the published v0.51.18 tag.

**#1477 (P1)** — a model download can no longer exhaust the system drive. `download_model` staged the whole file in a cache derived only from `homedir()`, regardless of the destination volume, and there was no free-space check anywhere in `src/`. The download is now refused before the first byte, naming both figures and `COMFYUI_DOWNLOAD_CACHE_DIR`.

Live-verified against the built artifact on main: an impossible download is refused with the full message, a small one is allowed, and the reserve scales (1.00 GB on a 232 GB volume, 0.200 GB on a 4 GB one).

The gate ran three rounds and found real holes each time — a resume path that silently skipped the guard, a `statfs` walk that could measure the wrong volume, and a refusal that lied to a resuming user about their partial. CI then caught a defect in my *test* (it hardcoded `M:/` as unmounted; the Windows runner has one). Final verdict: **PASS**.

Three of the reporter's four sub-reports are deliberately out of scope and recorded on the issue rather than silently dropped.