### PR TITLE
release: v0.51.57 — tools report what they observed, not what they requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,30 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.57] - 2026-08-16
+
+### MCP
+
+#### Fixed
+- a node read by id returns its full widget value, not a survey clip (#1634)
+- cancel_queued reports the removal it observed, not the one it requested (#1632)
+- a repo filed under a Comfy Registry id is refused, not swapped for another author's (#1624)
+- a run acknowledged after its reply timeout is not an unknown outcome (#1175)
+- a skill description with a colon in it ships with NO description at all (#1620)
+- a tree the server demonstrably reads is not refused over one stray file (#1147)
+- a session that came up without an MCP server says so (#1524)
+- a queued credential respawn waits for in-flight transfers instead of killing them (#1567)
+- a post-open exempt read that got no answer is REPORTED (#1560)
+- refuse the ambiguous from-source install instead of picking a repo (#1616)
+- a refused offer is not a verdict anyone was told (#1327)
+- a git-URL install stops asking a Manager channel nobody chose (#1539)
+- the Manager verdict never asserts more than it observed (#1374)
+- a drained ComfyUI-Manager queue is not evidence the file landed (#1374)
+
+#### Changed
+- rgthree skill — the toggles agents keep getting wrong (#1551)
+
+
 ## [0.51.56] - 2026-08-15
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.56",
+  "version": "0.51.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.56",
+      "version": "0.51.57",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.56",
+  "version": "0.51.57",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying nine fixes merged 2026-08-16 (artokun/comfyui-mcp#1637, artokun/comfyui-mcp#1636, artokun/comfyui-mcp#1631, artokun/comfyui-mcp#1630, artokun/comfyui-mcp#1628, artokun/comfyui-mcp#1627, artokun/comfyui-mcp#1614, artokun/comfyui-mcp#1613, artokun/comfyui-mcp#1607), plus artokun/comfyui-mcp#1619, artokun/comfyui-mcp#1618, artokun/comfyui-mcp#1611, and artokun/comfyui-mcp#1603 which landed since v0.51.56. The artokun/comfyui-mcp#1626 merge + artokun/comfyui-mcp#1633 revert pair nets to zero and is excluded from the changelog.

**Report what the server did, not what was asked** — `cancel_queued` verified its removal against the queue and now reports the removal it observed, not the one it requested (#1632); a run acknowledged after its reply timeout is reconciled as a late ack instead of an unknown outcome (#1175); a refused install offer is no longer journaled as a verdict anyone was told (#1327); and the ComfyUI-Manager verdict never asserts more than it observed — a drained Manager queue is not evidence the file landed (#1374).

**Refuse instead of guessing** — a node repo filed under a Comfy Registry id is refused rather than swapped for another author's repo (#1624), and an ambiguous from-source install is refused instead of picking a repo (#1616). Conversely, a tree the server demonstrably reads is no longer refused over one stray file (#1147), and a git-URL install stops asking for a Manager channel nobody chose (#1539).

**Say the awkward thing out loud** — a session that came up without an MCP server now says so instead of degrading silently (#1524), and a post-open exempt read that got no answer is reported rather than dropped (#1560). A queued credential respawn waits for in-flight transfers instead of killing them (#1567).

**Reads return the whole truth** — a node read by id returns its full widget value, not a survey clip (#1634), and a skill description containing a colon no longer ships with no description at all (#1620).

🤖 Generated with [Claude Code](https://claude.com/claude-code)