### PR TITLE
fix(742): the refuse-safe preflight is skipped when a local install is addressed remotely

### DIFF
--- a/src/__tests__/config-own-host-address.test.ts
+++ b/src/__tests__/config-own-host-address.test.ts
@@ -1,0 +1,173 @@
+// #742 (the 2026-08-12 recurrence) — the restart guard decided "not ours" from
+// "not loopback", and those are different questions.
+//
+// A Pinokio ComfyUI on the SAME machine, addressed through that machine's own
+// LAN address (`COMFYUI_URL=http://192.168.x.x:5000`), classified as remote.
+// `preflightLocalRestart` opens with `if (isRemoteMode()) return { ok: true }`,
+// so the refuse-safe check waved it through without assessing anything; the
+// Manager reboot stopped the server, and Pinokio only relaunches on the
+// dependency-install message, so it stayed down. The user's session was
+// unrecoverable until they started Pinokio by hand.
+//
+// The original report's parts 1 and 2 (a misleading "Cancelled", and no
+// failed-relaunch detection) were fixed, and the refuse-safe preflight already
+// exists with its own suite. Nothing was missing. The guard was UNREACHABLE for
+// this target — which is why these tests are about the classification, not the
+// guard.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// One fake NIC set for every test: a real-looking LAN address, a loopback pair,
+// and a link-local v6 with the zone suffix `networkInterfaces()` omits but URLs
+// carry.
+const FAKE_IFACES = {
+  Ethernet: [
+    { address: "192.168.1.179", family: "IPv4", internal: false },
+    { address: "fe80::5f10:6918:84e6:1873", family: "IPv6", internal: false },
+    { address: "2600:1700:5892:bc10::22", family: "IPv6", internal: false },
+  ],
+  "Loopback Pseudo-Interface 1": [
+    { address: "127.0.0.1", family: "IPv4", internal: true },
+    { address: "::1", family: "IPv6", internal: true },
+  ],
+  "vEthernet (Default Switch)": [{ address: "172.30.64.1", family: "IPv4", internal: false }],
+  // A down/unconfigured adapter reporting an empty address. Present so the
+  // empty-host guard is OBSERVABLE: without it, any host that normalizes to ""
+  // would match this entry and be called ours.
+  "Bluetooth Network Connection": [{ address: "", family: "IPv4", internal: false }],
+};
+
+let ifacesThrow = false;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const networkInterfaces = () => {
+    if (ifacesThrow) throw new Error("EPERM: locked-down container");
+    return FAKE_IFACES as unknown as ReturnType<typeof actual.networkInterfaces>;
+  };
+  return { ...actual, networkInterfaces, default: { ...actual, networkInterfaces } };
+});
+
+const OLD_ENV = process.env;
+const OLD_ARGV = process.argv;
+
+beforeEach(() => {
+  ifacesThrow = false;
+  vi.resetModules();
+  process.env = { ...OLD_ENV };
+  delete process.env.COMFYUI_URL;
+  delete process.env.COMFYUI_MCP_FORCE_REMOTE;
+  process.argv = ["node", "cli"];
+});
+
+afterEach(() => {
+  process.env = OLD_ENV;
+  process.argv = OLD_ARGV;
+  vi.resetModules();
+});
+
+async function loadConfig() {
+  return await import("../config.js");
+}
+
+describe("isOwnHostAddress — loopback is a SUBSET of 'this machine' (#742)", () => {
+  it("accepts the loopback names it always did", async () => {
+    const { isOwnHostAddress } = await loadConfig();
+    for (const h of ["127.0.0.1", "localhost", "::1", "[::1]", "0.0.0.0"]) {
+      expect(isOwnHostAddress(h), h).toBe(true);
+    }
+  });
+
+  it("accepts THIS machine's own LAN address — the case that caused the loss", async () => {
+    const { isOwnHostAddress, isLoopbackHost } = await loadConfig();
+    // The precise gap: not loopback, but unquestionably this machine.
+    expect(isLoopbackHost("192.168.1.179")).toBe(false);
+    expect(isOwnHostAddress("192.168.1.179")).toBe(true);
+  });
+
+  it("accepts an own IPv6 address, bracketed and with a zone suffix", async () => {
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("[2600:1700:5892:bc10::22]")).toBe(true);
+    // A URL can carry `%eth0`; networkInterfaces() reports the address without it.
+    expect(isOwnHostAddress("fe80::5f10:6918:84e6:1873%eth0")).toBe(true);
+  });
+
+  it("rejects a LAN address on the same subnet that is NOT ours", async () => {
+    // The neighbouring machine. Refusing here is what keeps this from becoming a
+    // guard that fires on other people's servers.
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("192.168.1.180")).toBe(false);
+    expect(isOwnHostAddress("10.0.0.5")).toBe(false);
+  });
+
+  it("rejects a HOSTNAME, even one that would resolve to us", async () => {
+    // Deliberate: resolving would mean DNS on a path that must not block, and a
+    // name can resolve differently — or be made to — between this check and the
+    // action it authorizes. This gates a REFUSAL, so "cannot prove" must mean
+    // "leave today's behaviour alone".
+    const { isOwnHostAddress } = await loadConfig();
+    for (const h of ["my-desktop.local", "comfy.lan", "example.com"]) {
+      expect(isOwnHostAddress(h), h).toBe(false);
+    }
+  });
+
+  it("rejects rather than throws when interfaces cannot be enumerated", async () => {
+    ifacesThrow = true;
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("192.168.1.179")).toBe(false);
+    // Loopback is decided without touching the interface list at all.
+    expect(isOwnHostAddress("127.0.0.1")).toBe(true);
+  });
+
+  it("rejects a host that normalizes to nothing, even against an empty interface address", async () => {
+    // `[]` and `%eth0` both normalize to "" while NOT being loopback, so they
+    // reach the comparison. An adapter reporting an empty address would then
+    // match them. This is what makes the empty-host guard load-bearing rather
+    // than decorative — remove it and these become true.
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("[]")).toBe(false);
+    expect(isOwnHostAddress("%eth0")).toBe(false);
+  });
+
+  it("rejects addresses that merely look like ours", async () => {
+    // No DNS and no range logic — plain equality against what the interfaces
+    // report. A malformed or near-miss address simply fails to match.
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("999.1.1.1")).toBe(false);
+    expect(isOwnHostAddress("192.168.1")).toBe(false);
+    expect(isOwnHostAddress("192.168.1.17")).toBe(false); // prefix of ours
+  });
+});
+
+describe("targetIsOnThisMachine — the classification vs the physical fact (#742)", () => {
+  it("is TRUE for a local install addressed by our own LAN address, while remote mode is also true", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.179:5000";
+    const { targetIsOnThisMachine, isRemoteMode } = await loadConfig();
+    // Both hold at once. That combination IS the bug, and the preflight now
+    // keys on the second rather than the first.
+    expect(isRemoteMode()).toBe(true);
+    expect(targetIsOnThisMachine()).toBe(true);
+  });
+
+  it("is FALSE for a genuinely remote host", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.180:8188";
+    const { targetIsOnThisMachine, isRemoteMode } = await loadConfig();
+    expect(isRemoteMode()).toBe(true);
+    expect(targetIsOnThisMachine()).toBe(false);
+  });
+
+  it("--force-remote WINS over our own address", async () => {
+    // A tunnel or port-forward makes the address say "here" about an instance
+    // that is elsewhere; the flag is the user saying so. An inference must not
+    // overrule an explicit statement of intent.
+    process.env.COMFYUI_URL = "http://192.168.1.179:5000";
+    process.env.COMFYUI_MCP_FORCE_REMOTE = "1";
+    const { targetIsOnThisMachine } = await loadConfig();
+    expect(targetIsOnThisMachine()).toBe(false);
+  });
+
+  it("is TRUE for an ordinary loopback target, so the local path is unchanged", async () => {
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    const { targetIsOnThisMachine } = await loadConfig();
+    expect(targetIsOnThisMachine()).toBe(true);
+  });
+});

--- a/src/__tests__/config-own-host-address.test.ts
+++ b/src/__tests__/config-own-host-address.test.ts
@@ -95,15 +95,42 @@ describe("isOwnHostAddress — loopback is a SUBSET of 'this machine' (#742)", (
     expect(isOwnHostAddress("2600:1700:5892:BC10::22")).toBe(true);
   });
 
-  it("accepts our IPv4 written as an IPv4-mapped IPv6 address", async () => {
-    // `::ffff:192.168.1.179` is our LAN address. Interfaces report the dotted
-    // form, and URL canonicalizes the mapped form to `::ffff:c0a8:1b3`, so
-    // without the explicit fold neither spelling meets the other.
+  it("accepts our IPv4 written as an IPv4-mapped IPv6 address, in EVERY spelling", async () => {
+    // All five of these are 192.168.1.179, which is what the interface reports.
+    // URL rewrites every one of them to `::ffff:c0a8:1b3`, so the fold back to
+    // dotted form has to happen AFTER canonicalization — a first version folded
+    // beforehand, caught only the dotted spelling, and left the hex forms
+    // classified as someone else's machine (round-2 review).
     const { isOwnHostAddress } = await loadConfig();
-    expect(isOwnHostAddress("::ffff:192.168.1.179")).toBe(true);
-    expect(isOwnHostAddress("[::ffff:192.168.1.179]")).toBe(true);
-    // ...and the mapped form of a NEIGHBOUR is still not ours.
+    for (const h of [
+      "::ffff:192.168.1.179",
+      "[::ffff:192.168.1.179]",
+      "::ffff:c0a8:1b3",
+      "0:0:0:0:0:ffff:c0a8:1b3",
+      "::FFFF:C0A8:1B3",
+    ]) {
+      expect(isOwnHostAddress(h), h).toBe(true);
+    }
+    // ...and the mapped forms of a NEIGHBOUR are still not ours.
     expect(isOwnHostAddress("::ffff:192.168.1.180")).toBe(false);
+    expect(isOwnHostAddress("::ffff:c0a8:1b4")).toBe(false);
+  });
+
+  it("keeps the wildcard binds local, and leaves the odd mapped zero alone", async () => {
+    const { isOwnHostAddress } = await loadConfig();
+    // `::` and `0.0.0.0` are already in LOOPBACK_HOSTS — a wildcard bind is
+    // reachable on loopback, so calling it local is pre-existing and right.
+    // (I first asserted `::` was false here, from assumption rather than from
+    // the set; the test caught me.)
+    expect(isOwnHostAddress("::")).toBe(true);
+    expect(isOwnHostAddress("0.0.0.0")).toBe(true);
+    // `::ffff:0:0` is the mapped spelling of 0.0.0.0 and is NOT in that set, so
+    // it folds to "0.0.0.0" and then matches no interface. Inconsistent with
+    // the line above, but in the SAFE direction: it leaves the remote
+    // short-circuit exactly as it was rather than pulling a target into
+    // assessment on a technicality. Not worth widening a security-adjacent set
+    // for a spelling nothing emits.
+    expect(isOwnHostAddress("::ffff:0:0")).toBe(false);
   });
 
   it("rejects a LAN address on the same subnet that is NOT ours", async () => {

--- a/src/__tests__/config-own-host-address.test.ts
+++ b/src/__tests__/config-own-host-address.test.ts
@@ -16,9 +16,9 @@
 // guard.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// One fake NIC set for every test: a real-looking LAN address, a loopback pair,
-// and a link-local v6 with the zone suffix `networkInterfaces()` omits but URLs
-// carry.
+// One fake NIC set for every test, shaped like a real Windows box: a LAN
+// address, a loopback pair, a global and a link-local IPv6, and a virtual
+// adapter.
 const FAKE_IFACES = {
   Ethernet: [
     { address: "192.168.1.179", family: "IPv4", internal: false },
@@ -84,11 +84,26 @@ describe("isOwnHostAddress — loopback is a SUBSET of 'this machine' (#742)", (
     expect(isOwnHostAddress("192.168.1.179")).toBe(true);
   });
 
-  it("accepts an own IPv6 address, bracketed and with a zone suffix", async () => {
+  it("accepts an own IPv6 address however it is SPELLED", async () => {
+    // URL canonicalization, not string equality. An interface reports
+    // `2600:1700:5892:bc10::22`; a config may carry the identical address
+    // written long-hand or upper-case, and calling those different machines is
+    // exactly the false-negative that keeps the bug alive (review finding).
     const { isOwnHostAddress } = await loadConfig();
     expect(isOwnHostAddress("[2600:1700:5892:bc10::22]")).toBe(true);
-    // A URL can carry `%eth0`; networkInterfaces() reports the address without it.
-    expect(isOwnHostAddress("fe80::5f10:6918:84e6:1873%eth0")).toBe(true);
+    expect(isOwnHostAddress("2600:1700:5892:bc10:0:0:0:22")).toBe(true);
+    expect(isOwnHostAddress("2600:1700:5892:BC10::22")).toBe(true);
+  });
+
+  it("accepts our IPv4 written as an IPv4-mapped IPv6 address", async () => {
+    // `::ffff:192.168.1.179` is our LAN address. Interfaces report the dotted
+    // form, and URL canonicalizes the mapped form to `::ffff:c0a8:1b3`, so
+    // without the explicit fold neither spelling meets the other.
+    const { isOwnHostAddress } = await loadConfig();
+    expect(isOwnHostAddress("::ffff:192.168.1.179")).toBe(true);
+    expect(isOwnHostAddress("[::ffff:192.168.1.179]")).toBe(true);
+    // ...and the mapped form of a NEIGHBOUR is still not ours.
+    expect(isOwnHostAddress("::ffff:192.168.1.180")).toBe(false);
   });
 
   it("rejects a LAN address on the same subnet that is NOT ours", async () => {
@@ -119,13 +134,25 @@ describe("isOwnHostAddress — loopback is a SUBSET of 'this machine' (#742)", (
   });
 
   it("rejects a host that normalizes to nothing, even against an empty interface address", async () => {
-    // `[]` and `%eth0` both normalize to "" while NOT being loopback, so they
-    // reach the comparison. An adapter reporting an empty address would then
-    // match them. This is what makes the empty-host guard load-bearing rather
-    // than decorative — remove it and these become true.
+    // `[]` normalizes to "" while NOT being loopback, so it reaches the
+    // comparison, where the adapter above reporting an empty address would match
+    // it. That is what makes the empty-host guard load-bearing rather than
+    // decorative — remove it and this becomes true.
     const { isOwnHostAddress } = await loadConfig();
     expect(isOwnHostAddress("[]")).toBe(false);
+  });
+
+  it("rejects a scoped address, which cannot reach here through a URL anyway", async () => {
+    // `%eth0` is NOT emptied — it survives canonicalization as written and then
+    // matches nothing. Asserted because an earlier version stripped the zone
+    // suffix on the theory that a configured target could carry one; it cannot.
+    // `new URL("http://[fe80::1%eth0]/")` throws, so that code was unreachable
+    // and its test was checking something production could never deliver.
+    const { isOwnHostAddress } = await loadConfig();
     expect(isOwnHostAddress("%eth0")).toBe(false);
+    expect(isOwnHostAddress("fe80::5f10:6918:84e6:1873%eth0")).toBe(false);
+    // The same address WITHOUT a scope is ours.
+    expect(isOwnHostAddress("fe80::5f10:6918:84e6:1873")).toBe(true);
   });
 
   it("rejects addresses that merely look like ours", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -8,6 +8,12 @@ const mockConfig = vi.hoisted(() => ({
   comfyuiPath: "/fake/ComfyUI" as string | undefined,
 }));
 
+// #742: the two classifications the preflight now distinguishes. `remote` is
+// how the target is ADDRESSED; `onThisMachine` is where the instance actually
+// runs. They disagree for a local install reached by its own LAN address, and
+// that disagreement is the bug.
+const mockLocality = vi.hoisted(() => ({ remote: false, onThisMachine: true }));
+
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockSpawn = vi.hoisted(() => vi.fn());
 const mockGetSystemStats = vi.hoisted(() => vi.fn());
@@ -19,7 +25,8 @@ vi.mock("../../config.js", () => ({
   getComfyUIAuthHeaders: () => ({}),
   // #848 instance fence — a stable target here; the retarget case has its own test.
   getComfyuiTargetGeneration: () => 0,
-  isRemoteMode: () => false,
+  isRemoteMode: () => mockLocality.remote,
+  targetIsOnThisMachine: () => mockLocality.onThisMachine,
 }));
 
 vi.mock("node:child_process", () => ({
@@ -176,6 +183,10 @@ beforeEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  // #742: back to an ordinary loopback-addressed local target. Without this a
+  // test that flips these leaks its classification into every test after it.
+  mockLocality.remote = false;
+  mockLocality.onThisMachine = true;
   process.env = { ...ORIGINAL_ENV };
   delete process.env.COMFYUI_ALWAYS_RESTART;
   delete process.env.COMFYUI_RESTART_MAX_ATTEMPTS;
@@ -936,6 +947,63 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(killSpy).not.toHaveBeenCalled();
 
     killSpy.mockRestore();
+  });
+
+  // ── #742 recurrence: the guard was UNREACHABLE, not missing ────────────────
+  //
+  // Reported on 0.51.18. A Pinokio ComfyUI on the same host, addressed as
+  // `http://192.168.x.x:5000`, classified as remote — so `preflightLocalRestart`
+  // returned ok:true from its first line and the refuse-safe check above never
+  // ran. The Manager reboot stopped the server and Pinokio did not relaunch it.
+  //
+  // The refusal that should have fired is the very test above this one; it was
+  // passing the whole time. So these assert REACHABILITY, and the sharpest
+  // observable is whether the assessment was entered at all: on the early-return
+  // path nothing is probed, so `getSystemStats` is never called.
+  describe("a LOCAL install addressed REMOTELY still gets assessed (#742)", () => {
+    it("remote + NOT this machine: passes without probing anything (unchanged)", async () => {
+      mockLocality.remote = true;
+      mockLocality.onThisMachine = false;
+      mockPinokioShapedInstall(); // would REFUSE if it were ever assessed
+
+      const preflight = await preflightLocalRestart();
+
+      expect(preflight.ok).toBe(true);
+      // The early return is correct for a genuinely remote target: there is no
+      // local process to look at, so nothing should be probed.
+      expect(mockGetSystemStats).not.toHaveBeenCalled();
+    });
+
+    it("remote + IS this machine: assesses, and REFUSES the Pinokio shape", async () => {
+      mockLocality.remote = true;
+      mockLocality.onThisMachine = true;
+      mockPinokioShapedInstall();
+
+      const preflight = await preflightLocalRestart();
+
+      // Identical to the loopback-addressed case above — which is the point.
+      // How the instance is ADDRESSED must not decide whether we check that it
+      // can come back.
+      expect(preflight.ok).toBe(false);
+      expect(preflight.reason).toMatch(/could not build a relaunch command/i);
+      expect(mockGetSystemStats).toHaveBeenCalled();
+    });
+
+    it("remote + IS this machine + resolvable install: assesses and PASSES", async () => {
+      // The guard must not become a blanket refusal for everyone who addresses a
+      // local ComfyUI by LAN IP. A normal install still restarts.
+      mockLocality.remote = true;
+      mockLocality.onThisMachine = true;
+      mockLivePortNoKill();
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: ["/fake/ComfyUI/main.py", "--port", "8188"] },
+      });
+
+      const preflight = await preflightLocalRestart();
+
+      expect(preflight.ok).toBe(true);
+      expect(mockGetSystemStats).toHaveBeenCalled();
+    });
   });
 
   it("preflightLocalRestart passes a resolvable local install", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -989,6 +989,39 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
       expect(mockGetSystemStats).toHaveBeenCalled();
     });
 
+    it("a refusal reached this way NAMES the assumption and the escape hatch", async () => {
+      // An address on one of our interfaces proves the ROUTE lands here, not
+      // that the instance does: a reverse proxy or port-forward bound to this
+      // machine's LAN address can front a ComfyUI that is genuinely elsewhere.
+      // Such a setup used to restart through the Manager and now meets the
+      // guard, so the refusal has to say which assumption produced it — a
+      // silent behaviour change is the part that would actually cost time.
+      mockLocality.remote = true;
+      mockLocality.onThisMachine = true;
+      mockPinokioShapedInstall();
+
+      const preflight = await preflightLocalRestart();
+
+      expect(preflight.ok).toBe(false);
+      expect(preflight.reason).toMatch(/could not build a relaunch command/i);
+      expect(preflight.reason).toMatch(/own network interfaces/i);
+      expect(preflight.reason).toMatch(/COMFYUI_MCP_FORCE_REMOTE=1|--force-remote/);
+    });
+
+    it("a LOOPBACK-addressed refusal does NOT carry that note", async () => {
+      // The note explains a decision only this new path makes. On the ordinary
+      // local path it would be noise pointing at an irrelevant setting.
+      mockLocality.remote = false;
+      mockLocality.onThisMachine = true;
+      mockPinokioShapedInstall();
+
+      const preflight = await preflightLocalRestart();
+
+      expect(preflight.ok).toBe(false);
+      expect(preflight.reason).not.toMatch(/own network interfaces/i);
+      expect(preflight.reason).not.toMatch(/FORCE_REMOTE/i);
+    });
+
     it("remote + IS this machine + resolvable install: assesses and PASSES", async () => {
       // The guard must not become a blanket refusal for everyone who addresses a
       // local ComfyUI by LAN IP. A normal install still restarts.

--- a/src/config.ts
+++ b/src/config.ts
@@ -303,16 +303,28 @@ export function isOwnHostAddress(host: string | undefined): boolean {
 function canonicalHostForCompare(host: string | undefined): string {
   const raw = (host ?? "").trim().toLowerCase().replace(/^\[|\]$/g, "");
   if (!raw) return "";
-  // ::ffff:a.b.c.d → a.b.c.d (the form interfaces report)
-  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(raw);
-  if (mapped) return mapped[1];
   if (!raw.includes(":")) return raw; // IPv4 or a name — already canonical
+  let canon: string;
   try {
     // URL canonicalizes IPv6 and re-brackets it; strip the brackets back off.
-    return new URL(`http://[${raw}]/`).hostname.replace(/^\[|\]$/g, "");
+    canon = new URL(`http://[${raw}]/`).hostname.replace(/^\[|\]$/g, "");
   } catch {
     return raw; // not a valid IPv6 literal — compare as written
   }
+  // The IPv4-mapped fold happens AFTER canonicalization, not before, and that
+  // ordering is the whole point (round-2 review). URL rewrites EVERY mapped
+  // spelling to the same hex form — `::ffff:192.168.1.179`,
+  // `0:0:0:0:0:ffff:c0a8:1b3` and `::FFFF:C0A8:1B3` all become
+  // `::ffff:c0a8:1b3` — so folding here catches all of them with one rule.
+  // Folding beforehand caught only the dotted spelling and left the rest
+  // classified as somebody else's machine.
+  const m = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(canon);
+  if (m) {
+    const hi = parseInt(m[1], 16);
+    const lo = parseInt(m[2], 16);
+    return `${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`;
+  }
+  return canon;
 }
 
 /** True when a hostname is loopback (or absent → assume local). Bracketed IPv6

--- a/src/config.ts
+++ b/src/config.ts
@@ -263,14 +263,14 @@ const LOOPBACK_HOSTS = new Set([
  */
 export function isOwnHostAddress(host: string | undefined): boolean {
   if (isLoopbackHost(host)) return true;
-  const h = normalizeHostForCompare(host);
+  const h = canonicalHostForCompare(host);
   // An empty host must never fall through to the comparison: an interface that
   // reported an empty address would then match it.
   if (!h) return false;
   try {
     for (const addrs of Object.values(networkInterfaces())) {
       for (const a of addrs ?? []) {
-        if (normalizeHostForCompare(a.address) === h) return true;
+        if (canonicalHostForCompare(a.address) === h) return true;
       }
     }
   } catch {
@@ -280,13 +280,39 @@ export function isOwnHostAddress(host: string | undefined): boolean {
   return false;
 }
 
-/** Lowercase, strip URL brackets, and drop an IPv6 zone suffix (`%eth0`), which
- *  `networkInterfaces()` omits on the addresses it reports. */
-function normalizeHostForCompare(host: string | undefined): string {
-  return (host ?? "")
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "")
-    .replace(/%.*$/, "");
+/**
+ * One canonical spelling for an address, so equality means "same address"
+ * rather than "same characters" (#742 review).
+ *
+ * Textual comparison alone is wrong in the direction that keeps the bug: an
+ * interface reports `2600:1700:5892:bc10::22` while a config may carry the same
+ * address written `2600:1700:5892:BC10:0:0:0:22`, and a plain `===` calls those
+ * different machines. `URL` already implements the canonicalization — it
+ * lowercases, collapses to the `::` form, and rewrites IPv4-mapped addresses —
+ * so both sides are run through it rather than hand-rolling the rules.
+ *
+ * IPv4-mapped IPv6 (`::ffff:192.168.1.179`) is folded to its dotted IPv4 form
+ * FIRST, because that is the form `networkInterfaces()` reports; left alone,
+ * `URL` canonicalizes it to `::ffff:c0a8:1b3` and it still would not match.
+ *
+ * No zone-suffix handling: `new URL("http://[fe80::1%eth0]/")` throws, so a
+ * scoped address cannot reach here through a configured target at all. An
+ * earlier version stripped `%eth0` and had a test for it — which passed while
+ * exercising something production could never deliver.
+ */
+function canonicalHostForCompare(host: string | undefined): string {
+  const raw = (host ?? "").trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (!raw) return "";
+  // ::ffff:a.b.c.d → a.b.c.d (the form interfaces report)
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(raw);
+  if (mapped) return mapped[1];
+  if (!raw.includes(":")) return raw; // IPv4 or a name — already canonical
+  try {
+    // URL canonicalizes IPv6 and re-brackets it; strip the brackets back off.
+    return new URL(`http://[${raw}]/`).hostname.replace(/^\[|\]$/g, "");
+  } catch {
+    return raw; // not a valid IPv6 literal — compare as written
+  }
 }
 
 /** True when a hostname is loopback (or absent → assume local). Bracketed IPv6

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { fileURLToPath } from "url";
 import { dirname, resolve, join } from "path";
 import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, networkInterfaces } from "node:os";
 import { isIP } from "node:net";
 import { normalizeInstallPathEnv } from "./utils/install-path-env.js";
 import { parseComfyUIUrl, type ComfyUITarget } from "./transport/comfyui-url.js";
@@ -229,6 +229,65 @@ const LOOPBACK_HOSTS = new Set([
   "::", // IPv6 wildcard bind — reachable on loopback (::1)
   "0000:0000:0000:0000:0000:0000:0000:0000",
 ]);
+
+/**
+ * True when `host` is an address THIS machine answers on — loopback, or any
+ * literal IP currently bound to one of its own interfaces (#742).
+ *
+ * `isLoopbackHost` answers a narrower question than most of its callers need.
+ * Loopback proves the ROUTE is local; it does not follow that a non-loopback
+ * address is a different machine. A ComfyUI on this very host addressed as
+ * `http://192.168.1.50:8188` — which is how anyone reaches it from a phone, or
+ * how Pinokio and several launchers advertise it — is not loopback and is not
+ * remote either. The recurrence on #742 is exactly that: the restart guard read
+ * "not loopback" as "not ours", skipped its refuse-safe check, and stopped a
+ * server it then could not bring back.
+ *
+ * NO DNS. A hostname is compared as a string against the literal addresses the
+ * interfaces report, so it simply never matches — `comfy.lan` returns false even
+ * if it resolves here. That is deliberate, not a gap: resolving would mean a DNS
+ * round trip on a path that must not block, and a name can resolve differently —
+ * or be made to — between this check and the action it authorizes. This gates a
+ * REFUSAL, so "cannot prove it is ours" is the safe answer; it leaves today's
+ * behaviour exactly as it was.
+ *
+ * (An earlier version guarded the comparison with an explicit is-this-a-literal-IP
+ * test. Mutation testing showed removing it changed no outcome — the equality
+ * below already refuses names — so it was a check that could never fire, next to
+ * a comment claiming it was what enforced the rule.)
+ *
+ * Not cached. `networkInterfaces()` is a cheap syscall, and a laptop that
+ * changes networks would keep answering from a stale snapshot — wrong in the
+ * direction that matters, since the whole point is to be right about which
+ * machine we are talking to right now.
+ */
+export function isOwnHostAddress(host: string | undefined): boolean {
+  if (isLoopbackHost(host)) return true;
+  const h = normalizeHostForCompare(host);
+  // An empty host must never fall through to the comparison: an interface that
+  // reported an empty address would then match it.
+  if (!h) return false;
+  try {
+    for (const addrs of Object.values(networkInterfaces())) {
+      for (const a of addrs ?? []) {
+        if (normalizeHostForCompare(a.address) === h) return true;
+      }
+    }
+  } catch {
+    // Enumerating interfaces can fail in a locked-down container. Unknown is
+    // not proof, and this gates a refusal — fall through to false.
+  }
+  return false;
+}
+
+/** Lowercase, strip URL brackets, and drop an IPv6 zone suffix (`%eth0`), which
+ *  `networkInterfaces()` omits on the addresses it reports. */
+function normalizeHostForCompare(host: string | undefined): string {
+  return (host ?? "")
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/%.*$/, "");
+}
 
 /** True when a hostname is loopback (or absent → assume local). Bracketed IPv6
  *  (`[::1]`, as URL parsing stores it) is normalized first so every consumer
@@ -771,6 +830,30 @@ export function isLocalMode(): boolean {
 /** For env-capabilities.ts, which classifies a URL independently of urlOverride. */
 export function isForceRemoteFlagSet(): boolean {
   return forceRemote;
+}
+
+/**
+ * True when the configured ComfyUI target is provably on THIS machine (#742).
+ *
+ * Distinct from `isLocalMode()`, which reports the classification. This reports
+ * the physical question that classification stands in for, and the two disagree
+ * for exactly one case: a local instance addressed by one of this host's own
+ * non-loopback addresses. That case is `isRemoteMode() === true` and
+ * `targetIsOnThisMachine() === true`, and it is the #742 recurrence.
+ *
+ * `--force-remote` / `COMFYUI_MCP_FORCE_REMOTE` wins outright. A tunnel or
+ * port-forward makes the address say "here" about an instance that is
+ * elsewhere, and the flag exists for the user to say so; an inference must not
+ * overrule it. (This is the mirror of the note in panel-tools about a cloud pod
+ * fronted at 127.0.0.1.)
+ */
+export function targetIsOnThisMachine(): boolean {
+  if (forceRemote) return false;
+  try {
+    return isOwnHostAddress(new URL(getComfyUIBaseUrl()).hostname);
+  } catch {
+    return false; // unparseable target — cannot prove it is ours
+  }
 }
 
 /** Filesystem-safe id for the target instance — scopes per-instance data (e.g. generations DB). */

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -24,6 +24,7 @@ import {
   getComfyUIBaseUrl,
   getComfyuiTargetGeneration,
   isRemoteMode,
+  targetIsOnThisMachine,
 } from "../config.js";
 import { comfyuiFetch, describeTargetDrift } from "../comfyui/fetch.js";
 import { scrubLogLines } from "../comfyui/json-guard.js";
@@ -4347,7 +4348,25 @@ export async function preflightLocalRestart(): Promise<{
   /** Whether the assessed instance is ComfyUI Desktop — selects the #848 remedy. */
   isDesktopApp?: boolean;
 }> {
-  if (isRemoteMode()) return { ok: true };
+  // Remote mode passes because there is no local process to assess — but that
+  // reasoning only holds when the target really is another machine, and the
+  // classification behind it does not establish that. `remoteUrlActive` is
+  // `forceRemote || !isLoopbackHost(host)`, so a ComfyUI on THIS host reached
+  // through its own LAN address is "remote" here, and this line waves the whole
+  // refuse-safe check through for an install we could have assessed.
+  //
+  // That is the #742 recurrence, reported on 0.51.18 — a Pinokio ComfyUI on the
+  // same machine addressed as `http://192.168.x.x:5000` with COMFYUI_PATH set to
+  // it. The preflight passed without looking, the Manager reboot stopped the
+  // server, and Pinokio does not relaunch on a plain restart, so it stayed down.
+  // The guard that exists precisely to refuse that stop never ran.
+  //
+  // An address bound to one of our own interfaces is assessable, so assess it.
+  // Forced remote is still honoured unconditionally: `--force-remote` is the
+  // user telling us the instance is elsewhere regardless of how it is addressed
+  // (a tunnel or port-forward makes the route say otherwise), and overriding an
+  // explicit statement of intent with an inference would be its own bug.
+  if (isRemoteMode() && !targetIsOnThisMachine()) return { ok: true };
   const { info, diagnostic } = await acquireProcessInfo();
   // NOTHING COULD BE RESOLVED — and that is not a pass (coordinator gate).
   //

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -4366,7 +4366,39 @@ export async function preflightLocalRestart(): Promise<{
   // user telling us the instance is elsewhere regardless of how it is addressed
   // (a tunnel or port-forward makes the route say otherwise), and overriding an
   // explicit statement of intent with an inference would be its own bug.
-  if (isRemoteMode() && !targetIsOnThisMachine()) return { ok: true };
+  const remoteAddressedButOurs = isRemoteMode() && targetIsOnThisMachine();
+  if (isRemoteMode() && !remoteAddressedButOurs) return { ok: true };
+  const assessed = await assessLocalRestart();
+  // An address on one of our interfaces proves the ROUTE lands here, not that
+  // the instance does — a reverse proxy or port-forward bound to this machine's
+  // LAN address can front a ComfyUI that is genuinely elsewhere (review, P2).
+  // Such a setup used to restart through the Manager and now meets the guard,
+  // so a refusal must say which assumption produced it and how to correct it.
+  // Silently changing behaviour and leaving the reader to guess is the part
+  // that would actually cost them time.
+  if (remoteAddressedButOurs && assessed.ok === false) {
+    return {
+      ...assessed,
+      reason:
+        `${assessed.reason ?? "the relaunch could not be established"} ` +
+        `NOTE: this target was assessed as LOCAL because its address is bound ` +
+        `to one of this machine's own network interfaces. If this ComfyUI is ` +
+        `actually somewhere else and merely reached through a proxy or ` +
+        `port-forward on this host, set COMFYUI_MCP_FORCE_REMOTE=1 (or pass ` +
+        `--force-remote) and the restart goes back through ComfyUI-Manager ` +
+        `without needing a local process to account for.`,
+    };
+  }
+  return assessed;
+}
+
+/** The assessment itself — everything after the locality decision above. */
+async function assessLocalRestart(): Promise<{
+  ok: boolean;
+  reason?: string;
+  observedArgv?: string[];
+  isDesktopApp?: boolean;
+}> {
   const { info, diagnostic } = await acquireProcessInfo();
   // NOTHING COULD BE RESOLVED — and that is not a pass (coordinator gate).
   //


### PR DESCRIPTION
Claims #742.

The original report (parts 1 and 2 — a misleading `Cancelled` and no failed-relaunch detection) was fixed, and there is a refuse-safe Pinokio preflight with its own suite. **The recurrence comment of 2026-08-12 is the live bug, on 0.51.18 — newer than that fix.**

> `panel_restart_comfyui` classified the target as remote, skipped the #742 preflight, returned `{rebooting:true, ready:false, confirmed_cycle:false, dispatched:true}`, and stopped ComfyUI without relaunching it.

A Pinokio install on the same host, addressed through its LAN IP (`COMFYUI_URL=http://192.168.x.x:5000`) with `COMFYUI_PATH` pointing at that install, is classified **remote** — so the guard that exists specifically to refuse this stop never runs.

This is the third or fourth report this cycle whose real defect is not a missing mechanism but an unreachable one, so the fix is about the gate, not the guard.