### PR TITLE
fix(1470): resolve "nightly" by asking the repository, not by guessing

### DIFF
--- a/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
+++ b/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
@@ -1,0 +1,68 @@
+// #1470 — `install_custom_node` with a direct Git URL and version:"nightly" cloned fine,
+// then failed at checkout and DELETED the clone:
+//
+//   fatal: '--detach' cannot be used with '-b/-B/--orphan'
+//
+// Reproduced the command shape locally (git 2.54 words it differently, same cause):
+//
+//   $ git checkout --detach --end-of-options nightly
+//   fatal: git checkout: --detach does not take a path argument 'nightly'
+//
+// With `--end-of-options`, an unresolvable ref is treated as a PATH and `--detach` rejects
+// paths; an older git phrases that as the -b/-B/--orphan clash. Either way "nightly" was
+// never a ref.
+//
+// It is this tool's word for the git-HEAD channel — and one of our OWN paths mints it: a
+// git-URL install with an absent/"latest" version is rewritten to version:"nightly" because
+// ComfyUI-Manager rejects a registry "latest" for a repository-style entry. So the system
+// produced the value that the ref resolver then misread. Same shape as #1254, one word over.
+import { describe, expect, it } from "vitest";
+import {
+  gitRefForInstall,
+  isGitHeadChannel,
+  isLatestSentinel,
+} from "../../services/node-management.js";
+
+describe("a channel word never becomes a git ref (#1470)", () => {
+  it("version:'nightly' yields NO ref — the reported failure", () => {
+    // The exact input from the report: a direct Git URL install with the nightly channel.
+    // Undefined means "leave the clone where it landed" (at HEAD), which is what nightly
+    // has always meant.
+    expect(gitRefForInstall({ version: "nightly" })).toBeUndefined();
+  });
+
+  it("still true for the spellings a caller actually types", () => {
+    expect(gitRefForInstall({ version: "Nightly" })).toBeUndefined();
+    expect(gitRefForInstall({ version: " NIGHTLY " })).toBeUndefined();
+  });
+
+  it("version:'latest' is unchanged — #1254's fix is not disturbed", () => {
+    expect(gitRefForInstall({ version: "latest" })).toBeUndefined();
+  });
+
+  it("an EXPLICIT ref:'nightly' is still honoured", () => {
+    // The direction that must not regress. A repository may genuinely have a branch or tag
+    // called `nightly`, and swallowing the caller's explicit ref would replace this bug
+    // with a quieter one: an install that silently checks out something else.
+    expect(gitRefForInstall({ ref: "nightly" })).toBe("nightly");
+    expect(gitRefForInstall({ urlRef: "nightly" })).toBe("nightly");
+    // …and an explicit ref still wins over the channel selector.
+    expect(gitRefForInstall({ ref: "nightly", version: "latest" })).toBe("nightly");
+  });
+
+  it("a real version/ref still passes through", () => {
+    expect(gitRefForInstall({ version: "v1.2.3" })).toBe("v1.2.3");
+    expect(gitRefForInstall({ version: "main" })).toBe("main");
+    expect(gitRefForInstall({ ref: "abc1234" })).toBe("abc1234");
+  });
+
+  it("the two sentinels stay SEPARATE predicates", () => {
+    // Not folded together: `isLatestSentinel` is also the test at the git-URL
+    // normalisation site, where "latest" is the input being translated and "nightly" is
+    // the result. Widening it there would make that translation match its own output.
+    expect(isLatestSentinel("latest")).toBe(true);
+    expect(isLatestSentinel("nightly")).toBe(false);
+    expect(isGitHeadChannel("nightly")).toBe(true);
+    expect(isGitHeadChannel("latest")).toBe(false);
+  });
+});

--- a/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
+++ b/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
@@ -8,61 +8,79 @@
 //   $ git checkout --detach --end-of-options nightly
 //   fatal: git checkout: --detach does not take a path argument 'nightly'
 //
-// With `--end-of-options`, an unresolvable ref is treated as a PATH and `--detach` rejects
-// paths; an older git phrases that as the -b/-B/--orphan clash. Either way "nightly" was
-// never a ref.
+// With `--end-of-options` an unresolvable ref is treated as a PATH and `--detach` rejects
+// paths; an older git phrases that as the -b/-B/--orphan clash.
 //
-// It is this tool's word for the git-HEAD channel — and one of our OWN paths mints it: a
-// git-URL install with an absent/"latest" version is rewritten to version:"nightly" because
-// ComfyUI-Manager rejects a registry "latest" for a repository-style entry. So the system
-// produced the value that the ref resolver then misread. Same shape as #1254, one word over.
+// THE WORD IS OVERLOADED IN OUR OWN SURFACE, which is the whole difficulty. For a Manager
+// install "nightly" names the git-HEAD channel — one of our paths even MINTS it, rewriting
+// an absent/"latest" version to "nightly" because the Manager rejects a registry "latest"
+// for a repository-style entry. For a from-source git install, `version` is documented as a
+// git ref. A caller typing version:"nightly" may mean either.
+//
+// A first fix collapsed the word to "no ref" up front. codex found the P1: a repository that
+// genuinely HAS a `nightly` branch would then silently install its DEFAULT branch, and a
+// quietly-wrong version is worse than the loud failure being fixed. So the meaning is
+// resolved by TRYING the ref and handling the failure, not by guessing.
 import { describe, expect, it } from "vitest";
-import {
-  gitRefForInstall,
-  isGitHeadChannel,
-  isLatestSentinel,
-} from "../../services/node-management.js";
+import { gitRefForInstall, isGitHeadChannel, isLatestSentinel } from "../../services/node-management.js";
 
-describe("a channel word never becomes a git ref (#1470)", () => {
-  it("version:'nightly' yields NO ref — the reported failure", () => {
-    // The exact input from the report: a direct Git URL install with the nightly channel.
-    // Undefined means "leave the clone where it landed" (at HEAD), which is what nightly
-    // has always meant.
-    expect(gitRefForInstall({ version: "nightly" })).toBeUndefined();
+describe("the channel word is still offered to git as a ref (#1470)", () => {
+  it("version:'nightly' is NOT collapsed — a real nightly branch must still win", () => {
+    // The P1 direction. If this returns undefined, a repo with a `nightly` branch gets its
+    // default branch instead and nobody is told.
+    expect(gitRefForInstall({ version: "nightly" })).toBe("nightly");
   });
 
-  it("still true for the spellings a caller actually types", () => {
-    expect(gitRefForInstall({ version: "Nightly" })).toBeUndefined();
-    expect(gitRefForInstall({ version: " NIGHTLY " })).toBeUndefined();
-  });
-
-  it("version:'latest' is unchanged — #1254's fix is not disturbed", () => {
+  it("version:'latest' IS collapsed — #1254, unchanged", () => {
+    // "latest" has no second reading: it is never a ref anyone means.
     expect(gitRefForInstall({ version: "latest" })).toBeUndefined();
   });
 
-  it("an EXPLICIT ref:'nightly' is still honoured", () => {
-    // The direction that must not regress. A repository may genuinely have a branch or tag
-    // called `nightly`, and swallowing the caller's explicit ref would replace this bug
-    // with a quieter one: an install that silently checks out something else.
-    expect(gitRefForInstall({ ref: "nightly" })).toBe("nightly");
-    expect(gitRefForInstall({ urlRef: "nightly" })).toBe("nightly");
-    // …and an explicit ref still wins over the channel selector.
-    expect(gitRefForInstall({ ref: "nightly", version: "latest" })).toBe("nightly");
+  it("an explicit ref still wins over the version selector", () => {
+    expect(gitRefForInstall({ ref: "v2", version: "nightly" })).toBe("v2");
+    expect(gitRefForInstall({ urlRef: "abc123", version: "latest" })).toBe("abc123");
   });
 
-  it("a real version/ref still passes through", () => {
-    expect(gitRefForInstall({ version: "v1.2.3" })).toBe("v1.2.3");
-    expect(gitRefForInstall({ version: "main" })).toBe("main");
-    expect(gitRefForInstall({ ref: "abc1234" })).toBe("abc1234");
+  it("the channel test recognises what a caller actually types", () => {
+    // Used only to decide what a FAILED checkout means, so its spelling tolerance is what
+    // keeps " Nightly " from being treated as a hard error.
+    expect(isGitHeadChannel("nightly")).toBe(true);
+    expect(isGitHeadChannel("Nightly")).toBe(true);
+    expect(isGitHeadChannel(" NIGHTLY ")).toBe(true);
+    expect(isGitHeadChannel("v1.2.3")).toBe(false);
+    expect(isGitHeadChannel("main")).toBe(false);
+    expect(isGitHeadChannel(undefined)).toBe(false);
   });
 
-  it("the two sentinels stay SEPARATE predicates", () => {
-    // Not folded together: `isLatestSentinel` is also the test at the git-URL
-    // normalisation site, where "latest" is the input being translated and "nightly" is
-    // the result. Widening it there would make that translation match its own output.
+  it("the two predicates stay separate", () => {
+    // `isLatestSentinel` is also the test at the git-URL normalisation site, where "latest"
+    // is the INPUT being translated and "nightly" is the RESULT. Folding them would make
+    // that translation match its own output.
     expect(isLatestSentinel("latest")).toBe(true);
     expect(isLatestSentinel("nightly")).toBe(false);
-    expect(isGitHeadChannel("nightly")).toBe(true);
     expect(isGitHeadChannel("latest")).toBe(false);
+  });
+});
+
+describe("a failed checkout of the CHANNEL word keeps the clone (#1470)", () => {
+  it("the clone path treats it as a warning, not a husk-and-throw", async () => {
+    // Asserted on the source: this branch needs a real clone + a real git repo to drive,
+    // and what is being pinned is the DECISION — that the channel word does not take the
+    // discard path — which is a fact about the code.
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../services/node-management.ts", import.meta.url),
+      "utf-8",
+    );
+    const at = src.indexOf("Cloned \"${gitId}\" but could not check out");
+    expect(at, "the checkout-failure site moved — re-anchor this test").toBeGreaterThan(-1);
+    // Look BACK from the throw: the channel-word branch must sit between the catch and it,
+    // so a failure of that word never reaches discardFailedClone.
+    const before = src.slice(Math.max(0, at - 1800), at);
+    expect(before).toMatch(/isGitHeadChannel\(gitRef\)/);
+    expect(before).toMatch(/warnings\.push/);
+    // And the ordinary ref path still discards, which is what stops "asked for v1.2.3,
+    // silently got HEAD".
+    expect(src.slice(at - 400, at)).toMatch(/discardFailedClone/);
   });
 });

--- a/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
+++ b/src/__tests__/services/nightly-is-not-a-git-ref.test.ts
@@ -8,26 +8,29 @@
 //   $ git checkout --detach --end-of-options nightly
 //   fatal: git checkout: --detach does not take a path argument 'nightly'
 //
-// With `--end-of-options` an unresolvable ref is treated as a PATH and `--detach` rejects
-// paths; an older git phrases that as the -b/-B/--orphan clash.
+// THE WORD IS OVERLOADED IN OUR OWN SURFACE. For a Manager install "nightly" names the
+// git-HEAD channel — one of our paths mints it, rewriting an absent/"latest" version because
+// the Manager rejects a registry "latest" for a repository-style entry. For a from-source
+// git install, `version` is documented as a git ref. A caller typing version:"nightly" may
+// mean either, so the meaning is resolved by ASKING the repository, not by guessing.
 //
-// THE WORD IS OVERLOADED IN OUR OWN SURFACE, which is the whole difficulty. For a Manager
-// install "nightly" names the git-HEAD channel — one of our paths even MINTS it, rewriting
-// an absent/"latest" version to "nightly" because the Manager rejects a registry "latest"
-// for a repository-style entry. For a from-source git install, `version` is documented as a
-// git ref. A caller typing version:"nightly" may mean either.
-//
-// A first fix collapsed the word to "no ref" up front. codex found the P1: a repository that
-// genuinely HAS a `nightly` branch would then silently install its DEFAULT branch, and a
-// quietly-wrong version is worse than the loud failure being fixed. So the meaning is
-// resolved by TRYING the ref and handling the failure, not by guessing.
+// Two review findings shaped this, both worth keeping visible:
+//   • collapsing the word to "no ref" up front would silently install the DEFAULT branch of
+//     a repository that genuinely HAS a `nightly` branch — a quietly-wrong version, worse
+//     than the loud failure being fixed;
+//   • deciding by CATCHING the checkout failure swallowed unrelated errors (corrupt repo,
+//     permissions) as "no such branch", and claimed a usable HEAD after a checkout that had
+//     just failed in an unknown way.
 import { describe, expect, it } from "vitest";
-import { gitRefForInstall, isGitHeadChannel, isLatestSentinel } from "../../services/node-management.js";
+import {
+  checkoutPlanForMissingRef,
+  gitRefForInstall,
+  isGitHeadChannel,
+  isLatestSentinel,
+} from "../../services/node-management.js";
 
-describe("the channel word is still offered to git as a ref (#1470)", () => {
+describe("the ref resolver keeps 'nightly' as a ref (#1470)", () => {
   it("version:'nightly' is NOT collapsed — a real nightly branch must still win", () => {
-    // The P1 direction. If this returns undefined, a repo with a `nightly` branch gets its
-    // default branch instead and nobody is told.
     expect(gitRefForInstall({ version: "nightly" })).toBe("nightly");
   });
 
@@ -40,14 +43,33 @@ describe("the channel word is still offered to git as a ref (#1470)", () => {
     expect(gitRefForInstall({ ref: "v2", version: "nightly" })).toBe("v2");
     expect(gitRefForInstall({ urlRef: "abc123", version: "latest" })).toBe("abc123");
   });
+});
+
+describe("what a MISSING ref means depends on where it came from (#1470)", () => {
+  it("a version-derived 'nightly' the repo lacks falls back to HEAD", () => {
+    // The reported case: the repository has no such branch, and the clone already sits at
+    // the default HEAD — which is what the channel reading of the word asks for.
+    expect(checkoutPlanForMissingRef({ ref: "nightly", fromVersion: true })).toBe("skip-at-head");
+    expect(checkoutPlanForMissingRef({ ref: " Nightly ", fromVersion: true })).toBe("skip-at-head");
+  });
+
+  it("an EXPLICIT ref:'nightly' the repo lacks still FAILS", () => {
+    // The caller named a git ref. Installing something else because the name happens to
+    // spell a channel word would be the wrong-version bug in a new place.
+    expect(checkoutPlanForMissingRef({ ref: "nightly", fromVersion: false })).toBe("fail");
+  });
+
+  it("any other missing ref fails, whatever its provenance", () => {
+    // Asking for v1.2.3 and silently getting HEAD is exactly what must not happen.
+    expect(checkoutPlanForMissingRef({ ref: "v1.2.3", fromVersion: true })).toBe("fail");
+    expect(checkoutPlanForMissingRef({ ref: "main", fromVersion: true })).toBe("fail");
+    expect(checkoutPlanForMissingRef({ ref: "v1.2.3", fromVersion: false })).toBe("fail");
+  });
 
   it("the channel test recognises what a caller actually types", () => {
-    // Used only to decide what a FAILED checkout means, so its spelling tolerance is what
-    // keeps " Nightly " from being treated as a hard error.
     expect(isGitHeadChannel("nightly")).toBe(true);
     expect(isGitHeadChannel("Nightly")).toBe(true);
     expect(isGitHeadChannel(" NIGHTLY ")).toBe(true);
-    expect(isGitHeadChannel("v1.2.3")).toBe(false);
     expect(isGitHeadChannel("main")).toBe(false);
     expect(isGitHeadChannel(undefined)).toBe(false);
   });
@@ -59,28 +81,5 @@ describe("the channel word is still offered to git as a ref (#1470)", () => {
     expect(isLatestSentinel("latest")).toBe(true);
     expect(isLatestSentinel("nightly")).toBe(false);
     expect(isGitHeadChannel("latest")).toBe(false);
-  });
-});
-
-describe("a failed checkout of the CHANNEL word keeps the clone (#1470)", () => {
-  it("the clone path treats it as a warning, not a husk-and-throw", async () => {
-    // Asserted on the source: this branch needs a real clone + a real git repo to drive,
-    // and what is being pinned is the DECISION — that the channel word does not take the
-    // discard path — which is a fact about the code.
-    const { readFileSync } = await import("node:fs");
-    const src = readFileSync(
-      new URL("../../services/node-management.ts", import.meta.url),
-      "utf-8",
-    );
-    const at = src.indexOf("Cloned \"${gitId}\" but could not check out");
-    expect(at, "the checkout-failure site moved — re-anchor this test").toBeGreaterThan(-1);
-    // Look BACK from the throw: the channel-word branch must sit between the catch and it,
-    // so a failure of that word never reaches discardFailedClone.
-    const before = src.slice(Math.max(0, at - 1800), at);
-    expect(before).toMatch(/isGitHeadChannel\(gitRef\)/);
-    expect(before).toMatch(/warnings\.push/);
-    // And the ordinary ref path still discards, which is what stops "asked for v1.2.3,
-    // silently got HEAD".
-    expect(src.slice(at - 400, at)).toMatch(/discardFailedClone/);
   });
 });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1672,6 +1672,31 @@ export function isLatestSentinel(version: unknown): boolean {
 }
 
 /**
+ * #1470 — "nightly" IS NOT A GIT REF EITHER. It is this tool's name for the git-HEAD
+ * channel, and one of our own code paths MINTS it: a git-URL install with an absent or
+ * "latest" version is rewritten to `version: "nightly"` on purpose, because
+ * ComfyUI-Manager rejects a registry "latest" for a repository-style entry.
+ *
+ * Two pieces, each right on its own, made the bug: that site means "git HEAD" by the word,
+ * and the ref resolver read the same word as a ref — so a direct Git URL with
+ * version:"nightly" reached `git checkout --detach --end-of-options nightly` and died. The
+ * clone is then discarded as a husk, which is exactly the reported experience: cloned
+ * successfully, failed, clone removed.
+ *
+ * Deliberately SEPARATE from `isLatestSentinel` rather than folded into it: that helper is
+ * also the test at the git-URL normalisation site, where "latest" and "nightly" mean
+ * different things (one is the input being translated, the other is the result). Widening
+ * it there would make the translation match its own output.
+ *
+ * And it is applied to `version` ONLY. An explicit `ref:"nightly"` still checks out a ref:
+ * a repository may genuinely have a branch or tag by that name, and silently ignoring the
+ * caller's explicit ref would be a new bug in place of this one.
+ */
+export function isGitHeadChannel(version: unknown): boolean {
+  return typeof version === "string" && version.trim().toLowerCase() === "nightly";
+}
+
+/**
  * Which git ref an install should check out, or undefined for "leave the clone
  * where it landed" (#1254).
  *
@@ -1709,7 +1734,11 @@ export function gitRefForInstall(opts: {
   // never fire.
   const explicit = opts.ref ?? opts.urlRef ?? undefined;
   if (explicit !== undefined) return explicit;
-  return isLatestSentinel(opts.version) ? undefined : opts.version;
+  // A CHANNEL is not a ref (#1254 for "latest", #1470 for "nightly"). Only `version` is
+  // collapsed here — `ref`/`urlRef` returned above are the caller's explicit git refs.
+  return isLatestSentinel(opts.version) || isGitHeadChannel(opts.version)
+    ? undefined
+    : opts.version;
 }
 
 function validateGitRef(ref: string): string {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1768,6 +1768,30 @@ export function gitRefForInstall(opts: {
  * checkout path — so an unreadable repo produces git's own error from the checkout rather
  * than a fabricated "no such branch".
  */
+function gitFetchAllTags(nodeDir: string, cwd: string): void {
+  // The SAME fetch runGitCheckout performs, hoisted so the existence probe below sees
+  // everything a checkout would (codex r3). A clone does not necessarily bring down every
+  // tag, so probing first would report an orphan/unreachable `nightly` TAG as missing and
+  // silently leave the clone at HEAD — while the original checkout would have fetched it and
+  // succeeded. That is the silent-wrong-version failure this whole change exists to avoid,
+  // reintroduced by the probe meant to prevent it.
+  //
+  // Best-effort: a fetch that fails leaves the probe to answer from what is already local,
+  // and a genuinely missing ref then still reaches the checkout, which reports git's own
+  // error. runGitCheckout fetches again; a second fetch is a cheap no-op next to being wrong.
+  try {
+    execFileSync("git", ["-C", nodeDir, "fetch", "--all", "--tags"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    /* probe falls back to what is local */
+  }
+}
+
 function gitRefExists(nodeDir: string, ref: string, cwd: string): boolean {
   try {
     execFileSync("git", ["-C", nodeDir, "rev-parse", "--verify", "--quiet", "--end-of-options", `${ref}^{commit}`], {
@@ -2411,6 +2435,7 @@ async function cloneCustomNodeFallback(
       // install. A repository that HAS a `nightly` branch must get it; one that does not
       // is not a caller error, it is the other reading of the same word — and the clone
       // already sits at HEAD, which is what that reading asks for.
+      gitFetchAllTags(nodeDir, comfyuiBase);
       const refMissing = !gitRefExists(nodeDir, gitRef, comfyuiBase);
       if (refMissing && checkoutPlanForMissingRef({ ref: gitRef, fromVersion: opts?.refFromVersion === true }) === "skip-at-head") {
         warnings.push(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1672,29 +1672,24 @@ export function isLatestSentinel(version: unknown): boolean {
 }
 
 /**
- * #1470 — "nightly" IS NOT A GIT REF EITHER. It is this tool's name for the git-HEAD
- * channel, and one of our own code paths MINTS it: a git-URL install with an absent or
- * "latest" version is rewritten to `version: "nightly"` on purpose, because
- * ComfyUI-Manager rejects a registry "latest" for a repository-style entry.
+ * #1470 — is this the CHANNEL word "nightly" rather than a git ref?
  *
- * Two pieces, each right on its own, made the bug: that site means "git HEAD" by the word,
- * and the ref resolver read the same word as a ref — so a direct Git URL with
- * version:"nightly" reached `git checkout --detach --end-of-options nightly` and died. The
- * clone is then discarded as a husk, which is exactly the reported experience: cloned
- * successfully, failed, clone removed.
+ * The word is overloaded in our own surface, which is what made the bug: for a Manager
+ * install it names the git-HEAD channel — one of our paths even MINTS it, rewriting an
+ * absent/"latest" version to "nightly" because the Manager rejects a registry "latest" for
+ * a repository-style entry — while for a from-source git install `version` is documented as
+ * a git ref. A user who types `version:"nightly"` may mean either.
  *
- * Deliberately SEPARATE from `isLatestSentinel` rather than folded into it: that helper is
- * also the test at the git-URL normalisation site, where "latest" and "nightly" mean
- * different things (one is the input being translated, the other is the result). Widening
- * it there would make the translation match its own output.
- *
- * And it is applied to `version` ONLY. An explicit `ref:"nightly"` still checks out a ref:
- * a repository may genuinely have a branch or tag by that name, and silently ignoring the
- * caller's explicit ref would be a new bug in place of this one.
+ * So this does NOT decide the meaning on its own (codex): collapsing it to "no ref" would
+ * silently install the DEFAULT branch of a repository that genuinely has a `nightly` branch,
+ * and a quietly-wrong version is worse than the loud failure being fixed. It is used only to
+ * choose what happens when the checkout FAILS — see the clone path, which keeps the clone at
+ * HEAD and says so instead of deleting it.
  */
 export function isGitHeadChannel(version: unknown): boolean {
   return typeof version === "string" && version.trim().toLowerCase() === "nightly";
 }
+
 
 /**
  * Which git ref an install should check out, or undefined for "leave the clone
@@ -1734,11 +1729,12 @@ export function gitRefForInstall(opts: {
   // never fire.
   const explicit = opts.ref ?? opts.urlRef ?? undefined;
   if (explicit !== undefined) return explicit;
-  // A CHANNEL is not a ref (#1254 for "latest", #1470 for "nightly"). Only `version` is
-  // collapsed here — `ref`/`urlRef` returned above are the caller's explicit git refs.
-  return isLatestSentinel(opts.version) || isGitHeadChannel(opts.version)
-    ? undefined
-    : opts.version;
+  // "latest" is collapsed because it is NEVER a ref anyone means (#1254). "nightly" is
+  // deliberately NOT (#1470): it is overloaded — this tool's git-HEAD channel AND a plausible
+  // branch name — so it is offered to git as a ref, and the clone path decides what a FAILED
+  // checkout of it means. Collapsing it here would silently install the default branch of a
+  // repository that genuinely has one (codex).
+  return isLatestSentinel(opts.version) ? undefined : opts.version;
 }
 
 function validateGitRef(ref: string): string {
@@ -2363,11 +2359,34 @@ async function cloneCustomNodeFallback(
       try {
         runGitCheckout(gitId, gitRef, comfyuiBase);
       } catch (err) {
-        const leftover = discardFailedClone(nodeDir, alreadyPresent);
-        throw new NodeManagementError(
-          `Cloned "${gitId}" but could not check out "${gitRef}": ` +
-            `${err instanceof Error ? err.message : String(err)}${leftover}`,
-        );
+        // #1470 — "nightly" IS BOTH A CHANNEL AND A POSSIBLE REF, so it is resolved by
+        // TRYING it rather than by guessing which the caller meant.
+        //
+        // A git install documents `version` as a git ref, and a repository may genuinely
+        // have a `nightly` branch — collapsing the word to "no ref" up front would install
+        // that repo's DEFAULT branch instead, and a quietly-wrong version is worse than the
+        // failure being fixed here. But the word is ALSO this tool's name for the git-HEAD
+        // channel (one of our own paths mints it for exactly that meaning), so a repository
+        // without such a branch is not a caller error — it is the other reading of the same
+        // word, and the clone already sits at HEAD, which is what that reading asks for.
+        //
+        // So: a failed checkout of the CHANNEL word keeps the clone and discloses, instead
+        // of deleting a working install over a word. Any other ref keeps the old behaviour —
+        // asking for `v1.2.3` and silently getting HEAD would be the wrong-version bug.
+        if (isGitHeadChannel(gitRef)) {
+          warnings.push(
+            `"${gitRef}" is not a ref in ${gitId}, so the clone was left at the repository's ` +
+              `default HEAD — which is what "nightly" means as a channel. If you meant a ref ` +
+              `by that name, this repository does not have one; pass ref:<branch-or-tag> for ` +
+              `an exact checkout.`,
+          );
+        } else {
+          const leftover = discardFailedClone(nodeDir, alreadyPresent);
+          throw new NodeManagementError(
+            `Cloned "${gitId}" but could not check out "${gitRef}": ` +
+              `${err instanceof Error ? err.message : String(err)}${leftover}`,
+          );
+        }
       }
     }
   }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1690,6 +1690,28 @@ export function isGitHeadChannel(version: unknown): boolean {
   return typeof version === "string" && version.trim().toLowerCase() === "nightly";
 }
 
+/**
+ * #1470 — what to do with a ref the freshly-cloned repository does NOT have.
+ *
+ * Decided from a rev-parse BEFORE the checkout, never by catching its failure (codex r2).
+ * Catching was wrong twice over: it swallowed unrelated failures — a corrupt repo, a
+ * permissions error — as "no such branch", and it claimed the clone was left at a usable
+ * HEAD after a checkout that had just failed in an unknown way. Asking first means a real
+ * checkout error still throws, and the skip path never runs a command at all, so the clone
+ * is exactly as `git clone` left it.
+ *
+ * Only a ref that came from `version` may be skipped. An explicit `ref:` is the caller
+ * naming a git ref, and quietly installing something else because the name happens to spell
+ * a channel word would be the wrong-version bug in a new place.
+ */
+export function checkoutPlanForMissingRef(opts: {
+  ref: string;
+  /** True when the ref came from the `version` selector rather than an explicit `ref`. */
+  fromVersion: boolean;
+}): "skip-at-head" | "fail" {
+  return opts.fromVersion && isGitHeadChannel(opts.ref) ? "skip-at-head" : "fail";
+}
+
 
 /**
  * Which git ref an install should check out, or undefined for "leave the clone
@@ -1735,6 +1757,30 @@ export function gitRefForInstall(opts: {
   // checkout of it means. Collapsing it here would silently install the default branch of a
   // repository that genuinely has one (codex).
   return isLatestSentinel(opts.version) ? undefined : opts.version;
+}
+
+/**
+ * #1470 — does the cloned repository actually have this ref? Asked BEFORE the checkout so a
+ * missing ref is distinguishable from a checkout that failed for any other reason.
+ *
+ * `--verify --quiet` with a `^{commit}` peel answers only "resolves to a commit", which is
+ * the question. A THROW here is read as "cannot tell", and the caller then takes the normal
+ * checkout path — so an unreadable repo produces git's own error from the checkout rather
+ * than a fabricated "no such branch".
+ */
+function gitRefExists(nodeDir: string, ref: string, cwd: string): boolean {
+  try {
+    execFileSync("git", ["-C", nodeDir, "rev-parse", "--verify", "--quiet", "--end-of-options", `${ref}^{commit}`], {
+      cwd,
+      encoding: "utf-8",
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function validateGitRef(ref: string): string {
@@ -2274,7 +2320,12 @@ async function cloneCustomNodeFallback(
    * policy refusal would be a wrong explanation for a correct action; the caller
    * that knows better passes its own.
    */
-  opts?: { managerRefusalNote?: string },
+  opts?: {
+    managerRefusalNote?: string;
+    /** #1470 — did `gitRef` come from the `version` selector rather than an explicit
+     *  `ref`? Only a version-derived ref may be skipped when the repo does not have it. */
+    refFromVersion?: boolean;
+  },
 ): Promise<NodeOpResult> {
   const because =
     opts?.managerRefusalNote ?? `"${repoName}" is not in the ComfyUI-Manager registry`;
@@ -2354,33 +2405,26 @@ async function cloneCustomNodeFallback(
       );
     }
     if (gitRef) {
-      // The checkout is part of producing the pack, so its failure leaves the
-      // same husk as a failed clone — and the clone directory is ours either way.
-      try {
-        runGitCheckout(gitId, gitRef, comfyuiBase);
-      } catch (err) {
-        // #1470 — "nightly" IS BOTH A CHANNEL AND A POSSIBLE REF, so it is resolved by
-        // TRYING it rather than by guessing which the caller meant.
-        //
-        // A git install documents `version` as a git ref, and a repository may genuinely
-        // have a `nightly` branch — collapsing the word to "no ref" up front would install
-        // that repo's DEFAULT branch instead, and a quietly-wrong version is worse than the
-        // failure being fixed here. But the word is ALSO this tool's name for the git-HEAD
-        // channel (one of our own paths mints it for exactly that meaning), so a repository
-        // without such a branch is not a caller error — it is the other reading of the same
-        // word, and the clone already sits at HEAD, which is what that reading asks for.
-        //
-        // So: a failed checkout of the CHANNEL word keeps the clone and discloses, instead
-        // of deleting a working install over a word. Any other ref keeps the old behaviour —
-        // asking for `v1.2.3` and silently getting HEAD would be the wrong-version bug.
-        if (isGitHeadChannel(gitRef)) {
-          warnings.push(
-            `"${gitRef}" is not a ref in ${gitId}, so the clone was left at the repository's ` +
-              `default HEAD — which is what "nightly" means as a channel. If you meant a ref ` +
-              `by that name, this repository does not have one; pass ref:<branch-or-tag> for ` +
-              `an exact checkout.`,
-          );
-        } else {
+      // #1470 — ASK WHETHER THE REF EXISTS, then act. "nightly" is overloaded in this
+      // tool's own surface: it names the git-HEAD channel for a Manager install (one of
+      // our paths mints it), and `version` is documented as a git ref for a from-source
+      // install. A repository that HAS a `nightly` branch must get it; one that does not
+      // is not a caller error, it is the other reading of the same word — and the clone
+      // already sits at HEAD, which is what that reading asks for.
+      const refMissing = !gitRefExists(nodeDir, gitRef, comfyuiBase);
+      if (refMissing && checkoutPlanForMissingRef({ ref: gitRef, fromVersion: opts?.refFromVersion === true }) === "skip-at-head") {
+        warnings.push(
+          `"${gitRef}" is not a branch or tag in ${gitId}, so the clone was left at the ` +
+            `repository's default HEAD — which is what "nightly" means as a channel here. ` +
+            `If you meant a ref by that name, this repository does not have one; pass ` +
+            `ref:<branch-or-tag> for an exact checkout.`,
+        );
+      } else {
+        // The checkout is part of producing the pack, so its failure leaves the
+        // same husk as a failed clone — and the clone directory is ours either way.
+        try {
+          runGitCheckout(gitId, gitRef, comfyuiBase);
+        } catch (err) {
           const leftover = discardFailedClone(nodeDir, alreadyPresent);
           throw new NodeManagementError(
             `Cloned "${gitId}" but could not check out "${gitRef}": ` +
@@ -2587,6 +2631,11 @@ async function installCustomNodeImpl(
     source === "git" && gitRefCandidate
       ? validateGitRef(gitRefCandidate)
       : gitRefCandidate;
+  // #1470 — provenance, not spelling. `gitRefForInstall` prefers an explicit ref/urlRef, so
+  // the candidate came from `version` exactly when neither was supplied. Only that case may
+  // fall back to HEAD for a repo that lacks the ref; an explicit `ref:` is the caller naming
+  // a git ref and must fail loudly if it is absent.
+  const refFromVersion = opts.ref === undefined && parsedGit.ref == null;
 
   // SECURITY: validate a git URL ONCE, up front, before it can reach ANY install
   // path — cm-cli (`cm-cli install <url>`), the Manager queue, or the clone
@@ -2724,6 +2773,7 @@ async function installCustomNodeImpl(
       });
       return withCliNote(
         await cloneCustomNodeFallback(gitId, repoName, gitRef, { manager_refused: refusedBy }, cliWorkspace, {
+          refFromVersion,
           managerRefusalNote:
             `ComfyUI-Manager REFUSED the git-URL install (HTTP ${refusedBy}) — on a legacy 3.x ` +
             `host that is its security_level / allow_git_url_install gate, or a build that does ` +
@@ -2745,7 +2795,9 @@ async function installCustomNodeImpl(
         details: status,
       });
     }
-    return withCliNote(await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace));
+    return withCliNote(
+      await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, { refFromVersion }),
+    );
   }
 
   // Registry (plain CNR id). Keep the prior defaults channel "default" /


### PR DESCRIPTION
Fixes #1470.

`install_custom_node` with a direct Git URL and `version:"nightly"` cloned fine, then failed at checkout and **deleted the clone**:

```
fatal: '--detach' cannot be used with '-b/-B/--orphan'
```

I reproduced the command shape rather than trusting the ticket's wording:

```
$ git checkout --detach --end-of-options nightly
fatal: git checkout: --detach does not take a path argument 'nightly'
```

git 2.54 words it differently from the reporter's git, same cause: with `--end-of-options` an unresolvable ref is treated as a **path**, and `--detach` rejects paths. Their diagnosis was right.

## Why this wasn't a one-liner

**The word is overloaded in our own surface.** For a Manager install `"nightly"` names the git-HEAD channel — one of our paths *mints* it, rewriting an absent/`"latest"` version because the Manager rejects a registry `"latest"` for a repository-style entry. For a from-source git install, `version` is documented as a **git ref**. A caller typing `version:"nightly"` may mean either.

My first fix collapsed it to "no ref" alongside `"latest"` (#1254). Three review rounds each found a distinct silent-wrong-version hazard in what I had:

1. **Collapsing it up front** would install the DEFAULT branch of a repository that genuinely has a `nightly` branch — quietly, which is worse than the loud failure being fixed.
2. **Deciding by catching the checkout failure** swallowed unrelated errors (corrupt repo, permissions) as "no such branch", and claimed a usable HEAD after a checkout that had just failed in an unknown way.
3. **Probing before the fetch** asked a question about less than the checkout would see, so a tag not yet fetched could read as missing.

## What ships

The meaning is resolved by **asking the repository**:

1. fetch tags (the same fetch the checkout performs), then
2. `git rev-parse --verify --quiet <ref>^{commit}` on the fresh clone
3. missing **and** the ref came from `version` → skip the checkout, leave the clone as cloned, warn
4. anything else → the original checkout-or-throw

Scoped by **provenance, not spelling**: an explicit `ref:"nightly"` still fails loudly if the repository lacks it. Only `"latest"` is collapsed in the resolver, unchanged from #1254.

The skip path runs no git command at all, so there is no post-failure HEAD to misreport; a rev-parse that throws reads as "cannot tell" and takes the normal checkout path, so an unreadable repo produces git's own error.

## Verification

- 8 tests; the decision is a pure exported function tested directly — round 2 correctly called out my earlier source-text assertion as passing on a broken implementation
- mutation-checked: ignoring provenance fails the explicit-ref test; collapsing in the resolver fails the real-branch test
- suite **9214** green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`, `asset-counts --check` all pass

**One honest note on round 3's finding:** I could not reproduce it. Building a bare remote with a tag on an unreachable commit and cloning fresh, `rev-parse` found the tag with **no fetch at all**. So that case is narrower than described and may be git-version dependent. I kept the fetch-then-probe ordering anyway — it is correct regardless, and costs one no-op fetch — but I am not claiming to have confirmed the scenario.