### PR TITLE
fix(1647): an unreadable parent PID degrades to a disclosed Desktop restart

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1074,11 +1074,18 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(preflight.ok).toBe(true);
   });
 
-  it("preflightLocalRestart REFUSES a Desktop app whose supervision cannot be established (#814)", async () => {
-    // The counterpart, and the policy the #814 loss forced. A reboot has not happened
-    // yet and cannot be undone, so "I could not establish that anything will restart
-    // this" refuses — unlike `listener_ownership`, where the launch has ALREADY
-    // happened and uncertainty is merely disclosed. Refuse before, disclose after.
+  it("preflightLocalRestart PASSES a Desktop app whose parentage is unreadable — disclosed, not silent (#1647)", async () => {
+    // The issue's own shape: a live Desktop backend whose argv carries the Desktop
+    // launch signatures (here: a `main.py` inside the Desktop install), on a host
+    // where the parent pid cannot be read — so the ancestry walk cannot prove a
+    // supervisor. The preflight used to refuse outright; it now passes on the
+    // strength of the launch arguments (only the Desktop app launches a backend
+    // that way) and CARRIES THE DISCLOSURE, so the caller that dispatches on this
+    // pass reports an inference as an inference.
+    //
+    // What has NOT changed: every other unreadable shape still refuses (a chain
+    // read partway and found ambiguous — see the lifecycle suite), and a parent
+    // PROVEN gone refuses outright (#814).
     mockLivePortNoKill();
     mockGetSystemStats.mockResolvedValue({
       system: {
@@ -1094,8 +1101,9 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
 
     const preflight = await preflightLocalRestart();
 
-    expect(preflight.ok).toBe(false);
-    expect(preflight.reason).toMatch(/could not be established/i);
+    expect(preflight.ok).toBe(true);
+    expect(preflight.note).toMatch(/INFERRED, not proven/i);
+    expect(preflight.note).toMatch(/could not be read/i);
   });
 
   it("preflightLocalRestart REFUSES when no running process can be identified", async () => {

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -305,8 +305,28 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // Refusing on missing evidence would take the Desktop restart away from every
     // host whose process tree cannot be read, which is the far more common and far
     // more damaging failure. Only a positive finding refuses.
-    const { verdict } = classifyDesktopSupervision(tree({ 500: {} }));
+    const { verdict, parentUnreadableAt } = classifyDesktopSupervision(tree({ 500: {} }));
     expect(verdict).toBe("unconfirmed");
+    // #1647: WHICH link failed is reported, so the caller's launch-signature
+    // fallback can tell "the FIRST hop was unreadable" (a host that cannot read
+    // parentage at all) from a walk that ran out of road partway up — only the
+    // former may proceed on the argv evidence.
+    expect(parentUnreadableAt).toBe(500);
+  });
+
+  it("an unreadable parent DEEPER in the chain is marked at that hop, not the first", () => {
+    // The walk read one link fine (a wrapper), then ran out of road. The marker
+    // names the hop that actually failed, so the #1647 fallback — which exists for
+    // the host that cannot read parentage AT ALL — cannot mistake a partially-read
+    // chain for it.
+    const { verdict, parentUnreadableAt } = classifyDesktopSupervision(
+      tree({
+        500: { parent: 400, started: "5000" },
+        400: { cmd: "wrapper", started: "1000" },
+      }),
+    );
+    expect(verdict).toBe("unconfirmed");
+    expect(parentUnreadableAt).toBe(400);
   });
 
   it("A RECYCLED parent pid that looks exactly like a supervisor is ABANDONED, not supervised", () => {
@@ -1348,12 +1368,19 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     expect(killWasIssued()).toBe(false);
   });
 
-  it("#400 is not disturbed: the refusal leaves the server RUNNING, it never kills it", async () => {
-    // The claim this policy had to be separated from. #400 established that a Desktop
-    // process must never be KILLED locally, because respawning the exe does not
-    // reliably bring the listener back. Refusing an unverified Manager stop does not
-    // touch that: the server stays up and the user is pointed at the app that
-    // restarts it reliably.
+  it("#1647: an unreadable parent pid DEGRADES to a disclosed reboot when Desktop launch signatures are present", async () => {
+    // The issue itself: a live ComfyUI Desktop instance (reported on macOS), whose
+    // backend's argv carries the Desktop launch signatures — `--enable-manager` and
+    // an `--extra-model-paths-config` pointing into the Comfy Desktop data
+    // directory — but whose parent pid could not be read, so the ancestry walk
+    // never got off the ground and the restart was REFUSED outright, blocking a
+    // just-installed custom node from loading.
+    //
+    // The same argv that identifies the instance as Desktop also names its
+    // launcher: only the Desktop app starts a backend with those flags. So the
+    // reboot now proceeds on that inference — DISCLOSED in the result, never
+    // silent — and #400 is still not disturbed: the process is never KILLED
+    // locally, the Manager reboot cycles it through its supervisor.
     desktopServer();
     __processControlTestHooks.setProcessIdentityResolver((pid) =>
       pid === 4321 ? { startedAt: "5000" } : undefined,
@@ -1364,10 +1391,50 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
 
     const result = await restartComfyUI();
 
-    expect(result.message).toMatch(/refusing to restart/i);
-    expect(result.message).toMatch(/Restart it from the ComfyUI Desktop app/i);
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    // The Manager reboot route was actually taken…
+    expect(fetchSpy).toHaveBeenCalled();
+    // …the inference is DISCLOSED, with what could not be read named…
+    expect(result.message).toMatch(/INFERRED, not proven/i);
+    expect(result.message).toMatch(/parent process of PID 4321 could not be read/i);
+    // …and the residual risk is stated, so a hand-started server is not silently
+    // stopped for good.
+    expect(result.message).toMatch(/started this server BY HAND/i);
+    // #400 stands: nothing was killed — the reboot cycles the process through its
+    // supervisor, it is never stopped locally.
     expect(killWasIssued()).toBe(false);
+  });
+
+  it("#1647: the fallback stops at the FIRST hop — an unreadable parent higher up still refuses", async () => {
+    // The boundary of the fallback. It exists for a host that cannot read
+    // parentage AT ALL (the port owner's own parent is unreadable). A walk that
+    // read one link — a wrapper, not a supervisor — and THEN hit an unreadable
+    // parent is a partially-read chain with an ambiguous middle, and that shape
+    // keeps the #814 refusal: nothing about the argv can speak for what sits
+    // above the wrapper.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          // Readable, causally sound, and plainly NOT the Desktop shell.
+          commandLine: "python.exe wrapper.py",
+          startedAt: "2000",
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => (pid === 4321 ? 300 : undefined));
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/the parent process of PID 300 could not be read/i);
     expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
   });
 
   it("a wedged DESKTOP instance is recognised from the OS command line and never killed", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -708,6 +708,7 @@ export const __panelToolsTestHooks = {
           reason?: string;
           observedArgv?: string[];
           isDesktopApp?: boolean;
+          note?: string;
         }>)
       | null,
   ): void {
@@ -1980,6 +1981,7 @@ let localRestartPreflightOverride:
       reason?: string;
       observedArgv?: string[];
       isDesktopApp?: boolean;
+      note?: string;
     }>)
   | null = null;
 
@@ -12725,6 +12727,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // the no-await invariant between the binding capture and the reboot stands.
         let preflightArgv: string[] | undefined;
         let preflightIsDesktop = false;
+        // #1647: set when the preflight passed on INFERRED Desktop supervision (the
+        // process tree was unreadable, so the launch signatures stood in). Appended
+        // to the outcome note below — a dispatch allowed on an inference says so.
+        let preflightNote: string | undefined;
         // The target generation as of BEFORE the preflight resolved that argv, so the
         // whole span up to the post-restart reading sits inside one instance fence.
         let preflightArgvGeneration = -1;
@@ -12797,6 +12803,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // exactly the fence this reading needs.
           preflightArgv = preflight.observedArgv;
           preflightIsDesktop = preflight.isDesktopApp === true;
+          preflightNote = preflight.note;
           preflightArgvGeneration = preflightTargetGeneration;
           // r8/r9/r10: the preflight AWAIT makes the pre-decision captures
           // STALE — and the preflight itself reads MUTABLE config (target URL,
@@ -13381,7 +13388,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               "There is no local boot endpoint I can safely probe from here, so I can't " +
               "confirm it finished coming back — a panel reconnect wouldn't prove this " +
               'instance actually cycled. Check get_system_stats (action:"health") / panel_node_queue_status in a ' +
-              "few seconds to confirm it's back.",
+              "few seconds to confirm it's back." +
+              (preflightNote ? ` ${preflightNote}` : ""),
           });
         }
         // The concurrent observer has been probing since dispatch (catching a fast down→up
@@ -13407,9 +13415,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             recovered_ms: recovery.waited_ms,
             probes: recovery.attempts,
             saw_down: recovery.sawDown,
-            note: recovery.sawDown
-              ? `Reboot was dispatched and ComfyUI went down, but it has not become healthy within ${waited}s — it may still be starting or the restart failed. Verify with get_system_stats (action:"health") / panel_node_queue_status before retrying; do NOT assume it is back.`
-              : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with get_system_stats (action:"health") / panel_node_queue_status; do NOT assume it restarted.`,
+            note:
+              (recovery.sawDown
+                ? `Reboot was dispatched and ComfyUI went down, but it has not become healthy within ${waited}s — it may still be starting or the restart failed. Verify with get_system_stats (action:"health") / panel_node_queue_status before retrying; do NOT assume it is back.`
+                : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with get_system_stats (action:"health") / panel_node_queue_status; do NOT assume it restarted.`) +
+              (preflightNote ? ` ${preflightNote}` : ""),
           });
         }
         // #400/#709: ComfyUI is healthy, but the panel's browser tab re-registers its own
@@ -13523,7 +13533,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
                   'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
                   "before issuing graph tools.") +
-            ".") + argvNote,
+            ".") + argvNote + (preflightNote ? ` ${preflightNote}` : ""),
         });
       },
     ),

--- a/src/services/listener-ownership.ts
+++ b/src/services/listener-ownership.ts
@@ -87,6 +87,19 @@ export function unclassifiedSupervision(): SupervisorRelaunch {
 export interface SupervisionAssessment {
   verdict: SupervisorRelaunch;
   because?: string;
+  /**
+   * Set ONLY when the walk stopped because the parent of this pid could not be
+   * read at all — the first shape of `unconfirmed` below. Recorded as a field
+   * (not just folded into `because`) so a caller can tell "the chain was
+   * unreadable from the start" apart from the later, richer shapes — a parent
+   * that exists but cannot be probed, an identity that cannot be read, start
+   * times that cannot be compared — without parsing prose. The distinction
+   * decides whether the #1647 fallback (proceed on the server's own Desktop
+   * launch signatures, disclosed) may even be considered: that fallback exists
+   * for the host that cannot read parentage at all, never for a chain that was
+   * read and found ambiguous partway up.
+   */
+  parentUnreadableAt?: number;
 }
 
 export interface SupervisionEvidence {
@@ -176,9 +189,14 @@ export function compareStartTimes(
  *   `unconfirmed`— the chain became unreadable, a pid could not be probed, or the hop
  *                  budget ran out. NOT an answer in either direction — and note that
  *                  it is the CALLER that decides what to do with it. For a reboot,
- *                  which is irreversible and has not happened yet, the caller refuses:
- *                  see assessDesktopSupervision. Each such outcome carries `because`,
- *                  so a refusal can name what it failed to establish.
+ *                  which is irreversible and has not happened yet, the caller refuses —
+ *                  with one disclosed exception (#1647: the FIRST link unreadable on a
+ *                  host that cannot read parentage at all, where the server's own
+ *                  Desktop launch signatures say who started it): see
+ *                  assessDesktopSupervision. Each such outcome carries `because`, so a
+ *                  refusal can name what it failed to establish, and
+ *                  `parentUnreadableAt`, so the fallback can tell the first-hop shape
+ *                  from a chain that ran out of road partway up.
  *
  * The hop budget is small on purpose. A Desktop backend sits one or two levels under
  * its shell; a chain longer than that is not a layout we can reason about, and
@@ -213,7 +231,15 @@ export function classifyDesktopSupervision(
   for (let hop = 0; hop < maxHops; hop++) {
     const parent = input.readParentPid(current);
     // The chain stopped being readable. Nothing was learned in either direction.
-    if (parent == null) return unconfirmed(`the parent process of PID ${current} could not be read`);
+    // WHICH pid failed is recorded: a caller that falls back to weaker evidence
+    // (#1647) may do so only when the FIRST link — the port owner's own parent —
+    // is the unreadable one, not when a walk that got partway up ran out of road.
+    if (parent == null) {
+      return {
+        ...unconfirmed(`the parent process of PID ${current} could not be read`),
+        parentUnreadableAt: current,
+      };
+    }
     // A process cannot be its own parent; that reading is damage, not a tree root.
     if (parent === current) return unconfirmed(`PID ${current} was reported as its own parent, which is not a tree this can be read from`);
     // The TOP of the tree, reached without passing a supervisor. On POSIX an

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1992,8 +1992,22 @@ function processExists(pid: number): boolean | undefined {
  * "couldn't confirm it came back" — a verdict computed AFTER the stop, about a stop
  * it should never have made.
  *
- * ONLY `supervised` proceeds. `unconfirmed` REFUSES, and the asymmetry with the rest
- * of this file is deliberate rather than an inconsistency (coordinator gate):
+ * ONLY `supervised` proceeds silently. `unconfirmed` REFUSES — with ONE disclosed
+ * exception (#1647): when the walk never got off the ground because the port owner's
+ * OWN parent could not be read (a host that cannot read parentage at all — the
+ * reporter's macOS Desktop install), and the server's own launch arguments carry the
+ * ComfyUI Desktop launch signatures (`--extra-model-paths-config` pointing into the
+ * `Comfy Desktop` data directory, a `main.py` inside the Desktop install), then the
+ * same argv that told us this IS a Desktop instance also tells us WHO launched it:
+ * the Desktop app. In that one shape the reboot proceeds and the inference is stated
+ * in the result (`note`) — what was not proven, what it was inferred from, and the
+ * residual case where nothing will bring the server back (a backend someone started
+ * BY HAND with Desktop's flags). Every other `unconfirmed` shape — a chain that was
+ * read and found ambiguous partway up — still refuses, and `abandoned` always does:
+ * a parent PROVEN gone is a fact, not a gap in the evidence.
+ *
+ * The asymmetry with the rest of this file is deliberate rather than an
+ * inconsistency (coordinator gate):
  *
  *   `listener_ownership` reports on an action that HAS ALREADY HAPPENED — the child
  *   was spawned, the server is answering — and only the DESCRIPTION of it is
@@ -2017,6 +2031,14 @@ function processExists(pid: number): boolean | undefined {
 function assessDesktopSupervision(info: ProcessInfo): {
   ok: boolean;
   reason?: string;
+  /**
+   * The disclosure owed when `ok` was reached by INFERENCE rather than by proof
+   * (#1647): what could not be established, what was proceeded on, and the case
+   * in which nothing brings the server back. Carried on the result so the
+   * caller's message can state it — proceeding quietly would be the silent
+   * success this file exists to prevent.
+   */
+  note?: string;
   supervision: SupervisorRelaunch;
 } {
   const cannotAssess = (because: string): {
@@ -2052,7 +2074,7 @@ function assessDesktopSupervision(info: ProcessInfo): {
   // already handles pid 0 the way it handles any pid it cannot read — the identity
   // and parent reads come back empty and the verdict is `unconfirmed`, which now
   // refuses — so letting it fall through inherits a path that IS tested.
-  const { verdict, because } = classifyDesktopSupervision({
+  const { verdict, because, parentUnreadableAt } = classifyDesktopSupervision({
     pid: info.pid,
     readParentPid,
     readIdentity: resolveProcessIdentity,
@@ -2069,6 +2091,41 @@ function assessDesktopSupervision(info: ProcessInfo): {
         `Desktop app is still supervising it — its parent process is gone. A restart from here ` +
         `asks ComfyUI-Manager to stop the process and relies on that supervisor to start it ` +
         `again, so it would be stopped and nothing would bring it back.`,
+    };
+  }
+  // #1647 — the host cannot read parentage AT ALL (the FIRST link failed), and the
+  // server's own argv already carries the Desktop launch signatures. The walk has
+  // nothing to say, but the argv does: only the Desktop app launches its backend
+  // with those flags, so Desktop is what started this server and a live Desktop app
+  // restarts a backend that exits under it. Proceed on that inference — DISCLOSED,
+  // via `note`, never silently — rather than refusing a restart that works.
+  //
+  // Restricted to the first hop on purpose: an unreadable parent DEEPER in the chain
+  // means wrappers between the backend and whatever spawned it, a layout nothing here
+  // can reason about. And the signature guard is the same test the Desktop routing
+  // itself used, re-applied rather than assumed, so this fallback can never be
+  // reached by an instance that was not independently identified as Desktop.
+  //
+  // The risk being accepted, and which the note names: a server started BY HAND with
+  // Desktop's flags (borrowing its model-paths config) has no supervisor, and the
+  // reboot would stop it for good. That is the disclosure's whole content — the user
+  // who did that knows they did, and is told to check afterwards.
+  if (
+    parentUnreadableAt === info.pid &&
+    isDesktopApp(info.argv.length > 0 ? info.argv : (info.osArgv ?? []))
+  ) {
+    return {
+      ok: true,
+      supervision: verdict,
+      note:
+        `NOTE: Desktop supervision was INFERRED, not proven — ${because ?? `the process tree above PID ${info.pid} could not be read`}, ` +
+        `so no live Desktop shell could be confirmed above this server. The restart proceeded on ` +
+        `the strength of the server's own launch arguments, which are the ones the ComfyUI Desktop ` +
+        `app passes when it launches its backend — so Desktop is what started it, and a running ` +
+        `Desktop app restarts its backend when it stops. If you actually started this server BY ` +
+        `HAND with Desktop's flags, nothing will bring it back: verify afterwards with ` +
+        `get_system_stats (action:"health"), and start it from the ComfyUI Desktop app if it does ` +
+        `not come back.`,
     };
   }
   return {
@@ -3595,6 +3652,13 @@ async function restartViaManagerReboot(context: {
   prior?: { argv: string[]; generation: number };
   /** Is this a ComfyUI Desktop instance? Selects the remedy in the #848 sentence. */
   isDesktop?: boolean;
+  /**
+   * Set when the reboot was allowed on INFERRED supervision (#1647) — the Desktop
+   * launch-signature fallback, reached when the process tree could not be read.
+   * Appended to the outcome message verbatim: a dispatch that proceeded on an
+   * inference must say so, on every path that reports one.
+   */
+  supervisionNote?: string;
 }): Promise<RestartResult> {
   logger.info(`Restarting ${context.label} ComfyUI via ComfyUI-Manager reboot...`);
 
@@ -3630,6 +3694,7 @@ async function restartViaManagerRebootDispatch(
     label: string;
     prior?: { argv: string[]; generation: number };
     isDesktop?: boolean;
+    supervisionNote?: string;
   },
   anchoredBase: string,
   witness: InstanceWitness | undefined,
@@ -3794,7 +3859,11 @@ async function restartViaManagerRebootDispatch(
         `another ${RECHECK_HINT_S}s before intervening. If it is still down then, start ` +
         "ComfyUI from whatever supervises it (" +
         (context.label === "Desktop" ? "the ComfyUI Desktop app" : "its host") +
-        "), or raise that budget to wait longer next time.",
+        "), or raise that budget to wait longer next time." +
+        // #1647: when the dispatch was allowed on inferred supervision, that
+        // caveat is part of the outcome — especially here, where nothing
+        // confirmed the server came back.
+        (context.supervisionNote ? ` ${context.supervisionNote}` : ""),
       listener_ownership: unclassifiedOwnership(),
     };
   }
@@ -3936,7 +4005,10 @@ async function restartViaManagerRebootDispatch(
       ` ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
       "restart. The cycle itself was not directly observed from here, so verify with " +
       'get_system_stats (action:"health") if you need certainty that it actually restarted.' +
-      argvNote,
+      argvNote +
+      // #1647: same disclosure as the not-ready branch — an inferred supervision
+      // is stated whatever the probes saw.
+      (context.supervisionNote ? ` ${context.supervisionNote}` : ""),
     // We launched nothing on this path — a supervisor is what would have cycled the
     // process — so the listener is never ours to claim. (Nor is it established that
     // one DID cycle it; that is `startup`'s business, and it says "unconfirmed".)
@@ -4046,6 +4118,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
       label: "Desktop",
       prior: { argv: info.argv, generation: infoGeneration },
       isDesktop: true,
+      // #1647: set when supervision was INFERRED from the launch signatures rather
+      // than proven from the process tree — the result must say so.
+      supervisionNote: desktop.note,
     });
   }
 
@@ -4347,6 +4422,13 @@ export async function preflightLocalRestart(): Promise<{
   observedArgv?: string[];
   /** Whether the assessed instance is ComfyUI Desktop — selects the #848 remedy. */
   isDesktopApp?: boolean;
+  /**
+   * The disclosure owed when the pass rests on INFERRED supervision (#1647 — the
+   * Desktop launch-signature fallback). A caller that dispatches on this pass
+   * appends it to the outcome it reports; passing silently would hide that the
+   * process tree was never read.
+   */
+  note?: string;
 }> {
   // Remote mode passes because there is no local process to assess — but that
   // reasoning only holds when the target really is another machine, and the
@@ -4398,6 +4480,7 @@ async function assessLocalRestart(): Promise<{
   reason?: string;
   observedArgv?: string[];
   isDesktopApp?: boolean;
+  note?: string;
 }> {
   const { info, diagnostic } = await acquireProcessInfo();
   // NOTHING COULD BE RESOLVED — and that is not a pass (coordinator gate).
@@ -4449,7 +4532,7 @@ async function assessLocalRestart(): Promise<{
     // property of the install. See assessDesktopSupervision for why UNCONFIRMED
     // refuses here while it is merely disclosed on the post-launch ownership path.
     const desktop = assessDesktopSupervision(info);
-    if (desktop.ok) return { ok: true, ...observedLaunch(info) };
+    if (desktop.ok) return { ok: true, ...observedLaunch(info), note: desktop.note };
     return { ok: false, reason: `${desktop.reason}${describeRecovery(recoveryHint(info))}` };
   }
   // NOTE (#776): the launch-ENVIRONMENT check is deliberately NOT applied here.


### PR DESCRIPTION
Closes #1647.

## Root cause

`panel_restart_comfyui` routes a ComfyUI **Desktop** instance through the ComfyUI-Manager reboot (never a local kill — #400), but only after `assessDesktopSupervision` proves a live Desktop shell stands above the backend. On the reporter's macOS Desktop install the parent PID of the backend could not be read at all, so the ancestry walk returned `unconfirmed` and the restart was **refused outright** — even though the server's own argv carried the Desktop launch signatures (`--extra-model-paths-config` pointing into `~/Library/Application Support/Comfy Desktop/…`, `--enable-manager`, Desktop feature flags) that only the Desktop app launches a backend with. A just-installed custom node could not be loaded.

## Fix

An unreadable parent PID now degrades to a **disclosed, still-safe** restart instead of a hard refusal:

- `classifyDesktopSupervision` (`src/services/listener-ownership.ts`) now reports **which** link was unreadable via a structured `parentUnreadableAt` field on the assessment, so the caller can tell "the first hop was unreadable" (a host that cannot read parentage at all) apart from a chain that was read and found ambiguous partway up — without parsing prose.
- `assessDesktopSupervision` (`src/services/process-control.ts`) turns exactly one shape into a pass: the **first-hop** unreadable parent **plus** Desktop-signed identifying argv (the same `isDesktopApp` test the Desktop routing itself used, re-applied). The reboot proceeds through ComfyUI-Manager as before — the process is never killed locally — and the inference is **disclosed** in a `note` carried on the result: what could not be read, what was proceeded on, and the residual case (a server started *by hand* with Desktop's flags has no supervisor) with the instruction to verify via `get_system_stats (action:"health")` afterwards.
- The note is threaded into both terminal messages of `restartViaManagerReboot` and into the `preflightLocalRestart` result, which `panel_restart_comfyui` (`src/orchestrator/panel-tools.ts`) appends to its dispatch-outcome notes — so the panel path discloses the inference too rather than passing silently.

Everything else is unchanged: a chain read partway and found ambiguous still refuses, a parent **proven** gone still refuses outright (#814), and the refusal messages still name what could not be established.

## Verification

In a clean worktree from `origin/main`:

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run` on the touched areas — all green:
  - `services/restart-relaunch-lifecycle.test.ts`, `services/process-control.test.ts` — 94 passed (incl. new #1647 tests: first-hop unreadable parent + Desktop argv → reboot dispatched with the disclosure, nothing killed; deeper-hop unreadable parent → still refuses; preflight passes with the disclosure note; classifier marks the failing hop)
  - `services/restart-launcher-env.test.ts`, `services/restart-instance-identity.test.ts`, `orchestrator/panel-restart-cancel-truth.test.ts`, `config-own-host-address.test.ts` — 126 passed
  - 8 panel-restart orchestrator suites — 105 passed; 7 restart/desktop services suites — 94 passed

No tool descriptions changed, so the docs/vocabulary gates do not apply.