### PR TITLE
fix(1371): refuse a download whose destination the server PROVABLY does not read

### DIFF
--- a/src/__tests__/services/download-root-correspondence.test.ts
+++ b/src/__tests__/services/download-root-correspondence.test.ts
@@ -1,122 +1,92 @@
 // #1371 — a model was written into a DIFFERENT local ComfyUI installation than the one
-// serving the session.
+// serving the session: connected to :8190 (…\ComfyUI_H3), streamed into …\ComfyUI\models
+// from a stale COMFYUI_PATH, while visibility was checked against the connected server.
 //
-// The reporter was connected to ComfyUI on :8190 (…\ComfyUI_H3), and download_model
-// streamed into …\ComfyUI\models — a stale COMFYUI_PATH from another install — while
-// visibility was checked against the connected server.
+// The existing divergence guard shipped in v0.49.4 and the reporter was on 0.50.107, so
+// it was present and did not fire: it proves divergence from CONTENT (files on disk the
+// server does not list), and an empty destination category proves nothing.
 //
-// The existing divergence guard has shipped since v0.49.4 and the reporter was on
-// 0.50.107, so it was present and did not fire: it proves divergence from CONTENT
-// (files on disk the server does not list), and an empty destination category proves
-// nothing. This adds POSITIVE evidence instead — the server naming its own root.
+// A FIRST attempt refused when the destination fell outside the install root the server
+// names for itself. Review knocked that down and was right — extra_model_paths.yaml
+// registers roots elsewhere by design, <install>/models is routinely a junction, and
+// #1474 (fixed the same day) is a Comfy Desktop install serving models from a SHARED
+// root outside its install directory. That guard would have refused it.
+//
+// This uses isUnderLiveModelRoots instead, which answers the question that actually
+// matters — does the connected server read this tree — and distinguishes UNKNOWN from NO.
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  divergentInstallRefusal,
-  isWithinRoot,
-} from "../../services/download-root-correspondence.js";
+import { divergentInstallRefusal } from "../../services/download-root-correspondence.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const SERVER_ROOT = "G:/Start_AI/AI_Test/ComfyUI_H3";
 const STALE_DEST = "G:/Start_AI/AI_Test/ComfyUI/models/vae";
-const GOOD_DEST = "G:/Start_AI/AI_Test/ComfyUI_H3/models/vae";
+const LIVE_ROOT = "G:/Start_AI/AI_Test/ComfyUI_H3/models";
 
-describe("#1371 the reporter's case now refuses", () => {
-  it("refuses a destination outside the root the server names for itself", () => {
-    const msg = divergentInstallRefusal({
+describe("#1371 the reporter's case refuses", () => {
+  const msg = () =>
+    divergentInstallRefusal({
       targetDir: STALE_DEST,
-      serverRoot: SERVER_ROOT,
+      inRoots: false,
+      liveRoot: LIVE_ROOT,
       serverUrl: "http://127.0.0.1:8190",
-    });
-    expect(msg).toBeTruthy();
-    expect(msg).toMatch(/NOT downloaded/);
-    expect(msg).toContain(STALE_DEST);
-    expect(msg).toContain(SERVER_ROOT);
-    expect(msg).toMatch(/127\.0\.0\.1:8190/);
+    })!;
+
+  it("refuses a destination the server demonstrably does not read", () => {
+    expect(msg()).toMatch(/NOT downloaded/);
+    expect(msg()).toContain(STALE_DEST);
+    expect(msg()).toMatch(/127\.0\.0\.1:8190/);
+  });
+
+  it("names the root the server DOES read, so the two can be compared", () => {
+    expect(msg()).toContain(LIVE_ROOT);
   });
 
   it("says nothing was written, and names COMFYUI_PATH as the usual cause", () => {
-    const msg = divergentInstallRefusal({
-      targetDir: STALE_DEST,
-      serverRoot: SERVER_ROOT,
-    })!;
-    expect(msg).toMatch(/Nothing was written/);
-    expect(msg).toMatch(/COMFYUI_PATH/);
-    expect(msg).toMatch(/left over from a different installation/);
+    expect(msg()).toMatch(/Nothing was written/);
+    expect(msg()).toMatch(/COMFYUI_PATH/);
+    expect(msg()).toMatch(/left over from a\s+different installation/);
   });
 
-  it("gives both ways forward without pretending either is automatic", () => {
-    const msg = divergentInstallRefusal({
-      targetDir: STALE_DEST,
-      serverRoot: SERVER_ROOT,
-    })!;
-    expect(msg).toMatch(/Point COMFYUI_PATH at the ComfyUI that\s+is actually running/);
-    expect(msg).toMatch(/--base-directory/);
-    // And the case where the user genuinely meant another install.
-    expect(msg).toMatch(/If you MEANT to place/);
+  it("states that extra roots and symlinks were accounted for", () => {
+    // Without this, a reader with a shared or junctioned models tree reasonably
+    // suspects the check simply does not understand their layout.
+    expect(msg()).toMatch(/extra_model_paths\.yaml/);
+    expect(msg()).toMatch(/junctions and symlinks resolved/);
+  });
+
+  it("gives both ways forward, including a deliberate other install", () => {
+    expect(msg()).toMatch(/Point COMFYUI_PATH ?\n?at the ComfyUI that is actually running/);
+    expect(msg()).toMatch(/--base-directory/);
+    expect(msg()).toMatch(/If you MEANT another install/);
   });
 });
 
-describe("#1371 it refuses ONLY on positive proof", () => {
-  it("proceeds when the destination is inside the server's own root", () => {
+describe("#1371 it refuses ONLY on a demonstrated mismatch", () => {
+  it("proceeds when the server DOES read the destination", () => {
     expect(
-      divergentInstallRefusal({ targetDir: GOOD_DEST, serverRoot: SERVER_ROOT }),
+      divergentInstallRefusal({ targetDir: STALE_DEST, inRoots: true, liveRoot: LIVE_ROOT }),
     ).toBeNull();
   });
 
-  it("proceeds when the server did not name a root", () => {
-    // Absence of evidence. The content-based guard's own note records that every
-    // tightening of that inference produced another FALSE REFUSAL.
-    for (const serverRoot of [undefined, ""]) {
-      expect(divergentInstallRefusal({ targetDir: STALE_DEST, serverRoot })).toBeNull();
-    }
-  });
-
-  it("proceeds when the destination came from the LIVE server", () => {
-    // Then the destination and the root have the same origin and cannot disagree;
-    // firing here would refuse a destination the server itself supplied.
-    expect(
-      divergentInstallRefusal({
-        targetDir: STALE_DEST,
-        serverRoot: SERVER_ROOT,
-        liveAuthoritative: true,
-      }),
-    ).toBeNull();
+  it("proceeds when membership is UNKNOWN — the whole point", () => {
+    // `undefined` means only local configuration could answer. Treating that as "the
+    // server cannot read it" is exactly the inference the surrounding code records as
+    // having produced false refusal after false refusal.
+    expect(divergentInstallRefusal({ targetDir: STALE_DEST, inRoots: undefined })).toBeNull();
   });
 
   it("proceeds when there is no destination to judge", () => {
-    expect(divergentInstallRefusal({ targetDir: "", serverRoot: SERVER_ROOT })).toBeNull();
-  });
-});
-
-describe("#1371 isWithinRoot", () => {
-  it("accepts the root itself and anything beneath it", () => {
-    expect(isWithinRoot(SERVER_ROOT, SERVER_ROOT)).toBe(true);
-    expect(isWithinRoot(`${SERVER_ROOT}/models/vae`, SERVER_ROOT)).toBe(true);
-    expect(isWithinRoot(`${SERVER_ROOT}/`, SERVER_ROOT)).toBe(true);
+    expect(divergentInstallRefusal({ targetDir: "", inRoots: false })).toBeNull();
   });
 
-  it("is not fooled by a SIBLING whose name shares a prefix", () => {
-    // The exact shape of this bug: ComfyUI vs ComfyUI_H3. A naive startsWith says the
-    // stale tree is inside the live one, or vice versa, and the refusal never fires.
-    expect(isWithinRoot("G:/Start_AI/AI_Test/ComfyUI_H3x/models", SERVER_ROOT)).toBe(false);
-    expect(isWithinRoot("G:/Start_AI/AI_Test/ComfyUI/models", SERVER_ROOT)).toBe(false);
-    expect(isWithinRoot(SERVER_ROOT, "G:/Start_AI/AI_Test/ComfyUI")).toBe(false);
-  });
-
-  it("treats Windows paths case-insensitively", () => {
-    // The same install is routinely spelled with a different drive-letter case.
-    if (process.platform === "win32") {
-      expect(isWithinRoot("g:/start_ai/AI_Test/ComfyUI_H3/models", SERVER_ROOT)).toBe(true);
-    }
-  });
-
-  it("never claims containment for empty input", () => {
-    expect(isWithinRoot("", SERVER_ROOT)).toBe(false);
-    expect(isWithinRoot(STALE_DEST, "")).toBe(false);
+  it("still refuses when the live root is unknown but membership is false", () => {
+    // The verdict comes from membership, not from having a root to print.
+    const m = divergentInstallRefusal({ targetDir: STALE_DEST, inRoots: false });
+    expect(m).toBeTruthy();
+    expect(m).not.toMatch(/It reads models from/);
   });
 });
 
@@ -131,33 +101,26 @@ describe("#1371 WIRING", () => {
     expect(src).toMatch(/if \(refusal\) throw new ModelError\(refusal/);
   });
 
+  it("asks the LIVE-ROOTS question, not an install-directory question", () => {
+    // The refuted premise. isUnderLiveModelRoots understands extra roots, junctions and
+    // symlinks; an install-root comparison does not.
+    expect(src).toMatch(/isUnderLiveModelRoots\(targetDir, normalizedSubfolderFor/);
+    expect(src).toMatch(/inRoots: membership\.inRoots/);
+  });
+
+  it("the refuted install-root helper is gone", () => {
+    expect((src.match(/serverInstallRootOrUndefined/g) ?? []).length).toBe(0);
+  });
+
+  it("scopes the check to the destination's CATEGORY", () => {
+    // Live extra roots are category-scoped: a `checkpoints` root must not vouch for a
+    // LoRA destination.
+    expect(src).toMatch(/function normalizedSubfolderFor\(targetSubfolder: string\)/);
+  });
+
   it("only runs when the destination did NOT come from the live server", () => {
-    // Otherwise it would second-guess a root the server itself supplied.
     const at = src.indexOf("if (!liveRootAtResolve) {");
     expect(at).toBeGreaterThan(-1);
-    const block = src.slice(at, at + 500);
-    expect(block).toMatch(/divergentInstallRefusal/);
-  });
-
-  it("derives the root from ARGV ONLY, never a live host probe", () => {
-    // The shared root resolver falls back to probing the live process table, and the
-    // repo gates against new code reaching it (#1290/#1263) because it makes a test
-    // assert one thing where ComfyUI is running and another where it is not. That gate
-    // caught this exact mistake — and then caught this TEST, because it scans test text
-    // for the entry-point NAME and my comment mentioned it. Hence the periphrasis.
-    expect(src).toMatch(/liveRootFromArgv\(argv, cwd\)/);
-    const at = src.indexOf("async function serverInstallRootOrUndefined");
-    const block = src.slice(at, at + 1400);
-    expect(block).toMatch(/ARGV ONLY/);
-  });
-
-  it("a failure to read the server root never fails the download", () => {
-    const at = src.indexOf("async function serverInstallRootOrUndefined");
-    expect(at).toBeGreaterThan(-1);
-    const block = src.slice(at, at + 2000);
-    // Plain containment: a regex spanning a line break is how these keep getting
-    // written wrong.
-    expect(block.includes("catch")).toBe(true);
-    expect(block.includes("return undefined;")).toBe(true);
+    expect(src.slice(at, at + 400)).toMatch(/isUnderLiveModelRoots/);
   });
 });

--- a/src/__tests__/services/download-root-correspondence.test.ts
+++ b/src/__tests__/services/download-root-correspondence.test.ts
@@ -1,0 +1,163 @@
+// #1371 — a model was written into a DIFFERENT local ComfyUI installation than the one
+// serving the session.
+//
+// The reporter was connected to ComfyUI on :8190 (…\ComfyUI_H3), and download_model
+// streamed into …\ComfyUI\models — a stale COMFYUI_PATH from another install — while
+// visibility was checked against the connected server.
+//
+// The existing divergence guard has shipped since v0.49.4 and the reporter was on
+// 0.50.107, so it was present and did not fire: it proves divergence from CONTENT
+// (files on disk the server does not list), and an empty destination category proves
+// nothing. This adds POSITIVE evidence instead — the server naming its own root.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  divergentInstallRefusal,
+  isWithinRoot,
+} from "../../services/download-root-correspondence.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SERVER_ROOT = "G:/Start_AI/AI_Test/ComfyUI_H3";
+const STALE_DEST = "G:/Start_AI/AI_Test/ComfyUI/models/vae";
+const GOOD_DEST = "G:/Start_AI/AI_Test/ComfyUI_H3/models/vae";
+
+describe("#1371 the reporter's case now refuses", () => {
+  it("refuses a destination outside the root the server names for itself", () => {
+    const msg = divergentInstallRefusal({
+      targetDir: STALE_DEST,
+      serverRoot: SERVER_ROOT,
+      serverUrl: "http://127.0.0.1:8190",
+    });
+    expect(msg).toBeTruthy();
+    expect(msg).toMatch(/NOT downloaded/);
+    expect(msg).toContain(STALE_DEST);
+    expect(msg).toContain(SERVER_ROOT);
+    expect(msg).toMatch(/127\.0\.0\.1:8190/);
+  });
+
+  it("says nothing was written, and names COMFYUI_PATH as the usual cause", () => {
+    const msg = divergentInstallRefusal({
+      targetDir: STALE_DEST,
+      serverRoot: SERVER_ROOT,
+    })!;
+    expect(msg).toMatch(/Nothing was written/);
+    expect(msg).toMatch(/COMFYUI_PATH/);
+    expect(msg).toMatch(/left over from a different installation/);
+  });
+
+  it("gives both ways forward without pretending either is automatic", () => {
+    const msg = divergentInstallRefusal({
+      targetDir: STALE_DEST,
+      serverRoot: SERVER_ROOT,
+    })!;
+    expect(msg).toMatch(/Point COMFYUI_PATH at the ComfyUI that\s+is actually running/);
+    expect(msg).toMatch(/--base-directory/);
+    // And the case where the user genuinely meant another install.
+    expect(msg).toMatch(/If you MEANT to place/);
+  });
+});
+
+describe("#1371 it refuses ONLY on positive proof", () => {
+  it("proceeds when the destination is inside the server's own root", () => {
+    expect(
+      divergentInstallRefusal({ targetDir: GOOD_DEST, serverRoot: SERVER_ROOT }),
+    ).toBeNull();
+  });
+
+  it("proceeds when the server did not name a root", () => {
+    // Absence of evidence. The content-based guard's own note records that every
+    // tightening of that inference produced another FALSE REFUSAL.
+    for (const serverRoot of [undefined, ""]) {
+      expect(divergentInstallRefusal({ targetDir: STALE_DEST, serverRoot })).toBeNull();
+    }
+  });
+
+  it("proceeds when the destination came from the LIVE server", () => {
+    // Then the destination and the root have the same origin and cannot disagree;
+    // firing here would refuse a destination the server itself supplied.
+    expect(
+      divergentInstallRefusal({
+        targetDir: STALE_DEST,
+        serverRoot: SERVER_ROOT,
+        liveAuthoritative: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("proceeds when there is no destination to judge", () => {
+    expect(divergentInstallRefusal({ targetDir: "", serverRoot: SERVER_ROOT })).toBeNull();
+  });
+});
+
+describe("#1371 isWithinRoot", () => {
+  it("accepts the root itself and anything beneath it", () => {
+    expect(isWithinRoot(SERVER_ROOT, SERVER_ROOT)).toBe(true);
+    expect(isWithinRoot(`${SERVER_ROOT}/models/vae`, SERVER_ROOT)).toBe(true);
+    expect(isWithinRoot(`${SERVER_ROOT}/`, SERVER_ROOT)).toBe(true);
+  });
+
+  it("is not fooled by a SIBLING whose name shares a prefix", () => {
+    // The exact shape of this bug: ComfyUI vs ComfyUI_H3. A naive startsWith says the
+    // stale tree is inside the live one, or vice versa, and the refusal never fires.
+    expect(isWithinRoot("G:/Start_AI/AI_Test/ComfyUI_H3x/models", SERVER_ROOT)).toBe(false);
+    expect(isWithinRoot("G:/Start_AI/AI_Test/ComfyUI/models", SERVER_ROOT)).toBe(false);
+    expect(isWithinRoot(SERVER_ROOT, "G:/Start_AI/AI_Test/ComfyUI")).toBe(false);
+  });
+
+  it("treats Windows paths case-insensitively", () => {
+    // The same install is routinely spelled with a different drive-letter case.
+    if (process.platform === "win32") {
+      expect(isWithinRoot("g:/start_ai/AI_Test/ComfyUI_H3/models", SERVER_ROOT)).toBe(true);
+    }
+  });
+
+  it("never claims containment for empty input", () => {
+    expect(isWithinRoot("", SERVER_ROOT)).toBe(false);
+    expect(isWithinRoot(STALE_DEST, "")).toBe(false);
+  });
+});
+
+describe("#1371 WIRING", () => {
+  const src = readFileSync(join(HERE, "../../services/model-resolver.ts"), "utf8");
+
+  it("resolveDownloadTarget consults it", () => {
+    expect(src).toMatch(
+      /import \{ divergentInstallRefusal \} from "\.\/download-root-correspondence\.js";/,
+    );
+    expect(src).toMatch(/divergentInstallRefusal\(\{/);
+    expect(src).toMatch(/if \(refusal\) throw new ModelError\(refusal/);
+  });
+
+  it("only runs when the destination did NOT come from the live server", () => {
+    // Otherwise it would second-guess a root the server itself supplied.
+    const at = src.indexOf("if (!liveRootAtResolve) {");
+    expect(at).toBeGreaterThan(-1);
+    const block = src.slice(at, at + 500);
+    expect(block).toMatch(/divergentInstallRefusal/);
+  });
+
+  it("derives the root from ARGV ONLY, never a live host probe", () => {
+    // The shared root resolver falls back to probing the live process table, and the
+    // repo gates against new code reaching it (#1290/#1263) because it makes a test
+    // assert one thing where ComfyUI is running and another where it is not. That gate
+    // caught this exact mistake — and then caught this TEST, because it scans test text
+    // for the entry-point NAME and my comment mentioned it. Hence the periphrasis.
+    expect(src).toMatch(/liveRootFromArgv\(argv, cwd\)/);
+    const at = src.indexOf("async function serverInstallRootOrUndefined");
+    const block = src.slice(at, at + 1400);
+    expect(block).toMatch(/ARGV ONLY/);
+  });
+
+  it("a failure to read the server root never fails the download", () => {
+    const at = src.indexOf("async function serverInstallRootOrUndefined");
+    expect(at).toBeGreaterThan(-1);
+    const block = src.slice(at, at + 2000);
+    // Plain containment: a regex spanning a line break is how these keep getting
+    // written wrong.
+    expect(block.includes("catch")).toBe(true);
+    expect(block.includes("return undefined;")).toBe(true);
+  });
+});

--- a/src/services/download-root-correspondence.ts
+++ b/src/services/download-root-correspondence.ts
@@ -2,86 +2,69 @@
  * #1371 — a model was written into a DIFFERENT local ComfyUI installation than the one
  * serving the session.
  *
- * The reporter was connected to ComfyUI on `:8190` (`…\ComfyUI_H3`), and the download
- * streamed into `…\ComfyUI\models` — a stale `COMFYUI_PATH` belonging to another
- * install — while visibility was checked against the connected server.
+ * Connected to ComfyUI on `:8190` (`…\ComfyUI_H3`), the download streamed into
+ * `…\ComfyUI\models` — a stale `COMFYUI_PATH` from another install — while visibility
+ * was checked against the connected server.
  *
  * ## Why the existing guard did not catch it
  *
- * `model-resolver.ts` has refused divergent destinations since v0.49.4, and the
- * reporter was on 0.50.107 — newer — so the guard was present and did not fire. It
- * proves divergence from CONTENT: files present on disk that the running server does
- * not list. With a sparse or empty destination category (`vae`, here) there is nothing
- * to compare, so nothing can be proven and the write proceeds.
+ * `model-resolver.ts` has refused divergent destinations since v0.49.4, and the reporter
+ * was on 0.50.107 — newer — so the guard was present and did not fire. It proves
+ * divergence from CONTENT: files on disk the running server does not list. With a sparse
+ * or empty destination category (`vae`, here) there is nothing to compare.
  *
- * That guard's own note explains why it cannot simply be widened: "the server lists
- * models this tree does not contain" is ABSENCE of evidence, and every time that rule
- * was tightened it produced another false refusal of a legitimate destination.
+ * ## The evidence used, and one that was REFUTED first
  *
- * ## The evidence this adds instead
+ * A first attempt refused when the destination fell outside the install root the server
+ * names for itself. Review knocked that down, correctly: being outside the install root
+ * does not mean the server cannot read it. `extra_model_paths.yaml` registers roots
+ * elsewhere by design, `<install>/models` is routinely a junction to another drive, and
+ * a container-mounted path and its host destination describe one directory through two
+ * unrelated strings. #1474 — fixed the same day — is a Comfy Desktop install serving
+ * models from a SHARED root outside its install directory; that guard would have refused
+ * it outright.
  *
- * `resolveModelSubfolderPreferServer` already roots the destination at the server's own
- * models dir when it can — but it falls back to `<COMFYUI_PATH>/models` when the server
- * was not launched with `--base-directory`, and nothing then checks that the fallback
- * plausibly belongs to THAT server.
+ * The right question is not "is this inside the install" but "does the connected server
+ * read this tree", and `isUnderLiveModelRoots` already answers exactly that: it checks
+ * the live primary models root AND live-registered extra roots, canonicalizes junctions
+ * and symlinks through `realpath`, is category-scoped, and returns `undefined` for
+ * UNKNOWN rather than folding it into "no".
  *
- * A server can still identify its install root through its `main.py` argv even without
- * `--base-directory` (`liveRootFromArgv`). When that root resolves AND the destination
- * lies outside it, the two installs are PROVABLY different — that is positive evidence,
- * not the absence of it, so refusing on it does not reintroduce the false-refusal class.
- *
- * Everything here is conditional on that proof existing. No server root, no refusal:
- * an unmeasurable setup must keep working exactly as it does today.
+ * So this refuses on `inRoots === false` — demonstrably not read — and never on
+ * `undefined`. That is the distinction the whole file exists to hold: the surrounding
+ * code's own note records that every time "the server did not vouch for it" was treated
+ * as "the server cannot read it", it produced another false refusal.
  */
 
-import { resolve, sep } from "node:path";
-
-/** Is `child` the same directory as `parent`, or inside it? Case-insensitive on
- *  Windows, where the same install is routinely spelled with a different drive-letter
- *  case or a mixed-case user directory. */
-export function isWithinRoot(child: string, parent: string): boolean {
-  if (!child || !parent) return false;
-  const norm = (p: string) => {
-    const r = resolve(p).replace(/[\\/]+$/, "");
-    return process.platform === "win32" ? r.toLowerCase() : r;
-  };
-  const c = norm(child);
-  const p = norm(parent);
-  return c === p || c.startsWith(p + sep) || c.startsWith(p + "/");
-}
-
 /**
- * The refusal for a destination the connected server provably does not read.
+ * The refusal for a destination the connected server demonstrably does not read.
  *
- * Returns `null` — proceed, unchanged — unless BOTH roots are known AND the
- * destination lies outside the server's own install root.
+ * `inRoots` comes from `isUnderLiveModelRoots`: `false` means demonstrably outside every
+ * tree the live server reads; `undefined` means only local configuration could answer,
+ * which proves nothing and must NOT refuse.
  */
 export function divergentInstallRefusal(opts: {
   targetDir: string;
-  /** The install root the CONNECTED server reported for itself (argv-derived). */
-  serverRoot?: string;
-  /** The URL of the connected server, for the message. */
+  inRoots: boolean | undefined;
+  /** The live models root the answer was computed against, when authoritative. */
+  liveRoot?: string;
   serverUrl?: string;
-  /** True when the destination came from the live server rather than local config —
-   *  then there is nothing to disagree with and this must not fire. */
-  liveAuthoritative?: boolean;
 }): string | null {
-  const { targetDir, serverRoot, serverUrl, liveAuthoritative } = opts;
-  if (liveAuthoritative) return null;
-  if (!targetDir || !serverRoot) return null; // no proof — behave exactly as before
-  if (isWithinRoot(targetDir, serverRoot)) return null;
+  const { targetDir, inRoots, liveRoot, serverUrl } = opts;
+  if (inRoots !== false) return null; // true = fine; undefined = unknown, never refuse
+  if (!targetDir) return null;
+  const where = liveRoot ? ` It reads models from "${liveRoot}" (and any extra roots it has registered).` : "";
   return (
-    `NOT downloaded: the destination "${targetDir}" is outside the install root the ` +
-    `connected ComfyUI${serverUrl ? ` (${serverUrl})` : ""} reports for itself ` +
-    `("${serverRoot}"), so that server does not read it. This destination came from ` +
-    `LOCAL CONFIGURATION — COMFYUI_PATH or the saved default workspace — not from the ` +
-    `running server, and a COMFYUI_PATH left over from a different installation is the ` +
-    `usual cause (#1371). Nothing was written.\n\n` +
-    `This is not a guess about an unverifiable destination: the server named its own ` +
-    `root and the destination is not under it. Point COMFYUI_PATH at the ComfyUI that ` +
-    `is actually running, or launch that server with an absolute --base-directory so ` +
-    `the destination can be taken from it directly, then retry. If you MEANT to place ` +
-    `the file in a different install, download it there — writing it here would report ` +
-    `success for a model the connected server can never load.`
+    `NOT downloaded: the connected ComfyUI${serverUrl ? ` (${serverUrl})` : ""} does not ` +
+    `read from "${targetDir}", so a model placed there would never be visible to it.` +
+    `${where} This destination came from LOCAL CONFIGURATION — COMFYUI_PATH or the saved ` +
+    `default workspace — not from the running server, and a COMFYUI_PATH left over from a ` +
+    `different installation is the usual cause (#1371). Nothing was written.\n\n` +
+    `This is a demonstrated mismatch, not an unverified one: the destination was checked ` +
+    `against the roots the live server actually reads, including any registered through ` +
+    `extra_model_paths.yaml, and with junctions and symlinks resolved. Point COMFYUI_PATH ` +
+    `at the ComfyUI that is actually running, or launch that server with an absolute ` +
+    `--base-directory, then retry. If you MEANT another install, download it there — ` +
+    `writing here would report success for a model the connected server can never load.`
   );
 }

--- a/src/services/download-root-correspondence.ts
+++ b/src/services/download-root-correspondence.ts
@@ -1,0 +1,87 @@
+/**
+ * #1371 — a model was written into a DIFFERENT local ComfyUI installation than the one
+ * serving the session.
+ *
+ * The reporter was connected to ComfyUI on `:8190` (`…\ComfyUI_H3`), and the download
+ * streamed into `…\ComfyUI\models` — a stale `COMFYUI_PATH` belonging to another
+ * install — while visibility was checked against the connected server.
+ *
+ * ## Why the existing guard did not catch it
+ *
+ * `model-resolver.ts` has refused divergent destinations since v0.49.4, and the
+ * reporter was on 0.50.107 — newer — so the guard was present and did not fire. It
+ * proves divergence from CONTENT: files present on disk that the running server does
+ * not list. With a sparse or empty destination category (`vae`, here) there is nothing
+ * to compare, so nothing can be proven and the write proceeds.
+ *
+ * That guard's own note explains why it cannot simply be widened: "the server lists
+ * models this tree does not contain" is ABSENCE of evidence, and every time that rule
+ * was tightened it produced another false refusal of a legitimate destination.
+ *
+ * ## The evidence this adds instead
+ *
+ * `resolveModelSubfolderPreferServer` already roots the destination at the server's own
+ * models dir when it can — but it falls back to `<COMFYUI_PATH>/models` when the server
+ * was not launched with `--base-directory`, and nothing then checks that the fallback
+ * plausibly belongs to THAT server.
+ *
+ * A server can still identify its install root through its `main.py` argv even without
+ * `--base-directory` (`liveRootFromArgv`). When that root resolves AND the destination
+ * lies outside it, the two installs are PROVABLY different — that is positive evidence,
+ * not the absence of it, so refusing on it does not reintroduce the false-refusal class.
+ *
+ * Everything here is conditional on that proof existing. No server root, no refusal:
+ * an unmeasurable setup must keep working exactly as it does today.
+ */
+
+import { resolve, sep } from "node:path";
+
+/** Is `child` the same directory as `parent`, or inside it? Case-insensitive on
+ *  Windows, where the same install is routinely spelled with a different drive-letter
+ *  case or a mixed-case user directory. */
+export function isWithinRoot(child: string, parent: string): boolean {
+  if (!child || !parent) return false;
+  const norm = (p: string) => {
+    const r = resolve(p).replace(/[\\/]+$/, "");
+    return process.platform === "win32" ? r.toLowerCase() : r;
+  };
+  const c = norm(child);
+  const p = norm(parent);
+  return c === p || c.startsWith(p + sep) || c.startsWith(p + "/");
+}
+
+/**
+ * The refusal for a destination the connected server provably does not read.
+ *
+ * Returns `null` — proceed, unchanged — unless BOTH roots are known AND the
+ * destination lies outside the server's own install root.
+ */
+export function divergentInstallRefusal(opts: {
+  targetDir: string;
+  /** The install root the CONNECTED server reported for itself (argv-derived). */
+  serverRoot?: string;
+  /** The URL of the connected server, for the message. */
+  serverUrl?: string;
+  /** True when the destination came from the live server rather than local config —
+   *  then there is nothing to disagree with and this must not fire. */
+  liveAuthoritative?: boolean;
+}): string | null {
+  const { targetDir, serverRoot, serverUrl, liveAuthoritative } = opts;
+  if (liveAuthoritative) return null;
+  if (!targetDir || !serverRoot) return null; // no proof — behave exactly as before
+  if (isWithinRoot(targetDir, serverRoot)) return null;
+  return (
+    `NOT downloaded: the destination "${targetDir}" is outside the install root the ` +
+    `connected ComfyUI${serverUrl ? ` (${serverUrl})` : ""} reports for itself ` +
+    `("${serverRoot}"), so that server does not read it. This destination came from ` +
+    `LOCAL CONFIGURATION — COMFYUI_PATH or the saved default workspace — not from the ` +
+    `running server, and a COMFYUI_PATH left over from a different installation is the ` +
+    `usual cause (#1371). Nothing was written.\n\n` +
+    `This is not a guess about an unverifiable destination: the server named its own ` +
+    `root and the destination is not under it. Point COMFYUI_PATH at the ComfyUI that ` +
+    `is actually running, or launch that server with an absolute --base-directory so ` +
+    `the destination can be taken from it directly, then retry. If you MEANT to place ` +
+    `the file in a different install, download it there — writing it here would report ` +
+    `success for a model the connected server can never load.`
+  );
+}

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2086,30 +2086,11 @@ export interface ResolvedDownloadTarget {
   liveRootAtResolve?: string;
 }
 
-/**
- * The install root the CONNECTED server reports for ITSELF, derived from its `main.py`
- * argv — available even when it was not launched with `--base-directory`.
- *
- * Returns undefined on any failure. #1371's refusal is conditional on this value, so a
- * throw here must never become a failed download: no root, no refusal.
- */
-async function serverInstallRootOrUndefined(): Promise<string | undefined> {
-  try {
-    const stats = await getSystemStats();
-    const argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
-    const cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
-    // ARGV ONLY — deliberately not resolveLiveServerRoot, which falls back to probing
-    // the live PROCESS TABLE. The repo has a gate against new code reaching that probe
-    // (#1290/#1263) precisely because it makes a test assert one thing on a machine
-    // where ComfyUI is running and another where it is not. I reached for the shared
-    // resolver first and that gate caught it.
-    //
-    // Argv is also the right evidence here: it is what the connected server itself
-    // reported, so it cannot describe some other process that happens to be running.
-    return liveRootFromArgv(argv, cwd) || undefined;
-  } catch {
-    return undefined;
-  }
+/** The models CATEGORY a target subfolder belongs to — its first segment. Live extra
+ *  roots are category-scoped, so a `checkpoints` root must not vouch for a LoRA. */
+function normalizedSubfolderFor(targetSubfolder: string): string | undefined {
+  const first = (targetSubfolder ?? "").trim().replace(/\\/g, "/").split("/")[0];
+  return first || undefined;
 }
 
 /**
@@ -2167,11 +2148,13 @@ export async function resolveDownloadTarget(
   // own note warns about — and it is skipped entirely when the destination came from
   // the live server (nothing to disagree with) or when no root can be derived.
   if (!liveRootAtResolve) {
+    const membership = await isUnderLiveModelRoots(targetDir, normalizedSubfolderFor(targetSubfolder));
     const refusal = divergentInstallRefusal({
       targetDir,
-      serverRoot: await serverInstallRootOrUndefined(),
-      // Defensive: this is decoration on a refusal, and an existing suite mocks
-      // config.js without this export — a message detail must never fail a download.
+      inRoots: membership.inRoots,
+      liveRoot: membership.liveRoot,
+      // Defensive: decoration on a refusal, and an existing suite mocks config.js
+      // without this export — a message detail must never fail a download.
       serverUrl: (() => {
         try {
           return getComfyUIBaseUrl();

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -6,7 +6,11 @@ import { dirname, join, basename, normalize, resolve, relative, sep, isAbsolute,
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getClient, getLogs, getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import { getExtraModelRoots, getLiveExtraModelRoots } from "./extra-paths.js";
-import { resolveEffectiveComfyUIBase, resolveLiveServerRoot } from "./workspace-env.js";
+import {
+  liveRootFromArgv,
+  resolveEffectiveComfyUIBase,
+  resolveLiveServerRoot,
+} from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError, unreachableHostMessage } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -14,6 +18,7 @@ import { downloadWithCache, probeRemoteModelPayload } from "./download-cache.js"
 import { reportDownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import { modelNotFoundMessage } from "./model-root-scope.js";
+import { divergentInstallRefusal } from "./download-root-correspondence.js";
 import {
   resolveModelsDir,
   resolveModelsDirWithBases,
@@ -2082,6 +2087,32 @@ export interface ResolvedDownloadTarget {
 }
 
 /**
+ * The install root the CONNECTED server reports for ITSELF, derived from its `main.py`
+ * argv — available even when it was not launched with `--base-directory`.
+ *
+ * Returns undefined on any failure. #1371's refusal is conditional on this value, so a
+ * throw here must never become a failed download: no root, no refusal.
+ */
+async function serverInstallRootOrUndefined(): Promise<string | undefined> {
+  try {
+    const stats = await getSystemStats();
+    const argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
+    const cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
+    // ARGV ONLY — deliberately not resolveLiveServerRoot, which falls back to probing
+    // the live PROCESS TABLE. The repo has a gate against new code reaching that probe
+    // (#1290/#1263) precisely because it makes a test assert one thing on a machine
+    // where ComfyUI is running and another where it is not. I reached for the shared
+    // resolver first and that gate caught it.
+    //
+    // Argv is also the right evidence here: it is what the connected server itself
+    // reported, so it cannot describe some other process that happens to be running.
+    return liveRootFromArgv(argv, cwd) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The SINGLE source of truth for a model download's final on-disk destination,
  * shared by downloadModel (the writer) AND the background job registry (which
  * keys jobs by this canonical `targetPath`, so any two requests that resolve to
@@ -2123,6 +2154,33 @@ export async function resolveDownloadTarget(
       "Refusing to write outside the target model directory.",
       { filename: rawFilename },
     );
+  }
+  // #1371 — a stale COMFYUI_PATH wrote a model into a DIFFERENT local install than the
+  // one serving the session. The destination is rooted at the server's own models dir
+  // when it can be, but falls back to <COMFYUI_PATH>/models when the server was not
+  // launched with --base-directory — and nothing then checked that the fallback belongs
+  // to THAT server.
+  //
+  // A server can still name its install root through its main.py argv. When it does and
+  // the destination is outside it, the installs are PROVABLY different. Positive
+  // evidence, so this does not reintroduce the false-refusal class the content check's
+  // own note warns about — and it is skipped entirely when the destination came from
+  // the live server (nothing to disagree with) or when no root can be derived.
+  if (!liveRootAtResolve) {
+    const refusal = divergentInstallRefusal({
+      targetDir,
+      serverRoot: await serverInstallRootOrUndefined(),
+      // Defensive: this is decoration on a refusal, and an existing suite mocks
+      // config.js without this export — a message detail must never fail a download.
+      serverUrl: (() => {
+        try {
+          return getComfyUIBaseUrl();
+        } catch {
+          return undefined;
+        }
+      })(),
+    });
+    if (refusal) throw new ModelError(refusal, { path: targetDir });
   }
   return { targetDir, filename: resolvedFilename, targetPath, liveRootAtResolve };
 }


### PR DESCRIPTION
Claims #1371 — a model was written into a **different local ComfyUI installation** than the one serving the session.

The reporter was connected to ComfyUI on `:8190` (`ComfyUI_H3`), and `download_model` streamed into `G:\Start_AI\AI_Test\ComfyUI\models` — a stale `COMFYUI_PATH` from another install — while visibility was checked against the connected server.

**Not already fixed, and I checked before assuming.** `model-resolver.ts` has carried a divergence refusal since **v0.49.4** (#794), and the reporter was on **0.50.107** — newer. So the guard was present and did not fire.

Why: it proves divergence from CONTENT — files present on disk that the running server does not list. The code deliberately refuses the inverse inference ("the server lists models this tree lacks") because absence of evidence produced false refusals. With a sparse or empty destination category (`vae`, in this report) there is nothing to compare, so nothing can be proven and the write proceeds.

**Direction, to be confirmed:** the server can advertise its own root via `/system_stats` argv, and the resolver already reasons about that elsewhere. A destination root that DIFFERS from a root the server itself reports is positive proof of divergence, not absence of it — so it can refuse without reintroducing the false-refusal class the existing note warns about.

Investigating. The thing this must not become is a blanket "refuse when unproven", which that same note documents as having been tried and reverted.