### PR TITLE
fix(1374): a relative interpreter path no longer sends a LOCAL download to Manager

### DIFF
--- a/src/__tests__/orchestrator/deferred-panel-tools.test.ts
+++ b/src/__tests__/orchestrator/deferred-panel-tools.test.ts
@@ -22,6 +22,7 @@ import { vi } from "vitest";
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/src/__tests__/orchestrator/startup-deadline.test.ts
+++ b/src/__tests__/orchestrator/startup-deadline.test.ts
@@ -28,6 +28,7 @@ import { fileURLToPath } from "node:url";
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 
 const { armStartupDeadline } = await import("../../orchestrator/index.js");

--- a/src/__tests__/services/custom-nodes-unreadable.test.ts
+++ b/src/__tests__/services/custom-nodes-unreadable.test.ts
@@ -40,6 +40,7 @@ const hoisted = vi.hoisted(() => ({
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 
 vi.mock("../../config.js", async () => {

--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -21,10 +21,14 @@ const hoisted = vi.hoisted(() => ({
   /** #1263 — the interpreter the live-process probe "finds", instead of whatever
    *  is really running on the developer's machine. undefined = nothing found. */
   livePython: undefined as string | undefined,
+  /** #1374 — the OS's own record of the running image, which is what the probe has
+   *  to work with when the launcher spelled the interpreter relatively (the stock
+   *  Windows portable bundle). undefined = the OS gave none either. */
+  liveImage: undefined as string | undefined,
   /** The stub itself, created here so the spec can assert BY IDENTITY that this
    *  is the function in force, and count the calls the code under test makes to
    *  it (codex). Its behaviour is installed in `beforeEach`. */
-  liveInterpreter: vi.fn() as ReturnType<typeof vi.fn>,
+  liveProcess: vi.fn() as ReturnType<typeof vi.fn>,
 }));
 
 // The live-root routing branch only streams local when the root exists locally.
@@ -48,7 +52,7 @@ vi.mock("../../services/workspace-env.js", async () => {
 });
 
 // #1263 — THE PROCESS TABLE IS NOT A FIXTURE. `resolveLiveServerRoot` falls back
-// to `observeLivePython()`, which calls `resolveLiveInterpreter` — and that
+// to `observeLivePython()`, which calls `observeLiveServerProcess` — and that
 // shells out to netstat/WMI to find whatever python is really serving the port
 // on THIS machine. So on a developer box with ComfyUI running, a relative
 // `main.py` argv anchors onto the live interpreter, a root resolves, the mocked
@@ -59,7 +63,7 @@ vi.mock("../../services/workspace-env.js", async () => {
 // That is why this file passed every CI run while failing locally: the assertion
 // depended on whether the machine running it happened to have a ComfyUI up.
 // Stubbed to "found nothing" by default, which is the state these cases describe;
-// `hoisted.livePython` opts a case into the other answer.
+// `hoisted.livePython` / `hoisted.liveImage` opt a case into the other answers.
 vi.mock("../../services/live-interpreter.js", async () => {
   const actual = await vi.importActual<typeof import("../../services/live-interpreter.js")>(
     "../../services/live-interpreter.js",
@@ -67,7 +71,7 @@ vi.mock("../../services/live-interpreter.js", async () => {
   // The stub is created in `vi.hoisted` and handed over here, so the spec can
   // assert BY IDENTITY that this is the function in force, and count the calls
   // the code under test makes to it (codex).
-  return { ...actual, resolveLiveInterpreter: hoisted.liveInterpreter };
+  return { ...actual, observeLiveServerProcess: hoisted.liveProcess };
 });
 
 // getSystemStats stands in for the connected server's /system_stats. getClient is
@@ -84,7 +88,7 @@ vi.mock("../../comfyui/client.js", () => ({
   }),
 }));
 
-import { resolveLiveInterpreter } from "../../services/live-interpreter.js";
+import { observeLiveServerProcess } from "../../services/live-interpreter.js";
 import { shouldDispatchDownloadToManager } from "../../services/model-resolver.js";
 
 beforeEach(() => {
@@ -94,12 +98,19 @@ beforeEach(() => {
   hoisted.statsThrows = false;
   hoisted.liveRootExists = true;
   hoisted.livePython = undefined;
+  hoisted.liveImage = undefined;
   // The stub is a spy now (so its calls can be counted), so its behaviour has to
   // be (re)installed here rather than living in the mock factory.
-  hoisted.liveInterpreter.mockReset();
-  hoisted.liveInterpreter.mockImplementation(() =>
-    hoisted.livePython ? { python: hoisted.livePython, pid: 4242 } : undefined,
-  );
+  hoisted.liveProcess.mockReset();
+  hoisted.liveProcess.mockImplementation(() => {
+    if (hoisted.livePython) {
+      return { python: hoisted.livePython, source: "process-table", pid: 4242, image: hoisted.liveImage };
+    }
+    // Only the OS image: the process was identified, but its argv[0] named no file
+    // we could probe (#1374).
+    if (hoisted.liveImage) return { pid: 4242, image: hoisted.liveImage };
+    return undefined;
+  });
 });
 
 // #1263 — THE STUB MUST BE PROVEN, NOT ASSUMED.
@@ -117,15 +128,15 @@ beforeEach(() => {
 // see whether the mock takes effect. This can, and it fails with its own name on
 // it rather than as a confusing routing assertion.
 describe("the live-process stub is actually in force (#1263)", () => {
-  it("the imported resolveLiveInterpreter IS this file's stub, by identity", () => {
+  it("the imported observeLiveServerProcess IS this file's stub, by identity", () => {
     // Identity, not behaviour (codex): a different implementation returning the
     // same two values would satisfy an output check.
     expect(
-      resolveLiveInterpreter,
+      observeLiveServerProcess,
       "vi.mock is not intercepting ../../services/live-interpreter.js — this file is " +
         "reading the REAL process table, so its assertions now depend on whether this " +
         "machine happens to have ComfyUI running (#1263).",
-    ).toBe(hoisted.liveInterpreter);
+    ).toBe(hoisted.liveProcess);
   });
 
   it("and the CODE UNDER TEST reaches that same stub — not another copy", async () => {
@@ -142,7 +153,7 @@ describe("the live-process stub is actually in force (#1263)", () => {
     await shouldDispatchDownloadToManager();
 
     expect(
-      hoisted.liveInterpreter.mock.calls.length,
+      hoisted.liveProcess.mock.calls.length,
       "the routing code never called the stubbed probe, so it is resolving a DIFFERENT " +
         "copy of live-interpreter than this file mocked — the stub is inert for the " +
         "assertions that depend on it (#1263).",
@@ -154,7 +165,10 @@ describe("the live-process stub is actually in force (#1263)", () => {
     // default proves nothing on its own.
     try {
       hoisted.livePython = "C:/probe/python.exe";
-      expect(resolveLiveInterpreter()).toEqual({ python: "C:/probe/python.exe", pid: 4242 });
+      expect(observeLiveServerProcess()).toMatchObject({
+        python: "C:/probe/python.exe",
+        pid: 4242,
+      });
     } finally {
       // Restored here rather than left to beforeEach, so a failure above cannot
       // leave the fixture mutated for anything that runs before it (codex).
@@ -267,6 +281,37 @@ describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
     hoisted.base = undefined;
     hoisted.stats = { system: { argv: ["main.py", "--listen"] } };
     hoisted.livePython = "/opt/comfy/.venv/bin/python";
+    hoisted.liveRootExists = false;
+
+    expect(await shouldDispatchDownloadToManager()).toBe(true);
+  });
+
+  // #1374 — THE ROUTE, not just the anchor. A LOCAL Windows install could download
+  // nothing: no COMFYUI_PATH, a relative `main.py` with no cwd, and a launcher that
+  // spelled the interpreter relatively (`.\python_embeded\python.exe`, or a bare
+  // `python` from an activated venv). argv[0] then named no file, the probe reported
+  // no interpreter, no root resolved, and every download was handed to a
+  // ComfyUI-Manager that was not serving its routes — a hard failure for a capability
+  // that needs no Manager at all.
+  //
+  // This is the decision that has to change, so it is asserted here and not only on
+  // the resolver: the OS image is enough to keep the download LOCAL.
+  it("#1374: no local base + a probe that could only report the OS IMAGE → streams local", async () => {
+    hoisted.base = undefined;
+    hoisted.stats = { system: { argv: ["main.py", "--windows-standalone-build"] } };
+    hoisted.livePython = undefined; // relative argv[0] — no interpreter answer
+    hoisted.liveImage = "/portable/python_embeded/python.exe";
+    hoisted.liveRootExists = true;
+
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+
+  it("#1374: an OS image whose anchored root is NOT on this filesystem still routes to Manager", async () => {
+    // The image is a weaker reading, not a privileged one: it earns a LOCAL route on
+    // exactly the same evidence an interpreter does, and no more.
+    hoisted.base = undefined;
+    hoisted.stats = { system: { argv: ["main.py", "--windows-standalone-build"] } };
+    hoisted.liveImage = "/portable/python_embeded/python.exe";
     hoisted.liveRootExists = false;
 
     expect(await shouldDispatchDownloadToManager()).toBe(true);

--- a/src/__tests__/services/env-capabilities-argv-contradiction.test.ts
+++ b/src/__tests__/services/env-capabilities-argv-contradiction.test.ts
@@ -20,6 +20,9 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 const resolveLiveInterpreterMock = vi.fn();
 vi.mock("../../services/live-interpreter.js", () => ({
   resolveLiveInterpreter: (...a: unknown[]) => resolveLiveInterpreterMock(...a),
+  // The same observation, uncollapsed (#1374). Stubbed alongside its wrapper so
+  // nothing this file loads can reach the real netstat/WMI probe.
+  observeLiveServerProcess: (...a: unknown[]) => resolveLiveInterpreterMock(...a),
 }));
 
 const comfyuiFetchMock = vi.fn();

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import {
   argv0FromCommandLine,
@@ -9,6 +9,7 @@ import {
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
   getLaunchedInterpreterRecord,
+  observeLiveServerProcess,
   resolveLiveInterpreter,
 } from "../../services/live-interpreter.js";
 
@@ -294,6 +295,136 @@ describe("resolveLiveInterpreter — ground truth only (#401)", () => {
         readIdentity: () => {
           throw new Error("wmi exploded");
         },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1374 — THE OS KNOWS WHERE THE PROCESS LIVES EVEN WHEN argv[0] DOES NOT SAY.
+//
+// A LOCAL Windows install could not download anything: every attempt was routed to
+// ComfyUI-Manager and died on "Manager's queue API is not reachable". The route is
+// chosen when no local models directory can be resolved, and the tier built for the
+// relative-`main.py` shape re-anchors that path on the interpreter the OS reports —
+// but it fails closed on a RELATIVE argv[0], which is exactly how the stock Windows
+// portable bundle launches (`.\python_embeded\python.exe -s ComfyUI\main.py`) and
+// how an activated venv launches (a bare `python`). Measured on Windows 11: the
+// command line the OS records is the literal launch string, so argv[0] comes back
+// relative, while `Win32_Process.ExecutablePath` is absolute for the same process.
+//
+// Failing closed is RIGHT for the interpreter question (#401) and wrong for the
+// anchor question, so the two answers are now reported separately rather than one
+// being widened.
+// ---------------------------------------------------------------------------
+describe("observeLiveServerProcess — the OS image survives a relative argv[0] (#1374)", () => {
+  it("reports NO interpreter but DOES report the image for a relative argv[0]", async () => {
+    const exe = await makeExe("python.exe");
+    const opts = {
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py"],
+      findPid: () => 5,
+      // The portable shape: a relative interpreter on the command line, and the OS's
+      // own absolute record of the same binary.
+      readIdentity: () => ({
+        commandLine: ".\\python_embeded\\python.exe main.py",
+        executablePath: exe,
+        startedAt: "t1",
+      }),
+    };
+    // The #401 line holds: nothing that could be mistaken for the interpreter.
+    expect(resolveLiveInterpreter(opts)).toBeUndefined();
+    expect(observeLiveServerProcess(opts)).toEqual({ pid: 5, image: exe });
+  });
+
+  it("NORMALIZES the image — Windows records it exactly as the launcher wrote it", async () => {
+    // Measured: a process launched as `..\python_embeded\python.exe` reports
+    // `…\ComfyUI\..\python_embeded\python.exe` — absolute, but not yet a path an
+    // install-root ascent can walk.
+    const exe = await makeExe("python.exe");
+    // Assembled with `sep`, NOT join(): join() collapses the `..` itself, so the
+    // fixture would already be normalized and the assertion would pass with the
+    // normalization deleted (it did — caught by mutating pathResolve away).
+    await mkdir(join(dir, "sub"), { recursive: true }); // POSIX stat() walks it for real
+    const detoured = `${dir}${sep}sub${sep}..${sep}python.exe`;
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py"],
+      findPid: () => 5,
+      readIdentity: () => ({
+        commandLine: "python main.py",
+        executablePath: detoured,
+        startedAt: "t1",
+      }),
+    });
+    expect(res).toEqual({ pid: 5, image: exe });
+  });
+
+  it("still carries the image alongside an interpreter it COULD read", async () => {
+    const exe = await makeExe("venv-python.exe");
+    const base = await makeExe("base-python.exe");
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py"],
+      findPid: () => 5,
+      readIdentity: () => ({
+        commandLine: `${exe} main.py`,
+        executablePath: base,
+        startedAt: "t1",
+      }),
+    });
+    // The interpreter still wins for the #401 question; the image is the weaker
+    // reading a caller may fall back to, never a replacement.
+    expect(res).toEqual({ pid: 5, python: exe, source: "process-table", image: base });
+  });
+
+  it("reports NO image for a PROXY on the port — the correlation still gates it", async () => {
+    const proxy = await makeExe("proxy-python.exe");
+    expect(
+      observeLiveServerProcess({
+        port: 8188,
+        remote: false,
+        serverArgv: COMFY_ARGV,
+        findPid: () => 999,
+        readIdentity: () => ({
+          commandLine: "python -m myproxy --listen 8188",
+          executablePath: proxy,
+          startedAt: "t1",
+        }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reports NO image when the OS gave none, or one that is relative / absent", () => {
+    for (const executablePath of [undefined, ".\\python.exe", join(dir, "gone.exe")]) {
+      expect(
+        observeLiveServerProcess({
+          port: 8188,
+          remote: false,
+          serverArgv: ["main.py"],
+          findPid: () => 5,
+          readIdentity: () => ({
+            commandLine: "python main.py",
+            executablePath,
+            startedAt: "t1",
+          }),
+        }),
+      ).toEqual({ pid: 5 });
+    }
+  });
+
+  it("reports nothing at all for a REMOTE server", async () => {
+    const exe = await makeExe("remote-python.exe");
+    expect(
+      observeLiveServerProcess({
+        port: 8188,
+        remote: true,
+        serverArgv: ["main.py"],
+        findPid: () => 5,
+        readIdentity: () => ({ commandLine: "python main.py", executablePath: exe }),
       }),
     ).toBeUndefined();
   });

--- a/src/__tests__/services/live-probe-gate.test.ts
+++ b/src/__tests__/services/live-probe-gate.test.ts
@@ -123,6 +123,30 @@ const PROBES: Probe[] = [
       "  }));\n",
   },
   {
+    // #1374 — SAME MODULE, SECOND DOOR. The shell-out moved down into
+    // `observeLiveServerProcess`, which reports the OS's own image record as well as
+    // the interpreter, and `resolveLiveInterpreter` is now a wrapper around it. A
+    // file that stubs only the wrapper (which six of them did, verbatim from the
+    // remedy above) still reaches the real process table through the other export —
+    // and the probe above cannot see that, because its `moduleHint` is satisfied by
+    // any mention of the module. So this one is keyed on the FUNCTION NAME: a file
+    // is exempt only if it actually names the export it has to replace.
+    id: "live process table (uncollapsed observation)",
+    callee: "observeLiveServerProcess",
+    privateSeeds: ["resolveLiveServerRoot"],
+    moduleHint: "observeLiveServerProcess",
+    expectEntries: ["resolveLiveServerRoot", "resolveLiveInterpreter"],
+    remedy:
+      "`observeLiveServerProcess` is where the netstat/WMI shell-out now lives, and " +
+      "`resolveLiveInterpreter` only wraps it — so stubbing the wrapper alone leaves " +
+      "these reading the REAL process table. Stub BOTH:\n\n" +
+      '  vi.mock("../../services/live-interpreter.js", async () => ({\n' +
+      '    ...(await vi.importActual("../../services/live-interpreter.js")),\n' +
+      "    resolveLiveInterpreter: () => undefined,\n" +
+      "    observeLiveServerProcess: () => undefined,\n" +
+      "  }));\n",
+  },
+  {
     id: "instance witness (real WebSocket)",
     callee: "acquireInstanceWitness",
     // Both call sites sit in NON-exported functions (`gatherProcessInfo`,
@@ -214,6 +238,16 @@ function unstubbedTests(probe: Probe): string[] {
  */
 const KNOWN_UNSTUBBED: Record<string, string[]> = {
   "live process table": ["__tests__/orchestrator/late-mutation-e2e.test.ts"],
+  // Pre-existing, and a finding about the FIRST probe rather than about #1374:
+  // `env-capabilities.test.ts` has read the real process table all along, and was
+  // exempted only because its prose mentions "live-interpreter" —
+  // `moduleHint` cannot tell a stub from a comment. The name-keyed probe below sees
+  // it. Ratcheted rather than fixed here for the reason the list exists: that file
+  // deliberately runs the real probe set to prove a per-gather read is not cached,
+  // and deciding what the process probe should answer for it is its own judgement.
+  "live process table (uncollapsed observation)": [
+    "__tests__/services/env-capabilities.test.ts",
+  ],
   // The witness channel as it stands today. Ratcheted rather than fixed wholesale, for
   // the same reason as the list above: five passing files is a large diff with no
   // observable failure behind it, and each needs its own judgement about what the

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../config.js", async (orig) => ({
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual<Record<string, unknown>>("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 
 vi.mock("../../comfyui/client.js", async (orig) => ({

--- a/src/__tests__/services/panel-desktop-observed-root.test.ts
+++ b/src/__tests__/services/panel-desktop-observed-root.test.ts
@@ -57,6 +57,7 @@ const generation = vi.hoisted(() => ({ value: 0 }));
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 
 vi.mock("../../config.js", () => ({

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -55,6 +55,7 @@ const generation = vi.hoisted(() => ({ value: 0 }));
 vi.mock("../../services/live-interpreter.js", async () => ({
   ...(await vi.importActual("../../services/live-interpreter.js")),
   resolveLiveInterpreter: () => undefined,
+  observeLiveServerProcess: () => undefined,
 }));
 
 vi.mock("../../config.js", () => ({

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -22,13 +22,19 @@ type ExecResult = { stdout?: string; stderr?: string } | Error;
 // Shared mutable state created via vi.hoisted so the vi.mock factories (which
 // are hoisted to the top of the module) can safely reference it.
 const h = vi.hoisted(() => {
+  // GROUND TRUTH seam (#401): undefined = "we could not observe the interpreter",
+  // which is the default and must always degrade to unknown.
+  const mockLiveInterpreter = vi.fn(() => undefined as unknown);
   return {
     mockConfig: { comfyuiPath: undefined as string | undefined, resolvedPort: 8188 },
     mockGetSystemStats: vi.fn(),
     remoteMode: { value: false },
-    // GROUND TRUTH seam (#401): undefined = "we could not observe the interpreter",
-    // which is the default and must always degrade to unknown.
-    mockLiveInterpreter: vi.fn(() => undefined as unknown),
+    mockLiveInterpreter,
+    // The SAME observation, reported without collapsing it to the interpreter
+    // (#1374). Defaults to whatever the interpreter seam says, so every case that
+    // only cares about the interpreter keeps configuring one thing; the cases that
+    // exercise the OS-image fallback override this one directly.
+    mockLiveProcess: vi.fn((...args: unknown[]) => mockLiveInterpreter(...(args as []))),
     execFileResponder: (() => new Error("not configured")) as (
       cmd: string,
       args: string[],
@@ -50,6 +56,7 @@ vi.mock("../../comfyui/client.js", () => ({
 
 vi.mock("../../services/live-interpreter.js", () => ({
   resolveLiveInterpreter: (...args: unknown[]) => h.mockLiveInterpreter(...(args as [])),
+  observeLiveServerProcess: (...args: unknown[]) => h.mockLiveProcess(...(args as [])),
 }));
 
 // execFile is wrapped by promisify() at module load. The mock invokes the
@@ -109,6 +116,12 @@ beforeEach(() => {
   h.remoteMode.value = false;
   h.mockLiveInterpreter.mockReset();
   h.mockLiveInterpreter.mockReturnValue(undefined); // no observation by default
+  h.mockLiveProcess.mockReset();
+  // Reinstalled here (mockReset drops the factory default): the process observation
+  // follows the interpreter seam unless a case overrides it.
+  h.mockLiveProcess.mockImplementation((...args: unknown[]) =>
+    h.mockLiveInterpreter(...(args as [])),
+  );
   mockGetSystemStats.mockReset();
   setExecFileResponder(() => new Error("not configured"));
   resetWorkspaceConfig();
@@ -1695,6 +1708,102 @@ describe("resolveLiveServerRoot (#369)", () => {
       });
       expect(res.source).toBe("unresolved");
       expect(res.root).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // #1374 — the tier above is built for the portable bundle, and on the stock
+  // portable bundle it did not run. `run_nvidia_gpu.bat` launches
+  // `.\python_embeded\python.exe -s ComfyUI\main.py`, so the command line the OS
+  // records has a RELATIVE argv[0] and the interpreter answer fails closed (#401,
+  // correctly — a relative argv[0] names no file). The install root then stayed
+  // unresolved, download_model routed to ComfyUI-Manager, and on an install where
+  // Manager is not serving its routes that is a hard failure for a capability that
+  // needs no Manager at all.
+  //
+  // These pin the fallback and its LIMIT: the OS image resolves the root, and a
+  // reading that cannot be placed inside the install still resolves nothing.
+  it("anchors on the OS IMAGE when the launcher spelled the interpreter relatively", async () => {
+    const dir = await tmpDir();
+    try {
+      const { python, serverRoot } = await makePortableBundle(dir);
+      // What the process table reports for the stock portable launch: no usable
+      // argv[0], but the OS's own record of the same binary.
+      h.mockLiveProcess.mockReturnValue({ pid: 4242, image: python });
+
+      const res = resolveLiveServerRoot(
+        [join("ComfyUI", "main.py"), "--windows-standalone-build"],
+        undefined,
+        {},
+      );
+      expect(res.source).toBe("observed-process");
+      expect(res.root).toBe(serverRoot);
+      expect(res.observedPid).toBe(4242);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("anchors a BARE main.py on the OS image when that image is inside the install", async () => {
+    const dir = await tmpDir();
+    try {
+      // The shape the reopened report describes: argv[0] is `main.py` with no cwd,
+      // so the server's install root IS its working directory.
+      await writeFile(join(dir, "main.py"), "", "utf-8");
+      const python = await makeVenvPython(dir);
+      h.mockLiveProcess.mockReturnValue({ pid: 7, image: python });
+
+      const res = resolveLiveServerRoot(["main.py"], undefined, {});
+      expect(res.source).toBe("observed-process");
+      expect(res.root).toBe(dir);
+      expect(res.relDir).toBe(".");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still REFUSES an image that sits outside the install — the containment test is what gates it", async () => {
+    const dir = await tmpDir();
+    try {
+      // A system python with an unrelated ComfyUI somewhere above it: exactly the
+      // reading `interpreterBelongsToInstall` exists to reject, and the OS image is
+      // no more privileged than argv[0] was. Windows reports a venv's BASE
+      // interpreter here, so this is the ordinary case, not an exotic one.
+      await mkdir(join(dir, "ComfyUI"), { recursive: true });
+      await writeFile(join(dir, "ComfyUI", "main.py"), "", "utf-8");
+      const systemPython = join(dir, "Python313", IS_WIN ? "python.exe" : "python3");
+      await mkdir(dirname(systemPython), { recursive: true });
+      await writeFile(systemPython, "", "utf-8");
+      h.mockLiveProcess.mockReturnValue({ pid: 9, image: systemPython });
+
+      const res = resolveLiveServerRoot([join("ComfyUI", "main.py")], undefined, {});
+      expect(res.source).toBe("unresolved");
+      expect(res.root).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the INTERPRETER over the image when both were observed", async () => {
+    const dir = await tmpDir();
+    try {
+      const { python, serverRoot } = await makePortableBundle(dir);
+      const venvPython = await makeVenvPython(serverRoot);
+      // Windows reports the bundle's base interpreter as the image while argv[0] is
+      // the venv python. Both anchor to the same root here — what is pinned is that
+      // the weaker reading never displaces the stronger one.
+      h.mockLiveProcess.mockReturnValue({
+        pid: 11,
+        python: venvPython,
+        source: "process-table",
+        image: python,
+      });
+
+      const res = resolveLiveServerRoot([join("ComfyUI", "main.py")], undefined, {});
+      expect(res.source).toBe("observed-process");
+      expect(res.root).toBe(serverRoot);
+      expect(res.observedPython).toBe(venvPython);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -1785,6 +1785,46 @@ describe("resolveLiveServerRoot (#369)", () => {
     }
   });
 
+  // ── The gap this does NOT close, measured rather than assumed ─────────────
+  //
+  // Worth being exact, because the two shapes look alike in a report and behave
+  // differently, and the difference decides whether #1374's recurring reporter is
+  // helped:
+  //
+  //   argv[0] = "ComfyUI\main.py"  → relDir "ComfyUI". Walking up from
+  //     <bundle>/python_embeded reaches <bundle>, and <bundle>/ComfyUI/main.py
+  //     exists — RESOLVED. This is what run_nvidia_gpu.bat produces, so the stock
+  //     portable bundle IS served by this tier.
+  //
+  //   argv[0] = "main.py"          → relDir ".". Walking up asks whether
+  //     <bundle>/python_embeded or <bundle> is itself the install root; neither
+  //     holds main.py, so it stays UNRESOLVED. This is the shape the recurrence
+  //     comment reports, and it is only helped when the interpreter lives INSIDE
+  //     the install (a venv at <install>/.venv), which the test above pins.
+  //
+  // Anchoring "." on a sibling would mean guessing which of <bundle>'s children is
+  // the install — the layout-guess tier this file deliberately does not have, and
+  // the one that wrote 4.88 GB into the wrong install in #369. So the gap stays,
+  // and stays recorded.
+  it("does NOT resolve a BARE main.py when the interpreter is a SIBLING of the install", async () => {
+    const dir = await tmpDir();
+    try {
+      const { python, serverRoot } = await makePortableBundle(dir);
+      h.mockLiveProcess.mockReturnValue({ pid: 4242, image: python });
+
+      // Same bundle, same image — only argv[0] differs from the resolving case.
+      const bare = resolveLiveServerRoot(["main.py"], undefined, {});
+      expect(bare.source).toBe("unresolved");
+      expect(bare.root).toBeUndefined();
+      // …and the contrast, so this cannot pass by the whole tier being broken.
+      const withDir = resolveLiveServerRoot([join("ComfyUI", "main.py")], undefined, {});
+      expect(withDir.source).toBe("observed-process");
+      expect(withDir.root).toBe(serverRoot);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("prefers the INTERPRETER over the image when both were observed", async () => {
     const dir = await tmpDir();
     try {

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -27,7 +27,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readlinkSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { isAbsolute, resolve as pathResolve } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
 import { logger } from "./../utils/logger.js";
@@ -461,6 +461,39 @@ export interface ResolveOptions {
   readIdentity?: (pid: number) => ProcessIdentity | undefined;
 }
 
+/** What the OS could establish about the ComfyUI holding our port. TWO readings,
+ *  because they answer two different questions and one is routinely available when
+ *  the other is not — see `image`. */
+export interface LiveServerProcess {
+  /** PID of the identified server process. */
+  pid: number;
+  /** The INTERPRETER answer (#401): argv[0] of the running process, when that is an
+   *  absolute path that exists. Absent when argv[0] is relative or bare. */
+  python?: string;
+  /** How `python` was established. Absent exactly when `python` is. */
+  source?: InterpreterSource;
+  /**
+   * The OS's OWN record of the running image (`Win32_Process.ExecutablePath`,
+   * `/proc/<pid>/exe`), absolute and normalized — usable when argv[0] is NOT (#1374).
+   *
+   * A Windows launcher routinely spells the interpreter RELATIVELY: the stock
+   * portable bundle runs `.\python_embeded\python.exe -s ComfyUI\main.py`, and a
+   * shell with an activated venv runs a bare `python`. The command line the OS
+   * records is that literal string, so argv[0] names no file we can probe and the
+   * interpreter answer fails closed — correctly, because this field is NOT a
+   * substitute for it: for a venv Windows reports the BASE interpreter the
+   * trampoline loads (measured live: `…\standalone-env\python.exe` while argv[0] is
+   * `…\ComfyUI\.venv\Scripts\python.exe`), whose site-packages are not the ones the
+   * server imports.
+   *
+   * It IS an answer to the weaker question "where does this process live?", which is
+   * all an install-root ANCHOR needs. Callers must use it only that way, and only
+   * behind a containment test — a base interpreter that sits outside the install
+   * simply fails it, so this reading can add a resolution but never redirect one.
+   */
+  image?: string;
+}
+
 /**
  * The interpreter the running ComfyUI is ACTUALLY using, or `undefined` when we
  * cannot observe it. Never infers from install layout.
@@ -476,6 +509,22 @@ export interface ResolveOptions {
  * confidently wrong package list is the entire bug (#401).
  */
 export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | undefined {
+  const observed = observeLiveServerProcess(opts);
+  if (!observed?.python || !observed.source) return undefined;
+  return { python: observed.python, source: observed.source, pid: observed.pid };
+}
+
+/**
+ * The same single observation `resolveLiveInterpreter` makes, reported WITHOUT
+ * collapsing it to the interpreter answer — so a caller that only needs to anchor an
+ * install root still gets something when argv[0] cannot supply it (#1374).
+ *
+ * Identity is established exactly as before (the two tiers above); all that differs
+ * is what is handed back. In particular the OS image is returned only AFTER the argv
+ * correlation has passed, so a proxy on the port can no more contribute an anchor
+ * than it can contribute an interpreter.
+ */
+export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProcess | undefined {
   if (opts.remote) return undefined;
   const findPid = opts.findPid ?? findPidByPort;
   const readIdentity = opts.readIdentity ?? readProcessIdentity;
@@ -494,6 +543,16 @@ export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | 
   } catch {
     identity = undefined;
   }
+
+  // The OS's own record of the image, normalized: Windows reports it verbatim from
+  // the launch, so a relative spelling comes back as an absolute path that still
+  // contains the `..` it was written with (measured: `…\ComfyUI\..\python_embeded\
+  // python.exe`).
+  const rawImage = identity?.executablePath;
+  const image =
+    rawImage && isAbsolute(rawImage) && existsSync(rawImage)
+      ? pathResolve(rawImage)
+      : undefined;
 
   // Tier 1 — the process we launched, confirmed by PID *and* start time.
   // The recorded interpreter must be ABSOLUTE: a bare `python` would be
@@ -521,7 +580,7 @@ export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | 
       launchRecord.startedAt === identity.startedAt &&
       corroborated
     ) {
-      return { python: launchRecord.python, source: "launched-by-us", pid };
+      return { python: launchRecord.python, source: "launched-by-us", pid, image };
     }
     // Same PID, different (or unreadable) start time → this is NOT our process, or
     // we cannot prove it is. Fall through to tier 2 rather than trust the record.
@@ -538,9 +597,10 @@ export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | 
   const argv0 = argv0FromCommandLine(identity?.commandLine ?? "");
   // A relative or bare argv[0] ("python", "./python") does not identify a file we
   // can probe — the process's cwd is not ours. Only an absolute path that exists
-  // is usable; anything else is honestly unknown.
+  // is usable; anything else is honestly unknown as an INTERPRETER. The OS image
+  // still travels with the result for the weaker anchor question (#1374).
   if (argv0 && isAbsolute(argv0) && existsSync(argv0)) {
-    return { python: argv0, source: "process-table", pid };
+    return { python: argv0, source: "process-table", pid, image };
   }
-  return undefined;
+  return { pid, image };
 }

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -746,6 +746,28 @@ function interpreterBelongsToInstall(python: string, base: string, root: string)
  * Linux and nothing supplied on Windows (#535). It falls out of the walk for free;
  * discarding it was why the restart path had no Windows anchor to use.
  */
+/**
+ * KNOWN GAP, measured and filed rather than implied — this anchors on where the
+ * BINARY lives, which is not proof of where the SCRIPT was resolved from.
+ *
+ * Review raised it against the #1374 image fallback: with a stale portable
+ * bundle's python on PATH, `cd D:\live && python ComfyUI\main.py` reports the
+ * STALE interpreter while the server runs the LIVE script, and the bundle-shape
+ * containment happily accepts `C:\stale\ComfyUI` — the #369 failure mode.
+ *
+ * Measured on this branch, both readings behave IDENTICALLY: an absolute argv[0]
+ * naming that same stale python anchors the stale root exactly as the image does.
+ * So the image fallback does not introduce this; it is a property of anchoring on
+ * the interpreter at all, and it has been reachable via argv[0] since that tier
+ * shipped. What the fallback changes is how many launch shapes reach the tier.
+ *
+ * Not fixed here because the fix is not local to this function: it needs a
+ * corroboration the server itself can supply (the models dir it actually reads),
+ * which is a different change from "make the relative-argv case resolvable".
+ * Tracked separately; do NOT paper over it by tightening the containment test,
+ * which would only shrink the set of installs that work without making any
+ * remaining answer more trustworthy.
+ */
 function anchorRelDirOnInterpreter(
   python: string,
   relDir: string,

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import { getSystemStats } from "../comfyui/client.js";
-import { resolveLiveInterpreter } from "./live-interpreter.js";
+import { observeLiveServerProcess, resolveLiveInterpreter } from "./live-interpreter.js";
 import { logger } from "../utils/logger.js";
 import { ValidationError } from "../utils/errors.js";
 
@@ -644,7 +644,10 @@ export interface LiveServerRootResolution {
    *  argv named a relative script. Present even when the root stays unresolved —
    *  callers use it to anchor a corroborated fallback and to explain a refusal. */
   relDir?: string;
-  /** The interpreter the OS reports for the process on our port, when observed. */
+  /** The binary the OS reports for the process on our port, when observed — its
+   *  interpreter (argv[0]), or the OS's own image record when argv[0] was written
+   *  relatively and names no probeable file (#1374). Reported so a refusal can name
+   *  what WAS seen; it is the anchor input, not a runnable interpreter. */
   observedPython?: string;
   /**
    * The directory `relDir` was resolved AGAINST to produce `root` — i.e. the
@@ -762,9 +765,21 @@ function anchorRelDirOnInterpreter(
 }
 
 /**
- * The interpreter the OS reports for the ComfyUI on our port.
+ * The BINARY the OS reports for the ComfyUI on our port — to anchor its install
+ * root on, which is the only thing this file does with it.
  *
- * DELIBERATELY NOT CACHED. `resolveLiveInterpreter` shells out (netstat/WMI on
+ * Prefers the interpreter (argv[0] of the running process). Falls back to the OS's
+ * own image record when argv[0] is relative or bare (#1374): the stock Windows
+ * portable bundle launches `.\python_embeded\python.exe`, and an activated venv
+ * launches a bare `python`, so on those installs argv[0] names no file to anchor on
+ * — the tier built for the relative-`main.py` shape then failed closed on the very
+ * layouts it exists to serve, and the download bounced to ComfyUI-Manager (a hard
+ * failure wherever Manager is not loaded). The fallback is weaker on purpose: for a
+ * venv Windows reports the BASE interpreter, which sits OUTSIDE the install and is
+ * rejected by anchorRelDirOnInterpreter's containment test — so it can only ever add
+ * a resolution, never move one.
+ *
+ * DELIBERATELY NOT CACHED. `observeLiveServerProcess` shells out (netstat/WMI on
  * Windows, lsof on POSIX), so memoizing it is tempting — but this answer decides
  * WHERE A DOWNLOAD IS WRITTEN. A cache keyed on port+argv cannot tell a restarted
  * server apart from the one it replaced (a relaunch of ComfyUI reports the same
@@ -783,16 +798,17 @@ function observeLivePython(
     /* unparseable target → no host filter */
   }
   try {
-    const live = resolveLiveInterpreter({
+    const live = observeLiveServerProcess({
       port: config.resolvedPort,
       host: statsHost,
       remote: false,
       serverArgv: argv,
     });
+    const binary = live?.python ?? live?.image;
     // The PID travels with the interpreter (#535). A caller that is about to STOP
     // a process must be able to confirm the anchor describes that very process
     // and not some other ComfyUI — an interpreter path alone cannot prove it.
-    return live ? { python: live.python, pid: live.pid } : undefined;
+    return live && binary ? { python: binary, pid: live.pid } : undefined;
   } catch {
     return undefined;
   }
@@ -814,10 +830,12 @@ function observeLivePython(
  *     both report (`ComfyUI\main.py`), and it is exactly why #369 kept recurring:
  *     with argv unresolvable, the download destination silently fell through to
  *     COMFYUI_PATH — a DIFFERENT, stale install — and the model landed where the
- *     running server never reads. So we ask the OS instead: `resolveLiveInterpreter`
+ *     running server never reads. So we ask the OS instead: `observeLiveServerProcess`
  *     identifies the process listening on our port (correlated against the server's
- *     own argv, so a proxy can't impersonate it) and reports its interpreter; the
- *     relative `main.py` dir is re-anchored on that interpreter's install tree.
+ *     own argv, so a proxy can't impersonate it) and reports the binary it runs — its
+ *     interpreter, or the OS's own image record when the launcher spelled the
+ *     interpreter relatively (#1374); the relative `main.py` dir is re-anchored on
+ *     that binary's install tree.
  *
  * Anything else is `unresolved`. There is deliberately NO layout-guess tier: a
  * COMFYUI_PATH that merely looks plausible is what wrote 4.88 GB into the wrong


### PR DESCRIPTION
Refs #1374 — **and it must not close it.** See "Does this fix the reporter?" below.

## What was broken

`live-interpreter.ts` tier 2 required `argv0 && isAbsolute(argv0) && existsSync(argv0)`. On Windows `argv0` comes from `Win32_Process.CommandLine`, which is the literal string `CreateProcess` received — so the stock portable bundle (`.\python_embeded\python.exe -s ComfyUI\main.py`) and any activated venv (bare `python`) report a **relative** argv[0] and the probe fails closed. Correctly: a relative argv[0] names no file to probe.

But the install root then stayed unresolved, `download_model` handed the job to ComfyUI-Manager, and on an install where Manager is not serving its routes that is a hard failure for a capability that needs no Manager at all. The tier built for the portable bundle did not run on the portable bundle.

## The fix

The OS's own image record (`Win32_Process.ExecutablePath`, `/proc/<pid>/exe`) is reported alongside the interpreter answer and used **only** to anchor an install root — never as a runnable interpreter, and only behind the existing containment test. It is returned only after the argv correlation has passed, so a proxy on the port can no more contribute an anchor than it can contribute an interpreter.

Deliberately weaker: for a venv, Windows reports the **base** interpreter, which sits outside the install and is rejected by `interpreterBelongsToInstall`. The reading can add a resolution, never redirect one — and a test pins that the interpreter still wins when both are observed.

## Correcting the draft's caveat

The draft said this "does NOT help a classic portable bundle … because `anchorRelDirOnInterpreter` only walks UP from the interpreter". **Measured against the branch, that is wrong**, and the correction is what decides whether the reporter is helped. The walk-up reaches `<bundle>` on its second step, and the containment test has an explicit branch for an env dir beside the install:

| argv[0] | relDir | portable bundle | result |
|---|---|---|---|
| `ComfyUI\main.py` | `ComfyUI` | `<bundle>/ComfyUI/main.py` exists | **resolved** |
| `main.py` | `.` | is `<bundle>` or `<bundle>/python_embeded` itself the root? no | **unresolved** |

The first is what `run_nvidia_gpu.bat` produces, so the stock portable bundle **is** served. Proven by mutation: reverting `live?.python ?? live?.image` to `live?.python` fails that exact test.

## Does this fix the reporter?

**Unconfirmed, and that is why #1374 stays open.** The recurrence comment reports `argv[0]=main.py` with no cwd — the second row. That shape resolves only when the interpreter lives *inside* the install (a venv at `<install>/.venv`); with a sibling `python_embeded` it does not, because anchoring `.` would mean guessing which of `<bundle>`'s children is the install. That is the layout-guess tier this file deliberately does not have — the one that wrote 4.88 GB into the wrong install in #369.

The gap is now a **test**, not a sentence in a PR body that goes stale the moment someone edits the anchor. It fails if a future change closes the gap by guessing, so that decision has to be made deliberately.

## Review finding, measured and filed

Review raised a P1: with a stale bundle's python on `PATH`, `cd D:\live && python ComfyUI\main.py` reports the stale interpreter while the server runs the live script, and the containment test accepts `C:\stale\ComfyUI`.

Real — and **measured to be pre-existing**. Both readings behave identically on the same fixture:

| reading | anchored the stale root? |
|---|---|
| OS image only (this PR's fallback) | yes |
| absolute `argv[0]` naming the same python (pre-existing) | yes |

So this PR does not introduce it; it is a property of anchoring on the interpreter at all. Filed separately — triage matched it to **#369** and reopened it, which is the right home. Documented at the function with the measurement, including why the two obvious repairs are wrong.

## Verification

- Merged `main` (0.51.42) first — the author's green was against a base 9 commits old.
- **499 files / 9386 tests green**, lint clean.
- `live-probe-gate.test.ts` — the gate that polices this subsystem and reads comments — passes.
- The new gap test dies under a mutation that closes the gap, and asserts the resolving case beside the refusing one so it cannot pass by the tier being broken.
