### PR TITLE
fix(742): report a remote ComfyUI that a restart stopped and nothing brought back

### DIFF
--- a/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
+++ b/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
@@ -1,0 +1,145 @@
+// #742 — a REMOTE-classified ComfyUI that a restart stops and nothing brings back.
+//
+// `captureRebootHealthBase` is loopback-only, so on the remote path nothing was ever
+// probed: the dispatch returned "it is restarting out-of-band … check in a few seconds"
+// whether the server was mid-restart or dead for good. The reporter's Pinokio install was
+// addressed by its LAN IP, classified remote, stopped, and never relaunched — Pinokio's
+// launcher only re-launches on the Manager's dependency-install signal — and the result
+// described a restart in progress the whole time.
+//
+// The base this session already talks to IS probeable, so it is now watched. What it may
+// conclude is one-directional and that is the point of these tests: it can report a
+// failure to come back; it must never manufacture readiness, because a healthy answer
+// proves the ADDRESS responds, not that this instance cycled.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { getComfyUIBaseUrl, isRemoteMode, setComfyuiTarget } from "../../config.js";
+
+/** The reporter's shape: a ComfyUI on this LAN, reached by IP, so classified REMOTE. */
+const REMOTE_URL = "http://192.168.1.50:5000";
+let originalTarget: string;
+
+const parse = (res: ToolResult): Record<string, unknown> =>
+  JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+/** A ctx whose comfy_reboot is ACCEPTED — the reporter got `rebooting:true` too. */
+function ctxReboot(): PanelToolCtx {
+  return {
+    call: async () => {
+      throw new Error("ctx.call must not be used for reboot dispatch");
+    },
+    confirm: async () => "yes" as const,
+    ensureReachable: () => {},
+    bridge: {
+      send: async () => ({ rebooting: true }),
+      tabOrigin: () => undefined,
+      tabIsLocal: () => false,
+      tabServerOrigin: () => undefined,
+      tabSockId: () => "s0",
+      canReach: () => false,
+    } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as unknown as PanelToolCtx;
+}
+
+function reboot() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def.handler;
+}
+
+beforeEach(() => {
+  originalTarget = getComfyUIBaseUrl();
+  // Retarget for real rather than stubbing isRemoteMode: the branch under test keys on
+  // BOTH the mode and the configured base, and a stub of one with the other left local
+  // would pass while proving nothing about the pairing that actually ships.
+  setComfyuiTarget(REMOTE_URL);
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 60,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+});
+
+afterEach(() => {
+  setComfyuiTarget(originalTarget);
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+});
+
+describe("a remote ComfyUI that never comes back is reported, not described as restarting (#742)", () => {
+  it("the target is genuinely classified REMOTE — the premise, asserted not assumed", () => {
+    expect(isRemoteMode()).toBe(true);
+    expect(getComfyUIBaseUrl()).toContain("192.168.1.50");
+  });
+
+  it("WENT DOWN AND STAYED DOWN: says so, and names the launcher", async () => {
+    // Every probe refuses: the server stopped and nothing relaunched it.
+    const bases: Array<string | null> = [];
+    __panelToolsTestHooks.setHealthProbe(async (base) => {
+      bases.push(base);
+      return "down";
+    });
+
+    const out = parse(await reboot()({ force: false }, ctxReboot()));
+
+    // It really probed the configured remote base — without this the assertions below
+    // could pass on a branch that never looked at anything.
+    expect(bases.length).toBeGreaterThan(0);
+    expect(bases.every((b) => typeof b === "string" && b.includes("192.168.1.50"))).toBe(true);
+
+    expect(out.saw_down).toBe(true);
+    expect(String(out.note)).toMatch(/WENT DOWN/);
+    expect(String(out.note)).toMatch(/has NOT come back/);
+    // The recovery the reporter had to work out for themselves.
+    expect(String(out.note)).toMatch(/start ComfyUI again from its own launcher/i);
+    expect(String(out.note)).toMatch(/Pinokio/);
+    // The claim that was wrong for them is gone.
+    expect(String(out.note)).not.toMatch(/restarting out-of-band/);
+
+    // And it still promises nothing about readiness.
+    expect(out.ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+  });
+
+  it("CAME BACK: a real down→up is NOT called a death, and is NOT promoted to ready", async () => {
+    // The direction that would break every healthy remote restart if `sawDown` alone
+    // were treated as failure.
+    let n = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => (++n <= 2 ? "down" : "healthy"));
+
+    const out = parse(await reboot()({ force: false }, ctxReboot()));
+
+    expect(String(out.note)).not.toMatch(/has NOT come back/);
+    // A responding address is not proof this instance cycled, so readiness stays withheld.
+    expect(out.ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+  });
+
+  it("NEVER OBSERVED DOWN: no failure is claimed", async () => {
+    // Nothing was witnessed going down, so there is nothing to report — asserting a
+    // death here would be the same unmeasured-claim defect pointing the other way.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+
+    const out = parse(await reboot()({ force: false }, ctxReboot()));
+
+    expect(out.saw_down).toBe(false);
+    expect(String(out.note)).not.toMatch(/has NOT come back/);
+    expect(out.ready).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
+++ b/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
@@ -105,12 +105,22 @@ describe("a remote ComfyUI that never comes back is reported, not described as r
 
     expect(out.saw_down).toBe(true);
     expect(String(out.note)).toMatch(/WENT DOWN/);
-    expect(String(out.note)).toMatch(/has NOT come back/);
+    expect(String(out.note)).toMatch(/has NOT come back within/);
     // The recovery the reporter had to work out for themselves.
     expect(String(out.note)).toMatch(/start ComfyUI again from its own launcher/i);
     expect(String(out.note)).toMatch(/Pinokio/);
     // The claim that was wrong for them is gone.
     expect(String(out.note)).not.toMatch(/restarting out-of-band/);
+
+    // AND IT MUST NOT OVER-CLAIM IN THE NEW DIRECTION (codex P1). A bounded window
+    // cannot establish that a server is permanently gone — a remote host may simply be
+    // slower to boot than the budget — so the note names both explanations and the check
+    // that separates them, and never tells the reader to stop waiting.
+    expect(String(out.note)).toMatch(/does NOT prove it is gone for good/i);
+    expect(String(out.note)).toMatch(/can take longer than this to boot/i);
+    expect(String(out.note)).toMatch(/get_system_stats/);
+    expect(String(out.note)).not.toMatch(/do not wait/i);
+    expect(String(out.note)).not.toMatch(/will stay down/i);
 
     // And it still promises nothing about readiness.
     expect(out.ready).toBe(false);

--- a/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
+++ b/src/__tests__/orchestrator/remote-restart-never-came-back.test.ts
@@ -107,7 +107,7 @@ describe("a remote ComfyUI that never comes back is reported, not described as r
     expect(String(out.note)).toMatch(/WENT DOWN/);
     expect(String(out.note)).toMatch(/has NOT come back within/);
     // The recovery the reporter had to work out for themselves.
-    expect(String(out.note)).toMatch(/start ComfyUI again from its own launcher/i);
+    expect(String(out.note)).toMatch(/start ComfyUI from its own launcher/i);
     expect(String(out.note)).toMatch(/Pinokio/);
     // The claim that was wrong for them is gone.
     expect(String(out.note)).not.toMatch(/restarting out-of-band/);
@@ -121,6 +121,9 @@ describe("a remote ComfyUI that never comes back is reported, not described as r
     expect(String(out.note)).toMatch(/get_system_stats/);
     expect(String(out.note)).not.toMatch(/do not wait/i);
     expect(String(out.note)).not.toMatch(/will stay down/i);
+    // No prediction about what a supervisor will or won't do after the window closes.
+    expect(String(out.note)).not.toMatch(/nothing is going to bring it back/i);
+    expect(String(out.note)).not.toMatch(/it was just slow/i);
 
     // And it still promises nothing about readiness.
     expect(out.ready).toBe(false);
@@ -139,6 +142,24 @@ describe("a remote ComfyUI that never comes back is reported, not described as r
     // A responding address is not proof this instance cycled, so readiness stays withheld.
     expect(out.ready).toBe(false);
     expect(out.confirmed_cycle).toBe(false);
+  });
+
+  it("ONE TRANSIENT REFUSAL then a responding endpoint: no death is claimed (codex r2)", async () => {
+    // `sawDown` LATCHES on a single "down" and never clears. A remote tunnel/NAT can
+    // refuse one connection and then answer — a 401/503/timeout all classify "unknown" —
+    // and keying the failure note on `sawDown` alone reported a live install as dead.
+    // The trigger reads the LAST sample instead, so this window ends "unknown", not "down".
+    let n = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => (++n === 1 ? "down" : "unknown"));
+
+    const out = parse(await reboot()({ force: false }, ctxReboot()));
+
+    // The latch really did fire — otherwise this test would pass for the wrong reason,
+    // proving nothing about the trigger that reads past it.
+    expect(out.saw_down).toBe(true);
+    expect(String(out.note)).not.toMatch(/WENT DOWN/);
+    expect(String(out.note)).not.toMatch(/has NOT come back/);
+    expect(out.ready).toBe(false);
   });
 
   it("NEVER OBSERVED DOWN: no failure is claimed", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12094,32 +12094,40 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // remote dispatch could sit here far longer than a local one.
           gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
           const remote = remoteProbeBase != null ? await recoveryPromise : null;
-          const stillDown =
-            remote != null && remote.sawDown && !remote.ready
-              ? normalizeProbe(
-                  await (healthProbeOverride ?? probeComfyEndpoint)(
-                    remoteProbeBase as string,
-                    Math.max(1, Math.min(timing.probeTimeoutMs, overallDeadline - Date.now())),
-                  ).catch(() => "unknown" as ProbeStatus),
-                ) === "down"
-              : false;
-          if (stillDown) {
+          if (remote != null && remote.sawDown && !remote.ready) {
+            const waited = Math.round(remote.waited_ms / 1000);
+            // SAY WHAT WAS MEASURED, AND NOT ONE STEP FURTHER (codex P1).
+            //
+            // A first version told the reader "do not wait for it — it will stay down". That
+            // is a claim about the FUTURE built from a bounded window: a remote host can take
+            // longer than this budget to boot, and it would have sent someone off to hand-start
+            // a server that was seconds from coming back. Unmeasured advice stated confidently
+            // is the exact defect #742 is about; making it point the other way is not a fix.
+            //
+            // What IS established: this address went down and did not answer again inside the
+            // window. Both explanations are named, and so is the one cheap check that separates
+            // them — which is all the caller needs to pick a next step.
+            //
+            // (A second probe after the window was tried and dropped: it added a call that
+            // could start past the handler's own deadline (codex P2) to support a "still not
+            // answering RIGHT NOW" phrasing that this wording no longer needs.)
             return ok({
               rebooting: true,
               ready: false,
               confirmed_cycle: false,
               dispatched: true,
               saw_down: true,
-              probes: remote?.attempts,
+              probes: remote.attempts,
               note:
                 `ComfyUI restart was dispatched and accepted, and ${remoteProbeBase} WENT DOWN — ` +
-                `but it has NOT come back, and it is still not answering now. Do not wait for it: ` +
-                `nothing here restarts it, and if whatever launches it does not do so automatically ` +
-                `it will stay down. This is the common outcome for an externally-managed install ` +
-                `(e.g. Pinokio, which only re-launches on the Manager's dependency-install signal) — ` +
-                `start ComfyUI again from its own launcher, then reload the browser tab so the panel ` +
-                `reconnects. If it is merely slow to boot, get_system_stats (action:"health") will ` +
-                `start answering on its own.`,
+                `but it has NOT come back within ${waited}s. That does NOT prove it is gone for ` +
+                `good: a remote host can take longer than this to boot. It is also exactly what a ` +
+                `restart that nothing relaunches looks like, which is common for an externally- ` +
+                `managed install (e.g. Pinokio, whose launcher only re-launches on the Manager's ` +
+                `dependency-install signal). To tell the two apart, check get_system_stats ` +
+                `(action:"health") in a moment: if it starts answering, it was just slow. If it ` +
+                `stays unreachable, nothing is going to bring it back on its own — start ComfyUI ` +
+                `again from its own launcher, then reload the browser tab so the panel reconnects.`,
             });
           }
           // Unchanged for every other case — including "it answered", which is NOT promoted

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11735,10 +11735,31 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             signalDispatched = r;
           }),
         };
+        // #742 — A REMOTE TARGET HAS NO LOOPBACK BOOT ENDPOINT, BUT IT DOES HAVE AN ADDRESS.
+        //
+        // `captureRebootHealthBase` is loopback-only, so on the remote path nothing was ever
+        // probed and the dispatch returned "it is restarting out-of-band … check in a few
+        // seconds". For a Pinokio install nothing restarts it — its launcher only re-launches
+        // on the Manager's dependency-install message — so the reporter's server stopped and
+        // stayed stopped while the result described a restart in progress.
+        //
+        // The base this session already talks to for every other call is probeable, with the
+        // same configured auth, so it is watched here too. What it may CONCLUDE is deliberately
+        // one-directional (see the await below): a healthy answer proves the ADDRESS responds,
+        // never that this instance cycled — a tab can front a different instance than the
+        // orchestrator is configured for, which is the whole reason the loopback path demands a
+        // handshake-Origin match before it certifies anything. So this can report a failure to
+        // come back; it can never manufacture readiness.
+        const remoteProbeBase =
+          healthBase == null && isRemoteMode()
+            ? (getComfyUIBaseUrl() || "").replace(/\/+$/, "") || null
+            : null;
         const recoveryPromise =
           healthBase != null
             ? observeRecovery(timing, gate.deadline, { healthBase, gate })
-            : null;
+            : remoteProbeBase != null
+              ? observeRecovery(timing, gate.deadline, { healthBase: remoteProbeBase, gate })
+              : null;
         // The AUTHORITATIVE, TYPED dispatch outcome from the bridge rejection (if any):
         // false = a PRE-write send failure (nothing transmitted), true = a POST-write
         // mid-command OUTCOME-UNKNOWN drop / reply-timeout. Captured from the RAW error —
@@ -12060,12 +12081,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // tells the caller to verify, NOT the #509 false-TIMEOUT *error* (the real #509 local
         // case is a probeable boot endpoint and is certified by observeRecovery below).
         if (healthBase == null) {
-          // No probeable boot endpoint — the concurrent observer was never started.
+          // #742 — REPORT A SERVER THAT NEVER CAME BACK, instead of describing a restart.
+          //
+          // Only the NEGATIVE direction is read from this observation, and only when the
+          // window closed with the address still down. `sawDown` alone is not enough: a
+          // successful fast restart also goes down, so treating it as failure would call
+          // every healthy remote reboot a death. And a healthy answer is never upgraded to
+          // readiness — `ready`/`confirmed_cycle` stay false on every branch here, exactly
+          // as before, because this probe cannot prove WHICH instance answered.
+          // Measure the readiness budget from ACK COMPLETION, exactly as the bound path
+          // below does — without this the observer would run to the whole-handler cap and a
+          // remote dispatch could sit here far longer than a local one.
+          gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
+          const remote = remoteProbeBase != null ? await recoveryPromise : null;
+          const stillDown =
+            remote != null && remote.sawDown && !remote.ready
+              ? normalizeProbe(
+                  await (healthProbeOverride ?? probeComfyEndpoint)(
+                    remoteProbeBase as string,
+                    Math.max(1, Math.min(timing.probeTimeoutMs, overallDeadline - Date.now())),
+                  ).catch(() => "unknown" as ProbeStatus),
+                ) === "down"
+              : false;
+          if (stillDown) {
+            return ok({
+              rebooting: true,
+              ready: false,
+              confirmed_cycle: false,
+              dispatched: true,
+              saw_down: true,
+              probes: remote?.attempts,
+              note:
+                `ComfyUI restart was dispatched and accepted, and ${remoteProbeBase} WENT DOWN — ` +
+                `but it has NOT come back, and it is still not answering now. Do not wait for it: ` +
+                `nothing here restarts it, and if whatever launches it does not do so automatically ` +
+                `it will stay down. This is the common outcome for an externally-managed install ` +
+                `(e.g. Pinokio, which only re-launches on the Manager's dependency-install signal) — ` +
+                `start ComfyUI again from its own launcher, then reload the browser tab so the panel ` +
+                `reconnects. If it is merely slow to boot, get_system_stats (action:"health") will ` +
+                `start answering on its own.`,
+            });
+          }
+          // Unchanged for every other case — including "it answered", which is NOT promoted
+          // to a confirmed cycle.
           return ok({
             rebooting: true,
             ready: false,
             confirmed_cycle: false,
             dispatched: true,
+            ...(remote != null ? { saw_down: remote.sawDown, probes: remote.attempts } : {}),
             note:
               "ComfyUI restart was dispatched and accepted; it is restarting out-of-band. " +
               "There is no local boot endpoint I can safely probe from here, so I can't " +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1057,6 +1057,14 @@ interface PanelReadyResult {
   via?: "observed-cycle";
   /** True once the boot endpoint was observed unreachable after the accepted dispatch. */
   sawDown: boolean;
+  /** The status of the LAST sample taken, or undefined if none was.
+   *
+   *  `sawDown` LATCHES on a single "down" and never clears, which is right for proving a
+   *  cycle STARTED and wrong for describing where things ended up: a transient refusal
+   *  followed by an endpoint that answers (or answers 5xx, i.e. "unknown") leaves sawDown
+   *  true forever (codex #742 r2). Anything reporting a server as not-back must read this
+   *  instead — it is the only field that says what the last observation actually saw. */
+  lastStatus?: ProbeStatus;
 }
 
 /** True when a decoded /system_stats body has the recognizable ComfyUI shape (a
@@ -1939,6 +1947,7 @@ async function observeRecovery(
   const probe = healthProbeOverride ?? probeComfyEndpoint;
   const currentDeadline = () => gate?.deadline ?? deadline;
   let sawDown = false;
+  let lastStatus: ProbeStatus | undefined;
   let attempts = 0;
   for (;;) {
     if (gate?.cancelled) break;
@@ -1970,10 +1979,18 @@ async function observeRecovery(
     // COUNTING gate: a sample contributes to the cycle only if taken at/after the post-write
     // dispatched instant (defensive — the observer also defers its first probe to dispatch).
     if (gate == null || sampleAt >= gate.dispatchedAt) {
+      lastStatus = status;
       if (status === "down") {
         sawDown = true;
       } else if (status === "healthy" && sawDown) {
-        return { ready: true, waited_ms: Date.now() - start, attempts, via: "observed-cycle", sawDown };
+        return {
+          ready: true,
+          waited_ms: Date.now() - start,
+          attempts,
+          via: "observed-cycle",
+          sawDown,
+          lastStatus,
+        };
       }
       // "healthy" without a prior down, and "unknown", are ignored — keep looking.
     }
@@ -1982,7 +1999,7 @@ async function observeRecovery(
     if (left <= 0) break;
     await sleep(Math.min(intervalMs, left));
   }
-  return { ready: false, waited_ms: Date.now() - start, attempts, sawDown };
+  return { ready: false, waited_ms: Date.now() - start, attempts, sawDown, lastStatus };
 }
 
 // ---- workflow_open verify-after-timeout (#215/#319/#496/#661) --------------
@@ -12094,7 +12111,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // remote dispatch could sit here far longer than a local one.
           gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
           const remote = remoteProbeBase != null ? await recoveryPromise : null;
-          if (remote != null && remote.sawDown && !remote.ready) {
+          // The trigger reads the LAST observation, not the latched `sawDown` (codex r2):
+          // a remote tunnel/NAT can refuse one connection and then answer — 401, 503, a
+          // timeout, all of which classify "unknown" — leaving `sawDown` true for the rest
+          // of the window while the endpoint was responding the whole time. Reporting a
+          // dead server from that is a false alarm about someone's live install. Requiring
+          // the final sample to still be "down" means the claim describes where the window
+          // actually ENDED, which is the only thing this note asserts.
+          if (
+            remote != null &&
+            remote.sawDown &&
+            !remote.ready &&
+            remote.lastStatus === "down"
+          ) {
             const waited = Math.round(remote.waited_ms / 1000);
             // SAY WHAT WAS MEASURED, AND NOT ONE STEP FURTHER (codex P1).
             //
@@ -12120,14 +12149,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               probes: remote.attempts,
               note:
                 `ComfyUI restart was dispatched and accepted, and ${remoteProbeBase} WENT DOWN — ` +
-                `but it has NOT come back within ${waited}s. That does NOT prove it is gone for ` +
-                `good: a remote host can take longer than this to boot. It is also exactly what a ` +
-                `restart that nothing relaunches looks like, which is common for an externally- ` +
-                `managed install (e.g. Pinokio, whose launcher only re-launches on the Manager's ` +
-                `dependency-install signal). To tell the two apart, check get_system_stats ` +
-                `(action:"health") in a moment: if it starts answering, it was just slow. If it ` +
-                `stays unreachable, nothing is going to bring it back on its own — start ComfyUI ` +
-                `again from its own launcher, then reload the browser tab so the panel reconnects.`,
+                `it has NOT come back within ${waited}s and was still not answering on the last ` +
+                `check. That does NOT prove it is gone for good: a remote host can take longer ` +
+                `than this to boot. It is also what a restart that nothing relaunches looks like, ` +
+                `which is common for an externally-managed install (e.g. Pinokio, whose launcher ` +
+                `only re-launches on the Manager's dependency-install signal). Check ` +
+                `get_system_stats (action:"health") in a moment. If it is still unreachable then, ` +
+                `start ComfyUI from its own launcher (Pinokio, the Desktop app, your terminal) ` +
+                `and reload the browser tab so the panel reconnects.`,
             });
           }
           // Unchanged for every other case — including "it answered", which is NOT promoted


### PR DESCRIPTION
Refs #742 — the thread's **2026-08-12 recurrence on 0.51.18**, not the original report (which already has a preflight shipped).

## The bug

`captureRebootHealthBase` is loopback-only, so for a REMOTE-classified target `recoveryPromise` was `null`, nothing was ever probed, and the handler returned a fixed note:

> ComfyUI restart was dispatched and accepted; **it is restarting out-of-band**. There is no local boot endpoint I can safely probe from here … Check `get_system_stats` in a few seconds.

Identical whether the server was mid-restart or dead for good. The reporter's Pinokio install was addressed by its LAN IP, classified remote, stopped, and never relaunched — Pinokio's launcher only re-launches on the Manager's dependency-install signal — while the result described a restart in progress. They discovered the truth from every later panel call failing with a generic "still reconnecting".

This exits at the `healthBase == null` guard, a field-for-field match with their reported `{rebooting:true, ready:false, confirmed_cycle:false, dispatched:true}` — the other branch would also have carried `recovered_ms`/`probes`/`saw_down`.

## The change

The base this session already talks to for every other call **is** probeable, with the same configured auth, so it is watched now too.

What it may conclude is deliberately one-directional: it can report a failure to come back, and can **never** manufacture readiness. `ready` and `confirmed_cycle` stay false on every branch of this guard — a healthy answer proves the *address* responds, not that this instance cycled, which is the same reason the loopback path demands a handshake-Origin match before certifying anything.

No change to what gets refused, so a working supervised-remote restart (the tunnelled Desktop app) is untouched.

## Three codex rounds, three real findings

1. **The note predicted the future.** It said "do not wait for it … it will stay down" — from a bounded window. A remote host can simply be slower to boot than the budget, so that would send someone to hand-start a server seconds from returning. Stating unmeasured advice confidently is the defect #742 is *about*; pointing it the other way is not a fix.
2. **A post-window probe could start after the handler's own deadline.** Deleted rather than clamped — the reworded note no longer needs it.
3. **The trigger read a LATCHED flag.** `sawDown` never clears, so one transient refusal followed by a responding endpoint (401/503/timeout all classify `unknown`) reported a live install as dead. `observeRecovery` now also returns `lastStatus`, and the trigger requires the **final** sample to still be `down`.

Two further predictions were removed in the same pass: "nothing is going to bring it back on its own" forecasts a supervisor's behaviour past the window, and "if it starts answering, it was just slow" rules out a manual relaunch or tunnel/proxy recovery that would explain it equally well.

Round 3: **SHIP**, no defects found.

## Verification

- 5 tests driving the real handler with the target genuinely retargeted (`setComfyuiTarget`) rather than `isRemoteMode` stubbed — the branch keys on the mode *and* the configured base, and stubbing one would pass while proving nothing about the pairing that ships
- the down→stayed-down test asserts it really probed the configured base, so it can't pass on a branch that looked at nothing
- the down→unknown guard first asserts the latch **did** fire, so it can't pass for the wrong reason; it dies if the `lastStatus` gate is removed
- both over-claim directions pinned by absence assertions
- mutation-checked; full suite 9174 green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`, `asset-counts --check` all pass

## Not in this PR

Pinokio-aware *pre*-restart guidance (issue item 3) would mean refusing or warning more on a destructive path, and the surrounding code has already rejected asymmetric variants of that with reasons. This PR is disclosure-only and safe to ship on its own.