### PR TITLE
fix(1524): an orchestrator that never binds stops lingering silently

### DIFF
--- a/src/__tests__/orchestrator/startup-deadline.test.ts
+++ b/src/__tests__/orchestrator/startup-deadline.test.ts
@@ -124,7 +124,16 @@ describe("the startup deadline (#1524)", () => {
       exits = [];
       process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS = bad;
       const disarm = armStartupDeadline(PORT, { exit, incumbent: () => undefined });
-      vi.advanceTimersByTime(91_000);
+
+      // WHEN it fires, not merely THAT it fires. Dropping the `raw > 0` guard
+      // turns "0" and "-1" into a ZERO-millisecond deadline that kills every
+      // startup instantly — strictly worse than disabling it — and an
+      // exits-are-[1]-after-91s assertion cannot tell that apart from a sane
+      // default. A surviving mutation is what exposed the gap.
+      vi.advanceTimersByTime(89_000);
+      expect(exits, `override ${JSON.stringify(bad)} must not fire early`).toEqual([]);
+
+      vi.advanceTimersByTime(2_000);
       expect(exits, `override ${JSON.stringify(bad)} should fall back to the default`).toEqual([1]);
       disarm();
     }
@@ -168,5 +177,23 @@ describe("the startup deadline (#1524)", () => {
     expect(timers).toBeGreaterThan(0);
     disarm();
     expect(vi.getTimerCount()).toBe(timers - 1);
+
+    // `unref` is not observable under fake timers — the count above is identical
+    // with or without it — so the call is asserted against the source instead.
+    // Without it a process that finishes its work inside the window cannot exit
+    // until the deadline elapses, which is a hang introduced by the anti-hang
+    // guard. A surviving mutation is what showed the behavioural test could not
+    // see this.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "..", "orchestrator", "index.ts"),
+      "utf8",
+    );
+    // SCOPED to this function. index.ts has more than one `timer.unref?.()`, so a
+    // file-wide match passed even with THIS one deleted — an assertion satisfied
+    // by an unrelated line. Only the deadline's own body counts.
+    const start = src.indexOf("export function armStartupDeadline");
+    expect(start, "armStartupDeadline is gone — this test is checking nothing").toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf("return () => clearTimeout(timer);", start));
+    expect(body).toMatch(/timer\.unref\?\.\(\)/);
   });
 });

--- a/src/__tests__/orchestrator/startup-deadline.test.ts
+++ b/src/__tests__/orchestrator/startup-deadline.test.ts
@@ -120,7 +120,11 @@ describe("the startup deadline (#1524)", () => {
   it("ignores a nonsense override rather than disabling itself", () => {
     // `0`, a negative, or a word must not silently switch the guard off — that
     // would reintroduce exactly the silent-zombie state, via a typo.
-    for (const bad of ["0", "-1", "soon", ""]) {
+    // `0.5` and anything past Node's 32-bit setTimeout ceiling both COERCE TO 1ms
+    // — so a value typed while trying to RAISE the deadline would fire almost
+    // instantly and kill every healthy startup. An escape hatch that can cause the
+    // outage it exists to prevent is worse than none (codex).
+    for (const bad of ["0", "-1", "soon", "", "0.5", "999", "2147483648", "1e30"]) {
       exits = [];
       process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS = bad;
       const disarm = armStartupDeadline(PORT, { exit, incumbent: () => undefined });

--- a/src/__tests__/orchestrator/startup-deadline.test.ts
+++ b/src/__tests__/orchestrator/startup-deadline.test.ts
@@ -1,0 +1,172 @@
+// #1524 — a respawned orchestrator was observed alive for HOURS holding no
+// listening ports, while an older instance owned 9180/9181/9183. From the user's
+// side the sidebar kept working; the agent session had simply lost the panel.
+//
+// WHY THE EXISTING GUARD DOES NOT COVER IT, which is the whole reason this is a
+// startup-wide deadline rather than a bind timeout: the bind-failure path is
+// already bounded and already exits. `attemptListen` retries EADDRINUSE five
+// times, then resolves `whenReady()` false; `runPanelOrchestrator` tries to
+// reclaim the port and, failing that, logs and exits non-zero. A process holding
+// NO port never reached any of that — it hung earlier. A guard wrapped around the
+// bind would have watched the one place the failure was not.
+//
+// So the deadline is armed before anything can block and disarmed only once the
+// port is genuinely held. It does not care where the hang is; the failure it
+// prevents is not "the bind failed" but "we never found out".
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Importing the orchestrator drags in `resolveLiveInterpreter`, which shells out
+// to find the python actually serving the port ON THIS MACHINE — so an unstubbed
+// import asserts one thing where ComfyUI is running and another where it is not,
+// and CI cannot tell you because CI is one of those machines (#1263). The repo
+// gates against exactly that, and it caught this file. Stubbed at the module
+// boundary; this suite never wants a live process table anyway, since it injects
+// its own `incumbent` lookup.
+vi.mock("../../services/live-interpreter.js", async () => ({
+  ...(await vi.importActual("../../services/live-interpreter.js")),
+  resolveLiveInterpreter: () => undefined,
+}));
+
+const { armStartupDeadline } = await import("../../orchestrator/index.js");
+
+const PORT = 9180;
+
+let exits: number[];
+let errors: string[];
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  exits = [];
+  errors = [];
+  // The orchestrator logs through the shared logger, which writes to stderr.
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    errors.push(String(chunk));
+    return true;
+  });
+  delete process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  errSpy.mockRestore();
+  delete process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS;
+});
+
+const exit = ((code: number) => {
+  exits.push(code);
+  return undefined as never;
+}) as (code: number) => never;
+
+describe("the startup deadline (#1524)", () => {
+  it("exits non-zero when startup never completes", () => {
+    armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+
+    vi.advanceTimersByTime(89_000);
+    expect(exits).toEqual([]); // still within the default window
+
+    vi.advanceTimersByTime(2_000);
+    expect(exits).toEqual([1]);
+  });
+
+  it("does NOTHING once startup disarms it", () => {
+    const disarm = armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+    disarm();
+
+    vi.advanceTimersByTime(10 * 60_000);
+    expect(exits).toEqual([]);
+    expect(errors.join("")).not.toMatch(/startup did not complete/);
+  });
+
+  it("names the incumbent pid when one holds the port", () => {
+    // The actionable case: an older comfyui-mcp still owns 9180. Telling the user
+    // WHICH pid is the difference between "something is wrong" and a fix.
+    armStartupDeadline(PORT, { exit, incumbent: () => 3807 });
+    vi.advanceTimersByTime(91_000);
+
+    const msg = errors.join("");
+    expect(msg).toMatch(/pid 3807/);
+    expect(msg).toMatch(/stop it/);
+  });
+
+  it("says the hang is BEFORE the bind when nothing holds the port", () => {
+    // The reporter's actual state: no listener at all, so the process did not even
+    // reach the bind. That is a different instruction — and a bug report, not a
+    // port conflict.
+    armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+    vi.advanceTimersByTime(91_000);
+
+    const msg = errors.join("");
+    expect(msg).toMatch(/before the bind/);
+    expect(msg).toMatch(/#1524/);
+    expect(msg).not.toMatch(/pid \d/);
+  });
+
+  it("honours COMFYUI_MCP_STARTUP_DEADLINE_MS", () => {
+    // A cold npx start on a slow disk is legitimately slow; the escape hatch has
+    // to work or the guard becomes the outage.
+    process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS = "5000";
+    armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+
+    vi.advanceTimersByTime(4_000);
+    expect(exits).toEqual([]);
+    vi.advanceTimersByTime(2_000);
+    expect(exits).toEqual([1]);
+  });
+
+  it("ignores a nonsense override rather than disabling itself", () => {
+    // `0`, a negative, or a word must not silently switch the guard off — that
+    // would reintroduce exactly the silent-zombie state, via a typo.
+    for (const bad of ["0", "-1", "soon", ""]) {
+      exits = [];
+      process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS = bad;
+      const disarm = armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+      vi.advanceTimersByTime(91_000);
+      expect(exits, `override ${JSON.stringify(bad)} should fall back to the default`).toEqual([1]);
+      disarm();
+    }
+  });
+
+  it("is ARMED before startup can block, and DISARMED only after the bind", () => {
+    // The placement is the whole fix and a unit test cannot see it:
+    // `runPanelOrchestrator` is far too large to drive here, so the ordering is
+    // asserted against the source. Armed too late and it misses the hang it
+    // exists for; disarmed too early and it stops guarding; never disarmed and it
+    // kills a healthy orchestrator 90 seconds in.
+    const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "orchestrator", "index.ts"), "utf8");
+    const lines = src.split(/\r?\n/);
+
+    // The CALL site, not the definition. `findIndex` on the bare name matches
+    // `export function armStartupDeadline(` first, which sits above everything
+    // and makes "armed before the bridge" true by construction — a test that
+    // passes whatever the wiring does. Third time today that shape has appeared.
+    const armAt = lines.findIndex((l) => /=\s*armStartupDeadline\(/.test(l));
+    const disarmAt = lines.findIndex((l) => l.trim().startsWith("disarmStartupDeadline()"));
+    const bridgeAt = lines.findIndex((l) => l.includes("startUiBridge("));
+    const boundAt = lines.findIndex((l) => l.includes("await bridge.whenReady()"));
+
+    // Every anchor must exist, or this test silently checks nothing.
+    for (const [name, at] of [["arm", armAt], ["disarm", disarmAt], ["startUiBridge", bridgeAt], ["whenReady", boundAt]] as const) {
+      expect(at, `could not find the ${name} site in orchestrator/index.ts`).toBeGreaterThan(-1);
+    }
+
+    // Armed before the bridge is even constructed — the reporter's process held
+    // NO port, so the hang was upstream of it.
+    expect(armAt).toBeLessThan(bridgeAt);
+    // Disarmed only after the port is confirmed held.
+    expect(disarmAt).toBeGreaterThan(boundAt);
+  });
+
+  it("does not hold the process open by itself", () => {
+    // The deadline must never be the reason a healthy short-lived run cannot
+    // exit; it is a guard, not a keepalive.
+    const disarm = armStartupDeadline(PORT, { exit, incumbent: () => undefined });
+    const timers = vi.getTimerCount();
+    expect(timers).toBeGreaterThan(0);
+    disarm();
+    expect(vi.getTimerCount()).toBe(timers - 1);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -986,6 +986,54 @@ export class DownloadProgressSnapshots {
   }
 }
 
+/**
+ * #1524 — a startup that never finishes must not become a silent resident.
+ *
+ * A respawn was observed alive for hours holding NO listening ports, while an
+ * older instance owned 9180/9181/9183. That is not the bind-failure path: that
+ * one is bounded (five attempts, then `whenReady()` resolves false), tries to
+ * reclaim the port, and exits non-zero with a clear message. A process with no
+ * ports at all never got that far — it hung EARLIER, so any guard wrapped around
+ * the bind itself would miss it.
+ *
+ * Hence a deadline over the whole of startup, armed before anything can block
+ * and disarmed only once the port is actually held. It does not care where the
+ * hang is, which is the point: the failure it prevents is not "bind failed" but
+ * "we never found out", and the reporter's own framing is that silently staying
+ * alive with zero bound ports is the worst of the available outcomes.
+ *
+ * Generous by default (90s) because a cold `npx` start on a slow disk is
+ * legitimately slow, and env-tunable for pathological machines. Exits non-zero so
+ * a supervisor restarts rather than inheriting a half-alive process.
+ */
+export function armStartupDeadline(
+  port: number,
+  deps: { exit?: (code: number) => never; incumbent?: (p: number) => number | undefined } = {},
+): () => void {
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+  const findIncumbent = deps.incumbent ?? pidListeningOnPort;
+  const raw = Number(process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS);
+  const ms = Number.isFinite(raw) && raw > 0 ? raw : 90_000;
+  const timer = setTimeout(() => {
+    const incumbent = findIncumbent(port);
+    logger.error(
+      `[panel-orchestrator] startup did not complete within ${Math.round(ms / 1000)}s and this ` +
+        `process holds no bridge port — exiting rather than lingering with no way to serve panel_* ` +
+        `tools.` +
+        (incumbent
+          ? ` Port ${port} is held by pid ${incumbent}; if that is an older comfyui-mcp, stop it ` +
+            `and start this one again.`
+          : ` Nothing is listening on ${port} either, so the hang is before the bind — please ` +
+            `report this with the last lines above (#1524).`) +
+        ` Raise COMFYUI_MCP_STARTUP_DEADLINE_MS if this machine is legitimately slower than that.`,
+    );
+    exit(1);
+  }, ms);
+  // Never hold the event loop open on this timer's account.
+  timer.unref?.();
+  return () => clearTimeout(timer);
+}
+
 export async function runPanelOrchestrator(): Promise<void> {
   // Crash guard: the orchestrator is a long-lived background process the user
   // can't see. A stray rejection (e.g. a fire-and-forget push to a tab that
@@ -998,6 +1046,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       `[panel-orchestrator] unhandled rejection (ignored): ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}`,
     );
   });
+
+  // #1524 — armed HERE, before anything that can block, and disarmed only once
+  // the bridge port is actually held. The port is re-derived rather than passed
+  // in because the deadline has to exist before the block that computes it.
+  const disarmStartupDeadline = armStartupDeadline(
+    Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180,
+  );
   process.on("uncaughtException", (err) => {
     // A synchronous uncaught throw leaves the process in an UNDEFINED state. The
     // old "log + continue" here was a zombie root cause — the orchestrator stayed
@@ -1202,6 +1257,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     );
     process.exit(1);
   }
+  // The port is ours — startup got where it needed to. Everything after this is
+  // long-running work the deadline must not police.
+  disarmStartupDeadline();
 
   // With a pinned pair token, bring the LAN pairing listener up now so a phone's
   // saved URL reconnects across restarts without ever touching the panel. This is

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -996,11 +996,24 @@ export class DownloadProgressSnapshots {
  * ports at all never got that far — it hung EARLIER, so any guard wrapped around
  * the bind itself would miss it.
  *
- * Hence a deadline over the whole of startup, armed before anything can block
- * and disarmed only once the port is actually held. It does not care where the
- * hang is, which is the point: the failure it prevents is not "bind failed" but
- * "we never found out", and the reporter's own framing is that silently staying
- * alive with zero bound ports is the worst of the available outcomes.
+ * Hence a deadline armed as early as this function runs and disarmed only once
+ * the port is actually held. It does not care WHERE the hang is, which is the
+ * point: the failure it prevents is not "bind failed" but "we never found out",
+ * and the reporter's framing is that silently staying alive with zero bound ports
+ * is the worst of the available outcomes.
+ *
+ * WHAT IT DOES NOT COVER, because an earlier draft of this comment claimed "the
+ * whole of startup" and that was false (codex):
+ *
+ *   - anything before `boot.ts` finishes dynamically importing this module — the
+ *     timer does not exist yet;
+ *   - a SYNCHRONOUS stall anywhere, which no timer can interrupt, because the
+ *     event loop it would fire on is the one that is blocked.
+ *
+ * So this closes the async-hang shape of the report and cannot close the
+ * synchronous one. If a portless process is ever seen again with this in place,
+ * that difference is the first thing to check, and it is written down here so the
+ * next reader does not have to rediscover it.
  *
  * Generous by default (90s) because a cold `npx` start on a slow disk is
  * legitimately slow, and env-tunable for pathological machines. Exits non-zero so
@@ -1012,8 +1025,16 @@ export function armStartupDeadline(
 ): () => void {
   const exit = deps.exit ?? ((code: number) => process.exit(code));
   const findIncumbent = deps.incumbent ?? pidListeningOnPort;
+  // CLAMPED, not merely "positive and finite" (codex). Node coerces a
+  // sub-millisecond delay AND anything past the 32-bit signed limit to 1ms — so
+  // `0.5`, or a large number typed by someone trying to RAISE the deadline, would
+  // fire almost instantly and kill every healthy startup. A guard whose escape
+  // hatch can cause the outage it prevents is worse than no guard, so out-of-range
+  // values fall back to the default rather than being honoured literally.
   const raw = Number(process.env.COMFYUI_MCP_STARTUP_DEADLINE_MS);
-  const ms = Number.isFinite(raw) && raw > 0 ? raw : 90_000;
+  const MIN_MS = 1_000;
+  const MAX_MS = 2_147_483_647; // Node's setTimeout ceiling
+  const ms = Number.isFinite(raw) && raw >= MIN_MS && raw <= MAX_MS ? Math.floor(raw) : 90_000;
   const timer = setTimeout(() => {
     const incumbent = findIncumbent(port);
     logger.error(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2037,11 +2037,18 @@ export class UiBridge {
         // tries to reclaim the port and then `process.exit(1)`s. So the sentence
         // described a mode the code cannot enter, and anyone diagnosing a
         // portless orchestrator against it was reading a fiction.
+        // Careful with what this promises. The first rewrite of this line said the
+        // orchestrator "will now try to take the port over" — also false, because
+        // tryReclaimBridgePort refuses immediately unless BOTH stdio streams are
+        // TTYs, so a non-interactive launch goes straight to the exit. Two false
+        // sentences in a row here is a fair sign that this path is easier to
+        // describe wrongly than rightly, so this one says only the part that holds
+        // in every case: the process does not continue without the port.
         logger.warn(
           `[ui-bridge] port ${this.port} still in use after ${UiBridge.MAX_BIND_ATTEMPTS} attempts — ` +
-            `another comfyui-mcp session almost certainly owns the panel. The orchestrator will ` +
-            `now try to take the port over, and will EXIT if it cannot: it does not continue in a ` +
-            `panel-less mode.`,
+            `another comfyui-mcp session almost certainly owns the panel. This process will EXIT ` +
+            `rather than run without it (an INTERACTIVE launch is offered the chance to take the ` +
+            `port over first; a non-interactive one is not).`,
         );
         this.readyResolve?.(false);
         this.readyResolve = null;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2030,8 +2030,18 @@ export class UiBridge {
           return;
         }
         this.portInUse = true;
+        // #1524 — this used to promise "this session's MCP tools still work, but
+        // panel_* commands are unavailable until that session exits", describing
+        // a degraded-but-running process. That process does not exist:
+        // `startUiBridge` has exactly ONE caller, and on a false `whenReady()` it
+        // tries to reclaim the port and then `process.exit(1)`s. So the sentence
+        // described a mode the code cannot enter, and anyone diagnosing a
+        // portless orchestrator against it was reading a fiction.
         logger.warn(
-          `[ui-bridge] port ${this.port} still in use after ${UiBridge.MAX_BIND_ATTEMPTS} attempts — another comfyui-mcp session likely owns the panel. This session's MCP tools still work, but panel_* commands are unavailable until that session exits.`,
+          `[ui-bridge] port ${this.port} still in use after ${UiBridge.MAX_BIND_ATTEMPTS} attempts — ` +
+            `another comfyui-mcp session almost certainly owns the panel. The orchestrator will ` +
+            `now try to take the port over, and will EXIT if it cannot: it does not continue in a ` +
+            `panel-less mode.`,
         );
         this.readyResolve?.(false);
         this.readyResolve = null;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2037,18 +2037,18 @@ export class UiBridge {
         // tries to reclaim the port and then `process.exit(1)`s. So the sentence
         // described a mode the code cannot enter, and anyone diagnosing a
         // portless orchestrator against it was reading a fiction.
-        // Careful with what this promises. The first rewrite of this line said the
-        // orchestrator "will now try to take the port over" — also false, because
-        // tryReclaimBridgePort refuses immediately unless BOTH stdio streams are
-        // TTYs, so a non-interactive launch goes straight to the exit. Two false
-        // sentences in a row here is a fair sign that this path is easier to
-        // describe wrongly than rightly, so this one says only the part that holds
-        // in every case: the process does not continue without the port.
+        // THREE rewrites of this sentence were false, each in a new way: it
+        // promised a degraded-but-running mode that cannot exist; then a takeover
+        // attempt that only happens on a TTY; then an interactive prompt that also
+        // requires a reclaimable pid, and an owner that need not be ours at all.
+        //
+        // Every error was the same mistake — narrating what the ORCHESTRATOR will
+        // do next, from a module that cannot see those conditions. So this now
+        // reports only what the bridge itself observed, and leaves the outcome to
+        // the code that decides it (which logs its own, accurate message).
         logger.warn(
-          `[ui-bridge] port ${this.port} still in use after ${UiBridge.MAX_BIND_ATTEMPTS} attempts — ` +
-            `another comfyui-mcp session almost certainly owns the panel. This process will EXIT ` +
-            `rather than run without it (an INTERACTIVE launch is offered the chance to take the ` +
-            `port over first; a non-interactive one is not).`,
+          `[ui-bridge] could not bind port ${this.port} after ${UiBridge.MAX_BIND_ATTEMPTS} ` +
+            `attempts — it is held by another process. The panel bridge is NOT listening.`,
         );
         this.readyResolve?.(false);
         this.readyResolve = null;


### PR DESCRIPTION
Claims #1524.

Two observations in one report. The reporter is explicit that they have **not** confirmed a causal link, and did not reproduce either deterministically. I am treating them separately and saying up front what I can and cannot establish.

## (2) The portless orchestrator — what I am fixing

A `v0.51.29` respawn appeared while `v0.51.23` still owned 9180/9181/9183. The new process bound **nothing** and sat idle for hours.

**The reporter's suggested fix already exists.** `index.ts` awaits `bridge.whenReady()`, falls back to `tryReclaimBridgePort` (which kills the incumbent and retries the bind), and on failure logs a clear message naming the port and `process.exit(1)`s. So bind-or-exit is implemented — which means their zombie **never reached it**. It hung somewhere earlier, before the bind resolved either way.

That reframes the fix. Not "add bind-or-exit" but "make a hang *before* the bind diagnosable", which covers the failure wherever it occurs:

- a bounded startup watchdog: if the bridge has not bound within a window, log loudly — naming the port, the incumbent pid/version if one can be identified — and exit non-zero
- so a silent resident process becomes a visible failure, which is the reporter's own framing: *"silently staying alive with zero bound ports is the worst of the three"*

Their point (3) — version-skew visibility — falls out of the same message when an incumbent is identifiable.

## (1) The 92 panel tools that never came back — what I am NOT claiming

Mid-session both MCP servers dropped; only the comfyui half re-registered. The panel half was gone for the rest of a 6-hour session, silently, with the orchestrator still alive and still serving the sidebar.

This is the higher-impact half and I will investigate it, but I will not claim to have fixed it unless I can demonstrate the mechanism. It was not reproduced deterministically, it involves a mid-session model switch that rebuilt the tool sessions, and the asymmetry may live in the harness rather than here. If I cannot show the cause, I will say so and report what I found rather than ship a speculative change and call the issue closed.

## Verification limits, stated now

I cannot reproduce a 6-hour session drop, and I have no second orchestrator racing for ports on this machine unless I construct one. The watchdog is testable in isolation; the reconnect asymmetry may not be.