### PR TITLE
fix(1374): a drained ComfyUI-Manager queue is not evidence the file landed

### DIFF
--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -2286,6 +2286,24 @@ describe("download job registry", () => {
 
     it("never confirms a Manager dispatch, even if a verdict got attached", () => {
       const r = describePlacement({ ...base, viaManager: true, live_visible: "visible" });
+      // THE invariant, unchanged: a listing proves a file of that NAME exists
+      // somewhere the server reads. That is placement, never validity (#473 — a
+      // login page saved as a .safetensors lists perfectly happily), so no
+      // Manager outcome may render as a confirmed success.
+      expect(r.confirmed).toBe(false);
+      // #1374 changed the WORDING deliberately, and only for the arms that now
+      // carry an observation. The old regex pinned one static sentence that was
+      // returned for every Manager outcome — true of all of them and therefore
+      // distinguishing none, which is what let a REJECTED dispatch read as `done`.
+      // What still has to hold is that this is not sold as verified.
+      expect(r.warning).toMatch(/PLACEMENT, not validity/);
+      expect(r.pathLabel).not.toBe("landed at");
+    });
+
+    it("still says NOT VERIFIED for a Manager dispatch with no observation (#1374)", () => {
+      // The arm that keeps the original wording: nothing was learned, so the
+      // pre-#1374 sentence is exactly right and must survive.
+      const r = describePlacement({ ...base, viaManager: true, live_visible: "unknown" });
       expect(r.confirmed).toBe(false);
       expect(r.warning).toMatch(/NOT verified as landed/);
     });

--- a/src/__tests__/services/manager-dispatch-visibility.test.ts
+++ b/src/__tests__/services/manager-dispatch-visibility.test.ts
@@ -20,20 +20,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
-  /** Resolves the mocked downloadModel, standing in for the Manager dispatch
-   *  returning once its queue drained. Never a real transfer. */
-  resolveDispatch: undefined as ((s: string) => void) | undefined,
+  /** One deferred PER downloadModel call, standing in for a Manager dispatch
+   *  returning once its queue drained. Never a real transfer.
+   *
+   *  Per-call, and created BY the call, because the baseline is now read inside
+   *  the settle closure (#1374 review, P1-2): a single resolver captured at
+   *  module scope was `undefined` at the moment a test tried to use it, and the
+   *  suite hung. Tests wait for the call with `nextDispatch`. */
+  dispatches: [] as Array<{ promise: Promise<string>; resolve: (s: string) => void }>,
   /** What the server answers BEFORE the dispatch (the baseline), and what it
    *  answers AFTER. They are separate on purpose: with one value, "the file
    *  appeared" and "the file was always there" are the same fixture, and the
    *  `listedBefore` guard this suite exists to pin becomes untestable. undefined
-   *  = could not be asked. */
+   *  = could not be asked. Read at CALL time, so a test can change the world
+   *  between two jobs. */
   baseline: undefined as boolean | undefined,
   after: undefined as boolean | undefined,
   /** Every (subfolder, filename) the listing probe was asked about, in order —
    *  so a test can prove the BASELINE was taken before the dispatch. */
   probed: [] as Array<{ sub: string; name: string }>,
+  /** How many baseline probes had happened when each dispatch was made. The
+   *  ORDERING evidence: a baseline read after its own dispatch is not a
+   *  baseline, and a count alone cannot see that. */
+  probedAtDispatch: [] as number[],
   visibilityCalls: 0,
+  /** Held open by a test that needs to observe the job WHILE the post-dispatch
+   *  check is still running — the window between publishing `done` and having a
+   *  verdict, which is the one a grace timer can expire in. */
+  visibilityGate: undefined as Promise<void> | undefined,
   landedCalls: 0,
   remote: true,
 }));
@@ -52,12 +66,15 @@ vi.mock("../../services/model-resolver.js", async () => {
   );
   return {
     shouldDispatchDownloadToManager: vi.fn(async () => hoisted.remote),
-    downloadModel: vi.fn(
-      () =>
-        new Promise<string>((resolve) => {
-          hoisted.resolveDispatch = resolve;
-        }),
-    ),
+    downloadModel: vi.fn(() => {
+      hoisted.probedAtDispatch.push(hoisted.probed.length);
+      let resolve!: (s: string) => void;
+      const promise = new Promise<string>((r) => {
+        resolve = r;
+      });
+      hoisted.dispatches.push({ promise, resolve });
+      return promise;
+    }),
     resolveDownloadTarget: vi.fn(async (_u: string, sub: string, filename?: string) => ({
       targetDir: `/M/${sub}`,
       filename: filename ?? "model.safetensors",
@@ -71,6 +88,7 @@ vi.mock("../../services/model-resolver.js", async () => {
     verifyManagerVisibility: vi.fn(
       async (sub: string, name: string, opts?: Record<string, unknown>) => {
         hoisted.visibilityCalls += 1;
+        if (hoisted.visibilityGate) await hoisted.visibilityGate;
         return actual.verifyManagerVisibility(sub, name, {
           ...opts,
           attempts: 1,
@@ -99,11 +117,24 @@ const URL_ = "https://huggingface.co/org/repo/resolve/main/te.safetensors";
 const SUB = "text_encoders";
 const NAME = "te.safetensors";
 
+/** The descriptor string the Manager route hands back on acceptance. */
+const DESCRIPTOR = (name = NAME) => `${SUB}/${name} (dispatched via ComfyUI-Manager)`;
+
+/** Wait until downloadModel has been called at least `index + 1` times, then hand
+ *  back that call's deferred. */
+async function nextDispatch(
+  index: number,
+): Promise<{ promise: Promise<string>; resolve: (s: string) => void }> {
+  await vi.waitFor(() => {
+    if (hoisted.dispatches.length <= index) throw new Error(`dispatch ${index} not made yet`);
+  });
+  return hoisted.dispatches[index]!;
+}
+
 /** Run one Manager-routed download to completion and return the settled job. */
-async function runManagerDownload(): Promise<DownloadJob> {
-  const started = await startDownloadJob(URL_, SUB, NAME);
-  // The dispatch "returns" the descriptor string the Manager route produces.
-  hoisted.resolveDispatch?.(`${SUB}/${NAME} (dispatched via ComfyUI-Manager)`);
+async function runManagerDownload(name = NAME): Promise<DownloadJob> {
+  const started = await startDownloadJob(URL_, SUB, name);
+  (await nextDispatch(0)).resolve(DESCRIPTOR(name));
   await started.settled;
   const job = getDownloadJob(started.job.id);
   if (!job) throw new Error("job vanished");
@@ -112,11 +143,13 @@ async function runManagerDownload(): Promise<DownloadJob> {
 
 beforeEach(() => {
   resetDownloadJobs();
-  hoisted.resolveDispatch = undefined;
+  hoisted.dispatches = [];
+  hoisted.probedAtDispatch = [];
   hoisted.baseline = undefined;
   hoisted.after = undefined;
   hoisted.probed = [];
   hoisted.visibilityCalls = 0;
+  hoisted.visibilityGate = undefined;
   hoisted.landedCalls = 0;
   hoisted.remote = true;
 });
@@ -141,11 +174,12 @@ describe("#1374 — a drained Manager queue is not evidence the file landed", ()
     // static caveat and the reporter read `done`.
     const r = describePlacement(job);
     expect(r.confirmed).toBe(false);
-    expect(r.wrongPlace).toBe(true);
     expect(r.warning).toMatch(/does NOT list/);
     // Names the cause the reporter actually hit, so the next one does not have to
     // discover it.
     expect(r.warning).toMatch(/security_level/);
+    // …but NOT as `wrongPlace` — see the dedicated describe below.
+    expect(r.wrongPlace).toBe(false);
   });
 
   it("records VISIBLE when the server lists it — and still refuses to call it confirmed", async () => {
@@ -183,8 +217,11 @@ describe("#1374 — a drained Manager queue is not evidence the file landed", ()
 
     const job = await runManagerDownload();
 
-    // The probe ran BEFORE the dispatch (that is the baseline) and again after.
+    // The probe ran BEFORE the dispatch (that is the baseline).
     expect(hoisted.probed[0]).toEqual({ sub: SUB, name: NAME });
+    // …and ORDERING, not just presence: zero baselines had been taken when the
+    // dispatch went out would mean this "baseline" was read after the fact.
+    expect(hoisted.probedAtDispatch[0]).toBe(1);
     // A pre-existing entry makes the post-check inconclusive, NOT successful.
     expect(job.live_visible).toBe("unknown");
     expect(job.verify_note).toMatch(/BEFORE this dispatch/);
@@ -211,12 +248,217 @@ describe("#1374 — a drained Manager queue is not evidence the file landed", ()
     hoisted.after = false;
 
     const started = await startDownloadJob(URL_, SUB, NAME);
-    hoisted.resolveDispatch?.(`/M/${SUB}/${NAME}`);
+    (await nextDispatch(0)).resolve(`/M/${SUB}/${NAME}`);
     await started.settled;
 
     expect(hoisted.visibilityCalls).toBe(0);
     // The local route's own verification still runs — this changed nothing there.
     expect(hoisted.landedCalls).toBe(1);
+  });
+
+  it("still baselines the LOCAL route, under its RESOLVED filename", async () => {
+    // The capture moved for both routes (#1374 review, P1-2), so the local
+    // route's baseline is re-pinned here: it was previously covered by nothing,
+    // and a refactor that dropped it would have been invisible.
+    //
+    // The resolved name matters. No filename was requested, so the local route's
+    // baseline must use the one resolveDownloadTarget derived — asking about a
+    // name nobody will ever write is a baseline of the wrong entry.
+    hoisted.remote = false;
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    const started = await startDownloadJob(URL_, SUB, undefined);
+    (await nextDispatch(0)).resolve(`/M/${SUB}/model.safetensors`);
+    await started.settled;
+
+    expect(hoisted.probed).toEqual([{ sub: SUB, name: "model.safetensors" }]);
+    expect(hoisted.probedAtDispatch[0]).toBe(1); // before the transfer, not after
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The four P1s the pre-merge review returned NO-SHIP on. Each is driven through
+// the REAL startDownloadJob settle path, because every one of them is a defect
+// of WIRING — the helper was already correct in isolation.
+// ---------------------------------------------------------------------------
+
+describe("#1374 review P1-1 — an UNKNOWN baseline is not a negative baseline", () => {
+  it("does not credit a listing to a dispatch whose baseline was never taken", async () => {
+    // No filename was asked for, so there is no name to baseline: the Manager
+    // derives it from the URL and only reports it in the dispatch descriptor.
+    // The post-check still has a name (from that descriptor) and the server
+    // answers YES — which, before this, read as a landing. It is not one: the
+    // file may have been sitting there the whole time.
+    hoisted.baseline = false; // would be a clean negative IF anyone had asked
+    hoisted.after = true;
+
+    const started = await startDownloadJob(URL_, SUB, undefined);
+    (await nextDispatch(0)).resolve(DESCRIPTOR());
+    await started.settled;
+    const job = getDownloadJob(started.job.id)!;
+
+    // Nothing was baselined — no name to baseline.
+    expect(hoisted.probed).toHaveLength(0);
+    expect(job.live_visible).toBe("unknown");
+    expect(job.verify_note).toMatch(/never established/);
+  });
+
+  it("does not credit a listing when the baseline read FAILED", async () => {
+    // The other route to the same conflation: the name was known, the listing
+    // call threw. "Could not ask" is not "was not there".
+    hoisted.after = true;
+    const { liveListingHasEntry } = await import("../../services/model-resolver.js");
+    vi.mocked(liveListingHasEntry).mockRejectedValueOnce(new Error("connection reset"));
+
+    const job = await runManagerDownload();
+
+    expect(job.live_visible).toBe("unknown");
+    expect(job.verify_note).toMatch(/never established/);
+  });
+
+  it("does not credit a listing when the baseline read was UNANSWERABLE", async () => {
+    // liveListingHasEntry's own third state: it resolved, with `undefined`.
+    // Collapsing that into `false` is the same bug wearing a return value.
+    hoisted.baseline = undefined;
+    hoisted.after = true;
+
+    const job = await runManagerDownload();
+
+    expect(hoisted.probed).toHaveLength(1); // it WAS asked
+    expect(job.live_visible).toBe("unknown");
+    expect(job.verify_note).toMatch(/never established/);
+  });
+});
+
+describe("#1374 review P1-2 — the baseline is taken AFTER the same-destination wait", () => {
+  it("does not credit a queued dispatch with the file the job ahead of it landed", async () => {
+    // Two dispatches to the SAME (subfolder, name) from DIFFERENT urls: distinct
+    // request keys, so the second does not adopt the first, but one shared
+    // remoteSerializeKey — so the second waits for the first (#467 P1-C).
+    //
+    // Taken at construction time, the second job's baseline was read BEFORE the
+    // first job had written anything: "not there". It then sat in the queue while
+    // the first landed the file, and its own post-check found it — and credited a
+    // dispatch that may have been REJECTED outright with someone else's bytes.
+    // That is #1374's exact failure, manufactured by the serialization.
+    hoisted.baseline = false; // nothing there when the FIRST job starts
+    hoisted.after = true; // the first job's file is listed afterwards
+
+    const first = await startDownloadJob(URL_, SUB, NAME);
+    const second = await startDownloadJob(`${URL_}?mirror=2`, SUB, NAME);
+
+    // The second job must not have dispatched yet — it is queued behind the first.
+    expect(hoisted.dispatches).toHaveLength(1);
+
+    // The first lands, and the world changes: the server now lists the name.
+    hoisted.baseline = true;
+    (await nextDispatch(0)).resolve(DESCRIPTOR());
+    await first.settled;
+    expect(getDownloadJob(first.job.id)!.live_visible).toBe("visible");
+
+    // Only NOW does the second dispatch go out — and its baseline must have been
+    // read from the world as it is at that moment, not as it was at construction.
+    (await nextDispatch(1)).resolve(DESCRIPTOR());
+    await second.settled;
+
+    expect(getDownloadJob(second.job.id)!.live_visible).toBe("unknown");
+    expect(getDownloadJob(second.job.id)!.verify_note).toMatch(/BEFORE this dispatch/);
+  });
+});
+
+describe("#1374 review P1-4 — a not-listed Manager dispatch is not a FAILURE", () => {
+  it("reports the finding without flagging wrongPlace", async () => {
+    // `wrongPlace` means DEMONSTRABLY misplaced, and apply_manifest renders it as
+    // `failed`. Nothing here was demonstrated: a Manager dispatch returns on
+    // ACCEPTANCE and its queue can drain long before the transfer does (#1197),
+    // so "not listed yet" is equally a 13 GB fetch still in flight. A caller who
+    // believes a false failure re-runs and pays for the transfer twice.
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    const r = describePlacement(await runManagerDownload());
+
+    expect(r.wrongPlace).toBe(false);
+    // Not softened — merely typed correctly. The observation is still stated.
+    expect(r.confirmed).toBe(false);
+    expect(r.warning).toMatch(/does NOT list/);
+    // …with the hedge that makes it honest rather than alarming.
+    expect(r.warning).toMatch(/still be arriving/);
+  });
+
+  it("never flags wrongPlace on ANY Manager outcome", async () => {
+    // The route has no on-disk observation at all, so no outcome it can reach is
+    // a demonstrated misplacement. Enumerated rather than sampled: this is the
+    // property apply_manifest's `failed` branch depends on.
+    for (const [baseline, after] of [
+      [false, false],
+      [false, true],
+      [true, true],
+      [undefined, undefined],
+    ] as Array<[boolean | undefined, boolean | undefined]>) {
+      resetDownloadJobs();
+      hoisted.dispatches = [];
+      hoisted.probed = [];
+      hoisted.baseline = baseline;
+      hoisted.after = after;
+
+      const job = await runManagerDownload();
+      expect(describePlacement(job).wrongPlace, `baseline=${baseline} after=${after}`).toBe(false);
+      expect(describePlacement(job).confirmed, `baseline=${baseline} after=${after}`).toBe(false);
+    }
+  });
+});
+
+describe("#1374 review P1-3 — the verdict is on the RECORD before any reader sees done", () => {
+  it("marks the Manager route pending in the same step it publishes done", async () => {
+    // The tool used to re-probe the server itself because a Manager job could be
+    // `done` with no verification field at all — an unreadable state that looked
+    // identical to a pre-fix record. The field is now always populated, so the
+    // record is the single source of the verdict and the second round trip (which
+    // could not pass the baseline, and so DEFEATED it) is gone.
+    hoisted.baseline = false;
+    hoisted.after = false;
+    // HOLD the check open. Without this the window closes in the same microtask
+    // and the assertion below reads the FINAL verdict instead of the transient
+    // one — which is exactly how an earlier version of this test survived the
+    // mutation that reverts the fix.
+    let openTheGate!: () => void;
+    hoisted.visibilityGate = new Promise<void>((r) => {
+      openTheGate = r;
+    });
+
+    const started = await startDownloadJob(URL_, SUB, NAME);
+    (await nextDispatch(0)).resolve(DESCRIPTOR());
+
+    // The check has been ENTERED, so `done` is already published — and it is
+    // parked on the gate, so no verdict has been written yet. This is precisely
+    // the state a reader whose grace window expired here would see.
+    await vi.waitFor(() => {
+      if (hoisted.visibilityCalls < 1) throw new Error("check not entered yet");
+    });
+    const midFlight = getDownloadJob(started.job.id)!;
+    expect(midFlight.status).toBe("done");
+    // The defect: `done` with NO verification field at all, indistinguishable
+    // from a pre-fix record, which is what the tool re-probed to cover for.
+    expect(midFlight.live_visible).toBe("pending");
+    // Whatever a reader catches here, it is never a confirmed success.
+    expect(describePlacement(midFlight).confirmed).toBe(false);
+
+    openTheGate();
+    await started.settled;
+    expect(getDownloadJob(started.job.id)!.live_visible).toBe("not-visible");
+  });
+
+  it("asks the server exactly ONCE per dispatch", async () => {
+    // The removed hot-path call made this 2, on the one route where a round trip
+    // costs a remote request.
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    await runManagerDownload();
+
+    expect(hoisted.visibilityCalls).toBe(1);
   });
 });
 

--- a/src/__tests__/services/manager-dispatch-visibility.test.ts
+++ b/src/__tests__/services/manager-dispatch-visibility.test.ts
@@ -1,0 +1,253 @@
+// #1374 — A COMFYUI-MANAGER DISPATCH IS ASKED ABOUT, NOT ASSUMED.
+//
+// The recurrence that motivated this: a Linux install whose ComfyUI-Manager
+// REFUSED the fetch outright (security_level / network_mode=personal_cloud).
+// `download_model action:"status"` reported the 13.2 GB job `done`; the target
+// directory and a filesystem-wide search found no file.
+//
+// The mechanism is not a mystery and the code already said so in prose: a
+// Manager job settles when the Manager QUEUE DRAINS, and Manager increments its
+// done counter for a rejected item exactly as for a fetched one — the v2 status
+// endpoint carries aggregate counts only, with no per-item result. So the drain
+// is not evidence, and nothing ever looked for evidence that was.
+//
+// `verifyManagerVisibility` (#1086) is that evidence and already existed: it asks
+// the CONNECTED server whether it now lists the entry, which is answerable
+// remotely where `verifyLandedModel`'s on-disk stat is not. This pins that it now
+// runs on the Manager route, that its baseline is captured, and — just as
+// importantly — the two things it must NOT do.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  /** Resolves the mocked downloadModel, standing in for the Manager dispatch
+   *  returning once its queue drained. Never a real transfer. */
+  resolveDispatch: undefined as ((s: string) => void) | undefined,
+  /** What the server answers BEFORE the dispatch (the baseline), and what it
+   *  answers AFTER. They are separate on purpose: with one value, "the file
+   *  appeared" and "the file was always there" are the same fixture, and the
+   *  `listedBefore` guard this suite exists to pin becomes untestable. undefined
+   *  = could not be asked. */
+  baseline: undefined as boolean | undefined,
+  after: undefined as boolean | undefined,
+  /** Every (subfolder, filename) the listing probe was asked about, in order —
+   *  so a test can prove the BASELINE was taken before the dispatch. */
+  probed: [] as Array<{ sub: string; name: string }>,
+  visibilityCalls: 0,
+  landedCalls: 0,
+  remote: true,
+}));
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return { ...actual, isRemoteMode: () => hoisted.remote };
+});
+
+vi.mock("../../services/model-resolver.js", async () => {
+  // The REAL verifyManagerVisibility, driven by an injected probe. Using the real
+  // one is the point: a hand-written stub would let this suite pass while the
+  // shipped verdict logic (including its `listedBefore` guard) did something else.
+  const actual = await vi.importActual<typeof import("../../services/model-resolver.js")>(
+    "../../services/model-resolver.js",
+  );
+  return {
+    shouldDispatchDownloadToManager: vi.fn(async () => hoisted.remote),
+    downloadModel: vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          hoisted.resolveDispatch = resolve;
+        }),
+    ),
+    resolveDownloadTarget: vi.fn(async (_u: string, sub: string, filename?: string) => ({
+      targetDir: `/M/${sub}`,
+      filename: filename ?? "model.safetensors",
+      targetPath: `/M/${sub}/${filename ?? "model.safetensors"}`,
+    })),
+    liveListingHasEntry: vi.fn(async (sub: string, name: string) => {
+      hoisted.probed.push({ sub, name });
+      return hoisted.baseline;
+    }),
+    managerJobFilename: actual.managerJobFilename,
+    verifyManagerVisibility: vi.fn(
+      async (sub: string, name: string, opts?: Record<string, unknown>) => {
+        hoisted.visibilityCalls += 1;
+        return actual.verifyManagerVisibility(sub, name, {
+          ...opts,
+          attempts: 1,
+          retryMs: 0,
+          probe: async () => hoisted.after,
+        });
+      },
+    ),
+    verifyLandedModel: vi.fn(async (targetPath: string) => {
+      hoisted.landedCalls += 1;
+      return { verifiedPath: targetPath, liveVisible: "unknown" as const, note: "n/a" };
+    }),
+  };
+});
+
+import {
+  startDownloadJob,
+  getDownloadJob,
+  resetDownloadJobs,
+  describePlacement,
+  type DownloadJob,
+} from "../../services/download-jobs.js";
+
+
+const URL_ = "https://huggingface.co/org/repo/resolve/main/te.safetensors";
+const SUB = "text_encoders";
+const NAME = "te.safetensors";
+
+/** Run one Manager-routed download to completion and return the settled job. */
+async function runManagerDownload(): Promise<DownloadJob> {
+  const started = await startDownloadJob(URL_, SUB, NAME);
+  // The dispatch "returns" the descriptor string the Manager route produces.
+  hoisted.resolveDispatch?.(`${SUB}/${NAME} (dispatched via ComfyUI-Manager)`);
+  await started.settled;
+  const job = getDownloadJob(started.job.id);
+  if (!job) throw new Error("job vanished");
+  return job;
+}
+
+beforeEach(() => {
+  resetDownloadJobs();
+  hoisted.resolveDispatch = undefined;
+  hoisted.baseline = undefined;
+  hoisted.after = undefined;
+  hoisted.probed = [];
+  hoisted.visibilityCalls = 0;
+  hoisted.landedCalls = 0;
+  hoisted.remote = true;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("#1374 — a drained Manager queue is not evidence the file landed", () => {
+  it("records NOT-VISIBLE when the connected server does not list the file", async () => {
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    const job = await runManagerDownload();
+
+    expect(job.viaManager).toBe(true);
+    expect(job.live_visible).toBe("not-visible");
+    expect(job.verify_note).toMatch(/does NOT list/);
+
+    // And the RENDERER turns that into a positive finding, which is what
+    // `action:"status"` prints. Before this, every Manager outcome printed one
+    // static caveat and the reporter read `done`.
+    const r = describePlacement(job);
+    expect(r.confirmed).toBe(false);
+    expect(r.wrongPlace).toBe(true);
+    expect(r.warning).toMatch(/does NOT list/);
+    // Names the cause the reporter actually hit, so the next one does not have to
+    // discover it.
+    expect(r.warning).toMatch(/security_level/);
+  });
+
+  it("records VISIBLE when the server lists it — and still refuses to call it confirmed", async () => {
+    // Not there before, there after — the only shape that credits a landing to
+    // THIS dispatch.
+    hoisted.baseline = false;
+    hoisted.after = true;
+
+    const job = await runManagerDownload();
+
+    expect(job.live_visible).toBe("visible");
+    const r = describePlacement(job);
+    // A listing proves a file of that NAME exists somewhere the server reads.
+    // That is placement, never validity (#473).
+    expect(r.confirmed).toBe(false);
+    expect(r.warning).toMatch(/PLACEMENT, not validity/);
+  });
+
+  it("stays UNKNOWN, with the original caveat, when the server cannot be asked", async () => {
+    hoisted.baseline = undefined;
+    hoisted.after = undefined;
+
+    const job = await runManagerDownload();
+
+    expect(job.live_visible).toBe("unknown");
+    expect(describePlacement(job).warning).toMatch(/NOT verified as landed/);
+  });
+
+  it("takes the BASELINE before dispatching, so a pre-existing file cannot read as a landing", async () => {
+    // The trap `listedBefore` exists for on the local path (#369), and the Manager
+    // path had no baseline at all: a file of the same name that was already there
+    // would answer "visible" and be credited to a dispatch that fetched nothing.
+    hoisted.baseline = true;
+    hoisted.after = true;
+
+    const job = await runManagerDownload();
+
+    // The probe ran BEFORE the dispatch (that is the baseline) and again after.
+    expect(hoisted.probed[0]).toEqual({ sub: SUB, name: NAME });
+    // A pre-existing entry makes the post-check inconclusive, NOT successful.
+    expect(job.live_visible).toBe("unknown");
+    expect(job.verify_note).toMatch(/BEFORE this dispatch/);
+  });
+
+  it("NEVER demotes the job's status on a not-listed verdict", async () => {
+    // Deliberate limit, and the reason it is a limit: a Manager dispatch returns
+    // on ACCEPTANCE, so a large file is still arriving for minutes afterwards.
+    // "not there yet" and "landed where the server cannot read" are
+    // indistinguishable from here, and turning the first into an error would
+    // break every slow download. The REPORT carries the finding; the status does
+    // not pretend to a certainty nothing established.
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    const job = await runManagerDownload();
+
+    expect(job.status).toBe("done");
+  });
+
+  it("does not run the Manager check on a LOCAL download", async () => {
+    hoisted.remote = false;
+    hoisted.baseline = false;
+    hoisted.after = false;
+
+    const started = await startDownloadJob(URL_, SUB, NAME);
+    hoisted.resolveDispatch?.(`/M/${SUB}/${NAME}`);
+    await started.settled;
+
+    expect(hoisted.visibilityCalls).toBe(0);
+    // The local route's own verification still runs — this changed nothing there.
+    expect(hoisted.landedCalls).toBe(1);
+  });
+});
+
+describe("#1374 — verifyManagerVisibility's own contract, exercised directly", () => {
+  // Through `importActual`, NOT the module-level import. The mock above wraps
+  // this function and OVERRIDES its `probe`, so calling the mocked binding here
+  // would have measured the fixture instead of the function — the first version
+  // of these two tests did exactly that and reported "unknown" for a probe that
+  // said no. A harness that answers its own question is worse than no test.
+  const real = async () =>
+    (await vi.importActual<typeof import("../../services/model-resolver.js")>(
+      "../../services/model-resolver.js",
+    )).verifyManagerVisibility;
+
+  it("answers not-listed only after actually being told no", async () => {
+    const r = await (await real())(SUB, NAME, {
+      attempts: 1,
+      retryMs: 0,
+      probe: async () => false,
+    });
+    expect(r.visibility).toBe("not-listed");
+  });
+
+  it("answers unknown — never not-listed — when the probe cannot answer", async () => {
+    // The distinction the whole fix rests on: "the server says no" and "the
+    // server could not be asked" must never collapse into one verdict.
+    const r = await (await real())(SUB, NAME, {
+      attempts: 1,
+      retryMs: 0,
+      probe: async () => undefined,
+    });
+    expect(r.visibility).toBe("unknown");
+  });
+});

--- a/src/__tests__/services/manager-visibility.test.ts
+++ b/src/__tests__/services/manager-visibility.test.ts
@@ -32,6 +32,9 @@ describe("verifyManagerVisibility asks the live server", () => {
     const probe = vi.fn().mockResolvedValue(true);
 
     const r = await verifyManagerVisibility("clip_vision", "clip_vision_h.safetensors", {
+      // The baseline is EXPLICIT and negative — the only shape that lets a
+      // listing be credited to this dispatch (#1374 review, P1-1).
+      listedBefore: false,
       attempts: 1,
       probe,
     });
@@ -93,6 +96,7 @@ describe("verifyManagerVisibility asks the live server", () => {
     const probe = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     const r = await verifyManagerVisibility("loras", "x.safetensors", {
+      listedBefore: false,
       attempts: 3,
       retryMs: 0,
       probe,
@@ -135,6 +139,7 @@ describe("a visible verdict never implies the payload is a real model", () => {
     const probe = vi.fn().mockResolvedValue(true);
 
     const r = await verifyManagerVisibility("loras", "KNP_000003000.safetensors", {
+      listedBefore: false,
       attempts: 1,
       probe,
     });
@@ -151,10 +156,71 @@ describe("a visible verdict never implies the payload is a real model", () => {
   it("does not use the word CONFIRMED for a Manager dispatch", async () => {
     const probe = vi.fn().mockResolvedValue(true);
 
-    const r = await verifyManagerVisibility("loras", "x.safetensors", { attempts: 1, probe });
+    const r = await verifyManagerVisibility("loras", "x.safetensors", {
+      listedBefore: false,
+      attempts: 1,
+      probe,
+    });
 
     // The label is the whole defect: "CONFIRMED" reads as "this worked".
     expect(r.note).not.toMatch(/\bCONFIRMED\b/);
+  });
+});
+
+// #1374 review, P1-1 — THE BASELINE IS A TRI-STATE AND THE THIRD STATE IS THE ONE
+// THAT WAS LOST.
+//
+// The guard checked `listedBefore === true` only, so BOTH "we asked and it was
+// not there" and "we never found out" arrived as `undefined` and were treated as
+// a clean negative. A dispatch that fetched nothing could then be credited with a
+// file that had been sitting there all along — #369, on the one route that had no
+// guard against it. Only an EXPLICIT `false` may license a `visible` verdict.
+describe("an UNKNOWN baseline is not a negative baseline", () => {
+  it("downgrades a listing to UNKNOWN when the baseline could not be established", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const r = await verifyManagerVisibility("checkpoints", "sdxl.safetensors", {
+      listedBefore: "unknown",
+      attempts: 1,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("unknown");
+    expect(r.note).toMatch(/never established/);
+    // It must not borrow the confident wording of a real landing.
+    expect(r.note).not.toMatch(/so the dispatch landed/);
+  });
+
+  it("downgrades a listing to UNKNOWN when NO baseline was passed at all", async () => {
+    // Omission is the shape a caller reaches by accident, so it must fail the
+    // same safe way as an explicit "unknown" rather than silently permitting.
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const r = await verifyManagerVisibility("checkpoints", "sdxl.safetensors", {
+      attempts: 1,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("unknown");
+    expect(r.note).toMatch(/never established/);
+  });
+
+  it("still reports a NEGATIVE observation with an unknown baseline", async () => {
+    // Only the POSITIVE direction is withheld. "The server says no" is a real
+    // observation and does not need a baseline to be worth reporting — folding it
+    // into `unknown` would throw away the whole #1374 finding.
+    const probe = vi.fn().mockResolvedValue(false);
+
+    const r = await verifyManagerVisibility("checkpoints", "sdxl.safetensors", {
+      listedBefore: "unknown",
+      attempts: 1,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("not-listed");
   });
 });
 
@@ -175,5 +241,40 @@ describe("the tool's Manager branch never labels a listing as confirmation", () 
     // The regression, stated exactly: `CONFIRMED: ${managerSeen.note}`.
     expect(branch).not.toMatch(/`CONFIRMED[:\s]/);
     expect(branch).toMatch(/LISTED \(placement only, NOT validity\)/);
+  });
+
+  // #1374 review, P1-3 — and it does not ASK AGAIN, either.
+  //
+  // downloadAction used to call verifyManagerVisibility a second time and prefer
+  // that result. The baseline lives inside startDownloadJob and is unreachable
+  // from a tool, so that call could never pass one — which made it structurally
+  // incapable of telling a landing from a pre-existing file, and preferring it
+  // DEFEATED the baselined verdict the job had just recorded. It also spent a
+  // second Manager-only network round trip on an answered question.
+  //
+  // A behavioural test cannot see this (both calls return the same thing on a
+  // healthy server — the defect is which one is trusted, and what it cost), so
+  // the call site is read, the way the label above is.
+  it("does not re-probe the server from the tool's hot path", () => {
+    const src = readFileSync(
+      new URL("../../tools/model-management.ts", import.meta.url),
+      "utf-8",
+    );
+    // Bound the slice to downloadAction's own body: a match anywhere else in this
+    // 1000-line file would be a different call site with different stakes.
+    const start = src.indexOf("async function downloadAction(");
+    expect(start, "downloadAction must still exist").toBeGreaterThan(-1);
+    const rest = src.slice(start);
+    const end = rest.indexOf("\r\n}\r\n") >= 0 ? rest.indexOf("\r\n}\r\n") : rest.indexOf("\n}\n");
+    expect(end, "downloadAction's body must be delimitable").toBeGreaterThan(0);
+    const body = rest.slice(0, end);
+
+    // Sanity: the slice really does contain the Manager render, or the assertion
+    // below would pass by looking at the wrong text.
+    expect(body).toMatch(/LISTED \(placement only, NOT validity\)/);
+    // The defect, stated exactly: a CALL, not the word in a comment.
+    expect(body).not.toMatch(/verifyManagerVisibility\s*\(/);
+    // And the replacement is actually wired: the verdict comes off the record.
+    expect(body).toMatch(/job\.live_visible === "visible"/);
   });
 });

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -63,6 +63,19 @@ const isUnderLiveModelRootsMock = vi.hoisted(() =>
 const currentLiveRootMock = vi.hoisted(() =>
   vi.fn(async (): Promise<string | undefined> => "/fake/ComfyUI/models"),
 );
+/** #1374 — the ROUTING decision inside startDownloadJob, which is NOT the same
+ *  question as manifest's own local-vs-remote branch. A local install with a
+ *  filesystem can still have its download dispatched to ComfyUI-Manager (that is
+ *  the reporter's own Linux/Pinokio shape), and only then does a manifest item
+ *  render from a `viaManager` job. Default mirrors the mode gate. */
+const shouldDispatchToManagerMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<boolean> => mockConfig.remote ?? !mockConfig.comfyuiPath),
+);
+/** #1374 — the Manager route's post-dispatch listing check. Default: the server
+ *  cannot be asked, which is the inert answer. */
+const verifyManagerVisibilityMock = vi.hoisted(() =>
+  vi.fn(async () => ({ visibility: "unknown" as const, note: "not asked" })),
+);
 const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
 const listLocalModelsMock = vi.hoisted(() => vi.fn());
 const savedWorkspaceMock = vi.hoisted(() => vi.fn(() => undefined as string | undefined));
@@ -130,9 +143,17 @@ vi.mock("../../services/model-resolver.js", () => ({
   ],
   downloadModel: (...a: unknown[]) => downloadModelMock(...a),
   // startDownloadJob consults this to choose local-vs-Manager routing (#420).
-  // Mirror the same mode gate the config mock uses so manifest downloads key the
-  // same way they always did (local unless remote).
-  shouldDispatchDownloadToManager: async () => mockConfig.remote ?? !mockConfig.comfyuiPath,
+  // Overridable per-test (#1374): the routing decision is INDEPENDENT of whether
+  // manifest itself took its local branch, and the gap between them is where the
+  // reporter's job came from.
+  shouldDispatchDownloadToManager: (...a: unknown[]) => shouldDispatchToManagerMock(...(a as [])),
+  // The Manager route's post-dispatch check, and the name it asks about. Both are
+  // REQUIRED here: download-jobs.ts calls them on that route, and a module mock
+  // that omits them makes the call throw into its own catch — so the arm under
+  // test would "pass" while exercising nothing (#1374 review).
+  verifyManagerVisibility: (...a: unknown[]) => verifyManagerVisibilityMock(...(a as [])),
+  managerJobFilename: (job: { filename?: string; path?: string }) =>
+    job.filename ?? ((job.path ?? "").split(" (")[0].split("/").pop() ?? ""),
   // startDownloadJob resolves the destination via this before streaming; stub it
   // so a distinct targetPath is derived per (subfolder, filename) without a server.
   resolveDownloadTarget: async (url: string, sub: string, filename?: string) => {
@@ -243,6 +264,12 @@ beforeEach(() => {
     }),
   );
   modelsDirMock.mockReset().mockResolvedValue("/fake/ComfyUI/models");
+  shouldDispatchToManagerMock
+    .mockReset()
+    .mockImplementation(async () => mockConfig.remote ?? !mockConfig.comfyuiPath);
+  verifyManagerVisibilityMock
+    .mockReset()
+    .mockResolvedValue({ visibility: "unknown" as const, note: "not asked" });
 });
 
 describe("loadManifestFile", () => {
@@ -1694,6 +1721,82 @@ describe("applyManifest", () => {
       // than claiming an apply nobody confirmed.
       expect(byAction.model.status).toBe("pending");
       expect(byAction.model.message).toMatch(/NOT verified as landed/);
+    });
+  });
+
+  // #1374 review, P1-4 — A FALSE FAILURE IS WORSE THAN AN UNCONFIRMED SUCCESS.
+  //
+  // The reachable shape, and the reporter's own: a LOCAL install (manifest takes
+  // its local branch, so this goes through startDownloadJob) whose download is
+  // nevertheless routed to ComfyUI-Manager. The dispatch is accepted, and the
+  // connected server does not list the file yet.
+  //
+  // That is genuinely ambiguous — a Manager dispatch returns on ACCEPTANCE and
+  // its queue can drain hours before the transfer does (#1197), so "not listed"
+  // is equally a 13 GB fetch still in flight. Rendering it `failed` invents a
+  // failure, and a caller who believes it re-issues the download and pays for the
+  // transfer twice.
+  describe("a Manager-routed model that isn't listed yet (#1374 review P1-4)", () => {
+    beforeEach(() => {
+      // Local filesystem present — manifest takes its local branch...
+      mockConfig.comfyuiPath = COMFY;
+      mockConfig.remote = false;
+      // ...but the DOWNLOAD is routed to Manager anyway. That gap is #1374.
+      shouldDispatchToManagerMock.mockResolvedValue(true);
+      // And the server does not list it afterwards.
+      verifyManagerVisibilityMock.mockResolvedValue({
+        visibility: "not-listed" as const,
+        note: "The connected ComfyUI does NOT list checkpoints/model.safetensors. That is not proof of failure — a large file may still be arriving.",
+      });
+    });
+
+    const applyOne = () =>
+      applyManifest({
+        manifest: {
+          models: [
+            {
+              url: "https://example.com/model.safetensors",
+              model_type: "checkpoints",
+              filename: "model.safetensors",
+            },
+          ],
+        },
+      });
+
+    it("reports PENDING, never FAILED", async () => {
+      const result = await applyManifest({
+        manifest: {
+          models: [
+            {
+              url: "https://example.com/model.safetensors",
+              model_type: "checkpoints",
+              filename: "model.safetensors",
+            },
+          ],
+        },
+      });
+
+      // The check really ran — otherwise "pending" below would be the untouched
+      // default and this test would pass while measuring nothing.
+      expect(verifyManagerVisibilityMock).toHaveBeenCalled();
+      expect(result.results[0]?.status).toBe("pending");
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+    });
+
+    it("still states the finding in the message", async () => {
+      // Not softened into silence: the whole point of #1374 is that the report
+      // now carries an observation instead of a caveat true of every outcome.
+      const result = await applyOne();
+
+      expect(result.results[0]?.message).toMatch(/does NOT list/);
+      expect(result.results[0]?.message).toMatch(/security_level/);
+    });
+
+    it("does not claim success either", async () => {
+      const result = await applyOne();
+
+      expect(result.results[0]?.status).not.toBe("applied");
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -26,6 +26,7 @@ import {
   verifyLandedModel,
   verifyManagerVisibility,
 } from "./model-resolver.js";
+import type { ListedBeforeBaseline } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
 import type { ResumeDiagnostic } from "./download-resume-diag.js";
 import { ModelError } from "../utils/errors.js";
@@ -265,6 +266,32 @@ function remoteSerializeKey(url: string, targetSubfolder: string, filename?: str
 }
 
 /**
+ * Read the pre-download listing baseline as a TRI-STATE (#1374 review, P1-1).
+ *
+ * Three distinct things used to arrive as `undefined` and be treated alike:
+ * the caller named no file, the listing call threw, and the server answered
+ * "cannot say". None of them is "the server did not list it before", and reading
+ * them as that is what lets a pre-existing file be credited to a dispatch that
+ * fetched nothing. Only a real, answered `false` is a negative baseline.
+ *
+ * Never throws — a baseline is a nicety and must not fail a download.
+ */
+async function captureListingBaseline(
+  targetSubfolder: string,
+  name: string | undefined,
+): Promise<ListedBeforeBaseline> {
+  if (!name) return "unknown";
+  try {
+    const has = await liveListingHasEntry(targetSubfolder, name);
+    // liveListingHasEntry ITSELF returns undefined for "could not be asked", and
+    // that is the state this whole helper exists to keep distinct.
+    return has === undefined ? "unknown" : has;
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * Point `key` at `entry`, ENTRY-SCOPED (#420 codex round 3, rule 2/3): never clobber
  * a row currently owned by a DIFFERENT, still-in-flight writer — that would orphan a
  * live download's index. Records the key on the entry so it can be retired later.
@@ -407,37 +434,33 @@ export async function startDownloadJob(
   // too (the local callback race is inherently local, but this keeps the server
   // write single-writer and the last-started result deterministic).
   let serializeKey: string;
-  /** Did the live server ALREADY list this exact entry before we started? Captured
-   *  HERE, before any bytes are written, so the post-landing check can tell "the
-   *  server sees it BECAUSE we wrote it" from "it already knew that name" (#369). */
-  let listedBefore: boolean | undefined;
+  /** Did the live server ALREADY list this exact entry before we started? Filled in
+   *  by `captureListingBaseline` inside `settled` — NOT here. See #1374 review P1-2
+   *  at the capture site for why the position matters. */
+  let listedBefore: ListedBeforeBaseline = "unknown";
+  /** The entry the baseline is about: the RESOLVED local filename on the local
+   *  route, the requested name on the Manager route. `undefined` on the Manager
+   *  route when the caller named no file — the Manager decides the name from the
+   *  URL and only reports it in the dispatch descriptor, so guessing one here
+   *  would baseline the WRONG entry, which is worse than having no baseline. */
+  let baselineName: string | undefined;
   if (!dispatchToManager) {
     const target = await resolveDownloadTarget(url, targetSubfolder, filename);
-    try {
-      listedBefore = await liveListingHasEntry(targetSubfolder, target.filename);
-    } catch {
-      listedBefore = undefined; // unknowable → the check stays conservative
-    }
+    baselineName = target.filename;
     // Fold auth into the destination key too (#467 P1-A): two concurrent calls to
     // the SAME on-disk destination with DIFFERENT auth are DIFFERENT downloads
     // (different representations) and must NOT dedup to one writer/one job.
     destKey = downloadJobIdFor(`${target.targetPath}\n${authIdentity(auth)}`);
     serializeKey = await localSerializeKey(target.targetPath);
   } else {
-    // #1374 — CAPTURE IT FOR THE MANAGER ROUTE TOO. The post-dispatch check below
-    // asks the connected server whether it now lists the file; without this
-    // baseline, a pre-existing file of the same name reads as a successful
-    // landing, which is the exact trap `listedBefore` was added for on the local
-    // path (#369). The Manager route resolves no local target, so the name asked
-    // for is the name to ask about — that is also what `managerJobFilename` will
-    // report, so the baseline and the check are about the same entry.
-    if (filename) {
-      try {
-        listedBefore = await liveListingHasEntry(targetSubfolder, filename);
-      } catch {
-        listedBefore = undefined; // unknowable → the check stays conservative
-      }
-    }
+    // #1374 — BASELINE THE MANAGER ROUTE TOO. The post-dispatch check below asks
+    // the connected server whether it now lists the file; without a baseline, a
+    // pre-existing file of the same name reads as a successful landing, which is
+    // the exact trap `listedBefore` was added for on the local path (#369). The
+    // Manager route resolves no local target, so the name asked for is the name
+    // to ask about — that is also what `managerJobFilename` will report, so the
+    // baseline and the check are about the same entry.
+    baselineName = filename;
     serializeKey = remoteSerializeKey(url, targetSubfolder, filename);
   }
   // The PUBLIC id (download_model action:"status" handle): the destination key when we have one
@@ -598,12 +621,18 @@ export async function startDownloadJob(
     job.path = landedPath;
     job.status = "done";
     job.finished_at = Date.now();
-    // A LOCAL landing is not yet a verified placement. Mark it PENDING in the SAME
+    // A landing is not yet a verified placement. Mark it PENDING in the SAME
     // synchronous step that publishes "done" (and in the same persisted record), so
     // no reader — this session's tool call inside its grace window, or another
-    // session reading the record — can ever see a completed local download with no
+    // session reading the record — can ever see a completed download with no
     // verification field and render it as confirmed success (#369, codex gate).
-    if (!dispatchToManager) job.live_visible = "pending";
+    //
+    // #1374 review, P1-3 — THE MANAGER ROUTE GETS THIS TOO. Its check runs a beat
+    // after this commit, so `done` with no field was a real, reachable window; a
+    // reader landing in it could not tell "not checked yet" from "pre-fix record"
+    // and the tool re-probed the server by hand to cover for it. With the field
+    // always populated, the record is the single source of the verdict.
+    job.live_visible = "pending";
     // #1545 — this return value was DISCARDED, and it is the one that says
     // whether any OTHER process can see the job finish. `persistDownloadJob`
     // returns false when the atomic replace loses to a reader holding the record
@@ -632,6 +661,20 @@ export async function startDownloadJob(
     // Wait for the prior same-destination job to fully finish (never fail THIS job
     // because that one errored — swallow its result).
     if (priorSameDest) await priorSameDest.catch(() => undefined);
+    // #1374 review, P1-2 — THE BASELINE IS TAKEN HERE, NOT BEFORE THE WAIT.
+    //
+    // It used to be read at job-construction time, which is BEFORE this job takes
+    // its turn in the same-destination chain (#467 P1-C). A second dispatch to the
+    // same (subfolder, name) therefore baselined a directory the FIRST job had not
+    // written to yet, sat in the queue while that job landed the file, and then
+    // read its own post-check as "it appeared → this dispatch landed it" — the
+    // #369 misattribution, manufactured by the serialization it was queued behind.
+    // Rejected second dispatches are exactly the case #1374 is about, so this
+    // window was the bug's own shape.
+    //
+    // Taken immediately before `downloadModel`, with nothing but this job's own
+    // transfer between the two observations.
+    listedBefore = await captureListingBaseline(targetSubfolder, baselineName);
     try {
       // A cancel that arrived before (or while waiting for) our turn makes downloadModel
       // throw at its up-front abort guard → the catch records the cancellation. So there
@@ -675,7 +718,14 @@ export async function startDownloadJob(
       // and the catch below keeps `done`.
       if (!dispatchToManager && (job.status as DownloadJob["status"]) === "done") {
         try {
-          const verdict = await verifyLandedModel(path, targetSubfolder, { listedBefore });
+          const verdict = await verifyLandedModel(path, targetSubfolder, {
+            // verifyLandedModel's own `visible` verdict is gated on the
+            // DESTINATION being one the running server named, not on this
+            // baseline — it uses it only to word an already-inconclusive answer,
+            // and already words `undefined` as "could not be checked". So the
+            // tri-state's third state maps onto the `undefined` it expects.
+            listedBefore: listedBefore === "unknown" ? undefined : listedBefore,
+          });
           if (verdict.verifiedPath) job.path = verdict.verifiedPath;
           job.verified_root = verdict.verifiedAgainstRoot;
           // No verifiedPath means the on-disk stat did NOT succeed — the file was
@@ -1081,9 +1131,25 @@ export function describePlacement(
     if (job.live_visible === "not-visible") {
       return {
         confirmed: false,
-        // The one Manager outcome that IS a positive finding, so it is flagged
-        // the same way the local route flags it rather than buried in prose.
-        wrongPlace: true,
+        // #1374 review, P1-4 — NOT `wrongPlace`, AND THE DIFFERENCE IS NOT
+        // COSMETIC.
+        //
+        // `wrongPlace` means DEMONSTRABLY misplaced, and its consumers act on it:
+        // apply_manifest renders it as `failed`. On the LOCAL route that is
+        // earned — the file was stat'd on disk, so "present but unlisted" is a
+        // real contradiction. Here nothing was stat'd at all. A Manager dispatch
+        // returns on ACCEPTANCE (and #1197: its queue can drain hours before the
+        // transfer does), so "not listed yet" is equally a 13 GB fetch still in
+        // flight or a stale listing. Calling that `failed` invents a failure, and
+        // a caller who believes it re-issues the download and pays for the
+        // transfer twice — the standing rule here is that a false failure costs
+        // more than an unconfirmed success.
+        //
+        // The finding is not softened, only correctly typed: the warning below
+        // states it in full, and `confirmed` stays false, so the item settles as
+        // PENDING — "the placement has not been established" — which is exactly
+        // what was observed.
+        wrongPlace: false,
         pathLabel: "requested destination",
         pathQualifier: "",
         warning:

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -20,9 +20,11 @@ import { extname, basename, dirname, join } from "node:path";
 import {
   downloadModel,
   liveListingHasEntry,
+  managerJobFilename,
   resolveDownloadTarget,
   shouldDispatchDownloadToManager,
   verifyLandedModel,
+  verifyManagerVisibility,
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
 import type { ResumeDiagnostic } from "./download-resume-diag.js";
@@ -422,6 +424,20 @@ export async function startDownloadJob(
     destKey = downloadJobIdFor(`${target.targetPath}\n${authIdentity(auth)}`);
     serializeKey = await localSerializeKey(target.targetPath);
   } else {
+    // #1374 — CAPTURE IT FOR THE MANAGER ROUTE TOO. The post-dispatch check below
+    // asks the connected server whether it now lists the file; without this
+    // baseline, a pre-existing file of the same name reads as a successful
+    // landing, which is the exact trap `listedBefore` was added for on the local
+    // path (#369). The Manager route resolves no local target, so the name asked
+    // for is the name to ask about — that is also what `managerJobFilename` will
+    // report, so the baseline and the check are about the same entry.
+    if (filename) {
+      try {
+        listedBefore = await liveListingHasEntry(targetSubfolder, filename);
+      } catch {
+        listedBefore = undefined; // unknowable → the check stays conservative
+      }
+    }
     serializeKey = remoteSerializeKey(url, targetSubfolder, filename);
   }
   // The PUBLIC id (download_model action:"status" handle): the destination key when we have one
@@ -674,6 +690,57 @@ export async function startDownloadJob(
           // post-download hook — swallowing this must not skip onComplete. The
           // on-disk check did not complete either, so nothing may claim it did.
           job.disk_verified = false;
+          job.live_visible = "unknown";
+          job.verify_note = `Placement could not be verified: ${err instanceof Error ? err.message : String(err)}`;
+        }
+        persistJobRecord(job);
+      }
+      // #1374 — ASK, DON'T ASSUME, ON THE MANAGER ROUTE EITHER.
+      //
+      // A Manager-dispatched download settles "done" when the Manager QUEUE
+      // DRAINS, and Manager increments its done counter for a REJECTED item
+      // exactly as for a fetched one — the v2 status endpoint carries only
+      // aggregate counts, with no per-item result. So a reporter whose Manager
+      // refused the fetch outright (security_level / network_mode=personal_cloud)
+      // got a job that said `done` for a 13.2 GB file that a filesystem-wide
+      // search could not find. Everything downstream was honest about this in
+      // PROSE and nothing ever looked.
+      //
+      // `verifyManagerVisibility` (#1086) is the look, and it already exists: it
+      // asks the CONNECTED server whether it now lists the entry, which is
+      // answerable remotely where `verifyLandedModel`'s on-disk stat is not. This
+      // runs the same shape as the local branch above, in the same place, so a
+      // download that settles inside download_model's grace window is already
+      // checked when the tool answers — and `action:"status"` reads the verdict
+      // off the record rather than reprinting a static caveat.
+      //
+      // WHAT THIS MUST NOT BECOME. "not-listed" is NOT failure and the verdict is
+      // deliberately not allowed to demote `status`: a Manager dispatch returns on
+      // ACCEPTANCE, so a large file is still arriving for minutes afterwards, and
+      // "not there yet" is indistinguishable from "landed where the server cannot
+      // read" from here. What changes is that the report now carries an OBSERVED
+      // answer where one is obtainable, instead of a caveat that was true of every
+      // outcome and therefore distinguished none of them.
+      if (dispatchToManager && (job.status as DownloadJob["status"]) === "done") {
+        try {
+          const verdict = await verifyManagerVisibility(
+            targetSubfolder,
+            managerJobFilename(job),
+            { listedBefore },
+          );
+          // Mapped onto the SAME three-valued field the local path writes, so
+          // every renderer keeps one vocabulary. "not-listed" is the Manager
+          // route's spelling of "the connected server does not list this".
+          job.live_visible =
+            verdict.visibility === "visible"
+              ? "visible"
+              : verdict.visibility === "not-listed"
+                ? "not-visible"
+                : "unknown";
+          job.verify_note = verdict.note;
+        } catch (err) {
+          // verifyManagerVisibility documents that it never throws; this is the
+          // belt for that brace, and it fails to UNKNOWN — never to a verdict.
           job.live_visible = "unknown";
           job.verify_note = `Placement could not be verified: ${err instanceof Error ? err.message : String(err)}`;
         }
@@ -998,6 +1065,46 @@ export function describePlacement(
     };
   }
   if (job.viaManager) {
+    // #1374 — REPORT WHAT WAS OBSERVED, when anything was.
+    //
+    // This arm used to return one static sentence for every Manager outcome. It
+    // was true — the queue reports 'done' on a drain, not on a landing — and
+    // precisely because it was true of every outcome it distinguished none of
+    // them. A reporter whose Manager REFUSED the fetch on security_level read
+    // `done` and went looking for a 13.2 GB file that was never fetched.
+    //
+    // `verifyManagerVisibility` now runs on this route (see startDownloadJob), so
+    // there is usually a real answer to print. `confirmed` stays FALSE in every
+    // arm: a listing proves a file of that NAME exists somewhere the server
+    // reads, which is placement and not validity (#473 — a login page saved as a
+    // .safetensors lists perfectly happily).
+    if (job.live_visible === "not-visible") {
+      return {
+        confirmed: false,
+        // The one Manager outcome that IS a positive finding, so it is flagged
+        // the same way the local route flags it rather than buried in prose.
+        wrongPlace: true,
+        pathLabel: "requested destination",
+        pathQualifier: "",
+        warning:
+          `the dispatch was ACCEPTED and the connected ComfyUI does NOT list this file — ` +
+          `${job.verify_note ?? "the running server does not list this entry."} ` +
+          `ComfyUI-Manager reports its queue task 'done' even when it refused the fetch ` +
+          `outright (a security_level / network_mode rejection is the common cause), so a ` +
+          `'done' here is not evidence the file exists.`,
+      };
+    }
+    if (job.live_visible === "visible") {
+      return {
+        confirmed: false,
+        wrongPlace: false,
+        pathLabel: "requested destination",
+        pathQualifier: " (the connected ComfyUI lists it)",
+        warning:
+          `the connected ComfyUI lists this file, so the dispatch landed somewhere it reads — ` +
+          `but that is PLACEMENT, not validity. ${job.verify_note ?? ""}`.trim(),
+      };
+    }
     return {
       confirmed: false,
       wrongPlace: false,
@@ -1005,8 +1112,9 @@ export function describePlacement(
       pathQualifier: "",
       warning:
         "the dispatch was ACCEPTED, NOT verified as landed — ComfyUI-Manager reports its queue " +
-        "task 'done' even on failure, so this does not guarantee the file is present. Confirm " +
-        "with list_local_models before relying on it.",
+        "task 'done' even on failure, so this does not guarantee the file is present. " +
+        (job.verify_note ? `${job.verify_note} ` : "") +
+        "Confirm with list_local_models before relying on it.",
     };
   }
   switch (job.live_visible) {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1406,6 +1406,21 @@ const LIVE_VISIBILITY_RETRY_MS = 1000;
 export type ManagerVisibility = "visible" | "not-listed" | "unknown";
 
 /**
+ * What the caller established about whether the connected server ALREADY listed
+ * this entry before the dispatch started. THREE states, and the third is
+ * load-bearing (#1374 review, P1-1).
+ *
+ * `false` is the only one that licenses crediting a later listing to THIS
+ * dispatch. `true` means a same-named file was already there. `"unknown"` means
+ * the baseline was never established — the name was not known up front, or the
+ * pre-dispatch listing could not be read — and that is NOT the same fact as
+ * "was not listed before". Spelling both as `undefined` is what let a
+ * PRE-EXISTING file answer "visible" for a dispatch that fetched nothing, which
+ * is the #369 trap wearing a Manager's clothes.
+ */
+export type ListedBeforeBaseline = boolean | "unknown";
+
+/**
  * Ask the CONNECTED server whether it now lists a model a Manager dispatch was
  * supposed to fetch (#1086).
  *
@@ -1435,7 +1450,11 @@ export async function verifyManagerVisibility(
   opts?: {
     attempts?: number;
     retryMs?: number;
-    listedBefore?: boolean;
+    /** Tri-state — see ListedBeforeBaseline. OMITTING it is NOT "it was not
+     *  there before": an absent baseline is an unknown one, and is treated
+     *  exactly like `"unknown"`. Only an explicit `false` licenses a `visible`
+     *  verdict. */
+    listedBefore?: ListedBeforeBaseline;
     /** The listing probe, injectable so this is testable without a live server.
      *  Defaults to liveListingHasEntry — which a test CANNOT intercept by mocking
      *  the module, because the call below resolves a module-local binding rather
@@ -1458,6 +1477,20 @@ export async function verifyManagerVisibility(
         `still be the older file. Compare the file size or hash on the server if that matters.`,
     };
   }
+  // #1374 review, P1-1 — AN UNKNOWN BASELINE IS NOT A NEGATIVE ONE.
+  //
+  // `listedBefore === false` is the ONLY answer that lets a listing seen now be
+  // credited to this dispatch. Anything else — an explicit `"unknown"`, or an
+  // omitted option — means nobody established what the server listed beforehand,
+  // so a hit here is equally consistent with a file that was always there. The
+  // previous shape checked only `=== true`, which folded "we could not find out"
+  // into "it was not there" and re-opened the #369 trap on the one route that
+  // had never had a guard against it.
+  //
+  // This is NOT short-circuited like the `true` case: a NEGATIVE answer is still
+  // worth reporting (and is the #1374 finding), and an unaskable server is still
+  // `unknown`. Only the POSITIVE direction is withheld.
+  const baselineIsNegative = opts?.listedBefore === false;
   const attempts = Math.max(1, opts?.attempts ?? LIVE_VISIBILITY_ATTEMPTS);
   const retryMs = opts?.retryMs ?? LIVE_VISIBILITY_RETRY_MS;
   let asked = false;
@@ -1467,6 +1500,16 @@ export async function verifyManagerVisibility(
       has = await probe(targetSubfolder, filename);
     } catch {
       has = undefined; // never throws outward — see the docblock
+    }
+    if (has === true && !baselineIsNegative) {
+      return {
+        visibility: "unknown",
+        note:
+          `The connected ComfyUI lists "${filename}" in ${targetSubfolder} now, but whether it ` +
+          `ALREADY listed that name before this dispatch was never established, so the listing ` +
+          `cannot be attributed to this download — it may be a pre-existing file of the same ` +
+          `name. Compare the file size or hash on the server if that matters.`,
+      };
     }
     if (has === true) {
       return {

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -10,7 +10,6 @@ import {
   describeManagerDestination,
   managerJobFilename,
   currentLiveModelsRoot,
-  verifyManagerVisibility,
   MODEL_SUBDIRS,
 } from "../services/model-resolver.js";
 import type { ModelListingCoverage } from "../services/model-resolver.js";
@@ -812,24 +811,25 @@ async function downloadAction(args: {
           // branch could only ever say "confirm with list_local_models yourself",
           // and a reporter who did not lost a multi-GB model to an ephemeral
           // overlay. The listing question IS answerable remotely, so answer it.
-          // "not-listed" is deliberately not rendered as failure: the dispatch
-          // returns on ACCEPTANCE, so a large file may still be arriving.
-          // unknown-ok: undefined is the COULD-NOT-VERIFY state, and it is kept
-          // distinct from both "visible" and "not-listed" below — the render
-          // appends the note only when one exists, and never upgrades a missing
-          // verification into a confirmation. (verifyManagerVisibility documents
-          // that it never throws, so this catch is belt-and-braces.)
-          const managerSeen = job.viaManager
-            ? await verifyManagerVisibility(
-                job.target_subfolder,
-                // #1086 (codex review) — was `job.filename ?? path.split(…).pop()`.
-                // For a Manager dispatch `job.path` is a DESCRIPTOR, not a path, so
-                // that returned the whole trailing note and made every URL-only
-                // download unverifiable. Pre-existing; exposed by the review.
-                managerJobFilename(job),
-                { attempts: 1 },
-              ).catch(() => undefined)
-            : undefined;
+          //
+          // #1374 review, P1-3 — THE ANSWER IS READ OFF THE RECORD, NOT RE-ASKED.
+          //
+          // This used to call verifyManagerVisibility a SECOND time, right here,
+          // and prefer its result. Two things were wrong with that. It could not
+          // pass `listedBefore` — the pre-dispatch baseline lives inside
+          // startDownloadJob and is unreachable from a tool — so this call was
+          // structurally incapable of telling "the dispatch landed it" from "a
+          // file of that name was already there", and preferring it DEFEATED the
+          // baselined verdict the job had just recorded. And it spent a second
+          // Manager-only network round trip re-asking a question already answered
+          // on the record.
+          //
+          // `startDownloadJob` now writes the verdict onto the job (and marks it
+          // "pending" in the same synchronous step it publishes "done"), so
+          // describePlacement below reads one baselined answer. When the grace
+          // window expires before the check concludes, that reads "pending" and
+          // renders as the honest unverified caveat — which is the truth at that
+          // instant, and re-probing here could not have made it otherwise.
           // #1086 — the destination is unknowable only until we LOOK.
           //
           // The standing caveat says we cannot know where a Manager dispatch
@@ -868,10 +868,9 @@ async function downloadAction(args: {
               // The word stays out of the Manager branch entirely. LISTED is the
               // observation; validity is not established here and must not be
               // implied by the label.
-              (managerSeen?.visibility === "visible"
-                ? `LISTED (placement only, NOT validity): ${managerSeen.note}`
-                : `NOTE: ${placement.warning}` +
-                  (managerSeen ? `\n\n${managerSeen.note}` : "")) +
+              (job.live_visible === "visible"
+                ? `LISTED (placement only, NOT validity): ${placement.warning}`
+                : `NOTE: ${placement.warning}`) +
               // Appended to BOTH Manager arms: a listed file whose destination is
               // outside the live root is exactly the #1086 shape, so the "LISTED"
               // arm needs this every bit as much as the unverified one.


### PR DESCRIPTION
Draft for the newest recurrence in artokun/comfyui-mcp issue 1374 (Linux, Pinokio, comfyui-mcp 0.51.48): ComfyUI-Manager explicitly rejected a 13.2 GB fetch on `security_level` / `network_mode=personal_cloud`, and `download_model action:"status"` nevertheless reported the job `done` — with no file anywhere on the filesystem.

## The mechanism was already known, and only ever written down as prose

A Manager job settles when the Manager **queue drains**, and Manager increments its done counter for a *rejected* item exactly as for a fetched one. The v2 status endpoint carries aggregate counts with no per-item result, so the drain never was evidence. Every renderer said so honestly. Nothing ever went and looked for evidence that *was*.

`verifyManagerVisibility` (artokun/comfyui-mcp issue 1086) is that look, and it already existed — it asks the connected server whether it now lists the entry, which is answerable remotely where `verifyLandedModel`'s on-disk stat is not. It ran in exactly one place: `downloadAction`, and only when the job happened to settle inside the grace window. `action:"status"` never called it.

## What changed

1. **The Manager route verifies.** `verifyManagerVisibility` now runs in `startDownloadJob`, in the same position and the same shape as the local route's verification, so the verdict lands on the **record**. `action:"status"` reads it instead of reprinting a static caveat.
2. **The baseline goes with it.** `listedBefore` was captured only on the local branch. Without it, a file of the same name that was already present answers "visible" and is credited to a dispatch that fetched nothing.
3. **The renderer distinguishes the three outcomes.** The old Manager arm returned one sentence for every result: true of all of them, and therefore distinguishing none — which is exactly what let a rejected dispatch read as a completed one.

## Review round 1 — four P1s, all reproduced, all fixed

A pre-merge review returned NO-SHIP. Each finding was checked against the code before being acted on; all four held. Every one is a defect of **wiring**, which is why the helper's own tests stayed green throughout.

### P1-1 — an unknown baseline was read as a negative one

**Reproduced.** `verifyManagerVisibility` special-cased `listedBefore === true` only. An omitted filename and a failed baseline read both left the value `undefined`, and `undefined` fell through to the same branch as an answered `false` — so "we never found out" was spelled exactly like "it was not there before". A later visible listing then credited a **pre-existing** file to this dispatch.

**Fixed.** The baseline is an explicit tri-state (`ListedBeforeBaseline = boolean | "unknown"`), captured through `captureListingBaseline`, which keeps all three of the collapsing cases distinct — no name to ask about, the call threw, and `liveListingHasEntry`'s own `undefined` "could not be asked". Only a real, answered `false` licenses a `visible` verdict. **Omitting the option is treated as unknown**, so a future caller cannot reach the permissive path by accident.

The **negative** direction is deliberately untouched: "the server says no" is a real observation and does not need a baseline to be worth reporting. Folding it into `unknown` would have thrown away the whole finding, so only the positive direction is withheld.

### P1-2 — the baseline predated the serialization wait

**Reproduced.** The capture ran at job-construction time, which is before the job takes its turn in the same-destination chain. Two dispatches to the same `(subfolder, name)` from different URLs share one `remoteSerializeKey` but have distinct request keys, so the second does not adopt the first — it queues behind it. Its baseline was read before the first job had written anything, it waited while that job landed the file, and its own post-check then found the file and credited it. A **rejected** second dispatch is exactly the case this issue is about, so the window was the bug's own shape.

**Fixed.** The capture moved inside `settled`, after `await priorSameDest`, with nothing but this job's own transfer between the two observations. This applies to the local route too, which had the same staleness.

### P1-3 — the hot path re-probed without the baseline and preferred its answer

**Reproduced.** `downloadAction` called `verifyManagerVisibility` a second time with `{ attempts: 1 }` and no `listedBefore`, then rendered from that result rather than the record. The baseline lives inside `startDownloadJob` and is unreachable from a tool, so this call was **structurally incapable** of telling a landing from a pre-existing file — and preferring it defeated the baselined verdict the job had just recorded. It also spent a second Manager-only network round trip re-asking an answered question.

**Fixed.** The call is gone and the verdict is read off the record. That exposed why it was there: a Manager job could be `done` with **no** verification field at all, in the beat between `commitDone` and the check completing — indistinguishable from a pre-fix record. `commitDone` now marks the Manager route `"pending"` in the same synchronous step it publishes `done`, exactly as the local route already did, so the record is the single source of the verdict and a reader whose grace window expires in that window gets the honest unverified caveat.

### P1-4 — `not-listed` produced a FALSE FAILURE

**Reproduced, and reachable.** `not-listed` set `wrongPlace: true`, and `apply_manifest` renders `wrongPlace` as `failed`. The route is reachable from a manifest whenever a **local** install has its download dispatched to Manager — the reporter's own Linux/Pinokio shape — because manifest's local-vs-remote branch and `shouldDispatchDownloadToManager` are separate decisions.

Nothing was demonstrated by that verdict. On the local route `wrongPlace` is earned: the file was stat'd on disk, so "present but unlisted" is a real contradiction. Here nothing was stat'd at all. A Manager dispatch returns on **acceptance**, and its queue can drain long before the transfer does (see artokun/comfyui-mcp issue 1197, where commit-done fires on drain up to four hours early), so "not listed yet" is equally a 13 GB fetch still in flight or a stale listing.

**Fixed.** The Manager arm no longer sets `wrongPlace`. The finding is not softened, only correctly typed — the warning states it in full, `confirmed` stays `false`, and the item settles as **pending**: "the placement has not been established", which is exactly what was observed. `apply_manifest` was the only behavioural consumer; the `action:"status"` renderer never consulted `wrongPlace` on the Manager arm, so no signal is lost there.

This is what makes the claim below true rather than aspirational: **a false failure costs more than an unconfirmed success**, because a caller who believes it re-issues the download and pays for the transfer twice.

## Two things it deliberately does not do

- **It does not demote `status`, anywhere.** Not the job status, and — since P1-4 — not a manifest item's status either. A Manager dispatch returns on acceptance, so a large file is still arriving for minutes afterwards. "Not there yet" and "landed where the server cannot read" are indistinguishable from here.
- **It does not call a listing a success.** `confirmed` stays `false` in every Manager arm. A listing proves a file of that *name* exists somewhere the server reads — placement, not validity (a login page saved as a `.safetensors` lists perfectly happily).

## Verified

- **Full suite: 514 files / 9565 tests green.** `npm run lint` and `npm run build` clean.
- Tests are driven through the real `startDownloadJob` settle path with the **real** `verifyManagerVisibility` behind an injected probe — a hand-written stub would have let the suite pass while the shipped verdict logic did something else.
- The P1-4 fix is pinned **end to end**, not just at the unit boundary: an `apply_manifest` test drives a local-filesystem manifest whose download is routed to Manager and asserts `pending`, never `failed`. It also asserts the visibility check actually ran, so it cannot pass by measuring the untouched default.
- No test can start a real download: `downloadModel` is mocked throughout.

### Mutation testing — 9 mutations, all confirmed applied, all killed

Each mutation was verified to have applied by count before the run (the tree is CRLF; a multi-line pattern that silently fails to apply would read as a passing gate).

| # | Mutation | Result |
|---|---|---|
| 1 | Revert the tri-state guard to `!== true` | killed (5 tests) |
| 2 | Collapse an unanswerable baseline read to `false` | killed |
| 3 | Move the baseline capture back before the serialization wait | killed (the P1-2 test specifically) |
| 4 | Restore `wrongPlace: true` on the Manager arm | killed (4 tests, incl. the end-to-end manifest test) |
| 5 | Revert the `"pending"` marking to local-only | killed |
| 6 | Reinstate the hot-path duplicate probe | killed |
| 7 | Drop the Manager baseline entirely | killed (4 tests) |
| 8 | Fold `not-listed` into `unknown` | killed (3 tests) |
| 9 | Drop the LOCAL route's baseline name | killed |

**Two of these needed a stronger test first, and both gaps were real.**

- **Number 5 survived on the first attempt.** The test used `vi.waitFor` on the job status, which resolved only after the check had already completed — so it read the final verdict, not the transient one, and the window it claimed to measure was never observed. The check is now held open on an explicit gate, and the assertion reads the state while it is parked there. A bounded wait cannot prove something about an instant.
- **Number 9 survived the entire 9564-test suite.** Dropping the local route's baseline name changed nothing any test could see. That is a **pre-existing** coverage gap — `verifyLandedModel` uses `listedBefore` only to word an already-inconclusive answer — but this refactor moves that capture, which would have made it easy to trip silently. It is now pinned, including that the baseline uses the **resolved** filename rather than the requested one.

## Not verified

- **Not reproduced against a live ComfyUI-Manager that rejects on `security_level`.** The rejection is modelled by the listing probe answering "no", which is what the code can observe — not by a real Manager refusal.
- **The routing decision is untouched.** This does not change whether a local install takes the Manager route; that is the other half of the issue and the owner's table of remaining `argv[0]` shapes (bare `main.py` with a sibling interpreter) still stands. This makes the *outcome* observable, it does not stop the route being taken.
- **`not-listed` is genuinely ambiguous** between "still arriving" and "landed unreadably", and this does not resolve it — it reports it. Resolving it needs Manager's per-task history `result`, which is reachable (`fetchManagerTaskHistoryEntry`, v4 only) but whose value vocabulary is not established anywhere in this repo; classifying failure by guessing at those strings would be a worse bug than the one being fixed. Left explicitly undone.
- The false-`done` for a **pre-existing** record (already settled before this ships) is unchanged — nothing can retroactively verify it.

## Inherited branches

Two branches on the remote carry this issue number; **both are already merged** and neither had unlanded work:

- `fix/1374-local-download-dispatch` — PR 1393, merged, shipped in 0.50.115.
- `fix/1374-local-download-manager-route` — PR 1555, merged, shipped in 0.51.43. Its two tip commits are in `main` too.

Nothing was salvageable from either; this branch starts from `origin/main`.

Fixes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
