### PR TITLE
fix(1634): a node read by id returns its full widget value, not a survey clip

### DIFF
--- a/src/__tests__/services/graph-query.test.ts
+++ b/src/__tests__/services/graph-query.test.ts
@@ -350,4 +350,79 @@ describe("queryApiGraph", () => {
       expect(r.text).toContain("narrow with `types`/`where`/`ids`/`depth`");
     });
   });
+
+  // #1634: a Discord reporter kept getting a CUT-OFF positive prompt back from the agent.
+  // It was not the outline ladder degrading on a big graph (the filed hypothesis) — it
+  // reproduces on a 4-node graph, because the compact projection's 60-char clip is a
+  // SURVEY cap and it also applied to a read that named the node explicitly by `ids`.
+  describe("#1634 — an explicit `ids` read is a PINPOINT read, not a survey", () => {
+    const PROMPT =
+      "masterpiece, best quality, ultra detailed, a lone astronaut standing on a windswept " +
+      "red dune at golden hour, visor reflecting twin suns, volumetric god rays, fine sand " +
+      "particles drifting, cinematic composition, 85mm lens, shallow depth of field, " +
+      "photorealistic, 8k, sharp focus, dramatic rim lighting";
+    const Gp = {
+      "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sdxl.safetensors" } },
+      "2": { class_type: "CLIPTextEncode", _meta: { title: "Positive Prompt" }, inputs: { text: PROMPT, clip: ["1", 1] } },
+      "3": { class_type: "KSampler", inputs: { seed: 1, model: ["1", 0], positive: ["2", 0] } },
+    };
+
+    it("returns the node's FULL widget value on a small graph, without fields:'detail'", () => {
+      expect(PROMPT.length).toBeGreaterThan(60);
+      const r = queryApiGraph(Gp, { ids: ["2"] });
+      // The whole reply is ~400 chars against a 12000 budget: the clip was never
+      // protecting anything here, it was starving the value that was asked for.
+      expect(r.text).toContain(PROMPT);
+      expect(r.text.length).toBeLessThan(1000);
+    });
+
+    it("does NOT emit a clip note when nothing was clipped", () => {
+      const r = queryApiGraph(Gp, { ids: ["2"] });
+      expect(r.text).not.toContain("widget value(s) clipped");
+    });
+
+    it("a SURVEY read (no ids) still clips at the fixed 60 and names fields:'detail'", () => {
+      const r = queryApiGraph(Gp, {});
+      expect(r.text).not.toContain(PROMPT);
+      expect(r.text).toContain('clipped to 60 chars by `fields`:"compact"');
+      expect(r.text).toContain('read fuller values with `fields`:"detail"');
+    });
+
+    it("a `where`/`types` filter is still a survey — only explicit ids are a pinpoint", () => {
+      const r = queryApiGraph(Gp, { types: ["CLIPTextEncode"] });
+      expect(r.text).not.toContain(PROMPT);
+      expect(r.text).toContain('clipped to 60 chars by `fields`:"compact"');
+    });
+
+    it("max_chars still bounds a large ids list — the token guard is intact", () => {
+      const big: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+      for (let i = 1; i <= 60; i++) big[String(i)] = { class_type: "CLIPTextEncode", inputs: { text: "z".repeat(900) } };
+      const ids = Object.keys(big);
+      // The FIRST row is protected from the budget and can never be dropped, so its
+      // per-value cap has to respect max_chars: an unreserved 2048 cap returned 740
+      // chars against max_chars=500 while main returned 465.
+      for (const maxChars of [500, 800, 1500, 2000, 4000, 12000, 60000]) {
+        const r = queryApiGraph(big, { ids, max_chars: maxChars });
+        expect(r.text.length).toBeLessThanOrEqual(maxChars);
+      }
+    });
+
+    it("a value past the fixed 2048 cap is still capped, and the note names no dead lever", () => {
+      const G7 = { "7": { class_type: "Note", inputs: { text: "b".repeat(5000) } } };
+      const r = queryApiGraph(G7, { ids: ["7"], max_chars: 60000 });
+      expect(r.text.length).toBeLessThan(5000);
+      expect(r.text).toContain("clipped to 2048 chars");
+      // `fields`:"detail" applies the SAME 2048 cap, so pointing there would be the dead
+      // retry #809 exists to remove.
+      expect(r.text).not.toContain('read fuller values with `fields`:"detail"');
+    });
+
+    it("when max_chars (not the fixed cap) is what cut a pinpoint value, it says so", () => {
+      const G8 = { "8": { class_type: "Note", inputs: { text: "c".repeat(4000) } } };
+      const r = queryApiGraph(G8, { ids: ["8"], max_chars: 2000 });
+      expect(r.text.length).toBeLessThanOrEqual(2000);
+      expect(r.text).toContain("`max_chars`=2000");
+      expect(r.text).toContain("raise `max_chars`");
+    });
+  });
 });

--- a/src/__tests__/services/graph-query.test.ts
+++ b/src/__tests__/services/graph-query.test.ts
@@ -417,12 +417,17 @@ describe("queryApiGraph", () => {
       expect(r.text).not.toContain('read fuller values with `fields`:"detail"');
     });
 
-    it("when max_chars (not the fixed cap) is what cut a pinpoint value, it says so", () => {
+    it("a pinpoint row that does NOT fit falls back to main's rendering and main's note", () => {
+      // The cap is raised only when the generous row demonstrably fits. Arithmetic
+      // reserves leaked: a per-widget floor still grows without bound across many
+      // widgets, so a 24-widget node breached max_chars on DEFAULT parameters while
+      // reporting truncated:false. A fit test cannot leak.
       const G8 = { "8": { class_type: "Note", inputs: { text: "c".repeat(4000) } } };
       const r = queryApiGraph(G8, { ids: ["8"], max_chars: 2000 });
       expect(r.text.length).toBeLessThanOrEqual(2000);
-      expect(r.text).toContain("`max_chars`=2000");
-      expect(r.text).toContain("raise `max_chars`");
+      // Fell back, so the note is main's: it names 60 and the lever that genuinely helps.
+      expect(r.text).toContain('clipped to 60 chars by `fields`:"compact"');
+      expect(r.text).toContain('read fuller values with `fields`:"detail"');
     });
     // Both found by the review gate on the first version of this fix, which capped each
     // value at 2048 INDEPENDENTLY and dropped the fields:"detail" pointer outright.
@@ -450,22 +455,28 @@ describe("queryApiGraph", () => {
         }
       });
 
-      it("below the fixed cap the note still names fields:'detail' — there it carries MORE", () => {
-        // Dropping the pointer is only honest AT the fixed cap, where detail applies the
-        // same 2048. Below it, capWidgets() reserves 256 where the compact row reserves
-        // 1024, so at max_chars=1084 compact carries 59 value chars against detail's 747.
-        // Suppressing the pointer there hands back the very 60-char clipped prompt this
-        // issue is about, with the one lever that works at that budget omitted.
-        const blob = { "9": { class_type: "Note", inputs: { t: "x".repeat(9000) } } };
-        for (const maxChars of [1200, 1500, 2000]) {
-          const r = queryApiGraph(blob, { ids: ["9"], max_chars: maxChars });
-          expect(r.text, `max_chars=${maxChars}`).toContain('`fields`:"detail"');
-          expect(r.text).toContain("`max_chars`=" + maxChars);
+      it("the note never names a cap that was in force for NO widget", () => {
+        // A budget-derived per-widget cap rendered values at 2048, 736 and 60 and reported
+        // them all as "clipped to 2048 … which no parameter raises", while raising
+        // max_chars demonstrably lifted them — the #809 wrong-lever defect verbatim. The
+        // cap is uniform across the row now, so the note has exactly two honest forms.
+        for (const [count, len, maxChars] of [[10, 3000, 12000], [40, 200, 2000], [24, 1200, 12000]] as const) {
+          const r = queryApiGraph(wide(count, len) as never, { ids: ["2"], max_chars: maxChars });
+          const note = r.text.slice(r.text.lastIndexOf("\n("));
+          const named = /clipped to (\d+) chars/.exec(note)?.[1];
+          expect([undefined, "60", "2048"], `cap named for ${count}x${len}@${maxChars}`).toContain(named);
+          if (named === "60") expect(note).toContain('`fields`:"detail"');
         }
-        // At the fixed cap, detail applies the SAME cap, so pointing there is a dead retry.
-        const atCap = queryApiGraph(blob, { ids: ["9"], max_chars: 60000 });
-        expect(atCap.text).toContain("clipped to 2048 chars");
-        expect(atCap.text).not.toContain('read fuller values with `fields`:"detail"');
+      });
+
+      it("only a SINGLE id is a pinpoint — a multi-id read keeps every row main returned", () => {
+        // Treating any ids list as a pinpoint cost rows the caller explicitly asked for:
+        // 20 ordinary 600-char prompts at the default budget went 20/20 -> 18/20.
+        const many: Record<string, unknown> = {};
+        for (let i = 1; i <= 30; i++) many[String(i)] = { class_type: "CLIPTextEncode", inputs: { text: "p".repeat(600) } };
+        const r = queryApiGraph(many as never, { ids: Object.keys(many) });
+        expect(r.shown).toBe(30);
+        expect(r.truncated).toBe(false);
       });
     });
   });

--- a/src/__tests__/services/graph-query.test.ts
+++ b/src/__tests__/services/graph-query.test.ts
@@ -424,5 +424,49 @@ describe("queryApiGraph", () => {
       expect(r.text).toContain("`max_chars`=2000");
       expect(r.text).toContain("raise `max_chars`");
     });
+    // Both found by the review gate on the first version of this fix, which capped each
+    // value at 2048 INDEPENDENTLY and dropped the fields:"detail" pointer outright.
+    describe("#1634 gate findings", () => {
+      const wide = (count: number, len: number) => {
+        const inputs: Record<string, unknown> = {};
+        for (let i = 0; i < count; i++) inputs[`w${i}`] = "x".repeat(len);
+        return { "2": { class_type: "Efficient Loader", inputs } };
+      };
+
+      it("a MULTI-widget pinpoint row respects max_chars — a per-value cap does not bound the row", () => {
+        // N widgets at the cap sum to N x cap, and the #609-protected first row can never
+        // be dropped to recover. The first version breached on DEFAULT parameters: 12169
+        // of 12000 with six long widgets, and 2700 of 2500 with an ordinary
+        // positive+negative pair.
+        const shapes: Array<[Record<string, unknown>, number]> = [
+          [wide(6, 2100), 12000],
+          [wide(4, 3000), 2000],
+          [wide(2, 3000), 2500],
+          [wide(1, 9000), 600],
+        ];
+        for (const [g, maxChars] of shapes) {
+          const r = queryApiGraph(g as never, { ids: ["2"], max_chars: maxChars });
+          expect(r.text.length, `max_chars=${maxChars}`).toBeLessThanOrEqual(maxChars);
+        }
+      });
+
+      it("below the fixed cap the note still names fields:'detail' — there it carries MORE", () => {
+        // Dropping the pointer is only honest AT the fixed cap, where detail applies the
+        // same 2048. Below it, capWidgets() reserves 256 where the compact row reserves
+        // 1024, so at max_chars=1084 compact carries 59 value chars against detail's 747.
+        // Suppressing the pointer there hands back the very 60-char clipped prompt this
+        // issue is about, with the one lever that works at that budget omitted.
+        const blob = { "9": { class_type: "Note", inputs: { t: "x".repeat(9000) } } };
+        for (const maxChars of [1200, 1500, 2000]) {
+          const r = queryApiGraph(blob, { ids: ["9"], max_chars: maxChars });
+          expect(r.text, `max_chars=${maxChars}`).toContain('`fields`:"detail"');
+          expect(r.text).toContain("`max_chars`=" + maxChars);
+        }
+        // At the fixed cap, detail applies the SAME cap, so pointing there is a dead retry.
+        const atCap = queryApiGraph(blob, { ids: ["9"], max_chars: 60000 });
+        expect(atCap.text).toContain("clipped to 2048 chars");
+        expect(atCap.text).not.toContain('read fuller values with `fields`:"detail"');
+      });
+    });
   });
 });

--- a/src/__tests__/services/graph-query.test.ts
+++ b/src/__tests__/services/graph-query.test.ts
@@ -469,6 +469,23 @@ describe("queryApiGraph", () => {
         }
       });
 
+      it("the fit test RESERVES budget for the framing that rides outside the row", () => {
+        // Gate class 4: mutating the reserve to 0 survived all 103 tests, so the constant
+        // was unpinned. The reserve is what the row does NOT get to spend: header, the
+        // row's own prefix and ref lists, the truncation tail and the clip note. Pin it by
+        // asserting the raise is DECLINED where the widgets alone would eat the budget.
+        const near = { "2": { class_type: "T", inputs: { w: "x".repeat(1500) } } };
+        // 1500 chars of value + framing against a 2000 budget: without a reserve the fit
+        // test says yes and the reply has no room left for its own tail and note.
+        const declined = queryApiGraph(near, { ids: ["2"], max_chars: 2000 });
+        expect(declined.text).toContain('clipped to 60 chars by `fields`:"compact"');
+        expect(declined.text.length).toBeLessThanOrEqual(2000);
+        // Raise the budget past the reserve and the SAME node renders in full.
+        const granted = queryApiGraph(near, { ids: ["2"], max_chars: 4000 });
+        expect(granted.text).toContain("x".repeat(1500));
+        expect(granted.text.length).toBeLessThanOrEqual(4000);
+      });
+
       it("only a SINGLE id is a pinpoint — a multi-id read keeps every row main returned", () => {
         // Treating any ids list as a pinpoint cost rows the caller explicitly asked for:
         // 20 ordinary 600-char prompts at the default budget went 20/20 -> 18/20.

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -435,6 +435,33 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
 
   // 4) Projection, char-bounded.
   const fields = opts.fields ?? "compact";
+  // #1634: a compact row's 60-char value clip is a SURVEY cap — it exists so a 200-node
+  // listing of nodes you have not identified yet stays small. When the caller passed
+  // explicit `ids` they have ALREADY identified the nodes, so the read is a PINPOINT one
+  // and the survey cap is simply starving the value they asked for. Measured on a 4-node
+  // graph: `{ids:["2"]}` returned the prompt cut at 60 chars in a 301-char reply against
+  // a 12000-char budget — the clip was not protecting anything, and the cut-off value was
+  // quoted back to the user as the node's prompt.
+  //
+  // So a pinpoint read gets the SAME per-value cap the `detail` projection uses. Note
+  // what this deliberately does NOT do: it does not exempt the row from `max_chars`, and
+  // it does not change the compact SHAPE (still one line per node). A large `ids` list
+  // still degrades through the existing row-drop path, so the token bound is intact.
+  //
+  // The cap is tightened to `max_chars` exactly as capWidgets() does for the detail
+  // projection. Without that reserve the FIRST row — which #609 protects from the budget
+  // and never drops — carries a 2048-char value on a 500-char budget and breaches the
+  // bound outright: measured 740 chars against `max_chars`=500, where main returned 465.
+  // The protected row is the one line that cannot be dropped to recover, so its per-value
+  // cap has to respect the budget itself.
+  // The reserve covers the rest of the reply the protected row has to share the budget
+  // with — header, the row's own prefix/refs, the truncation tail and this note — and the
+  // cap never falls BELOW the survey clip, so a small `max_chars` degrades to exactly
+  // main's behaviour instead of to something worse.
+  const pinpoint = !!wantIds?.length;
+  const compactValueCap = pinpoint
+    ? Math.min(WIDGET_VALUE_CAP, Math.max(COMPACT_VALUE_CLIP, maxChars - 1024))
+    : COMPACT_VALUE_CLIP;
   const header =
     `${matched.length} match(es) of ${candidates.length} in scope (graph: ${total} nodes)` +
     (scope ? ` · traversal${Number.isFinite(depth) ? ` depth≤${depth}` : ""}` : "");
@@ -523,7 +550,7 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
     } else {
       const w = Object.entries(widgetsOf(n))
         .map(([k, v]) => {
-          const c = clipFlag(v);
+          const c = clipFlag(v, compactValueCap);
           if (c.clipped) rowClips++;
           return `${k}=${c.text}`;
         })
@@ -583,10 +610,21 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   };
   // #809: the compact projection's 60-char value clip is FIXED — no parameter lifts it,
   // so point at the projection that carries fuller values instead of at a dead lever.
-  const buildClipNote = (n: number): string =>
-    n > 0
-      ? `\n(${n} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`
-      : "";
+  //
+  // #1634: on a PINPOINT read the values are already capped at WIDGET_VALUE_CAP, so
+  // "read fuller values with `fields`:"detail"" would be exactly the dead retry #809
+  // exists to remove — detail applies the SAME cap. Name the cap actually in force.
+  const buildClipNote = (n: number): string => {
+    if (n <= 0) return "";
+    if (!pinpoint)
+      return `\n(${n} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
+    // Name the cap ACTUALLY in force: below WIDGET_VALUE_CAP it was `max_chars` that cut
+    // the value, and raising `max_chars` genuinely helps — so say which lever applies
+    // rather than reporting the constant and sending the caller at a dead one.
+    return compactValueCap < WIDGET_VALUE_CAP
+      ? `\n(${n} widget value(s) clipped to ${compactValueCap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} for fuller values, up to a fixed ${WIDGET_VALUE_CAP}-char per-value cap.)`
+      : `\n(${n} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
+  };
   const assemble = (): string => {
     const body = fields === "ids" ? lines.join(",") : lines.join("\n");
     return `${header}\n${body}${buildTail(truncatedBy, shown)}${buildClipNote(lineClips.reduce((x, y) => x + y, 0))}`;

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -548,10 +548,22 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       // is never dropped yet can't flood — every rendered detail line ends up ≤ max_chars.
       line = fitDetailLine(line, { id, type: clip(n.class_type ?? "?", 200) }, maxChars);
     } else {
+      // #1634 (gate): a PER-VALUE cap does not bound the ROW — N widgets at the cap sum
+      // to N×cap, and the #609-protected first row can never be dropped to recover, so a
+      // multi-widget pinpoint node breached `max_chars` on DEFAULT parameters: measured
+      // 12169/12000 with six long widgets, and 2700/2500 with just TWO (an ordinary
+      // positive+negative pair). Spend ONE row budget across the widgets instead, so the
+      // raised cap is what a row may spend in total, not what each widget may spend.
+      // Never below the survey clip, so a tight budget degrades to main's behaviour.
+      let rowBudget = pinpoint
+        ? Math.max(COMPACT_VALUE_CLIP, maxChars - 1024)
+        : Number.POSITIVE_INFINITY;
       const w = Object.entries(widgetsOf(n))
         .map(([k, v]) => {
-          const c = clipFlag(v, compactValueCap);
+          const cap = Math.min(compactValueCap, Math.max(COMPACT_VALUE_CLIP, rowBudget));
+          const c = clipFlag(v, cap);
           if (c.clipped) rowClips++;
+          rowBudget -= c.text.length;
           return `${k}=${c.text}`;
         })
         .join(" ");
@@ -616,13 +628,25 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   // exists to remove — detail applies the SAME cap. Name the cap actually in force.
   const buildClipNote = (n: number): string => {
     if (n <= 0) return "";
-    if (!pinpoint)
+    // When the budget degraded the pinpoint cap all the way back to the survey clip, the
+    // cap in force IS the survey one and `fields`:"detail" is exactly the right lever —
+    // so emit main's note verbatim rather than a longer one saying the same thing. The
+    // longer text is not free: it rides inside `max_chars`, and at the 500 floor it was
+    // enough on its own to push a reply that fitted (465) past the bound (545).
+    if (!pinpoint || compactValueCap <= COMPACT_VALUE_CLIP)
       return `\n(${n} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
     // Name the cap ACTUALLY in force: below WIDGET_VALUE_CAP it was `max_chars` that cut
     // the value, and raising `max_chars` genuinely helps — so say which lever applies
     // rather than reporting the constant and sending the caller at a dead one.
+    //
+    // #1634 (gate): dropping the `fields`:"detail" pointer is only honest AT the fixed
+    // cap, where detail applies the same 2048. Below it detail is strictly better —
+    // capWidgets() reserves 256 where this row reserves 1024, so at `max_chars`=1084
+    // compact carries 59 value chars against detail's 747. Suppressing the pointer there
+    // would hand a caller the very 60-char clipped prompt #1634 is about, with the one
+    // lever that works at their budget omitted — the #809 wrong-lever class exactly.
     return compactValueCap < WIDGET_VALUE_CAP
-      ? `\n(${n} widget value(s) clipped to ${compactValueCap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} for fuller values, up to a fixed ${WIDGET_VALUE_CAP}-char per-value cap.)`
+      ? `\n(${n} widget value(s) clipped to ${compactValueCap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}, or read this node with \`fields\`:"detail", which reserves less of the budget for framing and so carries more at this size.)`
       : `\n(${n} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
   };
   const assemble = (): string => {

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -454,14 +454,26 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   // bound outright: measured 740 chars against `max_chars`=500, where main returned 465.
   // The protected row is the one line that cannot be dropped to recover, so its per-value
   // cap has to respect the budget itself.
-  // The reserve covers the rest of the reply the protected row has to share the budget
-  // with — header, the row's own prefix/refs, the truncation tail and this note — and the
-  // cap never falls BELOW the survey clip, so a small `max_chars` degrades to exactly
-  // main's behaviour instead of to something worse.
-  const pinpoint = !!wantIds?.length;
-  const compactValueCap = pinpoint
-    ? Math.min(WIDGET_VALUE_CAP, Math.max(COMPACT_VALUE_CLIP, maxChars - 1024))
-    : COMPACT_VALUE_CLIP;
+  // Only a SINGLE id is a pinpoint read. Treating any `ids` list as one cost rows the
+  // caller explicitly asked for and main returned in full — 20 ordinary 600-char prompts
+  // at the default budget went from 20/20 to 18/20 (gate). One id also means at most one
+  // row, so there is no budget to divide and no row-count to regress.
+  const pinpoint = wantIds?.length === 1;
+  // Raise the cap only when the generous row DEMONSTRABLY fits. Arithmetic reserves kept
+  // leaking — a floor of 60 per widget still grows without bound across many widgets, so
+  // a 24-widget node breached `max_chars` on default parameters while reporting
+  // truncated:false (gate). A fit test cannot leak: if the generous rendering does not fit,
+  // we use main's, so this is never worse than main on any shape.
+  const compactValueCap = ((): number => {
+    if (!pinpoint) return COMPACT_VALUE_CLIP;
+    const n = graph[wantIds[0]] ?? {};
+    let total = 0;
+    for (const [k, v] of Object.entries(widgetsOf(n)))
+      total += k.length + 2 + clipFlag(v, WIDGET_VALUE_CAP).text.length;
+    // The reserve covers what shares the budget with the row: header, the row's own
+    // prefix and ref lists, the truncation tail and the clip note.
+    return total <= maxChars - 1024 ? WIDGET_VALUE_CAP : COMPACT_VALUE_CLIP;
+  })();
   const header =
     `${matched.length} match(es) of ${candidates.length} in scope (graph: ${total} nodes)` +
     (scope ? ` · traversal${Number.isFinite(depth) ? ` depth≤${depth}` : ""}` : "");
@@ -548,22 +560,14 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       // is never dropped yet can't flood — every rendered detail line ends up ≤ max_chars.
       line = fitDetailLine(line, { id, type: clip(n.class_type ?? "?", 200) }, maxChars);
     } else {
-      // #1634 (gate): a PER-VALUE cap does not bound the ROW — N widgets at the cap sum
-      // to N×cap, and the #609-protected first row can never be dropped to recover, so a
-      // multi-widget pinpoint node breached `max_chars` on DEFAULT parameters: measured
-      // 12169/12000 with six long widgets, and 2700/2500 with just TWO (an ordinary
-      // positive+negative pair). Spend ONE row budget across the widgets instead, so the
-      // raised cap is what a row may spend in total, not what each widget may spend.
-      // Never below the survey clip, so a tight budget degrades to main's behaviour.
-      let rowBudget = pinpoint
-        ? Math.max(COMPACT_VALUE_CLIP, maxChars - 1024)
-        : Number.POSITIVE_INFINITY;
+      // ONE cap across the row (see compactValueCap above). A per-widget cap that varied
+      // as a budget drained made the clip note incoherent: values cut at 2048, 736 and 60
+      // were all reported as "clipped to 2048 … which no parameter raises", while raising
+      // `max_chars` demonstrably lifted them (gate).
       const w = Object.entries(widgetsOf(n))
         .map(([k, v]) => {
-          const cap = Math.min(compactValueCap, Math.max(COMPACT_VALUE_CLIP, rowBudget));
-          const c = clipFlag(v, cap);
+          const c = clipFlag(v, compactValueCap);
           if (c.clipped) rowClips++;
-          rowBudget -= c.text.length;
           return `${k}=${c.text}`;
         })
         .join(" ");
@@ -628,26 +632,13 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   // exists to remove — detail applies the SAME cap. Name the cap actually in force.
   const buildClipNote = (n: number): string => {
     if (n <= 0) return "";
-    // When the budget degraded the pinpoint cap all the way back to the survey clip, the
-    // cap in force IS the survey one and `fields`:"detail" is exactly the right lever —
-    // so emit main's note verbatim rather than a longer one saying the same thing. The
-    // longer text is not free: it rides inside `max_chars`, and at the 500 floor it was
-    // enough on its own to push a reply that fitted (465) past the bound (545).
-    if (!pinpoint || compactValueCap <= COMPACT_VALUE_CLIP)
+    // #1634: the cap is uniform across the row and is only ever the survey clip or the
+    // fixed per-value cap, so the note has exactly two honest forms. An intermediate,
+    // budget-derived cap was tried and removed: it made the note name a number that was in
+    // force for no widget, and called a cut "unraisable" that raising `max_chars` lifted.
+    if (compactValueCap <= COMPACT_VALUE_CLIP)
       return `\n(${n} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
-    // Name the cap ACTUALLY in force: below WIDGET_VALUE_CAP it was `max_chars` that cut
-    // the value, and raising `max_chars` genuinely helps — so say which lever applies
-    // rather than reporting the constant and sending the caller at a dead one.
-    //
-    // #1634 (gate): dropping the `fields`:"detail" pointer is only honest AT the fixed
-    // cap, where detail applies the same 2048. Below it detail is strictly better —
-    // capWidgets() reserves 256 where this row reserves 1024, so at `max_chars`=1084
-    // compact carries 59 value chars against detail's 747. Suppressing the pointer there
-    // would hand a caller the very 60-char clipped prompt #1634 is about, with the one
-    // lever that works at their budget omitted — the #809 wrong-lever class exactly.
-    return compactValueCap < WIDGET_VALUE_CAP
-      ? `\n(${n} widget value(s) clipped to ${compactValueCap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}, or read this node with \`fields\`:"detail", which reserves less of the budget for framing and so carries more at this size.)`
-      : `\n(${n} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
+    return `\n(${n} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
   };
   const assemble = (): string => {
     const body = fields === "ids" ? lines.join(",") : lines.join("\n");

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -444,16 +444,9 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   // quoted back to the user as the node's prompt.
   //
   // So a pinpoint read gets the SAME per-value cap the `detail` projection uses. Note
-  // what this deliberately does NOT do: it does not exempt the row from `max_chars`, and
-  // it does not change the compact SHAPE (still one line per node). A large `ids` list
-  // still degrades through the existing row-drop path, so the token bound is intact.
+  // what this deliberately does NOT do: it does not change the compact SHAPE (still one
+  // line per node), and it does not touch the survey path or the outline ladder.
   //
-  // The cap is tightened to `max_chars` exactly as capWidgets() does for the detail
-  // projection. Without that reserve the FIRST row — which #609 protects from the budget
-  // and never drops — carries a 2048-char value on a 500-char budget and breaches the
-  // bound outright: measured 740 chars against `max_chars`=500, where main returned 465.
-  // The protected row is the one line that cannot be dropped to recover, so its per-value
-  // cap has to respect the budget itself.
   // Only a SINGLE id is a pinpoint read. Treating any `ids` list as one cost rows the
   // caller explicitly asked for and main returned in full — 20 ordinary 600-char prompts
   // at the default budget went from 20/20 to 18/20 (gate). One id also means at most one
@@ -632,10 +625,6 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   };
   // #809: the compact projection's 60-char value clip is FIXED — no parameter lifts it,
   // so point at the projection that carries fuller values instead of at a dead lever.
-  //
-  // #1634: on a PINPOINT read the values are already capped at WIDGET_VALUE_CAP, so
-  // "read fuller values with `fields`:"detail"" would be exactly the dead retry #809
-  // exists to remove — detail applies the SAME cap. Name the cap actually in force.
   const buildClipNote = (n: number): string => {
     if (n <= 0) return "";
     // #1634: the cap is uniform across the row and is only ever the survey clip or the

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -463,7 +463,13 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   // leaking — a floor of 60 per widget still grows without bound across many widgets, so
   // a 24-widget node breached `max_chars` on default parameters while reporting
   // truncated:false (gate). A fit test cannot leak: if the generous rendering does not fit,
-  // we use main's, so this is never worse than main on any shape.
+  // we use main's rendering instead.
+  //
+  // Precisely: this does not make the `max_chars` bound any softer than main's. The bound
+  // is already soft — `clipLine` bounds the LINE, while the header and clip note ride
+  // outside it, so main overshoots by ~173 chars on hostile shapes too (1893 of 4000 in
+  // the gate's fuzz). This branch overshoots on 80 of those 4000 by the same magnitude.
+  // It does not FIX that pre-existing softness, and it must not be read as claiming to.
   const compactValueCap = ((): number => {
     if (!pinpoint) return COMPACT_VALUE_CLIP;
     const n = graph[wantIds[0]] ?? {};


### PR DESCRIPTION
Fixes #1634

## The filed hypothesis is not what happens

The issue proposed that `panel_graph_outline` sheds widget values on an over-budget graph, so an agent quoting a prompt out of the outline hands back a value cut off by design — with a falsifiable prediction attached: *"If the prompt is truncated on a small graph, this analysis is wrong and the bug is elsewhere."*

I measured it. It **reproduces on a four-node graph**, where no ladder rung degrades and nothing is near a budget:

```
PROMPT length = 300 chars

===== fields:'compact'  (ids:["2"]) =====
#2 CLIPTextEncode "Positive Prompt" · text=masterpiece, best quality, ultra detailed, a lone astronaut…  ← clip:1  → 4
(1 widget value(s) clipped to 60 chars by `fields`:"compact" — read fuller values with `fields`:"detail", …)

-> contains the FULL prompt? NO      -> reply length 301 chars   [budget: 12000]
```

301 characters against a 12000-character budget. The clip was not protecting anything — it was starving the one value that was asked for. So the prediction lands on the "this analysis is wrong" side, and the truncation is **not** graph-size dependent. That also explains the reporter's "**always**": a fixed clip fires every time, where a ladder rung would not.

## What actually happens

The compact projection clips widget values at a fixed 60 chars. That is a **survey** cap — it keeps a 200-node listing of nodes you have not identified yet small.

It was also applied when the caller named the node **explicitly by `ids`**, which is the opposite case: the node is already identified, so the clip only starves the value that was asked for. `panel_query_graph`'s own description calls `ids` "**THE** way to read ONE node's exact slot/widget detail", so the default did not match the documented intent.

And the shortfall is **silent** in the way the issue describes: a clipped prompt ends in an ellipsis that a real prompt could plausibly contain, so it gets quoted back to the user as the node's content. That is why it reads as a bug in the prompt node rather than in the retrieval.

## The fix

A **single-id** read renders its widget values at the same per-value cap the `detail` projection uses — but only when the generous row **demonstrably fits** the budget. If it does not fit, we render exactly what main renders.

Two deliberate restrictions, both of which I got wrong first and the gate caught:

- **Only one id is a pinpoint.** Treating any `ids` list as one cost rows the caller explicitly asked for: 20 ordinary 600-char prompts at the default budget went 20/20 → 18/20.
- **A fit test, not an arithmetic reserve.** Every reserve I tried leaked — a per-widget floor still grows without bound across many widgets, so a 24-widget node breached `max_chars` on *default* parameters while reporting `truncated:false`. A fit test cannot leak.

Deliberately **unchanged**: the compact **shape** (still one line per node), the **survey** path, **`max_chars`**, and the **outline ladder**, which the issue flagged as carrying expensive #809/#1184/#1203 invariants. This change does not touch it.

## Never worse than main — measured, not argued

Swept this branch against `origin/main` across **1316** shape × budget × projection cases (1–300 widgets, 10–9000 chars each, 1–60 nodes, budgets 500 → 60000, with and without `ids`):

```
cases=1316  breaches-vs-main=0  lost-rows=0  shorter=0  richer=92
```

Zero replies breach `max_chars` where main did not, zero lose a row main returned, zero come back shorter. 92 come back richer — the pinpoint reads this issue is about.

The gate's own independent fuzz (4000 hostile single-id shapes) agrees on the direction and adds a caveat I've since written into the source: the `max_chars` bound is *already* soft, because `clipLine` bounds the LINE while the header and clip note ride outside it. Main overshoots by ~173 chars on 1893 of those 4000; this branch does so on 80, by the same magnitude. It does not make that softness worse, and it does not fix it.

## Verification

- 43/43 in `graph-query.test.ts` (32 pre-existing + 11 new); **516 files / 9690 tests** green across the full suite; `tsc --noEmit` clean.
- **Mutation-tested**: reverting `graph-query.ts` to `origin/main` with the tests in place fails **3**. Mutating the fit test's reserve constant fails **1** (the gate found that constant unpinned; it now is).
- The new tests pin the survey path, the multi-id row count, the `max_chars` bound and the note's honesty — not just the happy path.

## Both engines

`src/services/graph-query.ts` is the semantic spec for the panel's hand-mirrored twin, and its own header mandates the port. The orchestrator change alone would **not** have fixed the reporter, who reads the live canvas:

- this PR — `queryApiGraph`, reached in production by `get_workflow` action:`"query"` (`src/tools/workflow-library.ts:690`)
- **artokun/comfyui-mcp-panel#1281** — the live-canvas twin the reporter actually hits, browser-verified

## What this PR does NOT do — symptom B

The issue also reports unrelated questions triggering reflexive graph lookups. **I have not fixed that, and I don't want to imply coverage I don't have.**

It is model-steering, not a code path: the candidate sites are the unconditional "read it FIRST to get oriented" in the outline's tool description and "ALWAYS start with `panel_graph_outline`" in `ollama-backend.ts:353`. Two reasons I left it:

1. There is no test that can fail-on-revert — "the model stopped calling a tool" is not assertable, and a description-string assertion would be the tested-but-unreachable class rather than evidence.
2. The reporter is on **Gemini (ACP)**, so the `ollama-backend.ts` line was never in their path. Changing it could not have produced their symptom and would not demonstrably fix it.

The tool descriptions are also byte-pinned by the tool-surface ratchet, so conditioning that guidance is a deliberate product edit, not a drive-by. Left for a separate decision.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead (`claude-gate.mjs`), which spawns a fresh reviewer that has never seen my reasoning. Disclosing the substitution is the condition it was accepted under.

It returned **NO-SHIP twice before SHIP**, and both rejections were right:

| round | finding | outcome |
|---|---|---|
| 1 | the protected first row breached `max_chars` (740/500 where main returned 465) | fixed |
| 1 | the note pointed at `fields`:"detail" where detail applies the same cap — a dead retry | fixed |
| 2 | **P0** the per-widget floor leaked: 24 widgets breached on *default* params reporting `truncated:false` | replaced arithmetic with the fit test |
| 2 | any `ids` list treated as pinpoint — multi-id reads lost rows main returned | pinpoint is now a single id |
| 2 | the note named a cap in force for *no* widget | cap is uniform per row again |
| 3 | **SHIP** — plus two non-blocking notes (unpinned reserve constant, overstated source comment) | both addressed in the last commit |
