### PR TITLE
release: v0.51.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.44] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- an INFERRED models root must still be corroborated before a download lands there (#1562)
+
+
 ## [0.51.43] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.43",
+  "version": "0.51.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.43",
+      "version": "0.51.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.43",
+  "version": "0.51.44",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.51.44 with #1562 (refs #369).

Only a models root the **server itself named** now skips #369's stale-install guards. A root we *inferred* from where the interpreter lives runs the same fail-open corroboration, and no longer earns a confident `visible` from a same-named entry the live server lists for an unrelated reason.

**#369 stays open** pending a reporter confirmation.

Live-verified on this machine, which resolves via `observed-root`: the check is active and loras/checkpoints/vae all still resolve. 499 files / 9390 tests green; 10 mutations all killed against a checked-green baseline.