### PR TITLE
fix(1415): let the spawned child make the #952 drift comparison

### DIFF
--- a/src/__tests__/comfyui/child-panel-origin-drift.test.ts
+++ b/src/__tests__/comfyui/child-panel-origin-drift.test.ts
@@ -1,0 +1,165 @@
+// #1415 — `list_packs (action:"list_templates")` failed against a stale
+// COMFYUI_URL while the sidebar panel was connected and working, and the error
+// made no comparison between the two addresses.
+//
+// #952 had already built that comparison (describeTargetDrift), and #954 had
+// already made the failure name its target. Neither was the gap. The gap was
+// REACHABILITY: the comparison's origin source is injected from the bridge at
+// orchestrator startup, and `list_packs` — like every other headless comfyui
+// tool — runs in the SPAWNED stdio child, which loads orchestrator/index.js never
+// (boot.ts imports it only behind --panel-orchestrator) and has no bridge. So in
+// the one process where these failures happen the source was null, the comparison
+// returned "", and the reporter was told only that "a CONNECTED sidebar panel
+// does not imply this address is reachable" — while the orchestrator was holding
+// the answer: their panel was on :8188 and the call went to a dead COMFYUI_URL.
+//
+// These tests drive the CHILD's configuration: no injected source, only the
+// spawn-env channel dir. Before the fix every drift assertion here fails.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const { comfyuiFetch, setConnectedPanelOrigins } = await import("../../comfyui/fetch.js");
+const { publishConnectedPanelOrigins, resetPublishedPanelOrigins } = await import(
+  "../../services/panel-origin-channel.js"
+);
+
+/** The exact shape undici throws for the reporter's dead target. */
+function undiciFailure(code: string, detail: string): Error {
+  const cause = new Error(detail);
+  (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
+let dir = "";
+const savedEnv = process.env.COMFYUI_MCP_PROGRESS_DIR;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-child-drift-"));
+  process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  resetPublishedPanelOrigins();
+  // The child has NO bridge — this is the state the defect lived in.
+  setConnectedPanelOrigins(null);
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  else process.env.COMFYUI_MCP_PROGRESS_DIR = savedEnv;
+  rmSync(dir, { recursive: true, force: true });
+  resetPublishedPanelOrigins();
+  setConnectedPanelOrigins(null);
+  vi.restoreAllMocks();
+});
+
+/** Drive a real comfyuiFetch network failure and return the wrapped message. */
+async function failureText(target: string): Promise<string> {
+  vi.spyOn(globalThis, "fetch").mockRejectedValue(
+    undiciFailure("ERR_INVALID_URL", "bad port"),
+  );
+  try {
+    await comfyuiFetch(target);
+    throw new Error("expected comfyuiFetch to throw");
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+describe("#1415: a spawned comfyui child names the connected panel's origin", () => {
+  // The reported call, verbatim: COMFYUI_URL=http://127.0.0.1:9, panel on :8188.
+  it("says DIFFERENT for the reporter's own list_templates failure", async () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    const text = await failureText("http://127.0.0.1:9/api/workflow_templates");
+    expect(text).toContain("http://127.0.0.1:8188");
+    expect(text).toContain("a DIFFERENT address");
+    // …without losing the network diagnosis it is attached to.
+    expect(text).toContain("bad port");
+    expect(text).toContain("http://127.0.0.1:9/api/workflow_templates");
+  });
+
+  it("RULES OUT drift when the panel is on the same ComfyUI", async () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    const text = await failureText("http://127.0.0.1:8188/api/workflow_templates");
+    expect(text).toContain("NOT a wrong-address problem");
+    expect(text).not.toContain("a DIFFERENT address");
+  });
+
+  // An absent comparison is not a negative result, and the child must not invent
+  // one. No panel connected → the message reads exactly as it did before.
+  it("says nothing about drift when no panel has been published", async () => {
+    const text = await failureText("http://127.0.0.1:9/api/workflow_templates");
+    expect(text).not.toContain("a DIFFERENT address");
+    expect(text).not.toContain("NOT a wrong-address problem");
+    expect(text).toContain("does not imply this address is reachable");
+  });
+
+  // The stale-claim direction. A tab that disconnected must stop being quoted.
+  it("stops naming a panel once it disconnects", async () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    publishConnectedPanelOrigins(dir, []);
+    const text = await failureText("http://127.0.0.1:9/api/workflow_templates");
+    expect(text).not.toContain("a DIFFERENT address");
+    expect(text).not.toContain("8188");
+  });
+
+  // In the orchestrator process the bridge is both live and authoritative, so an
+  // injected source must keep winning — the channel is the fallback, not a merge.
+  it("an injected bridge source still wins over the channel", async () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    setConnectedPanelOrigins(() => ["http://10.0.0.9:8188"]);
+    const text = await failureText("http://127.0.0.1:9/api/workflow_templates");
+    expect(text).toContain("http://10.0.0.9:8188");
+    expect(text).not.toContain("127.0.0.1:8188");
+  });
+
+  // A channel that cannot be read must cost a sentence, never the real error.
+  it("still reports the real failure when the channel file is unreadable", async () => {
+    rmSync(dir, { recursive: true, force: true });
+    const text = await failureText("http://127.0.0.1:9/api/workflow_templates");
+    expect(text).toContain("bad port");
+    expect(text).toContain("http://127.0.0.1:9/api/workflow_templates");
+  });
+});
+
+// The publisher runs inside a closure in the orchestrator's own startup, which no
+// test can construct. What CAN be pinned is that the call sits in the function the 700ms
+// timer drives — the property a future edit is most likely to break by moving it
+// somewhere that runs once at startup, when no tab has connected yet.
+describe("#1415 WIRING: the orchestrator publishes on its existing poll tick", () => {
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(HERE, "../../orchestrator/index.ts"), "utf8");
+
+  it("imports the publisher", () => {
+    expect(src).toMatch(
+      /import \{ publishConnectedPanelOrigins \} from "\.\.\/services\/panel-origin-channel\.js";/,
+    );
+  });
+
+  it("publishes the BRIDGE's server-observed origins, inside pollDownloads", () => {
+    const open = src.indexOf("const pollDownloads = () => {");
+    // pollDownloads' body ends exactly where the timer that drives it is created.
+    const close = src.indexOf("const downloadTimer = setInterval(pollDownloads, 700);");
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    const body = src.slice(open, close);
+    expect(body).toMatch(
+      /publishConnectedPanelOrigins\(\s*progressDir,\s*bridge\.connectedServerOrigins\(\)\s*\)/,
+    );
+    // …and nowhere else, so this test is asking about the only call site.
+    expect(src.split("publishConnectedPanelOrigins(").length - 1).toBe(1);
+  });
+
+  it("still publishes the SERVER-OBSERVED origins, not the spoofable hello claim", () => {
+    // tabOrigin is hello.comfyui_url — page-JS-writable. Naming it here would put
+    // a tab-chosen address into a diagnostic the reader is invited to trust.
+    const open = src.indexOf("const pollDownloads = () => {");
+    const close = src.indexOf("const downloadTimer = setInterval(pollDownloads, 700);");
+    expect(src.slice(open, close)).not.toMatch(/publishConnectedPanelOrigins\([^)]*tabOrigin/);
+  });
+});

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -7,7 +7,7 @@
 // file covers the small file channel that carries the set across.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -255,6 +255,62 @@ describe("panel-origin channel — heartbeat", () => {
     // slower than the limit would expire a live orchestrator's record between
     // refreshes, silently losing the diagnostic on every long-stable session.
     expect(PANEL_ORIGINS_HEARTBEAT_MS * 2).toBeLessThanOrEqual(PANEL_ORIGINS_MAX_AGE_MS);
+  });
+});
+
+describe("panel-origin channel — the write is atomic (review r2)", () => {
+  it("leaves no .tmp behind, and the channel file is the only artefact", () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    expect(readdirSync(dir)).toEqual([PANEL_ORIGINS_FILE]);
+  });
+
+  it("replaces rather than truncating — a reader never sees an empty file", () => {
+    // The torn-read this exists to prevent: `writeFileSync` on the live path
+    // truncates and refills, so a child reading mid-write parses nothing and
+    // answers [] — dropping every live origin at exactly the moment it is
+    // formatting the error those origins explain.
+    //
+    // Asserted through inode/identity rather than by racing a real write, which
+    // would be a flaky test: a rename REPLACES the directory entry, so the file
+    // seen before the second publish is not the file seen after.
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, ["http://a:1"], now);
+    const before = statSync(join(dir, PANEL_ORIGINS_FILE));
+    publishConnectedPanelOrigins(dir, ["http://b:2"], now + 700);
+    const after = statSync(join(dir, PANEL_ORIGINS_FILE));
+    // Precondition asserted SEPARATELY and loudly. Folding it into the check
+    // below (`ino === ino && ino !== 0`) would make this pass silently on any
+    // platform that reports 0, which is how a test quietly stops testing.
+    // Windows and Linux both report a real value; if one ever does not, this
+    // fails and asks for a decision instead of going green.
+    expect(before.ino).not.toBe(0);
+    expect(after.ino).not.toBe(before.ino);
+    expect(readPublishedPanelOrigins(now + 700)).toEqual(["http://b:2"]);
+  });
+
+  it("cleans up and stays unpublished when the replace cannot happen", () => {
+    // Reaches the retry-then-give-up path WITHOUT mocking: a directory at the
+    // destination makes every `renameSync` attempt fail on both platforms.
+    // (`vi.spyOn(fsModule, "renameSync")` cannot do this — an ES module
+    // namespace object is frozen, so redefining a member throws.)
+    //
+    // Two things must hold, and the second is the one that matters: the temp is
+    // dropped rather than accumulating one file per tick, and the publisher does
+    // NOT record the set as published — otherwise the change-only rule would
+    // suppress every retry and the channel would be stuck on the old record for
+    // as long as the set stayed the same.
+    const now = Date.now();
+    const blocked = join(dir, PANEL_ORIGINS_FILE);
+    mkdirSync(blocked);
+    publishConnectedPanelOrigins(dir, ["http://b:2"], now);
+    expect(readdirSync(dir)).toEqual([PANEL_ORIGINS_FILE]); // no stray .tmp
+    expect(readdirSync(blocked)).toEqual([]); // …and nothing written inside it
+
+    // Clear the obstruction; the SAME set must still be written, proving the
+    // failed attempt did not mark it published.
+    rmSync(blocked, { recursive: true, force: true });
+    publishConnectedPanelOrigins(dir, ["http://b:2"], now + 700);
+    expect(readPublishedPanelOrigins(now + 700)).toEqual(["http://b:2"]);
   });
 });
 

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -1,0 +1,106 @@
+// #1415 — the orchestrator→child half of the #952 drift comparison.
+//
+// The comparison itself already shipped and is already tested
+// (fetch-failure-diagnostics.test.ts). What was missing is the transport: its
+// source is injected from the bridge, which only exists in the orchestrator
+// process, while every headless comfyui tool runs in a spawned stdio child. This
+// file covers the small file channel that carries the set across.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PANEL_ORIGINS_FILE,
+  publishConnectedPanelOrigins,
+  readPublishedPanelOrigins,
+  resetPublishedPanelOrigins,
+} from "../../services/panel-origin-channel.js";
+import { CONTROL_PREFIX, listTargetChangeRequests } from "../../services/download-progress.js";
+
+let dir = "";
+const savedEnv = process.env.COMFYUI_MCP_PROGRESS_DIR;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-origins-"));
+  // The CHILD's view of the channel: the orchestrator hands it this dir in the
+  // spawn env (buildComfyuiMcpEnv → COMFYUI_MCP_PROGRESS_DIR).
+  process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  resetPublishedPanelOrigins();
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  else process.env.COMFYUI_MCP_PROGRESS_DIR = savedEnv;
+  rmSync(dir, { recursive: true, force: true });
+  resetPublishedPanelOrigins();
+});
+
+describe("panel-origin channel", () => {
+  it("carries the origins the orchestrator published", () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    expect(readPublishedPanelOrigins()).toEqual(["http://127.0.0.1:8188"]);
+  });
+
+  // The direction that matters most: a stale claim is worse than no claim. The
+  // publisher is level-triggered on the orchestrator's poll tick, so a tab that
+  // disconnects blanks the file rather than leaving the child quoting a panel
+  // that is gone.
+  it("BLANKS when the last panel disconnects", () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    publishConnectedPanelOrigins(dir, []);
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("reads nothing when there is no channel — a plain MCP server", () => {
+    delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("reads nothing when nothing has been published yet", () => {
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("reads nothing from a mid-write or corrupt file", () => {
+    writeFileSync(join(dir, PANEL_ORIGINS_FILE), '{"origins": ["http://127.');
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("ignores a payload whose origins are not strings", () => {
+    writeFileSync(join(dir, PANEL_ORIGINS_FILE), JSON.stringify({ origins: [1, null, "", "http://a:1"] }));
+    expect(readPublishedPanelOrigins()).toEqual(["http://a:1"]);
+  });
+
+  it("survives an unwritable directory instead of throwing into the poll tick", () => {
+    expect(() => publishConnectedPanelOrigins(join(dir, "nope", "\0bad"), ["http://a:1"])).not.toThrow();
+  });
+
+  it("does nothing at all without a dir", () => {
+    publishConnectedPanelOrigins("", ["http://127.0.0.1:8188"]);
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  // This runs on a 700ms tick for the life of the orchestrator.
+  it("writes only when the set changed", () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    const first = readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8");
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    expect(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8")).toBe(first);
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8189"]);
+    expect(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8")).not.toBe(first);
+  });
+});
+
+// The progress dir is shared with the download tray and the target-change
+// control channel. This file must be invisible to both, and the only thing
+// making that true is its name.
+describe("the channel file cannot be mistaken for a download row or a request", () => {
+  it("carries the control prefix pollDownloads filters on", () => {
+    expect(PANEL_ORIGINS_FILE.startsWith(CONTROL_PREFIX)).toBe(true);
+  });
+
+  it("is not read as a pending target-change request", () => {
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
+    expect(listTargetChangeRequests(dir)).toEqual([]);
+  });
+});

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -7,7 +7,7 @@
 // file covers the small file channel that carries the set across.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -226,6 +226,30 @@ describe("panel-origin channel — heartbeat", () => {
     expect(readPublishedPanelOrigins(now + 700)).toEqual(["http://127.0.0.1:8189"]);
   });
 
+  it("does not rewrite when only the ORDER or duplication changed", () => {
+    // The change key used to be the caller's raw array while the payload was the
+    // filtered list, so the same connected panels arriving in a different order
+    // rewrote the file to say exactly the same thing (review r2).
+    // `connectedServerOrigins()` walks a live socket collection — ordering is not
+    // something to assume stable.
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, ["http://a:1", "http://b:2"], now);
+    const first = readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8");
+    publishConnectedPanelOrigins(dir, ["http://b:2", "http://a:1"], now + 700);
+    publishConnectedPanelOrigins(dir, ["http://a:1", "http://a:1", "http://b:2"], now + 1_400);
+    publishConnectedPanelOrigins(dir, ["http://a:1", "", "http://b:2"], now + 2_100);
+    expect(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8")).toBe(first);
+  });
+
+  it("publishes a deduped, ordered set — and a real change still writes", () => {
+    // The other direction, so the test above cannot be satisfied by never writing.
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, ["http://b:2", "http://a:1", "http://a:1"], now);
+    expect(readPublishedPanelOrigins(now)).toEqual(["http://a:1", "http://b:2"]);
+    publishConnectedPanelOrigins(dir, ["http://a:1"], now + 700);
+    expect(readPublishedPanelOrigins(now + 700)).toEqual(["http://a:1"]);
+  });
+
   it("the heartbeat stays comfortably inside the age limit", () => {
     // The two constants are only correct RELATIVE to each other: a heartbeat
     // slower than the limit would expire a live orchestrator's record between
@@ -242,6 +266,16 @@ describe("panel-origin channel — bounded read (review, finding 3)", () => {
       join(dir, PANEL_ORIGINS_FILE),
       JSON.stringify({ origins: ["http://127.0.0.1:8188"], updated: Date.now(), pid: process.pid, pad: "x".repeat(70_000) }),
     );
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("refuses a path that is not a regular file", () => {
+    // The bound is only meaningful if the thing opened is a file. A directory at
+    // this path used to reach readFileSync; now fstat on the opened descriptor
+    // answers first. (The FIFO case this also covers cannot be built portably —
+    // Windows has no mkfifo — so a directory stands in for "not a regular file".)
+    rmSync(join(dir, PANEL_ORIGINS_FILE), { force: true });
+    mkdirSync(join(dir, PANEL_ORIGINS_FILE));
     expect(readPublishedPanelOrigins()).toEqual([]);
   });
 

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -8,10 +8,13 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   PANEL_ORIGINS_FILE,
+  PANEL_ORIGINS_HEARTBEAT_MS,
+  PANEL_ORIGINS_MAX_AGE_MS,
   publishConnectedPanelOrigins,
   readPublishedPanelOrigins,
   resetPublishedPanelOrigins,
@@ -67,7 +70,13 @@ describe("panel-origin channel", () => {
   });
 
   it("ignores a payload whose origins are not strings", () => {
-    writeFileSync(join(dir, PANEL_ORIGINS_FILE), JSON.stringify({ origins: [1, null, "", "http://a:1"] }));
+    // Carries pid/updated because the record format gained them (review, finding
+    // 1) — without those the reader now answers [] for a different reason and
+    // this would pass while proving nothing about the string filter.
+    writeFileSync(
+      join(dir, PANEL_ORIGINS_FILE),
+      JSON.stringify({ origins: [1, null, "", "http://a:1"], updated: Date.now(), pid: process.pid }),
+    );
     expect(readPublishedPanelOrigins()).toEqual(["http://a:1"]);
   });
 
@@ -102,5 +111,145 @@ describe("the channel file cannot be mistaken for a download row or a request", 
   it("is not read as a pending target-change request", () => {
     publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8188"]);
     expect(listTargetChangeRequests(dir)).toEqual([]);
+  });
+});
+
+// ── Staleness across the publisher's death (review, finding 1) ──────────────
+//
+// The blank-on-disconnect rule holds only while the orchestrator is alive to run
+// its tick. Killed, it leaves its last record on disk in a directory that
+// outlives it, and the drift sentence is one an agent acts on — quoting a panel
+// that has not existed since yesterday is worse than the generic message.
+
+/** A pid that is definitely NOT running: spawn something trivial, wait for it to
+ *  exit, and use its pid. Deterministic, unlike picking a large number. */
+function deadPid(): number {
+  const done = spawnSync(process.execPath, ["-e", "0"]);
+  if (typeof done.pid !== "number") throw new Error("could not obtain a dead pid");
+  return done.pid;
+}
+
+/** Write a record by hand — the publisher always stamps its OWN pid, so a record
+ *  from another (dead) process cannot be produced through the public API. */
+function writeRecord(record: unknown): void {
+  writeFileSync(join(dir, PANEL_ORIGINS_FILE), JSON.stringify(record));
+}
+
+describe("panel-origin channel — staleness", () => {
+  const origins = ["http://127.0.0.1:8188"];
+
+  it("ignores a record whose publisher is gone", () => {
+    writeRecord({ origins, updated: Date.now(), pid: deadPid() });
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("ignores a record with NO pid — an old-format file proves nothing", () => {
+    // The pre-review format. Reading it as live would be exactly the bug.
+    writeRecord({ origins, updated: Date.now() });
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("ignores a stale record even when the pid is alive (pid reuse)", () => {
+    // The hole a bare liveness check leaves: the OS handed the dead
+    // orchestrator's pid to something unrelated, which is alive and answers yes.
+    writeRecord({ origins, updated: Date.now() - PANEL_ORIGINS_MAX_AGE_MS - 1, pid: process.pid });
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("ignores a record stamped in the FUTURE", () => {
+    // A clock step must not read as maximally fresh — `now - updated` goes
+    // negative and would pass a naive age comparison forever.
+    writeRecord({ origins, updated: Date.now() + 60_000, pid: process.pid });
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("accepts a live, fresh record", () => {
+    // The direction that must keep working: everything above rejects, so a test
+    // that only asserted rejection could pass with the reader hard-wired to [].
+    writeRecord({ origins, updated: Date.now(), pid: process.pid });
+    expect(readPublishedPanelOrigins()).toEqual(origins);
+  });
+
+  it("accepts a record right up to the age limit, and not past it", () => {
+    const now = Date.now();
+    writeRecord({ origins, updated: now - PANEL_ORIGINS_MAX_AGE_MS + 1_000, pid: process.pid });
+    expect(readPublishedPanelOrigins(now)).toEqual(origins);
+    writeRecord({ origins, updated: now - PANEL_ORIGINS_MAX_AGE_MS - 1_000, pid: process.pid });
+    expect(readPublishedPanelOrigins(now)).toEqual([]);
+  });
+
+  it("the publisher stamps its own pid, so its OWN record reads back", () => {
+    // Ties the two halves together: whatever the writer stamps must be what the
+    // reader accepts. Asserted through the public API rather than by inspecting
+    // the JSON, so a change to the field name fails here too.
+    publishConnectedPanelOrigins(dir, origins);
+    expect(readPublishedPanelOrigins()).toEqual(origins);
+    const raw = JSON.parse(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8"));
+    expect(raw.pid).toBe(process.pid);
+  });
+});
+
+describe("panel-origin channel — heartbeat", () => {
+  const origins = ["http://127.0.0.1:8188"];
+
+  it("does NOT rewrite an unchanged set on every tick", () => {
+    // The property the change-only rule exists for: at a 700ms tick, writing per
+    // tick is ~86k writes an hour to say nothing changed.
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, origins, now);
+    const first = readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8");
+    publishConnectedPanelOrigins(dir, origins, now + 700);
+    publishConnectedPanelOrigins(dir, origins, now + 1_400);
+    expect(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8")).toBe(first);
+  });
+
+  it("DOES refresh an unchanged set once the heartbeat is due", () => {
+    // …and the reason it must: an unrefreshed record is indistinguishable from
+    // one left by a process that died, so a legitimately-unchanged set has to
+    // keep proving someone is home.
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, origins, now);
+    const first = JSON.parse(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8"));
+    publishConnectedPanelOrigins(dir, origins, now + PANEL_ORIGINS_HEARTBEAT_MS);
+    const second = JSON.parse(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8"));
+    expect(second.updated).toBeGreaterThan(first.updated);
+    expect(second.origins).toEqual(first.origins);
+  });
+
+  it("a change writes immediately, without waiting for the heartbeat", () => {
+    const now = Date.now();
+    publishConnectedPanelOrigins(dir, origins, now);
+    publishConnectedPanelOrigins(dir, ["http://127.0.0.1:8189"], now + 700);
+    // Read on the SAME clock the write used. Reading on the wall clock would put
+    // `updated` 700ms in the future and trip the clock-step guard — the test
+    // would fail for a reason that has nothing to do with what it asserts.
+    expect(readPublishedPanelOrigins(now + 700)).toEqual(["http://127.0.0.1:8189"]);
+  });
+
+  it("the heartbeat stays comfortably inside the age limit", () => {
+    // The two constants are only correct RELATIVE to each other: a heartbeat
+    // slower than the limit would expire a live orchestrator's record between
+    // refreshes, silently losing the diagnostic on every long-stable session.
+    expect(PANEL_ORIGINS_HEARTBEAT_MS * 2).toBeLessThanOrEqual(PANEL_ORIGINS_MAX_AGE_MS);
+  });
+});
+
+describe("panel-origin channel — bounded read (review, finding 3)", () => {
+  it("ignores an oversized file instead of parsing it", () => {
+    // This read happens while formatting a network failure. A huge file must not
+    // delay the error it is being read to explain.
+    writeFileSync(
+      join(dir, PANEL_ORIGINS_FILE),
+      JSON.stringify({ origins: ["http://127.0.0.1:8188"], updated: Date.now(), pid: process.pid, pad: "x".repeat(70_000) }),
+    );
+    expect(readPublishedPanelOrigins()).toEqual([]);
+  });
+
+  it("still reads a normal-sized record", () => {
+    writeFileSync(
+      join(dir, PANEL_ORIGINS_FILE),
+      JSON.stringify({ origins: ["http://127.0.0.1:8188"], updated: Date.now(), pid: process.pid }),
+    );
+    expect(readPublishedPanelOrigins()).toEqual(["http://127.0.0.1:8188"]);
   });
 });

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -1,6 +1,7 @@
 import { getComfyUIAuthHeaders } from "../config.js";
 import { describeFetchFailure, isBareFetchFailure } from "../utils/errors.js";
 import { sameOrigin } from "../utils/origin.js";
+import { readPublishedPanelOrigins } from "../services/panel-origin-channel.js";
 
 /** The request target, for the diagnostic. Never throws on an odd input. */
 export function targetOf(input: string | URL | Request): string {
@@ -34,6 +35,25 @@ function methodOf(input: string | URL | Request, init: RequestInit): string {
  */
 let connectedPanelOrigins: (() => string[]) | null = null;
 
+/**
+ * #1415 — WHERE THESE CALLS ACTUALLY RUN.
+ *
+ * Injection covers the orchestrator process, and almost nothing that fails this
+ * way lives there: every headless comfyui tool runs in the SPAWNED stdio child,
+ * which never loads orchestrator/index.js and has no bridge to inject from. So
+ * the comparison #952 built was silently skipped in exactly the sessions it was
+ * written for — the reporter's panel worked, `list_packs (action:"list_templates")`
+ * failed against a dead COMFYUI_URL, and the error made no comparison at all.
+ *
+ * The child reads the set the orchestrator publishes into the progress dir it
+ * already shares with it (services/panel-origin-channel.ts). Still a leaf
+ * dependency — a file read, not the bridge. An INJECTED source always wins: where
+ * the bridge is in the same process it is both fresher and authoritative.
+ */
+function panelOrigins(): string[] {
+  return connectedPanelOrigins ? connectedPanelOrigins() : readPublishedPanelOrigins();
+}
+
 /** Install the panel-origin source. Pass null to clear (tests, shutdown). */
 export function setConnectedPanelOrigins(fn: (() => string[]) | null): void {
   connectedPanelOrigins = fn;
@@ -62,14 +82,15 @@ function originOf(target: string): string | undefined {
  *                   the reader chasing the explanation the old text volunteered.
  *                   The panel reaches it from the browser; this process does not
  *                   (a firewall, a container boundary, a bound interface).
- *   - UNKNOWN     → no panel connected, no origin source installed, or the
- *                   handshake carried no usable Origin. Say nothing about drift;
- *                   an absent comparison is not a negative result.
+ *   - UNKNOWN     → no panel connected, no origin source installed AND nothing
+ *                   published on the channel, or the handshake carried no usable
+ *                   Origin. Say nothing about drift; an absent comparison is not
+ *                   a negative result.
  */
 export function describeTargetDrift(target: string): string {
   const origins = (() => {
     try {
-      return connectedPanelOrigins?.() ?? [];
+      return panelOrigins();
     } catch {
       return []; // a broken source must never replace the real network error
     }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -62,6 +62,7 @@ import {
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
+import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import { logger } from "../utils/logger.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
@@ -5572,6 +5573,15 @@ export async function runPanelOrchestrator(): Promise<void> {
     // no saved state
   }
   const pollDownloads = () => {
+    // #1415 — the OTHER half of the #952 drift comparison installed above. That
+    // source only serves THIS process, and the tools that fail with `fetch
+    // failed` run in the spawned comfyui children, which have no bridge. Publish
+    // the current set into the progress dir they already share so a child's
+    // failure can make the same comparison. Level-triggered on this tick (not on
+    // connect/disconnect events) so a tab that goes away blanks it within 700ms —
+    // the child must never quote a panel that has since disconnected. Writes only
+    // when the set changed.
+    publishConnectedPanelOrigins(progressDir, bridge.connectedServerOrigins());
     let files: string[] = [];
     try {
       files = readdirSync(progressDir).filter((f) => f.endsWith(".json"));

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -78,7 +78,17 @@
 // No-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — a plain (non-panel)
 // MCP server keeps the pre-#952 "" exactly as before.
 
-import { closeSync, constants, fstatSync, mkdirSync, openSync, readSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -121,6 +131,8 @@ function channelFile(dir?: string): string | null {
 let lastPublished: string | null = null;
 /** When this process last wrote the file, for the heartbeat below. */
 let lastWriteAt = 0;
+/** Distinguishes concurrent temp files from this process. */
+let publishSeq = 0;
 
 /** Refresh the record at least this often even when the set is UNCHANGED, so a
  *  reader can tell "still true" from "nobody has touched this since the
@@ -236,7 +248,37 @@ export function publishConnectedPanelOrigins(
   });
   try {
     mkdirSync(dir, { recursive: true });
-    writeFileSync(file, payload);
+    // Write-then-rename, NOT an in-place rewrite. `writeFileSync(file, …)`
+    // truncates and refills, so a child reading during that window sees a
+    // partial record, fails to parse, and answers [] — dropping every live
+    // origin at exactly the moment it is formatting the error those origins
+    // explain (review r2). A rename makes readers see the old record or the new
+    // one, never a torn one.
+    //
+    // Same shape as persistDownloadJob (download-progress.ts), including its
+    // reason for retrying: on Windows a reader briefly holding the target open
+    // makes rename fail transiently. On persistent failure the PRIOR complete
+    // record is left untouched and the temp dropped — the next tick retries, so
+    // this self-heals rather than degrading to a torn write.
+    const tmp = `${file}.${process.pid}-${publishSeq++}.tmp`;
+    writeFileSync(tmp, payload);
+    let renamed = false;
+    for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
+      try {
+        renameSync(tmp, file);
+        renamed = true;
+      } catch {
+        /* transient (e.g. Windows sharing violation) — retry */
+      }
+    }
+    if (!renamed) {
+      try {
+        rmSync(tmp, { force: true });
+      } catch {
+        /* ignore — a stray .tmp is not the channel file and is never read */
+      }
+      return; // do NOT record it as published; the next tick tries again
+    }
     lastPublished = key;
     lastWriteAt = now;
   } catch {

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -22,14 +22,40 @@
 //
 // LEVEL-TRIGGERED, not event-driven: the orchestrator re-publishes the CURRENT
 // set on its existing 700ms poll tick and writes only when it changed. A tab that
-// goes away therefore blanks the file within one tick, so the child can never
-// quote a panel that has disconnected — the one direction where being wrong
-// would be worse than saying nothing.
+// goes away therefore blanks the file within ONE TICK — so the worst case is a
+// failure raised inside that window quoting a panel that disconnected up to
+// ~700ms ago, not an unbounded stale claim. (An earlier version of this comment
+// said the child "can never" quote a disconnected panel. It can, for that
+// window; the bound is what makes it acceptable, so the bound is what is
+// written down. Review, finding 2.)
+//
+// ## Staleness across an orchestrator's DEATH (review, finding 1)
+//
+// The tick only blanks the file while the orchestrator is alive to run it. Kill
+// it — crash, task manager, a machine losing power — and the last record stays
+// on disk indefinitely, describing panels that are long gone. The progress dir
+// outlives the process, so the next orchestrator's children can read it before
+// its own first tick republishes.
+//
+// A plain `updated` comparison cannot fix that, because writes are CHANGE-ONLY:
+// a record that is legitimately unchanged for an hour is not stale, and a TTL
+// alone would expire it. So the record carries the publisher's `pid` and is
+// refreshed on a slow HEARTBEAT independent of change, and the reader requires
+// BOTH:
+//
+//   - the publishing process is still alive (`process.kill(pid, 0)`), which
+//     catches the death case immediately rather than after a timeout; and
+//   - the record was refreshed recently, which catches the case a bare pid check
+//     cannot — the OS reusing a dead orchestrator's pid for something unrelated.
+//
+// Either alone leaves a hole; together the failure mode is "says nothing", which
+// is the pre-#952 behaviour and costs a diagnostic sentence rather than
+// producing a wrong one.
 //
 // No-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — a plain (non-panel)
 // MCP server keeps the pre-#952 "" exactly as before.
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /** File name inside the progress dir. The `control-` prefix is load-bearing:
@@ -49,6 +75,42 @@ function channelFile(dir?: string): string | null {
 /** Last payload written by THIS process, so the 700ms tick writes only on a
  *  change rather than once per tick forever. */
 let lastPublished: string | null = null;
+/** When this process last wrote the file, for the heartbeat below. */
+let lastWriteAt = 0;
+
+/** Refresh the record at least this often even when the set is UNCHANGED, so a
+ *  reader can tell "still true" from "nobody has touched this since the
+ *  orchestrator died". 30s against a 700ms tick is ~2 writes a minute — the
+ *  change-only rule is what this exists to preserve, so it stays far away from
+ *  the per-tick write it replaced. */
+export const PANEL_ORIGINS_HEARTBEAT_MS = 30_000;
+
+/** How stale a record may be before the reader stops trusting it. Generous
+ *  against the heartbeat (4x) so ordinary scheduling jitter, a busy event loop,
+ *  or a slow disk never expires a live orchestrator's record — the cost of
+ *  expiring a good one is a lost diagnostic, but flapping would be worse. */
+export const PANEL_ORIGINS_MAX_AGE_MS = 120_000;
+
+/** A malformed or hostile-sized file must not delay the network error it is
+ *  being read to DESCRIBE (review, finding 3). The real payload is a handful of
+ *  origins; anything past this is not the file we wrote. */
+const MAX_CHANNEL_BYTES = 64 * 1024;
+
+/** Is the process that published this record still running?
+ *
+ *  `process.kill(pid, 0)` sends no signal — it only asks. EPERM means the pid
+ *  exists but belongs to another user, which still answers "alive". Anything
+ *  unreadable answers false, because this gates a claim and an unanswerable
+ *  question must not grant it. */
+function publisherAlive(pid: unknown): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
 
 /**
  * Orchestrator side: publish the origins the connected tabs actually front.
@@ -60,21 +122,32 @@ let lastPublished: string | null = null;
  * Best-effort: a failed write leaves the child on the previous value or on "",
  * which costs a diagnostic sentence and never a wrong one.
  */
-export function publishConnectedPanelOrigins(dir: string, origins: readonly string[]): void {
+export function publishConnectedPanelOrigins(
+  dir: string,
+  origins: readonly string[],
+  now: number = Date.now(),
+): void {
   const file = channelFile(dir);
   if (!file) return;
-  const payload = JSON.stringify({
-    origins: origins.filter((o) => typeof o === "string" && o !== ""),
-    updated: Date.now(),
-  });
   // Compare WITHOUT the timestamp — otherwise every tick differs and this writes
   // 86k files an hour to say nothing changed.
   const key = JSON.stringify(origins);
-  if (key === lastPublished) return;
+  // …but DO write when the heartbeat is due, even unchanged: an unrefreshed
+  // record is exactly what a dead orchestrator leaves behind, so "unchanged" and
+  // "nobody is home" have to be distinguishable on disk.
+  const changed = key !== lastPublished;
+  const heartbeatDue = now - lastWriteAt >= PANEL_ORIGINS_HEARTBEAT_MS;
+  if (!changed && !heartbeatDue) return;
+  const payload = JSON.stringify({
+    origins: origins.filter((o) => typeof o === "string" && o !== ""),
+    updated: now,
+    pid: process.pid,
+  });
   try {
     mkdirSync(dir, { recursive: true });
     writeFileSync(file, payload);
     lastPublished = key;
+    lastWriteAt = now;
   } catch {
     // ignore — retried on the next tick
   }
@@ -84,6 +157,7 @@ export function publishConnectedPanelOrigins(dir: string, origins: readonly stri
  *  publish writes unconditionally. */
 export function resetPublishedPanelOrigins(): void {
   lastPublished = null;
+  lastWriteAt = 0;
 }
 
 /**
@@ -92,12 +166,34 @@ export function resetPublishedPanelOrigins(): void {
  * mid-write. `[]` means UNKNOWN and the caller must say nothing about drift —
  * never "there is no drift".
  */
-export function readPublishedPanelOrigins(): string[] {
+export function readPublishedPanelOrigins(now: number = Date.now()): string[] {
   const file = channelFile();
   if (!file) return [];
   try {
-    const raw = JSON.parse(readFileSync(file, "utf-8")) as { origins?: unknown };
+    // Size FIRST. This runs while formatting a network failure, so a file that
+    // is huge (or is not our file at all) must not delay the error it exists to
+    // explain (review, finding 3).
+    if (statSync(file).size > MAX_CHANNEL_BYTES) return [];
+    const raw = JSON.parse(readFileSync(file, "utf-8")) as {
+      origins?: unknown;
+      updated?: unknown;
+      pid?: unknown;
+    };
     if (!Array.isArray(raw?.origins)) return [];
+    // A record whose publisher is gone describes panels that are gone with it.
+    // Both checks, for the reasons in the header: liveness catches the death,
+    // freshness catches a reused pid.
+    if (!publisherAlive(raw.pid)) return [];
+    // A missing or non-numeric stamp becomes 0, which the age comparison below
+    // rejects on its own — `now - 0` is ~55 years. An explicit `updated <= 0`
+    // guard was written here and removed: mutation testing showed deleting it
+    // killed nothing, because it is unreachable behind that arithmetic for any
+    // clock later than 1970. Redundant code that looks load-bearing is its own
+    // hazard.
+    const updated = typeof raw.updated === "number" ? raw.updated : 0;
+    // `updated > now` (a clock step, or a future-dated write) is NOT freshness
+    // evidence — without this it would read as maximally fresh, forever.
+    if (updated > now || now - updated > PANEL_ORIGINS_MAX_AGE_MS) return [];
     return raw.origins.filter((o): o is string => typeof o === "string" && o !== "");
   } catch {
     return [];

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -1,0 +1,105 @@
+// Connected-panel origins, ORCHESTRATOR → spawned MCP child (#1415).
+//
+// #952 built the drift comparison (describeTargetDrift, comfyui/fetch.ts): when a
+// ComfyUI call fails at the network layer, say whether a CONNECTED panel is on a
+// different ComfyUI than the address that failed. The orchestrator installs its
+// source from the bridge (orchestrator/index.ts, setConnectedPanelOrigins).
+//
+// But the orchestrator is not where those calls happen. Every headless comfyui
+// tool — `list_packs (action:"list_templates")` among them — runs in the SPAWNED
+// stdio child (`node dist/index.js`), which loads orchestrator/index.js never
+// (boot.ts imports it only for --panel-orchestrator) and has no bridge. So the
+// source was null there, the comparison returned "", and #1415's reporter got the
+// generic "a CONNECTED sidebar panel does not imply this address is reachable"
+// while the orchestrator was sitting on the exact answer: their panel was on
+// :8188 and the call went to the dead COMFYUI_URL.
+//
+// This is the missing HALF of that channel, and it reuses the plumbing the
+// control channel already proved (services/download-progress.ts): a small JSON
+// file in COMFYUI_MCP_PROGRESS_DIR, which the orchestrator shares with every
+// child it spawns. Named with the same `control-` prefix, so the tray poll and
+// the target-change reader both skip it.
+//
+// LEVEL-TRIGGERED, not event-driven: the orchestrator re-publishes the CURRENT
+// set on its existing 700ms poll tick and writes only when it changed. A tab that
+// goes away therefore blanks the file within one tick, so the child can never
+// quote a panel that has disconnected — the one direction where being wrong
+// would be worse than saying nothing.
+//
+// No-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — a plain (non-panel)
+// MCP server keeps the pre-#952 "" exactly as before.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** File name inside the progress dir. The `control-` prefix is load-bearing:
+ *  pollDownloads and listTargetChangeRequests both filter on it, so this file is
+ *  never mistaken for a download row or a target-change request. Kept as a
+ *  literal (not an import of CONTROL_PREFIX) so this module stays a leaf that
+ *  comfyui/fetch.ts can depend on; a test pins the two together. */
+export const PANEL_ORIGINS_FILE = "control-panel-origins.json";
+
+/** Read at CALL time, not at module load: a test can point the channel at a temp
+ *  dir, and nothing in production changes it after spawn anyway. */
+function channelFile(dir?: string): string | null {
+  const base = dir ?? process.env.COMFYUI_MCP_PROGRESS_DIR ?? "";
+  return base ? join(base, PANEL_ORIGINS_FILE) : null;
+}
+
+/** Last payload written by THIS process, so the 700ms tick writes only on a
+ *  change rather than once per tick forever. */
+let lastPublished: string | null = null;
+
+/**
+ * Orchestrator side: publish the origins the connected tabs actually front.
+ *
+ * `dir` is EXPLICIT because the orchestrator's own COMFYUI_MCP_PROGRESS_DIR is
+ * unset — it computes progressDir itself and only the children inherit it (the
+ * same reason listTargetChangeRequests takes a dir).
+ *
+ * Best-effort: a failed write leaves the child on the previous value or on "",
+ * which costs a diagnostic sentence and never a wrong one.
+ */
+export function publishConnectedPanelOrigins(dir: string, origins: readonly string[]): void {
+  const file = channelFile(dir);
+  if (!file) return;
+  const payload = JSON.stringify({
+    origins: origins.filter((o) => typeof o === "string" && o !== ""),
+    updated: Date.now(),
+  });
+  // Compare WITHOUT the timestamp — otherwise every tick differs and this writes
+  // 86k files an hour to say nothing changed.
+  const key = JSON.stringify(origins);
+  if (key === lastPublished) return;
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, payload);
+    lastPublished = key;
+  } catch {
+    // ignore — retried on the next tick
+  }
+}
+
+/** Test/shutdown hook: forget what this process last published, so the next
+ *  publish writes unconditionally. */
+export function resetPublishedPanelOrigins(): void {
+  lastPublished = null;
+}
+
+/**
+ * Child side: the origins the orchestrator last published, or `[]` when there is
+ * no channel (a plain MCP server), nothing has been published yet, or the file is
+ * mid-write. `[]` means UNKNOWN and the caller must say nothing about drift —
+ * never "there is no drift".
+ */
+export function readPublishedPanelOrigins(): string[] {
+  const file = channelFile();
+  if (!file) return [];
+  try {
+    const raw = JSON.parse(readFileSync(file, "utf-8")) as { origins?: unknown };
+    if (!Array.isArray(raw?.origins)) return [];
+    return raw.origins.filter((o): o is string => typeof o === "string" && o !== "");
+  } catch {
+    return [];
+  }
+}

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -52,11 +52,55 @@
 // is the pre-#952 behaviour and costs a diagnostic sentence rather than
 // producing a wrong one.
 //
+// ### What this still does NOT close, stated rather than implied
+//
+// Both remaining holes are the SAME shape — a dead publisher whose record is
+// younger than PANEL_ORIGINS_MAX_AGE_MS — and both are bounded by it:
+//
+//   - PID REUSE inside the window. The orchestrator crashes, the OS hands its
+//     pid to something unrelated that is alive, and the record has not yet aged
+//     out. Both checks pass for the remainder of the window.
+//   - A ZOMBIE publisher on Linux. A terminated-but-unreaped process still has a
+//     pid that `kill(pid, 0)` answers for, so liveness says yes while the
+//     orchestrator is gone. The heartbeat stopped when it died, so this expires
+//     on the same clock.
+//
+// Neither is closed by more checking of the same kind — a pid cannot prove it is
+// the same process that wrote, and only a lock or a handle the reader can
+// interrogate would settle it. That is not worth building here: the payload is a
+// DIAGNOSTIC SENTENCE, the worst outcome is naming an origin that stopped being
+// connected up to two minutes ago, it self-heals on the next read, and the
+// realistic path needs a child that outlived its own parent orchestrator (a live
+// one republishes within 30s, and within 700ms of starting). Recorded so the
+// next reader does not have to re-derive it — and so the bound is a number
+// somebody chose, not one that fell out.
+//
 // No-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — a plain (non-panel)
 // MCP server keeps the pre-#952 "" exactly as before.
 
-import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, constants, fstatSync, mkdirSync, openSync, readSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * The open flags, resolved at CALL time and defensively.
+ *
+ * Destructuring `constants` at module scope broke ten unrelated suites: this
+ * module is pulled in transitively by comfyui/fetch.ts, and a partial
+ * `vi.mock("node:fs")` that does not re-export `constants` makes the destructure
+ * throw during IMPORT — every test in the file then collects zero tests, with an
+ * error that names this line rather than the mock. Reading it inside the
+ * function means a mocked fs is simply a mocked fs.
+ *
+ * Falls back to the "r" string flag when the numbers are unavailable, so the
+ * open still happens; O_NONBLOCK is undefined on Windows, where the FIFO case it
+ * guards does not arise.
+ */
+function readFlags(): number | string {
+  const rd = constants?.O_RDONLY;
+  if (typeof rd !== "number") return "r";
+  const nonblock = constants?.O_NONBLOCK;
+  return rd | (typeof nonblock === "number" ? nonblock : 0);
+}
 
 /** File name inside the progress dir. The `control-` prefix is load-bearing:
  *  pollDownloads and listTargetChangeRequests both filter on it, so this file is
@@ -96,6 +140,43 @@ export const PANEL_ORIGINS_MAX_AGE_MS = 120_000;
  *  origins; anything past this is not the file we wrote. */
 const MAX_CHANNEL_BYTES = 64 * 1024;
 
+/**
+ * Read the channel file with a hard byte bound, through a single descriptor.
+ *
+ * Throws on anything unreadable, which the caller's catch turns into [] — the
+ * "say nothing" answer.
+ *
+ * O_NONBLOCK is part of the OPEN, not a detail of the read. A FIFO at this path
+ * blocks `openSync` itself until a writer arrives, so an fstat-based "is this a
+ * regular file?" check placed after the open can never run — the process is
+ * already parked, inside the error path, forever. (Written the other way first,
+ * with a comment claiming the fstat covered it. It did not.) Undefined on
+ * Windows, where the case does not arise, so it falls back to 0.
+ */
+function readChannelFile(file: string): string {
+  const fd = openSync(file, readFlags());
+  try {
+    const stat = fstatSync(fd);
+    // NOT covered by a portable test, and deliberately kept anyway. On Windows
+    // `openSync` already rejects a directory, and mkfifo does not exist there, so
+    // nothing this suite can build reaches this line — mutation testing correctly
+    // reports deleting it as killing no test. It states the POSIX case (a FIFO
+    // survives the non-blocking open and is not something to read), which is the
+    // reason the guard exists rather than an accident of the file layout.
+    if (!stat.isFile()) throw new Error("panel-origins channel is not a regular file");
+    if (stat.size > MAX_CHANNEL_BYTES) throw new Error("panel-origins channel is oversized");
+    // Sized from the fstat above, NOT re-clamped. A `Math.min(size, MAX)` here
+    // was removed: it is unreachable behind the check on the previous line, and
+    // worse, it MASKED it — an oversized file was truncated into a parse error,
+    // so the suite passed with either guard deleted and neither was proven.
+    const buf = Buffer.allocUnsafe(stat.size);
+    const read = readSync(fd, buf, 0, buf.length, 0);
+    return buf.subarray(0, read).toString("utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /** Is the process that published this record still running?
  *
  *  `process.kill(pid, 0)` sends no signal — it only asks. EPERM means the pid
@@ -129,9 +210,19 @@ export function publishConnectedPanelOrigins(
 ): void {
   const file = channelFile(dir);
   if (!file) return;
+  // What actually gets published: filtered, deduped, ordered. The comparison and
+  // the payload are both built from THIS, so they cannot disagree.
+  const published = [...new Set(origins.filter((o) => typeof o === "string" && o !== ""))].sort();
   // Compare WITHOUT the timestamp — otherwise every tick differs and this writes
   // 86k files an hour to say nothing changed.
-  const key = JSON.stringify(origins);
+  //
+  // …and compare the SET, not the caller's array. The key used to be
+  // `JSON.stringify(origins)` while the payload was the filtered list, so two
+  // ticks reporting the same connected panels in a different order — or with a
+  // duplicate, or with an empty string appearing and vanishing — rewrote the
+  // file to say exactly the same thing (review r2). `connectedServerOrigins()`
+  // walks a live socket collection, so ordering is not something to assume.
+  const key = JSON.stringify(published);
   // …but DO write when the heartbeat is due, even unchanged: an unrefreshed
   // record is exactly what a dead orchestrator leaves behind, so "unchanged" and
   // "nobody is home" have to be distinguishable on disk.
@@ -139,7 +230,7 @@ export function publishConnectedPanelOrigins(
   const heartbeatDue = now - lastWriteAt >= PANEL_ORIGINS_HEARTBEAT_MS;
   if (!changed && !heartbeatDue) return;
   const payload = JSON.stringify({
-    origins: origins.filter((o) => typeof o === "string" && o !== ""),
+    origins: published,
     updated: now,
     pid: process.pid,
   });
@@ -170,11 +261,14 @@ export function readPublishedPanelOrigins(now: number = Date.now()): string[] {
   const file = channelFile();
   if (!file) return [];
   try {
-    // Size FIRST. This runs while formatting a network failure, so a file that
-    // is huge (or is not our file at all) must not delay the error it exists to
-    // explain (review, finding 3).
-    if (statSync(file).size > MAX_CHANNEL_BYTES) return [];
-    const raw = JSON.parse(readFileSync(file, "utf-8")) as {
+    // Bounded read through ONE descriptor. `statSync` then `readFileSync` names
+    // the path twice, so the thing measured need not be the thing read — the
+    // file can grow or be replaced in between, and the bound applies to neither
+    // (review r2). Opening once and asking that fd for its size closes the gap,
+    // and reading into a fixed buffer bounds the work even if the answer is a
+    // lie. This runs while formatting a network failure; it must not delay the
+    // error it exists to explain.
+    const raw = JSON.parse(readChannelFile(file)) as {
       origins?: unknown;
       updated?: unknown;
       pid?: unknown;

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -134,6 +134,25 @@ let lastWriteAt = 0;
 /** Distinguishes concurrent temp files from this process. */
 let publishSeq = 0;
 
+/**
+ * A temp path no other writer can be using.
+ *
+ * pid + sequence alone is not unique: Node worker threads share `process.pid`
+ * and each initialises its own module state, so two workers both start at
+ * sequence 0 and pick the same name — one then renames the other's payload
+ * (review r3). Only one publisher exists today, which is exactly why this is
+ * worth making unconditional rather than relying on that staying true.
+ *
+ * NOT covered by a test, and mutation testing says so: stripping the entropy
+ * kills nothing, because a single-publisher suite cannot observe a collision.
+ * Kept as cheap insurance against a condition the tests cannot create, and
+ * recorded here so the next reader does not mistake the survivor for dead code.
+ */
+function tempPathFor(file: string): string {
+  const entropy = Math.random().toString(36).slice(2, 10);
+  return `${file}.${process.pid}-${publishSeq++}-${entropy}.tmp`;
+}
+
 /** Refresh the record at least this often even when the set is UNCHANGED, so a
  *  reader can tell "still true" from "nobody has touched this since the
  *  orchestrator died". 30s against a 700ms tick is ~2 writes a minute — the
@@ -260,25 +279,32 @@ export function publishConnectedPanelOrigins(
     // makes rename fail transiently. On persistent failure the PRIOR complete
     // record is left untouched and the temp dropped — the next tick retries, so
     // this self-heals rather than degrading to a torn write.
-    const tmp = `${file}.${process.pid}-${publishSeq++}.tmp`;
-    writeFileSync(tmp, payload);
+    const tmp = tempPathFor(file);
     let renamed = false;
-    for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
-      try {
-        renameSync(tmp, file);
-        renamed = true;
-      } catch {
-        /* transient (e.g. Windows sharing violation) — retry */
+    try {
+      writeFileSync(tmp, payload);
+      for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
+        try {
+          renameSync(tmp, file);
+          renamed = true;
+        } catch {
+          /* transient (e.g. Windows sharing violation) — retry */
+        }
+      }
+    } finally {
+      // In a `finally`, so a THROWING write is cleaned up too. With the removal
+      // sitting after the loop instead, a `writeFileSync` that failed partway —
+      // a full disk is the ordinary cause — left its partial temp behind and
+      // added another on every tick thereafter (review r3).
+      if (!renamed) {
+        try {
+          rmSync(tmp, { force: true });
+        } catch {
+          /* ignore — a stray .tmp is not the channel file and is never read */
+        }
       }
     }
-    if (!renamed) {
-      try {
-        rmSync(tmp, { force: true });
-      } catch {
-        /* ignore — a stray .tmp is not the channel file and is never read */
-      }
-      return; // do NOT record it as published; the next tick tries again
-    }
+    if (!renamed) return; // do NOT record it as published; the next tick retries
     lastPublished = key;
     lastWriteAt = now;
   } catch {


### PR DESCRIPTION
Refs #1415.

## What it does

`describeTargetDrift` (#952) compares a failing target against connected panel origins. Its source is INJECTED, and the only installer runs inside `runPanelOrchestrator` — but every headless comfyui tool runs in the SPAWNED stdio child, which has no bridge. So the comparison was dead in exactly the process where these failures happen. The orchestrator now publishes the origins into the progress dir it already shares with the child, and the child reads them as a fallback.

## Scope, stated plainly

**This does not make `list_templates` succeed.** It makes the failure say which of the two addresses is at fault. The issue's actual ask — routing the template fetch through the panel — needs a new panel bridge command and a consumer that chooses by source. **So this must not close #1415.**

## Review round 1 — three findings, now resolved

**1 (High) — stale origins outlive the orchestrator.** The blank-on-disconnect rule holds only while the orchestrator is alive to run its tick. Kill it and the last record stays in a progress dir that outlives it, so a later child can quote panels that are long gone. The drift sentence is one an agent acts on, which makes a confidently wrong answer worse than the generic one.

A plain `updated` comparison cannot fix it, because writes are CHANGE-ONLY: a record legitimately unchanged for an hour is not stale, and a TTL alone would expire it. So the record now carries the publisher's `pid`, is refreshed on a 30s heartbeat independent of change, and the reader requires **both** liveness (`process.kill(pid, 0)`, which catches the death immediately) **and** freshness (which catches what a bare pid check cannot — a reused pid). A future-dated stamp is treated as unknown, not as maximally fresh.

The heartbeat is 30s against a 120s limit, and a test asserts *that relation* rather than the two numbers: they are only correct relative to each other, and a heartbeat slower than the limit would expire a LIVE orchestrator's record between refreshes.

**2 (High) — the disconnect window is real.** The comment claimed the child "can never" quote a disconnected panel. It can, for up to one 700ms tick. The bound is what makes it acceptable, so the bound is what is written down now.

**3 (Medium) — unbounded read in the error path.** Size-checked before parsing.

## Review round 2

**Bounded read, done properly.** `statSync` then `readFileSync` names the path twice, so the thing measured need not be the thing read. Now one descriptor: open, `fstat` *that fd*, reject non-regular files and oversized ones, read into a fixed buffer. `O_NONBLOCK` is part of the open — a FIFO at this path blocks `openSync` itself, so an fstat-based check placed after the open could never run. (It was written that way first, with a comment claiming the fstat covered it. It did not.)

**The change key described the wrong thing.** It compared the caller's raw array while the payload was the filtered list, so the same connected panels arriving in a different order — or with a duplicate, or an empty string appearing and vanishing — rewrote the file to say exactly the same thing. Both are now built from one deduped, sorted set.

**Two residuals, documented rather than implied.** Both are the same shape — a dead publisher whose record is younger than the age limit — and both are bounded by it: PID reuse inside the window, and a Linux zombie whose pid still answers `kill(pid, 0)`. Neither is closed by more checking of the same kind; only a lock or an interrogable handle would settle it. That is not worth building for a diagnostic sentence whose worst outcome is naming an origin that stopped being connected up to two minutes ago, which self-heals on the next read, and whose realistic path needs a child that outlived its own parent orchestrator. Recorded in the header so the bound is a number somebody chose.

## Verification

- 27 tests in the channel file, 33 across both #1415 files; full suite and lint green.
- **16 mutations, all applied and all killed**: removing or inverting the liveness check, trusting ESRCH as alive, dropping freshness, accepting a future stamp, not stamping the pid, disabling the heartbeat, firing it every tick, setting it slower than the age limit, never advancing `lastWriteAt`, both directions of the size bound, the raw-array change key, and dropping the dedupe or the ordering.
- Mutation testing changed the code three times, not just the tests:
  - an explicit `updated <= 0` guard **survived** — unreachable behind the age arithmetic for any clock later than 1970. Deleted rather than tested around.
  - a `Math.min(size, MAX)` clamp **masked** the size check: an oversized file was truncated into a parse error, so the suite passed with *either* guard deleted and neither was proven. Removing the clamp made the check provable, and it is now killed.
  - the `isFile()` guard survives and is **kept anyway**, with a note: Windows rejects a directory at `openSync` and has no mkfifo, so nothing this suite can build reaches that line. It states the POSIX case rather than an accident of the file layout.
- Two pre-existing tests changed, neither weakened: the non-string-origins case now carries pid/updated (without them the reader answers `[]` for a different reason, and it would have passed while proving nothing about the string filter), and the change-writes-immediately case reads on the same injected clock it writes with, since reading on the wall clock puts the stamp 700ms in the future and trips the clock-step guard.
