### PR TITLE
release: v0.51.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.31
+
+### Fixed
+
+- **A trailing space in `COMFYUI_PATH` no longer breaks every install-root check silently (#1512).**
+  On Windows the usual launcher line -- `set COMFYUI_PATH=C:\...\ComfyUI && comfyui-mcp connect ...`
+  -- captures the space BEFORE the `&&`, because that is how `cmd.exe` assigns. The
+  orchestrator then consumed the value exactly as given, so nothing matched and the
+  connected ComfyUI was reported as undeterminable. The failure surfaced about forty
+  minutes later, at the first write, with a message that echoed the path back but never
+  pointed at the space. It cost a 12.3 GB download, stranded at 11.35 GB and finished by
+  hand. The panel pack had always stripped this; the orchestrator had not.
+
+  The value is normalized now -- surrounding whitespace, and a matched pair of surrounding
+  quotes, which is the other thing that survives a paste. This is a REPAIR, not a cleanup:
+  a value that already names a real directory is never touched, because a trailing space
+  is a legal filename character (on POSIX, and in fact on Windows too), and redirecting
+  someone away from a folder that works would be worse than the bug. Only a value that
+  names nothing is repaired.
+
+  It also says so at startup, naming both forms and the launcher line that produced them,
+  instead of leaving a malformed value to surface as a mystery much later. A launcher that
+  bakes in a bad value will hand the same one to everything else it starts.
+
+  Applied at every reader, not just the obvious one: the same value feeds workflow-library
+  lookups, the environment handed to spawned agents, and the check that decides whether a
+  ComfyUI root was named explicitly or inferred. Fixing only the first would have left the
+  rest wrong -- and would have made that last one worse, by comparing a normalized value
+  against a raw one.
+
 ## 0.51.30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.30",
+  "version": "0.51.31",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Releases the #1512 fix (merged as `ca10f23`).

**A trailing space in `COMFYUI_PATH` no longer silently breaks every install-root check.** `cmd.exe` captures the space before the `&&` in the usual Windows launcher line, and the orchestrator consumed the value as given — failing ~40 minutes later at the first write, with a message that echoed the path but never named the space. The panel pack had always stripped it; the orchestrator had not.

**The repair is non-destructive.** A value that already names a real directory is never touched — a trailing space is a legal filename character (on POSIX, and creatable on Windows too, measured). Only a value that names nothing gets repaired, and it says so at startup naming the launcher line that produced it.

**Applied at all five readers**, not the one the report named. The same value feeds workflow-library lookups, the spawned-agent environment, and the explicit-vs-inferred root check — and normalizing only `config.comfyuiPath` would have *introduced* a mismatch in that last one.

**Verification**
- Three codex rounds → **SHIP**; findings included a destructive-repair P1, four uncovered readers, and a source gate that was a rubber stamp (all closed, each verified by building the counterexample and watching it fail)
- 13 tests, **11/11 mutations killed**
- Suite **491 files / 9240 tests**; all six repo gates clean
- **Live against the built `dist/` in a real child process**: malformed value resolves to the real root, clean value untouched, quotes unwrapped, and a directory *genuinely* ending in a space left alone — 4/4

Follow-up filed: #1526 (same defect class on the other path env vars; `COMFYUI_MCP_DATA_DIR` has 8 unnormalized path-op reads).