### PR TITLE
fix(1524): a stale panel MCP session is a session problem, not a bad request

### DIFF
--- a/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
+++ b/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
@@ -1,0 +1,175 @@
+// #1524 — after a mid-session drop, the `comfyui` tools came back and the 92
+// `panel_*` tools never did.
+//
+// The two servers are declared to the backend with DIFFERENT transports
+// (orchestrator/index.ts, makeHttpBackendMcpServers): `comfyui` is **stdio** — a
+// child process the client owns and respawns — while `panel` is **http**, a
+// stateful session against this loopback server. So only the panel half depends
+// on a session surviving, or on being told when it has not.
+//
+// The protocol has exactly one signal for that, and it is a status code:
+//
+//   - a request with NO session id, that is not an initialize  → 400 Bad Request
+//   - a request carrying a session id the server does not know → 404 Not Found,
+//     on which the client MUST open a new session with a fresh InitializeRequest
+//
+// (MCP Streamable HTTP, 2025-11-25 `basic/transports`; the SDK's own reference
+// router returns `404 / -32001 Session not found` for the second case, and its
+// review notes call conflating the two a recurring catch — "clients need to
+// distinguish between a request error and a session issue".)
+//
+// This server answered BOTH with 400. A client holding a session id from before
+// an orchestrator restart — which is routine here, since the dev install
+// self-restarts on rebuild and every session map is process-local — therefore
+// received "your request was malformed" where the protocol says "your session is
+// gone, start another". There is no re-initialize on that path, so the panel
+// server stays absent for the remainder of the conversation while the stdio
+// `comfyui` server, which needs no such signal, is simply respawned.
+//
+// These tests drive the REAL server over a real socket. A fake would only prove
+// the shape I already believe.
+import { afterEach, describe, expect, it } from "vitest";
+
+import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "../../orchestrator/panel-mcp-http.js";
+import type { UiBridge } from "../../services/ui-bridge.js";
+
+const TAB = "tmp:1524";
+
+/** A bridge that is never actually reached — these tests stop at the transport. */
+const bridge = {
+  send: async () => ({ ok: true }),
+  push: () => 1,
+  canReach: () => true,
+  isHeadless: () => false,
+  tabs: () => [{ tab_id: TAB, title: "A", connected_at: 0 }],
+  resolveActiveTabId: () => TAB,
+} as unknown as UiBridge;
+
+let server: PanelMcpHttpServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** Bind on an ephemeral port so a developer's live orchestrator on 9181 is never
+ *  disturbed, and two of these files can run in parallel. */
+async function start(): Promise<PanelMcpHttpServer> {
+  server = await startPanelMcpHttpServer(bridge, 0);
+  return server;
+}
+
+interface Probe {
+  status: number;
+  code?: number;
+  message?: string;
+}
+
+async function probe(
+  s: PanelMcpHttpServer,
+  method: string,
+  headers: Record<string, string>,
+  body?: unknown,
+): Promise<Probe> {
+  const res = await fetch(s.urlFor(TAB), {
+    method,
+    headers: {
+      // The transport's DNS-rebinding guard admits only exact-loopback hosts,
+      // and `urlFor` already produces one — but be explicit so a future change
+      // to that helper fails loudly here rather than as a mystery 403.
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  let code: number | undefined;
+  let message: string | undefined;
+  try {
+    const j = (await res.json()) as { error?: { code?: number; message?: string } };
+    code = j?.error?.code;
+    message = j?.error?.message;
+  } catch {
+    /* a body-less response is fine; the status is the subject here */
+  }
+  return { status: res.status, code, message };
+}
+
+const STALE = "11111111-2222-4333-8444-555555555555";
+const CALL = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+
+describe("a stale panel MCP session is reported as a SESSION problem (#1524)", () => {
+  it("answers 404 to a POST carrying a session id this process never minted", async () => {
+    // The reported case, reduced: the client survived, its session id did not.
+    // 404 is the only status that tells it to re-initialize; on 400 it stays down.
+    const s = await start();
+    const r = await probe(s, "POST", { "mcp-session-id": STALE }, CALL);
+    expect(r.status, "an unknown session id is a session problem, not a bad request").toBe(404);
+    expect(r.code).toBe(-32001);
+  });
+
+  it("answers 404 to a GET (the SSE re-attach) carrying an unknown session id", async () => {
+    // This is the request a reconnecting client actually makes first, so getting
+    // it wrong is what makes the tools stay missing rather than merely fail once.
+    const s = await start();
+    const r = await probe(s, "GET", { "mcp-session-id": STALE });
+    expect(r.status).toBe(404);
+    expect(r.code).toBe(-32001);
+  });
+
+  it("answers 404 to a DELETE carrying an unknown session id", async () => {
+    // A client tidying up a session this process has already forgotten is not
+    // making a malformed request either.
+    const s = await start();
+    const r = await probe(s, "DELETE", { "mcp-session-id": STALE });
+    expect(r.status).toBe(404);
+    expect(r.code).toBe(-32001);
+  });
+
+  it("still answers 400 when there is NO session id and the POST is not an initialize", async () => {
+    // The other half of the distinction, and the reason this cannot be a blanket
+    // 404: a client that never initialized has no session to recover, and telling
+    // it to re-initialize a session it never had would send it round a loop.
+    const s = await start();
+    const r = await probe(s, "POST", {}, CALL);
+    expect(r.status).toBe(400);
+  });
+
+  it("still answers 400 to a GET with no session id at all", async () => {
+    const s = await start();
+    const r = await probe(s, "GET", {});
+    expect(r.status).toBe(400);
+  });
+
+  it("a session it DID mint keeps working — the 404 is not a blanket refusal", async () => {
+    // Guards the direction that would silently un-ship every panel tool: a fix
+    // that returns 404 too eagerly breaks the healthy path, and the two failures
+    // look identical from the issue's vantage point (tools missing).
+    const s = await start();
+    const init = await fetch(s.urlFor(TAB), {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-1524", version: "1" },
+        },
+      }),
+    });
+    expect(init.status).toBe(200);
+    const sid = init.headers.get("mcp-session-id");
+    expect(sid, "the server must mint a session id to have one to invalidate").toBeTruthy();
+    // Drain the initialize response so the connection is not left mid-stream.
+    await init.text();
+
+    const r = await probe(s, "POST", { "mcp-session-id": sid! }, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    expect(r.status, "a live session must not be told it is gone").not.toBe(404);
+  });
+});

--- a/src/orchestrator/panel-mcp-http.ts
+++ b/src/orchestrator/panel-mcp-http.ts
@@ -85,6 +85,14 @@ export function startPanelMcpHttpServer(
   // across reconnects; each is its own server+transport over the SAME tab ctx.
   const tabs = new Map<string, Map<string, Session>>();
 
+  // The port ACTUALLY bound, which is not always the port asked for: `listen(0)`
+  // means "any free port", and the OS picks it. Everything downstream — the URL
+  // handed to the backend, the transport's DNS-rebinding allowlist, and the Host
+  // guard below — has to name the real one, or a server that came up fine is
+  // unreachable at the address it advertises and rejects the requests that do
+  // arrive. Kept in sync at `listen`, before any of those readers can run.
+  let boundPort = port;
+
   const newSession = async (tabId: string): Promise<Session> => {
     const server = new McpServer({ name: "comfyui-panel", version: "1.0.0" });
     // Tab-bound context: every tool forwards to the bridge for THIS tab — the
@@ -96,7 +104,7 @@ export function startPanelMcpHttpServer(
       // host to 127.0.0.1 to reach this loopback server). We also Host/Origin-guard
       // in the request handler since we hand-roll http.createServer.
       enableDnsRebindingProtection: true,
-      allowedHosts: [`127.0.0.1:${port}`, `localhost:${port}`],
+      allowedHosts: [`127.0.0.1:${boundPort}`, `localhost:${boundPort}`],
       allowedOrigins: [], // no browser origin should ever reach this (Codex sends none)
       onsessioninitialized: (sid) => {
         let m = tabs.get(tabId);
@@ -127,7 +135,7 @@ export function startPanelMcpHttpServer(
         // local Codex app-server should reach it — and it sends an exact-loopback
         // Host and NO browser Origin. Reject anything else before doing any work.
         const hostHeader = req.headers.host;
-        if (hostHeader !== `127.0.0.1:${port}` && hostHeader !== `localhost:${port}`) {
+        if (hostHeader !== `127.0.0.1:${boundPort}` && hostHeader !== `localhost:${boundPort}`) {
           res.writeHead(403, { "content-type": "application/json" }).end(
             JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message: "Forbidden host." }, id: null }),
           );
@@ -149,6 +157,38 @@ export function startPanelMcpHttpServer(
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
         const tabSessions = tabs.get(tabId);
         const existing = sessionId ? tabSessions?.get(sessionId) : undefined;
+
+        // #1524 — a session id we do not know is a SESSION problem, and the status
+        // code is the only place the protocol says so. 404 means "that session is
+        // gone", on which the client MUST open a new one with a fresh
+        // InitializeRequest; 400 means "this request was malformed", which no
+        // client retries and none re-initializes on. Answering the first case with
+        // the second is why the panel half of a dropped session never came back
+        // while the stdio `comfyui` half — which the client simply respawns, and
+        // which needs no such signal — always did.
+        //
+        // Every session map here is process-local, so an orchestrator restart
+        // invalidates every id at once. That is not an edge case on this install:
+        // the dev build self-restarts on rebuild.
+        //
+        // Scoped deliberately to "an id was presented and is unknown". A request
+        // with NO id keeps its 400 below: there is no session to recover, and
+        // sending it to re-initialize something it never opened would loop it.
+        if (sessionId && !existing) {
+          res.writeHead(404, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32001,
+                message:
+                  "Session not found — this session id is not known to this orchestrator " +
+                  "(it may have restarted). Open a new session with an initialize request.",
+              },
+              id: null,
+            }),
+          );
+          return;
+        }
 
         if (existing) {
           // Established session — GET (SSE), POST (messages), DELETE (close).
@@ -204,10 +244,18 @@ export function startPanelMcpHttpServer(
   return new Promise<PanelMcpHttpServer>((resolve, reject) => {
     httpServer.on("error", (err) => reject(err));
     httpServer.listen(port, host, () => {
-      logger.info(`[panel-mcp-http] panel_* MCP listening on http://${host}:${port}/<tabId> (loopback, Codex)`);
+      // Read the port back off the socket rather than echoing the request. They
+      // are the same number for every caller that names one, and different for
+      // `listen(0)` — where echoing produced a server advertising `:0`, which no
+      // client can dial and whose own Host guard would reject anything that did.
+      const addr = httpServer.address();
+      boundPort = typeof addr === "object" && addr ? addr.port : port;
+      logger.info(
+        `[panel-mcp-http] panel_* MCP listening on http://${host}:${boundPort}/<tabId> (loopback, Codex)`,
+      );
       resolve({
-        port,
-        urlFor: (tabId: string) => `http://${host}:${port}/${encodeURIComponent(tabId)}`,
+        port: boundPort,
+        urlFor: (tabId: string) => `http://${host}:${boundPort}/${encodeURIComponent(tabId)}`,
         stop: async () => {
           for (const tabSessions of tabs.values()) {
             for (const s of tabSessions.values()) {


### PR DESCRIPTION
Claims the remaining half of artokun/comfyui-mcp#1524 — the asymmetry where a mid-session drop brought the `comfyui` tools back and left all 92 `panel_*` tools absent.

## What the asymmetry actually is

The two servers are declared with different transports (`makeHttpBackendMcpServers`): `comfyui` is **stdio**, a child process the client owns and respawns; `panel` is **http**, a stateful session against the orchestrator's loopback MCP. Only the panel half depends on a session surviving — or on being told when it has not.

The protocol's only signal for that is a status code:

| request | required | this server sent |
|---|---|---|
| session id present, unknown to the server | **404** → client MUST re-initialize | 400 |
| no session id, not an initialize | 400 | 400 |

The SDK's own review notes call conflating these a recurring catch: *clients need to distinguish a request error from a session issue*. No client re-initializes on a 400, so the panel server stayed gone for the rest of the conversation.

Session maps here are process-local, so an orchestrator restart invalidates every id at once — routine on this install, where the dev build self-restarts on rebuild.

## Scope, deliberately narrow

Only "an id was presented and is unknown" becomes 404. A request with **no** id keeps its 400: there is no session to recover, and telling such a client to re-initialize something it never opened would loop it. A test pins that direction, because a fix that 404s too eagerly breaks healthy sessions and looks identical from the issue's vantage point — tools missing.

## Also fixed

The server echoed the **requested** port back as its bound port — identical for every caller that names one, wrong for `listen(0)`, where it advertised `:0`. Found because it made the server untestable over a real socket. The port is now read off the socket, and the URL, DNS-rebinding allowlist and Host guard all name the real one.

## What this does NOT do

It does not explain **why** the session dropped. That is still unknown and still needs the reporter's `ss -lntp` / stderr observation, which the issue asks for. This fixes what happens next.

## Verification

Baseline green (6/6), then three mutations, each `grep`-confirmed applied:

- 404 branch never fires → the three recovery tests die
- 404 on any session id → the live-session test dies
- port echoed instead of read back → all six die

`npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)