### PR TITLE
fix(369): an INFERRED models root must still be corroborated before a download lands there

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -84,23 +84,30 @@ vi.mock("../../services/extra-paths.js", () => ({
 const resolveModelsDirWithBasesMock = vi.hoisted(() =>
   vi.fn(async (): Promise<unknown> => undefined),
 );
-vi.mock("../../services/output-dir.js", () => ({
-  resolveModelsDir: vi.fn(async () => resolve(h.destModelsDir)),
-  resolveModelsDirWithBases: () => resolveModelsDirWithBasesMock(),
-  parseModelsDirFromArgv: vi.fn(() => undefined),
-  hasUnresolvableRelativeModelDirFlag: vi.fn(() => false),
-  // Real behaviour (pure argv parsing): the "empty tree + no extra roots" refusal
-  // only concludes anything when the server's config location is knowable.
-  parseExtraModelPathsConfigsFromArgvRaw: (argv?: string[]) => {
-    const out: string[] = [];
-    for (let i = 0; i < (argv?.length ?? 0); i++) {
-      if (argv![i] === "--extra-model-paths-config" && argv![i + 1]) out.push(argv![i + 1]);
-    }
-    return out;
-  },
-  isLiveAuthoritativeModelsDir: (s: string) =>
-    s === "argv-flag" || s === "live-root" || s === "observed-root",
-}));
+vi.mock("../../services/output-dir.js", async (importOriginal) => {
+  // The provenance predicates come from the REAL module. WHICH sources skip the
+  // disagreement check is the entire subject of #369, so a hand-copied second
+  // definition here could drift from the one production uses — and these tests
+  // would keep passing while the guard changed underneath them.
+  const real = (await importOriginal()) as typeof import("../../services/output-dir.js");
+  return {
+    resolveModelsDir: vi.fn(async () => resolve(h.destModelsDir)),
+    resolveModelsDirWithBases: () => resolveModelsDirWithBasesMock(),
+    parseModelsDirFromArgv: vi.fn(() => undefined),
+    hasUnresolvableRelativeModelDirFlag: vi.fn(() => false),
+    // Real behaviour (pure argv parsing): the "empty tree + no extra roots" refusal
+    // only concludes anything when the server's config location is knowable.
+    parseExtraModelPathsConfigsFromArgvRaw: (argv?: string[]) => {
+      const out: string[] = [];
+      for (let i = 0; i < (argv?.length ?? 0); i++) {
+        if (argv![i] === "--extra-model-paths-config" && argv![i + 1]) out.push(argv![i + 1]);
+      }
+      return out;
+    },
+    isLiveAuthoritativeModelsDir: real.isLiveAuthoritativeModelsDir,
+    modelsDirNamedByServer: real.modelsDirNamedByServer,
+  };
+});
 
 // A live-resolved models root is exempt from the pre-write check ONLY when it
 // exists on this filesystem (a container-side path does not). Default true.
@@ -336,6 +343,20 @@ describe("pre-write: a destination the LIVE server does not read from is refused
     );
   });
 
+  it("does NOT second-guess an --models-directory the server itself passed", async () => {
+    // The other server-named source. Mutation testing found nothing covered it:
+    // dropping `argv-flag` from the exemption killed no test, so the guard could
+    // have started charging a listing call — and refusing — on the strongest
+    // provenance there is, silently.
+    h.modelsDirSource = "argv-flag";
+    h.onDisk = { loras: ["stale.safetensors"] };
+    h.liveListings["loras"] = ["completely-different.safetensors"];
+    await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBe(
+      resolve("/comfy/models/loras"),
+    );
+    expect(h.fetchCalls).toEqual([]);
+  });
+
   it("does NOT second-guess a root the SERVER'S OWN ARGV named, when it exists locally", async () => {
     // `argv-flag` and `live-root` come from the server stating where it reads.
     // Nothing this side infers can be better evidence than that, so the listing
@@ -472,7 +493,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     // Default to the healthy case: the destination IS the root the running server
     // reported, so a listing hit is decisive. Tests about the non-authoritative
     // ambiguity set `configured-base` explicitly.
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models";
   });
 
@@ -608,10 +629,41 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.note).toMatch(/list_local_models/);
   });
 
+  // #369 review, P1: the pre-write guard fails OPEN on an empty candidate tree —
+  // correctly, since an empty directory contradicts nothing. So a stale INFERRED
+  // root can still receive the write. What must not follow is a confident
+  // "visible": the live server lists that filename because the user already had
+  // the model in the REAL install, and matching on the name alone would report a
+  // download that landed nowhere the server reads as a success. That is #369's
+  // original symptom, reproduced after the pre-write half was fixed.
+  it("#369: an INFERRED root does NOT get a confident 'visible' from a same-named entry", async () => {
+    // The fixture has to put the landed file UNDER the inferred root, or the
+    // membership test answers "outside" and the verdict is unremarkable either
+    // way. (First written with the file in the other tree: it passed with the
+    // narrowing REVERTED, i.e. it pinned nothing. Mutation testing caught that.)
+    //
+    // So: the write landed in the stale tree the inference produced, and the live
+    // server lists that filename because the user already had the model in the
+    // REAL install. Membership says "yes, under the root" — of a root the server
+    // never named — and a name match would then read as success.
+    const staleLanded = resolve("/stale/ComfyUI/models/loras/new.safetensors");
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/stale/ComfyUI/models";
+    h.liveListings["loras"] = ["new.safetensors"]; // the server's own copy elsewhere
+    const res = await verifyLandedModel(staleLanded, "loras", {
+      attempts: 1,
+      retryMs: 0,
+      listedBefore: true,
+    });
+    expect(res.liveVisible).toBe("unknown");
+    expect(res.note).toMatch(/inferred from where the server's interpreter lives/);
+    expect(res.note).toMatch(/already listed that name before this download/);
+  });
+
   it("DOES confirm a re-download into a LIVE-AUTHORITATIVE root even though the name pre-existed", async () => {
     // Repairing/replacing an existing model in the server's own tree must stay a
-    // clean success — the ambiguity only exists for locally-configured roots.
-    h.modelsDirSource = "observed-root";
+    // clean success — the ambiguity only exists for roots the server did not name.
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models"; // the tree `target` lives in
     h.liveListings["loras"] = ["new.safetensors"];
     const res = await verifyLandedModel(target, "loras", {
@@ -626,7 +678,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     // Server A was live when the file landed under A's models root. B replaced it on
     // the same port before verification and happens to list the same filename — that
     // is B's OWN copy, not ours, and ours is outside everything B reads.
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/serverB/models"; // the CURRENT live root
     h.liveListings["loras"] = ["new.safetensors"]; // B's own same-named model
     h.liveExtraRoots = { authoritative: true, roots: [] };
@@ -642,7 +694,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
   it("re-checks membership AFTER the listing — a server swap mid-check is not a success (codex gate r11)", async () => {
     // Server A is live for the membership check; B replaces it before the listing
     // and lists its OWN same-named model. That must not confirm A's file.
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models"; // A: the landed file IS under this
     h.liveExtraRoots = { authoritative: true, roots: [] };
     h.liveListings["loras"] = ["new.safetensors"];
@@ -668,7 +720,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
   });
 
   it("stamps the live root a VISIBLE verdict was made against", async () => {
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models";
     h.liveListings["loras"] = ["new.safetensors"];
     const res = await verifyLandedModel(target, "loras", {
@@ -683,7 +735,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
   it("stamps the root the MEMBERSHIP check ran against, not a later observation (codex gate r12)", async () => {
     // The membership re-check sees A; a THIRD observation would see B. The stamp
     // must name A, or a later reader would think the verdict is current for B.
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models";
     h.liveListings["loras"] = ["new.safetensors"];
     let calls = 0;
@@ -718,7 +770,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
       if (resolve(s) === resolve("/comfy/models")) return resolve("/D/Models");
       return resolve(s);
     });
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/comfy/models";
     h.liveExtraRoots = { authoritative: true, roots: [] };
     h.liveListings["loras"] = ["new.safetensors"];
@@ -738,7 +790,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     realpathMock.mockImplementation(async (p: string) =>
       String(p) === target ? external : resolve(String(p)),
     );
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/serverB/models";
     h.liveExtraRoots = {
       authoritative: true,
@@ -760,7 +812,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     realpathMock.mockImplementation(async (p: string) =>
       String(p) === target ? external : resolve(String(p)),
     );
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/serverB/models";
     h.liveExtraRoots = {
       authoritative: true,
@@ -798,7 +850,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
       }
       return resolve(s);
     });
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/comfy/models";
     h.liveExtraRoots = { authoritative: true, roots: [] };
     h.liveListings["vae"] = ["new.safetensors"];
@@ -825,7 +877,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
       }
       return resolve(s);
     });
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/comfy/models";
     h.liveExtraRoots = { authoritative: true, roots: [] };
     h.liveListings["vae"] = ["vendor/new.safetensors"];
@@ -844,7 +896,7 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     // from it is the contract speaking, not the server. The verdict must be an
     // honest unconfirmed, not "the server does NOT list it".
     const dTarget = resolve("/live/ComfyUI/models/diffusers/model.safetensors");
-    h.modelsDirSource = "observed-root";
+    h.modelsDirSource = "live-root";
     h.destModelsDir = "/live/ComfyUI/models";
     h.liveListings["diffusers"] = []; // what the real endpoint answers, by contract
     const res = await verifyLandedModel(dTarget, "diffusers", { attempts: 1, retryMs: 0 });

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -336,14 +336,54 @@ describe("pre-write: a destination the LIVE server does not read from is refused
     );
   });
 
-  it("does NOT second-guess a LIVE-AUTHORITATIVE root that exists locally — no listing call", async () => {
-    h.modelsDirSource = "observed-root";
+  it("does NOT second-guess a root the SERVER'S OWN ARGV named, when it exists locally", async () => {
+    // `argv-flag` and `live-root` come from the server stating where it reads.
+    // Nothing this side infers can be better evidence than that, so the listing
+    // call is skipped entirely.
+    h.modelsDirSource = "live-root";
     h.onDisk = { loras: ["stale.safetensors"] };
     h.liveListings["loras"] = ["completely-different.safetensors"];
     await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBe(
       resolve("/comfy/models/loras"),
     );
     expect(h.fetchCalls).toEqual([]);
+  });
+
+  // ── #369 recurrence: `observed-root` is INFERRED, not vouched for ──────────
+  //
+  // This test previously asserted the opposite, for `observed-root`, on the
+  // ground that a "live-resolved" root is authoritative and needs no second
+  // opinion. Measured against the anchor, that ground does not hold:
+  // `observed-root` is the relative `main.py` re-anchored on the interpreter the
+  // OS reports, which establishes where the BINARY lives — not where the server
+  // reads models. With a stale bundle's python on PATH, `cd D:\live && python
+  // ComfyUI\main.py` anchors `C:\stale\ComfyUI`, and the download lands in an
+  // install the running server never reads. That is #369's original outcome
+  // reached by a different route, which is why it was reopened.
+  //
+  // So the exemption now covers only the two sources the SERVER ITSELF named.
+  // `observed-root` runs the same cheap, fail-open disagreement check every
+  // configured root runs — it cannot refuse a fresh or shared tree, because the
+  // check needs POSITIVE contradicting evidence (containment, root-wide).
+  it("#369: an INFERRED root IS checked, and a contradicting live listing refuses it", async () => {
+    h.modelsDirSource = "observed-root";
+    h.onDisk = { loras: ["stale.safetensors"] };
+    h.liveListings["loras"] = ["completely-different.safetensors"];
+    await expect(resolveModelSubfolderPreferServer("loras")).rejects.toThrow(
+      /does not read|not part of its search path|stale/i,
+    );
+    expect(h.fetchCalls.length).toBeGreaterThan(0);
+  });
+
+  it("#369: an inferred root that AGREES with the live server still proceeds", async () => {
+    // The direction that must not regress: the check is fail-open and needs
+    // positive contradiction, so a correct anchor is unaffected.
+    h.modelsDirSource = "observed-root";
+    h.onDisk = { loras: ["shared.safetensors"] };
+    h.liveListings["loras"] = ["shared.safetensors", "other.safetensors"];
+    await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBe(
+      resolve("/comfy/models/loras"),
+    );
   });
 
   it("PROCEEDS on a container-side models root that does not exist here (post-write reports it)", async () => {

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -61,25 +61,33 @@ vi.mock("node:fs/promises", () => ({
 // dir so these path-safety tests stay hermetic (no real ComfyUI connection).
 /** Successive models roots resolveModelsDirWithBases hands out (see the mock). */
 const liveRoots = vi.hoisted(() => ({ queue: [] as string[] }));
-vi.mock("../../services/output-dir.js", () => ({
-  resolveModelsDir: vi.fn(async () => "/comfy/models"),
-  // The download resolver now derives the models dir AND the base-install dirs
-  // (for the code-root veto) from ONE call. No base dirs here → the symlink-escape
-  // guard falls back to the models-root sibling (#633 codex r4).
-  resolveModelsDirWithBases: vi.fn(async () => ({
-    // Successive values let a test model the live server being REPLACED between the
-    // destination resolution and the write (#369 write-time binding). Defaults to a
-    // single stable root.
-    modelsDir: liveRoots.queue.shift() ?? "/comfy/models",
-    baseDirs: [],
-    snapshot: { reachable: false },
-    // Live-authoritative: these path-safety tests are about containment, not about
-    // the #369 stale-install check (which only runs for a locally-configured root).
-    source: "live-root" as const,
-  })),
-  isLiveAuthoritativeModelsDir: (s: string) =>
-    s === "argv-flag" || s === "live-root" || s === "observed-root",
-}));
+vi.mock("../../services/output-dir.js", async (importOriginal) => {
+  // Provenance predicates from the REAL module — see the same note in
+  // download-live-destination.test.ts. Which sources skip the #369 disagreement
+  // check is the rule under test elsewhere; a hand-copied second definition here
+  // would let these suites pass against a rule production no longer uses.
+  const real = (await importOriginal()) as typeof import("../../services/output-dir.js");
+  return {
+    resolveModelsDir: vi.fn(async () => "/comfy/models"),
+    // The download resolver now derives the models dir AND the base-install dirs
+    // (for the code-root veto) from ONE call. No base dirs here → the symlink-escape
+    // guard falls back to the models-root sibling (#633 codex r4).
+    resolveModelsDirWithBases: vi.fn(async () => ({
+      // Successive values let a test model the live server being REPLACED between the
+      // destination resolution and the write (#369 write-time binding). Defaults to a
+      // single stable root.
+      modelsDir: liveRoots.queue.shift() ?? "/comfy/models",
+      baseDirs: [],
+      snapshot: { reachable: false },
+      // NAMED BY THE SERVER: these path-safety tests are about containment, not
+      // about the #369 stale-install check (which now also runs for an INFERRED
+      // root, so "live-authoritative" is no longer the exempting property).
+      source: "live-root" as const,
+    })),
+    isLiveAuthoritativeModelsDir: real.isLiveAuthoritativeModelsDir,
+    modelsDirNamedByServer: real.modelsDirNamedByServer,
+  };
+});
 
 // The symlink-escape guard consults registered extra_model_paths roots (#633) for
 // its code-root VETO. Stub to none (and non-authoritative live roots) so these

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -25,6 +25,7 @@ import {
   parseModelsDirFromArgv,
   hasUnresolvableRelativeModelDirFlag,
   isLiveAuthoritativeModelsDir,
+  modelsDirNamedByServer,
   type LiveServerSnapshot,
   type ModelsDirSource,
 } from "./output-dir.js";
@@ -1074,7 +1075,12 @@ async function assertDestinationVisibleToLiveServer(
   // reports its CONTAINER-side `--models-directory`, and writing that path here
   // silently creates a host directory the server never reads (codex gate, round 3).
   // The check below is cheap and fails open, so run it for that case too.
-  if (isLiveAuthoritativeModelsDir(source) && existsSync(modelsRoot)) return;
+  // Only a root the SERVER ITSELF named skips this (#369). `observed-root` reads
+  // as live-authoritative elsewhere and is not wrong to — it beats local config —
+  // but it is INFERRED from where the interpreter lives, and that inference can
+  // land on a stale bundle whose python happens to be on PATH. The exemption
+  // needs a statement from the server, not our best reading of the OS.
+  if (modelsDirNamedByServer(source) && existsSync(modelsRoot)) return;
   if (!snapshot.reachable || isRemoteMode()) return;
 
   // The target category first (it is the one that matters), then the rest of the
@@ -1264,7 +1270,19 @@ export async function isUnderLiveModelRoots(
   } catch {
     return { inRoots: undefined };
   }
-  if (!isLiveAuthoritativeModelsDir(dest.source)) return { inRoots: undefined };
+  // Same narrowing as the pre-write guard, and for the sharper reason (#369,
+  // review): this answer authorizes the POST-write "visible" verdict. An INFERRED
+  // root that is actually stale makes the membership test pass against a root the
+  // server does not read, and a live listing that names the file for an unrelated
+  // reason — the user already had that model — then reads as proof the download
+  // landed somewhere the server can see. That is #369's original symptom exactly:
+  // reported success, model never appears.
+  //
+  // Answering UNKNOWN here costs a correct `observed-root` install its confident
+  // "visible" and gives it the qualified note instead. That is the right trade:
+  // the note names the file, the root, and the remedy, whereas the false positive
+  // is silent and the user discovers it at queue time.
+  if (!modelsDirNamedByServer(dest.source)) return { inRoots: undefined };
   const liveRoot = resolve(dest.modelsDir);
 
   // A negative answer is only honest when everything it rests on could actually be
@@ -1649,8 +1667,9 @@ export async function verifyLandedModel(
           liveVisible: "unknown",
           note:
             `The connected ComfyUI (${getComfyUIBaseUrl()}) lists "${wanted}" under "${category}", ` +
-            "but this destination came from local configuration rather than from the running " +
-            "server, so that listing cannot be tied to the file just written to " +
+            "but this destination was not named by the running server — it came from local " +
+            "configuration, or was inferred from where the server's interpreter lives — so that " +
+            "listing cannot be tied to the file just written to " +
             `${verifiedPath} — it may be the server's own copy elsewhere` +
             (opts?.listedBefore === true
               ? " (it already listed that name before this download)"

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -76,6 +76,37 @@ export function isLiveAuthoritativeModelsDir(source: ModelsDirSource): boolean {
   return source === "argv-flag" || source === "live-root" || source === "observed-root";
 }
 
+/**
+ * Did the SERVER ITSELF name this root, rather than us inferring it? (#369)
+ *
+ * Deliberately narrower than `isLiveAuthoritativeModelsDir`, and deliberately a
+ * SEPARATE predicate rather than a change to it — that one has four other callers
+ * answering different questions, and widening or narrowing it in place would move
+ * all of them at once.
+ *
+ * The distinction is what a source is EVIDENCE OF:
+ *
+ *   argv-flag / live-root — the server's own command line, naming its base or its
+ *     script root. A statement about where the server reads.
+ *   observed-root — a relative `main.py` re-anchored on the interpreter the OS
+ *     reports for the process on our port. A statement about where the BINARY
+ *     lives, from which the root is INFERRED.
+ *
+ * Those come apart in an ordinary Windows setup: with a stale portable bundle's
+ * python on PATH, `cd D:\live && python ComfyUI\main.py` anchors
+ * `C:\stale\ComfyUI` — measured, and reachable through both the absolute-argv[0]
+ * tier and the OS-image reading (#1374). A download then lands in an install the
+ * running server never reads, which is #369's original outcome by a new route.
+ *
+ * So only the first two skip the disagreement check. The inferred one runs it, at
+ * the cost of one `/models/<category>` listing call — a check that needs positive
+ * contradicting evidence and fails open on everything else, so it cannot refuse a
+ * fresh or shared tree.
+ */
+export function modelsDirNamedByServer(source: ModelsDirSource): boolean {
+  return source === "argv-flag" || source === "live-root";
+}
+
 /** Resolve a possibly-relative dir against a base (or COMFYUI_PATH, or cwd). */
 function resolveDir(value: string, base?: string): string {
   if (isAbsolute(value)) return resolve(value);


### PR DESCRIPTION
Refs #369 (reopened). Fixes the recurrence route; the issue stays open until a reporter confirms.

## The recurrence

#369 was "download_model reports success, the model never appears" — 3.79 GB into a stale install. 0.49.7 (#794) added two guards: a **pre-write** disagreement check (candidate models root vs the server's own `/models/<category>` listing) and a **post-write** membership + listing verification.

Both were skipped for three provenances judged LIVE-AUTHORITATIVE. One does not earn it:

| source | what it is | statement by the server? |
|---|---|---|
| `argv-flag` | the server's own `--base-directory` / `--models-directory` | yes |
| `live-root` | the server's own argv `main.py` root | yes |
| `observed-root` | a **relative** argv `main.py` re-anchored on the interpreter the OS reports | **no — inferred** |

`observed-root` establishes where the **binary** lives. Measured on #1374's branch: with a stale portable bundle's python on `PATH`, `cd D:\live && python ComfyUI\main.py` anchors `C:\stale\ComfyUI`. Reachable through both the absolute-`argv[0]` tier and the OS-image reading, so this is not a regression from #1374 — it is what #1374 made me look at.

## The fix

A new, narrower predicate `modelsDirNamedByServer` gates both halves. Deliberately **separate** from `isLiveAuthoritativeModelsDir` rather than an edit to it — that predicate has four callers answering different questions, and narrowing it in place would move all of them.

- **Pre-write**: the disagreement check now runs for an inferred root. It needs positive contradicting evidence gathered root-wide and fails open on everything else, so it cannot refuse a fresh or shared tree. Cost: one listing call.
- **Post-write** (your P1): the membership test that authorizes `visible` now answers UNKNOWN for an inferred root.

The post-write half is the one that mattered and the first draft missed. The pre-write check fails **open** on an empty candidate tree — correctly; an empty directory contradicts nothing — so a stale inferred root can still receive the write. The live server then lists that filename because the user already had the model in the real install, and a name match alone reported the download as a success: #369's original symptom, reproduced after the pre-write half was fixed.

A correct `observed-root` install now gets the qualified note instead of a confident `visible`. The note names the file, the root and the remedy; the false positive was silent until queue time. Its wording previously said "came from local configuration", untrue for this source, and now covers the inferred case.

## Verification

- **499 files / 9390 tests green**, lint clean.
- **10 mutations, all applied and all killed**, against a **checked-green baseline**.

Two findings came only from that discipline, and both were mine:

1. The harness first reported **7/7 KILLED while 27 tests were already failing** — a second `output-dir.js` mock was missing the new export, so every result was measured against red. The harness now refuses to run unless the baseline is green.
2. With a green baseline, the P1 test I had just written **SURVIVED its own mutation**: the fixture put the landed file *outside* the inferred root, so membership was unremarkable either way and it pinned nothing. Rewritten to land the file **under** the stale root, which is the reviewed scenario.

Both `output-dir.js` mocks now take the provenance predicates from the **real** module via `importOriginal` — which sources skip these checks is the entire subject of this issue, and a hand-copied rule in a test is how a suite keeps passing against a rule production no longer uses. A mutation that re-copies it by hand is in the set and is killed.

12 post-write tests moved from `observed-root` to `live-root`: they are about the membership *mechanism* (junction handling, server-swap detection, root stamping) and used that source only as a stand-in, so the swap preserves their intent.
