### PR TITLE
fix(1644): download_model action:"cancel" no longer asserts a live heartbeat it never probed

### DIFF
--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -576,6 +576,92 @@ describe('download_model action:"status"', () => {
       }
     });
   });
+
+  // ── #1644: cancel must not assert a live heartbeat it never checked ────────
+  describe("#1644 unprobed foreign record", () => {
+    it("cancel REFUSES without claiming liveness — and no longer contradicts status for the SAME id", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-1644-"));
+      setProgressDir(dir);
+      try {
+        // The reporter's shape: the record's heartbeat is still FRESH (the
+        // #858 reclaim gate keys on staleness, so cancel never probes the
+        // writer), yet the recorded pid is already dead — status proves it
+        // gone (#1479) while the old cancel fallback asserted "a live
+        // heartbeat … actively writing" about the SAME id.
+        const id = "fresh-dead-job-1644";
+        const res = spawnSync(process.execPath, ["-e", ""]);
+        await writeFile(
+          join(dir, `control-job-${id}-other-session.json`),
+          JSON.stringify({
+            id,
+            trayId: "freshtray164400",
+            progressId: "fresh-prog-1644",
+            url: "https://example.com/large.safetensors",
+            target_subfolder: "checkpoints",
+            status: "downloading",
+            started_at: Date.now() - 30 * 1000,
+            owner: "other-session",
+            pid: res.pid, // exited before this test runs — provably gone
+            updated: Date.now(), // heartbeat fresh: no reclaim verdict is produced
+          }),
+        );
+
+        const { cancelDownload, downloadStatus } = makeServer();
+
+        // status probes the pid regardless of staleness and reports the truth.
+        const status = (await downloadStatus({ id })).content[0].text;
+        expect(status).toContain("NOT running — the owning process is gone");
+
+        // cancel never probed anything, so it must SAY that — not assert the
+        // opposite of what status just reported.
+        const text = (await cancelDownload({ id, tray_id: "freshtray164400" })).content[0].text;
+        expect(text).toContain("status: downloading");
+        expect(text).not.toContain("live heartbeat");
+        expect(text).not.toContain("actively writing");
+        expect(text).toContain("could not be established from here");
+        // The remedy is the recovery that actually works for a dead writer:
+        // status decides, and re-issuing adopts the record and resumes.
+        expect(text).toContain('action:"status"');
+        expect(text).toContain("adopts the record and resumes from the .partial");
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("the explicit reclaim-denied verdicts keep their established wording", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-1644-"));
+      setProgressDir(dir);
+      try {
+        // owner-alive: stale heartbeat, but the pid probe PROVES a live owner —
+        // only there is "stop it from the panel download tray" the right remedy.
+        const id = "stale-live-job-1644";
+        await writeFile(
+          join(dir, `control-job-${id}-other-session.json`),
+          JSON.stringify({
+            id,
+            trayId: "livetray1644000",
+            progressId: "live-prog-1644",
+            url: "https://example.com/large.safetensors",
+            target_subfolder: "checkpoints",
+            status: "downloading",
+            started_at: Date.now() - 10 * 60 * 1000,
+            owner: "other-session",
+            pid: process.pid, // a live process stands in for the other session
+            updated: Date.now() - 5 * 60 * 1000,
+          }),
+        );
+
+        const { cancelDownload } = makeServer();
+        const text = (await cancelDownload({ id, tray_id: "livetray1644000" })).content[0].text;
+        expect(text).toContain("STILL RUNNING");
+        expect(text).toContain("panel download tray");
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });
 
 describe("list_local_models rendering", () => {

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1297,11 +1297,30 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
                 ? `its heartbeat has been stale for ${staleSecs}s, but whether the writing session is gone cannot be proven from here (its record carries no writer identity to check), so aborting it from here is refused — it may still be writing`
                 : res.reclaimDenied === "persist-failed"
                   ? `the session that started it is confirmed gone, but closing its stale record failed transiently`
-                  : `it is owned by another session with a live heartbeat, so the transfer is actively writing`;
+                  // #1644 — reaching this branch means NO reclaim verdict came
+                  // back (cancelDownloadJob returns the plain foreign-job result
+                  // with no `reclaimDenied`), so this call never probed the writer
+                  // at all. The previous text asserted "a live heartbeat …
+                  // actively writing" — the most confident liveness claim in the
+                  // function — from the one path that established none, and it
+                  // directly contradicted action:"status", which probes the
+                  // writer's pid and can report the SAME id's owner as proven
+                  // gone (#1479). Say only what is known: not owned here,
+                  // liveness not established here.
+                  : `this session does not own it and its writer was not probed by this call, so whether the transfer is still running could not be established from here`;
           const remedy =
             res.reclaimDenied === "persist-failed"
               ? `Retry download_model \`action:"cancel"\`.`
-              : `Stop it from the panel download tray instead.`;
+              : res.reclaimDenied
+                ? `Stop it from the panel download tray instead.`
+                // #1644 — with no reclaim verdict the old remedy ("stop it from
+                // the panel download tray") was a guess: the tray cannot close a
+                // record whose writer is already dead, which is exactly the case
+                // this branch cannot rule out. Point at the path that actually
+                // resolves it: action:"status" probes the writer's pid, and when
+                // it proves the writer gone, re-issuing action:"download" adopts
+                // the record and resumes from the leftover .partial.
+                : `Check download_model \`action:"status"\` for this id — it probes the writer's process directly. If status reports the owning process is gone, the transfer is NOT running and re-issuing download_model \`action:"download"\` for the same URL adopts the record and resumes from the .partial. Only if status shows it genuinely still writing, stop it from the panel download tray.`;
           return {
             content: [
               {


### PR DESCRIPTION
## Root cause

For a foreign in-flight download, `cancelDownloadJob` returns the plain `{ found, owned: false, aborted: false }` result with **no `reclaimDenied` verdict** whenever the reclaim path is not reached (e.g. the record's heartbeat is still fresh — the #858 reclaim gate keys on `staleInflight`). The cancel tool's message builder then treated the *absence* of a denial reason as *proof of life*, falling through to:

> it is owned by another session with a live heartbeat, so the transfer is actively writing

— the single most confident liveness claim in the function, emitted from the one path that never checked liveness. It directly contradicted `action:"status"` for the SAME id, which probes the writer's pid regardless of staleness and correctly reported the reporter's writer as proven gone (#1479). The reporter verified with on-disk `.partial` diffs (zero growth over ~20s) that status was right and cancel was wrong, and the offered remedy ("stop it from the panel download tray") cannot close a record whose writer is already dead — so the documented recovery path was unreachable.

## Fix

Message-layer only, matching the reporter's verified local patch — no reclaim/abort behavior changes:

- When no `reclaimDenied` verdict came back, the refusal now says what is actually known: this session does not own the download and its writer was not probed by this call, so whether the transfer is still running **could not be established from here**.
- The remedy for that case now points at the recovery that actually works: check `action:"status"` (it probes the writer's pid); if status proves the owner gone, re-issuing `action:"download"` adopts the record and resumes from the `.partial`. The panel-tray remedy is kept only for the explicit `owner-alive` / `owner-unknown` verdicts, where a live-or-unprovable writer is what the tray is for.

The suggested deeper change (have cancel reuse the pid probe status already runs, independent of heartbeat staleness) is deliberately NOT in this PR — it changes reclaim behavior around the #761/#858 invariants and deserves its own issue.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/tools/model-management.test.ts` — 19/19 pass, including two new #1644 tests:
  - a FRESH-heartbeat foreign record with a dead pid (the reporter's exact shape): status reports "NOT running — the owning process is gone" while cancel no longer claims "live heartbeat"/"actively writing", discloses that liveness was not established, and points at status + re-issue;
  - the explicit `owner-alive` verdict keeps its established "STILL RUNNING … panel download tray" wording.
- Neighboring download suites: `download-jobs`, `download-status-proven-dead`, `download-status-decline`, `download-status-promise` — 128/128 pass.
- Tool descriptions unchanged, so docs:gen/vocabulary gates are not implicated.

Closes #1644