### PR TITLE
fix(manifest): let the SERVER answer whether a model is installed (#1587)

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -625,8 +625,16 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     // An unverifiable result must say WHY and how to become verifiable, or the user
     // has nothing to act on.
     expect(res.note).toMatch(/RELATIVE main\.py/);
-    expect(res.note).toMatch(/could not be identified/);
     expect(res.note).toMatch(/list_local_models/);
+    // ...and the remedy has to be actionable: NAME the root.
+    expect(res.note).toMatch(/COMFYUI_PATH/);
+    expect(res.note).toMatch(/--base-directory/);
+    // #1587 — but it must not assert the process could not be identified. That is a
+    // CONJUNCT the code never established: ComfyUI Desktop identifies the process
+    // (python_probe_trusted:true, process-table PID) and the root is unpinnable
+    // anyway, so a user who reads this goes and "fixes" a working probe.
+    expect(res.note).not.toMatch(/main\.py with no working directory AND/);
+    expect(res.note).not.toMatch(/make its process observable/);
   });
 
   // #369 review, P1: the pre-write guard fails OPEN on an empty candidate tree —

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -588,16 +588,63 @@ describe("applyManifest", () => {
     expect(downloadModelMock).not.toHaveBeenCalled();
   });
 
-  it("reports PENDING (never skipped) when containment cannot be established — even if the server lists the NAME", async () => {
-    // The stale tree and the live tree both hold `big.safetensors`. A name-only
-    // listing hit must NOT promote an unconfirmed placement to "installed".
+  // #1587 — this block was previously pinned the other way ("reports PENDING
+  // (never skipped) ... even if the server lists the NAME"). It is deliberately
+  // re-pinned. The old fixture's own premise is that the LIVE tree holds the file,
+  // and it then asserted the manifest report it as unsatisfied: `pending`, and
+  // therefore `success:false`, for a model the connected server demonstrably has.
+  //
+  // The verdict came from `isUnderLiveModelRoots`, a filesystem containment test
+  // against a root the server never named — a source that does not look at
+  // /models at all. It cannot see a server-visible model, so it can only ever
+  // answer "unknown" here, and the message it produced asserted a specific and
+  // often false reason ("its install root could only be inferred from local
+  // configuration") — ComfyUI Desktop's OS-process-observed root lands in the same
+  // bucket.
+  //
+  // #369 is unaffected: its failure is a stale same-named file satisfying the
+  // manifest while the live server has NEVER seen it, and that case is the
+  // `listed === false` test below, which still reports pending and still downloads.
+  it("#1587 SKIPS a model the connected server already serves when containment is unknown", async () => {
     resolveExistingModelFileMock.mockResolvedValueOnce({
       path: "C:/comfy/models/checkpoints/big.safetensors",
       root: "C:/comfy/models",
       info: { isFile: () => true },
     });
     isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: undefined });
-    liveListingHasEntryMock.mockResolvedValueOnce(true);
+    liveListingHasBasenameMock.mockResolvedValueOnce(true);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/big.safetensors",
+            model_type: "checkpoints",
+            filename: "big.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ skipped: 1, failed: 0, pending: 0 });
+    expect(result.success).toBe(true);
+    expect(downloadModelMock).not.toHaveBeenCalled();
+    expect(result.results[0].message).toMatch(/already serves/);
+    // What was NOT established is still stated — the fix moves the uncertainty
+    // into a note, it does not delete it.
+    expect(result.results[0].message).toMatch(/NOT confirmed that the copy at/);
+    // ...and the claim that was never the code's to make is gone.
+    expect(result.results[0].message).not.toMatch(/inferred from local configuration/);
+  });
+
+  it("#1587 still reports PENDING when the server does NOT list it (#369's shape, unchanged)", async () => {
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/stale/models/checkpoints/big.safetensors",
+      root: "C:/stale/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: undefined });
+    liveListingHasBasenameMock.mockResolvedValueOnce(false);
 
     const result = await applyManifest({
       manifest: {
@@ -612,8 +659,84 @@ describe("applyManifest", () => {
     });
 
     expect(result.summary).toMatchObject({ skipped: 0, failed: 0, pending: 1 });
-    expect(result.results[0].message).toMatch(/not confirmed as installed/);
-    expect(result.results[0].message).toMatch(/may be its OWN copy elsewhere/);
+    expect(result.results[0].message).toMatch(/does NOT list/);
+  });
+
+  it("#1587 still reports PENDING when the server could not be ASKED (listing unavailable)", async () => {
+    // A failed observation and an observed negative must not collapse into the
+    // same answer, and neither may become a confirmation.
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/comfy/models/checkpoints/big.safetensors",
+      root: "C:/comfy/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: undefined });
+    liveListingHasBasenameMock.mockResolvedValueOnce(undefined);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/big.safetensors",
+            model_type: "checkpoints",
+            filename: "big.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ skipped: 0, failed: 0, pending: 1 });
+    expect(result.results[0].message).toMatch(/could not be asked/);
+  });
+
+  it("#1587 a NESTED target needs the EXACT category-relative entry, not a basename anywhere", async () => {
+    // `loras/Krea2/x.safetensors` is loaded by that exact string. A same-named
+    // file loose in loras/ does not satisfy it, so the basename probe must not be
+    // the one consulted here.
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/comfy/models/loras/Krea2/x.safetensors",
+      root: "C:/comfy/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: undefined });
+    liveListingHasEntryMock.mockResolvedValueOnce(false);
+    liveListingHasBasenameMock.mockResolvedValueOnce(true); // must be IGNORED here
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/x.safetensors",
+            local_path: "loras/Krea2/x.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ skipped: 0, pending: 1 });
+    expect(result.results[0].message).toMatch(/does NOT list/);
+  });
+
+  it("#1587 a NESTED target IS skipped when the server lists that exact entry", async () => {
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/comfy/models/loras/Krea2/x.safetensors",
+      root: "C:/comfy/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: undefined });
+    liveListingHasEntryMock.mockResolvedValueOnce(true);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/x.safetensors", local_path: "loras/Krea2/x.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ skipped: 1, pending: 0 });
+    expect(result.success).toBe(true);
+    expect(downloadModelMock).not.toHaveBeenCalled();
   });
 
   it("skips a CATEGORY-ROOT target found by filename anywhere in the served category", async () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1299,25 +1299,59 @@ async function applyManifestSections(
         if (visible === false) {
           staleOutsideLiveRoots = existing;
         } else if (visible === undefined) {
-          // We could not establish that the running server reads from this path, so
-          // "already exists" is an UNVERIFIED claim. Report it as pending, never as
-          // a satisfied item (codex gate, rounds 4 and 8).
-          const listed = await liveListingHasEntry(target.targetSubfolder, target.filename);
+          // #1587 — containment could not answer, and about THIS question it never
+          // could. `isUnderLiveModelRoots` compares `existing` against a models root
+          // the running server did not name (`modelsDirNamedByServer`); it never
+          // consults the server's own listing. Deriving `pending` from that silence
+          // overruled the one source that CAN answer — /models — with a source
+          // structurally blind to it, and then said so in a message that told the
+          // user their install root "could only be inferred from local
+          // configuration". That is not what `undefined` means here: an
+          // OS-process-observed root (ComfyUI Desktop's shape, where the interpreter
+          // is identified from the process table serving our port) lands in exactly
+          // this bucket, and the file was often FOUND by the server's own listing in
+          // the first place (findExistingModel step 3).
+          //
+          // So ask what the manifest actually needs to know — does the running server
+          // already have this model? — and let the server answer it. Precision
+          // mirrors findExistingModel: a category-root target is satisfied by the
+          // basename anywhere in the category, a nested target by the exact
+          // category-relative path.
+          //
+          // This does NOT weaken #369. #369's failure is a stale same-named file
+          // satisfying the manifest while the live server has never seen it — there
+          // the server does NOT list the entry, so this branch still reports pending
+          // and the download still runs. What is dropped is only the claim that the
+          // local copy is the served one, which the note now STATES instead of the
+          // verdict asserting its opposite.
+          const nested = target.targetSubfolder.split(/[\\/]+/).filter(Boolean).length > 1;
+          const listed = nested
+            ? await liveListingHasEntry(target.targetSubfolder, target.filename)
+            : await liveListingHasBasename(target.targetSubfolder, target.filename);
           results.push(
-            report(
-              "model",
-              item,
-              "pending",
-              `A file exists at ${existing}, but it could NOT be established that the ` +
-                "connected ComfyUI reads models from there (its install root could only be " +
-                "inferred from local configuration), so this is not confirmed as installed." +
-                (listed === true
-                  ? ` The server does list "${target.filename}" under "${target.targetSubfolder}", but that may be its OWN copy elsewhere.`
-                  : listed === false
-                    ? ` The server does NOT list "${target.filename}" under "${target.targetSubfolder}".`
-                    : "") +
-                " Check list_local_models.",
-            ),
+            listed === true
+              ? report(
+                  "model",
+                  item,
+                  "skipped",
+                  `The connected ComfyUI already serves "${target.filename}" in ` +
+                    `"${target.targetSubfolder}", so the manifest's model is present for it. ` +
+                    "NOTE: containment could not be established — the running server did not " +
+                    `name its models root — so it is NOT confirmed that the copy at ${existing} ` +
+                    "is the one it serves.",
+                )
+              : report(
+                  "model",
+                  item,
+                  "pending",
+                  `A file exists at ${existing}, but it could NOT be established that the ` +
+                    "connected ComfyUI reads models from there — the running server did not " +
+                    "name its models root, so the root had to be inferred — and " +
+                    (listed === false
+                      ? `the server does NOT list "${target.filename}" under "${target.targetSubfolder}".`
+                      : `the server could not be asked whether it lists "${target.filename}" under "${target.targetSubfolder}".`) +
+                    " Check list_local_models.",
+                ),
           );
           continue;
         }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1343,23 +1343,39 @@ export async function currentLiveModelsRoot(): Promise<string | undefined> {
  * into a verified answer.
  *
  * Saying "unconfirmed" without saying WHY leaves the user with nothing to act on.
- * There are exactly two reasons the live root stays unpinnable: the running server
- * reported a relative `main.py` with no working directory (so its own report is not
- * enough), and the OS process table could not be read to identify the process on our
- * port. The second is a TOOLING gap on POSIX — `lsof` is simply not installed on
- * many minimal images — and installing it converts this host into a verifiable one.
+ * The running server reported a relative `main.py` with no working directory, so its
+ * own report is not enough to pin the install, and the root had to come from
+ * somewhere it never named.
+ *
+ * #1587 — this used to assert a CONJUNCTION as the cause: "...AND the process
+ * listening on the ComfyUI port could not be identified". That second half is often
+ * FALSE. On ComfyUI Desktop the process is identified — the same session's
+ * `install_comfyui(action:"environment")` reports `python_probe_trusted:true` with a
+ * process-table PID — and the root is STILL unpinnable, because an interpreter's
+ * location is evidence of where the BINARY lives, not of where the server reads
+ * (see `modelsDirNamedByServer`, and the measured stale-portable-python shape in
+ * #1374). Telling that user their process could not be identified sends them to fix
+ * something that is not broken, and "make its process observable" is advice they
+ * have already followed.
+ *
+ * So the reasons are stated as ALTERNATIVES, and the `lsof` gap — real, and worth
+ * naming on POSIX — is offered as a possibility to check rather than as a finding.
  */
 function unverifiableDestinationRemedy(): string {
   const probe =
     platform() === "win32"
-      ? "the process listening on the ComfyUI port could not be identified"
-      : "the process listening on the ComfyUI port could not be identified (this needs `lsof`, " +
-        "which is missing on many minimal images — installing it makes future downloads verifiable)";
+      ? ""
+      : " If the process on that port could not be identified at all, that needs `lsof`, " +
+        "which is missing on many minimal images — installing it makes future downloads " +
+        "verifiable.";
   return (
-    "This happens when the running ComfyUI reports a RELATIVE main.py with no working " +
-    `directory AND ${probe}. To get a definite answer: point COMFYUI_PATH at the ComfyUI ` +
-    "that is actually running, launch it with an absolute --base-directory, or make its " +
-    "process observable. Meanwhile, confirm with list_local_models."
+    "This happens when the running ComfyUI names a RELATIVE main.py with no working " +
+    "directory, so its models root has to come from somewhere the server did not name — " +
+    "local configuration, or the install tree around the interpreter the OS reports for " +
+    "the process on that port (which locates the BINARY, not the models the server " +
+    `reads).${probe} To get a definite answer, NAME the root: point COMFYUI_PATH at the ` +
+    "ComfyUI that is actually running, or launch it with an absolute --base-directory. " +
+    "Meanwhile, confirm with list_local_models."
   );
 }
 


### PR DESCRIPTION
Fixes #1587.

## Where the `pending` verdict came from

Not a race. The verdict came from a source that cannot see server-visible models at all.

`applyManifest`'s existing-file branch decides each model's status from **one** input (`src/services/manifest.ts:1258-1284`):

```ts
const existing = await findExistingModel(target);
const visible  = (await isUnderLiveModelRoots(existing, <category>)).inRoots;
```

`isUnderLiveModelRoots` is a **filesystem containment test**. It resolves a models root and asks whether `existing` sits under it — and it refuses to answer unless the root was *named by the running server* (`src/services/model-resolver.ts:1285`):

```ts
if (!modelsDirNamedByServer(dest.source)) return { inRoots: undefined };
```

`modelsDirNamedByServer` is `source === "argv-flag" || source === "live-root"` (`src/services/output-dir.ts:106`). ComfyUI Desktop reports a *relative* `ComfyUI\main.py` with no cwd, so the root is re-anchored on the interpreter the OS reports for the process on our port and stamped `observed-root` — which is not in that set. So `visible` is `undefined`, and the old code reported `pending` and `continue`d.

Two things follow, and both are the bug:

1. **The server's listing was fetched and then discarded.** `liveListingHasEntry(...)` was called one line later, but only to decorate the message string — its value never reached the status. So `/models` listing the exact filename could not move the item off `pending`. Worse, `findExistingModel` step 3 (`manifest.ts:842`) often *found the file via that same listing in the first place*: the server answered "yes", and a check structurally blind to the server overruled it.
2. **The message asserted a cause the code had not established:** *"its install root could only be inferred from **local configuration**"*. `undefined` does not mean that. The reporter's root came from the OS process table — the same session's `install_comfyui(action:"environment")` returned `python_probe_trusted:true` with a PID. The one sentence that made the verdict look unarguable was false for exactly the user hitting it.

And `success` is `summary.failed === 0 && summary.pending === 0` (`manifest.ts:1480`), so four such models made `success:false` for a pack that was already installed.

## The change

When containment cannot answer, ask the question the manifest actually needs answered — *does the running server already have this model?* — and let the **server** answer it:

- server lists it → `skipped`, with a note stating plainly what was **not** established (that the local copy is the served one);
- server does not list it → `pending`, unchanged, download proceeds;
- server could not be asked → `pending`, with wording that distinguishes a failed observation from an observed negative.

Probe precision mirrors `findExistingModel`: a category-root target is satisfied by the basename anywhere in the category, a nested target (`loras/Krea2/x.safetensors`) only by the exact category-relative entry.

**This does not weaken #369.** That failure is a stale same-named file satisfying the manifest while the live server has *never seen it* — there the server does not list the entry, so this branch still reports `pending` and still downloads. What is dropped is only the claim that our local copy is the served one, which the note now states outright instead of the verdict asserting its opposite.

I also removed a second false assertion the report names: `unverifiableDestinationRemedy()` (`model-resolver.ts:1352`) told users *"This happens when ... **AND** the process listening on the ComfyUI port could not be identified"* and advised them to "make its process observable". On Desktop the process **is** identified and the root is unpinnable anyway, because an interpreter locates the *binary*, not the models the server reads. The reasons are now alternatives, the `lsof` gap is offered as something to check rather than as a finding, and the remedy says the actionable thing: NAME the root.

## What I verified

- Read on `origin/main` (0.51.53) via `git show`, not the working tree. The defect is present there — `grep` finds both `"inferred from local configuration"` and the `modelsDirNamedByServer(dest.source)` gate — and 0.51.53 is newer than the reporter's 0.50.107, so this is not a stale report. No commit in history mentions #1587.
- `npx vitest run src/__tests__/services/manifest.test.ts` — 54/54; with `download-live-destination.test.ts`, 102/102. Full suite with every change in place: **511 files passed, 9528 tests passed, 3 skipped, 0 failures**.
- `npm run lint`, `npm run build`, `check:vocabulary`, `check-unknown-collapse` all green.
- **Mutation-tested** against that green baseline, each mutation confirmed applied with `grep -cF` first:
  - `listed === true` → `listed !== false` (over-broad guard): kills the "could not be ASKED" test.
  - `nested` forced to `false` (collapse the precision rule): kills the nested-target test.
  - the remedy's conjunction restored: kills the download-side test.
- **Reachability, by deleting the call site.** Replacing `await applyManifest(args)` in `src/tools/manifest.ts:31` with a stub turns `tools/manifest.test.ts` red, so the branch is reached from the registered tool and not only from the service test.
- **No test can start a download.** `downloadModel` is mocked in this suite, and the two new skip tests assert `expect(downloadModelMock).not.toHaveBeenCalled()`.
- The re-pinned test is called out as re-pinned. The old one ("reports PENDING (never skipped) ... even if the server lists the NAME") asserted `pending` on a fixture whose own premise is that the **live** tree holds the file.

## What I did NOT verify, and did NOT change

- **No live run against a ComfyUI Desktop instance.** The mechanism is read from the source and exercised through mocks at `isUnderLiveModelRoots`/`liveListingHas*`; I did not reproduce the reporter's `observed-root` resolution end to end on a Desktop install.
- **`modelsDirNamedByServer` is untouched**, deliberately. Widening it to accept `observed-root` would move download *placement* authority everywhere it is consulted, and it has a measured counterexample (#1374: a stale portable python on PATH anchors `C:\stale\ComfyUI` for a server running from `D:\live`). This change never treats the inferred root as authoritative — it stops treating the *server's own listing* as inadmissible.
- **The download-side verdict is unchanged.** Only the remedy's prose changed there; `destinationIsLiveAuthoritative` and the `liveVisible` states behave exactly as before.
- The exact-provenance version of that note — plumbing `ModelsDirSource` through `LiveRootMembership` so the message can say *which* inference was used — is what the report's "reuse the trusted live process/workspace resolution consistently" asks for, and I did not attempt it here.
- The reporter's run also had a Manager-dispatched item. Manager dispatches are `pending` by design (accepted, not verified as landed) and that is untouched, so a manifest whose LoRA goes through Manager can still report `pending` for that item.
