### PR TITLE
fix(771): an ABSENT pack after a drained queue no longer blocks the reinstall that would fix it

### DIFF
--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -276,6 +276,13 @@ function makeDeps(opts: {
   revs?: Record<string, string>;
   /** Leave the swap primitives off the dep set (fallback unavailable). */
   withoutSwapOps?: boolean;
+  /**
+   * Manager UNLINKS the pack during the update and then fails to put it back,
+   * while still reporting a drained queue (#771 r2). This is the state every
+   * other test in this file cannot reach: they all leave the pack on disk, so
+   * the post-op reading is usable and the `!post.installed` throw never fires.
+   */
+  updateDeletesPack?: boolean;
 }): Harness {
   const revs = opts.revs ?? {};
   const h: Harness = { deps: null as never, updateCalls: 0, clones: [], gitMerges: 0 };
@@ -327,6 +334,7 @@ function makeDeps(opts: {
     update: async () => {
       h.updateCalls++;
       if (opts.updateThrows) throw new Error(opts.updateThrows);
+      if (opts.updateDeletesPack) rmSync(PANEL_DIR(), { recursive: true, force: true });
       return {
         mechanism: "manager-http",
         message: "updated",
@@ -912,6 +920,90 @@ describe("update no longer contradicts status on a registry-zip install (#771)",
     expect(h.clones).toHaveLength(1);
     // Staged OUTSIDE custom_nodes: a half-written clone in there would be served.
     expect(h.clones[0].startsWith(join(root, "custom_nodes"))).toBe(false);
+  });
+
+  // ── #771 r2: the pack is GONE after a drained queue ────────────────────────
+  //
+  // Every other test in this file writes the pack and leaves it there, so the
+  // post-op reading is always usable and the `!post.installed` throw never
+  // fires. That throw sits ~200 lines ABOVE the verified reinstall and gates it
+  // on `post.dir`, so the one state where a fresh clone is the ONLY remedy was
+  // the state routed to a bare throw — whose own text says "reinstall the panel
+  // from source", naming the operation it had just declined to run.
+  //
+  // Reported on 0.50.93; the file is byte-identical between that tag and main.
+  it("a pack DELETED by the update is reinstalled, not thrown about (#771)", async () => {
+    writePanelPack(PANEL_DIR(), "0.11.34");
+    const h = makeDeps({
+      updateDetails: { total_count: 0, done_count: 4 }, // Manager: queue drained
+      updateDeletesPack: true, // ...and the pack is gone
+      cloneVersion: "0.11.38",
+    });
+
+    const result = await runPanelActionInner("update", h.deps);
+
+    expect(result.installedVersion).toBe("0.11.38");
+    expect(h.clones).toHaveLength(1);
+    // Recovered in place, at the path it was detected at before the Manager ran.
+    expect(readFileSync(join(PANEL_DIR(), "pyproject.toml"), "utf-8")).toContain("0.11.38");
+    // Same staging invariant as the sibling path: never inside custom_nodes.
+    expect(h.clones[0].startsWith(join(root, "custom_nodes"))).toBe(false);
+  });
+
+  it("a pack left with an UNREADABLE version is reinstalled on the same path", async () => {
+    // The throw's other half. `post.installed` is true but `post.version` is
+    // not, which is equally unverifiable and equally recoverable by reinstall.
+    writePanelPack(PANEL_DIR(), "0.11.34");
+    const h = makeDeps({
+      updateDetails: { total_count: 0, done_count: 4 },
+      cloneVersion: "0.11.38",
+    });
+    // Manager leaves the directory but corrupts the manifest.
+    const orig = h.deps.update;
+    h.deps.update = async (...a: Parameters<typeof orig>) => {
+      const r = await orig(...a);
+      writeFileSync(join(PANEL_DIR(), "pyproject.toml"), "this is not toml\n");
+      return r;
+    };
+
+    const result = await runPanelActionInner("update", h.deps);
+
+    expect(result.installedVersion).toBe("0.11.38");
+    expect(h.clones).toHaveLength(1);
+  });
+
+  it("a CHECKOUT whose pack vanished still THROWS — a re-clone would destroy local work", async () => {
+    // The scope limit, and the reason this is not a blanket "reinstall on any
+    // unverifiable result". A git checkout has history and possibly local
+    // commits; wholesale replacement is the wrong answer even when the working
+    // tree is missing. Only the registry-zip shape (no previousRev) recovers.
+    writePanelPack(PANEL_DIR(), "0.11.34");
+    const h = makeDeps({
+      updateDetails: { total_count: 0, done_count: 4 },
+      updateDeletesPack: true,
+      revs: { [PANEL_DIR()]: "a".repeat(40) }, // it IS a checkout
+      cloneVersion: "0.11.38",
+    });
+
+    const err = await runPanelActionInner("update", h.deps).catch((e: Error) => e);
+
+    expect((err as Error).message).toMatch(/not present|could not verify/i);
+    expect(h.clones).toHaveLength(0);
+  });
+
+  it("with the swap primitives unavailable it still THROWS rather than half-acting", async () => {
+    writePanelPack(PANEL_DIR(), "0.11.34");
+    const h = makeDeps({
+      updateDetails: { total_count: 0, done_count: 4 },
+      updateDeletesPack: true,
+      withoutSwapOps: true,
+      cloneVersion: "0.11.38",
+    });
+
+    const err = await runPanelActionInner("update", h.deps).catch((e: Error) => e);
+
+    expect((err as Error).message).toMatch(/not present|could not verify/i);
+    expect(h.clones).toHaveLength(0);
   });
 
   it("the replaced copy is parked OUTSIDE custom_nodes, never beside the panel (#641)", async () => {

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -263,6 +263,29 @@ interface Harness {
   gitMerges: number;
 }
 
+/**
+ * Can this machine create a symlink/junction to a MISSING target? Windows needs
+ * either Developer Mode or elevation for symlinks; junctions usually work
+ * without, but a locked-down runner may refuse both.
+ *
+ * Probed rather than assumed, and used with `it.runIf` so the dangling-link test
+ * is either RUN or visibly SKIPPED — never silently degraded. An earlier version
+ * wrapped the creation in try/catch, which turned it into a duplicate of the
+ * plain-absent test on any machine without the privilege: green, and unable to
+ * detect removal of the very term it exists to pin (review finding).
+ */
+function canMakeDanglingLink(): boolean {
+  const probe = mkdtempSync(join(tmpdir(), "cmcp-linkprobe-"));
+  try {
+    symlinkSync(join(probe, "no-such-target"), join(probe, "link"), "junction");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+}
+
 function makeDeps(opts: {
   /** Version a `git clone` of the panel repo lands. undefined ⇒ clone fails. */
   cloneVersion?: string;
@@ -972,7 +995,9 @@ describe("update no longer contradicts status on a registry-zip install (#771)",
     expect(h.clones).toHaveLength(1);
   });
 
-  it("a DANGLING SYMLINK at the panel path is still moved aside, not skipped", async () => {
+  it.runIf(canMakeDanglingLink())(
+    "a DANGLING SYMLINK at the panel path is still moved aside, not skipped",
+    async () => {
     // `existsSync` follows the link, so a broken one reads as absent while the
     // directory ENTRY is still there. Skipping the backup move on that reading
     // would leave it in place and the final rename onto it would fail — a safe
@@ -983,17 +1008,22 @@ describe("update no longer contradicts status on a registry-zip install (#771)",
       updateDetails: { total_count: 0, done_count: 4 },
       cloneVersion: "0.11.38",
     });
-    const orig = h.deps.update;
-    h.deps.update = async (...a: Parameters<typeof orig>) => {
-      const r = await orig(...a);
-      // Manager replaces the pack with a link to somewhere that no longer exists.
+    // Simulated through the INJECTED probes rather than a real junction. A
+    // first version created one on disk and swallowed the failure on machines
+    // without the privilege — which silently degraded it into a duplicate of
+    // the plain-absent test above, unable to detect the very term it exists to
+    // pin. Review caught that. The dep set is the seam this file already uses,
+    // and it behaves identically on every platform and CI runner.
+    //
+    // The entry stays REAL on disk (so the backup rename can succeed) while the
+    // two probes report what they would for a dangling link: `existsSync`
+    // follows it and says absent, `isSymlink` lstats it and says present.
+    const origUpdate = h.deps.update;
+    h.deps.update = async (...a: Parameters<typeof origUpdate>) => {
+      const r = await origUpdate(...a);
+      // Manager replaces the pack with a link whose target no longer exists.
       rmSync(PANEL_DIR(), { recursive: true, force: true });
-      try {
-        symlinkSync(join(root, "gone-target"), PANEL_DIR(), "junction");
-      } catch {
-        // Windows without the privilege — fall back to proving the plain
-        // absent case, which the sibling test already covers in full.
-      }
+      symlinkSync(join(root, "gone-target"), PANEL_DIR(), "junction");
       return r;
     };
 
@@ -1001,7 +1031,21 @@ describe("update no longer contradicts status on a registry-zip install (#771)",
 
     expect(result.installedVersion).toBe("0.11.38");
     expect(readFileSync(join(PANEL_DIR(), "pyproject.toml"), "utf-8")).toContain("0.11.38");
-  });
+    // THE assertion that binds. The version check above passes either way — the
+    // final rename can still land — so it cannot see whether the entry was
+    // moved aside. Only the backup can: with the isSymlink term the old copy is
+    // preserved under custom_nodes_backup, without it the move is skipped and
+    // nothing is backed up. An earlier version of this test asserted only the
+    // version and survived the mutation that removes the term.
+    //
+    // Its CONTENTS are deliberately not read: what was moved aside IS the
+    // broken link, so it resolves to nothing. That the entry exists is the
+    // whole claim.
+    const backups = readdirSync(join(root, "custom_nodes_backup"));
+    expect(backups).toHaveLength(1);
+    expect(backups[0]).toContain("comfyui-agent-panel");
+    },
+  );
 
   it("a CHECKOUT whose pack vanished still THROWS — a re-clone would destroy local work", async () => {
     // The scope limit, and the reason this is not a blanket "reinstall on any

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -972,6 +972,37 @@ describe("update no longer contradicts status on a registry-zip install (#771)",
     expect(h.clones).toHaveLength(1);
   });
 
+  it("a DANGLING SYMLINK at the panel path is still moved aside, not skipped", async () => {
+    // `existsSync` follows the link, so a broken one reads as absent while the
+    // directory ENTRY is still there. Skipping the backup move on that reading
+    // would leave it in place and the final rename onto it would fail — a safe
+    // failure, but it would defeat this whole recovery on a real filesystem
+    // shape. Caught in review; `isSymlink` lstats and sees the link itself.
+    writePanelPack(PANEL_DIR(), "0.11.34");
+    const h = makeDeps({
+      updateDetails: { total_count: 0, done_count: 4 },
+      cloneVersion: "0.11.38",
+    });
+    const orig = h.deps.update;
+    h.deps.update = async (...a: Parameters<typeof orig>) => {
+      const r = await orig(...a);
+      // Manager replaces the pack with a link to somewhere that no longer exists.
+      rmSync(PANEL_DIR(), { recursive: true, force: true });
+      try {
+        symlinkSync(join(root, "gone-target"), PANEL_DIR(), "junction");
+      } catch {
+        // Windows without the privilege — fall back to proving the plain
+        // absent case, which the sibling test already covers in full.
+      }
+      return r;
+    };
+
+    const result = await runPanelActionInner("update", h.deps);
+
+    expect(result.installedVersion).toBe("0.11.38");
+    expect(readFileSync(join(PANEL_DIR(), "pyproject.toml"), "utf-8")).toContain("0.11.38");
+  });
+
   it("a CHECKOUT whose pack vanished still THROWS — a re-clone would destroy local work", async () => {
     // The scope limit, and the reason this is not a blanket "reinstall on any
     // unverifiable result". A git checkout has history and possibly local

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -5092,9 +5092,24 @@ async function updateViaRegistryZipReinstall(opts: {
 
   // STEP 2 — move the old panel OUT, to a sibling of custom_nodes. Leaving it
   // beside the new one would shadow it in the browser (#641).
-  try {
-    ops.rename(dir, backupDir);
-  } catch (err) {
+  //
+  // #771 r2 — there may be NO old panel to move. When ComfyUI-Manager unlinks
+  // the pack and then fails to put it back, this fallback is reached with
+  // `dir` already gone, and `rename` fails ENOENT. That failure was then
+  // reported as "could not move the existing panel out of custom_nodes … your
+  // panel at <dir> is untouched", which is false twice over: there is no panel
+  // there, and it is precisely the case where a clean install is the only
+  // remedy.
+  //
+  // Skipping the move is not a relaxation of the #641 guard. That guard exists
+  // so an OLD copy cannot shadow the new one, and here there is no old copy.
+  // Requires PROVEN absence — `existsSync` false — so a probe that merely
+  // failed still takes the careful path below.
+  const hadExistingPanel = deps.existsSync(dir);
+  if (hadExistingPanel) {
+    try {
+      ops.rename(dir, backupDir);
+    } catch (err) {
     // The old panel is still in place and serving; get the staged copy OUT of
     // custom_nodes so it cannot shadow it, and leave the install exactly as we
     // found it.
@@ -5130,7 +5145,8 @@ async function updateViaRegistryZipReinstall(opts: {
             `shadow it — remove that directory, then restart ComfyUI.`) +
         ` Check permissions / that ComfyUI does not hold the directory open (stop ` +
         `ComfyUI and retry).`,
-    );
+      );
+    }
   }
 
   // STEP 3 — put the new panel under its proper name. Until this lands the
@@ -5714,6 +5730,46 @@ async function runPanelActionCore(
     // cannot verify the applied version (fail closed; never trust a HEAD move
     // alone when the pyproject version can't be read).
     if (!post.installed || !post.version) {
+      // #771 r2 — REACHABILITY, not a missing remedy. The verified reinstall
+      // ~200 lines below (`zipSwapOps` → updateViaRegistryZipReinstall) exists
+      // for exactly this situation: "Manager drained its queue without moving
+      // the pack, and this is a registry-zip install with no .git to
+      // fast-forward". But it is gated on `post.dir`, and THIS throw fires
+      // first whenever the post-op reading is unusable.
+      //
+      // So the one state where a fresh clone is the ONLY possible remedy — the
+      // pack is GONE after a drained queue — was the state routed to a bare
+      // throw, whose own text tells the reader to "reinstall the panel from
+      // source": an operation this file already implements and had just
+      // decided not to run. That is the #771 self-blocking loop, one install
+      // shape over from the one it was filed about.
+      //
+      // The asymmetry made it easy to miss: when Manager THROWS, the sibling
+      // path substitutes `detection.dir` for a missing post-op dir and the
+      // rescue fires. When Manager LIES with a drained queue — the more common
+      // failure, and the reporter's case — it did not.
+      //
+      // Same substitution as that sibling path rather than a second rule, and
+      // the same shape gate: a registry zip (`!previousRev`) that WAS installed
+      // before. A checkout keeps the throw — it has a git history, so a
+      // destructive re-clone is not the right answer for it.
+      const rescueDir = post.dir ?? detection.dir;
+      const rescueOps =
+        !previousRev && detection.installed && rescueDir ? resolveSwapOps(deps) : undefined;
+      if (rescueOps && rescueDir) {
+        return updateViaRegistryZipReinstall({
+          deps,
+          ops: rescueOps,
+          dir: rescueDir,
+          comfyuiPath: comfyPath,
+          previousVersion,
+          result,
+          assertSameTarget,
+          managerReason: post.installed
+            ? `ComfyUI-Manager reported the queue drained but the pack's version is unreadable at ${rescueDir}`
+            : `ComfyUI-Manager reported the queue drained and the pack is no longer present at ${rescueDir}`,
+        });
+      }
       throw new PanelInstallError(
         `Could not verify the panel update applied: the pack is ${
           post.installed ? "present but its version is unreadable" : "not present"

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -5103,9 +5103,19 @@ async function updateViaRegistryZipReinstall(opts: {
   //
   // Skipping the move is not a relaxation of the #641 guard. That guard exists
   // so an OLD copy cannot shadow the new one, and here there is no old copy.
-  // Requires PROVEN absence — `existsSync` false — so a probe that merely
-  // failed still takes the careful path below.
-  const hadExistingPanel = deps.existsSync(dir);
+  //
+  // The question is "is there a directory ENTRY in the way", not "does a panel
+  // resolve there", and those differ for a DANGLING SYMLINK (review finding):
+  // `existsSync` follows the link and reports false, while the entry is still
+  // very much present — so skipping the move on `existsSync` alone would leave
+  // it sitting there and STEP 3's rename onto it would fail. That is milder
+  // than the bug it replaces (a safe failure, not a shadow) but it would defeat
+  // this very recovery on a real filesystem shape. `isSymlink` lstats, so it
+  // sees the link itself.
+  //
+  // Requires PROVEN absence in BOTH senses — no resolvable target and no link
+  // entry — so a probe that merely failed still takes the careful path below.
+  const hadExistingPanel = deps.existsSync(dir) || deps.isSymlink(dir) === true;
   if (hadExistingPanel) {
     try {
       ops.rename(dir, backupDir);


### PR DESCRIPTION
Claims #771 — the 2026-08-13 recurrence, reported on 0.50.93.

The original fix shipped in **v0.49.5** (`updateViaRegistryZipReinstall`) and does exactly what the reporter asked for: shallow-clone the panel repo to staging, validate, atomically swap it in. It is not missing. **It is unreachable for the reported shape** — the third instance of this pattern this cycle, after #1129/#1512/#1524 and #742.

`panel-installer.ts`, inside one linear `if (action === "update")` block:

| line | what happens |
|---|---|
| 5716 | `if (!post.installed \|\| !post.version) throw` — *"…reinstall the panel from source"* |
| 5919 | the verified reinstall, gated on `post.dir` (i.e. the pack still being present) |

So when ComfyUI-Manager drains its queue **and the pack is gone**, the throw fires ~200 lines before the recovery, and its own remedy text names the operation the file already implements.

The asymmetry is the bug: the automatic restore is available when Manager **errors** (that path substitutes `detection.dir` at ~5630 when the post-op reading has no dir), and unavailable when Manager **lies** with a drained queue — which is the more common failure and the reporter's exact case.

Verified against `origin/main` myself, not taken on report: `git rev-parse v0.50.93:src/services/panel-installer.ts` and `origin/main:…` are the **same blob**, so nothing about this changed between the reporter's version and now.