### PR TITLE
release: v0.51.52 — a workflow load adopts the instance it just proved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.52] - 2026-08-14
+
+### MCP
+
+#### Fixed
+- adopt the instance the load proved, instead of warning about it (#1478)
+- claim — an API load proves a new instance and leaves the fence stale
+
 ## [0.51.51] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.51",
+  "version": "0.51.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.51",
+      "version": "0.51.52",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.51",
+  "version": "0.51.52",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp#1478.

A workflow load re-mints the instance on the API path, and the session's fence was left pointing at the workflow the load had just replaced — so the next panel_* call, including a READ-ONLY `panel_get_errors`, was refused for "workflow instance mismatch".

The fence is now refreshed from the load's OWN reply (panel 0.14.41 publishes `workflow_uuid` there), the same race-proof shape already trusted for save / save-as / new. Every unproven path stays fail-closed: an older panel keeps its fence and its warning, a UI-format load is untouched, `loaded:false` adopts nothing, and a non-canonical uuid is refused.

Verified against the built dist, not just the unit suite: the reported scenario adopts, the warning is withdrawn only once repaired, and all three fail-closed paths hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)