### PR TITLE
fix(1560): a post-open exempt read that got no answer is REPORTED

### DIFF
--- a/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
+++ b/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
@@ -31,6 +31,7 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
+import { attachPanelAnswered } from "../../services/panel-answered.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "wf:workflows/a.json";
@@ -59,7 +60,11 @@ type ListBehaviour =
   /** The probe read fails and the NEXT one succeeds — a tab that reconnected in the
    *  gap. Two separate round trips, so this is a real production state, and it is the
    *  only one in which the fence is repaired DESPITE a silent probe. */
-  | "throw_then_ok";
+  | "throw_then_ok"
+  /** The panel RECEIVED the read and refused it — the bridge's `ok:false` branch,
+   *  whose error carries the "something answered" mark (`attachPanelAnswered`). This
+   *  is `isError` like a timeout and is its exact OPPOSITE: the tab is talking. */
+  | "acked_error";
 
 function bridge(openVerdict: string, list: ListBehaviour) {
   const calls: string[] = [];
@@ -70,6 +75,14 @@ function bridge(openVerdict: string, list: ListBehaviour) {
       calls.push(String(cmd.cmd));
       if (cmd.cmd === "workflow_list") {
         listCalls += 1;
+        if (list === "acked_error") {
+          // Worded to LOOK like a silence on purpose: the classification must come
+          // from the mark, and a message-shaped rule would also have to survive
+          // being translated. This is the shape ui-bridge mints on `ok:false`.
+          throw attachPanelAnswered(
+            new Error(`the panel could not answer workflow_list: its workflow store is not ready`),
+          );
+        }
         const silent = list === "throw" || (list === "throw_then_ok" && listCalls === 1);
         if (silent) throw new Error(`Panel tab ${TAB} did not reply to "workflow_list" within 6000 ms`);
         const active = {
@@ -195,6 +208,39 @@ describe("a post-open exempt read that did not answer is REPORTED (#1560)", () =
 
     expect(text).toMatch(/FENCE: NOT cleared/);
     expect(text).toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+
+  it("a panel that ANSWERS the probe with an ERROR is never called silent (review, P1)", async () => {
+    // THE FALSE CLAIM THIS NOTE COULD MAKE. `isError` covers two opposite
+    // observations: nothing came back, and the tab received the read, ran it and
+    // replied refusing it. The first version of this fix mapped both to "unanswered",
+    // so a working panel got `PANEL CHANNEL: NOT ANSWERING` — a statement contradicted
+    // by the very reply that produced it — plus a hard-refresh prescription for a
+    // problem this user does not have. The suite only covered the canonical timeout,
+    // where the two agree.
+    const { text, isError, calls } = await openWorkflow(IDENTITY_UNPROVEN, "acked_error");
+
+    // The probe really ran and really failed — this is not the "nothing to observe"
+    // case sneaking in through the back door.
+    expect(calls).toContain("workflow_list");
+    expect(isError).toBe(true);
+    // The panel's own verdict is still reported verbatim; only the CHANNEL claim goes.
+    expect(text).toContain("could not prove that the active canvas was rebound");
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+    // …including the remedy it carries. Sending this caller to reload their tab is
+    // the actionable half of the false claim.
+    expect(text).not.toMatch(/Ctrl\+Shift\+R/);
+    expect(text).not.toMatch(/reads the same channel that just failed/i);
+  });
+
+  it("the same, through the identity-PROVEN verdict", async () => {
+    // The other route to the note. Here the #1337 re-derivation runs first and hits
+    // the same answering-but-refusing panel, so the fence genuinely is not cleared —
+    // and that is still not evidence of a dead channel.
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, "acked_error");
+
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
   });
 
   it("a GENUINE acked failure provokes no probe and no note", async () => {

--- a/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
+++ b/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
@@ -1,0 +1,209 @@
+// artokun/comfyui-mcp#1560 — a post-open probe that got NO ANSWER was thrown away, and
+// it was the one fact that ended the reporter's retry loop.
+//
+// THE REPORTED SEQUENCE. `panel_open_workflow` returned the UNPROVEN verdict; every
+// `panel_*` graph call after it refused with `workflow instance mismatch`;
+// `panel_set_workflow_target({mode:"current"})` — the documented recovery — reported
+// "the panel did not answer"; and `panel_open_workflow` was retried TWICE more, each
+// time reproducing the identical error. No agent-side recovery existed.
+//
+// WHAT THIS PROCESS ALREADY KNEW. On the open's own error branch,
+// `observeActiveAfterOpen` sends a `workflow_list` — the read the fence EXEMPTS. In the
+// reporter's session that read cannot have answered either. Its failure was swallowed
+// ("could not ask — nothing was observed, so nothing is claimed") and the caller got the
+// panel's verdict verbatim, with no hint that the channel itself was the problem.
+//
+// That silence DISCRIMINATES. `panel_set_workflow_target({mode:"current"})` re-derives
+// via `rebindWorkflowFence`, which makes its own `workflow_list` round trip — the SAME
+// read that just failed. So "the exempt read did not come back" is what separates
+// "retry the open" (hopeless) from "the panel JS in the open tab is what needs fixing".
+//
+// NOT FIXED HERE, deliberately: the fence is still not adopted on an UNPROVEN verdict.
+// Pointing a session at a canvas the panel could not identify is the write-to-the-wrong-
+// graph failure the fence exists to prevent, and it has been rejected on this codebase
+// more than once. This makes the dead end NAMEABLE, not survivable.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const PATH = "workflows/a.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+
+/** The reporter's verdict: identity itself unproven. */
+const IDENTITY_UNPROVEN =
+  `workflow_open RAN but could not prove that the active canvas was rebound to ${PATH}, so treat ` +
+  `the canvas as unknown rather than unchanged. The panel could not confirm which workflow is ` +
+  `active, so the open may have left a different one active.`;
+
+/** The other verdict class: identity PROVEN, content unknown. */
+const IDENTITY_PROVEN_DRIFT =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded. Treat the canvas as UNKNOWN and re-read it ` +
+  `(panel_graph_outline) before editing.`;
+
+/** A GENUINE acked failure: nothing was opened, so no probe should be provoked. */
+const GENUINE_FAILURE = `no workflow matching "${PATH}" — it isn't among the saved/open workflows.`;
+
+type ListBehaviour =
+  | "throw"
+  | "ok"
+  | "ok_no_uuid"
+  /** The probe read fails and the NEXT one succeeds — a tab that reconnected in the
+   *  gap. Two separate round trips, so this is a real production state, and it is the
+   *  only one in which the fence is repaired DESPITE a silent probe. */
+  | "throw_then_ok";
+
+function bridge(openVerdict: string, list: ListBehaviour) {
+  const calls: string[] = [];
+  let stamp: string | undefined;
+  let listCalls = 0;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        const silent = list === "throw" || (list === "throw_then_ok" && listCalls === 1);
+        if (silent) throw new Error(`Panel tab ${TAB} did not reply to "workflow_list" within 6000 ms`);
+        const active = {
+          path: PATH,
+          routing_key: TAB,
+          ...(list === "ok_no_uuid" ? {} : { workflow_uuid: LIVE }),
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(openVerdict);
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function openWorkflow(openVerdict: string, list: ListBehaviour) {
+  const { b, calls } = bridge(openVerdict, list);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("a post-open exempt read that did not answer is REPORTED (#1560)", () => {
+  it("the reporter's dead end: the silence is named, with the consequence that follows", async () => {
+    const { text, isError, calls } = await openWorkflow(IDENTITY_UNPROVEN, "throw");
+
+    // The probe genuinely ran — the whole claim rests on that round trip.
+    expect(calls).toContain("workflow_list");
+    expect(isError).toBe(true);
+    // The panel's own verdict survives verbatim; this only ADDS what we measured.
+    expect(text).toContain("could not prove that the active canvas was rebound");
+    expect(text).toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+    // The measurement itself, including WHY it failed.
+    expect(text).toMatch(/did not reply to "workflow_list"/);
+    // The consequence that ends the loop the reporter ran: both remedies read the
+    // same channel, so neither is a different thing to try.
+    // Anchored on the CLAIM, not on a character window: the documented recovery reads
+    // the very channel that just failed, so it is not a fresh thing to try.
+    expect(text).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
+    expect(text).toMatch(/re-derives the fence from its own `workflow_list` round trip/i);
+    expect(text).toMatch(/reads the same channel that just failed/i);
+    expect(text).toMatch(/Retrying panel_open_workflow does not help/i);
+    // The remedy that is actually left.
+    expect(text).toMatch(/Ctrl\+Shift\+R/);
+  });
+
+  it("does NOT claim the panel is permanently gone — one bounded read is all it saw", async () => {
+    // CLAIM SHAPE MUST MATCH OBSERVATION SHAPE. A single 6s read timing out cannot
+    // establish permanence, and a tab still reconnecting after a ComfyUI restart
+    // answers late and recovers on its own. Saying "the panel is dead" here would be
+    // the same over-claim this cluster keeps producing.
+    const { text } = await openWorkflow(IDENTITY_UNPROVEN, "throw");
+
+    expect(text).toMatch(/does not (?:establish|prove)/i);
+    expect(text).toMatch(/still reconnecting/i);
+    expect(text).toMatch(/retry/i);
+  });
+
+  it("adopts NOTHING — the fence stays closed on an unidentifiable canvas", async () => {
+    // The direction that would be dangerous, and the reason the reporter's own
+    // suggested fix was declined. Naming the dead end must not become surviving it.
+    const { text, calls } = await openWorkflow(IDENTITY_UNPROVEN, "throw");
+
+    expect(calls.some((c) => c.startsWith("adopt:"))).toBe(false);
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+  });
+
+  it("an exempt read that ANSWERED says nothing about a silent channel", async () => {
+    // The false-positive direction. `ok_no_uuid` answers fully and simply carries no
+    // identity — a different failure with a different remedy, and telling that caller
+    // to hard-refresh their tab would name a cause that is not theirs.
+    const { text } = await openWorkflow(IDENTITY_UNPROVEN, "ok_no_uuid");
+
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+
+  it("a REPAIRED fence is not reported as a silent channel", async () => {
+    // On the identity-PROVEN verdict the fence is re-derived (#1337). If that
+    // re-derivation succeeded, the channel demonstrably answered, and the note would
+    // contradict the line above it.
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, "ok");
+
+    expect(text).toMatch(/FENCE: CLEARED/);
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+
+  it("a probe that went silent but a fence that CAME BACK is not called a dead channel", async () => {
+    // The two reads are separate round trips: the probe can time out and the #1337
+    // re-derivation, moments later, can succeed on a tab that reconnected in the gap.
+    // Saying "expect mode:current to fail the same way" on top of a line announcing
+    // FENCE: CLEARED would be self-contradicting — and the fence IS the thing the
+    // caller was blocked on.
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, "throw_then_ok");
+
+    expect(text).toMatch(/FENCE: CLEARED/);
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+
+  it("a silent channel on the identity-PROVEN verdict is reported too", async () => {
+    // Same dead end, reached through the other verdict: the #1337 re-derivation needs
+    // the same read, so its failure leaves the session just as fenced.
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, "throw");
+
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+
+  it("a GENUINE acked failure provokes no probe and no note", async () => {
+    // Nothing was opened, so there is no canvas question to ask and no channel claim
+    // to make. This repo already pins that a genuine error must not trigger a
+    // workflow_list round trip at all.
+    const { text, calls } = await openWorkflow(GENUINE_FAILURE, "throw");
+
+    expect(calls).not.toContain("workflow_list");
+    expect(text).not.toMatch(/PANEL CHANNEL: NOT ANSWERING/);
+  });
+});

--- a/src/__tests__/services/panel-answered-marker.test.ts
+++ b/src/__tests__/services/panel-answered-marker.test.ts
@@ -232,6 +232,33 @@ describe("the bridge marks a RECEIVED reply, and nothing else (#1560)", () => {
     expect(isPanelAnsweredError(err), "nothing answered, so nothing may claim it did").toBe(false);
   });
 
+  it("a REWRITTEN Unknown-command reply still says the panel answered", async () => {
+    // The bridge substitutes its own actionable "update your panel" error for an old
+    // panel's raw `Unknown command` reply. That rewrite is still a REPLY — the tab
+    // answered, it just answered that it does not know the command — so the mark has
+    // to survive the substitution. Without this the call site is untested and only
+    // the helper is: deleting the propagation kills nothing.
+    sock.on("message", (raw) => {
+      const msg = JSON.parse(String(raw)) as { rid?: string; cmd?: string };
+      if (!msg.rid || !msg.cmd) return;
+      sock.send(
+        JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }),
+      );
+    });
+
+    const err = await bridge
+      .send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 3000 })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    // The substitution REALLY happened — otherwise this test would pass on the
+    // pass-through path and prove nothing about the propagation.
+    expect((err as Error).message).toMatch(/does not implement "workflow_list"|too old for/);
+    expect((err as Error).message).not.toContain("Unknown command");
+    expect(isPanelAnsweredError(err), "a rewritten reply is still a reply").toBe(true);
+  });
+
   it("an ok:true reply is not an error at all", async () => {
     sock.on("message", (raw) => {
       const msg = JSON.parse(String(raw)) as { rid?: string; cmd?: string };

--- a/src/__tests__/services/panel-answered-marker.test.ts
+++ b/src/__tests__/services/panel-answered-marker.test.ts
@@ -1,0 +1,245 @@
+// artokun/comfyui-mcp#1560 (review, P1) — "the panel is not answering" must be a
+// MEASUREMENT, not a synonym for `isError`.
+//
+// The fix for #1560 makes `panel_open_workflow`'s post-open probe report a
+// fence-exempt `workflow_list` that never came back, and prescribe a hard refresh of
+// the ComfyUI tab. Review found it deciding that from `isError` alone — and an
+// ACKNOWLEDGED panel error is `isError` too: the tab received the command, ran it,
+// and replied refusing it. A panel that is demonstrably talking would be announced as
+// silent and its user sent to hard-refresh a healthy tab, which is exactly the
+// unmeasured claim #1560 is about, pointed the other way.
+//
+// WHY NOT THE MESSAGE. Acknowledged panel errors travel as arbitrary `msg.error`
+// text, so any sentence one class writes the other can contain — the same reasoning
+// that reverted the #1529 prose predicate as a P0. And the panel is TRANSLATED: a
+// rule matching English words answers wrongly for eleven of twelve locales, silently.
+//
+// So the bridge states it structurally at the one branch that RECEIVES a reply, and
+// this pins both halves — that the mark is minted where it is claimed to be (through
+// a real socket, not a source scan), and that it cannot be manufactured by a polluted
+// prototype.
+
+import { createServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+
+import {
+  PANEL_ANSWERED_PROP,
+  attachPanelAnswered,
+  inheritPanelAnswered,
+  isPanelAnsweredError,
+} from "../../services/panel-answered.js";
+import { UiBridge } from "../../services/ui-bridge.js";
+
+describe("the mark is OWN-property only (#1560)", () => {
+  it("reads back what the bridge attached", () => {
+    expect(isPanelAnsweredError(attachPanelAnswered(new Error("node not found")))).toBe(true);
+  });
+
+  it("an unmarked error claims nothing", () => {
+    expect(isPanelAnsweredError(new Error("did not reply within 6000 ms"))).toBe(false);
+    for (const junk of [null, undefined, "x", 42, {}, []]) {
+      expect(isPanelAnsweredError(junk), String(junk)).toBe(false);
+    }
+  });
+
+  it("an INHERITED mark cannot silence a genuine no-answer report", () => {
+    // The direction that matters: a polluted prototype (or a library that decorates
+    // Error) marking every failure as answered would restore the reporter's dead end
+    // — the silence swallowed again, with nothing said about the channel.
+    Object.defineProperty(Error.prototype, PANEL_ANSWERED_PROP, {
+      value: true,
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+    try {
+      const timedOut = new Error('Panel tab wf:a did not reply to "workflow_list" within 6000 ms');
+      expect((timedOut as unknown as Record<string, unknown>)[PANEL_ANSWERED_PROP]).toBe(true);
+      expect(isPanelAnsweredError(timedOut), "inherited must not read as answered").toBe(false);
+    } finally {
+      delete (Error.prototype as unknown as Record<string, unknown>)[PANEL_ANSWERED_PROP];
+    }
+    expect(PANEL_ANSWERED_PROP in Error.prototype).toBe(false);
+  });
+
+  it("a swapped hasOwnProperty cannot answer for the check", () => {
+    // #1529's P0 shape. The module binds the intrinsic at load, so the object under
+    // test never gets to answer the question asked about it.
+    const realHasOwn = Object.prototype.hasOwnProperty;
+    let inherited: boolean | undefined;
+    let genuine: boolean | undefined;
+    let swapWasLive = false;
+    Object.defineProperty(Error.prototype, PANEL_ANSWERED_PROP, {
+      value: true,
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+    Object.defineProperty(Object.prototype, "hasOwnProperty", {
+      value: () => true,
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+    try {
+      swapWasLive = realHasOwn.call({}, "nope") === false && {}.hasOwnProperty("nope") === true;
+      inherited = isPanelAnsweredError(new Error("the socket died mid-command"));
+      genuine = isPanelAnsweredError(attachPanelAnswered(new Error("x")));
+    } finally {
+      Object.defineProperty(Object.prototype, "hasOwnProperty", {
+        value: realHasOwn,
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+      delete (Error.prototype as unknown as Record<string, unknown>)[PANEL_ANSWERED_PROP];
+    }
+    expect(swapWasLive, "the swap was in place").toBe(true);
+    expect(inherited, "an inherited mark must not read as answered").toBe(false);
+    expect(genuine, "a real mark must still read under the swap").toBe(true);
+  });
+
+  it("a NON-true own value is not a mark", () => {
+    const err = new Error("x");
+    Object.defineProperty(err, PANEL_ANSWERED_PROP, { value: "yes", configurable: true });
+    expect(isPanelAnsweredError(err)).toBe(false);
+  });
+
+  it("attaching never collides with Error's own fields, and survives a frozen prototype slot", () => {
+    // Assignment would THROW in strict mode against a non-writable prototype
+    // property, turning a clear panel error into an unrelated TypeError.
+    Object.defineProperty(Error.prototype, PANEL_ANSWERED_PROP, {
+      value: false,
+      configurable: true,
+      writable: false,
+      enumerable: false,
+    });
+    try {
+      const err = attachPanelAnswered(new Error("boom"));
+      expect(err.message).toBe("boom");
+      expect(isPanelAnsweredError(err)).toBe(true);
+    } finally {
+      delete (Error.prototype as unknown as Record<string, unknown>)[PANEL_ANSWERED_PROP];
+    }
+  });
+
+  it("inheritPanelAnswered carries the mark across a SUBSTITUTED error, and only then", () => {
+    // The bridge rewrites an old panel's "Unknown command" reply into an actionable
+    // update-your-panel error. That rewrite is still a reply.
+    const answered = attachPanelAnswered(new Error('Unknown command "workflow_list"'));
+    expect(isPanelAnsweredError(inheritPanelAnswered(answered, new Error("update your panel")))).toBe(
+      true,
+    );
+    expect(isPanelAnsweredError(inheritPanelAnswered(new Error("no reply"), new Error("x")))).toBe(
+      false,
+    );
+  });
+});
+
+// ── REACHABILITY. The library is worthless if the branch that receives a reply does
+//    not mint the mark, and that branch lives inside the socket message loop. Driven
+//    through a real WebSocket rather than asserted against the source, so this fails
+//    if the attachment is deleted OR if the reply never reaches it.
+
+let bridge: UiBridge;
+let sock: WebSocket;
+const TAB = "tab-answers";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+beforeEach(async () => {
+  let port = 0;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    port = await freePort();
+    bridge = new UiBridge(port);
+    bridge.start();
+    if (await bridge.whenReady()) break;
+    await bridge.stop();
+  }
+  sock = new WebSocket(`ws://127.0.0.1:${port}`);
+  await new Promise<void>((resolve, reject) => {
+    sock.on("open", () => resolve());
+    sock.on("error", reject);
+  });
+  sock.send(
+    JSON.stringify({
+      type: "hello",
+      tab_id: TAB,
+      title: "answers",
+      enforces_workflow_stamp: true,
+      enforces_workflow_stamp_at_write: true,
+    }),
+  );
+  await new Promise((r) => setTimeout(r, 60));
+});
+
+afterEach(async () => {
+  try {
+    sock?.close();
+  } catch {
+    /* already closed */
+  }
+  await bridge?.stop();
+});
+
+describe("the bridge marks a RECEIVED reply, and nothing else (#1560)", () => {
+  it("an ok:false reply rejects with an error that says the panel answered", async () => {
+    // The panel served the command and refused it. Everything a caller can see about
+    // this failure is the same as a timeout's — except this.
+    sock.on("message", (raw) => {
+      const msg = JSON.parse(String(raw)) as { rid?: string; cmd?: string };
+      if (!msg.rid || !msg.cmd) return;
+      sock.send(
+        JSON.stringify({
+          rid: msg.rid,
+          ok: false,
+          // Deliberately worded like a silence, to prove nothing reads the text.
+          error: "the panel did not answer the workflow store in time",
+        }),
+      );
+    });
+
+    const err = await bridge
+      .send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 3000 })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(err, "the refusal must still reject").toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("the panel did not answer the workflow store in time");
+    expect(isPanelAnsweredError(err), "a served reply is an ANSWER").toBe(true);
+  });
+
+  it("a reply that never comes carries no mark — a silence stays a silence", async () => {
+    // The reporter's own state. The socket is live and the tab says nothing.
+    const err = await bridge
+      .send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 250 })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/did not reply to "workflow_list"/);
+    expect(isPanelAnsweredError(err), "nothing answered, so nothing may claim it did").toBe(false);
+  });
+
+  it("an ok:true reply is not an error at all", async () => {
+    sock.on("message", (raw) => {
+      const msg = JSON.parse(String(raw)) as { rid?: string; cmd?: string };
+      if (!msg.rid || !msg.cmd) return;
+      sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { workflows: [] } }));
+    });
+    await expect(bridge.send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 3000 })).resolves.toEqual({
+      workflows: [],
+    });
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -44,6 +44,7 @@ import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import { nodesInstallCommandArgs } from "../services/node-management.js";
+import { isPanelAnsweredError } from "../services/panel-answered.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
@@ -2250,6 +2251,45 @@ function isReplyTimeoutResult(res: ToolResult): boolean {
   return res?.isError === true && (res as Record<symbol, unknown>)[REPLY_TIMEOUT_RESULT] === true;
 }
 
+/**
+ * #1560 — the same translation problem, for the OTHER fact: did anything answer?
+ *
+ * `isReplyTimeoutResult` above identifies ONE way a command can go unanswered (the
+ * bridge's own tagged reply timeout). That is not the question a caller reporting on
+ * the CHANNEL is asking — a routing refusal, a dead socket and a mid-command
+ * disconnect are equally "no answer", and none of them carry that tag. The complement
+ * is what can be stated positively and exactly: the panel SENT a reply, which the
+ * bridge marks at the single branch that receives one (`attachPanelAnswered`).
+ *
+ * Kept off the JSON payload as a module-private Symbol, exactly like the marker
+ * above, so the result's serialisation is byte-identical and nothing downstream can
+ * observe it by accident. A Symbol created here is unreachable from any wire object,
+ * which is why this — unlike the string-keyed read on the Error — needs no
+ * own-property dance: there is no `Object.prototype` slot an attacker or a careless
+ * dependency could fill. And the read's failure direction is the safe one anyway: a
+ * mark wrongly seen suppresses a note, which is how this path behaved before #1560.
+ */
+const PANEL_ANSWERED_RESULT = Symbol("panel.answeredResult");
+
+function carryPanelAnsweredMark(err: unknown, res: ToolResult): ToolResult {
+  if (res?.isError !== true) return res;
+  if (!isPanelAnsweredError(err)) return res;
+  Object.defineProperty(res, PANEL_ANSWERED_RESULT, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return res;
+}
+
+/** True only for a ToolResult `ctx.call` produced from an error the BRIDGE minted
+ *  out of a received reply. A timeout, a routing refusal or a dead socket can never
+ *  carry this, whatever their text says — and neither can an error from a panel too
+ *  old to be marked, which is why its absence claims nothing on its own. */
+function isPanelAnsweredResult(res: ToolResult): boolean {
+  return res?.isError === true && (res as Record<symbol, unknown>)[PANEL_ANSWERED_RESULT] === true;
+}
+
 // ---- panel_exit_subgraph settle-after-ack-timeout (#1468) ------------------
 // `graph_exit_subgraph` timed out at 15 s while a following `panel_graph_outline`
 // proved the view HAD returned to root — an applied navigation reported as a
@@ -3907,11 +3947,24 @@ async function observeActiveAfterOpen(
   let list: Record<string, unknown> | null = null;
   try {
     const res = await ctx.call({ cmd: "workflow_list" }, 6000);
-    // An ERROR reply and a THROW are the same observation — the fence-exempt read did
-    // not come back with a usable list — and both are reported as such. A reply that
-    // ARRIVED and merely did not parse is NOT this: something answered, so the channel
-    // claim below would be false. That case keeps the old silence.
-    if (res?.isError) return { status: "unanswered", detail: toolResultText(res) };
+    // NOT EVERY `isError` IS A SILENCE (review, P1). The first version of this read
+    // every failed read as "the panel never came back", and an ACKNOWLEDGED panel
+    // error is `isError` too — the tab received the command, ran its gate and replied
+    // refusing it. Labelling that `NOT ANSWERING` states the opposite of what was
+    // observed and hands the user a hard-refresh for a tab that is working, which is
+    // this bug's own failure mode pointed the other way.
+    //
+    // The two are told apart STRUCTURALLY, at the bridge branch that receives the
+    // reply — never from the message, which is arbitrary panel text and is
+    // TRANSLATED, so a wording rule would answer wrongly in eleven of twelve locales.
+    // Absence of the mark is the honest default: a timeout, a routing refusal and a
+    // dead socket all mint no reply, and so does a panel too old to be marked at all.
+    if (res?.isError) {
+      // It answered. That says nothing about this workflow — same silence as a reply
+      // that arrived and did not parse, below — but it does refute a channel claim.
+      if (isPanelAnsweredResult(res)) return { status: "quiet" };
+      return { status: "unanswered", detail: toolResultText(res) };
+    }
     list = parseToolResultJson(res);
   } catch (err) {
     // BELT AND BRACES, and stated as such rather than dressed up as a guard: `ctx.call`
@@ -6946,10 +6999,17 @@ export function makePanelToolCtx(
     return bridge.send(routed as { cmd: string }, { tabId: ctx.tabId, timeoutMs, onDispatchedRid });
   };
 
-  const call = async (
+  const callOnce = async (
     cmd: Record<string, unknown>,
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
+    // #1560 — reports the error each attempt failed on, so the wrapper below can
+    // stamp the bridge's structural marks onto the ToolResult from ONE place. The
+    // catch has more than a dozen `fail(...)` exits, each shaping its own message;
+    // decorating them individually is the shape that goes stale the moment a
+    // fourteenth is added, and the fact being carried belongs to the ERROR rather
+    // than to any one of those wordings.
+    onFailure?: (err: unknown) => void,
   ): Promise<ToolResult> => {
     // #694: capture the rid of THIS call's dispatched attempt so an OUTCOME-UNKNOWN
     // mutating failure can name it as the caller's explicit retry token (see the
@@ -6985,6 +7045,7 @@ export function makePanelToolCtx(
       if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
       return firstTry;
     } catch (err) {
+      onFailure?.(err); // #1560 — the error this attempt failed on (see the wrapper).
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
       // transport (or replace it under a new tab id) the instant after we dispatch.
       // For idempotent commands, settle briefly, rebind onto the now-live tab, and
@@ -7038,6 +7099,10 @@ export function makePanelToolCtx(
           }
           return retried;
         } catch (err2) {
+          // #1560 — the RETRY's failure is the one every exit below describes, so it
+          // supersedes the first. A retried read that comes back refused is a panel
+          // that answered, whatever the flap that provoked the retry looked like.
+          onFailure?.(err2);
           // #1027 — a switch STILL in progress is not a reconnect, and saying so
           // would be the #1001 mistake again: the tab is connected and healthy,
           // it is simply mid-switch. Name the actual state and the actual wait.
@@ -7334,6 +7399,32 @@ export function makePanelToolCtx(
       }
       return carryReplyTimeoutMark(err, fail(err));
     }
+  };
+  /**
+   * #1560 — ONE exit, so a structural fact about the failure survives the trip into a
+   * ToolResult no matter which of `callOnce`'s exits produced it.
+   *
+   * `carryReplyTimeoutMark` is applied at three of those exits by hand, which is fine
+   * for a fact only those three can carry. "The panel answered" is not like that: an
+   * acknowledged `ok:false` reply can leave through the capability branch, the
+   * root-uuid branch, the mismatch branch or the bare tail, and a caller reading the
+   * mark has to be able to trust its ABSENCE. Stamping it here means a new `fail(...)`
+   * exit added later inherits the mark instead of quietly losing it.
+   *
+   * The failure is captured per invocation (a closure local, not shared state), so
+   * concurrent `ctx.call`s — including the `rebindWorkflowFence` round trip that
+   * `callOnce`'s own catch makes — cannot read each other's.
+   */
+  const call = async (
+    cmd: Record<string, unknown>,
+    timeoutMs?: number,
+    onDispatchedRid?: (rid: string) => void,
+  ): Promise<ToolResult> => {
+    let failure: unknown;
+    const res = await callOnce(cmd, timeoutMs, onDispatchedRid, (err) => {
+      failure = err;
+    });
+    return carryPanelAnsweredMark(failure, res);
   };
   // Human-in-the-loop confirmation for a DESTRUCTIVE op: render a yes/no card in
   // the panel and block on the user's pick. Returns false on decline, timeout, or

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3844,16 +3844,22 @@ export function readOpenActiveAgainstTarget(
 async function clearFenceOnIdentityProvenOpen(
   ctx: PanelToolCtx,
   res: ToolResult,
-): Promise<ToolResult> {
+): Promise<{ res: ToolResult; repaired: boolean }> {
   const text = toolResultText(res);
   // ONLY the class that states identity was proven. The UNPROVEN verdict ("could not
   // prove that the active canvas was rebound") must keep failing closed: re-deriving a
   // fence onto a canvas we cannot identify is how an edit lands on the wrong graph.
-  if (!/the canvas IS bound to/i.test(text)) return res;
+  if (!/the canvas IS bound to/i.test(text)) return { res, repaired: false };
 
   let note: string;
+  // #1560 — reported STRUCTURALLY, never re-read out of the sentence below. The caller
+  // uses this to decide whether a "the channel is not answering" note would contradict
+  // the line above it, and a prose predicate over our own wording is exactly the
+  // coupling that rots the first time someone edits the message.
+  let repaired = false;
   try {
     const rebind = await rebindWorkflowFence(ctx);
+    repaired = rebind.status === "refreshed" || rebind.status === "already_current";
     note =
       rebind.status === "refreshed" || rebind.status === "already_current"
         ? `\n\nFENCE: CLEARED. This reply published no workflow_uuid, so the fence was re-derived ` +
@@ -3871,25 +3877,110 @@ async function clearFenceOnIdentityProvenOpen(
       `\n\nFENCE: NOT cleared — the re-derivation threw, so the fence state is UNKNOWN and graph ` +
       `commands may still be refused. (${err instanceof Error ? err.message : String(err)})`;
   }
-  return appendToolResultText(res, note);
+  return { res: appendToolResultText(res, note), repaired };
 }
+
+/**
+ * #1560 — what the post-open exempt read ACTUALLY observed, kept as three answers
+ * rather than one nullable notice.
+ *
+ * The old shape returned `OpenDriftNotice | null`, and `null` carried two facts that
+ * want opposite remedies: "asked, and nothing has drifted" and "asked, and the panel
+ * never came back". The second was swallowed with the comment *"could not ask —
+ * nothing was observed, so nothing is claimed"* — true about the WORKFLOW, and it
+ * threw away a measurement about the CHANNEL that was the reporter's whole answer.
+ */
+type OpenActiveProbe =
+  /** The panel answered, and names a DIFFERENT workflow as active. */
+  | { status: "different"; activeLabel: string }
+  /** The panel answered; the active record is this target, or unreadable enough that
+   *  nothing may be claimed about it. Says nothing about the channel — it works. */
+  | { status: "quiet" }
+  /** The read did NOT come back. `detail` is the failure verbatim, so the note quotes
+   *  a measurement rather than paraphrasing one. */
+  | { status: "unanswered"; detail: string };
 
 async function observeActiveAfterOpen(
   ctx: PanelToolCtx,
   requestedPath: string,
-): Promise<OpenDriftNotice | null> {
+): Promise<OpenActiveProbe> {
   let list: Record<string, unknown> | null = null;
   try {
     const res = await ctx.call({ cmd: "workflow_list" }, 6000);
-    if (!res?.isError) list = parseToolResultJson(res);
-  } catch {
-    return null; // could not ask — nothing was observed, so nothing is claimed
+    // An ERROR reply and a THROW are the same observation — the fence-exempt read did
+    // not come back with a usable list — and both are reported as such. A reply that
+    // ARRIVED and merely did not parse is NOT this: something answered, so the channel
+    // claim below would be false. That case keeps the old silence.
+    if (res?.isError) return { status: "unanswered", detail: toolResultText(res) };
+    list = parseToolResultJson(res);
+  } catch (err) {
+    // BELT AND BRACES, and stated as such rather than dressed up as a guard: `ctx.call`
+    // converts a bridge throw into an `isError` ToolResult and does not rethrow, so on
+    // today's code this arm cannot be reached — the branch above is what fires for the
+    // reporter's timeout. It is kept (a) because the pre-existing code had a catch here
+    // and removing it would let a future throw escape a tool handler instead of
+    // degrading, and (b) because if it ever DOES fire, "the read did not come back" is
+    // the true statement, not silence. A mutation of this line therefore survives by
+    // construction, not for want of a test.
+    return { status: "unanswered", detail: err instanceof Error ? err.message : String(err) };
   }
-  if (!list) return null;
+  if (!list) return { status: "quiet" };
   if (readOpenActiveAgainstTarget(list.active, requestedPath, list.active_confirmed) !== "different") {
-    return null;
+    return { status: "quiet" };
   }
-  return { drifted: true, activeLabel: describeActiveRecord(list.active) };
+  return { status: "different", activeLabel: describeActiveRecord(list.active) };
+}
+
+/**
+ * #1560 — THE SILENCE IS THE ANSWER.
+ *
+ * The reporter called `panel_open_workflow`, got the UNPROVEN verdict, watched every
+ * `panel_*` graph call refuse with `workflow instance mismatch`, ran
+ * `panel_set_workflow_target({mode:"current"})` (the documented recovery, which reported
+ * "the panel did not answer"), and then retried `panel_open_workflow` TWICE more —
+ * because nothing had told them the retries could not work.
+ *
+ * This process already knew. `observeActiveAfterOpen` had just sent a `workflow_list`,
+ * which is the read the fence EXEMPTS, and it had not come back. That failure
+ * discriminates the two situations the reporter could not tell apart:
+ *
+ *  - `mode:"current"` re-derives through `rebindWorkflowFence`, whose ONLY probe is its
+ *    own `workflow_list` round trip. It reads the channel that just failed, so it is not
+ *    a different thing to try.
+ *  - `workflow_open` is fence-exempt, but exemption is about the STAMP, not the socket.
+ *    A retry still needs the panel to answer.
+ *
+ * WHAT IT MAY NOT SAY. One bounded read failed. That is not permanence: a tab still
+ * reconnecting after a ComfyUI restart answers late and the session recovers by itself.
+ * The note reports the reading and the retry, and only then names the tab as the thing
+ * to fix — it never asserts the panel is gone, and it never touches the fence.
+ *
+ * IT DELIBERATELY DOES NOT CARRY `panelTooOldNote`, even though #1560's reporter WAS on
+ * an old panel (0.11.37). That note diagnoses a panel that ANSWERS while publishing no
+ * `workflow_uuid`, and says "if it IS below {needed}, that is the whole cause of this
+ * failure". Here nothing answered at all — a current 0.14.x panel behind a closed or
+ * wedged tab produces this identical silence — so appending it would name a cause this
+ * observation cannot support. Review already caught that direction once on this note
+ * (`panel_set_workflow_target`), and the reasoning is the same.
+ */
+function panelChannelSilentNote(detail: string): string {
+  return (
+    `\n\nPANEL CHANNEL: NOT ANSWERING. Right after this open, a \`workflow_list\` read was sent — ` +
+    `the one read this session's workflow fence EXEMPTS — and it did not come back: ` +
+    `${detail || "no reason was reported"}. That is a measurement about the CHANNEL, not about ` +
+    `this workflow, and it is what tells the two remaining moves apart:\n` +
+    `  • panel_set_workflow_target({mode:"current"}) — the documented recovery — re-derives the ` +
+    `fence from its own \`workflow_list\` round trip. It reads the same channel that just failed, ` +
+    `so expect it to fail the same way; it is not a different thing to try.\n` +
+    `  • Retrying panel_open_workflow does not help either. The open is exempt from the FENCE, ` +
+    `not from needing an answer, and it did not get one.\n` +
+    `WHAT THIS DOES NOT ESTABLISH: one bounded read failed, which is not evidence that the panel ` +
+    `is permanently gone. A tab still reconnecting after a ComfyUI restart or reload answers late ` +
+    `and recovers on its own — so retry ONCE, a few seconds from now. If it is still silent, the ` +
+    `panel JS running in the open browser tab is the thing to fix: HARD-REFRESH the ComfyUI tab ` +
+    `(Ctrl+Shift+R). Restarting ComfyUI alone does NOT do it, and a ComfyUI-Manager pack update ` +
+    `that reported FAILED leaves the previous panel JS live in the tab that is already open.`
+  );
 }
 
 /**
@@ -5342,8 +5433,19 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       // (its own contract wording for "the load executed, the proof did not"),
       // which is exactly the class that can assert a false active workflow.
       if (!/workflow_open RAN/i.test(toolResultText(res))) return res;
-      const drift = await observeActiveAfterOpen(ctx, path);
-      if (!drift) return await clearFenceOnIdentityProvenOpen(ctx, res);
+      const probe = await observeActiveAfterOpen(ctx, path);
+      if (probe.status !== "different") {
+        const cleared = await clearFenceOnIdentityProvenOpen(ctx, res);
+        // #1560 — the probe's SILENCE, reported. Suppressed when the fence was in fact
+        // repaired: that re-derivation is itself a `workflow_list` round trip, so a
+        // success there proves the channel answered and the note would contradict the
+        // line above it. Gated on the STRUCTURED outcome, never on its wording.
+        if (probe.status === "unanswered" && !cleared.repaired) {
+          return appendToolResultText(cleared.res, panelChannelSilentNote(probe.detail));
+        }
+        return cleared.res;
+      }
+      const drift = probe;
       return fail(
         `${toolResultText(res)}\n\nAND — checked after that failure — ${drift.activeLabel} is the ` +
           `ACTIVE workflow now, not ${path}. Whatever that message says about ${path} being active, ` +

--- a/src/services/panel-answered.ts
+++ b/src/services/panel-answered.ts
@@ -1,0 +1,101 @@
+/**
+ * "SOMETHING ANSWERED" — the fact that separates an ACKNOWLEDGED panel error from a
+ * channel that never came back (#1560).
+ *
+ * ## Why this exists
+ *
+ * `ctx.call` flattens every failure into one shape: a ToolResult with `isError: true`
+ * and some text. That is the right shape for a caller who only has to report the
+ * failure, and the wrong shape for a caller who has to say WHY it failed — because
+ * two opposite observations arrive identical:
+ *
+ *   the panel replied `ok:false`      the tab is alive and served the command
+ *   the read never came back          the tab did not answer at all
+ *
+ * `panel_open_workflow`'s post-open probe (`observeActiveAfterOpen`) is exactly that
+ * second kind of caller: on a silent read it prints `PANEL CHANNEL: NOT ANSWERING`
+ * and sends the user to hard-refresh their ComfyUI tab. Told only `isError`, it makes
+ * that claim about a panel that demonstrably ANSWERED — a false statement in the
+ * bug's own direction, and a remedy for a problem the user does not have.
+ *
+ * ## Why it is not read out of the message
+ *
+ * The same reason `panel-refusal.ts` is not: acknowledged panel errors travel as
+ * arbitrary `msg.error` text, so any sentence one class writes is a sentence the
+ * other can also contain. Worse for a PROSE predicate specifically — the panel is
+ * translated, so a rule matching English words is a rule that stops working for
+ * eleven of twelve locales, silently, in whichever direction the default takes.
+ *
+ * So the bridge states it structurally at the ONE place that knows: the branch that
+ * turns a received `ok:false` reply into a rejection. Nothing else mints it, and the
+ * absence of the mark is not evidence of anything except that nothing said otherwise.
+ *
+ * ## The direction it fails in
+ *
+ * A missing mark reads as "did not answer", which is the direction #1560 exists to
+ * report: the pre-#1560 code swallowed a silent probe entirely, and defaulting the
+ * other way would restore that silence for every failure class nobody remembered to
+ * mark. The cost of the mark being wrongly ABSENT is one over-stated note; the cost
+ * of it being wrongly PRESENT is the reporter's original dead end. That asymmetry is
+ * why the mark is attached only where a reply was genuinely received, and why it is
+ * propagated (never re-derived) when an error is substituted downstream.
+ */
+
+import { hasOwnField } from "./panel-refusal.js";
+
+/** The property the bridge attaches to an error it minted from a RECEIVED reply.
+ *  Namespaced for the same reason `cmcpPanelRefusal` is: `code`/`cause` on an Error
+ *  already mean other things to other catch blocks. */
+export const PANEL_ANSWERED_PROP = "cmcpPanelAnswered";
+
+/**
+ * Mark an error as "the panel served this command and replied".
+ *
+ * `defineProperty`, not assignment — an assignment to a property that exists on the
+ * prototype as non-writable throws in strict mode, which would replace a clear panel
+ * error with an unrelated TypeError (the trap `attachPanelRefusal` documents). And
+ * decorating an error must never be able to fail the command harder than it already
+ * failed, so the whole thing is best-effort.
+ */
+export function attachPanelAnswered(err: Error): Error {
+  try {
+    Object.defineProperty(err, PANEL_ANSWERED_PROP, {
+      value: true,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  } catch {
+    // Best effort: an un-markable error falls back to the honest default (unknown,
+    // reported as "did not answer"), which is how every older path already behaves.
+  }
+  return err;
+}
+
+/**
+ * Carry the mark from an error onto the error that REPLACES it.
+ *
+ * The bridge rewrites an old panel's "Unknown command" rejection into an actionable
+ * update-your-panel error. That rewrite is still a REPLY — the panel answered, it
+ * just answered that it does not know the command — so dropping the mark there would
+ * label a talking panel silent, which is the whole defect. Propagated from the
+ * source, never re-derived from the replacement's text.
+ */
+export function inheritPanelAnswered(from: unknown, to: Error): Error {
+  return isPanelAnsweredError(from) ? attachPanelAnswered(to) : to;
+}
+
+/**
+ * Did this error come from a reply the panel actually sent?
+ *
+ * OWN property, `true` exactly. An inherited `cmcpPanelAnswered` — from a polluted
+ * prototype, or a library that decorates Error — would silence a genuine
+ * NOT-ANSWERING report, which is the reporter's dead end restored. `hasOwnField`
+ * binds `hasOwnProperty` at module load rather than reading it off the object under
+ * test, so the check cannot be answered by the thing it distrusts (#1529 P0).
+ */
+export function isPanelAnsweredError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  if (!hasOwnField(err, PANEL_ANSWERED_PROP)) return false;
+  return (err as Record<string, unknown>)[PANEL_ANSWERED_PROP] === true;
+}

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -19,6 +19,7 @@ import { randomUUID, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
 import { resolveLocale, trFor, type Locale } from "../i18n/index.js";
 import { logger } from "../utils/logger.js";
+import { attachPanelAnswered, inheritPanelAnswered } from "./panel-answered.js";
 import { attachPanelRefusal, hasOwnField, readPanelRefusal } from "./panel-refusal.js";
 import { midCommandDisconnectMessage } from "./mid-command-remedy.js";
 import {
@@ -2644,7 +2645,13 @@ export class UiBridge {
           //
           // Validated before it is attached, so only a complete pre-executor claim
           // travels; anything else leaves the error exactly as it was.
-          const err = new Error(String(msg.error ?? "panel reported an error"));
+          // #1560 — and record the fact that this reply EXISTS, structurally.
+          // `ctx.call` flattens every failure into `isError`, so a command the panel
+          // SERVED and refused arrives indistinguishable from one the tab never
+          // answered — and a caller that reports "the channel is not answering" then
+          // says it about a panel that is demonstrably talking. This branch is the
+          // one place that knows the difference: a reply was received.
+          const err = attachPanelAnswered(new Error(String(msg.error ?? "panel reported an error")));
           // OWN property on the WIRE message too (review, P0). A polluted
           // Object.prototype.refusal would otherwise give every ordinary panel
           // error — including a genuine mid-write one carrying no refusal of its
@@ -4477,7 +4484,13 @@ export class UiBridge {
       if (isUnknownCommandReply(err.message)) {
         target.provenSupportedCmds.delete(cmd.cmd);
       }
-      ctx.reject(friendly ?? err);
+      // #1560 — a rewrite is still a REPLY. `friendly` is minted from an "Unknown
+      // command" answer the panel sent, so the substituted error must carry the
+      // same "something answered" mark the original does; dropping it here would
+      // label a talking panel silent and send its user to hard-refresh a healthy
+      // tab. PROPAGATED from the source error, never re-derived from the
+      // replacement's wording.
+      ctx.reject(friendly ? inheritPanelAnswered(err, friendly) : err);
     };
     const timer = setTimeout(() => {
       this.pending.delete(rid);


### PR DESCRIPTION
Reported in artokun/comfyui-mcp#1560 — `panel_open_workflow` fails to rebind the canvas, then every `panel_*` call is permanently refused.

## What the reporter did

`panel_open_workflow` returned the UNPROVEN verdict. Every `panel_*` graph call after it refused with `workflow instance mismatch`. `panel_set_workflow_target({mode:"current"})` — the documented recovery — answered *"the panel did not answer"*. They then retried `panel_open_workflow` **twice more**, reproducing the identical error each time. Nothing had told them the retries could not work.

## What this process already knew and threw away

On the open's own error branch, `observeActiveAfterOpen` sends a `workflow_list` — the read the fence **exempts**. In that session it cannot have answered either. Its failure was swallowed with the comment *"could not ask — nothing was observed, so nothing is claimed"*. True about the **workflow**. It discarded a measurement about the **channel**, which was the whole answer.

That silence **discriminates**:

- `mode:"current"` re-derives through `rebindWorkflowFence`, whose only probe is its own `workflow_list` round trip — the same read that just failed. Not a different thing to try.
- `workflow_open` is exempt from the **fence**, not from needing a reply.

So "the exempt read did not come back" is what separates *retry* from *the panel JS in the open tab is what needs fixing*.

## The change

- `observeActiveAfterOpen` answers three ways instead of one nullable notice: `different` / `quiet` / `unanswered`.
- `clearFenceOnIdentityProvenOpen` returns whether the fence was actually repaired as a **structured** field, so the new note is suppressed when the re-derivation succeeded rather than by re-reading its own prose.
- A `PANEL CHANNEL: NOT ANSWERING` note quoting the failure verbatim, on both verdict classes, whenever the fence was not repaired.

## Claim discipline

One bounded read failed. That is **not** permanence, and the note says so: it names the still-reconnecting case that recovers on its own, asks for **one** retry, and only then names the tab (`Ctrl+Shift+R`, plus the failed-ComfyUI-Manager-update trap that leaves old panel JS live).

It deliberately does **not** carry `panelTooOldNote`, even though this reporter was on panel 0.11.37. That note diagnoses a panel that *answers* while publishing no `workflow_uuid`; here nothing answered at all, and a current 0.14.x panel behind a wedged tab produces identical silence. Appending it would name a cause this observation cannot support — review caught that same direction once already on that note, and a source-counting wiring test caught this attempt.

---

## Review finding — P1, NO-SHIP — and what it changed

> `observeActiveAfterOpen` maps every `isError` to "unanswered", but ACKNOWLEDGED PANEL ERRORS also become `isError` (`ui-bridge.ts` `ok:false` → `p.reject`, flattened by `ctx.call`). A responding panel can therefore be falsely labeled `NOT ANSWERING` and prescribed a hard refresh; the test covers only the canonical timeout.

**Confirmed, and it is this bug's own failure mode pointed the other way.** `isError` covers two opposite observations: nothing came back, and the tab *received* the command, ran it, and replied refusing it. Announcing `PANEL CHANNEL: NOT ANSWERING` about the second states the opposite of what was measured — contradicted by the very reply that produced it — and sends a user to hard-refresh a healthy tab. The comment above the branch already drew the distinction ("A reply that ARRIVED and merely did not parse is NOT this: something answered"); `isError` simply does not carry it.

**Not decidable from the message.** Acknowledged panel errors travel as arbitrary `msg.error` text, so any sentence one class writes the other can contain — the reasoning that got the #1529 prose predicate reverted as a P0. And the panel is **translated**: a rule matching English words answers wrongly for eleven of twelve locales, silently. So the fact is stated structurally, mirroring `panel-refusal.ts`:

- **`src/services/panel-answered.ts`** (new) — `attachPanelAnswered` / `inheritPanelAnswered` / `isPanelAnsweredError`, read as an **own** property with the intrinsic bound at module load (reusing `hasOwnField`, so no second weaker copy of the #1529 P0 check).
- **`ui-bridge.ts`** — the mark is attached at the single branch that *receives* a reply (the `ok:false` rejection), and **propagated** across the "Unknown command" → "update your panel" rewrite, because a rewrite is still a reply.
- **`panel-tools.ts`** — `ctx.call` is split into `callOnce` + a one-exit wrapper that stamps the mark onto the ToolResult (module-private `Symbol`, off the JSON payload, exactly like the existing `REPLY_TIMEOUT_RESULT`). Its dozen-plus `fail(...)` branches can no longer drop it, so a caller may trust the mark's **absence**.
- **`observeActiveAfterOpen`** reports `unanswered` only when the mark is absent. An answered-with-error probe returns `quiet` — the same silence as a reply that arrived and did not parse.

**Direction of failure, deliberately.** Absence of the mark still reads as "did not answer": a timeout, a routing refusal, a dead socket and a panel too old to be marked all mint no reply. A missing mark over-states one note; a wrongly-present one restores the swallowed silence this PR exists to end.

**Unchanged invariants:** the fence is still not adopted on an unproven verdict; a successful open with only a failed probe is still a success; the `catch` arm still survives by construction (below).

## Verified

- **516 test files / 9594 tests green** (`--maxWorkers=4`; the default worker count OOMs this machine and is a harness limit, not a product one), `npm run lint`, `npm run build`, `npm run check:vocabulary`.
- Original 5 mutations (occurrence-verified, all killed): the `isError` arm, the `!repaired` guard, the `unanswered` guard, the structural `repaired` signal, and the drift branch.
- **5 further mutations for the review fix**, each `grep -c`-verified as applied (1 → 0) against a green baseline, **all 5 killed**: (1) the bridge stops marking a received reply; (2) the classifier ignores the mark; (3) `ctx.call` stops carrying it onto the ToolResult; (4) the catch stops reporting its failure to the wrapper; (5) the Unknown-command rewrite drops the mark.
- Mutation (5) **survived the first round** — only the helper was covered, so deleting the call site killed nothing. A live-WebSocket test now drives an old panel's raw dispatch reply and asserts the substitution really occurred *before* asserting the mark rode along.
- New tests: `panel-answered-marker.test.ts` (own-property semantics under a polluted prototype and a swapped `hasOwnProperty`; plus reachability through a **real** `UiBridge` socket — an `ok:false` reply is marked, a reply timeout is not) and, in the existing file, a panel that **answers with an error** must not be called silent and must not be prescribed `Ctrl+Shift+R`, on both verdict classes.
- The probe's `catch` arm still **survives by construction** and says so in the source: `ctx.call` converts a bridge throw into an `isError` ToolResult and never rethrows, so that arm is unreachable today. It is kept so a future throw degrades instead of escaping a tool handler.

## What I did NOT do

- **The fence is still not adopted on an UNPROVEN verdict.** The reporter's suggestions 1 and 2 (clear it, or set it optimistically to the newly-opened workflow) remain declined: pointing a session at a canvas the panel could not identify is the write-to-the-wrong-graph failure the fence exists to prevent. **This makes the dead end nameable, not survivable.**
- **I did not reproduce their session.** The mechanism is read off the code path plus their own transcript; no rig repro of a wedged panel was performed.
- I did not touch the panel side of their report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
