### PR TITLE
fix(1649): a pack's install manifest is readable via list_packs action:"read_manifest"

### DIFF
--- a/docs/tools/skills-knowledge.mdx
+++ b/docs/tools/skills-knowledge.mdx
@@ -22,7 +22,7 @@ It is one tool, `list_packs`, driven by an `action` parameter. `action` is the
 only required field; everything else is per-action.
 
 <Warning>
-  Seven of the nine actions only read. Two can change your machine:
+  Eight of the ten actions only read. Two can change your machine:
 
   - `action: "install_deps"` **installs** custom node packs through
     ComfyUI-Manager, which downloads and runs third-party code on the connected
@@ -56,6 +56,17 @@ manifest, and the manifest path for `apply_manifest`.
 
 Return a bundled pack's ready `workflow.json` graph (discover names with
 `action: "list"`).
+
+<ParamField path="name" type="string" required>
+  The pack name (from `action: "list"`). Validated against path traversal; must
+  match an existing pack.
+</ParamField>
+
+### `action: "read_manifest"`
+
+Return a bundled pack's install manifest (its `manifest.yaml` — the custom nodes +
+model weights `apply_manifest` would install), as raw YAML. **Read-only** — the way
+to inspect what a pack installs **before** running the mutating `apply_manifest`.
 
 <ParamField path="name" type="string" required>
   The pack name (from `action: "list"`). Validated against path traversal; must

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -237,7 +237,7 @@ const HAND_WRITTEN_PAGES: Array<{ slug: string; tools: string[] }> = [
   {
     slug: "skills-knowledge",
     // One tool since 0.50.0 slice 9: the nine knowledge tools folded into
-    // `list_packs`, whose nine actions this page documents by hand.
+    // `list_packs`, whose ten actions this page documents by hand.
     tools: ["list_packs"],
   },
 ];

--- a/src/__tests__/orchestrator/call-tool-admission.test.ts
+++ b/src/__tests__/orchestrator/call-tool-admission.test.ts
@@ -153,6 +153,7 @@ describe("call_tool admission", () => {
     for (const action of [
       "list",
       "read_workflow",
+      "read_manifest",
       "list_templates",
       "check_runtime",
       "skill_list",

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -13,7 +13,7 @@ import { DEAD_NAMES, TOOL_NAMES } from "../../tools/vocabulary.js";
  * flat-enum shape actually EXPOSES its parameters (the discriminated-union trap
  * renders zero params).
  *
- * The one thing this tool has that `queue` did not: EIGHT read actions and ONE
+ * The one thing this tool has that `queue` did not: NINE read actions and ONE
  * that installs custom node packs (third-party code) on the connected ComfyUI.
  * A read-only-looking tool that silently installs is a wrong-expectation defect,
  * so "no read action reaches the install service" is asserted explicitly rather
@@ -50,7 +50,7 @@ vi.mock("../../config.js", () => ({
   getComfyUIAuthHeaders: () => ({}),
 }));
 
-import { registerSkillsAccessTools } from "../../tools/skills-access.js";
+import { registerSkillsAccessTools, enumeratePacks } from "../../tools/skills-access.js";
 
 type Handler = (args: Record<string, any>) => Promise<{
   isError?: boolean;
@@ -88,6 +88,7 @@ const text = (res: Awaited<ReturnType<Handler>>) => res.content.map((c) => c.tex
 const ACTIONS = [
   "list",
   "read_workflow",
+  "read_manifest",
   "list_templates",
   "check_runtime",
   "extract_deps",
@@ -158,7 +159,7 @@ describe("list_packs registration", () => {
   });
 
   // The description is the ONLY thing standing between a model and an unexpected
-  // write: seven actions read, one installs third-party code, and one overwrites
+  // write: eight actions read, one installs third-party code, and one overwrites
   // a file when `install_in` is given. A reworded description that drops either
   // warning re-opens exactly that wrong expectation — and a note that UNDERCOUNTS
   // the mutations (the first draft of this said "eight of nine only read") is the
@@ -235,6 +236,25 @@ describe("actions call the same services with the same arguments", () => {
     const res = await handler()({ action: "read_workflow", name: "definitely-not-a-pack" });
     expect(res.isError).toBe(true);
     expect(text(res)).toContain('No pack named "definitely-not-a-pack"');
+  });
+
+  it('action:"read_manifest" returns the pack\'s install manifest and refuses a bad name', async () => {
+    // The build ships at least one pack with a manifest (action:"list" reports
+    // has_manifest) — read it through the same name apply_manifest takes.
+    const pack = enumeratePacks().find((p) => p.has_manifest === true);
+    expect(pack, "expected at least one bundled pack with a manifest").toBeDefined();
+    const res = await handler()({ action: "read_manifest", name: String(pack!.name) });
+    expect(res.isError).toBeUndefined();
+    // Raw manifest.yaml text, like read_workflow returns the raw graph.
+    expect(text(res)).toMatch(/custom_nodes|models/);
+
+    const unknown = await handler()({ action: "read_manifest", name: "definitely-not-a-pack" });
+    expect(unknown.isError).toBe(true);
+    expect(text(unknown)).toContain('No pack named "definitely-not-a-pack"');
+
+    const traversal = await handler()({ action: "read_manifest", name: "../skills-access" });
+    expect(traversal.isError).toBe(true);
+    expect(text(traversal)).toContain("Invalid pack name");
   });
 
   it('action:"skill_read" resolves by skill name and reports an unknown one', async () => {
@@ -421,8 +441,8 @@ describe("only action:\"install_deps\" can reach the install service", () => {
 });
 
 describe("per-action presence guards (the flat shape cannot schema-require these)", () => {
-  it("read_workflow/skill_read without a name name the field and call nothing", async () => {
-    for (const action of ["read_workflow", "skill_read"]) {
+  it("read_workflow/read_manifest/skill_read without a name name the field and call nothing", async () => {
+    for (const action of ["read_workflow", "read_manifest", "skill_read"]) {
       const res = await handler()({ action });
       expect(res.isError).toBe(true);
       expect(text(res)).toContain(`list_packs action:"${action}" requires \`name\``);

--- a/src/orchestrator/call-tool-admission.ts
+++ b/src/orchestrator/call-tool-admission.ts
@@ -248,7 +248,7 @@ export const CALL_TOOL_ACTION_WHITELIST: ReadonlyMap<string, ReadonlySet<string>
   // action:"install_deps" stays REFUSED — it queues ComfyUI-Manager installs,
   // which download and execute third-party code on the rig, and no
   // confirmation-less call_tool frame ever had that reach. The remaining actions
-  // (list/read_workflow/list_templates/check_runtime/skill_list/skill_read),
+  // (list/read_workflow/read_manifest/list_templates/check_runtime/skill_list/skill_read),
   // though read-only, were never whitelisted either, and generate_skill writes a
   // file when `install_in` is set.
   ["list_packs", new Set(["extract_deps"])],

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -15,6 +15,7 @@ import {
   defaultWorkflowDepsDeps,
 } from "../services/workflow-deps.js";
 import { generateSkillCached } from "../services/skill-cache.js";
+import { resolvePackManifestFile } from "../services/manifest.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import { templateIndexScopeNote } from "../services/template-index-scope.js";
 import {
@@ -36,7 +37,7 @@ import {
 // The record's `tool` is the LIVE tool name and the action rides in `args`, so a
 // consumer (scripts/codex-knowledge-parity-smoke.mjs) reads exactly what was
 // invoked. Only the six actions whose pre-0.50.0 tools traced are traced — adding
-// the other three would change what the harness observes, which is behaviour, not
+// the other four would change what the harness observes, which is behaviour, not
 // surface.
 function traceToolCall(tool: string, args: Record<string, unknown>): void {
   const path = process.env.COMFYUI_MCP_TOOL_TRACE;
@@ -275,7 +276,7 @@ export function resolvePackWorkflowFile(packName: string): string | null {
  *   the cache write is unconditional on a miss and lands in configurable
  *   user-home state.
  *
- * The other seven actions read. Both mutations are stated in their own
+ * The other eight actions read. Both mutations are stated in their own
  * description bullets, because a read-only-looking tool that quietly installs or
  * overwrites is a wrong-expectation defect — and so is a safety note that
  * undercounts them.
@@ -284,8 +285,9 @@ export function registerSkillsAccessTools(server: McpServer): void {
   server.tool(
     "list_packs",
     "Bundled ComfyUI knowledge — installer packs, model-family skills, workflow templates — plus the two workflow-readiness checks. Driven by the `action` parameter:\n" +
-      '- action:"list" — List the bundled installer packs under packs/: one-command setups for a model family (custom nodes + model weights via manifest.yaml) PLUS a ready workflow.json graph. Each entry reports its family/kind, its runtime (these packs are LOCAL-GPU / FREE — they run on the user\'s own GPU and never spend paid API credits), whether it has a ready workflow + manifest, and the manifest path for install_comfyui apply_manifest. When asked to "set up / build a <model-family> workflow", PREFER applying the matching pack and loading its ready workflow (panel_load_workflow pack:<name>) over building a generic graph from scratch. Read the ready graph with action:"read_workflow".\n' +
+      '- action:"list" — List the bundled installer packs under packs/: one-command setups for a model family (custom nodes + model weights via manifest.yaml) PLUS a ready workflow.json graph. Each entry reports its family/kind, its runtime (these packs are LOCAL-GPU / FREE — they run on the user\'s own GPU and never spend paid API credits), whether it has a ready workflow + manifest, and the manifest path for install_comfyui apply_manifest. When asked to "set up / build a <model-family> workflow", PREFER applying the matching pack and loading its ready workflow (panel_load_workflow pack:<name>) over building a generic graph from scratch. Read the ready graph with action:"read_workflow", and inspect its install manifest with action:"read_manifest".\n' +
       '- action:"read_workflow" — Return a bundled pack\'s ready workflow.json graph by pack name (`name`; discover names + which packs have a workflow with action:"list"). This is the EXPERT graph for that model family — use it as the source of truth when setting up the family on the user\'s canvas: recreate it node-by-node with the panel_* tools (panel_add_node / panel_connect / panel_set_widget) so it lands on their live canvas, or enqueue it headlessly. Prefer this over inventing a graph from scratch. Names are validated (no path traversal) and must match an existing pack directory.\n' +
+      '- action:"read_manifest" — Return a bundled pack\'s install manifest (its manifest.yaml — the custom nodes + model weights apply_manifest would install) by pack name (`name`; discover names + which packs have a manifest with action:"list"). READ-ONLY — the way to INSPECT what a pack will install BEFORE calling the mutating apply_manifest. Names are validated (no path traversal) and must match an existing pack directory.\n' +
       '- action:"list_templates" — List CUSTOM-NODE-contributed ComfyUI workflow templates on the connected ComfyUI, grouped by source (each pack\'s own example_workflows/*.json). Hits the live server\'s /api/workflow_templates index. SCOPE LIMIT: this endpoint does NOT include ComfyUI\'s own core bundled templates from the comfyui-workflow-templates package (e.g. "Flux.1 Inpaint") — those are served to the frontend as static assets via a separate code path this action cannot see, so a small/empty result here does NOT mean no official template exists, only that no custom-node pack contributed one. When asked to "set up / build a <model-family> workflow", check here for a custom-node-contributed starter AFTER checking the bundled skills + installer packs (action:"skill_list" / action:"list"), and also tell the user to check the ComfyUI frontend\'s own Templates browser directly for core templates, since this action cannot enumerate those. NOTE: this lists what\'s available; loading a template onto the canvas is done in the ComfyUI frontend\'s Templates browser (the panel agent cannot load a template graph headlessly yet) — surface the matching template name to the user.\n' +
       '- action:"check_runtime" — Determine whether a workflow runs on the user\'s OWN GPU (LOCAL — free) or uses hosted API NODES (PAID api credits). Pass `pack` (a bundled pack name — always local/free) OR `graph` (a UI or API/prompt workflow JSON, as object or string). It scans the workflow\'s node class_types against the connected ComfyUI\'s API-node set (the same signal list_api_nodes uses) and returns { runtime: \'local\'|\'api\'|\'mixed\'|\'unknown\', usesApiNodes, apiNodes[], externalApiNodes[], unknownNodes[] } — \'unknown\' means some nodes couldn\'t be classified (could be paid), so treat it (and \'api\'/\'mixed\') as POSSIBLY PAID; only \'local\' is confirmed free. `externalApiNodes` is the THIRD-PARTY paid kind (a fal.ai-style pack, or any node taking a service credential): those are INSTALLED LOCALLY yet still cost money, billed by that provider on the user\'s own account with them rather than out of Comfy api credits — so when you ask the user, name the provider, not "Comfy credits" (`externalProviders` names it when recognised — e.g. ["fal.ai"]; it is absent when the node was flagged only by taking a service credential, which proves it authenticates somewhere but not to whom). ALWAYS call this before building OR loading a non-pack/ad-hoc workflow so you can ASK the user before spending paid API credits — never silently use API nodes.\n' +
       '- action:"extract_deps" — Analyze a ComfyUI workflow (`workflow`, API JSON) and determine which custom node packs it requires. Maps each node class_type to its owning node pack using ComfyUI-Manager mappings and the server\'s installed node definitions, reporting which packs are installed vs missing. READ-ONLY — it installs nothing. Works remotely (HTTP only) — mirrors `comfy-cli node deps-in-workflow`.\n' +
@@ -298,6 +300,7 @@ export function registerSkillsAccessTools(server: McpServer): void {
         .enum([
           "list",
           "read_workflow",
+          "read_manifest",
           "list_templates",
           "check_runtime",
           "extract_deps",
@@ -307,14 +310,14 @@ export function registerSkillsAccessTools(server: McpServer): void {
           "generate_skill",
         ])
         .describe(
-          'Which knowledge operation to perform. "list", "list_templates" and "skill_list" take no other parameters; "read_workflow" and "skill_read" require `name`; "check_runtime" takes `pack` OR `graph`; "extract_deps" and "install_deps" require `workflow` (and "install_deps" INSTALLS custom nodes — the only action here that installs, though "generate_skill" also WRITES to disk: its skill cache on every miss, plus `install_in` when set); "generate_skill" requires `source` (optional `install_in`/`refresh`).',
+          'Which knowledge operation to perform. "list", "list_templates" and "skill_list" take no other parameters; "read_workflow", "read_manifest" and "skill_read" require `name`; "check_runtime" takes `pack` OR `graph`; "extract_deps" and "install_deps" require `workflow` (and "install_deps" INSTALLS custom nodes — the only action here that installs, though "generate_skill" also WRITES to disk: its skill cache on every miss, plus `install_in` when set); "generate_skill" requires `source` (optional `install_in`/`refresh`).',
         ),
       name: z
         .string()
         .min(1)
         .optional()
         .describe(
-          'REQUIRED for action:"read_workflow" — the pack name (a directory under packs/, e.g. \'krea2-txt2img-manual\'), from action:"list". REQUIRED for action:"skill_read" — the skill name (a directory under plugin/skills/, e.g. \'krea2-txt2img\'), from action:"skill_list".',
+          'REQUIRED for action:"read_workflow" and action:"read_manifest" — the pack name (a directory under packs/, e.g. \'krea2-txt2img-manual\'), from action:"list". REQUIRED for action:"skill_read" — the skill name (a directory under plugin/skills/, e.g. \'krea2-txt2img\'), from action:"skill_list".',
         ),
       pack: z
         .string()
@@ -387,6 +390,10 @@ export function registerSkillsAccessTools(server: McpServer): void {
             return readPackWorkflowAction(
               requireName("read_workflow", "the pack whose ready workflow.json to read"),
             );
+          case "read_manifest":
+            return readPackManifestAction(
+              requireName("read_manifest", "the pack whose install manifest.yaml to read"),
+            );
           case "list_templates":
             return await listWorkflowTemplatesAction();
           case "check_runtime":
@@ -418,7 +425,7 @@ export function registerSkillsAccessTools(server: McpServer): void {
             // silent undefined if the schema and switch ever drift apart.
             const exhaustive: never = args.action;
             throw new Error(
-              `Unknown list_packs action "${String(exhaustive)}". Expected one of: list, read_workflow, list_templates, check_runtime, extract_deps, install_deps, skill_list, skill_read, generate_skill.`,
+              `Unknown list_packs action "${String(exhaustive)}". Expected one of: list, read_workflow, read_manifest, list_templates, check_runtime, extract_deps, install_deps, skill_list, skill_read, generate_skill.`,
             );
           }
         }
@@ -517,6 +524,51 @@ function readPackWorkflowAction(rawName: string): ToolText {
     };
   }
   const text = readFileSync(wfFile, "utf8");
+  return { content: [{ type: "text" as const, text }] };
+}
+
+/** action:"read_manifest" */
+function readPackManifestAction(rawName: string): ToolText {
+  const name = rawName.trim();
+  if (!SAFE_NAME.test(name)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: `Invalid pack name "${rawName}". Use a plain pack directory name from list_packs (action:"list").`,
+        },
+      ],
+    };
+  }
+  const packDir = join(packsDir(), name);
+  if (!packDir.startsWith(packsDir()) || !existsSync(packDir) || !statSync(packDir).isDirectory()) {
+    const known = enumeratePacks().map((p) => p.name);
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: `No pack named "${name}". Available packs: ${known.join(", ") || "(none bundled)"}.`,
+        },
+      ],
+    };
+  }
+  // Same resolver apply_manifest (pack:<name>) uses, so the manifest read here is
+  // exactly the one a later apply would install (.yaml or .yml, name-guarded).
+  const manifestFile = resolvePackManifestFile(name);
+  if (!manifestFile) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: `Pack "${name}" has no install manifest (manifest.yaml not found).`,
+        },
+      ],
+    };
+  }
+  const text = readFileSync(manifestFile, "utf8");
   return { content: [{ type: "text" as const, text }] };
 }
 


### PR DESCRIPTION
## Root cause

`list_packs(action:"read_manifest")` was rejected by the action enum, and there was **no read-only way to see what a bundled pack installs** — the only route to a pack's `manifest.yaml` was the mutating `apply_manifest`. (On current `main` the tool description no longer spelled the action out, but nothing closed the gap the report hit: a caller who wants to inspect a pack's manifest before installing had no supported action, and `action:"list"` hands out a `manifest_path` that points into an npx cache a later respawn no longer has — #1568.)

## Fix

Expose and implement `action:"read_manifest"` — the issue's first option:

- `src/tools/skills-access.ts` — new enum member, description bullet, switch branch, and `readPackManifestAction`. The pack name goes through the same validation as `read_workflow` (`SAFE_NAME` + must exist), and the file is resolved with `resolvePackManifestFile` — the **same resolver `apply_manifest (pack:<name>)` uses** — so the manifest read is exactly the one a later apply would install (`.yaml` or `.yml`). Returns the raw manifest text, the way `read_workflow` returns the raw graph. Read-only; it touches no service and cannot reach an install.
- `src/orchestrator/call-tool-admission.ts` — comment updated: like the other read-only actions, `read_manifest` was never whitelisted for the confirmation-less `call_tool` channel and stays refused there (pinned in the admission test).
- `docs/tools/skills-knowledge.mdx` — hand-written reference page (docs:gen never overwrites it): new `action: "read_manifest"` section, and the mutation warning corrected ("eight of the ten actions only read"). `scripts/gen-tool-docs.ts` comment updated to match.

## Verified

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run` on the touched areas — 201 passed, 0 failed: `skills-access.test.ts` (new tests: reads a real bundled pack's manifest, refuses unknown names with the pack list, rejects `../` traversal, and the `name`-presence guard), `skills-access-description.test.ts`, `call-tool-admission.test.ts` (pins `read_manifest` as refused on the admission channel), `vocabulary.test.ts`, `docs-schema-parity.test.ts`, `tool-annotations.test.ts`, `tool-surface-filter.test.ts`, `pack-manifest-resolution.test.ts`, `apply-manifest-pack-wiring.test.ts`
- `npm run docs:gen` — regenerates with no drift (only the hand-written page changed)
- `npm run check:vocabulary` — OK (1482 files, no live references to dead names)
- `npm run vocab:export -- --check` — OK (artefact matches the ledger)

Closes #1649