### PR TITLE
fix(1489): stop waiting 60s to report a lock whose owner is provably gone

### DIFF
--- a/src/__tests__/services/panel-lock-dead-owner.test.ts
+++ b/src/__tests__/services/panel-lock-dead-owner.test.ts
@@ -1,0 +1,154 @@
+// #1489 (lock half) — `acquireFileLock` polled until the 60 s deadline and only
+// THEN called `observePanelLock` to say what had blocked it. A lock left by an
+// orchestrator that died an hour ago therefore cost a full minute to report
+// something that was provable on the first tick.
+//
+// The narrowing is LATENCY ONLY: same refusal, same remedy, raised as soon as
+// the owner is provably gone. It must NOT become an auto-reclaim — #779 made
+// stale-lock recovery fail closed on purpose, because a concurrent pre-upgrade
+// orchestrator can replace an observed stale path with a fresh lock.
+//
+// The three liveness states are the whole test surface, and only ONE of them may
+// short-circuit:
+//   false     — no such process. Provably not our holder → fail fast.
+//   "unsure"  — pid exists but the lock is old enough that the number may have
+//               been recycled → keep waiting. Treating this as dead is the
+//               existence-for-identity fold `pidLiveness` exists to prevent.
+//   true      — a real operation may still be running → keep waiting.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string;
+
+/**
+ * A lock file owned by `pid`, made to look `ageMs` old.
+ *
+ * The age that decides anything is the file's MTIME, not the `startedAt` in the
+ * payload — `observePanelLock` reads `statSync(path).mtimeMs`. A first version of
+ * this helper only wrote an old-looking timestamp into the JSON, so every lock
+ * read as brand new, the stale gate never opened, and three tests sat through
+ * the full 30 s budget instead of failing loudly.
+ */
+function writeLock(pid: number, ageMs: number): void {
+  const path = join(dir, "panel-op.lock");
+  writeFileSync(
+    path,
+    JSON.stringify({
+      pid,
+      startedAt: new Date(Date.now() - ageMs).toISOString(),
+      token: "test-token",
+    }),
+  );
+  const when = (Date.now() - ageMs) / 1000;
+  utimesSync(path, when, when);
+}
+
+/** A pid that cannot exist, so `process.kill(pid, 0)` proves absence. */
+const DEAD_PID = 0x7ffffffe;
+
+beforeEach(() => {
+  vi.resetModules();
+  dir = mkdtempSync(join(tmpdir(), "cmcp-locktest-"));
+  process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_PANEL_LOCK;
+  rmSync(dir, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+async function lockModule() {
+  return await import("../../services/panel-pin-guard.js");
+}
+
+describe("#1489 a provably dead lock owner is reported at once", () => {
+  it("fails in well under the acquire budget instead of waiting it out", async () => {
+    // Ten minutes old and owned by a pid that does not exist.
+    writeLock(DEAD_PID, 20 * 60_000); // comfortably past STALE_LOCK_MS
+    const { withPanelMutationLock } = await lockModule();
+
+    const started = Date.now();
+    // A 30 s budget: before the fix this call could only settle at 30 s.
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 30_000,
+    }).catch((e: Error) => e);
+    const elapsed = Date.now() - started;
+
+    expect((err as Error).message).toMatch(/no longer\s+running/i);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("still refuses to delete it — the remedy is the unlock tool, not us", async () => {
+    // The #779 invariant. Failing FAST must not become failing DESTRUCTIVELY.
+    writeLock(DEAD_PID, 20 * 60_000); // comfortably past STALE_LOCK_MS
+    const { withPanelMutationLock } = await lockModule();
+    const { existsSync } = await import("node:fs");
+
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 30_000,
+    }).catch((e: Error) => e);
+
+    expect((err as Error).message).toMatch(/panel_action:'unlock'/);
+    expect(existsSync(join(dir, "panel-op.lock"))).toBe(true);
+  });
+
+  it("does NOT run the operation it was guarding", async () => {
+    // Failing fast must not be mistaken for proceeding without the lock, which
+    // is how a pinned user gets their panel moved.
+    writeLock(DEAD_PID, 20 * 60_000); // comfortably past STALE_LOCK_MS
+    const { withPanelMutationLock } = await lockModule();
+    const op = vi.fn(async () => "ran");
+
+    await withPanelMutationLock(op, { timeoutMs: 30_000 }).catch(() => {});
+
+    expect(op).not.toHaveBeenCalled();
+  });
+
+  it("an UNSURE owner keeps waiting and times out normally", async () => {
+    // A pid that DOES exist (our own) on a lock old enough that recycling is a
+    // plausible explanation → liveness is undetermined. Fast-failing here would
+    // be the exact wrong call: the operation may genuinely be running.
+    writeLock(process.pid, 20 * 60_000);
+    const { withPanelMutationLock } = await lockModule();
+
+    const started = Date.now();
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 1_200,
+    }).catch((e: Error) => e);
+    const elapsed = Date.now() - started;
+
+    expect((err as Error).message).toMatch(/Timed out/i);
+    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+    // It waited the budget rather than short-circuiting.
+    expect(elapsed).toBeGreaterThanOrEqual(1_000);
+  });
+
+  it("a LIVE owner keeps waiting and times out normally", async () => {
+    // Our own pid on a young lock: a real operation could be in flight.
+    writeLock(process.pid, 1_000);
+    const { withPanelMutationLock } = await lockModule();
+
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 1_200,
+    }).catch((e: Error) => e);
+
+    expect((err as Error).message).toMatch(/Timed out/i);
+    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+  });
+
+  it("an uninspectable lock keeps waiting — a bad read is not proof of death", async () => {
+    // Garbage where the record should be: `observePanelLock` cannot establish an
+    // owner, so nothing is proven and the careful path must still be taken.
+    writeFileSync(join(dir, "panel-op.lock"), "not json at all");
+    const { withPanelMutationLock } = await lockModule();
+
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 1_200,
+    }).catch((e: Error) => e);
+
+    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+  });
+});

--- a/src/__tests__/services/panel-lock-dead-owner.test.ts
+++ b/src/__tests__/services/panel-lock-dead-owner.test.ts
@@ -207,6 +207,36 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
     expect(elapsed).toBeGreaterThanOrEqual(1_800);
   });
 
+  it("a replacement reusing pid AND startedAt is still caught by the token", async () => {
+    // pid+startedAt is attribution, not identity — the record carries a `token`
+    // precisely because two locks from the same process can share both. A
+    // replacement that reuses them would collide on a fingerprint built from
+    // pid@startedAt alone and be confirmed as the earlier dead lock (review
+    // finding). Same elapsed-time discriminator as the sibling test: correct
+    // behaviour needs a fresh pair of matching probes after the swap.
+    const frozenAge = 20 * 60_000;
+    const stamp = new Date(Date.now() - frozenAge).toISOString();
+    const writeWithToken = (token: string) => {
+      const p = join(dir, "panel-op.lock");
+      writeFileSync(p, JSON.stringify({ pid: DEAD_PID, startedAt: stamp, token }));
+      const when = (Date.now() - frozenAge) / 1000;
+      utimesSync(p, when, when);
+    };
+    writeWithToken("token-A");
+    const { withPanelMutationLock } = await lockModule();
+    const swap = setTimeout(() => writeWithToken("token-B"), 400);
+
+    const started = Date.now();
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 8_000,
+    }).catch((e: Error) => e);
+    const elapsed = Date.now() - started;
+    clearTimeout(swap);
+
+    expect((err as Error).message).toMatch(/Not waiting out the remaining timeout/i);
+    expect(elapsed).toBeGreaterThanOrEqual(1_800);
+  });
+
   it("a lock REPLACED between probes resets the candidate and is not fast-failed", async () => {
     // The TOCTOU the two-observation rule exists for: a dead+stale lock is seen,
     // then a different holder takes the path before the next probe. Refusing on

--- a/src/__tests__/services/panel-lock-dead-owner.test.ts
+++ b/src/__tests__/services/panel-lock-dead-owner.test.ts
@@ -15,6 +15,13 @@
 //               been recycled → keep waiting. Treating this as dead is the
 //               existence-for-identity fold `pidLiveness` exists to prevent.
 //   true      — a real operation may still be running → keep waiting.
+//
+// NOTE ON ASSERTIONS: the fast path is identified by "Not waiting out the
+// remaining timeout", NOT by "is no longer running". The ORDINARY timeout
+// message contains that phrase too (describeObservedLock composes it), so
+// keying on it cannot tell the two paths apart in EITHER direction — every
+// assertion in this file was written that way at first, which made the
+// positives weak and one negative outright wrong.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -77,7 +84,7 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
     }).catch((e: Error) => e);
     const elapsed = Date.now() - started;
 
-    expect((err as Error).message).toMatch(/no longer\s+running/i);
+    expect((err as Error).message).toMatch(/Not waiting out the remaining timeout/i);
     expect(elapsed).toBeLessThan(5_000);
   });
 
@@ -121,7 +128,7 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
     const elapsed = Date.now() - started;
 
     expect((err as Error).message).toMatch(/Timed out/i);
-    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+    expect((err as Error).message).not.toMatch(/Not waiting out the remaining timeout/i);
     // It waited the budget rather than short-circuiting.
     expect(elapsed).toBeGreaterThanOrEqual(1_000);
   });
@@ -136,7 +143,7 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
     }).catch((e: Error) => e);
 
     expect((err as Error).message).toMatch(/Timed out/i);
-    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+    expect((err as Error).message).not.toMatch(/Not waiting out the remaining timeout/i);
   });
 
   it("an uninspectable lock keeps waiting — a bad read is not proof of death", async () => {
@@ -145,10 +152,81 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
     writeFileSync(join(dir, "panel-op.lock"), "not json at all");
     const { withPanelMutationLock } = await lockModule();
 
+    const started = Date.now();
     const err = await withPanelMutationLock(async () => "unreachable", {
       timeoutMs: 1_200,
     }).catch((e: Error) => e);
+    const elapsed = Date.now() - started;
 
-    expect((err as Error).message).not.toMatch(/no longer\s+running/i);
+    // Asserting only the ABSENCE of a phrase would pass on any early unrelated
+    // error, proving nothing about waiting (review finding). Assert the positive
+    // outcome and the elapsed time.
+    expect((err as Error).message).toMatch(/Timed out/i);
+    expect((err as Error).message).not.toMatch(/Not waiting out the remaining timeout/i);
+    expect(elapsed).toBeGreaterThanOrEqual(1_000);
+  });
+
+  it("a FRESH lock with a dead owner is NOT fast-failed, however long we wait", async () => {
+    // The age gate. `reclaimAbandonedPanelLock` refuses on AGE before it ever
+    // consults a pid, and this module must not hold a second opinion about what
+    // freshness means. The budget is long enough for several probes, so a
+    // missing age gate would fire here rather than hide behind a short timeout —
+    // which is exactly how mutation M3 slipped through a first version of these
+    // tests once the two-observation rule slowed the fast path down.
+    writeLock(DEAD_PID, 60_000); // a minute old: dead owner, but FRESH
+    const { withPanelMutationLock } = await lockModule();
+
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 2_500,
+    }).catch((e: Error) => e);
+
+    expect((err as Error).message).toMatch(/Timed out/i);
+    expect((err as Error).message).not.toMatch(/Not waiting out the remaining timeout/i);
+  });
+
+  it("a DIFFERENT dead lock at the same path restarts the two-observation count", async () => {
+    // Identity, not merely "something dead is there". If the fingerprint ignored
+    // pid/startedAt, probe 2 would confirm the FIRST lock's observation against
+    // a second, unrelated one and fast-fail a full interval early.
+    //
+    // Correct: probe1 sees A, probe2 sees B (candidate resets), probe3 confirms
+    // B — so the refusal lands near 2 s, not 1 s. The elapsed bound is what
+    // separates the two behaviours.
+    writeLock(DEAD_PID, 20 * 60_000);
+    const { withPanelMutationLock } = await lockModule();
+    const swap = setTimeout(() => writeLock(DEAD_PID - 1, 20 * 60_000), 400);
+
+    const started = Date.now();
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 8_000,
+    }).catch((e: Error) => e);
+    const elapsed = Date.now() - started;
+    clearTimeout(swap);
+
+    expect((err as Error).message).toMatch(/Not waiting out the remaining timeout/i);
+    expect(elapsed).toBeGreaterThanOrEqual(1_800);
+  });
+
+  it("a lock REPLACED between probes resets the candidate and is not fast-failed", async () => {
+    // The TOCTOU the two-observation rule exists for: a dead+stale lock is seen,
+    // then a different holder takes the path before the next probe. Refusing on
+    // the stale reading would reject a legitimate current holder while claiming
+    // its owner is dead.
+    writeLock(DEAD_PID, 20 * 60_000);
+    const { withPanelMutationLock } = await lockModule();
+
+    // Swap in a LIVE, fresh lock BETWEEN the two probes. The first fires
+    // immediately and the second one probe-interval (1 s) later, so the swap has
+    // to land inside that window — at 1_200 ms it arrived after the fast path
+    // had already confirmed and thrown at ~1 s.
+    const swap = setTimeout(() => writeLock(process.pid, 1_000), 400);
+
+    const err = await withPanelMutationLock(async () => "unreachable", {
+      timeoutMs: 3_000,
+    }).catch((e: Error) => e);
+    clearTimeout(swap);
+
+    expect((err as Error).message).toMatch(/Timed out/i);
+    expect((err as Error).message).not.toMatch(/Not waiting out the remaining timeout/i);
   });
 });

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -691,6 +691,9 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
   // an orchestrator that died some time ago, and that is answerable at once).
   const LIVENESS_PROBE_MS = 1_000;
   let nextLivenessProbe = 0;
+  /** `pid@startedAt` of a dead+stale lock seen on the PREVIOUS probe. The fast
+   *  path fires only when the next probe sees the same one — see below. */
+  let deadOwnerCandidate: string | undefined;
 
   for (;;) {
     try {
@@ -916,7 +919,29 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
       if (Date.now() >= nextLivenessProbe) {
         nextLivenessProbe = Date.now() + LIVENESS_PROBE_MS;
         const early = observePanelLock(path);
-        if (early?.alive === false && early.ageMs >= STALE_LOCK_MS) {
+        // TWO CONSISTENT OBSERVATIONS, a probe interval apart (review finding).
+        //
+        // One reading is not enough to cut a wait short. Between observing a
+        // dead+stale lock and raising the refusal, another process can release
+        // and a third can take a FRESH one at the same path — and we would then
+        // reject a legitimate current holder while asserting its owner is dead.
+        // The deadline path does not have this problem: by then the full budget
+        // is spent and the refusal is owed regardless of what sits there now.
+        //
+        // Identity is `pid + startedAt` from the record, not the path. A
+        // replacement changes it and resets the candidate, so the fast path only
+        // fires on a lock that was demonstrably the same one for a full probe
+        // interval. It cannot close the window absolutely — nothing short of an
+        // atomic take can — but it converts "one glance" into "unchanged across
+        // a second", and the failure it protects is a false refusal, never a
+        // deletion.
+        const fingerprint =
+          early && early.alive === false && early.ageMs >= STALE_LOCK_MS
+            ? `${String(early.pid)}@${String(early.startedAt)}`
+            : undefined;
+        const confirmed = fingerprint !== undefined && fingerprint === deadOwnerCandidate;
+        deadOwnerCandidate = fingerprint;
+        if (confirmed && early) {
           throw new Error(
             `The panel operation lock at ${path} is held by a process that is no longer ` +
               `running. ${describeObservedLock(path, early)} Not waiting out the remaining ` +

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -684,6 +684,13 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
   assertNotWritingRealHomeInTests(path, "the panel operation lock");
   mkdirSync(dirname(path), { recursive: true });
   const deadline = Date.now() + timeoutMs;
+  // #1489 — throttle for the dead-owner probe below. The poll runs every 100 ms
+  // and `observePanelLock` does a stat + read, so probing on every tick would be
+  // ~600 syscall pairs over a full wait to answer a question that cannot change
+  // that fast. First probe fires immediately (the common case is a lock left by
+  // an orchestrator that died some time ago, and that is answerable at once).
+  const LIVENESS_PROBE_MS = 1_000;
+  let nextLivenessProbe = 0;
 
   for (;;) {
     try {
@@ -881,6 +888,46 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
             `Or do it by hand: stop or restart every comfyui-mcp orchestrator, verify ` +
             `none remain, delete this exact lock file, then retry.`,
         );
+      }
+      // #1489 — a PROVABLY DEAD owner is knowable now, so do not spend the rest
+      // of the 60 s discovering it. This is a latency narrowing ONLY: the outcome
+      // is the same refusal with the same remedy, delivered when it is first
+      // provable instead of at the deadline.
+      //
+      // Deliberately NOT an auto-reclaim. #779 made stale-lock recovery
+      // fail closed on purpose — a concurrent pre-upgrade orchestrator can
+      // replace an observed stale path with a fresh lock, so deleting on our own
+      // observation can destroy a live holder's lock. `panel_action:"unlock"`
+      // re-verifies under its own rules and stays the only path that removes
+      // anything.
+      //
+      // ONLY `alive === false` short-circuits. `"unsure"` is a recycled-pid
+      // maybe and MUST keep waiting — treating it as dead is the exact
+      // existence-for-identity fold `pidLiveness` was written to stop. `true`
+      // means a real operation may still be running.
+      // AGE GATES BEFORE LIVENESS, matching `reclaimAbandonedPanelLock`, which
+      // refuses on age before it ever consults a pid. A FRESH lock is protected
+      // even when its recorded owner is dead — that is a deliberate rule with
+      // its own test ("does NOT reclaim a fresh lock even when its recorded pid
+      // is dead"), and an early report that ignored it would be this module
+      // holding two different opinions about what freshness means. Short-cutting
+      // only the STALE case still covers the report, whose lock had been
+      // blocking long enough to need a manual unlock.
+      if (Date.now() >= nextLivenessProbe) {
+        nextLivenessProbe = Date.now() + LIVENESS_PROBE_MS;
+        const early = observePanelLock(path);
+        if (early?.alive === false && early.ageMs >= STALE_LOCK_MS) {
+          throw new Error(
+            `The panel operation lock at ${path} is held by a process that is no longer ` +
+              `running. ${describeObservedLock(path, early)} Not waiting out the remaining ` +
+              `timeout, and not deleting it either: a concurrent orchestrator could have ` +
+              `replaced it since it was observed. To clear a proven abandoned lock, run ` +
+              `install_comfyui(action:'panel', panel_action:'unlock') — it re-verifies that the recorded ` +
+              `owner is dead and the lock is old before deleting anything, and refuses ` +
+              `otherwise. Or do it by hand: stop or restart every comfyui-mcp orchestrator, ` +
+              `verify none remain, delete this exact lock file, then retry.`,
+          );
+        }
       }
       await sleep(POLL_MS);
     }

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -679,6 +679,18 @@ export function reclaimAbandonedPanelLock(): PanelLockReclaimResult {
   }
 }
 
+/** The `token` from a lock record, or undefined when it cannot be read. Used to
+ *  identify a lock across observations (#1489); pid+startedAt alone cannot. */
+function lockRecordToken(obs: { raw?: string }): string | undefined {
+  if (typeof obs.raw !== "string") return undefined;
+  try {
+    const t = (JSON.parse(obs.raw) as { token?: unknown }).token;
+    return typeof t === "string" ? t : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function acquireFileLock(timeoutMs: number): Promise<() => void> {
   const path = panelLockPath();
   assertNotWritingRealHomeInTests(path, "the panel operation lock");
@@ -935,15 +947,29 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
         // atomic take can — but it converts "one glance" into "unchanged across
         // a second", and the failure it protects is a false refusal, never a
         // deletion.
+        // The record's `token` is what makes a lock IDENTIFIABLE rather than
+        // merely attributable — it exists because pid+startedAt cannot
+        // distinguish two locks taken by the same process, and a replacement
+        // could in principle reuse both (review finding). Include it, and fall
+        // back to the raw record when it cannot be parsed, so an unreadable
+        // record can never fingerprint-match a different unreadable one.
         const fingerprint =
           early && early.alive === false && early.ageMs >= STALE_LOCK_MS
-            ? `${String(early.pid)}@${String(early.startedAt)}`
+            ? `${String(early.pid)}@${String(early.startedAt)}#${lockRecordToken(early) ?? `raw:${String(early.raw)}`}`
             : undefined;
         const confirmed = fingerprint !== undefined && fingerprint === deadOwnerCandidate;
         deadOwnerCandidate = fingerprint;
         if (confirmed && early) {
+          // Stated as an OBSERVATION, not as present-tense fact. The lock can
+          // still be replaced between this read and this throw — that window is
+          // inherent to observe-then-act and no amount of re-reading removes it
+          // (review, round 2). What two matching probes DO establish is that the
+          // sentence below was true for a full interval, which is a claim this
+          // can actually keep. The cost of being overtaken is one spurious error
+          // on a retryable operation; nothing is deleted either way.
           throw new Error(
-            `The panel operation lock at ${path} is held by a process that is no longer ` +
+            `The panel operation lock at ${path} was held, for at least the last ` +
+              `${Math.round(LIVENESS_PROBE_MS / 1000)}s, by a process that is no longer ` +
               `running. ${describeObservedLock(path, early)} Not waiting out the remaining ` +
               `timeout, and not deleting it either: a concurrent orchestrator could have ` +
               `replaced it since it was observed. To clear a proven abandoned lock, run ` +


### PR DESCRIPTION
Claims the **lock half** of #1489 — the part PR #1507 explicitly scoped out ("left out of this PR to keep it scoped"), not an oversight.

`acquireFileLock` polls until `Date.now() >= deadline` (60 s) and only **then** calls `observePanelLock` to describe what blocked it. Liveness is never consulted before the deadline, so a lock left behind by an orchestrator that died an hour ago costs a full minute before the user is told anything — and the thing they are told was knowable at once.

**This is a latency narrowing only.** Same refusal, same remedy, delivered when it first becomes provable.

Deliberately NOT an auto-reclaim: #779 made stale-lock recovery fail closed on purpose, because a concurrent pre-upgrade orchestrator can replace an observed stale path with a fresh lock. `panel_action:"unlock"` remains the only thing that deletes anything.

Only `alive === false` short-circuits. `"unsure"` — a pid that exists but a lock old enough that the number may have been recycled — keeps waiting; treating it as dead would be exactly the existence-for-identity fold `pidLiveness` was written to stop.

Verified against `origin/main`: the reporter's literal ("The lock is never auto-reclaimed…") is still there, and `reclaimAbandonedPanelLock` still has exactly one production caller (the manual unlock tool).