### PR TITLE
fix(1473): take the graph read this refusal prescribes, and report what it found

### DIFF
--- a/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
+++ b/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
@@ -128,9 +128,12 @@ describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up 
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/CHECKED FOR YOU/);
     expect(out.text).toMatch(/it SUCCEEDED/);
-    expect(out.text).toMatch(/READS work against it/);
-    expect(out.text).toMatch(/reconciliation race/);
-    expect(out.text).toMatch(/No recovery step is needed/);
+    expect(out.text).toMatch(/did not reject THAT command/);
+    expect(out.text).toMatch(/evidence of a reconciliation race/);
+    // ONE observation stated as one: no generalisation to every command (codex r2).
+    expect(out.text).toMatch(/not a\s+guarantee about the next command/);
+    expect(out.text).not.toMatch(/READS work/);
+    expect(out.text).toMatch(/Nothing suggests a recovery step is needed/);
     // And it does not overclaim: the rebind itself is still reported as not having happened.
     expect(out.text).toMatch(/rebind itself still did not happen/);
   });
@@ -181,8 +184,8 @@ describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up 
       canMutate: false,
     });
 
-    expect(out.text).toMatch(/READS work against it/);
+    expect(out.text).toMatch(/did not reject THAT command/);
     expect(out.text).toMatch(/MUTATIONS are a separate matter/);
-    expect(out.text).not.toMatch(/No recovery step is needed/);
+    expect(out.text).not.toMatch(/Nothing suggests a recovery step is needed/);
   });
 });

--- a/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
+++ b/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
@@ -1,0 +1,136 @@
+// #1473 — right after a ComfyUI restart, `panel_set_workflow_target({mode:"current"})`
+// returned isError:true saying the graph binding was NOT restored… and the reporter's very
+// next `panel_graph_outline` succeeded with the expected graph. The session was never
+// wedged; it was told it was.
+//
+// #1401 had already got the MESSAGE right for this shape: when the panel's reported identity
+// MATCHES the fence the session already holds, it says so, says it is not a claim that graph
+// tools work, and tells the caller to settle it with a graph read. What was left is that it
+// still reported FAILURE — so this takes the advice it gives instead of handing the caller a
+// failure plus homework.
+//
+// Narrow by design: the probe runs only on the matching-uuid path, where the two remaining
+// possibilities (a reconciliation race vs a stale/background record) are indistinguishable
+// by inspection and trivially distinguishable by asking.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+/** The uuid the session is already fenced to AND the one the panel reports. */
+const SAME_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const OTHER_UUID = "99999999-8888-4777-8666-555555555555";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+let sent: string[] = [];
+
+/**
+ * A panel mid-reconciliation: it answers `workflow_list` but flags the active record
+ * UNCONFIRMED, so nothing may be adopted. `activeUuid` decides whether that record names the
+ * fence this session already holds. `graphReadOk` decides whether the settling probe passes.
+ */
+function bridge(opts: { activeUuid: string; graphReadOk: boolean }) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        return {
+          active: {
+            path: "workflows/a.json",
+            filename: "a.json",
+            title: "a.json",
+            key: "workflows/a.json",
+            routing_key: "wf:workflows/a.json",
+            workflow_uuid: opts.activeUuid,
+          },
+          open: [{ path: "workflows/a.json", active: true, modified: false, persisted: true }],
+          workflows: [{ path: "workflows/a.json", active: true, modified: false, persisted: true }],
+          // The panel itself says "do not trust this yet" — the reported shape.
+          active_confirmed: false,
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        if (!opts.graphReadOk) throw new Error("workflow instance mismatch: refused");
+        return { ids: [1] };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: SAME_UUID }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function setTargetCurrent(opts: { activeUuid: string; graphReadOk: boolean }) {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+  if (!def) throw new Error("panel_set_workflow_target is not registered");
+  const res: ToolResult = await def.handler({ mode: "current" } as never, ctx);
+  return { text: textOf(res), isError: res.isError === true };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up front (#1473)", () => {
+  it("probes a graph read and reports what it found", async () => {
+    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphReadOk: true });
+
+    // The probe really ran — without this the assertions could pass on a branch that
+    // simply stopped failing, which would be a claim rather than a measurement.
+    expect(sent).toContain("graph_query");
+
+    // STILL A FAILURE, and that is #1401's reasoned call, not an oversight: "softening the
+    // DIAGNOSIS must not soften the RESULT — the rebind genuinely did not happen." It did
+    // not. What changed is that the caller learns, in this reply, that nothing is broken —
+    // instead of discovering it one call later.
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/CHECKED FOR YOU/);
+    expect(out.text).toMatch(/it SUCCEEDED/);
+    expect(out.text).toMatch(/reconciliation race/);
+    expect(out.text).toMatch(/No recovery step is needed/);
+    // And it does not overclaim: the rebind itself is still reported as not having happened.
+    expect(out.text).toMatch(/rebind itself still did not happen/);
+  });
+
+  it("keeps the failure when the graph read is REFUSED", async () => {
+    // Then the reply really was stale and graph tools really are wedged — today's verdict
+    // is correct and stays, remedy and all.
+    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphReadOk: false });
+
+    expect(sent).toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/did NOT restore/);
+    // The probe's answer is reported either way — a refused read CONFIRMS the wedge, which
+    // is worth saying rather than leaving the caller to re-derive it.
+    expect(out.text).toMatch(/it was REFUSED/);
+  });
+
+  it("does NOT probe when the reported identity differs from the fence", async () => {
+    // The other path is a genuine certain failure: the session is fenced to a different
+    // instance and graph tools will keep failing. Probing there would spend a round trip to
+    // learn something already known, and a passing read would not make the fence right.
+    const out = await setTargetCurrent({ activeUuid: OTHER_UUID, graphReadOk: true });
+
+    expect(sent).not.toContain("graph_query");
+    expect(out.isError).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
+++ b/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
@@ -40,7 +40,12 @@ let sent: string[] = [];
  * UNCONFIRMED, so nothing may be adopted. `activeUuid` decides whether that record names the
  * fence this session already holds. `graphReadOk` decides whether the settling probe passes.
  */
-function bridge(opts: { activeUuid: string; graphReadOk: boolean }) {
+function bridge(opts: {
+  activeUuid: string;
+  /** "ok" passes; "mismatch" is a real fence refusal; "timeout" is an inconclusive failure. */
+  graphRead: "ok" | "mismatch" | "timeout";
+  canMutate?: boolean;
+}) {
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
@@ -61,7 +66,17 @@ function bridge(opts: { activeUuid: string; graphReadOk: boolean }) {
         };
       }
       if (cmd.cmd === "graph_query") {
-        if (!opts.graphReadOk) throw new Error("workflow instance mismatch: refused");
+        if (opts.graphRead === "mismatch") {
+          throw new Error(
+            "workflow instance mismatch: this command was issued for workflow instance X, " +
+              "and the active canvas reports Y. Nothing was applied.",
+          );
+        }
+        if (opts.graphRead === "timeout") {
+          // NOT a fence verdict: the tab was backgrounded and never answered. ctx.call turns
+          // this into an error result too, which is exactly the conflation being guarded.
+          throw new Error("timed out after 8000ms waiting for the panel to answer graph_query");
+        }
         return { ids: [1] };
       }
       return { ok: true };
@@ -73,12 +88,20 @@ function bridge(opts: { activeUuid: string; graphReadOk: boolean }) {
     resolveActiveTabId: () => TAB,
     refreshWorkflowUuid: () => true,
     workflowUuidFor: () => ({ known: true, uuid: SAME_UUID }),
-    tabCanMutateGraph: () => true,
-    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabCanMutateGraph: () => opts.canMutate !== false,
+    tabGraphMutationCapability: () => ({
+      known: true,
+      canMutate: opts.canMutate !== false,
+      ...(opts.canMutate === false ? { because: "capability" as const } : {}),
+    }),
   } as unknown as PanelToolCtx["bridge"];
 }
 
-async function setTargetCurrent(opts: { activeUuid: string; graphReadOk: boolean }) {
+async function setTargetCurrent(opts: {
+  activeUuid: string;
+  graphRead: "ok" | "mismatch" | "timeout";
+  canMutate?: boolean;
+}) {
   const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
   if (!def) throw new Error("panel_set_workflow_target is not registered");
@@ -92,7 +115,7 @@ beforeEach(() => {
 
 describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up front (#1473)", () => {
   it("probes a graph read and reports what it found", async () => {
-    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphReadOk: true });
+    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphRead: "ok" });
 
     // The probe really ran — without this the assertions could pass on a branch that
     // simply stopped failing, which would be a claim rather than a measurement.
@@ -105,6 +128,7 @@ describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up 
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/CHECKED FOR YOU/);
     expect(out.text).toMatch(/it SUCCEEDED/);
+    expect(out.text).toMatch(/READS work against it/);
     expect(out.text).toMatch(/reconciliation race/);
     expect(out.text).toMatch(/No recovery step is needed/);
     // And it does not overclaim: the rebind itself is still reported as not having happened.
@@ -114,23 +138,51 @@ describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up 
   it("keeps the failure when the graph read is REFUSED", async () => {
     // Then the reply really was stale and graph tools really are wedged — today's verdict
     // is correct and stays, remedy and all.
-    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphReadOk: false });
+    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphRead: "mismatch" });
 
     expect(sent).toContain("graph_query");
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/did NOT restore/);
     // The probe's answer is reported either way — a refused read CONFIRMS the wedge, which
     // is worth saying rather than leaving the caller to re-derive it.
-    expect(out.text).toMatch(/it was REFUSED/);
+    expect(out.text).toMatch(/REFUSED by the instance fence/);
   });
 
   it("does NOT probe when the reported identity differs from the fence", async () => {
     // The other path is a genuine certain failure: the session is fenced to a different
     // instance and graph tools will keep failing. Probing there would spend a round trip to
     // learn something already known, and a passing read would not make the fence right.
-    const out = await setTargetCurrent({ activeUuid: OTHER_UUID, graphReadOk: true });
+    const out = await setTargetCurrent({ activeUuid: OTHER_UUID, graphRead: "ok" });
 
     expect(sent).not.toContain("graph_query");
     expect(out.isError).toBe(true);
+  });
+
+  it("an INCONCLUSIVE probe claims nothing in either direction (codex P1)", async () => {
+    // `ctx.call` turns a transport failure into an error result too, so reading every error
+    // as "refused" would invent a wedge out of a backgrounded tab — and would contradict
+    // this block's own rule that an unknown answer says nothing.
+    const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphRead: "timeout" });
+
+    expect(sent).toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/REFUSED by the instance fence/);
+    expect(out.text).not.toMatch(/it SUCCEEDED/);
+  });
+
+  it("a passing READ does not promise MUTATIONS work (codex P1)", async () => {
+    // The write fence is a separate capability: a panel can serve reads while refusing every
+    // mutation. Saying "no recovery step is needed" there would send someone to edit a graph
+    // that will refuse them.
+    const out = await setTargetCurrent({
+      activeUuid: SAME_UUID,
+      graphRead: "ok",
+      canMutate: false,
+    });
+
+    expect(out.text).toMatch(/READS work against it/);
+    expect(out.text).toMatch(/MUTATIONS are a separate matter/);
+    expect(out.text).not.toMatch(/No recovery step is needed/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4135,6 +4135,11 @@ function describeFenceRebind(
 ): {
   binding: "bound" | "reads_only" | "unverified" | "not_recovered";
   note: string;
+  /** #1473 — this verdict is UNRESOLVED rather than negative, and one cheap graph read
+   *  settles it. Set only where the reported identity MATCHES the fence already held: the
+   *  session is then either fine (a reconciliation race) or fenced to a stale record, and
+   *  those are indistinguishable from here but trivially distinguishable by asking. */
+  settleByRead?: true;
 } {
   // A panel that cannot fence a WRITE gives reads only, however good the stamp is.
   const mutationsRefused = canMutate === false;
@@ -4425,6 +4430,7 @@ function describeFenceRebind(
       if (fenceStillMatches) {
         return {
           binding: "not_recovered",
+          settleByRead: true,
           note:
             `${lead}. This session's fence was NOT re-derived, and whether that reply describes ` +
             `the LIVE canvas is exactly what could not be confirmed — a stale or background ` +
@@ -10794,11 +10800,60 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const fence = fenceRebind
           ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause)
           : undefined;
+        // #1473 — TAKE THE ADVICE THIS MESSAGE GIVES, instead of assigning it as homework.
+        //
+        // The reporter restarted ComfyUI, called this, was told the binding was NOT
+        // restored — and their very next `panel_graph_outline` succeeded with the expected
+        // graph. #1401 already made the message right for this shape: when the panel's
+        // reported identity MATCHES the fence this session already holds, it says so, says
+        // it is NOT a claim that graph tools work, and prescribes a cheap graph read to
+        // settle it. All true. It just left the caller to run that read themselves.
+        //
+        // So the read is taken here, on the matching-uuid path ONLY, and its ANSWER is put
+        // in the message.
+        //
+        // THE RESULT STILL REPORTS FAILURE, deliberately, and that is #1401's call not
+        // mine: "softening the DIAGNOSIS must not soften the RESULT — the rebind genuinely
+        // did not happen". It did not. What changes is that the caller no longer has to
+        // discover, one call later, that nothing was wrong: the answer arrives with the
+        // refusal instead of after it. Whether this should become a SUCCESS is a real
+        // product question and a reversal of a reasoned decision, so it is raised on the
+        // issue rather than decided here.
+        let settledNote = "";
+        if (fence && fence.binding === "not_recovered" && fence.settleByRead) {
+          let probeOk: boolean | undefined;
+          try {
+            // The cheapest fenced read there is: ids only, one row. It is refused by the
+            // same instance fence every graph command carries, which is exactly the
+            // question — a full outline would answer it no better and would cost the caller
+            // a page of graph on a recovery path.
+            const probe = await ctx.call({ cmd: "graph_query", fields: "ids", limit: 1 }, 8000);
+            probeOk = !probe.isError;
+          } catch {
+            probeOk = undefined; // a probe that throws settles nothing, and says nothing
+          }
+          settledNote =
+            probeOk === true
+              ? `
+
+CHECKED FOR YOU: the graph read this message prescribes was just run, and ` +
+                `it SUCCEEDED — so graph tools do work against the fence this session already ` +
+                `holds. This was a reconciliation race after the reconnect, not a broken ` +
+                `binding. No recovery step is needed; carry on. (The rebind itself still did ` +
+                `not happen, which is why this is reported as a failure.)`
+              : probeOk === false
+                ? `
+
+CHECKED FOR YOU: the graph read this message prescribes was just run, and ` +
+                  `it was REFUSED — so the reply was stale after all and graph tools really are ` +
+                  `wedged. The remedy above applies.`
+                : "";
+        }
         if (fence && fence.binding === "not_recovered") {
           return fail(
             `panel_set_workflow_target({mode:"current"}) did NOT restore this session's graph ` +
               `binding.\n\nAPPLIED (do not repeat this part): the workflow target is now ` +
-              `mode:"current"${rebindNote ? `.${rebindNote}` : "."}\n\nNOT APPLIED:${fence.note}`,
+              `mode:"current"${rebindNote ? `.${rebindNote}` : "."}\n\nNOT APPLIED:${fence.note}${settledNote}`,
           );
         }
         // #888 — SAY what the scope repin did. A silent success is as unhelpful

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10849,17 +10849,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
           if (probeOk) {
             settledNote =
+              // ONE OBSERVATION, STATED AS ONE (codex r2). A passing graph_query proves that
+              // read passed this fence just now — not that every command will, and not that
+              // the cause "was" a race. The earlier wording generalised to "READS work" and
+              // asserted the cause outright, which is the same overclaim this reply exists to
+              // stop making.
               `
 
-CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
-              `SUCCEEDED — so this fence does NOT reject graph commands, and READS work against ` +
-              `it right now. This was a reconciliation race after the reconnect, not a broken ` +
-              `binding.` +
+CHECKED FOR YOU: the graph read this message prescribes was just run — a ` +
+              `graph_query against this fence — and it SUCCEEDED. So the fence did not reject ` +
+              `THAT command a moment ago, which is the single fact this settles: it is evidence ` +
+              `of a reconciliation race after the reconnect rather than a broken binding, not a ` +
+              `guarantee about the next command.` +
               (canMutateNow === false
                 ? ` MUTATIONS are a separate matter and remain refused on this tab — that is the ` +
                   `write-fence capability above, not the binding, and re-running this will not ` +
                   `change it.`
-                : ` No recovery step is needed for the binding; carry on.`) +
+                : ` Nothing suggests a recovery step is needed for the binding; the next graph ` +
+                  `command is still the authority.`) +
               ` (The rebind itself still did not happen, which is why this is reported as a ` +
               `failure.)`;
           } else if (probeRefused === true) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10821,33 +10821,58 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // issue rather than decided here.
         let settledNote = "";
         if (fence && fence.binding === "not_recovered" && fence.settleByRead) {
-          let probeOk: boolean | undefined;
+          // WHAT THE PROBE PROVES, AND ONLY THAT (codex).
+          //
+          // Two ways to overclaim here, and the first version did both:
+          //
+          //  • EVERY error read as "refused". `ctx.call` turns a transport failure into an
+          //    error result too, so a `graph_query` that merely TIMED OUT on a backgrounded
+          //    tab would have been reported as a confirmed fence refusal — inventing a wedge
+          //    out of a slow tab, and contradicting this block's own "unknown says nothing"
+          //    rule. Only an actual instance-mismatch refusal proves the fence rejected it.
+          //  • A passing READ read as "graph tools work". The write fence is a SEPARATE
+          //    capability: a panel can serve reads while refusing every mutation, and the
+          //    capability probe above already knows. So the claim is scoped to reads, and the
+          //    known-negative write case is stated rather than papered over.
+          let probeRefused: boolean | undefined;
+          let probeOk = false;
           try {
             // The cheapest fenced read there is: ids only, one row. It is refused by the
             // same instance fence every graph command carries, which is exactly the
             // question — a full outline would answer it no better and would cost the caller
             // a page of graph on a recovery path.
             const probe = await ctx.call({ cmd: "graph_query", fields: "ids", limit: 1 }, 8000);
-            probeOk = !probe.isError;
-          } catch {
-            probeOk = undefined; // a probe that throws settles nothing, and says nothing
+            if (!probe.isError) probeOk = true;
+            else probeRefused = isWorkflowInstanceMismatch(toolResultText(probe));
+          } catch (err) {
+            probeRefused = isWorkflowInstanceMismatch(err);
           }
-          settledNote =
-            probeOk === true
-              ? `
+          if (probeOk) {
+            settledNote =
+              `
 
-CHECKED FOR YOU: the graph read this message prescribes was just run, and ` +
-                `it SUCCEEDED — so graph tools do work against the fence this session already ` +
-                `holds. This was a reconciliation race after the reconnect, not a broken ` +
-                `binding. No recovery step is needed; carry on. (The rebind itself still did ` +
-                `not happen, which is why this is reported as a failure.)`
-              : probeOk === false
-                ? `
+CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
+              `SUCCEEDED — so this fence does NOT reject graph commands, and READS work against ` +
+              `it right now. This was a reconciliation race after the reconnect, not a broken ` +
+              `binding.` +
+              (canMutateNow === false
+                ? ` MUTATIONS are a separate matter and remain refused on this tab — that is the ` +
+                  `write-fence capability above, not the binding, and re-running this will not ` +
+                  `change it.`
+                : ` No recovery step is needed for the binding; carry on.`) +
+              ` (The rebind itself still did not happen, which is why this is reported as a ` +
+              `failure.)`;
+          } else if (probeRefused === true) {
+            settledNote =
+              `
 
-CHECKED FOR YOU: the graph read this message prescribes was just run, and ` +
-                  `it was REFUSED — so the reply was stale after all and graph tools really are ` +
-                  `wedged. The remedy above applies.`
-                : "";
+CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
+              `was REFUSED by the instance fence — so the reply was stale after all and graph ` +
+              `commands really are being rejected. The remedy above applies.`;
+          }
+          // Anything else — a timeout, a dropped tab, an error that is not a fence refusal —
+          // settles NOTHING and says nothing. An inconclusive probe must not become evidence
+          // in either direction.
         }
         if (fence && fence.binding === "not_recovered") {
           return fail(


### PR DESCRIPTION
Refs #1473.

After a ComfyUI restart, `panel_set_workflow_target({mode:"current"})` reported the binding was **NOT restored** — and the reporter's very next `panel_graph_outline` succeeded with the expected graph. The session was never wedged; it was told it was, and then sent to do the check itself.

## Half of this was already fixed

**#1401** had made the *message* right for this exact shape: when the panel's reported identity **matches** the fence the session already holds, it says so, says plainly it is not a claim that graph tools work, and prescribes a cheap graph read to settle it. All correct — it just left the caller to run that read one call later.

So the read is taken here, on the matching-uuid path **only**, and its answer goes into the reply.

## The result still reports failure — deliberately, and not my call

#1401's own test asserts it: *"softening the DIAGNOSIS must not soften the RESULT — the rebind genuinely did not happen."* It did not.

My first version returned **success**, and broke four of #1401's tests. That was the signal I was overwriting a reasoned decision rather than fixing a bug. All four pass untouched now.

**Open question for the owner, not decided here:** whether this case should stop being an error at all. An agent seeing `isError:true` may run recovery regardless of what the text says, which is the reporter's practical complaint — but changing it reverses a documented decision.

## Two review rounds, three overclaims removed — all mine

1. **Every probe error read as "refused."** `ctx.call` turns a transport failure into an error result too, so a `graph_query` that merely **timed out** on a backgrounded tab was reported as a confirmed fence refusal — inventing a wedge out of a slow tab, and contradicting the rule written three lines above it. Only an instance-mismatch refusal counts now; anything else says nothing.
2. **A passing READ read as "graph tools work."** The write fence is a separate capability — a panel can serve reads while refusing every mutation, and the capability probe directly above already knows. "No recovery step is needed" there would send someone to edit a graph that will refuse them.
3. **One observation generalised.** A single passing `graph_query` proves *that* read passed *that* fence a moment ago — not that "READS work", and not that the cause *was* a race. It now names the command, says the fence did not reject **that** command, offers it as evidence rather than a verdict, and says the next graph command is still the authority.

## Verification

- 6 new tests covering pass / mismatch-refusal / **timeout** / write-capability-false / differing-uuid
- mutation-checked on the **live** path — and worth noting: my first mutation attempt left every test green because `ctx.call` does not *throw* on a timeout, it returns an error result. I had mutated dead code. Mutating the real branch fails the inconclusive-probe test.
- tests pin the **absence** of the generalisations, not just the presence of the new wording
- suite **9219** green; `lint`, `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`, `asset-counts --check` all pass
- #1401's four guarantees untouched

## Scope

The probe runs only where the two remaining possibilities — a reconciliation race, or a stale record carrying the right uuid — are indistinguishable by inspection and trivially distinguishable by asking. On the differing-uuid path nothing is probed: that failure is already certain, and a passing read would not make the fence right.
