### PR TITLE
fix(test): the rgthree skill check reads the file the way the loader does

### DIFF
--- a/src/__tests__/orchestrator/rgthree-authoring-awareness.test.ts
+++ b/src/__tests__/orchestrator/rgthree-authoring-awareness.test.ts
@@ -18,7 +18,16 @@ const PROMPT_SRC = readFileSync(new URL("../../orchestrator/index.ts", import.me
 // bundled" below), not as a module-scope throw that collects zero tests and hides which
 // of the two halves of #1551 regressed.
 const SKILL_URL = new URL("../../../plugin/skills/rgthree/SKILL.md", import.meta.url);
-const SKILL = existsSync(SKILL_URL) ? readFileSync(SKILL_URL, "utf-8") : "";
+// Normalized the way the LOADER normalizes it. `splitFrontmatter` (tools/skills-access.ts)
+// strips the BOM and folds CRLF before it matches the fence, so the bytes on disk are not
+// what any consumer of this file ever sees — and asserting on the raw bytes made the
+// frontmatter check fail on every Windows checkout with `core.autocrlf=true` (the default
+// for most Windows developers), where `/^---\n/` cannot match `---\r\n`. The product was
+// never affected; only this assertion was, and it failed for a reason that says nothing
+// about the thing it is testing.
+const SKILL = existsSync(SKILL_URL)
+  ? readFileSync(SKILL_URL, "utf-8").replace(/^﻿/, "").replace(/\r\n/g, "\n")
+  : "";
 
 describe("the system prompt teaches AUTHORING rgthree toggles, not just reading them (#1551)", () => {
   it("carries the authoring section", () => {


### PR DESCRIPTION
`rgthree-authoring-awareness` asserts `/^---\nname: rgthree\n/` against the **raw bytes** of `plugin/skills/rgthree/SKILL.md`. With `core.autocrlf=true` — the default for most Windows developers — that file checks out CRLF, the anchor cannot match, and the suite is **red on a clean clone** for a reason that says nothing about what the test is checking.

Reproduced on a fresh `origin/main` worktree, not inferred: 1 failed / 15 passed, `expect(SKILL).toMatch(/^---\nname: rgthree\n/)`.

## The product was never affected

`splitFrontmatter` (`src/tools/skills-access.ts`) already does this before it matches the fence:

```ts
// Normalize BOM + CRLF so the fence match is reliable cross-platform.
const norm = text.replace(/^﻿/, "").replace(/\r\n/g, "\n");
```

So no consumer of `SKILL.md` ever sees the bytes the test was reading, and `list_packs (action:"skill_read")` works fine on Windows today. Nothing in `src/` changes here.

## Why normalize rather than pin the file to LF

`.gitattributes` would also work, but it only takes effect on checkout — existing clones need `git add --renormalize` — and it would be fixing the wrong layer. What the test cares about is that **the loader can read the frontmatter**, not how git happened to write the file to disk. Reading it the way the loader reads it is the assertion that was meant.

CI is unaffected (LF there, so the fold is a no-op); this only ever showed up locally on Windows.

Found while verifying #1600 on Windows — it was the one red file in an otherwise green suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)