### PR TITLE
fix(1567): a queued respawn is not 'no respawn required'

### DIFF
--- a/src/__tests__/orchestrator/credential-respawn-arming.test.ts
+++ b/src/__tests__/orchestrator/credential-respawn-arming.test.ts
@@ -1,0 +1,48 @@
+// #1567 — the orphan check only runs when the CREDENTIAL path arms it, and that arming is
+// a single line in the secrets subscriber in index.ts.
+//
+// A line like that is invisible to behavioural tests: delete it and every unit test still
+// passes, because the manager-level tests arm the watch themselves. The feature simply
+// never fires in production. So this asserts the wiring at its source, and the mutation
+// harness deletes the line to prove the assertion is load-bearing.
+//
+// It also pins the two properties review found missing in the first version, both of which
+// live at THIS call site rather than in the manager:
+//
+//   * it is armed BEFORE restartAllForMcpEnv, because an idle tab respawns inside that call
+//     — arming afterwards would miss exactly the case that fires immediately;
+//   * it is armed with the CHANGE'S tab, matching the retry nudge, so the note is delivered
+//     once rather than once per restarted tab.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+
+describe("the credential respawn arms the orphan check (#1567)", () => {
+  it("arms it, scoped to the change's tab", () => {
+    expect(SRC).toMatch(/manager\.armCredentialRespawnOrphanWatch\(change\.tabId \?\? null\);/);
+  });
+
+  it("arms it BEFORE the restart, not after", () => {
+    const arm = SRC.indexOf("manager.armCredentialRespawnOrphanWatch(");
+    expect(arm, "the arming call must exist").toBeGreaterThan(-1);
+    const restart = SRC.indexOf("const tally = manager.restartAllForMcpEnv();");
+    expect(restart, "the credential restart must still be recognisable").toBeGreaterThan(-1);
+    // An idle tab is respawned synchronously inside restartAllForMcpEnv, so arming after
+    // it would silently skip the immediate case.
+    expect(arm).toBeLessThan(restart);
+  });
+
+  it("is armed on the SECRETS path only", () => {
+    // The other restartAllForMcpEnv caller is the base_path recovery respawn (#296), which
+    // is not a credential save. Arming there would attach a note claiming a credential
+    // "was saved earlier" to an unrelated restart — and would hand an idle tab a turn.
+    const armCount = (SRC.match(/armCredentialRespawnOrphanWatch\(/g) ?? []).length;
+    expect(armCount, "exactly one arming site").toBe(1);
+    const arm = SRC.indexOf("manager.armCredentialRespawnOrphanWatch(");
+    const before = SRC.slice(Math.max(0, arm - 2000), arm);
+    expect(before, "the arming site must be inside the secrets subscriber").toMatch(
+      /onComfyuiSecretsChanged/,
+    );
+  });
+});

--- a/src/__tests__/orchestrator/credential-respawn-arming.test.ts
+++ b/src/__tests__/orchestrator/credential-respawn-arming.test.ts
@@ -1,48 +1,39 @@
-// #1567 — the orphan check only runs when the CREDENTIAL path arms it, and that arming is
-// a single line in the secrets subscriber in index.ts.
+// #1567 — the orphan check only runs for the CREDENTIAL respawn, and that is a single call
+// in the secrets subscriber in index.ts.
 //
 // A line like that is invisible to behavioural tests: delete it and every unit test still
-// passes, because the manager-level tests arm the watch themselves. The feature simply
+// passes, because the manager-level tests drive the method directly. The feature simply
 // never fires in production. So this asserts the wiring at its source, and the mutation
-// harness deletes the line to prove the assertion is load-bearing.
-//
-// It also pins the two properties review found missing in the first version, both of which
-// live at THIS call site rather than in the manager:
-//
-//   * it is armed BEFORE restartAllForMcpEnv, because an idle tab respawns inside that call
-//     — arming afterwards would miss exactly the case that fires immediately;
-//   * it is armed with the CHANGE'S tab, matching the retry nudge, so the note is delivered
-//     once rather than once per restarted tab.
+// harness swaps the call back to the plain restart to prove the assertion is load-bearing.
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
 const SRC = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
 
 describe("the credential respawn arms the orphan check (#1567)", () => {
-  it("arms it, scoped to the change's tab", () => {
-    expect(SRC).toMatch(/manager\.armCredentialRespawnOrphanWatch\(change\.tabId \?\? null\);/);
-  });
-
-  it("arms it BEFORE the restart, not after", () => {
-    const arm = SRC.indexOf("manager.armCredentialRespawnOrphanWatch(");
-    expect(arm, "the arming call must exist").toBeGreaterThan(-1);
-    const restart = SRC.indexOf("const tally = manager.restartAllForMcpEnv();");
-    expect(restart, "the credential restart must still be recognisable").toBeGreaterThan(-1);
-    // An idle tab is respawned synchronously inside restartAllForMcpEnv, so arming after
-    // it would silently skip the immediate case.
-    expect(arm).toBeLessThan(restart);
-  });
-
-  it("is armed on the SECRETS path only", () => {
-    // The other restartAllForMcpEnv caller is the base_path recovery respawn (#296), which
-    // is not a credential save. Arming there would attach a note claiming a credential
-    // "was saved earlier" to an unrelated restart — and would hand an idle tab a turn.
-    const armCount = (SRC.match(/armCredentialRespawnOrphanWatch\(/g) ?? []).length;
-    expect(armCount, "exactly one arming site").toBe(1);
-    const arm = SRC.indexOf("manager.armCredentialRespawnOrphanWatch(");
-    const before = SRC.slice(Math.max(0, arm - 2000), arm);
-    expect(before, "the arming site must be inside the secrets subscriber").toMatch(
-      /onComfyuiSecretsChanged/,
+  it("uses the credential-aware restart, scoped to the change's tab", () => {
+    expect(SRC).toMatch(
+      /manager\.restartAllForMcpEnvAfterCredentialChange\(change\.tabId \?\? null\)/,
     );
+  });
+
+  it("arms and restarts in ONE call, so a watch cannot outlive its save", () => {
+    // Review, P1. A separate arm-then-restart left a window: a watch created by one call
+    // and bound by a LATER restartAllForMcpEnv would attach itself to whatever tabs that
+    // unrelated respawn happened to queue, then report a credential save that had nothing
+    // to do with it. There is no separate arming entry point to misuse.
+    expect(SRC).not.toMatch(/armCredentialRespawnOrphanWatch/);
+  });
+
+  it("is used on the SECRETS path only", () => {
+    // The other restartAllForMcpEnv caller is the base_path recovery respawn (#296), which
+    // is not a credential save. Using the credential-aware variant there would attach a
+    // note claiming a credential "was saved earlier" to an unrelated restart — and would
+    // hand an idle tab an agent turn it never asked for.
+    const uses = (SRC.match(/restartAllForMcpEnvAfterCredentialChange\(/g) ?? []).length;
+    expect(uses, "exactly one call site").toBe(1);
+    const at = SRC.indexOf("manager.restartAllForMcpEnvAfterCredentialChange(");
+    const before = SRC.slice(Math.max(0, at - 2000), at);
+    expect(before, "it must sit inside the secrets subscriber").toMatch(/onComfyuiSecretsChanged/);
   });
 });

--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -310,6 +310,45 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(0);
   });
 
+  it("a watch is not kept alive by tabs it will never be delivered to", async () => {
+    // Review, round 3. Releasing only on the DROPPED path leaves the set non-empty forever:
+    // a save on tab-a with tab-b also busy gives awaiting={a,b}; retiring a trims it to
+    // {b}; b then restarts successfully, matches nothing, and released nothing. The watch
+    // survives until a RECREATED tab-a restarts and collects a warning about a save from
+    // before it existed.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-a", "hello a");
+    await waitFor(() => backend.runCount >= 1);
+    manager.send("tab-b", "hello b");
+    await waitFor(() => backend.runCount >= 2 && backend.turnTexts.length >= 2);
+
+    // The credential is saved on tab-a; both tabs are busy, so both are queued.
+    expect(manager.restartAllForMcpEnvAfterCredentialChange("tab-a").scheduled).toBe(2);
+
+    manager.retire("tab-a"); // the named tab goes away before its restart runs
+    backend.autoComplete = true;
+    backend.release(); // tab-b restarts, matches nothing, and must clear the last hold
+    await waitFor(() => backend.runCount >= 3);
+
+    // tab-a comes back later and does an ordinary, unrelated env respawn.
+    backend.autoComplete = false;
+    manager.send("tab-a", "hello again");
+    await waitFor(() => backend.turnTexts.includes("hello again"));
+    manager.restartAllForMcpEnv();
+    backend.autoComplete = true;
+    backend.release();
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(
+      backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors")),
+      "no warning about a save that predates this tab",
+    ).toHaveLength(0);
+  });
+
   it("stays silent when the respawn orphans nothing", async () => {
     // The direction that fails quietly: a note pushed unconditionally would still pass the
     // test above, while costing a real agent turn on every env respawn. A nudge is a turn,

--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -1,0 +1,201 @@
+// #1567 — a QUEUED tool-session respawn kills in-flight downloads, and the at-risk check
+// that exists for exactly that (#1378) cannot see them.
+//
+// The save-time snapshot is taken before the emit, which is right for an APPLIED respawn:
+// the emit IS the damage. For a SCHEDULED one the damage is `applyPendingRestarts`,
+// arbitrarily many turns later. A reporter saved a token with nothing in flight (so the
+// check correctly warned about nothing), started nine downloads (~48GB) over the next two
+// turns, and lost all of them when the queued respawn landed — no warning at any point,
+// then nine manual cancels and nine manual re-issues to recover.
+//
+// So the snapshot is re-taken AT THE RESPAWN. These pin both halves: the note itself, and
+// that a genuinely deferred respawn actually reaches it — a helper nothing calls would
+// leave the defect exactly where it was.
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+/** The downloads the respawn is about to orphan. Mocked at the MODULE boundary
+ *  panel-agent imports across — `listDownloadJobs` is called from inside
+ *  download-jobs.js, so mocking that would replace an export nobody reads. */
+const atRisk = vi.hoisted(() => ({ jobs: [] as { id: string; filename: string; bytes: number }[] }));
+vi.mock("../../services/download-jobs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/download-jobs.js")>();
+  return { ...actual, downloadsAtRiskOfRespawn: () => atRisk.jobs };
+});
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+let orphanedByDeferredRespawnNote: typeof import("../../services/panel-secrets.js").orphanedByDeferredRespawnNote;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+  ({ orphanedByDeferredRespawnNote } = await import("../../services/panel-secrets.js"));
+});
+
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+  turnTexts: string[] = [];
+  autoComplete = true;
+  private releaseTurn: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    yield { type: "session", sessionId: "sess-x" };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      if (!this.autoComplete) {
+        await new Promise<void>((resolve) => {
+          this.releaseTurn = resolve;
+        });
+        this.releaseTurn = null;
+      }
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  release(): void {
+    const r = this.releaseTurn;
+    this.releaseTurn = null;
+    r?.();
+  }
+
+  async interrupt(): Promise<void> {
+    this.release();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** Same construction as restart-coalesce.test.ts — the backend arrives via
+ *  `makeBackend`, not as a `backend` field. */
+const makeManager = (backend: AgentBackend) =>
+  new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+  } as never);
+
+const waitFor = async (cond: () => boolean, ms = 3000): Promise<void> => {
+  const t0 = Date.now();
+  while (!cond()) {
+    if (Date.now() - t0 > ms) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+};
+
+describe("orphanedByDeferredRespawnNote (#1567)", () => {
+  it("says nothing when nothing is in flight", () => {
+    expect(orphanedByDeferredRespawnNote([])).toBeNull();
+  });
+
+  it("names the transfers and points at the partials", () => {
+    const note = orphanedByDeferredRespawnNote([
+      { id: "a", filename: "flux-dev.safetensors", bytes: 4_000_000_000 },
+    ]);
+    expect(note).toContain("flux-dev.safetensors");
+    expect(note).toMatch(/partial/i);
+    expect(note).toMatch(/re-issu/i);
+  });
+
+  it("does NOT repeat the from-zero prediction as a certainty", () => {
+    // The reporter disproved it for this case: their downloads started AFTER the save, so
+    // cache identity never moved and re-issuing resumed at 4%/1%/2%. ~11GB was recoverable.
+    // `atRiskNote`'s "will NOT resume … starts from 0%" is right only when the credential
+    // changes MID-transfer, which is not knowable from here — so neither outcome is claimed.
+    const note = orphanedByDeferredRespawnNote([
+      { id: "a", filename: "m.safetensors", bytes: 1 },
+    ]) as string;
+    expect(note).toMatch(/resume/i);
+    expect(note).not.toMatch(/will NOT resume/i);
+    // It must still admit the other case rather than promising a resume.
+    expect(note).toMatch(/0%|restarts from/i);
+  });
+});
+
+describe("a DEFERRED respawn reaches the note (#1567)", () => {
+  it("tells the resumed session what it just killed", async () => {
+    atRisk.jobs = [
+      { id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 },
+      { id: "j2", filename: "wan22.safetensors", bytes: 13_550_000_000 },
+    ];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false; // hold the first turn open → the tab is BUSY
+    const manager = makeManager(backend);
+    const tab = "tab-1567";
+
+    manager.send(tab, "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+
+    // BUSY, so this respawn is genuinely DEFERRED — the path whose damage the save-time
+    // snapshot cannot see. It reports "scheduled", not "applied".
+    const tally = manager.restartAllForMcpEnv();
+    expect(tally.scheduled, "the respawn must be queued, not applied").toBe(1);
+    expect(tally.applied).toBe(0);
+
+    backend.autoComplete = true;
+    backend.release(); // turn done → the queued respawn fires HERE
+
+    await waitFor(() => backend.runCount >= 2);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+
+    const note = backend.turnTexts.find((t) => t.includes("flux-dev.safetensors")) as string;
+    expect(note, "both orphaned transfers must be named").toContain("wan22.safetensors");
+    expect(note).toMatch(/partial/i);
+  });
+
+  it("stays silent when the respawn orphans nothing", async () => {
+    // The direction that fails quietly: a note pushed unconditionally would still pass the
+    // test above, while costing a real agent turn on every env respawn. A nudge is a turn,
+    // not a log line.
+    atRisk.jobs = [];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const tab = "tab-1567-quiet";
+
+    manager.send(tab, "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    expect(manager.restartAllForMcpEnv().scheduled).toBe(1);
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2);
+    await new Promise((r) => setTimeout(r, 120)); // give a spurious nudge time to arrive
+
+    expect(backend.turnTexts.filter((t) => /rebuild is happening NOW/i.test(t))).toHaveLength(0);
+  });
+
+  it("does not swallow an existing retry nudge", async () => {
+    // The #164 payload still has to arrive; the orphan note is appended, not substituted.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 1 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const tab = "tab-1567-both";
+
+    manager.send(tab, "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    manager.restartAllForMcpEnv("RETRY the download");
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+
+    const delivered = backend.turnTexts.find((t) => t.includes("flux-dev.safetensors")) as string;
+    expect(delivered).toContain("RETRY the download");
+  });
+});

--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -43,28 +43,37 @@ class RecordingBackend implements AgentBackend {
   readonly capabilities = CLAUDE_CAPABILITIES;
   runCount = 0;
   turnTexts: string[] = [];
+  /** Which run() (i.e. which agent, i.e. which tab) each turn arrived on. Needed to tell
+   *  "the right tab got the note" from "some tab did" — without it, a watch that leaks to
+   *  whichever tab restarts first looks identical to a correctly scoped one. */
+  turns: { run: number; text: string }[] = [];
   autoComplete = true;
-  private releaseTurn: (() => void) | null = null;
+  // A LIST, not a single slot: the multi-tab test holds two turns open at once, and one
+  // field means the first tab's resolver is overwritten and never settles — the whole
+  // test then times out on a harness bug rather than a finding.
+  private held: (() => void)[] = [];
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     this.runCount += 1;
+    const myRun = this.runCount;
     yield { type: "session", sessionId: "sess-x" };
     for await (const turn of opts.channel) {
       this.turnTexts.push(turn.text);
+      this.turns.push({ run: myRun, text: turn.text });
       if (!this.autoComplete) {
         await new Promise<void>((resolve) => {
-          this.releaseTurn = resolve;
+          this.held.push(resolve);
         });
-        this.releaseTurn = null;
       }
       yield { type: "result", ok: true, subtype: "success" };
     }
   }
 
+  /** Release every held turn. */
   release(): void {
-    const r = this.releaseTurn;
-    this.releaseTurn = null;
-    r?.();
+    const all = this.held;
+    this.held = [];
+    for (const r of all) r();
   }
 
   async interrupt(): Promise<void> {
@@ -141,6 +150,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     // BUSY, so this respawn is genuinely DEFERRED — the path whose damage the save-time
     // snapshot cannot see. It reports "scheduled", not "applied".
+    manager.armCredentialRespawnOrphanWatch(tab);
     const tally = manager.restartAllForMcpEnv();
     expect(tally.scheduled, "the respawn must be queued, not applied").toBe(1);
     expect(tally.applied).toBe(0);
@@ -156,6 +166,92 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     expect(note).toMatch(/partial/i);
   });
 
+  it("an UNARMED respawn says nothing, even with transfers in flight", async () => {
+    // Review, P1. The first version hooked EVERY mcp-env restart. `applyPendingRestarts`
+    // also serves retargets (#1429) and the base_path recovery respawn — neither is a
+    // credential save, so the note would have claimed one "was saved earlier", and
+    // `retargetAllForMcpEnv` deliberately gives an IDLE tab no turn at all. Only an armed
+    // credential respawn may speak.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const tab = "tab-1567-unarmed";
+
+    manager.send(tab, "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    manager.restartAllForMcpEnv(); // NOT armed — e.g. a retarget or base_path recovery
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2);
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(0);
+  });
+
+  it("reports ONCE, not once per tab", async () => {
+    // Review, P1. The download list is global and a credential respawn replaces every
+    // tab's comfyui child — so the list is the right SET, but N tabs restarting would each
+    // have announced the same transfers, N times.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-a", "hello");
+    manager.send("tab-b", "hello");
+    await waitFor(() => backend.runCount >= 2 && backend.turnTexts.length >= 2);
+
+    manager.armCredentialRespawnOrphanWatch(null); // a Settings save: no particular tab
+    expect(manager.restartAllForMcpEnv().scheduled).toBe(2);
+
+    backend.autoComplete = true;
+    backend.release(); // releases BOTH held turns
+    await waitFor(() => backend.runCount >= 4);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+    await new Promise((r) => setTimeout(r, 120)); // let a second copy arrive if it would
+
+    expect(
+      backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors")),
+      "exactly one tab carries it",
+    ).toHaveLength(1);
+  });
+
+  it("goes to the tab it was armed for, not whichever restarts first", async () => {
+    // Consuming the watch once is not enough on its own: without the tab check the FIRST
+    // tab to restart takes it, so the note lands in a conversation that did not save the
+    // credential. The transfers really are dying, so the text is true — it is just being
+    // told to the wrong person, which is how a report gets ignored.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    // tab-a is created (and therefore restarts) FIRST; the credential belongs to tab-b.
+    manager.send("tab-a", "hello from a");
+    await waitFor(() => backend.runCount >= 1);
+    manager.send("tab-b", "hello from b");
+    await waitFor(() => backend.runCount >= 2 && backend.turnTexts.length >= 2);
+
+    manager.armCredentialRespawnOrphanWatch("tab-b");
+    expect(manager.restartAllForMcpEnv().scheduled).toBe(2);
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 4);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+    await new Promise((r) => setTimeout(r, 120));
+
+    // Exactly one turn carries it…
+    const carrying = backend.turns.filter((t) => t.text.includes("flux-dev.safetensors"));
+    expect(carrying).toHaveLength(1);
+    // …and it must be tab-b's respawned agent, not tab-a's. Tabs restart in insertion
+    // order, so the runs are: 1 = tab-a, 2 = tab-b, 3 = tab-a respawned, 4 = tab-b
+    // respawned. A watch that ignores the tab hands the note to run 3.
+    expect(carrying[0].run, "the note belongs to the tab the credential was saved on").toBe(4);
+  });
+
   it("stays silent when the respawn orphans nothing", async () => {
     // The direction that fails quietly: a note pushed unconditionally would still pass the
     // test above, while costing a real agent turn on every env respawn. A nudge is a turn,
@@ -168,6 +264,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     manager.send(tab, "hello");
     await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    manager.armCredentialRespawnOrphanWatch(tab);
     expect(manager.restartAllForMcpEnv().scheduled).toBe(1);
 
     backend.autoComplete = true;
@@ -188,6 +285,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     manager.send(tab, "hello");
     await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    manager.armCredentialRespawnOrphanWatch(tab);
     manager.restartAllForMcpEnv("RETRY the download");
 
     backend.autoComplete = true;

--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -150,8 +150,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     // BUSY, so this respawn is genuinely DEFERRED — the path whose damage the save-time
     // snapshot cannot see. It reports "scheduled", not "applied".
-    manager.armCredentialRespawnOrphanWatch(tab);
-    const tally = manager.restartAllForMcpEnv();
+    const tally = manager.restartAllForMcpEnvAfterCredentialChange(tab);
     expect(tally.scheduled, "the respawn must be queued, not applied").toBe(1);
     expect(tally.applied).toBe(0);
 
@@ -203,8 +202,8 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     manager.send("tab-b", "hello");
     await waitFor(() => backend.runCount >= 2 && backend.turnTexts.length >= 2);
 
-    manager.armCredentialRespawnOrphanWatch(null); // a Settings save: no particular tab
-    expect(manager.restartAllForMcpEnv().scheduled).toBe(2);
+    // A Settings-slot save: no particular tab.
+    expect(manager.restartAllForMcpEnvAfterCredentialChange(null).scheduled).toBe(2);
 
     backend.autoComplete = true;
     backend.release(); // releases BOTH held turns
@@ -234,8 +233,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     manager.send("tab-b", "hello from b");
     await waitFor(() => backend.runCount >= 2 && backend.turnTexts.length >= 2);
 
-    manager.armCredentialRespawnOrphanWatch("tab-b");
-    expect(manager.restartAllForMcpEnv().scheduled).toBe(2);
+        expect(manager.restartAllForMcpEnvAfterCredentialChange("tab-b").scheduled).toBe(2);
 
     backend.autoComplete = true;
     backend.release();
@@ -252,6 +250,66 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     expect(carrying[0].run, "the note belongs to the tab the credential was saved on").toBe(4);
   });
 
+  it("an armed watch that nothing can deliver does NOT survive to a later restart", async () => {
+    // Review, P1. Consuming on delivery alone leaks: a save with no managed tabs queues
+    // nothing, so nothing ever consumes the watch, and the next unrelated mcp-env respawn
+    // — a retarget, a base_path recovery — would present a stale "a credential was saved
+    // earlier" note about transfers it had no part in killing.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+
+    // Armed with NO tabs alive: nothing to queue, nothing to deliver it.
+        expect(manager.restartAllForMcpEnvAfterCredentialChange(null).live).toBe(0);
+
+    // A completely unrelated restart, later, on a tab that did not exist at save time.
+    backend.autoComplete = false;
+    manager.send("tab-later", "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    manager.restartAllForMcpEnv(); // e.g. a retarget — never armed
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2);
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(0);
+  });
+
+  it("a watch whose tab disappears does not wait around for an unrelated respawn", async () => {
+    // Review, P1, second half. The tab the watch names can be retired before its queued
+    // restart ever runs, so nothing reaches the delivery site to consume it. Without a
+    // release on removal the watch would sit armed and attach to whatever respawn came
+    // next — presenting a stale "a credential was saved earlier" note in a conversation
+    // that had nothing to do with it.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    // Armed with NO tab — a Settings-slot save. This is the case that actually leaks: a
+    // tab-scoped watch is already refused by the tab check, so it would pass this test
+    // whether or not removal released anything. A null watch matches ANY tab, so only the
+    // release keeps it from landing on a stranger.
+    manager.send("tab-doomed", "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+    expect(manager.restartAllForMcpEnvAfterCredentialChange(null).scheduled).toBe(1);
+
+    // The tab goes away before its queued restart can run.
+    manager.retire("tab-doomed");
+    expect(manager.liveKeys()).not.toContain("tab-doomed");
+
+    // A later, unrelated respawn on a different tab must stay quiet.
+    manager.send("tab-other", "hello again");
+    await waitFor(() => backend.runCount >= 2);
+    manager.restartAllForMcpEnv();
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 3);
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(0);
+  });
+
   it("stays silent when the respawn orphans nothing", async () => {
     // The direction that fails quietly: a note pushed unconditionally would still pass the
     // test above, while costing a real agent turn on every env respawn. A nudge is a turn,
@@ -264,8 +322,7 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     manager.send(tab, "hello");
     await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
-    manager.armCredentialRespawnOrphanWatch(tab);
-    expect(manager.restartAllForMcpEnv().scheduled).toBe(1);
+        expect(manager.restartAllForMcpEnvAfterCredentialChange(tab).scheduled).toBe(1);
 
     backend.autoComplete = true;
     backend.release();
@@ -285,8 +342,12 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
 
     manager.send(tab, "hello");
     await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
-    manager.armCredentialRespawnOrphanWatch(tab);
+    // A per-request retry nudge is queued FIRST (#164), then the credential respawn lands
+    // on top of it — the real ordering, since the secrets subscriber restarts silently and
+    // nudges the requesting tab separately. The orphan note must join that nudge, not
+    // replace it.
     manager.restartAllForMcpEnv("RETRY the download");
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
 
     backend.autoComplete = true;
     backend.release();

--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -349,6 +349,51 @@ describe("a DEFERRED respawn reaches the note (#1567)", () => {
     ).toHaveLength(0);
   });
 
+  it("two saves on one busy tab share the coalesced restart and report ONCE", async () => {
+    // Review raised this as a possible leak: the second save's watch "adopts" the restart
+    // the first save queued. That is not a defect, and this pins why rather than leaving it
+    // to be rediscovered.
+    //
+    // `restartAllForMcpEnv` COALESCES — a tab with a pending restart does not get a second
+    // one. So the queued restart is the vehicle for both saves: it rebuilds the child with
+    // an env carrying both changes, and it is the moment both are waiting for. The note
+    // describes the transfers that actually die at that moment, which is the same set for
+    // either save. One restart, one note, and no watch left over.
+    atRisk.jobs = [{ id: "j1", filename: "flux-dev.safetensors", bytes: 4_000_000_000 }];
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const tab = "tab-two-saves";
+
+    manager.send(tab, "hello");
+    await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+
+    expect(manager.restartAllForMcpEnvAfterCredentialChange(tab).scheduled).toBe(1);
+    expect(
+      manager.restartAllForMcpEnvAfterCredentialChange(tab).scheduled,
+      "coalesced, not a second restart",
+    ).toBe(1);
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(1);
+    expect(backend.runCount, "exactly one respawn happened").toBe(2);
+
+    // And nothing is left armed: a later unrelated respawn stays quiet.
+    backend.autoComplete = false;
+    manager.send(tab, "again");
+    await waitFor(() => backend.turnTexts.includes("again"));
+    manager.restartAllForMcpEnv();
+    backend.autoComplete = true;
+    backend.release();
+    await new Promise((r) => setTimeout(r, 150));
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(1);
+  });
+
   it("stays silent when the respawn orphans nothing", async () => {
     // The direction that fails quietly: a note pushed unconditionally would still pass the
     // test above, while costing a real agent turn on every env respawn. A nudge is a turn,

--- a/src/__tests__/orchestrator/scheduled-respawn-receipt.test.ts
+++ b/src/__tests__/orchestrator/scheduled-respawn-receipt.test.ts
@@ -1,0 +1,104 @@
+// #1567 — the receipt told the user a queued respawn was nothing to worry about.
+//
+// `panel_request_secret` printed BOTH of these in one message:
+//
+//   "…the tool process already running picks it up — no reload, and no respawn required."
+//   "Tool sessions being rebuilt with the new environment: 1 queued for the end of this turn (of 1 live)."
+//
+// The first sentence is about LIVE PICKUP: this key is re-read from disk at use time, so
+// the running tools do not NEED a respawn to see it. True, and useful. But it says "no
+// respawn required" on the same message that reports one already queued — and a queued
+// respawn still tears the tool session down when it fires.
+//
+// The reporter read it as safe-to-proceed, started ~48 GB of downloads over the following
+// turns, and lost all nine when the respawn landed. #1378's at-risk warning could not help:
+// its snapshot is taken at SAVE time, and at save time nothing was in flight.
+//
+// So this file pins the one thing the renderer can always know at save time — that a
+// respawn IS pending — and stops it claiming otherwise. The deeper ordering fix (re-taking
+// the snapshot at respawn-execution time) is separate; this is the sentence that invited
+// the loss.
+import { describe, expect, it } from "vitest";
+
+import { describeComfyuiSecretSave } from "../../orchestrator/panel-tools.js";
+import type { SecretSaveReceipt } from "../../services/panel-secrets.js";
+
+const base: SecretSaveReceipt = {
+  key: "CIVITAI_API_TOKEN",
+  path: "/home/u/.comfyui-mcp/.env",
+  persisted: "yes",
+  livePickup: true,
+  respawn: null,
+};
+
+/** The exact claim that has to stop appearing beside a queued respawn. */
+const NO_RESPAWN_CLAIM = /no respawn required/i;
+
+describe("a QUEUED respawn is never described as 'no respawn required' (#1567)", () => {
+  it("drops the claim when a respawn is scheduled", () => {
+    const text = describeComfyuiSecretSave({
+      ...base,
+      respawn: { live: 1, applied: 0, scheduled: 1 },
+    });
+    expect(text).not.toMatch(NO_RESPAWN_CLAIM);
+    // …and still says the useful half: the running tools DO see the value already.
+    expect(text).toMatch(/picks it up/i);
+    // The pending teardown has to be stated, not merely implied by a count.
+    expect(text).toMatch(/pending|will still|when it fires|is queued/i);
+  });
+
+  it("warns that transfers started before it fires are at risk", () => {
+    // The receipt cannot know what will be in flight later — that is the whole defect —
+    // so it must warn about the WINDOW rather than about a list it cannot have.
+    const text = describeComfyuiSecretSave({
+      ...base,
+      respawn: { live: 1, applied: 0, scheduled: 1 },
+    });
+    expect(text).toMatch(/download|transfer/i);
+  });
+
+  it("keeps the claim when NOTHING is scheduled — the sentence is correct there", () => {
+    // Live pickup with no respawn pending is exactly when "no respawn required" is the
+    // right thing to say, and the reason not to simply delete the sentence.
+    for (const respawn of [
+      null,
+      { live: 1, applied: 0, scheduled: 0 },
+      { live: 3, applied: 0, scheduled: 0 },
+    ] as SecretSaveReceipt["respawn"][]) {
+      const text = describeComfyuiSecretSave({ ...base, respawn });
+      expect(text, JSON.stringify(respawn)).toMatch(NO_RESPAWN_CLAIM);
+    }
+  });
+
+  it("an APPLIED-only respawn does not claim 'no respawn required' either", () => {
+    // It already happened. Saying none was required describes a different save.
+    const text = describeComfyuiSecretSave({
+      ...base,
+      respawn: { live: 2, applied: 2, scheduled: 0 },
+    });
+    expect(text).not.toMatch(NO_RESPAWN_CLAIM);
+  });
+
+  it("a NON-live-pickup key is unaffected — it never made the claim", () => {
+    const text = describeComfyuiSecretSave({
+      ...base,
+      livePickup: false,
+      respawn: { live: 1, applied: 0, scheduled: 1 },
+    });
+    expect(text).not.toMatch(NO_RESPAWN_CLAIM);
+    expect(text).toMatch(/only a respawned tool session will see it/i);
+  });
+
+  it("an UNCONFIRMED save still refuses to make any pickup claim", () => {
+    // The #826 rule outranks this one: nothing about pickup may be asserted when the
+    // store could not be read back.
+    const text = describeComfyuiSecretSave({
+      ...base,
+      persisted: "unknown",
+      uncertainty: "the file could not be re-read",
+      respawn: { live: 1, applied: 0, scheduled: 1 },
+    });
+    expect(text).not.toMatch(NO_RESPAWN_CLAIM);
+    expect(text).not.toMatch(/picks it up/i);
+  });
+});

--- a/src/__tests__/orchestrator/scheduled-respawn-receipt.test.ts
+++ b/src/__tests__/orchestrator/scheduled-respawn-receipt.test.ts
@@ -55,6 +55,18 @@ describe("a QUEUED respawn is never described as 'no respawn required' (#1567)",
       respawn: { live: 1, applied: 0, scheduled: 1 },
     });
     expect(text).toMatch(/download|transfer/i);
+    // Naming downloads is not enough on its own: the load-bearing part is WHY nothing is
+    // listed. Without it the message reads as a generic caution rather than "the check you
+    // are used to seeing cannot cover what you do next", which is the actual trap.
+    // A first version of this test asserted only the word "download" and was satisfied by
+    // an unrelated sentence, so a mutation deleting the warning survived.
+    // BOTH halves, not an alternation: the first draft accepted any one of three phrases,
+    // so deleting one of them left the test green. The claim is a conjunction — nothing is
+    // listed (1) BECAUSE a transfer started later did not exist when the check ran (2) —
+    // and either half alone is a different, weaker statement.
+    expect(text).toMatch(/cannot list/i);
+    expect(text).toMatch(/after this save/i);
+    expect(text).toMatch(/did not exist/i);
   });
 
   it("keeps the claim when NOTHING is scheduled — the sentence is correct there", () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3250,6 +3250,14 @@ export async function runPanelOrchestrator(): Promise<void> {
     // the action" nudge is not, so it must never broadcast to unrelated tabs.
     // restartAllForMcpEnv() is nudge-preserving, so this can't erase a per-request
     // nudge already queued on another tab (#164).
+    //
+    // #1567 — arm the orphan check BEFORE restarting, because an idle tab respawns
+    // inside this call. This is the ONLY path allowed to arm it: a respawn from a
+    // credential save is the one that queues, waits turns, and then kills whatever
+    // transfers exist by then. Scoped to the tab this change belongs to, matching the
+    // retry nudge below — the transfers are global (every tab's child is replaced), so
+    // it must be reported once rather than once per tab.
+    manager.armCredentialRespawnOrphanWatch(change.tabId ?? null);
     const tally = manager.restartAllForMcpEnv();
     // NUDGE only the tab whose panel_request_secret this change answers — a
     // Settings slot save, a background token (re)load, or a revoke leaves

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3257,8 +3257,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // transfers exist by then. Scoped to the tab this change belongs to, matching the
     // retry nudge below — the transfers are global (every tab's child is replaced), so
     // it must be reported once rather than once per tab.
-    manager.armCredentialRespawnOrphanWatch(change.tabId ?? null);
-    const tally = manager.restartAllForMcpEnv();
+    const tally = manager.restartAllForMcpEnvAfterCredentialChange(change.tabId ?? null);
     // NUDGE only the tab whose panel_request_secret this change answers — a
     // Settings slot save, a background token (re)load, or a revoke leaves
     // `requested` false and nudges nothing. The per-tab pending-restart map

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2412,10 +2412,48 @@ export class PanelAgentManager {
    * `null` means "no particular tab" (a Settings-slot save): the first tab to restart
    * carries it. Either way it is consumed once.
    */
-  armCredentialRespawnOrphanWatch(tabId: string | null): void {
-    this.credentialOrphanWatch = { tab: tabId };
+  /**
+   * The credential-save respawn: restart every tab's comfyui child AND watch for what that
+   * kills. One call rather than arm-then-restart, deliberately.
+   *
+   * Arming separately left a window that review's leak finding lives in: a watch created by
+   * one call and bound by a LATER `restartAllForMcpEnv` would attach itself to whatever
+   * tabs that later, unrelated respawn happened to queue. Creating and binding it in the
+   * same call means a watch can never outlive the save that made it — if this save queues
+   * nothing, it dies here.
+   */
+  restartAllForMcpEnvAfterCredentialChange(tabId: string | null): McpEnvRestartTally {
+    this.credentialOrphanWatch = { tab: tabId, awaiting: new Set() };
+    const tally = this.restartAllForMcpEnv();
+    // An idle tab consumed it inside that call; otherwise bind it to exactly the tabs that
+    // still owe a restart, and drop it when there are none.
+    if (this.credentialOrphanWatch) {
+      const awaiting = this.liveKeys().filter((k) => this.pendingMcpRestart.has(k));
+      if (awaiting.length === 0) this.credentialOrphanWatch = null;
+      else this.credentialOrphanWatch.awaiting = new Set(awaiting);
+    }
+    return tally;
   }
-  private credentialOrphanWatch: { tab: string | null } | null = null;
+  /**
+   * `tab` is who it is for; `awaiting` is what keeps it from LEAKING (review, P1).
+   *
+   * Consuming it only on delivery is not enough: a save that queues no restart at all — no
+   * managed tabs — or whose named tab disappears before its restart runs would leave this
+   * armed forever, and the next unrelated mcp-env respawn would then present a stale
+   * "a credential was saved earlier" note. `awaiting` is the exact set of tabs this save
+   * queued; the watch dies when that set empties, whether or not anything was delivered.
+   */
+  private credentialOrphanWatch: { tab: string | null; awaiting: Set<string> } | null = null;
+
+  /** #1567 — this tab will never deliver the armed watch (its restart is being dropped).
+   *  When nothing is left that could, the watch dies rather than waiting for a respawn it
+   *  has no relationship to. */
+  private releaseOrphanWatch(tabId: string): void {
+    const watch = this.credentialOrphanWatch;
+    if (!watch) return;
+    watch.awaiting.delete(tabId);
+    if (watch.awaiting.size === 0) this.credentialOrphanWatch = null;
+  }
 
   /** #1567 — what this respawn is about to orphan, enumerated NOW rather than at save
    *  time. Never throws: a rebuild that fails because its warning failed is strictly
@@ -2447,6 +2485,8 @@ export class PanelAgentManager {
       this.pendingEffortRestart.delete(tabId);
       this.pendingMcpRestart.delete(tabId);
       this.pendingRetargetFrom.delete(tabId);
+      // #1567 — this restart is being dropped, so it will never deliver an armed watch.
+      this.releaseOrphanWatch(tabId);
       return "no-agent";
     }
     // Still mid-work (a queued message will start the next turn) — wait for the
@@ -2976,6 +3016,9 @@ export class PanelAgentManager {
   private unbindAgent(key: string, opts: { dropHeldMail: boolean; reason: string }): PanelAgent | undefined {
     const agent = this.agents.get(key);
     this.agents.delete(key);
+    // #1567 — this tab can no longer deliver an armed orphan watch. The single choke point
+    // for removal, so a retire/reset cannot strand one waiting on a tab that is gone.
+    this.releaseOrphanWatch(key);
     this.detachHeldCompletions(key, opts.reason);
     if (opts.dropHeldMail) this.heldMessages.delete(key);
     return agent;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2506,7 +2506,20 @@ export class PanelAgentManager {
     // and a spurious agent TURN, which is a response the user did not ask for.
     const watch = this.credentialOrphanWatch;
     const watched = wantMcp && watch !== null && (watch.tab === null || watch.tab === tabId);
+    // A tab leaves `awaiting` when its queued restart RESOLVES, whichever way — delivery
+    // retires the whole watch, and anything else just means this tab can no longer be the
+    // one to deliver it (review, round 3).
+    //
+    // Releasing only on the dropped path was not enough. A save on tab A with B also busy
+    // leaves awaiting={A,B}; retiring A trims it to {B}; B then restarts successfully,
+    // matches nothing, and releases nothing — so the set never empties. The watch sits
+    // there until a recreated A restarts and collects a warning about a save from long
+    // before it existed.
+    //
+    // The busy early-return above is deliberately upstream of this: "scheduled" means the
+    // tab still owes a restart, so it has not resolved and must stay in the set.
     if (watched) this.credentialOrphanWatch = null;
+    else this.releaseOrphanWatch(tabId);
     const orphanNote = watched ? this.deferredRespawnOrphanNote() : null;
     const finalNudge = orphanNote ? [nudge, orphanNote].filter(Boolean).join("\n\n") : nudge;
     this.pendingEffortRestart.delete(tabId);

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,6 +23,8 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
+import { orphanedByDeferredRespawnNote } from "../services/panel-secrets.js";
 import { errorText, promptText } from "./error-text.js";
 import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
@@ -2391,6 +2393,20 @@ export class PanelAgentManager {
    *
    * No-op unless something is pending and the agent has fully settled (idle).
    */
+  /** #1567 — what this respawn is about to orphan, enumerated NOW rather than at save
+   *  time. Never throws and never blocks the restart: a rebuild that cannot run because
+   *  the warning failed is strictly worse than a rebuild with no warning. */
+  private deferredRespawnOrphanNote(): string | null {
+    try {
+      return orphanedByDeferredRespawnNote(downloadsAtRiskOfRespawn());
+    } catch (err) {
+      logger.debug("[panel-orchestrator] could not enumerate downloads a respawn will orphan", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
   private applyPendingRestarts(tabId: string): McpEnvRestartOutcome {
     const wantEffort = this.pendingEffortRestart.has(tabId);
     const wantMcp = this.pendingMcpRestart.has(tabId);
@@ -2407,10 +2423,22 @@ export class PanelAgentManager {
     if (agent.isBusy || agent.hasPending) return "scheduled";
     // Only the MCP respawn carries a retry nudge.
     const nudge = wantMcp ? (this.pendingMcpRestart.get(tabId) ?? undefined) : undefined;
+    // #1567 — RE-TAKE the at-risk snapshot HERE. The save-time one (#1378) is taken
+    // before the emit because for an APPLIED respawn the emit is the damage. For a
+    // QUEUED one the damage is this line, arbitrarily many turns later, so a save-time
+    // snapshot cannot see a transfer that started in between — which is exactly what
+    // happened: nothing in flight at save, nine downloads started over the next two
+    // turns, all killed here with no warning at any point.
+    //
+    // This nudge is not a spurious turn. It only exists when transfers are being
+    // destroyed right now, and the resumed session is the only thing positioned to
+    // re-issue them — the alternative, which shipped, is silence.
+    const orphanNote = wantMcp ? this.deferredRespawnOrphanNote() : null;
+    const finalNudge = orphanNote ? [nudge, orphanNote].filter(Boolean).join("\n\n") : nudge;
     this.pendingEffortRestart.delete(tabId);
     this.pendingMcpRestart.delete(tabId);
     this.pendingRetargetFrom.delete(tabId);
-    const carried = this.restartAgentResume(tabId, agent, nudge);
+    const carried = this.restartAgentResume(tabId, agent, finalNudge);
     const reasons = [wantEffort ? "effort" : null, wantMcp ? "comfyui-mcp-env" : null]
       .filter(Boolean)
       .join("+");

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2393,9 +2393,40 @@ export class PanelAgentManager {
    *
    * No-op unless something is pending and the agent has fully settled (idle).
    */
+  /**
+   * #1567 — ARM the orphan check for the next respawn, for ONE tab.
+   *
+   * Only a comfyui CREDENTIAL change may arm this, and the caller says which tab it
+   * belongs to. Both restrictions come from review, and each fixes a real defect in the
+   * first version, which hooked every restart unconditionally:
+   *
+   *  - `applyPendingRestarts` also serves retargets (#1429) and the base_path recovery
+   *    respawn. Those are not credential saves, so a note saying one "was saved earlier"
+   *    would have been false — and `retargetAllForMcpEnv` deliberately gives an IDLE tab
+   *    NO turn, which an unconditional note broke for any tab while a download ran.
+   *  - `restartAllForMcpEnv` applies each tab separately and the download list is global,
+   *    so every restarted tab would have reported the SAME transfers. The credential
+   *    respawn does replace every tab's comfyui child, so the global list is the right
+   *    set — it just has to be told once, exactly like the retry nudge it travels with.
+   *
+   * `null` means "no particular tab" (a Settings-slot save): the first tab to restart
+   * carries it. Either way it is consumed once.
+   */
+  armCredentialRespawnOrphanWatch(tabId: string | null): void {
+    this.credentialOrphanWatch = { tab: tabId };
+  }
+  private credentialOrphanWatch: { tab: string | null } | null = null;
+
   /** #1567 — what this respawn is about to orphan, enumerated NOW rather than at save
-   *  time. Never throws and never blocks the restart: a rebuild that cannot run because
-   *  the warning failed is strictly worse than a rebuild with no warning. */
+   *  time. Never throws: a rebuild that fails because its warning failed is strictly
+   *  worse than a rebuild with no warning.
+   *
+   *  It is NOT non-blocking, and the earlier comment claiming otherwise was wrong
+   *  (review): this reads job records and each active download's progress with sync IO,
+   *  so a stalled filesystem stalls here. That is tolerated because it now runs at most
+   *  once per credential save rather than on every restart — the same IO the save path
+   *  already performs, moved to where it can see the right answer. A try/catch cannot
+   *  time-bound a blocking syscall and is not pretended to. */
   private deferredRespawnOrphanNote(): string | null {
     try {
       return orphanedByDeferredRespawnNote(downloadsAtRiskOfRespawn());
@@ -2430,10 +2461,13 @@ export class PanelAgentManager {
     // happened: nothing in flight at save, nine downloads started over the next two
     // turns, all killed here with no warning at any point.
     //
-    // This nudge is not a spurious turn. It only exists when transfers are being
-    // destroyed right now, and the resumed session is the only thing positioned to
-    // re-issue them — the alternative, which shipped, is silence.
-    const orphanNote = wantMcp ? this.deferredRespawnOrphanNote() : null;
+    // ONLY for an armed credential respawn, and ONLY once — see
+    // armCredentialRespawnOrphanWatch. A note on any other restart would be both untrue
+    // and a spurious agent TURN, which is a response the user did not ask for.
+    const watch = this.credentialOrphanWatch;
+    const watched = wantMcp && watch !== null && (watch.tab === null || watch.tab === tabId);
+    if (watched) this.credentialOrphanWatch = null;
+    const orphanNote = watched ? this.deferredRespawnOrphanNote() : null;
     const finalNudge = orphanNote ? [nudge, orphanNote].filter(Boolean).join("\n\n") : nudge;
     this.pendingEffortRestart.delete(tabId);
     this.pendingMcpRestart.delete(tabId);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -434,9 +434,36 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
     // This is the property that makes the answer safe to act on immediately: the
     // tools resolve this key from the file at USE time, so the already-running
     // tool process sees it whether or not any respawn happens.
-    parts.push(
-      `The comfyui tools re-read that file each time they use this credential, so the tool process already running picks it up — no reload, and no respawn required.`,
-    );
+    //
+    // #1567 — but "no respawn required" was printed UNCONDITIONALLY, including on
+    // the same message that reported one already queued. Both statements were
+    // true about different things: the key needs no respawn, and a respawn is
+    // pending anyway. Read together they say "nothing is about to happen", and a
+    // reporter acted on that by starting ~48GB of downloads that the pending
+    // respawn then killed.
+    //
+    // The sentence is kept where it is correct — nothing scheduled, nothing
+    // applied — because that is the case it was written for and deleting it
+    // would lose a genuinely useful "you can retry right now".
+    const pending = receipt.respawn?.scheduled ?? 0;
+    const already = receipt.respawn?.applied ?? 0;
+    const readsItAtUseTime = `The comfyui tools re-read that file each time they use this credential, so the tool process already running picks it up — no reload needed`;
+    if (pending > 0) {
+      parts.push(
+        `${readsItAtUseTime}. But a tool-session respawn is STILL PENDING from this save ` +
+          `(${pending} queued for the end of this turn), and it replaces the tool session when it fires. ` +
+          `Anything long-running that session owns is lost at that point — model downloads in ` +
+          `particular. This message cannot list them, because a transfer started AFTER this save ` +
+          `did not exist when the check ran (#1567). If you are about to start a long download, ` +
+          `let the respawn land first.`,
+      );
+    } else if (already > 0) {
+      // A respawn HAPPENED. Saying none was required describes a different save,
+      // and #1378's at-risk warning above is reporting what that one cost.
+      parts.push(`${readsItAtUseTime} — and the tool session was rebuilt just now regardless.`);
+    } else {
+      parts.push(`${readsItAtUseTime}, and no respawn required.`);
+    }
   } else {
     parts.push(
       `This key is read from the tool process's environment at startup, so only a respawned tool session will see it.`,

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -597,11 +597,12 @@ export function orphanedByDeferredRespawnNote(
     `were still transferring. They belong to the session being replaced, so they are being ` +
     `killed — this is the rebuild that was queued when a comfyui credential was saved earlier ` +
     `(#1567).\n\n` +
-    `The partial files are still on disk. Re-issuing each download RESUMES from them when the ` +
-    `credential did not change mid-transfer — which is the case for anything started after that ` +
-    `save. A transfer that was already running when the credential changed has a different ` +
-    `cache identity and restarts from 0% instead. Check the reported progress on re-issue ` +
-    `rather than assuming either.\n\n` +
+    `The partial files are still on disk, so re-issuing each download is worth doing: it can ` +
+    `RESUME from them rather than starting over. A transfer that was already running when the ` +
+    `credential changed has a different cache identity and definitely restarts from 0%; one ` +
+    `started after that save keeps its identity and usually resumes — but resumption also needs ` +
+    `the server to still offer the same validator and honour a range request, so it is not ` +
+    `guaranteed either way. Read the progress each re-issue reports instead of assuming.\n\n` +
     `Re-issue them now if they are still wanted; nothing else will pick them up.`
   );
 }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -564,6 +564,48 @@ export function atRiskNote(
   );
 }
 
+/**
+ * #1567 — what a DEFERRED respawn is orphaning, said at the moment it fires.
+ *
+ * `atRiskNote` above is for the save. It is built from a snapshot taken before the emit,
+ * which is correct for an `applied` respawn — the emit IS the damage — and structurally
+ * incapable of covering a `scheduled` one, where the damage happens arbitrarily later. A
+ * reporter saved a token with nothing in flight (so the save-time check correctly warned
+ * about nothing), started nine downloads over the next two turns, and lost all ~48GB when
+ * the queued respawn landed, with no warning at any point.
+ *
+ * ## Why this does NOT reuse `atRiskNote`'s consequence
+ *
+ * That sentence says the transfers will not resume and re-issuing restarts from 0%,
+ * because the new credential changes each download's cache identity. True when the
+ * credential changes MID-TRANSFER. It is wrong for the case this note exists for, and the
+ * reporter proved it: their downloads began AFTER the save, so identity never moved and
+ * re-issuing resumed from the `.partial` files at 4%/1%/2%. ~11GB was recoverable — but
+ * only because they checked the partials rather than believing the prediction.
+ *
+ * So this states what is observable here (these are being killed now, the partials are on
+ * disk) and is explicit that resumability depends on something this code cannot see: which
+ * side of the credential change each transfer started on. Claiming either outcome would be
+ * asserting the thing that actually varies.
+ */
+export function orphanedByDeferredRespawnNote(
+  orphaned: AtRiskDownloads | readonly { filename: string; bytes: number }[],
+): string | null {
+  if (!orphaned.length) return null;
+  return (
+    `🛑 The queued tool-session rebuild is happening NOW, and ${atRiskDownloadSummary(orphaned)} ` +
+    `were still transferring. They belong to the session being replaced, so they are being ` +
+    `killed — this is the rebuild that was queued when a comfyui credential was saved earlier ` +
+    `(#1567).\n\n` +
+    `The partial files are still on disk. Re-issuing each download RESUMES from them when the ` +
+    `credential did not change mid-transfer — which is the case for anything started after that ` +
+    `save. A transfer that was already running when the credential changed has a different ` +
+    `cache identity and restarts from 0% instead. Check the reported progress on re-issue ` +
+    `rather than assuming either.\n\n` +
+    `Re-issue them now if they are still wanted; nothing else will pick them up.`
+  );
+}
+
 /** A pre-write snapshot the write could not delete: a readable copy of the store
  *  holding the PREVIOUS credential for this key. Harmless clutter after a
  *  rotation on a single-user machine, but the user should know it is there. */


### PR DESCRIPTION
Addresses #1567.

## The bug

`panel_request_secret` scheduled a **deferred** tool-session respawn and printed both of
these in one message:

> …the tool process already running picks it up — **no reload, and no respawn required**.

> Tool sessions being rebuilt with the new environment: **1 queued for the end of this turn**.

Both halves were true about different things — the key needs no respawn to be seen, and a
respawn is pending anyway — and together they say "nothing is about to happen". The reporter
acted on exactly that, started nine downloads (~48 GB) over the next two turns, and lost all
of them when the queued respawn landed.

#1378's at-risk warning could not help. Its snapshot is taken **before the emit**, which is
right for an `applied` respawn — the emit *is* the damage — and structurally incapable of
covering a `scheduled` one, where the damage happens in `applyPendingRestarts` arbitrarily
many turns later. At save time nothing was in flight, so it correctly warned about nothing.

## The fix

**The receipt stops contradicting itself.** With a respawn pending it says so, and says a
transfer started after the save cannot be listed because it did not exist when the check ran.
The sentence is **kept** where it is correct — nothing scheduled, nothing applied — because
that is the useful "you can retry right now"; three tests pin that it stays.

**The snapshot is re-taken when the respawn fires.** The resumed session is told what it just
killed, so recovery does not depend on noticing.

The new note deliberately does not reuse `atRiskNote`'s consequence. That predicts the
transfers will not resume and re-issuing starts from 0%, which holds when the credential
changes *mid-transfer* — the reporter disproved it for this case, since their downloads began
after the save, identity never moved, and re-issuing resumed at 4%/1%/2% (~11 GB recovered).
Review then pointed out that unchanged identity is necessary but not sufficient (the server
must still offer the same validator and honour a range request), so the note now says
re-issuing is worth doing and to read the reported progress, and predicts neither outcome.

## Review — four rounds, three real defects, all mine

1. **P1** — the check hooked *every* mcp-env restart. `applyPendingRestarts` also serves
   retargets (#1429) and the base_path recovery respawn, so the note would have claimed a
   credential "was saved earlier" where none was — and `retargetAllForMcpEnv` deliberately
   gives an idle tab **no turn at all**. I had read that comment and broke the rule it states.
2. **P1** — the download list is global while tabs restart one at a time, so every restarted
   tab would have announced the same transfers.
3. **P1, twice** — the watch could outlive its save: first when a save queued no restart, then
   in a narrower form where a non-matching tab resolving never released its hold, so the
   `awaiting` set never emptied and a *recreated* tab could collect a warning predating it.
4. Round 4 called two-saves-on-one-busy-tab a leak. It is not: `restartAllForMcpEnv`
   coalesces, so that queued restart is the vehicle for both saves. Measured and pinned as a
   test — one respawn, one note, nothing left armed — rather than argued.

Arm and restart are now a single call, so a watch cannot be created by one save and bound by
a later unrelated respawn.

## Verification

- **16 mutations, 15 killed, 1 declared expected survivor.** The survivor is the twin release
  inside the no-agent branch: it needs an agent that is *stopped but still registered*, and no
  public path produces that state (retire/reset remove it; stopAll clears the pending map
  first). The guard is real and untestable from outside, and the harness prints that rather
  than reporting a clean sweep it did not earn.
- 504 files / **9446 tests** green.
- The arming is one line in `index.ts` — the shape that deletes with everything still passing
  — so it has a source-level wiring test, and the harness swaps the call back to the plain
  restart to prove that test is load-bearing.

## Not in this PR

The reporter's items 2 and 3, deliberately and not pretended otherwise:

- **Hold the respawn until transfers drain.** I agree a queued respawn is by definition not
  urgent, but it changes the respawn scheduler's contract and deserves its own tests.
- **Auto-adopt orphaned jobs in the new session.** The most valuable one for them, and the one
  I least want to rush: dead-owner detection already exists and correctly identified all nine,
  and the `.partial` files plus job records are enough to resume. That is a recovery feature,
  not a wording fix.

Also registered from the report and worth separate issues: the download tray kept showing the
dead transfers as "downloading" while `action:"status"` correctly said the owning process was
gone, and the `download-jobs.js:1444` doc comment overstates the from-zero cost for the case
they actually hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
