### PR TITLE
release: v0.51.51 — two tools stop claiming things they cannot know

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.51] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- the refusal says UNKNOWN where it cannot know reads still work
+- prefer the EXACT (id, target) record over a targetless one
+- a write refusal stops promising that graph reads still work
+- scope identity by (id, target), and stop contradicting the caveat
+- DISCLOSE the disagreement — suppressing it was worse, and inert besides
+- never announce a completion this orchestrator's own status tool contradicts
+
+
 ## [0.51.50] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.50",
+  "version": "0.51.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.50",
+      "version": "0.51.51",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.50",
+  "version": "0.51.51",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.51.51.

Two fixes, both the same shape: a message asserting something the code was in no position to
establish.

**The download tray announced "transfer completed" while the transfer was still streaming**
(#1574). `download_model action:"status"` reported it downloading, `list_local_models` showed
the file absent, and the category count only rose minutes later — the file landed *after* the
event. The completion is built from a progress row; `status` answers from the job record. Two
stores, and the event consulted only one.

It now **discloses** the disagreement rather than announcing a bare completion — and
deliberately does **not** suppress the event. A terminal record can legitimately lag a real
completion until the persistence heartbeat retries, and the debounce bucket is deleted before
the check and never requeued, so dropping it would permanently lose a notification the user is
waiting for.

**A write refusal told users "reads and view-only commands still work"** on connections where
reads were being refused (#1519). It now says that only where it holds, and says **UNKNOWN**
where the bridge genuinely cannot tell: the panel owns the stamp-versus-active-canvas equality,
and a pre-dispatch refusal must not take a round trip to ask.

Also lands tests correcting an earlier claim that a divergent-install refusal was dead code
(#1550). It is not — it fires when the connected server changes underneath a single download,
through a TOCTOU window between two independently-resolved observations. In the steady state it
cannot fire, which is why the underlying cause of artokun/comfyui-mcp#1371 is unchanged.

Every one of these was caught by a codex review that returned NO-SHIP on the first attempt, and
each was then confirmed by measurement rather than argued down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
