### PR TITLE
release: v0.52.0 — the panel starts MCP for you, through a launcher you install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.0] - 2026-08-17
+
+### MCP
+
+#### Added
+- panel MCP autostart — an explicit per-user launcher starts MCP when the panel opens, loopback-only and bearer-authenticated, with live provider discovery (#1590)
+- exact per-action tool allowlist — COMFYUI_MCP_TOOL_ACTION_ALLOW names the tool:action pairs an operator permits, no wildcards (#1452)
+
+#### Fixed
+- get_defaults names the live-preview id the frontend actually reads (#1638)
+- download_civitai sends the per-request auth override instead of dropping it (#1635)
+- a pack's install manifest is readable via list_packs action:"read_manifest" (#1649)
+- panel_search_nodes documents its own limit bound (#1287)
+
+
 ## [0.51.57] - 2026-08-16
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.57",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.57",
+      "version": "0.52.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.57",
+  "version": "0.52.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying two features — artokun/comfyui-mcp#1590 (panel MCP autostart) and artokun/comfyui-mcp#1453 (per-action tool allowlist) — plus fixes artokun/comfyui-mcp#1662, artokun/comfyui-mcp#1663, artokun/comfyui-mcp#1664, artokun/comfyui-mcp#1666, the docs-only specs artokun/comfyui-mcp#1151 and artokun/comfyui-mcp#645, and the MCP Registry publish workflow artokun/comfyui-mcp#1673. This is a MINOR bump to 0.52.0 on the strength of the two features.

**#1590 — panel MCP autostart (the flagship).** The Agent panel needs a safe OS-level path to start MCP when the panel opens, and the Registry-scanned panel package must stay process-spawn-free. The answer is an explicit per-user launcher companion: `comfyui-mcp launcher install|status|uninstall` backs onto Windows Task Scheduler, macOS launchd, Linux systemd user units, or an XDG fallback. The launcher broker is loopback-only and bearer-authenticated — MCP starts only after an authenticated request from the panel proxy. Provider discovery now distinguishes live local and CLI providers from installed-but-unavailable backends, so the panel stops offering backends that cannot answer. Companion panel change: artokun/comfyui-mcp-panel#1243.

**#1453 — exact per-action tool allowlist.** #873 / #1383 made tool names enforceable, but consolidated tools mix actions with very different blast radii: an operator could not allow `queue:list` and targeted `queue:cancel` without also exposing `queue:edit` and global `queue:clear`. `COMFYUI_MCP_TOOL_ACTION_ALLOW` is an exact comma-separated `tool:action` allowlist — malformed, empty, or wildcard rules are rejected at startup, enforcement runs before handlers across direct MCP registration, the compact `call_tool` catalog, and both panel servers, and the policy is forwarded to spawned children so they fail closed. No wildcards, deliberately: actions introduced by a future release stay denied until the operator names them.

**The fixes.** `get_defaults` names the live-preview id the frontend actually reads, not a stale one (#1638); `download_civitai` sends the per-request auth override instead of silently dropping it (#1635); a pack's install manifest is readable via `list_packs` action `read_manifest` (#1649); and `panel_search_nodes` documents its own limit bound (#1287).

Heads-up for tagging: v0.52.0 will be the first real tag to fire the new `mcp-registry.yml` workflow (#1673), which publishes every release tag to the MCP Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)