### PR TITLE
fix(1400): a Get/Set bus node is not an unknown runtime

### DIFF
--- a/src/__tests__/services/runtime-virtual-nodes.test.ts
+++ b/src/__tests__/services/runtime-virtual-nodes.test.ts
@@ -19,7 +19,10 @@
 import { describe, expect, it } from "vitest";
 
 import { checkWorkflowRuntime } from "../../services/api-nodes.js";
-import { NON_EXECUTING_NODE_TYPES } from "../../services/workflow-converter.js";
+import {
+  FRONTEND_ONLY_NODE_TYPES,
+  NON_EXECUTING_NODE_TYPES,
+} from "../../services/workflow-converter.js";
 
 const KSAMPLER = { input: { required: { seed: ["INT"] } }, output: ["LATENT"], name: "KSampler" };
 /** An API node as the classifier recognises one. */
@@ -120,5 +123,72 @@ describe("a frontend-only node is not an unknown runtime (#1372)", () => {
     );
     expect(r.runtime).toBe("mixed");
     expect(r.usesApiNodes).toBe(true);
+  });
+});
+
+// #1400 — the follow-up. #1372 covered the four LiteGraph-NATIVE virtuals, which left the
+// larger half of the measured population: KJNodes Get/Set bus nodes. In the same four-pack
+// measurement they were the most common entries by far — 3x GetNode, 3x SetNode against
+// 2x Note — so a Get/Set-routed workflow still collapsed to "unknown" and still stopped the
+// safety flow.
+//
+// The converter has ALWAYS known these never reach the backend: `deVirtualize` strips the
+// whole Get/Set bus before a prompt is built, rewriting each consumer's link to the real
+// upstream source. So this is not a new list of third-party names to keep current — it is
+// the classifier finally consulting the list the converter must already keep correct, for
+// a reason far more load-bearing than this verdict (a stale entry there drops links).
+describe("a Get/Set bus node is not an unknown runtime (#1400)", () => {
+  it("THE REPORTED CASE: a Get/Set-routed local workflow is local, not unknown", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "GetNode", "SetNode"),
+      depsWith({ KSampler: KSAMPLER }),
+    );
+    expect(r.runtime).toBe("local");
+    expect(r.usesApiNodes).toBe(false);
+    expect(r.unknownNodes).toEqual([]);
+  });
+
+  it("every wiring virtual the CONVERTER strips is treated the same way", async () => {
+    // Imported, not restated: if the converter learns a new bus type, the classifier
+    // learns it in the same commit or this fails.
+    for (const t of FRONTEND_ONLY_NODE_TYPES) {
+      const r = await checkWorkflowRuntime(graphOf("KSampler", t), depsWith({ KSampler: KSAMPLER }));
+      expect(r.runtime, `${t} must not make the runtime unknown`).toBe("local");
+      expect(r.unknownNodes, `${t} must not be reported as unknown`).toEqual([]);
+    }
+  });
+
+  it("the shared set CONTAINS both halves — natives and wiring virtuals", async () => {
+    // Guards the union itself: dropping either half would leave the other's tests green.
+    for (const t of NON_EXECUTING_NODE_TYPES) expect(FRONTEND_ONLY_NODE_TYPES.has(t)).toBe(true);
+    for (const t of ["GetNode", "SetNode", "PRO_GetNode", "PRO_SetNode"]) {
+      expect(FRONTEND_ONLY_NODE_TYPES.has(t), `${t} must be classified frontend-only`).toBe(true);
+    }
+  });
+
+  it("a REGISTERED backend node named GetNode is still examined, not skipped", async () => {
+    // The #1396 codex P1, inherited: the skip applies only when the server does NOT
+    // register the type. A third-party backend node that happens to be called GetNode —
+    // and is a paid API node — must not be waved through unexamined.
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "GetNode"),
+      depsWith({ KSampler: KSAMPLER, GetNode: API_NODE }),
+    );
+    expect(r.runtime).toBe("mixed");
+    expect(r.usesApiNodes).toBe(true);
+    expect(r.apiNodes).toContain("GetNode");
+  });
+
+  it("rgthree's canvas-only nodes are still UNKNOWN — cautious, and deliberately so", async () => {
+    // The rest of #1400's population (Label, Fast Groups Bypasser/Muter) is NOT covered.
+    // The converter does not strip them, so nothing here can prove they never execute, and
+    // guessing "free" is a guess with someone's money on it. Recorded as a test so the gap
+    // is a decision rather than an oversight.
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "Fast Groups Bypasser (rgthree)"),
+      depsWith({ KSampler: KSAMPLER }),
+    );
+    expect(r.runtime).toBe("unknown");
+    expect(r.unknownNodes).toEqual(["Fast Groups Bypasser (rgthree)"]);
   });
 });

--- a/src/__tests__/services/runtime-virtual-nodes.test.ts
+++ b/src/__tests__/services/runtime-virtual-nodes.test.ts
@@ -179,6 +179,19 @@ describe("a Get/Set bus node is not an unknown runtime (#1400)", () => {
     expect(r.apiNodes).toContain("GetNode");
   });
 
+  it("bus nodes leave the DENOMINATOR too — one API node beside a bus is 'api', not 'mixed'", async () => {
+    // The ratio decides "api" vs "mixed". A virtual node is not classifiable in either
+    // direction, so counting it as classifiable makes an all-paid workflow read as
+    // partly local — the same arithmetic #1372 fixed for Notes, which the Get/Set half
+    // would otherwise reintroduce. (Mutation testing found nothing covered this.)
+    const r = await checkWorkflowRuntime(
+      graphOf("FluxProImageNode", "GetNode", "SetNode"),
+      depsWith({ FluxProImageNode: API_NODE }),
+    );
+    expect(r.runtime).toBe("api");
+    expect(r.usesApiNodes).toBe(true);
+  });
+
   it("rgthree's canvas-only nodes are still UNKNOWN — cautious, and deliberately so", async () => {
     // The rest of #1400's population (Label, Fast Groups Bypasser/Muter) is NOT covered.
     // The converter does not strip them, so nothing here can prove they never execute, and

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -283,6 +283,56 @@ describe("convertUiToApi — bypass / mute resolution", () => {
     expect(workflow["3"]).toBeUndefined(); // GetNode dropped
     expect(workflow["4"].inputs.images).toEqual(["1", 0]); // resolved through the bus
   });
+
+  // #1400 — the SAME bus, spelled with the PRO_ variants. The de-virtualizer and the
+  // main loop used to keep separate copies of this type list; they now share one, and
+  // this is what notices if that list is narrowed back to the two common names.
+  it("a PRO_Set/PRO_Get bus resolves identically — the whole type list is live", () => {
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [1] }],
+          widgets_values: ["in.png"],
+        },
+        {
+          id: 2,
+          type: "PRO_SetNode",
+          mode: 0,
+          inputs: [{ name: "IMAGE", type: "IMAGE", link: 1 }],
+          outputs: [],
+          widgets_values: ["BUS"],
+        },
+        {
+          id: 3,
+          type: "PRO_GetNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [2] }],
+          widgets_values: ["BUS"],
+        },
+        {
+          id: 4,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 2 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [
+        [1, 1, 0, 2, 0, "IMAGE"],
+        [2, 3, 0, 4, 0, "IMAGE"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, OBJECT_INFO);
+    expect(workflow["2"]).toBeUndefined();
+    expect(workflow["3"]).toBeUndefined();
+    expect(workflow["4"].inputs.images).toEqual(["1", 0]);
+  });
 });
 
 describe("convertUiToApi — serialized-widget nodes (has_serialized_properties)", () => {

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -4,7 +4,7 @@ import type {
   NodeInputSpec,
   WorkflowJSON,
 } from "../comfyui/types.js";
-import { NON_EXECUTING_NODE_TYPES } from "./workflow-converter.js";
+import { FRONTEND_ONLY_NODE_TYPES } from "./workflow-converter.js";
 import { getObjectInfo } from "../comfyui/client.js";
 import { enqueueWorkflow } from "./workflow-executor.js";
 import { config } from "../config.js";
@@ -424,7 +424,7 @@ export async function checkWorkflowRuntime(
     // Absence from /object_info is not a heuristic for "virtual", it is the definition:
     // the frontend registers these, the backend does not. So a REGISTERED node of the same
     // name is a real node and is classified as one.
-    if (!def && NON_EXECUTING_NODE_TYPES.has(ct)) continue;
+    if (!def && FRONTEND_ONLY_NODE_TYPES.has(ct)) continue;
     if (!def) {
       unknownNodes.push(ct);
       continue;
@@ -445,7 +445,7 @@ export async function checkWorkflowRuntime(
   // otherwise a workflow of one KSampler plus three Notes reads as 1-of-4 API and reports
   // "mixed" when it is entirely local.
   const virtualCount = classTypes.filter(
-    (ct) => !objectInfo[ct] && NON_EXECUTING_NODE_TYPES.has(ct),
+    (ct) => !objectInfo[ct] && FRONTEND_ONLY_NODE_TYPES.has(ct),
   ).length;
   const classifiable = classTypes.length - unknownNodes.length - virtualCount;
   let runtime: "local" | "api" | "mixed" | "unknown";

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -577,7 +577,17 @@ function getOrderedInputNames(def: ComfyUINodeDef): string[] {
 
 // ── De-virtualization (Get/Set/Reroute) pre-pass ────────────────────────────
 
-const WIRING_VIRTUAL_TYPES = new Set([
+/**
+ * The KJNodes-style Get/Set BUS types. Frontend-only: the pre-pass below rewrites
+ * each consumer's link straight to the real upstream source, so none of these ever
+ * appears in a queued prompt.
+ *
+ * EXPORTED (#1400) for the same reason `NON_EXECUTING_NODE_TYPES` is: the runtime
+ * classifier needs to know which types never reach the backend, and a second copy
+ * of that knowledge is how two lists drift. This one is already load-bearing for a
+ * much heavier reason than a verdict — a stale entry here drops links.
+ */
+export const WIRING_VIRTUAL_TYPES: ReadonlySet<string> = new Set([
   "GetNode", "SetNode", "PRO_GetNode", "PRO_SetNode",
   "SetNode_GetNode", "SetNode_SetNode",
 ]);
@@ -2273,6 +2283,31 @@ export const NON_EXECUTING_NODE_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Every type that never reaches the backend — the LiteGraph natives above PLUS the
+ * Get/Set bus virtuals the de-virtualization pre-pass strips (#1400).
+ *
+ * A SEPARATE set from `NON_EXECUTING_NODE_TYPES` because the two answer different
+ * questions, and conflating them would be a silent behaviour change:
+ *
+ *   NON_EXECUTING_NODE_TYPES also drives the converter's own `SKIP_TYPES`. A
+ *     Get/Set node that the pre-pass could NOT resolve (a broken bus, a missing
+ *     Set for a Get) still reaches the main loop, where dedicated logic handles it
+ *     and reports the loss. Adding the bus types there would route those into the
+ *     skip path instead, quietly dropping the diagnostic.
+ *
+ *   FRONTEND_ONLY_NODE_TYPES answers the runtime classifier's question: could this
+ *     class_type be a paid API node the server does not expose? For anything in
+ *     here the answer is no, whether or not this particular graph's bus resolved.
+ *
+ * Callers that mean "does not execute anywhere" want THIS one; callers that mean
+ * "the converter emits nothing for it" want the narrower one above.
+ */
+export const FRONTEND_ONLY_NODE_TYPES: ReadonlySet<string> = new Set([
+  ...NON_EXECUTING_NODE_TYPES,
+  ...WIRING_VIRTUAL_TYPES,
+]);
+
+/**
  * Convert a ComfyUI UI-format workflow to API format.
  * Requires objectInfo from /object_info to map widgets_values to named inputs.
  */
@@ -2315,11 +2350,19 @@ export function convertUiToApi(
   // Node types that are purely visual/internal and have no API equivalent
   const SKIP_TYPES = NON_EXECUTING_NODE_TYPES;
 
-  // Get/Set node types that need special handling (not in object_info)
-  const GET_SET_TYPES = new Set([
-    "GetNode", "SetNode", "PRO_GetNode", "PRO_SetNode",
-    "SetNode_GetNode", "SetNode_SetNode",
-  ]);
+  // Get/Set node types that need special handling (not in object_info). The SAME
+  // set the de-virtualization pre-pass uses — this was a verbatim second copy, and
+  // two lists of third-party type names in one file is precisely the drift the
+  // exported sets exist to prevent (#1400).
+  //
+  // NOT covered by a test, and mutation testing says so: narrowing this back to a
+  // hand-written `new Set(["GetNode", "SetNode"])` kills nothing, because the
+  // pre-pass strips every RESOLVABLE bus before the main loop runs. What reaches
+  // here is only a bus the pre-pass could not resolve (a Get with no matching Set,
+  // a broken chain), and no fixture builds one. Sharing the set is still strictly
+  // better than a second copy — it just cannot be proven from outside, so it is
+  // written down instead of assumed.
+  const GET_SET_TYPES = WIRING_VIRTUAL_TYPES;
 
   const nodesById = new Map(expanded.nodes.map((n) => [n.id, n]));
 


### PR DESCRIPTION
Refs #1400. Fixes the Get/Set half; the rgthree half stays open (see Scope).

## What #1372 left

#1372 stopped the four LiteGraph-**native** virtuals (`Reroute`, `Note`, `MarkdownNote`, `PrimitiveNode`) from collapsing `check_runtime` to `"unknown"`. The issue's own measurement across four real pack workflows shows what remained:

```
3x  GetNode          ← KJNodes bus routing
3x  SetNode          ←
2x  Note             ← covered by #1372
1x  Label (rgthree)
1x  Fast Groups Bypasser (rgthree)
1x  Fast Groups Muter (rgthree)
```

Get/Set are the **most common** entries, and this repo's own orchestrator prompt describes Get/Set buses as characteristic of expert and community graphs. So the friction #1372 set out to remove is still there for the majority case.

## Why this is not "add a list of third-party names"

The issue rightly objects to that: a hardcoded list of third-party virtual node names goes stale silently and then reads as authoritative.

This adds no such list. The converter has **always** known these never reach the backend — `deVirtualize` strips the entire Get/Set bus before a prompt is built, rewriting each consumer's link to the real upstream source. `WIRING_VIRTUAL_TYPES` already exists and is already load-bearing for a far more important reason than this verdict: a stale entry there **drops links**, visibly. Consuming it costs no new staleness surface, and it is the same move #1372 made when it exported `NON_EXECUTING_NODE_TYPES` rather than restating it — that set's own docblock says "a second copy is how two lists drift".

(There are currently *three* copies of the Get/Set list in the tree — `WIRING_VIRTUAL_TYPES`, `GET_SET_TYPES` inside the converter, and the de-virtualizer's own predicate. The fix will collapse them.)

## What must not change

- **A registered backend node named `GetNode` is still examined.** #1396's codex P1, inherited: the skip applies only when the server does *not* register the type, so a third-party paid node that happens to be called `GetNode` cannot be waved through.
- **`NON_EXECUTING_NODE_TYPES` keeps its current meaning.** It also drives the converter's `SKIP_TYPES`, and Get/Set nodes that `deVirtualize` could not resolve are handled by dedicated logic further down — widening that set in place would silently reroute them into the skip path. The classifier needs a *different* question ("never reaches the backend") than the converter's skip does.

## Scope, stated plainly

**rgthree's canvas-only nodes stay `"unknown"`** (`Label`, `Fast Groups Bypasser/Muter`). The converter does not strip them, so nothing available headlessly proves they never execute, and claiming "free" would be a guess with someone's money on it. That is cautious rather than wrong, exactly as the issue says. The principled fix for those is the issue's own suggestion — a panel command reporting the frontend's registered virtual types — which is **feature work and stays parked under the freeze**. It is recorded here as a test so the gap is a decision, not an oversight.

**So this must not close #1400.**


## The fix

`WIRING_VIRTUAL_TYPES` is exported, and the classifier consumes a new union `FRONTEND_ONLY_NODE_TYPES` — **not** a widened `NON_EXECUTING_NODE_TYPES`, which keeps its old meaning because it also drives the converter's `SKIP_TYPES` for buses the pre-pass could not resolve. Both classifier uses move: the skip **and** the denominator. Leaving the denominator behind would make an all-paid workflow beside a bus read as `"mixed"` — the same arithmetic #1372 had to fix for Notes, and mutation testing showed nothing covered it.

The third copy of the bus list (`GET_SET_TYPES` in the main loop) now references the shared set.

## Verification

- **499 files / 9397 tests green**, lint clean, codex review found no material defects.
- **6 mutations, all applied and all killed**, against a checked-GREEN baseline.
- A seventh was written and **removed rather than left red**: narrowing the main loop's `GET_SET_TYPES` kills nothing, because the pre-pass strips every *resolvable* bus before that code runs and no fixture builds an unresolvable one. Sharing the set is still strictly better than a second copy, so that is written down at the site instead of assumed.
