### PR TITLE
chore(release): 0.51.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.19
+
+### Fixed
+
+- **A download can no longer land in a ComfyUI the connected server does not read (#1371).** A
+  model was written into a DIFFERENT local installation than the one serving the session: connected
+  to ComfyUI on `:8190`, the download streamed into a tree belonging to another install, resolved
+  from a stale `COMFYUI_PATH`, while visibility was checked against the connected server.
+
+  The existing divergence guard shipped in v0.49.4 and the reporter was on 0.50.107, so it was
+  present and did not fire: it proves divergence from CONTENT -- files on disk the running server
+  does not list -- and a sparse or empty destination category proves nothing.
+
+  The destination is now checked against the roots the live server actually reads, including any
+  registered through `extra_model_paths.yaml`, with junctions and symlinks resolved and the check
+  scoped to the destination's category. It refuses only on a demonstrated mismatch, never on an
+  unverifiable one -- an unknown answer proceeds exactly as before, because treating "the server
+  did not vouch for it" as "the server cannot read it" is what produced false refusals every
+  previous time that inference was tightened.
+
 ## 0.51.18
 
 ### Fixed
@@ -251,6 +271,17 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.51.19] - 2026-08-12
+
+### MCP
+
+#### Added
+- ship the twelve locale catalogs the runtime has been waiting for (#1486)
+
+#### Fixed
+- refuse a download whose destination the server PROVABLY does not read (#1487)
+
 
 ## [0.51.18] - 2026-08-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.18",
+  "version": "0.51.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.18",
+      "version": "0.51.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.18",
+  "version": "0.51.19",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected main with the published v0.51.19 tag.

**#1371** — a model was written into a **different local ComfyUI installation** than the one serving the session. Connected to `:8190`, the download streamed into another install's tree from a stale `COMFYUI_PATH`, while visibility was checked against the connected server.

**Not already fixed, and I verified before building:** the divergence guard shipped in **v0.49.4** and the reporter was on **0.50.107** — newer — so it was present and did not fire. It proves divergence from *content* (files on disk the server does not list), and a sparse or empty destination category proves nothing.

**A first attempt was refuted by review**, correctly. I refused when the destination fell outside the install root the server names for itself — but `extra_model_paths.yaml` registers roots elsewhere by design, `<install>/models` is routinely a junction, and container mappings describe one directory through two strings. **#1474, fixed and released the same day, is a Comfy Desktop install serving models from a shared root outside its install directory** — that guard would have refused it.

The shipped version uses the repo's existing `isUnderLiveModelRoots`, which asks the question that matters — does the connected server read this tree — checking live primary and extra roots, canonicalizing junctions and symlinks, scoped to the destination's category, and returning **undefined for unknown**. It refuses only on `inRoots === false`, never on unknown.

That distinction is the whole point: treating "the server did not vouch for it" as "the server cannot read it" is what produced a false refusal every previous time this inference was tightened.

14 tests, 4 mutations including one that treats unknown as a mismatch. Full suite: **9059 passed**. Gate: **PASS**. Verified against the built artifact on main.