### PR TITLE
fix(1560): a panel too old to help is also too old to say so

### DIFF
--- a/src/__tests__/services/panel-version-gap.test.ts
+++ b/src/__tests__/services/panel-version-gap.test.ts
@@ -150,6 +150,21 @@ describe("the rebind failure message carries the version gap (#1043)", () => {
     expect(r.tooOld).toBe(false);
   });
 
+  it("an UNRESOLVABLE tab is not narrated as an old panel (review, P1)", async () => {
+    // resolveTarget throwing leaves version undefined, which is indistinguishable
+    // from "never sent one" unless the lookup's own success is tracked. Without
+    // that, a CURRENT panel whose socket closed mid-command would be told to
+    // update — a false accusation built from a failed observation.
+    const { UiBridge } = await import("../../services/ui-bridge.js");
+    const b = new UiBridge(0) as UiBridge & { resolveTarget: () => never };
+    b.resolveTarget = () => {
+      throw new Error("no such tab");
+    };
+    const r = b.panelTooOldForReplyUuid("ghost");
+    expect(r.neverAdvertised, "an unreadable tab proves nothing about the panel").toBeUndefined();
+    expect(r.tooOld).toBe(false);
+  });
+
   it("the never-advertised note hedges, and names a reader that can answer", async () => {
     const { readFileSync } = await import("node:fs");
     const src = readFileSync(
@@ -162,9 +177,13 @@ describe("the rebind failure message carries the version gap (#1043)", () => {
     // It must not assert a version it never saw.
     // Asserted on text that is CONTIGUOUS in source — the sentence spans a string
     // concatenation, so the full phrase never appears as one literal.
-    expect(body).toContain("has never reported its");
-    expect(body).toMatch(/OLDER than/);
-    expect(body).toMatch(/very likely/, "a hedge, because this is inferred from an absent field");
+    expect(body).toContain("has never ");
+    // Review, P1: an absent version proves only "below 0.11.83". Panels in
+    // 0.11.45–0.11.82 publish the reply uuid and simply do not advertise, so the
+    // note must NOT conclude they are too old — it must say what to check.
+    expect(body).toMatch(/does NOT by itself mean it is too old/i);
+    expect(body).toMatch(/0.11.45–0.11.82 do that while still not advertising/);
+    expect(body).toMatch(/WORTH CHECKING/);
     // The remedy must name tools that exist — a citation nobody can run reads as
     // the answer while being a dead end.
     expect(body).toMatch(/panel_action:"status"/);

--- a/src/__tests__/services/panel-version-gap.test.ts
+++ b/src/__tests__/services/panel-version-gap.test.ts
@@ -112,11 +112,65 @@ describe("the rebind failure message carries the version gap (#1043)", () => {
       "utf-8",
     );
     const start = src.indexOf("function panelTooOldNote");
-    const body = src.slice(start, start + 1200);
+    // Widened for #1560, which inserted the never-advertised branch ahead of this
+    // one. The bound is the function, not a byte count that silently truncates:
+    // a slice that stops early would pass by asserting against the wrong text.
+    const end = src.indexOf("\n}", src.indexOf("if (!v?.tooOld) return \"\"", start));
+    const body = src.slice(start, end);
     expect(body).toContain("${v.version}");
     expect(body).toContain("${v.needed}");
     expect(body).toMatch(/panel_action:"sync"/);
     // And it stays silent unless PROVEN too old.
     expect(body).toMatch(/if \(!v\?\.tooOld\) return ""/);
+  });
+
+  // ── #1560: a panel too old to help is also too old to say so ────────────────
+
+  it("a panel that NEVER advertised a version is reported as never-advertised", async () => {
+    const { UiBridge } = await import("../../services/ui-bridge.js");
+    const b = new UiBridge(0) as UiBridge & { resolveTarget: (id: string) => unknown };
+    // No version has ever arrived on this tab — only possible below panel 0.11.83,
+    // which is where `panel_version` started riding the hello.
+    b.resolveTarget = () => ({ panelVersion: undefined, panelVersionAdvertised: false });
+    const r = b.panelTooOldForReplyUuid("t");
+    expect(r.neverAdvertised).toBe(true);
+    // NOT asserted as a version comparison — it is an inference from a missing field.
+    expect(r.tooOld).toBe(false);
+  });
+
+  it("an INHERITED version stays silent — the original guard is unchanged", async () => {
+    const { UiBridge } = await import("../../services/ui-bridge.js");
+    const b = new UiBridge(0) as UiBridge & { resolveTarget: (id: string) => unknown };
+    // A re-hello omitted panel_version, so the previous value is inherited. This is
+    // the case the tri-state guard was written for: saying anything here could tell
+    // someone to update a panel they just updated.
+    b.resolveTarget = () => ({ panelVersion: "0.11.43", panelVersionAdvertised: false });
+    const r = b.panelTooOldForReplyUuid("t");
+    expect(r.neverAdvertised, "an inherited version is NOT never-advertised").toBeUndefined();
+    expect(r.tooOld).toBe(false);
+  });
+
+  it("the never-advertised note hedges, and names a reader that can answer", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("if (v?.neverAdvertised) {");
+    expect(start, "the never-advertised branch must exist").toBeGreaterThan(-1);
+    const body = src.slice(start, start + 1400);
+    // It must not assert a version it never saw.
+    // Asserted on text that is CONTIGUOUS in source — the sentence spans a string
+    // concatenation, so the full phrase never appears as one literal.
+    expect(body).toContain("has never reported its");
+    expect(body).toMatch(/OLDER than/);
+    expect(body).toMatch(/very likely/, "a hedge, because this is inferred from an absent field");
+    // The remedy must name tools that exist — a citation nobody can run reads as
+    // the answer while being a dead end.
+    expect(body).toMatch(/panel_action:"status"/);
+    expect(body).toMatch(/panel_action:"sync"/);
+    // The reporter's actual trap: Manager said the update failed, so the OLD JS is
+    // still running in the open tab.
+    expect(body).toMatch(/HARD-REFRESH/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4194,25 +4194,29 @@ function panelTooOldNote(ctx: PanelToolCtx): string {
     // reporter of #1560 (on 0.11.37, after two Manager self-updates of the pack
     // crashed) got a bare "the panel did not answer" with nothing to act on.
     //
-    // Deliberately WEAKER wording than the version case: this is inferred from a
-    // field that is absent, not from a comparison, so it says "older than" and
-    // "very likely" rather than asserting a version. It also names the check, so
-    // a reader can confirm rather than take it on faith.
+    // Deliberately WEAKER than the version case, and weaker still after review: an
+    // absent version proves only "below 0.11.83", NOT "below the minimum". Panels
+    // in 0.11.45–0.11.82 publish the reply uuid and simply predate version
+    // advertisement, so this must read as SOMETHING TO CHECK and never as a finding
+    // — naming a cause that is not theirs is the failure this whole cluster exists
+    // to avoid.
     if (v?.neverAdvertised) {
       return (
         `
 
-WHY THIS READ WAS NEEDED AT ALL: this session's panel has never reported its ` +
-        `version. Panels have advertised one on connect since 0.11.83, so a panel that ` +
-        `reports none is OLDER than that — and therefore older than ${v.needed}, from which ` +
-        `a panel reports the new workflow's identity ON THE REPLY. From ${v.needed}+ the ` +
-        `command that re-pointed the canvas repairs the fence from its own reply and never ` +
-        `makes this read, so an outdated panel is very likely the whole cause here rather ` +
-        `than anything about this workflow. Check it with install_comfyui (action:"panel", ` +
-        `panel_action:"status"); update with install_comfyui (action:"panel", ` +
-        `panel_action:"sync"), then restart ComfyUI and ` +
-        `HARD-REFRESH the browser tab (Ctrl+Shift+R) — a pack update that ComfyUI-Manager ` +
-        `reported as failed leaves the OLD panel JS running in the open tab.`
+WORTH CHECKING — THE PANEL'S VERSION IS UNKNOWN HERE: this session's panel has never ` +
+        `reported its version, and panels have advertised one on connect since 0.11.83, so ` +
+        `this one is older than that. That does NOT by itself mean it is too old: a panel ` +
+        `reports the new workflow's identity ON THE REPLY from ${v.needed} onwards, and ` +
+        `0.11.45–0.11.82 do that while still not advertising a version. But if it IS below ` +
+        `${v.needed}, that is the whole cause of this failure rather than anything about this ` +
+        `workflow — on ${v.needed}+ the command that re-pointed the canvas repairs the fence ` +
+        `from its own reply and never makes the read that just failed. ` +
+        `Find out with install_comfyui (action:"panel", panel_action:"status"). If it is ` +
+        `older, update with install_comfyui (action:"panel", panel_action:"sync"), restart ` +
+        `ComfyUI, and HARD-REFRESH the browser tab (Ctrl+Shift+R) — a pack update that ` +
+        `ComfyUI-Manager reported as FAILED leaves the old panel JS running in the open tab, ` +
+        `so a restart alone does not pick it up.`
       );
     }
     if (!v?.tooOld) return "";

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4186,6 +4186,35 @@ async function unreadableOrHealed(
 function panelTooOldNote(ctx: PanelToolCtx): string {
   try {
     const v = ctx.bridge?.panelTooOldForReplyUuid?.(ctx.tabId);
+    // #1560 — A PANEL TOO OLD TO HELP IS ALSO TOO OLD TO SAY SO.
+    //
+    // The note below needs an advertised version, and `panel_version` has only
+    // ridden the hello since panel v0.11.83. So the panels most likely to be
+    // causing this deadlock — anything below 0.11.45 — cannot report it, and the
+    // reporter of #1560 (on 0.11.37, after two Manager self-updates of the pack
+    // crashed) got a bare "the panel did not answer" with nothing to act on.
+    //
+    // Deliberately WEAKER wording than the version case: this is inferred from a
+    // field that is absent, not from a comparison, so it says "older than" and
+    // "very likely" rather than asserting a version. It also names the check, so
+    // a reader can confirm rather than take it on faith.
+    if (v?.neverAdvertised) {
+      return (
+        `
+
+WHY THIS READ WAS NEEDED AT ALL: this session's panel has never reported its ` +
+        `version. Panels have advertised one on connect since 0.11.83, so a panel that ` +
+        `reports none is OLDER than that — and therefore older than ${v.needed}, from which ` +
+        `a panel reports the new workflow's identity ON THE REPLY. From ${v.needed}+ the ` +
+        `command that re-pointed the canvas repairs the fence from its own reply and never ` +
+        `makes this read, so an outdated panel is very likely the whole cause here rather ` +
+        `than anything about this workflow. Check it with install_comfyui (action:"panel", ` +
+        `panel_action:"status"); update with install_comfyui (action:"panel", ` +
+        `panel_action:"sync"), then restart ComfyUI and ` +
+        `HARD-REFRESH the browser tab (Ctrl+Shift+R) — a pack update that ComfyUI-Manager ` +
+        `reported as failed leaves the OLD panel JS running in the open tab.`
+      );
+    }
     if (!v?.tooOld) return "";
     return (
       `

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2953,18 +2953,33 @@ export class UiBridge {
      * Never having one is different, and it is evidence rather than absence:
      * `panel_version` has ridden the hello since panel v0.11.83 (measured — the
      * commit is an ancestor of v0.11.83 and of no earlier tag), so a panel that
-     * has never sent one is BELOW that, and therefore also below the 0.11.45 this
-     * check is about. A panel old enough to cause the #1043 deadlock is, by
-     * construction, too old to report that it is — which is why #1560's reporter
-     * got a bare "the panel did not answer" on a panel from 0.11.37.
+     * has never sent one is BELOW 0.11.83.
+     *
+     * THAT IS ALL IT PROVES, and an earlier version of this said more (review, P1):
+     * "below 0.11.83" does NOT imply "below 0.11.45". Panels in 0.11.45–0.11.82
+     * publish the reply uuid perfectly well and simply predate version
+     * advertisement, so telling one of those to update would name a cause that is
+     * not theirs. The caller renders this as a possibility to CHECK, never as a
+     * finding.
+     *
+     * It is still worth saying, because the band that cannot speak for itself is
+     * where the #1043 deadlock lives: #1560's reporter was on 0.11.37 and got a
+     * bare "the panel did not answer" with nothing to act on.
      */
     neverAdvertised?: boolean;
   } {
     const needed = PANEL_MIN_VERSION_REPLY_UUID;
     let version: string | undefined;
     let advertised = false;
+    // Did the LOOKUP itself succeed? A throw leaves `version` undefined, which is
+    // indistinguishable from "the panel never sent one" unless it is tracked
+    // separately — and rendering an unreadable tab as "your panel is old" would
+    // accuse a CURRENT panel whose socket merely closed (review, P1). Absence of
+    // evidence, one level down.
+    let resolved = false;
     try {
       const t = this.resolveTarget(tabId);
+      resolved = true;
       version = t.panelVersion;
       // #1043 (codex review) — the version must come from THIS connection's own
       // hello. A re-hello that omits `panel_version` INHERITS the previous value,
@@ -2984,7 +2999,7 @@ export class UiBridge {
     // field, not a version comparison, and the two must not be reported with the
     // same confidence. The caller renders it as a hedge.
     if (!advertised) {
-      return version === undefined
+      return resolved && version === undefined
         ? { tooOld: false, needed, neverAdvertised: true }
         : { tooOld: false, needed };
     }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2943,6 +2943,22 @@ export class UiBridge {
     tooOld: boolean;
     version?: string;
     needed: string;
+    /**
+     * The panel has NEVER advertised a version on this tab (#1560).
+     *
+     * Distinct from `advertised === false`, which only means THIS connection's
+     * hello omitted it while a previous one supplied a value — the inherited case
+     * the tri-state guard above exists for, where staying silent is right.
+     *
+     * Never having one is different, and it is evidence rather than absence:
+     * `panel_version` has ridden the hello since panel v0.11.83 (measured — the
+     * commit is an ancestor of v0.11.83 and of no earlier tag), so a panel that
+     * has never sent one is BELOW that, and therefore also below the 0.11.45 this
+     * check is about. A panel old enough to cause the #1043 deadlock is, by
+     * construction, too old to report that it is — which is why #1560's reporter
+     * got a bare "the panel did not answer" on a panel from 0.11.37.
+     */
+    neverAdvertised?: boolean;
   } {
     const needed = PANEL_MIN_VERSION_REPLY_UUID;
     let version: string | undefined;
@@ -2960,7 +2976,18 @@ export class UiBridge {
     } catch {
       version = undefined;
     }
-    if (!advertised) return { tooOld: false, needed };
+    // NEVER advertised is not the same as "not advertised on this connection"
+    // (#1560). The latter inherits a known value and must stay silent; the former
+    // is only possible below v0.11.83, which is itself below `needed`.
+    //
+    // `tooOld` stays FALSE for it on purpose: this is an inference from a missing
+    // field, not a version comparison, and the two must not be reported with the
+    // same confidence. The caller renders it as a hedge.
+    if (!advertised) {
+      return version === undefined
+        ? { tooOld: false, needed, neverAdvertised: true }
+        : { tooOld: false, needed };
+    }
     if (!version || !SEMVER_RE.test(version.trim())) return { tooOld: false, needed };
     return { tooOld: compareSemver(version, needed) < 0, version, needed };
   }


### PR DESCRIPTION
Refs #1560. **Draft.**

## The report

One `panel_open_workflow` put a session into a permanent lockout: every later `panel_*` call refused with `workflow instance mismatch`, and `panel_set_workflow_target({mode:"current"})` — the documented recovery — failed with *"Could NOT read the live canvas identity — the panel did not answer"*. Retrying the fence-exempt open reproduced it twice more. No agent-side recovery existed.

## What it actually is

The reporter is on **panel 0.11.37** against orchestrator 0.51.42, after two ComfyUI-Manager self-updates of the panel pack crashed with `KeyError: 'comfyui-mcp-panel'` — so the panel never updated.

That is #1043's deadlock exactly: the repair that avoids the fenced read (`refreshFenceFromOwnReply`) trusts a `workflow_uuid` the panel only publishes from **0.11.45**, so on an older panel the fix is present and inert.

**And the diagnosis that exists for it did not fire.** `panelTooOldNote` is already applied on this precise path, and it stayed silent — because it requires the panel to have *advertised* its version, and `panel_version` in the hello first shipped in panel **v0.11.83** (measured: the commit is an ancestor of v0.11.83 and of no earlier tag).

So a panel old enough to cause this is, by construction, too old to say so. The guard written to avoid a false *"your panel is too old"* suppresses the **true** one for exactly the panels most likely to be the cause.

## The change

Distinguish two states the current code folds together:

- **version known, not advertised on THIS connection** — a re-hello that omitted it inherits the previous value. Stay silent; this is the case the guard was written for and it stays exactly as it is.
- **no version at all, ever** — the panel has never advertised one, which is only possible below 0.11.83. That is not a guess, it is implied by the mechanism, and it is worth saying.

The second gets an honest, hedged note: this panel reports no version, panels have advertised one since 0.11.83, so it is older than that — and therefore older than 0.11.45, whose reply-carried identity would have avoided this read entirely.

## Explicitly NOT doing what the report asks for first

The report's suggestion 1 is to have a failed `workflow_open` clear or optimistically set the fence. **That is the wrong-graph-write hazard**, and it is the same fix review has already rejected twice on this codebase (#1478, and again on the panel side this week): a fence adopted without proof points the session at whatever is active, and the next edit lands on the wrong graph. A lockout is recoverable; a silent write to the wrong workflow is not.

What the reporter is owed is the *reason* and a working remedy, which is what this delivers.
