### PR TITLE
release: v0.51.48 — a reconnect refusal is waited out, not handed back (#1529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.48] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- bind the own-property test at load, not through the prototype
+- require an OWN property at every hop of the refusal claim
+- retry a PRE-EXECUTOR refusal, keyed on the field the panel publishes
+- wait out a reconnect refusal instead of handing it back
+
+
 ## [0.51.47] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.47",
+  "version": "0.51.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.47",
+      "version": "0.51.48",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.47",
+  "version": "0.51.48",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.51.48.

Ships the orchestrator half of issue 1529 (PR #1538). The panel half went out in panel
0.14.35.

**`panel_set_widget` refused during a backend reconnect is now waited out rather than
handed back.** The refusal was always correct — a mutation dispatched while the backend
reconnects lands on a canvas the reconnect is about to rebuild — and always safe to
retry, because the panel's gate runs before its executor. The orchestrator was
discarding the field that said so.

Reading it from the message text was the first attempt and was reverted as a P0: any
sentence the gate writes is one a genuine mid-write failure can also carry, and being
wrong here re-issues a mutation that already landed. This keys on the panel's structured
claim and nothing else, and requires every part of it.

Verified against the live panel on this machine: its real gate output is accepted, the
same reply with the field stripped authorises nothing, and the identical wording alone
authorises nothing. 13 mutations killed, 501 files / 9424 tests green.

The two commits the changelog tool skipped are a revert and a wip from inside #1538 —
both intermediate steps of the entry already listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
