### PR TITLE
release: v0.51.56 — a refusal stops pointing at the wrong machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.56] - 2026-08-15
+
+### MCP
+
+#### Fixed
+- the restart refusal stops sending you at a server it knows is the wrong one (#1593)
+- pack VRAM tiers say what their own manifest fetches (#1585)
+
 ## [0.51.55] - 2026-08-15
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.55",
+  "version": "0.51.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.55",
+      "version": "0.51.56",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.55",
+  "version": "0.51.56",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp#1593 and artokun/comfyui-mcp#1585.

**#1593** — `panel_restart_comfyui`'s refusal ended with "USE restart_comfyui INSTEAD" unconditionally, which points the user at the wrong machine whenever the panel is on a different ComfyUI than the headless tool would restart. The discriminator already existed one function away, unused; it is now shared, so a provably different panel gets a warning naming both addresses, same-install still gets the recommendation, and unknown stays unknown.

Not done, deliberately: delegating to the panel's own restart, as the issue asks. That path has no busy guard, so it could abort a running render.

**#1585** — nine packs advertised a `vram:` tier contradicting the UNet their own manifest fetches. Measured against real `Content-Length`: Q4_K_S = 8.15 GB, fp16 = 26.62 GB, so "24GB+" on an fp16 pack is not a small understatement — one UNet exceeds the card. The gate for this class is tracked separately in #1609 after three executed refutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)