### PR TITLE
fix(1479): status must not call a PROVEN-dead download 'still streaming'

### DIFF
--- a/src/__tests__/services/download-status-proven-dead.test.ts
+++ b/src/__tests__/services/download-status-proven-dead.test.ts
@@ -93,6 +93,12 @@ describe("#1479 the proven-dead note", () => {
     expect(note()).toMatch(/NOT running on this machine/);
     expect(note()).toMatch(/would look the same from\s+here/);
     expect(note()).toMatch(/before re-issuing/);
+    // Round 4: cancel runs the SAME local probe, so claiming it is safe either way was
+    // false for a foreign-host writer. The message names the shared blind spot instead
+    // of promising around it.
+    expect(note()).toMatch(/cancel uses/);
+    expect(note()).toMatch(/SAME local probe/);
+    expect(note()).not.toMatch(/safe either way/);
     expect(note()).not.toMatch(/is safe to re-issue the download/);
   });
 

--- a/src/__tests__/services/download-status-proven-dead.test.ts
+++ b/src/__tests__/services/download-status-proven-dead.test.ts
@@ -141,3 +141,37 @@ describe("#1479 WIRING", () => {
     expect(tool).toMatch(/the transfer may still be running/);
   });
 });
+
+describe("#1479 a Manager dispatch is never declared dead", () => {
+  const m = () => provenDeadStatusNote({ staleForMs: 102_000, viaManager: true });
+
+  it("does not OPEN by calling the transfer dead", () => {
+    // The first cut said "this transfer is NOT running" and then admitted the
+    // server-side fetch may still be live — the same self-contradiction this issue is
+    // about, written into its own fix. My tests asserted only the tail, so they passed
+    // while the opening sentence was wrong; review caught it, and a mutation confirmed
+    // the case was uncovered.
+    expect(m()).not.toMatch(/this transfer is NOT running/);
+    expect(m()).toMatch(/the local owner of this record is gone/);
+  });
+
+  it("scopes the pid evidence to the LOCAL owner", () => {
+    expect(m()).toMatch(/only the local record's owner is proven gone/);
+  });
+
+  it("the non-Manager note still states the plain verdict", () => {
+    expect(provenDeadStatusNote({ staleForMs: 1000 })).toMatch(/this transfer is NOT running/);
+  });
+});
+
+describe("#1479 WIRING: the status line is route-aware too", () => {
+  const tool2 = readFileSync(join(HERE, "../../tools/model-management.ts"), "utf8");
+
+  it("a Manager dispatch does not read 'NOT running' at a glance", () => {
+    // The status line is what a reader takes first; leaving it absolute would have it
+    // contradict the note directly beneath it.
+    expect(tool2).toMatch(/j\.viaManager/);
+    expect(tool2).toContain("local owner gone");
+    expect(tool2).toContain("the server-side fetch may still be running");
+  });
+});

--- a/src/__tests__/services/download-status-proven-dead.test.ts
+++ b/src/__tests__/services/download-status-proven-dead.test.ts
@@ -1,0 +1,143 @@
+// #1479 — download_model action:"status" reported PROVEN-dead downloads as
+// "still streaming".
+//
+// Three transfers died with their owning process. Status rendered them as
+// **downloading — still streaming** with "the transfer may still be running … Do not
+// report this download as failed or missing", while action:"cancel" on the same ids
+// answered "that session is confirmed GONE — its process no longer exists".
+//
+// The evidence was already in the process: writerProcessGone() probes the owner pid
+// (ESRCH ⇒ proven dead) but was only reached from the cancel path. Status branched on
+// heartbeat AGE alone.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  inflightNoteKind,
+  provenDeadStatusNote,
+} from "../../services/download-status-proven-dead.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("#1479 which note to render", () => {
+  it("a PROVEN-gone writer gets the proven-dead note", () => {
+    expect(
+      inflightNoteKind({ status: "downloading", staleInflight: true, provenGone: true }),
+    ).toBe("proven-dead");
+  });
+
+  it("proven-gone wins even when the heartbeat is not yet stale", () => {
+    // The pid probe is the stronger evidence; waiting for the heartbeat to age would
+    // keep reporting a dead transfer as live for no reason.
+    expect(
+      inflightNoteKind({ status: "downloading", staleInflight: false, provenGone: true }),
+    ).toBe("proven-dead");
+  });
+
+  it("UNKNOWN keeps the cautious wording — the whole point", () => {
+    // writerProcessGone returns undefined when there is no recorded pid or the probe
+    // failed. #761: a reconnect can interrupt persistence, so a missed heartbeat alone
+    // does not prove the transfer stopped, and claiming death would be the same
+    // over-reach in the other direction.
+    expect(
+      inflightNoteKind({ status: "downloading", staleInflight: true, provenGone: undefined }),
+    ).toBe("stale");
+  });
+
+  it("a live writer with a stale heartbeat stays cautious", () => {
+    expect(
+      inflightNoteKind({ status: "downloading", staleInflight: true, provenGone: false }),
+    ).toBe("stale");
+  });
+
+  it("says nothing when the record is not in flight", () => {
+    for (const status of ["completed", "cancelled", "failed", undefined]) {
+      expect(inflightNoteKind({ status, staleInflight: true, provenGone: true })).toBe("none");
+    }
+  });
+
+  it("says nothing for a healthy in-flight record", () => {
+    expect(inflightNoteKind({ status: "downloading" })).toBe("none");
+  });
+});
+
+describe("#1479 the proven-dead note", () => {
+  const note = () => provenDeadStatusNote({ staleForMs: 102_000 });
+
+  it("states plainly that the transfer is not running", () => {
+    expect(note()).toMatch(/NOT running/);
+    expect(note()).toMatch(/no longer\s+exists/);
+  });
+
+  it("gives the EVIDENCE, not just the verdict", () => {
+    // A caller told moments ago not to touch this download needs to know why the
+    // answer changed.
+    expect(note()).toMatch(/probed by pid/);
+    expect(note()).toMatch(/died with its session/);
+  });
+
+  it("does not repeat the do-not-act caution it replaces", () => {
+    expect(note()).not.toMatch(/may still be running/);
+    expect(note()).not.toMatch(/Do not report this download as failed or missing/);
+  });
+
+  it("says a re-issue is safe, because nothing is writing the file", () => {
+    expect(note()).toMatch(/Nothing is writing this file/);
+    expect(note()).toMatch(/safe to re-issue/);
+  });
+
+  it("reports how long ago the heartbeat stopped when known", () => {
+    expect(note()).toMatch(/heartbeat stopped 102s ago/);
+    // and omits the clause rather than printing a bogus 0s
+    expect(provenDeadStatusNote({})).not.toMatch(/heartbeat stopped/);
+    expect(provenDeadStatusNote({ staleForMs: 0 })).not.toMatch(/heartbeat stopped/);
+  });
+
+  it("does NOT claim a Manager dispatch is dead — only its local owner", () => {
+    // The server-side fetch runs elsewhere; declaring it dead would be the same
+    // over-reach this issue is about, pointed the other way.
+    const m = provenDeadStatusNote({ staleForMs: 102_000, viaManager: true });
+    expect(m).toMatch(/SERVER-side fetch may still\s+be running/);
+    expect(m).toMatch(/only the local record's owner is proven gone/);
+    expect(m).not.toMatch(/safe to re-issue/);
+    expect(m).toMatch(/list_local_models/);
+  });
+});
+
+describe("#1479 WIRING", () => {
+  const jobs = readFileSync(join(HERE, "../../services/download-jobs.ts"), "utf8");
+  const tool = readFileSync(join(HERE, "../../tools/model-management.ts"), "utf8");
+
+  it("the pid verdict is carried onto the job view", () => {
+    expect(jobs).toMatch(/writerProvenGone\?: boolean;/);
+    expect(jobs).toMatch(/writerProvenGone: writerProcessGone\(rec\) === true \? true : undefined/);
+  });
+
+  it("only TRUE is carried — 'cannot tell' must not render as death", () => {
+    // The projection maps undefined/false to absent, so the renderer can never read a
+    // failed probe as proof.
+    expect(jobs).not.toMatch(/writerProvenGone: writerProcessGone\(rec\),/);
+  });
+
+  it("status renders through the shared decision", () => {
+    expect(tool).toMatch(
+      /import \{[\s\S]*?inflightNoteKind,[\s\S]*?\} from "\.\.\/services\/download-status-proven-dead\.js";/,
+    );
+    expect(tool).toMatch(/const noteKind = inflightNoteKind\(\{/);
+    expect(tool).toMatch(/noteKind === "proven-dead"/);
+  });
+
+  it("the STATUS LINE agrees with the note", () => {
+    // The note alone would leave the reply contradicting itself: "still streaming"
+    // immediately followed by "this transfer is NOT running".
+    expect(tool).toMatch(/j\.writerProvenGone === true/);
+    expect(tool).toMatch(/NOT running — the owning process is gone/);
+  });
+
+  it("the cautious stale wording survives for the unproven case", () => {
+    expect(tool).toMatch(/heartbeat stale for/);
+    expect(tool).toMatch(/the transfer may still be running/);
+  });
+});

--- a/src/__tests__/services/download-status-proven-dead.test.ts
+++ b/src/__tests__/services/download-status-proven-dead.test.ts
@@ -68,13 +68,13 @@ describe("#1479 the proven-dead note", () => {
 
   it("states plainly that the transfer is not running", () => {
     expect(note()).toMatch(/NOT running/);
-    expect(note()).toMatch(/no longer\s+exists/);
+    expect(note().includes("recorded pid exists here")).toBe(true);
   });
 
   it("gives the EVIDENCE, not just the verdict", () => {
     // A caller told moments ago not to touch this download needs to know why the
     // answer changed.
-    expect(note()).toMatch(/probed by pid/);
+    expect(note()).toMatch(/recorded pid exists here/);
     expect(note()).toMatch(/died with its session/);
   });
 
@@ -84,8 +84,16 @@ describe("#1479 the proven-dead note", () => {
   });
 
   it("says a re-issue is safe, because nothing is writing the file", () => {
-    expect(note()).toMatch(/Nothing is writing this file/);
-    expect(note()).toMatch(/safe to re-issue/);
+    expect(note()).toMatch(/No local process is writing this file/);
+    // Round 3 of review: a pid from another host or container ESRCHes here too, and the
+    // record carries no host to check against. So the verdict is scoped to the local
+    // evidence and recovery routes through cancel, which re-probes and refuses when it
+    // cannot confirm. A wrong verdict then costs a refused cancel, not a duplicated
+    // multi-gigabyte download.
+    expect(note()).toMatch(/NOT running on this machine/);
+    expect(note()).toMatch(/would look the same from\s+here/);
+    expect(note()).toMatch(/before re-issuing/);
+    expect(note()).not.toMatch(/is safe to re-issue the download/);
   });
 
   it("reports how long ago the heartbeat stopped when known", () => {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -129,6 +129,10 @@ export interface DownloadJob {
   /** A persisted in-flight record missed its owner heartbeat. It stays visible
    *  because this is not proof the physical transfer stopped (#761). */
   staleInflight?: boolean;
+  /** The writer's process is PROVEN gone — its pid answers ESRCH (#1479). Only ever
+   *  `true` or absent: "cannot tell" must never render as death, which is the whole
+   *  reason `staleInflight` alone was the wrong branch for the status note. */
+  writerProvenGone?: boolean;
   /** Age of the missing persisted heartbeat, used only for status diagnostics. */
   staleForMs?: number;
   /** This "cancelled" record was written by a LATER session reclaiming a stale
@@ -854,6 +858,11 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
     verified_root: rec.verified_root,
     staleInflight: rec.staleInflight,
     staleForMs: rec.staleForMs,
+    // #1479 — the cancel path already probed this and status never asked, so the two
+    // actions answered the same question with opposite verdicts. Carried as `true` or
+    // absent: `writerProcessGone` returns undefined when it cannot tell, and that must
+    // keep the cautious note rather than becoming a death claim.
+    writerProvenGone: writerProcessGone(rec) === true ? true : undefined,
     reclaimedDead: rec.reclaimed_dead,
     interruptedByRestart: rec.interrupted_by_restart,
   };

--- a/src/services/download-status-proven-dead.ts
+++ b/src/services/download-status-proven-dead.ts
@@ -37,8 +37,11 @@
  * inconclusive for a writer in another container or on another host, whose pid means
  * nothing locally. Review raised exactly that, and the record carries no host to check
  * it against — so the verdict is scoped to what was measured, and the recovery routes
- * through `cancel`, which re-probes and refuses when it cannot confirm. A wrong verdict
- * then costs a refused cancel, not a duplicated multi-gigabyte download.
+ * through `cancel` first, and says plainly that cancel shares the same blind spot: it
+ * re-runs the SAME local probe, so it cannot see a foreign writer either. Review had to
+ * point that out twice before I stopped trying to promise a safe path and simply named
+ * the limit. The one outcome worth avoiding is a duplicate transfer into the same
+ * destination, so that is what the message tells the reader to rule out.
  *
  * Deliberately states the evidence rather than just the verdict: a caller who was told
  * five seconds ago not to touch this download needs to know why the answer changed.
@@ -61,9 +64,11 @@ export function provenDeadStatusNote(opts: {
       `be running — only the local record's owner is proven gone. Check ` +
       `list_local_models to see whether the file landed.`
     : ` No local process is writing this file. Close the record with download_model ` +
-      `action:"cancel" (this id and tray_id) before re-issuing — cancel re-probes and ` +
-      `refuses if it cannot confirm, so it is safe either way, and it is the step that ` +
-      `makes a re-issue safe rather than a possible duplicate.`;
+      `action:"cancel" (this id and tray_id) before re-issuing. Note that cancel uses ` +
+      `this SAME local probe, so it cannot see a writer on another host or container ` +
+      `either — if this download was started somewhere other than here, confirm it is ` +
+      `really stopped at its source before re-issuing, because a duplicate transfer ` +
+      `into the same destination is the one outcome worth avoiding.`;
   // The OPENING verdict has to be route-aware too. Saying "this transfer is NOT
   // running" and then admitting the server-side fetch may still be live is the same
   // self-contradiction this issue is about — review caught me writing it into the fix.
@@ -74,8 +79,7 @@ export function provenDeadStatusNote(opts: {
     : `\n    NOTE: this transfer is NOT running on this machine. No process with its ` +
       `recorded pid exists here, so it died with its session (#1479). That evidence is ` +
       `LOCAL: a writer owned by another host or container would look the same from ` +
-      `here, which is why the recovery below goes through cancel rather than straight ` +
-      `to a re-issue.`;
+      `here, and cancel uses the same probe, so neither can rule that out.`;
   return `${head}${stale}${tail}`;
 }
 

--- a/src/services/download-status-proven-dead.ts
+++ b/src/services/download-status-proven-dead.ts
@@ -1,0 +1,81 @@
+/**
+ * #1479 — `download_model action:"status"` reported PROVEN-dead downloads as
+ * "still streaming".
+ *
+ * After a session drop, three transfers that died with their owning process were
+ * rendered as **downloading — still streaming**, with a note saying "the transfer may
+ * still be running … Do not report this download as failed or missing." Nothing was
+ * writing them: no `.partial`/`.part`/`.tmp` under `models/` or `%TEMP%`, and
+ * `~/.comfyui-mcp/download-records/` was empty. `action:"cancel"` on the same ids
+ * answered "that session is confirmed GONE — its process no longer exists".
+ *
+ * ## The evidence was already in the process
+ *
+ * `writerProcessGone()` settles it by probing the owner pid (ESRCH ⇒ proven dead), but
+ * it was only reached from the CANCEL path. The status render branched solely on
+ * `staleInflight`, which is heartbeat AGE. So two actions answered the same question
+ * from the same process with opposite verdicts — and the wrong one was the one telling
+ * the caller not to act.
+ *
+ * ## What must NOT change
+ *
+ * The cautious wording is right for a MERELY stale record. #761 established that a
+ * reconnect can interrupt persistence, so a missed heartbeat alone does not prove the
+ * transfer stopped, and refusing to say so is what keeps a live download from being
+ * re-issued underneath itself.
+ *
+ * This changes only the case where death is PROVEN — the distinction that caution
+ * exists to protect. `writerProcessGone` returns `undefined` when it cannot tell (no
+ * recorded pid, or the probe itself failed), and `undefined` must keep the caution.
+ */
+
+/**
+ * The status note for an in-flight record whose writer is PROVEN gone.
+ *
+ * Deliberately states the evidence rather than just the verdict: a caller who was told
+ * five seconds ago not to touch this download needs to know why the answer changed.
+ */
+export function provenDeadStatusNote(opts: {
+  staleForMs?: number;
+  /** True when the record was a remote ComfyUI-Manager dispatch. */
+  viaManager?: boolean;
+}): string {
+  const { staleForMs, viaManager } = opts;
+  const stale =
+    typeof staleForMs === "number" && staleForMs > 0
+      ? ` Its heartbeat stopped ${Math.round(staleForMs / 1000)}s ago.`
+      : "";
+  // A Manager dispatch runs SERVER-side, so the local writer being gone says nothing
+  // about the host's own fetch — claiming the transfer is dead there would be the same
+  // over-reach in the other direction.
+  const tail = viaManager
+    ? ` This was a remote ComfyUI-Manager dispatch, so the SERVER-side fetch may still ` +
+      `be running — only the local record's owner is proven gone. Check ` +
+      `list_local_models to see whether the file landed.`
+    : ` Nothing is writing this file. There is no local transfer to interrupt, so it ` +
+      `is safe to re-issue the download — or call download_model action:"cancel" with ` +
+      `this id and tray_id first to close the stale record.`;
+  return (
+    `\n    NOTE: this transfer is NOT running. The process that owned it no longer ` +
+    `exists (probed by pid), so it died with its session (#1479).${stale}${tail}`
+  );
+}
+
+/**
+ * Which in-flight note to render.
+ *
+ * Returns `"proven-dead"` only on a demonstrated death, `"stale"` for a missed
+ * heartbeat that proves nothing, and `"none"` otherwise. `provenGone === undefined`
+ * is deliberately NOT proven-dead: absence of evidence is not evidence of absence,
+ * and the caution is correct there.
+ */
+export function inflightNoteKind(opts: {
+  status?: string;
+  staleInflight?: boolean;
+  provenGone?: boolean;
+}): "proven-dead" | "stale" | "none" {
+  const { status, staleInflight, provenGone } = opts;
+  if (status !== "downloading") return "none";
+  if (provenGone === true) return "proven-dead";
+  return staleInflight ? "stale" : "none";
+}

--- a/src/services/download-status-proven-dead.ts
+++ b/src/services/download-status-proven-dead.ts
@@ -55,10 +55,16 @@ export function provenDeadStatusNote(opts: {
     : ` Nothing is writing this file. There is no local transfer to interrupt, so it ` +
       `is safe to re-issue the download — or call download_model action:"cancel" with ` +
       `this id and tray_id first to close the stale record.`;
-  return (
-    `\n    NOTE: this transfer is NOT running. The process that owned it no longer ` +
-    `exists (probed by pid), so it died with its session (#1479).${stale}${tail}`
-  );
+  // The OPENING verdict has to be route-aware too. Saying "this transfer is NOT
+  // running" and then admitting the server-side fetch may still be live is the same
+  // self-contradiction this issue is about — review caught me writing it into the fix.
+  // For a Manager dispatch the pid proves only that the LOCAL record's owner is gone.
+  const head = viaManager
+    ? `\n    NOTE: the local owner of this record is gone — the process that started ` +
+      `it no longer exists (probed by pid), so it died with its session (#1479).`
+    : `\n    NOTE: this transfer is NOT running. The process that owned it no longer ` +
+      `exists (probed by pid), so it died with its session (#1479).`;
+  return `${head}${stale}${tail}`;
 }
 
 /**

--- a/src/services/download-status-proven-dead.ts
+++ b/src/services/download-status-proven-dead.ts
@@ -30,7 +30,15 @@
  */
 
 /**
- * The status note for an in-flight record whose writer is PROVEN gone.
+ * The status note for an in-flight record whose writer is gone by the LOCAL pid probe.
+ *
+ * The probe is `kill(pid, 0)`: ESRCH means no process with that id exists HERE. That is
+ * conclusive for the ordinary case (the writer was this machine's own orchestrator) and
+ * inconclusive for a writer in another container or on another host, whose pid means
+ * nothing locally. Review raised exactly that, and the record carries no host to check
+ * it against — so the verdict is scoped to what was measured, and the recovery routes
+ * through `cancel`, which re-probes and refuses when it cannot confirm. A wrong verdict
+ * then costs a refused cancel, not a duplicated multi-gigabyte download.
  *
  * Deliberately states the evidence rather than just the verdict: a caller who was told
  * five seconds ago not to touch this download needs to know why the answer changed.
@@ -52,9 +60,10 @@ export function provenDeadStatusNote(opts: {
     ? ` This was a remote ComfyUI-Manager dispatch, so the SERVER-side fetch may still ` +
       `be running — only the local record's owner is proven gone. Check ` +
       `list_local_models to see whether the file landed.`
-    : ` Nothing is writing this file. There is no local transfer to interrupt, so it ` +
-      `is safe to re-issue the download — or call download_model action:"cancel" with ` +
-      `this id and tray_id first to close the stale record.`;
+    : ` No local process is writing this file. Close the record with download_model ` +
+      `action:"cancel" (this id and tray_id) before re-issuing — cancel re-probes and ` +
+      `refuses if it cannot confirm, so it is safe either way, and it is the step that ` +
+      `makes a re-issue safe rather than a possible duplicate.`;
   // The OPENING verdict has to be route-aware too. Saying "this transfer is NOT
   // running" and then admitting the server-side fetch may still be live is the same
   // self-contradiction this issue is about — review caught me writing it into the fix.
@@ -62,8 +71,11 @@ export function provenDeadStatusNote(opts: {
   const head = viaManager
     ? `\n    NOTE: the local owner of this record is gone — the process that started ` +
       `it no longer exists (probed by pid), so it died with its session (#1479).`
-    : `\n    NOTE: this transfer is NOT running. The process that owned it no longer ` +
-      `exists (probed by pid), so it died with its session (#1479).`;
+    : `\n    NOTE: this transfer is NOT running on this machine. No process with its ` +
+      `recorded pid exists here, so it died with its session (#1479). That evidence is ` +
+      `LOCAL: a writer owned by another host or container would look the same from ` +
+      `here, which is why the recovery below goes through cancel rather than straight ` +
+      `to a re-issue.`;
   return `${head}${stale}${tail}`;
 }
 

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -43,6 +43,10 @@ import {
 } from "./extra-paths.js";
 import { resolveMissingModelsAction } from "./missing-models.js";
 import { getEmbeddingsAction } from "./memory-management.js";
+import {
+  inflightNoteKind,
+  provenDeadStatusNote,
+} from "../services/download-status-proven-dead.js";
 
 /**
  * The fourteen model tools collapsed into two action-parameterized tools
@@ -1101,10 +1105,28 @@ async function statusAction(args: {
                     // destination file preserved under a .bak path because it couldn't be
                     // restored) — surface it so the user can recover, not mask it.
                     (j.error ? `\n    IMPORTANT: ${j.error}` : "")
-                  : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
+                  : // #1479 — do not say "still streaming" about a transfer whose writer is
+                    // PROVEN gone. The note below explains it, but the STATUS LINE is what a
+                    // reader takes at a glance, and leaving it would have this reply
+                    // contradict itself in consecutive sentences.
+                    j.writerProvenGone === true
+                    ? `\n    NOT running — the owning process is gone; started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`
+                    : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
           const route = downloadRoute(j);
+          // #1479 — a PROVEN-dead writer must not be reported as "still streaming".
+          // The pid probe that settles it was already being run on the cancel path;
+          // status branched on heartbeat AGE alone and so told callers not to act on a
+          // transfer that had died with its session. A merely-stale record keeps the
+          // cautious wording, because a missed heartbeat still proves nothing (#761).
+          const noteKind = inflightNoteKind({
+            status: j.status,
+            staleInflight: j.staleInflight,
+            provenGone: j.writerProvenGone,
+          });
           const staleNote =
-            j.status === "downloading" && j.staleInflight
+            noteKind === "proven-dead"
+              ? provenDeadStatusNote({ staleForMs: j.staleForMs, viaManager: j.viaManager })
+              : noteKind === "stale"
               ? `\n    NOTE: heartbeat stale for ${Math.round((j.staleForMs ?? 0) / 1000)}s. The owning session may have reconnected, and the transfer may still be running. Do NOT re-issue download_model action:"download" while this warning remains: ${stillWritingClause(route)}. To recover, call download_model \`action:"cancel"\` with this id and tray_id — it closes the stale record once the writer is PROVEN gone (its process no longer exists) and refuses while that cannot be proven. ONCE THAT CANCEL SUCCEEDS: ${afterCancelAdvice(route)} Do not report this download as failed or missing.`
               : "";
           // Surface a declined resume so the agent/user knows a pre-existing

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1110,7 +1110,9 @@ async function statusAction(args: {
                     // reader takes at a glance, and leaving it would have this reply
                     // contradict itself in consecutive sentences.
                     j.writerProvenGone === true
-                    ? `\n    NOT running — the owning process is gone; started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`
+                    ? (j.viaManager
+                        ? `\n    local owner gone — this was a ComfyUI-Manager dispatch, so the server-side fetch may still be running; started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`
+                        : `\n    NOT running — the owning process is gone; started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`)
                     : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
           const route = downloadRoute(j);
           // #1479 — a PROVEN-dead writer must not be reported as "still streaming".


### PR DESCRIPTION
Claims #1479.

After a session drop, `download_model action:"status"` reported three dead transfers as **downloading — still streaming**, with a note telling the caller *"the transfer may still be running … Do not report this download as failed or missing."* Nothing was writing them: no `.partial`/`.part`/`.tmp` anywhere under `models/` or `%TEMP%`, and `~/.comfyui-mcp/download-records/` was empty. `action:"cancel"` on the same ids answered *"that session is confirmed GONE — its process no longer exists and its heartbeat had stopped."*

**The reporter located it precisely.** `writerProcessGone()` in `download-jobs.ts` already settles this by probing the owner pid (ESRCH ⇒ proven dead), but it is only reached from the CANCEL path. The status render in `model-management.ts` branches solely on `j.staleInflight`, which is heartbeat age only. Status has the evidence available and never asks for it.

So two tools answer the same question from the same process with opposite verdicts — and the one that is wrong is the one telling you not to act.

**Scope.** The cautious wording stays for a MERELY stale record: #761 established that a reconnect can interrupt persistence, and a stale heartbeat alone genuinely does not prove death. This changes only the case where death is PROVEN, which is the distinction the caution exists to protect.

Investigating.