### PR TITLE
chore(release): 0.51.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.28
+
+### Fixed
+
+- **Installing a custom node from a Git URL with `version:"nightly"` no longer fails and
+  deletes the clone (#1470).** The repository cloned successfully, then the checkout died
+  with `fatal: '--detach' cannot be used with '-b/-B/--orphan'` and the clone was discarded
+  as a husk -- so a perfectly good install left nothing behind.
+
+  "nightly" is overloaded in this tool's own surface, which is what made it awkward to fix.
+  For a Manager install it names the git-HEAD channel -- one of our own paths mints it,
+  rewriting an absent or "latest" version because ComfyUI-Manager rejects a registry
+  "latest" for a repository-style entry. For a from-source git install, `version` is
+  documented as a git ref. Someone typing it may mean either.
+
+  So the meaning is resolved by ASKING the repository rather than guessing: tags are
+  fetched, the ref is looked up, and only if the repository genuinely has no such ref -- and
+  the ref came from `version` rather than an explicit `ref:` -- is the checkout skipped and
+  the clone left at the default HEAD, which is what the channel reading asks for. The reply
+  says that happened.
+
+  Everything else is unchanged: a repository that DOES have a `nightly` branch gets it, an
+  explicit `ref:"nightly"` still fails loudly when it is absent, and any other missing ref
+  still fails rather than quietly installing something else. Asking for `v1.2.3` and
+  silently receiving HEAD would be a worse bug than the one being fixed.
+
 ## 0.51.27
 
 ### Fixed
@@ -499,6 +525,14 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.51.28] - 2026-08-13
+
+### MCP
+
+#### Fixed
+- resolve "nightly" by asking the repository, not by guessing (#1513)
+
 
 ## [0.51.27] - 2026-08-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.27",
+  "version": "0.51.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.27",
+      "version": "0.51.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.27",
+  "version": "0.51.28",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.51.28.

Ships the #1470 fix: a Git-URL install with `version:"nightly"` no longer fails at checkout and deletes the clone. The meaning of the overloaded word is resolved by asking the repository — fetch, look up the ref, and fall back to HEAD only when the repo genuinely lacks it AND the ref came from `version` rather than an explicit `ref:`.

Three codex rounds, each catching a distinct silent-wrong-version hazard in earlier versions of my fix. See #1513.

Merge with a MERGE commit (not squash) so the tag lands on the exact reconciled SHA.