### PR TITLE
fix(#1327): a refused offer is not a verdict anyone was told

### DIFF
--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -52,7 +52,7 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
     const dispatchedAt = Date.now();
     // The render finishes and the panel forwards `executed` BEFORE the /prompt reply
     // has made it back to us — so there is no ticket to correlate against yet.
-    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, CONV);
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
     // …and only now does panel_run learn the id and open the ticket.
     journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 118, dispatchedAt });
 
@@ -69,11 +69,14 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
     // born `reused`, and EVERY later completion for that id read UNDETERMINED too.
     // One race therefore degraded the whole run, not just one notification.
     const dispatchedAt = Date.now();
-    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, CONV);
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
     journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
     drain();
 
     // A second completion for the same run (a re-sent frame) must still correlate.
+    // NOTE: `correlate` takes the conversation as a bare string, while `record`
+    // takes it inside an options object. Easy to get backwards — and getting it
+    // backwards silently drops the conversation rather than failing to compile.
     const again = journal.correlate(TAB, { prompt_id: PID }, CONV);
     expect(again.status).toBe("matched");
   });
@@ -83,7 +86,7 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
     // completion that predates this dispatch, and claiming it would attribute an
     // older run's result to a new one — the misattribution the journal is built to
     // refuse, which is strictly worse than saying "undetermined".
-    journal.record(TAB, { prompt_id: PID, duration_s: 9 }, CONV);
+    journal.record(TAB, { prompt_id: PID, duration_s: 9 }, { conversation: CONV });
     const dispatchedAt = Date.now() + 5_000; // dispatch happens AFTER that arrival
     journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
 
@@ -93,7 +96,7 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
 
   it("another party's completion for the same id is not claimed", () => {
     const dispatchedAt = Date.now();
-    journal.record("wf:other.json", { prompt_id: PID }, "conv-2");
+    journal.record("wf:other.json", { prompt_id: PID }, { conversation: "conv-2" });
     journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
 
     // Nothing landed on OUR tab…
@@ -118,7 +121,7 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
     // without an ack), which puts the entry back to `pending` — which is also why the
     // guard is keyed on `attempts`, not on `state`.
     const tokens: string[] = [];
-    journal.record(TAB, { prompt_id: PID }, CONV);
+    journal.record(TAB, { prompt_id: PID }, { conversation: CONV });
     journal.deliverPending(TAB, (payload, token) => {
       expect((payload as unknown as Record<string, unknown>).run_correlation).toBe("foreign");
       tokens.push(token);
@@ -139,7 +142,7 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
   it("without a dispatch timestamp nothing is claimed — no proof, no change", () => {
     // Callers that cannot supply the dispatch time keep exactly the old behaviour
     // rather than getting a timing guess.
-    journal.record(TAB, { prompt_id: PID }, CONV);
+    journal.record(TAB, { prompt_id: PID }, { conversation: CONV });
     journal.openRun(PID, { tabId: TAB, conversation: CONV });
 
     const [payload] = drain();
@@ -148,11 +151,112 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
 
   it("an ID-LESS completion is never claimed on timing alone", () => {
     const dispatchedAt = Date.now();
-    journal.record(TAB, { duration_s: 0.1 }, CONV); // no prompt_id at all
+    journal.record(TAB, { duration_s: 0.1 }, { conversation: CONV }); // no prompt_id at all
     journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
 
     const [payload] = drain();
     expect(payload.run_correlation).toBe("unidentified");
+  });
+});
+
+// #1327 RECURRENCE — reported 2026-08-15 on comfyui-mcp 0.51.56, five releases after
+// the fix above shipped (v0.50.100). Same symptom, exact prompt-id match, same tool:
+// `panel_run({to_node_id: 19})` came back RE-DELIVERED with origin UNDETERMINED.
+//
+// The fix above was real but only reachable in the ordering ITS OWN TESTS used. The
+// orchestrator flushes the journal the instant a completion arrives (index.ts:
+// `record(...)` then `flushRunCompletions(...)`), and at that instant the agent is
+// still inside the `panel_run` tool call that queued the render — so the offer is
+// REFUSED. Refused or not, it counted an `attempts`, and `claimRaced` skipped any
+// entry with attempts > 0. The guard therefore fired on precisely the race it was
+// written to repair:
+//
+//   record → flush REFUSED (attempts=1, nobody told) → openRun → claim SKIPPED
+//
+// `attempts` counts OFFERS; only a taken hand-off tells an agent anything.
+describe("the recurrence: a refused offer is not a verdict anyone was told (#1327)", () => {
+  it("the production ordering — arrival flush cannot hand off, THEN openRun", () => {
+    const dispatchedAt = Date.now();
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
+    // flushRunCompletions fires here, and injectEvent refuses: the agent is busy
+    // inside the very panel_run call whose reply has not come back yet.
+    const refused = journal.deliverPending(TAB, () => false);
+    expect(refused.delivered).toBe(0);
+    expect(refused.blockedOn).not.toBeNull(); // it really was offered and refused
+    // …and only now does the /prompt reply arrive and the ticket get opened.
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 19, dispatchedAt });
+
+    const [payload] = drain();
+    expect(payload).toBeDefined();
+    expect(payload?.prompt_id).toBe(PID);
+    // THE RECURRENCE: this was "foreign" — the reporter's "origin is UNDETERMINED".
+    expect(payload?.run_correlation).toBe("matched");
+    // Still honestly flagged as a late arrival; that part was never wrong.
+    expect(payload?.replayed).toBe(true);
+  });
+
+  it("but a verdict an agent ACTUALLY took is still never rewritten", () => {
+    // The guard's other direction, and the reason it cannot simply be deleted: once
+    // an agent has been handed the text, correcting the entry under it would rewrite
+    // an answer already given. A TAKEN hand-off that is later released back to
+    // `pending` must stay unclaimable — which is why this counts hand-offs rather
+    // than reading `state`.
+    const tokens: string[] = [];
+    journal.record(TAB, { prompt_id: PID }, { conversation: CONV });
+    journal.deliverPending(TAB, (_p, token) => {
+      tokens.push(token);
+      return true; // TAKEN this time
+    });
+    journal.release(tokens[0] as string, { carried: true });
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt: Date.now() });
+
+    const after = drain();
+    expect(after).toHaveLength(1); // the replay really happened — not a vacuous pass
+    expect(after[0]?.run_correlation).not.toBe("matched");
+  });
+
+  it("the claim BINDS the entry to the run, so a resend is flagged as a repeat", () => {
+    // Re-stamping only the verdict left the claim cosmetic downstream. The entry was
+    // journaled at generation 0 ("this tab never ticketed the id"), and `ack()` reads
+    // generation 0 as unprovable: no delivered-memo, and the ticket never settles. So
+    // after the agent had been given the render and its turn had ended, a re-sent
+    // frame came back as a SECOND delivery with no repeat flag — indistinguishable
+    // from a second render.
+    const dispatchedAt = Date.now();
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
+    journal.deliverPending(TAB, () => false);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 19, dispatchedAt });
+
+    const tokens: string[] = [];
+    journal.deliverPending(TAB, (_p, token) => {
+      tokens.push(token);
+      return true;
+    });
+    journal.ack(tokens[0] as string); // the carrying turn ended
+
+    // The panel re-sends the same completion frame.
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
+    const [resend] = drain();
+    // Duplicate-over-loss is the standing rule, so it IS delivered — but it must say
+    // so rather than presenting itself as a fresh render.
+    expect(resend?.possible_repeat).toBe(true);
+  });
+});
+
+describe("WIRING: the orchestrator offers a completion the moment it arrives (#1327)", () => {
+  it("record() is followed by flushRunCompletions() on the executed path", async () => {
+    // This is what makes the refused offer above a PRODUCTION ordering rather than a
+    // hypothesis. If the flush ever moves after the ticket is opened, the recurrence
+    // test would still pass while testing a sequence that no longer happens.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+
+    const record = src.indexOf("RunCompletions.record(event.tab_id");
+    expect(record).toBeGreaterThan(-1);
+    const flush = src.indexOf("flushRunCompletions(event.tab_id)", record);
+    expect(flush).toBeGreaterThan(record);
+    // …and nothing opens a ticket in between — the whole point is that there is none.
+    expect(src.slice(record, flush)).not.toContain("openRun");
   });
 });
 

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -195,7 +195,25 @@ export interface JournalEntry {
    *  by then. Undefined when the caller named none (see ownsRun). */
   conversation?: string;
   arrivedAt: number;
+  /** Delivery OFFERS made for this entry — including ones nothing could take.
+   *  Drives the `replayed` flag ("this landed late"), which is true of a refused
+   *  offer too: the completion really did fail to reach the agent when it
+   *  arrived. NOT a record of what an agent was told — see `handoffs`. */
   attempts: number;
+  /**
+   * Offers an agent actually TOOK onto its queue.
+   *
+   * Distinct from `attempts`, and the distinction is load-bearing (#1327): the
+   * orchestrator flushes the journal the instant a completion arrives, so a
+   * render that finishes while its own `panel_run` call is still in flight gets
+   * offered to an agent that cannot take it. That offer is REFUSED — it tells
+   * nobody anything — yet it still counts an attempt. Anything asking "has an
+   * agent been told this?" must read this counter, never `attempts`.
+   *
+   * Survives a release back to `pending`, which is why the question cannot be
+   * answered from `state` either.
+   */
+  handoffs: number;
   state: EntryState;
   /** Content fingerprint — set only for ID-LESS completions, which have no run
    *  identity to dedupe on. See idlessFingerprint(). */
@@ -453,11 +471,25 @@ export class RunCompletionJournalImpl {
     // No dispatch time means no proof — do nothing rather than guess.
     if (typeof meta.dispatchedAt !== "number") return claimed;
     for (const entry of this.entries.values()) {
-      // NOBODY HAS BEEN TOLD YET is the real condition, and `attempts` is what says so
-      // — not `state`. A released entry (handed to an agent whose turn ended without an
+      // NOBODY HAS BEEN TOLD YET is the real condition, and only `handoffs` says so.
+      //
+      // Not `state`: a released entry (handed to an agent whose turn ended without an
       // ack) goes back to `pending`, so a state check would silently re-stamp a verdict
-      // an agent had already been given. `attempts` survives that round trip.
-      if (entry.attempts > 0) continue;
+      // an agent had already been given.
+      //
+      // And NOT `attempts`, which is what this guard used to read — the recurrence of
+      // #1327. The orchestrator flushes the journal the moment a completion arrives, so
+      // a render that beats its own /prompt reply is offered to an agent still sitting
+      // inside the `panel_run` call that queued it. That offer is REFUSED, which tells
+      // the agent nothing at all, but it still counted an attempt — so this guard fired
+      // on the exact race it exists to repair, and the reporter got their own render
+      // back as "RE-DELIVERED … origin is UNDETERMINED" a second time.
+      //
+      // A refused offer reached nobody; only a TAKEN one commits a verdict to an agent.
+      if (entry.handoffs > 0) continue;
+      // Subsumed by the line above today (every non-pending state is reached through a
+      // taken hand-off), and kept because it can only ever REFUSE a claim: a future
+      // state that arrives without one would otherwise be claimed by default.
       if (entry.state !== "pending") continue;
       // An ID-LESS completion carries no run identity at all, so nothing can prove it
       // belongs here — it stays unidentified rather than being claimed on timing alone.
@@ -479,6 +511,32 @@ export class RunCompletionJournalImpl {
       );
     }
     return claimed;
+  }
+
+  /**
+   * Bind claimed entries to the generation of the ticket that now owns them.
+   *
+   * The claim is otherwise only half-applied. A completion that beat its ticket was
+   * journaled with generation 0 — "this tab never ticketed the id" — and `claimRaced`
+   * only rewrites the VERDICT. Generation 0 is a bucket rather than an identity, so
+   * `ack()` reads the entry as unprovable: it writes no delivered-memo and settles no
+   * ticket. MEASURED consequence, not a theoretical one — after the agent had been
+   * given the render and its turn had ended, a re-sent frame for the same run was
+   * delivered a SECOND time with no `possible_repeat` flag, i.e. as though a second
+   * render had happened.
+   *
+   * Called once the generation exists, which is why it cannot live inside
+   * `claimRaced`: on the fresh-ticket path the ticket is minted after the claim.
+   *
+   * `ambiguousId` is deliberately left as it was. It only blocks a later completion
+   * from merging into this entry, which costs an extra delivery at worst and never a
+   * loss — the standing trade — so it is not worth widening the merge surface here.
+   */
+  private bindClaimed(claimed: Set<JournalEntry>, seq: number): void {
+    for (const entry of claimed) {
+      if (entry.correlation.status === "unidentified") continue;
+      entry.ticketSeq = seq;
+    }
   }
 
   private hasHistoryFor(
@@ -559,6 +617,7 @@ export class RunCompletionJournalImpl {
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
       // never suppressed as a duplicate of the other generation.
       existing.reused = true;
+      this.bindClaimed(claimed, existing.seq);
       this.retireOlderEntriesFor(promptId, claimed);
       return true;
     }
@@ -575,11 +634,12 @@ export class RunCompletionJournalImpl {
     // the same run undetermined; `claimed` is exactly the set proven to be ours.
     const hasHistory =
       this.hasHistoryFor(meta.tabId, promptId, meta.conversation, claimed) || false;
+    const seq = ++this.ticketSeq;
     this.tickets.set(promptId, {
       promptId,
       tabId: meta.tabId,
       ...(meta.conversation !== undefined ? { conversation: meta.conversation } : {}),
-      seq: ++this.ticketSeq,
+      seq,
       queuedAt: Date.now(),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
       settled: false,
@@ -590,6 +650,7 @@ export class RunCompletionJournalImpl {
         `[run-completions] prompt ${promptId} was queued again for tab ${meta.tabId.slice(0, 8)} after its ticket had been evicted — this tab already has history for that id, so it is treated as REUSED (every completion for it reported as undetermined)`,
       );
     }
+    this.bindClaimed(claimed, seq);
     // …and on THIS branch too. A fresh ticket after the old one was evicted is
     // still a NEW run for an id that already has journaled completions: without
     // this, an older `matched` entry survives untouched and goes on telling the
@@ -818,6 +879,7 @@ export class RunCompletionJournalImpl {
       ...(conversation !== undefined ? { conversation } : {}),
       arrivedAt: Date.now(),
       attempts: 0,
+      handoffs: 0,
       state: "pending",
       ...(correlation.status === "unidentified"
         ? { fingerprint: idlessFingerprint(key, payload) }
@@ -973,6 +1035,10 @@ export class RunCompletionJournalImpl {
     const entry = this.entries.get(token);
     if (!entry) return;
     entry.attempts += 1;
+    // …and count separately whether the offer was actually TAKEN. A refused one
+    // reached no agent, so it must not answer "has this verdict been read?" — see
+    // JournalEntry.handoffs (#1327).
+    if (handedOff) entry.handoffs += 1;
     entry.state = handedOff ? "handed_off" : "pending";
   }
 


### PR DESCRIPTION
Recurrence of #1327, reported 2026-08-15 on comfyui-mcp **0.51.56** — five releases after #1342 shipped it fixed (v0.50.100). Same symptom, same tool, exact prompt-id match: `panel_run({to_node_id:19})` came back `RE-DELIVERED` with `origin is UNDETERMINED`.

## Why the first fix did not hold

#1342 was a real fix, but it was only reachable in the ordering **its own tests used** — `record()` then `openRun()` back to back. Production does not do that. `index.ts` flushes the journal the *instant* a completion arrives, and at that instant the agent is still sitting inside the `panel_run` call that queued the render, so the offer is **refused**:

```
record → flush REFUSED (attempts=1, nobody told) → openRun → claim SKIPPED
```

`noteAttempt()` counts every *offer*, taken or not, and `claimRaced()` skipped any entry with `attempts > 0` under the heading `NOBODY HAS BEEN TOLD YET`. A refused offer tells nobody anything — so the guard fired on precisely the race it was written to repair.

Reproduced on the rig **before** writing any fix. The re-delivered payload came back byte-identical to the report:

```json
{"prompt_id":"e69d89b1-…","run_correlation":"foreign","replayed":true}
```

`handoffs` now counts only offers an agent actually **took**. That is the counter that answers "has this verdict been read?", and it still survives the release-back-to-`pending` round trip that rules out `state` (the reason #1342 reached for `attempts` in the first place).

## A second defect, measured while proving the first

The claim was **cosmetic downstream**. A completion that beats its ticket is journaled at generation `0` ("this tab never ticketed the id"), and `claimRaced` only rewrote the *verdict*. `ack()` reads generation 0 as unprovable, so it wrote no delivered-memo and never settled the ticket — and a re-sent frame after the agent's turn ended was delivered a **second time with no `possible_repeat` flag**, indistinguishable from a second render. `bindClaimed()` binds the entry to the generation that now owns it.

## Mutation verification

Four mutations, each killed:

| mutation | result |
|---|---|
| `handoffs` → `attempts` in the guard | both new correlation tests fail |
| delete both `bindClaimed` calls | the resend test fails |
| increment `handoffs` unconditionally | both fail |
| delete the arrival flush in `index.ts` | the wiring test fails |

That last one is the **reachability proof**. A test for this ordering is worthless if the flush ever moves after `openRun`, so the wiring test pins `record()` → `flushRunCompletions()` with no `openRun` between them.

## Also

The sibling tests in this file passed the conversation as a bare string into an *options* parameter, so every one of them silently ran with **no conversation** and the conversation-keyed ownership branch was never exercised. Corrected, and the asymmetry noted inline (`correlate()` really does take a bare string; `record()` does not).

Defect 2 of the original report stays where it was split: artokun/comfyui-mcp-panel#996.

`src/__tests__/orchestrator/` — 2402 tests across 149 files pass; `tsc --noEmit` clean.

Refs #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)