### PR TITLE
release: v0.51.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.33
+
+### Fixed
+
+- **An install ComfyUI-Manager accepted but never queued no longer looks like it worked (#1129).**
+  On legacy ComfyUI-Manager 3.x, `panel_install_node` could report an install as queued
+  while the Manager silently dropped it -- the queue then sat idle having seen no task
+  at all, and nothing appeared under `custom_nodes`. The panel's "queued" is an
+  acknowledgement, not a receipt, and it was being passed on as though it were one.
+
+  The reply now carries what a follow-up read actually found. It is careful about how
+  much that proves: the same counters are cleared by a queue reset, which other
+  operations here can issue, so an install that really did run can look identical. So it
+  says what was observed, says plainly that this settles nothing on its own, and asks for
+  the one check that does -- `panel_list_nodes`. It does not guess at the cause, and it
+  does not report a failure it cannot demonstrate; a wrong "this definitely failed" would
+  cost a needless reinstall, which is the same harm as the false success in the other
+  direction.
+
+  A related fix from 0.50.40 handled the case where the Manager REFUSES the install
+  outright (it falls back to a direct clone). This is the opposite shape -- accepted, then
+  dropped -- which that path could never catch, because nothing was refused.
+
+  The follow-up read is also pinned to the exact panel the install went to, so a browser
+  tab that reconnects or is replaced mid-install can never have its empty queue reported
+  as evidence about someone else's install.
+
 ## 0.51.32
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.32",
+  "version": "0.51.33",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Releases the #1129 fix (merged as `7085f6bf`).

**An install ComfyUI-Manager accepted but never queued no longer looks like it worked.** Legacy Manager 3.x answers the POST with `queued: true` and silently drops the task; the queue then reports it saw no task at all and nothing appears under `custom_nodes`. #1143 handled the opposite shape — an outright refusal, which falls back to a direct clone — and could never catch this one, because nothing was refused.

**It is careful about what it proves.** The same counters are cleared by a queue reset, which other operations here can issue, so a successful install can read identically. The reply states what was observed, says plainly that this settles nothing alone, and asks for the one check that does. It makes no guess at the cause and reports no failure it cannot demonstrate.

**Verification**
- Six codex rounds; every finding closed. Each round found a real defect, and each fix *removed* a claim rather than adding one: a verdict → a warning → no causal claim → no claim at all when identity is unknown
- 13 tests; every identity guard mutation-killed independently. Three **vacuous tests** were caught by surviving mutations — cases that passed because a newer guard short-circuited ahead of the one they were named for
- Suite **492 files / 9264**; all gates clean
- **Live against the built `dist/` with a real `UiBridge`** — 8/8, including confirming the real bridge actually reports a `tabIncarnation`, without which the identity guard would be silently vacuous in production

**Not verified:** legacy Manager 3.x itself. The dropped-enqueue behaviour is modelled from the reporter's reply shapes.