### PR TITLE
chore(release): 0.51.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.24
+
+### Fixed
+
+- **The MCP server now reports the version it actually is (#1447).** `serverInfo.version` was
+  the hardcoded literal `0.1.0` -- a version this package has never shipped. That string is what
+  an MCP client displays and what a bug report quotes, so every report was ambiguous about which
+  build produced it, including the reports we ask people to send us. It is now read from the
+  package's own manifest, once, at startup.
+
+  Deliberately kept CHEAP: resolving it through the install-mode detector would have put a
+  symlink-resolving directory walk in front of the MCP handshake, which is self-defeating in a
+  fix filed under "startup exceeds the client's timeout". It is one small read of our own
+  manifest, resolved relative to the module so it can never pick up a parent directory's
+  package.json, and a UTF-8 byte-order mark no longer downgrades a working install to the
+  fallback.
+
+  If that read ever fails the version reads `0.0.0-unknown` -- a sentinel no release can carry,
+  rather than a plausible-looking number that would recreate the same ambiguity.
+
+  This is the second defect in #1447 and does not close it: the report's headline -- a cold `npx`
+  install exceeding the client's startup budget -- is a distribution problem measured on the
+  issue, where the tempting one-flag fix was tried and rejected because it produces an install
+  that cannot start.
+
 ## 0.51.23
 
 ### Fixed
@@ -385,6 +410,14 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.51.24] - 2026-08-12
+
+### MCP
+
+#### Fixed
+- advertise the real version instead of a hardcoded 0.1.0 (#1503)
+
 
 ## [0.51.23] - 2026-08-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.23",
+  "version": "0.51.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.23",
+      "version": "0.51.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.23",
+  "version": "0.51.24",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.51.24.

Ships the #1447 version-reporting fix: `serverInfo.version` no longer advertises a hardcoded `0.1.0`, so bug reports stop being ambiguous about which build produced them. Verified post-merge from main — a real `initialize` returns 0.51.23 (the version that build actually is).

#1447 stays OPEN: its headline cold-start defect is a distribution problem, analysed with measurements on #1503.

Merge with a MERGE commit (not squash) so the tag lands on the exact reconciled SHA.