### PR TITLE
fix(369): a landed file the core listing contractually omits is unconfirmed, never "not-visible"

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -593,10 +593,13 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
   });
 
   it("still says MOVE IT when the file is outside the live models root", async () => {
-    const stray = resolve("/somewhere/else/new.safetensors");
-    realpathMock.mockImplementation(async () => stray);
+    // The write path itself is outside the live root (no junction involved), so
+    // membership cannot vouch for it and the remedy stays "move it". (A write
+    // path INSIDE the root whose realpath escapes is the junction case — covered
+    // below — and takes the refresh remedy by design.)
+    const strayTarget = resolve("/somewhere/else/new.safetensors");
     h.liveListings["loras"] = ["something-else.safetensors"];
-    const res = await verifyLandedModel(target, "loras", { attempts: 2, retryMs: 0 });
+    const res = await verifyLandedModel(strayTarget, "loras", { attempts: 2, retryMs: 0 });
     expect(res.liveVisible).toBe("not-visible");
     expect(res.note).toMatch(/does NOT list "new\.safetensors"/);
     expect(res.note).toMatch(/will not be usable/);
@@ -975,5 +978,66 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.verifiedPath).toBe(dTarget);
     expect(res.note).toMatch(/never lists individual files/);
     expect(res.note).not.toMatch(/does NOT list/);
+  });
+
+  it("reports UNKNOWN — never a false not-visible — for a .gguf the core listing contractually omits (#369, 0.51.56)", async () => {
+    // Core /models/diffusion_models enumerates only supported_pt_extensions — no
+    // .gguf (those surface via ComfyUI-GGUF's *_gguf views, #526). A correctly
+    // placed GGUF therefore NEVER appears in this listing, and reading that
+    // contractual absence as "the server does NOT list it" is the 0.51.56 report:
+    // WARNING: NOT VISIBLE plus a "move the file" remedy for a file that was
+    // already where the server reads.
+    const gTarget = resolve("/live/ComfyUI/models/diffusion_models/new.gguf");
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.liveListings["diffusion_models"] = ["other.safetensors"]; // answered; the .gguf is absent BY CONTRACT
+    const res = await verifyLandedModel(gTarget, "diffusion_models", { attempts: 2, retryMs: 0 });
+    expect(res.liveVisible).toBe("unknown");
+    expect(res.verifiedPath).toBe(gTarget);
+    expect(res.note).toMatch(/contractual/);
+    expect(res.note).toMatch(/list_local_models/);
+    expect(res.note).not.toMatch(/does NOT list/);
+    expect(res.note).not.toMatch(/Move the file/);
+  });
+
+  it("still confirms a .gguf the server DOES list (a node re-registered the core category to admit it)", async () => {
+    // Only the MISS is contractual. A custom node can re-register a core category
+    // to admit .gguf, and then the listing names the file — that confirmation
+    // must survive the extension gate.
+    const gTarget = resolve("/live/ComfyUI/models/diffusion_models/new.gguf");
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.liveListings["diffusion_models"] = ["new.gguf"];
+    const res = await verifyLandedModel(gTarget, "diffusion_models", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("visible");
+  });
+
+  it("prescribes REFRESH, not a move, when a junctioned destination realpaths outside the live root (#369/#870)", async () => {
+    // StabilityMatrix: models/vae is a junction to the shared store, so the LEXICAL
+    // write path is inside the live root while the REALPATH'd verified path is not.
+    // The not-visible remedy must follow the membership answer (lexical and
+    // canonical), not a comparison of the realpath against the lexical root —
+    // that comparison names a directory the file is already reachable from and
+    // tells the user to move it, which is the 0.51.56 report's remedy half.
+    const smTarget = resolve("/comfy/models/vae/new.safetensors");
+    const real = resolve("/E/StabilityMatrix/models/VAE/new.safetensors");
+    realpathMock.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === smTarget) return real;
+      if (resolve(s) === resolve("/comfy/models/vae")) {
+        return resolve("/E/StabilityMatrix/models/VAE");
+      }
+      return resolve(s);
+    });
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/comfy/models";
+    h.liveExtraRoots = { authoritative: true, roots: [] };
+    h.liveListings["vae"] = ["something-else.safetensors"]; // answered; ours not yet listed
+    const res = await verifyLandedModel(smTarget, "vae", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("not-visible");
+    expect(res.verifiedPath).toBe(real);
+    expect(res.note).toMatch(/Do NOT move the file/);
+    expect(res.note).toMatch(/junction/);
+    expect(res.note).not.toMatch(/Move the file into the running server's models tree/);
   });
 });

--- a/src/__tests__/services/placement-stale-listing.test.ts
+++ b/src/__tests__/services/placement-stale-listing.test.ts
@@ -79,6 +79,27 @@ describe("a file outside that root keeps the move remedy", () => {
   });
 });
 
+describe("a file inside via a junction keeps the refresh remedy (#369/#870)", () => {
+  // StabilityMatrix: the write path is inside the live root, but the REALPATH
+  // escapes it through the junction. The membership answer (knownInsideLiveRoots)
+  // — not the path comparison — decides which remedy is followable.
+  const junctioned = notVisibleVerdict({
+    ...BASE,
+    verifiedPath: "E:/StabilityMatrix/models/VAE/example.safetensors",
+    liveModelsDir: "C:/ComfyUI/models",
+    knownInsideLiveRoots: true,
+  });
+
+  it("does not prescribe moving a file the server already reads", () => {
+    expect(junctioned.note).toMatch(/Do NOT move the file/);
+    expect(junctioned.note).not.toMatch(/Move the file into the running server's models tree/);
+  });
+
+  it("still reports not-visible — the verdict did not weaken", () => {
+    expect(junctioned.liveVisible).toBe("not-visible");
+  });
+});
+
 describe("isUnderRoot", () => {
   // The platform is a PARAMETER, not read from the host, so the Windows case is
   // genuinely exercised on ubuntu CI rather than quietly passing there for the

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1822,6 +1822,36 @@ export async function verifyLandedModel(
         `"${category}" model folder, so it could not be confirmed that it reads from this location.`,
     };
   }
+  // A CORE category's listing enumerates only ComfyUI's own weight extensions
+  // (folder_paths.supported_pt_extensions — mirrored above as CORE_MODEL_EXTENSIONS).
+  // A landed file of any OTHER type (.gguf, .onnx, .engine, …) is served, if at all,
+  // through a custom node's OWN registered category (ComfyUI-GGUF's unet_gguf /
+  // clip_gguf views, #526), so its absence from THIS listing is contractual — the
+  // #844 diffusers fold one level down: not the category but the FILE'S EXTENSION is
+  // outside the enumeration contract. A listing HIT above still confirmed the file
+  // (a node may re-register the core category to admit the type); only the MISS is
+  // inconclusive, and it must not render as "the server does NOT list it". The
+  // 0.51.56 #369 report was exactly that fold: a correctly-placed .gguf answered
+  // with WARNING: NOT VISIBLE and a "move the file" remedy for a file that was
+  // already where the server reads.
+  const ext = extname(basename(targetPath)).toLowerCase();
+  const isCoreCategory = (MODEL_SUBDIRS as readonly string[]).includes(category.toLowerCase());
+  if (isCoreCategory && !CORE_MODEL_EXTENSIONS.has(ext)) {
+    return {
+      verifiedPath,
+      liveVisible: "unknown",
+      note:
+        `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
+        `(${getComfyUIBaseUrl()}) cannot confirm it from its "${category}" listing: that ` +
+        `endpoint enumerates only ComfyUI's core weight extensions ` +
+        `(${[...CORE_MODEL_EXTENSIONS].join(", ")}), and "${ext || "(none)"}" is not one ` +
+        `of them. A file of this type is served through a custom node's own registered ` +
+        `category instead (for .gguf, ComfyUI-GGUF's "unet_gguf"/"clip_gguf" views), so ` +
+        `its ABSENCE here is contractual, not evidence of misplacement. Confirm with ` +
+        `list_local_models, which reads those categories too — and if no installed node ` +
+        `registers a category serving this file type, this server cannot load it at all.`,
+    };
+  }
   let liveModelsDir: string | undefined;
   try {
     liveModelsDir = await resolveModelsDir();
@@ -1836,6 +1866,12 @@ export async function verifyLandedModel(
       wanted,
       category,
       baseUrl: getComfyUIBaseUrl(),
+      // The membership answer above was computed on the LEXICAL write path and is
+      // canonical-aware: a destination reached through an in-tree junction
+      // (StabilityMatrix, #870) realpaths OUTSIDE the lexical live root, so the
+      // verdict's own path comparison would call a correctly-placed file
+      // misplaced and prescribe moving it (#369, 0.51.56).
+      knownInsideLiveRoots: membership.inRoots === true,
     }),
   };
 }
@@ -1862,22 +1898,35 @@ export function notVisibleVerdict(args: {
   wanted: string;
   category: string;
   baseUrl: string;
+  /** The caller's CANONICAL membership answer for the lexical write path
+   *  (isUnderLiveModelRoots). true means the file sits in a tree the server reads
+   *  even when the REALPATH'd verifiedPath escapes the lexical root — a
+   *  StabilityMatrix junction (`models/vae` → the shared store, #870) realpaths
+   *  outside it, and comparing paths alone would prescribe moving a file that is
+   *  already in the right place (#369). */
+  knownInsideLiveRoots?: boolean;
 }): { liveVisible: "not-visible"; note: string } {
   const { verifiedPath, liveModelsDir, wanted, category, baseUrl } = args;
-  const insideLiveRoot = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
+  const insideLexically = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
+  const insideLiveRoot = insideLexically || args.knownInsideLiveRoots === true;
   return {
     // Still not VISIBLE — we did not observe it in the listing, and #369 exists
     // because an unobserved placement must not render as confirmed. The verdict
     // is unchanged; what changes is the explanation and the remedy.
     liveVisible: "not-visible",
     note: insideLiveRoot
-      ? `The file IS on disk at ${verifiedPath}, which is INSIDE the models directory the ` +
-        `connected ComfyUI reads (${liveModelsDir}) — so it is in the right place. That server ` +
-        `does not list "${wanted}" under "${category}" YET, which almost always means its ` +
-        `cached loader options have not been re-read since the write (ComfyUI invalidates them ` +
-        `on the directory's mtime). Do NOT move the file. Refresh the node/model definitions ` +
-        `— install_comfyui (action:"refresh_nodes"), or the panel's refresh — or restart ` +
-        `ComfyUI, then check list_local_models again.`
+      ? (insideLexically
+          ? `The file IS on disk at ${verifiedPath}, which is INSIDE the models directory the ` +
+            `connected ComfyUI reads (${liveModelsDir}) — so it is in the right place. `
+          : `The file IS on disk at ${verifiedPath}, which is inside a models tree the ` +
+            `connected ComfyUI reads — reached through a link/junction` +
+            `${liveModelsDir ? ` under ${liveModelsDir}` : ""}, so its real path lying ` +
+            `outside that directory is the layout working as intended, not a misplacement. `) +
+        `That server does not list "${wanted}" under "${category}" YET, which almost always ` +
+        `means its cached loader options have not been re-read since the write (ComfyUI ` +
+        `invalidates them on the directory's mtime). Do NOT move the file. Refresh the ` +
+        `node/model definitions — install_comfyui (action:"refresh_nodes"), or the panel's ` +
+        `refresh — or restart ComfyUI, then check list_local_models again.`
       : `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
         `(${baseUrl}) does NOT list "${wanted}" under "${category}" — it will not be ` +
         `usable in a workflow from there.` +


### PR DESCRIPTION
## What was still wrong

#369's destination side is fixed on main — `resolveModelsDirWithBases` prefers the live root (argv / observed-process) over COMFYUI_PATH / the saved default workspace (#794, #1562), and the pre-write refusal plus post-write verification are in place. The latest recurrence report (0.51.56, GGUF → `diffusion_models`, StabilityMatrix at `C:\SM`) hits what remains: the file landed **correctly** — through the package's junctioned `models` tree into the shared store, which is why the reported path was the realpath'd `C:\SM\Models\DiffusionModels` — and the post-write check still answered **WARNING: NOT VISIBLE** with a "move the file" remedy. Two folds produced that:

1. **A `.gguf` can never appear in `/models/<category>`.** Core ComfyUI enumerates only `supported_pt_extensions` there (no `.gguf` — those surface via ComfyUI-GGUF's `*_gguf` views, the #526 note in this very file). `verifyLandedModel` read that contractual absence as "the server does NOT list it" — the same could-not-determine → determined-not fold `diffusers` already got fixed for at the category level (#844); this is the file-**extension** level of it, unhandled.
2. **The remedy compared the realpath against the lexical root.** `notVisibleVerdict`'s inside-the-live-root test used the REALPATH'd verified path, which escapes the root through a StabilityMatrix junction (#870) — so a file the membership check had just vouched for (lexically, canonically) was prescribed a move into the directory it is already reachable from. "Moving the file + refreshing" restored usability for the reporter because the refresh was the operative half.

## The fix (`src/services/model-resolver.ts` only)

- `verifyLandedModel`: when the landed file's extension is outside `CORE_MODEL_EXTENSIONS` (= `supported_pt_extensions`) in a CORE category, a listing **miss** now returns `unknown` with a note that says the absence is contractual and how to actually confirm (`list_local_models`, which reads the `*_gguf` views) — including the honest caveat that if no installed node serves the type, the server cannot load it at all. A listing **hit** still confirms: a node may re-register the core category to admit the type, and the note never claims what wasn't observed.
- `notVisibleVerdict` takes the caller's canonical membership answer (`knownInsideLiveRoots`, from `isUnderLiveModelRoots` on the lexical write path) and falls back to the path comparison only without it. The verdict itself is unchanged — still `not-visible`, never a fabricated success — only the remedy stops naming a directory the file is already in, and the junction case says so.

Deliberately untouched: the pre-write refusal, the membership-false early return (a demonstrably-outside destination still reports not-visible regardless of extension), and the Manager dispatch path (`verifyManagerVisibility` already hedges its not-listed note).

## Verification (worktree off origin/main, 0.52.0)

- `npm ci` — clean.
- `npm run build` (tsc) — clean.
- `npx vitest run src/__tests__/services/download-live-destination.test.ts src/__tests__/services/placement-stale-listing.test.ts` — 69 passed (4 new: GGUF miss → unknown; GGUF hit still visible; junctioned destination keeps the refresh remedy; `notVisibleVerdict` junction unit). One existing test fixture had to change: "still says MOVE IT" realpath'd its target out of the live root while keeping the write path inside it — that shape now takes the refresh remedy by design, so the test uses a target that is genuinely outside the root, which is the case it always claimed to pin.
- Full `src/__tests__/services` + `src/__tests__/tools`: 294 files, 6319 passed / 3 skipped.

Closes #369
