### PR TITLE
fix(1524): a respawned session reconnects a down MCP server before announcing it

### DIFF
--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -51,7 +51,14 @@ const hoisted = vi.hoisted(() => ({
   lastMcpServers: null as Record<string, unknown> | null,
   /** What `q.mcpServerStatus()` answers, and how many times it was asked. */
   statusPoll: null as null | Array<{ name: string; status: string }>,
+  /** Sequential poll answers: each mcpServerStatus() call shifts one entry, and
+   *  the static statusPoll answers once the queue is drained. Lets a test give
+   *  the settle poll and the post-reconnect verify poll DIFFERENT outcomes. */
+  statusPollQueue: [] as Array<Array<{ name: string; status: string }>>,
   statusPolls: 0,
+  /** `q.reconnectMcpServer()` calls, in order, and whether it throws. */
+  reconnectCalls: [] as string[],
+  reconnectThrows: false,
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -66,10 +73,15 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
       supportedCommands: async () => [],
       interrupt: async () => {},
       setModel: async () => {},
+      reconnectMcpServer: async (name: string) => {
+        hoisted.reconnectCalls.push(name);
+        if (hoisted.reconnectThrows) throw new Error("reconnect refused");
+      },
       mcpServerStatus: async () => {
         hoisted.statusPolls += 1;
-        if (!hoisted.statusPoll) throw new Error("no status available");
-        return hoisted.statusPoll;
+        const poll = hoisted.statusPollQueue.shift() ?? hoisted.statusPoll;
+        if (!poll) throw new Error("no status available");
+        return poll;
       },
     });
   },
@@ -79,7 +91,10 @@ beforeEach(() => {
   hoisted.queue.reset();
   hoisted.lastMcpServers = null;
   hoisted.statusPoll = null;
+  hoisted.statusPollQueue = [];
   hoisted.statusPolls = 0;
+  hoisted.reconnectCalls = [];
+  hoisted.reconnectThrows = false;
 });
 
 const initWith = (mcp_servers?: Array<{ name: string; status: string }>) => ({
@@ -264,7 +279,11 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
     const notices = noticesOf(events);
     expect(notices).toHaveLength(1);
     expect(notices[0].message).toContain("panel");
-    expect(hoisted.statusPolls).toBe(1);
+    // #1228 — the failure was reconnect-attempted and verified still down before
+    // the notice went out: one settle poll, one reconnect, one verify poll.
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    expect(hoisted.statusPolls).toBe(2);
+    expect(notices[0].message).toMatch(/reconnect was already attempted/);
   });
 
   it("says nothing when it settled as connected", async () => {
@@ -328,5 +347,155 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
     );
     expect(noticesOf(events)).toHaveLength(0);
     expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+  });
+});
+
+describe("a down server gets ONE reconnect attempt before any notice (#1228)", () => {
+  // The reported failure: a tool-session respawn reconnected `comfyui` but never
+  // re-registered the in-process `panel` server, and the reconnect notice read
+  // as success. The respawn path now tries the one remedy short of a new session
+  // — an explicit reconnectMcpServer — and only announces what is still down.
+
+  it("recovers without a notice when the reconnect brings the panel server back", async () => {
+    // The reporter's exact shape at init — panel failed — but the reconnect
+    // fixes it. The tool surface is intact, so there is nothing to announce.
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "connected" },
+    ];
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    expect(noticesOf(events)).toHaveLength(0);
+    // The recovery is only claimed after being READ BACK: one verify poll.
+    expect(hoisted.statusPolls).toBe(1);
+  });
+
+  it("announces only what is STILL down after the attempt, and says the attempt happened", async () => {
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "failed" },
+    ];
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).not.toContain("comfyui");
+    // Verified still down AFTER the attempt — the notice must say so, or the
+    // agent would try the same reconnect itself and call that a remedy.
+    expect(notices[0].message).toMatch(/reconnect was already attempted/);
+  });
+
+  it("still reports when the reconnect itself throws", async () => {
+    hoisted.reconnectThrows = true;
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "failed" },
+    ];
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+  });
+
+  it("does not claim the attempt failed when its outcome could not be verified", async () => {
+    // The reconnect ran but the verify poll is unavailable. "Did not come back"
+    // would be a claim nobody checked — the notice falls back to the plain
+    // observation, still naming the server.
+    hoisted.statusPoll = null; // the poll throws
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).not.toMatch(/reconnect was already attempted/);
+  });
+
+  it("attempts nothing when every configured server connected", async () => {
+    // Recovery must not cost a healthy session a control round-trip.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual([]);
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("recovers a server that was still connecting at init and failed by the first turn end", async () => {
+    // Same remedy on the settle path: the settle poll sees the failure, the
+    // reconnect fixes it, the verify poll confirms — nothing is announced.
+    hoisted.statusPollQueue = [
+      [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ],
+      [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ],
+    ];
+    const events = await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.statusPolls).toBe(2);
+  });
+
+  it("a server still CONNECTING after the reconnect is settled later, not announced", async () => {
+    // The reconnect turned `failed` into `pending`: neither down nor verified
+    // up. It is carried into the first-turn-end settle, which reads it once
+    // more — connected here, so the session never hears about it.
+    hoisted.statusPollQueue = [
+      [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "pending" },
+      ],
+      [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ],
+    ];
+    const events = await driveTurns(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "failed" },
+      ]),
+    );
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.statusPolls).toBe(2);
   });
 });

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -148,4 +148,24 @@ describe("degradedMcpNotice — states the observation, and stops", () => {
     const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
     expect(note).not.toMatch(/because|caused by|due to/i);
   });
+
+  it("names the reconnect attempt only when it was made AND verified still down (#1228)", () => {
+    // The agent's standing guidance is to recover its tools; a notice that
+    // hides the failed reconnect would send it retrying the same remedy and
+    // calling the retry a fix.
+    const note = degradedMcpNotice([{ name: "panel", status: "failed" }], {
+      reconnectAttempted: true,
+    });
+    expect(note).toMatch(/automatic reconnect was already attempted/);
+    // …and the manual remedy is still named, still without a promise.
+    expect(note).toMatch(/Disconnect → Connect/);
+    expect(note).not.toMatch(/will fix|will restore|restores them/);
+  });
+
+  it("says nothing about a reconnect that was not verified", () => {
+    // reconnectAttempted is unset when no attempt ran OR its outcome could not
+    // be read back — "did not come back" would be an unverified claim either way.
+    const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
+    expect(note).not.toMatch(/reconnect/);
+  });
 });

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -431,6 +431,16 @@ export class ClaudeBackend implements AgentBackend {
    *  Settled once, at the first turn end, by settlePendingMcpServers(). */
   private pendingMcpServers: string[] = [];
 
+  /** Configured servers the `init` report showed as DOWN (#1524), carried out of
+   *  route() — a sync generator that cannot await the reconnect control request —
+   *  so run() can attempt recovery BEFORE the loss is announced (#1228).
+   *  null = nothing was down at init (or it was already handled). */
+  private initMcpDegraded: {
+    degraded: DegradedMcpServer[];
+    reported: readonly { name: string; status: string }[] | undefined;
+    sessionId: string;
+  } | null = null;
+
   /** Say — in the log — that this session does not have servers it was given.
    *  Shared by the init check and the deferred settle so both report identically. */
   private reportDegradedMcp(
@@ -444,6 +454,91 @@ export class ClaudeBackend implements AgentBackend {
         `${degraded.map((d) => `${d.name}=${d.status ?? "absent"}`).join(" ")} ` +
         `(reported: ${(reported ?? []).map((s) => `${s.name}=${s.status}`).join(" ") || "none"})`,
     );
+  }
+
+  /**
+   * One bounded recovery attempt per down server (#1228): ask the harness to
+   * reconnect each (`reconnectMcpServer`), then re-read the status report and
+   * return only the servers that are STILL down. The respawn this issue reports
+   * reconnected the comfyui stdio child but never re-registered the in-process
+   * panel server — an explicit reconnect is the one remedy short of a full new
+   * session, and trying it before speaking turns "your tools are gone" from a
+   * guess at init time into a verified fact.
+   *
+   * `verified` is false when the outcome could not be READ (a harness without
+   * the control method, or a status poll that threw): the caller still reports
+   * the servers as down — clearing a degradation nobody checked is the false
+   * success this change exists to prevent — but without the "reconnect did not
+   * help" sentence, which would itself be an unverified claim.
+   *
+   * A server that went back to CONNECTING after the reconnect is neither
+   * declared down nor cleared: with `rearmPending` it is handed to the
+   * first-turn-end settle, which re-reads it once (the init path). The settle
+   * path passes false — it IS that re-read, and re-arming there would retry a
+   * flapping server on every turn end.
+   */
+  private async attemptMcpReconnect(
+    degraded: readonly DegradedMcpServer[],
+    rearmPending: boolean,
+  ): Promise<{ stillDown: DegradedMcpServer[]; verified: boolean }> {
+    if (degraded.length === 0) return { stillDown: [], verified: true };
+    const q = this.q as (Query & { reconnectMcpServer?: (name: string) => Promise<void> }) | null;
+    if (typeof q?.reconnectMcpServer !== "function") {
+      return { stillDown: [...degraded], verified: false };
+    }
+    for (const d of degraded) {
+      try {
+        await q.reconnectMcpServer(d.name);
+      } catch (err) {
+        logger.warn(`[claude-backend] reconnectMcpServer(${d.name}) failed: ${msgOf(err)}`);
+      }
+    }
+    let after: Array<{ name: string; status: string }> | undefined;
+    try {
+      after = await q.mcpServerStatus?.();
+    } catch (err) {
+      logger.debug(`[claude-backend] mcpServerStatus after reconnect: ${msgOf(err)}`);
+    }
+    if (!after) return { stillDown: [...degraded], verified: false };
+    const check = inspectMcpServers(
+      degraded.map((d) => d.name),
+      after,
+    );
+    const recovered = degraded.filter(
+      (d) => !check.degraded.some((s) => s.name === d.name) && !check.pending.includes(d.name),
+    );
+    if (recovered.length) {
+      logger.info(
+        `[claude-backend] reconnect recovered MCP server(s): ${recovered.map((d) => d.name).join(", ")}`,
+      );
+    }
+    if (rearmPending) {
+      for (const name of check.pending) {
+        if (!this.pendingMcpServers.includes(name)) this.pendingMcpServers.push(name);
+      }
+    }
+    return { stillDown: check.degraded, verified: true };
+  }
+
+  /**
+   * Recover-or-report for the servers the `init` report showed as down (#1228),
+   * run once per session right after init. Only what is still down after one
+   * reconnect attempt earns the notice; a server the reconnect brought back is
+   * logged and stays silent — the tool surface is intact, so there is nothing
+   * to degrade, and the harness's own reconnected notice already says so.
+   */
+  private async settleInitMcpServers(): Promise<AgentEvent | null> {
+    const pending = this.initMcpDegraded;
+    if (!pending) return null;
+    this.initMcpDegraded = null;
+    const { stillDown, verified } = await this.attemptMcpReconnect(pending.degraded, true);
+    if (!stillDown.length) return null;
+    this.reportDegradedMcp(stillDown, pending.reported, pending.sessionId);
+    return {
+      type: "error",
+      sessionNotice: true,
+      message: degradedMcpNotice(stillDown, { reconnectAttempted: verified }),
+    };
   }
 
   /**
@@ -479,8 +574,16 @@ export class ClaudeBackend implements AgentBackend {
     }
     const { degraded } = inspectMcpServers(names, reported);
     if (!degraded.length) return null;
-    this.reportDegradedMcp(degraded, reported, this.registrySessionId ?? "", "is running");
-    return { type: "error", sessionNotice: true, message: degradedMcpNotice(degraded) };
+    // #1228 — one reconnect attempt before the loss is announced, same as the
+    // init path; only a server that is STILL down afterwards is reported.
+    const { stillDown, verified } = await this.attemptMcpReconnect(degraded, false);
+    if (!stillDown.length) return null;
+    this.reportDegradedMcp(stillDown, reported, this.registrySessionId ?? "", "is running");
+    return {
+      type: "error",
+      sessionNotice: true,
+      message: degradedMcpNotice(stillDown, { reconnectAttempted: verified }),
+    };
   }
 
   /**
@@ -595,6 +698,7 @@ export class ClaudeBackend implements AgentBackend {
     // the previous run's pending set and its "already settled" mark must not
     // suppress the new session's report.
     this.pendingMcpServers = [];
+    this.initMcpDegraded = null;
     this.parkedInterrupted.clear(); // dead session's parks die with it
     this.consumedInterrupted.clear(); // …and its landing history
     this.markerBase = this.lastResultTurnId; // turn markers are run-relative (#728)
@@ -669,6 +773,14 @@ export class ClaudeBackend implements AgentBackend {
           continue;
         }
         yield streamTurn === undefined ? ev : { ...ev, turn: streamTurn - this.markerBase };
+      }
+      // #1228 — init's down-servers get ONE reconnect attempt before any notice
+      // goes out (route() carried them into initMcpDegraded; it cannot await the
+      // control round-trip itself). Placed after init's own events so the
+      // session id lands first, ahead of any notice.
+      if (message.type === "system" && (message as { subtype?: string }).subtype === "init") {
+        const initNotice = await this.settleInitMcpServers();
+        if (initNotice) yield initNotice;
       }
       // #1524 — settle whatever was still CONNECTING at init, once, at the first
       // turn end. Placed here rather than in route() because it has to await a
@@ -859,9 +971,19 @@ export class ClaudeBackend implements AgentBackend {
           // to fail would never be mentioned. Remember the names and settle them
           // at the first turn end (see settlePendingMcpServers).
           this.pendingMcpServers = health.pending;
+          // #1228 — a down server gets ONE reconnect attempt before the loss is
+          // announced (the respawn this issue reports reconnected `comfyui` but
+          // never re-registered `panel`; an explicit reconnect is the remedy
+          // short of a new session). The attempt awaits a control round-trip this
+          // sync generator cannot make, so the degraded set is carried out to
+          // run()'s loop (settleInitMcpServers), which announces only what is
+          // still down afterwards.
           if (health.degraded.length) {
-            this.reportDegradedMcp(health.degraded, message.mcp_servers, message.session_id);
-            yield { type: "error", sessionNotice: true, message: degradedMcpNotice(health.degraded) };
+            this.initMcpDegraded = {
+              degraded: health.degraded,
+              reported: message.mcp_servers,
+              sessionId: message.session_id,
+            };
           }
         } else if (message.subtype === "thinking_tokens") {
           // Live extended-thinking token count → drives a "thinking… (N)" meter

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -128,18 +128,31 @@ const FAILED_STATUSES = new Set(["failed", "needs-auth", "disabled", "error"]);
  * not say a restart fixes it (a cause that persists survives a restart), and does
  * not vouch for the servers that DID come up — the reader can see those in the
  * same sentence.
+ *
+ * `reconnectAttempted` is set only when an automatic reconnect was tried AND the
+ * re-read afterwards confirmed the server is still down (#1228) — the sentence it
+ * adds is then a verified fact, not a hope. When the attempt's outcome could not
+ * be verified the caller leaves it unset, because "did not come back" would be a
+ * claim nobody checked.
  */
-export function degradedMcpNotice(degraded: readonly DegradedMcpServer[]): string {
+export function degradedMcpNotice(
+  degraded: readonly DegradedMcpServer[],
+  opts?: { reconnectAttempted?: boolean },
+): string {
   if (degraded.length === 0) return "";
   const named = degraded
     .map((d) => (d.status === null ? `\`${d.name}\` (not reported)` : `\`${d.name}\` (${d.status})`))
     .join(", ");
   const plural = degraded.length > 1 ? "servers" : "server";
   const theirTools = degraded.length > 1 ? "Their tools are" : "Its tools are";
+  const reconnect = opts?.reconnectAttempted
+    ? `An automatic reconnect was already attempted and did not bring ${degraded.length > 1 ? "them" : "it"} back. `
+    : "";
   return (
     `This session started without ${degraded.length} of its MCP ${plural}: ${named}. ` +
     `${theirTools} not available to the agent for the rest of this session, ` +
     `so anything that needs them will fail or be worked around silently. ` +
+    reconnect +
     `Starting a new session (Disconnect → Connect) is what re-runs the connection; ` +
     `whether it succeeds depends on why this one did not, which this message does not know.`
   );


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#1228 · Refs #1524

## Root cause

A queued tool-session respawn (e.g. `panel_request_secret` saving a key) tears the agent session down and rebuilds it. On the rebuild the harness reconnected the `comfyui` stdio MCP child but never re-registered the in-process `panel` server — and the reconnect notice read as success, so all 92 `panel_*` tools stayed gone for the rest of the session with no error and no remedy short of a manual restart. 45b61e0 (#1614) already made that loss **loud** by reading the `system`/`init` `mcp_servers` report; this PR adds the **recovery** half the issue asks for.

## Fix

`src/orchestrator/claude-backend.ts` — both points that detect a down server now attempt recovery before speaking:

- `route()`'s init branch no longer announces immediately; it carries the degraded set out to `run()`'s loop (a sync generator can't await the control round-trip), which makes **one** `reconnectMcpServer` attempt per down server, re-reads `mcpServerStatus()`, and announces only what is still down (`settleInitMcpServers`).
- The first-turn-end settle for init-`pending` servers gets the same recover-then-report treatment.
- A server that went back to `pending` after the reconnect is neither declared down nor cleared — it is handed to the first-turn-end settle, which re-reads it once. The settle path does not re-arm, so a flapping server is never retried on every turn end.
- A recovered server is logged (`reconnect recovered MCP server(s): …`), not announced: the tool surface is intact, so there is nothing to degrade, and the harness's own reconnected notice already says so.

`src/orchestrator/mcp-session-health.ts` — `degradedMcpNotice` gains an optional `reconnectAttempted` flag that adds "An automatic reconnect was already attempted and did not bring it back." to the notice. Two honesty guards:

- Recovery is only claimed after being **read back** — a reconnect whose outcome cannot be verified (no control method, poll threw) changes nothing in the notice.
- The "already attempted" sentence only appears when the re-read confirmed the server is **still down** — otherwise the agent would retry the same remedy itself and call the retry a fix.

The manual remedy (Disconnect → Connect) stays in the notice, still without promising it fixes anything.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npm run lint` (tsc --noEmit) — clean
- `npx vitest run src/__tests__/orchestrator` — **159 files / 2788 tests, all green**, including:
  - 7 new recovery tests in `claude-init-mcp-degraded.test.ts` (reconnect fixes it → silent; still down → notice names the attempt; reconnect throws → still reported; unverifiable outcome → no "attempted" claim; healthy session → no control round-trips; settle-path recovery; pending-after-reconnect re-arm)
  - 2 new wording tests in `mcp-session-health.test.ts`
  - the existing settle-failed test updated: it now expects the reconnect attempt + verify poll (2 polls) before the notice

No tool descriptions changed, so `docs:gen` / `check:vocabulary` / `vocab:export --check` are not implicated.

Not fixed here (still tracked on #1524): *why* the respawn's rebuild leaves the panel server unregistered in the first place, and the orphan-orchestrator bind-or-exit ask. This change makes that failure self-heal when a reconnect suffices and name itself — with the remedy — when it does not.