### PR TITLE
fix(1447): advertise the real version instead of a hardcoded 0.1.0

### DIFF
--- a/src/__tests__/boot-server-version.test.ts
+++ b/src/__tests__/boot-server-version.test.ts
@@ -3,53 +3,78 @@
 // so it made every report ambiguous about which build produced it — the reporter found it
 // while filing a report about something else entirely.
 //
-// ASSERTED ON THE SOURCE, deliberately. The obvious functional test — start the server and
-// read its initialize response — cannot run here: `boot.ts` is a program, not a module you
-// can import without it taking over stdio. And the failure mode being guarded is a literal
-// creeping back into one specific object, which the source is the honest place to check.
-// (The behaviour itself was verified live: a real `initialize` against the built server
-// returns the package version, where it returned "0.1.0" before this change.)
+// The resolution is EXECUTED here, not described. A first version of this file asserted on
+// `boot.ts`'s source text, which codex correctly rejected: source text cannot distinguish
+// "reads the manifest" from "reads the manifest and then returns something else". Pulling
+// the logic into `readPackageVersion` made it runnable — `boot.ts` itself is a program that
+// seizes stdio, so a test can never import it.
+//
+// The wiring is still checked textually, because that IS a text fact: the one line in
+// boot.ts that decides whether any of this reaches the handshake.
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { readPackageVersion, UNKNOWN_VERSION } from "../utils/package-version.js";
 
 const bootSrc = readFileSync(new URL("../boot.ts", import.meta.url), "utf-8");
+const manifest = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+) as { version: string };
 
-describe("the MCP server advertises its REAL version (#1447)", () => {
+const fakeManifest = (body: string) => (): string => body;
+
+describe("readPackageVersion resolves the REAL version (#1447)", () => {
+  it("reads this package's actual version by default", () => {
+    // No injection: the default URL must land on our own manifest from wherever this
+    // module ends up, which is the whole point of resolving from import.meta.url.
+    expect(readPackageVersion()).toBe(manifest.version);
+    expect(readPackageVersion()).not.toBe("0.1.0");
+  });
+
+  it("survives a UTF-8 BOM (codex)", () => {
+    // npm writes manifests without one, but a hand-edited file on Windows can carry it,
+    // and JSON.parse throws on the BOM — losing the real version to an editor's byte-order
+    // mark would reintroduce exactly the ambiguity this fixes.
+    const withBom = "﻿" + JSON.stringify({ version: "1.2.3" });
+    expect(readPackageVersion(new URL("file:///x/package.json"), fakeManifest(withBom))).toBe(
+      "1.2.3",
+    );
+  });
+
+  it("an unreadable, malformed, or version-less manifest yields an IMPOSSIBLE version", () => {
+    // Not a plausible one. The literal this replaced was "0.1.0", which read as data.
+    const boom = (): string => {
+      throw new Error("ENOENT");
+    };
+    expect(readPackageVersion(new URL("file:///x/package.json"), boom)).toBe(UNKNOWN_VERSION);
+    expect(
+      readPackageVersion(new URL("file:///x/package.json"), fakeManifest("{not json")),
+    ).toBe(UNKNOWN_VERSION);
+    expect(
+      readPackageVersion(new URL("file:///x/package.json"), fakeManifest('{"name":"x"}')),
+    ).toBe(UNKNOWN_VERSION);
+    expect(
+      readPackageVersion(new URL("file:///x/package.json"), fakeManifest('{"version":""}')),
+    ).toBe(UNKNOWN_VERSION);
+    expect(UNKNOWN_VERSION).toBe("0.0.0");
+  });
+});
+
+describe("the MCP server is wired to it (#1447)", () => {
   it("the McpServer identity block carries no hardcoded version literal", () => {
-    // Anchor on the construction itself rather than scanning the whole file: a version
-    // string elsewhere (a comment, a compatibility floor) is not this bug.
+    // WIRING, not behaviour: a correct helper nothing calls would leave the bug shipped.
     const at = bootSrc.indexOf('name: "comfyui-mcp",');
     expect(at, "the McpServer identity block moved — re-anchor this test").toBeGreaterThan(-1);
     const block = bootSrc.slice(at, at + 200);
 
     expect(block).toMatch(/version:\s*SERVER_VERSION/);
-    // The specific regression: any quoted semver back in that slot.
     expect(block).not.toMatch(/version:\s*["'`]\d+\.\d+\.\d+/);
   });
 
-  it("SERVER_VERSION is resolved from the install, not written down", () => {
-    const at = bootSrc.indexOf("const SERVER_VERSION");
-    expect(at, "SERVER_VERSION was removed or renamed").toBeGreaterThan(-1);
-    const decl = bootSrc.slice(at, at + 400);
-
-    // It must READ our own manifest, resolved from this module's own URL so it cannot
-    // pick up a parent directory's package.json.
-    expect(decl).toMatch(/readFileSync\(new URL\("\.\.\/package\.json", import\.meta\.url\)/);
-    // And it must NOT reach for detectInstallMode: that helper lstat/realpath-walks the
-    // install, and this value is built on the handshake path — the very thing #1447 is
-    // about (codex). Cheap here is not a nicety, it is the point.
-    expect(decl).not.toMatch(/detectInstallMode/);
-    // And its fallback must be an OBVIOUSLY impossible version. A plausible-looking one
-    // (like the 0.1.0 this replaced) is a lie that reads as data.
-    expect(decl).toMatch(/["'`]0\.0\.0["'`]/);
-    expect(decl).not.toMatch(/["'`]0\.1\.0["'`]/);
-  });
-
-  it("the resolution happens ONCE, at module load", () => {
-    // A per-call read could only ever differ if the files changed under a running
-    // process, which would report a version this process is not executing.
-    const at = bootSrc.indexOf("const SERVER_VERSION");
-    const decl = bootSrc.slice(at, at + 400);
-    expect(decl).toMatch(/const SERVER_VERSION: string = \(\(\)/);
+  it("SERVER_VERSION comes from the helper, once, and not from the install walk", () => {
+    expect(bootSrc).toMatch(/const SERVER_VERSION: string = readPackageVersion\(\);/);
+    // detectInstallMode() lstat/realpath-walks the install. It is fine after a transport is
+    // up (the orchestrator and the issue reporter both use it there) and wrong HERE, on the
+    // handshake path — which is the very thing #1447 is about (codex).
+    expect(bootSrc).not.toMatch(/detectInstallMode/);
   });
 });

--- a/src/__tests__/boot-server-version.test.ts
+++ b/src/__tests__/boot-server-version.test.ts
@@ -40,8 +40,10 @@ describe("readPackageVersion resolves the REAL version (#1447)", () => {
     );
   });
 
-  it("an unreadable, malformed, or version-less manifest yields an IMPOSSIBLE version", () => {
-    // Not a plausible one. The literal this replaced was "0.1.0", which read as data.
+  it("an unreadable, malformed, or version-less manifest yields a NON-COLLIDING sentinel", () => {
+    // Not a plausible one. The literal this replaced was "0.1.0", which read as data —
+    // and plain "0.0.0" was rejected in review for the same reason: it is a legal SemVer a
+    // real manifest could carry, so it could not be told apart from a genuine value.
     const boom = (): string => {
       throw new Error("ENOENT");
     };
@@ -55,7 +57,11 @@ describe("readPackageVersion resolves the REAL version (#1447)", () => {
     expect(
       readPackageVersion(new URL("file:///x/package.json"), fakeManifest('{"version":""}')),
     ).toBe(UNKNOWN_VERSION);
-    expect(UNKNOWN_VERSION).toBe("0.0.0");
+    expect(UNKNOWN_VERSION).toBe("0.0.0-unknown");
+    // A real manifest reading 0.0.0 must NOT be mistaken for the failure sentinel.
+    expect(
+      readPackageVersion(new URL("file:///x/package.json"), () => '{"version":"0.0.0"}'),
+    ).toBe("0.0.0");
   });
 });
 

--- a/src/__tests__/boot-server-version.test.ts
+++ b/src/__tests__/boot-server-version.test.ts
@@ -32,9 +32,13 @@ describe("the MCP server advertises its REAL version (#1447)", () => {
     expect(at, "SERVER_VERSION was removed or renamed").toBeGreaterThan(-1);
     const decl = bootSrc.slice(at, at + 400);
 
-    // It must READ the running install — the same source the orchestrator and the issue
-    // reporter already use, so all three cannot disagree about which build is running.
-    expect(decl).toMatch(/detectInstallMode\(\)\.currentVersion/);
+    // It must READ our own manifest, resolved from this module's own URL so it cannot
+    // pick up a parent directory's package.json.
+    expect(decl).toMatch(/readFileSync\(new URL\("\.\.\/package\.json", import\.meta\.url\)/);
+    // And it must NOT reach for detectInstallMode: that helper lstat/realpath-walks the
+    // install, and this value is built on the handshake path — the very thing #1447 is
+    // about (codex). Cheap here is not a nicety, it is the point.
+    expect(decl).not.toMatch(/detectInstallMode/);
     // And its fallback must be an OBVIOUSLY impossible version. A plausible-looking one
     // (like the 0.1.0 this replaced) is a lie that reads as data.
     expect(decl).toMatch(/["'`]0\.0\.0["'`]/);

--- a/src/__tests__/boot-server-version.test.ts
+++ b/src/__tests__/boot-server-version.test.ts
@@ -1,0 +1,51 @@
+// #1447 — `serverInfo.version` advertised a hardcoded `0.1.0`, a version this package has
+// never shipped. That string is what an MCP client displays and what a bug report quotes,
+// so it made every report ambiguous about which build produced it — the reporter found it
+// while filing a report about something else entirely.
+//
+// ASSERTED ON THE SOURCE, deliberately. The obvious functional test — start the server and
+// read its initialize response — cannot run here: `boot.ts` is a program, not a module you
+// can import without it taking over stdio. And the failure mode being guarded is a literal
+// creeping back into one specific object, which the source is the honest place to check.
+// (The behaviour itself was verified live: a real `initialize` against the built server
+// returns the package version, where it returned "0.1.0" before this change.)
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const bootSrc = readFileSync(new URL("../boot.ts", import.meta.url), "utf-8");
+
+describe("the MCP server advertises its REAL version (#1447)", () => {
+  it("the McpServer identity block carries no hardcoded version literal", () => {
+    // Anchor on the construction itself rather than scanning the whole file: a version
+    // string elsewhere (a comment, a compatibility floor) is not this bug.
+    const at = bootSrc.indexOf('name: "comfyui-mcp",');
+    expect(at, "the McpServer identity block moved — re-anchor this test").toBeGreaterThan(-1);
+    const block = bootSrc.slice(at, at + 200);
+
+    expect(block).toMatch(/version:\s*SERVER_VERSION/);
+    // The specific regression: any quoted semver back in that slot.
+    expect(block).not.toMatch(/version:\s*["'`]\d+\.\d+\.\d+/);
+  });
+
+  it("SERVER_VERSION is resolved from the install, not written down", () => {
+    const at = bootSrc.indexOf("const SERVER_VERSION");
+    expect(at, "SERVER_VERSION was removed or renamed").toBeGreaterThan(-1);
+    const decl = bootSrc.slice(at, at + 400);
+
+    // It must READ the running install — the same source the orchestrator and the issue
+    // reporter already use, so all three cannot disagree about which build is running.
+    expect(decl).toMatch(/detectInstallMode\(\)\.currentVersion/);
+    // And its fallback must be an OBVIOUSLY impossible version. A plausible-looking one
+    // (like the 0.1.0 this replaced) is a lie that reads as data.
+    expect(decl).toMatch(/["'`]0\.0\.0["'`]/);
+    expect(decl).not.toMatch(/["'`]0\.1\.0["'`]/);
+  });
+
+  it("the resolution happens ONCE, at module load", () => {
+    // A per-call read could only ever differ if the files changed under a running
+    // process, which would report a version this process is not executing.
+    const at = bootSrc.indexOf("const SERVER_VERSION");
+    const decl = bootSrc.slice(at, at + 400);
+    expect(decl).toMatch(/const SERVER_VERSION: string = \(\(\)/);
+  });
+});

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { randomBytes } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -12,6 +11,7 @@ import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { tryInstallRetiredNameRedirect } from "./tools/retired-redirect.js";
 import { logger } from "./utils/logger.js";
+import { readPackageVersion } from "./utils/package-version.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
@@ -117,36 +117,14 @@ function selfUpdateOnLoad(): void {
  * a bug report quotes, so a constant here makes every report ambiguous about which build
  * produced it — including the reports we ask people to send us.
  *
- * READ DIRECTLY, NOT VIA `detectInstallMode()` (codex). That helper answers a bigger
- * question — which install mode is this, global vs npx vs checkout — and pays for it with
- * an `lstatSync`/`realpathSync` chain. The orchestrator and the issue reporter can afford
- * that because they run it AFTER their transport is up; this value is needed while
- * building the server, i.e. on the handshake path. Putting a symlink-resolving directory
- * walk in front of the handshake would be self-defeating in a fix filed under "startup
- * exceeds the client's timeout", even though the cost is normally microseconds.
- *
- * What is left is ONE small read of our own manifest, resolved from this module's own URL
- * so it cannot pick up a parent directory's package.json: `dist/boot.js` → `dist/../` and
- * `src/boot.ts` → the repo root, both the package root. Node already performed far more
- * I/O importing this file, so this adds no meaningful class of risk.
+ * Resolution lives in `readPackageVersion` (utils/package-version.ts) — cheap enough to sit
+ * on the handshake path, and testable by execution rather than by reading this file's text.
  *
  * Read ONCE at module load rather than per call: a running process cannot hot-swap its own
  * code, so a later read could only differ if the files changed underneath it — which would
  * report a version this process is not executing.
- *
- * Falls back to `0.0.0` — deliberately not `0.1.0`. If the read ever fails, an obviously
- * impossible version is a signal that something is wrong; a plausible one is a lie that
- * looks like data.
  */
-const SERVER_VERSION: string = ((): string => {
-  try {
-    const raw = readFileSync(new URL("../package.json", import.meta.url), "utf-8");
-    const version = (JSON.parse(raw) as { version?: unknown }).version;
-    return typeof version === "string" && version ? version : "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
-})();
+const SERVER_VERSION: string = readPackageVersion();
 
 async function createConfiguredServer(toolMode: ToolMode = "compact"): Promise<McpServer> {
   const server = new McpServer(

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -11,6 +11,7 @@ import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { tryInstallRetiredNameRedirect } from "./tools/retired-redirect.js";
 import { logger } from "./utils/logger.js";
+import { detectInstallMode } from "./services/self-update.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
@@ -107,11 +108,37 @@ function selfUpdateOnLoad(): void {
     .catch(() => {});
 }
 
+/**
+ * #1447 — THE VERSION WE ADVERTISE MUST BE THE VERSION WE ARE.
+ *
+ * This was hardcoded `0.1.0`, so every `initialize` response told the client a version
+ * this package has never shipped. The reporter noticed while filing a bug about something
+ * else, and that is exactly the cost: `serverInfo.version` is what a client shows and what
+ * a bug report quotes, so a constant here makes every report ambiguous about which build
+ * produced it — including the reports we ask people to send us.
+ *
+ * Resolved the SAME way the orchestrator and the issue reporter already resolve it
+ * (`detectInstallMode().currentVersion`), read ONCE at module load rather than per call: a
+ * running process cannot hot-swap its own code, so a later read could only drift if the
+ * files changed underneath it, which would report a version this process is not running.
+ *
+ * Falls back to `0.0.0` — deliberately not `0.1.0`. If detection ever fails, an obviously
+ * impossible version is a signal that something is wrong; a plausible one is a lie that
+ * looks like data.
+ */
+const SERVER_VERSION: string = ((): string => {
+  try {
+    return detectInstallMode().currentVersion ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 async function createConfiguredServer(toolMode: ToolMode = "compact"): Promise<McpServer> {
   const server = new McpServer(
     {
       name: "comfyui-mcp",
-      version: "0.1.0",
+      version: SERVER_VERSION,
     },
     {
       // We declare `resources` and `prompts` (with noop list handlers below)

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -11,7 +12,6 @@ import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { tryInstallRetiredNameRedirect } from "./tools/retired-redirect.js";
 import { logger } from "./utils/logger.js";
-import { detectInstallMode } from "./services/self-update.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
@@ -117,18 +117,32 @@ function selfUpdateOnLoad(): void {
  * a bug report quotes, so a constant here makes every report ambiguous about which build
  * produced it — including the reports we ask people to send us.
  *
- * Resolved the SAME way the orchestrator and the issue reporter already resolve it
- * (`detectInstallMode().currentVersion`), read ONCE at module load rather than per call: a
- * running process cannot hot-swap its own code, so a later read could only drift if the
- * files changed underneath it, which would report a version this process is not running.
+ * READ DIRECTLY, NOT VIA `detectInstallMode()` (codex). That helper answers a bigger
+ * question — which install mode is this, global vs npx vs checkout — and pays for it with
+ * an `lstatSync`/`realpathSync` chain. The orchestrator and the issue reporter can afford
+ * that because they run it AFTER their transport is up; this value is needed while
+ * building the server, i.e. on the handshake path. Putting a symlink-resolving directory
+ * walk in front of the handshake would be self-defeating in a fix filed under "startup
+ * exceeds the client's timeout", even though the cost is normally microseconds.
  *
- * Falls back to `0.0.0` — deliberately not `0.1.0`. If detection ever fails, an obviously
+ * What is left is ONE small read of our own manifest, resolved from this module's own URL
+ * so it cannot pick up a parent directory's package.json: `dist/boot.js` → `dist/../` and
+ * `src/boot.ts` → the repo root, both the package root. Node already performed far more
+ * I/O importing this file, so this adds no meaningful class of risk.
+ *
+ * Read ONCE at module load rather than per call: a running process cannot hot-swap its own
+ * code, so a later read could only differ if the files changed underneath it — which would
+ * report a version this process is not executing.
+ *
+ * Falls back to `0.0.0` — deliberately not `0.1.0`. If the read ever fails, an obviously
  * impossible version is a signal that something is wrong; a plausible one is a lie that
  * looks like data.
  */
 const SERVER_VERSION: string = ((): string => {
   try {
-    return detectInstallMode().currentVersion ?? "0.0.0";
+    const raw = readFileSync(new URL("../package.json", import.meta.url), "utf-8");
+    const version = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof version === "string" && version ? version : "0.0.0";
   } catch {
     return "0.0.0";
   }

--- a/src/utils/package-version.ts
+++ b/src/utils/package-version.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+
+/** The version reported when our own manifest cannot be read or parsed. */
+export const UNKNOWN_VERSION = "0.0.0";
+
+/**
+ * #1447 — the version this build actually is, for `serverInfo.version`.
+ *
+ * Lives in its own module for two reasons, both learned in review:
+ *
+ *  - it must be CHEAP. `detectInstallMode()` answers a bigger question (global vs npx vs
+ *    checkout) and pays an `lstatSync`/`realpathSync` walk for it. Callers that run after
+ *    their transport is up can afford that; this value is needed while the MCP server is
+ *    being constructed, i.e. on the handshake path — and a symlink-resolving directory walk
+ *    in front of the handshake is self-defeating in a fix filed under "startup exceeds the
+ *    client's timeout".
+ *  - it must be TESTABLE for real. Asserting on `boot.ts`'s source text cannot tell "reads
+ *    the manifest" from "reads the manifest and then returns something else" (codex), and
+ *    `boot.ts` is a program that seizes stdio, so a test cannot import it. A small function
+ *    with an injectable reader can be executed instead of described.
+ *
+ * The default manifest URL is resolved from THIS module's own location, so it can never
+ * pick up a parent directory's package.json: `dist/utils/package-version.js` → `dist/../`
+ * and `src/utils/package-version.ts` → the repo root, both the package root.
+ */
+export function readPackageVersion(
+  manifestUrl: URL = new URL("../../package.json", import.meta.url),
+  read: (url: URL) => string = (url) => readFileSync(url, "utf-8"),
+): string {
+  try {
+    // A UTF-8 BOM makes JSON.parse throw (codex): npm writes manifests without one, but a
+    // hand-edited file on Windows can carry it, and losing the real version to an editor's
+    // byte-order mark would be a silly way to reintroduce the exact ambiguity this fixes.
+    const raw = read(manifestUrl).replace(/^﻿/, "");
+    const version = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof version === "string" && version ? version : UNKNOWN_VERSION;
+  } catch {
+    // Deliberately NOT a plausible-looking version. The literal this replaced was "0.1.0",
+    // which read as data and made every bug report ambiguous; an impossible version is a
+    // signal that something is wrong.
+    return UNKNOWN_VERSION;
+  }
+}

--- a/src/utils/package-version.ts
+++ b/src/utils/package-version.ts
@@ -1,7 +1,14 @@
 import { readFileSync } from "node:fs";
 
-/** The version reported when our own manifest cannot be read or parsed. */
-export const UNKNOWN_VERSION = "0.0.0";
+/**
+ * The version reported when our own manifest cannot be read or parsed.
+ *
+ * `0.0.0` was used first and codex was right to reject it: it is a legal SemVer that a real
+ * manifest could carry, so the fallback was indistinguishable from a genuine value — the
+ * same ambiguity the hardcoded "0.1.0" created. A prerelease tag cannot collide with a
+ * published release of this package and still parses as SemVer for any client that tries.
+ */
+export const UNKNOWN_VERSION = "0.0.0-unknown";
 
 /**
  * #1447 — the version this build actually is, for `serverInfo.version`.
@@ -36,8 +43,8 @@ export function readPackageVersion(
     return typeof version === "string" && version ? version : UNKNOWN_VERSION;
   } catch {
     // Deliberately NOT a plausible-looking version. The literal this replaced was "0.1.0",
-    // which read as data and made every bug report ambiguous; an impossible version is a
-    // signal that something is wrong.
+    // which read as data and made every bug report ambiguous; a sentinel no release of this
+    // package can carry is a signal that something is wrong.
     return UNKNOWN_VERSION;
   }
 }


### PR DESCRIPTION
Refs #1447 — fixes the **second** defect in that report. Does **not** close it; the headline cold-start loop is analysed below with a measured negative result.

## What this fixes

`serverInfo.version` was the literal `"0.1.0"` — a version this package has never shipped. That string is what an MCP client displays and what a bug report quotes, so **every report was ambiguous about which build produced it**, including the reports we ask people to send us. The reporter noticed while filing a report about something else.

It now resolves from our own manifest, once, at module load.

**Verified live**, not only in tests — a real `initialize` against the built server:

```
before: {"name":"comfyui-mcp","version":"0.1.0"}
after:  {"name":"comfyui-mcp","version":"0.51.22"}
```

## Three codex rounds, three real findings

1. **The first version put `detectInstallMode()`'s `lstatSync`/`realpathSync` walk on the handshake path.** Self-defeating in a fix filed under *"startup exceeds the client's timeout"*, however small the cost usually is. Replaced by one read of our own manifest, resolved from `import.meta.url` so it cannot pick up a parent directory's `package.json`.
2. **A UTF-8 BOM made `JSON.parse` throw**, silently downgrading a working install to the fallback. Stripped.
3. **The test was source-text only**, so it could not tell *"reads the manifest"* from *"reads the manifest and then returns something else"*. `boot.ts` is a program that seizes stdio, so a test can never import it — the resolution moved into `readPackageVersion` (`utils/package-version.ts`), which a test can **execute**. Mutation-checked: making the helper read the file and return a constant now fails 3 tests.
4. Round 3 also caught that I called `0.0.0` an *"impossible version"* — it is legal SemVer a real manifest could carry, i.e. the same ambiguity I was fixing. The sentinel is now `0.0.0-unknown`, with a test that a manifest genuinely reading `0.0.0` is **not** confused with it.

Suite 9189 green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`, `asset-counts --check` all pass.

## The headline defect — measured, and the one-knob fix REJECTED

The report's root cause is real: `npx -y comfyui-mcp` must fetch the whole tree before the process exists, the client kills the un-handshaken server, and the kill discards npx's partial install, so retries never converge.

I measured a genuinely cold install on this machine (neutral cwd — my first attempt ran inside the repo, where npx resolved the local package and installed nothing, so those numbers were void):

| | packages | node_modules | install |
|---|---|---|---|
| default | 215 | **922 MB** | 12 s |
| `--omit=optional` | 137 | **64 MB** | 7 s |

14× smaller looks like the fix, and **it is not one — that install is broken.** The slimmed server dies on startup:

```
sharp/dist/utility.mjs:31  TypeError: Cannot read properties of undefined (reading 'output')
```

`sharp` ships its platform binaries (`@img/sharp-*`) **as optionalDependencies**, so a blanket omit strips exactly the thing it needs. Shipping `npm_config_omit=optional` in `.mcp.json` would have turned a slow install into a broken one — quieter and worse.

**Where the weight actually is**, from the installed tree:

| package | size | needed by the stdio tool server? |
|---|---|---|
| `@openai` (codex) | 405 MB | **no** — panel orchestrator only |
| `@anthropic-ai` (agent SDK) | 307 MB | **no** — panel orchestrator only |
| `cloudflared` | 52 MB | no — tunnel |
| `@azure`, `@aws-sdk`, `@ai-sdk`, `ai` | ~51 MB | no |
| everything else | ~107 MB | yes |

**~77% of the install is two packages the plugin's server never loads.** The real fix is therefore to stop shipping the agent backends in the package the plugin launches — split them out, or install them on demand when the orchestrator first needs one. That is an architectural change to how backends are distributed, it touches the orchestrator's startup path, and it lands during a consolidation freeze, so I am not doing it unannounced inside a version-string PR.

Pinning the spec in `.mcp.json` (the report's option 2) is cheap and real but only removes a per-launch registry round-trip — it does not stop a cold install from blowing the budget, so it is not a fix on its own.

Leaving #1447 open for that decision.