### PR TITLE
release: v0.51.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.38",
+  "version": "0.51.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.38",
+      "version": "0.51.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.38",
+  "version": "0.51.39",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.39 with #771.

When ComfyUI-Manager reports a drained queue but has **deleted** the panel pack, the update no longer throws — it reaches the verified reinstall that already existed for exactly this situation, and which its own error text was telling the user to run by hand.

A checkout still refuses (it has history; a wholesale re-clone is the wrong answer), and a dangling symlink at the panel path is moved aside rather than left to block the final rename.

**Verification:** 4 new unit tests against the real `runPanelActionCore` — including the two negatives that keep this from becoming a destructive catch-all — plus 6 mutations killed, among them a straight revert of the fix. Full suite 495 files / 9315 tests green.

**Not done, stated plainly:** no end-to-end live run. The path is only reachable when Manager fails mid-update, and provoking that for real would mean deleting the working panel pack on this machine. A standalone rig was attempted and abandoned once it became clear it was re-implementing the unit harness's dependency surface without adding signal.