### PR TITLE
release: v0.51.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.34
+
+### Fixed
+
+- **`list_tools` search finds the tool you named, and stops returning half the catalog (#1525).**
+  Searching `"download model"` returned only `runpod` -- while the unfiltered catalog
+  plainly contains `download_model`. The filter was matching the phrase literally, and
+  tool names are identifiers: `download_model` is spelled with an underscore, so the
+  phrase never occurred in it, whereas another tool's prose happens to say "download
+  model" as ordinary English. The one tool you obviously wanted was the one excluded,
+  and the only result was the coincidence.
+
+  Underscores and hyphens are now folded on both sides, so you can type a tool's name
+  the way you say it, and the words are matched individually rather than as a fixed
+  phrase. Dots and slashes are deliberately left alone, so a literal query like `v1.2`
+  still means what it says.
+
+  Matching every word across names, descriptions and parameter docs turned out to be
+  barely a filter on its own -- `"install node"` matched 19 of 37 tools, since those are
+  ordinary words in a dozen descriptions. So a tool whose NAME matches now wins outright:
+  `"download model"` gives you `download_model`, `"install node"` gives you
+  `install_custom_node`. When no name matches -- `"checkpoint"`, `"free vram"` -- the
+  search still looks through descriptions and parameters, which is the case that made
+  searching them worthwhile.
+
+  When results were chosen by name, the reply says so and tells you how many other tools
+  also matched, so a short list is never mistaken for the whole answer.
+
 ## 0.51.33
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.33",
+  "version": "0.51.34",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Releases the #1525 fix (merged as `73ec201d`).

**`list_tools search:"download model"` returned only `runpod`.** The filter matched the literal phrase; `download_model` is an identifier spelled with an underscore, so the phrase never occurred in it, while another tool's prose says it as ordinary English. The one tool the caller wanted was the one excluded.

Separators are folded (`_`, `-` — **not** dots/slashes, so `v1.2` keeps its meaning) and words matched individually. And because term-matching alone was barely a filter on the real surface — **19 of 37 tools for `"install node"`** — a tool whose NAME matches now wins outright, falling back to the full corpus when no name matches.

**Verification**
- Four codex rounds. Every finding was a **statement-level** defect — the code did the right thing and the sentence about it did not: a false "strictly wider, never narrower", a disclosure claiming *where* tools matched, a header stamping `(filtered)` on an unfiltered view, and two "exactly as before" claims about genuine behaviour changes
- **60 tests, 9/9 mutations killed.** Two mutations escaped first and were the most useful results: one exposed a **vacuous test** (the fixture's corpus contained the reversed phrase by accident), the other a mutation that silently **never applied** and reported as SKIP
- Suite **492 files / 9274**; all gates clean
- **Live against the built `dist/` with the real 37-tool catalog** — 7/7, including the reporter's exact query