### PR TITLE
feat: add Grok 4.6 to Agent Panel catalog

### DIFF
--- a/src/__tests__/orchestrator/grok-backend.test.ts
+++ b/src/__tests__/orchestrator/grok-backend.test.ts
@@ -178,13 +178,14 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 let GrokBackend: typeof import("../../orchestrator/grok-backend.js").GrokBackend;
 let buildAcpMcpServers: typeof import("../../orchestrator/grok-backend.js").buildAcpMcpServers;
+let GROK_DEFAULT_MODEL: typeof import("../../orchestrator/grok-backend.js").GROK_DEFAULT_MODEL;
 
 beforeEach(async () => {
   hoisted.procs.length = 0;
   hoisted.spawnArgs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
-  ({ GrokBackend, buildAcpMcpServers } = await import("../../orchestrator/grok-backend.js"));
+  ({ GrokBackend, buildAcpMcpServers, GROK_DEFAULT_MODEL } = await import("../../orchestrator/grok-backend.js"));
 });
 
 describe("buildAcpMcpServers", () => {
@@ -355,7 +356,8 @@ describe("GrokBackend (ACP over stdio)", () => {
   it("listModels returns the static Grok catalog (no effort metadata)", async () => {
     const backend = new GrokBackend();
     const models = await backend.listModels();
-    expect(models.map((m) => m.id)).toEqual(["grok-4.5", "grok-composer-2.5-fast", "grok-build"]);
+    expect(models.map((m) => m.id)).toEqual(["grok-4.6", "grok-4.5", "grok-composer-2.5-fast", "grok-build"]);
+    expect(GROK_DEFAULT_MODEL).toBe("grok-4.6");
     // Grok has no discrete effort scale → no effort metadata (panel hides picker).
     expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
   });

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -417,13 +417,14 @@ interface AcpInitializeResult {
 // Grok's reasoning control is not exposed as a discrete effort scale here, so we do
 // NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
 // then hides the effort dropdown (omission is the documented "no effort control"
-// signal). grok-4.5 is the current CLI default.
+// signal). grok-4.6 is the current CLI default.
 const GROK_MODELS: ModelChoice[] = [
+  { id: "grok-4.6", label: "Grok 4.6" },
   { id: "grok-4.5", label: "Grok 4.5" },
   { id: "grok-composer-2.5-fast", label: "Grok Composer 2.5 Fast" },
   { id: "grok-build", label: "Grok Build" },
 ];
-const GROK_DEFAULT_MODEL = "grok-4.5";
+const GROK_DEFAULT_MODEL = "grok-4.6";
 
 /** Does this id look like a Grok model (vs. the Claude panel model PanelAgent
  *  unconditionally passes as opts.model)? Used so the configured Grok model

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -417,7 +417,12 @@ interface AcpInitializeResult {
 // Grok's reasoning control is not exposed as a discrete effort scale here, so we do
 // NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
 // then hides the effort dropdown (omission is the documented "no effort control"
-// signal). grok-4.6 is the current CLI default.
+// signal). grok-4.6 is the current CLI default: xAI shipped it on 2026-08-12 and
+// Grok Build now defaults to it. Verified against docs.x.ai/developers/grok-4-6 on
+// 2026-08-14 — it is a real id in BOTH namespaces this file spans (the CLI's
+// `--model` flag and the raw xAI `/v1` API), which matters because
+// GROK_DEFAULT_MODEL below also seeds GROK_XAI_DEFAULT_MODEL on the direct-token
+// path. The older ids stay listed so a session pinned to one keeps resolving.
 const GROK_MODELS: ModelChoice[] = [
   { id: "grok-4.6", label: "Grok 4.6" },
   { id: "grok-4.5", label: "Grok 4.5" },
@@ -1200,14 +1205,15 @@ export class GrokBackend implements AgentBackend {
 //     (redactTokens, from oauth-flow.ts — the single shared redactor) before
 //     it can reach a thrown message or a log line — the access token itself
 //     is never logged anywhere in this path.
-//   - Model slug + exact endpoint sub-path are UNVERIFIED against the live xAI
-//     API (no network access at authoring time, and no Task-1 research
-//     artifact survived for this session to consult). GROK_XAI_DEFAULT_MODEL
-//     reuses the ACP CLI's existing composer alias as a placeholder rather
-//     than inventing a new model string; listModels() prefers a live
-//     `GET /v1/models` probe over any hardcoded catalog. CONFIRM both against
-//     xAI's docs (or override via COMFYUI_MCP_GROK_XAI_MODEL) before relying
-//     on this path in production — see the task-6 report for the flagged risk.
+//   - The exact endpoint SUB-PATH is still UNVERIFIED against the live xAI API
+//     (no network access at authoring time, and no Task-1 research artifact
+//     survived for this session to consult); override it via
+//     COMFYUI_MCP_GROK_XAI_RESPONSES_URL if the real path differs.
+//     The MODEL SLUG is no longer in that bucket: GROK_XAI_DEFAULT_MODEL
+//     inherits GROK_DEFAULT_MODEL, which is `grok-4.6` — documented by
+//     docs.x.ai/developers/grok-4-6 as a real xAI `/v1` API model id (verified
+//     2026-08-14). listModels() still prefers a live `GET /v1/models` probe over
+//     any hardcoded catalog, and COMFYUI_MCP_GROK_XAI_MODEL still overrides.
 // ---------------------------------------------------------------------------
 
 export const GROK_XAI_API_BASE = "https://api.x.ai/v1";
@@ -1226,10 +1232,13 @@ function grokApiHostAllowlist(): string[] {
   return OAUTH_PROVIDERS.grok?.apiHostAllowlist ?? ["x.ai"];
 }
 
-// UNVERIFIED against the live xAI model catalog (see the divergences note
-// above) — reuses the ACP CLI's default composer alias as a safe, non-invented
-// placeholder rather than guessing a raw-API model slug. Override with
-// COMFYUI_MCP_GROK_XAI_MODEL once confirmed, or rely on listModels()'s live
+// Inherits the ACP CLI default (GROK_DEFAULT_MODEL). That used to be an
+// UNVERIFIED placeholder, but as of grok-4.6 the two namespaces coincide:
+// docs.x.ai/developers/grok-4-6 documents `grok-4.6` as a real xAI `/v1` API
+// model id (verified 2026-08-14), so this fallback is now a valid raw-API slug
+// rather than a CLI alias borrowed on faith. The endpoint SUB-PATH is a separate
+// question and remains unverified — see the divergences note above. Override the
+// model with COMFYUI_MCP_GROK_XAI_MODEL, or rely on listModels()'s live
 // /v1/models probe to surface the account's real slugs.
 export const GROK_XAI_DEFAULT_MODEL =
   process.env.COMFYUI_MCP_GROK_XAI_MODEL?.trim() || GROK_DEFAULT_MODEL;


### PR DESCRIPTION
## Summary

- add `grok-4.6` to the Grok model catalog (`GROK_MODELS`) so the Agent Panel can display and select it
- make `grok-4.6` the default for new Grok sessions (`GROK_DEFAULT_MODEL`)
- retain Grok 4.5, Grok Composer 2.5 Fast, and Grok Build, so a session already pinned to one keeps resolving
- correct three now-stale comments that described the pre-4.6 state (see "Second-order reach" below)

## Why

Grok Build now reports `grok-4.6` as its default model, but the Grok ACP backend cannot enumerate models dynamically and still exposes a static catalog whose default is `grok-4.5`. The orchestrator therefore explicitly launches `grok agent --model grok-4.5`, overriding the CLI's current default. Because `grok-4.6` is absent from the catalog, connected Agent Panel clients also cannot display or select it.

## Model id verification

`grok-4.6` is xAI's real id in **both** namespaces this file spans — the Grok CLI `--model` flag and the raw xAI `/v1` API. Verified against <https://docs.x.ai/developers/grok-4-6> on 2026-08-14; xAI shipped the model on 2026-08-12 and Grok Build defaults to it.

## Second-order reach: the direct-token xAI path

`GROK_DEFAULT_MODEL` does not only feed the ACP catalog. `GROK_XAI_DEFAULT_MODEL` — used by the direct `api.x.ai` backend that takes over when `~/.grok/auth.json` holds a usable OAuth token — falls back to it, so this change moves that path from `grok-4.5` to `grok-4.6` as well.

That is an improvement rather than a risk. The old value was explicitly commented as an **UNVERIFIED** placeholder: `grok-4.5` was a CLI alias borrowed on faith because no raw-API slug had been confirmed. `grok-4.6` is a documented xAI `/v1` model id, so the fallback is now a valid raw-API slug. The comments claiming the slug was unverified have been corrected, and the divergences block is narrowed to the endpoint **sub-path**, which genuinely is still unverified and is still overridable via `COMFYUI_MCP_GROK_XAI_RESPONSES_URL`.

Confirmed reachable, not just argued: the direct backend logs `[grok-backend] ready (direct xAI OAuth, model grok-4.6, ...)` in the OAuth test run.

## Catalog sites audited

Adding a model usually needs more than the id list, so every site an existing Grok id touches was checked:

| Site | Location | Status |
| --- | --- | --- |
| id list + display labels | `GROK_MODELS`, `src/orchestrator/grok-backend.ts` | **updated** |
| default model | `GROK_DEFAULT_MODEL`, `src/orchestrator/grok-backend.ts` | **updated** |
| id-shape guard | `isGrokModel()` — `/^grok[-/]/i` | already matches `grok-4.6`, no change needed |
| spawn-time model | `grokModel` in `src/orchestrator/index.ts` (`COMFYUI_MCP_GROK_MODEL ?? GROK_DEFAULT_MODEL`) | inherits, no change needed |
| direct xAI API default | `GROK_XAI_DEFAULT_MODEL` | inherits; stale comment corrected |
| test expectations | `src/__tests__/orchestrator/grok-backend.test.ts` | **updated** |
| capability / pricing map keyed by model id | none exists for Grok | n/a |
| settings allowlist / panel-side model list | none — the panel receives the catalog over the wire from `listModels()` | n/a |
| docs | `docs/backends.mdx` names the provider, never model ids | n/a |
| CHANGELOG | written by release commits only | n/a |

A repo-wide search for every existing Grok model id (`grok-4.5`, `grok-composer-2.5-fast`, `grok-build`) returns only the backend, its two test files, and one provider-level comment in `agent-backend.ts` — so the catalog really is a single source, and no half-added-model runtime failure is possible here.

## Validation

Re-validated **2026-08-14** as freeze upkeep, against `origin/main` at `a2a483a` (v0.51.52). Everything below is a fresh measurement on the re-merged head, not carried over.

- `origin/main` merged in again — **clean, no conflicts**, no manual resolution. The branch still contributes exactly two files (`src/orchestrator/grok-backend.ts`, `src/__tests__/orchestrator/grok-backend.test.ts`); nothing main brought in touched a Grok path.
- `npm run lint` (`tsc --noEmit`): **pass**
- `npm run build` (`tsc`): **pass**
- Full Vitest suite: **511 files / 9527 tests — 511 files passed, 9524 passed, 3 skipped, 0 failed.** No exclusions and no isolation re-runs needed this time; the whole suite is green as a single run.
- **On the earlier "green once load flakes are excluded" wording:** that caveat is no longer load-bearing, and it was checked rather than dropped. A first run on this box did fail one file (`src/__tests__/services/panel-base-clear-epoch.test.ts`), which passed 7/7 in isolation. To establish whether the branch could be responsible, the full suite was also run on **pristine `origin/main`** in a separate worktree: **511/511 files, 9512 passed, 0 failed**. So main is clean alone, this branch is clean alone, and the one-off was machine load — not a defect on either side.
- All CI side gates re-run and green: `npm run check:vocabulary`, `check:unknown-collapse`, `i18n:check`, `check:docs-links`, `check:docs-locale`, `vocab:export -- --check`, and `node scripts/asset-counts.mjs --check` (that one is a raw script invoked by `ci.yml`/`release.yml`, not an npm script — the earlier body listed it as `asset-counts --check` as though it were one).

## Freeze status

This is a **feature**, and the repo is under a bug/stability freeze. It is prepared and reviewable, **not a merge candidate** — landing it needs an explicit owner decision on the freeze. It is kept merged up to `main` and re-measured purely so it does not rot while parked.

One thing worth flagging to whoever eventually lands it: the value of this PR **decays**. It pins a "current default" (`grok-4.6`, shipped 2026-08-12) that will keep moving, and the freshness claims above are dated for that reason. Re-check <https://docs.x.ai/developers/grok-4-6> and the Grok CLI's own default before merging rather than trusting this body's date.

