### PR TITLE
docs: click the logo to go home, not to GitHub

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,8 +11,7 @@
   "favicon": "/favicon.svg",
   "logo": {
     "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg",
-    "href": "https://github.com/artokun/comfyui-mcp"
+    "dark": "/logo/dark.svg"
   },
   "appearance": {
     "default": "system"


### PR DESCRIPTION
Clicking the docs logo navigated to the GitHub repo instead of back to the docs root.

`docs.json` set an explicit `logo.href` pointing at the repository. Worth noting the rendered markup was already self-contradictory — the anchor carries `<span class="sr-only">ComfyUI MCP home page</span>` while pointing at GitHub, so the accessible name and the destination disagreed.

### Why remove the field rather than set a path

`href` is optional in Mintlify's schema — it's a *custom* click-through override, so dropping it restores the default home destination.

Hardcoding `"/docs"` would be the obvious alternative, but the docs deploy under a `/docs` subpath that Mintlify prefixes onto internal links automatically (`./quickstart` in the MDX renders as `href="/docs/quickstart"` live). A literal `/docs` in this field risks resolving to `/docs/docs`. Omitting it avoids depending on that behavior either way.

### GitHub is not lost

Still reachable from the navbar in three places — the "⭐ Star on GitHub" primary button, the github icon link, and the footer social.

### Verification

`docs.json` re-parsed after the edit. As with #1580 there's no PR preview (Mintlify Deployment reports SKIPPED on this repo), so I'll confirm the rendered logo anchor against the live site after merge.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)