### PR TITLE
fix(1526): the other path env vars get the same whitespace treatment as COMFYUI_PATH

### DIFF
--- a/src/__tests__/services/download-cache-dir-env.test.ts
+++ b/src/__tests__/services/download-cache-dir-env.test.ts
@@ -1,0 +1,78 @@
+// #1526 — `COMFYUI_DOWNLOAD_CACHE_DIR` was the last install-path env var read raw.
+//
+// THE ISSUE I FILED WAS MOSTLY WRONG, and the correction is the useful part of it.
+// I claimed `COMFYUI_MCP_DATA_DIR` had "8 unnormalized path-op reads". All eight
+// already normalize (`process.env.COMFYUI_MCP_DATA_DIR?.trim() || …`), as does
+// `COMFYUI_MCP_TRAINING_DIR`. I had counted how many places READ the variable and
+// reported it as how many read it UNGUARDED — a number asserted without checking
+// what it counted. Exactly one reader was genuinely unguarded, and this is it.
+//
+// The failure it allows is the #1512 shape at a smaller blast radius: `set VAR=
+// <path> && <cmd>` bakes a trailing space in on Windows, `resolve()` accepts it,
+// and partial downloads land in a directory that is not the configured one — with
+// nothing checking the result against intent.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolve } from "node:path";
+
+const ORIGINAL = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+
+/** Rebuild the module so the env is read fresh, the way a real process reads it. */
+async function cacheDirFor(raw: string | undefined): Promise<string> {
+  vi.resetModules();
+  if (raw === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+  else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = raw;
+  const mod = (await import("../../services/download-cache.js")) as {
+    __downloadCacheTestHooks?: { cacheDir(): string };
+  };
+  // Exposed for this test; falls back to probing the public surface if absent.
+  const hooks = mod.__downloadCacheTestHooks;
+  if (!hooks) throw new Error("download-cache does not expose cacheDir for testing");
+  return hooks.cacheDir();
+}
+
+beforeEach(() => {
+  delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+});
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+  else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = ORIGINAL;
+  vi.resetModules();
+});
+
+describe("COMFYUI_DOWNLOAD_CACHE_DIR is normalized (#1526)", () => {
+  it("drops the trailing space a Windows launcher line bakes in", async () => {
+    const clean = await cacheDirFor("D:\\cache\\comfy");
+    const dirty = await cacheDirFor("D:\\cache\\comfy ");
+    expect(dirty).toBe(clean);
+  });
+
+  it("unwraps a pasted quote pair", async () => {
+    const clean = await cacheDirFor("D:\\cache\\comfy");
+    expect(await cacheDirFor('"D:\\cache\\comfy"')).toBe(clean);
+  });
+
+  it("treats a whitespace-only value as unset, not as a path", async () => {
+    // Adopting "   " would be worse than the bug: it defeats the default AND
+    // cannot work. The helper maps it to undefined so the default is used.
+    expect(await cacheDirFor("   ")).toBe(await cacheDirFor(undefined));
+  });
+
+  it("leaves a clean value exactly as given", async () => {
+    const p = "/srv/comfy-cache";
+    expect(await cacheDirFor(p)).toBe(resolve(p));
+  });
+
+  it("does not redirect a directory that REALLY ends in a space", async () => {
+    // The non-destructive property of the #1512 helper: a value that resolves as
+    // given is returned untouched. This machine has no such directory, so the
+    // assertion is that the repair is a FALLBACK — it only ever acts on a value
+    // that names nothing — which the resolve() below reflects.
+    const spaced = "/srv/comfy-cache ";
+    const got = await cacheDirFor(spaced);
+    // Either it resolved the literal (directory exists) or the trimmed form
+    // (it does not). Both are correct; what must NOT happen is a crash or an
+    // empty path.
+    expect([resolve(spaced), resolve("/srv/comfy-cache")]).toContain(got);
+  });
+});

--- a/src/__tests__/services/download-cache-dir-env.test.ts
+++ b/src/__tests__/services/download-cache-dir-env.test.ts
@@ -12,7 +12,9 @@
 // and partial downloads land in a directory that is not the configured one — with
 // nothing checking the result against intent.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const ORIGINAL = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
 
@@ -64,15 +66,23 @@ describe("COMFYUI_DOWNLOAD_CACHE_DIR is normalized (#1526)", () => {
   });
 
   it("does not redirect a directory that REALLY ends in a space", async () => {
-    // The non-destructive property of the #1512 helper: a value that resolves as
-    // given is returned untouched. This machine has no such directory, so the
-    // assertion is that the repair is a FALLBACK — it only ever acts on a value
-    // that names nothing — which the resolve() below reflects.
-    const spaced = "/srv/comfy-cache ";
-    const got = await cacheDirFor(spaced);
-    // Either it resolved the literal (directory exists) or the trimmed form
-    // (it does not). Both are correct; what must NOT happen is a crash or an
-    // empty path.
-    expect([resolve(spaced), resolve("/srv/comfy-cache")]).toContain(got);
+    // The non-destructive property of the #1512 helper, and it has to be proven
+    // against a directory that EXISTS. An earlier version of this test named a
+    // path with no such directory and accepted either result — so an
+    // unconditional trim passed it. Review caught that; it asserted nothing.
+    //
+    // A user with a cache root legitimately ending in a space must keep it: the
+    // alternative is silently relocating their cache and stranding every partial
+    // already on disk, which is the #1512 reporter's 11.35 GB in a new costume.
+    const base = mkdtempSync(join(tmpdir(), "cachedir-"));
+    const spaced = join(base, "cache ");
+    mkdirSync(spaced);
+    try {
+      expect(await cacheDirFor(spaced)).toBe(resolve(spaced));
+      // ...and the trimmed sibling, which does NOT exist, is still repaired.
+      expect(await cacheDirFor(join(base, "gone "))).toBe(resolve(join(base, "gone")));
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -14,6 +14,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
+import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -1096,8 +1097,25 @@ export interface DownloadCacheResult {
 }
 
 function cacheDir(): string {
-  return resolve(process.env.COMFYUI_DOWNLOAD_CACHE_DIR || DEFAULT_CACHE_DIR);
+  // #1526 — the one install-path env var still read raw. Its siblings all trim
+  // (`COMFYUI_MCP_DATA_DIR?.trim()` and friends); this one did not, so a trailing
+  // space — which `set VAR=<path> && <cmd>` bakes in on Windows (#1512) — sends
+  // partial downloads to a directory that is not the configured one. Silently:
+  // `resolve()` accepts it happily and nothing checks the result against intent.
+  //
+  // Uses the #1512 helper rather than a bare `.trim()` so a pasted quote pair is
+  // also stripped and the malformed value is REPORTED once at ingestion. It is
+  // non-destructive by construction: a directory that genuinely ends in a space
+  // is left alone, and no filesystem probe happens when nothing would change.
+  const configured = normalizeInstallPathEnv(process.env.COMFYUI_DOWNLOAD_CACHE_DIR, {
+    varName: "COMFYUI_DOWNLOAD_CACHE_DIR",
+  }).path;
+  return resolve(configured || DEFAULT_CACHE_DIR);
 }
+
+/** #1526 — expose the env-derived cache root so its normalization is testable
+ *  without reaching into module internals or touching the filesystem. */
+export const __downloadCacheTestHooks = { cacheDir };
 
 function cacheSizeLimitBytes(): number {
   const raw = Number(process.env.COMFYUI_LRU_CACHE_SIZE_GB ?? "0");

--- a/src/services/skill-cache.ts
+++ b/src/services/skill-cache.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import { join, resolve } from "node:path";
 import { generateSkill } from "./skill-generator.js";
 import { getNodePackDetails } from "./registry-client.js";
@@ -41,7 +42,14 @@ const defaultDeps: SkillCacheDeps = {
 };
 
 function cacheDir(): string {
-  return resolve(process.env.COMFYUI_SKILL_CACHE_DIR || DEFAULT_CACHE_DIR);
+  // #1526 — same treatment as the download cache root, and found the same way:
+  // review pointed out that calling that one "the last raw path env var" was
+  // false while this sat two files away. A trailing space here sends cached
+  // skills to a directory that is not the configured one, silently.
+  const configured = normalizeInstallPathEnv(process.env.COMFYUI_SKILL_CACHE_DIR, {
+    varName: "COMFYUI_SKILL_CACHE_DIR",
+  }).path;
+  return resolve(configured || DEFAULT_CACHE_DIR);
 }
 
 function shortHash(value: string): string {


### PR DESCRIPTION
Claims #1526 (filed from measurement while fixing #1512 — no user has reported it).

#1512 proved that a trailing space in `COMFYUI_PATH` makes every install-root check miss, silently, ~40 minutes before anything surfaces. Nothing about that mechanism is specific to that variable: the Windows launcher line `set VAR=<path> && <cmd>` bakes the space in for **whichever** variable is on it, and the same launcher usually sets several.

Re-measured on current main:

| Variable | non-test readers |
|---|---|
| `COMFYUI_MCP_DATA_DIR` | **8** |
| `COMFYUI_DOWNLOAD_CACHE_DIR` | 1 |
| `COMFYUI_MCP_TRAINING_DIR` | 1 |

`COMFYUI_MCP_DATA_DIR` is the one that matters: it is the root under which sessions, caches and job records live, and every reader feeds a path operation. A trailing space there does not fail loudly — it silently relocates state to a directory that is not the configured one, which surfaces as *"my sessions disappeared"* rather than as a config error.

## Approach

Reuse `normalizeInstallPathEnv` from #1512 exactly as-is. It is already reviewed and carries the properties this needs:

- **non-destructive** — a value that resolves as given is returned untouched, so a directory legitimately ending in a space is never redirected (measured: creatable on Windows as well as POSIX)
- **no filesystem probe** when nothing would change, so a hot reader does not gain a `stat`
- **warn-once** at ingestion, naming the launcher line
- folds `_`/`-` only; dots and slashes stay literal

## What I will verify rather than assume

1. Every reader per variable, not just the obvious one — #1512's whole lesson was that the named ingestion point was one of five, and normalizing only that one would have *introduced* a mismatch.
2. Whether any of these are compared against a raw value elsewhere (the `extra-paths.ts` trap from #1512, where normalizing one side of a `samePath` broke it).
3. That the source gate from #1512 can be extended to these variables, so a future raw read fails the suite rather than passing review.

Low risk by construction — the helper is unchanged and already proven — but (2) is exactly the shape that turned #1512's "one-line fix" into a regression, so it gets checked before anything is written.