### PR TITLE
chore(release): 0.51.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.20
+
+### Fixed
+
+- **`download_model action:"status"` no longer reports a dead download as "still streaming" (#1479).**
+  Three transfers died with their owning process, and status rendered them as *downloading --
+  still streaming* with "the transfer may still be running ... Do not report this download as failed
+  or missing" -- while `action:"cancel"` on the same ids, in the same process, answered "that session
+  is confirmed GONE".
+
+  The evidence was already there: `writerProcessGone()` probes the owner pid, but it was only reached
+  from the cancel path, and the status render branched on heartbeat AGE alone. Status now consults
+  the same probe, and both the status line and the note change together.
+
+  A merely-stale record keeps the cautious wording -- a missed heartbeat still does not prove the
+  transfer stopped (#761) -- and the pid verdict is carried as "proven gone" or absent, never as a
+  tri-state, so "cannot tell" can never render as death. The verdict is scoped to what was measured:
+  no process with that pid exists ON THIS MACHINE. A writer on another host or container looks the
+  same from here, and `cancel` shares that blind spot, so the message says so rather than promising
+  a safe recovery it cannot guarantee.
+
 ## 0.51.19
 
 ### Fixed
@@ -271,6 +292,14 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.51.20] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- status must not call a PROVEN-dead download 'still streaming' (#1490)
+
 
 ## [0.51.19] - 2026-08-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.19",
+  "version": "0.51.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.19",
+      "version": "0.51.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.19",
+  "version": "0.51.20",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected main with the published v0.51.20 tag.

**#1479** — `download_model action:"status"` reported PROVEN-dead downloads as *still streaming*, with "the transfer may still be running … Do not report this download as failed or missing" — while `action:"cancel"` on the same ids, in the same process, answered *"that session is confirmed GONE"*.

The reporter located it exactly: `writerProcessGone()` probes the owner pid, but was only reached from the cancel path; status branched on heartbeat AGE alone. Status had the evidence and never asked for it.

Four gate rounds, each finding something real:

- the **status line** still said "still streaming" after I fixed only the note — the reply would have contradicted itself in consecutive sentences
- the **Manager branch** opened with "this transfer is NOT running" then admitted the server-side fetch may still be live — the same self-contradiction, written into its own fix; my tests asserted the note's tail and never its opening sentence, and a mutation confirmed the case was uncovered
- **ESRCH is local evidence**: a writer on another host or container looks identical from here, and my added "safe to re-issue" advice made a wrong verdict cost a duplicate multi-gigabyte download
- routing recovery through `cancel` **did not fix that**, because cancel re-runs the same local probe — so the message now names the blind spot instead of promising around it

The pid verdict is carried as *proven gone* or absent, never a tri-state, so "cannot tell" can never render as death — the distinction #761's caution exists to protect.

21 tests, 6 mutations. Full suite: **9164 passed**. Final gate: **PASS**.