### PR TITLE
fix(cli): stop telling users to turn on a setting that does not exist

### DIFF
--- a/locales/ar/main.json
+++ b/locales/ar/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "تبقى هذه النافذة صامتة حتى تضغط «اتصال» — وهذا متوقَّع وليس تعليقًا.\nفالوكيل يعمل هنا، على تسجيل دخولك في Claude/Codex؛ ولا يُثبَّت أي\nشيء على جهاز ComfyUI. أبقِ هذه الطرفية مفتوحة.",
     "connect_secure_note": "لوحة HTTPS الخاصة بالـ pod تتصل تلقائيًا عبر نفق\nمشفَّر — لا يوجد رابط تلصقه، وتعمل في أي متصفح.",
     "connect_step_click_connect": "اضغط «اتصال» في اللوحة (قائمة الاتصال المنسدلة في لوحة Agent).",
-    "connect_step_enable_external_orchestrator": "في لوحة Agent، من الإعدادات ← عام، فعّل\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "افتح ComfyUI ذاك في متصفحك: {url}",
     "connect_title": "جارٍ تشغيل جسر الوكيل المحلي",
     "connect_url_invalid": "تم تمرير رابط ComfyUI غير صالح إلى `connect`: ‏\"{url}\" ‏({reason}). مرّر رابط http(s) كاملًا، مثل https://abcd-8188.proxy.runpod.net أو http://127.0.0.1:8188 .",

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Until you click Connect this window stays quiet — that's expected, not\na hang. The agent runs HERE on your Claude/Codex login; nothing is\ninstalled on the ComfyUI box. Keep this terminal open.",
     "connect_secure_note": "the pod's HTTPS panel connects automatically over an\nencrypted tunnel — no URL to paste, works in any browser.",
     "connect_step_click_connect": "Click Connect in the panel (the Agent panel's Connect dropdown).",
-    "connect_step_enable_external_orchestrator": "In the Agent panel's Settings → General, turn ON\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "Open that ComfyUI in your browser: {url}",
     "connect_title": "local agent bridge is starting",
     "connect_url_invalid": "Invalid ComfyUI URL passed to `connect`: \"{url}\" ({reason}). Pass a full http(s) URL, e.g. https://abcd-8188.proxy.runpod.net or http://127.0.0.1:8188.",

--- a/locales/es/main.json
+++ b/locales/es/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Hasta que pulses Conectar esta ventana se queda en silencio: es lo\nesperado, no está colgada. El agente se ejecuta AQUÍ, con tu cuenta\nde Claude/Codex; en la máquina de ComfyUI no se instala nada.\nDeja esta terminal abierta.",
     "connect_secure_note": "el panel HTTPS del pod se conecta automáticamente\npor un túnel cifrado: no hay URL que pegar y\nfunciona en cualquier navegador.",
     "connect_step_click_connect": "Pulsa Conectar en el panel (el desplegable Conectar del panel Agent).",
-    "connect_step_enable_external_orchestrator": "En el panel Agent, en Ajustes → General, activa\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "Abre ese ComfyUI en tu navegador: {url}",
     "connect_title": "iniciando el puente del agente local",
     "connect_url_invalid": "Se pasó a `connect` una URL de ComfyUI no válida: \"{url}\" ({reason}). Indica una URL http(s) completa, por ejemplo https://abcd-8188.proxy.runpod.net o http://127.0.0.1:8188.",

--- a/locales/fa/main.json
+++ b/locales/fa/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "تا وقتی «اتصال» را نزنید این پنجره ساکت می‌ماند — این طبیعی است و\nبه معنای گیر کردن نیست. عامل همین‌جا و با ورود Claude/Codex شما\nاجرا می‌شود؛ روی دستگاه ComfyUI چیزی نصب نمی‌شود.\nاین پایانه را باز نگه دارید.",
     "connect_secure_note": "پنل HTTPS این pod به‌صورت خودکار از راه یک تونل\nرمزگذاری‌شده وصل می‌شود — نشانی‌ای برای چسباندن\nنیست و در هر مرورگری کار می‌کند.",
     "connect_step_click_connect": "در پنل روی «اتصال» بزنید (منوی اتصال در پنل Agent).",
-    "connect_step_enable_external_orchestrator": "در پنل Agent، از تنظیمات ← عمومی گزینهٔ\n'Use external/local orchestrator (advanced)' را روشن کنید.",
     "connect_step_open_comfyui": "آن ComfyUI را در مرورگرتان باز کنید: {url}",
     "connect_title": "پل عامل محلی در حال راه‌اندازی است",
     "connect_url_invalid": "نشانی ComfyUI نامعتبری به `connect` داده شد: ‏\"{url}\" ‏({reason}). یک نشانی کامل http(s) بدهید، مثلاً https://abcd-8188.proxy.runpod.net یا http://127.0.0.1:8188 .",

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Tant que vous ne cliquez pas sur Connecter, cette fenêtre reste\nsilencieuse — c'est normal, ce n'est pas un blocage. L'agent tourne\nICI, sur votre compte Claude/Codex ; rien n'est installé sur la\nmachine ComfyUI. Laissez ce terminal ouvert.",
     "connect_secure_note": "le panneau HTTPS du pod se connecte automatiquement par\nun tunnel chiffré — aucune URL à coller, fonctionne\ndans tout navigateur.",
     "connect_step_click_connect": "Cliquez sur Connecter dans le panneau (menu Connecter du panneau Agent).",
-    "connect_step_enable_external_orchestrator": "Dans le panneau Agent, Paramètres → Général, activez\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "Ouvrez ce ComfyUI dans le navigateur : {url}",
     "connect_title": "démarrage du pont d'agent local",
     "connect_url_invalid": "URL ComfyUI invalide passée à `connect` : \"{url}\" ({reason}). Indiquez une URL http(s) complète, par exemple https://abcd-8188.proxy.runpod.net ou http://127.0.0.1:8188.",

--- a/locales/ja/main.json
+++ b/locales/ja/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "「接続」を押すまで、このウィンドウは静かなままです —\n止まっているわけではありません。エージェントはあなたの\nClaude/Codex ログインでここで動き、ComfyUI 側には何も\nインストールされません。このターミナルは開いたままにしてください。",
     "connect_secure_note": "ポッドの HTTPS パネルは暗号化された\nトンネルで自動接続します — 貼り付ける URL は\nなく、どのブラウザーでも動きます。",
     "connect_step_click_connect": "パネルで「接続」を押してください（Agent パネルの接続ドロップダウン）。",
-    "connect_step_enable_external_orchestrator": "Agent パネルの設定 → 一般で\n'Use external/local orchestrator (advanced)' をオンにしてください。",
     "connect_step_open_comfyui": "その ComfyUI をブラウザーで開く: {url}",
     "connect_title": "ローカルのエージェントブリッジを起動しています",
     "connect_url_invalid": "`connect` に不正な ComfyUI URL が渡されました: \"{url}\"（{reason}）。https://abcd-8188.proxy.runpod.net や http://127.0.0.1:8188 のような完全な http(s) URL を指定してください。",

--- a/locales/ko/main.json
+++ b/locales/ko/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "연결을 누르기 전까지 이 창은 조용합니다 — 멈춘 것이 아니라\n정상입니다. 에이전트는 회원님의 Claude/Codex 로그인으로 바로\n여기서 실행되며, ComfyUI 쪽에는 아무것도 설치되지 않습니다.\n이 터미널을 열어 두세요.",
     "connect_secure_note": "파드의 HTTPS 패널이 암호화된 터널로 자동 연결됩니다 —\n붙여넣을 URL이 없고 어떤 브라우저에서도 동작합니다.",
     "connect_step_click_connect": "패널에서 연결을 누르세요 (Agent 패널의 연결 드롭다운).",
-    "connect_step_enable_external_orchestrator": "Agent 패널의 설정 → 일반에서\n'Use external/local orchestrator (advanced)'를 켜세요.",
     "connect_step_open_comfyui": "해당 ComfyUI를 브라우저에서 여세요: {url}",
     "connect_title": "로컬 에이전트 브리지를 시작하는 중",
     "connect_url_invalid": "`connect`에 잘못된 ComfyUI URL이 전달되었습니다: \"{url}\" ({reason}). https://abcd-8188.proxy.runpod.net 또는 http://127.0.0.1:8188 처럼 전체 http(s) URL을 넣으세요.",

--- a/locales/pt-BR/main.json
+++ b/locales/pt-BR/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Até você clicar em Conectar, esta janela fica em silêncio — isso é\nesperado, não é travamento. O agente roda AQUI, no seu login do\nClaude/Codex; nada é instalado na máquina do ComfyUI.\nMantenha este terminal aberto.",
     "connect_secure_note": "o painel HTTPS do pod se conecta automaticamente por um\ntúnel criptografado — nenhuma URL para colar,\nfunciona em qualquer navegador.",
     "connect_step_click_connect": "Clique em Conectar no painel (o menu Conectar do painel Agent).",
-    "connect_step_enable_external_orchestrator": "No painel Agent, em Configurações → Geral, ative\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "Abra esse ComfyUI no seu navegador: {url}",
     "connect_title": "iniciando a ponte do agente local",
     "connect_url_invalid": "URL do ComfyUI inválida passada para `connect`: \"{url}\" ({reason}). Informe uma URL http(s) completa, por exemplo https://abcd-8188.proxy.runpod.net ou http://127.0.0.1:8188.",

--- a/locales/ru/main.json
+++ b/locales/ru/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Пока вы не нажмёте «Подключиться», это окно молчит — так и должно\nбыть, это не зависание. Агент работает ЗДЕСЬ, на вашем логине\nClaude/Codex; на машине с ComfyUI ничего не устанавливается.\nНе закрывайте этот терминал.",
     "connect_secure_note": "HTTPS-панель пода подключается автоматически по\nшифрованному туннелю — URL вставлять не нужно,\nработает в любом браузере.",
     "connect_step_click_connect": "Нажмите «Подключиться» в панели (меню подключения в панели Agent).",
-    "connect_step_enable_external_orchestrator": "В панели Agent откройте Настройки → Общие и включите\n'Use external/local orchestrator (advanced)'.",
     "connect_step_open_comfyui": "Откройте этот ComfyUI в браузере: {url}",
     "connect_title": "запускается локальный мост агента",
     "connect_url_invalid": "В `connect` передан некорректный URL ComfyUI: \"{url}\" ({reason}). Укажите полный http(s) URL, например https://abcd-8188.proxy.runpod.net или http://127.0.0.1:8188.",

--- a/locales/tr/main.json
+++ b/locales/tr/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "Bağlan'a tıklayana kadar bu pencere sessiz kalır — bu beklenen bir\ndurumdur, takılma değildir. Aracı BURADA, sizin Claude/Codex\noturumunuzla çalışır; ComfyUI makinesine hiçbir şey kurulmaz.\nBu terminali açık bırakın.",
     "connect_secure_note": "pod'un HTTPS paneli şifreli bir tünel üzerinden otomatik\nbağlanır — yapıştırılacak URL yok, her tarayıcıda çalışır.",
     "connect_step_click_connect": "Panelde Bağlan'a tıklayın (Agent panelindeki Bağlan menüsü).",
-    "connect_step_enable_external_orchestrator": "Agent panelinde Ayarlar → Genel bölümünde\n'Use external/local orchestrator (advanced)' seçeneğini AÇIN.",
     "connect_step_open_comfyui": "O ComfyUI'yi tarayıcınızda açın: {url}",
     "connect_title": "yerel aracı köprüsü başlatılıyor",
     "connect_url_invalid": "`connect` komutuna geçersiz bir ComfyUI URL'si verildi: \"{url}\" ({reason}). Tam bir http(s) URL'si verin, örneğin https://abcd-8188.proxy.runpod.net veya http://127.0.0.1:8188.",

--- a/locales/zh-TW/main.json
+++ b/locales/zh-TW/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "在你按下「連線」之前，這個視窗會一直安靜 —— 這是正常的，\n不是卡住了。代理程式就在這裡執行，使用你的 Claude/Codex 登入；\nComfyUI 那台機器上不會安裝任何東西。請讓這個終端機保持開啟。",
     "connect_secure_note": "Pod 的 HTTPS 面板會透過加密通道自動連線 ——\n不需貼上任何 URL，在任何瀏覽器都能用。",
     "connect_step_click_connect": "在面板中按下「連線」（Agent 面板的連線下拉選單）。",
-    "connect_step_enable_external_orchestrator": "在 Agent 面板的設定 → 一般中開啟\n'Use external/local orchestrator (advanced)'。",
     "connect_step_open_comfyui": "在瀏覽器開啟該 ComfyUI：{url}",
     "connect_title": "正在啟動本機代理程式橋接",
     "connect_url_invalid": "傳給 `connect` 的 ComfyUI URL 無效：\"{url}\"（{reason}）。請傳入完整的 http(s) URL，例如 https://abcd-8188.proxy.runpod.net 或 http://127.0.0.1:8188 。",

--- a/locales/zh/main.json
+++ b/locales/zh/main.json
@@ -30,7 +30,6 @@
     "connect_quiet_note": "在你点击“连接”之前，这个窗口会一直安静 —— 这是正常的，\n不是卡住了。智能体就运行在这里，使用你的 Claude/Codex 登录；\nComfyUI 那台机器上不会安装任何东西。请保持这个终端打开。",
     "connect_secure_note": "Pod 的 HTTPS 面板会通过加密隧道自动连接 ——\n无需粘贴任何 URL，在任何浏览器中都能用。",
     "connect_step_click_connect": "在面板中点击“连接”（Agent 面板的连接下拉菜单）。",
-    "connect_step_enable_external_orchestrator": "在 Agent 面板的设置 → 常规中打开\n'Use external/local orchestrator (advanced)'。",
     "connect_step_open_comfyui": "在浏览器中打开该 ComfyUI：{url}",
     "connect_title": "正在启动本地智能体桥接",
     "connect_url_invalid": "传给 `connect` 的 ComfyUI URL 无效：\"{url}\"（{reason}）。请传入完整的 http(s) URL，例如 https://abcd-8188.proxy.runpod.net 或 http://127.0.0.1:8188 。",

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -428,14 +428,19 @@ async function main() {
       // the only wording that still matches the button the user has to find. A catalog entry
       // for one of these keys is only correct if it uses the panel's translation of that
       // control, not a fresh translation of the sentence.
+      // There used to be a step here telling the user to turn ON "Use external/local
+      // orchestrator (advanced)" in the panel's Settings → General. That control does not
+      // exist. The panel declares the setting id and never registers a row for it, and
+      // `externalOrchestratorMode()` returns true unconditionally — its own comment calls the
+      // setting "a back-compat no-op", because a Registry-compliant pure-frontend pack can no
+      // longer spawn the orchestrator, so external/local is the only mode there is. The step
+      // therefore sent people hunting for a toggle that isn't there, to enable something that
+      // cannot be turned off. It had just been translated into eleven languages, which is how
+      // it surfaced: faithfully wrong in twelve.
       const steps = [
         tr("cli.connect_step_open_comfyui", "Open that ComfyUI in your browser: {url}", {
           url: cli.comfyuiUrl,
         }),
-        tr(
-          "cli.connect_step_enable_external_orchestrator",
-          "In the Agent panel's Settings → General, turn ON\n'Use external/local orchestrator (advanced)'.",
-        ),
         tr(
           "cli.connect_step_click_connect",
           "Click Connect in the panel (the Agent panel's Connect dropdown).",

--- a/src/i18n/catalogs.test.ts
+++ b/src/i18n/catalogs.test.ts
@@ -159,7 +159,6 @@ const BOXED_KEYS = [
   "connect_secure_note",
   "connect_next_steps",
   "connect_step_open_comfyui",
-  "connect_step_enable_external_orchestrator",
   "connect_step_click_connect",
   "connect_quiet_note",
   "tunnel_title",


### PR DESCRIPTION
The connect banner's step 2 read:

> In the Agent panel's Settings → General, turn ON
> `'Use external/local orchestrator (advanced)'.`

**There is no such control.** Three independent checks against the panel's `origin/main`:

| check | result |
|---|---|
| `grep -c SETTING_EXTERNAL_ORCH` | **1** — the constant is declared and never registered as a settings row |
| `grep 'Use external/local orchestrator'` | **no match** — the label the CLI names does not exist |
| `externalOrchestratorMode()` | `return true;` unconditionally |

The panel's own comment is explicit: *"Always ON now: the pack is pure-frontend and can no longer spawn the orchestrator (Comfy Registry security standards), so external/local is the ONLY mode — … the setting is a back-compat no-op."*

So the step sent people hunting for a toggle that isn't there, to enable something that can't be turned off.

## What changed

- The step and its `tr()` call site in `src/boot.ts`.
- `cli.connect_step_enable_external_orchestrator` pruned from **all twelve** catalogs — the locale gate uses `.strict()`, so leaving it in any translation would be a hard failure.
- Its entry in `catalogs.test.ts`'s `BOXED_KEYS`.

English goes 153 → 152 keys; every translation stays at **100%**.

## How it surfaced

It had just been translated into eleven languages. The wrong instruction was about to be faithfully wrong in twelve — reported by the unit that wrote those catalogs.

## Verification

`numberedSteps` numbers from the array index, so the remaining steps renumber themselves. Observed rather than assumed, by rendering the actual block:

```
--- ko ---            --- ar ---
 다음 단계:            الخطوات التالية:
   1. 해당 ComfyUI…       1. افتح ComfyUI ذاك في متصفحك…
   2. 패널에서 연결을…      2. اضغط «اتصال» في اللوحة…
```

- `npm run lint` (tsc --noEmit) → clean
- `npm run i18n:check` → `locales OK`, all eleven at 152 keys / 100%
- `npm test` → **481 files, 9169 passed, 0 failed**

**Flake disclosure:** `tool-surface-filter` and `vocabulary` failed on one early run in this worktree and did not reproduce across three subsequent runs — including the identical full-suite invocation on this branch and a full run on pristine `main` (481/481). They are flaky on this machine, not caused by this change.