### PR TITLE
fix(1478): a load adopts the instance it proved, instead of warning about it

### DIFF
--- a/src/__tests__/orchestrator/load-refreshes-fence.test.ts
+++ b/src/__tests__/orchestrator/load-refreshes-fence.test.ts
@@ -1,0 +1,146 @@
+// #1478 — an API-format load re-mints the workflow instance, and the fence is left stale.
+//
+// The reporter loaded a workflow, then had a READ-ONLY `panel_get_errors` refused for
+// "workflow instance mismatch". Every later panel_* call was fenced against a uuid that the
+// load itself had invalidated.
+//
+// `panel_load_workflow` already DETECTS this precisely: the panel's API path re-mints
+// (`app.loadApiJson` passes no keep-instance option) while the UI path deliberately
+// preserves the instance, and the reply carries `format:"api"` only on the re-minting
+// branch. Having detected it, the tool appends a note saying the fence is now stale — and
+// leaves it stale.
+//
+// It no longer has to. Panel 0.14.39+ publishes `workflow_uuid` on the graph_load reply
+// (comfyui-mcp-panel#1225), which is the same race-proof shape `refreshFenceFromOwnReply`
+// already trusts for workflow_save / workflow_save_as / workflow_new (#1161): the uuid is
+// read from the command's OWN reply, never re-derived from "whatever is active now" — a
+// re-derivation this project has rejected as a P1 more than once, because the active
+// workflow can move during the await.
+//
+// So the fix is to adopt the uuid the load itself proved, and keep the warning for the case
+// where nothing was published.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+// WORKFLOW_UUID_RE requires a [1-5] version nibble and an [89ab] variant nibble — an
+// arbitrary placeholder is rejected, which would make a positive test pass for the wrong
+// reason.
+const LOADED_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+
+let fence: string | undefined;
+let stamps: string[];
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+/** A bridge whose graph_load answers with `reply`. */
+function bridgeFor(reply: Record<string, unknown>) {
+  return {
+    send: async (c: Record<string, unknown>) => {
+      if (c.cmd === "graph_load") return reply;
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "A", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      stamps.push(uuid);
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+const ctxWith = (b: ReturnType<typeof bridgeFor>): PanelToolCtx => makePanelToolCtx(b, "tab-1");
+const loadTool = () => buildPanelToolDefs().find((d) => d.name === "panel_load_workflow")!;
+const API_GRAPH = { last_node_id: 1, nodes: [], links: [] };
+
+beforeEach(() => {
+  stamps = [];
+  fence = PRIOR_UUID; // the fence the load is about to invalidate
+});
+
+describe("an API-format load adopts the uuid it proved (#1478)", () => {
+  it("REFRESHES the fence from the load's own reply", async () => {
+    // The reported case. The load re-mints, the reply says which instance it produced, and
+    // the session should be fenced to THAT — not left pointing at the workflow it replaced.
+    const res = await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: true, format: "api", workflow_uuid: LOADED_UUID })),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(fence, "the session must be fenced to the instance the load produced").toBe(
+      LOADED_UUID,
+    );
+    expect(stamps).toEqual([LOADED_UUID]);
+  });
+
+  it("stops telling the caller the fence is stale once it has been refreshed", async () => {
+    // Warning about a staleness we just repaired sends the user to fix something that is
+    // already fixed — and the remedy it names costs them a tool call.
+    const res = await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: true, format: "api", workflow_uuid: LOADED_UUID })),
+    );
+    expect(textOf(res)).not.toMatch(/re-mint/i);
+  });
+
+  it("KEEPS the warning when the reply publishes no uuid (older panel)", async () => {
+    // Panels before 0.14.39 do not publish it. Nothing can be adopted, the fence really is
+    // stale, and withdrawing the warning there would leave the reporter's exact bug silent.
+    const res = await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: true, format: "api" })),
+    );
+    expect(fence, "nothing was published, so nothing may be adopted").toBe(PRIOR_UUID);
+    expect(stamps).toEqual([]);
+    expect(textOf(res)).toMatch(/re-mint/i);
+  });
+
+  it("does NOT touch the fence on a UI-format load", async () => {
+    // The UI path passes __cmcpKeepInstance and deliberately PRESERVES the instance, so the
+    // fence is still correct. Re-stamping it would be a write with no event behind it.
+    const res = await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: true, format: "ui", workflow_uuid: LOADED_UUID })),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(fence).toBe(PRIOR_UUID);
+    expect(stamps).toEqual([]);
+  });
+
+  it("does NOT touch the fence when the load reports it did not happen", async () => {
+    // `loaded:false` in a non-error envelope replaced nothing. Adopting a uuid from a load
+    // that did not occur is the fabricated-consequence defect the existing note guards.
+    await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: false, format: "api", workflow_uuid: LOADED_UUID })),
+    );
+    expect(fence).toBe(PRIOR_UUID);
+    expect(stamps).toEqual([]);
+  });
+
+  it("does NOT adopt a malformed uuid", async () => {
+    // The stamp gates future mutations. A value that is not a canonical instance uuid must
+    // not become the fence — better to keep the stale one and warn than to fence against
+    // something no canvas will ever report.
+    const res = await loadTool().handler(
+      { graph: API_GRAPH },
+      ctxWith(bridgeFor({ loaded: true, format: "api", workflow_uuid: "not-a-uuid" })),
+    );
+    expect(fence).toBe(PRIOR_UUID);
+    expect(stamps).toEqual([]);
+    expect(textOf(res)).toMatch(/re-mint/i);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9352,7 +9352,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // signal rather than an inference.
           const reply = parseToolResultJson(loaded);
           const remintedInstance = reply?.loaded === true && reply?.format === "api";
-          return remintedInstance ? appendNote(loaded, noteStaleFenceAfterLoad()) : loaded;
+          if (!remintedInstance) return loaded;
+          // #1478 — ADOPT the instance this load just proved, rather than warning about it.
+          //
+          // The note below is the right answer only while we cannot know the new uuid. Panel
+          // 0.14.39+ publishes `workflow_uuid` on this very reply
+          // (comfyui-mcp-panel#1225), which is the same race-proof shape
+          // `refreshFenceFromOwnReply` already trusts for workflow_save / workflow_save_as /
+          // workflow_new (#1161): read from the command's OWN reply, never re-derived from
+          // whatever is active now — a re-derivation rejected as a P1 here more than once,
+          // because the active workflow can move during the await.
+          //
+          // It validates before adopting (canonical uuid or nothing), so a malformed or
+          // absent field leaves the fence alone and falls through to the warning. That
+          // matters: anyone on a panel below 0.14.39 still has the original bug, and
+          // withdrawing the note for them would make it silent.
+          const refreshed = refreshFenceFromOwnReply(ctx, loaded);
+          return refreshed ? loaded : appendNote(loaded, noteStaleFenceAfterLoad());
         } catch (err) {
           return fail(err);
         }


### PR DESCRIPTION
**Draft — claiming #1478.** A red test is in (2 fail, 4 pass); the fix follows.

## The gap

You loaded a workflow, then a **read-only** `panel_get_errors` was refused for *workflow
instance mismatch* — and every later `panel_*` call stayed fenced against a uuid your load had
already invalidated.

`panel_load_workflow` **already detects this exactly right.** The panel's API path re-mints the
instance (`app.loadApiJson` passes no keep-instance option) while the UI path deliberately
preserves it, and the reply carries `format:"api"` only on the re-minting branch — so the
signal is read, not inferred. Having detected it, the tool appends a note explaining the
refusal you are about to hit, and then leaves the fence stale.

## Why it can do better now

Panel **0.14.39+** publishes `workflow_uuid` on the `graph_load` reply
(comfyui-mcp-panel#1225 — shipped). That is precisely the race-proof shape
`refreshFenceFromOwnReply` already trusts for `workflow_save`, `workflow_save_as` and
`workflow_new` (#1161): the uuid comes from the command's **own reply**, never re-derived from
"whatever workflow is active now" — a re-derivation rejected as a P1 here more than once,
because the active workflow can move during the await.

So the load should adopt the instance it just proved, instead of warning about a staleness it
is holding the fix for.

## The constraints matter more than the fix

Four of the six tests already pass, and they are what keeps this from being worse than the bug:

- a **UI-format** load must not be re-stamped — it preserves the instance, so the fence is
  already correct, and re-stamping would be a write with no event behind it;
- a `loaded:false` reply must not be adopted — nothing was replaced, and adopting a uuid from a
  load that did not happen is a fabricated consequence;
- a **malformed** uuid must not become the fence — the stamp gates future mutations, and
  fencing against something no canvas will report is worse than keeping the stale one;
- the warning must **survive** for panels that publish nothing. Anyone below 0.14.39 still has
  the original bug, and withdrawing the note there would make it silent.

## Status

- [x] Red test + the four constraints
- [ ] Adopt the reply's uuid via `refreshFenceFromOwnReply`
- [ ] Drop the note only when the refresh actually succeeded
- [ ] Mutation pass, codex review, live verification

Two corrections to my own first draft, both the same mistake: my assertions grepped for the
word "stale", but the real note says "re-mint" and quotes the refusal — so neither wording
assertion could ever have fired, and the harness could not tell whether the note appeared at
all. Read the actual string and retargeted.

Refs #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
