### PR TITLE
fix(1652): training runs no longer trip the hard stall floor while the server stays alive

### DIFF
--- a/src/services/queue-monitor.stall.test.ts
+++ b/src/services/queue-monitor.stall.test.ts
@@ -8,7 +8,10 @@
 // here (no ws frame + no successful /queue poll within the window). A reachable
 // ComfyUI keeps the 1 Hz poll fresh, so a busy decode stays live; a crashed /
 // wedged server lets the heartbeat lapse → a real stall still surfaces. A hard
-// floor of 30 min backstops a genuine in-node deadlock on a reachable server.
+// floor of 30 min backstops a genuine in-node deadlock on a reachable server —
+// but NOT for runs whose graph contains a known TRAINING node class (#1652):
+// TrainLoraNode & co. emit no per-step progress frames for hours by design, so
+// the floor fired on every healthy long training run.
 import { beforeEach, describe, expect, it } from "vitest";
 import { QueueMonitor, type CompletionEvent, type StallReport } from "./queue-monitor.js";
 
@@ -22,6 +25,7 @@ type Priv = {
     progressValue: number | null;
     progressMax: number | null;
     queueRemaining: number;
+    runningNodeClassTypes: Record<string, string>;
     lastActivityTs: number | null;
     lastFrameTs: number | null;
     lastServerAliveTs: number | null;
@@ -41,6 +45,7 @@ function primeRunning(opts: {
   serverAliveAgoMs: number | null; // null = never / stale beyond memory
   wsFrameAgoMs: number | null;
   currentNode?: string | null;
+  nodeClassTypes?: Record<string, string>;
 }): void {
   const now = Date.now();
   priv.state.runningPromptId = "prompt-1";
@@ -48,6 +53,7 @@ function primeRunning(opts: {
   priv.state.progressValue = 4;
   priv.state.progressMax = 8;
   priv.state.queueRemaining = 1;
+  priv.state.runningNodeClassTypes = opts.nodeClassTypes ?? {};
   priv.state.lastActivityTs = now - opts.idleForMs;
   priv.state.lastServerAliveTs = opts.serverAliveAgoMs == null ? null : now - opts.serverAliveAgoMs;
   priv.state.lastFrameTs = opts.wsFrameAgoMs == null ? null : now - opts.wsFrameAgoMs;
@@ -62,6 +68,7 @@ beforeEach(() => {
   priv.state.progressValue = null;
   priv.state.progressMax = null;
   priv.state.queueRemaining = 0;
+  priv.state.runningNodeClassTypes = {};
   priv.state.lastActivityTs = null;
   priv.state.lastFrameTs = null;
   priv.state.lastServerAliveTs = null;
@@ -104,5 +111,92 @@ describe("QueueMonitor.report — liveness-gated stall (#183)", () => {
     priv.state.runningPromptId = null;
     priv.state.lastActivityTs = Date.now() - 10 * HARD_FLOOR_MS;
     expect(priv.report(STALL_MS).stalled).toBe(false);
+  });
+});
+
+describe("QueueMonitor.report — training exemption from the hard floor (#1652)", () => {
+  // A TrainLoraNode run emits no per-step progress frames: idleFor grows for
+  // the whole run while ComfyUI stays perfectly responsive. The hard floor
+  // fired on EVERY training run past 30 minutes and the injected note told the
+  // agent to cancel it — killing a healthy 65-minute job.
+  const TRAINING_GRAPH = {
+    "3": "LoadImageTextDataSetFromFolder",
+    "5": "MakeTrainingDataset",
+    "7": "TrainLoraNode",
+    "9": "SaveLoRA",
+  };
+
+  it("does NOT flag a healthy training run past the hard floor — current node unknown (the reported case)", () => {
+    // Attached mid-run: no progress_state transition ever arrives, so
+    // currentNode stays null and only the /queue graph names the trainer.
+    primeRunning({
+      idleForMs: HARD_FLOOR_MS + 15 * 60_000, // 45 min in — mid-training
+      serverAliveAgoMs: 800, // /queue poll fresh: server fully responsive
+      wsFrameAgoMs: null,
+      currentNode: null,
+      nodeClassTypes: TRAINING_GRAPH,
+    });
+    const rep = priv.report(STALL_MS);
+    expect(rep.stalled).toBe(false);
+    expect(rep.stalledForMs).toBe(0);
+  });
+
+  it("does NOT flag when the current node IS the trainer", () => {
+    primeRunning({
+      idleForMs: HARD_FLOOR_MS + 60_000,
+      serverAliveAgoMs: 800,
+      wsFrameAgoMs: null,
+      currentNode: "7",
+      nodeClassTypes: TRAINING_GRAPH,
+    });
+    expect(priv.report(STALL_MS).stalled).toBe(false);
+  });
+
+  it("still hard-flags a NON-training node past the floor, even inside a training graph", () => {
+    // Stuck on an ordinary node in a graph that also trains: the exemption is
+    // scoped to the trainer itself, so the deadlock backstop is preserved.
+    primeRunning({
+      idleForMs: HARD_FLOOR_MS + 60_000,
+      serverAliveAgoMs: 500,
+      wsFrameAgoMs: null,
+      currentNode: "9", // SaveLoRA
+      nodeClassTypes: TRAINING_GRAPH,
+    });
+    expect(priv.report(STALL_MS).stalled).toBe(true);
+  });
+
+  it("still hard-flags an ordinary render past the floor when class types were captured", () => {
+    primeRunning({
+      idleForMs: HARD_FLOOR_MS + 60_000,
+      serverAliveAgoMs: 500,
+      wsFrameAgoMs: null,
+      currentNode: "4",
+      nodeClassTypes: { "4": "KSampler", "6": "SaveImage" },
+    });
+    expect(priv.report(STALL_MS).stalled).toBe(true);
+  });
+
+  it("still flags a training run when the server has gone DARK (liveness gate is untouched)", () => {
+    primeRunning({
+      idleForMs: STALL_MS + 60_000,
+      serverAliveAgoMs: STALL_MS + 60_000,
+      wsFrameAgoMs: STALL_MS + 60_000,
+      currentNode: null,
+      nodeClassTypes: TRAINING_GRAPH,
+    });
+    expect(priv.report(STALL_MS).stalled).toBe(true);
+  });
+
+  it("applies the floor as before when the /queue graph was never captured", () => {
+    // No class types on record (poll never succeeded / pre-fix state) → nothing
+    // is exempt; behaviour is exactly the pre-fix backstop.
+    primeRunning({
+      idleForMs: HARD_FLOOR_MS + 60_000,
+      serverAliveAgoMs: 500,
+      wsFrameAgoMs: null,
+      currentNode: null,
+      nodeClassTypes: {},
+    });
+    expect(priv.report(STALL_MS).stalled).toBe(true);
   });
 });

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -47,6 +47,14 @@ interface MonitorState {
   // ComfyUI's status.exec_info.queue_remaining — the total tasks the server still
   // has (running + pending). Last-known value between status frames.
   queueRemaining: number;
+  // Node id → class_type for the RUNNING prompt's graph, captured from the
+  // /queue poll's queue_running entry — the only place this passive client
+  // learns class types on modern ComfyUI (sid-scoped frames never arrive here).
+  // Drives the training exemption in report() (#1652): TrainLoraNode & co. emit
+  // no per-step progress frames, so the hard stall floor would otherwise fire on
+  // EVERY healthy training run past 30 minutes. Empty until the poll captures
+  // the graph; cleared with the run.
+  runningNodeClassTypes: Record<string, string>;
   // Monotonic ms timestamp of the last FORWARD-progress signal (node advanced or
   // progress value ticked up) while a job runs. A stuck step re-emits the same
   // progress value, which must NOT refresh this — that's how we see the stall.
@@ -134,9 +142,26 @@ const HISTORY_TAIL_ITEMS = 32;
 // Absolute floor of zero-forward-progress time after which a running job is
 // flagged as stalled EVEN when the server still looks alive here — the backstop
 // for a genuine in-node deadlock on a reachable ComfyUI (#183). Far beyond any
-// legitimate single-node runtime (a long tiled VAE decode / video sample is
-// minutes, not half an hour), so it never trips on a healthy render.
+// legitimate single-node NON-training runtime (a long tiled VAE decode / video
+// sample is minutes, not half an hour), so it never trips on a healthy render.
+// Training nodes legitimately exceed it (hours of silent tqdm), which is why
+// report() exempts runs whose graph contains a known trainer class (#1652).
 const HARD_STALL_FLOOR_MS = 30 * 60 * 1000; // 30 minutes
+// Node classes whose HEALTHY runtime legitimately exceeds the hard floor with
+// ZERO forward-progress frames: ComfyUI's built-in LoRA training only rewrites
+// a tqdm bar on stdout — no per-step `progress` WS frames — so lastActivityTs
+// never bumps and idleFor grows monotonically for the whole run (#1652). A
+// 1500-step SDXL LoRA at ~2.6 s/it runs ~65 minutes and crossed the 30-minute
+// floor every single time; the false STALLED note (whose remedy is to CANCEL
+// the run) was structural, not a race. Best-effort list of known trainer
+// classes — deliberately narrow: a class that also appears in ordinary render
+// graphs (e.g. LoraModelLoader) must NOT be added, or common renders would
+// silently lose the deadlock backstop.
+const TRAINING_NODE_CLASS_TYPES = new Set([
+  "TrainLoraNode", // ComfyUI core
+  "TrainLoraNodeAdvanced", // core advanced variant
+  "LoraTrainer", // common community trainer packs
+]);
 
 class QueueMonitorImpl {
   private ws: WebSocket | null = null;
@@ -158,6 +183,7 @@ class QueueMonitorImpl {
     progressValue: null,
     progressMax: null,
     queueRemaining: 0,
+    runningNodeClassTypes: {},
     lastActivityTs: null,
     lastFrameTs: null,
     lastServerAliveTs: null,
@@ -471,6 +497,7 @@ class QueueMonitorImpl {
     this.state.currentNode = null;
     this.state.progressValue = null;
     this.state.progressMax = null;
+    this.state.runningNodeClassTypes = {};
     this.state.lastActivityTs = null;
   }
 
@@ -688,6 +715,19 @@ class QueueMonitorImpl {
     const first = running[0];
     if (Array.isArray(first) && typeof first[1] === "string") {
       this.adoptRunningPrompt(first[1]);
+      // Index 2 is the full prompt graph (node id → { class_type, ... }) — the
+      // ONLY place this passive client learns the running run's class types.
+      // Captured so report() can tell a long TRAINING node (no per-step
+      // progress frames by design, #1652) from a wedge.
+      const prompt = first[2];
+      const types: Record<string, string> = {};
+      if (prompt && typeof prompt === "object" && !Array.isArray(prompt)) {
+        for (const [nodeId, def] of Object.entries(prompt as Record<string, unknown>)) {
+          const ct = (def as { class_type?: unknown } | null)?.class_type;
+          if (typeof ct === "string") types[nodeId] = ct;
+        }
+      }
+      this.state.runningNodeClassTypes = types;
     } else if (running.length === 0 && this.state.runningPromptId !== null) {
       // Empty queue → the tracked run is over. Skip the clear if a run was
       // adopted AFTER this fetch began (the response would be stale for it).
@@ -812,11 +852,26 @@ class QueueMonitorImpl {
     // also freezes ComfyUI's own HTTP handler → the /queue heartbeat lapses and
     // `serverAlive` catches it at stallMs without this floor; the floor only
     // covers the rarer non-GIL wedge (a node stuck in a network/IO wait) that
-    // keeps HTTP alive. The floor is a deliberate finite tradeoff: a healthy but
-    // progress-silent node exceeding it is re-flagged (unavoidable — "busy" and
-    // "wedged" are indistinguishable from outside past some horizon), so it is
-    // set far beyond any legitimate single-node runtime.
-    const hardStalled = running && idleFor >= Math.max(stallMs, HARD_STALL_FLOOR_MS);
+    // keeps HTTP alive.
+    //
+    // TRAINING EXEMPTION (#1652): a run whose CURRENT node is a known trainer —
+    // or, when the current node is unknown here (the reported case: attaching
+    // mid-run sees no progress_state transition, so currentNode stays null for
+    // the whole training), whose GRAPH contains one — legitimately sits silent
+    // for HOURS, so the floor must not override liveness for it: while the
+    // server keeps answering, it is not stalled. The tradeoff, stated plainly:
+    // a genuinely wedged trainer on a still-reachable server is no longer
+    // hard-flagged — but a GIL-holding deadlock freezes ComfyUI's HTTP too, and
+    // `serverAlive` catches that at stallMs regardless of node class. When the
+    // graph was never captured (poll never succeeded), nothing is exempt and
+    // the floor applies exactly as before.
+    const types = this.state.runningNodeClassTypes;
+    const currentType = this.state.currentNode !== null ? types[this.state.currentNode] : undefined;
+    const trainingRun =
+      currentType !== undefined
+        ? TRAINING_NODE_CLASS_TYPES.has(currentType)
+        : Object.values(types).some((t) => TRAINING_NODE_CLASS_TYPES.has(t));
+    const hardStalled = running && !trainingRun && idleFor >= Math.max(stallMs, HARD_STALL_FLOOR_MS);
     const stalled = running && idleFor >= stallMs && (!serverAlive || hardStalled);
     const progress =
       this.state.progressValue !== null && this.state.progressMax !== null


### PR DESCRIPTION
Closes #1652.

## Root cause

ComfyUI's `TrainLoraNode` only rewrites a tqdm bar on stdout — it emits no per-step websocket progress frames — so the queue monitor's `lastActivityTs` never bumps and `idleFor` grows monotonically for the whole run. The `serverAlive` liveness gate (#183) correctly suppressed the stall, but the `hardStalled` backstop (`idleFor >= max(stallMs, HARD_STALL_FLOOR_MS)`, 30 min) overrode it. Any training run longer than 30 minutes was **guaranteed** to be flagged STALLED, and the injected note's remedy is to cancel the run — structural, not a race.

## Fix

The monitor's `/queue` poll already receives the running prompt's full graph (`queue_running[0][2]`: node id → `{ class_type, ... }`) — the only place this passive client learns class types on modern ComfyUI. The monitor now captures it and `report()` exempts a run from the hard floor's liveness override when:

- the **current node's** class type is a known trainer (`TrainLoraNode`, `TrainLoraNodeAdvanced`, `LoraTrainer`), or
- the current node is unknown (the reported case: attaching mid-run sees no `progress_state` transition, so `currentNode` stays `null` for the whole training) but the **graph contains** a known trainer.

While the server keeps answering the 1 Hz poll, such a run is never flagged — a healthy multi-hour training run can no longer be killed by the floor. Deliberately preserved behavior:

- the floor still backstops a **non-training** node past 30 min, including a non-training node inside a training graph (e.g. a wedged `SaveLoRA`);
- a server that goes **dark** is still flagged at `stallMs` regardless of node class (the liveness gate is untouched — a GIL-holding deadlock freezes ComfyUI's HTTP too);
- when the graph was never captured (poll never succeeded), nothing is exempt and the floor applies exactly as before.

The trainer class list is deliberately narrow — a class that also appears in ordinary render graphs (e.g. `LoraModelLoader`) is excluded so common renders don't silently lose the deadlock backstop.

The tradeoff, stated plainly: a genuinely wedged trainer on a *still-reachable* server (the rare non-GIL IO-wait wedge the floor exists for) is no longer hard-flagged — it now relies on the liveness gate, same as every other long progress-silent node since #183.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/services/queue-monitor.stall.test.ts src/services/queue-monitor.poll.test.ts src/services/queue-monitor.self-attribution.test.ts` — 33/33 pass, including 6 new #1652 cases: healthy training past the floor not flagged (current node known and unknown), non-training node in a training graph still hard-flagged, ordinary render with captured class types still hard-flagged, dark server still flagged, uncaptured graph unchanged
- `npx vitest run src/services/queue-status-broadcast.test.ts src/__tests__/orchestrator/panel-run-backpressure.test.ts src/__tests__/orchestrator/inject-event-wiring.test.ts` — 40/40 pass

Not verified live (no 65-minute GPU training run was executed here); the verdict logic is covered by the unit cases above, which reproduce the issue's exact reported state (`currentNode: null`, fresh `/queue` heartbeat, `idleFor` past the floor).