### PR TITLE
fix(1478): name the load as the cause of a workflow-instance mismatch

### DIFF
--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -100,10 +100,17 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
 
     expect(out.isError).toBe(false);
     expect(out.text).toMatch(/loaded/i);
-    expect(out.text).toMatch(/instance fence now names the OLD one/);
+    expect(out.text).toMatch(/CAN re-mint the canvas workflow instance/);
     expect(out.text).toMatch(/panel_set_workflow_target/);
     // The specific misdirection this replaces: the downstream refusal blames a tab switch.
-    expect(out.text).toMatch(/not by the user switching tabs/);
+    expect(out.text).toMatch(/NOT the user switching tabs/);
+    // CONDITIONAL, never categorical. Four review rounds falsified every version that
+    // asserted the fence IS stale: a UI load preserves the instance outright, and a second
+    // API load into the same already-active workflow reuses the object so its uuid does
+    // not change either. The reply cannot tell those apart, so the note must not pretend to.
+    expect(out.text).toMatch(/If your next graph command is refused/);
+    expect(out.text).toMatch(/If the next command is not refused, nothing needs doing/);
+    expect(out.text).not.toMatch(/will be refused/);
   });
 
   it("does NOT adopt whatever is active — the P0 an auto-rebind would have created", async () => {
@@ -132,7 +139,7 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
     // unmeasured-claim defect this note exists to remove.
     const out = await load({ loaded: false, error: "nothing was applied" });
 
-    expect(out.text).not.toMatch(/instance fence now names the OLD one/);
+    expect(out.text).not.toMatch(/CAN re-mint the canvas workflow instance/);
     expect(out.text).not.toMatch(/panel_set_workflow_target/);
   });
 
@@ -147,7 +154,7 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
     const out = await load({ loaded: true, node_count: 12 });
 
     expect(out.text).toMatch(/loaded/i);
-    expect(out.text).not.toMatch(/instance fence now names the OLD one/);
+    expect(out.text).not.toMatch(/CAN re-mint the canvas workflow instance/);
     expect(out.text).not.toMatch(/panel_set_workflow_target/);
   });
 });

--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -1,0 +1,153 @@
+// #1478 — `panel_load_workflow` returned `loaded:true` and the very NEXT graph call failed
+// with `workflow instance mismatch`. Loading replaces the graph, which mints a new canvas
+// instance id, so the session's fence is stale the instant the load succeeds. The reporter
+// hit it deterministically twice, and their recovery was always the same
+// `panel_set_workflow_target({mode:"current"})`.
+//
+// The load now performs that claim itself. Two things are asserted that reading the code
+// cannot establish:
+//
+//   1. the claim actually RUNS — a `workflow_list` really goes out after the load. #814
+//      warns that this generic re-derivation can be refused by the fence it repairs
+//      (#1071); that warning is about a session with no trustworthy identity, whereas here
+//      the load has just minted one. Rather than trust that reasoning, the test drives it.
+//   2. a claim that FAILS is disclosed rather than swallowed — `loaded:true` with a silent
+//      stale fence is the bug, and returning it quietly would be the bug again.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+/** The identity the canvas reports AFTER the load — a new instance, as a load always mints. */
+const AFTER_LOAD_UUID = "632e8dd7-30df-4de9-b28c-b6c98b9532aa";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+let sent: string[] = [];
+
+/** A tab whose graph_load succeeds; `listMode` decides what the follow-up claim sees. */
+function bridge(listMode: "ok" | "refused" | "throws") {
+  let stamp = "e592452b-c172-416d-a8bc-0ec6b96b56e1"; // the pre-load fence, as reported
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd === "graph_load") return { loaded: true, node_count: 59 };
+      if (cmd.cmd === "workflow_list") {
+        if (listMode === "throws") throw new Error("panel did not answer");
+        if (listMode === "refused") throw new Error("workflow instance mismatch: refused");
+        return {
+          active: {
+            path: "workflows/loaded.json",
+            filename: "loaded.json",
+            title: "loaded.json",
+            key: "workflows/loaded.json",
+            routing_key: "wf:workflows/loaded.json",
+            workflow_uuid: AFTER_LOAD_UUID,
+          },
+          open: [{ path: "workflows/loaded.json", active: true, modified: true, persisted: true }],
+          // `workflows` is REQUIRED, not decoration: corroborateActiveForFence refuses to
+          // adopt an identity unless the reply also carries a comparable list, so a
+          // fixture without it makes the claim silently fail and looks like a product
+          // bug. (It cost me one debugging round here.) This matches the shape a live rig
+          // actually returns.
+          workflows: [
+            { path: "workflows/loaded.json", active: true, modified: true, persisted: true },
+          ],
+          active_confirmed: true,
+        };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    __stamp: () => stamp,
+  } as unknown as PanelToolCtx["bridge"] & { __stamp: () => string };
+}
+
+async function load(listMode: "ok" | "refused" | "throws") {
+  const b = bridge(listMode);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_load_workflow");
+  if (!def) throw new Error("panel_load_workflow is not registered");
+  const res: ToolResult = await def.handler(
+    { graph: { nodes: [{ id: 1, type: "KSampler" }] } } as never,
+    ctx,
+  );
+  return { text: textOf(res), isError: res.isError === true, stamp: b.__stamp() };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("a load claims the instance it just created (#1478)", () => {
+  it("re-derives the fence onto the new instance, and says nothing extra when it works", async () => {
+    const out = await load("ok");
+
+    // The claim really went out — without this the assertions below could pass on a load
+    // that never attempted anything.
+    expect(sent).toContain("graph_load");
+    expect(sent).toContain("workflow_list");
+    // And it LANDED: the session's stamp is now the post-load identity, so the next graph
+    // call carries the id the canvas actually reports.
+    expect(out.stamp).toBe(AFTER_LOAD_UUID);
+
+    expect(out.isError).toBe(false);
+    // A successful claim is the expected case and does not editorialise.
+    expect(out.text).not.toMatch(/could NOT be re-claimed/);
+  });
+
+  it("the claim survives the state a load leaves behind (#814's caveat, checked)", async () => {
+    // #814 warns the generic re-derivation can be refused by the fence it repairs. That is
+    // a different starting state — no trustworthy identity at all — and `workflow_list` is
+    // not a fenced command, which is why the reporter's manual recovery works. Driven here
+    // rather than argued: the list is answered and the stamp moves.
+    await load("ok");
+    expect(sent.filter((c) => c === "workflow_list").length).toBeGreaterThan(0);
+  });
+
+  it("a claim that FAILS is disclosed, not swallowed", async () => {
+    // The whole defect is a silent stale fence behind `loaded:true`. If the claim cannot
+    // be made, the caller has to hear it here rather than from the next call's mismatch.
+    const out = await load("refused");
+
+    expect(out.text).toMatch(/loaded/i);
+    expect(out.text).toMatch(/could NOT be re-claimed/);
+    expect(out.text).toMatch(/panel_set_workflow_target/);
+  });
+
+  it("an unreadable panel never turns a successful load into a failure", async () => {
+    // The load happened. Reporting it as an error would invite a re-load, which replaces
+    // the user's graph a second time.
+    //
+    // Note the claim does NOT throw out to us here: rebindWorkflowFence catches its own
+    // read failures and returns a status. The `THREW` branch exists for a rebind that
+    // fails in some way it does not model, and asserting on it here was wrong — the real
+    // path returns an unreadable status, which is still disclosed.
+    const out = await load("throws");
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/could NOT be re-claimed|THREW/);
+    expect(out.text).toMatch(/panel_set_workflow_target/);
+  });
+});

--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -1,18 +1,17 @@
 // #1478 — `panel_load_workflow` returned `loaded:true` and the very NEXT graph call failed
 // with `workflow instance mismatch`. Loading replaces the graph, which mints a new canvas
-// instance id, so the session's fence is stale the instant the load succeeds. The reporter
-// hit it deterministically twice, and their recovery was always the same
-// `panel_set_workflow_target({mode:"current"})`.
+// instance id, so the session's fence is stale the instant the load succeeds. The refusal
+// then says "NO PANEL COMMAND CLAIMED IT", pointing the reader at "the user switched tabs"
+// when a panel command one call earlier is what moved it.
 //
-// The load now performs that claim itself. Two things are asserted that reading the code
-// cannot establish:
+// THE LOAD DOES NOT AUTO-REPAIR THE FENCE, and that is the interesting part. An earlier
+// version of this fix ran the same re-derivation the documented recovery runs, and codex
+// found the P1: that call adopts WHATEVER IS ACTIVE NOW with no tie to the load, so a user
+// switching to canvas B between the load's ack and the follow-up read would stamp the
+// session to B — and the next edit would land on B though the load modified A. A
+// wrong-graph write is exactly what the fence exists to prevent.
 //
-//   1. the claim actually RUNS — a `workflow_list` really goes out after the load. #814
-//      warns that this generic re-derivation can be refused by the fence it repairs
-//      (#1071); that warning is about a session with no trustworthy identity, whereas here
-//      the load has just minted one. Rather than trust that reasoning, the test drives it.
-//   2. a claim that FAILS is disclosed rather than swallowed — `loaded:true` with a silent
-//      stale fence is the bug, and returning it quietly would be the bug again.
+// So the load states the fact instead, at the moment it becomes true.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -27,41 +26,36 @@ import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 const TAB = "11111111-2222-3333-4444-555555555555";
-/** The identity the canvas reports AFTER the load — a new instance, as a load always mints. */
-const AFTER_LOAD_UUID = "632e8dd7-30df-4de9-b28c-b6c98b9532aa";
+const PRE_LOAD_UUID = "e592452b-c172-416d-a8bc-0ec6b96b56e1";
+/** A DIFFERENT workflow, as if the user switched tabs during the load. */
+const OTHER_UUID = "632e8dd7-30df-4de9-b28c-b6c98b9532aa";
 
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
 
 let sent: string[] = [];
 
-/** A tab whose graph_load succeeds; `listMode` decides what the follow-up claim sees. */
-function bridge(listMode: "ok" | "refused" | "throws") {
-  let stamp = "e592452b-c172-416d-a8bc-0ec6b96b56e1"; // the pre-load fence, as reported
+function bridge() {
+  let stamp = PRE_LOAD_UUID;
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
       if (cmd.cmd === "graph_load") return { loaded: true, node_count: 59 };
       if (cmd.cmd === "workflow_list") {
-        if (listMode === "throws") throw new Error("panel did not answer");
-        if (listMode === "refused") throw new Error("workflow instance mismatch: refused");
+        // The hazard shape: by the time anyone asks, the ACTIVE canvas is a different
+        // workflow. Adopting this would retarget the session away from what was loaded.
         return {
           active: {
-            path: "workflows/loaded.json",
-            filename: "loaded.json",
-            title: "loaded.json",
-            key: "workflows/loaded.json",
-            routing_key: "wf:workflows/loaded.json",
-            workflow_uuid: AFTER_LOAD_UUID,
+            path: "workflows/other.json",
+            filename: "other.json",
+            title: "other.json",
+            key: "workflows/other.json",
+            routing_key: "wf:workflows/other.json",
+            workflow_uuid: OTHER_UUID,
           },
-          open: [{ path: "workflows/loaded.json", active: true, modified: true, persisted: true }],
-          // `workflows` is REQUIRED, not decoration: corroborateActiveForFence refuses to
-          // adopt an identity unless the reply also carries a comparable list, so a
-          // fixture without it makes the claim silently fail and looks like a product
-          // bug. (It cost me one debugging round here.) This matches the shape a live rig
-          // actually returns.
+          open: [{ path: "workflows/other.json", active: true, modified: false, persisted: true }],
           workflows: [
-            { path: "workflows/loaded.json", active: true, modified: true, persisted: true },
+            { path: "workflows/other.json", active: true, modified: false, persisted: true },
           ],
           active_confirmed: true,
         };
@@ -84,8 +78,8 @@ function bridge(listMode: "ok" | "refused" | "throws") {
   } as unknown as PanelToolCtx["bridge"] & { __stamp: () => string };
 }
 
-async function load(listMode: "ok" | "refused" | "throws") {
-  const b = bridge(listMode);
+async function load() {
+  const b = bridge();
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_load_workflow");
   if (!def) throw new Error("panel_load_workflow is not registered");
@@ -100,54 +94,34 @@ beforeEach(() => {
   sent = [];
 });
 
-describe("a load claims the instance it just created (#1478)", () => {
-  it("re-derives the fence onto the new instance, and says nothing extra when it works", async () => {
-    const out = await load("ok");
-
-    // The claim really went out — without this the assertions below could pass on a load
-    // that never attempted anything.
-    expect(sent).toContain("graph_load");
-    expect(sent).toContain("workflow_list");
-    // And it LANDED: the session's stamp is now the post-load identity, so the next graph
-    // call carries the id the canvas actually reports.
-    expect(out.stamp).toBe(AFTER_LOAD_UUID);
+describe("a load discloses the fence it just invalidated (#1478)", () => {
+  it("says the fence is stale, why, and how to clear it", async () => {
+    const out = await load();
 
     expect(out.isError).toBe(false);
-    // A successful claim is the expected case and does not editorialise.
-    expect(out.text).not.toMatch(/could NOT be re-claimed/);
-  });
-
-  it("the claim survives the state a load leaves behind (#814's caveat, checked)", async () => {
-    // #814 warns the generic re-derivation can be refused by the fence it repairs. That is
-    // a different starting state — no trustworthy identity at all — and `workflow_list` is
-    // not a fenced command, which is why the reporter's manual recovery works. Driven here
-    // rather than argued: the list is answered and the stamp moves.
-    await load("ok");
-    expect(sent.filter((c) => c === "workflow_list").length).toBeGreaterThan(0);
-  });
-
-  it("a claim that FAILS is disclosed, not swallowed", async () => {
-    // The whole defect is a silent stale fence behind `loaded:true`. If the claim cannot
-    // be made, the caller has to hear it here rather than from the next call's mismatch.
-    const out = await load("refused");
-
     expect(out.text).toMatch(/loaded/i);
-    expect(out.text).toMatch(/could NOT be re-claimed/);
+    expect(out.text).toMatch(/instance fence now names the OLD one/);
     expect(out.text).toMatch(/panel_set_workflow_target/);
+    // The specific misdirection this replaces: the downstream refusal blames a tab switch.
+    expect(out.text).toMatch(/not by the user switching tabs/);
   });
 
-  it("an unreadable panel never turns a successful load into a failure", async () => {
-    // The load happened. Reporting it as an error would invite a re-load, which replaces
-    // the user's graph a second time.
-    //
-    // Note the claim does NOT throw out to us here: rebindWorkflowFence catches its own
-    // read failures and returns a status. The `THREW` branch exists for a rebind that
-    // fails in some way it does not model, and asserting on it here was wrong — the real
-    // path returns an unreadable status, which is still disclosed.
-    const out = await load("throws");
+  it("does NOT adopt whatever is active — the P0 an auto-rebind would have created", async () => {
+    // With the user on a different canvas, an auto-rebind would stamp OTHER_UUID and the
+    // next edit would land on the wrong graph. The fence must stay where it was, so the
+    // next command is REFUSED (loudly) rather than silently retargeted.
+    const out = await load();
 
-    expect(out.isError).toBe(false);
-    expect(out.text).toMatch(/could NOT be re-claimed|THREW/);
-    expect(out.text).toMatch(/panel_set_workflow_target/);
+    expect(out.stamp).toBe(PRE_LOAD_UUID);
+    expect(out.stamp).not.toBe(OTHER_UUID);
+  });
+
+  it("costs no extra round trip", async () => {
+    // The earlier version called the re-derivation, which on a panel that cannot
+    // corroborate spends up to four 6-second probes plus recheck sleeps — to reach an
+    // answer it must not use. Only the load itself goes out now.
+    await load();
+
+    expect(sent).toEqual(["graph_load"]);
   });
 });

--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -35,12 +35,12 @@ const textOf = (res: ToolResult): string =>
 
 let sent: string[] = [];
 
-function bridge() {
+function bridge(loadReply: Record<string, unknown> = { loaded: true, node_count: 59 }) {
   let stamp = PRE_LOAD_UUID;
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
-      if (cmd.cmd === "graph_load") return { loaded: true, node_count: 59 };
+      if (cmd.cmd === "graph_load") return loadReply;
       if (cmd.cmd === "workflow_list") {
         // The hazard shape: by the time anyone asks, the ACTIVE canvas is a different
         // workflow. Adopting this would retarget the session away from what was loaded.
@@ -78,8 +78,8 @@ function bridge() {
   } as unknown as PanelToolCtx["bridge"] & { __stamp: () => string };
 }
 
-async function load() {
-  const b = bridge();
+async function load(loadReply?: Record<string, unknown>) {
+  const b = bridge(loadReply);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_load_workflow");
   if (!def) throw new Error("panel_load_workflow is not registered");
@@ -123,5 +123,16 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
     await load();
 
     expect(sent).toEqual(["graph_load"]);
+  });
+
+  it("a reply that did NOT replace the graph gets no stale-fence claim (codex r2)", async () => {
+    // Keyed on the reply saying `loaded:true`, not merely on the call not erroring. A
+    // non-error envelope reporting `loaded:false` replaced nothing, and asserting a stale
+    // fence there would invent a consequence of a load that never happened — the same
+    // unmeasured-claim defect this note exists to remove.
+    const out = await load({ loaded: false, error: "nothing was applied" });
+
+    expect(out.text).not.toMatch(/instance fence now names the OLD one/);
+    expect(out.text).not.toMatch(/panel_set_workflow_target/);
   });
 });

--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -35,7 +35,7 @@ const textOf = (res: ToolResult): string =>
 
 let sent: string[] = [];
 
-function bridge(loadReply: Record<string, unknown> = { loaded: true, node_count: 59 }) {
+function bridge(loadReply: Record<string, unknown> = { loaded: true, format: "api", node_count: 59 }) {
   let stamp = PRE_LOAD_UUID;
   return {
     send: async (cmd: Record<string, unknown>) => {
@@ -132,6 +132,21 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
     // unmeasured-claim defect this note exists to remove.
     const out = await load({ loaded: false, error: "nothing was applied" });
 
+    expect(out.text).not.toMatch(/instance fence now names the OLD one/);
+    expect(out.text).not.toMatch(/panel_set_workflow_target/);
+  });
+
+  it("a UI-format load PRESERVES the instance, so it gets no note (codex r3)", async () => {
+    // Checked in the panel: the UI path passes `__cmcpKeepInstance: true` whenever a
+    // workflow is active, deliberately keeping the instance so the agent's own follow-up
+    // commands are not rejected. Only the API path (`loadApiJson`) re-mints — and it is
+    // the one the reporter hit, whose reply reads `format:"api"`.
+    //
+    // A blanket note would therefore have been FALSE for the commonest load, which is the
+    // same fabricated-consequence defect this whole change exists to remove.
+    const out = await load({ loaded: true, node_count: 12 });
+
+    expect(out.text).toMatch(/loaded/i);
     expect(out.text).not.toMatch(/instance fence now names the OLD one/);
     expect(out.text).not.toMatch(/panel_set_workflow_target/);
   });

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -104,8 +104,12 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     expect(fetchApi).toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent("workflows/722-gordo-10Eros_10SNodes_I2V_DMD_v1.json")}`,
     );
-    // And the fetched graph was dropped on the canvas.
-    expect(calls).toHaveLength(1);
+    // And the fetched graph was dropped on the canvas — EXACTLY once. Counted by command
+    // rather than by total calls (#1478): the load now also claims the workflow-instance
+    // fence it just invalidated, so a bare length check would fail on the extra
+    // workflow_list while proving nothing about what this test guards, which is that the
+    // graph is not loaded twice.
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(calls[0]).toMatchObject({ cmd: "graph_load" });
     expect(calls[0].graph).toMatchObject(graph);
   });
@@ -156,7 +160,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
 
       expect(res.isError).toBeUndefined();
       expect(fetchApi).toHaveBeenCalled(); // authoritative source was consulted first
-      expect(calls).toHaveLength(1);
+      expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
       expect(calls[0].graph).toMatchObject(runtime); // NOT the stale default-dir file
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -531,7 +535,7 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
       const res = await loadWorkflow().handler({ path: "staged.json" }, ctx);
 
       expect(res.isError).toBeUndefined();
-      expect(calls).toHaveLength(1);
+      expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
       expect(calls[0].graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -639,7 +643,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: nfd }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(calls[0].graph).toMatchObject(graph);
     // It fetched the SERVER's key, not a locally reconstructed path.
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
@@ -659,7 +663,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: nfc }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(calls[0].graph).toMatchObject(graph);
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
   });
@@ -960,7 +964,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: nfd }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(calls[0].graph).toMatchObject(graph);
     expect(fetchApi).not.toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/${upper}`)}`,
@@ -1062,7 +1066,7 @@ describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-
     expect(fetchApi).not.toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent("workflows/workflows/Daily Anime Portrait - Fast Preview.json")}`,
     );
-    expect(calls).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(calls[0].graph).toMatchObject(graph);
   });
 
@@ -1095,7 +1099,7 @@ describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-
       const res = await loadWorkflow().handler({ path: "workflows/Foo.json" }, ctx);
 
       expect(res.isError).toBeUndefined();
-      expect(calls).toHaveLength(1);
+      expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
       expect(calls[0].graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -532,10 +532,15 @@ describe("panel-tools: panel_load_workflow path (server-side disk read)", () => 
     const res = await defByName("panel_load_workflow").handler({ path: file }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({ cmd: "graph_load" });
+    // Counted by COMMAND, not by total calls (#1478): the load now also claims the
+    // workflow-instance fence it just invalidated, and on a fake ctx that cannot
+    // corroborate an identity the rebind rechecks a few times. What this test guards is
+    // that the graph is loaded EXACTLY once — a second graph_load would replace the
+    // user's canvas twice — and that is now asserted directly.
+    const loads = calls.filter((c) => c.cmd === "graph_load");
+    expect(loads).toHaveLength(1);
     // The big JSON was read SERVER-SIDE and handed to graph_load verbatim.
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(loads[0].graph).toMatchObject(graph);
   });
 
   it("rejects a non-existent path WITHOUT firing graph_load", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8897,7 +8897,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
           const loaded = await ctx.call({ cmd: "graph_load", graph: data }, 30000);
           if (loaded.isError) return loaded;
-          return appendNote(loaded, noteStaleFenceAfterLoad());
+          // Keyed on the reply SAYING the graph was replaced, not merely on the call not
+          // erroring (codex r2). A non-error envelope that reports `loaded:false` did not
+          // replace anything, and telling that caller their fence is stale would be a
+          // fabricated consequence of a load that never happened — the same
+          // unmeasured-claim defect this note exists to remove.
+          const replaced = parseToolResultJson(loaded)?.loaded === true;
+          return replaced ? appendNote(loaded, noteStaleFenceAfterLoad()) : loaded;
         } catch (err) {
           return fail(err);
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3892,47 +3892,48 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
 const FENCE_CORROBORATION_RECHECK_STEPS_MS = [400, 900, 1600] as const;
 
 /**
- * #1478 — A LOAD INVALIDATES ITS OWN FENCE, AND MUST SAY SO.
+ * #1478 — NAME THE CAUSE OF A MISMATCH THE LOAD MAY HAVE CREATED.
  *
- * `graph_load` replaces the graph, which mints a NEW canvas instance id — so the session's
- * fence is stale the instant the load succeeds, and the very next `panel_graph_outline`
- * fails with `workflow instance mismatch`. Worse, that refusal reports "NO PANEL COMMAND
- * CLAIMED IT", which points the reader at "the user switched tabs" when a panel command
- * one call earlier is what actually moved it.
+ * An API-format `graph_load` can re-mint the canvas workflow instance, which leaves this
+ * session's fence naming the old one — so the very next `panel_graph_outline` is refused
+ * with `workflow instance mismatch`. The reporter hit that twice, deterministically. The
+ * refusal then says "NO PANEL COMMAND CLAIMED IT", pointing at "the user switched tabs"
+ * when a panel command one call earlier is the actual cause.
  *
- * WHY THIS DOES NOT AUTO-REPAIR THE FENCE, having tried to (codex P1). The obvious fix is
- * to run the same re-derivation the documented recovery runs. It is not safe here: that
- * call adopts WHATEVER IS ACTIVE NOW, and it has no tie to the load. If the user switches
- * to canvas B in the window between the load's ack and the follow-up read, a perfectly
- * coherent reply for B passes corroboration, the session gets stamped to B, and the next
- * edit lands on B though the load modified A. That is a wrong-graph write — the exact
- * thing the fence exists to prevent — traded for a saved round trip.
+ * WHAT THIS DELIBERATELY DOES NOT DO — and four review rounds are the reason:
  *
- * `panel_set_workflow_target({mode:"current"})` runs that same adoption, and it is sound
- * THERE precisely because it is explicit: the user asked to follow whatever is live.
- * Doing it implicitly on their behalf is a different act.
+ *  1. It does NOT auto-repair the fence. The obvious fix runs the same re-derivation the
+ *     documented recovery runs, and that adopts WHATEVER IS ACTIVE NOW with no tie to the
+ *     load: a user switching canvases in the window would stamp the session to a different
+ *     workflow and the next edit would land on the wrong graph. `panel_set_workflow_target`
+ *     is sound doing this only because the user explicitly asked to follow what is live.
+ *  2. It does NOT claim the fence IS stale. Every categorical version of that sentence was
+ *     falsified: a UI-format load with an active workflow passes `__cmcpKeepInstance: true`
+ *     and preserves the instance outright; and a second API load into the same
+ *     already-active `graph_load.json` workflow reuses that object, so its uuid — which is
+ *     object-keyed — does not change either. The reply carries nothing that separates
+ *     "re-minted" from "reused", so asserting staleness is a guess dressed as a fact.
  *
- * The honest repair is panel-side: give `graph_load`'s reply a `workflow_uuid`, as #762/#800
- * did for `workflow_new` / `workflow_save`, and the load can then claim the identity IT
- * created rather than whatever happens to be active — refused-proof and race-proof, which
- * is why those two do it that way. Until then this states the fact plainly at the moment it
- * becomes true, so the caller acts on an accurate sentence instead of decoding a mismatch
- * one call later.
+ * So it states the CONDITIONAL, which is true on every path: this kind of load can move
+ * the instance, here is the symptom, here is the cause, here is the one call that clears
+ * it. A reader who is not refused ignores it; a reader who is refused stops hunting a tab
+ * switch that never happened.
  *
- * Deliberately NO round trip: an earlier version called the re-derivation and, on a panel
- * that cannot corroborate, spent up to four 6-second probes plus recheck sleeps to arrive
- * at an answer it must not use anyway.
+ * The categorical version needs the panel's help: give `graph_load`'s reply a
+ * `workflow_uuid`, as #762/#800 did for `workflow_new` / `workflow_save`, and the load can
+ * then compare it against the fence and say exactly what happened — or claim the identity
+ * it created outright, which is race-proof and refusal-proof and is why those two work
+ * that way.
  */
 function noteStaleFenceAfterLoad(): string {
   return (
     `
 
-NOTE: loading REPLACED the canvas graph, which mints a new workflow instance, so ` +
-    `this session's instance fence now names the OLD one and the next graph command will be ` +
-    `refused with "workflow instance mismatch". This is expected and is caused by the load ` +
-    `you just ran — not by the user switching tabs. Clear it with ` +
-    `panel_set_workflow_target({mode:"current"}), which re-derives the fence from the live ` +
-    `canvas, then continue.`
+NOTE: an API-format load CAN re-mint the canvas workflow instance. If your next ` +
+    `graph command is refused with "workflow instance mismatch", that is why — the cause is ` +
+    `this load, NOT the user switching tabs (the refusal's own text suggests otherwise). ` +
+    `Clear it with panel_set_workflow_target({mode:"current"}), which re-derives the fence ` +
+    `from the live canvas, then retry. If the next command is not refused, nothing needs doing.`
   );
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3891,6 +3891,70 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
  */
 const FENCE_CORROBORATION_RECHECK_STEPS_MS = [400, 900, 1600] as const;
 
+/**
+ * #1478 — A LOAD MUST CLAIM THE INSTANCE IT JUST CREATED.
+ *
+ * `graph_load` replaces the graph, which mints a NEW canvas instance id — so the session's
+ * fence is stale the instant the load succeeds, and the very next `panel_graph_outline`
+ * fails with `workflow instance mismatch`. Reproduced deterministically by the reporter,
+ * twice in one session; the recovery is always the same
+ * `panel_set_workflow_target({mode:"current"})`.
+ *
+ * WHY NOT #814'S PATTERN. `workflow_new` / `workflow_save` / `workflow_save_as` repair
+ * their own fence from THEIR OWN REPLY, which is strictly better because it cannot be
+ * refused by the fence it is repairing. That is unavailable here: `graph_load`'s reply
+ * carries no `workflow_uuid` at all (checked — it returns `loaded`/`format`/`node_count`),
+ * because #762/#800 added that field to the save/new replies and nobody added it to this
+ * one. Giving `graph_load` a uuid-bearing reply is the better long-term shape and is a
+ * PANEL change; this is the half that can ship on its own.
+ *
+ * So it uses the generic re-derivation — the SAME call the reporter's manual recovery
+ * makes, which they observed returning `refreshed` and working. #814 warns that this read
+ * can be refused by the fence it repairs (#1071), and that warning describes a different
+ * starting state: there the session had no trustworthy identity at all. Here the load has
+ * just minted one and `workflow_list` is not a fenced command, which is exactly why the
+ * manual recovery works today.
+ *
+ * DISCLOSED, NEVER ASSUMED. A load that could not re-claim its own fence returns
+ * `loaded:true` plus the reason and the manual recovery, rather than a bare success that
+ * leaves the next call to discover it.
+ */
+/** The rebind's own reason, when its variant carries one — the union does not share a
+ *  single field, and inventing one would report "undefined" as a cause. */
+function describeRebindReason(rebind: WorkflowFenceRebind): string {
+  if ("why" in rebind && typeof rebind.why === "string" && rebind.why) return `: ${rebind.why}`;
+  if ("detail" in rebind && typeof rebind.detail === "string" && rebind.detail) {
+    return `: ${rebind.detail}`;
+  }
+  return "";
+}
+
+async function claimLoadedInstance(ctx: PanelToolCtx): Promise<string> {
+  let rebind: WorkflowFenceRebind;
+  try {
+    rebind = await rebindWorkflowFence(ctx);
+  } catch (err) {
+    return (
+      `\n\nNOTE: the graph was loaded, but re-claiming this session's workflow-instance ` +
+      `fence THREW (${err instanceof Error ? err.message : String(err)}), so the next graph ` +
+      `call may fail with a workflow instance mismatch. Recover with ` +
+      `panel_set_workflow_target({mode:"current"}).`
+    );
+  }
+  if (rebind.status === "refreshed" || rebind.status === "already_current") {
+    // The common path, and it is worth stating: the load moved the canvas AND claimed it,
+    // so the caller can go straight on to reading or editing the graph.
+    return "";
+  }
+  return (
+    `\n\nNOTE: the graph was loaded, but this session's workflow-instance fence could NOT ` +
+    `be re-claimed (${rebind.status}${describeRebindReason(rebind)}). Loading replaces ` +
+    `the graph and mints a new canvas instance, so the next graph call may fail with a ` +
+    `workflow instance mismatch — clear it with panel_set_workflow_target({mode:"current"}), ` +
+    `then retry.`
+  );
+}
+
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
   const tabAtStart = ctx.tabId;
   let before = currentWorkflowFence(ctx);
@@ -8850,7 +8914,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             throw new Error("Provide one of `pack` (a bundled pack name), `path` (a workflow .json on disk), or `graph` (a UI workflow).");
           }
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
-          return await ctx.call({ cmd: "graph_load", graph: data }, 30000);
+          const loaded = await ctx.call({ cmd: "graph_load", graph: data }, 30000);
+          if (loaded.isError) return loaded;
+          return appendNote(loaded, await claimLoadedInstance(ctx));
         } catch (err) {
           return fail(err);
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3892,66 +3892,47 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
 const FENCE_CORROBORATION_RECHECK_STEPS_MS = [400, 900, 1600] as const;
 
 /**
- * #1478 — A LOAD MUST CLAIM THE INSTANCE IT JUST CREATED.
+ * #1478 — A LOAD INVALIDATES ITS OWN FENCE, AND MUST SAY SO.
  *
  * `graph_load` replaces the graph, which mints a NEW canvas instance id — so the session's
  * fence is stale the instant the load succeeds, and the very next `panel_graph_outline`
- * fails with `workflow instance mismatch`. Reproduced deterministically by the reporter,
- * twice in one session; the recovery is always the same
- * `panel_set_workflow_target({mode:"current"})`.
+ * fails with `workflow instance mismatch`. Worse, that refusal reports "NO PANEL COMMAND
+ * CLAIMED IT", which points the reader at "the user switched tabs" when a panel command
+ * one call earlier is what actually moved it.
  *
- * WHY NOT #814'S PATTERN. `workflow_new` / `workflow_save` / `workflow_save_as` repair
- * their own fence from THEIR OWN REPLY, which is strictly better because it cannot be
- * refused by the fence it is repairing. That is unavailable here: `graph_load`'s reply
- * carries no `workflow_uuid` at all (checked — it returns `loaded`/`format`/`node_count`),
- * because #762/#800 added that field to the save/new replies and nobody added it to this
- * one. Giving `graph_load` a uuid-bearing reply is the better long-term shape and is a
- * PANEL change; this is the half that can ship on its own.
+ * WHY THIS DOES NOT AUTO-REPAIR THE FENCE, having tried to (codex P1). The obvious fix is
+ * to run the same re-derivation the documented recovery runs. It is not safe here: that
+ * call adopts WHATEVER IS ACTIVE NOW, and it has no tie to the load. If the user switches
+ * to canvas B in the window between the load's ack and the follow-up read, a perfectly
+ * coherent reply for B passes corroboration, the session gets stamped to B, and the next
+ * edit lands on B though the load modified A. That is a wrong-graph write — the exact
+ * thing the fence exists to prevent — traded for a saved round trip.
  *
- * So it uses the generic re-derivation — the SAME call the reporter's manual recovery
- * makes, which they observed returning `refreshed` and working. #814 warns that this read
- * can be refused by the fence it repairs (#1071), and that warning describes a different
- * starting state: there the session had no trustworthy identity at all. Here the load has
- * just minted one and `workflow_list` is not a fenced command, which is exactly why the
- * manual recovery works today.
+ * `panel_set_workflow_target({mode:"current"})` runs that same adoption, and it is sound
+ * THERE precisely because it is explicit: the user asked to follow whatever is live.
+ * Doing it implicitly on their behalf is a different act.
  *
- * DISCLOSED, NEVER ASSUMED. A load that could not re-claim its own fence returns
- * `loaded:true` plus the reason and the manual recovery, rather than a bare success that
- * leaves the next call to discover it.
+ * The honest repair is panel-side: give `graph_load`'s reply a `workflow_uuid`, as #762/#800
+ * did for `workflow_new` / `workflow_save`, and the load can then claim the identity IT
+ * created rather than whatever happens to be active — refused-proof and race-proof, which
+ * is why those two do it that way. Until then this states the fact plainly at the moment it
+ * becomes true, so the caller acts on an accurate sentence instead of decoding a mismatch
+ * one call later.
+ *
+ * Deliberately NO round trip: an earlier version called the re-derivation and, on a panel
+ * that cannot corroborate, spent up to four 6-second probes plus recheck sleeps to arrive
+ * at an answer it must not use anyway.
  */
-/** The rebind's own reason, when its variant carries one — the union does not share a
- *  single field, and inventing one would report "undefined" as a cause. */
-function describeRebindReason(rebind: WorkflowFenceRebind): string {
-  if ("why" in rebind && typeof rebind.why === "string" && rebind.why) return `: ${rebind.why}`;
-  if ("detail" in rebind && typeof rebind.detail === "string" && rebind.detail) {
-    return `: ${rebind.detail}`;
-  }
-  return "";
-}
-
-async function claimLoadedInstance(ctx: PanelToolCtx): Promise<string> {
-  let rebind: WorkflowFenceRebind;
-  try {
-    rebind = await rebindWorkflowFence(ctx);
-  } catch (err) {
-    return (
-      `\n\nNOTE: the graph was loaded, but re-claiming this session's workflow-instance ` +
-      `fence THREW (${err instanceof Error ? err.message : String(err)}), so the next graph ` +
-      `call may fail with a workflow instance mismatch. Recover with ` +
-      `panel_set_workflow_target({mode:"current"}).`
-    );
-  }
-  if (rebind.status === "refreshed" || rebind.status === "already_current") {
-    // The common path, and it is worth stating: the load moved the canvas AND claimed it,
-    // so the caller can go straight on to reading or editing the graph.
-    return "";
-  }
+function noteStaleFenceAfterLoad(): string {
   return (
-    `\n\nNOTE: the graph was loaded, but this session's workflow-instance fence could NOT ` +
-    `be re-claimed (${rebind.status}${describeRebindReason(rebind)}). Loading replaces ` +
-    `the graph and mints a new canvas instance, so the next graph call may fail with a ` +
-    `workflow instance mismatch — clear it with panel_set_workflow_target({mode:"current"}), ` +
-    `then retry.`
+    `
+
+NOTE: loading REPLACED the canvas graph, which mints a new workflow instance, so ` +
+    `this session's instance fence now names the OLD one and the next graph command will be ` +
+    `refused with "workflow instance mismatch". This is expected and is caused by the load ` +
+    `you just ran — not by the user switching tabs. Clear it with ` +
+    `panel_set_workflow_target({mode:"current"}), which re-derives the fence from the live ` +
+    `canvas, then continue.`
   );
 }
 
@@ -8916,7 +8897,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
           const loaded = await ctx.call({ cmd: "graph_load", graph: data }, 30000);
           if (loaded.isError) return loaded;
-          return appendNote(loaded, await claimLoadedInstance(ctx));
+          return appendNote(loaded, noteStaleFenceAfterLoad());
         } catch (err) {
           return fail(err);
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8902,8 +8902,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // replace anything, and telling that caller their fence is stale would be a
           // fabricated consequence of a load that never happened — the same
           // unmeasured-claim defect this note exists to remove.
-          const replaced = parseToolResultJson(loaded)?.loaded === true;
-          return replaced ? appendNote(loaded, noteStaleFenceAfterLoad()) : loaded;
+          // ONLY THE API-FORMAT LOAD MINTS A NEW INSTANCE (codex r3, checked in the panel).
+          // The UI-format path passes `__cmcpKeepInstance: true` whenever a workflow is
+          // active, deliberately PRESERVING the instance so the agent's own follow-up
+          // commands are not rejected — so a note claiming the fence went stale would be
+          // false for the commonest load. The API path (`app.loadApiJson`) passes no such
+          // option and does re-mint, and it is the path the reporter hit: their reply reads
+          // `format:"api"`. That field is present only on this branch, which makes it the
+          // signal rather than an inference.
+          const reply = parseToolResultJson(loaded);
+          const remintedInstance = reply?.loaded === true && reply?.format === "api";
+          return remintedInstance ? appendNote(loaded, noteStaleFenceAfterLoad()) : loaded;
         } catch (err) {
           return fail(err);
         }


### PR DESCRIPTION
Refs #1478 — fixes the **misdirection** in defect 1. Does not close the issue: the categorical repair needs a panel change, and defect 2 is panel-side.

## The reported problem

`panel_load_workflow({pack:…})` returns `{loaded:true, format:"api", node_count:59}`, and the very next `panel_graph_outline({})` fails:

```
workflow instance mismatch: … The active workflow last moved to tmp:… and
NO PANEL COMMAND CLAIMED IT.
```

A panel command *did* cause it, one call earlier. So the refusal points the reader at "the user switched tabs" — the reporter hit this deterministically twice and had to work out the real cause themselves.

## What ships

One sentence on the load result, and no round trip:

> an API-format load CAN re-mint the canvas workflow instance. If your next graph command is refused with "workflow instance mismatch", that is why — the cause is this load, NOT the user switching tabs. Clear it with `panel_set_workflow_target({mode:"current"})` … If the next command is not refused, nothing needs doing.

## Four review rounds, four false claims of mine

This PR is much smaller than what I opened it with, and every reduction was a review finding:

1. **Auto-repairing the fence was a wrong-graph write.** Running the same re-derivation the documented recovery runs adopts *whatever is active now*, with no tie to the load — a user switching canvases in the window would stamp the session to a different workflow and the next edit would land on **B** though the load modified **A**. `panel_set_workflow_target` is sound doing exactly this only because the user explicitly asked to follow what is live.
2. **Asserting staleness without confirming the load landed.** The note was keyed on "the call did not error", so a `loaded:false` envelope would have been told its fence went stale.
3. **A UI-format load PRESERVES the instance.** It passes `__cmcpKeepInstance: true` whenever a workflow is active, deliberately, so the agent's own follow-up commands are not rejected — a blanket note would have been false for the commonest load.
4. **A second API load into the same active workflow reuses the object**, whose uuid is object-keyed, so the fence stays valid there too.

After (3) and (4), every categorical version of "your fence is now stale" had been falsified by a different real path — and the reply carries nothing that separates *re-minted* from *reused*. So the claim became conditional, which is true everywhere, and the sentence stopped pretending to knowledge the data does not contain.

Also dropped along the way: an added `workflow_list` round trip that, on a panel which cannot corroborate, spent up to four 6-second probes reaching an answer it must not use.

## Verification

- 5 tests on the real tool path; suite **9206** green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`, `asset-counts --check` all pass
- pins **both** directions: the note appears for an API load, and is **absent** for a UI-format load and for a `loaded:false` envelope
- pins the P1 directly: with the user on a **different** canvas, the session stamp must not move
- mutation-checked — removing the note, hardcoding the payload gate, and dropping the format gate each fail a different test
- two pre-existing assertions counted *total* bridge calls as a proxy for "the graph was loaded once"; they now count `graph_load` specifically, which is the guarantee they were guarding

## Still open on #1478

- **The categorical fix is panel-side**: put `workflow_uuid` on `graph_load`'s reply, as #762/#800 did for `workflow_new`/`workflow_save`. The load could then compare it against the fence and say exactly what happened — or claim the identity it created, which is race-proof and refusal-proof, and is why those two work that way.
- **Defect 2** (read-only `panel_get_errors` refused by the dirty-**mutation** guard, whose text even says *"this mutation was NOT applied"*) is a panel-side classification bug.