### PR TITLE
release: v0.51.53 — a run completion stops turning one turn into gigabytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.53] - 2026-08-15
+
+### MCP
+
+#### Fixed
+- bound the images a run completion attaches to an agent turn (#1516)
+- account for the unnamed outputs the counts already include
+- the drain CORRECTS the claim, rather than only enforcing the number
+- the preview budget is per TURN — a per-event cap was not a cap
+
 ## [0.51.52] - 2026-08-14
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.52",
+  "version": "0.51.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.52",
+      "version": "0.51.53",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.52",
+  "version": "0.51.53",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp#1516 (PR #1521, contributed by @JusticeWay).

A Codex panel session reached ~3.02 GB and stopped replying: two foreign run completions at startup produced a 105,703,660-byte record with 28 inline images, and journal replay produced another one just like it.

Foreign/unidentified completions now arrive as text with their pixels detached — matching the correlation preamble, which already calls those runs UNDETERMINED. A matched completion attaches at most 8 images **per turn**, corrected at the drain. Withheld outputs are named with get_image coordinates; outputs with no filename say so and point at get_history.

Post-merge follow-up in this cut: the disclosure now also accounts for unnamed outputs on a MIXED event, where one named sibling had kept the generic "attached below" wording alive and made attached+omitted fail to sum to the total the same sentence quoted. Verified by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)