### PR TITLE
release: v0.51.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.51.35
+
+### Fixed
+
+- **An orchestrator that never finishes starting no longer lingers silently (#1524).**
+  A respawned instance was found alive for hours holding no listening ports at all,
+  while an older one still owned them. Nothing was wrong from the sidebar's point of
+  view, and nothing reported a problem -- the process simply sat there, burning a slot
+  and making "which one is the orchestrator?" ambiguous for anything that looks by
+  process name.
+
+  Failing to claim the port was already handled: that path retries, tries to take the
+  port over, and exits with a clear message. A process holding NO port never got that
+  far, so there was nothing to catch it. There is now a deadline covering startup
+  itself: if the bridge port has not been claimed within the window, the process says
+  why and exits instead of staying. It names the process holding the port when it can
+  identify one -- which is also when "your other copy is on an older version" becomes
+  worth saying -- and says plainly that the stall is earlier than the port when nothing
+  is holding it.
+
+  Tunable with `COMFYUI_MCP_STARTUP_DEADLINE_MS` for a genuinely slow machine, and a
+  value outside a sane range falls back to the default rather than being taken
+  literally: a number large enough to overflow, or smaller than a millisecond, would
+  otherwise be rounded into an immediate exit -- the guard causing the very outage it
+  exists to prevent.
+
+  Deliberately scoped: this catches a startup that hangs waiting on something. It
+  cannot catch one wedged in a tight loop with the event loop blocked, and the code
+  says so rather than implying otherwise.
+
+- **A misleading warning when the panel port is already taken (#1524).** It claimed the
+  session would keep working with only `panel_*` unavailable. No such mode exists -- the
+  process does not continue without that port -- and the sentence sent this session's
+  own debugging down a false path within minutes. It now reports what was actually
+  observed and leaves the outcome to the code that decides it.
+
 ## 0.51.34
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.34",
+  "version": "0.51.35",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Releases the #1524 startup-watchdog fix (merged as `0bcb416b`).

**Scope: the portless-zombie half only.** #1524 reports two observations and states the causal link is unconfirmed. The panel-tools reconnect asymmetry is **not** fixed here and the issue stays open for it.

**The reported fix already existed.** Bind-or-exit is implemented — retries, reclaim attempt, clear message, `exit(1)`. The reporter's process held *no* port, so it never reached that path; it hung earlier, where a bind guard cannot see. Hence a deadline over startup itself.

**Verification**
- Two codex rounds; every finding closed. They included a genuine near-miss: the escape hatch accepted any positive number, and Node coerces both sub-millisecond values **and anything past the 32-bit ceiling** to 1 ms — so a large number typed to *raise* the deadline would have killed every startup. Now clamped, with `0.5`, `999`, `2147483648`, `1e30` all tested
- 8 tests, **8/8 mutations killed** — one took three attempts, each exposing a different verification defect (wrong line mutated, then an assertion satisfied by unrelated code)
- Suite **493 files / 9282**; all gates clean
- **Live against the built `dist/` with real timers** — 3/3, including that an out-of-range override does not collapse to ~1 ms

**Also fixed:** a warning claiming a degraded-but-running mode that cannot exist. It took four rewrites to state truthfully, and the lesson is in the source: a module should not narrate another module's conditional behaviour. It now reports only what it observed.