### PR TITLE
fix(1520): the two civitai reads that await the fetch get the tolerant read bound

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -29,7 +29,11 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
-import { BRIDGE_READ_DEFAULT_TIMEOUT_MS, markReplyTimeout } from "../../services/ui-bridge.js";
+import {
+  BRIDGE_DEFAULT_TIMEOUT_MS,
+  BRIDGE_READ_DEFAULT_TIMEOUT_MS,
+  markReplyTimeout,
+} from "../../services/ui-bridge.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 import { AskAnswers } from "../../orchestrator/ask-answer-journal.js";
@@ -54,8 +58,11 @@ function makeFakeCtx(
     // inspect the panel's reply. Record the forwarded cmd on the same `calls`
     // array and hand back a caller-supplied reply.
     bridge: {
-      send: async (cmd: Forwarded) => {
+      // Record the bound on the same index-aligned `timeouts` array as ctx.call,
+      // so a bound assertion reads the same way for both dispatch paths (#1520).
+      send: async (cmd: Forwarded, opts?: { timeoutMs?: number }) => {
         calls.push(cmd);
+        timeouts.push(opts?.timeoutMs);
         return bridgeReply ?? {};
       },
     } as unknown as PanelToolCtx["bridge"],
@@ -2238,10 +2245,17 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
   // them a bound sized for a local read fails a *healthy* panel.
   //
   // This asserts BOTH directions. Raising the coupled pair is the fix; leaving
-  // the other four alone is the scope, and a test that only checked the pair
+  // the local commands alone is the scope, and a test that only checked the pair
   // would pass just as happily if someone raised all six — which would hide a
-  // genuinely dead tab behind an extra 10 s on four commands that answer
-  // locally and immediately.
+  // genuinely dead tab behind an extra 10 s on commands that answer locally and
+  // immediately.
+  //
+  // The family is NOT uniform, and an earlier version of this comment said it
+  // was ("all six were on 10000; the other four keep the tighter bound"). Both
+  // halves were false. civitai_search dispatches through ctx.bridge.send, not
+  // ctx.call, and already takes BRIDGE_DEFAULT_TIMEOUT_MS — #1468 raised it for
+  // an unrelated reason. So only THREE keep 10 s, and search is pinned below on
+  // its own path so "raise search too" cannot pass unnoticed.
   describe("civitai bridge bounds (#1520)", () => {
     const COUPLED = ["panel_civitai_results", "panel_civitai_highlight"] as const;
     const LOCAL = [
@@ -2278,6 +2292,17 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
         expect(timeouts[i], `${name} bound`).toBe(10000);
         expect(timeouts[i]).toBeLessThan(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
       }
+    });
+
+    it("civitai_search keeps its own path and bound — it is not part of this change", async () => {
+      // Pinned so the scope assertion above cannot be quietly widened: search is
+      // the sixth command, it does NOT go through ctx.call, and its bound was
+      // already raised by #1468 because driveSearch dispatches without awaiting.
+      const { ctx, calls, timeouts } = makeFakeCtx({ ok: true, results: [] });
+      await defByName("panel_civitai_search").handler({ query: "flux" }, ctx);
+      const i = calls.findIndex((c) => c.cmd === "civitai_search");
+      expect(i, "panel_civitai_search never forwarded civitai_search").toBeGreaterThanOrEqual(0);
+      expect(timeouts[i], "civitai_search bound").toBe(BRIDGE_DEFAULT_TIMEOUT_MS);
     });
   });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -29,7 +29,7 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
-import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { BRIDGE_READ_DEFAULT_TIMEOUT_MS, markReplyTimeout } from "../../services/ui-bridge.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 import { AskAnswers } from "../../orchestrator/ask-answer-journal.js";
@@ -2228,6 +2228,57 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     ]) {
       expect(names).toContain(expected);
     }
+  });
+
+  // ── #1520: the two commands coupled to CivitAI get the tolerant read bound ──
+  //
+  // Of the six civitai_* commands, exactly two await the in-flight fetch panel
+  // side (`state.activeReloadPromise`): civitai_results and civitai_highlight.
+  // Their reply time is bounded by a third party, not by the tab, so charging
+  // them a bound sized for a local read fails a *healthy* panel.
+  //
+  // This asserts BOTH directions. Raising the coupled pair is the fix; leaving
+  // the other four alone is the scope, and a test that only checked the pair
+  // would pass just as happily if someone raised all six — which would hide a
+  // genuinely dead tab behind an extra 10 s on four commands that answer
+  // locally and immediately.
+  describe("civitai bridge bounds (#1520)", () => {
+    const COUPLED = ["panel_civitai_results", "panel_civitai_highlight"] as const;
+    const LOCAL = [
+      "panel_civitai_clear_highlight",
+      "panel_civitai_switch_tab",
+      "panel_civitai_open_lightbox",
+    ] as const;
+    // Minimal valid args per tool — the bound is forwarded before any of these
+    // matter, but the handlers must not reject before reaching ctx.call.
+    const ARGS: Record<string, Record<string, unknown>> = {
+      panel_civitai_results: { limit: 20 },
+      panel_civitai_highlight: { ids: ["1"] },
+      panel_civitai_clear_highlight: {},
+      panel_civitai_switch_tab: { tab: "models" },
+      panel_civitai_open_lightbox: { id: "1" },
+    };
+
+    it("the two fetch-coupled reads forward the 20s read bound, not 10s", async () => {
+      for (const name of COUPLED) {
+        const { ctx, calls, timeouts } = makeFakeCtx();
+        await defByName(name).handler(ARGS[name], ctx);
+        const i = calls.findIndex((c) => String(c.cmd).startsWith("civitai_"));
+        expect(i, `${name} never forwarded a civitai_* command`).toBeGreaterThanOrEqual(0);
+        expect(timeouts[i], `${name} bound`).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+      }
+    });
+
+    it("the commands that answer locally keep the tighter bound", async () => {
+      for (const name of LOCAL) {
+        const { ctx, calls, timeouts } = makeFakeCtx();
+        await defByName(name).handler(ARGS[name], ctx);
+        const i = calls.findIndex((c) => String(c.cmd).startsWith("civitai_"));
+        expect(i, `${name} never forwarded a civitai_* command`).toBeGreaterThanOrEqual(0);
+        expect(timeouts[i], `${name} bound`).toBe(10000);
+        expect(timeouts[i]).toBeLessThan(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+      }
+    });
   });
 
   it("panel_open_civitai forwards a dock flag alongside the existing args", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -87,6 +87,7 @@ function journalConversationFor(ctx: PanelToolCtx): string | undefined {
 }
 import {
   BRIDGE_DEFAULT_TIMEOUT_MS,
+  BRIDGE_READ_DEFAULT_TIMEOUT_MS,
   dispatchOutcomeOf,
   isCapabilityRefusal,
   isPanelCmdUnsupportedError,
@@ -3094,6 +3095,34 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
 const CIVITAI_SAMPLE_MAX_BYTES = 4 * 1024 * 1024; // per-thumbnail cap (450px jpeg ≈ tens of KB)
 const CIVITAI_SAMPLE_DEFAULT = 4; // thumbnails delivered by default — bounds context
 const CIVITAI_SAMPLE_MAX = 8; // hard ceiling even if the agent asks for more
+
+/**
+ * The `civitai_*` commands whose reply time is bounded by CivitAI rather than by
+ * the tab (#1520). Of the six in the family, exactly these two await the
+ * in-flight fetch panel-side (`state.activeReloadPromise`): `civitai_results`
+ * and `civitai_highlight`. `clear_highlight`, `switch_tab`, `open_lightbox` and
+ * `search` do not, and keep the family's tighter bound.
+ *
+ * That await is deliberate (panel#793): without it an agent that opened the
+ * browser and immediately asked for results got `{count:0, total:0}`, which
+ * reads as "this search found nothing" while a concurrent `civitai_highlight`
+ * *did* wait and *did* see cards — two commands disagreeing about whether
+ * results existed. So the fix is not to remove the wait but to stop charging it
+ * against a bound sized for a local read.
+ *
+ * Timing out here is not harmless in either case:
+ *   - `civitai_results` is a pure read; the caller simply loses the answer.
+ *   - `civitai_highlight` *lands* — the panel installs the glow once the reload
+ *     resolves — so the caller is told the command failed while its effect
+ *     arrives anyway. That is the #1468 false-failure shape. Re-issuing is safe
+ *     (`driveHighlight` clears before installing), but the report was wrong.
+ *
+ * 20 s is not a cure — no bound covers a CivitAI 503-and-retry. It is the
+ * tolerant bound every other read already gets (#357: a busy-but-alive tab
+ * fails a tight one), and it is the window the panel's own bounded wait has to
+ * fit inside to be able to answer at all.
+ */
+const CIVITAI_COUPLED_READ_TIMEOUT_MS = BRIDGE_READ_DEFAULT_TIMEOUT_MS;
 const CIVITAI_SAMPLE_FETCH_TIMEOUT_MS = 8000;
 // Extra fetch ATTEMPTS allowed beyond the requested image count, so a few
 // 404/non-image/oversize URLs don't starve the result — but a malformed reply
@@ -10506,7 +10535,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           ),
       },
       async (args: A, ctx) => {
-        const res = await ctx.call({ cmd: "civitai_results", limit: args.limit }, 10000);
+        const res = await ctx.call(
+          { cmd: "civitai_results", limit: args.limit },
+          CIVITAI_COUPLED_READ_TIMEOUT_MS,
+        );
         // Enrich with inline sample pixels (#623). Best-effort + additive: on any
         // problem we return the untouched text results, so the read path can never
         // regress to an error just because a thumbnail fetch failed.
@@ -10553,7 +10585,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .optional()
           .describe("Which result kind these ids refer to (media = images/videos, model = checkpoints/loras/workflows). Match the active tab if omitted."),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "civitai_highlight", ids: args.ids, kind: args.kind }, 10000),
+      async (args: A, ctx) =>
+        ctx.call(
+          { cmd: "civitai_highlight", ids: args.ids, kind: args.kind },
+          CIVITAI_COUPLED_READ_TIMEOUT_MS,
+        ),
     ),
     def(
       "panel_civitai_clear_highlight",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3100,8 +3100,14 @@ const CIVITAI_SAMPLE_MAX = 8; // hard ceiling even if the agent asks for more
  * The `civitai_*` commands whose reply time is bounded by CivitAI rather than by
  * the tab (#1520). Of the six in the family, exactly these two await the
  * in-flight fetch panel-side (`state.activeReloadPromise`): `civitai_results`
- * and `civitai_highlight`. `clear_highlight`, `switch_tab`, `open_lightbox` and
- * `search` do not, and keep the family's tighter bound.
+ * and `civitai_highlight`. `clear_highlight`, `switch_tab` and `open_lightbox`
+ * do not, and keep the tighter bound.
+ *
+ * `civitai_search` is the sixth and is not on either path: it dispatches through
+ * `ctx.bridge.send` so the handler can inspect the reply, and already takes
+ * `BRIDGE_DEFAULT_TIMEOUT_MS` — #1468 raised it because `driveSearch` returns
+ * without awaiting at all. The family is not uniform; do not assume a single
+ * bound describes it.
  *
  * That await is deliberate (panel#793): without it an agent that opened the
  * browser and immediately asked for results got `{count:0, total:0}`, which


### PR DESCRIPTION
Claims #1520.

Measured on `origin/main` of both repos: of the six `civitai_*` commands, exactly **two** await `state.activeReloadPromise` — `driveGetResults` and `driveHighlight`. The other four (`clear_highlight`, `switch_tab`, `open_lightbox`, `search`) do not, so they keep their existing bound.

All six are on a hard-coded `10000` against this codebase's own `BRIDGE_READ_DEFAULT_TIMEOUT_MS = 20_000`.

**A correction to the issue as I filed it.** #1520 names only `civitai_results`. `civitai_highlight` awaits the same promise, and its timeout is worse: the panel installs the highlight once the reload lands, so the caller is told the command *failed* while the effect *does* arrive — the #1468 false-failure shape, on a command that has an effect. It is idempotent on retry (`driveHighlight` clears before installing), so there is no double-apply hazard.

Orchestrator half only in this PR; the panel half (an honest bounded interim answer) follows and is dead code without this one.