### PR TITLE
release: v0.51.50 — apply a bundled pack by name, not by a path that expires (#1568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.50] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- let the loader fail first, then append the remedy
+- refuse a stale path with the remedy — never substitute the manifest
+- resolve a pack manifest by NAME, and recognise a path that expired
+
+#### Changed
+- click the logo to go home, not to GitHub (#1581)
+- play the panel demo on the landing page instead of a placeholder (#1580)
+- Korean pilot — five entry pages, and the hreflang gate (#1577)
+
+
 ## [0.51.49] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.49",
+  "version": "0.51.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.49",
+      "version": "0.51.50",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.49",
+  "version": "0.51.50",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.51.50.

Ships the fix for issue 1568 (PR #1579).

`list_packs` returns an absolute `manifest_path` built from the **running** package root.
Under `npx` that is an ephemeral cache directory keyed by a hash, so a path captured earlier
in a conversation stats `ENOENT` on the next respawn — while the pack is still there under
its name. The lookup was never broken; only the string we hand out goes stale.

`apply_manifest` now accepts **`pack: "<name>"`**, resolved against the running build at
apply time. And when a dead path is unmistakably one of ours, the failure keeps its real
`ENOENT` and gains a hedged remedy naming the pack, instead of reading like a missing pack.

It does **not** substitute the manifest. Review killed that version, correctly: the
recogniser authenticated only the last four path segments — enough to retarget a developer's
own checkout — and this operation installs custom nodes and downloads model weights, so
running a file the caller did not name is far worse than the error it replaced. Review also
caught that three of my tests could have started real multi-gigabyte downloads on whatever
machine ran the suite; they are all error paths now.

16 mutations killed, 507 files / 9469 tests green, verified against the built dist with the
reporter's exact path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
