### PR TITLE
release: v0.51.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.37",
+  "version": "0.51.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.37",
+      "version": "0.51.38",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.37",
+  "version": "0.51.38",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.38 with #742.

The refuse-safe restart preflight opened with `if (isRemoteMode()) return { ok: true }`, and remote mode is `forceRemote || !isLoopbackHost(host)`. A ComfyUI on **this** machine reached through its own LAN address therefore skipped the guard entirely — which is how a Pinokio install got stopped and never relaunched.

Loopback proves the route is local; it does not follow that a non-loopback address is a different machine. The preflight now short-circuits only when the target is remote **and** not on this machine. `--force-remote` still wins outright.

Verified live against the built `dist/` using this machine's real interfaces: its LAN address and the IPv4-mapped spelling of it are recognised, a neighbour on the same subnet is not, and loopback is unchanged.