### PR TITLE
fix(1495): bound the inline image so a huge render stays inspectable

### DIFF
--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -43,6 +43,12 @@ Fetch, browse and inspect ComfyUI images and registered assets. Driven by the `a
 <ParamField path="save_dir" type="string">
   action:"get" — absolute local directory to save the file in. Defaults to a 'comfyui-images' folder inside the platform temp directory (os.tmpdir()), which is created if missing. A RELATIVE value is resolved against this MCP process's working directory, which is the client's choice and may not be writable. On Windows a drive-less path like \out is resolved against this process's CURRENT DRIVE, not a drive you chose. Prefer a fully-qualified path (C:\... or \\server\share); the returned 'Saved to:' line always names the resolved absolute path.
 </ParamField>
+<ParamField path="max_preview_bytes" type="integer">
+  action:"get" — ceiling on the base64 payload returned INLINE (default ~16MB). The file saved to disk is never affected. Lower it when your client rejects or truncates large tool results; the reply says when it downscaled and by how much.
+</ParamField>
+<ParamField path="max_preview_dimension" type="integer">
+  action:"get" — ceiling on the inline preview's longest side in pixels (default 4096). Applies even when the byte budget is satisfied, since some consumers reject by dimension — but only for an image this server can decode; an undecodable one under the byte budget is passed through as-is. Does not affect the saved file.
+</ParamField>
 <ParamField path="path" type="string">
   A source image path. action:"convert" — a path under COMFYUI_PATH/output (provide exactly one of asset_id or path). action:"analyze_color" — an absolute image path, or a path under the ComfyUI output dir (videos: extract a frame to PNG first).
 </ParamField>

--- a/src/__tests__/services/inline-preview.test.ts
+++ b/src/__tests__/services/inline-preview.test.ts
@@ -1,0 +1,117 @@
+// #1495 — get_image inlined an 8504×17008 PNG (~267 MB encoded) and blew the caller's
+// 64 MB IPC frame, so a render that saved perfectly could not be looked at.
+//
+// These use REAL images built with sharp, not stubs. The whole claim of the fix is that a
+// predicted compression ratio is not trustworthy — base64 inflates by 4/3 and PNG size
+// swings by an order of magnitude with content — so the implementation MEASURES the
+// re-encode. A test that stubbed the encoder would be asserting the prediction I chose not
+// to trust.
+import { describe, expect, it } from "vitest";
+import sharp from "sharp";
+import {
+  boundInlineImage,
+  DEFAULT_MAX_PREVIEW_DIMENSION,
+} from "../../services/inline-preview.js";
+
+/** A NOISY image: incompressible, so its encoded size tracks its pixel count. */
+async function noisyPng(width: number, height: number): Promise<string> {
+  const px = Buffer.alloc(width * height * 3);
+  // Deterministic pseudo-noise — a flat fill would compress to almost nothing and would
+  // not exercise a byte budget at all.
+  let seed = 12345;
+  for (let i = 0; i < px.length; i++) {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    px[i] = seed & 0xff;
+  }
+  const buf = await sharp(px, { raw: { width, height, channels: 3 } })
+    .png({ compressionLevel: 0 })
+    .toBuffer();
+  return buf.toString("base64");
+}
+
+async function dimsOf(base64: string): Promise<{ width?: number; height?: number }> {
+  const m = await sharp(Buffer.from(base64, "base64")).metadata();
+  return { width: m.width, height: m.height };
+}
+
+describe("boundInlineImage caps what goes on the wire (#1495)", () => {
+  it("an OVER-BUDGET image is downscaled to fit, and says so", async () => {
+    const original = await noisyPng(900, 900);
+    const budget = 100_000; // far below what 900×900 of noise encodes to
+
+    const out = await boundInlineImage(original, "image/png", { budgetBytes: budget });
+
+    // The actual payload fits — measured, not predicted. This is the assertion the whole
+    // design exists for.
+    expect(out.base64.length).toBeLessThanOrEqual(budget);
+    expect(out.refused).toBeNull();
+
+    // And it announces itself, with the TRUE original dimensions, so an agent cannot read
+    // fine detail off a preview believing it is the full render.
+    expect(out.preview).not.toBeNull();
+    expect(out.preview?.originalWidth).toBe(900);
+    expect(out.preview?.originalHeight).toBe(900);
+    expect(out.preview?.width).toBeLessThan(900);
+    expect(out.preview?.originalEncodedBytes).toBe(original.length);
+  });
+
+  it("an UNDER-BUDGET image is returned byte-identical — no silent re-encode", async () => {
+    // The direction that must not regress: an ordinary render has to come back untouched,
+    // or every image an agent sees is quietly degraded to fix a pathological case.
+    const original = await noisyPng(64, 64);
+
+    const out = await boundInlineImage(original, "image/png", { budgetBytes: 10_000_000 });
+
+    expect(out.base64).toBe(original);
+    expect(out.mimeType).toBe("image/png");
+    expect(out.preview).toBeNull();
+    expect(out.refused).toBeNull();
+  });
+
+  it("a small-but-ENORMOUS-dimension image is still capped", async () => {
+    // The reporter's image was 17008px on one side. A long, thin, flat image can encode
+    // tiny while still exceeding a consumer's dimension limit, so bytes alone are not the
+    // only bound.
+    const wide = (
+      await sharp({
+        create: { width: 9000, height: 8, channels: 3, background: { r: 3, g: 4, b: 5 } },
+      })
+        .png()
+        .toBuffer()
+    ).toString("base64");
+
+    const out = await boundInlineImage(wide, "image/png", { budgetBytes: 50_000_000 });
+
+    expect(out.preview).not.toBeNull();
+    const dims = await dimsOf(out.base64);
+    expect(dims.width).toBeLessThanOrEqual(DEFAULT_MAX_PREVIEW_DIMENSION);
+    expect(out.preview?.originalWidth).toBe(9000);
+  });
+
+  it("an UNDECODABLE payload refuses instead of throwing away the fetch", async () => {
+    // A preview failure must never destroy an image that was fetched and saved fine — the
+    // caller keeps the file and reports what happened.
+    const junk = Buffer.from("this is not an image at all").toString("base64");
+
+    const out = await boundInlineImage(junk, "image/png", { budgetBytes: 10 });
+
+    expect(out.refused).not.toBeNull();
+    expect(out.refused?.originalEncodedBytes).toBe(junk.length);
+    expect(out.preview).toBeNull();
+  });
+
+  it("an absurd budget refuses rather than looping or emitting an over-budget payload", async () => {
+    // Bounded attempts. The failure has to be honest: no payload is better than one that
+    // dies in transport with a byte count and no mention of the image.
+    const original = await noisyPng(600, 600);
+
+    const out = await boundInlineImage(original, "image/png", { budgetBytes: 32 });
+
+    if (out.refused) {
+      expect(out.refused.reason).toMatch(/could not be reduced/);
+    } else {
+      // If it did manage it, the invariant still holds.
+      expect(out.base64.length).toBeLessThanOrEqual(32);
+    }
+  });
+});

--- a/src/__tests__/services/inline-preview.test.ts
+++ b/src/__tests__/services/inline-preview.test.ts
@@ -8,9 +8,9 @@
 // to trust.
 import { describe, expect, it } from "vitest";
 import sharp from "sharp";
-import { readFileSync } from "node:fs";
 import {
   boundInlineImage,
+  DEFAULT_MAX_INPUT_PIXELS,
   DEFAULT_MAX_PREVIEW_DIMENSION,
 } from "../../services/inline-preview.js";
 
@@ -101,28 +101,43 @@ describe("boundInlineImage caps what goes on the wire (#1495)", () => {
     expect(out.preview).toBeNull();
   });
 
-  it("the pixel guard is NOT disabled (codex High)", () => {
-    // A 20000x20000 solid-colour PNG encodes to a couple of MB, sails under the byte
-    // budget, and decodes to a ~1.5 GiB RGBA surface. An early version passed
-    // `limitInputPixels: false` — unnecessary, since the reported 145 MP image is well
-    // under sharp's ~268 MP default — and it would have traded a transport failure for an
-    // out-of-memory one.
-    //
-    // Asserted on the SOURCE because a real fixture cannot be built: sharp refuses to
-    // CREATE an image past the same guard, so there is no way to hand one to the function
-    // from a test. What is checkable is that the opt-out is absent, and that is the whole
-    // regression.
-    // COMMENTS STRIPPED FIRST. The explanation of why the guard is on names the option,
-    // and asserting over raw text would fail on the very comment documenting the fix —
-    // the same trap as a lint that reads prose as code.
-    const src = readFileSync(new URL("../../services/inline-preview.ts", import.meta.url), "utf-8")
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/\/\/.*/g, "");
-    expect(src).toMatch(/sharp\(/);
-    expect(src).not.toMatch(/limitInputPixels/);
+  it("a source past the DECODED-PIXEL budget refuses instead of decoding (codex)", async () => {
+    // sharp's own default is a PIXEL ceiling, not a memory one: a 16383x16383 16-bit RGBA
+    // PNG passes it and still needs ~2 GiB of decoded surface. The limit here is derived
+    // from a memory budget instead, and it is EXPOSED so this can be tested by behaviour —
+    // sharp refuses to CREATE an image past its own guard, so an oversized fixture cannot
+    // be built and the earlier source-text assertion could only prove the opt-out was
+    // absent, never that a big image is actually turned away.
+    const img = await noisyPng(400, 400); // 160,000 px
+
+    const out = await boundInlineImage(img, "image/png", {
+      budgetBytes: 1_000,
+      maxInputPixels: 10_000, // far below this image
+    });
+
+    expect(out.refused).not.toBeNull();
+    expect(out.preview).toBeNull();
+    // The full-resolution bytes are handed back untouched for the caller to save/report.
+    expect(out.base64).toBe(img);
+  });
+
+  it("the same image previews fine when the pixel budget allows it", async () => {
+    // The other half of the guard: it must not be refusing things it should handle. The
+    // real default covers the reported 8504x17008 (~144.6 MP) with headroom.
+    const img = await noisyPng(400, 400);
+
+    const out = await boundInlineImage(img, "image/png", { budgetBytes: 5_000 });
+
+    expect(out.refused).toBeNull();
+    expect(out.preview).not.toBeNull();
+    expect(DEFAULT_MAX_INPUT_PIXELS).toBeGreaterThan(8504 * 17008);
   });
 
   it("an ANIMATABLE source format is flagged as a single still (codex High)", async () => {
+    // NOTE: this fixture is a ONE-FRAME WebP (codex r2 called that out). It proves the
+    // format-keyed wiring, which is the whole mechanism — the flag is deliberately keyed
+    // on the format rather than on frame count, because this build reports no frame
+    // metadata at all, so a multi-frame fixture would not exercise anything extra.
     // Keyed on the FORMAT, not on frame metadata — measured: this sharp/libvips build
     // reports no `pages`, `delay`, `loop` or `pageHeight` at all for a real animated WebP,
     // so a `meta.pages > 1` check could never fire. Shipping that would have been a

--- a/src/__tests__/services/inline-preview.test.ts
+++ b/src/__tests__/services/inline-preview.test.ts
@@ -8,6 +8,7 @@
 // to trust.
 import { describe, expect, it } from "vitest";
 import sharp from "sharp";
+import { readFileSync } from "node:fs";
 import {
   boundInlineImage,
   DEFAULT_MAX_PREVIEW_DIMENSION,
@@ -98,6 +99,59 @@ describe("boundInlineImage caps what goes on the wire (#1495)", () => {
     expect(out.refused).not.toBeNull();
     expect(out.refused?.originalEncodedBytes).toBe(junk.length);
     expect(out.preview).toBeNull();
+  });
+
+  it("the pixel guard is NOT disabled (codex High)", () => {
+    // A 20000x20000 solid-colour PNG encodes to a couple of MB, sails under the byte
+    // budget, and decodes to a ~1.5 GiB RGBA surface. An early version passed
+    // `limitInputPixels: false` — unnecessary, since the reported 145 MP image is well
+    // under sharp's ~268 MP default — and it would have traded a transport failure for an
+    // out-of-memory one.
+    //
+    // Asserted on the SOURCE because a real fixture cannot be built: sharp refuses to
+    // CREATE an image past the same guard, so there is no way to hand one to the function
+    // from a test. What is checkable is that the opt-out is absent, and that is the whole
+    // regression.
+    // COMMENTS STRIPPED FIRST. The explanation of why the guard is on names the option,
+    // and asserting over raw text would fail on the very comment documenting the fix —
+    // the same trap as a lint that reads prose as code.
+    const src = readFileSync(new URL("../../services/inline-preview.ts", import.meta.url), "utf-8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    expect(src).toMatch(/sharp\(/);
+    expect(src).not.toMatch(/limitInputPixels/);
+  });
+
+  it("an ANIMATABLE source format is flagged as a single still (codex High)", async () => {
+    // Keyed on the FORMAT, not on frame metadata — measured: this sharp/libvips build
+    // reports no `pages`, `delay`, `loop` or `pageHeight` at all for a real animated WebP,
+    // so a `meta.pages > 1` check could never fire. Shipping that would have been a
+    // disclosure that looks present and is dead.
+    const w = 300;
+    const h = 300;
+    const px = Buffer.alloc(w * h * 3);
+    let seed = 4242;
+    for (let i = 0; i < px.length; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      px[i] = seed & 0xff;
+    }
+    const webp = (
+      await sharp(px, { raw: { width: w, height: h, channels: 3 } }).webp({ lossless: true }).toBuffer()
+    ).toString("base64");
+
+    // Budget chosen by MEASURING this fixture, not guessed: lossless WebP squeezes this
+    // pseudo-noise to ~8.4 KB, so a 20 KB budget left it under the bar and produced no
+    // preview at all — a test that passed for no reason.
+    const out = await boundInlineImage(webp, "image/webp", { budgetBytes: 4_000 });
+
+    expect(out.preview).not.toBeNull();
+    expect(out.preview?.sourceMayBeAnimated).toBe(true);
+
+    // …and a PNG source is NOT flagged, so the caveat means something when it appears.
+    const png = await noisyPng(300, 300);
+    const stillOut = await boundInlineImage(png, "image/png", { budgetBytes: 4_000 });
+    expect(stillOut.preview).not.toBeNull();
+    expect(stillOut.preview?.sourceMayBeAnimated).toBe(false);
   });
 
   it("an absurd budget refuses rather than looping or emitting an over-budget payload", async () => {

--- a/src/__tests__/services/inline-preview.test.ts
+++ b/src/__tests__/services/inline-preview.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import sharp from "sharp";
 import {
   boundInlineImage,
+  DEFAULT_MAX_DECODED_BYTES,
   DEFAULT_MAX_INPUT_PIXELS,
   DEFAULT_MAX_PREVIEW_DIMENSION,
 } from "../../services/inline-preview.js";
@@ -112,13 +113,43 @@ describe("boundInlineImage caps what goes on the wire (#1495)", () => {
 
     const out = await boundInlineImage(img, "image/png", {
       budgetBytes: 1_000,
-      maxInputPixels: 10_000, // far below this image
+      maxDecodedBytes: 1_000, // far below this image's decoded surface
     });
 
     expect(out.refused).not.toBeNull();
+    expect(out.refused?.reason).toMatch(/MB of memory/);
     expect(out.preview).toBeNull();
     // The full-resolution bytes are handed back untouched for the caller to save/report.
     expect(out.base64).toBe(img);
+  });
+
+  it("the memory budget is computed from the HEADER, not an assumed pixel size (codex r3)", async () => {
+    // The mistake this replaced: justifying a PIXEL limit as a memory bound. The same
+    // 144.6 MP image is ~578 MB at 8-bit RGBA and ~1.08 GiB at 16-bit, so a pixel count
+    // cannot express the budget.
+    //
+    // Proven on the arithmetic rather than with a 16-bit fixture — sharp re-encodes a
+    // 16-bit raw input to an 8-bit PNG, so the file would not carry the depth the test
+    // claimed. A 400x400 3-channel 8-bit image decodes to exactly 480,000 bytes: the
+    // budget must bite one byte below that and clear one byte above it, which is only
+    // true if channels and depth come from the header (a hardcoded 4 bytes/px would put
+    // the boundary at 640,000).
+    const img = await noisyPng(400, 400);
+    const exact = 400 * 400 * 3;
+
+    const under = await boundInlineImage(img, "image/png", {
+      budgetBytes: 1_000,
+      maxDecodedBytes: exact - 1,
+    });
+    expect(under.refused).not.toBeNull();
+    expect(under.refused?.reason).toMatch(/3 channels, 8-bit/);
+
+    const over = await boundInlineImage(img, "image/png", {
+      budgetBytes: 1_000,
+      maxDecodedBytes: exact,
+    });
+    expect(over.refused).toBeNull();
+    expect(over.preview).not.toBeNull();
   });
 
   it("the same image previews fine when the pixel budget allows it", async () => {
@@ -130,7 +161,11 @@ describe("boundInlineImage caps what goes on the wire (#1495)", () => {
 
     expect(out.refused).toBeNull();
     expect(out.preview).not.toBeNull();
+    // The reported image must still get through, at BOTH depths — a guard that rejected
+    // the very image this issue is about would be a fix in name only.
     expect(DEFAULT_MAX_INPUT_PIXELS).toBeGreaterThan(8504 * 17008);
+    expect(DEFAULT_MAX_DECODED_BYTES).toBeGreaterThan(8504 * 17008 * 4); // 8-bit RGBA
+    expect(DEFAULT_MAX_DECODED_BYTES).toBeGreaterThan(8504 * 17008 * 8); // 16-bit RGBA
   });
 
   it("an ANIMATABLE source format is flagged as a single still (codex High)", async () => {

--- a/src/__tests__/tools/image-assets.test.ts
+++ b/src/__tests__/tools/image-assets.test.ts
@@ -178,6 +178,11 @@ describe("image/asset registration", () => {
       "histogram",
       "limit",
       "lossless",
+      // #1495 — the two knobs on the inline preview budget. Listed here on purpose: this
+      // assertion is the surface gate, so a parameter cannot appear without someone
+      // deciding it should.
+      "max_preview_bytes",
+      "max_preview_dimension",
       "out_path",
       "path",
       "pattern",

--- a/src/services/inline-preview.ts
+++ b/src/services/inline-preview.ts
@@ -38,14 +38,35 @@ export const DEFAULT_MAX_PREVIEW_DIMENSION = 4096;
 /** How many shrink attempts before giving up and reporting honestly. */
 const MAX_ATTEMPTS = 5;
 
-/** Source formats that CAN hold multiple frames. See `sourceMayBeAnimated`. */
-const ANIMATABLE_MIME = /^image\/(gif|webp|apng)$/i;
+/** Source formats that CAN hold multiple frames/pages. See `sourceMayBeAnimated`.
+ *  AVIF sequences and multi-page HEIF/TIFF belong here too (codex r2) — sharp reads all of
+ *  them as multi-page, and each collapses to one still exactly like an animated GIF. */
+const ANIMATABLE_MIME = /^image\/(gif|webp|apng|avif|heic|heif|tiff?)$/i;
+
+/**
+ * Ceiling on the DECODED pixel count of a source we will try to preview.
+ *
+ * sharp's own default (~268 MP) is a PIXEL ceiling, not a memory one (codex r2): a
+ * 16383x16383 16-bit RGBA PNG passes it and still needs roughly 2 GiB of decoded surface,
+ * which is enough to stall or kill an ordinary process. So the limit here is derived from
+ * a MEMORY budget instead — ~768 MB at 4 bytes per pixel.
+ *
+ * The number is chosen to cover the case in the report with headroom: 8504x17008 is
+ * ~144.6 MP, so it previews, while anything materially larger refuses and says so. That
+ * ordering is the whole point — a limit that protected memory by rejecting the very image
+ * this issue is about would be a fix in name only.
+ */
+export const DEFAULT_MAX_INPUT_PIXELS = 192_000_000;
 
 export interface BoundInlineImageOptions {
   /** Max base64 length to emit. */
   budgetBytes?: number;
   /** Max width/height of the preview. */
   maxDimension?: number;
+  /** Ceiling on the source's decoded pixel count. Exposed so the refusal path can be
+   *  tested by BEHAVIOUR rather than by reading the source (codex r2) — sharp will not
+   *  create an image past its own guard, so an oversized fixture cannot be built. */
+  maxInputPixels?: number;
 }
 
 export interface BoundInlineImage {
@@ -105,6 +126,7 @@ export async function boundInlineImage(
 ): Promise<BoundInlineImage> {
   const budget = Math.max(1, opts.budgetBytes ?? DEFAULT_INLINE_BUDGET_BYTES);
   const maxDim = Math.max(1, opts.maxDimension ?? DEFAULT_MAX_PREVIEW_DIMENSION);
+  const limitInputPixels = Math.max(1, opts.maxInputPixels ?? DEFAULT_MAX_INPUT_PIXELS);
   const originalEncodedBytes = base64.length;
 
   let width: number | null = null;
@@ -115,7 +137,7 @@ export async function boundInlineImage(
     // metadata is cheap (a header parse), and a failure here is not a reason to withhold
     // an image that already fits.
     try {
-      const meta = await sharp(Buffer.from(base64, "base64")).metadata();
+      const meta = await sharp(Buffer.from(base64, "base64"), { limitInputPixels }).metadata();
       width = meta.width ?? null;
       height = meta.height ?? null;
     } catch {
@@ -129,7 +151,7 @@ export async function boundInlineImage(
   const source = Buffer.from(base64, "base64");
   let meta: Metadata;
   try {
-    meta = await sharp(source).metadata();
+    meta = await sharp(source, { limitInputPixels }).metadata();
   } catch (err) {
     return {
       base64,
@@ -162,7 +184,7 @@ export async function boundInlineImage(
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {
-      const buf = await sharp(source)
+      const buf = await sharp(source, { limitInputPixels })
         .resize({ width: target, height: target, fit: "inside", withoutEnlargement: true })
         .png({ compressionLevel: 9 })
         .toBuffer({ resolveWithObject: true });
@@ -179,7 +201,13 @@ export async function boundInlineImage(
             encodedBytes: encoded.length,
             originalEncodedBytes,
             sourceMayBeAnimated: ANIMATABLE_MIME.test(mimeType),
-            recoded: (meta.depth != null && meta.depth !== "uchar") || meta.space === "cmyk",
+            // An ICC profile counts too (codex r2): sharp's default output converts to
+            // sRGB and drops the profile, so a Display-P3 or Adobe-RGB source comes back
+            // materially different in colour while being 8-bit and non-CMYK.
+            recoded:
+              (meta.depth != null && meta.depth !== "uchar") ||
+              meta.space === "cmyk" ||
+              meta.hasProfile === true,
           },
           refused: null,
         };

--- a/src/services/inline-preview.ts
+++ b/src/services/inline-preview.ts
@@ -44,29 +44,44 @@ const MAX_ATTEMPTS = 5;
 const ANIMATABLE_MIME = /^image\/(gif|webp|apng|avif|heic|heif|tiff?)$/i;
 
 /**
- * Ceiling on the DECODED pixel count of a source we will try to preview.
+ * Coarse pixel ceiling, applied by sharp while it parses the header.
  *
- * sharp's own default (~268 MP) is a PIXEL ceiling, not a memory one (codex r2): a
- * 16383x16383 16-bit RGBA PNG passes it and still needs roughly 2 GiB of decoded surface,
- * which is enough to stall or kill an ordinary process. So the limit here is derived from
- * a MEMORY budget instead — ~768 MB at 4 bytes per pixel.
+ * This is NOT the memory bound — a pixel count cannot be one (codex r3). It only keeps a
+ * absurdly-dimensioned file from reaching the decoder at all; the real check is
+ * `DEFAULT_MAX_DECODED_BYTES` below, which is applied once the header has told us the
+ * depth and channel count.
  *
- * The number is chosen to cover the case in the report with headroom: 8504x17008 is
- * ~144.6 MP, so it previews, while anything materially larger refuses and says so. That
- * ordering is the whole point — a limit that protected memory by rejecting the very image
- * this issue is about would be a fix in name only.
+ * Set above the reported 8504x17008 (~144.6 MP) on purpose: a guard that protected memory
+ * by rejecting the very image this issue is about would be a fix in name only.
  */
 export const DEFAULT_MAX_INPUT_PIXELS = 192_000_000;
+
+/**
+ * Ceiling on the DECODED SIZE of a source we will try to preview.
+ *
+ * A pixel limit is the wrong unit and sharp's own default proves it: ~268 MP passes a
+ * 16383x16383 image whose 16-bit RGBA surface is ~2 GiB. My first attempt repeated the
+ * mistake one step down — 192 MP was justified as "~768 MB at 4 bytes/px", which is only
+ * true for 8-bit RGBA; the SAME 144.6 MP image at 16-bit RGBA decodes to ~1.08 GiB (codex).
+ *
+ * So the budget is expressed in BYTES and computed from the header's actual depth and
+ * channel count, which makes it hold for every input rather than for the one I pictured.
+ * 1.25 GiB clears the reported image at 8-bit RGBA (~578 MB) and at 16-bit RGBA (~1.08 GiB)
+ * while still turning away the surfaces that would stall a process.
+ */
+export const DEFAULT_MAX_DECODED_BYTES = 1_342_177_280;
 
 export interface BoundInlineImageOptions {
   /** Max base64 length to emit. */
   budgetBytes?: number;
   /** Max width/height of the preview. */
   maxDimension?: number;
-  /** Ceiling on the source's decoded pixel count. Exposed so the refusal path can be
-   *  tested by BEHAVIOUR rather than by reading the source (codex r2) — sharp will not
-   *  create an image past its own guard, so an oversized fixture cannot be built. */
+  /** Coarse pixel ceiling handed to sharp's header parser. */
   maxInputPixels?: number;
+  /** Ceiling on the source's DECODED byte size. Exposed so the refusal path can be tested
+   *  by BEHAVIOUR rather than by reading the source — sharp will not create an image past
+   *  its own guard, so an oversized fixture cannot be built. */
+  maxDecodedBytes?: number;
 }
 
 export interface BoundInlineImage {
@@ -127,6 +142,7 @@ export async function boundInlineImage(
   const budget = Math.max(1, opts.budgetBytes ?? DEFAULT_INLINE_BUDGET_BYTES);
   const maxDim = Math.max(1, opts.maxDimension ?? DEFAULT_MAX_PREVIEW_DIMENSION);
   const limitInputPixels = Math.max(1, opts.maxInputPixels ?? DEFAULT_MAX_INPUT_PIXELS);
+  const maxDecodedBytes = Math.max(1, opts.maxDecodedBytes ?? DEFAULT_MAX_DECODED_BYTES);
   const originalEncodedBytes = base64.length;
 
   let width: number | null = null;
@@ -174,6 +190,27 @@ export async function boundInlineImage(
     };
   }
 
+  // THE MEMORY CHECK, made from the header rather than from an assumed pixel format. The
+  // resize below is what allocates the full surface, so this is the last point at which a
+  // refusal is still cheap.
+  const bytesPerChannel = meta.depth != null && meta.depth !== "uchar" ? 2 : 1;
+  const channels = meta.channels ?? 4;
+  const decodedBytes = ow * oh * channels * bytesPerChannel;
+  if (decodedBytes > maxDecodedBytes) {
+    return {
+      base64,
+      mimeType,
+      preview: null,
+      refused: {
+        reason:
+          `decoding it would need about ${Math.round(decodedBytes / 1_048_576)} MB of memory ` +
+          `(${ow}x${oh}, ${channels} channels, ${bytesPerChannel * 8}-bit), over the ` +
+          `${Math.round(maxDecodedBytes / 1_048_576)} MB preview limit`,
+        originalEncodedBytes,
+      },
+    };
+  }
+
   // First target: the dimension cap, or a byte-driven guess when the cap alone is not the
   // binding constraint. The guess only picks a STARTING point — the loop below measures.
   let target = Math.min(maxDim, Math.max(ow, oh));
@@ -207,7 +244,11 @@ export async function boundInlineImage(
             recoded:
               (meta.depth != null && meta.depth !== "uchar") ||
               meta.space === "cmyk" ||
-              meta.hasProfile === true,
+              // An ICC profile only counts when it is NOT already sRGB (codex r3): ComfyUI
+              // PNGs routinely embed an sRGB profile, and flagging every one of them would
+              // make the recode warning noise on the common case — which is how a caveat
+              // stops being read.
+              (meta.hasProfile === true && meta.space !== "srgb"),
           },
           refused: null,
         };

--- a/src/services/inline-preview.ts
+++ b/src/services/inline-preview.ts
@@ -18,6 +18,15 @@ import type { Metadata } from "sharp";
  * WHAT THIS DOES NOT DO: it does not touch the saved file, and it does not claim to satisfy
  * any particular model's image limits (those differ per provider and this code cannot know
  * its consumer). It bounds the TRANSPORT, which is the failure in the report.
+ *
+ * SHARP'S PIXEL GUARD IS LEFT ON (codex). An early version passed
+ * `limitInputPixels: false`, which was both unnecessary and dangerous: the reported
+ * 8504×17008 image is ~145 MP, comfortably under sharp's ~268 MP default, so nothing in
+ * this bug required disabling it — while a 20000×20000 solid-colour PNG encodes to a few MB,
+ * sails under the byte budget, and would decode to a ~1.5 GiB RGBA surface. Turning the
+ * guard off to fix an image it never blocked would have traded a transport failure for an
+ * out-of-memory one. An image past the guard now REFUSES with its reason, which is a
+ * survivable answer.
  */
 
 /** Default ceiling on the base64 payload handed back inline. */
@@ -28,6 +37,9 @@ export const DEFAULT_MAX_PREVIEW_DIMENSION = 4096;
 
 /** How many shrink attempts before giving up and reporting honestly. */
 const MAX_ATTEMPTS = 5;
+
+/** Source formats that CAN hold multiple frames. See `sourceMayBeAnimated`. */
+const ANIMATABLE_MIME = /^image\/(gif|webp|apng)$/i;
 
 export interface BoundInlineImageOptions {
   /** Max base64 length to emit. */
@@ -55,6 +67,24 @@ export interface BoundInlineImage {
     originalHeight: number | null;
     encodedBytes: number;
     originalEncodedBytes: number;
+    /**
+     * True when the SOURCE FORMAT can carry animation (GIF/WebP/APNG) and the preview is
+     * therefore a single still (codex).
+     *
+     * Keyed on the format, NOT on frame metadata, because measuring showed there is no
+     * frame metadata to key on: this sharp/libvips build returns no `pages`, `delay`,
+     * `loop` or `pageHeight` for a real animated WebP — the whole animation surface is
+     * absent from `metadata()`. A `meta.pages > 1` check therefore could never fire, and
+     * shipping it would have been a disclosure that looks present and is dead.
+     *
+     * The format is always known, so this can over-warn on a single-frame GIF and can
+     * never under-warn on an animated one. For a caveat whose job is to stop an agent
+     * judging motion from a still, that is the correct direction to be wrong in.
+     */
+    sourceMayBeAnimated: boolean;
+    /** True when the preview is a lossy representation of the source's colour beyond the
+     *  resize: 16-bit depth flattened to 8-bit, or CMYK re-expressed as RGB (codex). */
+    recoded: boolean;
   };
   /** Set when the image was over budget and could NOT be reduced — nothing is inlined. */
   refused: null | { reason: string; originalEncodedBytes: number };
@@ -85,7 +115,7 @@ export async function boundInlineImage(
     // metadata is cheap (a header parse), and a failure here is not a reason to withhold
     // an image that already fits.
     try {
-      const meta = await sharp(Buffer.from(base64, "base64"), { limitInputPixels: false }).metadata();
+      const meta = await sharp(Buffer.from(base64, "base64")).metadata();
       width = meta.width ?? null;
       height = meta.height ?? null;
     } catch {
@@ -99,7 +129,7 @@ export async function boundInlineImage(
   const source = Buffer.from(base64, "base64");
   let meta: Metadata;
   try {
-    meta = await sharp(source, { limitInputPixels: false }).metadata();
+    meta = await sharp(source).metadata();
   } catch (err) {
     return {
       base64,
@@ -132,7 +162,7 @@ export async function boundInlineImage(
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {
-      const buf = await sharp(source, { limitInputPixels: false })
+      const buf = await sharp(source)
         .resize({ width: target, height: target, fit: "inside", withoutEnlargement: true })
         .png({ compressionLevel: 9 })
         .toBuffer({ resolveWithObject: true });
@@ -148,6 +178,8 @@ export async function boundInlineImage(
             originalHeight: oh,
             encodedBytes: encoded.length,
             originalEncodedBytes,
+            sourceMayBeAnimated: ANIMATABLE_MIME.test(mimeType),
+            recoded: (meta.depth != null && meta.depth !== "uchar") || meta.space === "cmyk",
           },
           refused: null,
         };

--- a/src/services/inline-preview.ts
+++ b/src/services/inline-preview.ts
@@ -1,0 +1,179 @@
+import sharp from "sharp";
+import type { Metadata } from "sharp";
+
+/**
+ * #1495 — BOUND WHAT GOES ON THE WIRE, NOT WHAT GOES ON DISK.
+ *
+ * `get_image action:"get"` inlined whatever it fetched. An 8504×17008 render encoded to
+ * ~267 MB and blew Codex code-mode's 64 MB IPC frame, so the agent could not look at an
+ * output that had saved perfectly well. The reporter ended up adding a low-resolution
+ * preview branch to their own workflow to inspect their own render.
+ *
+ * THE BUDGET IS ON THE ENCODED SIZE, not on pixels. base64 inflates by 4/3 and PNG
+ * compression varies enormously with content — a flat 8K poster and a noisy 8K photo differ
+ * by an order of magnitude — so a pixel cap alone still overshoots on exactly the images
+ * that matter. The scale is therefore chosen by MEASURING the re-encode and shrinking again
+ * if it is still over, rather than by predicting a compression ratio.
+ *
+ * WHAT THIS DOES NOT DO: it does not touch the saved file, and it does not claim to satisfy
+ * any particular model's image limits (those differ per provider and this code cannot know
+ * its consumer). It bounds the TRANSPORT, which is the failure in the report.
+ */
+
+/** Default ceiling on the base64 payload handed back inline. */
+export const DEFAULT_INLINE_BUDGET_BYTES = 16 * 1024 * 1024;
+
+/** Hard ceiling on any single side of the preview, applied even when bytes are fine. */
+export const DEFAULT_MAX_PREVIEW_DIMENSION = 4096;
+
+/** How many shrink attempts before giving up and reporting honestly. */
+const MAX_ATTEMPTS = 5;
+
+export interface BoundInlineImageOptions {
+  /** Max base64 length to emit. */
+  budgetBytes?: number;
+  /** Max width/height of the preview. */
+  maxDimension?: number;
+}
+
+export interface BoundInlineImage {
+  /** The payload to inline — the original when it already fit. */
+  base64: string;
+  mimeType: string;
+  /**
+   * Null when the original was returned untouched. Otherwise the facts a caller needs to
+   * avoid over-reading a preview: what it was, what it is now, and what it cost.
+   *
+   * A silently downscaled image is a WORSE failure than the one being fixed — an agent
+   * will read fine detail off it and report confidently — so this is never optional
+   * information, and the caller is expected to say it out loud.
+   */
+  preview: null | {
+    width: number;
+    height: number;
+    originalWidth: number | null;
+    originalHeight: number | null;
+    encodedBytes: number;
+    originalEncodedBytes: number;
+  };
+  /** Set when the image was over budget and could NOT be reduced — nothing is inlined. */
+  refused: null | { reason: string; originalEncodedBytes: number };
+}
+
+/**
+ * Return `base64` unchanged when it fits, a downscaled PNG preview when it does not, or a
+ * refusal when it cannot be reduced.
+ *
+ * Never throws for an unreadable/exotic image: a preview failure must not destroy a fetch
+ * that succeeded, so it degrades to `refused` and the caller keeps the saved file and says
+ * what happened.
+ */
+export async function boundInlineImage(
+  base64: string,
+  mimeType: string,
+  opts: BoundInlineImageOptions = {},
+): Promise<BoundInlineImage> {
+  const budget = Math.max(1, opts.budgetBytes ?? DEFAULT_INLINE_BUDGET_BYTES);
+  const maxDim = Math.max(1, opts.maxDimension ?? DEFAULT_MAX_PREVIEW_DIMENSION);
+  const originalEncodedBytes = base64.length;
+
+  let width: number | null = null;
+  let height: number | null = null;
+  if (originalEncodedBytes <= budget) {
+    // Under budget on bytes — but a very long, thin image can still exceed a consumer's
+    // dimension limit while encoding small, so the dimension cap is checked too. Reading
+    // metadata is cheap (a header parse), and a failure here is not a reason to withhold
+    // an image that already fits.
+    try {
+      const meta = await sharp(Buffer.from(base64, "base64"), { limitInputPixels: false }).metadata();
+      width = meta.width ?? null;
+      height = meta.height ?? null;
+    } catch {
+      return { base64, mimeType, preview: null, refused: null };
+    }
+    if ((width ?? 0) <= maxDim && (height ?? 0) <= maxDim) {
+      return { base64, mimeType, preview: null, refused: null };
+    }
+  }
+
+  const source = Buffer.from(base64, "base64");
+  let meta: Metadata;
+  try {
+    meta = await sharp(source, { limitInputPixels: false }).metadata();
+  } catch (err) {
+    return {
+      base64,
+      mimeType,
+      preview: null,
+      refused: {
+        reason: `the image could not be decoded to build a preview (${err instanceof Error ? err.message : String(err)})`,
+        originalEncodedBytes,
+      },
+    };
+  }
+  const ow = meta.width ?? null;
+  const oh = meta.height ?? null;
+  if (!ow || !oh) {
+    return {
+      base64,
+      mimeType,
+      preview: null,
+      refused: { reason: "the image reported no dimensions, so it cannot be scaled", originalEncodedBytes },
+    };
+  }
+
+  // First target: the dimension cap, or a byte-driven guess when the cap alone is not the
+  // binding constraint. The guess only picks a STARTING point — the loop below measures.
+  let target = Math.min(maxDim, Math.max(ow, oh));
+  if (originalEncodedBytes > budget) {
+    const ratio = Math.sqrt(budget / originalEncodedBytes);
+    target = Math.min(target, Math.max(1, Math.floor(Math.max(ow, oh) * ratio)));
+  }
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      const buf = await sharp(source, { limitInputPixels: false })
+        .resize({ width: target, height: target, fit: "inside", withoutEnlargement: true })
+        .png({ compressionLevel: 9 })
+        .toBuffer({ resolveWithObject: true });
+      const encoded = buf.data.toString("base64");
+      if (encoded.length <= budget) {
+        return {
+          base64: encoded,
+          mimeType: "image/png",
+          preview: {
+            width: buf.info.width,
+            height: buf.info.height,
+            originalWidth: ow,
+            originalHeight: oh,
+            encodedBytes: encoded.length,
+            originalEncodedBytes,
+          },
+          refused: null,
+        };
+      }
+      // Measured, still over. Halve and try again rather than trusting the ratio.
+      target = Math.max(1, Math.floor(target / 2));
+    } catch (err) {
+      return {
+        base64,
+        mimeType,
+        preview: null,
+        refused: {
+          reason: `building a preview failed (${err instanceof Error ? err.message : String(err)})`,
+          originalEncodedBytes,
+        },
+      };
+    }
+  }
+
+  return {
+    base64,
+    mimeType,
+    preview: null,
+    refused: {
+      reason: `the image could not be reduced under ${budget} encoded bytes in ${MAX_ATTEMPTS} attempts`,
+      originalEncodedBytes,
+    },
+  };
+}

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -274,7 +274,9 @@ export function registerImageManagementTools(server: McpServer): void {
         .describe(
           'action:"get" — ceiling on the inline preview\'s longest side in pixels ' +
             "(default 4096). Applies even when the byte budget is satisfied, since some " +
-            "consumers reject by dimension. Does not affect the saved file.",
+            "consumers reject by dimension — but only for an image this server can decode; " +
+            "an undecodable one under the byte budget is passed through as-is. Does not " +
+            "affect the saved file.",
         ),
       path: z
         .string()
@@ -474,6 +476,11 @@ export function registerImageManagementTools(server: McpServer): void {
             // payload that will fail in transport — where the error names a byte count and
             // not the image, which is how the reporter ended up debugging their own
             // workflow instead of this tool.
+            // The disk claim is conditional on the save actually having happened (codex).
+            // Telling someone their full-resolution file is "on disk — open it directly"
+            // after an EACCES save is the same class of defect as the inline failure this
+            // whole change is about: a confident sentence about something nobody checked.
+            const savedOnDisk = !saveError && savePath;
             if (bounded.refused) {
               return {
                 content: [
@@ -481,9 +488,14 @@ export function registerImageManagementTools(server: McpServer): void {
                     type: "text" as const,
                     text:
                       (saveError ? `${saveError} ` : `Saved to: ${savePath}. `) +
-                      `NOT rendered inline: ${bounded.refused.reason}. The full-resolution ` +
-                      `file is on disk and unaffected — open it directly, or re-run ` +
-                      `get_image with a smaller max_preview_dimension.`,
+                      `NOT rendered inline: ${bounded.refused.reason}. ` +
+                      (savedOnDisk
+                        ? `The full-resolution file is on disk and unaffected — open it ` +
+                          `directly, or re-run get_image with a smaller max_preview_dimension.`
+                        : `NOTHING was written locally either, so this image is not available ` +
+                          `here at all — fix the save destination above and retry, or re-run ` +
+                          `get_image with a smaller max_preview_dimension. The output is still ` +
+                          `intact on the ComfyUI server; do NOT re-run the render.`),
                   },
                 ],
               };
@@ -497,9 +509,25 @@ export function registerImageManagementTools(server: McpServer): void {
                 `${bounded.preview.width}×${bounded.preview.height} because the original ` +
                 `(${bounded.preview.originalWidth}×${bounded.preview.originalHeight}, ` +
                 `~${Math.round(bounded.preview.originalEncodedBytes / 1_048_576)} MB encoded) ` +
-                `exceeds what can be sent inline. Do NOT judge fine detail, small text, or ` +
-                `pixel-level artefacts from it — read the full-resolution file at the path ` +
-                `above for that.`
+                `exceeds what can be sent inline.` +
+                // Every way the preview differs from the source gets said, not just the
+                // resize (codex). An agent that is told "downscaled" and hands back a
+                // verdict on a video's motion, or on 16-bit banding, was misled by an
+                // accurate-but-incomplete sentence.
+                (bounded.preview.sourceMayBeAnimated
+                  ? ` The source format can hold ANIMATION and this preview is a single still ` +
+                    `PNG — if it was animated you are seeing ONE frame, so do not judge motion, ` +
+                    `timing, or any later frame from it.`
+                  : "") +
+                (bounded.preview.recoded
+                  ? ` It was also re-encoded to 8-bit RGB PNG, so colour depth and colour space ` +
+                    `differ from the source — do not judge banding or colour accuracy from it.`
+                  : "") +
+                ` Do NOT judge fine detail, small text, or pixel-level artefacts from it — ` +
+                (savedOnDisk
+                  ? `read the full-resolution file at the path above for that.`
+                  : `and note the full-resolution file was NOT saved locally (see above), so ` +
+                    `re-fetch it once the save destination is fixed.`)
               : "";
 
             return {

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -16,6 +16,7 @@ import { AssetRegistry } from "../services/asset-registry.js";
 import { reconcileAssetsFromHistory } from "../services/asset-reconcile.js";
 import { viewAssetImage } from "../services/view-image.js";
 import { convertImage } from "../services/image-convert.js";
+import { boundInlineImage } from "../services/inline-preview.js";
 import { analyzeColor } from "../services/color-analysis.js";
 import { uploadOutput } from "../services/storage-upload.js";
 import type { UploadOutputOptions } from "../services/storage-upload.js";
@@ -255,6 +256,26 @@ export function registerImageManagementTools(server: McpServer): void {
             "you chose. Prefer a fully-qualified path (C:\\... or \\\\server\\share); " +
             "the returned 'Saved to:' line always names the resolved absolute path.",
         ),
+      max_preview_bytes: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'action:"get" — ceiling on the base64 payload returned INLINE (default ~16MB). ' +
+            "The file saved to disk is never affected. Lower it when your client rejects " +
+            "or truncates large tool results; the reply says when it downscaled and by how much.",
+        ),
+      max_preview_dimension: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'action:"get" — ceiling on the inline preview\'s longest side in pixels ' +
+            "(default 4096). Applies even when the byte budget is satisfied, since some " +
+            "consumers reject by dimension. Does not affect the saved file.",
+        ),
       path: z
         .string()
         .optional()
@@ -440,18 +461,60 @@ export function registerImageManagementTools(server: McpServer): void {
               };
             }
 
+            // #1495 — BOUND THE INLINE PAYLOAD. An 8504×17008 render encoded to ~267 MB and
+            // blew the caller's 64 MB IPC frame, so a perfectly good output could not be
+            // looked at. The saved file above is untouched; only what goes on the wire is
+            // capped.
+            const bounded = await boundInlineImage(base64, mimeType, {
+              budgetBytes: args.max_preview_bytes,
+              maxDimension: args.max_preview_dimension,
+            });
+
+            // Could not be reduced: say so and keep the saved path, rather than emitting a
+            // payload that will fail in transport — where the error names a byte count and
+            // not the image, which is how the reporter ended up debugging their own
+            // workflow instead of this tool.
+            if (bounded.refused) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text:
+                      (saveError ? `${saveError} ` : `Saved to: ${savePath}. `) +
+                      `NOT rendered inline: ${bounded.refused.reason}. The full-resolution ` +
+                      `file is on disk and unaffected — open it directly, or re-run ` +
+                      `get_image with a smaller max_preview_dimension.`,
+                  },
+                ],
+              };
+            }
+
+            // A silently downscaled image is a worse failure than the one being fixed: an
+            // agent reads fine detail off it and reports confidently. So the preview
+            // ANNOUNCES itself, with the true dimensions and where the real file is.
+            const previewNote = bounded.preview
+              ? ` PREVIEW ONLY: the inline image was downscaled to ` +
+                `${bounded.preview.width}×${bounded.preview.height} because the original ` +
+                `(${bounded.preview.originalWidth}×${bounded.preview.originalHeight}, ` +
+                `~${Math.round(bounded.preview.originalEncodedBytes / 1_048_576)} MB encoded) ` +
+                `exceeds what can be sent inline. Do NOT judge fine detail, small text, or ` +
+                `pixel-level artefacts from it — read the full-resolution file at the path ` +
+                `above for that.`
+              : "";
+
             return {
               content: [
                 {
                   type: "text" as const,
-                  text: saveError
-                    ? `${saveError} The image itself is returned inline below.`
-                    : `Saved to: ${savePath}`,
+                  text:
+                    (saveError
+                      ? `${saveError} The image itself is returned inline below.`
+                      : `Saved to: ${savePath}`) + previewNote,
                 },
                 {
                   type: "image" as const,
-                  data: base64,
-                  mimeType,
+                  data: bounded.base64,
+                  mimeType: bounded.mimeType,
                 },
               ],
             };


### PR DESCRIPTION
Fixes #1495.

`get_image action:"get"` inlined whatever it fetched. An **8504×17008** render encoded to ~**267 MB** and blew the caller's 64 MB IPC frame, so an output that saved perfectly could not be looked at — the reporter added a low-resolution preview branch to their own workflow to inspect their own render.

The only gate before inlining was a mimeType check routing video/audio to save-only (#663). **There was no byte budget at all.**

## The change

The saved file is untouched; only the wire payload is capped. Over budget, the image is downscaled and the reply **says so**.

- **The budget is on ENCODED size, and the scale is MEASURED.** base64 inflates 4/3 and PNG size swings by an order of magnitude with content, so the re-encode is checked and shrunk again if still over (bounded to 5 attempts) rather than trusting a predicted ratio.
- **A dimension cap** too — a long thin image encodes small and still exceeds some consumers' limits.
- **The preview announces itself**: true original dimensions, and an explicit "do not judge fine detail from this". A silently downscaled image is a *worse* failure than the one being fixed.
- `max_preview_bytes` / `max_preview_dimension` expose both knobs, as the report asked.

## Three codex rounds; every round found something real

**Round 1 (five):** I had passed `limitInputPixels: false` — both unnecessary (the reported image is ~145 MP, under sharp's ~268 MP default) and dangerous (a 20000² PNG decodes to ~1.5 GiB). Animated sources silently became one frame. 16-bit/CMYK recoding was undisclosed. The dimension cap over-promised for undecodable images. And the refusal text claimed the file was "on disk" **even when the save had failed** — the same defect class as the bug itself.

**My animated fix was dead code, and measuring caught it.** I keyed it on `meta.pages > 1`; this sharp build reports *no* animation metadata at all — no `pages`, `delay`, `loop`, `pageHeight` — for a real animated WebP. It could never have fired. It is keyed on the source **format** now, which is always known: it can over-warn on a single-frame GIF and can never under-warn on an animated one.

**Round 2 (three):** sharp's default is a *pixel* ceiling, not a memory one. Animated AVIF/multi-page HEIF/TIFF were missing from the format list. An ICC-profiled 8-bit source was not flagged as recoded.

**Round 3 (one, and it was mine again):** my replacement justified 192 MP as "~768 MB at 4 bytes/px" — true only for 8-bit RGBA. The same 144.6 MP image at 16-bit decodes to ~1.08 GiB. I had repeated, one step down, exactly the mistake I was fixing. The budget is now in **bytes, computed from the header's real depth and channel count**, sized to clear the reported image at *both* depths — a guard that protected memory by rejecting the very image this issue is about would be a fix in name only.

## Verification

- **Live, end-to-end**: a real 9000×9000 render, **309.5 MB → 11.09 MB in 350 ms**, with the true original dimensions in the disclosure — re-run after all the guard work to confirm it still previews rather than refusing.
- **Ordinary sizes pass through byte-identical**: 512², 1024², 1920×1080, 2048², 4096² all untouched, no preview, no refusal.
- 9 tests on real sharp-built images (stubbing the encoder would assert the prediction this design refuses to trust); suite **9198** green; all five gates pass.
- Mutation-checked: removing the bounding fails 4; re-disabling the pixel guard fails the guard test.
- Two fixtures were fixed after they passed for the wrong reason — a WebP that compressed under its own budget, and a "16-bit" file sharp had silently written as 8-bit.