### PR TITLE
fix(1568): a pack manifest resolves by name, not by a path that expires

### DIFF
--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -158,7 +158,10 @@ Apply a ComfyUI setup manifest from an inline object or .json/.yaml/.yml file. C
   Inline manifest object. Provide exactly one of `manifest` or `path`.
 </ParamField>
 <ParamField path="path" type="string">
-  Path to a .json, .yaml, or .yml manifest file. Provide exactly one of `manifest` or `path`.
+  Path to a .json, .yaml, or .yml manifest file. Provide exactly one of `manifest`, `path`, or `pack`.
+</ParamField>
+<ParamField path="pack" type="string">
+  A bundled installer pack by NAME, as reported by list_packs (action:"list"). PREFER THIS over `path` for a bundled pack: the name is resolved against the running build at apply time, while a manifest_path captured earlier points into an npx cache directory that a later respawn no longer has (#1568). Provide exactly one of `manifest`, `path`, or `pack`.
 </ParamField>
 
 ### Example

--- a/src/__tests__/services/apply-manifest-pack.test.ts
+++ b/src/__tests__/services/apply-manifest-pack.test.ts
@@ -1,0 +1,124 @@
+// #1568 — apply_manifest takes a pack by NAME, and a dead npx path is recognised.
+//
+// The resolution helpers are unit-tested next door (pack-manifest-resolution.test.ts). This
+// file is about the SEAM: that applyManifest actually consults them, enforces exactly-one-of
+// across three inputs now rather than two, and REPORTS a substitution instead of quietly
+// running a different file than the caller named.
+//
+// applyManifestSections is stubbed — installing custom nodes and downloading model weights
+// is not what is under test, and letting it run would make this a network test.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const applied = vi.hoisted(() => ({ manifests: [] as unknown[] }));
+
+vi.mock("../../services/node-management.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/node-management.js")>();
+  return {
+    ...actual,
+    listInstalledNodes: async () => [],
+    installCustomNode: async () => ({ status: "applied" }),
+    installModelViaManager: async () => ({ status: "applied" }),
+  };
+});
+
+let applyManifest: typeof import("../../services/manifest.js").applyManifest;
+let resolvePackManifestFile: typeof import("../../services/manifest.js").resolvePackManifestFile;
+
+beforeEach(async () => {
+  vi.resetModules();
+  applied.manifests = [];
+  ({ applyManifest, resolvePackManifestFile } = await import("../../services/manifest.js"));
+});
+
+/** Run apply against an input, tolerating whatever the (unmocked) section applier does with
+ *  a real pack manifest — what matters here is WHICH manifest it resolved, and the error
+ *  when it resolved none. */
+const applyAndCatch = async (opts: Record<string, unknown>) => {
+  try {
+    return { ok: true as const, result: await applyManifest(opts as never) };
+  } catch (err) {
+    return { ok: false as const, message: err instanceof Error ? err.message : String(err) };
+  }
+};
+
+describe("apply_manifest input selection (#1568)", () => {
+  it("REFUSES more than one of manifest / path / pack", async () => {
+    for (const opts of [
+      { manifest: { models: [] }, pack: "krea2-combo" },
+      { path: "/x/manifest.yaml", pack: "krea2-combo" },
+      { manifest: { models: [] }, path: "/x/manifest.yaml" },
+      { manifest: { models: [] }, path: "/x/manifest.yaml", pack: "krea2-combo" },
+    ]) {
+      const r = await applyAndCatch(opts);
+      expect(r.ok, JSON.stringify(opts)).toBe(false);
+      expect(r.ok === false && r.message).toMatch(/exactly one of/i);
+    }
+  });
+
+  it("REFUSES none of them", async () => {
+    const r = await applyAndCatch({});
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.message).toMatch(/exactly one of/i);
+    // The message must name the new input too, or an agent reading it cannot discover the
+    // durable form that exists precisely to stop this bug recurring.
+    expect(r.ok === false && r.message).toMatch(/pack/);
+  });
+
+  it("an unknown pack name says so, and points at how to find a real one", async () => {
+    const r = await applyAndCatch({ pack: "no-such-pack-1568" });
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.message).toMatch(/no-such-pack-1568/);
+    expect(r.ok === false && r.message).toMatch(/list_packs/);
+    // NOT an ENOENT with a path in it — that is the confusing failure this replaces.
+    expect(r.ok === false && r.message).not.toMatch(/ENOENT/);
+  });
+
+  it("a traversal attempt in `pack` is refused as an unknown pack, never opened", async () => {
+    for (const bad of ["../../etc/passwd", "a/b", ".."]) {
+      const r = await applyAndCatch({ pack: bad });
+      expect(r.ok, bad).toBe(false);
+      expect(r.ok === false && r.message).toMatch(/No bundled pack named/);
+    }
+  });
+});
+
+describe("a stale npx path is repaired AND reported (#1568)", () => {
+  const STALE =
+    "C:/Users/u/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
+
+  it("resolves the pack and says which file actually ran", async () => {
+    const r = await applyAndCatch({ path: STALE });
+    // Whatever the section applier concluded, resolution must have succeeded — the failure
+    // being fixed is "this file does not exist", and that must be gone.
+    expect(r.ok, r.ok === false ? r.message : "").toBe(true);
+    const repair = r.ok ? r.result.resolved_from_stale_path : undefined;
+    expect(repair, "a substitution must be reported, not silent").toBeTruthy();
+    expect(repair?.requested).toBe(STALE);
+    expect(repair?.pack).toBe("krea2-combo");
+    expect(repair?.applied).toBe(resolvePackManifestFile("krea2-combo"));
+  });
+
+  it("a genuinely missing file that is NOT a bundled pack still fails as missing", async () => {
+    const r = await applyAndCatch({ path: "/home/u/my-project/packs/krea2-combo/manifest.yaml" });
+    expect(r.ok).toBe(false);
+    // It must NOT have been silently replaced by the bundled pack of the same name.
+    expect(r.ok === false && r.message).not.toMatch(/applied the bundled pack/i);
+  });
+
+  it("a normal apply reports NO substitution", async () => {
+    const live = resolvePackManifestFile("krea2-combo") as string;
+    expect(live).toBeTruthy();
+    const r = await applyAndCatch({ path: live });
+    expect(r.ok).toBe(true);
+    expect(
+      r.ok && r.result.resolved_from_stale_path,
+      "nothing was substituted, so nothing may be claimed",
+    ).toBeUndefined();
+  });
+
+  it("`pack` reports no substitution either — it was never a path", async () => {
+    const r = await applyAndCatch({ pack: "krea2-combo" });
+    expect(r.ok).toBe(true);
+    expect(r.ok && r.result.resolved_from_stale_path).toBeUndefined();
+  });
+});

--- a/src/__tests__/services/apply-manifest-pack.test.ts
+++ b/src/__tests__/services/apply-manifest-pack.test.ts
@@ -68,9 +68,13 @@ describe("a stale npx path refuses with the remedy, and installs NOTHING (#1568)
   const STALE =
     "C:/Users/u/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
 
-  it("names the pack to use instead", async () => {
+  it("keeps the REAL loader error and appends the remedy", async () => {
+    // Review, round 2. An earlier version decided "this is a stale npx path" BEFORE trying
+    // to open it, which relabelled an ordinary ENOENT/EACCES under any node_modules install
+    // and hid what actually went wrong. The loader's own error is what the caller needs; the
+    // suggestion is additional.
     const msg = await failureOf({ path: STALE });
-    expect(msg).toMatch(/no longer exists/i);
+    expect(msg, "the underlying failure must still be visible").toMatch(/ENOENT|EACCES|ENOTDIR/);
     expect(msg).toMatch(/pack: "krea2-combo"/);
     // The reason matters as much as the remedy: without it this reads as a missing pack.
     expect(msg).toMatch(/npx/i);

--- a/src/__tests__/services/apply-manifest-pack.test.ts
+++ b/src/__tests__/services/apply-manifest-pack.test.ts
@@ -1,43 +1,31 @@
-// #1568 — apply_manifest takes a pack by NAME, and a dead npx path is recognised.
+// #1568 — apply_manifest's INPUT SELECTION: `pack` is accepted, and a dead npx path is
+// refused with the one-call remedy instead of a bare ENOENT.
 //
-// The resolution helpers are unit-tested next door (pack-manifest-resolution.test.ts). This
-// file is about the SEAM: that applyManifest actually consults them, enforces exactly-one-of
-// across three inputs now rather than two, and REPORTS a substitution instead of quietly
-// running a different file than the caller named.
+// Every case here is an ERROR path, deliberately. An earlier version of this file called
+// applyManifest with a real pack to prove the happy path, and review caught what that means:
+// only `node-management` was mocked, so with a local ComfyUI base resolvable the model loop
+// would reach `startDownloadJob` and start pulling this pack's multi-gigabyte weights on
+// whatever machine ran the suite. A test must not be able to do that.
 //
-// applyManifestSections is stubbed — installing custom nodes and downloading model weights
-// is not what is under test, and letting it run would make this a network test.
+// The happy path is covered where it costs nothing: `resolvePackManifestFile` proves the
+// name resolves (pack-manifest-resolution.test.ts), and the tool-schema test proves the
+// input is offered. Nothing here can install anything, because nothing here gets past
+// resolution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const applied = vi.hoisted(() => ({ manifests: [] as unknown[] }));
-
-vi.mock("../../services/node-management.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../services/node-management.js")>();
-  return {
-    ...actual,
-    listInstalledNodes: async () => [],
-    installCustomNode: async () => ({ status: "applied" }),
-    installModelViaManager: async () => ({ status: "applied" }),
-  };
-});
-
 let applyManifest: typeof import("../../services/manifest.js").applyManifest;
-let resolvePackManifestFile: typeof import("../../services/manifest.js").resolvePackManifestFile;
 
 beforeEach(async () => {
   vi.resetModules();
-  applied.manifests = [];
-  ({ applyManifest, resolvePackManifestFile } = await import("../../services/manifest.js"));
+  ({ applyManifest } = await import("../../services/manifest.js"));
 });
 
-/** Run apply against an input, tolerating whatever the (unmocked) section applier does with
- *  a real pack manifest — what matters here is WHICH manifest it resolved, and the error
- *  when it resolved none. */
-const applyAndCatch = async (opts: Record<string, unknown>) => {
+const failureOf = async (opts: Record<string, unknown>): Promise<string> => {
   try {
-    return { ok: true as const, result: await applyManifest(opts as never) };
+    await applyManifest(opts as never);
+    return "__NO_ERROR__";
   } catch (err) {
-    return { ok: false as const, message: err instanceof Error ? err.message : String(err) };
+    return err instanceof Error ? err.message : String(err);
   }
 };
 
@@ -49,76 +37,85 @@ describe("apply_manifest input selection (#1568)", () => {
       { manifest: { models: [] }, path: "/x/manifest.yaml" },
       { manifest: { models: [] }, path: "/x/manifest.yaml", pack: "krea2-combo" },
     ]) {
-      const r = await applyAndCatch(opts);
-      expect(r.ok, JSON.stringify(opts)).toBe(false);
-      expect(r.ok === false && r.message).toMatch(/exactly one of/i);
+      expect(await failureOf(opts), JSON.stringify(opts)).toMatch(/exactly one of/i);
     }
   });
 
-  it("REFUSES none of them", async () => {
-    const r = await applyAndCatch({});
-    expect(r.ok).toBe(false);
-    expect(r.ok === false && r.message).toMatch(/exactly one of/i);
-    // The message must name the new input too, or an agent reading it cannot discover the
-    // durable form that exists precisely to stop this bug recurring.
-    expect(r.ok === false && r.message).toMatch(/pack/);
+  it("REFUSES none of them, and names all three", async () => {
+    const msg = await failureOf({});
+    expect(msg).toMatch(/exactly one of/i);
+    // An agent that cannot discover `pack` from the error keeps reaching for the path that
+    // expires, which is the whole failure.
+    expect(msg).toMatch(/pack/);
   });
 
-  it("an unknown pack name says so, and points at how to find a real one", async () => {
-    const r = await applyAndCatch({ pack: "no-such-pack-1568" });
-    expect(r.ok).toBe(false);
-    expect(r.ok === false && r.message).toMatch(/no-such-pack-1568/);
-    expect(r.ok === false && r.message).toMatch(/list_packs/);
+  it("an unknown pack says so, and points at how to find a real one", async () => {
+    const msg = await failureOf({ pack: "no-such-pack-1568" });
+    expect(msg).toMatch(/no-such-pack-1568/);
+    expect(msg).toMatch(/list_packs/);
     // NOT an ENOENT with a path in it — that is the confusing failure this replaces.
-    expect(r.ok === false && r.message).not.toMatch(/ENOENT/);
+    expect(msg).not.toMatch(/ENOENT/);
   });
 
   it("a traversal attempt in `pack` is refused as an unknown pack, never opened", async () => {
-    for (const bad of ["../../etc/passwd", "a/b", ".."]) {
-      const r = await applyAndCatch({ pack: bad });
-      expect(r.ok, bad).toBe(false);
-      expect(r.ok === false && r.message).toMatch(/No bundled pack named/);
+    for (const bad of ["../../etc/passwd", "a/b", "..", "krea2-combo/../krea2-combo"]) {
+      expect(await failureOf({ pack: bad }), bad).toMatch(/No bundled pack named/);
     }
   });
 });
 
-describe("a stale npx path is repaired AND reported (#1568)", () => {
+describe("a stale npx path refuses with the remedy, and installs NOTHING (#1568)", () => {
   const STALE =
     "C:/Users/u/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
 
-  it("resolves the pack and says which file actually ran", async () => {
-    const r = await applyAndCatch({ path: STALE });
-    // Whatever the section applier concluded, resolution must have succeeded — the failure
-    // being fixed is "this file does not exist", and that must be gone.
-    expect(r.ok, r.ok === false ? r.message : "").toBe(true);
-    const repair = r.ok ? r.result.resolved_from_stale_path : undefined;
-    expect(repair, "a substitution must be reported, not silent").toBeTruthy();
-    expect(repair?.requested).toBe(STALE);
-    expect(repair?.pack).toBe("krea2-combo");
-    expect(repair?.applied).toBe(resolvePackManifestFile("krea2-combo"));
+  it("names the pack to use instead", async () => {
+    const msg = await failureOf({ path: STALE });
+    expect(msg).toMatch(/no longer exists/i);
+    expect(msg).toMatch(/pack: "krea2-combo"/);
+    // The reason matters as much as the remedy: without it this reads as a missing pack.
+    expect(msg).toMatch(/npx/i);
   });
 
-  it("a genuinely missing file that is NOT a bundled pack still fails as missing", async () => {
-    const r = await applyAndCatch({ path: "/home/u/my-project/packs/krea2-combo/manifest.yaml" });
-    expect(r.ok).toBe(false);
-    // It must NOT have been silently replaced by the bundled pack of the same name.
-    expect(r.ok === false && r.message).not.toMatch(/applied the bundled pack/i);
+  it("says plainly that nothing was installed", async () => {
+    // apply_manifest installs custom nodes and downloads weights. A failure part-way
+    // through and a failure before anything started are very different situations, and the
+    // caller cannot tell them apart from an ENOENT.
+    expect(await failureOf({ path: STALE })).toMatch(/nothing was installed/i);
   });
 
-  it("a normal apply reports NO substitution", async () => {
-    const live = resolvePackManifestFile("krea2-combo") as string;
-    expect(live).toBeTruthy();
-    const r = await applyAndCatch({ path: live });
-    expect(r.ok).toBe(true);
-    expect(
-      r.ok && r.result.resolved_from_stale_path,
-      "nothing was substituted, so nothing may be claimed",
-    ).toBeUndefined();
+  it("does NOT silently apply the bundled pack in its place", async () => {
+    // The direction review attacked: substituting a file the caller did not name, for an
+    // operation that installs things. It must refuse, not succeed.
+    expect(await failureOf({ path: STALE })).not.toBe("__NO_ERROR__");
   });
 
-  it("`pack` reports no substitution either — it was never a path", async () => {
-    const r = await applyAndCatch({ pack: "krea2-combo" });
-    expect(r.ok).toBe(true);
-    expect(r.ok && r.result.resolved_from_stale_path).toBeUndefined();
+  it("opens the path EXACTLY as given, whitespace included", async () => {
+    // Review, P2. Trimming was only ever meant to decide whether an input was PRESENT.
+    // Trimming what gets opened silently retargets a legitimate POSIX path whose name
+    // begins or ends with a space — and could push one into stale-path handling that the
+    // untrimmed original would never have matched.
+    //
+    // Asserted through the error text, which quotes the path the loader actually tried.
+    // The error quotes the path the loader actually tried, so the padding is observable.
+    // Asserted on the TRAILING spaces rather than the whole string: the leading ones are
+    // consumed by path resolution differently per platform, but a trim would remove both.
+    const padded = "  /home/u/no such manifest .yaml  ";
+    const msg = await failureOf({ path: padded });
+    expect(msg).not.toBe("__NO_ERROR__");
+    expect(msg, "the trailing whitespace must survive to the open").toMatch(
+      /no such manifest \.yaml {2}/,
+    );
+    // …and the space INSIDE the name, which a naive normalisation would also eat.
+    expect(msg).toMatch(/manifest \.yaml/);
+  });
+
+  it("a missing file that is NOT an installed pack path fails as the missing file it is", async () => {
+    for (const other of [
+      "/home/u/my-project/packs/krea2-combo/manifest.yaml",
+      "/home/u/dev/comfyui-mcp/packs/krea2-combo/manifest.yaml", // a source checkout
+    ]) {
+      const msg = await failureOf({ path: other });
+      expect(msg, other).not.toMatch(/re-run with pack/i);
+    }
   });
 });

--- a/src/__tests__/services/pack-manifest-resolution.test.ts
+++ b/src/__tests__/services/pack-manifest-resolution.test.ts
@@ -1,0 +1,92 @@
+// #1568 — `list_packs` hands out an absolute manifest_path, and that path dies.
+//
+// The path is built from the RUNNING package root, which under npx is an ephemeral cache
+// directory (…/npm-cache/_npx/<hash>/node_modules/comfyui-mcp). The next npx respawn gets a
+// different <hash>, so a path captured earlier in the conversation — or written into notes,
+// or repeated by an agent from memory — stats ENOENT:
+//
+//   ENOENT: no such file or directory, stat
+//   '~/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml'
+//
+// `packsDir()` already resolves from the current package root, so the LOOKUP is fine; what
+// goes stale is the string handed out. Two things follow, and this file pins both:
+//
+//   1. `apply_manifest` should take the pack by NAME. A name cannot go stale, and it is what
+//      `list_packs` already uses everywhere else (read_workflow, panel_load_workflow).
+//   2. A path that IS one of our bundled packs, merely under a dead package root, should be
+//      recognised rather than reported as a missing file — the pack is right there.
+import { describe, expect, it } from "vitest";
+
+import { resolvePackManifestFile, repairStalePackManifestPath } from "../../services/manifest.js";
+
+describe("a pack manifest resolves by NAME, never by a captured path (#1568)", () => {
+  it("resolves a real bundled pack", () => {
+    // krea2-combo is the pack from the report. Any bundled pack proves the mechanism; this
+    // one proves it against the case that was reported.
+    const file = resolvePackManifestFile("krea2-combo");
+    expect(file, "the reported pack must resolve from the running package root").toBeTruthy();
+    expect(file).toMatch(/krea2-combo[\\/]manifest\.ya?ml$/);
+  });
+
+  it("refuses a name that is not a plain pack directory", () => {
+    // The name reaches the filesystem, so traversal must not.
+    for (const bad of ["../../etc/passwd", "a/b", "..", "", "  ", "pack;rm -rf /"]) {
+      expect(resolvePackManifestFile(bad), bad).toBeNull();
+    }
+  });
+
+  it("returns null for a pack that does not exist, rather than a path that does not", () => {
+    expect(resolvePackManifestFile("no-such-pack-1568")).toBeNull();
+  });
+});
+
+describe("a stale npx path is recognised as the pack it names (#1568)", () => {
+  const STALE =
+    "C:/Users/u/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
+
+  it("repairs the exact path from the report", () => {
+    const repaired = repairStalePackManifestPath(STALE);
+    expect(repaired, "a dead npx root naming a real pack must be recoverable").toBeTruthy();
+    expect(repaired).toMatch(/krea2-combo[\\/]manifest\.ya?ml$/);
+    expect(repaired).not.toContain("_npx");
+  });
+
+  it("repairs the POSIX form too", () => {
+    const posix =
+      "/home/u/.npm/_npx/9f2c1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
+    expect(repairStalePackManifestPath(posix)).toMatch(/krea2-combo[\\/]manifest\.ya?ml$/);
+  });
+
+  it("does NOT repair a path that is not a bundled pack manifest", () => {
+    // This substitutes a file the caller did not name, so it may only fire when the path is
+    // unmistakably one of OUR packs. Everything else must fail as the missing file it is —
+    // silently applying a different manifest is far worse than an ENOENT.
+    for (const other of [
+      "/home/u/my-project/packs/krea2-combo/manifest.yaml", // not under a comfyui-mcp root
+      "/npx/x/node_modules/comfyui-mcp/packs/krea2-combo/other.yaml", // not the manifest
+      "/npx/x/node_modules/comfyui-mcp/manifest.yaml", // no pack segment
+      "/npx/x/node_modules/comfyui-mcp/packs/../../evil/manifest.yaml", // traversal
+      "/npx/x/node_modules/other-pkg/packs/krea2-combo/manifest.yaml", // a different package
+    ]) {
+      expect(repairStalePackManifestPath(other), other).toBeNull();
+    }
+  });
+
+  it("does NOT repair a path naming a pack this build does not ship", () => {
+    // The name has to exist HERE. Otherwise this invents a file for a pack that was removed
+    // between versions, which is exactly the confusion it is meant to remove.
+    expect(
+      repairStalePackManifestPath(
+        "/x/_npx/abc/node_modules/comfyui-mcp/packs/no-such-pack-1568/manifest.yaml",
+      ),
+    ).toBeNull();
+  });
+
+  it("leaves a path that still EXISTS completely alone", () => {
+    // Repair is for a dead path only. A live one is already correct, and re-deriving it
+    // could retarget a legitimately different checkout.
+    const live = resolvePackManifestFile("krea2-combo") as string;
+    expect(live).toBeTruthy();
+    expect(repairStalePackManifestPath(live)).toBeNull();
+  });
+});

--- a/src/__tests__/services/pack-manifest-resolution.test.ts
+++ b/src/__tests__/services/pack-manifest-resolution.test.ts
@@ -20,7 +20,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { resolvePackManifestFile, repairStalePackManifestPath } from "../../services/manifest.js";
+import { resolvePackManifestFile, bundledPackNamedByStalePath } from "../../services/manifest.js";
 
 describe("a pack manifest resolves by NAME, never by a captured path (#1568)", () => {
   it("resolves a real bundled pack", () => {
@@ -57,16 +57,14 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     "C:/Users/u/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
 
   it("repairs the exact path from the report", () => {
-    const repaired = repairStalePackManifestPath(STALE);
-    expect(repaired, "a dead npx root naming a real pack must be recoverable").toBeTruthy();
-    expect(repaired).toMatch(/krea2-combo[\\/]manifest\.ya?ml$/);
-    expect(repaired).not.toContain("_npx");
+    const repaired = bundledPackNamedByStalePath(STALE);
+    expect(repaired, "a dead npx root naming a real pack must be recognised").toBe("krea2-combo");
   });
 
   it("repairs the POSIX form too", () => {
     const posix =
       "/home/u/.npm/_npx/9f2c1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml";
-    expect(repairStalePackManifestPath(posix)).toMatch(/krea2-combo[\\/]manifest\.ya?ml$/);
+    expect(bundledPackNamedByStalePath(posix)).toBe("krea2-combo");
   });
 
   it("does NOT repair a path that is not a bundled pack manifest", () => {
@@ -79,8 +77,14 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
       "/npx/x/node_modules/comfyui-mcp/manifest.yaml", // no pack segment
       "/npx/x/node_modules/comfyui-mcp/packs/../../evil/manifest.yaml", // traversal
       "/npx/x/node_modules/other-pkg/packs/krea2-combo/manifest.yaml", // a different package
+      // A SOURCE CHECKOUT, not an install (review). The first version authenticated only
+      // the last four segments, so a developer's own tree — or any directory that happened
+      // to be called comfyui-mcp — was accepted. The reported failure is an installed copy
+      // under an npx cache, so `node_modules` is required.
+      "/home/u/dev/comfyui-mcp/packs/krea2-combo/manifest.yaml",
+      "/home/u/comfyui-mcp/packs/krea2-combo/manifest.yaml",
     ]) {
-      expect(repairStalePackManifestPath(other), other).toBeNull();
+      expect(bundledPackNamedByStalePath(other), other).toBeNull();
     }
   });
 
@@ -88,7 +92,7 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     // The name has to exist HERE. Otherwise this invents a file for a pack that was removed
     // between versions, which is exactly the confusion it is meant to remove.
     expect(
-      repairStalePackManifestPath(
+      bundledPackNamedByStalePath(
         "/x/_npx/abc/node_modules/comfyui-mcp/packs/no-such-pack-1568/manifest.yaml",
       ),
     ).toBeNull();
@@ -99,7 +103,7 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     // could retarget a legitimately different checkout.
     const live = resolvePackManifestFile("krea2-combo") as string;
     expect(live).toBeTruthy();
-    expect(repairStalePackManifestPath(live)).toBeNull();
+    expect(bundledPackNamedByStalePath(live)).toBeNull();
   });
 
   it("leaves an EXISTING path alone even when it is shaped like an install", () => {
@@ -118,7 +122,7 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     try {
       expect(existsSync(file), "the fixture must actually exist").toBe(true);
       expect(
-        repairStalePackManifestPath(file),
+        bundledPackNamedByStalePath(file),
         "a live installed path is already correct — repairing it would retarget a real checkout",
       ).toBeNull();
     } finally {
@@ -131,7 +135,7 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     // the pack name IS real, so only the segment rule can refuse it. The earlier refusal
     // case had a non-matching owner and so passed with this rule deleted.
     expect(
-      repairStalePackManifestPath(
+      bundledPackNamedByStalePath(
         "/x/_npx/abc/node_modules/comfyui-mcp/skills/krea2-combo/manifest.yaml",
       ),
     ).toBeNull();

--- a/src/__tests__/services/pack-manifest-resolution.test.ts
+++ b/src/__tests__/services/pack-manifest-resolution.test.ts
@@ -16,6 +16,9 @@
 //   2. A path that IS one of our bundled packs, merely under a dead package root, should be
 //      recognised rather than reported as a missing file — the pack is right there.
 import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { resolvePackManifestFile, repairStalePackManifestPath } from "../../services/manifest.js";
 
@@ -33,6 +36,15 @@ describe("a pack manifest resolves by NAME, never by a captured path (#1568)", (
     for (const bad of ["../../etc/passwd", "a/b", "..", "", "  ", "pack;rm -rf /"]) {
       expect(resolvePackManifestFile(bad), bad).toBeNull();
     }
+  });
+
+  it("refuses a name that traverses but LANDS BACK inside packs/", () => {
+    // Isolates the name test from the containment test. `../../etc/passwd` escapes the
+    // packs root, so the `startsWith` guard refuses it and the name pattern is never
+    // exercised — deleting the pattern left that case passing. This one resolves to a real
+    // pack directory, so containment is satisfied and only the name rule can refuse it.
+    expect(resolvePackManifestFile("krea2-combo/../krea2-combo")).toBeNull();
+    expect(resolvePackManifestFile("./krea2-combo")).toBeNull();
   });
 
   it("returns null for a pack that does not exist, rather than a path that does not", () => {
@@ -88,5 +100,40 @@ describe("a stale npx path is recognised as the pack it names (#1568)", () => {
     const live = resolvePackManifestFile("krea2-combo") as string;
     expect(live).toBeTruthy();
     expect(repairStalePackManifestPath(live)).toBeNull();
+  });
+
+  it("leaves an EXISTING path alone even when it is shaped like an install", () => {
+    // Isolates the exists-check from the owner-check. This repo's checkout directory is not
+    // named `comfyui-mcp`, so the test above is refused by the OWNER guard and passes with
+    // the exists-check deleted — the case that matters in production, where the path really
+    // does live under `node_modules/comfyui-mcp/packs/…`, was never covered.
+    //
+    // So build one on disk: a real file, at the real installed shape, that must be returned
+    // untouched because it is not stale.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-1568-"));
+    const dir = join(root, "node_modules", "comfyui-mcp", "packs", "krea2-combo");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "manifest.yaml");
+    writeFileSync(file, "models: []\n");
+    try {
+      expect(existsSync(file), "the fixture must actually exist").toBe(true);
+      expect(
+        repairStalePackManifestPath(file),
+        "a live installed path is already correct — repairing it would retarget a real checkout",
+      ).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires the `packs` segment, not merely a comfyui-mcp root", () => {
+    // Isolates the packs-segment check from the owner check: owner IS comfyui-mcp here, and
+    // the pack name IS real, so only the segment rule can refuse it. The earlier refusal
+    // case had a non-matching owner and so passed with this rule deleted.
+    expect(
+      repairStalePackManifestPath(
+        "/x/_npx/abc/node_modules/comfyui-mcp/skills/krea2-combo/manifest.yaml",
+      ),
+    ).toBeNull();
   });
 });

--- a/src/__tests__/tools/apply-manifest-pack-wiring.test.ts
+++ b/src/__tests__/tools/apply-manifest-pack-wiring.test.ts
@@ -1,0 +1,35 @@
+// #1568 — the service accepting `pack` is useless if the TOOL never offers it.
+//
+// The schema is a separate file from the resolver, and adding an input there is the kind of
+// one-liner that can be dropped in a refactor with every service test still green: an agent
+// simply never learns the durable form exists and keeps passing the path that expires.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../../tools/manifest.ts", import.meta.url), "utf-8");
+
+describe("apply_manifest offers `pack` (#1568)", () => {
+  it("declares the input", () => {
+    expect(SRC).toMatch(/\bpack:\s*z\s*\n?\s*\.string\(\)/);
+    expect(SRC).toMatch(/\.optional\(\)/);
+  });
+
+  it("its description tells the agent WHY to prefer it", () => {
+    // The whole failure is an agent reusing a captured manifest_path. A description that
+    // merely says "a pack name" gives it no reason to change, so the reason is the payload.
+    const at = SRC.indexOf("pack: z");
+    expect(at).toBeGreaterThan(-1);
+    const block = SRC.slice(at, at + 900);
+    expect(block).toMatch(/list_packs/);
+    expect(block).toMatch(/npx/i);
+    expect(block).toMatch(/prefer/i);
+  });
+
+  it("the exactly-one-of rule names all three inputs", () => {
+    // `path`'s own description still said "one of `manifest` or `path`", which contradicts
+    // the runtime rule and would read as `pack` being additive rather than exclusive.
+    const at = SRC.indexOf("path: z");
+    const block = SRC.slice(at, at + 600);
+    expect(block).toMatch(/`manifest`, `path`, or `pack`/);
+  });
+});

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -12,6 +12,7 @@ import {
   resolve,
   sep,
 } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { config, isRemoteMode } from "../config.js";
@@ -132,6 +133,92 @@ export type ComfyManifest = z.infer<typeof manifestSchema>;
 export interface ApplyManifestOptions {
   manifest?: unknown;
   path?: string;
+  /** #1568 — a bundled pack by NAME. Resolved against the RUNNING package root at apply
+   *  time, so it cannot expire the way a captured path does. */
+  pack?: string;
+}
+
+// ---------------------------------------------------------------------------
+// #1568 — bundled pack manifests, resolved by name rather than by a path that expires
+//
+// `list_packs` hands out an absolute `manifest_path` built from the running package root.
+// Under npx that root is `…/_npx/<hash>/node_modules/comfyui-mcp`, and the next respawn
+// gets a different <hash> — so a path captured earlier stats ENOENT while the pack is
+// still sitting there under its name.
+//
+// The lookup was never the broken part. `packsDir()` already derives from the current
+// root; what goes stale is the string we publish and invite the caller to hand back.
+// ---------------------------------------------------------------------------
+
+/** A single safe path segment — a pack directory name with no traversal or separators.
+ *  Mirrors skills-access.ts's SAFE_NAME, which guards the same directory. */
+const SAFE_PACK_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** The bundled packs directory of the CURRENTLY RUNNING build. */
+function bundledPacksDir(): string {
+  return join(fileURLToPath(new URL("../../", import.meta.url)), "packs");
+}
+
+/**
+ * The manifest file of a bundled pack, or null when there is no such pack.
+ *
+ * Name-guarded and existence-checked: the name reaches the filesystem, so traversal must
+ * not. Returns the `.yaml` or `.yml` form, whichever the pack actually ships.
+ */
+export function resolvePackManifestFile(packName: string): string | null {
+  const name = String(packName ?? "").trim();
+  if (!SAFE_PACK_NAME.test(name)) return null;
+  const root = bundledPacksDir();
+  const packDir = join(root, name);
+  // Belt and braces over the name test: never leave the packs directory.
+  if (!packDir.startsWith(root)) return null;
+  for (const file of ["manifest.yaml", "manifest.yml"]) {
+    const candidate = join(packDir, file);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Recognise a DEAD path as the bundled pack it names, and return the live one.
+ *
+ * Returns null unless every one of these holds — and the strictness is the point. This
+ * substitutes a file the caller did not name, and applying the wrong manifest installs
+ * custom nodes and downloads model weights, so a wrong answer here is far worse than the
+ * ENOENT it replaces:
+ *
+ *   - the path does not exist (a live path is already correct, and re-deriving it could
+ *     retarget a legitimately different checkout);
+ *   - it ends `packs/<name>/manifest.(yaml|yml)`;
+ *   - `<name>` is a plain segment naming a pack THIS BUILD ships;
+ *   - and the segment before `packs` is a `comfyui-mcp` package root, so a user's own
+ *     `packs/` directory — or another package's — is never adopted.
+ */
+export function repairStalePackManifestPath(candidate: string): string | null {
+  const raw = String(candidate ?? "").trim();
+  if (!raw) return null;
+  // A path that still resolves is not stale; leave it alone.
+  if (existsSync(raw)) return null;
+  // Compare on a normalised, separator-agnostic form — the report's path is Windows-shaped
+  // and the same defect exists on POSIX.
+  const parts = raw.replace(/\\/g, "/").split("/").filter(Boolean);
+  if (parts.length < 4) return null;
+  const [file, name, packs, owner] = [
+    parts[parts.length - 1],
+    parts[parts.length - 2],
+    parts[parts.length - 3],
+    parts[parts.length - 4],
+  ];
+  if (file !== "manifest.yaml" && file !== "manifest.yml") return null;
+  if (packs !== "packs") return null;
+  // The owning package must be ours. Without this, a user's own
+  // `my-project/packs/<name>/manifest.yaml` would be silently replaced by a bundled pack
+  // that merely shares a directory name.
+  if (owner !== "comfyui-mcp") return null;
+  if (!SAFE_PACK_NAME.test(name)) return null;
+  // …and the pack has to exist HERE. Otherwise this invents a file for a pack that was
+  // removed between versions, which is the confusion it exists to remove.
+  return resolvePackManifestFile(name);
 }
 
 export type ManifestAction =
@@ -153,6 +240,10 @@ export interface ApplyManifestResult {
   success: boolean;
   summary: Record<ManifestItemStatus, number>;
   results: ManifestItemReport[];
+  /** #1568 — set when the `path` given was a dead npx-cache path and a bundled pack of the
+   *  same name was applied instead. Reported rather than done silently: this is a different
+   *  file from the one the caller named, and they are entitled to know which one ran. */
+  resolved_from_stale_path?: { requested: string; applied: string; pack: string };
 }
 
 function parseManifestText(path: string, text: string): unknown {
@@ -178,16 +269,57 @@ export async function loadManifestFile(path: string): Promise<ComfyManifest> {
   return manifestSchema.parse(raw);
 }
 
-async function resolveManifest(opts: ApplyManifestOptions): Promise<ComfyManifest> {
+/** What `resolveManifest` resolved, plus how — so the caller can report a substitution it
+ *  did not ask for (#1568). */
+interface ResolvedManifest {
+  manifest: ComfyManifest;
+  staleRepair?: { requested: string; applied: string; pack: string };
+}
+
+async function resolveManifest(opts: ApplyManifestOptions): Promise<ResolvedManifest> {
   const hasInline = opts.manifest !== undefined;
   const hasPath = opts.path !== undefined && opts.path.trim().length > 0;
-  if (hasInline === hasPath) {
+  const hasPack = opts.pack !== undefined && opts.pack.trim().length > 0;
+  const given = [hasInline, hasPath, hasPack].filter(Boolean).length;
+  if (given !== 1) {
     throw new ValidationError(
-      "Provide exactly one of `manifest` or `path` to apply_manifest.",
+      "Provide exactly one of `manifest`, `path`, or `pack` to apply_manifest.",
     );
   }
-  if (hasInline) return manifestSchema.parse(opts.manifest);
-  return loadManifestFile(opts.path!);
+  if (hasInline) return { manifest: manifestSchema.parse(opts.manifest) };
+
+  // #1568 — a NAME, resolved against the running package root. This is the durable form: a
+  // pack name cannot expire the way a path captured under an npx cache hash does.
+  if (hasPack) {
+    const name = opts.pack!.trim();
+    const file = resolvePackManifestFile(name);
+    if (!file) {
+      throw new ValidationError(
+        `No bundled pack named "${name}" ships a manifest in this build. ` +
+          `List the available packs with list_packs (action:"list") and use the \`name\` it reports.`,
+      );
+    }
+    return { manifest: await loadManifestFile(file) };
+  }
+
+  const requested = opts.path!.trim();
+  // #1568 — the reported failure: a path handed out by an EARLIER npx process, whose cache
+  // directory no longer exists. Recognise it as the bundled pack it names rather than
+  // reporting a missing file, but only under the strict conditions in
+  // repairStalePackManifestPath — this substitutes a file the caller did not name.
+  const repaired = repairStalePackManifestPath(requested);
+  if (repaired) {
+    const pack = basename(dirname(repaired));
+    logger.info(
+      "apply_manifest: the manifest path given no longer exists; applying the bundled pack of the same name from this build (#1568)",
+      { requested, applied: repaired, pack },
+    );
+    return {
+      manifest: await loadManifestFile(repaired),
+      staleRepair: { requested, applied: repaired, pack },
+    };
+  }
+  return { manifest: await loadManifestFile(requested) };
 }
 
 function commandExists(cmd: string): boolean {
@@ -830,7 +962,7 @@ async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
 export async function applyManifest(
   opts: ApplyManifestOptions,
 ): Promise<ApplyManifestResult> {
-  const manifest = await resolveManifest(opts);
+  const { manifest, staleRepair } = await resolveManifest(opts);
 
   // Resolve the LOCAL ComfyUI base this call should target, WITHOUT mutating the
   // process-global config.comfyuiPath (a global temp-set would leak the path to
@@ -847,7 +979,10 @@ export async function applyManifest(
   // classification + pip's interpreter, never where a model lands.
   const localBase = await resolveLocalManifestBase();
 
-  return applyManifestSections(manifest, localBase);
+  const result = await applyManifestSections(manifest, localBase);
+  // #1568 — surface the substitution on the RESULT, not only in the log. The caller named
+  // one file and a different one ran; that belongs in the answer they read.
+  return staleRepair ? { ...result, resolved_from_stale_path: staleRepair } : result;
 }
 
 /**

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -307,16 +307,27 @@ async function resolveManifest(opts: ApplyManifestOptions): Promise<ComfyManifes
   // #1568 — the reported failure: a path handed out by an EARLIER npx process, whose cache
   // directory no longer exists. Turn the bare ENOENT into the one-call remedy rather than
   // applying a file nobody named.
-  const stalePack = bundledPackNamedByStalePath(requested);
-  if (stalePack) {
+  // ATTEMPT THE OPEN FIRST, and only then explain (review, round 2). Deciding "this is a
+  // stale npx path" before trying it replaced the loader's real error — an ordinary npm
+  // install under node_modules, or a permission failure, would both have been relabelled,
+  // hiding the actual ENOENT/EACCES and pointing at a pack the caller never asked for.
+  //
+  // So the real error is what surfaces, and the remedy is appended to it.
+  try {
+    return await loadManifestFile(requested);
+  } catch (err) {
+    const stalePack = bundledPackNamedByStalePath(requested);
+    if (!stalePack) throw err;
+    const cause = err instanceof Error ? err.message : String(err);
     throw new ValidationError(
-      `That manifest path no longer exists: it points into a package directory from an earlier ` +
-        `npx run, which is replaced on each respawn (#1568). The pack itself is still here — ` +
-        `re-run with pack: "${stalePack}" instead of a path, which resolves against the running ` +
-        `build and cannot go stale. (Nothing was installed.)`,
+      `${cause}\n\nThat path points inside an installed comfyui-mcp package directory. If it came ` +
+        `from an earlier npx run, that directory is replaced on each respawn, which is why a ` +
+        `manifest_path captured earlier stops resolving (#1568). This build does ship a pack ` +
+        `called "${stalePack}" — if that is the one you meant, re-run with pack: "${stalePack}" ` +
+        `instead of a path: it resolves against the running build and cannot go stale. ` +
+        `(Nothing was installed.)`,
     );
   }
-  return loadManifestFile(requested);
 }
 
 function commandExists(cmd: string): boolean {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -180,45 +180,47 @@ export function resolvePackManifestFile(packName: string): string | null {
 }
 
 /**
- * Recognise a DEAD path as the bundled pack it names, and return the live one.
+ * Which bundled pack a MISSING path was almost certainly naming, or null.
  *
- * Returns null unless every one of these holds — and the strictness is the point. This
- * substitutes a file the caller did not name, and applying the wrong manifest installs
- * custom nodes and downloads model weights, so a wrong answer here is far worse than the
- * ENOENT it replaces:
+ * This deliberately does NOT substitute the file. An earlier version of this returned the
+ * live path and applied it, and review was right to attack that: `apply_manifest` installs
+ * custom nodes and downloads model weights, so running a file the caller did not name is a
+ * much worse failure than the ENOENT it replaces — and the recogniser authenticated only
+ * the last four segments, so a user's own `~/dev/comfyui-mcp/packs/<name>/manifest.yaml`
+ * would have been retargeted at a bundled pack that merely shares a directory name.
  *
- *   - the path does not exist (a live path is already correct, and re-deriving it could
- *     retarget a legitimately different checkout);
- *   - it ends `packs/<name>/manifest.(yaml|yml)`;
- *   - `<name>` is a plain segment naming a pack THIS BUILD ships;
- *   - and the segment before `packs` is a `comfyui-mcp` package root, so a user's own
- *     `packs/` directory — or another package's — is never adopted.
+ * So it answers a question instead: "is there a bundled pack this dead path was pointing
+ * at?" The caller turns that into an actionable refusal naming `pack:<name>`, which is one
+ * call away and leaves the choice with the user. `pack:` is the actual fix for #1568; this
+ * only stops the failure being a bare ENOENT that reads like a missing pack.
+ *
+ * Still requires `node_modules` in the path, because the reported failure is an INSTALLED
+ * copy under an npx cache — that keeps a source checkout out of it entirely.
  */
-export function repairStalePackManifestPath(candidate: string): string | null {
-  const raw = String(candidate ?? "").trim();
-  if (!raw) return null;
-  // A path that still resolves is not stale; leave it alone.
+export function bundledPackNamedByStalePath(candidate: string): string | null {
+  const raw = String(candidate ?? "");
+  if (!raw.trim()) return null;
+  // Only a path that resolves to nothing is a candidate. This is not a security boundary —
+  // nothing is substituted on the strength of it — so an ambiguous stat (a permission
+  // error, a dangling symlink) costing us a suggestion is the harmless direction.
   if (existsSync(raw)) return null;
-  // Compare on a normalised, separator-agnostic form — the report's path is Windows-shaped
-  // and the same defect exists on POSIX.
   const parts = raw.replace(/\\/g, "/").split("/").filter(Boolean);
-  if (parts.length < 4) return null;
-  const [file, name, packs, owner] = [
-    parts[parts.length - 1],
-    parts[parts.length - 2],
-    parts[parts.length - 3],
-    parts[parts.length - 4],
-  ];
+  if (parts.length < 5) return null;
+  const file = parts[parts.length - 1];
+  const name = parts[parts.length - 2];
+  const packs = parts[parts.length - 3];
+  const owner = parts[parts.length - 4];
+  const container = parts[parts.length - 5];
   if (file !== "manifest.yaml" && file !== "manifest.yml") return null;
   if (packs !== "packs") return null;
-  // The owning package must be ours. Without this, a user's own
-  // `my-project/packs/<name>/manifest.yaml` would be silently replaced by a bundled pack
-  // that merely shares a directory name.
   if (owner !== "comfyui-mcp") return null;
+  // An INSTALLED copy, which is what an npx cache holds. A working checkout at
+  // `~/dev/comfyui-mcp/packs/…` is not this, and its missing file is its own business.
+  if (container !== "node_modules") return null;
   if (!SAFE_PACK_NAME.test(name)) return null;
-  // …and the pack has to exist HERE. Otherwise this invents a file for a pack that was
-  // removed between versions, which is the confusion it exists to remove.
-  return resolvePackManifestFile(name);
+  // …and only if this build actually ships it, so the hint never names a pack that is not
+  // there to apply.
+  return resolvePackManifestFile(name) ? name : null;
 }
 
 export type ManifestAction =
@@ -240,10 +242,6 @@ export interface ApplyManifestResult {
   success: boolean;
   summary: Record<ManifestItemStatus, number>;
   results: ManifestItemReport[];
-  /** #1568 — set when the `path` given was a dead npx-cache path and a bundled pack of the
-   *  same name was applied instead. Reported rather than done silently: this is a different
-   *  file from the one the caller named, and they are entitled to know which one ran. */
-  resolved_from_stale_path?: { requested: string; applied: string; pack: string };
 }
 
 function parseManifestText(path: string, text: string): unknown {
@@ -276,7 +274,7 @@ interface ResolvedManifest {
   staleRepair?: { requested: string; applied: string; pack: string };
 }
 
-async function resolveManifest(opts: ApplyManifestOptions): Promise<ResolvedManifest> {
+async function resolveManifest(opts: ApplyManifestOptions): Promise<ComfyManifest> {
   const hasInline = opts.manifest !== undefined;
   const hasPath = opts.path !== undefined && opts.path.trim().length > 0;
   const hasPack = opts.pack !== undefined && opts.pack.trim().length > 0;
@@ -286,7 +284,7 @@ async function resolveManifest(opts: ApplyManifestOptions): Promise<ResolvedMani
       "Provide exactly one of `manifest`, `path`, or `pack` to apply_manifest.",
     );
   }
-  if (hasInline) return { manifest: manifestSchema.parse(opts.manifest) };
+  if (hasInline) return manifestSchema.parse(opts.manifest);
 
   // #1568 — a NAME, resolved against the running package root. This is the durable form: a
   // pack name cannot expire the way a path captured under an npx cache hash does.
@@ -299,27 +297,26 @@ async function resolveManifest(opts: ApplyManifestOptions): Promise<ResolvedMani
           `List the available packs with list_packs (action:"list") and use the \`name\` it reports.`,
       );
     }
-    return { manifest: await loadManifestFile(file) };
+    return loadManifestFile(file);
   }
 
-  const requested = opts.path!.trim();
+  // The path is opened EXACTLY as given. Trimming was only ever meant to decide whether an
+  // input was present; trimming what gets opened would silently retarget a legitimate
+  // POSIX path with leading or trailing whitespace (review).
+  const requested = opts.path!;
   // #1568 — the reported failure: a path handed out by an EARLIER npx process, whose cache
-  // directory no longer exists. Recognise it as the bundled pack it names rather than
-  // reporting a missing file, but only under the strict conditions in
-  // repairStalePackManifestPath — this substitutes a file the caller did not name.
-  const repaired = repairStalePackManifestPath(requested);
-  if (repaired) {
-    const pack = basename(dirname(repaired));
-    logger.info(
-      "apply_manifest: the manifest path given no longer exists; applying the bundled pack of the same name from this build (#1568)",
-      { requested, applied: repaired, pack },
+  // directory no longer exists. Turn the bare ENOENT into the one-call remedy rather than
+  // applying a file nobody named.
+  const stalePack = bundledPackNamedByStalePath(requested);
+  if (stalePack) {
+    throw new ValidationError(
+      `That manifest path no longer exists: it points into a package directory from an earlier ` +
+        `npx run, which is replaced on each respawn (#1568). The pack itself is still here — ` +
+        `re-run with pack: "${stalePack}" instead of a path, which resolves against the running ` +
+        `build and cannot go stale. (Nothing was installed.)`,
     );
-    return {
-      manifest: await loadManifestFile(repaired),
-      staleRepair: { requested, applied: repaired, pack },
-    };
   }
-  return { manifest: await loadManifestFile(requested) };
+  return loadManifestFile(requested);
 }
 
 function commandExists(cmd: string): boolean {
@@ -962,7 +959,7 @@ async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
 export async function applyManifest(
   opts: ApplyManifestOptions,
 ): Promise<ApplyManifestResult> {
-  const { manifest, staleRepair } = await resolveManifest(opts);
+  const manifest = await resolveManifest(opts);
 
   // Resolve the LOCAL ComfyUI base this call should target, WITHOUT mutating the
   // process-global config.comfyuiPath (a global temp-set would leak the path to
@@ -979,10 +976,7 @@ export async function applyManifest(
   // classification + pip's interpreter, never where a model lands.
   const localBase = await resolveLocalManifestBase();
 
-  const result = await applyManifestSections(manifest, localBase);
-  // #1568 — surface the substitution on the RESULT, not only in the log. The caller named
-  // one file and a different one ran; that belongs in the answer they read.
-  return staleRepair ? { ...result, resolved_from_stale_path: staleRepair } : result;
+  return applyManifestSections(manifest, localBase);
 }
 
 /**

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -17,7 +17,13 @@ export function registerManifestTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Path to a .json, .yaml, or .yml manifest file. Provide exactly one of `manifest` or `path`.",
+          "Path to a .json, .yaml, or .yml manifest file. Provide exactly one of `manifest`, `path`, or `pack`.",
+        ),
+      pack: z
+        .string()
+        .optional()
+        .describe(
+          "A bundled installer pack by NAME, as reported by list_packs (action:\"list\"). PREFER THIS over `path` for a bundled pack: the name is resolved against the running build at apply time, while a manifest_path captured earlier points into an npx cache directory that a later respawn no longer has (#1568). Provide exactly one of `manifest`, `path`, or `pack`.",
         ),
     },
     async (args) => {


### PR DESCRIPTION
Addresses #1568.

## The bug

`list_packs(action:"list")` returns an absolute `manifest_path` built from the **running**
package root. Under `npx` that is an ephemeral cache directory keyed by a hash:

```
~/AppData/Local/npm-cache/_npx/28eae33d00f3f7f1/node_modules/comfyui-mcp/packs/krea2-combo/manifest.yaml
```

The next respawn gets a different hash, so a path captured earlier stats `ENOENT` — while
the pack is still there under its name.

`packsDir()` already derived from the current root, so the **lookup** was never broken. What
went stale is the string we publish and then invite the caller to hand back.

## The fix

**`apply_manifest` takes `pack: "<name>"`.** Resolved against the running build at apply
time, so it cannot expire. This is the reporter's own suggestion, and I confirmed the tool
accepted only `manifest`/`path` before writing anything. Exactly-one-of now spans three
inputs, and the description tells the agent *why* to prefer the name — an agent that can't
discover the durable form keeps reaching for the path that dies.

**A dead path that names a bundled pack gets a remedy appended to its error.** Not a
substitution — see below.

## What review changed, and it changed a lot

My first version **applied** the bundled manifest in place of the dead path. Two P1s killed
that, both correct:

- The recogniser authenticated only the last four segments, so *any* nonexistent path ending
  `comfyui-mcp/packs/<shipped-pack>/manifest.yaml` was retargeted — a developer's own checkout
  at `~/dev/comfyui-mcp` included. It required neither an npx cache nor `node_modules`.
- And the operation it silently redirected **installs custom nodes and downloads model
  weights**. Running a file the caller did not name is far worse than the `ENOENT` it
  replaced, and my disclosure arrived *after* the side effects.

So it now answers a question rather than substituting a file: it returns the pack **name**,
and the caller gets an actionable error. Round 2 then caught that deciding "this is stale"
*before* attempting the open relabelled ordinary `ENOENT`/`EACCES` failures under any
`node_modules` install. The open is attempted first now; the loader's real error surfaces and
the suggestion is appended, hedged — *this build ships a pack of that name; if that's the one
you meant, use `pack:`*.

**A third finding was about my tests, not the code:** three of them called `applyManifest`
with a real pack while only `node-management` was mocked. With a local ComfyUI base
resolvable, the model loop reaches `startDownloadJob` and pulls this pack's multi-gigabyte
weights on whatever machine runs the suite. I had checked the summary on *this* machine and
seen every item skipped — a property of this configuration, not of the test. Every case in
that file is now an error path that cannot reach the installer.

Also fixed from review: the path is opened **exactly as given**. Trimming was only ever meant
to decide whether an input was present; trimming what gets opened would retarget a legitimate
POSIX path with leading or trailing whitespace.

## Verification

- **16 mutations, all applied and all killed** — including one that re-applies the manifest
  instead of refusing, one that drops the `node_modules` requirement, one that accepts a
  source checkout, and one that re-introduces the trim.
- 507 files / **9469 tests** green.
- Three mutations survived the first pass, all the same lesson: **layered guards masking each
  other**, so the tests were passing via the wrong guard. `../../etc/passwd` is refused by
  *containment* before the name pattern is consulted; this checkout isn't named `comfyui-mcp`,
  so the live-path test was refused by the *owner* check rather than the exists-check that
  matters in production. Each now has a case only the intended rule can refuse, including a
  real on-disk fixture at the installed shape.

Refs #1568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
