### PR TITLE
release: v0.51.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.36",
+  "version": "0.51.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.36",
+      "version": "0.51.37",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.36",
+  "version": "0.51.37",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.37 with #1520.

`panel_civitai_results` and `panel_civitai_highlight` are the only two commands in the family that await the in-flight CivitAI fetch panel-side, so their reply time was set by a third party while they were held to a bound sized for a local read. Both now get `BRIDGE_READ_DEFAULT_TIMEOUT_MS`; the three that answer locally keep the tighter bound, and `civitai_search` keeps its own path.

The panel half (artokun/comfyui-mcp-panel#1189) answers inside that window with an honest interim result rather than letting the bridge time out.

Bounds verified live against the built `dist/` by executing the shipped handlers — the values compile to a constant reference, so a text scan cannot read them.