### PR TITLE
fix(1621): list_paths resolves the live root the OS can see, instead of refusing a local install

### DIFF
--- a/src/__tests__/services/extra-paths-observed-live-root.test.ts
+++ b/src/__tests__/services/extra-paths-observed-live-root.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * #1621 — `list_local_models action:"list_paths"` reported UNRESOLVED against a LOCAL,
+ * connected, perfectly reachable ComfyUI, and `getExtraModelRoots()` (model discovery)
+ * contributed nothing, so callers fell back to reading loader combo options.
+ *
+ * The shape that does it is the most ordinary launch there is:
+ *
+ *     cd /opt/ComfyUI && python main.py --listen
+ *
+ * `sys.argv[0]` is then the RELATIVE string "main.py", and current ComfyUI does not
+ * report its working directory in /system_stats — so nothing in the server's own argv
+ * names an absolute path, and extra-paths' argv-only derivation gave up. With
+ * COMFYUI_PATH unset and no saved default workspace (the normal state for a
+ * panel-connected install), the static fallback then THREW rather than fell back.
+ *
+ * The OS knows the answer: it can name the process listening on the port and where its
+ * interpreter lives. That is `resolveLiveServerRoot`'s observed-process tier — the same
+ * resolver that already decides where a DOWNLOADED MODEL is written (#369). These tests
+ * pin that extra-paths resolves through it too.
+ */
+
+// Spread the real config so every consumer of this module (workspace-env,
+// live-interpreter) keeps the exports it reads at import time; only the two knobs these
+// cases drive are overridden.
+const mockIsRemoteMode = vi.hoisted(() => vi.fn(() => false));
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    config: { ...actual.config, comfyuiPath: undefined as string | undefined },
+    isRemoteMode: mockIsRemoteMode,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  };
+});
+
+// #1263 — THE PROCESS TABLE IS NOT A FIXTURE. `resolveLiveServerRoot`'s observed-process
+// tier shells out to netstat/WMI/lsof to find whatever is really serving the port on THIS
+// machine, so a developer box with ComfyUI up would anchor onto a real interpreter and a
+// CI box would not. Stubbed to "found nothing" by default — the state the refusal cases
+// describe — and opted into per case.
+const hoisted = vi.hoisted(() => ({
+  liveProcess: vi.fn((): { pid: number; python?: string; image?: string } | undefined => undefined),
+}));
+vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
+  return { ...actual, observeLiveServerProcess: hoisted.liveProcess };
+});
+
+const mockGetSystemStats = vi.hoisted(() =>
+  vi.fn(async (): Promise<{ system?: { argv?: string[]; cwd?: string } }> => {
+    throw new Error("ComfyUI unreachable (test default)");
+  }),
+);
+vi.mock("../../comfyui/client.js", () => ({ getSystemStats: mockGetSystemStats }));
+
+import { config } from "../../config.js";
+import { observeLiveServerProcess } from "../../services/live-interpreter.js";
+import {
+  addExtraPath,
+  getExtraModelRoots,
+  listExtraPaths,
+} from "../../services/extra-paths.js";
+import { configureWorkspace, resetWorkspaceConfig } from "../../services/workspace-env.js";
+
+let dirs: string[] = [];
+const oldComfyuiPathEnv = process.env.COMFYUI_PATH;
+
+async function trackTmp(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "comfyui-observed-root-"));
+  dirs.push(dir);
+  return dir;
+}
+
+/**
+ * A ComfyUI install laid out the way a manual Linux/macOS install is: `main.py` in the
+ * root and the interpreter in `<root>/.venv/bin`, which is what makes the interpreter
+ * provably INSIDE this install rather than beside it.
+ */
+async function install(): Promise<{ root: string; python: string }> {
+  const root = await trackTmp();
+  await writeFile(join(root, "main.py"), "# comfyui\n", "utf-8");
+  const bin = join(root, ".venv", "bin");
+  await mkdir(bin, { recursive: true });
+  const python = join(bin, "python3");
+  await writeFile(python, "#!/bin/sh\n", "utf-8");
+  return { root, python };
+}
+
+beforeEach(() => {
+  config.comfyuiPath = undefined;
+  delete process.env.COMFYUI_PATH;
+  dirs = [];
+  mockIsRemoteMode.mockReturnValue(false);
+  // mockReturnValue does NOT clear the call log, and one case asserts the probe was
+  // never reached — without this it would read a previous case's calls.
+  hoisted.liveProcess.mockClear();
+  hoisted.liveProcess.mockReturnValue(undefined);
+  mockGetSystemStats.mockRejectedValue(new Error("ComfyUI unreachable (test default)"));
+  // No saved default workspace — point the store at a path that cannot exist, so these
+  // cases can never pick up the developer's real one.
+  configureWorkspace({ configPath: join(tmpdir(), "comfyui-mcp-no-such-workspace.json") });
+});
+
+afterEach(async () => {
+  if (oldComfyuiPathEnv === undefined) delete process.env.COMFYUI_PATH;
+  else process.env.COMFYUI_PATH = oldComfyuiPathEnv;
+  config.comfyuiPath = undefined;
+  resetWorkspaceConfig();
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("extra-paths resolves the live root the OS can see (#1621)", () => {
+  it("the imported observeLiveServerProcess IS this file's stub, by identity", () => {
+    // Without this, a mock that silently stopped applying would make every case below
+    // pass for the wrong reason — or hit the real process table.
+    expect(observeLiveServerProcess).toBe(hoisted.liveProcess);
+  });
+
+  it("lists the RUNNING server's own extra_model_paths.yaml for a bare `python main.py` launch", async () => {
+    const { root, python } = await install();
+    await writeFile(
+      join(root, "extra_model_paths.yaml"),
+      "mine:\n  base_path: /srv/models\n  loras: loras/\n",
+      "utf-8",
+    );
+    // Exactly what `cd <root> && python main.py --listen` reports: a RELATIVE argv[0]
+    // and no cwd.
+    mockGetSystemStats.mockResolvedValue({ system: { argv: ["main.py", "--listen"] } });
+    hoisted.liveProcess.mockReturnValue({ pid: 4242, python });
+
+    const listed = await listExtraPaths();
+
+    expect(listed.path).toBe(join(root, "extra_model_paths.yaml"));
+    expect(listed.exists).toBe(true);
+    expect(listed.groups[0].categories).toEqual([{ category: "loras", paths: ["loras/"] }]);
+    // Reported as the LIVE server's own file, not as the local heuristic's guess —
+    // `serverResolved` is internal, so the caption is what the caller actually sees.
+    expect(listed.notes.join(" ")).toContain(
+      `Resolved from the RUNNING ComfyUI's own install root (${root})`,
+    );
+    expect(listed.notes.join(" ")).not.toMatch(/not confirmation that the live server reads it/i);
+  });
+
+  it("feeds MODEL DISCOVERY the live server's extra roots, not an empty set", async () => {
+    // getExtraModelRoots deliberately does NOT take the display-only #764 fallback, so
+    // before this fix it saw the refusal and returned [] — which is why the reporter had
+    // to read loader combo options instead of the path resolver.
+    //
+    // A relative DIR rather than a bare script (`ComfyUI/main.py`) — the ComfyUI Desktop
+    // and Windows-portable shape — anchored on an interpreter inside that nested root.
+    const bundle = await trackTmp();
+    const nested = join(bundle, "ComfyUI");
+    await mkdir(join(nested, ".venv", "bin"), { recursive: true });
+    await writeFile(join(nested, "main.py"), "# comfyui\n", "utf-8");
+    const nestedPython = join(nested, ".venv", "bin", "python3");
+    await writeFile(nestedPython, "#!/bin/sh\n", "utf-8");
+    const models = await trackTmp();
+    await writeFile(
+      join(nested, "extra_model_paths.yaml"),
+      `mine:\n  base_path: ${models}\n  loras: loras/\n`,
+      "utf-8",
+    );
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--listen"] },
+    });
+    hoisted.liveProcess.mockReturnValue({ pid: 99, python: nestedPython });
+
+    await expect(getExtraModelRoots()).resolves.toEqual([
+      { category: "loras", dir: resolve(models, "loras"), group: "mine" },
+    ]);
+  });
+
+  it("targets the live root for a WRITE, instead of refusing an install it can see", async () => {
+    // The same root this MCP would stream a DOWNLOADED MODEL into (resolveLiveServerRoot
+    // is that resolver): refusing to write the yaml beside those models while happily
+    // writing the models is the disagreement #369 exists to prevent.
+    const { root, python } = await install();
+    mockGetSystemStats.mockResolvedValue({ system: { argv: ["main.py"] } });
+    hoisted.liveProcess.mockReturnValue({ pid: 7, python });
+
+    await addExtraPath({ category: "loras", path: "/mnt/big/loras" });
+
+    const written = await readFile(join(root, "extra_model_paths.yaml"), "utf-8");
+    expect(written).toMatch(/loras/);
+    expect(written).toMatch(/\/mnt\/big\/loras/);
+  });
+
+  it("still refuses, and says what it observed, when the OS cannot anchor the process", async () => {
+    // Nothing found on the port — genuinely unavailable. The refusal must state what was
+    // observed (a relative script, no cwd, no anchor) and must NOT claim the argv
+    // revealed no main.py, which it plainly did.
+    const stale = await trackTmp();
+    config.comfyuiPath = stale;
+    process.env.COMFYUI_PATH = stale;
+    mockGetSystemStats.mockResolvedValue({ system: { argv: ["main.py", "--listen"] } });
+    hoisted.liveProcess.mockReturnValue(undefined);
+
+    await expect(addExtraPath({ category: "loras", path: "/mnt/big/loras" })).rejects.toThrow(
+      /UNRESOLVED[\s\S]*RELATIVELY[\s\S]*could not be anchored/,
+    );
+    // …and the false cause is gone. Matched WITHOUT the "at all" suffix so it also
+    // catches the refusal's own hardcoded copy of that claim, not just localityGap's.
+    await expect(addExtraPath({ category: "loras", path: "/mnt/big/loras" })).rejects.not.toThrow(
+      /does not reveal a main\.py/,
+    );
+  });
+
+  it("does not consult the process table when the argv already resolves", async () => {
+    // The observed-process tier may only ADD a resolution. An absolute argv[0] is already
+    // authoritative, so the probe must not run at all — it shells out, and a second
+    // answer could disagree with the one being reported.
+    const { root } = await install();
+    await writeFile(join(root, "extra_model_paths.yaml"), "mine:\n  loras: /x\n", "utf-8");
+    mockGetSystemStats.mockResolvedValue({ system: { argv: ["python", join(root, "main.py")] } });
+
+    const listed = await listExtraPaths();
+
+    expect(listed.path).toBe(join(root, "extra_model_paths.yaml"));
+    expect(hoisted.liveProcess).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -10,10 +10,12 @@ import {
   type LiveServerSnapshot,
 } from "./output-dir.js";
 import {
+  liveRelDirFromArgv,
   liveRootFromArgv,
   liveScriptFromArgv,
   didLaunchLocalComfyUI,
   getLiveServerSnapshot,
+  resolveLiveServerRoot,
   resolveEffectiveComfyUIBase,
 } from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
@@ -776,6 +778,14 @@ function implicitLiveTarget(
  * has to be resolving from the live server rather than warning about a divergence.
  * Skipped in remote mode (the live root is a path on the remote host).
  *
+ * When argv names its script RELATIVELY and the server reports no cwd — `cd <root> &&
+ * python main.py`, and ComfyUI Desktop / the Windows portable bundle's `ComfyUI\main.py`
+ * — the argv derivation yields nothing absolute, and every branch below used to refuse a
+ * local install that was sitting right there (#1621). That shape is resolved through
+ * `resolveLiveServerRoot`'s observed-process tier instead: the same canonical live root
+ * (#369) the DOWNLOAD DESTINATION is written into. See the call site for why that tier can
+ * only ever add a resolution, never move one.
+ *
  * Everything the live server contributes comes from ONE `/system_stats` snapshot, so the
  * launch flags and the install root can never be read from two different server states.
  * And when the server IS reachable but tells us nothing usable — a relative
@@ -809,17 +819,62 @@ async function resolveTargetPathPreferServer(
   // written to in that state. Proven once, for every argv-derived branch below: a main.py
   // present-but-unresolvable throws here; NO main.py at all leaves liveRoot undefined, and
   // every branch below refuses on that before touching an argv-derived path.
-  const script = liveScriptFromArgv(snapshot.argv, snapshot.cwd);
+  const argvScript = liveScriptFromArgv(snapshot.argv, snapshot.cwd);
+  // #1621: `cd <root> && python main.py` reports argv[0] as the RELATIVE string "main.py"
+  // and current ComfyUI reports no cwd, so the server's own argv names NOTHING absolute —
+  // the ordinary manual Linux/macOS launch, and (as `ComfyUI\main.py`) the shape ComfyUI
+  // Desktop and the Windows portable bundle report too. The argv derivation above then
+  // yields no script, every branch below refuses, and a LOCAL server sitting right there
+  // was answered with UNRESOLVED — including for getExtraModelRoots(), which left model
+  // discovery with no filesystem roots at all.
+  //
+  // `resolveLiveServerRoot` is the ONE canonical notion of the live install root (#369),
+  // and its observed-process tier answers exactly this shape: the OS names the process
+  // listening on our port (correlated against this same argv, so a proxy cannot
+  // impersonate it) and the relative main.py dir is re-anchored on the install its
+  // interpreter lives in. That resolver already decides where a DOWNLOADED MODEL is
+  // written, so resolving the yaml that sits BESIDE those models through anything else is
+  // how the two come to disagree about which install is "the live one".
+  //
+  // It can only ever ADD a resolution: `liveRootFromArgv` and `liveScriptFromArgv` share
+  // scriptTokenFromArgv, so a script-less argv is a root-less one — the argv tier inside
+  // `resolveLiveServerRoot` has already failed wherever this runs, and no path that
+  // resolves today can be redirected by it. `remote:false` is settled, not assumed:
+  // `getLiveServerSnapshot` only reports reachable in local mode.
+  const observed = argvScript
+    ? undefined
+    : resolveLiveServerRoot(snapshot.argv, snapshot.cwd, { remote: false });
+  // `anchorDir` is the working directory the server MUST have had for its relative
+  // main.py to name that install, so feeding it back through the same parser yields the
+  // absolute SCRIPT — which is what `realLiveRoot` needs to follow a symlinked main.py
+  // the way ComfyUI's own os.path.realpath(__file__) does. No second parser is
+  // introduced, and the root still has to prove itself on this filesystem below.
+  const script =
+    argvScript ??
+    (observed?.source === "observed-process" && observed.anchorDir
+      ? liveScriptFromArgv(snapshot.argv, observed.anchorDir)
+      : undefined);
   // The REAL (symlink-resolved) install root, kept for every downstream use — notably the
   // "other configs" disclosure, which must name the file ComfyUI actually loads
   // (realpath(__file__) dir), not the launcher spelling (codex round 10).
   const rootResult: LiveRootResult = script ? realLiveRoot(script) : { why: "absent" };
   const liveRoot = rootResult.root;
 
+  /** The relative `main.py` dir the server reported, when its argv named one relatively.
+   *  Present exactly when "argv revealed no main.py" would be a FALSE account of why the
+   *  script could not be resolved. */
+  const relDir = liveRelDirFromArgv(snapshot.argv);
+
   /** Why locality is unproven, stated as what was OBSERVED. Reused by the refusals and
    *  by the read-only disclosures, so the two can never drift apart. */
   const localityGap = !script || rootResult.root !== undefined
-    ? "its /system_stats launch argv does not reveal a main.py at all"
+    ? relDir === undefined
+      ? "its /system_stats launch argv does not reveal a main.py at all"
+      : `its /system_stats launch argv names its launch script RELATIVELY (${
+          relDir === "." ? "a bare main.py" : `under "${relDir}"`
+        }) and the server reports no working directory, so its argv names no absolute ` +
+        "path, and the process listening on its port could not be anchored to an install " +
+        "holding that script on this filesystem either"
     : rootResult.why === "indeterminate"
       ? `this process could not determine whether its launch script "${script}" is a file on ` +
         `this filesystem (the lookup failed with ${rootResult.detail ?? "an unknown error"}); ` +
@@ -878,7 +933,11 @@ async function resolveTargetPathPreferServer(
     }
     throw new ValidationError(
       "UNRESOLVED: the running ComfyUI was not launched with --extra-model-paths-config and " +
-        "its launch argv does not reveal a main.py, so the extra_model_paths.yaml it reads " +
+        // Built from `localityGap` for the same reason the read-only caption above is:
+        // this arm is reached whenever the script could not be resolved, and hardcoding
+        // "argv does not reveal a main.py" states a cause that is false for every
+        // relative-argv launch (#1621) and for a lookup that merely failed.
+        `${localityGap}, so the extra_model_paths.yaml it reads ` +
         "cannot be located. Nothing was read or written — the local heuristic would just be a " +
         'guess at a file this server may not read. Pass config_path explicitly, or target: ' +
         '"standalone"/"desktop" to use the local heuristic deliberately.',


### PR DESCRIPTION
Fixes #1621.

## What the reporter saw

`list_local_models(action:"list_paths")` answered **UNRESOLVED** against a LOCAL, connected,
perfectly reachable ComfyUI, so model discovery had to fall back to reading loader combo
options instead of the path resolver.

## Why

The launch shape is the most ordinary one there is:

```
cd /opt/ComfyUI && python main.py --listen
```

`sys.argv[0]` is then the **relative** string `"main.py"`, and current ComfyUI does not report
its working directory in `/system_stats`. So nothing in the server's own argv names an
absolute path, and `extra-paths.ts`' argv-only derivation (`liveScriptFromArgv`) produced
nothing. With `COMFYUI_PATH` unset and no saved default workspace — the normal state for a
panel-connected install — the static fallback then *threw* rather than fell back:

```
UNRESOLVED: no local ComfyUI path is known, so the standalone
extra_model_paths.yaml cannot be located
```

Same for `getExtraModelRoots()`, which deliberately does not take the display-only #764
fallback: it saw the refusal and returned `[]`. That is the "model discovery had to rely on
node combo options" half of the report.

The OS knew the answer the whole time. `resolveLiveServerRoot` — the ONE canonical notion of
the live install root (#369) — has an **observed-process** tier built for exactly this shape:
it names the process listening on our port (correlated against the server's own argv, so a
proxy cannot impersonate it) and re-anchors the relative `main.py` dir on the install its
interpreter lives in. `extra-paths.ts` never consulted it, so the yaml **beside** the models
resolved through a weaker rule than the models themselves — the disagreement #369 exists to
prevent. This is also the ComfyUI Desktop / Windows-portable `ComfyUI\main.py` shape.

## The fix

When — and only when — the argv derivation yields no script, resolve through
`resolveLiveServerRoot`. Its `anchorDir` is the working directory the server must have had
for its relative `main.py` to name that install, so feeding it back through the *same*
parser yields the absolute script; `realLiveRoot` still has to prove that file on this
filesystem, and the root is still guarded and `createParents:false` like every other derived
root. No second parser, no new trust level.

**It can only ADD a resolution, never move one.** `liveRootFromArgv` and `liveScriptFromArgv`
share `scriptTokenFromArgv`, so a script-less argv is a root-less one — the argv tier inside
`resolveLiveServerRoot` has already failed wherever this runs. Every path that resolves today
resolves to the same file after this change.

Also fixed: the refusal for this state claimed *"its launch argv does not reveal a main.py"* —
a false cause, since the argv plainly revealed one. It now states what was observed (a
relative script, no reported cwd, and no anchorable process on the port), which is the
structured reason the issue asked for. That message was hardcoded in one arm rather than
built from `localityGap`, which the surrounding comments already warn against.

## Verification

`src/__tests__/services/extra-paths-observed-live-root.test.ts` (6 cases). All 4 behavioural
cases fail on `origin/main` with the exact reported error; the fix was then **deleted three
separate ways** and each mutation killed tests:

| mutation | tests killed |
|---|---|
| drop the observed-process tier | 3 (list, model discovery, write) |
| restore the hardcoded `localityGap` string | 1 |
| restore the hardcoded refusal message | 1 |

One case pins that the probe is **not** consulted when argv already resolves (it shells out to
netstat/lsof — a second answer must never be able to disagree with the one being reported), and
one asserts the `observeLiveServerProcess` stub is in force by identity, so no case can pass by
hitting the real process table (#1263).

`npm test` (517 files / 9686 tests), `npm run lint`, `npm run check:vocabulary` all green.

Not done: a relative `--extra-model-paths-config` value is still not anchored on `anchorDir`.
That is a second inference on top of this one, it already degrades to the implicit
`<root>/extra_model_paths.yaml` that the server provably also reads, and it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
