### PR TITLE
release: v0.51.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.39",
+  "version": "0.51.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.39",
+      "version": "0.51.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.39",
+  "version": "0.51.40",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.40 with the lock half of #1489.

`acquireFileLock` polled to a 60 s deadline and only then looked at what was blocking it, so a lock left by a dead orchestrator cost a full minute to report something provable immediately. It now reports as soon as it is provable.

**Latency only.** Same refusal, same remedy. Not an auto-reclaim — #779 made stale-lock recovery fail closed deliberately, and `panel_action:'unlock'` stays the only thing that deletes anything.

Three conditions gate it, each earned: the owner is provably absent (`"unsure"` keeps waiting), the lock is past `STALE_LOCK_MS` (matching the reclaim path's age-before-liveness rule), and **two probes a second apart see the same lock** — identified by pid + startedAt + token, so a replacement resets the candidate.

The residual observe-then-act window is inherent and is not papered over: the message now states what was observed over the last second rather than asserting present-tense fact.

Six mutations killed, including a straight revert, dropping the age gate, treating `"unsure"` as dead, an identity-free fingerprint, and deleting the lock on the fast path.