### PR TITLE
fix(1147): a tree the server demonstrably reads is not refused over one stray file

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -297,6 +297,69 @@ describe("pre-write: a destination the LIVE server does not read from is refused
     );
   });
 
+  // #1147 (recurrence, 0.51.56) — CORROBORATED READERSHIP OUTWEIGHS ONE STRAY FILE.
+  //
+  // A reporter's ComfyUI Desktop install was refused an `animatediff_models`
+  // download because ONE unlisted file in `ipadapter` was read as proof the server
+  // reads a different install — while other categories of that same tree were
+  // listed by that same server, file for file.
+  //
+  // Those two facts are not symmetric. A category the server lists COMPLETELY is
+  // positive evidence it scans this root: for a wrong install to produce that, every
+  // name in the category would have to coincide. A single file the server does not
+  // name has ordinary explanations that say nothing about the root — an extension not
+  // registered for that category, a listing cached before the file arrived, a nested
+  // HuggingFace dump, a folder a custom node registers elsewhere. The #369 signature
+  // is a tree the server accounts for NOWHERE, so corroborated readership must win.
+  it("#1147: PROCEEDS when another category is FULLY accounted for by the same server", async () => {
+    h.onDisk = {
+      // Alphabetically first, so the contradiction is found BEFORE the corroboration
+      // and the scan must not stop at it.
+      animatediff_models: [],
+      ipadapter: ["ip-adapter_sd15.safetensors", "stale/pytorch_model.bin"],
+      loras: ["a.safetensors", "b.safetensors"],
+    };
+    h.liveListings["ipadapter"] = ["ip-adapter_sd15.safetensors"];
+    h.liveListings["loras"] = ["a.safetensors", "b.safetensors"];
+
+    await expect(resolveModelSubfolderPreferServer("animatediff_models")).resolves.toBe(
+      resolve("/comfy/models/animatediff_models"),
+    );
+  });
+
+  it("#1147: a ONE-FILE coincidence does NOT corroborate — the refusal stands (codex gate r5)", async () => {
+    // The round-5 hole at category granularity: two unrelated installs routinely
+    // share ONE popular checkpoint, and a category that holds only that file is
+    // "fully accounted for" by pure coincidence. Corroboration needs a category
+    // whose every name coincides AND that holds more than one file.
+    h.onDisk = {
+      checkpoints: ["sd_xl_base_1.0.safetensors"],
+      loras: ["stale-a.safetensors", "stale-b.safetensors"],
+    };
+    h.liveListings["checkpoints"] = ["sd_xl_base_1.0.safetensors", "live-only.safetensors"];
+    h.liveListings["loras"] = ["live-lora.safetensors"];
+
+    await expect(resolveModelSubfolderPreferServer("loras")).rejects.toThrow(
+      /DIFFERENT install/,
+    );
+  });
+
+  it("#1147: an INFERRED root is corroborated the same way (#1562 stays fixed either way)", async () => {
+    // #1562 made `observed-root` run this check. A stale bundle reached through a
+    // python-on-PATH inference is accounted for NOWHERE, so it still refuses; a
+    // correct one that the server lists file-for-file must not be refused over a
+    // stray file.
+    h.modelsDirSource = "observed-root";
+    h.onDisk = {
+      ipadapter: ["listed.safetensors", "unlisted.bin"],
+      loras: ["a.safetensors", "b.safetensors"],
+    };
+    h.liveListings["ipadapter"] = ["listed.safetensors"];
+    h.liveListings["loras"] = ["a.safetensors", "b.safetensors"];
+
+    await expect(resolveModelSubfolderPreferServer("ipadapter")).resolves.toBeTruthy();
+  });
+
   // There is deliberately NO "the server lists models this tree cannot account for"
   // refusal. Not being able to EXPLAIN the server's models is absence of evidence,
   // not proof of a different install: the roots may come from a config we cannot

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1010,6 +1010,13 @@ async function coreModelFilesUnder(categoryDir: string): Promise<string[]> {
  *  per folder. */
 const DISAGREEMENT_PROBE_CATEGORIES = 6;
 
+/** How many model files a fully-agreeing category must hold before it CORROBORATES
+ *  that the live server reads this root (#1147). One is not enough: two unrelated
+ *  installs routinely share a single popular checkpoint, and a category holding
+ *  only that file is "fully accounted for" by coincidence (codex gate, round 5).
+ *  Two independent names both coinciding is not an ordinary explanation. */
+const CORROBORATING_CONTAINMENT_MIN_FILES = 2;
+
 /** Immediate subdirectories of the candidate models root, in a stable order. */
 async function categoriesUnder(modelsRoot: string): Promise<string[]> {
   try {
@@ -1050,6 +1057,15 @@ async function categoriesUnder(modelsRoot: string): Promise<string[]> {
  * server scans has ALL of its model files in that server's listing. A single shared
  * filename proves nothing — two unrelated installs routinely hold the same popular
  * checkpoint — so overlap alone must never suppress the refusal.
+ *
+ * CORROBORATION (#1147): a category the server lists COMPLETELY, holding more than
+ * one file, is positive evidence that it reads this ROOT — every one of those names
+ * would have to coincide otherwise. That outweighs a single unaccounted file in
+ * another category, which has ordinary explanations that say nothing about the root
+ * (an unregistered extension, a cached listing, a nested HuggingFace dump). So the
+ * scan does not stop at the first disagreement, and a tree the server demonstrably
+ * reads is not refused over a stray file. A tree it accounts for NOWHERE — the #369
+ * signature — has no such category to offer and still refuses.
  *
  * POSITIVE EVIDENCE ONLY. There is deliberately no "the live server lists models
  * this tree cannot account for" rule: being unable to EXPLAIN the server's models is
@@ -1092,6 +1108,7 @@ async function assertDestinationVisibleToLiveServer(
 
   let probed = 0;
   let worst: { category: string; missing: string[]; onDisk: number; live: number } | undefined;
+  let corroborating: { category: string; files: number } | undefined;
 
   for (const category of primary) {
     if (probed >= DISAGREEMENT_PROBE_CATEGORIES) break;
@@ -1129,9 +1146,61 @@ async function assertDestinationVisibleToLiveServer(
     // `b/shared.safetensors` (codex gate, round 9).
     const liveNames = new Set(listing.map((n) => normRel(n)));
     const missing = onDisk.filter((n) => !liveNames.has(n));
-    if (missing.length === 0) continue; // this folder is fully accounted for — agrees
-    worst = { category, missing, onDisk: onDisk.length, live: listing.length };
-    break;
+    if (missing.length === 0) {
+      // This folder is fully accounted for — it AGREES, and that is itself positive
+      // evidence (see the corroboration note below). Keep the largest such category:
+      // the more names that had to coincide, the less coincidence explains it.
+      if (
+        onDisk.length >= CORROBORATING_CONTAINMENT_MIN_FILES &&
+        onDisk.length > (corroborating?.files ?? 0)
+      ) {
+        corroborating = { category, files: onDisk.length };
+      }
+      continue;
+    }
+    // Record the FIRST disagreement, but do NOT stop scanning. Evidence that this
+    // root IS read can only come from the categories after it, and breaking here
+    // threw it away — see the corroboration note below (#1147, 0.51.56).
+    if (!worst) worst = { category, missing, onDisk: onDisk.length, live: listing.length };
+  }
+
+  // #1147 — CORROBORATED READERSHIP OUTWEIGHS A SINGLE UNACCOUNTED FILE.
+  //
+  // A reporter's ComfyUI Desktop install was refused an `animatediff_models`
+  // download because ONE unlisted file under `ipadapter` was read as proof of a
+  // different install, while that same server listed other categories of that same
+  // tree file for file. This guard gathered positive evidence in the REFUSE
+  // direction and discarded the positive evidence it had already computed in the
+  // PROCEED direction — `missing.length === 0` was a bare `continue`, and the first
+  // disagreement `break`ed before any later category could speak.
+  //
+  // The two facts are not symmetric:
+  //
+  //   A category the server lists COMPLETELY is evidence about the ROOT. For a
+  //   different install to produce it, EVERY name in that category would have to
+  //   coincide — which is why one file is not enough (two unrelated installs really
+  //   do share `sd_xl_base_1.0.safetensors`; codex gate round 5), and why the
+  //   largest agreeing category is the one worth keeping.
+  //
+  //   A file the server does not name is evidence about that FILE. It has ordinary
+  //   explanations that say nothing about the root: an extension not registered for
+  //   that category, a listing cached before the file arrived, a nested HuggingFace
+  //   dump (#1147's original birefnet report), a folder a custom node registers
+  //   against a different path.
+  //
+  // The #369 signature is a tree the server accounts for NOWHERE — 3 files on disk,
+  // 24 unrelated files live. That still refuses, here and for an inferred root
+  // (#1562), because a stale bundle has no fully-agreeing category to offer.
+  //
+  // Bounded by DISAGREEMENT_PROBE_CATEGORIES like the disagreement scan itself: a
+  // tree whose agreeing category sorts past the budget is refused as before.
+  if (worst && corroborating) {
+    logger.info(
+      `[models] "${worst.category}" holds ${worst.missing.length} file(s) the server does not ` +
+        `list, but it lists all ${corroborating.files} file(s) of "${corroborating.category}" ` +
+        `in this same tree — proceeding (#1147).`,
+    );
+    worst = undefined;
   }
 
   if (worst) {


### PR DESCRIPTION
Reopened on **0.51.56**: a ComfyUI Desktop install was refused an `animatediff_models` download because ONE unlisted file under `ipadapter` was read as proof the running server reads a DIFFERENT install — while that same server listed other categories of that same tree, file for file.

## The defect

The pre-write guard gathered positive evidence in the REFUSE direction and threw away the positive evidence it had already computed in the PROCEED direction. `missing.length === 0` was a bare `continue`, and the first disagreement `break`ed before any later category could speak — so a category the server accounts for completely never got to answer, and a single unaccounted file decided the root.

The two facts are not symmetric:

- A category the server lists **COMPLETELY** is evidence about the **ROOT**. For a different install to produce it, every name in that category would have to coincide.
- A file the server does not name is evidence about that **FILE**. It has ordinary explanations that say nothing about the root — an extension not registered for that category, a listing cached before the file arrived, a nested HuggingFace dump (this issue's original `birefnet` report), a folder a custom node registers against a different path.

## The change

The scan no longer stops at the first disagreement, and a disagreement is overridden by a fully-agreeing category holding **more than one** file. One file is not enough, and the threshold is pinned by a test: two unrelated installs really do share `sd_xl_base_1.0.safetensors`, and a category holding only that file is "fully accounted for" by coincidence (codex gate, round 5).

| tree | live listing | before | after |
|---|---|---|---|
| `ipadapter` 1 stray + `loras` 2 files | `loras` both listed | refuse | **proceed** |
| 3 files, accounted for nowhere | 24 unrelated files | refuse | refuse (#369, unchanged) |
| 1 shared popular checkpoint | that name + others | refuse | refuse (round 5, unchanged) |

## Why it came back after 0.50.44

#1168 only made an **EMPTY** listing non-evidence. This reporter's `ipadapter` listing is **POPULATED**, so that fix could not reach it — and #1562 (v0.51.44) widened the guard to run for **inferred** roots too, which is how a correct Desktop install started being probed at all.

## Verification

- Bug stated as failing tests first (2 red), then fixed.
- Mutation-tested, 3 applied and 3 killed against a green baseline: dropping the override → 2 fail; restoring the early `break` → 2 fail; accepting a one-file coincidence → 1 fail (the round-5 hole).
- Reachability checked rather than assumed: `download_model` reaches this guard via `resolveDownloadTarget` → `resolveModelSubfolderWithLiveRoot`, on both the direct writer and the background job registry paths.
- Full suite: **516 files, 9683 passed**, 3 skipped. `tsc --noEmit` clean.

Fixes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)