### PR TITLE
fix(1567): a queued credential respawn waits for in-flight transfers instead of killing them

### DIFF
--- a/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
+++ b/src/__tests__/orchestrator/deferred-respawn-orphans.test.ts
@@ -11,7 +11,17 @@
 // So the snapshot is re-taken AT THE RESPAWN. These pin both halves: the note itself, and
 // that a genuinely deferred respawn actually reaches it — a helper nothing calls would
 // leave the defect exactly where it was.
-import { beforeAll, describe, expect, it, vi } from "vitest";
+//
+// ## What item 2 changed under this file, and why it still asserts the same things
+//
+// A queued credential respawn now WAITS for in-flight transfers instead of killing them
+// (respawn-holds-for-transfers.test.ts). So every test here that puts transfers in flight
+// now reaches this note by the OTHER route: the hold gives up on transfers that make no
+// progress, and a mocked list returning a constant byte count is, correctly, exactly that.
+// The assertions are unchanged and mean what they always did — when the rebuild does go
+// ahead over live-looking transfers, it names them — and the windows below are shortened
+// only so the stall is reached in test time rather than in two minutes.
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type {
   AgentBackend,
@@ -34,8 +44,17 @@ let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelA
 let orphanedByDeferredRespawnNote: typeof import("../../services/panel-secrets.js").orphanedByDeferredRespawnNote;
 
 beforeAll(async () => {
+  // #1567 item 2 — reach the hold's give-up in test time. Read live by the manager, so
+  // setting them here covers every manager this file builds.
+  process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS = "10";
+  process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS = "40";
   ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
   ({ orphanedByDeferredRespawnNote } = await import("../../services/panel-secrets.js"));
+});
+
+afterAll(() => {
+  delete process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS;
+  delete process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS;
 });
 
 class RecordingBackend implements AgentBackend {

--- a/src/__tests__/orchestrator/respawn-holds-for-transfers.test.ts
+++ b/src/__tests__/orchestrator/respawn-holds-for-transfers.test.ts
@@ -30,10 +30,20 @@ import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
 /** The transfers a respawn would orphan. Mocked at the MODULE boundary panel-agent imports
  *  across — `listDownloadJobs` is called from inside download-jobs.js, so mocking that would
  *  replace an export nobody reads. */
-const atRisk = vi.hoisted(() => ({ jobs: [] as { id: string; filename: string; bytes: number }[] }));
+const atRisk = vi.hoisted(() => ({
+  jobs: [] as { id: string; filename: string; bytes: number }[],
+  /** The enumeration reads job records and each progress file with sync IO, so it CAN throw. */
+  throws: false,
+}));
 vi.mock("../../services/download-jobs.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/download-jobs.js")>();
-  return { ...actual, downloadsAtRiskOfRespawn: () => atRisk.jobs };
+  return {
+    ...actual,
+    downloadsAtRiskOfRespawn: () => {
+      if (atRisk.throws) throw new Error("EIO: reading the download job store failed");
+      return atRisk.jobs;
+    },
+  };
 });
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
@@ -59,6 +69,7 @@ afterEach(() => {
   delete process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS;
   delete process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS;
   atRisk.jobs = [];
+  atRisk.throws = false;
 });
 
 class RecordingBackend implements AgentBackend {
@@ -336,6 +347,85 @@ describe("a queued credential respawn waits for in-flight transfers (#1567 item 
       spawns.filter((t) => t === "tab-busy"),
       "the busy tab's respawn must wait too",
     ).toHaveLength(1);
+  });
+
+  it("an unreadable job store does not END a hold that is working", async () => {
+    // Codex gate, P1. The enumeration does sync IO, so it can throw, and a failure was being
+    // converted into the same empty list as "everything finished" — so one EIO on one poll
+    // tick reads as the good ending, releases an hour of correctly protecting a live 48 GB
+    // transfer, and kills it. "I could not tell" may not answer a question it did not answer.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [job(4_000_000_000)];
+    const backend = new RecordingBackend();
+    const spawns: string[] = [];
+    const manager = makeManager(backend, spawns);
+    const tab = "tab-unreadable";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+    await sleep(60); // established: held, and the transfer is real
+
+    atRisk.throws = true;
+    await sleep(200); // ~20 poll ticks, every one of them unable to read the store
+    expect(spawns.filter((t) => t === tab), "the hold must survive an unreadable store").toHaveLength(1);
+
+    // …and the store coming back with the transfer really finished still releases it.
+    atRisk.throws = false;
+    atRisk.jobs = [];
+    await waitFor(() => spawns.filter((t) => t === tab).length >= 2);
+  });
+
+  it("an unreadable job store does not START a hold either", async () => {
+    // The other direction of the same rule. A respawn held on a state nobody can read is a
+    // respawn that may never fire, so an unreadable store at the decision point leaves the
+    // pre-#1567 behaviour in place rather than inventing transfers to wait for.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.throws = true;
+    const backend = new RecordingBackend();
+    const spawns: string[] = [];
+    const manager = makeManager(backend, spawns);
+    const tab = "tab-unreadable-start";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => spawns.filter((t) => t === tab).length >= 2);
+  });
+
+  it("a store that stays unreadable gives the hold up after one stall window", async () => {
+    // Bounded, for the same reason a frozen transfer is: an unreadable store cannot show
+    // progress, so `movedAt` never advances and the ordinary give-up applies. Without this
+    // the respawn is pinned for as long as the IO failure lasts.
+    //
+    // The transfer is kept MOVING right up to the failure, which is what isolates this path:
+    // with a frozen list the hold would end on the ordinary stall whether or not the
+    // unreadable case is bounded at all, and a first version of this test passed against a
+    // hold that could never be given up.
+    setWindows({ pollMs: 10, stallMs: 60 });
+    atRisk.jobs = [job(1_000_000)];
+    const backend = new RecordingBackend();
+    const spawns: string[] = [];
+    const manager = makeManager(backend, spawns);
+    const tab = "tab-unreadable-forever";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+
+    const ticker = setInterval(() => {
+      atRisk.jobs = [job((atRisk.jobs[0]?.bytes ?? 0) + 5_000_000)];
+    }, 10);
+    await sleep(140); // twice the stall window, still moving, still held
+    expect(spawns.filter((t) => t === tab), "a live transfer is held, not given up on").toHaveLength(1);
+
+    clearInterval(ticker);
+    atRisk.throws = true; // …and now the store itself goes unreadable, permanently
+    await waitFor(() => spawns.filter((t) => t === tab).length >= 2);
   });
 
   it("does not delay an unrelated restart after the credential respawn has resolved", async () => {

--- a/src/__tests__/orchestrator/respawn-holds-for-transfers.test.ts
+++ b/src/__tests__/orchestrator/respawn-holds-for-transfers.test.ts
@@ -1,0 +1,367 @@
+// #1567 item 2 — a QUEUED credential respawn WAITS for in-flight transfers instead of
+// killing them.
+//
+// The first half of #1567 shipped in 0.51.49: the at-risk snapshot is re-taken when the
+// respawn fires, so the nine downloads it destroys are at least NAMED. That is a better
+// obituary, not a fix — the reporter still loses ~48 GB and still has to issue nine cancels
+// and nine re-issues. The reporter's own argument is the fix: a respawn that has already
+// waited turns is by definition not urgent, and for a comfyui credential the running tools
+// re-read the value from disk at use time, so the rebuild is a tidy-up. The transfers cost
+// hours. So the respawn yields to them.
+//
+// What these pin, in order of what would silently un-ship the fix:
+//   * the hold actually happens on the reporter's timeline (save with nothing in flight,
+//     downloads started later, respawn comes due);
+//   * something WAKES it — `applyPendingRestarts` runs at turn-done, and a user watching a
+//     download is idle, so without the poll the respawn would simply never fire;
+//   * it waits on PROGRESS, not on a clock, so a healthy 48 GB transfer is never killed for
+//     being long and a dead one cannot pin the respawn for the rest of the session;
+//   * only a CREDENTIAL respawn may wait — a retarget must not.
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+/** The transfers a respawn would orphan. Mocked at the MODULE boundary panel-agent imports
+ *  across — `listDownloadJobs` is called from inside download-jobs.js, so mocking that would
+ *  replace an export nobody reads. */
+const atRisk = vi.hoisted(() => ({ jobs: [] as { id: string; filename: string; bytes: number }[] }));
+vi.mock("../../services/download-jobs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/download-jobs.js")>();
+  return { ...actual, downloadsAtRiskOfRespawn: () => atRisk.jobs };
+});
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/**
+ * Both windows are set PER TEST rather than shared, because the two directions need
+ * opposite settings and racing them against one shared window is how this file would go
+ * flaky. A test asserting the respawn is HELD sets a stall window it cannot reach, so "no
+ * respawn within 200ms" means held rather than "not stalled yet"; a test asserting the hold
+ * is GIVEN UP sets a tiny one. Read live by the manager (like COMFYUI_MCP_TURN_IDLE_MS), so
+ * assigning here is enough.
+ */
+const setWindows = (opts: { pollMs: number; stallMs: number }): void => {
+  process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS = String(opts.pollMs);
+  process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS = String(opts.stallMs);
+};
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS;
+  delete process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS;
+  atRisk.jobs = [];
+});
+
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+  turnTexts: string[] = [];
+  autoComplete = true;
+  private held: (() => void)[] = [];
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    yield { type: "session", sessionId: "sess-x" };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      if (!this.autoComplete) {
+        await new Promise<void>((resolve) => {
+          this.held.push(resolve);
+        });
+      }
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  release(): void {
+    const all = this.held;
+    this.held = [];
+    for (const r of all) r();
+  }
+
+  async interrupt(): Promise<void> {
+    this.release();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** `spawns` records WHICH TAB each agent construction was for. `runCount` cannot answer
+ *  that — the backend's `run()` starts asynchronously, so a respawn of tab A can land after
+ *  a later assertion and read as tab B having been replaced. The multi-tab test turns on
+ *  exactly that distinction. */
+const makeManager = (backend: AgentBackend, spawns: string[] = []) =>
+  new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: (tabId: string) => {
+      spawns.push(tabId);
+      return backend;
+    },
+  } as never);
+
+const waitFor = async (cond: () => boolean, ms = 3000): Promise<void> => {
+  const t0 = Date.now();
+  while (!cond()) {
+    if (Date.now() - t0 > ms) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const job = (bytes: number) => ({ id: "j1", filename: "flux-dev.safetensors", bytes });
+
+/** A tab with a live agent, mid-turn (so a save's respawn is genuinely DEFERRED). */
+const busyTab = async (manager: InstanceType<typeof PanelAgentManager>, backend: RecordingBackend, tab: string) => {
+  backend.autoComplete = false;
+  manager.send(tab, "hello");
+  await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+};
+
+describe("a queued credential respawn waits for in-flight transfers (#1567 item 2)", () => {
+  it("does NOT fire while downloads started after the save are running", async () => {
+    // The reporter's timeline exactly. The save-time check saw nothing because nothing was
+    // in flight; the downloads came afterwards; the respawn came due later still. Before
+    // this, that moment killed all nine.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = []; // nothing in flight AT SAVE TIME — as reported
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-hold";
+    await busyTab(manager, backend, tab);
+
+    expect(manager.restartAllForMcpEnvAfterCredentialChange(tab).scheduled).toBe(1);
+
+    // …and only THEN the downloads start, in the window the save could not see.
+    atRisk.jobs = [job(4_000_000_000), { id: "j2", filename: "wan22.safetensors", bytes: 9_000_000_000 }];
+
+    backend.autoComplete = true;
+    backend.release(); // turn done → this is where the respawn used to happen
+    await sleep(200); // many poll ticks
+
+    expect(backend.runCount, "the tool session must NOT have been replaced").toBe(1);
+    expect(backend.turnTexts.filter((t) => t.includes("flux-dev.safetensors"))).toHaveLength(0);
+  });
+
+  it("fires by ITSELF once the transfers finish, with no further turn", async () => {
+    // The half that makes the hold safe rather than a wedge. Nothing calls
+    // `applyPendingRestarts` while a tab sits idle, so a hold with no poll behind it is a
+    // respawn that never happens — and the credential would then only reach a rebuilt child
+    // on the next unrelated restart.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [job(4_000_000_000)];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-drain";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+    await sleep(120);
+    expect(backend.runCount, "held while it was still transferring").toBe(1);
+
+    atRisk.jobs = []; // the download finishes. No turn, no message, no user action.
+    await waitFor(() => backend.runCount >= 2);
+
+    // The good ending: the respawn happened and killed nothing, so there is nothing to say.
+    expect(backend.turnTexts.filter((t) => /rebuild is happening NOW/i.test(t))).toHaveLength(0);
+  });
+
+  it("gives up on transfers that stop making progress, and says it waited", async () => {
+    // A hold with no exit is a respawn a dead download can pin for the rest of the session.
+    // The exit is stall, NOT a wall-clock cap — a cap would kill exactly the healthy 48 GB
+    // transfer this exists to protect. When it does give up, the #1567 note fires (that is
+    // the 0.51.49 half) and has to say the wait happened, or it reads as the original
+    // "killed the moment it came due".
+    setWindows({ pollMs: 10, stallMs: 60 });
+    atRisk.jobs = [job(4_000_000_000)]; // frozen: same byte count every read
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-stalled";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.runCount >= 2);
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+    const note = backend.turnTexts.find((t) => t.includes("flux-dev.safetensors")) as string;
+    expect(note, "the note must not describe an instant kill any more").toMatch(/WAITED/);
+    expect(note).toMatch(/stopped making progress/i);
+  });
+
+  it("waits on PROGRESS, not on a clock — a moving transfer is never given up on", async () => {
+    // The distinction the stall window exists for, and the one a wall-clock cap loses. This
+    // runs well past the stall window while bytes keep arriving; a timer-based hold fires
+    // partway through and kills a perfectly healthy download.
+    setWindows({ pollMs: 10, stallMs: 50 });
+    atRisk.jobs = [job(1_000_000)];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-moving";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+
+    const ticker = setInterval(() => {
+      atRisk.jobs = [job((atRisk.jobs[0]?.bytes ?? 0) + 5_000_000)];
+    }, 10);
+    await sleep(300); // 6× the stall window
+    clearInterval(ticker);
+    expect(backend.runCount, "still transferring, so still held").toBe(1);
+
+    // Now it really does stop, and the hold ends on its own.
+    await waitFor(() => backend.runCount >= 2);
+  });
+
+  it("a transfer FINISHING does not read as a stall", async () => {
+    // The total can DROP: one of two downloads completing shrinks the set and the byte
+    // total. Treating only an increase as activity would start the stall clock during the
+    // very thing being waited for, and the survivor gets killed for its neighbour finishing.
+    setWindows({ pollMs: 10, stallMs: 80 });
+    atRisk.jobs = [job(9_000_000_000), { id: "j2", filename: "wan22.safetensors", bytes: 1_000_000 }];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-shrink";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+    await sleep(40);
+    // The BIG one finishes; the small one is left, so the total falls sharply.
+    atRisk.jobs = [{ id: "j2", filename: "wan22.safetensors", bytes: 1_000_000 }];
+    await sleep(60); // past the stall window measured from the save, not from this change
+    expect(backend.runCount, "the survivor is still transferring").toBe(1);
+  });
+
+  it("a RETARGET that lands on a credential respawn is NOT held", async () => {
+    // #1429. A retarget's child is addressing the machine the user just left, so every call
+    // it serves lands on the wrong ComfyUI — silently, when that machine is still up. Waiting
+    // there prolongs the exact failure retargeting exists to end.
+    //
+    // The tab has to be MARKED for this to test anything: the two restarts coalesce onto one
+    // queued respawn, so the question is what that single respawn does once it is BOTH a
+    // credential save's and a retarget's. A first version of this test retargeted a tab no
+    // credential had ever been saved on — it passed with the exclusion deleted, because
+    // nothing had marked the tab in the first place.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [job(4_000_000_000)];
+    const backend = new RecordingBackend();
+    const spawns: string[] = [];
+    const manager = makeManager(backend, spawns);
+    const tab = "tab-retarget";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab); // marks the tab, queues a respawn
+    manager.retargetAllForMcpEnv("http://old:8188", "http://new:8188"); // …now it is a retarget too
+    backend.autoComplete = true;
+    backend.release();
+
+    // A stall window of a minute means this can only pass if it never held at all.
+    await waitFor(() => spawns.filter((t) => t === tab).length >= 2);
+    // …and the transfers it did kill are still reported, by the watch the save armed.
+    await waitFor(() => backend.turnTexts.some((t) => t.includes("flux-dev.safetensors")));
+  });
+
+  it("an ordinary env respawn never waits either", async () => {
+    // The base_path recovery respawn and every other plain `restartAllForMcpEnv`. This has
+    // no license to delay them — only a credential save's own respawn may wait.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [job(4_000_000_000)];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-plain";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnv();
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.runCount >= 2);
+  });
+
+  it("holds a SECOND tab even after the first has already been served", async () => {
+    // The design decision this file exists to pin. "Who gets told, once" (the #1567 orphan
+    // watch) and "may this child be torn down yet" are different questions: the watch is
+    // consumed by the first delivery, so a hold keyed off it silently stops protecting every
+    // other tab of the same save. That is not hypothetical — the first tab is served with
+    // NOTHING in flight (so it correctly fires and consumes the watch), and the downloads
+    // start afterwards, in the window the busy tab is still waiting through.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [];
+    const backend = new RecordingBackend();
+    const spawns: string[] = [];
+    const manager = makeManager(backend, spawns);
+
+    // tab-idle is idle at save time; tab-busy is mid-turn.
+    backend.autoComplete = true;
+    manager.send("tab-idle", "hi");
+    await waitFor(() => backend.runCount >= 1);
+    await busyTab(manager, backend, "tab-busy");
+    await waitFor(() => backend.turnTexts.length >= 2);
+
+    const tally = manager.restartAllForMcpEnvAfterCredentialChange("tab-idle");
+    expect(tally.applied, "the idle tab respawns inside the save, consuming the watch").toBe(1);
+    expect(tally.scheduled, "the busy tab still owes one").toBe(1);
+    expect(spawns.filter((t) => t === "tab-idle"), "…and it really did respawn").toHaveLength(2);
+
+    // The downloads start now — after the first tab was served, before the second fires.
+    atRisk.jobs = [job(4_000_000_000)];
+    backend.autoComplete = true;
+    backend.release();
+    await sleep(200);
+
+    expect(
+      spawns.filter((t) => t === "tab-busy"),
+      "the busy tab's respawn must wait too",
+    ).toHaveLength(1);
+  });
+
+  it("does not delay an unrelated restart after the credential respawn has resolved", async () => {
+    // The mark is per-restart, not per-tab-forever. If it outlived the save, every later
+    // env respawn on that tab would start waiting for downloads it has no relationship to.
+    setWindows({ pollMs: 10, stallMs: 60_000 });
+    atRisk.jobs = [];
+    const backend = new RecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-spent";
+    await busyTab(manager, backend, tab);
+
+    manager.restartAllForMcpEnvAfterCredentialChange(tab);
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runCount >= 2); // nothing in flight → fires, mark spent
+
+    // Later: downloads ARE running, and an ordinary respawn is queued.
+    atRisk.jobs = [job(4_000_000_000)];
+    backend.autoComplete = false;
+    manager.send(tab, "again");
+    await waitFor(() => backend.turnTexts.includes("again"));
+    manager.restartAllForMcpEnv();
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.runCount >= 3);
+  });
+});

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -168,6 +168,24 @@ function toolBusyMaxMs(): number {
   return Number(process.env.COMFYUI_MCP_TOOL_BUSY_MAX_MS) || 900_000;
 }
 
+/** #1567 — how often a HELD credential respawn re-asks whether the transfers it is waiting
+ *  on have finished. Nothing else can wake it: `applyPendingRestarts` runs at turn-done, and
+ *  a user watching a long download is idle by definition. Read live (not a load-time const)
+ *  so it stays overridable per test, like `toolBusyMaxMs` above. */
+function respawnHoldPollMs(): number {
+  return Number(process.env.COMFYUI_MCP_RESPAWN_HOLD_POLL_MS) || 15_000;
+}
+
+/** #1567 — how long every at-risk transfer may make NO progress before a held respawn stops
+ *  waiting on them and fires anyway (with the orphan note). This is the ONLY thing that ends
+ *  a hold other than the transfers finishing: a wall-clock cap would kill a healthy 48 GB
+ *  download for being long, which is the loss the hold exists to prevent. Generous enough to
+ *  ride out a slow mirror's stall, short enough that a dead transfer cannot pin a respawn for
+ *  the rest of the session. Overridable via COMFYUI_MCP_RESPAWN_HOLD_STALL_MS. */
+function respawnHoldStallMs(): number {
+  return Number(process.env.COMFYUI_MCP_RESPAWN_HOLD_STALL_MS) || 120_000;
+}
+
 /** How long after an interrupt to wait for the aborted turn's `result` (which
  *  releases the turn gate at the correct moment) before force-releasing it as a
  *  fallback. Short enough to feel immediate if a result somehow never arrives;
@@ -2630,6 +2648,16 @@ export class PanelAgentManager {
    */
   restartAllForMcpEnvAfterCredentialChange(tabId: string | null): McpEnvRestartTally {
     this.credentialOrphanWatch = { tab: tabId, awaiting: new Set() };
+    // #1567 item 2 — mark EVERY tab this save is about to respawn, BEFORE the loop that
+    // respawns them, because an idle tab is replaced inside that call and would otherwise
+    // reach the hold check unmarked.
+    //
+    // This deliberately does NOT ride on `credentialOrphanWatch`. That watch answers "who
+    // gets TOLD, once" and is consumed by the first delivery; the hold has to answer "may
+    // THIS tab's child be torn down yet", per tab, for as long as the restart is owed. An
+    // early version keyed the hold off the watch and lost the second tab of a two-tab save
+    // the moment the first one was served — that tab then killed its own transfers.
+    for (const key of this.liveKeys()) this.credentialRespawnTabs.add(key);
     const tally = this.restartAllForMcpEnv();
     // An idle tab consumed it inside that call; otherwise bind it to exactly the tabs that
     // still owe a restart, and drop it when there are none.
@@ -2637,6 +2665,11 @@ export class PanelAgentManager {
       const awaiting = this.liveKeys().filter((k) => this.pendingMcpRestart.has(k));
       if (awaiting.length === 0) this.credentialOrphanWatch = null;
       else this.credentialOrphanWatch.awaiting = new Set(awaiting);
+    }
+    // Same trim for the marks: a tab that respawned (or had no agent) inside that call owes
+    // nothing more to this save, so it must not stay marked and hold a LATER restart.
+    for (const key of [...this.credentialRespawnTabs]) {
+      if (!this.pendingMcpRestart.has(key)) this.credentialRespawnTabs.delete(key);
     }
     return tally;
   }
@@ -2661,6 +2694,139 @@ export class PanelAgentManager {
     if (watch.awaiting.size === 0) this.credentialOrphanWatch = null;
   }
 
+  /** #1567 item 2 — tabs whose still-owed MCP respawn came from a CREDENTIAL save, and are
+   *  therefore allowed to wait for in-flight transfers. Membership is dropped the moment the
+   *  restart resolves (applied, or the tab is gone), so it can never delay an unrelated one. */
+  private credentialRespawnTabs = new Set<string>();
+
+  /**
+   * #1567 item 2 — a credential respawn that came due while transfers are running is HELD.
+   *
+   * `bytes`/`movedAt` are the stall detector, and the reason the hold has no wall-clock cap:
+   * a cap does precisely the damage the hold exists to prevent — it kills a healthy 48 GB
+   * transfer for being long. What it waits on instead is PROGRESS, so a dead or wedged
+   * transfer stops being waited on after one stall window while a live one is waited on for
+   * as long as it keeps moving.
+   *
+   * One record for the whole manager because the thing being waited on is global: the at-risk
+   * enumeration lists every downloading job on this machine, not this tab's.
+   */
+  private respawnHold: {
+    tabs: Set<string>;
+    timer: ReturnType<typeof setInterval> | null;
+    since: number;
+    /** Total bytes fetched across the at-risk set at the last observation. */
+    bytes: number;
+    /** When that total last CHANGED — not when it was last read. */
+    movedAt: number;
+  } | null = null;
+
+  /** How long the respawn now being applied was held, for the note. 0 when it was not. */
+  private heldForMs(tabId: string): number {
+    const hold = this.respawnHold;
+    return hold?.tabs.has(tabId) ? Math.max(0, Date.now() - hold.since) : 0;
+  }
+
+  /** What a respawn would orphan right now. Never throws — see deferredRespawnOrphanNote. */
+  private atRiskNow(): { id: string; filename: string; bytes: number }[] {
+    try {
+      return downloadsAtRiskOfRespawn();
+    } catch (err) {
+      logger.debug("[panel-orchestrator] could not enumerate downloads a respawn would orphan", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // An enumeration that failed establishes NOTHING about what is in flight, so it must
+      // not read as "nothing is". It cannot hold either — a hold on an unknown is a respawn
+      // that may never fire — so the respawn proceeds, exactly as it did before this change.
+      return [];
+    }
+  }
+
+  /**
+   * #1567 item 2 — WAIT rather than kill: is this credential respawn still worth holding?
+   *
+   * The reporter's loss was not that the respawn was late, it was that firing it destroyed
+   * ~48 GB of transfers that had every reason to be alive. A QUEUED respawn is by definition
+   * not urgent — it has already waited turns — and for a comfyui credential the running tools
+   * re-read the value from disk at use time, so nothing about the new credential is waiting on
+   * the rebuild. The transfers are what cannot be recreated cheaply, so they win.
+   *
+   * Called once per decision point (turn-done, or a poll tick), and it is also where the
+   * stall bookkeeping is updated — so it must be called ONLY when the answer will be acted on.
+   */
+  private holdRespawnForTransfers(tabId: string): boolean {
+    const atRisk = this.atRiskNow();
+    const now = Date.now();
+    if (atRisk.length === 0) {
+      // Drained. This is the good ending: the respawn fires having killed nothing.
+      if (this.respawnHold?.tabs.has(tabId)) {
+        logger.info(
+          `[panel-orchestrator] tab ${tabId.slice(0, 8)} credential respawn released after ` +
+            `${Math.round(this.heldForMs(tabId) / 1000)}s — the transfers it was waiting on are done (#1567)`,
+        );
+      }
+      this.releaseRespawnHold(tabId);
+      return false;
+    }
+    const bytes = atRisk.reduce((n, d) => n + d.bytes, 0);
+    const hold = this.respawnHold;
+    if (!hold) {
+      this.respawnHold = { tabs: new Set([tabId]), timer: null, since: now, bytes, movedAt: now };
+      this.startRespawnHoldPoll();
+      logger.info(
+        `[panel-orchestrator] tab ${tabId.slice(0, 8)} credential respawn HELD — ${atRisk.length} ` +
+          `download(s) in flight; it fires when they finish, or stop making progress (#1567)`,
+      );
+      return true;
+    }
+    hold.tabs.add(tabId);
+    // ANY change is activity, including a DECREASE: one transfer finishing shrinks the set
+    // and the total, and reading that as "no progress" would start the stall clock running
+    // during the very thing being waited for.
+    if (bytes !== hold.bytes) {
+      hold.bytes = bytes;
+      hold.movedAt = now;
+    }
+    if (now - hold.movedAt < respawnHoldStallMs()) return true;
+    logger.info(
+      `[panel-orchestrator] tab ${tabId.slice(0, 8)} credential respawn giving up its hold after ` +
+        `${Math.round((now - hold.since) / 1000)}s — ${atRisk.length} download(s) made no progress ` +
+        `for ${Math.round(respawnHoldStallMs() / 1000)}s (#1567)`,
+    );
+    return false;
+  }
+
+  /** Drop this tab from the hold, and retire the whole record (and its timer) with the last
+   *  one. Called from every path that resolves a restart, so a hold cannot outlive its tabs. */
+  private releaseRespawnHold(tabId: string): void {
+    const hold = this.respawnHold;
+    if (!hold) return;
+    hold.tabs.delete(tabId);
+    if (hold.tabs.size > 0) return;
+    if (hold.timer) clearInterval(hold.timer);
+    this.respawnHold = null;
+  }
+
+  /**
+   * The only thing that can wake a held respawn.
+   *
+   * `applyPendingRestarts` runs at turn-done, so without this a tab that goes idle and stays
+   * idle — which is exactly what a user watching a 48 GB download does — would hold its
+   * respawn forever with nothing left to re-ask the question. The tick re-enters
+   * `applyPendingRestarts`, which re-evaluates the hold and fires the restart when it lifts.
+   *
+   * unref'd: a pending respawn must never be the reason the process cannot exit.
+   */
+  private startRespawnHoldPoll(): void {
+    const hold = this.respawnHold;
+    if (!hold || hold.timer) return;
+    hold.timer = setInterval(() => {
+      // Snapshot: applyPendingRestarts mutates hold.tabs (and can retire the record).
+      for (const tabId of [...(this.respawnHold?.tabs ?? [])]) this.applyPendingRestarts(tabId);
+    }, respawnHoldPollMs());
+    hold.timer.unref?.();
+  }
+
   /** #1567 — what this respawn is about to orphan, enumerated NOW rather than at save
    *  time. Never throws: a rebuild that fails because its warning failed is strictly
    *  worse than a rebuild with no warning.
@@ -2671,9 +2837,9 @@ export class PanelAgentManager {
    *  once per credential save rather than on every restart — the same IO the save path
    *  already performs, moved to where it can see the right answer. A try/catch cannot
    *  time-bound a blocking syscall and is not pretended to. */
-  private deferredRespawnOrphanNote(): string | null {
+  private deferredRespawnOrphanNote(heldMs: number): string | null {
     try {
-      return orphanedByDeferredRespawnNote(downloadsAtRiskOfRespawn());
+      return orphanedByDeferredRespawnNote(downloadsAtRiskOfRespawn(), heldMs);
     } catch (err) {
       logger.debug("[panel-orchestrator] could not enumerate downloads a respawn will orphan", {
         error: err instanceof Error ? err.message : String(err),
@@ -2691,13 +2857,38 @@ export class PanelAgentManager {
       this.pendingEffortRestart.delete(tabId);
       this.pendingMcpRestart.delete(tabId);
       this.pendingRetargetFrom.delete(tabId);
-      // #1567 — this restart is being dropped, so it will never deliver an armed watch.
+      // #1567 — this restart is being dropped, so it will never deliver an armed watch,
+      // and there is no longer a session whose transfers a hold could protect.
       this.releaseOrphanWatch(tabId);
+      this.credentialRespawnTabs.delete(tabId);
+      this.releaseRespawnHold(tabId);
       return "no-agent";
     }
     // Still mid-work (a queued message will start the next turn) — wait for the
     // next idle so we don't restart between back-to-back turns.
     if (agent.isBusy || agent.hasPending) return "scheduled";
+    // #1567 item 2 — WAIT FOR THE TRANSFERS, don't kill them.
+    //
+    // Everything below this line replaces the tool session, which is what orphaned the
+    // reporter's nine downloads. A credential respawn has no deadline — the tools re-read
+    // the credential from disk at use time, so it is a tidy-up, not the thing that makes
+    // the new value work — and the transfers it would destroy cost hours and tens of GB.
+    //
+    // Two exclusions, both about respawns that are NOT tidy-ups:
+    //   * unmarked tabs — a base_path recovery or any other plain mcp-env respawn, which
+    //     this has no license to delay;
+    //   * a RETARGET (#1429), where the running child is addressing the machine the user
+    //     just left. Waiting there prolongs calls landing on the wrong ComfyUI, which is
+    //     the failure retargeting exists to end. It kills the transfers, and the note
+    //     below says so.
+    const mayHold =
+      wantMcp && this.credentialRespawnTabs.has(tabId) && !this.pendingRetargetFrom.has(tabId);
+    if (mayHold && this.holdRespawnForTransfers(tabId)) return "scheduled";
+    // Held or not, this restart is now resolving, so the mark is spent. Read the hold's age
+    // BEFORE releasing it — that is what the note reports.
+    const heldMs = this.heldForMs(tabId);
+    this.credentialRespawnTabs.delete(tabId);
+    this.releaseRespawnHold(tabId);
     // Only the MCP respawn carries a retry nudge.
     const nudge = wantMcp ? (this.pendingMcpRestart.get(tabId) ?? undefined) : undefined;
     // #1567 — RE-TAKE the at-risk snapshot HERE. The save-time one (#1378) is taken
@@ -2726,7 +2917,7 @@ export class PanelAgentManager {
     // tab still owes a restart, so it has not resolved and must stay in the set.
     if (watched) this.credentialOrphanWatch = null;
     else this.releaseOrphanWatch(tabId);
-    const orphanNote = watched ? this.deferredRespawnOrphanNote() : null;
+    const orphanNote = watched ? this.deferredRespawnOrphanNote(heldMs) : null;
     const finalNudge = orphanNote ? [nudge, orphanNote].filter(Boolean).join("\n\n") : nudge;
     this.pendingEffortRestart.delete(tabId);
     this.pendingMcpRestart.delete(tabId);
@@ -3091,6 +3282,12 @@ export class PanelAgentManager {
       this.pendingMcpRestart.set(newKey, this.pendingMcpRestart.get(oldKey)!);
       this.pendingMcpRestart.delete(oldKey);
     }
+    // #1567 — the mark and the hold classify that same queued restart, so they travel with
+    // it. Left behind, the renamed tab's credential respawn stops being one this may wait
+    // for, and fires into whatever downloads are running under the new key.
+    if (this.credentialRespawnTabs.delete(oldKey)) this.credentialRespawnTabs.add(newKey);
+    const hold = this.respawnHold;
+    if (hold?.tabs.delete(oldKey)) hold.tabs.add(newKey);
     // The marker classifies that value (#1429), so it has to travel with it: left
     // behind, the renamed tab's queued retarget nudge reads as a per-request one
     // and the next retarget preserves an obsolete target instead of recomposing.
@@ -3245,6 +3442,11 @@ export class PanelAgentManager {
     // #1567 — this tab can no longer deliver an armed orphan watch. The single choke point
     // for removal, so a retire/reset cannot strand one waiting on a tab that is gone.
     this.releaseOrphanWatch(key);
+    // …and its held respawn dies with it: the session whose transfers the hold was protecting
+    // is being torn down here regardless, so waiting longer protects nothing and would leave
+    // a poll timer re-entering applyPendingRestarts for a key with no agent.
+    this.credentialRespawnTabs.delete(key);
+    this.releaseRespawnHold(key);
     this.detachHeldCompletions(key, opts.reason);
     if (opts.dropHeldMail) this.heldMessages.delete(key);
     return agent;
@@ -3415,6 +3617,12 @@ export class PanelAgentManager {
   async stopAll(): Promise<void> {
     this.pendingEffortRestart.clear();
     this.pendingMcpRestart.clear();
+    // #1567 — no restart is owed any more, so nothing may be held for one. The poll timer is
+    // unref'd, but a shutdown that leaves it running would keep re-entering
+    // applyPendingRestarts against agents this method is in the middle of stopping.
+    this.credentialRespawnTabs.clear();
+    if (this.respawnHold?.timer) clearInterval(this.respawnHold.timer);
+    this.respawnHold = null;
     // #468 — go through the same detach seam as reset()/retire() for EVERY key
     // before dropping held mail. The journal is about to be reported on by the
     // orchestrator's shutdown disclosure, and an entry still marked `handed_off`

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2727,18 +2727,20 @@ export class PanelAgentManager {
     return hold?.tabs.has(tabId) ? Math.max(0, Date.now() - hold.since) : 0;
   }
 
-  /** What a respawn would orphan right now. Never throws — see deferredRespawnOrphanNote. */
-  private atRiskNow(): { id: string; filename: string; bytes: number }[] {
+  /** What a respawn would orphan right now, or `null` for COULD NOT TELL. Never throws.
+   *
+   *  The two are different answers and the caller treats them differently — collapsing a
+   *  failed enumeration into `[]` is a real defect the gate caught here: an EIO on one poll
+   *  tick reads as "the downloads finished", releases a hold that was working, and kills the
+   *  48 GB transfer it had been protecting for an hour. */
+  private atRiskNow(): { id: string; filename: string; bytes: number }[] | null {
     try {
       return downloadsAtRiskOfRespawn();
     } catch (err) {
       logger.debug("[panel-orchestrator] could not enumerate downloads a respawn would orphan", {
         error: err instanceof Error ? err.message : String(err),
       });
-      // An enumeration that failed establishes NOTHING about what is in flight, so it must
-      // not read as "nothing is". It cannot hold either — a hold on an unknown is a respawn
-      // that may never fire — so the respawn proceeds, exactly as it did before this change.
-      return [];
+      return null;
     }
   }
 
@@ -2757,6 +2759,26 @@ export class PanelAgentManager {
   private holdRespawnForTransfers(tabId: string): boolean {
     const atRisk = this.atRiskNow();
     const now = Date.now();
+    if (atRisk === null) {
+      // COULD NOT TELL. This may not answer either question, so it answers neither: it does
+      // not start a hold (a hold on an unknown is a respawn that may never fire, and this is
+      // the pre-#1567 behaviour, which killed nothing that was not already being killed), and
+      // it does not END one — the case the gate found, where one EIO on a poll tick undoes an
+      // hour of correctly protecting a live transfer.
+      //
+      // A hold survives on the stall clock, which is exactly right while the state is
+      // unreadable: no progress can be OBSERVED, so `movedAt` does not advance, and repeated
+      // failure gives up after the same window a frozen transfer would. Unreadable state
+      // therefore delays the respawn by at most one stall window rather than indefinitely.
+      const held = this.respawnHold;
+      if (!held?.tabs.has(tabId)) return false;
+      if (now - held.movedAt < respawnHoldStallMs()) return true;
+      logger.info(
+        `[panel-orchestrator] tab ${tabId.slice(0, 8)} credential respawn giving up its hold — the ` +
+          `transfers it was waiting on could not be read for ${Math.round(respawnHoldStallMs() / 1000)}s (#1567)`,
+      );
+      return false;
+    }
     if (atRisk.length === 0) {
       // Drained. This is the good ending: the respawn fires having killed nothing.
       if (this.respawnHold?.tabs.has(tabId)) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -470,11 +470,19 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
     if (pending > 0) {
       parts.push(
         `${readsItAtUseTime}. But a tool-session respawn is STILL PENDING from this save ` +
-          `(${pending} queued for the end of this turn), and it replaces the tool session when it fires. ` +
-          `Anything long-running that session owns is lost at that point — model downloads in ` +
-          `particular. This message cannot list them, because a transfer started AFTER this save ` +
-          `did not exist when the check ran (#1567). If you are about to start a long download, ` +
-          `let the respawn land first.`,
+          `(${pending} queued, normally for the end of this turn), and it replaces the tool session ` +
+          `when it fires. Anything long-running that session owns is lost at that point — model ` +
+          `downloads in particular. This message cannot list them, because a transfer started AFTER ` +
+          `this save did not exist when the check ran (#1567). ` +
+          // #1567 item 2 — the advice used to be "let the respawn land before you start a long
+          // download", which put the burden on the user to sequence around a rebuild they cannot
+          // see. The respawn now WAITS instead, so this says what the scheduler will actually do
+          // — including the one case that still costs transfers, since a promise with an
+          // unstated exception is how this receipt misled someone the first time.
+          `You do not have to sequence around it: when it comes due it waits for in-flight model ` +
+          `downloads to finish rather than killing them. It stops waiting only if every one of them ` +
+          `makes no progress for a couple of minutes, and it reports what it gave up on when that ` +
+          `happens.`,
       );
     } else if (already > 0) {
       // A respawn HAPPENED. Saying none was required describes a different save,

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -587,16 +587,33 @@ export function atRiskNote(
  * disk) and is explicit that resumability depends on something this code cannot see: which
  * side of the credential change each transfer started on. Claiming either outcome would be
  * asserting the thing that actually varies.
+ *
+ * ## `heldMs` — why the rebuild is going ahead anyway
+ *
+ * A queued respawn now WAITS for in-flight transfers instead of killing them (#1567 item
+ * 2), so reaching this note at all means the wait was given up on: every remaining transfer
+ * stopped making progress for the whole stall window. That is a different event from the
+ * original report — "it killed them the moment it came due" — and saying so is what stops
+ * the note reading as though the wait never happened. Omitted when there was no wait (the
+ * transfers are being killed immediately), because inventing one would be a false claim
+ * about how long the user had.
  */
 export function orphanedByDeferredRespawnNote(
   orphaned: AtRiskDownloads | readonly { filename: string; bytes: number }[],
+  heldMs?: number,
 ): string | null {
   if (!orphaned.length) return null;
+  const waited =
+    typeof heldMs === "number" && heldMs > 0
+      ? ` The rebuild WAITED ${Math.round(heldMs / 1000)}s for them rather than killing them ` +
+        `when it came due, and gave up because they stopped making progress — so each of these ` +
+        `is either stalled or already dead, and re-issuing is how you find out which.`
+      : ``;
   return (
     `🛑 The queued tool-session rebuild is happening NOW, and ${atRiskDownloadSummary(orphaned)} ` +
     `were still transferring. They belong to the session being replaced, so they are being ` +
     `killed — this is the rebuild that was queued when a comfyui credential was saved earlier ` +
-    `(#1567).\n\n` +
+    `(#1567).${waited}\n\n` +
     `The partial files are still on disk, so re-issuing each download is worth doing: it can ` +
     `RESUME from them rather than starting over. A transfer that was already running when the ` +
     `credential changed has a different cache identity and definitely restarts from 0%; one ` +


### PR DESCRIPTION
Item 2 of #1567. (Items 1 and 4 shipped in 0.51.49 via #1576; item 3 is a separate,
feature-shaped piece of work and is not in here.)

## What was still broken

0.51.49 made the deferred respawn *tell* the user what it destroyed — the at-risk snapshot
is re-taken when the respawn fires rather than at save time. The reporter still loses the
transfers. In their case that was ~48 GB and nine manual cancels plus nine re-issues.

Their argument for the real fix is right and is what this implements: **a queued respawn is
by definition not urgent.** It has already waited turns, and for a comfyui credential the
running tools re-read the value from disk at use time — so the rebuild is a tidy-up, while
the transfers cost hours. The respawn yields.

## The rules

- **Waits on progress, not on a clock.** A wall-clock cap would kill precisely the healthy
  48 GB download the hold exists to protect. Instead every at-risk transfer must make no
  progress for one stall window (default 120s) before the respawn goes ahead anyway — with
  the #1567 orphan note, which now says it waited and why.
- **A shrinking byte total is progress.** Two downloads running and one finishing makes the
  total fall; reading that as a stall would start the give-up clock during the very thing
  being waited for, and kill the survivor for its neighbour finishing.
- **Only a credential save's respawn may wait.** A retarget (#1429) is excluded even when it
  coalesces onto the same queued restart — its child is addressing the machine the user just
  left, and waiting prolongs the failure retargeting exists to end. A plain mcp-env respawn
  (base_path recovery) is excluded because nothing marked it.
- **Per tab, and not keyed off the #1567 orphan watch.** Those answer different questions:
  the watch is "who gets told, once" and is consumed by the first delivery, so a hold keyed
  off it silently stops protecting every other tab of the same save. There is a test on that
  exact timeline (first tab served with nothing in flight, downloads start, second tab still
  owes a respawn).
- **A held respawn is woken by an unref'd poll.** `applyPendingRestarts` runs at turn-done
  and a user watching a download is idle, so without it the respawn would never fire at all.

## The receipt

It used to say "if you are about to start a long download, let the respawn land first",
which puts the burden on the user to sequence around a rebuild they cannot see. It now says
the respawn waits — and states the one case that still costs transfers, because an unstated
exception is how this receipt misled someone in the first place.

## Verification

Seven separate deletions/reversals of the fix were each caught by
`respawn-holds-for-transfers.test.ts`, including the two that look most obviously correct
(keying the hold off the orphan watch; treating only a byte *increase* as progress). Full
suite green: 9555 passed, 2 pre-existing parallel-load flakes (`late-mutation-e2e`,
`training-jobs`) that pass in isolation and touch none of this. `lint`, `check:vocabulary`,
`check:unknown-collapse`, `vocab:export --check`, `asset-counts --check`, `build` all green.

The underlying cause of #1378 is unchanged — that path (an `applied`, immediate respawn) is
still correct to snapshot at save time and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
