### PR TITLE
fix(1524): a session that came up without an MCP server says so

### DIFF
--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -49,6 +49,9 @@ const hoisted = vi.hoisted(() => ({
   })(),
   /** The mcpServers object the backend actually handed the SDK. */
   lastMcpServers: null as Record<string, unknown> | null,
+  /** What `q.mcpServerStatus()` answers, and how many times it was asked. */
+  statusPoll: null as null | Array<{ name: string; status: string }>,
+  statusPolls: 0,
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -63,6 +66,11 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
       supportedCommands: async () => [],
       interrupt: async () => {},
       setModel: async () => {},
+      mcpServerStatus: async () => {
+        hoisted.statusPolls += 1;
+        if (!hoisted.statusPoll) throw new Error("no status available");
+        return hoisted.statusPoll;
+      },
     });
   },
 }));
@@ -70,6 +78,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 beforeEach(() => {
   hoisted.queue.reset();
   hoisted.lastMcpServers = null;
+  hoisted.statusPoll = null;
+  hoisted.statusPolls = 0;
 });
 
 const initWith = (mcp_servers?: Array<{ name: string; status: string }>) => ({
@@ -105,6 +115,36 @@ async function drive(
   })();
   hoisted.queue.push(init);
   await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+  hoisted.queue.end();
+  await done;
+  return events;
+}
+
+/** Same, but the session takes a turn and ends it — the point at which a server
+ *  still connecting at init is re-read. `turns` result messages are pushed. */
+async function driveTurns(
+  deps: { mcpServers?: Record<string, unknown>; panelServer?: unknown },
+  init: unknown,
+  turns = 1,
+): Promise<AgentEvent[]> {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({
+    mcpServers: (deps.mcpServers ?? {}) as never,
+    systemAppend: "",
+    ...(deps.panelServer ? { panelServer: deps.panelServer as never } : {}),
+  });
+  const events: AgentEvent[] = [];
+  async function* oneTurn(): AsyncGenerator<{ text: string }> {
+    yield { text: "hello" };
+    await new Promise<void>(() => {});
+  }
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: oneTurn() as never })) events.push(ev);
+  })();
+  hoisted.queue.push(init);
+  await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+  for (let i = 0; i < turns; i++) hoisted.queue.push({ type: "result", subtype: "success" });
+  await waitFor(() => expect(events.filter((e) => e.type === "result")).toHaveLength(turns));
   hoisted.queue.end();
   await done;
   return events;
@@ -180,6 +220,19 @@ describe("a Claude session that started without an MCP server reports it (#1524)
     expect(noticesOf(events)).toHaveLength(0);
   });
 
+  it("stays silent for a server still CONNECTING at init", async () => {
+    // Server startup does not block the session, so `pending` at init is a slow
+    // connection, not a failed one. Reporting it would fire on healthy sessions.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
   it("still emits the session event alongside the notice", async () => {
     // The notice must not displace init's real job — a swallowed session id
     // would break resume, which is a far worse bug than the one being fixed.
@@ -189,5 +242,91 @@ describe("a Claude session that started without an MCP server reports it (#1524)
     );
     expect(events.filter((e) => e.type === "session")).toHaveLength(1);
     expect(noticesOf(events)).toHaveLength(1);
+  });
+});
+
+describe("a server that was still connecting at init gets settled (#1524)", () => {
+  it("reports it when it settled as FAILED", async () => {
+    // The hole an init-only check leaves: `init` is the only MCP report the
+    // session pushes, so `pending` there followed by a failure is silent forever
+    // — the same six-hour silence, moved a few hundred milliseconds later.
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "failed" },
+    ];
+    const events = await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+    );
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(hoisted.statusPolls).toBe(1);
+  });
+
+  it("says nothing when it settled as connected", async () => {
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "connected" },
+    ];
+    const events = await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.statusPolls).toBe(1);
+  });
+
+  it("re-reads ONCE, not on every turn", async () => {
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "connected" },
+    ];
+    await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+      3,
+    );
+    expect(hoisted.statusPolls).toBe(1);
+  });
+
+  it("does not poll at all when nothing was pending", async () => {
+    // The re-read is a control round-trip. A healthy session must not pay for it
+    // on every turn it completes.
+    hoisted.statusPoll = [{ name: "comfyui", status: "connected" }];
+    await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+      2,
+    );
+    expect(hoisted.statusPolls).toBe(0);
+  });
+
+  it("stays silent when the poll is unavailable or throws", async () => {
+    // `mcpServerStatus()` is an optional Query method. A harness without it
+    // leaves the pending servers unmentioned rather than guessed at — and must
+    // never take the turn stream down with it.
+    hoisted.statusPoll = null; // the mock throws
+    const events = await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+    expect(events.filter((e) => e.type === "result")).toHaveLength(1);
   });
 });

--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -1,0 +1,193 @@
+// #1524, WIRING — the check has to run on the real init path, against the real
+// configured server set.
+//
+// A helper-only suite would pass with the call site deleted: `degradedMcpServers`
+// is pure, and a test that builds both sides itself proves only that it compares
+// two arrays. What has to be pinned is that `route()`'s `system`/`init` branch
+// feeds it (a) the servers this session was actually GIVEN — including the
+// in-process `panel` server, which is added inside buildOptions and appears in no
+// dep — and (b) the report the harness sent, and that a degraded session yields a
+// visible event.
+//
+// Harness pattern follows claude-turn-markers.test.ts: the optional Agent SDK is
+// mocked, the backend is driven through run(), and the canonical AgentEvents are
+// collected.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+process.env.COMFYUI_MCP_TURN_REGISTRY_DIR = mkdtempSync(join(tmpdir(), "claude-init-mcp-registry-"));
+
+const hoisted = vi.hoisted(() => ({
+  queue: new (class {
+    private buf: unknown[] = [];
+    private waiters: Array<() => void> = [];
+    private closed = false;
+    reset(): void {
+      this.buf = [];
+      this.closed = false;
+    }
+    push(m: unknown): void {
+      this.buf.push(m);
+      for (const w of this.waiters.splice(0)) w();
+    }
+    end(): void {
+      this.closed = true;
+      for (const w of this.waiters.splice(0)) w();
+    }
+    async *iterate(): AsyncGenerator<unknown> {
+      for (;;) {
+        while (this.buf.length) yield this.buf.shift();
+        if (this.closed) return;
+        await new Promise<void>((resolve) => this.waiters.push(resolve));
+      }
+    }
+  })(),
+  /** The mcpServers object the backend actually handed the SDK. */
+  lastMcpServers: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (arg: { prompt?: AsyncIterable<unknown>; options?: { mcpServers?: Record<string, unknown> } }) => {
+    hoisted.lastMcpServers = arg.options?.mcpServers ?? null;
+    void (async () => {
+      for await (const _ of arg.prompt ?? []) void _;
+    })();
+    const iter = hoisted.queue.iterate();
+    return Object.assign(iter, {
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      interrupt: async () => {},
+      setModel: async () => {},
+    });
+  },
+}));
+
+beforeEach(() => {
+  hoisted.queue.reset();
+  hoisted.lastMcpServers = null;
+});
+
+const initWith = (mcp_servers?: Array<{ name: string; status: string }>) => ({
+  type: "system",
+  subtype: "init",
+  session_id: "00000000-1111-2222-3333-444444444444",
+  model: "claude-test-1",
+  apiKeySource: "none",
+  skills: [],
+  ...(mcp_servers ? { mcp_servers } : {}),
+});
+
+/** A stand-in for the in-process panel server (createSdkMcpServer's shape). */
+const PANEL_SERVER = { type: "sdk", name: "comfyui-panel", instance: {} } as never;
+const COMFYUI_SERVER = { type: "stdio", command: "node", args: [] } as never;
+
+async function drive(
+  deps: { mcpServers?: Record<string, unknown>; panelServer?: unknown },
+  init: unknown,
+): Promise<AgentEvent[]> {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({
+    mcpServers: (deps.mcpServers ?? {}) as never,
+    systemAppend: "",
+    ...(deps.panelServer ? { panelServer: deps.panelServer as never } : {}),
+  });
+  const events: AgentEvent[] = [];
+  async function* idle(): AsyncGenerator<{ text: string }> {
+    await new Promise<void>(() => {}); // never submits a turn
+  }
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: idle() as never })) events.push(ev);
+  })();
+  hoisted.queue.push(init);
+  await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+  hoisted.queue.end();
+  await done;
+  return events;
+}
+
+const noticesOf = (events: AgentEvent[]) =>
+  events.filter(
+    (e): e is Extract<AgentEvent, { type: "error" }> =>
+      e.type === "error" && (e as { sessionNotice?: boolean }).sessionNotice === true,
+  );
+
+describe("a Claude session that started without an MCP server reports it (#1524)", () => {
+  it("names the panel server when the session came up without it", async () => {
+    // The reporter's exact split: comfyui back, the 92 panel_* tools gone.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    // …and does NOT accuse the server that DID come up. Over-reporting here is
+    // the same defect pointing the other way.
+    expect(notices[0].message).not.toContain("comfyui");
+  });
+
+  it("compares against the server set the session was GIVEN, panel included", async () => {
+    // The `panel` entry is added inside the backend, not passed in deps. A check
+    // that compared the report against `deps.mcpServers` alone would never see
+    // the panel server go missing — which is the entire reported failure.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([{ name: "comfyui", status: "connected" }]),
+    );
+    expect(hoisted.lastMcpServers && Object.keys(hoisted.lastMcpServers).sort()).toEqual([
+      "comfyui",
+      "panel",
+    ]);
+    expect(noticesOf(events)[0]?.message).toContain("panel");
+  });
+
+  it("stays silent when every configured server connected", async () => {
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("stays silent when the harness sends no report at all", async () => {
+    // Older/other harnesses omit the field. Silence there is mandatory: this
+    // path runs on every session start.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith(undefined),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("does not report `panel` for a backend that was never given one", async () => {
+    // makePanelServer returns undefined for non-claude keys, so `panel` is not in
+    // that session's set and its absence from the report is correct, not a fault.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER } },
+      initWith([{ name: "comfyui", status: "connected" }]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("still emits the session event alongside the notice", async () => {
+    // The notice must not displace init's real job — a swallowed session id
+    // would break resume, which is a far worse bug than the one being fixed.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([{ name: "comfyui", status: "failed" }]),
+    );
+    expect(events.filter((e) => e.type === "session")).toHaveLength(1);
+    expect(noticesOf(events)).toHaveLength(1);
+  });
+});

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -1,0 +1,133 @@
+// #1524 — a session that comes up WITHOUT one of its MCP servers must say so.
+//
+// The reported failure: mid-session both MCP servers dropped, `comfyui` came back,
+// and all 92 `panel_*` tools did not. The orchestrator stayed up and kept its
+// ports, the panel looked healthy, and the agent spent the rest of a six-hour
+// session unable to touch the user's canvas — with no error anywhere. The reporter
+// established it by hand: they noticed a tool-list diff and then probed with
+// `ToolSearch` twice.
+//
+// The harness had already told us. Every Claude session opens with a `system`/`init`
+// message carrying `mcp_servers: {name, status}[]`; `route()` read the session id
+// off it and discarded the rest. Verified against the installed agent SDK (0.3.197)
+// with one server of each kind configured, the report covers BOTH transports the
+// panel uses:
+//
+//   [{"name":"deadstdio","status":"failed"},{"name":"panel","status":"connected"}]
+//
+// — the in-process `createSdkMcpServer` panel server included. That is what makes
+// this worth wiring: it fires on the reporter's symptom without needing to know the
+// cause, which is still open.
+//
+// The direction that matters most here is the QUIET one. A false "your tools are
+// gone" on a healthy session is worse than the silence it replaces, so every
+// ambiguity resolves to saying nothing.
+
+import { describe, expect, it } from "vitest";
+import {
+  degradedMcpNotice,
+  degradedMcpServers,
+} from "../../orchestrator/mcp-session-health.js";
+
+const CONFIGURED = ["comfyui", "panel"];
+
+describe("degradedMcpServers — what the session reports vs what it was given", () => {
+  it("says nothing when every configured server connected", () => {
+    expect(
+      degradedMcpServers(CONFIGURED, [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("names a server the session reports as failed", () => {
+    // The reporter's shape: one half of the pair back, the other not.
+    expect(
+      degradedMcpServers(CONFIGURED, [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    ).toEqual([{ name: "panel", status: "failed" }]);
+  });
+
+  it("names a server MISSING from a populated report", () => {
+    // A connection that fails before the server is advertised is absent, not
+    // failed. Both readings of the reporter's evidence land here: their
+    // `ToolSearch` found the panel server genuinely gone from the session, not
+    // merely un-indexed.
+    expect(
+      degradedMcpServers(CONFIGURED, [{ name: "comfyui", status: "connected" }]),
+    ).toEqual([{ name: "panel", status: null }]);
+  });
+
+  it("says nothing when the report is absent or empty", () => {
+    // A harness that does not populate the field tells us nothing about our
+    // servers. Reading its silence as failure would fire on EVERY healthy
+    // session — the one outcome worse than the bug being fixed.
+    expect(degradedMcpServers(CONFIGURED, undefined)).toEqual([]);
+    expect(degradedMcpServers(CONFIGURED, [])).toEqual([]);
+  });
+
+  it("treats an unrecognized status as connected", () => {
+    // The status vocabulary belongs to the CLI and can grow. A new value must
+    // not become an alarm here; only the ones that DO mean unusable are alarms.
+    expect(
+      degradedMcpServers(CONFIGURED, [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "some-future-status" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("catches the failure vocabulary the CLI actually uses", () => {
+    for (const status of ["failed", "needs-auth", "error", "disabled", "FAILED"]) {
+      expect(degradedMcpServers(["panel"], [{ name: "panel", status }])).toHaveLength(1);
+    }
+  });
+
+  it("ignores servers we did not configure", () => {
+    // `strictMcpConfig: true` means the set should be exactly ours, but a report
+    // naming something else is not this message's business either way.
+    expect(
+      degradedMcpServers(["comfyui"], [
+        { name: "comfyui", status: "connected" },
+        { name: "somebody-elses", status: "failed" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("degradedMcpNotice — states the observation, and stops", () => {
+  it("is empty when nothing is degraded", () => {
+    expect(degradedMcpNotice([])).toBe("");
+  });
+
+  it("names each server and its reported state", () => {
+    const note = degradedMcpNotice([
+      { name: "panel", status: "failed" },
+      { name: "comfyui", status: null },
+    ]);
+    expect(note).toContain("panel");
+    expect(note).toContain("failed");
+    expect(note).toContain("comfyui");
+    expect(note).toContain("not reported");
+  });
+
+  it("says the loss lasts the session, without promising a restart fixes it", () => {
+    // Same discipline as NO_PANEL_TOOLS_OVERRIDE: a cause that persists survives
+    // a restart, so "reconnecting restores them" is a claim this cannot make.
+    const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
+    expect(note).toMatch(/rest of this session/);
+    expect(note).toMatch(/whether it succeeds depends on why this one did not/);
+    expect(note).not.toMatch(/will fix|will restore|restores them/);
+  });
+
+  it("does not diagnose a cause it does not know", () => {
+    // WHY a server goes missing is still open on #1524, and the candidates need
+    // different fixes. Guessing here would be the same defect this replaces,
+    // wearing the fix's clothes.
+    const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
+    expect(note).not.toMatch(/because|caused by|due to/i);
+  });
+});

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -26,29 +26,31 @@
 import { describe, expect, it } from "vitest";
 import {
   degradedMcpNotice,
-  degradedMcpServers,
+  inspectMcpServers,
 } from "../../orchestrator/mcp-session-health.js";
 
 const CONFIGURED = ["comfyui", "panel"];
 
-describe("degradedMcpServers — what the session reports vs what it was given", () => {
+const HEALTHY = { degraded: [], pending: [] };
+
+describe("inspectMcpServers — what the session reports vs what it was given", () => {
   it("says nothing when every configured server connected", () => {
     expect(
-      degradedMcpServers(CONFIGURED, [
+      inspectMcpServers(CONFIGURED, [
         { name: "comfyui", status: "connected" },
         { name: "panel", status: "connected" },
       ]),
-    ).toEqual([]);
+    ).toEqual(HEALTHY);
   });
 
   it("names a server the session reports as failed", () => {
     // The reporter's shape: one half of the pair back, the other not.
     expect(
-      degradedMcpServers(CONFIGURED, [
+      inspectMcpServers(CONFIGURED, [
         { name: "comfyui", status: "connected" },
         { name: "panel", status: "failed" },
       ]),
-    ).toEqual([{ name: "panel", status: "failed" }]);
+    ).toEqual({ degraded: [{ name: "panel", status: "failed" }], pending: [] });
   });
 
   it("names a server MISSING from a populated report", () => {
@@ -56,45 +58,61 @@ describe("degradedMcpServers — what the session reports vs what it was given",
     // failed. Both readings of the reporter's evidence land here: their
     // `ToolSearch` found the panel server genuinely gone from the session, not
     // merely un-indexed.
-    expect(
-      degradedMcpServers(CONFIGURED, [{ name: "comfyui", status: "connected" }]),
-    ).toEqual([{ name: "panel", status: null }]);
+    expect(inspectMcpServers(CONFIGURED, [{ name: "comfyui", status: "connected" }])).toEqual({
+      degraded: [{ name: "panel", status: null }],
+      pending: [],
+    });
   });
 
   it("says nothing when the report is absent or empty", () => {
     // A harness that does not populate the field tells us nothing about our
     // servers. Reading its silence as failure would fire on EVERY healthy
     // session — the one outcome worse than the bug being fixed.
-    expect(degradedMcpServers(CONFIGURED, undefined)).toEqual([]);
-    expect(degradedMcpServers(CONFIGURED, [])).toEqual([]);
+    expect(inspectMcpServers(CONFIGURED, undefined)).toEqual(HEALTHY);
+    expect(inspectMcpServers(CONFIGURED, [])).toEqual(HEALTHY);
   });
 
   it("treats an unrecognized status as connected", () => {
     // The status vocabulary belongs to the CLI and can grow. A new value must
     // not become an alarm here; only the ones that DO mean unusable are alarms.
     expect(
-      degradedMcpServers(CONFIGURED, [
+      inspectMcpServers(CONFIGURED, [
         { name: "comfyui", status: "connected" },
         { name: "panel", status: "some-future-status" },
       ]),
-    ).toEqual([]);
+    ).toEqual(HEALTHY);
   });
 
   it("catches the failure vocabulary the CLI actually uses", () => {
     for (const status of ["failed", "needs-auth", "error", "disabled", "FAILED"]) {
-      expect(degradedMcpServers(["panel"], [{ name: "panel", status }])).toHaveLength(1);
+      expect(inspectMcpServers(["panel"], [{ name: "panel", status }]).degraded).toHaveLength(1);
     }
+  });
+
+  it("holds a STILL-CONNECTING server apart from a failed one", () => {
+    // `pending` is settled-later, not failed: server startup does not block the
+    // session, so a slow server is legitimately pending in the init report and
+    // connected a moment after. Reporting it would fire on healthy sessions…
+    const health = inspectMcpServers(CONFIGURED, [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "pending" },
+    ]);
+    expect(health.degraded).toEqual([]);
+    // …and dropping it would be the silence this whole change exists to end:
+    // init is the only report the session pushes, so a pending server that goes
+    // on to FAIL would never be mentioned anywhere. It is carried, not ignored.
+    expect(health.pending).toEqual(["panel"]);
   });
 
   it("ignores servers we did not configure", () => {
     // `strictMcpConfig: true` means the set should be exactly ours, but a report
     // naming something else is not this message's business either way.
     expect(
-      degradedMcpServers(["comfyui"], [
+      inspectMcpServers(["comfyui"], [
         { name: "comfyui", status: "connected" },
         { name: "somebody-elses", status: "failed" },
       ]),
-    ).toEqual([]);
+    ).toEqual(HEALTHY);
   });
 });
 

--- a/src/__tests__/orchestrator/session-notice-render.test.ts
+++ b/src/__tests__/orchestrator/session-notice-render.test.ts
@@ -1,0 +1,105 @@
+// #1524, RENDERING — a session notice is not a turn failure, and must not be
+// painted as one or charged to the turn's one error slot.
+//
+// The generic `error` line reads "The <model> turn failed: … Nothing was lost —
+// try again". For "this session started without its panel MCP server" all three
+// clauses are wrong: no turn failed, nothing was lost in a turn, and trying again
+// re-runs a turn rather than the connection.
+//
+// The sharper hazard is the slot. `errorSurfaced` allows ONE chat line per turn,
+// and init legitimately lands AFTER the first turn was dispatched — the SDK's
+// prompt drain pulls the first batch before init is processed. A notice that took
+// the slot would silence that turn's real failure, turning a message about a
+// missing toolset into the "three Hellos into the void" bug it was written to
+// prevent.
+
+import { describe, expect, it } from "vitest";
+import { PanelAgent } from "../../orchestrator/panel-agent.js";
+import type {
+  AgentBackend,
+  AgentCapabilities,
+  AgentEvent,
+  BackendStartOptions,
+} from "../../orchestrator/agent-backend.js";
+
+const CAPS: AgentCapabilities = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: true,
+  modelEnumeration: false,
+  slashCommands: false,
+  hooks: false,
+  vision: true,
+  turnMarkers: true,
+};
+
+const NOTICE = "This session started without 1 of its MCP servers: `panel` (failed).";
+const TURN_FAILURE = "REAL_TURN_FAILURE";
+
+/** Emits the notice INSIDE the turn — the real ordering when init lands after the
+ *  prompt drain has already dispatched the first batch — then the turn's own
+ *  failure behind it. */
+function noticeThenTurnErrorBackend(): AgentBackend {
+  return {
+    id: "claude" as AgentBackend["id"],
+    capabilities: CAPS,
+    async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+      yield { type: "session", sessionId: "s1" };
+      for await (const _turn of opts.channel) {
+        void _turn;
+        yield { type: "error", sessionNotice: true, message: NOTICE };
+        yield { type: "error", message: TURN_FAILURE };
+        yield { type: "result", ok: false, subtype: "error_during_execution", turn: 1 };
+      }
+    },
+    async interrupt() {},
+    async listModels() {
+      return [];
+    },
+  };
+}
+
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+
+describe("a session notice renders on its own terms (#1524)", () => {
+  it("is shown verbatim, without the turn-failure framing", async () => {
+    const said: string[] = [];
+    const agent = new PanelAgent(
+      "tab-notice",
+      { mcpServers: undefined, systemAppend: "", model: "claude-test-1", onSay: (_t, m) => said.push(m) } as never,
+      noticeThenTurnErrorBackend(),
+    );
+    void agent.start();
+    agent.send("hello");
+    await settle();
+    await agent.stop().catch(() => {});
+
+    const line = said.find((m) => m.includes("panel"));
+    expect(line).toBeDefined();
+    expect(line).toBe(`⚠️ ${NOTICE}`);
+    // The generic framing would name a turn that never failed and offer a retry
+    // that re-runs nothing.
+    expect(line).not.toMatch(/turn failed/);
+    expect(line).not.toMatch(/Nothing was lost/);
+  });
+
+  it("does not spend the turn's one error line", async () => {
+    // Without this, a notice arriving mid-turn silences the turn's REAL failure —
+    // the user watches the turn end with only a message about MCP servers.
+    const said: string[] = [];
+    const agent = new PanelAgent(
+      "tab-slot",
+      { mcpServers: undefined, systemAppend: "", model: "claude-test-1", onSay: (_t, m) => said.push(m) } as never,
+      noticeThenTurnErrorBackend(),
+    );
+    void agent.start();
+    agent.send("hello");
+    await settle();
+    await agent.stop().catch(() => {});
+
+    expect(said.some((m) => m.includes(NOTICE))).toBe(true);
+    expect(said.some((m) => m.includes(TURN_FAILURE))).toBe(true);
+  });
+});

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -149,6 +149,14 @@ export type AgentEvent = (
        *  verified success, so renderers must not frame it as either (no "turn
        *  failed", no "nothing was lost — try again"). */
       unverifiedCompletion?: boolean;
+      /** The error is about the SESSION, not about a turn (#1524): it is emitted
+       *  at session start — before any turn exists — so the turn framing every
+       *  other error gets ("the <model> turn failed … try again") would name a
+       *  turn that never ran and offer a retry that changes nothing. It must be
+       *  rendered as its own self-contained line, and must NOT consume the
+       *  once-per-turn error slot, or a session notice would silence the first
+       *  REAL turn error that follows it. */
+      sessionNotice?: boolean;
     }
 ) & {
   /** Backend-minted TURN MARKER (#728): a monotonically increasing id (1 = the

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -23,6 +23,7 @@ import { logger } from "../utils/logger.js";
 import { errorText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import { loadTurnRegistry, saveTurnRegistry, tombstoneTurn } from "./turn-registry.js";
+import { degradedMcpNotice, degradedMcpServers } from "./mcp-session-health.js";
 import { randomUUID } from "node:crypto";
 import {
   type AgentBackend,
@@ -419,6 +420,25 @@ export class ClaudeBackend implements AgentBackend {
     };
   }
 
+  /**
+   * The MCP server set this session is given: the comfyui stdio child, plus the
+   * in-process panel server when this key drives the canvas.
+   *
+   * Split out of buildOptions() so #1524's init check can name the servers we
+   * ASKED for without re-deriving them. Deriving them twice is how the check
+   * would end up comparing the session's report against a set the session was
+   * never handed — which is a false alarm in one direction and blindness in the
+   * other, and neither shows up in a test that builds both sides itself.
+   */
+  private mcpServersForRun(): Options["mcpServers"] {
+    return {
+      ...this.deps.mcpServers,
+      // Live-graph control of THIS tab's open workflow (in-process; talks to
+      // the bridge). Lets the agent build on what the user sees.
+      ...(this.deps.panelServer ? { panel: this.deps.panelServer } : {}),
+    };
+  }
+
   private buildOptions(opts: BackendStartOptions): Options {
     const model = opts.model;
     const effort = toClaudeEffort(opts.effort);
@@ -440,12 +460,7 @@ export class ClaudeBackend implements AgentBackend {
       // these into onStream deltas; the final assistant message still commits the
       // authoritative text via onSay (reconciled by message id).
       includePartialMessages: true,
-      mcpServers: {
-        ...this.deps.mcpServers,
-        // Live-graph control of THIS tab's open workflow (in-process; talks to
-        // the bridge). Lets the agent build on what the user sees.
-        ...(this.deps.panelServer ? { panel: this.deps.panelServer } : {}),
-      },
+      mcpServers: this.mcpServersForRun(),
       // Only our comfyui MCP — never inherit the user's project/user MCP config
       // (which may run a second comfyui that grabs the bridge port).
       strictMcpConfig: true,
@@ -738,6 +753,30 @@ export class ClaudeBackend implements AgentBackend {
           logger.info(
             `[panel-agent] init model=${message.model} session=${message.session_id.slice(0, 8)} apiKeySource=${message.apiKeySource} skills=${message.skills?.length ?? 0}`,
           );
+          // #1524 — the session just told us which of its MCP servers actually
+          // connected. Say so when one did not, instead of letting the agent run
+          // for hours against a toolset that was silently thinned. This is the
+          // reported failure exactly: `comfyui` came back after a mid-session
+          // drop, the 92 `panel_*` tools did not, and the only signal anywhere
+          // was a tool-list diff the agent had to notice on its own.
+          //
+          // It reports the observation, not a cause. WHY a server goes missing is
+          // still open on #1524 and the candidates need different fixes; this
+          // fires the same either way, which is the point — it turns a silent,
+          // unreproducible degradation into one that names itself the moment it
+          // happens, on whichever transport it happens to.
+          const degraded = degradedMcpServers(
+            Object.keys(this.mcpServersForRun() ?? {}),
+            message.mcp_servers,
+          );
+          if (degraded.length) {
+            logger.error(
+              `[claude-backend] session ${message.session_id.slice(0, 8)} started WITHOUT ` +
+                `${degraded.map((d) => `${d.name}=${d.status ?? "absent"}`).join(" ")} ` +
+                `(reported: ${(message.mcp_servers ?? []).map((s) => `${s.name}=${s.status}`).join(" ") || "none"})`,
+            );
+            yield { type: "error", sessionNotice: true, message: degradedMcpNotice(degraded) };
+          }
         } else if (message.subtype === "thinking_tokens") {
           // Live extended-thinking token count → drives a "thinking… (N)" meter
           // so the user can see the agent reasoning (not stuck) before any text.

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -23,7 +23,8 @@ import { logger } from "../utils/logger.js";
 import { errorText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import { loadTurnRegistry, saveTurnRegistry, tombstoneTurn } from "./turn-registry.js";
-import { degradedMcpNotice, degradedMcpServers } from "./mcp-session-health.js";
+import { degradedMcpNotice, inspectMcpServers } from "./mcp-session-health.js";
+import type { DegradedMcpServer } from "./mcp-session-health.js";
 import { randomUUID } from "node:crypto";
 import {
   type AgentBackend,
@@ -420,6 +421,62 @@ export class ClaudeBackend implements AgentBackend {
     };
   }
 
+  /** Configured servers still CONNECTING in this session's `init` report (#1524).
+   *  Settled once, at the first turn end, by settlePendingMcpServers(). */
+  private pendingMcpServers: string[] = [];
+
+  /** Say — in the log — that this session does not have servers it was given.
+   *  Shared by the init check and the deferred settle so both report identically. */
+  private reportDegradedMcp(
+    degraded: readonly DegradedMcpServer[],
+    reported: readonly { name: string; status: string }[] | undefined,
+    sessionId: string,
+    when = "started",
+  ): void {
+    logger.error(
+      `[claude-backend] session ${sessionId.slice(0, 8)} ${when} WITHOUT ` +
+        `${degraded.map((d) => `${d.name}=${d.status ?? "absent"}`).join(" ")} ` +
+        `(reported: ${(reported ?? []).map((s) => `${s.name}=${s.status}`).join(" ") || "none"})`,
+    );
+  }
+
+  /**
+   * Settle the servers that were still connecting at `init` (#1524).
+   *
+   * `init` is the only MCP report the session PUSHES, and server startup does not
+   * block it — so a server that is `pending` there and FAILS a moment later would
+   * otherwise never be mentioned anywhere, which is the same silence this change
+   * exists to end, just moved a few hundred milliseconds later.
+   *
+   * Re-read once per run, at the first turn end: by then a pending server has
+   * settled, and a turn boundary needs no timer and cannot spam. A session that
+   * never takes a turn is never re-read, which is the right trade — there is no
+   * agent work to degrade.
+   *
+   * Best-effort by construction: `mcpServerStatus()` is an optional Query method
+   * (a harness that lacks it, or a poll that throws, leaves the pending servers
+   * unmentioned rather than guessed at).
+   */
+  private async settlePendingMcpServers(): Promise<AgentEvent | null> {
+    const names = this.pendingMcpServers;
+    if (names.length === 0) return null;
+    // Taking the names IS the once-only guard: the next turn end finds the list
+    // empty and returns before the poll. A re-read on every turn would spend a
+    // control round-trip per turn for a question that is already answered.
+    this.pendingMcpServers = [];
+    let reported: Array<{ name: string; status: string }> | undefined;
+    try {
+      reported = await this.q?.mcpServerStatus?.();
+    } catch (err) {
+      logger.debug(`[claude-backend] mcpServerStatus: ${msgOf(err)}`);
+      return null;
+    }
+    const { degraded } = inspectMcpServers(names, reported);
+    if (!degraded.length) return null;
+    this.reportDegradedMcp(degraded, reported, this.registrySessionId ?? "", "is running");
+    return { type: "error", sessionNotice: true, message: degradedMcpNotice(degraded) };
+  }
+
   /**
    * The MCP server set this session is given: the comfyui stdio child, plus the
    * in-process panel server when this key drives the canvas.
@@ -520,6 +577,10 @@ export class ClaudeBackend implements AgentBackend {
     this.turns.length = 0;
     this.lastResultTurnId = this.turnSeq;
     this.classificationPoisoned = false;
+    // #1524 — MCP health is per SESSION. A restart re-runs every connection, so
+    // the previous run's pending set and its "already settled" mark must not
+    // suppress the new session's report.
+    this.pendingMcpServers = [];
     this.parkedInterrupted.clear(); // dead session's parks die with it
     this.consumedInterrupted.clear(); // …and its landing history
     this.markerBase = this.lastResultTurnId; // turn markers are run-relative (#728)
@@ -594,6 +655,14 @@ export class ClaudeBackend implements AgentBackend {
           continue;
         }
         yield streamTurn === undefined ? ev : { ...ev, turn: streamTurn - this.markerBase };
+      }
+      // #1524 — settle whatever was still CONNECTING at init, once, at the first
+      // turn end. Placed here rather than in route() because it has to await a
+      // control request, and after the turn's own events so a session notice
+      // never interleaves into the middle of a reply.
+      if (message.type === "result") {
+        const settled = await this.settlePendingMcpServers();
+        if (settled) yield settled;
       }
     }
   }
@@ -765,17 +834,20 @@ export class ClaudeBackend implements AgentBackend {
           // fires the same either way, which is the point — it turns a silent,
           // unreproducible degradation into one that names itself the moment it
           // happens, on whichever transport it happens to.
-          const degraded = degradedMcpServers(
+          const health = inspectMcpServers(
             Object.keys(this.mcpServersForRun() ?? {}),
             message.mcp_servers,
           );
-          if (degraded.length) {
-            logger.error(
-              `[claude-backend] session ${message.session_id.slice(0, 8)} started WITHOUT ` +
-                `${degraded.map((d) => `${d.name}=${d.status ?? "absent"}`).join(" ")} ` +
-                `(reported: ${(message.mcp_servers ?? []).map((s) => `${s.name}=${s.status}`).join(" ") || "none"})`,
-            );
-            yield { type: "error", sessionNotice: true, message: degradedMcpNotice(degraded) };
+          // A server still CONNECTING at init is not a failure — server startup
+          // does not block the session, so a slow one is legitimately `pending`
+          // here and connected a moment later. It is not "fine" either: `init` is
+          // the only report the session PUSHES, so a pending server that goes on
+          // to fail would never be mentioned. Remember the names and settle them
+          // at the first turn end (see settlePendingMcpServers).
+          this.pendingMcpServers = health.pending;
+          if (health.degraded.length) {
+            this.reportDegradedMcp(health.degraded, message.mcp_servers, message.session_id);
+            yield { type: "error", sessionNotice: true, message: degradedMcpNotice(health.degraded) };
           }
         } else if (message.subtype === "thinking_tokens") {
           // Live extended-thinking token count → drives a "thinking… (N)" meter

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -1,0 +1,118 @@
+// #1524 — read the harness's OWN report of which MCP servers a session came up
+// with, instead of discarding it.
+//
+// The reported failure: mid-session both MCP servers dropped; the `comfyui` half
+// came back and all 92 `panel_*` tools did not. The orchestrator kept running and
+// kept its ports, the panel looked healthy, and the agent spent the rest of a
+// six-hour session unable to touch the user's canvas. Nothing anywhere said so —
+// the reporter established it by hand, by noticing a tool-list diff and then
+// probing with `ToolSearch`.
+//
+// It did not have to be established by hand. Every Claude session opens with a
+// `system`/`init` message carrying `mcp_servers: {name, status}[]`, which is the
+// CLI's authoritative per-session statement of what actually connected. Verified
+// against the installed harness (agent SDK 0.3.197) with one server of each kind
+// configured:
+//
+//   [{"name":"deadstdio","status":"failed"},{"name":"panel","status":"connected"}]
+//
+// — so it covers BOTH transports the panel uses: the in-process `createSdkMcpServer`
+// panel server (Claude lane) and the stdio `comfyui` child. `route()` already reads
+// that message for the session id and throws the rest away.
+//
+// This module is only the comparison. It says what was observed and nothing more:
+// it does not diagnose WHY a server is missing (still unknown for #1524, and the
+// two candidate causes need different fixes), and it does not promise a restart
+// would help.
+
+/** One entry of the `system`/`init` `mcp_servers` report. */
+export interface ReportedMcpServer {
+  name: string;
+  status: string;
+}
+
+/** A configured server the session did not come up with. */
+export interface DegradedMcpServer {
+  name: string;
+  /** The reported status, or `null` when the server was absent from the report. */
+  status: string | null;
+}
+
+/**
+ * Compare the MCP servers we handed the session against the ones it reports.
+ *
+ * `configured` is the set of names passed as `Options.mcpServers`. Because the
+ * panel always sets `strictMcpConfig: true`, the session's server set is exactly
+ * ours — no user/project config can appear in the report and no name of ours can
+ * be legitimately replaced.
+ *
+ * Returns the configured servers that are NOT connected, in the order they were
+ * configured. Empty means every server we asked for is up — which is the case this
+ * has to get right first, since a false "your tools are gone" is worse than the
+ * silence it replaces.
+ *
+ * Two deliberate silences:
+ *
+ *  - An ABSENT or empty report yields nothing. A harness that does not populate
+ *    the field at all (or has not yet) tells us nothing about our servers, and
+ *    reading its silence as failure would fire on every healthy session.
+ *  - Any status that is not recognizably a failure is treated as fine. The set of
+ *    statuses is the CLI's to grow; a new one must not become an alarm here.
+ *
+ * Absence from a NON-EMPTY report does count: the report is populated, the config
+ * is strict, so a name of ours missing from it is a server the session does not
+ * have. That case matters — a server whose connection fails before it is
+ * advertised is missing rather than failed.
+ */
+export function degradedMcpServers(
+  configured: readonly string[],
+  reported: readonly ReportedMcpServer[] | undefined,
+): DegradedMcpServer[] {
+  if (!Array.isArray(reported) || reported.length === 0) return [];
+  const byName = new Map<string, string>();
+  for (const entry of reported) {
+    if (entry && typeof entry.name === "string") byName.set(entry.name, String(entry.status ?? ""));
+  }
+  const out: DegradedMcpServer[] = [];
+  for (const name of configured) {
+    if (!byName.has(name)) {
+      out.push({ name, status: null });
+      continue;
+    }
+    const status = byName.get(name) ?? "";
+    if (!isConnectedStatus(status)) out.push({ name, status });
+  }
+  return out;
+}
+
+/** Whether a reported status means the server is usable this session. Unknown
+ *  statuses count as connected — see the silence rules above. */
+function isConnectedStatus(status: string): boolean {
+  const s = status.trim().toLowerCase();
+  return s !== "failed" && s !== "needs-auth" && s !== "disabled" && s !== "error";
+}
+
+/**
+ * The line the user sees when a session starts without a server it was given.
+ *
+ * Scoped the way `NO_PANEL_TOOLS_OVERRIDE` is scoped: it states the observation
+ * and its one consequence, and then stops. It does not say why (unknown), does
+ * not say a restart fixes it (a cause that persists survives a restart), and does
+ * not vouch for the servers that DID come up — the reader can see those in the
+ * same sentence.
+ */
+export function degradedMcpNotice(degraded: readonly DegradedMcpServer[]): string {
+  if (degraded.length === 0) return "";
+  const named = degraded
+    .map((d) => (d.status === null ? `\`${d.name}\` (not reported)` : `\`${d.name}\` (${d.status})`))
+    .join(", ");
+  const plural = degraded.length > 1 ? "servers" : "server";
+  const theirTools = degraded.length > 1 ? "Their tools are" : "Its tools are";
+  return (
+    `This session started without ${degraded.length} of its MCP ${plural}: ${named}. ` +
+    `${theirTools} not available to the agent for the rest of this session, ` +
+    `so anything that needs them will fail or be worked around silently. ` +
+    `Starting a new session (Disconnect → Connect) is what re-runs the connection; ` +
+    `whether it succeeds depends on why this one did not, which this message does not know.`
+  );
+}

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -38,6 +38,27 @@ export interface DegradedMcpServer {
   status: string | null;
 }
 
+/** What a report says about the servers we configured. */
+export interface McpSessionHealth {
+  /** Configured servers the session does not have. */
+  degraded: DegradedMcpServer[];
+  /**
+   * Configured servers still CONNECTING when this report was taken.
+   *
+   * `pending` is a settled-later status, not a failure: the SDK's server startup
+   * does not block the session, so a slow server is legitimately pending in the
+   * `init` report and connects a moment afterwards. Calling that degraded would
+   * fire on healthy sessions, which is the one outcome worse than the silence
+   * this replaces.
+   *
+   * But it must not be read as "fine" either — a server pending at init can go
+   * on to FAIL, and since `init` is the only report the session pushes, nothing
+   * would ever say so. The caller re-reads these names later (the SDK's
+   * `mcpServerStatus()` poll) and reports whatever they settled as.
+   */
+  pending: string[];
+}
+
 /**
  * Compare the MCP servers we handed the session against the ones it reports.
  *
@@ -46,10 +67,11 @@ export interface DegradedMcpServer {
  * ours — no user/project config can appear in the report and no name of ours can
  * be legitimately replaced.
  *
- * Returns the configured servers that are NOT connected, in the order they were
- * configured. Empty means every server we asked for is up — which is the case this
- * has to get right first, since a false "your tools are gone" is worse than the
- * silence it replaces.
+ * Splits the configured servers into the ones the session does not have
+ * (`degraded`) and the ones still connecting (`pending`), in the order they were
+ * configured. Both empty means every server we asked for is up — which is the
+ * case this has to get right first, since a false "your tools are gone" is worse
+ * than the silence it replaces.
  *
  * Two deliberate silences:
  *
@@ -64,33 +86,39 @@ export interface DegradedMcpServer {
  * have. That case matters — a server whose connection fails before it is
  * advertised is missing rather than failed.
  */
-export function degradedMcpServers(
+export function inspectMcpServers(
   configured: readonly string[],
   reported: readonly ReportedMcpServer[] | undefined,
-): DegradedMcpServer[] {
-  if (!Array.isArray(reported) || reported.length === 0) return [];
+): McpSessionHealth {
+  if (!Array.isArray(reported) || reported.length === 0) return { degraded: [], pending: [] };
   const byName = new Map<string, string>();
   for (const entry of reported) {
     if (entry && typeof entry.name === "string") byName.set(entry.name, String(entry.status ?? ""));
   }
-  const out: DegradedMcpServer[] = [];
+  const degraded: DegradedMcpServer[] = [];
+  const pending: string[] = [];
   for (const name of configured) {
     if (!byName.has(name)) {
-      out.push({ name, status: null });
+      degraded.push({ name, status: null });
       continue;
     }
-    const status = byName.get(name) ?? "";
-    if (!isConnectedStatus(status)) out.push({ name, status });
+    const status = (byName.get(name) ?? "").trim().toLowerCase();
+    if (status === "pending") pending.push(name);
+    else if (FAILED_STATUSES.has(status)) degraded.push({ name, status: byName.get(name) ?? "" });
   }
-  return out;
+  return { degraded, pending };
 }
 
-/** Whether a reported status means the server is usable this session. Unknown
- *  statuses count as connected — see the silence rules above. */
-function isConnectedStatus(status: string): boolean {
-  const s = status.trim().toLowerCase();
-  return s !== "failed" && s !== "needs-auth" && s !== "disabled" && s !== "error";
-}
+/**
+ * Statuses that mean the server is not usable. Taken from the SDK's own
+ * `McpServerStatus` union (`connected | failed | needs-auth | pending |
+ * disabled`), plus `error` for a host that words it that way.
+ *
+ * A closed list, deliberately: anything the CLI adds later reads as connected
+ * rather than as an alarm, so a vocabulary change cannot start telling healthy
+ * sessions their tools are gone.
+ */
+const FAILED_STATUSES = new Set(["failed", "needs-auth", "disabled", "error"]);
 
 /**
  * The line the user sees when a session starts without a server it was given.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2011,6 +2011,17 @@ export class PanelAgent {
         // was already surfaced (the stall watchdog's warning, or an earlier
         // error event this turn), skip the chat line but still log it (#728).
         const detail = typeof ev.message === "string" && ev.message.trim() ? ev.message.trim() : "unknown error";
+        // #1524 — a SESSION notice (an MCP server the session did not come up
+        // with) is not a turn failure. It arrives at init, before any turn
+        // exists, so the turn framing below would name a turn that never ran and
+        // offer a retry that re-runs nothing. It also must not spend the
+        // once-per-turn error slot: doing so would let a notice about the
+        // toolset swallow the first genuine turn error after it.
+        if (ev.sessionNotice) {
+          this.deps.onSay(this.tabId, `⚠️ ${detail}`);
+          logger.error(`[panel-agent ${this.short()}] session notice: ${detail}`);
+          break;
+        }
         if (!this.errorSurfaced) {
           this.errorSurfaced = true;
           // #886: a "completed but unverified" disclosure is NOT a turn failure


### PR DESCRIPTION
Claims the remaining half of #1524 — the asymmetry where a mid-session drop brought the `comfyui` tools back and left all 92 `panel_*` tools absent, silently, for the rest of a six-hour session.

## First: 0.51.54 does not cover the reporter's configuration

Worth stating plainly so this thread is not closed on it. The shipped fix (#1596) corrects the **loopback HTTP** panel MCP, which serves the codex/gemini lane through `makeHttpBackendMcpServers`. The reporter's environment block says `Backend: Claude`, and on the Claude lane `panel` is an **in-process `createSdkMcpServer`** passed straight to the Agent SDK — a different attachment path entirely, with no session id and no status code. Their case is still open.

## What this changes

Every Claude session opens with a `system`/`init` message carrying `mcp_servers: {name, status}[]`. That is the harness's authoritative, per-session statement of what actually connected. `route()` read the session id off that message and threw the rest away — so the fact the reporter reconstructed by hand (tool-list diff, then two `ToolSearch` probes) was sitting in the first message of the session that lost the tools.

Verified against the installed agent SDK (0.3.197), because the whole change rests on whether the report covers the in-process server too:

```
mcp_servers: [{"name":"deadstdio","status":"failed"},{"name":"panel","status":"connected"}]
mcp tools:   ["mcp__panel__panel_ping"]
```

It covers both transports. So the check fires on the reporter's symptom **without needing to know the cause** — which is the part that is still unknown, and whose two candidates the thread notes need different fixes.

## Scope, and the direction that matters

A false "your tools are gone" on a healthy session is worse than the silence it replaces, so every ambiguity resolves to saying nothing:

| situation | result |
|---|---|
| every configured server `connected` | silent |
| report absent or empty | silent — a harness that does not populate the field tells us nothing |
| unrecognized status | silent — the vocabulary is the CLI's to grow |
| server we did not configure | silent — not ours |
| configured server reported `failed`/`needs-auth`/`error`/`disabled` | reported |
| configured server **missing** from a populated report | reported |

Absence from a *populated* report counts: `strictMcpConfig: true` makes the set exactly ours, and a connection that fails before the server is advertised goes missing rather than failed — the reporter's shape.

The notice states the observation and stops. It does not diagnose a cause, and it does not promise a restart fixes it (a cause that persists survives one) — the same discipline `NO_PANEL_TOOLS_OVERRIDE` is held to.

## Rendering

It is not a turn failure, so it is not painted as one. The generic line — "The &lt;model&gt; turn failed … nothing was lost, try again" — would name a turn that never ran and offer a retry that re-runs nothing.

The sharper hazard is the slot: `errorSurfaced` allows one chat line per turn, and init legitimately lands **after** the first batch is dispatched (the SDK's prompt drain pulls it before init is processed). A notice that took the slot would silence that turn's real failure — the "three Hellos into the void" bug this guard exists to prevent, pointing the other way. A test pins that.

## What this does NOT do

- It does not explain **why** the panel server went missing. Still unknown; the issue's request for `ss -lntp` + stderr at the moment of the drop still stands. This makes the next occurrence name itself instead of costing six hours.
- The notice reaches the **user** (panel line) and the **operator** (`logger.error`), not the model's context. The system prompt is fixed when the session opens, and injecting a turn at session start would make the agent speak unprompted. Telling the model its toolset was thinned is a separate, larger change.

One mechanism was checked and **not** shipped, recorded so nobody re-derives it: MCP SDK 1.29.0's `Protocol.connect()` throws `Already connected to a transport` if the instance is still attached, and `Query.connectSdkMcpServer` swallows that rejection and deletes the server from its map — one mis-ordered attach would remove the panel tools for a whole session, silently, exactly as reported. But the orchestrator never reaches it: `makePanelServer` builds a fresh instance per agent, `restartAgentResume` spawns a new agent and retires the old, and within one agent `start()`'s restart loop is strictly sequential. Confirmed on the rig — three sequential `query()` calls sharing one instance all connect `ok`. Real constraint, no reachable trigger here.

## Verification

19 new tests green, then four mutations, each `grep`-confirmed applied:

- init call site removed → 3 die
- comparison pointed at `deps.mcpServers`, making the in-process panel server invisible → 2 die
- render branch removed → 2 die
- empty-report guard removed → 1 dies

Full suite **516 files / 9567 tests** green. `npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
