### PR TITLE
release: v0.51.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.40",
+  "version": "0.51.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.40",
+      "version": "0.51.41",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.40",
+  "version": "0.51.41",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.41 with #1545.

A download's terminal record is published with write-temp + `renameSync`. `commitDone` called `persistJobRecord(job)` and **discarded the boolean** — and that function returns `false` when the atomic replace loses to a reader holding the record open, keeping the PRIOR record rather than risking a torn write. So the completion event (raised from the orchestrator's memory) and `download_model action:"status"` (read from disk in the spawned child) disagreed until the ~15 s heartbeat.

The contention is self-inflicted in the reported shape: polling `status` opens the exact file the writer is replacing, so the tool the event tells you to call is the one that keeps the answer stale.

Two changes: the failed persist is re-attempted and then **logged with its consequence named**, and the replace's retries — which previously ran with **no delay**, so all five collided with one reader open — are now spread.

**Reproduced against the built `dist/`**: holding the record open makes the replace return `false` after ~70 ms of spread retries, with no `.tmp` litter, and an uncontended replace still takes no delay at all.

Three review findings fixed, including a timing floor that would have failed a correct implementation on Linux CI, and a fallback spin on the non-monotonic `Date.now()`.