### PR TITLE
fix(870): apply_manifest stops refusing junctioned model folders

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1540,60 +1540,113 @@ describe("applyManifest", () => {
     );
   });
 
-  it("rejects model local_path when a symlinked parent escapes models", async () => {
+  it("#870 — a junctioned category folder is NOT refused up front (StabilityMatrix)", async () => {
+    // The reporter's install junctions models/vae -> E:\comfy\StabilityMatrix\
+    // models\VAE. `realpath` of the parent therefore lands OUTSIDE the models
+    // root, which apply_manifest used to read as "local_path escapes the models
+    // directory" and refuse before any download started.
+    //
+    // Since #919 the canonical resolver authorizes an in-tree redirect by its
+    // LOCATION (ComfyUI's own scanner follows the junction), so this layer must
+    // not veto it: the item has to reach the downloader, which applies the one
+    // remaining refusal (a custom_nodes landing) on the same path.
+    //
     // The product resolves these paths with node:path, yielding
     // backslash-separated absolute paths on Windows. Build the mock keys the
     // same way so they match what the product passes to realpath.
     const modelsDir = resolve(COMFY, "models");
-    const linkDir = join(modelsDir, "link");
-    const outside = resolve("/tmp/outside");
+    const junction = join(modelsDir, "vae");
+    const shared = resolve("E:/comfy/StabilityMatrix/models/VAE");
     realpathMock.mockImplementation((path: string) => {
       if (path === modelsDir) return Promise.resolve(modelsDir);
-      if (path === linkDir) return Promise.resolve(outside);
+      if (path === junction) return Promise.resolve(shared);
       return Promise.resolve(path);
     });
 
     const result = await applyManifest({
       manifest: {
-        models: [{ url: "https://example.com/model.safetensors", local_path: "link/model.safetensors" }],
+        models: [
+          { url: "https://example.com/qwen_image_vae.safetensors", local_path: "vae/qwen_image_vae.safetensors" },
+        ],
       },
     });
 
-    expect(result.success).toBe(false);
     expect(result.results).toMatchObject([
-      { action: "model", status: "failed", item: "link/model.safetensors" },
+      { action: "model", item: "vae/qwen_image_vae.safetensors" },
     ]);
-    expect(downloadModelMock).not.toHaveBeenCalled();
+    expect(result.results[0].status).not.toBe("failed");
+    expect(downloadModelMock.mock.calls[0]?.slice(0, 3)).toEqual([
+      "https://example.com/qwen_image_vae.safetensors",
+      "vae",
+      "qwen_image_vae.safetensors",
+    ]);
   });
 
-  it("validates local_path symlinks against the LIVE models dir, not a stale COMFYUI_PATH (#490)", async () => {
-    // #490: COMFYUI_PATH is a stale install; the connected server writes under a
-    // DIFFERENT live root. A symlink that escapes the LIVE models dir must be
-    // caught — the guard has to run against the live write root the downloader
-    // uses, NOT <COMFYUI_PATH>/models (which is never written to here).
-    mockConfig.comfyuiPath = "/stale/ComfyUI";
-    const liveModels = resolve("/live/ComfyUI/models");
-    modelsDirMock.mockResolvedValue(liveModels);
-    const linkDir = join(liveModels, "link");
-    const outside = resolve("/tmp/escape");
-    realpathMock.mockImplementation((path: string) => {
-      if (path === liveModels) return Promise.resolve(liveModels);
-      if (path === linkDir) return Promise.resolve(outside);
-      return Promise.resolve(path);
-    });
+  it("#870 — junctioned and real category folders behave IDENTICALLY (the krea2 pack's three models)", async () => {
+    // The reporter's asymmetry: text_encoders is a real directory under the
+    // package models root and succeeded, while vae and diffusion_models are
+    // junctions and were both refused. All three must now enqueue.
+    const modelsDir = resolve(COMFY, "models");
+    const junctions = new Map([
+      [join(modelsDir, "vae"), resolve("E:/comfy/StabilityMatrix/models/VAE")],
+      [join(modelsDir, "diffusion_models"), resolve("E:/comfy/StabilityMatrix/models/DiffusionModels")],
+    ]);
+    realpathMock.mockImplementation((path: string) =>
+      Promise.resolve(junctions.get(path) ?? path),
+    );
 
     const result = await applyManifest({
       manifest: {
-        models: [{ url: "https://example.com/m.safetensors", local_path: "link/m.safetensors" }],
+        models: [
+          { url: "https://example.com/krea2_turbo_fp8.safetensors", local_path: "diffusion_models/krea2_turbo_fp8.safetensors" },
+          { url: "https://example.com/qwen3vl_4b_fp8_scaled.safetensors", local_path: "text_encoders/qwen3vl_4b_fp8_scaled.safetensors" },
+          { url: "https://example.com/qwen_image_vae.safetensors", local_path: "vae/qwen_image_vae.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.results.filter((r) => r.status === "failed")).toEqual([]);
+    expect(downloadModelMock.mock.calls.map((c) => c[1]).sort()).toEqual([
+      "diffusion_models",
+      "text_encoders",
+      "vae",
+    ]);
+  });
+
+  it("still refuses a local_path that traverses out of models/ lexically", async () => {
+    const result = await applyManifest({
+      manifest: {
+        models: [{ url: "https://example.com/m.safetensors", local_path: "../evil.safetensors" }],
       },
     });
 
     expect(result.success).toBe(false);
     expect(result.results).toMatchObject([
-      { action: "model", status: "failed", item: "link/m.safetensors" },
+      { action: "model", status: "failed", item: "../evil.safetensors" },
     ]);
     expect(result.results[0].message).toMatch(/escapes the models directory/i);
     expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("targets the LIVE models dir, not a stale COMFYUI_PATH (#490)", async () => {
+    // #490: COMFYUI_PATH is a stale install; the connected server writes under a
+    // DIFFERENT live root. The destination this layer computes — the path the
+    // "already installed?" check is asked about — must be rooted at the LIVE
+    // models dir, never at <COMFYUI_PATH>/models (which is never written to).
+    mockConfig.comfyuiPath = "/stale/ComfyUI";
+    const liveModels = resolve("/live/ComfyUI/models");
+    modelsDirMock.mockResolvedValue(liveModels);
+
+    await applyManifest({
+      manifest: {
+        models: [{ url: "https://example.com/m.safetensors", local_path: "loras/m.safetensors" }],
+      },
+    });
+
+    expect(statMock).toHaveBeenCalledWith(join(liveModels, "loras", "m.safetensors"));
+    expect(statMock).not.toHaveBeenCalledWith(
+      join(resolve("/stale/ComfyUI/models"), "loras", "m.safetensors"),
+    );
   });
 
   describe("remote mode (no COMFYUI_PATH) — per-section handling", () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { lstat, mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { platform } from "node:os";
 import {
   basename,
@@ -649,67 +649,14 @@ function defaultFilenameForUrl(url: string): string {
   return basename(new URL(url).pathname) || "model.safetensors";
 }
 
-function isWithinRoot(root: string, candidate: string): boolean {
-  const rel = relative(root, candidate);
-  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
-}
-
-async function rejectEscapingSymlinkTarget(
-  root: string,
-  path: string,
-  label: string,
-): Promise<void> {
-  try {
-    const info = await lstat(path);
-    if (!info.isSymbolicLink()) return;
-    const realTarget = await realpath(path);
-    if (!isWithinRoot(root, realTarget)) {
-      throw new ValidationError(`${label} escapes the models directory: ${path}`);
-    }
-  } catch (err) {
-    if (err instanceof ValidationError) throw err;
-    // Missing final target is fine; downloadModel will create it.
-  }
-}
-
-async function validateExistingModelAncestors(
-  root: string,
-  parent: string,
-  realRoot: string,
-  localPath: string,
-): Promise<void> {
-  let cursor = parent;
-  while (cursor !== root && cursor.startsWith(root + sep)) {
-    try {
-      const info = await lstat(cursor);
-      if (info.isSymbolicLink()) {
-        const realCursor = await realpath(cursor);
-        if (!isWithinRoot(realRoot, realCursor)) {
-          throw new ValidationError(
-            `Model local_path escapes the models directory: ${localPath}`,
-          );
-        }
-      } else if (!info.isDirectory()) {
-        throw new ValidationError(`Model local_path parent is not a directory: ${localPath}`);
-      }
-      return;
-    } catch (err) {
-      if (err instanceof ValidationError) throw err;
-      cursor = dirname(cursor);
-    }
-  }
-}
-
 async function resolveLocalModelPath(
   model: ComfyManifest["models"][number],
 ): Promise<{ targetSubfolder: string; filename: string; targetPath: string }> {
-  // Root the target — and therefore the local_path symlink/containment guards
-  // below — at the SAME directory the downloader actually writes to: the live
-  // connected server's models dir (resolveModelsDir, live-first), NOT
-  // <COMFYUI_PATH>/models. When the connected install differs from a stale
-  // COMFYUI_PATH (#490), validating against COMFYUI_PATH/models would leave a
-  // symlink that escapes the LIVE models dir unchecked and redirect the write
-  // outside it. Same canonical root as the writer = one authoritative guard.
+  // Root the target — and therefore the local_path containment guard below — at
+  // the SAME directory the downloader actually writes to: the live connected
+  // server's models dir (resolveModelsDir, live-first), NOT <COMFYUI_PATH>/models.
+  // When the connected install differs from a stale COMFYUI_PATH (#490), a target
+  // computed against COMFYUI_PATH/models is not the path the write uses at all.
   const root = resolve(await resolveModelsDir());
 
   if (model.local_path) {
@@ -734,17 +681,27 @@ async function resolveLocalModelPath(
     if (filename === "." || filename === ".." || filename.length === 0) {
       throw new ValidationError(`Model local_path must include a filename: ${model.local_path}`);
     }
-    await mkdir(root, { recursive: true });
-    const realRoot = await realpath(root);
-    await validateExistingModelAncestors(root, dirname(targetPath), realRoot, model.local_path);
-    await mkdir(dirname(targetPath), { recursive: true });
-    const realParent = await realpath(dirname(targetPath));
-    if (!isWithinRoot(realRoot, realParent)) {
-      throw new ValidationError(
-        `Model local_path escapes the models directory: ${model.local_path}`,
-      );
-    }
-    await rejectEscapingSymlinkTarget(realRoot, targetPath, "Model local_path");
+    // NO symlink/realpath policy here (#870). This function used to walk the
+    // parents itself and refuse any that resolved outside the models root — the
+    // pre-#870 rule, kept alive in a second copy. #919 replaced that rule in the
+    // canonical resolver (an in-tree symlink's redirect is authorized by its
+    // LOCATION inside the user's own models tree, because ComfyUI's own scanner
+    // follows it), but this copy was never updated, so apply_manifest kept
+    // refusing the mainstream StabilityMatrix layout — `models/vae` and
+    // `models/diffusion_models` are junctions to shared storage while
+    // `models/text_encoders` is a real directory, which is exactly the
+    // some-categories-work asymmetry #870 reports.
+    //
+    // The guard is not lost, it is de-duplicated: EVERY model this function
+    // resolves is downloaded through startDownloadJob → resolveDownloadTarget →
+    // resolveModelSubfolderWithLiveRoot, which runs assertNoEscapingSymlinkAncestor
+    // on the same destination before a single byte is written — with the
+    // custom_nodes code-root veto and the dangling-symlink refusal intact, and
+    // with the base-install dirs and live snapshot from the SAME /system_stats
+    // call that resolved the root (which this layer does not have). Duplicating
+    // the policy here is what let the two drift; model-resolver.ts says so at the
+    // guard itself ("so it can never diverge from a caller's separate
+    // pre-validation (e.g. apply_manifest resolving the root a second time)").
     return {
       targetSubfolder: dirname(rel),
       filename,


### PR DESCRIPTION
Fixes the half of #870 that is still live: `apply_manifest`.

## Status: complete and green — HOLDING on the codex gate

The codex gate returned **INDETERMINATE (exit 2)**, not a pass: `You've hit your usage limit […] try again at Aug 19th, 2026 8:43 PM` (confirmed by calling `codex exec` directly, not just through the wrapper's text match). Per the autopilot rule an indeterminate gate is never a pass, so this is **not merged**. It needs one gate run once quota returns.

## What was still broken

#919 fixed `download_model` by moving the authorization rule into the canonical resolver: an in-tree symlink's redirect is authorized by its **location** inside the user's own models tree, because ComfyUI's own scanner follows it (`folder_paths.recursive_search` walks with `followlinks=True`). Only a `custom_nodes` landing and a dangling/unresolvable link are still refused.

`apply_manifest` never got that fix, because it kept a **second copy of the old rule**. `resolveLocalModelPath` in `src/services/manifest.ts` realpath'd the destination's parent and refused anything landing outside the models root:

```ts
const realParent = await realpath(dirname(targetPath));
if (!isWithinRoot(realRoot, realParent)) throw ...escapes the models directory
```

On a StabilityMatrix install `models/vae` and `models/diffusion_models` are NTFS junctions into shared storage, so `realpath` of the parent **is** outside the root and every model under them was refused before a byte moved — while `models/text_encoders`, a real directory, sailed through. That is the exact some-categories-work asymmetry #870 reports, and it is why the reporter still hits it on 0.51.56 via the bundled `krea2-txt2img-manual` pack (its three models are `diffusion_models/`, `text_encoders/`, `vae/`).

## Verified on a real junction, not a mock

Built `models/vae` as an actual `mklink /J` junction to `shared/VAE` and replayed the pre-fix checks:

```
--- vae/qwen_image_vae.safetensors
  lstat(parent).isSymbolicLink() = true
  lstat(parent).isDirectory()    = false
  realpath(parent)               = ...\shared\VAE
  isWithinRoot(realRoot, realParent) = false
  PRE-FIX  VERDICT: REFUSED -> "Model local_path escapes the models directory: vae/..."
  POST-FIX VERDICT: accepted (passed to the downloader)
--- text_encoders/qwen3vl.safetensors        (a real directory, side by side)
  PRE-FIX  VERDICT: accepted
--- ../evil.safetensors
  POST-FIX VERDICT: REFUSED (lexical escape)
```

## The guard is not lost, it is de-duplicated

Every model this function resolves is downloaded through `startDownloadJob` → `resolveDownloadTarget` → `resolveModelSubfolderWithLiveRoot`, which runs `assertNoEscapingSymlinkAncestor` on the same destination before any write — with the `custom_nodes` code-root veto, the dangling-symlink refusal, and the base dirs + live snapshot from the **same** `/system_stats` call that resolved the root (context the manifest layer does not have). `model-resolver.ts` says so at the guard itself: it lives there *"so it can never diverge from a caller's separate pre-validation (e.g. apply_manifest resolving the root a second time)"*. Duplicating it is what let the two drift. Its behaviour is covered by `download-dest-roots.test.ts`, including `REFUSES a symlink into a registered custom_nodes root` and `REFUSES when a symlink ancestor exists but its target cannot be resolved (dangling)`.

What `manifest.ts` still enforces is the part that is purely about the manifest's own input and needs no filesystem: an absolute `local_path`, a `..` traversal out of `models/`, a path with no filename.

## One deliberate removal

The removed ancestor walk also carried a `parent is not a directory` check — no test, no issue behind it. Dropped rather than kept, because `lstat` on a junction reports `isDirectory() === false` (see the probe above): keeping it would have re-broken the same installs through a different message. A parent that really is a file now surfaces as the downloader's own `ENOTDIR` on that item.

## Tests

- The two cases that pinned the superseded rule are **inverted** to assert the new behaviour (a junctioned category folder reaches the downloader).
- The krea2 pack's three models are pinned to behave **identically** whether their folder is a junction or real — the reporter's asymmetry as a test.
- New: the lexical `..` traversal refusal, and #490's live-root targeting (which the old test only covered incidentally through the symlink guard).
- **Mutation-checked**: reverting `src/services/manifest.ts` to `origin/main` fails exactly the two #870 tests and nothing else.
- Full suite: 516 files / 9682 passed, 3 skipped. `tsc --noEmit` clean.

## Not done here

The `download_model` route named in the issue title was already fixed by #919 (v0.50.x) and is covered by `download-dest-roots.test.ts` `(b) #870 — a StabilityMatrix junction into UNDECLARED storage is allowed`. This PR does not touch it.

closes #870
