### PR TITLE
fix(1129): a Manager install that is accepted but never enqueued no longer reports success

### DIFF
--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -106,7 +106,7 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     // this way — the message must say so rather than assert the task never ran.
     expect(out.text).toMatch(/total_count, done, in_progress all 0/);
     expect(out.text).toMatch(/not a receipt/);
-    expect(out.text).toMatch(/it is NOT proof/);
+    expect(out.text).toMatch(/NOT PROOF EITHER WAY/);
     expect(out.text).toMatch(/cleared by a queue RESET/);
     expect(out.text).toMatch(/do not reinstall on\s+the assumption it did not/);
     // The earlier wording asserted both of these outright; neither is supportable
@@ -116,8 +116,15 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     // Names the confirmation and the tool that CAN clone.
     expect(out.text).toMatch(/panel_list_nodes/);
     expect(out.text).toMatch(/install_custom_node/);
-    // Hedged, not asserted: "likely to be dropped".
-    expect(out.text).toMatch(/likely to be dropped/);
+
+    // NO PROVENANCE CLAIM, in either direction. Five review rounds each found the
+    // explanation of WHY the task was dropped false in some reachable state — an
+    // id-only install submits no URL, and a `repository` that is any non-empty
+    // string need not be one. Every fix branched on a fact the request does not
+    // reliably carry. The observation needs no such fact, so the message no
+    // longer makes one: less useful in the common case, never false.
+    expect(out.text).not.toMatch(/git URL/i);
+    expect(out.text).not.toMatch(/does not recognise/);
 
     // NOT an error. Absence could not be proven, so the result is not flipped —
     // a false definite failure on a working install is the mirror of this bug.
@@ -305,35 +312,6 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
 
     expect(textOf(res)).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
-  });
-
-  it("does not blame a git URL on an id-only install (codex P2)", async () => {
-    // panel_install_node also accepts a registry `id`. For an id-only request no
-    // URL was submitted and none is retained, so "the Manager dropped a git URL"
-    // is an unsupported cause and "install it from its git URL" is an instruction
-    // the caller cannot follow. Same observation, different remedy.
-    const ctx = makePanelToolCtx(bridge({}), TAB, new WorkflowTargetStore());
-    const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
-    const res: ToolResult = await def!.handler({ id: "comfyui-kjnodes" } as never, ctx);
-    const text = textOf(res);
-
-    // The OBSERVATION is unchanged — that part is not about how it was requested.
-    expect(text).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
-    expect(text).toMatch(/cleared by a queue RESET/);
-    // ...but the git-URL cause and remedy must not appear.
-    expect(text).not.toMatch(/accepting a git URL/);
-    expect(text).not.toMatch(/install it from its git URL/);
-    // It names what they actually have instead.
-    expect(text).toMatch(/pass `repository` rather than `id`/);
-  });
-
-  it("still blames the git URL when one WAS submitted", async () => {
-    // The other half, so the branch above cannot quietly suppress the git-URL
-    // guidance for the case this issue was actually filed about.
-    const out = await install({});
-
-    expect(out.text).toMatch(/accepting a git URL/);
-    expect(out.text).toMatch(/install it from its git URL/);
   });
 
   it("claims nothing when the queue read itself fails", async () => {

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -1,0 +1,171 @@
+// #1129 (reopened) — legacy ComfyUI-Manager 3.x answers the install POST with
+// `queued: true` and then never enqueues the task. The reporter's follow-up read
+// showed an idle queue with `total_count: 0` and no directory under
+// custom_nodes, while panel_install_node had already reported success.
+//
+// #1143 fixed the OTHER half of this family — a pre-queue 403/404 refusal now
+// falls through to a direct clone. That fix keys on the rejection status, so it
+// cannot fire here: the POST succeeded.
+//
+// WHY THIS IS NOT THE SAME FIX AS install_custom_node's. That tool already
+// verifies and clones, and it may: it owns the filesystem it installs into.
+// panel_install_node drives whatever ComfyUI the PANEL is bound to, which need
+// not be this machine — so it may report the truth but must not clone somewhere
+// else on the caller's behalf.
+//
+// THE BAR FOR CONTRADICTING THE PANEL is two NEGATIVE observations, because
+// either alone is too weak: a queue shape without `total_count` proves nothing,
+// and a pack missing from the installed list moments after enqueuing is entirely
+// normal — it has not been cloned yet.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const REPO = "https://github.com/NikoDemon80/ComfyUI-H3-Motion-Context";
+
+const textOf = (r: ToolResult): string =>
+  r.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+let sent: string[] = [];
+
+/**
+ * `install` is what the panel says to the install POST; `total` is the queue's
+ * `total_count` afterwards; `installedNames` is what the node list reports.
+ */
+function bridge(opts: {
+  install?: Record<string, unknown>;
+  total?: number | null;
+  installedNames?: string[];
+  queueErrors?: boolean;
+  listErrors?: boolean;
+}) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd === "nodes_install") {
+        // The reporter's exact reply shape.
+        return opts.install ?? { queued: true, pending: true, dialect: "legacy" };
+      }
+      if (cmd.cmd === "nodes_queue_status") {
+        if (opts.queueErrors) throw new Error("queue unreachable");
+        return opts.total === null
+          ? { status: { done_count: 0 } } // a v4-ish shape with no total_count
+          : { status: { total_count: opts.total ?? 0, done_count: 0 } };
+      }
+      if (cmd.cmd === "nodes_list") {
+        if (opts.listErrors) throw new Error("list unreachable");
+        return { nodes: (opts.installedNames ?? []).map((n) => ({ name: n })) };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function install(
+  args: Record<string, unknown>,
+  opts: Parameters<typeof bridge>[0],
+): Promise<{ text: string; isError: boolean }> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+  if (!def) throw new Error("panel_install_node is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return { text: textOf(res), isError: res.isError === true };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("an install the Manager accepted and dropped is reported as such (#1129)", () => {
+  it("contradicts the queued reply when the queue saw NOTHING and the pack is absent", async () => {
+    const out = await install({ repository: REPO }, { total: 0, installedNames: [] });
+
+    // Both observations really happened — otherwise this asserts on a verdict
+    // reached without looking, which is the defect itself.
+    expect(sent).toContain("nodes_queue_status");
+    expect(sent).toContain("nodes_list");
+
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/CHECKED, AND IT WAS NOT/);
+    expect(out.text).toMatch(/ComfyUI-H3-Motion-Context/);
+    // The reason total_count 0 is decisive gets stated, not assumed.
+    expect(out.text).toMatch(/includes finished ones/);
+    // ...and it points at the tool that CAN clone, rather than cloning here.
+    expect(out.text).toMatch(/install_custom_node/);
+    expect(out.text).toMatch(/Do NOT simply retry/);
+  });
+
+  it("says nothing when the queue DID see a task", async () => {
+    // The normal case: enqueued, not yet cloned. Absent from the installed list
+    // is expected here and must not be read as a failure.
+    const out = await install({ repository: REPO }, { total: 1, installedNames: [] });
+
+    expect(sent).toContain("nodes_queue_status");
+    // The second read is not even reached — one positive observation settles it.
+    expect(sent).not.toContain("nodes_list");
+    expect(out.isError).toBe(false);
+    expect(out.text).not.toMatch(/CHECKED, AND IT WAS NOT/);
+  });
+
+  it("says nothing when the pack IS installed despite an empty queue", async () => {
+    // A fast install whose task already cleared. One negative observation is not
+    // enough, and this is precisely the case that makes it not enough.
+    const out = await install(
+      { repository: REPO },
+      { total: 0, installedNames: ["ComfyUI-H3-Motion-Context"] },
+    );
+
+    expect(sent).toContain("nodes_list");
+    expect(out.isError).toBe(false);
+    expect(out.text).not.toMatch(/CHECKED, AND IT WAS NOT/);
+  });
+
+  it("claims nothing when the queue shape cannot answer", async () => {
+    // A v4-style status with no `total_count` proves neither way, so the panel's
+    // own reply stands (#1473's rule).
+    const out = await install({ repository: REPO }, { total: null, installedNames: [] });
+
+    expect(out.isError).toBe(false);
+    expect(sent).not.toContain("nodes_list");
+  });
+
+  it("claims nothing when either read fails", async () => {
+    const q = await install({ repository: REPO }, { queueErrors: true });
+    expect(q.isError).toBe(false);
+
+    sent = [];
+    const l = await install({ repository: REPO }, { total: 0, listErrors: true });
+    expect(l.isError).toBe(false);
+  });
+
+  it("does not probe at all when the panel never claimed it was queued", async () => {
+    // A reply that makes no such claim has nothing to contradict, and probing it
+    // would spend two round trips per install for nothing.
+    const out = await install(
+      { repository: REPO },
+      { install: { installed: true, dialect: "v4" }, total: 0 },
+    );
+
+    expect(sent).not.toContain("nodes_queue_status");
+    expect(out.isError).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -307,6 +307,35 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     expect(textOf(res)).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
   });
 
+  it("does not blame a git URL on an id-only install (codex P2)", async () => {
+    // panel_install_node also accepts a registry `id`. For an id-only request no
+    // URL was submitted and none is retained, so "the Manager dropped a git URL"
+    // is an unsupported cause and "install it from its git URL" is an instruction
+    // the caller cannot follow. Same observation, different remedy.
+    const ctx = makePanelToolCtx(bridge({}), TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+    const res: ToolResult = await def!.handler({ id: "comfyui-kjnodes" } as never, ctx);
+    const text = textOf(res);
+
+    // The OBSERVATION is unchanged — that part is not about how it was requested.
+    expect(text).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+    expect(text).toMatch(/cleared by a queue RESET/);
+    // ...but the git-URL cause and remedy must not appear.
+    expect(text).not.toMatch(/accepting a git URL/);
+    expect(text).not.toMatch(/install it from its git URL/);
+    // It names what they actually have instead.
+    expect(text).toMatch(/pass `repository` rather than `id`/);
+  });
+
+  it("still blames the git URL when one WAS submitted", async () => {
+    // The other half, so the branch above cannot quietly suppress the git-URL
+    // guidance for the case this issue was actually filed about.
+    const out = await install({});
+
+    expect(out.text).toMatch(/accepting a git URL/);
+    expect(out.text).toMatch(/install it from its git URL/);
+  });
+
   it("claims nothing when the queue read itself fails", async () => {
     const out = await install({ queueErrors: true });
 

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -241,6 +241,72 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     expect(textOf(res)).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
   });
 
+  it("claims nothing when the SAME key is taken over by another panel (codex P1)", async () => {
+    // The route key is not the panel. A `wf:` key is `wf:<tabRouteId>:<path>` — it
+    // names a WORKFLOW, so it recurs, and a different browser tab can take it over
+    // with `ctx.tabId` completely unchanged. The previous guard compared only the
+    // key and would have read the REPLACEMENT panel's empty queue while the
+    // message claimed it was "on that same panel".
+    let incarnation = "inc-A";
+    const b = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(String(cmd.cmd));
+        if (cmd.cmd === "nodes_install") {
+          incarnation = "inc-B"; // another browser tab takes over the same key
+          return { queued: true, pending: true, dialect: "legacy" };
+        }
+        return { status: { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false } };
+      },
+      tabIncarnation: () => incarnation,
+      push: () => 1,
+      canReach: (id: string) => id === TAB,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: false }),
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+    const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
+
+    // The key really did NOT change — that is the whole point of this case.
+    expect(ctx.tabId).toBe(TAB);
+    expect(textOf(res)).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("still warns when the same panel holds the key throughout", async () => {
+    // The other half: a stable incarnation must not suppress the warning, or the
+    // guard above would quietly switch the whole feature off.
+    const b = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(String(cmd.cmd));
+        return cmd.cmd === "nodes_install"
+          ? { queued: true, pending: true, dialect: "legacy" }
+          : { status: { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false } };
+      },
+      tabIncarnation: () => "inc-STABLE",
+      push: () => 1,
+      canReach: (id: string) => id === TAB,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: false }),
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+    const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
+
+    expect(textOf(res)).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
   it("claims nothing when the queue read itself fails", async () => {
     const out = await install({ queueErrors: true });
 

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -51,6 +51,8 @@ function bridge(opts: {
   /** The `status` block nodes_queue_status wraps. */
   status?: Record<string, unknown> | null;
   queueErrors?: boolean;
+  /** Model a bridge that cannot say which panel holds the route key. */
+  noIncarnation?: boolean;
 }) {
   return {
     send: async (cmd: Record<string, unknown>) => {
@@ -66,6 +68,10 @@ function bridge(opts: {
       }
       return { ok: true };
     },
+    // The REAL UiBridge always reports this; a fixture without it models a
+    // bridge that cannot identify which panel answered, which is a separate case
+    // asserted below.
+    tabIncarnation: () => (opts.noIncarnation ? undefined : "inc-A"),
     push: () => 1,
     canReach: (id: string) => id === TAB,
     isHeadless: () => false,
@@ -224,6 +230,12 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
         }
         return { status: { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false } };
       },
+      // A STABLE incarnation on purpose: the route key must be the only thing
+      // that differs, or this case stops isolating the route-key pin. Without it
+      // the fail-closed unknown-incarnation rule short-circuits first and the
+      // test passes for the wrong reason — a surviving mutation caught exactly
+      // that.
+      tabIncarnation: () => "inc-STABLE",
       push: () => 1,
       canReach: (id: string) => (gone ? id === OTHER : id === TAB),
       isHeadless: () => false,
@@ -312,6 +324,18 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
 
     expect(textOf(res)).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("claims nothing when the bridge cannot identify the panel (codex final)", async () => {
+    // UNKNOWN is not "unchanged". Comparing two undefined incarnations yields
+    // equality, so a same-key takeover would pass the guard while the message
+    // claims the read happened "on that same panel" — a false statement produced
+    // by a guard that cannot see. A bridge that cannot answer does not get to.
+    const out = await install({ noIncarnation: true });
+
+    expect(sent).toContain("nodes_queue_status");
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+    expect(out.text).not.toMatch(/on that same panel/);
   });
 
   it("claims nothing when the queue read itself fails", async () => {

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -1,22 +1,30 @@
 // #1129 (reopened) — legacy ComfyUI-Manager 3.x answers the install POST with
-// `queued: true` and then never enqueues the task. The reporter's follow-up read
+// `queued: true` and never enqueues the task. The reporter's follow-up read
 // showed an idle queue with `total_count: 0` and no directory under
 // custom_nodes, while panel_install_node had already reported success.
 //
-// #1143 fixed the OTHER half of this family — a pre-queue 403/404 refusal now
-// falls through to a direct clone. That fix keys on the rejection status, so it
-// cannot fire here: the POST succeeded.
+// #1143 fixed the OTHER half of this family — a pre-queue 403/404 refusal falls
+// through to a direct clone. It keys on the rejection status, so it cannot fire
+// here: the POST succeeded.
 //
-// WHY THIS IS NOT THE SAME FIX AS install_custom_node's. That tool already
-// verifies and clones, and it may: it owns the filesystem it installs into.
-// panel_install_node drives whatever ComfyUI the PANEL is bound to, which need
-// not be this machine — so it may report the truth but must not clone somewhere
-// else on the caller's behalf.
+// WHY THIS ONLY WARNS, AND DOES NOT REPORT FAILURE. The first version checked the
+// installed list too and, finding the pack absent, flipped the result to an
+// error. Adversarial review killed that, correctly, on three counts:
 //
-// THE BAR FOR CONTRADICTING THE PANEL is two NEGATIVE observations, because
-// either alone is too weak: a queue shape without `total_count` proves nothing,
-// and a pack missing from the installed list moments after enqueuing is entirely
-// normal — it has not been cloned yet.
+//   - it substring-searched the RAW reply text instead of a validated shape, so
+//     an error envelope or an unfamiliar dialect payload read as "absent" —
+//     breaking this file's own rule that an unknown answer claims nothing;
+//   - the fixture it was tested against (`{nodes:[{name}]}`) is not the panel's
+//     production shape at all (`{installed: ...}`), so the check was only ever
+//     passing because it searched text;
+//   - a git URL's checkout directory need not match its URL basename, and the
+//     panel documents those targets as rename-prone. Absence by derived name
+//     therefore cannot PROVE failure.
+//
+// Since the second observation cannot be made decisive, the honest reply is a
+// warning that says exactly what WAS observed — the queue has no such task — and
+// tells the caller to confirm. A false "definitely failed" on a working install
+// is the same class of harm as the false success this issue is about.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -38,33 +46,23 @@ const textOf = (r: ToolResult): string =>
 
 let sent: string[] = [];
 
-/**
- * `install` is what the panel says to the install POST; `total` is the queue's
- * `total_count` afterwards; `installedNames` is what the node list reports.
- */
 function bridge(opts: {
   install?: Record<string, unknown>;
-  total?: number | null;
-  installedNames?: string[];
+  /** The `status` block nodes_queue_status wraps. */
+  status?: Record<string, unknown> | null;
   queueErrors?: boolean;
-  listErrors?: boolean;
 }) {
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
       if (cmd.cmd === "nodes_install") {
-        // The reporter's exact reply shape.
+        // The reporter's exact reply.
         return opts.install ?? { queued: true, pending: true, dialect: "legacy" };
       }
       if (cmd.cmd === "nodes_queue_status") {
         if (opts.queueErrors) throw new Error("queue unreachable");
-        return opts.total === null
-          ? { status: { done_count: 0 } } // a v4-ish shape with no total_count
-          : { status: { total_count: opts.total ?? 0, done_count: 0 } };
-      }
-      if (cmd.cmd === "nodes_list") {
-        if (opts.listErrors) throw new Error("list unreachable");
-        return { nodes: (opts.installedNames ?? []).map((n) => ({ name: n })) };
+        // The panel wraps it: `{ status }` (plus recent_failures/note sometimes).
+        return { status: opts.status ?? { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false } };
       }
       return { ok: true };
     },
@@ -81,13 +79,12 @@ function bridge(opts: {
 }
 
 async function install(
-  args: Record<string, unknown>,
   opts: Parameters<typeof bridge>[0],
 ): Promise<{ text: string; isError: boolean }> {
   const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
   if (!def) throw new Error("panel_install_node is not registered");
-  const res: ToolResult = await def.handler(args as never, ctx);
+  const res: ToolResult = await def.handler({ repository: REPO } as never, ctx);
   return { text: textOf(res), isError: res.isError === true };
 }
 
@@ -95,75 +92,86 @@ beforeEach(() => {
   sent = [];
 });
 
-describe("an install the Manager accepted and dropped is reported as such (#1129)", () => {
-  it("contradicts the queued reply when the queue saw NOTHING and the pack is absent", async () => {
-    const out = await install({ repository: REPO }, { total: 0, installedNames: [] });
+describe("an install the Manager accepted and dropped says so (#1129)", () => {
+  it("warns when the queue is IDLE and has seen no task at all", async () => {
+    const out = await install({});
 
-    // Both observations really happened — otherwise this asserts on a verdict
-    // reached without looking, which is the defect itself.
+    // The read really happened — otherwise this asserts on a verdict reached
+    // without looking, which is the defect itself.
     expect(sent).toContain("nodes_queue_status");
-    expect(sent).toContain("nodes_list");
 
-    expect(out.isError).toBe(true);
-    expect(out.text).toMatch(/CHECKED, AND IT WAS NOT/);
-    expect(out.text).toMatch(/ComfyUI-H3-Motion-Context/);
-    // The reason total_count 0 is decisive gets stated, not assumed.
+    expect(out.text).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+    // States what was observed and why zero is decisive, rather than asserting it.
     expect(out.text).toMatch(/includes finished ones/);
-    // ...and it points at the tool that CAN clone, rather than cloning here.
+    expect(out.text).toMatch(/not a receipt/);
+    // Names the confirmation and the tool that CAN clone.
+    expect(out.text).toMatch(/panel_list_nodes/);
     expect(out.text).toMatch(/install_custom_node/);
-    expect(out.text).toMatch(/Do NOT simply retry/);
+    expect(out.text).toMatch(/Retrying HERE will be dropped/);
+
+    // NOT an error. Absence could not be proven, so the result is not flipped —
+    // a false definite failure on a working install is the mirror of this bug.
+    expect(out.isError).toBe(false);
+  });
+
+  it("says nothing while the worker is PROCESSING, even at total_count 0 (codex P1)", async () => {
+    // A snapshot taken mid-accept can read zero before the counters move. Treating
+    // that as "never queued" would warn about an install that is starting
+    // normally — the reporter's own signature requires an IDLE queue.
+    const out = await install({
+      status: { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: true },
+    });
+
+    expect(sent).toContain("nodes_queue_status");
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("says nothing when idleness is UNKNOWN", async () => {
+    // No `is_processing` at all: the shape cannot answer whether the worker is
+    // running, so it is not made to.
+    const out = await install({ status: { total_count: 0, done_count: 0 } });
+
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
   });
 
   it("says nothing when the queue DID see a task", async () => {
-    // The normal case: enqueued, not yet cloned. Absent from the installed list
-    // is expected here and must not be read as a failure.
-    const out = await install({ repository: REPO }, { total: 1, installedNames: [] });
+    const out = await install({
+      status: { total_count: 1, done_count: 0, in_progress_count: 1, is_processing: true },
+    });
 
-    expect(sent).toContain("nodes_queue_status");
-    // The second read is not even reached — one positive observation settles it.
-    expect(sent).not.toContain("nodes_list");
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("says nothing on INCOHERENT counts", async () => {
+    // total 0 with work recorded against it does not match the 3.x contract
+    // (total = done + in_progress + queued), so this reasoning does not describe
+    // that payload and must not be applied to it.
+    const out = await install({
+      status: { total_count: 0, done_count: 3, in_progress_count: 0, is_processing: false },
+    });
+
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("says nothing on a v4-style shape with no total_count", async () => {
+    // v4 reports `pending_count` directly. The dropped-enqueue defect is legacy
+    // 3.x behaviour, so a shape that cannot answer is left alone.
+    const out = await install({ status: { pending_count: 0, in_progress_count: 0, is_processing: false } });
+
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("claims nothing when the queue read itself fails", async () => {
+    const out = await install({ queueErrors: true });
+
+    expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
     expect(out.isError).toBe(false);
-    expect(out.text).not.toMatch(/CHECKED, AND IT WAS NOT/);
   });
 
-  it("says nothing when the pack IS installed despite an empty queue", async () => {
-    // A fast install whose task already cleared. One negative observation is not
-    // enough, and this is precisely the case that makes it not enough.
-    const out = await install(
-      { repository: REPO },
-      { total: 0, installedNames: ["ComfyUI-H3-Motion-Context"] },
-    );
-
-    expect(sent).toContain("nodes_list");
-    expect(out.isError).toBe(false);
-    expect(out.text).not.toMatch(/CHECKED, AND IT WAS NOT/);
-  });
-
-  it("claims nothing when the queue shape cannot answer", async () => {
-    // A v4-style status with no `total_count` proves neither way, so the panel's
-    // own reply stands (#1473's rule).
-    const out = await install({ repository: REPO }, { total: null, installedNames: [] });
-
-    expect(out.isError).toBe(false);
-    expect(sent).not.toContain("nodes_list");
-  });
-
-  it("claims nothing when either read fails", async () => {
-    const q = await install({ repository: REPO }, { queueErrors: true });
-    expect(q.isError).toBe(false);
-
-    sent = [];
-    const l = await install({ repository: REPO }, { total: 0, listErrors: true });
-    expect(l.isError).toBe(false);
-  });
-
-  it("does not probe at all when the panel never claimed it was queued", async () => {
-    // A reply that makes no such claim has nothing to contradict, and probing it
-    // would spend two round trips per install for nothing.
-    const out = await install(
-      { repository: REPO },
-      { install: { installed: true, dialect: "v4" }, total: 0 },
-    );
+  it("does not read the queue at all when nothing claimed it was queued", async () => {
+    // Nothing to contradict, and probing would spend a round trip per install for
+    // no reason (codex P2 — this is the only extra read, and it is conditional).
+    const out = await install({ install: { installed: true, dialect: "v4" } });
 
     expect(sent).not.toContain("nodes_queue_status");
     expect(out.isError).toBe(false);

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -101,13 +101,23 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     expect(sent).toContain("nodes_queue_status");
 
     expect(out.text).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
-    // States what was observed and why zero is decisive, rather than asserting it.
-    expect(out.text).toMatch(/includes finished ones/);
+    // States WHAT WAS OBSERVED, and refuses to convert it into proof. A queue
+    // reset clears these same counters, so an install that really ran can read
+    // this way — the message must say so rather than assert the task never ran.
+    expect(out.text).toMatch(/total_count, done, in_progress all 0/);
     expect(out.text).toMatch(/not a receipt/);
+    expect(out.text).toMatch(/it is NOT proof/);
+    expect(out.text).toMatch(/cleared by a queue RESET/);
+    expect(out.text).toMatch(/do not reinstall on\s+the assumption it did not/);
+    // The earlier wording asserted both of these outright; neither is supportable
+    // once a queue reset can produce this same reading after a real install.
+    expect(out.text).not.toMatch(/this is not a task that already ran/);
+    expect(out.text).not.toMatch(/Retrying HERE will be dropped/);
     // Names the confirmation and the tool that CAN clone.
     expect(out.text).toMatch(/panel_list_nodes/);
     expect(out.text).toMatch(/install_custom_node/);
-    expect(out.text).toMatch(/Retrying HERE will be dropped/);
+    // Hedged, not asserted: "likely to be dropped".
+    expect(out.text).toMatch(/likely to be dropped/);
 
     // NOT an error. Absence could not be proven, so the result is not flipped —
     // a false definite failure on a working install is the mirror of this bug.
@@ -156,9 +166,79 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
   it("says nothing on a v4-style shape with no total_count", async () => {
     // v4 reports `pending_count` directly. The dropped-enqueue defect is legacy
     // 3.x behaviour, so a shape that cannot answer is left alone.
-    const out = await install({ status: { pending_count: 0, in_progress_count: 0, is_processing: false } });
+    //
+    // EVERY OTHER FIELD IS PRESENT AND ZERO on purpose. An earlier version of this
+    // fixture also omitted `done_count`, so the presence requirement rejected it
+    // before `total_count` was ever consulted — the case passed while proving
+    // nothing about the check it names. A surviving mutation ("treat a missing
+    // total_count as zero") is what exposed that.
+    const out = await install({
+      status: { pending_count: 0, done_count: 0, in_progress_count: 0, is_processing: false },
+    });
 
     expect(out.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("claims nothing when a count is MISSING rather than zero (codex P2)", async () => {
+    // Absent is not zero. The repo's established legacy-empty proof requires every
+    // count to be reported and exact; accepting a missing field would let a
+    // payload that never described the queue stand in for one that did.
+    const noDone = await install({
+      status: { total_count: 0, in_progress_count: 0, is_processing: false },
+    });
+    expect(noDone.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+
+    const noInProgress = await install({
+      status: { total_count: 0, done_count: 0, is_processing: false },
+    });
+    expect(noInProgress.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+
+    // A reported pending_count has to agree too.
+    const pending = await install({
+      status: { total_count: 0, done_count: 0, in_progress_count: 0, pending_count: 2, is_processing: false },
+    });
+    expect(pending.text).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("claims nothing when the read lands on a DIFFERENT tab (codex P1)", async () => {
+    // ctx.call runs ensureReachable first, which silently rebinds an unpinned
+    // current-mode session onto the sole remaining interactive tab. Another
+    // ComfyUI's empty queue is not evidence about an install dispatched
+    // elsewhere. Same guard #1468 needed — this is the second probe in this file
+    // to need it, which is why it is asserted rather than assumed.
+    const OTHER = "99999999-8888-7777-6666-555555555555";
+    let gone = false;
+    const b = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(String(cmd.cmd));
+        if (cmd.cmd === "nodes_install") {
+          gone = true; // the bound tab disappears right after the install
+          return { queued: true, pending: true, dialect: "legacy" };
+        }
+        return { status: { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false } };
+      },
+      push: () => 1,
+      canReach: (id: string) => (gone ? id === OTHER : id === TAB),
+      isHeadless: () => false,
+      tabs: () =>
+        gone
+          ? [{ tab_id: OTHER, title: "other", connected_at: 0 }]
+          : [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => (gone ? OTHER : TAB),
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: false }),
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+    const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
+
+    // The rebind really happened — asserted, not inferred, or this test would
+    // stay green if ensureReachable quietly declined to rebind.
+    expect(ctx.tabId).toBe(OTHER);
+    expect(textOf(res)).not.toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
   });
 
   it("claims nothing when the queue read itself fails", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2287,7 +2287,19 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
  *
  * Anything inconclusive returns the panel's own reply untouched (#1473's rule).
  */
-async function settleDroppedEnqueue(ctx: PanelToolCtx, res: ToolResult): Promise<ToolResult> {
+/** The panel identity a route key currently resolves to. `undefined` on a bridge
+ *  that cannot report one, which then compares equal and preserves the older
+ *  behaviour for lightweight contexts. */
+function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined {
+  const b = ctx.bridge as { tabIncarnation?: (t: string) => string | undefined };
+  return typeof b.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
+}
+
+async function settleDroppedEnqueue(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+  dispatch: { tab: string; incarnation: string | undefined },
+): Promise<ToolResult> {
   if (res.isError) return res;
   if (!claimsQueued(parseToolResultJson(res))) return res;
 
@@ -2297,9 +2309,18 @@ async function settleDroppedEnqueue(ctx: PanelToolCtx, res: ToolResult): Promise
   // current-mode session onto the sole remaining interactive tab. A reconnect
   // between the two calls would let ANOTHER ComfyUI's empty queue be reported as
   // evidence about this install.
-  const dispatchTab = ctx.tabId;
+  // The ROUTE KEY alone is not the panel (codex P1, round 3). A `wf:` key is
+  // `wf:<tabRouteId>:<path>` — it names a WORKFLOW, so it recurs, and a different
+  // browser tab can take it over without `ctx.tabId` changing at all. The bridge
+  // draws exactly this distinction and exposes `tabIncarnation` for it (#486), so
+  // both are captured: the key AND the incarnation currently holding it.
   const queue = await ctx.call({ cmd: "nodes_queue_status" }, 15000);
-  if (ctx.tabId !== dispatchTab) return res;
+  if (ctx.tabId !== dispatch.tab) return res;
+  // Both captured BEFORE the install was dispatched, not here — a takeover that
+  // happens DURING the install is already baked in by the time this function
+  // runs, so comparing two post-install readings would always agree and the guard
+  // would be decorative. Its own test caught exactly that.
+  if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
   if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
 
   return appendNote(
@@ -11657,6 +11678,13 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // repository install that works, and disclose the rewrite.
         const { conflict, note, ...cmdArgs } = nodesInstallCommandArgs(args);
         if (conflict) return fail(conflict);
+        // #1129 — the panel identity is captured BEFORE dispatch, because a
+        // takeover during the install is exactly what the follow-up read must not
+        // be attributed to.
+        const dispatch = {
+          tab: ctx.tabId,
+          incarnation: panelIncarnation(ctx, ctx.tabId),
+        };
         const res = await ctx.call(
           { cmd: "nodes_install", ...cmdArgs },
           30000,
@@ -11667,7 +11695,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // queue, and silently does nothing. Found by printing the real reply
         // rather than by reasoning about it: the first version of this shipped
         // the check and the check never ran.
-        const settled = await settleDroppedEnqueue(ctx, res);
+        const settled = await settleDroppedEnqueue(ctx, res, dispatch);
         if (note) {
           const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2204,6 +2204,99 @@ async function settleExitSubgraphAfterAckTimeout(
   return timedOut;
 }
 
+// ---- panel_install_node: accepted-but-never-enqueued (#1129) ---------------
+// #1143 fixed the pre-queue REFUSAL (403/404 → direct clone). This is the other
+// half of the same family: legacy Manager 3.x answers the install POST with
+// `queued: true`, and the task never enters the queue at all. The reporter's
+// follow-up read showed an idle queue with `total_count: 0` and no directory
+// under custom_nodes, while this tool had already said "queued".
+//
+// It is the third time this repo has met the same lesson, so it is worth stating
+// once: ComfyUI-Manager's acknowledgement is not a receipt. `getlist` cannot
+// distinguish an unreachable registry from an empty one; a download reports done
+// when the QUEUE DRAINS rather than when the transfer finishes; and here an
+// accepted request is simply dropped. "Accepted" is never evidence of "happened",
+// so the only honest reply is one that went and looked.
+//
+// NOTE the asymmetry with install_custom_node, which already verifies and clones:
+// that path owns the filesystem it installs into. This one drives whatever
+// ComfyUI the PANEL is bound to, which need not be this machine — so it can
+// report the truth but must not quietly clone somewhere else.
+
+/** True when the panel's reply claims the install was accepted/queued. */
+function claimsQueued(reply: Record<string, unknown> | null): boolean {
+  if (!reply) return false;
+  return reply.queued === true || reply.pending === true;
+}
+
+/**
+ * `total_count` counts EVERY task the Manager has seen this run, completed ones
+ * included — so a fast install that already finished still leaves it ≥ 1. Zero
+ * therefore means nothing was ever enqueued, which is the decisive reading and
+ * the reporter's exact signature. Anything else (missing, non-numeric, a v4 shape
+ * without it) answers nothing and is treated as such.
+ */
+function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
+  const status = (reply?.status ?? reply) as Record<string, unknown> | undefined;
+  return typeof status?.total_count === "number" && status.total_count === 0;
+}
+
+/**
+ * After an install the panel reported as queued, confirm it actually was.
+ *
+ * Two NEGATIVE observations are required before this contradicts the panel: the
+ * queue never saw a task, AND the pack is absent from the installed list. Either
+ * alone is too weak — a queue shape without `total_count` proves nothing, and a
+ * pack missing from the list moments after enqueuing is normal, because it has
+ * not been cloned yet. Together they are the reported failure exactly.
+ *
+ * Anything inconclusive returns the panel's own reply untouched (#1473's rule).
+ */
+async function settleDroppedEnqueue(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+  packId: unknown,
+): Promise<ToolResult> {
+  if (res.isError) return res;
+  if (!claimsQueued(parseToolResultJson(res))) return res;
+
+  const queue = await ctx.call({ cmd: "nodes_queue_status" }, 15000);
+  if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
+
+  const listed = await ctx.call({ cmd: "nodes_list" }, 20000);
+  if (listed.isError) return res;
+  const name = typeof packId === "string" ? packId : "";
+  const haystack = (listed.content.find((c) => c.type === "text")?.text ?? "").toLowerCase();
+  // Match on the repo/dir NAME rather than the full URL: the installed list
+  // reports directories, so a git-URL install lands as its last path segment.
+  const needle = name.replace(/\.git$/i, "").split(/[/\\]/).filter(Boolean).pop() ?? "";
+  if (!needle || haystack.includes(needle.toLowerCase())) return res;
+
+  return {
+    ...res,
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text:
+          `${res.content.find((c) => c.type === "text")?.text ?? ""}\n\n` +
+          `CHECKED, AND IT WAS NOT: the Manager ACCEPTED this install and then never queued ` +
+          `it. Its queue reports it has seen NO tasks at all (total_count 0 — that counter ` +
+          `includes finished ones, so this is not a task that already completed), and "${needle}" ` +
+          `is absent from the installed list. Nothing was installed, and the "queued" above is ` +
+          `the Manager's acknowledgement, not a receipt.\n\n` +
+          `This is a known legacy ComfyUI-Manager 3.x behaviour for a git URL it does not ` +
+          `recognise (#1129): the POST succeeds, the task is dropped silently.\n\n` +
+          `WHAT WORKS: install it from its git URL with the headless install_custom_node ` +
+          `(action:"install", source:"git"). That path owns the local filesystem and falls back ` +
+          `to a direct clone when the Manager will not take it — this tool drives whatever ` +
+          `ComfyUI the panel is bound to, which need not be this machine, so it will not clone ` +
+          `on your behalf. Do NOT simply retry here: the same request is dropped the same way.`,
+      },
+    ],
+  };
+}
+
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
 function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
   if (!res || res.isError) return null;
@@ -11543,13 +11636,20 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           { cmd: "nodes_install", ...cmdArgs },
           30000,
         );
+        // #1129 — settle BEFORE the note is appended. The note is glued on after
+        // the JSON body, which makes the payload unparseable as JSON, so a probe
+        // running afterwards reads `null`, concludes the panel never claimed a
+        // queue, and silently does nothing. Found by printing the real reply
+        // rather than by reasoning about it: the first version of this shipped
+        // the check and the check never ran.
+        const settled = await settleDroppedEnqueue(ctx, res, cmdArgs.id ?? cmdArgs.repository);
         if (note) {
-          const text = res.content.find((c) => c.type === "text");
+          const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {
             text.text += `\n\nNOTE: ${note}`;
           }
         }
-        return res;
+        return settled;
       },
     ),
     def(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2287,9 +2287,17 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
  *
  * Anything inconclusive returns the panel's own reply untouched (#1473's rule).
  */
-/** The panel identity a route key currently resolves to. `undefined` on a bridge
- *  that cannot report one, which then compares equal and preserves the older
- *  behaviour for lightweight contexts. */
+/**
+ * The panel identity a route key currently resolves to, or `undefined` when this
+ * bridge cannot report one.
+ *
+ * `undefined` means UNKNOWN, and callers must treat it as such rather than as
+ * "unchanged" (codex, final pass). Comparing two unknowns yields equality, which
+ * would let a same-key takeover pass the guard while the message claims the read
+ * happened "on that same panel" — a false statement produced by a guard that
+ * cannot see. The real UiBridge always implements this; only lightweight or mock
+ * contexts do not, and those simply do not get the warning.
+ */
 function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined {
   const b = ctx.bridge as { tabIncarnation?: (t: string) => string | undefined };
   return typeof b.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
@@ -2320,6 +2328,10 @@ async function settleDroppedEnqueue(
   // happens DURING the install is already baked in by the time this function
   // runs, so comparing two post-install readings would always agree and the guard
   // would be decorative. Its own test caught exactly that.
+  // UNKNOWN is not "unchanged": a bridge that cannot report an incarnation cannot
+  // rule out a same-key takeover, so it does not get to make a claim about which
+  // panel answered.
+  if (dispatch.incarnation === undefined) return res;
   if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
   if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2243,13 +2243,28 @@ function claimsQueued(reply: Record<string, unknown> | null): boolean {
  * this simply never fires there. That is correct: the dropped-enqueue defect is a
  * legacy-3.x behaviour, and a shape that cannot answer must not be made to.
  *
- * Should a Manager ever RESET the counter after draining, this would read zero on
- * a genuine success — which is exactly why a second, independent observation is
- * required before anything is contradicted.
+ * ONE KNOWN WAY THIS READS ZERO AFTER A REAL INSTALL: the counters are cleared by
+ * `POST /manager/queue/reset`, which this codebase itself issues from
+ * manager-config.ts and workflow-deps.ts. Neither is in panel_install_node's
+ * path, and the read below happens immediately after the install returns, so it
+ * takes a CONCURRENT reset from another operation to land in that window.
+ *
+ * That residual case is the reason this only WARNS. A definite failure verdict
+ * would be wrong there, and wrong in the same direction as the bug being fixed —
+ * a confident claim the evidence does not support. A spurious "go and check"
+ * costs one read; a spurious "it definitely failed" costs a reinstall.
  */
 function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
   const status = (reply?.status ?? reply) as Record<string, unknown> | undefined;
   if (typeof status?.total_count !== "number" || status.total_count !== 0) return false;
+  // PRESENT and zero, not absent-or-zero (codex P2). `panel-installer.ts`'s
+  // established legacy-empty proof requires every count to be reported and exact;
+  // accepting a missing field would let a payload that never described the queue
+  // stand in for one that did. A `pending_count`, if this build reports one, has
+  // to agree as well.
+  const presentZero = (v: unknown): boolean => v === 0;
+  if (!presentZero(status.done_count) || !presentZero(status.in_progress_count)) return false;
+  if (status.pending_count !== undefined && !presentZero(status.pending_count)) return false;
   // IDLE TOO, not just empty (codex P1). A snapshot taken while the Manager is
   // mid-accept can read zero before its counters move, and a running worker is
   // the one state where zero means "not yet" rather than "never". The panel's own
@@ -2258,8 +2273,7 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
   if (status.is_processing !== false) return false;
   // Coherent, by the 3.x contract quoted above: with total 0, both of these must
   // be 0 as well. Anything else is a shape this reasoning does not describe.
-  const zeroish = (v: unknown): boolean => v === undefined || v === 0;
-  return zeroish(status.done_count) && zeroish(status.in_progress_count);
+  return true;
 }
 
 /**
@@ -2277,22 +2291,34 @@ async function settleDroppedEnqueue(ctx: PanelToolCtx, res: ToolResult): Promise
   if (res.isError) return res;
   if (!claimsQueued(parseToolResultJson(res))) return res;
 
+  // The queue is only evidence about the panel the install was DISPATCHED to
+  // (codex P1 — and the same guard #1468 needed, which I did not carry across).
+  // `ctx.call` runs ensureReachable first, which silently rebinds an unpinned
+  // current-mode session onto the sole remaining interactive tab. A reconnect
+  // between the two calls would let ANOTHER ComfyUI's empty queue be reported as
+  // evidence about this install.
+  const dispatchTab = ctx.tabId;
   const queue = await ctx.call({ cmd: "nodes_queue_status" }, 15000);
+  if (ctx.tabId !== dispatchTab) return res;
   if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
 
   return appendNote(
     res,
-    `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but ` +
-      `its queue is IDLE and reports it has seen no tasks at all (total_count 0, a counter that ` +
-      `includes finished ones — so this is not a task that already ran). On legacy ` +
-      `ComfyUI-Manager 3.x a git URL it does not recognise is accepted and then dropped ` +
-      `silently (#1129): "queued" is its acknowledgement, not a receipt.\n\n` +
-      `VERIFY BEFORE RELYING ON IT: call panel_list_nodes and confirm the pack is actually ` +
-      `there. Do not restart on the assumption it installed.\n\n` +
+    `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but a ` +
+      `read taken immediately afterwards, on that same panel, reports an IDLE queue holding no ` +
+      `tasks at all (total_count, done, in_progress all 0).\n\n` +
+      `WHAT THAT DOES AND DOES NOT MEAN. The likely reading is legacy ComfyUI-Manager 3.x ` +
+      `accepting a git URL it does not recognise and dropping it silently (#1129) — there ` +
+      `"queued" is an acknowledgement, not a receipt. But it is NOT proof: those counters are ` +
+      `also cleared by a queue RESET, which other operations in this server issue, so an install ` +
+      `that really ran can read this way if a reset landed in between.\n\n` +
+      `SO CHECK, do not assume either way: call panel_list_nodes and see whether the pack is ` +
+      `actually there. Do not restart on the assumption it installed, and do not reinstall on ` +
+      `the assumption it did not.\n\n` +
       `IF IT IS ABSENT: install it from its git URL with the headless install_custom_node ` +
       `(action:"install", source:"git"), which clones directly and verifies a real pack landed. ` +
-      `Retrying HERE will be dropped the same way. This tool cannot clone for you — it drives ` +
-      `whatever ComfyUI the panel is bound to, which need not be this machine.`,
+      `A plain retry here is likely to be dropped the same way. This tool cannot clone for you — ` +
+      `it drives whatever ComfyUI the panel is bound to, which need not be this machine.`,
   );
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2230,15 +2230,36 @@ function claimsQueued(reply: Record<string, unknown> | null): boolean {
 }
 
 /**
- * `total_count` counts EVERY task the Manager has seen this run, completed ones
- * included — so a fast install that already finished still leaves it ≥ 1. Zero
- * therefore means nothing was ever enqueued, which is the decisive reading and
- * the reporter's exact signature. Anything else (missing, non-numeric, a v4 shape
- * without it) answers nothing and is treated as such.
+ * `total_count` counts EVERY task the Manager has seen, completed ones included —
+ * so a fast install that already finished still leaves it ≥ 1. Zero therefore
+ * means nothing was ever enqueued, which is the decisive reading and the
+ * reporter's exact signature.
+ *
+ * Not my arithmetic: `countsFromStatus` in node-management.ts states the 3.x
+ * contract outright — "total_count = done + in_progress + queued exactly" — and
+ * derives pending from it. So `done_count` cannot be non-zero while total is 0.
+ *
+ * v4 reports `pending_count` directly and need not carry `total_count` at all, so
+ * this simply never fires there. That is correct: the dropped-enqueue defect is a
+ * legacy-3.x behaviour, and a shape that cannot answer must not be made to.
+ *
+ * Should a Manager ever RESET the counter after draining, this would read zero on
+ * a genuine success — which is exactly why a second, independent observation is
+ * required before anything is contradicted.
  */
 function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
   const status = (reply?.status ?? reply) as Record<string, unknown> | undefined;
-  return typeof status?.total_count === "number" && status.total_count === 0;
+  if (typeof status?.total_count !== "number" || status.total_count !== 0) return false;
+  // IDLE TOO, not just empty (codex P1). A snapshot taken while the Manager is
+  // mid-accept can read zero before its counters move, and a running worker is
+  // the one state where zero means "not yet" rather than "never". The panel's own
+  // queue predicate draws the same line, so this matches rather than invents one.
+  // Absent/non-boolean is NOT treated as idle: unknown answers nothing.
+  if (status.is_processing !== false) return false;
+  // Coherent, by the 3.x contract quoted above: with total 0, both of these must
+  // be 0 as well. Anything else is a shape this reasoning does not describe.
+  const zeroish = (v: unknown): boolean => v === undefined || v === 0;
+  return zeroish(status.done_count) && zeroish(status.in_progress_count);
 }
 
 /**
@@ -2252,49 +2273,27 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
  *
  * Anything inconclusive returns the panel's own reply untouched (#1473's rule).
  */
-async function settleDroppedEnqueue(
-  ctx: PanelToolCtx,
-  res: ToolResult,
-  packId: unknown,
-): Promise<ToolResult> {
+async function settleDroppedEnqueue(ctx: PanelToolCtx, res: ToolResult): Promise<ToolResult> {
   if (res.isError) return res;
   if (!claimsQueued(parseToolResultJson(res))) return res;
 
   const queue = await ctx.call({ cmd: "nodes_queue_status" }, 15000);
   if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
 
-  const listed = await ctx.call({ cmd: "nodes_list" }, 20000);
-  if (listed.isError) return res;
-  const name = typeof packId === "string" ? packId : "";
-  const haystack = (listed.content.find((c) => c.type === "text")?.text ?? "").toLowerCase();
-  // Match on the repo/dir NAME rather than the full URL: the installed list
-  // reports directories, so a git-URL install lands as its last path segment.
-  const needle = name.replace(/\.git$/i, "").split(/[/\\]/).filter(Boolean).pop() ?? "";
-  if (!needle || haystack.includes(needle.toLowerCase())) return res;
-
-  return {
-    ...res,
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text:
-          `${res.content.find((c) => c.type === "text")?.text ?? ""}\n\n` +
-          `CHECKED, AND IT WAS NOT: the Manager ACCEPTED this install and then never queued ` +
-          `it. Its queue reports it has seen NO tasks at all (total_count 0 — that counter ` +
-          `includes finished ones, so this is not a task that already completed), and "${needle}" ` +
-          `is absent from the installed list. Nothing was installed, and the "queued" above is ` +
-          `the Manager's acknowledgement, not a receipt.\n\n` +
-          `This is a known legacy ComfyUI-Manager 3.x behaviour for a git URL it does not ` +
-          `recognise (#1129): the POST succeeds, the task is dropped silently.\n\n` +
-          `WHAT WORKS: install it from its git URL with the headless install_custom_node ` +
-          `(action:"install", source:"git"). That path owns the local filesystem and falls back ` +
-          `to a direct clone when the Manager will not take it — this tool drives whatever ` +
-          `ComfyUI the panel is bound to, which need not be this machine, so it will not clone ` +
-          `on your behalf. Do NOT simply retry here: the same request is dropped the same way.`,
-      },
-    ],
-  };
+  return appendNote(
+    res,
+    `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but ` +
+      `its queue is IDLE and reports it has seen no tasks at all (total_count 0, a counter that ` +
+      `includes finished ones — so this is not a task that already ran). On legacy ` +
+      `ComfyUI-Manager 3.x a git URL it does not recognise is accepted and then dropped ` +
+      `silently (#1129): "queued" is its acknowledgement, not a receipt.\n\n` +
+      `VERIFY BEFORE RELYING ON IT: call panel_list_nodes and confirm the pack is actually ` +
+      `there. Do not restart on the assumption it installed.\n\n` +
+      `IF IT IS ABSENT: install it from its git URL with the headless install_custom_node ` +
+      `(action:"install", source:"git"), which clones directly and verifies a real pack landed. ` +
+      `Retrying HERE will be dropped the same way. This tool cannot clone for you — it drives ` +
+      `whatever ComfyUI the panel is bound to, which need not be this machine.`,
+  );
 }
 
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
@@ -11642,7 +11641,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // queue, and silently does nothing. Found by printing the real reply
         // rather than by reasoning about it: the first version of this shipped
         // the check and the check never ran.
-        const settled = await settleDroppedEnqueue(ctx, res, cmdArgs.id ?? cmdArgs.repository);
+        const settled = await settleDroppedEnqueue(ctx, res);
         if (note) {
           const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2298,9 +2298,8 @@ function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined 
 async function settleDroppedEnqueue(
   ctx: PanelToolCtx,
   res: ToolResult,
-  dispatch: { tab: string; incarnation: string | undefined; fromGitUrl: boolean },
+  dispatch: { tab: string; incarnation: string | undefined },
 ): Promise<ToolResult> {
-  const { fromGitUrl } = dispatch;
   if (res.isError) return res;
   if (!claimsQueued(parseToolResultJson(res))) return res;
 
@@ -2324,35 +2323,34 @@ async function settleDroppedEnqueue(
   if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
   if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
 
+  // NO PROVENANCE CLAIM AT ALL — deliberately, after five review rounds.
+  //
+  // Earlier drafts explained WHY the task was probably dropped ("the Manager
+  // accepted a git URL it does not recognise") and prescribed accordingly. Every
+  // round found that explanation false in some reachable state: an id-only
+  // install submits no URL; a `repository` that is any non-empty string is not
+  // necessarily a URL. Each fix branched on a fact the request does not reliably
+  // carry, and each branch was a fresh chance to assert the wrong cause.
+  //
+  // What this function actually observed is the queue reading. That is worth
+  // saying, needs no provenance, and cannot be wrong. The cause belongs to
+  // whoever can see the install — so the message asks for the ONE check that
+  // settles it and stops there. Less useful in the common case; never false.
   return appendNote(
     res,
     `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but a ` +
       `read taken immediately afterwards, on that same panel, reports an IDLE queue holding no ` +
-      `tasks at all (total_count, done, in_progress all 0).\n\n` +
-      `WHAT THAT DOES AND DOES NOT MEAN. "queued" is the Manager's acknowledgement, not a ` +
-      (fromGitUrl
-        ? `receipt — and the likely reading here is legacy ComfyUI-Manager 3.x accepting a git URL ` +
-          `it does not recognise and dropping it silently (#1129). `
-        : `receipt. `) +
-      `But it is NOT proof: those counters are ` +
-      `also cleared by a queue RESET, which other operations in this server issue, so an install ` +
-      `that really ran can read this way if a reset landed in between.\n\n` +
-      `SO CHECK, do not assume either way: call panel_list_nodes and see whether the pack is ` +
-      `actually there. Do not restart on the assumption it installed, and do not reinstall on ` +
-      `the assumption it did not.\n\n` +
-      (fromGitUrl
-        ? `IF IT IS ABSENT: install it from its git URL with the headless install_custom_node ` +
-          `(action:"install", source:"git"), which clones directly and verifies a real pack ` +
-          `landed. `
-        : // No URL was submitted and none is retained, so "install it from its git
-          // URL" would be an instruction the caller cannot follow (codex P2). Name
-          // what they actually have: a registry id, and the tool that verifies.
-          `IF IT IS ABSENT: retry through the headless install_custom_node ` +
-          `(action:"install"), which verifies the pack really landed rather than trusting the ` +
-          `queue. If this pack is not in the Manager's registry at all, install it from its ` +
-          `repository URL instead — pass \`repository\` rather than \`id\`. `) +
-      `A plain retry here is likely to be dropped the same way. This tool cannot clone for you — ` +
-      `it drives whatever ComfyUI the panel is bound to, which need not be this machine.`,
+      `tasks at all (total_count, done, in_progress all 0). "queued" is its acknowledgement, not ` +
+      `a receipt.\n\n` +
+      `THIS IS NOT PROOF EITHER WAY. Those counters are also cleared by a queue RESET, which ` +
+      `other operations in this server issue, so an install that really ran can read exactly ` +
+      `like this if a reset landed in between.\n\n` +
+      `SO CHECK: call panel_list_nodes and see whether the pack is actually there. Do not restart ` +
+      `on the assumption it installed, and do not reinstall on the assumption it did not.\n\n` +
+      `IF IT IS ABSENT: install it through the headless install_custom_node, which verifies the ` +
+      `pack really landed instead of trusting the queue, and can clone a repository URL directly ` +
+      `when the Manager will not take it. This tool cannot clone for you — it drives whatever ` +
+      `ComfyUI the panel is bound to, which need not be this machine.`,
   );
 }
 
@@ -11697,9 +11695,6 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const dispatch = {
           tab: ctx.tabId,
           incarnation: panelIncarnation(ctx, ctx.tabId),
-          // Whether a repository URL was actually submitted. An id-only install
-          // has no URL to be told to use (codex P2).
-          fromGitUrl: typeof cmdArgs.repository === "string" && cmdArgs.repository.length > 0,
         };
         const res = await ctx.call(
           { cmd: "nodes_install", ...cmdArgs },

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2298,8 +2298,9 @@ function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined 
 async function settleDroppedEnqueue(
   ctx: PanelToolCtx,
   res: ToolResult,
-  dispatch: { tab: string; incarnation: string | undefined },
+  dispatch: { tab: string; incarnation: string | undefined; fromGitUrl: boolean },
 ): Promise<ToolResult> {
+  const { fromGitUrl } = dispatch;
   if (res.isError) return res;
   if (!claimsQueued(parseToolResultJson(res))) return res;
 
@@ -2328,16 +2329,28 @@ async function settleDroppedEnqueue(
     `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but a ` +
       `read taken immediately afterwards, on that same panel, reports an IDLE queue holding no ` +
       `tasks at all (total_count, done, in_progress all 0).\n\n` +
-      `WHAT THAT DOES AND DOES NOT MEAN. The likely reading is legacy ComfyUI-Manager 3.x ` +
-      `accepting a git URL it does not recognise and dropping it silently (#1129) — there ` +
-      `"queued" is an acknowledgement, not a receipt. But it is NOT proof: those counters are ` +
+      `WHAT THAT DOES AND DOES NOT MEAN. "queued" is the Manager's acknowledgement, not a ` +
+      (fromGitUrl
+        ? `receipt — and the likely reading here is legacy ComfyUI-Manager 3.x accepting a git URL ` +
+          `it does not recognise and dropping it silently (#1129). `
+        : `receipt. `) +
+      `But it is NOT proof: those counters are ` +
       `also cleared by a queue RESET, which other operations in this server issue, so an install ` +
       `that really ran can read this way if a reset landed in between.\n\n` +
       `SO CHECK, do not assume either way: call panel_list_nodes and see whether the pack is ` +
       `actually there. Do not restart on the assumption it installed, and do not reinstall on ` +
       `the assumption it did not.\n\n` +
-      `IF IT IS ABSENT: install it from its git URL with the headless install_custom_node ` +
-      `(action:"install", source:"git"), which clones directly and verifies a real pack landed. ` +
+      (fromGitUrl
+        ? `IF IT IS ABSENT: install it from its git URL with the headless install_custom_node ` +
+          `(action:"install", source:"git"), which clones directly and verifies a real pack ` +
+          `landed. `
+        : // No URL was submitted and none is retained, so "install it from its git
+          // URL" would be an instruction the caller cannot follow (codex P2). Name
+          // what they actually have: a registry id, and the tool that verifies.
+          `IF IT IS ABSENT: retry through the headless install_custom_node ` +
+          `(action:"install"), which verifies the pack really landed rather than trusting the ` +
+          `queue. If this pack is not in the Manager's registry at all, install it from its ` +
+          `repository URL instead — pass \`repository\` rather than \`id\`. `) +
       `A plain retry here is likely to be dropped the same way. This tool cannot clone for you — ` +
       `it drives whatever ComfyUI the panel is bound to, which need not be this machine.`,
   );
@@ -11684,6 +11697,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const dispatch = {
           tab: ctx.tabId,
           incarnation: panelIncarnation(ctx, ctx.tabId),
+          // Whether a repository URL was actually submitted. An id-only install
+          // has no URL to be told to use (codex P2).
+          fromGitUrl: typeof cmdArgs.repository === "string" && cmdArgs.repository.length > 0,
         };
         const res = await ctx.call(
           { cmd: "nodes_install", ...cmdArgs },


### PR DESCRIPTION
Claims #1129 (reopened).

#1143 fixed the **pre-queue refusal** — legacy Manager 3.x rejects a git-URL install with 403/404, which now falls through to a direct clone. This is the other half: the POST **succeeds**, returns `queued: true`, and the task is never enqueued. The reporter's follow-up read showed an idle queue, `total_count: 0`, and no directory under `custom_nodes`.

## What the report asks for already exists — in the other tool

`install_custom_node` already enqueues, verifies, and clones when nothing landed. The reporter used **`panel_install_node`**, which forwards `nodes_install` over the bridge and never reaches that code. Their reply shape (`queued/pending/dialect`) is the panel's, not that function's.

I deliberately did **not** copy the clone across. `install_custom_node` may clone because it owns the filesystem it writes to; `panel_install_node` drives whatever ComfyUI the panel is bound to, which need not be this machine. So it reports what it saw and names the tool that *can* clone.

## It warns; it does not declare failure

The first version also read the installed list and, finding the pack absent, flipped the result to an error. Review killed that on three counts, all correct:

- it substring-searched **raw reply text** instead of a validated shape, so an error envelope or unfamiliar dialect read as "absent"
- the fixture it was tested against (`{nodes:[{name}]}`) **is not the panel's shape** (`{installed: ...}`) — the check only ever passed *because* it searched text
- a git URL's checkout directory need not match its URL basename, and the panel documents those targets as rename-prone, so **absence by derived name cannot prove failure**

With no decisive second observation, a definite verdict is unjustified. A false "definitely failed" on a working install is the mirror of the false success this issue is about.

The message also stopped asserting *"this is not a task that already ran"* and *"retrying will be dropped"*. A queue **reset** clears these same counters — and this codebase issues one from `manager-config.ts` and `workflow-deps.ts` — so an install that really ran can read this way. Severity is not accuracy: it now states what was observed, names the reset as a real alternative, and says not to assume in either direction.

## Guards

| Guard | Why |
|---|---|
| queue must be **idle** | a mid-accept snapshot reads zero before counters move |
| counts **present** and zero | absent ≠ zero; matches the repo's legacy-empty proof |
| `pending_count` must agree | if the build reports one |
| **dispatch-tab pin** | `ctx.call` can rebind; another ComfyUI's empty queue is not evidence about this install |
| probe only when queued was claimed | one conditional read, no cost on other paths |

The dispatch-tab pin is the same guard #1468 needed **earlier today**. I built it there and did not carry it to this probe; that is why it is now asserted by a test that checks the rebind actually occurred.

## Verification

- **10 tests, 9/9 mutations killed.** One mutation *survived* first and was the most useful result: it exposed a **vacuous test** — the v4 fixture omitted `done_count`, so the presence check rejected it before `total_count` was consulted. Fixture fixed, not the mutation.
- Mutation M2 restores the ordering bug I originally shipped, where the panel's appended note broke JSON parsing and the entire check ran dead with every test green.
- Suite **492 files / 9261**; lint, vocabulary, unknown-collapse, vocab-export clean.

## Not verified

I do not have legacy Manager 3.x. The dropped-enqueue behaviour is modelled from the reporter's reply shapes, not reproduced against a real 3.x install.