### PR TITLE
fix(1589): panel_strip_workflow hands back a graph a script can parse

### DIFF
--- a/src/__tests__/orchestrator/strip-workflow-parseable-reply.test.ts
+++ b/src/__tests__/orchestrator/strip-workflow-parseable-reply.test.ts
@@ -1,0 +1,234 @@
+// #1589 — `panel_strip_workflow`'s reply could not be parsed as JSON.
+//
+// The tool's whole purpose is to hand back a resolved graph, and it did — glued to
+// the end of a summary sentence inside ONE text block:
+//
+//   Stripped to 12 nodes
+//   Node types: 3× KSampler, …
+//
+//   { "1": { … } }
+//
+// so `JSON.parse(content[0].text)` died on the "S". Every programmatic caller had to
+// find the first `{` and slice from there, which is not merely inconvenient — it is
+// WRONG whenever a conversion note quotes a brace, and the notes name widget values,
+// so they can. The "hostile" test below is that exact case.
+//
+// The fix keeps the prose ordering #361 chose (notes BEFORE the graph they apply to)
+// and stops concatenating: block 0 is the summary, block 1 is the graph alone, and
+// `structuredContent.graph` carries the parsed form for callers that read it.
+//
+// The protocol test at the bottom is the one that matters. A handler can return
+// whatever it likes; whether `structuredContent` SURVIVES depends on the MCP SDK,
+// which drops or rejects it under some declarations (a tool that declares an
+// `outputSchema` and returns no structured half is a hard protocol error). So this
+// asserts through a real McpServer + real Client over the SDK's own transport,
+// registered by the same `registerPanelTools` production uses.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  // The live-canvas path must never reach this (#1359); it is mocked to throw so a
+  // regression that reintroduces the COMFYUI_URL fetch fails loudly here too.
+  getObjectInfo: async () => {
+    throw new Error("COMFYUI_URL must not be consulted for a live-canvas strip");
+  },
+  backfillObjectInfo: async (bulk: unknown) => bulk,
+  resetClient: () => {},
+  resetObjectInfoCache: () => {},
+}));
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const { buildPanelToolDefs, makePanelToolCtx, registerPanelTools } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/**
+ * A node type carrying a BRACE in its name. An unknown type is reported as a
+ * conversion warning quoting the type, so this puts a `{` into the prose — ahead of
+ * the graph — which is precisely what breaks a "slice from the first brace" caller.
+ */
+const BRACED_TYPE = 'Weird{"node"}Type';
+
+const KSAMPLER_DEF = {
+  input: { required: { seed: ["INT"], steps: ["INT"] } },
+  output: [],
+  name: "KSampler",
+};
+
+function liveNodes(includeBraced: boolean) {
+  const nodes: Array<Record<string, unknown>> = [
+    { id: 1, type: "KSampler", widgets_values: [7, 20], inputs: [], outputs: [] },
+    { id: 2, type: "KSampler", widgets_values: [8, 25], inputs: [], outputs: [] },
+  ];
+  if (includeBraced) nodes.push({ id: 3, type: BRACED_TYPE, widgets_values: [], inputs: [], outputs: [] });
+  return nodes;
+}
+
+function bridge(includeBraced: boolean) {
+  const nodes = liveNodes(includeBraced);
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "graph_serialize" || cmd.cmd === "graph_get_state") {
+        return { workflow: { nodes, links: [] }, nodes, links: [] };
+      }
+      if (cmd.cmd === "graph_get_object_info") {
+        // Defines KSampler and NOT the braced type — the uninstalled-custom-node
+        // case, which converts with a warning rather than refusing.
+        return { ok: true, served_by: "http://127.0.0.1:8188", object_info: { KSampler: KSAMPLER_DEF } };
+      }
+      return { ok: true, workflow: { nodes: [], links: [] } };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabServerOrigin: () => "http://127.0.0.1:8188",
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+function ctxFor(includeBraced: boolean): PanelToolCtx {
+  return makePanelToolCtx(bridge(includeBraced), TAB, new WorkflowTargetStore());
+}
+
+async function strip(includeBraced = false): Promise<ToolResult> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_strip_workflow");
+  if (!def) throw new Error("panel_strip_workflow is not registered");
+  return (await def.handler({}, ctxFor(includeBraced))) as ToolResult;
+}
+
+const textAt = (res: ToolResult, i: number): string => (res.content[i] as { text?: string }).text ?? "";
+
+describe("panel_strip_workflow returns a graph a script can parse (#1589)", () => {
+  it("puts the graph in its OWN block, which JSON.parse accepts as-is", async () => {
+    const res = await strip();
+    expect(res.content).toHaveLength(2);
+    const graphText = textAt(res, 1);
+    // No slicing, no trimming to a brace — the raw block text.
+    const parsed = JSON.parse(graphText) as Record<string, { class_type?: string }>;
+    expect(Object.keys(parsed)).toHaveLength(2);
+    expect(parsed["1"]?.class_type).toBe("KSampler");
+  });
+
+  it("keeps the summary FIRST and free of the graph — the #361 ordering is unchanged", async () => {
+    const res = await strip();
+    const prose = textAt(res, 0);
+    expect(prose).toMatch(/^Stripped to 2 nodes/);
+    expect(prose).toContain("Node types: 2× KSampler");
+    // The regression itself: the summary block must not carry the document.
+    expect(prose).not.toContain("class_type");
+    expect(prose).not.toContain(textAt(res, 1));
+    // NOT "the prose contains no brace" — it does, and that is the point of the
+    // hostile test below. The #959 widget-capture note this very fixture produces
+    // ends by suggesting `panel_query_graph {fields:'detail'}`, so a real reply's
+    // FIRST `{` has always been able to belong to the prose. Measured, not assumed.
+    expect(prose).toContain("{");
+  });
+
+  it("carries the parsed graph as structuredContent.graph, matching the text block byte for byte", async () => {
+    const res = await strip();
+    expect(res.structuredContent).toBeDefined();
+    const structured = res.structuredContent as { graph: unknown; node_count: number; node_types: unknown };
+    expect(structured.graph).toEqual(JSON.parse(textAt(res, 1)));
+    expect(structured.node_count).toBe(2);
+    expect(structured.node_types).toEqual({ KSampler: 2 });
+  });
+
+  it("HOSTILE: a conversion note containing a brace no longer poisons the reply", async () => {
+    // The case that makes "slice from the first `{`" wrong rather than merely ugly.
+    // The old single-block reply put this warning BEFORE the graph, so the first
+    // brace in the text belonged to the warning and the slice produced garbage.
+    const res = await strip(true);
+    const prose = textAt(res, 0);
+    expect(prose).toContain(BRACED_TYPE);
+    expect(prose).toContain("conversion note");
+    // Prove the old heuristic really would have failed on this reply…
+    const oldStyleSingleBlock = `${prose}\n\n${textAt(res, 1)}`;
+    expect(() => JSON.parse(oldStyleSingleBlock.slice(oldStyleSingleBlock.indexOf("{")))).toThrow();
+    // …while the block the tool actually returns parses.
+    const parsed = JSON.parse(textAt(res, 1)) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toHaveLength(2); // the braced type is unknown, so it is skipped
+    expect((res.structuredContent as { warnings: string[] }).warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("WIRING: structuredContent survives the real MCP transport (#1589)", () => {
+  it("a real Client sees structuredContent.graph on the tool result", async () => {
+    // The reachability claim. `registerPanelTools` casts the handler result to the
+    // SDK's type (`res as never`), so nothing in TypeScript proves the field is
+    // forwarded — and the SDK's validateToolOutput is the layer that would reject
+    // it if these tools ever declared an outputSchema. Assert it over the wire.
+    const server = new McpServer({ name: "strip-structured-test", version: "1.0.0" });
+    registerPanelTools(server, ctxFor(false));
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "strip-structured-test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const res = await client.callTool({ name: "panel_strip_workflow", arguments: {} });
+      expect(res.isError).toBeFalsy();
+      const structured = res.structuredContent as { graph: Record<string, { class_type?: string }> } | undefined;
+      expect(structured, "structuredContent did not survive the MCP round trip").toBeDefined();
+      expect(structured?.graph?.["1"]?.class_type).toBe("KSampler");
+      // …and the mirrored text block is still there for clients that ignore it.
+      const blocks = res.content as Array<{ text?: string }>;
+      expect(JSON.parse(blocks[1]?.text ?? "")).toEqual(structured?.graph);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("SOURCE: the handler returns structuredContent rather than concatenating the graph", () => {
+    // A protocol test proves TODAY's build forwards the field. It cannot see a future
+    // edit that puts the JSON back on the end of the summary string while leaving a
+    // structuredContent that happens to still be produced elsewhere. Read the source,
+    // bounded by the enclosing def(...) block rather than a character window.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+    // Anchor on the NAME (line endings and indentation are not the claim), then walk
+    // back to the `def(` that opens its registration.
+    const nameAt = src.indexOf('"panel_strip_workflow",');
+    expect(nameAt, "panel_strip_workflow is not registered by name any more").toBeGreaterThan(0);
+    const start = src.lastIndexOf("def(", nameAt);
+    expect(start, "no def( opens the panel_strip_workflow registration").toBeGreaterThan(0);
+    // Walk to the matching close of this def( … ) call, so the slice is the tool's
+    // own body and nothing of panel_flatten_workflow below it.
+    const open = src.indexOf("(", start + 3);
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < src.length; i++) {
+      const c = src[i];
+      if (c === "(") depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    const body = src.slice(start, end);
+    // The slice must be THIS tool and only this tool: an unbalanced paren inside a
+    // string would run the window on into the next def and make the negative
+    // assertion below meaningless.
+    expect(body, "the def( walk overran into the next tool").not.toContain('"panel_flatten_workflow",');
+    expect(body).toContain("structuredContent");
+    expect(body).toContain("graph: workflow");
+    // The exact shape of the bug: the summary template ending in the serialized graph.
+    expect(body).not.toMatch(/\+\s*`\\n\\n\$\{JSON\.stringify\(workflow/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -234,6 +234,25 @@ export type ToolResult = {
     | { type: "image"; data: string; mimeType: string }
   >;
   isError?: boolean;
+  /**
+   * #1589 — the MACHINE-READABLE half of a reply, for tools whose result is a
+   * DOCUMENT rather than a sentence.
+   *
+   * `content` is written for the model: prose first, so a conversion warning is
+   * read before the graph it applies to (#361). That ordering is right for the
+   * reader and useless for a script, which then has to hunt for the first `{`
+   * and slice. `structuredContent` is the MCP field for exactly this — the same
+   * data, already parsed.
+   *
+   * NO `outputSchema` is declared for these tools, deliberately. The MCP SDK
+   * validates structuredContent ONLY when the tool declares one
+   * (`validateToolOutput` returns early on `!tool.outputSchema`), and it hard-
+   * fails a reply that declares a schema and omits the structured half. Adding a
+   * schema would make every future non-structured branch of the same tool — every
+   * `fail(...)`, every early return — a protocol error, so the field stays
+   * additive: present when there is a document, absent otherwise.
+   */
+  structuredContent?: Record<string, unknown>;
 };
 
 function ok(value: unknown): ToolResult {
@@ -9058,7 +9077,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         "plus a node-type summary for INSPECTION / EXECUTION / REBUILD — it does NOT and CANNOT load the " +
         "result back onto the canvas (the canvas only loads UI-format graphs). Use it to understand an " +
         "expert workflow's real wiring, run the resolved graph headless, or rebuild connections with the " +
-        "graph edit tools. The resolved graph is much smaller than the raw UI JSON.",
+        "graph edit tools. The resolved graph is much smaller than the raw UI JSON. The reply is TWO " +
+        "blocks — the summary and any conversion notes first, then the graph alone as a whole JSON " +
+        "document — and the same graph is returned as structuredContent.graph, so nothing has to be " +
+        "sliced out of prose to parse it.",
       {
         pack: z
           .string()
@@ -9154,21 +9176,56 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .map(([t, c]) => `${c}× ${t}`)
           .join(", ");
 
-        return ok(
+        // #1589 — THE GRAPH IS NOW ITS OWN CONTENT BLOCK, and its own
+        // `structuredContent.graph`.
+        //
+        // It used to be string-concatenated onto the end of the summary, so the
+        // single text block began "Stripped to N nodes" and `JSON.parse` of it
+        // failed on the first character. Every programmatic caller had to find the
+        // first `{` and slice — a heuristic that is wrong the moment a conversion
+        // note quotes a brace, which the warning lines can and do (they name
+        // widget values).
+        //
+        // The PROSE ORDER IS UNCHANGED on purpose. #361 put the conversion notes
+        // ahead of the graph so a model reads "this differs from the source"
+        // before the thing it differs from; moving the JSON first to make
+        // `content[0]` parse would have traded a script's convenience for the
+        // reader's warning. Splitting instead keeps both: block 0 is the same
+        // sentence it always was, block 1 is a whole JSON document with nothing
+        // before or after it, and `structuredContent` is the parsed form for
+        // callers that read it.
+        const proseSummary =
           `Stripped to ${Object.keys(workflow).length} nodes` +
-            (warnings.length ? ` · ⚠ ${warnings.length} conversion note(s)` : "") +
-            `\nNode types: ${summary}` +
-            // #361: a strip that quietly loses a Set/Get link or substitutes a
-            // widget value produces a graph that LOOKS fine and renders
-            // differently. Say plainly that these are places the stripped graph
-            // does NOT match the source, so they are not skimmed as noise.
-            (warnings.length
-              ? `\nThe stripped graph DIFFERS from the source workflow where listed below — read these before running or rebuilding from it:\n${warnings
-                  .map((w) => `- ${w}`)
-                  .join("\n")}`
-              : "") +
-            `\n\n${JSON.stringify(workflow, null, 2)}`,
-        );
+          (warnings.length ? ` · ⚠ ${warnings.length} conversion note(s)` : "") +
+          `\nNode types: ${summary}` +
+          // #361: a strip that quietly loses a Set/Get link or substitutes a
+          // widget value produces a graph that LOOKS fine and renders
+          // differently. Say plainly that these are places the stripped graph
+          // does NOT match the source, so they are not skimmed as noise.
+          (warnings.length
+            ? `\nThe stripped graph DIFFERS from the source workflow where listed below — read these before running or rebuilding from it:\n${warnings
+                .map((w) => `- ${w}`)
+                .join("\n")}`
+            : "");
+        // Annotated, not inferred. `def()`'s handler type is enough for TS to accept
+        // this object but NOT to reject a key ToolResult does not declare — excess-
+        // property checking does not survive the inferred return type (measured: with
+        // `structuredContent` deleted from ToolResult, `tsc --noEmit` still exited 0).
+        // A typed local restores it, so the field is a contract the compiler enforces
+        // rather than a comment.
+        const reply: ToolResult = {
+          content: [
+            { type: "text", text: proseSummary },
+            { type: "text", text: JSON.stringify(workflow, null, 2) },
+          ],
+          structuredContent: {
+            graph: workflow,
+            node_count: Object.keys(workflow).length,
+            node_types: hist,
+            warnings,
+          },
+        };
+        return reply;
       },
     ),
     def(


### PR DESCRIPTION
Report: artokun/comfyui-mcp#1589 — `panel_strip_workflow` text is not directly parseable as JSON.

## Which half owns it

The ORCHESTRATOR, unambiguously. The reply is built in `src/orchestrator/panel-tools.ts`; `comfyui-mcp-panel` has no `strip_workflow` handler at all (`git grep strip_workflow origin/main -- web` → no hits). No panel change is needed or made.

## What was wrong

The handler ended with a single `ok(...)`, and the graph was string-concatenated onto the end of the summary:

```
`Stripped to ${n} nodes` + … + `\n\n${JSON.stringify(workflow, null, 2)}`
```

so `content[0].text` began `Stripped to 12 nodes` and `JSON.parse` failed on the `S`, exactly as reported.

The workaround the report describes — find the first `{` and slice — is not just inconvenient, it is **wrong on real replies**. The #959 widget-capture note this tool routinely emits ends by suggesting `panel_query_graph {fields:'detail'}`; that brace sits in the PROSE, ahead of the graph. I did not assume this — the first version of the test asserted "the summary contains no `{`" and **failed against the product**, on the default fixture. The test now pins that reply and shows the old slice producing garbage on it.

## The fix

* `content[0]` — the summary and conversion notes, byte-identical to what shipped before.
* `content[1]` — the graph alone: a whole JSON document, nothing before or after it.
* `structuredContent.graph` — the parsed form (plus `node_count`, `node_types`, `warnings`), which is the shape the report asked for.

**The prose order is deliberately unchanged.** #361 put the conversion notes ahead of the graph so a model reads "this differs from the source" before the thing it differs from. Moving the JSON to `content[0]` would have made the literal reproduction step pass while selling that warning for a script's convenience. Splitting keeps both.

**No `outputSchema` is declared, on purpose.** The SDK's `validateToolOutput` returns early on `!tool.outputSchema`, and hard-fails a schema-declaring reply that omits the structured half — declaring one would turn every `fail(...)` branch of the same tool into a protocol error. The field stays additive.

## What I verified

* **Reachability over the real transport.** The wiring test builds a genuine `McpServer`, registers through the production `registerPanelTools`, connects a real `Client` over `InMemoryTransport`, and asserts `structuredContent.graph` arrives. That path casts the handler result to the SDK's type (`res as never`), so nothing in TypeScript proved the field was forwarded — it is now proven over the wire, not read out of the SDK source.
* **Mutation-tested against a verified-green baseline**, each mutation confirmed applied with `grep -c` before running:
  * restore the original concatenation → **6/6 fail**
  * drop `structuredContent`, keep the two blocks → **4/6 fail** (including the transport test)
  * swap the block order (JSON first) → **5/6 fail**
  * delete `structuredContent` from the `ToolResult` type → **`tsc --noEmit` exits 2**
* **The type mutation initially did NOT fail** (`tsc` exited 0): excess-property checking does not survive `def()`'s inferred handler return type, and `src/__tests__` is excluded from `tsconfig.json`, so the field was decorative. The return is now assigned to a typed local first, which makes it a compiler-enforced contract — re-measured, and only then did the mutation die.
* The source assertion is bounded by walking the enclosing `def( … )` parens, not a character window, and asserts it did not overrun into `panel_flatten_workflow`.
* Gates: `npm run lint`, `npm run build`, `npm run check:vocabulary`, `npm run check:unknown-collapse`, `npm run vocab:export -- --check` all clean. `npm run docs:gen` is still a no-op (panel tool descriptions are not in `docs/tools/*.mdx`; the only local churn was CRLF, discarded). Full `vitest run`: 9490 passed, 0 failed.

## What I did NOT verify / did NOT change

* **Not live-verified against a real canvas.** Everything here is fixture-driven plus the in-memory MCP round trip; no browser panel was driven.
* **The Claude in-process backend (`createPanelMcpServer`) was not asserted end to end.** Its `CallToolResult` schema accepts `structuredContent`, but the transport test covers the MCP-SDK path only. The text blocks are what that backend's model reads, and those are unchanged in content and order.
* **`get_workflow (action:"strip")` in `src/tools/workflow-library.ts` is untouched.** It was checked: it already returns the graph as its own second content block, so it never had the concatenation defect. It gains no `structuredContent` here — that would mean widening the core `TextResult` type and the whole stdio surface, which is out of scope for this report.
* The full local suite reported 6 Windows worker-spawn errors (`errno -4094`, machine resource exhaustion, exit code 0, zero failing tests). CI is the authority on that.
* No release/version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
