### PR TITLE
release: v0.51.49 — a queued respawn no longer kills downloads in silence (#1567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.49] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- a tab leaves the watch when its restart RESOLVES, not only when dropped
+- a watch can no longer outlive the save that created it
+- only an ARMED credential respawn may speak, and only once
+- take the at-risk snapshot when the respawn FIRES, not when it is queued
+
+#### Changed
+- fix what the docs claim, before translating them into eleven languages (#1558)
+
+
 ## [0.51.48] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.48",
+  "version": "0.51.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.48",
+      "version": "0.51.49",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.48",
+  "version": "0.51.49",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.51.49.

Ships the fix for issue 1567 (PR #1576).

Saving a comfyui credential can queue a tool-session respawn for the end of the turn. The
receipt printed **"no reload, and no respawn required"** on the same message that reported
one queued. Both halves were true about different things — the key needs no respawn to be
seen, and a respawn is pending anyway — and together they read as "nothing is about to
happen". A user acted on exactly that, started ~48 GB of downloads over the next two turns,
and lost all nine when the respawn landed.

The at-risk warning that exists for this (#1378) could not help. Its snapshot is taken
**before the emit**, which is right for an immediate respawn — the emit *is* the damage — and
structurally incapable of covering a queued one, where the damage happens arbitrarily later.
At save time nothing was in flight, so it correctly warned about nothing.

Two changes: the receipt now says a respawn is pending and why nothing can be listed (keeping
the sentence where it is correct — with nothing queued it is the useful "you can retry right
now"), and the snapshot is re-taken when the respawn actually fires, so the resumed session is
told what it just killed instead of the transfers vanishing.

Four review rounds found three real defects, all mine: the check initially fired on every
mcp-env restart (breaking the rule that a retarget gives an idle tab no turn), reported the
same global transfer list once per tab, and left its watch able to outlive the save that
created it — twice, the second time in a narrower form. 16 mutations, 15 killed and one
declared expected survivor; 504 files / 9446 tests green; verified against the built dist.

Not included, and stated as such in the PR: holding the respawn until transfers drain, and
auto-adopting orphaned jobs in the new session. Both are real work in the respawn scheduler
and the download-recovery layer rather than wording fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
