### PR TITLE
fix(1480): the mismatch guard names a selector an unsaved tab actually has

### DIFF
--- a/src/__tests__/orchestrator/tmp-workflow-mismatch-remedy.test.ts
+++ b/src/__tests__/orchestrator/tmp-workflow-mismatch-remedy.test.ts
@@ -161,6 +161,36 @@ describe("root-workflow-uuid-mismatch names a remedy the tab can accept (#1480)"
     expect(text).not.toContain("tmp:");
   });
 
+  it("a message that merely QUOTES the token is not this refusal (codex)", async () => {
+    // The classifier is anchored, so it keys on the panel's real shape — its executor
+    // error text becomes the Error message verbatim, no prefix — instead of on any
+    // message that happens to contain the token. Unanchored, a wrapped or re-surfaced
+    // refusal would burn a workflow_list round trip and be told to re-open a workflow.
+    const ctx = makePanelToolCtx(
+      {
+        ...bridge(UNSAVED_LIST),
+        send: async (cmd: Record<string, unknown>) => {
+          if (cmd.cmd === "workflow_list") {
+            listCalls += 1;
+            return UNSAVED_LIST;
+          }
+          throw new Error(`Validation failed: "[root-workflow-uuid-mismatch]" is reserved`);
+        },
+      } as unknown as PanelToolCtx["bridge"],
+      TAB,
+      new WorkflowTargetStore(),
+    );
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_connect");
+    if (!def) throw new Error("panel_connect is not registered");
+    const res: ToolResult = await def.handler({ from_node_id: 1, to_node_id: 2 } as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    // The probe never ran, which is the whole point: no round trip, no remedy invented.
+    expect(listCalls).toBe(0);
+    expect(text).not.toMatch(/NEVER BEEN SAVED/);
+    expect(text).not.toContain(ROUTING_KEY);
+  });
+
   it("UNREADABLE: promises nothing, because nothing was established", async () => {
     // The failure direction that matters. Naming a selector we could not establish would
     // send the agent to "no workflow matching" — the exact turn #1480 wasted.

--- a/src/__tests__/orchestrator/tmp-workflow-mismatch-remedy.test.ts
+++ b/src/__tests__/orchestrator/tmp-workflow-mismatch-remedy.test.ts
@@ -1,0 +1,175 @@
+// #1480 — the root-workflow-uuid-mismatch guard had no followable exit on a NEVER-SAVED
+// tab, so a session could read the canvas and change nothing.
+//
+// The panel's remedy for this verdict is `panel_open_workflow(<path>)`. An unsaved tab has
+// no path — `workflow_list` reports `path: null, filename: null` for it by contract (#186,
+// because native ComfyUI reuses the "Unsaved Workflow" title across unsaved tabs) — so the
+// reporter passed the TITLE, got "no workflow matching", and found every other documented
+// exit closed as well: reload refuses while unsaved, save refuses under this same guard
+// (#708). The exit existed the whole time and nothing named it: the per-instance ROUTING
+// KEY is a valid `workflow_open` selector, and `workflow_list` already publishes it.
+//
+// The refusal text below is the panel's VERBATIM message (graph-binding.js
+// `graphBindingRefusalMessage`), and the workflow_list replies are the shapes a live rig
+// actually returns — an unsaved tab measured on the rig reports exactly the
+// `path: null / filename: null / key: tmp:<uuid> / routing_key: tmp:<uuid>` record used
+// here. A fixture invented from the issue text would not have proven the classifier keys
+// on a field that exists.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const ROUTING_KEY = "tmp:ffadfd06-41bb-4448-9ad2-fe307ff3356f";
+const SAVED_PATH = "workflows/sdxl-txt2img.json";
+
+/** The panel's own text for this verdict, copied from graphBindingRefusalMessage. */
+const PANEL_REFUSAL =
+  `[root-workflow-uuid-mismatch] The live canvas carries a different workflow's identity tag ` +
+  `than the active workflow, so this command was NOT applied. What the panel observed is the ` +
+  `disagreement itself, not what produced it — a load, tab switch or reconnect leaving a stale ` +
+  `tag behind is the usual explanation, but none of them was witnessed here. Re-open the active ` +
+  `workflow tab (panel_open_workflow) to rebind the graph in place; if that does not clear it, ` +
+  `reload the panel (panel_reload scope:frontend), then retry.`;
+
+/** As measured on a live rig: an unsaved tab publishes its routing key and nothing else. */
+const UNSAVED_LIST = {
+  active: {
+    path: null,
+    filename: null,
+    title: "Unsaved Workflow",
+    key: ROUTING_KEY,
+    routing_key: ROUTING_KEY,
+    workflow_uuid: "defb7763-6e20-4f5a-b9cd-2aeabfea6f08",
+  },
+  open: [
+    {
+      path: null,
+      filename: null,
+      title: "Unsaved Workflow",
+      key: ROUTING_KEY,
+      routing_key: ROUTING_KEY,
+      active: true,
+      modified: true,
+      persisted: false,
+    },
+  ],
+  active_confirmed: true,
+};
+
+const SAVED_LIST = {
+  active: {
+    path: SAVED_PATH,
+    filename: "sdxl-txt2img.json",
+    title: "sdxl-txt2img.json",
+    key: SAVED_PATH,
+    routing_key: `wf:${SAVED_PATH}`,
+    workflow_uuid: "defb7763-6e20-4f5a-b9cd-2aeabfea6f08",
+  },
+  open: [{ path: SAVED_PATH, active: true, modified: false, persisted: true }],
+  active_confirmed: true,
+};
+
+let listCalls = 0;
+
+/** A tab whose every graph command is refused by the panel's binding guard. */
+function bridge(list: unknown | "unreadable") {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        if (list === "unreadable") throw new Error("the panel did not answer");
+        return list;
+      }
+      throw new Error(PANEL_REFUSAL);
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: "defb7763-6e20-4f5a-b9cd-2aeabfea6f08" }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function run(tool: string, args: Record<string, unknown>, list: unknown): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(list), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === tool);
+  if (!def) throw new Error(`${tool} is not registered`);
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+beforeEach(() => {
+  listCalls = 0;
+});
+
+describe("root-workflow-uuid-mismatch names a remedy the tab can accept (#1480)", () => {
+  it("UNSAVED tab: names the routing key, the only selector it has", async () => {
+    const text = await run("panel_connect", { from_node_id: 1, to_node_id: 2 }, UNSAVED_LIST);
+
+    // The tab state was really read. Without this every assertion below could be
+    // satisfied by a canned string that never consulted the panel — and a branch that
+    // never runs is the failure mode this whole diagnosis exists to avoid.
+    expect(listCalls).toBeGreaterThan(0);
+
+    // THE fix: the selector that exists, spelled the way it must be passed.
+    expect(text).toContain(ROUTING_KEY);
+    expect(text).toMatch(/panel_open_workflow\(\{path: "tmp:/);
+    expect(text).toMatch(/NEVER BEEN SAVED/);
+
+    // The two exits the reporter burned turns on, both of which refuse from this state.
+    expect(text).toMatch(/Do NOT reach for panel_save_workflow first/);
+    expect(text).toMatch(/do NOT reload while the tab is unsaved/);
+
+    // The panel's own refusal is preserved — the diagnosis annotates, it never replaces.
+    expect(text).toContain("[root-workflow-uuid-mismatch]");
+  });
+
+  it("READS get it too — panel_graph_outline refusing was half the dead end", async () => {
+    // The issue's secondary complaint: the read path refused while panel_query_graph
+    // succeeded, which made a persistent fault look intermittent. A read that refuses
+    // must still name the way out, or the agent only learns it from a later write.
+    const text = await run("panel_graph_outline", {}, UNSAVED_LIST);
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(text).toContain(ROUTING_KEY);
+    expect(text).toMatch(/NEVER BEEN SAVED/);
+  });
+
+  it("SAVED tab: the panel's own <path> advice is reachable, so it is named, not replaced", async () => {
+    // The direction that must not regress. This guard is correct for a saved tab, and an
+    // over-broad fix that told everyone to pass a routing key would be a new wrong answer.
+    const text = await run("panel_connect", { from_node_id: 1, to_node_id: 2 }, SAVED_LIST);
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(text).toContain(SAVED_PATH);
+    expect(text).toMatch(/IS saved/);
+    expect(text).not.toMatch(/NEVER BEEN SAVED/);
+    expect(text).not.toContain("tmp:");
+  });
+
+  it("UNREADABLE: promises nothing, because nothing was established", async () => {
+    // The failure direction that matters. Naming a selector we could not establish would
+    // send the agent to "no workflow matching" — the exact turn #1480 wasted.
+    const text = await run("panel_connect", { from_node_id: 1, to_node_id: 2 }, "unreadable");
+
+    expect(text).toMatch(/the answer is UNKNOWN/);
+    expect(text).toMatch(/routing_key/);
+    expect(text).not.toMatch(/NEVER BEEN SAVED/);
+    // Still fails, and still on the panel's own terms.
+    expect(text).toContain("[root-workflow-uuid-mismatch]");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -931,12 +931,17 @@ function isNoTrustedIdentityRefusal(err: unknown): boolean {
  * "was NOT applied" claim is structural — the same property that makes the two above
  * safe to annotate.
  *
- * Matched on the bracketed leading token the panel emits for exactly this purpose
- * (`[root-workflow-uuid-mismatch] …`), not on the prose after it.
+ * Matched on the bracketed token the panel emits for exactly this purpose
+ * (`[root-workflow-uuid-mismatch] …`), not on the prose after it, and ANCHORED to the
+ * start (codex): a bare `contains` also fires on any message that merely QUOTES the
+ * token — a wrapped or re-surfaced refusal, an error about the token as a value — and
+ * would then spend a round trip telling that caller to re-open a workflow. The anchor is
+ * the panel's real shape, not a hopeful one: a panel executor's error text becomes this
+ * Error's message verbatim, with no prefix (ui-bridge's reply-error reject).
  */
 function isRootWorkflowUuidMismatch(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err ?? "");
-  return /\[root-workflow-uuid-mismatch\]/i.test(msg);
+  return /^\s*\[root-workflow-uuid-mismatch\]/i.test(msg);
 }
 
 /**

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -918,6 +918,94 @@ function isNoTrustedIdentityRefusal(err: unknown): boolean {
   return /no trusted identity/i.test(msg);
 }
 
+/**
+ * #1480 — the panel's GRAPH-BINDING guard refused: the live canvas carries a different
+ * workflow's identity tag than the active workflow (`graphBindingRefusalMessage`'s
+ * `root-workflow-uuid-mismatch` verdict).
+ *
+ * A THIRD distinct refusal, and the trio is easy to conflate. The two above are the
+ * bridge's per-command STAMP fence (`workflow instance mismatch`) and the bridge having
+ * NO identity to stamp with (`no trusted identity`); this one is the panel comparing the
+ * tag on the mounted LiteGraph root against the active workflow's identity and finding
+ * two tags that disagree. It is raised by the panel, before every executor, so its
+ * "was NOT applied" claim is structural — the same property that makes the two above
+ * safe to annotate.
+ *
+ * Matched on the bracketed leading token the panel emits for exactly this purpose
+ * (`[root-workflow-uuid-mismatch] …`), not on the prose after it.
+ */
+function isRootWorkflowUuidMismatch(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /\[root-workflow-uuid-mismatch\]/i.test(msg);
+}
+
+/**
+ * #1480 — WHICH `panel_open_workflow` SELECTOR EXISTS FOR THE ACTIVE TAB.
+ *
+ * The mismatch refusal's remedy is `panel_open_workflow(<path>)`, and for a NEVER-SAVED
+ * tab there is no path to pass: `workflow_list` reports `path: null` and `filename: null`
+ * for it by contract, because native ComfyUI reuses the "Unsaved Workflow" title across
+ * unsaved tabs (#186). The reporter followed the remedy with the tab's TITLE, got "no
+ * workflow matching", and every other documented exit was blocked too — reload refuses on
+ * unsaved changes, save refuses under this very guard (#708) — so the session dead-ended
+ * with the canvas readable and unedittable.
+ *
+ * The exit was there the whole time and nothing named it: the per-instance ROUTING KEY
+ * (`tmp:<uuid>`) is a valid `workflow_open` selector — for an unsaved tab it is the ONLY
+ * one it has (`workflowRecordMatchesSelector`) — and `workflow_list` already publishes it
+ * as `routing_key` on every record. So this reads the ONE fact that decides which remedy
+ * is followable, and the caller names that one instead of the generic `<path>`.
+ *
+ * Read-only, and `workflow_list` is exempt from the fence being reported on, so this can
+ * run on the refusal path without being refused by it. Anything unreadable answers
+ * "unknown" and the caller says so rather than picking a selector it cannot support.
+ */
+interface ActiveTabRebindSelector {
+  status: "unsaved" | "saved" | "unknown";
+  /** The selector to pass to `panel_open_workflow`, when one is established. */
+  selector: string | null;
+  /** Display label, for a message that has to refer to the tab a human is looking at. */
+  title: string | null;
+  /** Why the answer is "unknown" — never a guess dressed as a reason. */
+  why: string;
+}
+
+async function readActiveTabRebindSelector(ctx: PanelToolCtx): Promise<ActiveTabRebindSelector> {
+  const unknown = (why: string): ActiveTabRebindSelector => ({
+    status: "unknown",
+    selector: null,
+    title: null,
+    why,
+  });
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+    if (res?.isError) return unknown(`the workflow list read failed (${toolResultText(res)})`);
+    parsed = parseToolResultJson(res);
+  } catch (err) {
+    return unknown(
+      `the workflow list read threw (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const active = parsed?.active;
+  if (!active || typeof active !== "object") {
+    return unknown("the workflow list reported no active workflow");
+  }
+  const rec = active as Record<string, unknown>;
+  const str = (v: unknown): string | null => (typeof v === "string" && v ? v : null);
+  const title = str(rec.title);
+  const path = str(rec.path);
+  const routingKey = str(rec.routing_key) ?? str(rec.key);
+  // SAVED is decided by the presence of a real path, the same fact the panel keys
+  // `persisted` on — never by the routing key's spelling, which is panel-owned and
+  // would silently reclassify every tab if its prefix ever changed.
+  if (path) return { status: "saved", selector: path, title, why: "" };
+  if (!routingKey) {
+    return unknown("the active tab reported neither a path nor a routing key");
+  }
+  return { status: "unsaved", selector: routingKey, title, why: "" };
+}
+
 let retrySettleMsOverride: number | null = null;
 /** Short pause before the single post-drop retry, letting the replacement tab
  *  finish its reconnect hello so ensureReachable can resolve it. Test-overridable. */
@@ -6396,6 +6484,57 @@ export function makePanelToolCtx(
             `stands on its own terms. (${rebindErr instanceof Error ? rebindErr.message : String(rebindErr)})`;
         }
         return fail(`${name} was NOT applied — nothing changed. ${raw}${verdict}`);
+      }
+      // #1480 — NAME A REMEDY THE TAB CAN ACTUALLY ACCEPT.
+      //
+      // The panel's own remedy for this verdict is `panel_open_workflow(<path>)`, which
+      // is right for a saved tab and unfollowable for a never-saved one: that tab has no
+      // path, and its title is not a selector. The reporter tried the title, was told
+      // "no workflow matching", and found every other exit closed as well — reload
+      // refuses while unsaved, save refuses under this same guard (#708). Canvas
+      // readable, canvas unedittable, and the only way out was a human pressing Ctrl+S.
+      //
+      // Nothing here is auto-applied and the guard is NOT weakened. One read-only
+      // `workflow_list` (exempt from this fence) establishes the single fact that decides
+      // which remedy is reachable, and the refusal then names THAT one. Applied to reads
+      // as well as mutations on purpose: `panel_graph_outline` refusing was half of the
+      // reported dead end, and this verdict is raised before every executor, so the
+      // "NOT applied" claim it rides on is equally true either way.
+      if (isRootWorkflowUuidMismatch(err)) {
+        const raw = err instanceof Error ? err.message : String(err);
+        try {
+          const tab = await readActiveTabRebindSelector(ctx);
+          if (tab.status === "unsaved" && tab.selector) {
+            return fail(
+              `${raw}\n\nCHECKED, so this is not a guess: the active tab has NEVER BEEN SAVED ` +
+                `(the workflow list reports path: null, filename: null${
+                  tab.title ? `, title: ${JSON.stringify(tab.title)}` : ""
+                }). The remedy above names a <path> that DOES NOT EXIST for this tab, and its ` +
+                `title is not a selector — passing either fails with "no workflow matching". ` +
+                `USE ITS ROUTING KEY, which is the only selector an unsaved tab has and needs ` +
+                `no file on disk: panel_open_workflow({path: ${JSON.stringify(tab.selector)}}). ` +
+                `Do NOT reach for panel_save_workflow first — under this same guard it refuses ` +
+                `too (#708) — and do NOT reload while the tab is unsaved. If re-opening by ` +
+                `routing key still refuses, the two identities genuinely disagree and the user ` +
+                `has to save or reload the tab by hand.`,
+            );
+          }
+          if (tab.status === "saved" && tab.selector) {
+            return fail(
+              `${raw}\n\nCHECKED: the active tab IS saved, so the remedy above is reachable as ` +
+                `written — panel_open_workflow({path: ${JSON.stringify(tab.selector)}}).`,
+            );
+          }
+          return fail(
+            `${raw}\n\nCHECKED, and the answer is UNKNOWN: which panel_open_workflow selector ` +
+              `this tab accepts could not be established (${tab.why}). If it turns out to have ` +
+              `never been saved, <path> will not name it — read panel_list_workflows and pass ` +
+              `the active record's routing_key instead.`,
+          );
+        } catch {
+          // The diagnosis must never change how the call failed.
+          return fail(raw);
+        }
       }
       if (isCapabilityRefusal(err)) {
         return fail(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
Fixes #1480.

`[root-workflow-uuid-mismatch]` fires on a tab that has **never been saved** (a tmp tab from a workflow embedded in an image), and in that state every remedy it recommends is itself blocked:

1. `panel_set_widget` → refused by the guard; it suggests re-opening the tab, else `panel_reload scope:frontend`
2. `panel_open_workflow` → the reporter passed the tab's **title** and got `no workflow matching`
3. `panel_reload scope:frontend` → refused, correctly, because unsaved work is open
4. `panel_save_workflow` → refused by the **same** guard (#708)

Can't edit, can't open, can't reload, can't save.

## What I expected to build, and why I didn't

The plan in this PR's first draft was a `force_new` escape hatch on `panel_save_workflow`: a save to a genuinely new path cannot overwrite either workflow, so it is safe by construction, and it would give the tab a path.

Reading the panel first killed that as the *first* thing to try, because **step 2 was never actually blocked** — it was mis-addressed:

- `workflowRecordMatchesSelector` accepts a record's **per-instance routing id**, and for an unsaved tab that is explicitly "the ONLY authority" (#186) — the shared `Unsaved Workflow` title/key must never select an arbitrary unsaved tab.
- `workflow_list` already publishes it as `routing_key` on **every** record.
- The orchestrator already handles `panel_open_workflow(tmp:<uuid>)`, including the fence refresh that a saved path gets (#812).

So the exit existed, needed no file on disk, and nothing in the failure path named it. The guard's remedy says `<path>` unconditionally; for this tab `<path>` does not exist and the title is not a selector, which is exactly the turn the reporter burned.

I confirmed the record shape on a live rig rather than from the issue text — an unsaved tab really does report `path: null, filename: null, key: "tmp:…", routing_key: "tmp:…"`, and that measured shape is the test fixture.

## The change

This refusal now does what the two refusals beside it already do (#1330, #1331): one read-only `workflow_list` — exempt from the fence being reported on — establishes the single fact that decides which remedy is followable, and the message names **that** one:

- **unsaved** → `panel_open_workflow({path: "tmp:<uuid>"})`, plus an explicit warn-off for the two exits that refuse from this state
- **saved** → the panel's own `<path>` advice, named concretely so it isn't guessed at
- **unreadable** → says so, and promises nothing

Applied to reads as well as mutations: `panel_graph_outline` refusing was half the reported dead end, and the verdict is raised before every executor, so its "NOT applied" claim holds either way.

Nothing is auto-applied. The guard is not weakened — #708's concern is untouched, and the saved-tab direction is pinned by a test so an over-broad fix can't tell everyone to pass a routing key.

## Verification

- 4 new tests on the real tool path, using the panel's **verbatim** refusal text and the rig-measured `workflow_list` shapes
- each asserts the `workflow_list` read actually ran, so a branch that never executes can't pass
- **mutation-checked**: stubbing the classifier to `false` fails all 4
- full suite: 481 files / 9168 tests green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check` all pass

## Deliberately not in this PR

Both are panel-side and larger; they remain open on the issue:

- the `force_new` save escape hatch (issue item 2)
- making the two read paths agree (item 3) — `panel_query_graph` succeeding where `panel_graph_outline` refused is the `staleTagReadBypass` content-equality proof (#995) landing differently at two moments, not a structural read/write split; it deserves its own change