### PR TITLE
fix(1624): a repo filed under a Comfy Registry id is refused, not swapped for another author's

### DIFF
--- a/scripts/gen-manager-name-collisions.mjs
+++ b/scripts/gen-manager-name-collisions.mjs
@@ -68,11 +68,11 @@ function ownerRepo(url) {
  * every candidate is order-independent and refuses both spellings, which is the standing
  * rule: name the candidates, never pick between them.
  */
-async function channelMap(channel) {
+async function channelEntries(channel) {
   const res = await fetch(`${CHANNEL_URLS[channel]}/custom-node-list.json`);
   if (!res.ok) throw new Error(`${channel}: HTTP ${res.status}`);
   const raw = await res.json();
-  const out = new Map();
+  const out = [];
   for (const x of raw.custom_nodes) {
     const files = x.files ?? [];
     // len(files) > 1 is keyed by files[0] — a whole URL, unreachable by a bare name.
@@ -84,16 +84,27 @@ async function channelMap(channel) {
     if (!viaFile && x.id === undefined) continue;
     const repo = ownerRepo(url);
     if (!repo) continue;
-    const key = url.split("/").pop().trim().toLowerCase();
+    out.push({ repo, bare: url.split("/").pop().trim() });
+  }
+  return out;
+}
+
+/** lower(bare name) -> Set(owner/repo), the shape AMBIGUOUS_BARE_NAMES is built from. */
+function channelMap(entries) {
+  const out = new Map();
+  for (const { repo, bare } of entries) {
+    const key = bare.toLowerCase();
     if (!out.has(key)) out.set(key, new Set());
     out.get(key).add(repo);
   }
   return out;
 }
 
+const entries = {};
 const maps = {};
 for (const c of CHANNELS) {
-  maps[c] = await channelMap(c);
+  entries[c] = await channelEntries(c);
+  maps[c] = channelMap(entries[c]);
   process.stderr.write(`${c}: ${maps[c].size} bare-name keys\n`);
 }
 
@@ -185,6 +196,96 @@ process.stderr.write(
     `${Object.keys(registryTargets).length} names have a registry pack of their own name\n`,
 );
 
+/**
+ * #1624 — THE SAME SUBSTITUTION WITHOUT ANY CHANNEL COLLISION.
+ *
+ * The table above is keyed by CONTESTED bare names, which is a narrower thing than the
+ * hazard. Re-keying needs no second channel to hand back another author's repository: it
+ * is enough that the repo a caller names is registered under an id that is not its own
+ * name (so `get_custom_nodes` files it under THAT id and a bare-name lookup can never
+ * return it) and that something else answers to the name. Measured, that is 56 live
+ * repositories the contested-name table does not cover at all.
+ *
+ * So simulate the real lookup instead of approximating it. For every repository a caller
+ * could plausibly name — everything in the six channel lists plus everything in the
+ * registry — replay 4.2.2's own resolution:
+ *
+ *   get_custom_nodes: key = get_cnr_by_repo(files[0]) ? cnr['id'] : files[0].basename
+ *                     (repo_cnr_map is a PLAIN dict on a case-preserving normalize_url,
+ *                      so that match is case-SENSITIVE and is done that way here)
+ *   install_by_id:    the_node = custom_nodes.get(bare)        # NormalizedKeyDict, lower
+ *                     miss + nightly -> cnr_map.get(bare)      # the registry's repo
+ *
+ * and record only the repositories for which that lands somewhere ELSE. A repo that is
+ * re-keyed but whose name resolves to nothing at all (1271 of them) is NOT recorded:
+ * Manager answers "not found" there, which installs nobody's code and is a different bug.
+ */
+const REKEY_CHANNELS = CHANNELS;
+const bareOf = (repo) => repo.split("/")[1];
+const sameRepo = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+// channel -> Map(lower(node_id Manager files it under) -> Set(owner/repo))
+const keyedByManager = {};
+for (const c of REKEY_CHANNELS) {
+  const m = new Map();
+  for (const { repo, bare } of entries[c]) {
+    const id = repoToId.get(repo); // case-sensitive, mirrors repo_cnr_map
+    const key = (id !== undefined ? id : bare).trim().toLowerCase();
+    if (!m.has(key)) m.set(key, new Set());
+    m.get(key).add(repo);
+  }
+  keyedByManager[c] = m;
+}
+
+const nameable = new Set();
+for (const c of REKEY_CHANNELS) for (const e of entries[c]) nameable.add(e.repo);
+for (const r of repoToId.keys()) nameable.add(r);
+
+const substitutions = [];
+let unreachableButHarmless = 0;
+for (const repo of [...nameable].sort()) {
+  const nameKey = bareOf(repo).trim().toLowerCase();
+  const id = repoToId.get(repo);
+  // Not registered, or registered under its own name: a bare-name lookup CAN return it.
+  if (id === undefined || id.trim().toLowerCase() === nameKey) continue;
+  const channelTargets = {};
+  for (const c of REKEY_CHANNELS) {
+    // By construction none of these can be `repo` itself — it is filed under `id`, not
+    // under its name — but filter anyway rather than trust the construction, because a
+    // record naming the caller's own repository as the substitute would be nonsense.
+    const hit = [...(keyedByManager[c].get(nameKey) ?? [])].filter((r) => !sameRepo(r, repo)).sort();
+    if (hit.length) channelTargets[c] = hit;
+  }
+  const target = idToRepo.get(nameKey);
+  const registryTarget = target && !sameRepo(target, repo) ? target : undefined;
+  if (!Object.keys(channelTargets).length && !registryTarget) {
+    unreachableButHarmless++; // resolves to nothing -> Manager's "not found", not a swap
+    continue;
+  }
+  substitutions.push({ repo, id, channelTargets, registryTarget });
+}
+
+// The lookup key is lowercased, so two DIFFERENT repositories differing only in case
+// would collapse onto one record and the guard would answer about the wrong one. Nothing
+// in the guard could detect that, so it is caught HERE, where the fix is to change the
+// key rather than to ship a table that quietly answers wrong.
+{
+  const seen = new Map();
+  for (const s of substitutions) {
+    const k = s.repo.toLowerCase();
+    if (seen.has(k)) throw new Error(`case-collision on ${k}: ${seen.get(k)} vs ${s.repo}`);
+    seen.set(k, s.repo);
+  }
+}
+const onDefault = substitutions.filter(
+  (s) => (s.channelTargets.default ?? []).length > 0 || s.registryTarget !== undefined,
+).length;
+process.stderr.write(
+  `\nre-keyed repositories whose own name resolves to someone ELSE: ${substitutions.length} ` +
+    `(${onDefault} of them on the "default" channel); ` +
+    `${unreachableButHarmless} more are re-keyed but resolve to nothing (Manager answers "not found")\n`,
+);
+
 const measured = new Date().toISOString().slice(0, 10);
 const body = ambiguous
   .map(([name, per]) => {
@@ -242,6 +343,44 @@ export const REGISTRY_TARGETS: Readonly<Record<string, string>> = {
 ${Object.entries(registryTargets)
   .sort((a, b) => a[0].localeCompare(b[0]))
   .map(([n, repo]) => `  ${JSON.stringify(n)}: ${JSON.stringify(repo)},`)
+  .join("\n")}
+};
+
+//
+// #1624 — REPOSITORIES THAT CANNOT BE INSTALLED BY THEIR OWN NAME, AND WHO ANSWERS INSTEAD.
+//
+// Keyed by the caller's \`owner/repo\`, LOWERCASED: the question this answers is "did the
+// caller name one of these", and a caller types whatever case they like. (The generator
+// throws if two distinct repositories ever collapse onto one such key.)
+//
+// Every repository here is registered in the Comfy Registry under an id that is not its
+// own bare name, so \`get_custom_nodes\` files it under that id and a bare-name lookup
+// CANNOT return it — from any channel, whatever the channel's list appears to say. What a
+// lookup returns instead is recorded: \`channelTargets\` per channel, and \`registryTarget\`
+// for the nightly fallback that fires when the channel carries nothing under the name.
+//
+// Recorded ONLY where something else actually answers. A re-keyed repository whose name
+// resolves nowhere gets Manager's "not found", which installs nobody's code, and is left
+// out rather than turned into a refusal.
+export interface RekeyedSubstitution {
+  /** The repository, cased as the Comfy Registry records it. */
+  readonly repo: string;
+  /** The Comfy Registry id it is filed under — the reason its own name misses. */
+  readonly id: string;
+  /** Per channel, what a bare-name lookup DOES reach under that name. */
+  readonly channelTargets: Readonly<Partial<Record<ManagerChannelName, readonly string[]>>>;
+  /** What \`cnr_map[<bare name>]\` clones when the channel carries nothing under it. */
+  readonly registryTarget?: string;
+}
+export const REKEYED_SUBSTITUTIONS: Readonly<Record<string, RekeyedSubstitution>> = {
+${substitutions
+  .map((s) => {
+    const chans = REKEY_CHANNELS.filter((c) => s.channelTargets[c])
+      .map((c) => `${c}: [${s.channelTargets[c].map((r) => JSON.stringify(r)).join(", ")}]`)
+      .join(", ");
+    const reg = s.registryTarget ? `, registryTarget: ${JSON.stringify(s.registryTarget)}` : "";
+    return `  ${JSON.stringify(s.repo.toLowerCase())}: { repo: ${JSON.stringify(s.repo)}, id: ${JSON.stringify(s.id)}, channelTargets: { ${chans} }${reg} },`;
+  })
   .join("\n")}
 };
 

--- a/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
+++ b/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
@@ -1,0 +1,252 @@
+// #1624 — A REPOSITORY THAT CANNOT BE INSTALLED BY ITS OWN NAME IS REFUSED, NOT SWAPPED.
+//
+// #1619 refuses the from-source install when the BARE NAME is contested across the six
+// channel lists. This is the same substitution reached without any contest, and the
+// mechanism is re-read at ComfyUI-Manager 4.2.2's own source
+// (comfyui_manager/glob/manager_core.py at tag 4.2.2 — NOT `main`, which is the 3.41
+// line and has no CNR fallback at all):
+//
+//   get_custom_nodes  cnr = self.get_cnr_by_repo(v['files'][0])
+//                     if cnr: v['id'] = cnr['id']; node_id = v['id']
+//                     else:   node_id = v['files'][0].split('/')[-1]
+//   install_by_id     the_node = custom_nodes.get(node_id)          # NormalizedKeyDict
+//                     if the_node is None and version_spec == 'nightly':
+//                         cnr_fallback = self.cnr_map.get(node_id)
+//                         repo_url = cnr_fallback['repository']     # someone ELSE's repo
+//
+// So a repository registered under an id that is not its own bare name is filed under
+// that id, and a lookup for its name cannot return it from ANY channel. What answers
+// instead is another channel entry that was not re-keyed, or the registry pack whose id
+// IS that name. Either way the caller gets code they did not ask for, reported as a
+// success.
+//
+// ## What was measured, replaying that resolution over the six channel lists plus the
+// ## whole Comfy Registry (5117 repositories)
+//
+//   * 1366 repositories are re-keyed;
+//   * 1268 of those resolve to NOTHING — Manager answers "not found", installs nobody's
+//     code, and they are deliberately NOT recorded, because turning a clean failure into
+//     a refusal is not this bug;
+//   * 98 resolve to a DIFFERENT repository, 84 of them on the channel this code defaults
+//     to. 56 are invisible to #1619's contested-name table, which is the gap this closes.
+//
+// ## What this deliberately does not cover
+//
+// The table is keyed by the CALLER'S repository, so it fires only for repositories the
+// registry knows. An unregistered, unlisted fork named `ComfyUI-GGUF` hits exactly the
+// same substitution and is not in here — that set is not enumerable from any snapshot.
+// Those keep today's behaviour and the standing dispatch note.
+import { describe, expect, it, vi } from "vitest";
+import { nodesInstallCommandArgs } from "../../services/node-management.js";
+import {
+  AMBIGUOUS_BARE_NAMES,
+  bareNameAmbiguity,
+  REKEYED_REPOS,
+  REKEYED_SUBSTITUTIONS,
+  rekeyedRegistryVersionAmbiguity,
+  rekeyedRepoAmbiguity,
+  rekeyedRepoRefusal,
+} from "../../services/manager-bare-name-collisions.js";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+// A CHANNEL-route case: Mattabyte's fork is registered as "ComfyUI-GGUF_Forked", so the
+// name "ComfyUI-GGUF" is filed under city96's entry and `default` answers with city96.
+const FORK_CHANNEL = "https://github.com/Mattabyte/ComfyUI-GGUF";
+const FORK_CHANNEL_LANDS = "city96/ComfyUI-GGUF";
+// A CNR-FALLBACK case: hekmon's repo is registered as "openai-api", nothing in `default`
+// answers to "comfyui-openai-api", so the nightly fallback clones the registry's pack.
+const FALLBACK = "https://github.com/hekmon/comfyui-openai-api";
+const FALLBACK_LANDS = "bgreene2/ComfyUI-OpenAI-API";
+// The counterpart that MUST still dispatch: city96's own repo is registered under its own
+// name, so the lookup reaches it and there is nothing to refuse.
+const UPSTREAM = "https://github.com/city96/ComfyUI-GGUF";
+
+describe("#1624 — a re-keyed repository is refused instead of substituted", () => {
+  it("refuses the defaulted-channel install and NAMES what would land instead", () => {
+    // THE CALL-SITE TEST. `rekeyedRepoAmbiguity` returning the right object proves
+    // nothing about production: the whole fix on this path is one `if` in
+    // `nodesInstallCommandArgs`, and a helper-level assertion survives deleting it.
+    const res = nodesInstallCommandArgs({ repository: FORK_CHANNEL });
+    expect(res.conflict).toBeTruthy();
+    expect(res.conflict).toContain(FORK_CHANNEL_LANDS);
+    // The reason has to be the real one — the id it is filed under, quoted.
+    expect(res.conflict).toContain("ComfyUI-GGUF_Forked");
+    // ...and it must not dispatch anything while refusing.
+    expect(res.id).toBeUndefined();
+    expect(res.repository).toBeUndefined();
+  });
+
+  it("refuses the CNR-fallback case and says the registry, not a channel, decides it", () => {
+    const res = nodesInstallCommandArgs({ repository: FALLBACK });
+    expect(res.conflict).toBeTruthy();
+    expect(res.conflict).toContain(FALLBACK_LANDS);
+    expect(res.conflict).toContain("cnr_map");
+    // Claiming a channel's list carries the name when it carries nothing would be a
+    // fabricated mechanism — the same failure #1619's gate round 6 caught.
+    expect(res.conflict).not.toContain("channel's list DOES answer");
+  });
+
+  it("still dispatches the repository the name actually resolves to", () => {
+    // The fix must not degrade into "refuse anything that looks like a fork". city96's
+    // repo is registered as `comfyui-gguf`, so `get_custom_nodes` files it under its own
+    // name and the install is correct. This is the assertion that fails if the table is
+    // keyed by bare NAME instead of by the caller's repository.
+    expect(REKEYED_SUBSTITUTIONS["city96/comfyui-gguf"]).toBeUndefined();
+    const res = nodesInstallCommandArgs({ repository: UPSTREAM });
+    expect(res.conflict).toBeUndefined();
+    expect(res.repository).toBe(UPSTREAM);
+  });
+
+  it("dispatches when the caller named a channel, but says the choice aimed nothing", () => {
+    // Same escape as #1619: a named channel is the caller's own choice and the one way
+    // past a stale snapshot, and on Manager 3.x the URL passed IS what gets cloned. What
+    // it must NOT do is repeat the "you chose the channel" framing — no channel argument
+    // can reach a repository filed under an id that is not its name.
+    const res = nodesInstallCommandArgs({ repository: FORK_CHANNEL, channel: "default" });
+    expect(res.conflict).toBeUndefined();
+    expect(res.repository).toBe(FORK_CHANNEL);
+    expect(res.note).toContain("RE-KEYED PACK");
+    expect(res.note).toContain(FORK_CHANNEL_LANDS);
+    expect(res.note).toContain('install_custom_node (source:"git")');
+  });
+
+  it("refuses the registry-version route too, and does not offer dropping `version`", () => {
+    // An explicit version skips `get_custom_nodes` entirely and installs the registry
+    // pack whose id is the bare name — city96's. Unlike #1619's registry-version refusal,
+    // dropping `version` is NOT the remedy here: the from-source route resolves the same
+    // name and cannot reach this repository either.
+    const res = nodesInstallCommandArgs({ repository: FORK_CHANNEL, version: "1.2.3" });
+    expect(res.conflict).toBeTruthy();
+    expect(res.conflict).toContain(FORK_CHANNEL_LANDS);
+    expect(res.conflict).toContain("does NOT rescue this one");
+    expect(res.conflict).toContain('install_custom_node (source:"git")');
+  });
+
+  it("does not treat a from-source spec as a registry version", () => {
+    // "nightly" and "unknown" DO consult the channel, so they belong to the from-source
+    // refusal — routing them to the registry-version message would state a mechanism that
+    // is not the one running.
+    for (const spec of ["nightly", "unknown", "NIGHTLY", " nightly "]) {
+      expect(rekeyedRegistryVersionAmbiguity(FORK_CHANNEL, spec), spec).toBeUndefined();
+    }
+    expect(rekeyedRegistryVersionAmbiguity(FORK_CHANNEL, "1.2.3")).toBeTruthy();
+  });
+
+  it("leaves the contested-name refusal in charge where BOTH tables know the repo", () => {
+    // wildminder/ComfyUI-Chatterbox is in both tables — #1619's because
+    // `comfyui-chatterbox` is contested, this one's because the repo is re-keyed. Only
+    // one refusal may be produced, and it must be the one that already reasons about
+    // re-keying for that name, or the caller reads the same finding twice in two voices.
+    expect(REKEYED_SUBSTITUTIONS["wildminder/comfyui-chatterbox"]).toBeTruthy();
+    const res = nodesInstallCommandArgs({
+      repository: "https://github.com/wildminder/ComfyUI-Chatterbox",
+    });
+    expect(res.conflict).toBeTruthy();
+    expect(res.conflict).toContain("sm079/comfyui-chatterbox");
+    expect(res.conflict).toContain("registered in the Comfy Registry under a different id");
+    expect(res.conflict).not.toContain("RE-KEYED PACK");
+  });
+
+  it("independently agrees with #1619's table on the reproduction #1624 was filed with", () => {
+    // The two tables are computed by separate passes over the same registry fetch. If
+    // they ever disagreed about the same repository, one of them would be wrong and
+    // nothing else in the suite would notice.
+    const rec = REKEYED_SUBSTITUTIONS["wildminder/comfyui-chatterbox"];
+    expect(rec?.registryTarget).toBe("sm079/comfyui-chatterbox");
+    expect(REKEYED_REPOS["comfyui-chatterbox"] ?? []).toContain("wildminder/ComfyUI-Chatterbox");
+    // The shipped guard reaches the same landing for the same call.
+    expect(bareNameAmbiguity("https://github.com/wildminder/ComfyUI-Chatterbox", "default")
+      ?.registryTarget).toBe("sm079/comfyui-chatterbox");
+  });
+
+  it("does not match an `owner/repo` that came off another host", () => {
+    // The snapshot holds github repositories only. A gitlab URL that merely shares the
+    // path is a DIFFERENT repository, and refusing it would quote back a github repo the
+    // caller never named — the same reasoning `comparableToSnapshot` already encodes.
+    expect(rekeyedRepoAmbiguity("https://gitlab.com/Mattabyte/ComfyUI-GGUF", "default"))
+      .toBeUndefined();
+    expect(rekeyedRegistryVersionAmbiguity("https://gitlab.com/Mattabyte/ComfyUI-GGUF", "1.0.0"))
+      .toBeUndefined();
+  });
+
+  it("matches the caller's repository however they cased it", () => {
+    // Manager's case-sensitivity applies to the CHANNEL entry's URL against the registry,
+    // not to what the caller typed. Someone who types the repo in the wrong case names
+    // the same repository and is exposed to exactly the same substitution.
+    expect(rekeyedRepoAmbiguity("https://github.com/MATTABYTE/comfyui-gguf", "default"))
+      .toBeTruthy();
+    expect(rekeyedRepoAmbiguity(`${FORK_CHANNEL}.git`, "default")).toBeTruthy();
+  });
+
+  it("tolerates channel names Manager would reject, and inherited keys, without throwing", () => {
+    // `normalize_channel` raises InvalidChannel before any list is read, so there is no
+    // substitution to warn about — and an object literal ANSWERS for `__proto__` and
+    // `constructor`, which is how the same shape threw in #1619's gate round 3.
+    expect(rekeyedRepoAmbiguity(FORK_CHANNEL, "not-a-channel")).toBeUndefined();
+    for (const inherited of ["__proto__", "constructor", "toString", "valueOf"]) {
+      expect(rekeyedRepoAmbiguity(FORK_CHANNEL, inherited), inherited).toBeUndefined();
+      expect(
+        rekeyedRepoAmbiguity(`https://github.com/someone/${inherited}`, "default"),
+        inherited,
+      ).toBeUndefined();
+      expect(
+        nodesInstallCommandArgs({ repository: FORK_CHANNEL, channel: inherited }).conflict,
+        inherited,
+      ).toBeUndefined();
+    }
+  });
+
+  it("never names the caller's own repository as the substitute", () => {
+    // A record saying "you asked for X and would get X" would be nonsense, and a refusal
+    // built on it would be unanswerable. By construction it cannot happen — a re-keyed
+    // repo is filed under its id, not its name — but the table is generated, so pin it.
+    for (const [key, rec] of Object.entries(REKEYED_SUBSTITUTIONS)) {
+      expect(key, `${key} must be the lowercased repo`).toBe(rec.repo.toLowerCase());
+      const targets = [...Object.values(rec.channelTargets).flat()];
+      if (rec.registryTarget) targets.push(rec.registryTarget);
+      expect(targets.length, `${key} records no substitute at all`).toBeGreaterThan(0);
+      for (const t of targets) {
+        expect(t.toLowerCase(), `${key} lists itself as the substitute`).not.toBe(key);
+      }
+      expect(rec.id.trim().toLowerCase(), `${key} is not actually re-keyed`).not.toBe(
+        rec.repo.split("/")[1].trim().toLowerCase(),
+      );
+    }
+  });
+
+  it("agrees with #1619's re-keyed table wherever both cover the same channel entry", () => {
+    // REKEYED_REPOS records the same property for the CANDIDATES of a contested name. A
+    // repository in both tables must be marked re-keyed in both, or one pass read the
+    // registry differently from the other.
+    for (const [key, rec] of Object.entries(REKEYED_SUBSTITUTIONS)) {
+      const name = rec.repo.split("/")[1].trim().toLowerCase();
+      const per = AMBIGUOUS_BARE_NAMES[name] as Record<string, string[]> | undefined;
+      if (!per) continue;
+      const listed = Object.values(per).flat();
+      if (!listed.includes(rec.repo)) continue; // registry-only, nothing to cross-check
+      expect(REKEYED_REPOS[name] ?? [], `${key} is re-keyed here but not in REKEYED_REPOS`)
+        .toContain(rec.repo);
+    }
+  });
+
+  it("states the mechanism it is actually running, on both routes", () => {
+    // The refusal text is the only thing a caller acts on, so the branch that produced it
+    // has to be the branch described. A channel-route refusal must not claim the registry
+    // fallback fired, and vice versa.
+    const chan = rekeyedRepoAmbiguity(FORK_CHANNEL, "default");
+    expect(chan?.resolvedVia).toBe("channel");
+    expect(rekeyedRepoRefusal(chan!)).toContain("channel's list DOES answer");
+
+    const fall = rekeyedRepoAmbiguity(FALLBACK, "default");
+    expect(fall?.resolvedVia).toBe("cnr-fallback");
+    const text = rekeyedRepoRefusal(fall!);
+    expect(text).toContain("falls back to the registry map");
+    expect(text).not.toContain("channel's list DOES answer");
+  });
+});

--- a/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
+++ b/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
@@ -153,6 +153,37 @@ describe("#1624 — a re-keyed repository is refused instead of substituted", ()
     expect(res.conflict).not.toContain("RE-KEYED PACK");
   });
 
+  it("says it ONCE on the named-channel path too, where neither message returns early", () => {
+    // The refusal path above returns at the first conflict, so the ordering guard costs
+    // nothing there and a mutation that drops it survives. The WARNING path is where it
+    // is load-bearing: both messages ride the same `note`, so without the guard a caller
+    // who named a channel reads the same finding twice, in two voices, with two different
+    // remedies. Measured with the guard removed: the note carries both.
+    const res = nodesInstallCommandArgs({
+      repository: "https://github.com/wildminder/ComfyUI-Chatterbox",
+      channel: "default",
+    });
+    expect(res.conflict).toBeUndefined();
+    expect(res.note).toContain("NAMED-CHANNEL COLLISION");
+    expect(res.note).not.toContain("RE-KEYED PACK");
+  });
+
+  it("does not refuse a re-keyed repo whose name resolves to nothing on the asked channel", () => {
+    // RUFFY-369/ComfyUI-StreamDiffusion is re-keyed ("streamdiffusion") and `dev` answers
+    // to its name — but `default` answers with nothing and the registry holds no pack of
+    // that name, so Manager returns "not found". That installs nobody's code. Refusing it
+    // would turn a clean failure into a refusal and widen this fix past what it measured;
+    // this is the assertion that fails if the not-found branch is dropped.
+    const url = "https://github.com/RUFFY-369/ComfyUI-StreamDiffusion";
+    expect(REKEYED_SUBSTITUTIONS["ruffy-369/comfyui-streamdiffusion"]).toBeTruthy();
+    expect(REKEYED_SUBSTITUTIONS["ruffy-369/comfyui-streamdiffusion"]?.registryTarget)
+      .toBeUndefined();
+    expect(rekeyedRepoAmbiguity(url, "default")).toBeUndefined();
+    expect(nodesInstallCommandArgs({ repository: url }).conflict).toBeUndefined();
+    // ...and on the channel that DOES answer, it is refused.
+    expect(rekeyedRepoAmbiguity(url, "dev")?.resolvedVia).toBe("channel");
+  });
+
   it("independently agrees with #1619's table on the reproduction #1624 was filed with", () => {
     // The two tables are computed by separate passes over the same registry fetch. If
     // they ever disagreed about the same repository, one of them would be wrong and

--- a/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
+++ b/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
@@ -43,6 +43,7 @@ import {
   bareNameAmbiguity,
   REKEYED_REPOS,
   REKEYED_SUBSTITUTIONS,
+  registryVersionAmbiguity,
   rekeyedRegistryVersionAmbiguity,
   rekeyedRepoAmbiguity,
   rekeyedRepoRefusal,
@@ -137,7 +138,12 @@ describe("#1624 — a re-keyed repository is refused instead of substituted", ()
     // reads a channel: it calls `cnr_install("ComfyUI-ElevenLabs", "1.2.3")`, finds no
     // such id, and fails. Refusing was directionally right and the remedy was correct,
     // which is precisely how a fabricated mechanism survives — so the call dispatches and
-    // takes Manager's own "not found" instead. 12 of the 98 records are in this shape.
+    // takes Manager's own "not found" instead.
+    //
+    // Counted, not estimated: 26 of the 98 records have no `registryTarget`. 12 of them
+    // are reachable on the channel this code defaults to and were REFUSED (this test);
+    // the other 14 answer only on an explicitly named channel and got the WARNING
+    // instead (the test below).
     const url = "https://github.com/GuardSkill/ComfyUI-ElevenLabs";
     const rec = REKEYED_SUBSTITUTIONS["guardskill/comfyui-elevenlabs"];
     expect(rec?.channelTargets.default ?? []).toHaveLength(1);
@@ -149,6 +155,31 @@ describe("#1624 — a re-keyed repository is refused instead of substituted", ()
     expect(nodesInstallCommandArgs({ repository: url }).conflict).toContain(
       "jerilseb/ComfyUI-ElevenLabs",
     );
+  });
+
+  it("does not ride the warning on a registry-version route either", () => {
+    // The same gate finding on the OTHER side of the channel split. The warning is what a
+    // caller who NAMED the channel gets, and it describes the same channel resolution —
+    // so on a route where no channel is read it is just as fabricated as the refusal,
+    // and it rides a call that DISPATCHES, where nothing later contradicts it.
+    // RUFFY-369/ComfyUI-StreamDiffusion is re-keyed ("streamdiffusion"), nothing is
+    // registered as `comfyui-streamdiffusion`, and only `dev` answers to the name — with
+    // pschroedl's. Deliberately NOT one of the contested names: those are refused a step
+    // earlier by #1616's registry-version check, which would mask what this pins.
+    const url = "https://github.com/RUFFY-369/ComfyUI-StreamDiffusion";
+    const rec = REKEYED_SUBSTITUTIONS["ruffy-369/comfyui-streamdiffusion"];
+    expect(rec?.registryTarget).toBeUndefined();
+    expect(rec?.channelTargets.default ?? []).toHaveLength(0);
+    expect(registryVersionAmbiguity(url, "1.2.3")).toBeUndefined();
+    expect(rekeyedRepoAmbiguity(url, "dev")).toBeTruthy();
+    const res = nodesInstallCommandArgs({ repository: url, version: "1.2.3", channel: "dev" });
+    expect(res.conflict).toBeUndefined();
+    expect(res.note ?? "").not.toContain("RE-KEYED PACK");
+    // Drop the version and the same call IS on the from-source route, where the channel
+    // it names is genuinely read — so the warning is true there and does ride.
+    const fromSource = nodesInstallCommandArgs({ repository: url, channel: "dev" });
+    expect(fromSource.conflict).toBeUndefined();
+    expect(fromSource.note ?? "").toContain("RE-KEYED PACK");
   });
 
   it("does not treat a from-source spec as a registry version", () => {

--- a/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
+++ b/src/__tests__/orchestrator/install-node-rekeyed-repo.test.ts
@@ -128,6 +128,29 @@ describe("#1624 — a re-keyed repository is refused instead of substituted", ()
     expect(res.conflict).toContain('install_custom_node (source:"git")');
   });
 
+  it("does not apply channel reasoning to a route Manager reads no channel for", () => {
+    // GATE FINDING. GuardSkill/ComfyUI-ElevenLabs is re-keyed ("ElevenLabs") and `default`
+    // answers to its name with jerilseb's — but the registry holds no pack called
+    // `comfyui-elevenlabs`, so `rekeyedRegistryVersionAmbiguity` declines and the call
+    // used to fall through to the FROM-SOURCE refusal, which told the caller the default
+    // channel's list was what would be cloned. With an explicit version Manager never
+    // reads a channel: it calls `cnr_install("ComfyUI-ElevenLabs", "1.2.3")`, finds no
+    // such id, and fails. Refusing was directionally right and the remedy was correct,
+    // which is precisely how a fabricated mechanism survives — so the call dispatches and
+    // takes Manager's own "not found" instead. 12 of the 98 records are in this shape.
+    const url = "https://github.com/GuardSkill/ComfyUI-ElevenLabs";
+    const rec = REKEYED_SUBSTITUTIONS["guardskill/comfyui-elevenlabs"];
+    expect(rec?.channelTargets.default ?? []).toHaveLength(1);
+    expect(rec?.registryTarget).toBeUndefined();
+    const res = nodesInstallCommandArgs({ repository: url, version: "1.2.3" });
+    expect(res.conflict).toBeUndefined();
+    expect(res.note ?? "").not.toContain("RE-KEYED PACK");
+    // The same URL with no version IS on the from-source route, and is still refused.
+    expect(nodesInstallCommandArgs({ repository: url }).conflict).toContain(
+      "jerilseb/ComfyUI-ElevenLabs",
+    );
+  });
+
   it("does not treat a from-source spec as a registry version", () => {
     // "nightly" and "unknown" DO consult the channel, so they belong to the from-source
     // refusal — routing them to the registry-version message would state a mechanism that

--- a/src/services/manager-bare-name-collisions.ts
+++ b/src/services/manager-bare-name-collisions.ts
@@ -67,10 +67,12 @@
  *    list appears to say. `REGISTRY_TARGETS` records what `cnr_map[name]` then clones, so
  *    the refusal names that repository outright instead of guessing.
  *
- *    STILL NOT CLOSED IN GENERAL, and that is #1624: this covers the 111 names measured
- *    here, but the hazard needs no channel collision at all — ANY pack whose entry is
- *    re-keyed and whose bare name matches a different registry id is exposed, and those
- *    are not enumerated here.
+ *    NOW ALSO COVERED WITHOUT A CHANNEL COLLISION (#1624). The paragraph above used to
+ *    end "still not closed in general": this table is keyed by CONTESTED names, and the
+ *    hazard needs no contest — a pack whose entry is re-keyed and whose bare name answers
+ *    to a different registry id is exposed on its own. That class is enumerated now, in
+ *    `REKEYED_SUBSTITUTIONS` and `rekeyedRepoAmbiguity` below: 98 repositories, 56 of them
+ *    invisible to this table. What remains uncovered is stated there.
  *
  *  * A pip-installed Manager. `get_data_by_mode` reads the cache file for the configured
  *    channel URL, else the snapshot BUNDLED in the package — a stale, default-flavoured
@@ -107,7 +109,9 @@ import {
   MANAGER_CHANNEL_NAMES,
   REGISTRY_TARGETS,
   REKEYED_REPOS,
+  REKEYED_SUBSTITUTIONS,
   type ManagerChannelName,
+  type RekeyedSubstitution,
 } from "./manager-bare-name-data.js";
 
 export {
@@ -116,8 +120,9 @@ export {
   MANAGER_CHANNEL_NAMES,
   REGISTRY_TARGETS,
   REKEYED_REPOS,
+  REKEYED_SUBSTITUTIONS,
 };
-export type { ManagerChannelName };
+export type { ManagerChannelName, RekeyedSubstitution };
 
 /**
  * The pack name Manager will resolve by — EXACTLY the panel's `gitRepoName`
@@ -324,6 +329,242 @@ export function bareNameAmbiguity(url: string, channel: string): BareNameAmbigui
     resolvedVia: channelCandidates.length === 0 ? "cnr-fallback" : "channel",
     allCandidates,
   };
+}
+
+/**
+ * #1624 — THE SUBSTITUTION THAT NEEDS NO CHANNEL COLLISION AT ALL.
+ *
+ * Everything above is keyed by a CONTESTED bare name: a name the six channel lists carry
+ * under more than one repository. That is narrower than the hazard, and #1619 shipped
+ * saying so. Re-keying alone is enough:
+ *
+ *   1. the repository a caller names is registered in the Comfy Registry under an id that
+ *      is not its own bare name, so `get_custom_nodes` files it under THAT id
+ *      (`if cnr: node_id = v['id']`) and a bare-name lookup cannot return it — from any
+ *      channel, however plainly that channel's list carries it; and
+ *   2. something else answers to the bare name: another channel entry that was not
+ *      re-keyed, or, when the channel carries nothing, the registry pack whose id IS that
+ *      name, which `install_by_id`'s nightly branch falls back to and clones.
+ *
+ * Both are properties of the global registry, so a pack needs no cross-channel collision
+ * to be exposed. Replaying 4.2.2's resolution over every repository in the six channel
+ * lists plus the whole registry (5117 repos), the shipped guard misses 56 live
+ * repositories that resolve to another author's code today — the class this closes.
+ *
+ * WHY A PRECOMPUTED VERDICT RATHER THAN THE RAW MAP. #1624 proposed mirroring the
+ * registry's `repository -> id` and `id -> repository` tables into the snapshot and
+ * simulating at call time. The simulation is the right idea; shipping its INPUT is not.
+ * Both directions of a 5117-row table are needed to answer one yes/no question per repo,
+ * the answer never varies per caller, and a runtime simulation is a second implementation
+ * of Manager's keying that can drift from the generator's. So the generator runs the
+ * simulation once, against data it fetched in the same pass as the channel lists, and
+ * emits only the repositories whose answer is "someone else": 98 records instead of 5117
+ * rows, with the losing 1268 (re-keyed but resolving to nothing, where Manager answers
+ * "not found" and installs nobody's code) deliberately left out.
+ *
+ * WHAT IS STILL NOT COVERED, stated rather than implied. This is keyed by the CALLER'S
+ * repository, so it can only fire for repositories the registry knows. A fork that is
+ * neither registered nor channel-listed — `someone/ComfyUI-GGUF`, say — hits exactly the
+ * same substitution (the name resolves to city96's) and is not in here, because the set
+ * of unregistered forks is not enumerable from any snapshot. Those keep today's behaviour:
+ * the standing dispatch note warns that the name, not the URL, is what resolves.
+ */
+export interface RekeyedRepoAmbiguity {
+  /** The name as it will be SENT (case preserved) — the id `install_by_id` looks up. */
+  bare: string;
+  /** The URL the caller passed, verbatim. */
+  callerUrl: string;
+  /** `owner/repo` the caller named, cased as they typed it. */
+  callerRepo: string;
+  /** The same repository, cased as the Comfy Registry records it. */
+  registeredRepo: string;
+  /** The Comfy Registry id it is filed under — the reason its own name misses. */
+  registryId: string;
+  /** The channel about to be asked. */
+  channel: string;
+  /** What a bare-name lookup DOES reach in that channel — never the caller's own repo. */
+  channelCandidates: readonly string[];
+  /** What `cnr_map[<bare name>]` clones when the channel carries nothing under the name. */
+  registryTarget?: string;
+  /** Which of the two decides the clone, exactly as in `BareNameAmbiguity`. */
+  resolvedVia: "channel" | "cnr-fallback";
+}
+
+/** The caller's repo, looked up the way the table is keyed, or undefined. */
+function rekeyedRecordFor(url: string): { repo: string; rec: RekeyedSubstitution } | undefined {
+  // An `owner/repo` that came off another host is a DIFFERENT repository that merely
+  // shares a path, exactly as `bareNameAmbiguity` reasons — matching it here would refuse
+  // a gitlab URL by quoting a github repository the caller never named.
+  if (!comparableToSnapshot(url)) return undefined;
+  const repo = ownerRepoOf(url);
+  if (!repo) return undefined;
+  const rec = ownCandidates(REKEYED_SUBSTITUTIONS, repo.toLowerCase());
+  return rec ? { repo, rec } : undefined;
+}
+
+/**
+ * Would a from-source install of this URL land on a repository other than the caller's,
+ * because theirs is filed under a Comfy Registry id rather than under its own name?
+ *
+ * `undefined` when the repository is not one the snapshot measured as re-keyed, when the
+ * channel is not one Manager accepts, or when the name resolves to NOTHING on that channel
+ * — the last being Manager's "not found", which substitutes nobody's code and is a
+ * different complaint than this one.
+ */
+export function rekeyedRepoAmbiguity(url: string, channel: string): RekeyedRepoAmbiguity | undefined {
+  const found = rekeyedRecordFor(url);
+  if (!found) return undefined;
+  const asked = channel.trim().toLowerCase();
+  // Same reasoning as `bareNameAmbiguity`: `normalize_channel` raises InvalidChannel on a
+  // name Manager does not accept, so no list is consulted and there is no CNR fallback to
+  // reach. This is also what keeps an INHERITED key from being read as a miss.
+  if (!KNOWN_CHANNELS.has(asked)) return undefined;
+  const { repo, rec } = found;
+  const channelCandidates = ownCandidates(rec.channelTargets, asked as ManagerChannelName) ?? [];
+  if (channelCandidates.length === 0 && rec.registryTarget === undefined) return undefined;
+  return {
+    bare: managerBareName(url),
+    callerUrl: url.trim(),
+    callerRepo: repo,
+    registeredRepo: rec.repo,
+    registryId: rec.id,
+    channel,
+    channelCandidates,
+    registryTarget: rec.registryTarget,
+    resolvedVia: channelCandidates.length === 0 ? "cnr-fallback" : "channel",
+  };
+}
+
+/**
+ * The one sentence both messages below are built on, kept in one place so the refusal and
+ * the warning cannot drift into saying different things about the same repository.
+ */
+function rekeyedMechanism(a: RekeyedRepoAmbiguity): string {
+  return (
+    `ComfyUI-Manager v4 does not look a from-source install up by the URL you pass — it ` +
+    `files every channel entry under the pack's Comfy Registry id when the repo is ` +
+    `registered, and under the bare repo name only when it is not (get_custom_nodes: ` +
+    `\`cnr = get_cnr_by_repo(files[0]); if cnr: node_id = v['id']\`). ` +
+    `https://github.com/${a.registeredRepo} is registered as "${a.registryId}", so it is ` +
+    `filed under THAT id and a lookup for "${a.bare}" cannot return it — on any channel, ` +
+    `however plainly a channel's list carries it.`
+  );
+}
+
+/** What actually lands instead, for either message. */
+function rekeyedLanding(a: RekeyedRepoAmbiguity): string {
+  return a.resolvedVia === "channel"
+    ? `The "${a.channel}" channel's list DOES answer to "${a.bare}" — with ` +
+        `${listRepos(a.channelCandidates)} — so that is what would be cloned`
+    : `Nothing in the "${a.channel}" channel's list answers to "${a.bare}", which is not ` +
+        `the end of it: on a "nightly" spec v4 falls back to the registry map ` +
+        `(install_by_id → cnr_map) and clones what the id "${a.bare}" is registered to, ` +
+        `which is https://github.com/${a.registryTarget}`;
+}
+
+/**
+ * The pre-dispatch refusal. Unlike `ambiguousBareNameRefusal` there is no channel that
+ * resolves this name to the caller's repository — not "none in the snapshot", but none
+ * that can exist, because the id it is filed under is not its name — so the remedy is the
+ * verbatim-clone route and the message says only that.
+ */
+export function rekeyedRepoRefusal(a: RekeyedRepoAmbiguity): string {
+  return (
+    `REFUSED before dispatch — this install would have fetched a repository other than ` +
+    `the one you named. ${rekeyedMechanism(a)} You asked for ` +
+    `https://github.com/${a.callerRepo}. ${rekeyedLanding(a)}, and the install would have ` +
+    `reported success. Not picked for you: no \`channel\` argument can rescue this one — ` +
+    `changing the list consulted cannot make your repository reachable by a name it is ` +
+    `not filed under — so use install_custom_node (source:"git"), which clones the URL ` +
+    `you pass verbatim instead of resolving a name. ` +
+    `(This check ran because no \`channel\` was named, against a snapshot of the Comfy ` +
+    `Registry and the six published channel lists measured ` +
+    `${AMBIGUOUS_BARE_NAMES_MEASURED}; naming a \`channel\` explicitly does still bypass ` +
+    `it, but it cannot aim the install — the one reason to take that bypass is a ComfyUI ` +
+    `running Manager 3.x, where the from-source request carries the URL in \`files\` and ` +
+    `IS cloned as passed, and this check cannot tell the generations apart because the ` +
+    `panel picks the dialect after the request leaves here.)`
+  );
+}
+
+/**
+ * The same finding for a caller who DID name the channel. It dispatches — their choice,
+ * and on 3.x the URL is what gets cloned — but it must not repeat `ambiguousBareNameWarning`'s
+ * "you chose the channel" framing, because here the channel choice decided nothing at all.
+ */
+export function rekeyedRepoWarning(a: RekeyedRepoAmbiguity): string {
+  return (
+    `RE-KEYED PACK: you asked for https://github.com/${a.callerRepo}, and naming a ` +
+    `channel did not aim this install. ${rekeyedMechanism(a)} ${rekeyedLanding(a)}. ` +
+    `Dispatched because you named a channel, and because on Manager 3.x the URL you ` +
+    `passed IS what gets cloned; if this is v4 and you need the repository you typed, ` +
+    `install_custom_node (source:"git") clones it directly instead of resolving a name. ` +
+    `Verify with panel_list_nodes before you restart or report success. ` +
+    `(Snapshot measured ${AMBIGUOUS_BARE_NAMES_MEASURED}.)`
+  );
+}
+
+/**
+ * The registry-version route for the same repositories. `registryVersionAmbiguity` below
+ * covers it only for the CONTESTED names, and the reasoning transfers unchanged: an
+ * explicit version skips `get_custom_nodes` entirely and installs the Comfy Registry pack
+ * whose id is the bare repo name. For a re-keyed repository that id is by definition not
+ * the one it is registered under, so what lands is `registryTarget` — someone else.
+ *
+ * Requires `registryTarget`: with no registry pack of that name `cnr_install` fails and
+ * nobody's code is installed, which is not this bug.
+ */
+export interface RekeyedRegistryVersionAmbiguity {
+  bare: string;
+  callerUrl: string;
+  callerRepo: string;
+  registeredRepo: string;
+  registryId: string;
+  version: string;
+  registryTarget: string;
+}
+
+export function rekeyedRegistryVersionAmbiguity(
+  url: string,
+  version: string,
+): RekeyedRegistryVersionAmbiguity | undefined {
+  const spec = version.trim().toLowerCase();
+  if (spec === "nightly" || spec === "unknown" || spec.length === 0) return undefined;
+  const found = rekeyedRecordFor(url);
+  if (!found?.rec.registryTarget) return undefined;
+  return {
+    bare: managerBareName(url),
+    callerUrl: url.trim(),
+    callerRepo: found.repo,
+    registeredRepo: found.rec.repo,
+    registryId: found.rec.id,
+    version: version.trim(),
+    registryTarget: found.rec.registryTarget,
+  };
+}
+
+/**
+ * The refusal for that route. Dropping `version` is NOT the remedy here — unlike
+ * `registryVersionRefusal`, where the from-source path does honour the channel's entry —
+ * because the from-source path cannot reach this repository by name either.
+ */
+export function rekeyedRegistryVersionRefusal(a: RekeyedRegistryVersionAmbiguity): string {
+  return (
+    `REFUSED before dispatch — the version you passed takes this install off the ` +
+    `from-source path, and on the path it lands on your \`repository\` is not read at ` +
+    `all. ComfyUI-Manager only consults a channel's list for version "nightly" or ` +
+    `"unknown"; with an explicit version ("${a.version}") it installs the Comfy Registry ` +
+    `pack whose ID is the bare repo name — here "${a.bare}" — which is registered to ` +
+    `https://github.com/${a.registryTarget}, not to you. You asked for ` +
+    `https://github.com/${a.callerRepo}, and that repository is registered under the id ` +
+    `"${a.registryId}" instead, so the name you sent belongs to somebody else's pack. ` +
+    `Not picked for you: dropping \`version\` does NOT rescue this one — the from-source ` +
+    `route resolves the same name and cannot reach a repository filed under a different ` +
+    `id — so use install_custom_node (source:"git"), which clones the URL you pass ` +
+    `verbatim. If you specifically want the registry pack, pass its id as \`id\` instead ` +
+    `of a URL, so what you are asking for is the thing that gets installed. ` +
+    `(Snapshot measured ${AMBIGUOUS_BARE_NAMES_MEASURED}.)`
+  );
 }
 
 /**

--- a/src/services/manager-bare-name-collisions.ts
+++ b/src/services/manager-bare-name-collisions.ts
@@ -524,12 +524,30 @@ export interface RekeyedRegistryVersionAmbiguity {
   registryTarget: string;
 }
 
+/**
+ * Does this version spec put the install on the FROM-SOURCE path — the one where Manager
+ * reads a channel's list at all? `install_by_id` consults `get_custom_nodes` only for
+ * "unknown"/"nightly" and otherwise goes straight to `cnr_install` (quoted in full above
+ * `RegistryVersionAmbiguity`).
+ *
+ * One predicate for every caller, because the two things it decides are opposites: the
+ * channel-based messages are only TRUE here, and the registry-id ones are only true where
+ * this is false. Two copies that drifted would not fail loudly — each side would simply
+ * describe the wrong route to somebody.
+ *
+ * An absent version counts as from-source: `normalizeGitUrlInstallArgs` sends "nightly"
+ * for it.
+ */
+export function isFromSourceSpec(version: string | undefined): boolean {
+  const spec = version?.trim().toLowerCase() ?? "";
+  return spec === "nightly" || spec === "unknown" || spec.length === 0;
+}
+
 export function rekeyedRegistryVersionAmbiguity(
   url: string,
   version: string,
 ): RekeyedRegistryVersionAmbiguity | undefined {
-  const spec = version.trim().toLowerCase();
-  if (spec === "nightly" || spec === "unknown" || spec.length === 0) return undefined;
+  if (isFromSourceSpec(version)) return undefined;
   const found = rekeyedRecordFor(url);
   if (!found?.rec.registryTarget) return undefined;
   return {
@@ -618,8 +636,7 @@ export function registryVersionAmbiguity(
   url: string,
   version: string,
 ): RegistryVersionAmbiguity | undefined {
-  const spec = version.trim().toLowerCase();
-  if (spec === "nightly" || spec === "unknown" || spec.length === 0) return undefined;
+  if (isFromSourceSpec(version)) return undefined;
   const bare = managerBareName(url);
   const entry = ownCandidates(AMBIGUOUS_BARE_NAMES, bare.trim().toLowerCase());
   if (!entry) return undefined;

--- a/src/services/manager-bare-name-data.ts
+++ b/src/services/manager-bare-name-data.ts
@@ -255,5 +255,132 @@ export const REGISTRY_TARGETS: Readonly<Record<string, string>> = {
   "was-node-suite-comfyui": "WASasquatch/was-node-suite-comfyui",
 };
 
+//
+// #1624 — REPOSITORIES THAT CANNOT BE INSTALLED BY THEIR OWN NAME, AND WHO ANSWERS INSTEAD.
+//
+// Keyed by the caller's `owner/repo`, LOWERCASED: the question this answers is "did the
+// caller name one of these", and a caller types whatever case they like. (The generator
+// throws if two distinct repositories ever collapse onto one such key.)
+//
+// Every repository here is registered in the Comfy Registry under an id that is not its
+// own bare name, so `get_custom_nodes` files it under that id and a bare-name lookup
+// CANNOT return it — from any channel, whatever the channel's list appears to say. What a
+// lookup returns instead is recorded: `channelTargets` per channel, and `registryTarget`
+// for the nightly fallback that fires when the channel carries nothing under the name.
+//
+// Recorded ONLY where something else actually answers. A re-keyed repository whose name
+// resolves nowhere gets Manager's "not found", which installs nobody's code, and is left
+// out rather than turned into a refusal.
+export interface RekeyedSubstitution {
+  /** The repository, cased as the Comfy Registry records it. */
+  readonly repo: string;
+  /** The Comfy Registry id it is filed under — the reason its own name misses. */
+  readonly id: string;
+  /** Per channel, what a bare-name lookup DOES reach under that name. */
+  readonly channelTargets: Readonly<Partial<Record<ManagerChannelName, readonly string[]>>>;
+  /** What `cnr_map[<bare name>]` clones when the channel carries nothing under it. */
+  readonly registryTarget?: string;
+}
+export const REKEYED_SUBSTITUTIONS: Readonly<Record<string, RekeyedSubstitution>> = {
+  "1038lab/comfyui-sparktts": { repo: "1038lab/ComfyUI-SparkTTS", id: "Comfyui-Spark-TTS", channelTargets: {  }, registryTarget: "civen-cn/ComfyUI_SparkTTS" },
+  "1038lab/kittentts": { repo: "1038lab/KittenTTS", id: "ComfyUI-KittenTTS", channelTargets: {  }, registryTarget: "neverbiasu/ComfyUI-KittenTTS" },
+  "aifsh/comfyui-aurasr": { repo: "AIFSH/ComfyUI-AuraSR", id: "AIFSH_ComfyUI-AuraSR", channelTargets: { dev: ["alexisrolland/ComfyUI-AuraSR"] }, registryTarget: "alexisrolland/ComfyUI-AuraSR" },
+  "aigcteam/comfyui_kktranslator_nodes": { repo: "AIGCTeam/ComfyUI_kkTranslator_nodes", id: "kingzcheung_ComfyUI_kkTranslator_nodes", channelTargets: {  }, registryTarget: "kingzcheung/ComfyUI_kkTranslator_nodes" },
+  "akshaylaghate/comfyui_catvton_wrapper": { repo: "AkshayLaghate/ComfyUI_CatVTON_Wrapper", id: "catvton_wrapper", channelTargets: { default: ["chflame163/ComfyUI_CatVTON_Wrapper"] }, registryTarget: "chflame163/ComfyUI_CatVTON_Wrapper" },
+  "akshaylaghate/comfyui_segment_anything": { repo: "AkshayLaghate/comfyui_segment_anything", id: "comfyui_segment_anything_alt", channelTargets: { default: ["storyicon/comfyui_segment_anything"] }, registryTarget: "storyicon/comfyui_segment_anything" },
+  "apache0ne/comfyui-kokoro": { repo: "Apache0ne/ComfyUI-kokoro", id: "ComfyUI-kokoro-TTS", channelTargets: { default: ["stavsap/comfyui-kokoro"] }, registryTarget: "stavsap/comfyui-kokoro" },
+  "bikecicle/comfyui-waveform-extensions": { repo: "Bikecicle/ComfyUI-Waveform-Extensions", id: "Bikecicle_ComfyUI-Waveform-Extensions", channelTargets: {  }, registryTarget: "NeuralNotW0rk/ComfyUI-Waveform-Extensions" },
+  "cy-chenyue/comfyui-gemini-api": { repo: "CY-CHENYUE/ComfyUI-Gemini-API", id: "gemini-api", channelTargets: { dev: ["JiangAogo/ComfyUI-Gemini-API"] } },
+  "cyber-bcat/comfyui_auto_caption": { repo: "Cyber-BCat/ComfyUI_Auto_Caption", id: "Cyber-BCat_ComfyUI_Auto_Caption", channelTargets: { default: ["Cyber-BlackCat/ComfyUI_Auto_Caption"] }, registryTarget: "Cyber-BlackCat/ComfyUI_Auto_Caption" },
+  "darioft/comfyui-qwen3-asr": { repo: "DarioFT/ComfyUI-Qwen3-ASR", id: "comfyui-qwen-asr", channelTargets: { default: ["kaushiknishchay/ComfyUI-Qwen3-ASR"] }, registryTarget: "kaushiknishchay/ComfyUI-Qwen3-ASR" },
+  "delcado19/comfyui-nag": { repo: "Delcado19/ComfyUI-NAG", id: "comfyui-nag-delcado", channelTargets: { default: ["ChenDarYen/ComfyUI-NAG"] }, registryTarget: "AkshayLaghate/ComfyUI-NAG" },
+  "delcado19/comfyui-nodes-docs": { repo: "Delcado19/comfyui-nodes-docs", id: "comfyui-nodes-docs-en", channelTargets: { default: ["CavinHuang/comfyui-nodes-docs"] }, registryTarget: "CavinHuang/comfyui-nodes-docs" },
+  "docworkbox/heartmula_comfyui": { repo: "DocWorkBox/HeartMuLa_ComfyUI", id: "zhaoke1006-heartmula-comfyui", channelTargets: {  }, registryTarget: "benjiyaya/HeartMuLa_ComfyUI" },
+  "flibens/comfyui-image-browser": { repo: "Flibens/comfyui-image-browser", id: "image-browser", channelTargets: {  }, registryTarget: "laurigates/comfyui-image-browser" },
+  "franckyb/comfyui-prompt-manager": { repo: "FranckyB/ComfyUI-Prompt-Manager", id: "prompt-manager", channelTargets: { dev: ["colorAi/comfyui-prompt-manager"] }, registryTarget: "colorAi/comfyui-prompt-manager" },
+  "guardskill/comfyui-elevenlabs": { repo: "GuardSkill/ComfyUI-ElevenLabs", id: "ElevenLabs", channelTargets: { default: ["jerilseb/ComfyUI-ElevenLabs"], recent: ["jerilseb/ComfyUI-ElevenLabs"] } },
+  "juanberta/comfyui_ollama_vl_prompt": { repo: "JuanBerta/comfyui_ollama_vl_prompt", id: "ollama_vl_prompt", channelTargets: {  }, registryTarget: "JuanBerta/ollama_vl_prompt" },
+  "juanberta/ollama_vl_prompt": { repo: "JuanBerta/ollama_vl_prompt", id: "comfyui_ollama_vl_prompt", channelTargets: { default: ["JuanBerta/comfyui_ollama_vl_prompt"] }, registryTarget: "JuanBerta/comfyui_ollama_vl_prompt" },
+  "karurochori/comfy_felsirnodes": { repo: "KaruroChori/Comfy_Felsirnodes", id: "felsir-image-tools", channelTargets: {  }, registryTarget: "Felsir/Comfy_Felsirnodes" },
+  "koinnai/comfyui-dynpromptsimplified": { repo: "KoinnAI/ComfyUI-DynPromptSimplified", id: "dynpromptsimplified", channelTargets: { default: ["RegulusAlpha/ComfyUI-DynPromptSimplified"] } },
+  "mattabyte/comfyui-gguf": { repo: "Mattabyte/ComfyUI-GGUF", id: "ComfyUI-GGUF_Forked", channelTargets: { default: ["city96/ComfyUI-GGUF"] }, registryTarget: "city96/ComfyUI-GGUF" },
+  "mattabyte/comfyui-gimm-vfi": { repo: "Mattabyte/ComfyUI-GIMM-VFI", id: "comfy-gimm-vfi", channelTargets: { default: ["kijai/ComfyUI-GIMM-VFI"] }, registryTarget: "kijai/ComfyUI-GIMM-VFI" },
+  "mattabyte/comfyui-wanvideowrapper": { repo: "Mattabyte/ComfyUI-WanVideoWrapper", id: "ComfyUI-WanVideoWrapper_ALPHA", channelTargets: { default: ["kijai/ComfyUI-WanVideoWrapper"] }, registryTarget: "kijai/ComfyUI-WanVideoWrapper" },
+  "momentfactory/comfyui-mf-piponodes": { repo: "MomentFactory/ComfyUI-MF-PipoNodes", id: "mf-piponodes", channelTargets: { default: ["pierreb-mf/ComfyUI-MF-PipoNodes"] } },
+  "pozzettiandrea/comfyui-pixal3d": { repo: "PozzettiAndrea/ComfyUI-Pixal3D", id: "ComfyUI-Pixal3D-Pozzetti", channelTargets: { default: ["dreamrec/ComfyUI-Pixal3D"] }, registryTarget: "dreamrec/ComfyUI-Pixal3D" },
+  "ruffy-369/comfyui-streamdiffusion": { repo: "RUFFY-369/ComfyUI-StreamDiffusion", id: "streamdiffusion", channelTargets: { dev: ["pschroedl/ComfyUI-StreamDiffusion"] } },
+  "rinne414/comfyui-bananaforge": { repo: "Rinne414/ComfyUI-BananaForge", id: "bananaforge", channelTargets: { default: ["peter119lee/ComfyUI-BananaForge"] } },
+  "sxqbw/comfyui-qwen": { repo: "SXQBW/ComfyUI-Qwen", id: "ComfyUI-Qwen3", channelTargets: { dev: ["Lovzu/ComfyUI-Qwen", "ZHO-ZHO-ZHO/ComfyUI-Qwen", "mr-krak3n/ComfyUI-Qwen"] }, registryTarget: "ZHO-ZHO-ZHO/ComfyUI-Qwen" },
+  "saganaki22/comfyui-kittentts": { repo: "Saganaki22/ComfyUI-KittenTTS", id: "comfyui-kitten-tts", channelTargets: { default: ["Lovzu/ComfyUI-KittenTTS"] }, registryTarget: "1038lab/KittenTTS" },
+  "sergey004/comfyui-telegram-sender": { repo: "Sergey004/ComfyUI-Telegram-Sender", id: "telegram-sender", channelTargets: { dev: ["gulajawalegit/ComfyUI-Telegram-Sender"] } },
+  "t8mars/comfyui-purgevram": { repo: "T8mars/comfyui-purgevram", id: "purgevram", channelTargets: { legacy: ["T8star1984/comfyui-purgevram"] } },
+  "tothebeginning/comfyui-dreamo": { repo: "ToTheBeginning/ComfyUI-DreamO", id: "dreamo", channelTargets: { dev: ["jax-explorer/ComfyUI-DreamO"] } },
+  "ttl/comfyui_nnlatentupscale": { repo: "Ttl/ComfyUi_NNLatentUpscale", id: "Ttl_ComfyUi_NNLatentUpscale", channelTargets: {  }, registryTarget: "Goktug/ComfyUi_NNLatentUpscale" },
+  "zho-zho-zho/comfyui-gemini": { repo: "ZHO-ZHO-ZHO/ComfyUI-Gemini", id: "ZHO-ZHO-ZHO_ComfyUI-Gemini", channelTargets: { default: ["Visionatrix/ComfyUI-Gemini"], dev: ["NakanoSanku/ComfyUI-Gemini"] }, registryTarget: "Visionatrix/ComfyUI-Gemini" },
+  "zuellni/comfyui-custom-nodes": { repo: "Zuellni/ComfyUI-Custom-Nodes", id: "Zuellni_ComfyUI-Custom-Nodes", channelTargets: { default: ["rcsaquino/comfyui-custom-nodes"], dev: ["DanielBartolic/comfyui-custom-nodes", "artisanalcomputing/ComfyUI-Custom-Nodes", "brycegoh/comfyui-custom-nodes"], tutorial: ["foxtrot-roger/comfyui-custom-nodes"] }, registryTarget: "rcsaquino/comfyui-custom-nodes" },
+  "ai-joe-git/comfyui-qwen3-tts": { repo: "ai-joe-git/ComfyUI-Qwen3-TTS", id: "comfyui-simple-qwen3-tts", channelTargets: { legacy: ["ncky/ComfyUI-Qwen3-TTS"], dev: ["DarioFT/ComfyUI-Qwen3-TTS", "NaomiVK/comfyui-qwen3-tts", "amenoyoya/ComfyUI-Qwen3-TTS"] }, registryTarget: "DarioFT/ComfyUI-Qwen3-TTS" },
+  "ai-joe-git/comfyui-faster-whisper": { repo: "ai-joe-git/ComfyUI-faster-whisper", id: "comfyui-fast-whisper", channelTargets: {  }, registryTarget: "jhj0517/ComfyUI-faster-whisper" },
+  "aistudynow/comfyui-qwenvl": { repo: "aistudynow/ComfyUI-QwenVL", id: "aistudynow-qwenvl", channelTargets: { default: ["1038lab/ComfyUI-QwenVL"], dev: ["Malloc-pix/comfyui-QwenVL"] }, registryTarget: "1038lab/ComfyUI-QwenVL" },
+  "awsl1110/comfyui-oss-upload": { repo: "awsl1110/ComfyUI-OSS-Upload", id: "oss-upload", channelTargets: { dev: ["ahkimkoo/ComfyUI-OSS-Upload"] }, registryTarget: "ahkimkoo/ComfyUI-OSS-Upload" },
+  "benjiyaya/comfyui-kokorotts": { repo: "benjiyaya/ComfyUI-KokoroTTS", id: "benjiyaya_ComfyUI-KokoroTTS", channelTargets: {  }, registryTarget: "1038lab/ComfyUI-KokoroTTS" },
+  "billwuhao/comfyui_csm": { repo: "billwuhao/ComfyUI_CSM", id: "csm_mw", channelTargets: { legacy: ["AiSatan/ComfyUI_CSM"] } },
+  "brantje/comfyui_magicquill": { repo: "brantje/ComfyUI_MagicQuill", id: "comfyui_magicquill_fixed", channelTargets: { legacy: ["magic-quill/ComfyUI_MagicQuill"] }, registryTarget: "magic-quill/ComfyUI_MagicQuill" },
+  "bytedance/comfyui_infiniteyou": { repo: "bytedance/ComfyUI_InfiniteYou", id: "infiniteyou", channelTargets: { dev: ["ZenAI-Vietnam/ComfyUI_InfiniteYou"] } },
+  "ciga2011/comfyui-pollinations": { repo: "ciga2011/ComfyUI-Pollinations", id: "pollinations", channelTargets: { default: ["1038lab/ComfyUI-Pollinations"] }, registryTarget: "1038lab/ComfyUI-Pollinations" },
+  "deforum-art/deforum-comfy-nodes": { repo: "deforum-art/deforum-comfy-nodes", id: "comfyui-deforum", channelTargets: { default: ["XmYx/deforum-comfy-nodes"] }, registryTarget: "XmYx/deforum-comfy-nodes" },
+  "diffus3/comfyui-extensions": { repo: "diffus3/ComfyUI-extensions", id: "diffus3_ComfyUI-extensions", channelTargets: {  }, registryTarget: "ailex000/ComfyUI-Extensions" },
+  "dseditor/comfyui-listhelper": { repo: "dseditor/ComfyUI-ListHelper", id: "Listhelper", channelTargets: { dev: ["panchovial-max/ComfyUI-ListHelper"] } },
+  "eliteprox/comfyui-sam2-realtime": { repo: "eliteprox/ComfyUI-SAM2-Realtime", id: "sam2_realtime_forktest", channelTargets: { default: ["pschroedl/ComfyUI-SAM2-Realtime"] }, registryTarget: "pschroedl/ComfyUI-SAM2-Realtime" },
+  "endman100/comfyui-qwen3-asr": { repo: "endman100/ComfyUI-Qwen3-ASR", id: "comfyui-qwen3-asr-endman100", channelTargets: { default: ["kaushiknishchay/ComfyUI-Qwen3-ASR"] }, registryTarget: "kaushiknishchay/ComfyUI-Qwen3-ASR" },
+  "eokoo/comfyui-photopea": { repo: "eokoo/ComfyUI-Photopea", id: "ComfyUI_Photopea", channelTargets: { default: ["coolzilj/ComfyUI-Photopea"] }, registryTarget: "coolzilj/ComfyUI-Photopea" },
+  "ethanfel/comfyui-omnivoice": { repo: "ethanfel/ComfyUI-Omnivoice", id: "comfyui-omnivoice-fel", channelTargets: { default: ["PGCRT/ComfyUI-OmniVoice_CRT"] }, registryTarget: "PGCRT/ComfyUI-OmniVoice_CRT" },
+  "evrardt/comfyui-spectrum": { repo: "evrardt/ComfyUI-Spectrum", id: "lafabrique-spectrum-flux", channelTargets: { dev: ["benjiyaya/ComfyUI-Spectrum"] } },
+  "flybirdxx/comfyui-qwen-tts": { repo: "flybirdxx/ComfyUI-Qwen-TTS", id: "qwen3-tts-comfyui", channelTargets: {  }, registryTarget: "mailzwj/ComfyUI-Qwen-TTS" },
+  "fredconex/comfyui-soundflow": { repo: "fredconex/ComfyUI-SoundFlow", id: "soundflow", channelTargets: { forked: ["huixingyun/ComfyUI-SoundFlow"] } },
+  "fredconex/comfyui-triposg": { repo: "fredconex/ComfyUI-TripoSG", id: "triposg", channelTargets: {  }, registryTarget: "tungnguyensipher/ComfyUI-TripoSG" },
+  "hben35096/comfyui-toolbox": { repo: "hben35096/ComfyUI-ToolBox", id: "hben35096_ComfyUI-ToolBox", channelTargets: { default: ["zcfrank1st/Comfyui-Toolbox"], dev: ["synthetai/ComfyUI-ToolBox"] }, registryTarget: "zcfrank1st/Comfyui-Toolbox" },
+  "hekmon/comfyui-openai-api": { repo: "hekmon/comfyui-openai-api", id: "openai-api", channelTargets: {  }, registryTarget: "bgreene2/ComfyUI-OpenAI-API" },
+  "hieuck/comfyui-birefnet": { repo: "hieuck/ComfyUI-BiRefNet", id: "viperyl_ComfyUI-BiRefNet", channelTargets: { legacy: ["viperyl/ComfyUI-BiRefNet"], dev: ["MohammadAboulEla/ComfyUI-BiRefNet"] }, registryTarget: "viperyl/ComfyUI-BiRefNet" },
+  "hylarucoder/comfyui-copilot": { repo: "hylarucoder/comfyui-copilot", id: "hylarucoder_comfyui-copilot", channelTargets: { default: ["AIDC-AI/ComfyUI-Copilot"] }, registryTarget: "AIDC-AI/ComfyUI-Copilot" },
+  "juemingai/comfyui-jm-gemini-api": { repo: "juemingai/ComfyUI-JM-Gemini-API", id: "jm-gemini-api", channelTargets: { default: ["synthetai/ComfyUI-JM-Gemini-API"] } },
+  "katalist-ai/comfyui-nsfw-detection": { repo: "katalist-ai/comfyUI-nsfw-detection", id: "katalist-ai_comfyUI-nsfw-detection", channelTargets: { default: ["trumanwong/ComfyUI-NSFW-Detection"] }, registryTarget: "trumanwong/ComfyUI-NSFW-Detection" },
+  "kosbeko/comfyui-glifnodes": { repo: "kosbeko/ComfyUI-GlifNodes", id: "comfyui-glifnodes-fork", channelTargets: { default: ["glifxyz/ComfyUI-GlifNodes"] }, registryTarget: "glifxyz/ComfyUI-GlifNodes" },
+  "laubsauger/comfyui-storyboard": { repo: "laubsauger/comfyui-storyboard", id: "storyboard", channelTargets: {  }, registryTarget: "colorAi/comfyui-storyboard" },
+  "lordgasmic/comfyui-wildcards": { repo: "lordgasmic/ComfyUI-Wildcards", id: "lordgasmic_ComfyUI-Wildcards", channelTargets: { default: ["lordgasmic/comfyui_wildcards"] }, registryTarget: "lordgasmic/comfyui_wildcards" },
+  "ltdrdata/was-node-suite-comfyui": { repo: "ltdrdata/was-node-suite-comfyui", id: "was-ns", channelTargets: { legacy: ["WASasquatch/was-node-suite-comfyui"] }, registryTarget: "WASasquatch/was-node-suite-comfyui" },
+  "m957ymj75urz/comfyui-custom-nodes": { repo: "m957ymj75urz/ComfyUI-Custom-Nodes", id: "m957ymj75urz_ComfyUI-Custom-Nodes", channelTargets: { default: ["rcsaquino/comfyui-custom-nodes"], dev: ["DanielBartolic/comfyui-custom-nodes", "artisanalcomputing/ComfyUI-Custom-Nodes", "brycegoh/comfyui-custom-nodes"], tutorial: ["foxtrot-roger/comfyui-custom-nodes"] }, registryTarget: "rcsaquino/comfyui-custom-nodes" },
+  "mailzwj/comfyui-qwen3-asr": { repo: "mailzwj/ComfyUI-Qwen3-ASR", id: "comfyui_qwen3_asr", channelTargets: { default: ["kaushiknishchay/ComfyUI-Qwen3-ASR"] }, registryTarget: "kaushiknishchay/ComfyUI-Qwen3-ASR" },
+  "molbal/comfyui-gguf": { repo: "molbal/ComfyUI-GGUF", id: "comfyui-gguf-reboot", channelTargets: { default: ["city96/ComfyUI-GGUF"] }, registryTarget: "city96/ComfyUI-GGUF" },
+  "mr-pepe69/comfyui-selectstringfromlistwithindex": { repo: "mr-pepe69/ComfyUI-SelectStringFromListWithIndex", id: "Iterator-Nodes-MrPepe", channelTargets: { default: ["wirytiox/ComfyUI-SelectStringFromListWithIndex"] } },
+  "muse-collective-26/minimaxh3-director": { repo: "muse-collective-26/MiniMaxH3-Director", id: "muse-minimax-director", channelTargets: {  }, registryTarget: "seesee75-commits/ComfyUI-MiniMaxH3-Director" },
+  "nazgut/comfyui-pulid-flux-chroma": { repo: "nazgut/ComfyUI-PuLID-Flux-Chroma", id: "pulid-flux-chroma", channelTargets: { default: ["PaoloC68/ComfyUI-PuLID-Flux-Chroma"] } },
+  "neverbiasu/comfyui-kittentts": { repo: "neverbiasu/ComfyUI-KittenTTS", id: "kittentts", channelTargets: { default: ["Lovzu/ComfyUI-KittenTTS"] }, registryTarget: "1038lab/KittenTTS" },
+  "npiriou/comfyui-pid": { repo: "npiriou/ComfyUI-PiD", id: "nvidia-pid-decoder", channelTargets: { default: ["Merserk/ComfyUI-PiD"] }, registryTarget: "Merserk/ComfyUI-PiD" },
+  "open-ghibli/comfyui-easycontrol": { repo: "open-ghibli/ComfyUI-EasyControl", id: "EasyControl", channelTargets: { default: ["jax-explorer/ComfyUI-easycontrol"] } },
+  "pamparamm/comfyui_ipadapter_plus": { repo: "pamparamm/ComfyUI_IPAdapter_plus", id: "comfyui_ipadapter_plus_fork", channelTargets: { default: ["cubiq/ComfyUI_IPAdapter_plus"] }, registryTarget: "cubiq/ComfyUI_IPAdapter_plus" },
+  "rabanti-github/comfymath": { repo: "rabanti-github/ComfyMath", id: "comfymath-ng", channelTargets: { default: ["evanspearman/ComfyMath"] }, registryTarget: "evanspearman/ComfyMath" },
+  "rafek1241/comfy-pilot": { repo: "rafek1241/comfy-pilot", id: "comfyui-pilot-extended", channelTargets: {  }, registryTarget: "ConstantineB6/comfy-pilot" },
+  "rslosh/comfyui-nodesweet": { repo: "rslosh/comfyui-nodesweet", id: "nodesweet", channelTargets: { default: ["rslosch/comfyui-nodesweet"] } },
+  "silveroxides/comfyui_bitsandbytes_nf4": { repo: "silveroxides/ComfyUI_bitsandbytes_NF4", id: "ComfyUI_bnb_nf4_fp4_Loaders", channelTargets: { dev: ["comfyanonymous/ComfyUI_bitsandbytes_NF4"] } },
+  "silveroxides/comfyui-lama-remover": { repo: "silveroxides/comfyui-lama-remover", id: "ComfyUI_Lama_Remover_Revived", channelTargets: { default: ["Layer-norm/comfyui-lama-remover"] }, registryTarget: "Layer-norm/comfyui-lama-remover" },
+  "sinfisum/comfyui-prompter": { repo: "sinfisum/comfyui-prompter", id: "prompter", channelTargets: { dev: ["saltchicken/ComfyUI-Prompter"] } },
+  "space-nuko/comfyui-openpose-editor": { repo: "space-nuko/ComfyUI-OpenPose-Editor", id: "space-nuko_ComfyUI-OpenPose-Editor", channelTargets: { default: ["huchenlei/ComfyUI-openpose-editor"] }, registryTarget: "huchenlei/ComfyUI-openpose-editor" },
+  "starsfriday/comfyui-matanyone2": { repo: "starsFriday/ComfyUI-MatAnyone2", id: "MatAnyone2", channelTargets: { default: ["ijoy222333/ComfyUI-MatAnyone2"], dev: ["AJbeckliy/ComfyUI-MatAnyone2"] } },
+  "starsfriday/comfyui-qwen3-tts": { repo: "starsFriday/ComfyUI-Qwen3-TTS", id: "Qwen3-TTS-Audio", channelTargets: { legacy: ["ncky/ComfyUI-Qwen3-TTS"], dev: ["DarioFT/ComfyUI-Qwen3-TTS", "NaomiVK/comfyui-qwen3-tts", "amenoyoya/ComfyUI-Qwen3-TTS"] }, registryTarget: "DarioFT/ComfyUI-Qwen3-TTS" },
+  "starsfriday/comfyui-sapiens2": { repo: "starsFriday/ComfyUI-Sapiens2", id: "Sapiens2", channelTargets: {  }, registryTarget: "kijai/ComfyUI-Sapiens2" },
+  "starsfriday/comfyui-voxcpm": { repo: "starsFriday/ComfyUI-VoxCPM", id: "VoxCPM2", channelTargets: { default: ["wildminder/ComfyUI-VoxCPM"] }, registryTarget: "wildminder/ComfyUI-VoxCPM" },
+  "symbiotica-ai/comfyui-nodes": { repo: "symbiotica-ai/comfyui-nodes", id: "symbiotica", channelTargets: { dev: ["Ronnasayd/comfyui-nodes"] } },
+  "time-river/comfyui-clipseg": { repo: "time-river/ComfyUI-CLIPSeg", id: "time-river_ComfyUI-CLIPSeg", channelTargets: { dev: ["shadowcz007/comfyui-CLIPSeg", "zhengxyz123/ComfyUI-CLIPSeg"] }, registryTarget: "alessandrozonta/ComfyUI-CLIPSeg" },
+  "trashkollector/tknodes": { repo: "trashkollector/TKNodes", id: "ComfyUI-HandyNodes-KT", channelTargets: { default: ["throttlekitty/tkNodes"] } },
+  "wanaigc/comfyui-qwen3-tts": { repo: "wanaigc/ComfyUI-Qwen3-TTS", id: "qwen3-tts", channelTargets: { legacy: ["ncky/ComfyUI-Qwen3-TTS"], dev: ["DarioFT/ComfyUI-Qwen3-TTS", "NaomiVK/comfyui-qwen3-tts", "amenoyoya/ComfyUI-Qwen3-TTS"] }, registryTarget: "DarioFT/ComfyUI-Qwen3-TTS" },
+  "wildminder/comfyui-chatterbox": { repo: "wildminder/ComfyUI-Chatterbox", id: "ComfyUI-ChatterboxTTS", channelTargets: { dev: ["ai-joe-git/ComfyUI-Chatterbox"] }, registryTarget: "sm079/comfyui-chatterbox" },
+  "xmarre/comfyui-cfg-ctrl": { repo: "xmarre/ComfyUI-CFG-Ctrl", id: "cfg-ctrl", channelTargets: { default: ["flyghtxmz/ComfyUI-CFG-Ctrl"], dev: ["ethanfel/ComfyUI-CFG-CTRL"] } },
+  "yabo083/comfyui-saveimages3": { repo: "yabo083/ComfyUI-SaveImageS3", id: "comfyui-saveimages3-r2-sidebar", channelTargets: { default: ["mrchipset/ComfyUI-SaveImageS3"] }, registryTarget: "mrchipset/ComfyUI-SaveImageS3" },
+  "yichengup/comfyui-deepseek": { repo: "yichengup/Comfyui-Deepseek", id: "yichengup_Comfyui-Deepseek", channelTargets: { dev: ["neverbiasu/ComfyUI-DeepSeek", "yanhuifair/comfyui-deepseek"] }, registryTarget: "yanhuifair/comfyui-deepseek" },
+  "yourusername/comfyui_qwen3-vl": { repo: "yourusername/ComfyUI_Qwen3-VL", id: "ComfyUI-Qwen3-VL", channelTargets: { dev: ["xuchenxu168/ComfyUI_Qwen3-VL"] } },
+  "zade23/comfyui-moge2": { repo: "zade23/ComfyUI-MoGe2", id: "moge2", channelTargets: {  }, registryTarget: "PozzettiAndrea/ComfyUI-MoGe2" },
+  "zhonglushu/comfyui_frontend_vue_basic": { repo: "zhonglushu/ComfyUI_frontend_vue_basic", id: "comfyui_browser_url_workflow", channelTargets: { dev: ["jtydhr88/ComfyUI_frontend_vue_basic"] }, registryTarget: "jtydhr88/ComfyUI_frontend_vue_basic" },
+};
+
 /** When AMBIGUOUS_BARE_NAMES was measured, for the refusal to cite. */
 export const AMBIGUOUS_BARE_NAMES_MEASURED = "2026-08-15";

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -34,6 +34,11 @@ import {
   bareNameAmbiguity,
   registryVersionAmbiguity,
   registryVersionRefusal,
+  rekeyedRegistryVersionAmbiguity,
+  rekeyedRegistryVersionRefusal,
+  rekeyedRepoAmbiguity,
+  rekeyedRepoRefusal,
+  rekeyedRepoWarning,
 } from "./manager-bare-name-collisions.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -4571,12 +4576,32 @@ export function nodesInstallCommandArgs(args: {
       ? registryVersionAmbiguity(norm.repository, norm.version)
       : undefined;
   if (registryAmbiguity) return { conflict: registryVersionRefusal(registryAmbiguity) };
+  // #1624 — THE SAME REGISTRY-ROUTE HAZARD FOR A REPO THAT NO CHANNEL CONTESTS. Above is
+  // scoped to the contested names; a repository filed under a Comfy Registry id that is
+  // not its own name loses the id race just as completely, and needs no second channel to
+  // do it. Same route, same reason it takes no channel bypass — Manager reads no channel
+  // here — so it is refused in the same place rather than warned about later.
+  const rekeyedVersionAmbiguity =
+    rerouted && norm.repository && norm.version
+      ? rekeyedRegistryVersionAmbiguity(norm.repository, norm.version)
+      : undefined;
+  if (rekeyedVersionAmbiguity) {
+    return { conflict: rekeyedRegistryVersionRefusal(rekeyedVersionAmbiguity) };
+  }
   // Past that return, the request is necessarily on the from-source route — a contested
   // name with a registry version has already been refused — so the channel-based
   // reasoning below is only ever applied where a channel is actually consulted.
   const ambiguity =
     rerouted && norm.repository ? bareNameAmbiguity(norm.repository, effectiveChannel) : undefined;
   if (ambiguity && defaultedChannel) return { conflict: ambiguousBareNameRefusal(ambiguity) };
+  // #1624 — AND THE FROM-SOURCE ROUTE FOR THE SAME REPOSITORIES. Consulted only when the
+  // contested-name table said nothing, because when it DOES fire it already reasons about
+  // re-keying (`REKEYED_REPOS`) for that name and a second message would say it twice.
+  const rekeyed =
+    rerouted && norm.repository && !ambiguity
+      ? rekeyedRepoAmbiguity(norm.repository, effectiveChannel)
+      : undefined;
+  if (rekeyed && defaultedChannel) return { conflict: rekeyedRepoRefusal(rekeyed) };
   // The substitution warning rides EVERY git-URL install (gate round 2), because
   // bare-name resolution is a property of the v4 from-source route rather than of
   // who chose the channel — an explicit `channel:"dev"` substitutes just as readily.
@@ -4585,6 +4610,7 @@ export function nodesInstallCommandArgs(args: {
       norm.note,
       rerouted && norm.repository ? gitInstallSubstitutionNote(effectiveChannel, norm.repository) : undefined,
       ambiguity ? ambiguousBareNameWarning(ambiguity) : undefined,
+      rekeyed ? rekeyedRepoWarning(rekeyed) : undefined,
       defaultedChannel ? gitInstallChannelNote(GIT_INSTALL_DEFAULT_CHANNEL) : undefined,
     ]
       .filter((s): s is string => typeof s === "string" && s.length > 0)

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -32,6 +32,7 @@ import {
   ambiguousBareNameRefusal,
   ambiguousBareNameWarning,
   bareNameAmbiguity,
+  isFromSourceSpec,
   registryVersionAmbiguity,
   registryVersionRefusal,
   rekeyedRegistryVersionAmbiguity,
@@ -4597,8 +4598,20 @@ export function nodesInstallCommandArgs(args: {
   // #1624 — AND THE FROM-SOURCE ROUTE FOR THE SAME REPOSITORIES. Consulted only when the
   // contested-name table said nothing, because when it DOES fire it already reasons about
   // re-keying (`REKEYED_REPOS`) for that name and a second message would say it twice.
+  //
+  // GATE FINDING — AND ONLY ON THE ROUTE THAT READS A CHANNEL. The two returns above do
+  // NOT leave "necessarily from-source" true for this table the way they do for the
+  // contested one. `registryVersionAmbiguity` covers every contested name a channel can
+  // answer to, but `rekeyedRegistryVersionAmbiguity` requires a `registryTarget`, and 12
+  // of the 98 re-keyed records have none — the registry holds nothing under their bare
+  // name. For those, an explicit version fell through to a refusal that told the caller
+  // the channel's list was what would be cloned, when on that route Manager calls
+  // `cnr_install(bare, version)`, reads no channel, finds no such id and fails. Refusing
+  // was directionally defensible and the remedy it named was even correct, which is how a
+  // fabricated mechanism survives review — so the check is scoped to the route it
+  // describes, and Manager's own "not found" (which substitutes nobody's code) stands.
   const rekeyed =
-    rerouted && norm.repository && !ambiguity
+    rerouted && norm.repository && !ambiguity && isFromSourceSpec(norm.version)
       ? rekeyedRepoAmbiguity(norm.repository, effectiveChannel)
       : undefined;
   if (rekeyed && defaultedChannel) return { conflict: rekeyedRepoRefusal(rekeyed) };


### PR DESCRIPTION
Closes #1624.

ComfyUI-Manager v4 does not resolve a from-source install by the URL you pass. It files
each channel entry under the pack's **Comfy Registry id** when the repo is registered, and
under the bare repo name only when it is not — so a repository registered under an id that
is not its own name is unreachable by that name, and something else answers instead.

#1619 refuses this only where the bare name is **contested** across the six channel lists.
The hazard needs no contest at all, which is what #1624 was split out to say.

## The mechanism, read at tag 4.2.2

Read at **`4.2.2`**, not at `main`. `main` is the **3.41** line — its `install_by_id` has
no CNR fallback whatsoever, so quoting `main` here would have described code that does not
run on any v4 host. (The channel URLs in `channels.list.template` *do* point at `main`,
which is why the generator still fetches the lists from there.)

```python
# get_custom_nodes — comfyui_manager/glob/manager_core.py @ 4.2.2
cnr = self.get_cnr_by_repo(v['files'][0])      # repo_cnr_map: a PLAIN dict on a
if cnr:                                        # case-PRESERVING normalize_url
    v['id'] = cnr['id']; node_id = v['id']     # <- the CNR ID
else:
    node_id = v['files'][0].split('/')[-1]     # <- the bare repo name
res[node_id] = v                               # NormalizedKeyDict; get() lowercases

# install_by_id, nightly branch
the_node = custom_nodes.get(node_id)
if the_node is None and version_spec == 'nightly':
    cnr_fallback = self.cnr_map.get(node_id)
    repo_url = cnr_fallback['repository']      # <- CLONES THE REGISTRY'S REPO
```

The panel sends `version: "nightly"` for every git URL on the v2/v4 dialect
(`manager-install.js`), so that fallback is reachable from this tool, not hypothetical.

## What was measured

Replaying that resolution over the six published channel lists **plus the whole Comfy
Registry** (5117 repositories, fetched 2026-08-15):

| | |
|---|---|
| repositories re-keyed (registered under an id ≠ their bare name) | **1366** |
| …of those, resolve to **nothing** — Manager answers "not found" | 1268 |
| …of those, resolve to a **different repository** | **98** |
| …on the channel this code defaults to | **84** |
| …**missed by #1619's contested-name table** | **56** |

The 1268 are deliberately **not** recorded. Manager returns `Node '<name>@nightly' not
found`, installs nobody's code, and turning a clean failure into a refusal is a different
bug from this one.

Concrete examples of the 56, none of which needs a channel collision:

```
Mattabyte/ComfyUI-GGUF        registered "ComfyUI-GGUF_Forked"  -> city96/ComfyUI-GGUF
hekmon/comfyui-openai-api     registered "openai-api"           -> bgreene2/ComfyUI-OpenAI-API
1038lab/KittenTTS             registered "ComfyUI-KittenTTS"    -> neverbiasu/ComfyUI-KittenTTS
pamparamm/ComfyUI_IPAdapter_plus  registered "…_fork"           -> cubiq/ComfyUI_IPAdapter_plus
```

## Why a precomputed verdict, and not the map #1624 asked for

#1624 proposed mirroring the registry's `repository -> id` **and** `id -> repository` maps
into the snapshot and simulating at call time, and costed that at ~5163 rows churning
continuously. The simulation is the right idea; shipping its *input* is not:

* both directions of a 5117-row table exist to answer one yes/no question per repository,
  and that answer never varies per caller;
* a runtime simulation would be a **second implementation** of Manager's keying, free to
  drift from the generator's.

So the generator runs the simulation once — against registry data it already fetched in
the same pass, for `REKEYED_REPOS` — and emits only the repositories whose answer is
"someone else": **98 records**, not 5117 rows. Same verdicts, one implementation, and the
losing 1268 never enter the snapshot.

## What it does

`REKEYED_SUBSTITUTIONS` is keyed by the caller's lowercased `owner/repo` and records the
id it is filed under, what each channel's list *does* answer to the name, and what
`cnr_map[name]` clones on a miss.

* **from-source route, channel defaulted** → refused, naming the repository that would
  actually land and the id that makes theirs unreachable. Unlike #1619's refusal there is
  no channel that could aim it — the id is not the name on *any* channel — so the remedy
  offered is `install_custom_node (source:"git")`, which clones the URL verbatim.
* **from-source route, channel named** → dispatches (their choice; and on Manager 3.x the
  URL passed *is* what gets cloned) with a warning that does **not** repeat #1619's "you
  chose the channel" framing, because here the channel choice decided nothing.
* **registry-version route** → refused too. An explicit version skips `get_custom_nodes`
  entirely and installs the registry pack whose id is the bare name, which for these
  repositories is by definition someone else's. Dropping `version` is **not** offered as
  the remedy here — unlike #1619's version refusal — because the from-source route cannot
  reach the repository by name either.

Where both tables know a repository (`wildminder/ComfyUI-Chatterbox` is in both), #1619's
message stays in charge; the two are pinned to agree on the landing.

## What it deliberately does not cover

Keyed by the **caller's** repository, so it fires only for repositories the registry knows.
An unregistered, unlisted fork named `ComfyUI-GGUF` hits exactly the same substitution and
is not in here — that set is not enumerable from any snapshot. Those keep today's
behaviour and the standing dispatch note. Stated in the module, not implied.

## Verification

* **Mutation-tested, six mutations, all killed.** Two survived the first pass and got tests
  written for them: dropping the `!ambiguity` ordering guard (free on the refusal path,
  which returns at the first conflict — load-bearing on the *warning* path, where both
  messages ride one `note`), and dropping the "resolves to nothing" branch. The three
  wiring deletions each kill a distinct call-site test, so the one-line `if`s are not
  invisible to the suite.
* Full suite green: **517 files, 9696 passed**, 3 skipped.
* `tsc --noEmit` clean — and verified non-vacuous by planting a type error in the edited
  file and watching it fail.
* Registry and channel data re-fetched live; the regenerated data file is **pure
  additions** (127 lines) — `AMBIGUOUS_BARE_NAMES`, `REKEYED_REPOS` and `REGISTRY_TARGETS`
  are byte-identical to what #1619 shipped.
* **No browser verification, and none is implied.** Nothing in the panel repo changes;
  this is a pre-dispatch decision in the orchestrator that either returns a `conflict` or
  the same args as before.
