### PR TITLE
release: v0.51.55 — two tools stop answering from the wrong source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.55] - 2026-08-15
+
+### MCP
+
+#### Fixed
+- let the SERVER answer whether a model is installed (#1587)
+- panel_strip_workflow hands back a graph a script can parse (#1589)
+
 ## [0.51.54] - 2026-08-15
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.54",
+  "version": "0.51.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.54",
+      "version": "0.51.55",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.54",
+  "version": "0.51.55",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp#1587 and artokun/comfyui-mcp#1589.

**#1587** — `apply_manifest` marked installed, server-visible models as `pending` and returned `success: false`. The verdict came from a filesystem containment test that only answers when the models root was *named by* the running server; Desktop reports a relative `main.py`, so it never answers. That source is blind to the server's own listing — which the earlier lookup had often already used to find the file. Now, when containment cannot answer, the server is asked. Listed → `skipped` with a note on what was *not* established; not listed → still `pending` (that is #369's stale-install case, deliberately not weakened).

**#1589** — `panel_strip_workflow` glued the graph onto the end of its summary in one text block. Summary and graph are now separate blocks with the parsed graph in structured content. Prose order deliberately unchanged (#361 put warnings ahead of the graph).

Both reviewed pre-merge with no P0/P1 findings. Reachability on #1587 proven by deleting the call site; #1589 verified over a real MCP client on an in-memory transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)