### PR TITLE
fix(1574): never announce a completion the status tool contradicts

### DIFF
--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -87,3 +87,53 @@ describe("a completion the record contradicts is not announced (#1574)", () => {
     expect(completionContradictedByRecord(row(), null as never)).toBe(false);
   });
 });
+
+// ── WIRING. The guard is inert unless the emit path consults it, and that is a few lines
+//    inside the orchestrator tick — the shape that deletes with every unit test green.
+
+describe("the emit path actually consults the guard (#1574)", () => {
+  const source = async (): Promise<string> => {
+    const { readFileSync } = await import("node:fs");
+    return readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+  };
+
+  it("filters the settled bucket before injecting the event", async () => {
+    const src = await source();
+    const at = src.indexOf('kind: "download_done"');
+    expect(at, "the download_done injection must still be recognisable").toBeGreaterThan(-1);
+    // Bounded by the injection itself rather than a byte count — a fixed window around
+    // growing code has reported missing wiring three times in this repo already.
+    const block = src.slice(Math.max(0, at - 2500), at + 200);
+    expect(block).toMatch(/listDownloadJobs\(\)/);
+    // The FILTER specifically, not merely a mention of the guard. Deleting the filter while
+    // keeping the log line below it left an earlier version of this green: the call still
+    // appeared in the block, just no longer on the path that decides anything.
+    expect(block).toMatch(
+      /settled\.filter\(\(d\) => !completionContradictedByRecord\(d, records\)\)/,
+    );
+  });
+
+  it("injects the FILTERED list, not the raw bucket", async () => {
+    // The defect this would leave: compute `honest`, log about it, and then hand `settled`
+    // to injectEvent anyway. Every guard test would still pass.
+    const src = await source();
+    expect(src).toMatch(/kind: "download_done", downloads: honest/);
+    expect(src).not.toMatch(/kind: "download_done", downloads: settled/);
+  });
+
+  it("skips the turn entirely when everything was contradicted", async () => {
+    // Injecting an empty download_done wakes the agent for nothing.
+    const src = await source();
+    expect(src).toMatch(/if \(honest\.length === 0\) continue;/);
+  });
+
+  it("a failure to read the record does not break the event path", async () => {
+    // A completion we cannot check is still a completion worth delivering. The guard must
+    // never be able to turn a working notification into a lost one.
+    const src = await source();
+    const at = src.indexOf("listDownloadJobs()");
+    const block = src.slice(at - 200, at + 400);
+    expect(block).toMatch(/catch/);
+    expect(block).toMatch(/return \[\];/);
+  });
+});

--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -1,136 +1,164 @@
 // #1574 — the tray announced "transfer completed" while the transfer was still streaming.
 //
-// The reporter checked three independent things immediately after the event arrived:
+// The reporter checked three things immediately after the event arrived:
 //
 //   download_model action:"status" {id}  → **downloading** … still streaming, started 634s ago
 //   list_local_models                    → the file was ABSENT
 //   get_system_stats a few minutes later → the category count went 8 → 9
 //
-// So the file landed AFTER the completion event. They also read the formatting code and
-// correctly concluded it is not at fault: it emits `transfer completed` for rows where
-// `d.status === "done"`, so something upstream had already put the row in that state.
+// The file landed AFTER the event. They also read the formatting code and correctly ruled it
+// out: it emits the completion clause for rows where `status === "done"`, so something
+// upstream had already put the row in that state.
 //
-// ## What this pins
+// The completion event is built from a PROGRESS ROW; `download_model action:"status"` answers
+// from the JOB RECORD. Two stores, and the event consults only one.
 //
-// The completion event is driven by a PROGRESS ROW read off disk, while
-// `download_model action:"status"` answers from the JOB RECORD. Two stores, and the event
-// consults only one of them. A false `done` is the dangerous direction — the natural next
-// action is to USE the file — and #1150 was the same disagreement on the `error` side, where
-// the wording at least warns the reader.
+// ## Two review findings shaped this file
 //
-// This does not require knowing which writer set the row: whatever did, the orchestrator
-// holds the authoritative record in the same tick and can decline to announce a completion
-// that its own status tool would contradict.
+// 1. SUPPRESSING the contradicted event is wrong. A terminal record can legitimately still
+//    read "downloading" until the ~15s persistence heartbeat retries (#1545), and the
+//    debounce bucket is deleted before the check and never requeued — so dropping the event
+//    would PERMANENTLY lose the completion for a download that genuinely finished. The event
+//    always fires; the disagreement is disclosed on it.
+//
+// 2. The first guard compared the row's id to the JOB's id. Those are different identities —
+//    the report shows both (`6226e26ba97f8527` against tray `93015fbfa0fa9933`) — so it never
+//    matched and was completely INERT. Its unit tests missed that because they fed synthetic
+//    rows carrying whatever id the assertion wanted. Every fixture here now uses the REAL
+//    shape: the row carries the progress/tray id, the job carries its own separate id.
 import { describe, expect, it } from "vitest";
 
-import { completionContradictedByRecord } from "../../orchestrator/download-done-guard.js";
+import {
+  COMPLETION_DISAGREEMENT_NOTE,
+  completionDisagreesWithRecord,
+} from "../../orchestrator/download-done-guard.js";
 
+/** A progress row: identified by the PROGRESS/TRAY id, as written on disk. */
 const row = (over: Record<string, unknown> = {}) => ({
-  id: "6226e26ba97f8527",
+  id: "93015fbfa0fa9933",
   name: "model.safetensors",
   status: "done",
   ...over,
 });
 
+/** A job record: its own public `id`, plus the tray/progress identity the rows use. */
 const job = (over: Record<string, unknown> = {}) => ({
   id: "6226e26ba97f8527",
+  trayId: "93015fbfa0fa9933",
   filename: "model.safetensors",
   status: "downloading",
   ...over,
 });
 
-describe("a completion the record contradicts is not announced (#1574)", () => {
-  it("REFUSES the reported case: row says done, the job record still says downloading", () => {
-    expect(completionContradictedByRecord(row(), [job()])).toBe(true);
+describe("a completion the record disagrees with is DISCLOSED (#1574)", () => {
+  it("flags the reported case: row says done, the job record still says downloading", () => {
+    expect(completionDisagreesWithRecord(row(), [job()])).toBe(true);
   });
 
-  it("allows a completion the record agrees with", () => {
-    expect(completionContradictedByRecord(row(), [job({ status: "done" })])).toBe(false);
-  });
-
-  it("allows a completion when the record has no opinion", () => {
-    // The record store is reset by an orchestrator respawn — which is exactly the session
-    // the reporter hit. An ABSENT record is not evidence the transfer is still running, and
-    // suppressing every completion after a respawn would lose the events entirely.
-    expect(completionContradictedByRecord(row(), [])).toBe(false);
-    expect(completionContradictedByRecord(row(), [job({ id: "someone-else" })])).toBe(false);
-  });
-
-  it("matches on ID, not on filename", () => {
-    // A retry of a 404 is a DIFFERENT id writing the SAME filename (#1150). Matching by name
-    // would let an unrelated live attempt suppress a genuine completion.
+  it("matches on the PROGRESS identity, not the job's public id", () => {
+    // The bug that made the first version inert. A row is never written under the job's
+    // public id, so comparing against it matched nothing and silently agreed with everything.
+    expect(completionDisagreesWithRecord(row({ id: "6226e26ba97f8527" }), [job()])).toBe(false);
+    // progressId wins over trayId when both are present — it is what writes the rows.
     expect(
-      completionContradictedByRecord(row({ id: "attempt-2" }), [
-        job({ id: "attempt-1", status: "downloading" }),
+      completionDisagreesWithRecord(row({ id: "prog-1" }), [job({ progressId: "prog-1" })]),
+    ).toBe(true);
+    expect(
+      completionDisagreesWithRecord(row({ id: "93015fbfa0fa9933" }), [
+        job({ progressId: "prog-1" }),
       ]),
     ).toBe(false);
   });
 
-  it("only guards COMPLETIONS — a failure row is never suppressed", () => {
-    // #1150's direction. A FAILED event carries its own hedged wording and must keep
-    // firing; silencing it would strand the user with no signal at all.
-    expect(completionContradictedByRecord(row({ status: "error" }), [job()])).toBe(false);
+  it("says nothing when the record agrees", () => {
+    expect(completionDisagreesWithRecord(row(), [job({ status: "done" })])).toBe(false);
   });
 
-  it("a terminal record other than done does not contradict", () => {
-    // cancelled / error in the record are terminal too. The guard exists for the one
-    // disagreement that matters: the record says the bytes are STILL MOVING.
-    for (const status of ["error", "cancelled"]) {
-      expect(completionContradictedByRecord(row(), [job({ status })]), status).toBe(false);
+  it("says nothing when the record has no opinion", () => {
+    // The record store resets on an orchestrator respawn — exactly the reported session. An
+    // ABSENT record is not evidence the transfer is still running.
+    expect(completionDisagreesWithRecord(row(), [])).toBe(false);
+    expect(completionDisagreesWithRecord(row(), [job({ trayId: "someone-else" })])).toBe(false);
+  });
+
+  it("only looks at COMPLETIONS — a failure row is untouched", () => {
+    expect(completionDisagreesWithRecord(row({ status: "error" }), [job()])).toBe(false);
+  });
+
+  it("a terminal record other than downloading does not disagree", () => {
+    for (const status of ["error", "cancelled", "done"]) {
+      expect(completionDisagreesWithRecord(row(), [job({ status })]), status).toBe(false);
     }
   });
 
   it("junk never throws — this runs on the event path", () => {
     for (const bad of [null, undefined, {}, { status: "done" }]) {
-      expect(() => completionContradictedByRecord(bad as never, [job()])).not.toThrow();
+      expect(() => completionDisagreesWithRecord(bad as never, [job()])).not.toThrow();
     }
-    expect(completionContradictedByRecord(row(), null as never)).toBe(false);
+    expect(completionDisagreesWithRecord(row(), null as never)).toBe(false);
+  });
+
+  it("the note states BOTH readings rather than picking a winner", () => {
+    // It cannot establish which store is right, and saying "this download is not finished"
+    // would be a claim it has not earned — the record legitimately lags sometimes.
+    expect(COMPLETION_DISAGREEMENT_NOTE).toMatch(/still reports this transfer as downloading/i);
+    expect(COMPLETION_DISAGREEMENT_NOTE).toMatch(/can lag/i);
+    expect(COMPLETION_DISAGREEMENT_NOTE).toMatch(/before loading it/i);
+    // …and it must NOT assert the download is unfinished. It cannot establish that — the
+    // record legitimately lags sometimes — and stating it would make every lagging record
+    // read as a failed download.
+    expect(COMPLETION_DISAGREEMENT_NOTE).not.toMatch(/is NOT finished|did not finish|has not finished/i);
+    expect(COMPLETION_DISAGREEMENT_NOTE).toMatch(/may simply be that/i);
   });
 });
 
-// ── WIRING. The guard is inert unless the emit path consults it, and that is a few lines
-//    inside the orchestrator tick — the shape that deletes with every unit test green.
+// ── WIRING. The guard is inert unless the tick sets the flag, the bucket carries the id the
+//    match needs, and the formatter renders the note. All three are single lines.
 
-describe("the emit path actually consults the guard (#1574)", () => {
-  const source = async (): Promise<string> => {
+describe("the disagreement actually reaches the user (#1574)", () => {
+  const read = async (file: string): Promise<string> => {
     const { readFileSync } = await import("node:fs");
-    return readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+    return readFileSync(new URL(`../../orchestrator/${file}`, import.meta.url), "utf-8");
   };
 
-  it("filters the settled bucket before injecting the event", async () => {
-    const src = await source();
-    const at = src.indexOf('kind: "download_done"');
-    expect(at, "the download_done injection must still be recognisable").toBeGreaterThan(-1);
-    // Bounded by the injection itself rather than a byte count — a fixed window around
-    // growing code has reported missing wiring three times in this repo already.
-    const block = src.slice(Math.max(0, at - 2500), at + 200);
-    expect(block).toMatch(/listDownloadJobs\(\)/);
-    // The FILTER specifically, not merely a mention of the guard. Deleting the filter while
-    // keeping the log line below it left an earlier version of this green: the call still
-    // appeared in the block, just no longer on the path that decides anything.
-    expect(block).toMatch(
-      /settled\.filter\(\(d\) => !completionContradictedByRecord\(d, records\)\)/,
-    );
+  it("the bucket carries the row id the match depends on", async () => {
+    // Without this the guard has nothing to match a job against, and agrees with everything.
+    // That is precisely how the first version shipped as a no-op.
+    const src = await read("index.ts");
+    const at = src.indexOf("bucket.downloads.set(supKey, {");
+    expect(at).toBeGreaterThan(-1);
+    expect(src.slice(at, at + 400)).toMatch(/id: typeof row\.id === "string" \? row\.id : undefined/);
   });
 
-  it("injects the FILTERED list, not the raw bucket", async () => {
-    // The defect this would leave: compute `honest`, log about it, and then hand `settled`
-    // to injectEvent anyway. Every guard test would still pass.
-    const src = await source();
-    expect(src).toMatch(/kind: "download_done", downloads: honest/);
-    expect(src).not.toMatch(/kind: "download_done", downloads: settled/);
+  it("the tick FLAGS the disagreeing entries", async () => {
+    const src = await read("index.ts");
+    expect(src).toMatch(/settled\.filter\(\(d\) => completionDisagreesWithRecord\(d, records\)\)/);
+    expect(src).toMatch(/\.recordDisagrees = true/);
   });
 
-  it("skips the turn entirely when everything was contradicted", async () => {
-    // Injecting an empty download_done wakes the agent for nothing.
-    const src = await source();
-    expect(src).toMatch(/if \(honest\.length === 0\) continue;/);
+  it("and still injects EVERY settled entry", async () => {
+    // The review finding. Suppressing loses a real completion permanently, because the
+    // bucket is already deleted and never requeued.
+    const src = await read("index.ts");
+    // EXACTLY settled, with nothing chained onto it. A .filter() appended here reads as
+    // "still uses settled" to a looser regex, and is the exact regression this forbids.
+    expect(src).toMatch(/kind: "download_done", downloads: settled }/);
+    expect(src).not.toMatch(/downloads: settled\s*\.filter/);
+    expect(src).not.toMatch(/downloads: honest/);
+    expect(src).not.toMatch(/if \(honest\.length === 0\) continue;/);
   });
 
-  it("a failure to read the record does not break the event path", async () => {
-    // A completion we cannot check is still a completion worth delivering. The guard must
-    // never be able to turn a working notification into a lost one.
-    const src = await source();
+  it("the formatter renders the caveat beside the completion", async () => {
+    const src = await read("panel-agent.ts");
+    const at = src.indexOf("transfer completed: ${done.join");
+    expect(at).toBeGreaterThan(-1);
+    const block = src.slice(at, at + 900);
+    expect(block).toMatch(/recordDisagrees/);
+    expect(block).toMatch(/COMPLETION_DISAGREEMENT_NOTE/);
+  });
+
+  it("a record read that throws leaves the event untouched", async () => {
+    const src = await read("index.ts");
     const at = src.indexOf("listDownloadJobs()");
     const block = src.slice(at - 200, at + 400);
     expect(block).toMatch(/catch/);

--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -1,0 +1,89 @@
+// #1574 — the tray announced "transfer completed" while the transfer was still streaming.
+//
+// The reporter checked three independent things immediately after the event arrived:
+//
+//   download_model action:"status" {id}  → **downloading** … still streaming, started 634s ago
+//   list_local_models                    → the file was ABSENT
+//   get_system_stats a few minutes later → the category count went 8 → 9
+//
+// So the file landed AFTER the completion event. They also read the formatting code and
+// correctly concluded it is not at fault: it emits `transfer completed` for rows where
+// `d.status === "done"`, so something upstream had already put the row in that state.
+//
+// ## What this pins
+//
+// The completion event is driven by a PROGRESS ROW read off disk, while
+// `download_model action:"status"` answers from the JOB RECORD. Two stores, and the event
+// consults only one of them. A false `done` is the dangerous direction — the natural next
+// action is to USE the file — and #1150 was the same disagreement on the `error` side, where
+// the wording at least warns the reader.
+//
+// This does not require knowing which writer set the row: whatever did, the orchestrator
+// holds the authoritative record in the same tick and can decline to announce a completion
+// that its own status tool would contradict.
+import { describe, expect, it } from "vitest";
+
+import { completionContradictedByRecord } from "../../orchestrator/download-done-guard.js";
+
+const row = (over: Record<string, unknown> = {}) => ({
+  id: "6226e26ba97f8527",
+  name: "model.safetensors",
+  status: "done",
+  ...over,
+});
+
+const job = (over: Record<string, unknown> = {}) => ({
+  id: "6226e26ba97f8527",
+  filename: "model.safetensors",
+  status: "downloading",
+  ...over,
+});
+
+describe("a completion the record contradicts is not announced (#1574)", () => {
+  it("REFUSES the reported case: row says done, the job record still says downloading", () => {
+    expect(completionContradictedByRecord(row(), [job()])).toBe(true);
+  });
+
+  it("allows a completion the record agrees with", () => {
+    expect(completionContradictedByRecord(row(), [job({ status: "done" })])).toBe(false);
+  });
+
+  it("allows a completion when the record has no opinion", () => {
+    // The record store is reset by an orchestrator respawn — which is exactly the session
+    // the reporter hit. An ABSENT record is not evidence the transfer is still running, and
+    // suppressing every completion after a respawn would lose the events entirely.
+    expect(completionContradictedByRecord(row(), [])).toBe(false);
+    expect(completionContradictedByRecord(row(), [job({ id: "someone-else" })])).toBe(false);
+  });
+
+  it("matches on ID, not on filename", () => {
+    // A retry of a 404 is a DIFFERENT id writing the SAME filename (#1150). Matching by name
+    // would let an unrelated live attempt suppress a genuine completion.
+    expect(
+      completionContradictedByRecord(row({ id: "attempt-2" }), [
+        job({ id: "attempt-1", status: "downloading" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("only guards COMPLETIONS — a failure row is never suppressed", () => {
+    // #1150's direction. A FAILED event carries its own hedged wording and must keep
+    // firing; silencing it would strand the user with no signal at all.
+    expect(completionContradictedByRecord(row({ status: "error" }), [job()])).toBe(false);
+  });
+
+  it("a terminal record other than done does not contradict", () => {
+    // cancelled / error in the record are terminal too. The guard exists for the one
+    // disagreement that matters: the record says the bytes are STILL MOVING.
+    for (const status of ["error", "cancelled"]) {
+      expect(completionContradictedByRecord(row(), [job({ status })]), status).toBe(false);
+    }
+  });
+
+  it("junk never throws — this runs on the event path", () => {
+    for (const bad of [null, undefined, {}, { status: "done" }]) {
+      expect(() => completionContradictedByRecord(bad as never, [job()])).not.toThrow();
+    }
+    expect(completionContradictedByRecord(row(), null as never)).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -223,3 +223,35 @@ describe("the event does not contradict its own caveat (#1574)", () => {
     expect(src.slice(at, at + 200)).toMatch(/see the caveat above/);
   });
 });
+
+describe("an exact (id, target) record wins over a targetless one (#1574)", () => {
+  it("does not let a targetless DOWNLOADING shadow the exact DONE", () => {
+    // Review, round 3. Scanning in array order and accepting the first id match reported a
+    // disagreement that does not exist — hedging a completion that was perfectly fine.
+    expect(
+      completionDisagreesWithRecord(row({ target: "/local/models" }), [
+        job({ target: undefined, status: "downloading" }),
+        job({ target: "/local/models", status: "done" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("…and finds the exact DOWNLOADING behind a targetless DONE", () => {
+    // The same ordering hazard in the direction that must still be reported.
+    expect(
+      completionDisagreesWithRecord(row({ target: "/local/models" }), [
+        job({ target: undefined, status: "done" }),
+        job({ target: "/local/models", status: "downloading" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("falls back to a targetless record only when nothing matches on target", () => {
+    expect(
+      completionDisagreesWithRecord(row({ target: "/local/models" }), [
+        job({ target: "/pod/models", status: "done" }),
+        job({ target: undefined, status: "downloading" }),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -165,3 +165,61 @@ describe("the disagreement actually reaches the user (#1574)", () => {
     expect(block).toMatch(/return \[\];/);
   });
 });
+
+// ── (id, target) IDENTITY and the CONTRADICTING SENTENCE — both from review round 2.
+
+describe("a row is identified by (id, target), not id alone (#1574)", () => {
+  it("does not match a record for the same id at a DIFFERENT target", () => {
+    // A concurrent LOCAL and POD transfer of one URL share an id and must stay two
+    // transfers with two outcomes — the same reason supersession keys on (id, target).
+    // Matching id alone could annotate the wrong completion, or miss a real disagreement
+    // by finding the other one first.
+    expect(
+      completionDisagreesWithRecord(row({ target: "/local/models" }), [
+        job({ target: "/pod/models", status: "downloading" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches when the targets agree", () => {
+    expect(
+      completionDisagreesWithRecord(row({ target: "/local/models" }), [
+        job({ target: "/local/models", status: "downloading" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("still matches when EITHER side has no target", () => {
+    // Rows and records predating the field, or a route that never sets it, must keep
+    // matching — requiring it on both sides would make the check inert again, which is
+    // exactly how the first version shipped.
+    expect(completionDisagreesWithRecord(row(), [job({ target: "/pod/models" })])).toBe(true);
+    expect(completionDisagreesWithRecord(row({ target: "/local" }), [job()])).toBe(true);
+  });
+});
+
+describe("the event does not contradict its own caveat (#1574)", () => {
+  const formatter = async (): Promise<string> => {
+    const { readFileSync } = await import("node:fs");
+    return readFileSync(new URL("../../orchestrator/panel-agent.ts", import.meta.url), "utf-8");
+  };
+
+  it("the bytes-finished claim is conditional on there being no disagreement", async () => {
+    // Review found the caveat being appended and then flatly contradicted two sentences
+    // later by an unconditional "The bytes finished transferring" — the same defect #1150
+    // fixed here in the other direction.
+    const src = await formatter();
+    const at = src.indexOf("The bytes finished transferring");
+    expect(at).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, at - 700), at + 200);
+    expect(block).toMatch(/disagrees/);
+    expect(block).toMatch(/The tray reported the bytes finished/);
+  });
+
+  it("the disagreeing wording reports what the tray SAID rather than asserting it", async () => {
+    const src = await formatter();
+    const at = src.indexOf("The tray reported the bytes finished");
+    expect(at).toBeGreaterThan(-1);
+    expect(src.slice(at, at + 200)).toMatch(/see the caveat above/);
+  });
+});

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -37,12 +37,16 @@
  *  degrade to "no disagreement", never throw on the event path. */
 interface RowLike {
   id?: unknown;
+  /** #1574 review — a progress row is scoped by (id, target), NOT id alone: a concurrent
+   *  LOCAL and POD transfer of the same URL share an id and must stay distinguishable. */
+  target?: unknown;
   status?: unknown;
 }
 interface JobLike {
   id?: unknown;
   trayId?: unknown;
   progressId?: unknown;
+  target?: unknown;
   status?: unknown;
 }
 
@@ -68,7 +72,22 @@ export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLi
   const id = typeof row.id === "string" ? row.id : null;
   if (!id) return false;
   if (!Array.isArray(jobs)) return false;
-  const record = jobs.find((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
+  // (id, target) — the SAME key the supersession logic uses, and for the same reason: a
+  // concurrent LOCAL and POD transfer of one URL shares an id but is two transfers with two
+  // outcomes. Matching on id alone could annotate the wrong completion, or miss a real
+  // disagreement by finding the other one first (review).
+  //
+  // A target is compared only when BOTH sides carry one. Rows and records that predate the
+  // field, or a route that never sets it, must not silently stop matching — that would make
+  // the check inert again, which is exactly how the first version shipped.
+  const target = typeof row.target === "string" ? row.target : null;
+  const record = jobs.find((j) => {
+    if (!j || typeof j !== "object") return false;
+    if (progressIdentityOf(j) !== id) return false;
+    const jobTarget = typeof j.target === "string" ? j.target : null;
+    if (target && jobTarget && target !== jobTarget) return false;
+    return true;
+  });
   if (!record) return false;
   return record.status === "downloading";
 }

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -1,69 +1,83 @@
 /**
- * #1574 — do not announce a completion this orchestrator's own status tool would contradict.
+ * #1574 — when the completion event and `download_model action:"status"` disagree, say so.
  *
  * The tray raised `transfer completed` for an 11.46GB download while
- * `download_model action:"status"` reported it still streaming, `list_local_models` showed
- * the file absent, and the category count only rose minutes later. The file landed AFTER the
+ * `download_model action:"status"` reported it still streaming, `list_local_models` showed the
+ * file absent, and the category count only rose minutes later. The file landed AFTER the
  * event.
  *
- * ## Why the guard sits here and not at the writer
- *
- * The completion event is driven by a PROGRESS ROW read off disk each tick. `status` answers
+ * The completion event is built from a PROGRESS ROW read off disk each tick. `status` answers
  * from the JOB RECORD. Two stores, and the event consults only one — the same split #1545
- * documented from the other side, where the completion is raised from this process's memory
- * while `status` reads the record from the spawned stdio child.
+ * documented from the other side.
  *
- * Which writer set that row to `done` is not established. The three sites that write it look
- * sound in isolation (a `stat()` on the landed file; the filename appearing in the server's
- * model listing; the rename itself), and the reported session had both an orchestrator
- * respawn mid-transfer and two comfyui-mcp copies in the npx cache — so a stale or foreign
- * writer is the open question, and naming one without evidence would be a guess.
+ * ## Why this ANNOTATES and never suppresses
  *
- * The guard does not need the answer. Whatever wrote the row, the authoritative record is in
- * hand in the same tick, and announcing a completion it contradicts is the one outcome worth
- * preventing: a false `done` invites USING the file, where #1150's false `FAILED` at least
- * warned the reader.
+ * The first version of this dropped the contradicted event. Review killed it, correctly: a
+ * terminal record may legitimately still read `downloading` until the ~15s persistence
+ * heartbeat retries (see `persistDownloadJob`'s return value, #1545). The debounce bucket is
+ * deleted before filtering and never requeued, so suppressing on a lagging record would
+ * PERMANENTLY lose the completion notification for a download that genuinely finished.
  *
- * ## Everything ambiguous stays silent
+ * That trades a confusing message for a missing one, which is worse: the user is waiting on
+ * that event. So the event always fires, and a disagreement is disclosed on it. The harm in
+ * the report is a CONFIDENT false completion — "the natural next action is to use the file" —
+ * and a hedge is precisely what removes that.
  *
- * This suppresses an event a user is waiting for, so it fires only on a POSITIVE
- * contradiction — the record exists, is for this exact download, and says the bytes are still
- * moving. In particular an ABSENT record is NOT evidence: the record store resets on an
- * orchestrator respawn, which is precisely the reported session, and treating absence as "in
- * flight" would silence every completion after any respawn.
+ * ## Identity
+ *
+ * The two stores do not share an id. A progress row's `id` is the progress/tray identity;
+ * the job's `id` is its public status handle (`6226e26ba97f8527` in the report, against tray
+ * `93015fbfa0fa9933`). The row is matched against the job's `progressId ?? trayId`, which is
+ * what writes those rows. An earlier version compared row id to job id and was therefore
+ * INERT — it never matched anything, and its unit tests missed that because they fed
+ * synthetic rows carrying whatever id the assertion wanted.
  */
 
-/** The fields this reads. Deliberately structural rather than importing the row/job types:
- *  both stores are read as parsed JSON here, and a shape mismatch must degrade to "no
- *  opinion", never throw on the event path. */
+/** Only the fields this reads. Both stores arrive as parsed JSON, so a shape mismatch must
+ *  degrade to "no disagreement", never throw on the event path. */
 interface RowLike {
   id?: unknown;
   status?: unknown;
 }
 interface JobLike {
   id?: unknown;
+  trayId?: unknown;
+  progressId?: unknown;
   status?: unknown;
 }
 
+/** The identity a PROGRESS ROW is written under. */
+function progressIdentityOf(job: JobLike): string | null {
+  const progress = typeof job.progressId === "string" ? job.progressId : null;
+  const tray = typeof job.trayId === "string" ? job.trayId : null;
+  return progress ?? tray;
+}
+
 /**
- * Would `download_model action:"status"` disagree with announcing this row as completed?
+ * Does the job record disagree with announcing this row as completed?
  *
- * True ONLY when the record for this exact id says `downloading`. Anything else — a missing
- * record, a different id, a non-completion row, a record that is terminal in some other way —
- * answers false, because none of them establish that the transfer is still running.
+ * True ONLY on a positive contradiction: a record exists for this exact progress identity and
+ * still says `downloading`. A missing record is not evidence — the record store resets on an
+ * orchestrator respawn, which is exactly the reported session.
  */
-export function completionContradictedByRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
+export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
   if (!row || typeof row !== "object") return false;
-  // Only COMPLETIONS are guarded. A failure event carries its own hedged wording (#1150) and
-  // suppressing it would strand the user with no signal at all.
+  // Only COMPLETIONS. A failure event carries its own hedged wording (#1150) and must be
+  // left entirely alone.
   if (row.status !== "done") return false;
   const id = typeof row.id === "string" ? row.id : null;
   if (!id) return false;
   if (!Array.isArray(jobs)) return false;
-  // Matched on ID, never filename: a corrected retry of a 404 is a DIFFERENT id writing the
-  // SAME name (#1150), so a name match would let an unrelated live attempt silence a genuine
-  // completion.
-  const record = jobs.find((j) => j && typeof j === "object" && j.id === id);
-  if (!record) return false; // no opinion — see the respawn note above
+  const record = jobs.find((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
+  if (!record) return false;
   return record.status === "downloading";
 }
+
+/** The disclosure appended to a completion the record disagrees with. Deliberately states
+ *  BOTH readings and what to do, rather than picking a winner this cannot establish. */
+export const COMPLETION_DISAGREEMENT_NOTE =
+  "CAVEAT: `download_model action:\"status\"` still reports this transfer as downloading. " +
+  "The two are read from different stores and the record can lag a real completion by a few " +
+  "seconds, so this may simply be that — but a completion event has also been observed to " +
+  "arrive minutes before the file existed (#1574). Check `download_model action:\"status\"` " +
+  "and that the file is present before loading it.";

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -81,13 +81,20 @@ export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLi
   // field, or a route that never sets it, must not silently stop matching — that would make
   // the check inert again, which is exactly how the first version shipped.
   const target = typeof row.target === "string" ? row.target : null;
-  const record = jobs.find((j) => {
-    if (!j || typeof j !== "object") return false;
-    if (progressIdentityOf(j) !== id) return false;
-    const jobTarget = typeof j.target === "string" ? j.target : null;
-    if (target && jobTarget && target !== jobTarget) return false;
-    return true;
-  });
+  const sameId = jobs.filter((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
+  if (!sameId.length) return false;
+  // PREFER THE EXACT (id, target) MATCH (review, round 3). Taking the first id match in
+  // array order let a TARGETLESS record shadow the exact one: a targetless "downloading"
+  // sitting before an exact-target "done" reported a disagreement that does not exist, and
+  // would have hedged a completion that was perfectly fine.
+  //
+  // The targetless record still stands in when nothing matches on target — that is what
+  // keeps rows and records predating the field from silently going unmatched, which would
+  // make the whole check inert again.
+  const record =
+    (target ? sameId.find((j) => j.target === target) : undefined) ??
+    sameId.find((j) => typeof j.target !== "string") ??
+    (target ? undefined : sameId[0]);
   if (!record) return false;
   return record.status === "downloading";
 }

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -1,0 +1,69 @@
+/**
+ * #1574 — do not announce a completion this orchestrator's own status tool would contradict.
+ *
+ * The tray raised `transfer completed` for an 11.46GB download while
+ * `download_model action:"status"` reported it still streaming, `list_local_models` showed
+ * the file absent, and the category count only rose minutes later. The file landed AFTER the
+ * event.
+ *
+ * ## Why the guard sits here and not at the writer
+ *
+ * The completion event is driven by a PROGRESS ROW read off disk each tick. `status` answers
+ * from the JOB RECORD. Two stores, and the event consults only one — the same split #1545
+ * documented from the other side, where the completion is raised from this process's memory
+ * while `status` reads the record from the spawned stdio child.
+ *
+ * Which writer set that row to `done` is not established. The three sites that write it look
+ * sound in isolation (a `stat()` on the landed file; the filename appearing in the server's
+ * model listing; the rename itself), and the reported session had both an orchestrator
+ * respawn mid-transfer and two comfyui-mcp copies in the npx cache — so a stale or foreign
+ * writer is the open question, and naming one without evidence would be a guess.
+ *
+ * The guard does not need the answer. Whatever wrote the row, the authoritative record is in
+ * hand in the same tick, and announcing a completion it contradicts is the one outcome worth
+ * preventing: a false `done` invites USING the file, where #1150's false `FAILED` at least
+ * warned the reader.
+ *
+ * ## Everything ambiguous stays silent
+ *
+ * This suppresses an event a user is waiting for, so it fires only on a POSITIVE
+ * contradiction — the record exists, is for this exact download, and says the bytes are still
+ * moving. In particular an ABSENT record is NOT evidence: the record store resets on an
+ * orchestrator respawn, which is precisely the reported session, and treating absence as "in
+ * flight" would silence every completion after any respawn.
+ */
+
+/** The fields this reads. Deliberately structural rather than importing the row/job types:
+ *  both stores are read as parsed JSON here, and a shape mismatch must degrade to "no
+ *  opinion", never throw on the event path. */
+interface RowLike {
+  id?: unknown;
+  status?: unknown;
+}
+interface JobLike {
+  id?: unknown;
+  status?: unknown;
+}
+
+/**
+ * Would `download_model action:"status"` disagree with announcing this row as completed?
+ *
+ * True ONLY when the record for this exact id says `downloading`. Anything else — a missing
+ * record, a different id, a non-completion row, a record that is terminal in some other way —
+ * answers false, because none of them establish that the transfer is still running.
+ */
+export function completionContradictedByRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
+  if (!row || typeof row !== "object") return false;
+  // Only COMPLETIONS are guarded. A failure event carries its own hedged wording (#1150) and
+  // suppressing it would strand the user with no signal at all.
+  if (row.status !== "done") return false;
+  const id = typeof row.id === "string" ? row.id : null;
+  if (!id) return false;
+  if (!Array.isArray(jobs)) return false;
+  // Matched on ID, never filename: a corrected retry of a 404 is a DIFFERENT id writing the
+  // SAME name (#1150), so a name match would let an unrelated live attempt silence a genuine
+  // completion.
+  const record = jobs.find((j) => j && typeof j === "object" && j.id === id);
+  if (!record) return false; // no opinion — see the respawn note above
+  return record.status === "downloading";
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5482,6 +5482,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           // #1574 — the PROGRESS/tray id. The record cross-check at the flush needs it, and
           // it is a different identity from the job's public `id`.
           id?: string;
+          target?: string;
           name: string;
           status: string;
           attempt?: number;
@@ -5689,6 +5690,7 @@ export async function runPanelOrchestrator(): Promise<void> {
                   string,
                   {
                     id?: string;
+                    target?: string;
                     name: string;
                     status: string;
                     attempt?: number;
@@ -5708,6 +5710,9 @@ export async function runPanelOrchestrator(): Promise<void> {
               // nothing to match a job against, silently agrees with everything, and the
               // whole disclosure is a no-op. That is exactly how the first version shipped.
               id: typeof row.id === "string" ? row.id : undefined,
+              // (id, target) is the row identity — id alone collides for a concurrent
+              // LOCAL + POD transfer of the same URL (review).
+              target: typeof row.target === "string" ? row.target : undefined,
               name: String(row.name ?? row.id ?? "model"),
               status: String(status),
               attempt: typeof row.attempt === "number" ? row.attempt : undefined,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -65,7 +65,7 @@ import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
-import { completionContradictedByRecord } from "./download-done-guard.js";
+import { completionDisagreesWithRecord } from "./download-done-guard.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
 
@@ -5476,7 +5476,19 @@ export async function runPanelOrchestrator(): Promise<void> {
   const downloadDonePending = new Map<
     string,
     {
-      downloads: Map<string, { name: string; status: string; attempt?: number; supKey: string }>;
+      downloads: Map<
+        string,
+        {
+          // #1574 — the PROGRESS/tray id. The record cross-check at the flush needs it, and
+          // it is a different identity from the job's public `id`.
+          id?: string;
+          name: string;
+          status: string;
+          attempt?: number;
+          supKey: string;
+          recordDisagrees?: boolean;
+        }
+      >;
       flushAt: number;
     }
   >();
@@ -5672,13 +5684,30 @@ export async function runPanelOrchestrator(): Promise<void> {
           if (key && manager.hasLiveAgent(key)) {
             const bucket =
               downloadDonePending.get(key) ??
-              { downloads: new Map<string, { name: string; status: string; attempt?: number; supKey: string }>(), flushAt: 0 };
+              {
+                downloads: new Map<
+                  string,
+                  {
+                    id?: string;
+                    name: string;
+                    status: string;
+                    attempt?: number;
+                    supKey: string;
+                    recordDisagrees?: boolean;
+                  }
+                >(),
+                flushAt: 0,
+              };
             // Identify each pending download by its (id, target) supersession key — NOT
             // the id alone: a concurrent LOCAL + POD transfer of the same URL shares an id
             // but must produce TWO #547 outcomes, and the same key lets a newer attempt
             // evict this entry above. Fall back to the file path when the row has no id.
             const supKey = downloadAttemptKey(row) ?? ` ${full}`;
             bucket.downloads.set(supKey, {
+              // #1574 — CARRY THE ROW ID. Without it the record cross-check at the flush has
+              // nothing to match a job against, silently agrees with everything, and the
+              // whole disclosure is a no-op. That is exactly how the first version shipped.
+              id: typeof row.id === "string" ? row.id : undefined,
               name: String(row.name ?? row.id ?? "model"),
               status: String(status),
               attempt: typeof row.attempt === "number" ? row.attempt : undefined,
@@ -5745,16 +5774,17 @@ export async function runPanelOrchestrator(): Promise<void> {
           return [];
         }
       })();
-      const honest = settled.filter((d) => !completionContradictedByRecord(d, records));
-      if (honest.length === 0) continue;
-      if (honest.length !== settled.length) {
+      // ANNOTATE, never suppress (review). A terminal record can legitimately still read
+      // "downloading" until the ~15s persistence heartbeat retries (#1545), and this bucket
+      // is deleted before this point and never requeued — so dropping the event here would
+      // permanently lose the completion for a download that genuinely finished. That trades
+      // a confusing message for a missing one, which is worse: the user is waiting on it.
+      const disagreeing = settled.filter((d) => completionDisagreesWithRecord(d, records));
+      for (const d of disagreeing) (d as { recordDisagrees?: boolean }).recordDisagrees = true;
+      if (disagreeing.length) {
         logger.warn(
-          "[panel-orchestrator] suppressed download completion(s) the job record contradicts (#1574)",
-          {
-            suppressed: settled
-              .filter((d) => completionContradictedByRecord(d, records))
-              .map((d) => String((d as { id?: unknown }).id ?? "")),
-          },
+          "[panel-orchestrator] a download completion disagrees with the job record; disclosing rather than suppressing (#1574)",
+          { ids: disagreeing.map((d) => String((d as { id?: unknown }).id ?? "")) },
         );
       }
       // #884 — a download has no originating TAB (its row names the owning
@@ -5766,7 +5796,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // ran — the turn routed to whatever tab was active (confirming gate 3,
       // P1). The minted mid contributes nothing and the batch close inherits
       // (or refuses, when no origin was ever established).
-      manager.injectEvent(key, { kind: "download_done", downloads: honest }, {
+      manager.injectEvent(key, { kind: "download_done", downloads: settled }, {
         mid: turnOrigins.mintInheritedOrigin(),
       });
     }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -64,6 +64,8 @@ import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import { logger } from "../utils/logger.js";
+import { listDownloadJobs } from "../services/download-jobs.js";
+import { completionContradictedByRecord } from "./download-done-guard.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
 
@@ -5723,6 +5725,38 @@ export async function runPanelOrchestrator(): Promise<void> {
       // filename, so the (id, target) eviction above cannot see it. The live rows
       // are already in hand this tick; markSupersededByLive asks them by name.
       markSupersededByLive(settled, downloads);
+      // #1574 — DROP a completion this orchestrator's own status tool would contradict.
+      //
+      // The event is built from the progress ROW; `download_model action:"status"` answers
+      // from the job RECORD. A reporter got "transfer completed" for an 11.46GB file while
+      // status said it was still streaming and the file was not on disk — it landed minutes
+      // later. Whatever wrote that row, the record is in hand right here.
+      //
+      // Only a POSITIVE contradiction drops it (the record exists, same id, still
+      // "downloading"). An absent record means nothing: the record store resets on a
+      // respawn, which is the reported session, and treating absence as in-flight would
+      // silence every completion after any respawn.
+      const records = (() => {
+        try {
+          return listDownloadJobs();
+        } catch {
+          // Never let the guard break the event path — a completion we cannot check is
+          // still a completion worth delivering.
+          return [];
+        }
+      })();
+      const honest = settled.filter((d) => !completionContradictedByRecord(d, records));
+      if (honest.length === 0) continue;
+      if (honest.length !== settled.length) {
+        logger.warn(
+          "[panel-orchestrator] suppressed download completion(s) the job record contradicts (#1574)",
+          {
+            suppressed: settled
+              .filter((d) => completionContradictedByRecord(d, records))
+              .map((d) => String((d as { id?: unknown }).id ?? "")),
+          },
+        );
+      }
       // #884 — a download has no originating TAB (its row names the owning
       // conversation), so its turn INHERITS the conversation's LAST
       // ESTABLISHED origin — never the active tab (confirming gate 2, P0 rule:
@@ -5732,7 +5766,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // ran — the turn routed to whatever tab was active (confirming gate 3,
       // P1). The minted mid contributes nothing and the batch close inherits
       // (or refuses, when no origin was ever established).
-      manager.injectEvent(key, { kind: "download_done", downloads: settled }, {
+      manager.injectEvent(key, { kind: "download_done", downloads: honest }, {
         mid: turnOrigins.mintInheritedOrigin(),
       });
     }

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -841,9 +841,8 @@ export class PanelAgent {
       // got "transfer completed" for an 11.46GB file minutes before it existed on disk, and
       // acted on it. Disclosed, never suppressed — see download-done-guard.ts for why
       // dropping the event would be the worse failure.
-      if (dl.some((d) => d.status === "done" && d.recordDisagrees)) {
-        parts.push(COMPLETION_DISAGREEMENT_NOTE);
-      }
+      const disagrees = dl.some((d) => d.status === "done" && d.recordDisagrees);
+      if (disagrees) parts.push(COMPLETION_DISAGREEMENT_NOTE);
       if (failedDead.length) parts.push(`FAILED: ${failedDead.map((d) => d.name).join(", ")}`);
       if (failedRetried.length) {
         parts.push(
@@ -860,7 +859,15 @@ export class PanelAgent {
         // transfer completed while the file was still streaming (#1150). It is
         // only ever a statement about the `done` entries.
         (done.length
-          ? `The bytes finished transferring for the completed one${done.length > 1 ? "s" : ""}; ` +
+          ? // #1574 — this sentence ASSERTS the bytes finished. When the job record still
+            // says they are moving, that is precisely the claim we cannot make, and stating
+            // it right after the caveat argues against our own disclosure — the same defect
+            // #1150 fixed here for the FAILED case, in the other direction. Report what the
+            // tray said instead of asserting it happened.
+            (disagrees
+              ? `The tray reported the bytes finished for the completed one${done.length > 1 ? "s" : ""}, ` +
+                `but see the caveat above before relying on that; `
+              : `The bytes finished transferring for the completed one${done.length > 1 ? "s" : ""}; `) +
             `whether the connected ComfyUI can actually LOAD ${plural} is confirmed separately. `
           : `NOTHING is claimed to have transferred here. `) +
         `If you were waiting on ${plural} to continue a task, ` +

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,6 +23,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { COMPLETION_DISAGREEMENT_NOTE } from "./download-done-guard.js";
 import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
 import { orphanedByDeferredRespawnNote } from "../services/panel-secrets.js";
 import { errorText, promptText } from "./error-text.js";
@@ -664,7 +665,14 @@ export class PanelAgent {
       images?: ImageRef[];
       error?: string;
       note?: string;
-      downloads?: Array<{ name: string; status: string; supersededByLive?: boolean }>;
+      // #1574 — set by the orchestrator when the job RECORD still reads "downloading" for
+      // a row claiming done. Disclosed on the event; never used to suppress it.
+      downloads?: Array<{
+        name: string;
+        status: string;
+        supersededByLive?: boolean;
+        recordDisagrees?: boolean;
+      }>;
       /** #468 — run identity + how it correlates to a run this session queued. */
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
@@ -827,6 +835,15 @@ export class PanelAgent {
       // install the running server never reads — so the wording says only what the
       // event actually proves and points at download_model action:"status" for the verdict.
       if (done.length) parts.push(`transfer completed: ${done.join(", ")}`);
+      // #1574 — the completion is built from the progress ROW; `download_model
+      // action:"status"` answers from the job RECORD. When the record still says the bytes
+      // are moving, say so ON the event rather than announcing a bare completion: a reporter
+      // got "transfer completed" for an 11.46GB file minutes before it existed on disk, and
+      // acted on it. Disclosed, never suppressed — see download-done-guard.ts for why
+      // dropping the event would be the worse failure.
+      if (dl.some((d) => d.status === "done" && d.recordDisagrees)) {
+        parts.push(COMPLETION_DISAGREEMENT_NOTE);
+      }
       if (failedDead.length) parts.push(`FAILED: ${failedDead.map((d) => d.name).join(", ")}`);
       if (failedRetried.length) {
         parts.push(
@@ -2602,7 +2619,14 @@ export class PanelAgentManager {
       images?: ImageRef[];
       error?: string;
       note?: string;
-      downloads?: Array<{ name: string; status: string; supersededByLive?: boolean }>;
+      // #1574 — set by the orchestrator when the job RECORD still reads "downloading" for
+      // a row claiming done. Disclosed on the event; never used to suppress it.
+      downloads?: Array<{
+        name: string;
+        status: string;
+        supersededByLive?: boolean;
+        recordDisagrees?: boolean;
+      }>;
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
       run_correlation_prior?: boolean;


### PR DESCRIPTION
**Draft — claiming #1574.** A red test is in; the fix follows.

## What the reporter established, and it holds up

The tray announced `transfer completed` for an 11.46 GB download while three independent
checks said otherwise: `download_model action:"status"` reported **downloading … still
streaming**, `list_local_models` showed the file **absent**, and the category count only went
8 → 9 minutes later. The file landed *after* the event.

They also read the formatting code and ruled it out — it emits the completion clause for rows
where `status === "done"`, so something upstream had already put the row in that state. That
is correct, and it is where I started.

## What I traced

The completion event is driven by a **progress row** read off disk each tick and bucketed for
a debounced `download_done`. `download_model action:"status"` answers from the **job record**.

Two stores, and the event consults only one of them. This is the same split #1545 documented
from the other side, where the completion is raised from the orchestrator's memory while
`status` reads the record from the spawned stdio child.

## What I have NOT established

Which writer set that row to `done`. The three sites that write it all look sound in
isolation:

| site | when it writes `done` |
| --- | --- |
| `model-resolver` | after `stat()` on the landed file succeeds |
| `node-management` | only once the filename appears in the server's model listing |
| `download-jobs.commitDone` | synchronously on the rename into the destination |

The reported session had an orchestrator respawn mid-transfer *and* two `comfyui-mcp` copies
in the npx cache, so a stale or foreign writer is the open question. I would rather say that
than name one of these and be wrong.

## Why the fix does not depend on that

Whatever wrote the row, the orchestrator holds the authoritative record **in the same tick**
and can decline to announce a completion its own `status` tool would contradict. A false
`done` is the dangerous direction — the natural next action is to *use* the file — where
#1150 was this same disagreement on the failure side, which at least warns the reader.

## The constraints, pinned before the fix exists

Four of the seven tests exist to stop a careless version being worse than the bug:

- an **absent** record must not suppress the event. The record store resets on respawn —
  exactly the reported session — and suppressing everything after a respawn would lose the
  completion events entirely;
- matching is by **id**, not filename: a retry of a 404 is a different id writing the same
  name (#1150), and matching by name would let an unrelated live attempt silence a genuine
  completion;
- a **failed** row is never suppressed;
- a record that is terminal but *not* `done` (error, cancelled) does not contradict — the
  guard is for the one disagreement that matters, where the record says the bytes are still
  moving.

## Status

- [x] Red test + the four constraints
- [ ] `completionContradictedByRecord()`
- [ ] Wire it into the `download_done` emit path
- [ ] Keep hunting the writer — a guard that hides the symptom without explaining it is only
      half the answer, and I will say which half shipped

Refs #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
