### PR TITLE
fix(1489): coalesce a burst of run_errors instead of nesting them

### DIFF
--- a/src/__tests__/orchestrator/run-error-burst.test.ts
+++ b/src/__tests__/orchestrator/run-error-burst.test.ts
@@ -90,11 +90,11 @@ describe("a BURST of run_errors coalesces instead of nesting (#1489)", () => {
 
     // Three cleared prompts land in quick succession, as they do when a cancelled batch is
     // reconciled after a reconnect.
-    await agent.injectRunError("PROMPT_ONE could not be confirmed");
+    await agent.injectRunError("PROMPT_ONE could not be confirmed", { originTab: "tab1", mid: "m1" });
     await settle();
-    await agent.injectRunError("PROMPT_TWO could not be confirmed");
+    await agent.injectRunError("PROMPT_TWO could not be confirmed", { originTab: "tab1", mid: "m2" });
     await settle();
-    await agent.injectRunError("PROMPT_THREE could not be confirmed");
+    await agent.injectRunError("PROMPT_THREE could not be confirmed", { originTab: "tab1", mid: "m3" });
     await settle();
 
     // Drain: let each held turn finish so everything queued is actually delivered.
@@ -139,7 +139,7 @@ describe("a BURST of run_errors coalesces instead of nesting (#1489)", () => {
 
     agent.send("USER_PROMPT");
     await settle();
-    await agent.injectRunError("ONLY_PROMPT could not be confirmed");
+    await agent.injectRunError("ONLY_PROMPT could not be confirmed", { originTab: "tab1", mid: "m1" });
     await settle();
 
     // The error turn was dispatched ahead of the user's work rather than waiting for it.
@@ -150,5 +150,54 @@ describe("a BURST of run_errors coalesces instead of nesting (#1489)", () => {
     await settle();
     void running;
     await agent.stop().catch(() => {});
+  });
+
+  it("notices from DIFFERENT tabs are never merged (codex P0)", async () => {
+    // The origin `mid` pins the error-handling turn to the ERRORING workflow's tab —
+    // #884's P0, "a render error on A silently editing B". Coalescing keeps ONE mid per
+    // item, so folding tab B's notice into tab A's item would discard B's origin and aim
+    // "diagnose and fix it" at A's graph. That is the P0 reintroduced, and it is why
+    // coalescing is scoped to the origin tab rather than applied to any pending error.
+    const { backend, releaseNow } = holdingBackend();
+    // ASSERTED ON THE ORIGINS, not on the text. `onSeen` fires once per queue ITEM at
+    // dequeue, carrying that item's `mid` — and the mid is what pins the turn. Two items
+    // batching into one turn text is normal and harmless; losing a mid is the P0, because
+    // the batch's mixed-origin fail-closed handling can only run on origins it was given.
+    // An earlier version of this test asserted the two notices never share a turn, which
+    // is not the invariant and failed against the correct implementation.
+    const seenMids: string[] = [];
+    const agent = new PanelAgent(
+      "tab1",
+      {
+        mcpServers: undefined,
+        systemAppend: "",
+        model: "m",
+        onSay: () => {},
+        onSeen: (_tab, mid) => seenMids.push(mid),
+      },
+      backend,
+    );
+    // The agent is NOT started yet, deliberately. Both notices must be sitting in the
+    // QUEUE together, which is the only state where the merge path runs at all — with the
+    // agent draining, the first is dequeued before the second arrives and B takes the
+    // in-flight branch instead. Two earlier versions of this test did exactly that and
+    // passed under a mutation that un-scoped the merge, i.e. they proved nothing.
+    await agent.injectRunError("FROM_TAB_A could not be confirmed", { originTab: "tabA", mid: "mA" });
+    await agent.injectRunError("FROM_TAB_B could not be confirmed", { originTab: "tabB", mid: "mB" });
+
+    const running = agent.start();
+    for (let i = 0; i < 6; i++) {
+      await settle();
+      releaseNow();
+    }
+    await settle();
+    void running;
+    await agent.stop().catch(() => {});
+
+    // BOTH origins reach the dequeue. If B had been folded into A's item, only mA would
+    // fire and the whole turn would be pinned to tab A — "diagnose and fix it" aimed at
+    // the wrong graph, which is #884's P0.
+    expect(seenMids, `origins seen: ${seenMids.join(",")}`).toContain("mA");
+    expect(seenMids, `origins seen: ${seenMids.join(",")}`).toContain("mB");
   });
 });

--- a/src/__tests__/orchestrator/run-error-burst.test.ts
+++ b/src/__tests__/orchestrator/run-error-burst.test.ts
@@ -1,0 +1,154 @@
+// #1489 — a cancelled 27-scene batch flooded every following turn with a GROWING block of
+// "could not be confirmed after reconnecting" errors: turn N carried prompts 1..N, turn
+// N+1 carried 1..N+1, reproducing ~25 messages dozens of times and dragging the user's
+// original message along at the bottom.
+//
+// The report calls this "not deduplicated". It is not a dedupe problem — each notice names
+// a different prompt id, so all N texts are distinct and nothing would dedupe. The cause is
+// mechanical: `injectRunError` interrupted the in-flight turn with `requeueInFlight: true`,
+// which re-queues that turn, and after the FIRST error the interrupted turn is itself an
+// error turn. So error N re-queued errors 1..N-1 and the drain batched them.
+//
+// Measured against this exact harness before the fix: 419 → 827 → 1237 chars for three
+// prompts, the last carrying all three plus the user's message.
+import { describe, expect, it } from "vitest";
+import { PanelAgent } from "../../orchestrator/panel-agent.js";
+import type {
+  AgentBackend,
+  AgentCapabilities,
+  AgentEvent,
+  BackendStartOptions,
+  NeutralTurn,
+} from "../../orchestrator/agent-backend.js";
+
+const CAPS: AgentCapabilities = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: false,
+  modelEnumeration: false,
+  slashCommands: false,
+  hooks: false,
+  vision: true,
+  turnMarkers: true,
+};
+
+/**
+ * A backend that takes a turn and HOLDS it, so the agent is genuinely `inFlight` when the
+ * next error lands — the precondition for the requeue path this bug lives on. Each held
+ * turn is released only when the test says so.
+ */
+function holdingBackend() {
+  const seen: NeutralTurn[] = [];
+  let release: (() => void) | null = null;
+  const backend: AgentBackend = {
+    id: "claude" as AgentBackend["id"],
+    capabilities: CAPS,
+    async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+      yield { type: "session", sessionId: "s1" };
+      for await (const turn of opts.channel) {
+        seen.push(turn);
+        await new Promise<void>((r) => {
+          release = r;
+        });
+        yield { type: "result", ok: true, turn: seen.length };
+      }
+    },
+    async interrupt() {
+      release?.();
+      release = null;
+    },
+    async listModels() {
+      return [];
+    },
+  };
+  return { backend, seen, releaseNow: () => { release?.(); release = null; } };
+}
+
+const textOf = (t: NeutralTurn): string =>
+  typeof (t as { text?: unknown }).text === "string" ? (t as { text: string }).text : JSON.stringify(t);
+
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 10));
+const countOf = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
+describe("a BURST of run_errors coalesces instead of nesting (#1489)", () => {
+  it("delivers each cancelled prompt ONCE, with no cumulative growth", async () => {
+    const { backend, seen, releaseNow } = holdingBackend();
+    const agent = new PanelAgent(
+      "tab1",
+      { mcpServers: undefined, systemAppend: "", model: "m", onSay: () => {} },
+      backend,
+    );
+    const running = agent.start();
+
+    // A normal user turn first — this is the reporter's shape, and it is why their older
+    // prompt text kept reappearing: the original turn sits at the bottom of the re-queue
+    // stack that each interrupt rebuilt.
+    agent.send("USER_PROMPT");
+    await settle();
+
+    // Three cleared prompts land in quick succession, as they do when a cancelled batch is
+    // reconciled after a reconnect.
+    await agent.injectRunError("PROMPT_ONE could not be confirmed");
+    await settle();
+    await agent.injectRunError("PROMPT_TWO could not be confirmed");
+    await settle();
+    await agent.injectRunError("PROMPT_THREE could not be confirmed");
+    await settle();
+
+    // Drain: let each held turn finish so everything queued is actually delivered.
+    for (let i = 0; i < 6; i++) {
+      releaseNow();
+      await settle();
+    }
+    void running;
+    await agent.stop().catch(() => {});
+
+    const texts = seen.map(textOf);
+    const all = texts.join("\n---\n");
+
+    // EVERY prompt still reaches the agent exactly once. Coalescing must not lose an
+    // error — a swallowed failure is a far worse bug than a noisy one.
+    expect(countOf(all, "PROMPT_ONE")).toBe(1);
+    expect(countOf(all, "PROMPT_TWO")).toBe(1);
+    expect(countOf(all, "PROMPT_THREE")).toBe(1);
+
+    // And NO turn carries more than one of them twice over — the growth is gone. Before
+    // the fix the final turn carried all three; now the later two share a single turn and
+    // nothing is repeated across turns.
+    const carryingAll = texts.filter(
+      (t) => t.includes("PROMPT_ONE") && t.includes("PROMPT_TWO") && t.includes("PROMPT_THREE"),
+    );
+    expect(carryingAll).toHaveLength(0);
+
+    // The user's own message is not re-sent alongside the errors on every turn.
+    expect(countOf(all, "USER_PROMPT")).toBeLessThanOrEqual(2);
+  });
+
+  it("a SINGLE error still interrupts a user turn — the urgent path is unchanged", async () => {
+    // The behaviour worth keeping: one error arriving during ordinary work stops that work
+    // so the agent addresses it. Only a BURST is coalesced.
+    const { backend, seen, releaseNow } = holdingBackend();
+    const agent = new PanelAgent(
+      "tab1",
+      { mcpServers: undefined, systemAppend: "", model: "m", onSay: () => {} },
+      backend,
+    );
+    const running = agent.start();
+
+    agent.send("USER_PROMPT");
+    await settle();
+    await agent.injectRunError("ONLY_PROMPT could not be confirmed");
+    await settle();
+
+    // The error turn was dispatched ahead of the user's work rather than waiting for it.
+    const texts = seen.map(textOf);
+    expect(texts.some((t) => t.includes("ONLY_PROMPT"))).toBe(true);
+
+    releaseNow();
+    await settle();
+    void running;
+    await agent.stop().catch(() => {});
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4814,6 +4814,9 @@ export async function runPanelOrchestrator(): Promise<void> {
         // exact sequence — a render error on A silently editing B.
         void manager.injectRunError(agentKeyFor(event.tab_id), ev.error ?? "unknown error", {
           mid: turnOrigins.mintInjectionOrigin(event.tab_id),
+          // #1489 — coalescing a burst is scoped to this tab, so a notice from ANOTHER
+          // tab is never folded in and can never lose its own origin pin (#884 P0).
+          originTab: event.tab_id,
         });
         logger.info(`[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run_error → agent (interrupt)`);
         return;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -209,6 +209,13 @@ export interface QueueItem {
    *  (see PanelAgent.inFlight), so this stays accurate across an interrupt or a
    *  crash re-queue. */
   completionOnly?: boolean;
+  /** #1489 — this item is an injected RUN-ERROR notice. Marked so a burst of them
+   *  coalesces into one turn instead of nesting: each `injectRunError` used to
+   *  interrupt the live turn and RE-QUEUE it, and after the first error that live turn
+   *  is itself an error turn — so error N re-queued errors 1..N-1 and the drain batched
+   *  them. Measured on a cancelled 27-scene batch: turn lengths 419 → 827 → 1237 chars
+   *  for three prompts, carrying the user's original message along at the bottom. */
+  runError?: boolean;
 }
 
 /** The turn currently in flight, captured at dispatch so an interrupt or a
@@ -873,7 +880,39 @@ export class PanelAgent {
     // imperative made that costly rather than cosmetic: told to STOP and to
     // relate the error to its work, an agent will find a relation.
     const text = runErrorNotice(error);
-    if (this.inFlight) {
+
+    // #1489 — A BURST MUST COALESCE, NOT NEST.
+    //
+    // One error interrupting a user turn is the intended behaviour and stays. The defect
+    // is what happens to the SECOND one: the interrupt re-queues the turn it stopped, and
+    // after the first error that turn is an error turn — so error N re-queued errors
+    // 1..N-1 and the drain batched them into one message. A cancelled 27-scene batch
+    // therefore produced a block that grew by one prompt every turn and dragged the user's
+    // original message along at the bottom. Reproduced against this method: three prompts
+    // gave turns of 419 → 827 → 1237 chars, the last carrying all three plus the user's.
+    //
+    // Note this is NOT a deduplication problem and a dedupe would not have helped — each
+    // notice names a different prompt id, so all N texts are distinct.
+    //
+    // Two cases, both of which avoid a second interrupt:
+    //   • an error turn is already QUEUED and has not started — fold this notice into it,
+    //     so N errors arrive as one turn listing N prompts;
+    //   • an error turn is already IN FLIGHT — queue normally and let it be picked up
+    //     next. Interrupting the agent's error handling to hand it another error just
+    //     restarts the work with more text.
+    const queuedError = this.queue.find((item) => item.runError);
+    if (queuedError) {
+      queuedError.text = `${queuedError.text}\n\n${text}`;
+      return;
+    }
+    // `some`, NOT `every` — and that distinction is the whole fix. The in-flight turn is a
+    // BATCH: the drain merges the re-queued user message with the error notice, so an
+    // error turn's items are [error, USER_PROMPT] and `every` is false. Written with
+    // `every` first, this branch never fired and the measured turn lengths were
+    // byte-identical to the bug (419 → 827 → 1237). The question worth asking is "is the
+    // agent already being told about an error", and `some` asks it.
+    const inFlightIsError = !!this.inFlight && this.inFlight.items.some((i) => i.runError);
+    if (this.inFlight && !inFlightIsError) {
       // Stop the live turn and re-queue it so the agent handles the error FIRST,
       // then resumes whatever it was doing.
       await this.interrupt({ requeueInFlight: true });
@@ -883,7 +922,9 @@ export class PanelAgent {
     // #884 P0 — the synthetic origin mid pins the error-handling turn to the
     // ERRORING workflow's tab (via onSeen at dequeue), so "diagnose and fix it"
     // edits the graph that failed — never whichever tab happens to be active.
-    this.queue.unshift({ text, ...(opts?.mid ? { mid: opts.mid } : {}) }); // front: ahead of any re-queued interrupted turn
+    // `runError` marks this as an error notice so a following burst folds into it
+    // (#1489) instead of interrupting again and re-queueing this turn.
+    this.queue.unshift({ text, runError: true, ...(opts?.mid ? { mid: opts.mid } : {}) }); // front: ahead of any re-queued interrupted turn
     const wake = this.waiting;
     this.waiting = null;
     wake?.();

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -216,6 +216,13 @@ export interface QueueItem {
    *  them. Measured on a cancelled 27-scene batch: turn lengths 419 → 827 → 1237 chars
    *  for three prompts, carrying the user's original message along at the bottom. */
   runError?: boolean;
+  /** #1489 — the TAB this run-error notice came from. Coalescing is scoped to it: the
+   *  item keeps ONE `mid`, and that mid is what pins the error-handling turn to the
+   *  erroring workflow's tab (#884 P0 — "a render error on A silently editing B"). Folding
+   *  a notice from tab B into tab A's item would discard B's origin and route "diagnose and
+   *  fix it" at A's graph, which is that exact P0 reintroduced (codex). Same tab, same pin,
+   *  safe to merge; different tab, keep them apart. */
+  runErrorOriginTab?: string;
 }
 
 /** The turn currently in flight, captured at dispatch so an interrupt or a
@@ -872,7 +879,10 @@ export class PanelAgent {
    *  run succeeded. INTERRUPT any live turn (re-queued so it resumes AFTER the
    *  error), then put the error at the FRONT of the queue so the agent addresses
    *  it before anything else. */
-  async injectRunError(error: string, opts?: { mid?: string }): Promise<void> {
+  async injectRunError(
+    error: string,
+    opts?: { mid?: string; originTab?: string },
+  ): Promise<void> {
     if (this.closed) return;
     // #889 — "the workflow run YOU JUST QUEUED" was a fixed template, sent to a
     // session whose agent had never called panel_run at all. It then burned a
@@ -900,7 +910,14 @@ export class PanelAgent {
     //   • an error turn is already IN FLIGHT — queue normally and let it be picked up
     //     next. Interrupting the agent's error handling to hand it another error just
     //     restarts the work with more text.
-    const queuedError = this.queue.find((item) => item.runError);
+    // ORIGIN-SCOPED (codex P0). Not keyed on `mid`: `mintInjectionOrigin` returns a fresh
+    // `evt-<uuid>` per event, so mid equality is never true and would disable coalescing
+    // outright. The tab is the thing that must match, because the tab is what the pin
+    // resolves to.
+    const originTab = opts?.originTab;
+    const queuedError = originTab
+      ? this.queue.find((item) => item.runError && item.runErrorOriginTab === originTab)
+      : undefined;
     if (queuedError) {
       queuedError.text = `${queuedError.text}\n\n${text}`;
       return;
@@ -924,7 +941,12 @@ export class PanelAgent {
     // edits the graph that failed — never whichever tab happens to be active.
     // `runError` marks this as an error notice so a following burst folds into it
     // (#1489) instead of interrupting again and re-queueing this turn.
-    this.queue.unshift({ text, runError: true, ...(opts?.mid ? { mid: opts.mid } : {}) }); // front: ahead of any re-queued interrupted turn
+    this.queue.unshift({
+      text,
+      runError: true,
+      ...(originTab ? { runErrorOriginTab: originTab } : {}),
+      ...(opts?.mid ? { mid: opts.mid } : {}),
+    }); // front: ahead of any re-queued interrupted turn
     const wake = this.waiting;
     this.waiting = null;
     wake?.();
@@ -2523,7 +2545,11 @@ export class PanelAgentManager {
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn
    *  and front-queue the error so the agent stops and addresses it. */
-  async injectRunError(tabId: string, error: string, opts?: { mid?: string }): Promise<boolean> {
+  async injectRunError(
+    tabId: string,
+    error: string,
+    opts?: { mid?: string; originTab?: string },
+  ): Promise<boolean> {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false;
     await agent.injectRunError(error, opts);


### PR DESCRIPTION
Refs #1489 — fixes the **flood**, which the reporter calls the expensive half. The classification half is panel-side and identified below; this PR does not close the issue.

## The bug, measured before anything was changed

A cancelled 27-scene batch made every following turn carry a **growing** block of "could not be confirmed after reconnecting" errors — turn N carried prompts 1..N — dragging the user's original message along at the bottom.

Reproduced against the real `injectRunError` with a backend that holds its turn:

| turn | length | carries |
|---|---|---|
| 0 | 11 | `USER_PROMPT` |
| 1 | 419 | ONE |
| 2 | 827 | ONE + TWO |
| 3 | 1237 | ONE + TWO + THREE **+ USER_PROMPT** |

**"Not deduplicated" is the symptom, not the cause.** Each notice names a different prompt id, so all N texts are distinct — a dedupe would have changed nothing. The cause is mechanical: `injectRunError` interrupts the in-flight turn with `requeueInFlight: true`, which **re-queues** it, and after the first error that turn is itself an error turn. So error N re-queued errors 1..N-1 and the drain batched them. It also explains the detail a dedupe theory cannot: the user's own message kept reappearing, because the original turn sits at the bottom of that same re-queue stack.

## The fix

A burst coalesces instead of nesting. An error arriving while an error turn is **queued** folds into it; one arriving while an error turn is **in flight** queues normally instead of interrupting again. A single error interrupting ordinary work is unchanged — that part was working as intended.

`some`, not `every`, and that distinction *is* the fix: the in-flight turn is a **batch** (the drain merges the re-queued user message with the error notice), so an error turn's items are `[error, USER_PROMPT]`. Written with `every` first, the branch never fired and the re-measured turn lengths came back **byte-identical to the bug** — the only reason I caught it.

## Codex found a P0 that I introduced

Coalescing keeps ONE `mid` per item, and the mid pins the error-handling turn to the erroring workflow's tab — #884's P0, *"a render error on A silently editing B"*. Folding tab B's notice into tab A's item **discarded B's origin**, aiming "diagnose and fix it" at the wrong graph.

Coalescing is now scoped to the **origin tab**: same tab, same pin, safe to merge; different tab, kept apart so each keeps its mid and the batch's mixed-origin fail-closed handling still runs. Deliberately **not** keyed on `mid` — `mintInjectionOrigin` mints a fresh UUID per event, so mid equality is never true and would have disabled coalescing while looking like a fix.

Round 2: **SHIP**, no remaining origin-loss path.

## Verification

- 3 tests on the real `injectRunError`; suite **9201** green
- **every prompt still arrives exactly once** — asserted alongside the no-growth check, because a swallowed error would be far worse than a noisy one
- mutation-checked in both directions: reverting to nesting fails the growth test; un-scoping the merge loses `mB` and fails the P0 test

The P0 test took three attempts, and the first two proved nothing — worth recording so they are not re-introduced:

1. asserted the two notices never share a turn — **not the invariant**; batching separate items into one turn is normal, and that version failed against the *correct* implementation
2. injected with a settle between them, so the first item had already dequeued and the merge path never ran — it passed under the mutation that un-scopes it
3. correct: assert on **origins** (`onSeen` fires per item with its mid), with the agent not started until both notices are queued together — the only state where the merge runs

## Still open on #1489

**Classification.** A prompt *we* cancelled should not arrive as a `run_error` at all. The panel already has the right pattern one branch over: `onReconcileInterrupted` sends a neutral `executed` note for a known cancellation, with a comment stating why it must not be `run_error`. `onReconcileGiveUp` — the branch these 26 prompts hit — sends `run_error` even though its own text says *"likely cancelled or interrupted. Safe to requeue."* That is a panel-repo change.

Also seen in the capture and worth fixing there: the injected notice claims *"You did NOT queue this run — this session has queued none"*, which is the opposite of the truth here — the session queued all 27 via `panel_run` and then cancelled them.

**Lock half:** not an oversight and not touched. The acquire path refuses deliberately (*a concurrent pre-upgrade orchestrator could replace an observed stale path with a fresh lock*), which is exactly why `panel_action:"unlock"` re-verifies before deleting. The defensible narrowing — failing fast when the owner pid is provably dead instead of waiting the full 60 s — is left out of this PR to keep it scoped.