### PR TITLE
release: v0.51.54 — a dropped panel session can be reopened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.54] - 2026-08-15
+
+### MCP
+
+#### Fixed
+- a stale panel MCP session is a session problem, not a bad request (#1524)
+- the loopback MCP reports the port it BOUND, not the one it was asked for
+
 ## [0.51.53] - 2026-08-15
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.53",
+  "version": "0.51.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.53",
+      "version": "0.51.54",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.53",
+  "version": "0.51.54",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp#1524 (the panel-tools half; the root cause of the drop itself is still open on the issue).

A mid-session MCP drop returned the `comfyui` tools and left all 92 `panel_*` tools absent. The two are declared with different transports — `comfyui` is stdio (respawned by the client), `panel` is http (a stateful session). Only the panel half needs to be *told* its session is gone, and the protocol's only signal for that is the status code: **404** for a session id the server does not know, 400 for no session id at all. This server sent 400 for both, and no client re-initializes on a 400.

Scoped narrowly: only "an id was presented and is unknown" becomes 404, so a client that never initialized is not sent round a loop.

Also carries a latent fix — the loopback server echoed the *requested* port as its bound port, advertising `:0` under `listen(0)`.

Verified against the built dist over a real socket (8/8), plus mutation testing of each guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)