### PR TITLE
fix(1593): the restart refusal stops sending you at a server it knows is the wrong one

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -841,6 +841,46 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
+  it("#1593: the DISPATCH-POINT refusal also stops recommending the wrong server", async () => {
+    // THE SECOND CALL SITE, driven through the real handler. The test above proves
+    // this branch is reached and refuses; it says nothing about what it then tells
+    // the caller, and reverting this site to the old unconditional "USE
+    // restart_comfyui INSTEAD" survives it — and survives the whole suite. So the
+    // fix shipped one tested call site and one untested one.
+    //
+    // This is also the only path that reaches the "different" verdict with a
+    // NON-NULL panelBase: the retarget moves the configured target to :9999 while
+    // the tab stays provably on the boot instance, so both sides of the comparison
+    // are concrete and proven. The preflight-site test reaches the same verdict by
+    // the other limb (null base, concrete observed Origin).
+    let calls = 0;
+    const { ctx, sends } = makeCtx({
+      confirm: "yes",
+      frontsBoot: true,
+      onEnsureReachable: () => {
+        calls++;
+        if (calls >= 3) {
+          hoistedConfig.configBase.value = "http://127.0.0.1:9999";
+          hoistedConfig.generation.value += 1;
+        }
+      },
+    });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    expect(out.refused).toBe(true);
+    expect(note).toMatch(/the panel connection changed while the restart was being prepared/i);
+    // Sending this caller to restart_comfyui would aim it at :9999 — the target
+    // that was just retargeted AWAY from the instance they are working in.
+    expect(note).toMatch(/Do NOT reach for restart_comfyui/);
+    expect(note).not.toMatch(/USE restart_comfyui/);
+    // Both addresses named, so the reader can see which two failed to match.
+    expect(note).toContain("http://127.0.0.1:9999");
+    expect(note).toContain(BOOT_BASE);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
   it("a REMOTE target is not assessed — the Manager reboot is its only restart path", async () => {
     // There is no local process to assess, and a supervised remote (the tunnelled
     // Desktop app) restarts through exactly this reboot by design. Refusing here

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -73,6 +73,13 @@ function makeCtx(opts: {
   /** Called on every ctx.ensureReachable() — lets a test land a retarget at a
    *  specific point in the handler (the DISPATCH point is the third call). */
   onEnsureReachable?: () => void;
+  /** #1593 — the SERVER-OBSERVED handshake Origin, overridden independently of
+   *  `frontsBoot`. The two are separable in reality and the distinction is the
+   *  whole point: a tab can be unbindable (so the restart is refused) while its
+   *  origin is a perfectly concrete address that PROVES it is a different server
+   *  from the configured one. Without this the fixture can only produce the
+   *  "unproven" verdict, and the branch that matters is unreachable. */
+  serverOrigin?: string;
 }): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
   const sends: Array<Record<string, unknown>> = [];
   const frontsBoot = opts.frontsBoot ?? true;
@@ -86,7 +93,7 @@ function makeCtx(opts: {
     },
     tabOrigin: () => (fronted() ? BOOT_BASE : undefined),
     // The gate reads the SERVER-OBSERVED handshake origin, not the spoofable hello URL.
-    tabServerOrigin: () => (fronted() ? BOOT_BASE : undefined),
+    tabServerOrigin: () => opts.serverOrigin ?? (fronted() ? BOOT_BASE : undefined),
     tabIsLocal: () => fronted(),
     canReach: () => true,
   } as unknown as PanelToolCtx["bridge"];
@@ -711,6 +718,62 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(preflight).not.toHaveBeenCalled();
     // CRITICAL: nothing was dispatched, so nothing was stopped.
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("#1593: the refusal does NOT send you to restart_comfyui when it would hit a DIFFERENT server", async () => {
+    // REACHABILITY, and the reason this issue is not just a wording change.
+    //
+    // #1593's reporter had a panel on :8189 while the orchestrator was configured
+    // for another address. The refusal fired — correctly, it could not account for
+    // that instance — and then told them to run restart_comfyui, which targets the
+    // CONFIGURED address. That is #851's defect verbatim, in the branch #851 did
+    // not cover: a call that recommends another tool without checking which machine
+    // that tool points at. On a shared instance, restarting the wrong one is worse
+    // than doing nothing.
+    //
+    // The tab is unbindable (so the refusal fires) but its server-observed Origin
+    // is concrete and provably different — the exact shape that was previously
+    // collapsed into "recommend it anyway".
+    const preflight = vi.fn(async () => ({ ok: true }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({
+      confirm: "yes",
+      frontsBoot: false,
+      serverOrigin: "http://127.0.0.1:8189",
+    });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    expect(out.refused).toBe(true);
+    expect(note).toMatch(/cannot tell which server the restart would stop/i);
+    // THE change: it warns instead of recommending, and names BOTH addresses so
+    // the reader can see which two things failed to be shown equal.
+    expect(note).toMatch(/Do NOT reach for restart_comfyui/);
+    expect(note).toContain("http://127.0.0.1:8189");
+    expect(note).toContain(BOOT_BASE);
+    expect(note).not.toMatch(/USE restart_comfyui/);
+    // Everything the #814 refusal guarantees is untouched.
+    expect(preflight).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("#1593: a DNS-ambiguous localhost origin still gets the recommendation", async () => {
+    // Absence of proof is not proof of difference (a coordinator P0 that
+    // captureRebootHealthBase already honours). `localhost` can resolve to either
+    // family, so warning here would send a user away from a tool that would very
+    // likely have worked — the cry-wolf failure #1233 was filed for.
+    __panelToolsTestHooks.setLocalRestartPreflight(vi.fn(async () => ({ ok: true })));
+    const { ctx } = makeCtx({
+      confirm: "yes",
+      frontsBoot: false,
+      serverOrigin: "http://localhost:8188",
+    });
+
+    const note = String(parse(await restartTool().handler({}, ctx)).note ?? "");
+
+    expect(note).toMatch(/USE restart_comfyui/);
+    expect(note).not.toMatch(/Do NOT reach for restart_comfyui/);
   });
 
   it("#814: a BOUND local target with a failing assessment refuses with its reason", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -25,6 +25,9 @@ import {
   __panelToolsTestHooks,
   __panelRunTestHooks,
   __panelAskTestHooks,
+  classifyRestartFallbackTarget,
+  restartRefusalHandoffAdvice,
+  restartTimeoutFallbackAdvice,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -6596,6 +6599,12 @@ describe("panel#769 restart refusal names the tunnelled-remote case", () => {
   // local process to account for — because there is none. The refusal was right
   // about what it observed and useless about what to do: the reader goes looking
   // for a local install that does not exist.
+  // BOUNDED BY THE ENCLOSING BLOCK, not by a character count. The original
+  // `slice(i, i + 3000)` broke the moment #1593 made part of this note a function
+  // call: the window is not a unit of anything, so growing the block by a comment
+  // silently moves a real assertion outside it and the test fails for a reason
+  // unrelated to what it checks. Walk to the brace that closes the `ok({ … })`
+  // this note lives in, and the assertion tracks the block instead of its length.
   const refusal = () => {
     const src = readFileSync(
       new URL("../../orchestrator/panel-tools.ts", import.meta.url),
@@ -6603,7 +6612,15 @@ describe("panel#769 restart refusal names the tunnelled-remote case", () => {
     );
     const i = src.indexOf("Refusing to restart ComfyUI: I could not confirm");
     expect(i).toBeGreaterThan(-1);
-    return src.slice(i, i + 3000);
+    let depth = 0;
+    for (let j = i; j < src.length; j++) {
+      if (src[j] === "{") depth++;
+      else if (src[j] === "}") {
+        if (depth === 0) return src.slice(i, j);
+        depth--;
+      }
+    }
+    throw new Error("refusal block is unterminated");
   };
 
   it("names the classification as HOST-based, not instance-based", () => {
@@ -6628,7 +6645,101 @@ describe("panel#769 restart refusal names the tunnelled-remote case", () => {
   it("keeps the original alternative — this is additive", () => {
     // restart_comfyui remains the answer for a genuinely local install that
     // simply could not be identified; the tunnel note must not displace it.
-    const t = refusal();
+    //
+    // #1593 moved this sentence out of the literal and into
+    // restartRefusalHandoffAdvice, because it must no longer be unconditional —
+    // so it is asserted on the RUNTIME message rather than on the source, which
+    // is a stronger check than the one it replaces: source proximity never
+    // proved the sentence was reached, and this does. The "unproven" verdict is
+    // the shape this branch was written for (a local install we could not tie to
+    // the panel's instance).
+    expect(
+      restartRefusalHandoffAdvice({
+        headlessBase: "http://127.0.0.1:8188",
+        panelBase: null,
+        observedOrigin: null,
+      }),
+    ).toMatch(/USE restart_comfyui/);
+  });
+});
+
+// #1593 — the refusal must stop recommending a restart aimed at a DIFFERENT
+// server.
+//
+// The #814 refusal ended "USE restart_comfyui INSTEAD" for every caller. #851 is
+// the record of why that is a defect: restart_comfyui targets COMFYUI_URL, not the
+// ComfyUI the panel is inside, and a reporter who followed exactly that advice
+// restarted a different machine. #851 fixed the confirmation-TIMEOUT branch and
+// left the discriminator unused in the refusal — which fires precisely when the
+// two addresses are most likely to differ.
+describe("#1593 restart refusal checks WHICH server the fallback would hit", () => {
+  const HEADLESS = "http://127.0.0.1:8188";
+
+  it("endorses the handoff when the panel is PROVABLY on the configured target", () => {
+    const t = restartRefusalHandoffAdvice({ headlessBase: HEADLESS, panelBase: HEADLESS });
     expect(t).toMatch(/USE restart_comfyui/);
+    expect(t).toContain(HEADLESS);
+    // The difference from "unproven": this one was checked, and says so.
+    expect(t).toMatch(/PROVABLY/);
+    expect(t).not.toMatch(/could NOT confirm/);
+  });
+
+  it("REFUSES to recommend it when the panel is provably on a different server", () => {
+    const t = restartRefusalHandoffAdvice({
+      headlessBase: HEADLESS,
+      panelBase: null,
+      // Server-observed handshake Origin; page JS cannot forge it.
+      observedOrigin: "http://127.0.0.1:8189",
+    });
+    expect(t).toMatch(/Do NOT reach for restart_comfyui/);
+    // BOTH addresses named — the reporter had to paraphrase one back to us.
+    expect(t).toContain(HEADLESS);
+    expect(t).toContain("http://127.0.0.1:8189");
+    // And it must not also tell them to run it.
+    expect(t).not.toMatch(/USE restart_comfyui/);
+  });
+
+  it("recommends it, naming what was NOT established, when nothing is proven", () => {
+    const t = restartRefusalHandoffAdvice({
+      headlessBase: HEADLESS,
+      panelBase: null,
+      observedOrigin: null,
+    });
+    expect(t).toMatch(/USE restart_comfyui/);
+    expect(t).toMatch(/could NOT confirm/);
+    expect(t).toContain(HEADLESS);
+  });
+
+  it("does NOT call a DNS-ambiguous localhost a different server", () => {
+    // A coordinator P0 that captureRebootHealthBase already honours: `localhost`
+    // can resolve to either family, so it is not proof of difference. Firing the
+    // strong warning here would send a user away from a tool that would have
+    // worked — the cry-wolf failure, which is how the same bug was found in #1233.
+    const t = restartRefusalHandoffAdvice({
+      headlessBase: HEADLESS,
+      panelBase: null,
+      observedOrigin: "http://localhost:8188",
+    });
+    expect(t).not.toMatch(/Do NOT reach for restart_comfyui/);
+    expect(t).toMatch(/USE restart_comfyui/);
+  });
+
+  it("shares ONE comparison with the #851 timeout advice", () => {
+    // Two readers of the same evidence that can disagree is the defect being
+    // fixed, pointed inward. Same inputs, same verdict, different wording.
+    const inputs = [
+      { headlessBase: HEADLESS, panelBase: HEADLESS, observedOrigin: null },
+      { headlessBase: HEADLESS, panelBase: null, observedOrigin: "http://127.0.0.1:8189" },
+      { headlessBase: HEADLESS, panelBase: null, observedOrigin: null },
+    ];
+    for (const args of inputs) {
+      const verdict = classifyRestartFallbackTarget(args);
+      const timeoutAdvice = restartTimeoutFallbackAdvice(args);
+      const refusalAdvice = restartRefusalHandoffAdvice(args);
+      const timeoutWarns = /Do NOT reach for restart_comfyui/.test(timeoutAdvice);
+      const refusalWarns = /Do NOT reach for restart_comfyui/.test(refusalAdvice);
+      expect(timeoutWarns).toBe(verdict.kind === "different");
+      expect(refusalWarns).toBe(verdict.kind === "different");
+    }
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -6676,6 +6676,12 @@ describe("#1593 restart refusal checks WHICH server the fallback would hit", () 
   const HEADLESS = "http://127.0.0.1:8188";
 
   it("endorses the handoff when the panel is PROVABLY on the configured target", () => {
+    // A TOTALITY check, not a shipped message. Neither refusal can reach this
+    // verdict — both are guarded by `!bound`, and `bound` is this same predicate,
+    // so a refusal that fires has already ruled `same` out (a tripwire here is not
+    // hit by any handler-driven test). It is asserted so that a future call site
+    // with a different boundness test gets this text rather than falling through
+    // to "unproven" and claiming a check failed that actually succeeded.
     const t = restartRefusalHandoffAdvice({ headlessBase: HEADLESS, panelBase: HEADLESS });
     expect(t).toMatch(/USE restart_comfyui/);
     expect(t).toContain(HEADLESS);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1519,6 +1519,53 @@ export function classifyTabReconnect({
   return baselineCaptured ? false : "unknown";
 }
 
+/**
+ * Is `restart_comfyui` aimed at the same ComfyUI this panel is on? (#851, #1233)
+ *
+ * Extracted from restartTimeoutFallbackAdvice for #1593, which needs the same
+ * DECISION with different wording. The alternative was a second comparison
+ * somewhere else, and two readers of the same evidence that can disagree is the
+ * defect #851 itself was: a call that recommends another tool without checking
+ * which machine that tool points at.
+ *
+ *  - `same`     — provably one instance. Recommending the headless tool is safe.
+ *  - `different`— PROVEN two. `proven` names the panel's side. Recommending the
+ *                 headless tool would aim a restart at the wrong server, which on
+ *                 a shared instance is worse than doing nothing.
+ *  - `unproven` — no proof either way. Recommend it, and say what was not checked.
+ *
+ * Nothing here is new logic; the branches and their reasons are documented at
+ * their original site below and are unchanged.
+ */
+export function classifyRestartFallbackTarget({
+  headlessBase,
+  panelBase,
+  observedOrigin = null,
+}: {
+  headlessBase: string;
+  panelBase: string | null;
+  observedOrigin?: string | null;
+}): { kind: "same" } | { kind: "different"; proven: string } | { kind: "unproven" } {
+  if (panelBase != null && sameHttpBase(headlessBase, panelBase)) return { kind: "same" };
+  const dnsAmbiguous = (u: string | null) => {
+    if (!u) return false;
+    try {
+      return new URL(u).hostname.toLowerCase().replace(/^\[|\]$/g, "") === "localhost";
+    } catch {
+      return false;
+    }
+  };
+  const originMismatch =
+    observedOrigin != null &&
+    !dnsAmbiguous(observedOrigin) &&
+    !dnsAmbiguous(headlessBase) &&
+    !sameHttpOrigin(headlessBase, observedOrigin)
+      ? observedOrigin
+      : null;
+  const proven = panelBase ?? originMismatch;
+  return proven != null ? { kind: "different", proven } : { kind: "unproven" };
+}
+
 export function restartTimeoutFallbackAdvice({
   headlessBase,
   panelBase,
@@ -1539,7 +1586,11 @@ export function restartTimeoutFallbackAdvice({
    */
   observedOrigin?: string | null;
 }): string {
-  if (panelBase != null && sameHttpBase(headlessBase, panelBase)) {
+  // The DECISION lives in classifyRestartFallbackTarget (above) so #1593's refusal
+  // reaches the same verdict rather than re-deriving it. The prose below, and the
+  // reasoning attached to each branch, is unchanged.
+  const verdict = classifyRestartFallbackTarget({ headlessBase, panelBase, observedOrigin });
+  if (verdict.kind === "same") {
     return "or use restart_comfyui to restart the server directly without a panel card.";
   }
   // Proven different: either the proof resolved a base that differs, or the observed
@@ -1559,26 +1610,10 @@ export function restartTimeoutFallbackAdvice({
   // is very likely the same instance. Absence of proof is not proof of difference, so
   // an ambiguous host degrades to UNPROVEN — the same direction captureRebootHealthBase
   // takes for the same input.
-  const dnsAmbiguous = (u: string | null) => {
-    if (!u) return false;
-    try {
-      return new URL(u).hostname.toLowerCase().replace(/^\[|\]$/g, "") === "localhost";
-    } catch {
-      return false;
-    }
-  };
-  const originMismatch =
-    observedOrigin != null &&
-    !dnsAmbiguous(observedOrigin) &&
-    !dnsAmbiguous(headlessBase) &&
-    !sameHttpOrigin(headlessBase, observedOrigin)
-      ? observedOrigin
-      : null;
-  const proven = panelBase ?? originMismatch;
-  if (proven != null) {
+  if (verdict.kind === "different") {
     return (
       `Do NOT reach for restart_comfyui here without checking: it targets ${headlessBase}, ` +
-      `while this panel is running inside ${proven}. Restarting the first would hit a ` +
+      `while this panel is running inside ${verdict.proven}. Restarting the first would hit a ` +
       "different server than the one you have been working on. That may find nothing there " +
       "at all — or it may SUCCEED and take down a ComfyUI you did not mean to touch, which " +
       "on a shared instance is the worse outcome."
@@ -1588,6 +1623,66 @@ export function restartTimeoutFallbackAdvice({
     `or use restart_comfyui, which restarts ${headlessBase} directly without a panel ` +
     "card — check that this is the same ComfyUI you have been working on, since I " +
     "could not confirm which one this panel is running inside."
+  );
+}
+
+/**
+ * #1593 — WHAT TO TELL A CALLER WHOSE PANEL RESTART WAS REFUSED.
+ *
+ * The #814 refusal ends "USE restart_comfyui INSTEAD", unconditionally. #851 is
+ * the record of why an unconditional recommendation is a defect: `restart_comfyui`
+ * targets COMFYUI_URL, not the ComfyUI the panel is running inside, and a reporter
+ * who followed exactly that advice aimed a restart at a different machine.
+ *
+ * #851 fixed the branch it was filed against — the confirmation-card timeout — and
+ * that fix has been sitting next door ever since, never consulted here. This is
+ * the same evidence reaching the branch a user is far more likely to hit, because
+ * the refusal fires whenever the panel's instance cannot be accounted for, which is
+ * precisely when the two addresses are most likely to differ.
+ *
+ * The three answers are not cosmetic variations:
+ *
+ *   same       — the handoff is PROVEN good. The caller is told so, and told why,
+ *                so the second tool is not treated as a gamble.
+ *   different  — the handoff is PROVEN bad, and the old text recommended it anyway.
+ *                This is the case that matters: on a shared instance, aiming a
+ *                restart at the wrong server is worse than doing nothing.
+ *   unproven   — recommend it, and NAME what was not established, rather than
+ *                implying a check that did not happen.
+ *
+ * Both addresses are named in every branch. The refusal previously named neither,
+ * so the reader could not tell which two things had failed to be shown equal —
+ * #1593's reporter had to paraphrase the address back to us.
+ */
+export function restartRefusalHandoffAdvice(args: {
+  headlessBase: string;
+  panelBase: string | null;
+  observedOrigin?: string | null;
+}): string {
+  const verdict = classifyRestartFallbackTarget(args);
+  if (verdict.kind === "same") {
+    return (
+      `USE restart_comfyui INSTEAD: it is not tied to a browser tab — it acts on ` +
+      `${args.headlessBase}, which this panel is PROVABLY on, and which it CAN identify and ` +
+      `check before stopping. That handoff is verified here, not assumed.`
+    );
+  }
+  if (verdict.kind === "different") {
+    return (
+      `Do NOT reach for restart_comfyui here: it targets ${args.headlessBase}, while this ` +
+      `panel is running inside ${verdict.proven} — a DIFFERENT server, so it would restart ` +
+      `something you have not been working on. That may find nothing there at all, or it may ` +
+      `SUCCEED and take down a ComfyUI you did not mean to touch. Restart this one from ` +
+      `whatever launches it (its own launcher, the Desktop app, or your terminal).`
+    );
+  }
+  return (
+    `USE restart_comfyui INSTEAD: unlike this panel-scoped restart, it is not tied to a ` +
+    `browser tab — it acts on the ComfyUI this server is configured for ` +
+    `(${args.headlessBase}), which it CAN identify and check before stopping. I could NOT ` +
+    `confirm that this is the same ComfyUI this panel is running inside, so check that ` +
+    `before you run it. Or restart ComfyUI from whatever launches it (its own launcher, ` +
+    `the Desktop app, or your terminal).`
   );
 }
 
@@ -12265,17 +12360,25 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               // A claim about what I DID, not about a server I have just said I cannot
               // identify: "it is still running" would be exactly the unvalidated
               // assertion the stale-target rule forbids (r8).
-              "again. Nothing was dispatched, so nothing was stopped. USE restart_comfyui " +
+              "again. Nothing was dispatched, so nothing was stopped. " +
               // The alternative is NAMED and the difference EXPLAINED (coordinator
               // ruling): this tool restarts whatever the calling TAB fronts, which is
               // exactly the thing that could not be identified here. restart_comfyui is
               // not tab-scoped — it acts on the ComfyUI this server is configured for,
               // which it can identify and assess — so it remains available. A user who
               // loses one entry point must be told the other one works, and why.
-              "INSTEAD: unlike this panel-scoped restart, it is not tied to a browser tab " +
-              "— it acts on the ComfyUI this server is configured for, which it CAN " +
-              "identify and check before stopping. Or restart ComfyUI from whatever " +
-              "launches it (its own launcher, the Desktop app, or your terminal)." +
+              //
+              // #1593 — but only when it is actually the other one. This line used to
+              // recommend restart_comfyui unconditionally, which is #851's defect
+              // exactly: it targets COMFYUI_URL, not the ComfyUI the panel is inside,
+              // and this branch fires precisely when those are most likely to differ.
+              // The discriminator #851 built has been next door ever since and was
+              // never consulted here; now it is, and both addresses are named.
+              restartRefusalHandoffAdvice({
+                headlessBase: getComfyUIBaseUrl(),
+                panelBase: preflightHealthBase,
+                observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
+              }) +
               // artokun/comfyui-mcp-panel#769 — a REMOTE ComfyUI reached over a
               // tunnel or port-forward has a LOOPBACK host, and remoteUrlActive is
               // derived from exactly that (`forceRemote || !isLoopbackHost(host)`).
@@ -12427,9 +12530,16 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               "fronts — a restart STOPS a server, so it is never sent to one I cannot " +
               // Again: what I did, not what an unidentified instance is doing.
               "identify. Nothing was dispatched, so nothing was stopped. Retry once the " +
-              "panel has settled, or USE restart_comfyui INSTEAD: unlike this panel-scoped " +
-              "restart, it is not tied to a browser tab — it acts on the ComfyUI this " +
-              "server is configured for, which it CAN identify and check before stopping.",
+              // #1593 — the SAME unconditional recommendation, in the second refusal.
+              // Fixing only the first would leave half the door open, and this branch
+              // fires on a connection that just CHANGED, which is if anything a
+              // stronger reason to check which server the other tool would hit.
+              "panel has settled. " +
+              restartRefusalHandoffAdvice({
+                headlessBase: getComfyUIBaseUrl(),
+                panelBase: healthBase,
+                observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
+              }),
           });
         }
         const timing = getPanelRebootTiming();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1642,13 +1642,21 @@ export function restartTimeoutFallbackAdvice({
  *
  * The three answers are not cosmetic variations:
  *
- *   same       — the handoff is PROVEN good. The caller is told so, and told why,
- *                so the second tool is not treated as a gamble.
  *   different  — the handoff is PROVEN bad, and the old text recommended it anyway.
  *                This is the case that matters: on a shared instance, aiming a
  *                restart at the wrong server is worse than doing nothing.
  *   unproven   — recommend it, and NAME what was not established, rather than
  *                implying a check that did not happen.
+ *   same       — NOT REACHABLE FROM EITHER REFUSAL, and deliberately kept anyway.
+ *                Both call sites are guarded by `!bound`, and `bound` is the same
+ *                predicate as this verdict (panelBase != null && sameHttpBase(...)),
+ *                so a refusal that fires has already excluded `same`. It is not a
+ *                user-visible branch and must not be described as one. It stays
+ *                because this function is TOTAL over the classifier's three
+ *                verdicts: a future caller whose boundness test is not that exact
+ *                predicate would otherwise fall through to the "unproven" text and
+ *                claim a check failed that in fact succeeded. A tripwire in this
+ *                branch is not hit by any of the handler-driven tests.
  *
  * Both addresses are named in every branch. The refusal previously named neither,
  * so the reader could not tell which two things had failed to be shown equal —


### PR DESCRIPTION
Draft for artokun/comfyui-mcp#1593 — `panel_restart_comfyui` refuses when it cannot account for the panel's local ComfyUI, and then tells the caller to run `restart_comfyui` instead.

## The defect

That recommendation was **unconditional**, and #851 is the record of why that is a bug: `restart_comfyui` targets `COMFYUI_URL`, not the ComfyUI the panel is running inside. A reporter who followed exactly that advice got `No ComfyUI process found on port 8188` while their panel worked fine — a restart aimed at the wrong machine, recommended by a call that never checked which machine that was.

#851 fixed the branch it was filed against (the confirmation-card **timeout**) and built `restartTimeoutFallbackAdvice` to make the decision. That decision has been sitting one function away ever since and **was never consulted by the refusal** — which fires precisely when the two addresses are most likely to differ, since being unable to account for the panel's instance is itself evidence the configured one may not be it. #1593's reporter had a panel on `:8189` and was sent to `restart_comfyui` anyway.

## What changed

The comparison is **extracted** (`classifyRestartFallbackTarget`) rather than duplicated — two readers of the same evidence that can disagree is this bug pointed inward. `restartTimeoutFallbackAdvice` now calls it with unchanged behaviour, and **both** refusal sites (the #814 preflight refusal and the dispatch-point refusal) get refusal-appropriate wording from the same verdict:

| verdict | before | now |
|---|---|---|
| provably the **same** server | "USE restart_comfyui INSTEAD" | same, but says the handoff was *verified*, not assumed |
| provably a **different** server | "USE restart_comfyui INSTEAD" ← **restarts the wrong box** | "Do NOT reach for restart_comfyui here", both addresses named, points at the launcher instead |
| **unproven** | "USE restart_comfyui INSTEAD" | recommends it *and names what was not established* |

Both addresses are named in every branch. The refusal previously named neither, so the reader could not see which two things had failed to be shown equal — #1593's reporter had to paraphrase the address back to us.

## What this deliberately does NOT do

The issue asks `panel_restart_comfyui` to **delegate** to the headless restart path when the panel target cannot be locally accounted for. It does not, for two reasons that are not stylistic:

1. **`restartComfyUI()` has no busy guard.** The busy guard lives in the panel's own `comfy_reboot` handler and is only reached after the command is sent — ~250 lines past this refusal. Delegating would silently drop the guard this tool's own description promises ("⚠️ BUSY GUARD … this tool REFUSES") and abort a running render.
2. **It contradicts a tested #814 invariant.** `panel-restart-legacy-fallback.test.ts` asserts `restartComfyUI` is *not* called for an unbound tab, under the heading "does NOT restart the wrong local server". Delegation is only safe when the two are the same instance — the very thing this branch could not establish.

So the honest answer to "don't force a cross-tool workaround" is to make the handoff **verified** rather than automatic: when it *is* the same server the caller is told so positively, and when it provably is not, they are no longer sent there at all. If you want the automatic delegation anyway, the missing piece is an orchestrator-side queue check gated on `force` — happy to add it, but it is new behaviour in the most safety-critical handler in the repo and I did not want to smuggle it in under a wording fix.

## A pre-existing test was rebounded, not loosened

The panel#769 assertions read the **source** and sliced a fixed 3000 characters from the refusal's string literal. A character window is not a unit of anything: growing the block by one comment moved a real assertion outside it, and the test failed for a reason unrelated to what it checks. It now walks to the brace closing the enclosing `ok({ … })`. The `USE restart_comfyui` half moved to a **runtime** assertion — strictly stronger, since source proximity never proved the sentence was reached.

## Verified

- 38 tests in `panel-restart-cancel-truth.test.ts` (2 new, driving the **real handler**, not the helper) and 334 in `panel-tools.test.ts` (5 new).
- **6 mutations, all confirmed applied and all killed**: reverting the refusal to unconditional, disabling the proven-different branch, dropping the DNS-ambiguous-`localhost` guard, collapsing proven-same into unproven, desynchronising the timeout advice from the shared classifier, and leaving the second refusal unconditional.
- **Reachability separately**: the `different` verdict is only producible when the tab is unbindable *and* its server-observed Origin is concrete, so the fixture gained a `serverOrigin` knob independent of `frontsBoot`. Without it that branch is unreachable from the tests and could have shipped dead.
- Full orchestrator suite: 2337 tests, 146/147 files green. The lone `late-mutation-e2e` failure is the known load flake and passes in isolation.
- `npm run lint` and `npm run build` clean.

## Not verified

- **Not live-tested against a real panel.** The refusal is exercised through the real handler with a stubbed bridge, not a browser.
- **The reporter's exact null cause is not established.** `captureRebootHealthBase` returns null for several distinct reasons (a boot base that is not loopback, a non-loopback-listener tab, a `localhost` origin, a basePath mount, or a boot base that no longer matches the retargeted one). Their report does not distinguish these, and this change improves the message in all of them without claiming to know which they hit. Notably, if their case is the DNS-ambiguous `localhost` one, they will still get the *unproven* wording — better than before, but not a positive endorsement.
- **The refusal still fires after the confirmation card**, so a user who clicks "yes" is then told nothing happened. Moving it earlier is tempting and I did not do it: the inputs can change across `ctx.ensureReachable()`, which heals an orphaned session onto the live tab, so an early check risks a *false* refusal for a session that would have worked.
- **No change to whether the refusal is correct** — the #814/#509 proof is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
