### PR TITLE
fix(1508): apply_manifest stops force-failing in a uv-managed (PEP 668) Python

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1048,6 +1048,32 @@ describe("applyManifest", () => {
     expect(result.results[0].item).toMatch(/example\.invalid\/pkg-1\.0/);
   });
 
+  it("redacts the spec on an ORDINARY failure too, not just the PEP 668 one", async () => {
+    // The non-PEP-668 path rethrows raw by design — right for diagnosis — and the
+    // caller reports err.message, which Node builds as `Command failed: <argv>`.
+    // So every pip failure that is NOT this issue's case was still echoing the
+    // spec. Closed at report(), the one place every item passes through, rather
+    // than at each call site.
+    const SPEC = "https://ci:s3cr3t-token@example.invalid/pkg-1.0.whl";
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw new Error(`Command failed: python -m pip install ${SPEC}\nERROR: no matching dist`);
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: [SPEC] } });
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).not.toMatch(/s3cr3t-token/);
+    // The real cause still survives — redaction must not cost the diagnosis.
+    expect(result.results[0].message ?? "").toMatch(/no matching dist/);
+  });
+
   it("redacts a password containing '@' and one sitting past the output clip", async () => {
     // Two ways a redaction can look right and not be (codex P1):
     //   - the pattern stopping at the FIRST '@' when the password contains one;

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -985,6 +985,63 @@ describe("applyManifest", () => {
     expect(msg).toMatch(/EXTERNALLY MANAGED/);
   });
 
+  it("does not fire on the PEP 668 token appearing MID-LINE (codex P2)", async () => {
+    // The token is anchored to the start of a line because that is where pip
+    // prints it. Unanchored, any output merely CONTAINING it — a path, a package
+    // name, a vendored log — would be rewritten as this failure and lose its own
+    // cause. That is the same defect as the prose case, one token narrower.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("build failed"), {
+          stderr:
+            "  Downloading from /var/cache/externally-managed-environment/wheels/x.whl\n" +
+            "error: metadata generation failed",
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["somepkg"] } });
+
+    const msg = result.results[0].message ?? "";
+    expect(msg).not.toMatch(/EXTERNALLY MANAGED \(PEP 668\)/);
+    expect(msg).toMatch(/metadata generation failed|build failed/);
+  });
+
+  it("never echoes the command line — a direct-URL spec can carry credentials", async () => {
+    // Node builds execFileSync's Error.message as `Command failed: <whole argv>`,
+    // so it embeds the package spec. A pip spec may legitimately be a direct URL,
+    // and a direct URL may carry credentials — that entry passes
+    // validatePipPackageSpec, which only rejects options, control chars and
+    // whitespace. Carrying the message into a user-facing refusal would copy the
+    // token into it. Detection may still read the message; only what is SHOWN is
+    // narrowed.
+    const SPEC = "https://ci:s3cr3t-token@example.invalid/pkg-1.0-py3-none-any.whl";
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error(`Command failed: python -m pip install ${SPEC}`), {
+          stderr: PEP668,
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: [SPEC] } });
+    const msg = result.results[0].message ?? "";
+
+    expect(msg).toMatch(/EXTERNALLY MANAGED/);
+    expect(msg).not.toMatch(/s3cr3t-token/);
+    expect(msg).not.toMatch(/Command failed:/);
+  });
+
   it("still surfaces an ORDINARY pip failure as itself (#1508)", async () => {
     // The guard must not swallow every pip error into a managed-environment
     // story — a missing package is a different problem with a different answer.

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1040,6 +1040,38 @@ describe("applyManifest", () => {
     expect(msg).toMatch(/EXTERNALLY MANAGED/);
     expect(msg).not.toMatch(/s3cr3t-token/);
     expect(msg).not.toMatch(/Command failed:/);
+    // THE WHOLE RESULT, not just the message. `item` echoes the manifest entry
+    // verbatim, so asserting only on `message` claimed more than it checked —
+    // the structured result is what travels into transcripts and logs.
+    expect(JSON.stringify(result)).not.toMatch(/s3cr3t-token/);
+    // ...and the entry is still identifiable by host and path.
+    expect(result.results[0].item).toMatch(/example\.invalid\/pkg-1\.0/);
+  });
+
+  it("redacts a password containing '@' and one sitting past the output clip", async () => {
+    // Two ways a redaction can look right and not be (codex P1):
+    //   - the pattern stopping at the FIRST '@' when the password contains one;
+    //   - clipping the carried output BEFORE redacting, severing the '@' the
+    //     pattern anchors on so a secret near the cut survives.
+    const SPEC = "https://ci:alpha@beta-s3cr3t@example.invalid/pkg-1.0.whl";
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), {
+          // Filler pushes the credential past the 1200-char clip boundary.
+          stderr: `${PEP668}\n${"x".repeat(1250)}\nLooking in: ${SPEC}`,
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: [SPEC] } });
+
+    expect(JSON.stringify(result)).not.toMatch(/s3cr3t/);
+    expect(JSON.stringify(result)).not.toMatch(/alpha@beta/);
   });
 
   it("still surfaces an ORDINARY pip failure as itself (#1508)", async () => {

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -928,6 +928,63 @@ describe("applyManifest", () => {
     expect(result.results[0].message ?? "").toMatch(/EXTERNALLY MANAGED/);
   });
 
+  it("does NOT claim PEP 668 for prose that merely says 'externally managed' (codex P2)", async () => {
+    // The detector originally matched the bare phrase anywhere in the output. Build
+    // and dependency errors do say it in passing, and rewriting one of those as the
+    // managed-environment story discards the real cause AND hands over a remedy
+    // that does not apply — a strictly worse failure than the raw error.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("build failed"), {
+          stderr:
+            "note: This package vendors a library whose headers are externally managed by the " +
+            "distribution; see BUILD.md.\nerror: command 'cl.exe' failed with exit code 2",
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["somepkg"] } });
+
+    expect(result.success).toBe(false);
+    const msg = result.results[0].message ?? "";
+    expect(msg).not.toMatch(/EXTERNALLY MANAGED \(PEP 668\)/);
+    expect(msg).not.toMatch(/uv venv/);
+    // The real cause survives.
+    expect(msg).toMatch(/cl\.exe|build failed/);
+  });
+
+  it("carries the installer's OWN output into the refusal (codex P2)", async () => {
+    // The refusal REPLACES the underlying error and apply_manifest reports only
+    // `err.message` per item, so anything the tool said that this message does not
+    // anticipate would be lost silently. An earlier draft even told the reader the
+    // output was "above" when nothing had been printed.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), {
+          stderr: `${PEP668}\nhint: See PEP 668 for the detailed specification.`,
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["imageio-ffmpeg"] } });
+    const msg = result.results[0].message ?? "";
+
+    expect(msg).toMatch(/This Python installation is managed by uv/);
+    expect(msg).toMatch(/hint: See PEP 668/);
+    // ...and the actionable part is still there, not drowned by it.
+    expect(msg).toMatch(/EXTERNALLY MANAGED/);
+  });
+
   it("still surfaces an ORDINARY pip failure as itself (#1508)", async () => {
     // The guard must not swallow every pip error into a managed-environment
     // story — a missing package is a different problem with a different answer.

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -792,6 +792,158 @@ describe("applyManifest", () => {
     );
   });
 
+  // #1508 — the interpreter declares itself EXTERNALLY MANAGED (PEP 668), so its
+  // own pip refuses by design. Stability Matrix's uv-managed CPython does exactly
+  // this. The refusal text below is the reporter's, verbatim.
+  //
+  // TWO routes reach it, which is why there are three tests rather than one:
+  // uv-absent goes straight to bare pip (the reporter's route, because Stability
+  // Matrix keeps uv inside its own directory rather than on PATH), and the #377
+  // non-venv fallback lands on bare pip too — so a managed interpreter can hit
+  // the same wall one step later, with uv's unrelated complaint on top of it.
+  const PEP668 =
+    "error: externally-managed-environment\n" +
+    "This Python installation is managed by uv and should not be modified.";
+
+  it("refuses with an actionable message when pip is EXTERNALLY MANAGED, uv absent (#1508)", async () => {
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), { stderr: PEP668 });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["imageio-ffmpeg"] } });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toMatchObject([{ action: "pip", status: "failed" }]);
+    const msg = result.results[0].message ?? "";
+    // Names the CAUSE as a deliberate guard, not a broken interpreter...
+    expect(msg).toMatch(/EXTERNALLY MANAGED/);
+    expect(msg).toMatch(/PEP 668/);
+    expect(msg).toMatch(/deliberate guard, not a broken interpreter/);
+    // ...and both supported routes out.
+    expect(msg).toMatch(/uv pip install --python/);
+    expect(msg).toMatch(/COMFYUI_PYTHON/);
+    // The refusal must SAY it declined to force it, and why — otherwise the
+    // obvious next move is the one that quietly breaks their install later.
+    expect(msg).toMatch(/break-system-packages/);
+    expect(msg).toMatch(/may reset/);
+    // It must NOT have actually forced it.
+    expect(execFileSyncMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining(["--break-system-packages"]),
+      expect.anything(),
+    );
+  });
+
+  it("uses the actionable refusal when UV ITSELF reports PEP 668 (#1508)", async () => {
+    // The third route, and the one a mutation caught me not covering: uv is
+    // present and `uv pip install --python <interp>` is itself refused, because
+    // uv will not modify a managed environment either. Without the check that
+    // runs BEFORE the #377 non-venv branch, this falls through to a bare rethrow
+    // and the caller gets uv's raw output with no route out of it.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "uv" && args[0] === "pip") {
+        throw Object.assign(new Error("uv failed"), { stderr: PEP668 });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["imageio-ffmpeg"] } });
+
+    expect(result.success).toBe(false);
+    const msg = result.results[0].message ?? "";
+    expect(msg).toMatch(/EXTERNALLY MANAGED/);
+    expect(msg).toMatch(/uv pip install --python/);
+    // It must NOT have quietly retried through bare pip after uv refused — that
+    // walks into the same wall and buries the reason under a second failure.
+    expect(execFileSyncMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/python/),
+      ["-m", "pip", "install", "imageio-ffmpeg"],
+      expect.anything(),
+    );
+  });
+
+  it("does not blame uv's non-venv error when the FALLBACK hits PEP 668 (#1508)", async () => {
+    // uv is present, rejects the non-venv interpreter (#377), and the bare-pip
+    // fallback is then refused as externally managed. Reporting uv's complaint
+    // here would send the reader to create a venv when the real obstacle is the
+    // managed environment.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "uv" && args[0] === "pip") {
+        throw Object.assign(new Error("uv failed"), {
+          stderr: "error: No virtual environment found for executable name python",
+        });
+      }
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), { stderr: PEP668 });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["imageio-ffmpeg"] } });
+
+    expect(result.success).toBe(false);
+    const msg = result.results[0].message ?? "";
+    expect(msg).toMatch(/EXTERNALLY MANAGED/);
+    expect(msg).not.toMatch(/No virtual environment found/);
+  });
+
+  it("keys on the PEP 668 error id, not uv's distributor wording (#1508)", async () => {
+    // The second line comes from the distributor's EXTERNALLY-MANAGED file, so it
+    // reads differently on Debian and Homebrew. Matching only uv's sentence would
+    // have fixed this one reporter and nobody else.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), {
+          stderr:
+            "error: externally-managed-environment\n" +
+            "× This environment is externally managed\n" +
+            "╰─> To install Python packages system-wide, try apt install python3-xyz.",
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["imageio-ffmpeg"] } });
+
+    expect(result.success).toBe(false);
+    expect(result.results[0].message ?? "").toMatch(/EXTERNALLY MANAGED/);
+  });
+
+  it("still surfaces an ORDINARY pip failure as itself (#1508)", async () => {
+    // The guard must not swallow every pip error into a managed-environment
+    // story — a missing package is a different problem with a different answer.
+    execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      const probesUv = IS_WIN
+        ? cmd === "where" && args[0] === "uv"
+        : cmd === "uv" && args[0] === "--version";
+      if (probesUv) throw new Error("no uv");
+      if (args[0] === "-m" && args[1] === "pip") {
+        throw Object.assign(new Error("pip failed"), {
+          stderr: "ERROR: Could not find a version that satisfies the requirement nope",
+        });
+      }
+      return "ok";
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["nope"] } });
+
+    expect(result.success).toBe(false);
+    const msg = result.results[0].message ?? "";
+    expect(msg).not.toMatch(/EXTERNALLY MANAGED/);
+    expect(msg).toMatch(/Could not find a version|pip failed/);
+  });
+
   it("reports pip as failed — never applied — when the server interpreter cannot be verified (#651)", async () => {
     installInterpreterMock.mockResolvedValue({
       source: "undetermined",

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -826,13 +826,21 @@ describe("applyManifest", () => {
     expect(msg).toMatch(/EXTERNALLY MANAGED/);
     expect(msg).toMatch(/PEP 668/);
     expect(msg).toMatch(/deliberate guard, not a broken interpreter/);
-    // ...and both supported routes out.
-    expect(msg).toMatch(/uv pip install --python/);
+    // ...and routes out that ACTUALLY WORK. An earlier draft of this message
+    // recommended `uv pip install --python <interp>`; measured against a real
+    // uv-managed CPython, uv refuses that too ("the interpreter ... is externally
+    // managed", hint: `uv venv`). A remedy that cannot work is worse than none —
+    // it reads as the answer and costs the reader the time to disprove it. So the
+    // message now says uv is NOT a way around this, and points at a venv.
+    expect(msg).toMatch(/uv does NOT get around this/);
+    expect(msg).toMatch(/uv venv/);
     expect(msg).toMatch(/COMFYUI_PYTHON/);
+    // The wrong remedy must not creep back as a bare suggestion.
+    expect(msg).not.toMatch(/^\s*-\s*.*uv pip install --python/m);
     // The refusal must SAY it declined to force it, and why — otherwise the
     // obvious next move is the one that quietly breaks their install later.
     expect(msg).toMatch(/break-system-packages/);
-    expect(msg).toMatch(/may reset/);
+    expect(msg).toMatch(/may later reset/);
     // It must NOT have actually forced it.
     expect(execFileSyncMock).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -859,7 +867,7 @@ describe("applyManifest", () => {
     expect(result.success).toBe(false);
     const msg = result.results[0].message ?? "";
     expect(msg).toMatch(/EXTERNALLY MANAGED/);
-    expect(msg).toMatch(/uv pip install --python/);
+    expect(msg).toMatch(/uv does NOT get around this/);
     // It must NOT have quietly retried through bare pip after uv refused — that
     // walks into the same wall and buries the reason under a second failure.
     expect(execFileSyncMock).not.toHaveBeenCalledWith(

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -277,25 +277,29 @@ function errorText(err: unknown): string {
  * that names the two supported routes is worth more than a write that appears to
  * work.
  */
-function externallyManagedRefusal(pkg: string, python: string, uvAvailable: boolean): string {
+function externallyManagedRefusal(pkg: string, python: string): string {
   return (
     `Refusing to install "${pkg}": the Python that ComfyUI runs (${python}) declares itself ` +
-    `EXTERNALLY MANAGED (PEP 668), so its own pip will not install into it. This is normal for ` +
-    `a uv-managed install (Stability Matrix), and for distro Pythons on Linux — it is a ` +
-    `deliberate guard, not a broken interpreter.\n\n` +
-    (uvAvailable
-      ? `Installing through uv was attempted and also failed; the output above is uv's own.\n\n`
-      : `\`uv\` is not on PATH here, which is why the interpreter's pip was used directly. If ` +
-        `your install ships uv (Stability Matrix does, inside its own directory), putting it on ` +
-        `PATH lets this install through the supported route.\n\n`) +
-    `What works:\n` +
-    `  - install the package with the manager that owns this environment (Stability Matrix's ` +
-    `own package UI, or \`uv pip install --python "${python}" ${pkg}\`);\n` +
-    `  - or point COMFYUI_PYTHON at a virtual environment you control, and restart ComfyUI ` +
-    `through this server so the manifest installs there.\n\n` +
-    `Not doing it for you: forcing the install (\`--break-system-packages\`) would write into an ` +
-    `environment uv manages and may reset, which turns this clear failure into a broken ComfyUI ` +
-    `later. That is your call to make deliberately, not one to inherit from a manifest.`
+    `EXTERNALLY MANAGED (PEP 668), so nothing may install into it directly. This is normal for a ` +
+    `uv-managed install (Stability Matrix) and for distro Pythons on Linux — a deliberate guard, ` +
+    `not a broken interpreter.\n\n` +
+    `uv does NOT get around this: \`uv pip install --python "${python}"\` is refused by uv too, ` +
+    `with "the interpreter ... is externally managed". Measured, not assumed — so do not spend ` +
+    `time on it.\n\n` +
+    `What actually works — the environment needs to be a VIRTUAL one:\n` +
+    `  - if your launcher owns this install (Stability Matrix), add the package through its own ` +
+    `Python-packages UI, which installs into the environment it manages for ComfyUI;\n` +
+    `  - or create a venv and run ComfyUI from it: \`uv venv <dir>\` (uv's own suggestion for ` +
+    `exactly this error), install there, then set COMFYUI_PYTHON to that interpreter and restart ` +
+    `ComfyUI through this server so the manifest installs into it.\n\n` +
+    `WORTH CHECKING FIRST: if ComfyUI already runs from a virtual environment, then the ` +
+    `interpreter above is the wrong one — a base install picked up instead of the venv — and the ` +
+    `fix is to point COMFYUI_PYTHON at the venv rather than to change anything about packaging. ` +
+    `The path in this message is the one to compare against.\n\n` +
+    `Not doing it for you: pip offers \`--break-system-packages\` and this refuses to pass it. On ` +
+    `a uv-managed interpreter that writes into an environment uv owns and may later reset, which ` +
+    `turns a clear failure now into a broken ComfyUI later. That stays a decision you make ` +
+    `deliberately, not one inherited from a manifest.`
   );
 }
 
@@ -322,7 +326,7 @@ async function installPipPackage(
       // directory rather than on PATH, so `useUv` is false and we come straight
       // here — into an interpreter whose pip refuses by design (PEP 668).
       if (isExternallyManagedError(errorText(err))) {
-        throw new ValidationError(externallyManagedRefusal(pkg, python, false));
+        throw new ValidationError(externallyManagedRefusal(pkg, python));
       }
       throw err;
     }
@@ -346,7 +350,7 @@ async function installPipPackage(
     // bare pip there walks straight into the same wall one step later, burying
     // the real reason under a second failure.
     if (isExternallyManagedError(detail)) {
-      throw new ValidationError(externallyManagedRefusal(pkg, python, true));
+      throw new ValidationError(externallyManagedRefusal(pkg, python));
     }
     if (isUvNonVenvError(detail)) {
       // System-Python ComfyUI (no venv): uv can't use the interpreter directly.
@@ -363,7 +367,7 @@ async function installPipPackage(
         // case it is, not as a bare pip error, so the caller is not left reading
         // uv's non-venv complaint as the cause.
         if (isExternallyManagedError(errorText(err2))) {
-          throw new ValidationError(externallyManagedRefusal(pkg, python, true));
+          throw new ValidationError(externallyManagedRefusal(pkg, python));
         }
         throw err2;
       }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -256,7 +256,29 @@ function isUvNonVenvError(text: string): boolean {
  * would have fixed this reporter and no one else.
  */
 function isExternallyManagedError(text: string): boolean {
-  return /externally[- ]managed[- ]environment|externally managed/i.test(text);
+  return (
+    // pip's canonical PEP 668 error IDENTIFIER. Stable across distributors —
+    // the line under it is the distributor's prose and says something different
+    // on Debian, Homebrew and uv, so keying on that would have fixed one
+    // reporter and nobody else.
+    /externally-managed-environment/i.test(text) ||
+    // uv's own refusal, which uses no error id:
+    //   error: The interpreter at <path> is externally managed, and indicates ...
+    // Anchored on "interpreter at ... is externally managed" rather than the bare
+    // phrase (codex P2): plain "externally managed" appears in ordinary build and
+    // dependency output, and matching it would rewrite an unrelated failure as a
+    // managed-environment story — discarding the real cause behind a remedy that
+    // does not apply. Both forms below were MEASURED against uv 0.11.21 and a
+    // uv-managed CPython 3.12.13, not transcribed from documentation.
+    /interpreter at .+ is externally managed/i.test(text)
+  );
+}
+
+/** Cap the installer's own output carried into a refusal. Enough to diagnose,
+ *  bounded so a verbose failure cannot swamp the actionable part. */
+function clipInstallerOutput(text: string): string {
+  const cleaned = text.replace(/\r/g, "").split("\n").filter((l) => l.trim()).join("\n").trim();
+  return cleaned.length > 1200 ? `${cleaned.slice(0, 1200)}\n… (truncated)` : cleaned;
 }
 
 /** Both pip and uv write the refusal to stderr, but a non-zero exit from
@@ -277,8 +299,16 @@ function errorText(err: unknown): string {
  * that names the two supported routes is worth more than a write that appears to
  * work.
  */
-function externallyManagedRefusal(pkg: string, python: string): string {
+function externallyManagedRefusal(pkg: string, python: string, output = ""): string {
+  // The installer's OWN output is carried through (codex P2). This refusal
+  // replaces the underlying error rather than wrapping it, and apply_manifest
+  // reports only `err.message` per item — so without this the actual diagnostic
+  // is gone, and an earlier draft even claimed it was "above" when nothing had
+  // been printed. Anything the tool said that this message does not anticipate
+  // would have been lost silently.
+  const detail = clipInstallerOutput(output);
   return (
+    (detail ? `${detail}\n\n` : "") +
     `Refusing to install "${pkg}": the Python that ComfyUI runs (${python}) declares itself ` +
     `EXTERNALLY MANAGED (PEP 668), so nothing may install into it directly. This is normal for a ` +
     `uv-managed install (Stability Matrix) and for distro Pythons on Linux — a deliberate guard, ` +
@@ -326,7 +356,7 @@ async function installPipPackage(
       // directory rather than on PATH, so `useUv` is false and we come straight
       // here — into an interpreter whose pip refuses by design (PEP 668).
       if (isExternallyManagedError(errorText(err))) {
-        throw new ValidationError(externallyManagedRefusal(pkg, python));
+        throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err)));
       }
       throw err;
     }
@@ -350,7 +380,7 @@ async function installPipPackage(
     // bare pip there walks straight into the same wall one step later, burying
     // the real reason under a second failure.
     if (isExternallyManagedError(detail)) {
-      throw new ValidationError(externallyManagedRefusal(pkg, python));
+      throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err)));
     }
     if (isUvNonVenvError(detail)) {
       // System-Python ComfyUI (no venv): uv can't use the interpreter directly.
@@ -366,8 +396,12 @@ async function installPipPackage(
         // The fallback's OWN refusal (#1508). Reported as the managed-environment
         // case it is, not as a bare pip error, so the caller is not left reading
         // uv's non-venv complaint as the cause.
+        // `err2`, NOT `err`. The output carried into the refusal must be the one
+        // that actually refused — pip's. Attaching uv's earlier non-venv complaint
+        // here is precisely the misdirection this branch exists to prevent, and it
+        // would send the reader off to create a venv for the wrong reason.
         if (isExternallyManagedError(errorText(err2))) {
-          throw new ValidationError(externallyManagedRefusal(pkg, python));
+          throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err2)));
         }
         throw err2;
       }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -411,7 +411,7 @@ async function installPipPackage(
   const useUv = commandExists("uv");
 
   if (!useUv) {
-    logger.info("Installing manifest Python package", { package: pkg, installer: "pip" });
+    logger.info("Installing manifest Python package", { package: redactUrlCredentials(pkg), installer: "pip" });
     try {
       runPythonPipInstall(python, pkg, comfyuiPath);
     } catch (err) {
@@ -426,7 +426,7 @@ async function installPipPackage(
     return resolved;
   }
 
-  logger.info("Installing manifest Python package", { package: pkg, installer: "uv" });
+  logger.info("Installing manifest Python package", { package: redactUrlCredentials(pkg), installer: "uv" });
   try {
     const out = execFileSync("uv", ["pip", "install", "--python", python, pkg], {
       cwd: comfyuiPath,
@@ -451,7 +451,7 @@ async function installPipPackage(
       // what we want (#377).
       logger.info(
         "uv rejected the non-venv ComfyUI interpreter; falling back to `python -m pip install`",
-        { package: pkg },
+        { package: redactUrlCredentials(pkg) },
       );
       try {
         runPythonPipInstall(python, pkg, comfyuiPath);
@@ -729,7 +729,20 @@ function report(
   //
   // The entry stays identifiable: only the userinfo is masked, so the host and
   // path a reader matches on are untouched.
-  return { action, item: redactUrlCredentials(item), status, message };
+  //
+  // `message` too, and this is the CHOKE POINT that closes the class rather than
+  // the instances (codex r4). An ordinary, non-PEP-668 failure is rethrown raw by
+  // design — that is the right call for diagnosis — and the caller reports
+  // `err.message`, which Node builds as `Command failed: <whole argv>`. So every
+  // pip failure that ISN'T the case this issue is about was still echoing the
+  // spec. Redacting here covers those, the model and custom-node paths, and any
+  // future one, instead of requiring each new call site to remember.
+  return {
+    action,
+    item: redactUrlCredentials(item),
+    status,
+    message: redactUrlCredentials(message),
+  };
 }
 
 /**

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -241,6 +241,64 @@ function isUvNonVenvError(text: string): boolean {
   );
 }
 
+/**
+ * #1508 — PEP 668: the interpreter declares itself EXTERNALLY MANAGED, so its own
+ * pip refuses to install into it. Stability Matrix's uv-managed CPython does
+ * exactly this:
+ *
+ *   error: externally-managed-environment
+ *   This Python installation is managed by uv and should not be modified.
+ *
+ * Keyed on the PEP's own error id first (`externally-managed-environment`, the
+ * literal pip emits) and the prose form second, because the second line is
+ * supplied by the distributor's EXTERNALLY-MANAGED file and therefore says
+ * something different on Debian, Homebrew, and uv. Matching only the uv wording
+ * would have fixed this reporter and no one else.
+ */
+function isExternallyManagedError(text: string): boolean {
+  return /externally[- ]managed[- ]environment|externally managed/i.test(text);
+}
+
+/** Both pip and uv write the refusal to stderr, but a non-zero exit from
+ *  execFileSync carries it across `stderr`, `stdout` and `message` inconsistently
+ *  depending on how the child died — so every failure is read from all three. */
+function errorText(err: unknown): string {
+  const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
+  return `${e?.stderr?.toString() ?? ""}\n${e?.stdout?.toString() ?? ""}\n${e?.message ?? ""}`;
+}
+
+/**
+ * #1508 — the refusal, said in a way that can be acted on.
+ *
+ * Deliberately does NOT reach for `--break-system-packages`, which is the
+ * reporter's own caution and the right one: on a uv-managed interpreter that
+ * writes into an environment uv owns and may later reset, converting a clean
+ * refusal into a silent, delayed breakage of their ComfyUI install. A refusal
+ * that names the two supported routes is worth more than a write that appears to
+ * work.
+ */
+function externallyManagedRefusal(pkg: string, python: string, uvAvailable: boolean): string {
+  return (
+    `Refusing to install "${pkg}": the Python that ComfyUI runs (${python}) declares itself ` +
+    `EXTERNALLY MANAGED (PEP 668), so its own pip will not install into it. This is normal for ` +
+    `a uv-managed install (Stability Matrix), and for distro Pythons on Linux — it is a ` +
+    `deliberate guard, not a broken interpreter.\n\n` +
+    (uvAvailable
+      ? `Installing through uv was attempted and also failed; the output above is uv's own.\n\n`
+      : `\`uv\` is not on PATH here, which is why the interpreter's pip was used directly. If ` +
+        `your install ships uv (Stability Matrix does, inside its own directory), putting it on ` +
+        `PATH lets this install through the supported route.\n\n`) +
+    `What works:\n` +
+    `  - install the package with the manager that owns this environment (Stability Matrix's ` +
+    `own package UI, or \`uv pip install --python "${python}" ${pkg}\`);\n` +
+    `  - or point COMFYUI_PYTHON at a virtual environment you control, and restart ComfyUI ` +
+    `through this server so the manifest installs there.\n\n` +
+    `Not doing it for you: forcing the install (\`--break-system-packages\`) would write into an ` +
+    `environment uv manages and may reset, which turns this clear failure into a broken ComfyUI ` +
+    `later. That is your call to make deliberately, not one to inherit from a manifest.`
+  );
+}
+
 async function installPipPackage(
   pkg: string,
   comfyuiPath: string,
@@ -257,7 +315,17 @@ async function installPipPackage(
 
   if (!useUv) {
     logger.info("Installing manifest Python package", { package: pkg, installer: "pip" });
-    runPythonPipInstall(python, pkg, comfyuiPath);
+    try {
+      runPythonPipInstall(python, pkg, comfyuiPath);
+    } catch (err) {
+      // #1508 — THE reporter's path. Stability Matrix bundles uv inside its own
+      // directory rather than on PATH, so `useUv` is false and we come straight
+      // here — into an interpreter whose pip refuses by design (PEP 668).
+      if (isExternallyManagedError(errorText(err))) {
+        throw new ValidationError(externallyManagedRefusal(pkg, python, false));
+      }
+      throw err;
+    }
     return resolved;
   }
 
@@ -272,8 +340,14 @@ async function installPipPackage(
     void out;
     return resolved;
   } catch (err) {
-    const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
-    const detail = `${e.stderr?.toString() ?? ""}\n${e.stdout?.toString() ?? ""}\n${e.message ?? ""}`;
+    const detail = errorText(err);
+    // #1508 — checked BEFORE the #377 fallback. uv's non-venv message and a PEP
+    // 668 refusal can both appear on a managed interpreter, and falling back to
+    // bare pip there walks straight into the same wall one step later, burying
+    // the real reason under a second failure.
+    if (isExternallyManagedError(detail)) {
+      throw new ValidationError(externallyManagedRefusal(pkg, python, true));
+    }
     if (isUvNonVenvError(detail)) {
       // System-Python ComfyUI (no venv): uv can't use the interpreter directly.
       // The interpreter's own pip installs into that exact environment, which is
@@ -282,7 +356,17 @@ async function installPipPackage(
         "uv rejected the non-venv ComfyUI interpreter; falling back to `python -m pip install`",
         { package: pkg },
       );
-      runPythonPipInstall(python, pkg, comfyuiPath);
+      try {
+        runPythonPipInstall(python, pkg, comfyuiPath);
+      } catch (err2) {
+        // The fallback's OWN refusal (#1508). Reported as the managed-environment
+        // case it is, not as a bare pip error, so the caller is not left reading
+        // uv's non-venv complaint as the cause.
+        if (isExternallyManagedError(errorText(err2))) {
+          throw new ValidationError(externallyManagedRefusal(pkg, python, true));
+        }
+        throw err2;
+      }
       return resolved;
     }
     throw err;

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -261,7 +261,13 @@ function isExternallyManagedError(text: string): boolean {
     // the line under it is the distributor's prose and says something different
     // on Debian, Homebrew and uv, so keying on that would have fixed one
     // reporter and nobody else.
-    /externally-managed-environment/i.test(text) ||
+    // Anchored to the START OF A LINE, which is where pip prints it:
+    //   error: externally-managed-environment
+    // (measured). An unanchored match would fire on any output that merely
+    // CONTAINS the token — a file path, a package name, a vendored log line —
+    // and rewrite an unrelated failure as this one, discarding its real cause
+    // (codex P2).
+    /^\s*error: externally-managed-environment/im.test(text) ||
     // uv's own refusal, which uses no error id:
     //   error: The interpreter at <path> is externally managed, and indicates ...
     // Anchored on "interpreter at ... is externally managed" rather than the bare
@@ -272,10 +278,38 @@ function isExternallyManagedError(text: string): boolean {
     // uv-managed CPython 3.12.13, not transcribed from documentation.
     /interpreter at .+ is externally managed/i.test(text)
   );
+  // WHICH WAY THIS FAILS MATTERS, and it is chosen deliberately (codex P2, the
+  // opposite direction). PEP 668 requires only that the installer error out; it
+  // does not mandate pip's renderer token, so a distributor-patched or localized
+  // installer can refuse in wording neither pattern above matches.
+  //
+  // That miss is the SAFE failure. It surfaces the installer's own error
+  // unchanged — exactly today's behaviour, no regression — and that error already
+  // names PEP 668 itself. The reader loses this message's extra guidance and
+  // nothing else. The opposite error, matching too eagerly, REPLACES a real cause
+  // with a remedy that does not apply, which is strictly worse than saying
+  // nothing. So this stays tight and is widened only against a refusal someone
+  // has actually seen.
 }
 
 /** Cap the installer's own output carried into a refusal. Enough to diagnose,
  *  bounded so a verbose failure cannot swamp the actionable part. */
+/**
+ * Mask credentials embedded in a URL's userinfo (`https://user:token@host/...`).
+ *
+ * A pip entry may legitimately BE such a URL — `validatePipPackageSpec` only
+ * rejects options, control characters and whitespace — so the spec itself is a
+ * secret-bearing string, not just the command line built around it. Applied to
+ * everything this refusal renders: the package name it echoes AND the installer
+ * output it carries, since pip prints the URL it is fetching.
+ */
+function redactUrlCredentials(text: string): string {
+  // Userinfo runs from `://` to the LAST `@` before the host, and may contain
+  // ':' in the password. Bounded to a single line/token so it cannot run away
+  // across an entire log.
+  return text.replace(/(\w+:\/\/)([^/\s@]+)@/g, (_m, scheme: string) => `${scheme}***:***@`);
+}
+
 function clipInstallerOutput(text: string): string {
   const cleaned = text.replace(/\r/g, "").split("\n").filter((l) => l.trim()).join("\n").trim();
   return cleaned.length > 1200 ? `${cleaned.slice(0, 1200)}\n… (truncated)` : cleaned;
@@ -287,6 +321,27 @@ function clipInstallerOutput(text: string): string {
 function errorText(err: unknown): string {
   const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
   return `${e?.stderr?.toString() ?? ""}\n${e?.stdout?.toString() ?? ""}\n${e?.message ?? ""}`;
+}
+
+/**
+ * The installer's OWN output — stderr and stdout only, deliberately WITHOUT
+ * `Error.message`.
+ *
+ * Node builds that message as `Command failed: <the whole argv>`, so it embeds
+ * the package spec. A pip spec may legitimately be a direct URL, and a direct URL
+ * may carry credentials (`https://user:token@host/pkg.whl`) — that entry passes
+ * `validatePipPackageSpec`, which only rejects options, control characters and
+ * whitespace. Echoing the command back into a user-facing refusal would copy the
+ * token into it.
+ *
+ * `errorText` still includes the message, because DETECTION wants the breadth (a
+ * child that dies before writing to a stream can leave the reason only there).
+ * What gets shown is narrower than what gets matched, which is the right way
+ * round.
+ */
+function installerOutput(err: unknown): string {
+  const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
+  return `${e?.stderr?.toString() ?? ""}\n${e?.stdout?.toString() ?? ""}`;
 }
 
 /**
@@ -306,10 +361,10 @@ function externallyManagedRefusal(pkg: string, python: string, output = ""): str
   // is gone, and an earlier draft even claimed it was "above" when nothing had
   // been printed. Anything the tool said that this message does not anticipate
   // would have been lost silently.
-  const detail = clipInstallerOutput(output);
+  const detail = redactUrlCredentials(clipInstallerOutput(output));
   return (
     (detail ? `${detail}\n\n` : "") +
-    `Refusing to install "${pkg}": the Python that ComfyUI runs (${python}) declares itself ` +
+    `Refusing to install "${redactUrlCredentials(pkg)}": the Python that ComfyUI runs (${python}) declares itself ` +
     `EXTERNALLY MANAGED (PEP 668), so nothing may install into it directly. This is normal for a ` +
     `uv-managed install (Stability Matrix) and for distro Pythons on Linux — a deliberate guard, ` +
     `not a broken interpreter.\n\n` +
@@ -356,7 +411,7 @@ async function installPipPackage(
       // directory rather than on PATH, so `useUv` is false and we come straight
       // here — into an interpreter whose pip refuses by design (PEP 668).
       if (isExternallyManagedError(errorText(err))) {
-        throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err)));
+        throw new ValidationError(externallyManagedRefusal(pkg, python, installerOutput(err)));
       }
       throw err;
     }
@@ -380,7 +435,7 @@ async function installPipPackage(
     // bare pip there walks straight into the same wall one step later, burying
     // the real reason under a second failure.
     if (isExternallyManagedError(detail)) {
-      throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err)));
+      throw new ValidationError(externallyManagedRefusal(pkg, python, installerOutput(err)));
     }
     if (isUvNonVenvError(detail)) {
       // System-Python ComfyUI (no venv): uv can't use the interpreter directly.
@@ -401,7 +456,7 @@ async function installPipPackage(
         // here is precisely the misdirection this branch exists to prevent, and it
         // would send the reader off to create a venv for the wrong reason.
         if (isExternallyManagedError(errorText(err2))) {
-          throw new ValidationError(externallyManagedRefusal(pkg, python, errorText(err2)));
+          throw new ValidationError(externallyManagedRefusal(pkg, python, installerOutput(err2)));
         }
         throw err2;
       }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -210,13 +210,13 @@ async function resolveWorkspacePython(comfyuiPath: string): Promise<InstallInter
 
 function validatePipPackageSpec(pkg: string): void {
   if (pkg.startsWith("-")) {
-    throw new ValidationError(`Manifest pip entry must be a package spec, not an option: ${pkg}`);
+    throw new ValidationError(`Manifest pip entry must be a package spec, not an option: ${redactUrlCredentials(pkg)}`);
   }
   if (ASCII_CONTROL_RE.test(pkg)) {
     throw new ValidationError("Manifest pip entry cannot contain ASCII control characters.");
   }
   if (WHITESPACE_RE.test(pkg)) {
-    throw new ValidationError(`Manifest pip entry cannot contain whitespace: ${pkg}`);
+    throw new ValidationError(`Manifest pip entry cannot contain whitespace: ${redactUrlCredentials(pkg)}`);
   }
 }
 
@@ -304,10 +304,15 @@ function isExternallyManagedError(text: string): boolean {
  * output it carries, since pip prints the URL it is fetching.
  */
 function redactUrlCredentials(text: string): string {
-  // Userinfo runs from `://` to the LAST `@` before the host, and may contain
-  // ':' in the password. Bounded to a single line/token so it cannot run away
-  // across an entire log.
-  return text.replace(/(\w+:\/\/)([^/\s@]+)@/g, (_m, scheme: string) => `${scheme}***:***@`);
+  // Userinfo runs from `://` to the LAST `@` before the path, and may contain
+  // BOTH ':' and '@' in the password — `https://u:alpha@beta@host` is a valid URL
+  // whose password is `alpha@beta`. An earlier version stopped at the FIRST `@`
+  // ([^/\s@]+@) and so rendered that as `https://***:***@beta@host`, leaking half
+  // the secret while looking redacted (codex P1).
+  //
+  // `[^/\s]*` is GREEDY and cannot cross `/` or whitespace, so it runs to the
+  // last `@` within the authority and no further.
+  return text.replace(/(\w+:\/\/)[^/\s]*@/g, (_m, scheme: string) => `${scheme}***:***@`);
 }
 
 function clipInstallerOutput(text: string): string {
@@ -361,7 +366,10 @@ function externallyManagedRefusal(pkg: string, python: string, output = ""): str
   // is gone, and an earlier draft even claimed it was "above" when nothing had
   // been printed. Anything the tool said that this message does not anticipate
   // would have been lost silently.
-  const detail = redactUrlCredentials(clipInstallerOutput(output));
+  // REDACT, then clip — never the other way round (codex P1). Clipping first can
+  // sever the `@` that the redaction pattern anchors on, so a secret sitting near
+  // the cut survives as `https://u:token` in a message that looks sanitised.
+  const detail = clipInstallerOutput(redactUrlCredentials(output));
   return (
     (detail ? `${detail}\n\n` : "") +
     `Refusing to install "${redactUrlCredentials(pkg)}": the Python that ComfyUI runs (${python}) declares itself ` +
@@ -396,7 +404,7 @@ async function installPipPackage(
   const resolved = await resolveWorkspacePython(comfyuiPath);
   if (!resolved.python) {
     throw new ValidationError(
-      `Refusing to install "${pkg}". ${resolved.reason} Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.`,
+      `Refusing to install "${redactUrlCredentials(pkg)}". ${resolved.reason} Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.`,
     );
   }
   const python = resolved.python;
@@ -713,7 +721,15 @@ function report(
   status: ManifestItemStatus,
   message: string,
 ): ManifestItemReport {
-  return { action, item, status, message };
+  // `item` is echoed back verbatim from the manifest, and a pip entry or a model
+  // URL may legitimately carry credentials in its userinfo. Redacting only the
+  // MESSAGE left the secret in the structured result — which is what actually
+  // travels into transcripts and logs (codex, and my own test asserted the
+  // narrower claim while believing the wider one).
+  //
+  // The entry stays identifiable: only the userinfo is masked, so the host and
+  // path a reader matches on are untouched.
+  return { action, item: redactUrlCredentials(item), status, message };
 }
 
 /**


### PR DESCRIPTION
Claims #1508.

`apply_manifest` ran `python -m pip install <pkg>` against Stability Matrix's uv-managed CPython and was refused under PEP 668.

## The routing fix

Reading the code widened it: **three** routes reach that refusal, not the one reported.

| Route | Why it happens |
|---|---|
| uv **absent** → bare pip | the reporter's path — Stability Matrix keeps uv in its own directory, not on PATH |
| uv **present**, refused itself | uv won't modify a managed environment either; this fell through to a bare rethrow with no route out |
| uv's #377 non-venv fallback → bare pip | same wall one step later, with uv's unrelated "no virtual environment" complaint on top of the real reason |

All three now raise one actionable refusal. `--break-system-packages` is declined and the message says why — on a uv-managed interpreter that writes into an environment uv may reset, turning a clear failure now into a broken ComfyUI later.

**The first version of that message was wrong and measurement caught it.** It recommended `uv pip install --python <interp>`. Against a real uv-managed CPython (uv 0.11.21, standalone 3.12.13), uv refuses that too — `hint: Consider creating a virtual environment`. A remedy that reads as the answer and cannot work costs the reader the time to disprove it, so the message now says uv is *not* a way around this and points where uv points.

The detector keys on pip's PEP 668 error id **anchored to line start** plus uv's own form. Missing a distributor-patched refusal is the deliberate, safe direction — it surfaces the installer's own error unchanged, which already names PEP 668. Matching too eagerly instead replaces a real cause with an inapplicable remedy.

## What this PR also became

Carrying the installer's output into the refusal opened a credential-disclosure problem, since a pip spec may legitimately be a direct URL with `user:token@`. Four review rounds closed it:

- `Error.message` embeds the whole argv → carry stderr/stdout only (detection still reads the message: **shown is narrower than matched**)
- the refusal echoed the spec itself → redact URL userinfo
- clip-before-redact severed the anchor; the pattern stopped at the **first** `@` (`https://u:alpha@beta@host` leaked half) → redact first, greedy to the last `@`
- `results[].item` and ordinary-failure messages still carried it → redacted at **`report()`**, the one point every item passes through

Two of those paths predate this issue. This grew out of my fix rather than the reported bug, and is worth reviewing as such.

## Verification

- **50 tests**; suite 491 files / 9251; lint, vocabulary, unknown-collapse, vocab-export, asset-counts clean
- environment **shape reproduced** — uv-managed CPython carries the `EXTERNALLY-MANAGED` marker, bare pip refuses exactly as reported, `uv pip install --python` refuses too
- redaction probed directly against `@`-in-password, credential-free, and multi-URL inputs

## What I could NOT verify

That a real Stability Matrix install accepts the route this message recommends. I reproduced the environment *shape*, not their launcher. Asking the reporter rather than implying otherwise.