### PR TITLE
fix(1287): panel_search_nodes documents its own limit bound

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12336,7 +12336,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     def(
       "panel_search_nodes",
       "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager.",
-      { query: z.string().describe("Search text, e.g. 'kjnodes', 'controlnet', 'ipadapter'."), limit: z.number().int().min(1).max(40).optional() },
+      { query: z.string().describe("Search text, e.g. 'kjnodes', 'controlnet', 'ipadapter'."), limit: z.number().int().min(1).max(40).optional().describe("Max results to return, 1-40 (default 15). Requests above 40 are refused; the panel also clamps to 40 and discloses limit_cap.") },
       async (args: A, ctx) => ctx.call({ cmd: "nodes_search", query: args.query, limit: args.limit }, 20000),
     ),
     def(


### PR DESCRIPTION
Companion to comfyui-mcp-panel#1304 (merged).

**Root cause:** the `panel_search_nodes` zod schema has always enforced `limit` 1–40, but the tool description documented no maximum, so an agent only discovered the bound by being refused with `-32602 maximum: 40`.

**Fix:** the `limit` field description now states the 1–40 bound and default, and names the panel-side `limit_cap` disclosure that the panel adds when it clamps (shipped in comfyui-mcp-panel#1304). One-line schema-description change; no behavior change.

**Verified:** `npm run build` clean; `check:vocabulary` and `vocab:export --check` OK; `docs:gen` produces no content diff (panel tool pages are hand-written; `docs/panel.mdx` carries no per-field detail). No description-pinning test convention exists for panel tools in this repo, so none added.

Closes nothing on its own — #1287 itself is closed by the panel PR; this finishes the published-contract gap it flagged.