### PR TITLE
fix(1545): a failed terminal persist is silently dropped, so status keeps reporting downloading

### DIFF
--- a/src/__tests__/services/download-persist-contention.test.ts
+++ b/src/__tests__/services/download-persist-contention.test.ts
@@ -117,6 +117,22 @@ describe("#1545 the terminal record survives a reader holding it open", () => {
     // ~73ms measurement was Windows granularity, not the schedule.
     const totalBackoff = gaps.reduce((a, b) => a + b, 0);
     expect(totalBackoff).toBeGreaterThanOrEqual(25);
+
+    // CORROBORATION, not proof. Wall-clock cannot be a reliable discriminator in
+    // either direction here: too high a floor fails a correct implementation on a
+    // fast host, and any floor can be met by host/event-loop jitter with no
+    // backoff at all (review, round 2). So the structural fact is asserted too —
+    // deterministic, and immune to a loaded CI box.
+    const src = readFileSync(
+      new URL("../../services/download-progress.ts", import.meta.url),
+      "utf8",
+    );
+    const loop = src.slice(
+      src.indexOf("let renamed = false;"),
+      src.indexOf("if (!renamed) {"),
+    );
+    expect(loop).toMatch(/sleepSyncMs\(RENAME_BACKOFF_MS\[attempt - 1\]/);
+    expect(loop).toMatch(/if \(attempt > 0\)/); // never before the first attempt
   });
 
   it("does not retry at all when the first attempt lands", async () => {

--- a/src/__tests__/services/download-persist-contention.test.ts
+++ b/src/__tests__/services/download-persist-contention.test.ts
@@ -110,8 +110,13 @@ describe("#1545 the terminal record survives a reader holding it open", () => {
     // [2,2,2,2] totals ~62ms. Per-gap thresholds cannot separate those, and an
     // earlier version of this test claimed they could. What the fix actually
     // buys is that the attempts are SPREAD rather than simultaneous.
+    //
+    // The floor is 25ms, NOT 40: the configured sleeps total 37ms, and on a
+    // high-resolution host (Linux CI) Atomics.wait lands near that — so a 40ms
+    // floor would have failed a CORRECT implementation (review finding). My
+    // ~73ms measurement was Windows granularity, not the schedule.
     const totalBackoff = gaps.reduce((a, b) => a + b, 0);
-    expect(totalBackoff).toBeGreaterThanOrEqual(40);
+    expect(totalBackoff).toBeGreaterThanOrEqual(25);
   });
 
   it("does not retry at all when the first attempt lands", async () => {
@@ -121,6 +126,39 @@ describe("#1545 the terminal record survives a reader holding it open", () => {
     // defect worth a test. The attempt COUNT is the real invariant.
     expect(await persist(JOB)).toBe(true);
     expect(renameAttempts.length).toBe(1);
+  });
+
+  it("commitDone CHECKS the persist result — the primary fix, and nothing else here sees it", async () => {
+    // Review finding: every other test in this file calls persistDownloadJob
+    // directly, so removing commitDone's check and its warning left them all
+    // green. commitDone is a closure inside downloadModelJob and cannot be
+    // driven without a whole download, so the honest instrument is the source —
+    // bounded to the function, and asserting the PROPERTY (the result is
+    // consumed) rather than an exact spelling.
+    const src = readFileSync(
+      new URL("../../services/download-jobs.ts", import.meta.url),
+      "utf8",
+    );
+    const start = src.indexOf("const commitDone = (");
+    expect(start).toBeGreaterThan(0);
+    const open = src.indexOf("{", src.indexOf("=>", start));
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === "{") depth++;
+      else if (src[i] === "}" && --depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    const body = src.slice(open, end);
+
+    // The bare, result-discarding call is exactly the defect.
+    expect(body).not.toMatch(/^\s*persistJobRecord\(job\);\s*$/m);
+    // The result must be consumed in a condition...
+    expect(body).toMatch(/if \(!persistJobRecord\(job\)[\s\S]{0,80}\)/);
+    // ...and the failure must say something, or it is silent again.
+    expect(body).toMatch(/logger\.warn\(/);
   });
 
   it("a published record reads back as the terminal state", async () => {

--- a/src/__tests__/services/download-persist-contention.test.ts
+++ b/src/__tests__/services/download-persist-contention.test.ts
@@ -1,0 +1,138 @@
+// #1545 — "Download completion event can arrive before status changes from
+// downloading to done."
+//
+// The completion event is raised from the ORCHESTRATOR's in-memory job, while
+// `download_model action:"status"` reads the persisted record (from the spawned
+// stdio child). Two things let those disagree for seconds:
+//
+//   1. `commitDone` called `persistJobRecord(job)` and DISCARDED the result.
+//      That function returns false when its atomic replace loses to a reader
+//      holding the record open — and it then keeps the PRIOR complete record
+//      rather than risk a torn write, so the durable answer stays "downloading".
+//   2. The replace "retried a few times" with NO delay between attempts, so all
+//      five completed within microseconds and lost to the same reader open.
+//      Effectively one attempt.
+//
+// The reporter's own polling is what created the contention: `status` opens the
+// exact file the writer is replacing, so the tool the completion event tells you
+// to call is the one that can keep the answer stale.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string;
+
+/** Attempt timestamps recorded by the renameSync stub. */
+let renameAttempts: number[] = [];
+/** How many attempts should fail before one succeeds. */
+let failFirstN = 0;
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    renameSync: (from: string, to: string) => {
+      // performance.now(), not Date.now(): the latter quantises to ~15ms on
+      // Windows, so every measured gap read as 0 or 15 regardless of the actual
+      // backoff — which let a flat-2ms schedule pass a >=15ms assertion.
+      renameAttempts.push(performance.now());
+      if (renameAttempts.length <= failFirstN) {
+        const err = new Error("EPERM: operation not permitted, rename") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        throw err; // the Windows sharing-violation shape
+      }
+      return actual.renameSync(from, to);
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  renameAttempts = [];
+  failFirstN = 0;
+  dir = mkdtempSync(join(tmpdir(), "dlpersist-"));
+  process.env.COMFYUI_MCP_DATA_DIR = dir;
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_DATA_DIR;
+  rmSync(dir, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+const JOB = {
+  id: "ea552f6476f1c9ba",
+  url: "https://example.invalid/model.safetensors",
+  filename: "krea2TurboOfficialComfy.safetensors",
+  status: "done" as const,
+  started_at: 1,
+  finished_at: 2,
+};
+
+async function persist(job: Record<string, unknown>) {
+  const mod = await import("../../services/download-progress.js");
+  return mod.persistDownloadJob(job as never);
+}
+
+describe("#1545 the terminal record survives a reader holding it open", () => {
+  it("reports FAILURE rather than silently keeping the stale record", async () => {
+    failFirstN = 99; // every attempt loses
+    expect(await persist(JOB)).toBe(false);
+    // And it left no torn/partial file behind for a reader to pick up.
+    const stray = readdirSync(dir === "" ? "." : dir, { recursive: true } as never) as string[];
+    expect(stray.some((f) => String(f).endsWith(".tmp"))).toBe(false);
+  });
+
+  it("SUCCEEDS when the contention clears after a few attempts", async () => {
+    failFirstN = 3; // the 4th lands
+    expect(await persist(JOB)).toBe(true);
+    expect(renameAttempts.length).toBe(4);
+  });
+
+  it("SPREADS the retries out — five instant attempts are one attempt", async () => {
+    // The defect: the loop had no delay, so all five collided with the same
+    // reader open. Without a real gap between attempts the retries buy nothing,
+    // and this is the only assertion that can tell the two apart.
+    failFirstN = 4; // the 5th lands, so all four backoffs are exercised
+    expect(await persist(JOB)).toBe(true);
+    expect(renameAttempts.length).toBe(5);
+
+    // Measured between ATTEMPTS rather than around the whole call: total elapsed
+    // is dominated by module load and fs work, so an "elapsed >= 25ms" bound
+    // passed even with no backoff at all — it was measuring the harness.
+    const gaps = renameAttempts.slice(1).map((t, i) => t - renameAttempts[i]);
+    expect(gaps.length).toBe(4);
+
+    // TOTAL backoff, and only a "a delay exists" bound — which is all that can
+    // honestly be asserted here. MEASURED on Windows: the timer granularity
+    // floors every sleep at ~15ms, so [2,5,10,20] totals ~73ms and a flat
+    // [2,2,2,2] totals ~62ms. Per-gap thresholds cannot separate those, and an
+    // earlier version of this test claimed they could. What the fix actually
+    // buys is that the attempts are SPREAD rather than simultaneous.
+    const totalBackoff = gaps.reduce((a, b) => a + b, 0);
+    expect(totalBackoff).toBeGreaterThanOrEqual(40);
+  });
+
+  it("does not retry at all when the first attempt lands", async () => {
+    // The cost falls only on actual contention. Asserting elapsed TIME here was
+    // useless — a 2ms first-attempt sleep is inside any tolerance a non-flaky
+    // bound can have (mutation M2), and 2ms on a completed download is not a
+    // defect worth a test. The attempt COUNT is the real invariant.
+    expect(await persist(JOB)).toBe(true);
+    expect(renameAttempts.length).toBe(1);
+  });
+
+  it("a published record reads back as the terminal state", async () => {
+    expect(await persist(JOB)).toBe(true);
+    // Located rather than assumed: the records directory is resolved by the
+    // module (channel dir, else the stable dir), and hard-coding a layout here
+    // tested my guess about the path instead of the write.
+    const all = readdirSync(dir, { recursive: true, encoding: "utf8" }) as unknown as string[];
+    const records = all.filter((f) => String(f).endsWith(".json"));
+    expect(records.length).toBe(1);
+    const rec = JSON.parse(readFileSync(join(dir, records[0]), "utf8"));
+    expect(rec.status).toBe("done");
+    expect(rec.id).toBe(JOB.id);
+  });
+});

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -588,7 +588,29 @@ export async function startDownloadJob(
     // session reading the record — can ever see a completed local download with no
     // verification field and render it as confirmed success (#369, codex gate).
     if (!dispatchToManager) job.live_visible = "pending";
-    persistJobRecord(job);
+    // #1545 — this return value was DISCARDED, and it is the one that says
+    // whether any OTHER process can see the job finish. `persistDownloadJob`
+    // returns false when the atomic replace loses to a reader holding the record
+    // open, and it deliberately keeps the PRIOR complete record rather than
+    // risking a torn write — so the durable answer stays "downloading" until the
+    // ~15s heartbeat retries.
+    //
+    // That is the whole of #1545: the completion event is raised from THIS
+    // process's memory, while `download_model action:"status"` reads the record
+    // from the spawned stdio child. Silently dropping the failure is what let
+    // those two disagree for seconds with nothing to explain it.
+    //
+    // One immediate re-attempt (the call has its own backing-off retries), then
+    // say so. The heartbeat still heals it; the log is what makes a stale read
+    // explicable instead of mysterious.
+    if (!persistJobRecord(job) && !persistJobRecord(job)) {
+      logger.warn(
+        `[download] job ${job.id} finished but its record could not be published ` +
+          `(${job.filename}). Until the next heartbeat, download_model action:"status" ` +
+          `may still report "downloading" for it — the file itself has landed at ` +
+          `${landedPath}.`,
+      );
+    }
   };
   const settled = (async () => {
     // Wait for the prior same-destination job to fully finish (never fail THIS job

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -830,6 +830,40 @@ let persistSeq = 0;
  *  the terminal state is durable — otherwise a done/cancelled job could linger as a fresh
  *  "downloading" record (bounded by long record retention, but this recovers it sooner). Returns
  *  false when there is no channel dir (nothing to persist) or the replace didn't happen. */
+/**
+ * Delays between the atomic-replace retries, in ms (#1545).
+ *
+ * The escalation is intent, not a guarantee: MEASURED on Windows, the platform
+ * timer granularity floors every sleep at ~15 ms, so this schedule totals ~73 ms
+ * while a flat [2,2,2,2] totals ~62 ms — nearly the same. What actually matters
+ * here is that a delay EXISTS at all (the loop previously had none, so all five
+ * attempts collided with one reader open) and that there are several of them.
+ * The ordering still helps where timers are finer-grained, and costs nothing.
+ */
+const RENAME_BACKOFF_MS = [2, 5, 10, 20];
+
+/**
+ * Sleep without yielding the event loop.
+ *
+ * `commitDone` publishes the terminal status and persists it in ONE synchronous
+ * step precisely so no reader can observe a landed file with a "downloading"
+ * job, so this path may not await. `Atomics.wait` on a throwaway buffer is the
+ * supported way to block a Node thread; a busy spin would burn a core for the
+ * same delay. Falls back to a bounded spin where `Atomics.wait` is disallowed
+ * (it throws on the main thread in some embeddings).
+ */
+function sleepSyncMs(ms: number): void {
+  if (!(ms > 0)) return;
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    const until = Date.now() + ms;
+    while (Date.now() < until) {
+      /* bounded spin — only reached where Atomics.wait is unavailable */
+    }
+  }
+}
+
 export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): boolean {
   const dir = recordsDir();
   if (!dir) return false;
@@ -854,8 +888,21 @@ export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): 
     // the temp; the next ~15s heartbeat retries the atomic replace (self-healing). A
     // terminal persist that can't replace ages out via long record retention instead
     // of ever corrupting the scanned .json.
+    // #1545 — the retries need to be SPREAD OUT to be retries at all. This loop
+    // had no delay, so all five attempts completed within microseconds of each
+    // other and lost to the same reader's `readFileSync` open: "retried a few
+    // times" was effectively one attempt. A reporter polling
+    // `download_model action:"status"` — i.e. opening this exact file — while a
+    // download completed saw the terminal record fail to land, and `status` kept
+    // answering "downloading" from the prior record until the ~15s heartbeat.
+    //
+    // The backoff is SYNCHRONOUS on purpose: `commitDone` publishes the terminal
+    // state and persists it in one step with no await in between, so nothing may
+    // yield here. Worst case is ~37 ms, and only under actual contention — the
+    // first attempt is unchanged and does not sleep.
     let renamed = false;
     for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
+      if (attempt > 0) sleepSyncMs(RENAME_BACKOFF_MS[attempt - 1] ?? 20);
       try {
         renameSync(tmpPath, finalPath); // readers see old or new complete record, never torn
         renamed = true;

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -857,8 +857,13 @@ function sleepSyncMs(ms: number): void {
   try {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
   } catch {
-    const until = Date.now() + ms;
-    while (Date.now() < until) {
+    // performance.now() is MONOTONIC; Date.now() is not. A backward wall-clock
+    // adjustment (NTP step, DST on some platforms) during this loop would make
+    // the exit condition unreachable and freeze the event loop in the very
+    // fallback meant to be safe (review finding). The iteration cap is a second
+    // belt: even a pathological clock cannot make this run forever.
+    const until = performance.now() + ms;
+    for (let i = 0; performance.now() < until && i < 5_000_000; i++) {
       /* bounded spin — only reached where Atomics.wait is unavailable */
     }
   }


### PR DESCRIPTION
Claims #1545.

`commitDone` (download-jobs.ts) publishes the terminal state and persists it:

```ts
job.status = "done";
job.finished_at = Date.now();
if (!dispatchToManager) job.live_visible = "pending";
persistJobRecord(job);          // <- return value DISCARDED
```

`persistDownloadJob` returns **false** on failure, and its own comment names the failure this hits:

> Atomic replace, retried a few times for a TRANSIENT Windows sharing violation (**a reader briefly holding the target open during its own readFileSync**).

After five failed `renameSync` attempts it drops the temp file and **keeps the prior COMPLETE record** — which still says `downloading`. Recovery is the ~15 s heartbeat.

That is exactly the reported timeline: the completion event fires (raised from the orchestrator's in-memory state), two `download_model action:"status"` calls ~5 s apart still read `downloading` from the persisted record, and a later call reads `done`.

The contention is self-inflicted in the reporter's shape: they were polling `status` — i.e. holding the record open for `readFileSync` — precisely while the writer was trying to replace it. Polling makes the collision **more** likely, so the tool the event tells you to call is the one that can keep the answer stale.

Scope: make the failed terminal persist non-silent. Not touching the atomic-replace strategy — the comment is right that an in-place rewrite would be worse.