### PR TITLE
fix(1654): restart relaunches the interpreter the healthy server was observed running under

### DIFF
--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -614,6 +614,122 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
   });
 });
 
+describe("restart_comfyui — the interpreter the HEALTHY server runs wins (#1654)", () => {
+  // #1654: a Stability Matrix package holding BOTH `.venv` and `venv`. The layout
+  // resolution prefers `.venv` whenever both exist, and this one was an EMPTY,
+  // unrelated Python — so the restart stopped a healthy server and relaunched an
+  // interpreter with no torch/sqlalchemy (exit 1 at `import sqlalchemy`), leaving
+  // ComfyUI down. The working environment was `venv/Scripts/python.exe` — named
+  // all along by the OS command line of the very process being restarted.
+  const SM_EMPTY_PY = join(SM_PKG, ".venv", "Scripts", "python.exe");
+  const SM_ARGV = [SM_MAIN, "--preview-method", "auto", "--enable-manager"];
+
+  /**
+   * The issue's disk shape: both environments exist under the package, the layout
+   * resolution prefers the EMPTY `.venv`, and the launcher tooling roots are
+   * present so the environment plan is reproducible either way.
+   */
+  function useDualVenvStabilityMatrix(): void {
+    mockFindComfyuiPython.mockReturnValue(SM_EMPTY_PY);
+    mockLiveRootFromArgv.mockReturnValue(SM_PKG);
+    mockGetSystemStats.mockResolvedValue({ system: { argv: SM_ARGV } });
+    const roots = [SM_GIT_ROOT, SM_FFMPEG_ROOT];
+    // A real filesystem implies every ancestor of an existing directory.
+    const existingDirs = new Set<string>();
+    for (const root of roots) {
+      let cur = root;
+      while (cur.length > SM_DATA.length && cur.startsWith(SM_DATA)) {
+        existingDirs.add(cur);
+        cur = dirname(cur);
+      }
+      existingDirs.add(SM_DATA);
+    }
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      if (s === SM_MAIN || s === SM_PY || s === SM_EMPTY_PY) return true;
+      if (existingDirs.has(s)) return true;
+      if (s === SM_GIT_EXE || s === SM_FFMPEG_EXE) return true;
+      return false;
+    });
+  }
+
+  /** The OS's view of the healthy server, as WMI reports it on Windows. */
+  function osReportsInterpreter(commandLine: string): void {
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321 ? { startedAt: "stable-stamp", commandLine } : undefined,
+    );
+  }
+
+  async function restartAndReturnSpawn(): Promise<{
+    result: Awaited<ReturnType<typeof restartComfyUI>>;
+    exe: string;
+    args: string[];
+  }> {
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args] = mockSpawn.mock.calls[0];
+    killSpy.mockRestore();
+    return { result, exe: String(exe), args: args as string[] };
+  }
+
+  it("relaunches the interpreter the OS reports for the running server, not the layout's empty `.venv`", async () => {
+    // THE issue shape: the healthy server runs under `venv`, the layout prefers
+    // `.venv`. The restart must preserve the environment the process was observed
+    // running under — that observation is corroborated against the server's own
+    // argv, so it cannot be a different install's interpreter.
+    useDualVenvStabilityMatrix();
+    osReportsInterpreter(
+      `"${SM_PY}" "${SM_MAIN}" --preview-method auto --enable-manager`,
+    );
+
+    const { result, exe, args } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+    expect(exe).not.toBe(SM_EMPTY_PY);
+    expect(args).toEqual(SM_ARGV);
+    // The launcher environment is still reconstructed around the observed
+    // interpreter — the #776 preservation is untouched.
+    expect(result.launch_env?.source).toBe("stability-matrix");
+  });
+
+  it("falls back to the layout resolution when the OS names no usable interpreter", async () => {
+    // A shell with an activated venv launches a BARE `python`: argv[0] names no
+    // file we can verify (the process's cwd is not ours), so the observation is
+    // honestly unknown and the pre-#1654 resolution is what remains.
+    useDualVenvStabilityMatrix();
+    osReportsInterpreter(`python "${SM_MAIN}" --preview-method auto --enable-manager`);
+    mockFindComfyuiPython.mockReturnValue(SM_PY);
+
+    const { exe } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+  });
+
+  it("never adopts the SCRIPT as the interpreter (a directly exec'd main.py)", async () => {
+    // A shebang-launched server has main.py AS argv[0]. Adopting that as the
+    // interpreter would spawn a Python file as a program after the stop.
+    useDualVenvStabilityMatrix();
+    osReportsInterpreter(`"${SM_MAIN}" --preview-method auto --enable-manager`);
+    mockFindComfyuiPython.mockReturnValue(SM_PY);
+
+    const { exe, args } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+    expect(args).toEqual(SM_ARGV);
+  });
+});
+
 describe("launcher layout detection — path-root handling (#776)", () => {
   // The paths come from the running ComfyUI's sys.argv, which is WINDOWS-flavored
   // whenever ComfyUI runs on Windows regardless of this host. These are pure

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -121,6 +121,20 @@ interface ProcessInfo {
   /** The OS's raw command line — the recovery hint even when argv is not spawnable. */
   osCommandLine?: string;
   /**
+   * The interpreter the HEALTHY server is actually running under (#1654): argv[0]
+   * of the corroborated OS command line, captured at gather-time while the process
+   * is alive. The layout-based interpreter resolution prefers `<root>/.venv` over
+   * `<root>/venv` whenever both exist, and a Stability Matrix package routinely HAS
+   * both — an empty `.venv` beside the working `venv` — so a restart that trusted
+   * the layout stopped the healthy server and relaunched an environment with no
+   * torch/sqlalchemy, leaving ComfyUI down. This is the observed truth the layout
+   * guess is only ever a fallback for: the command line it came from was already
+   * matched against the server's own argv, so it describes THIS server. Set only
+   * when the observation is an absolute, existing, non-script path; absent
+   * otherwise, and the layout resolution stands.
+   */
+  observedInterpreter?: string;
+  /**
    * TRUE when `pid` was found by SCANNING PROCESS NAMES for a Desktop shell, rather
    * than resolved from the port.
    *
@@ -1435,6 +1449,34 @@ function resolveCorroboratedIdentity(
 }
 
 /**
+ * The interpreter a CORROBORATED OS identity says this server is running under
+ * (#1654) — argv[0] of the observed command line.
+ *
+ * The command line was already matched against the server's own argv, so its first
+ * token is the interpreter THAT process was launched with: the ground truth the
+ * install-layout resolution in resolveLaunchCommand is only ever a guess at. The
+ * guess prefers `<root>/.venv` over `<root>/venv` whenever both exist, and a
+ * Stability Matrix package routinely has both (an empty `.venv` beside the working
+ * `venv`), which is how a restart relaunched an environment with no
+ * torch/sqlalchemy and left the server down.
+ *
+ * Accepted only as an ABSOLUTE path that exists on disk and is not itself the
+ * script (a shebang-launched `main.py` has the script AS argv[0] — adopting that
+ * as the interpreter would spawn a Python file as a program). A relative or bare
+ * argv[0] (`python`, `.\python`) names no file we can verify — the process's cwd
+ * is not ours — so it is honestly unknown and the layout resolution stands. Same
+ * acceptance rule as live-interpreter's tier 2.
+ */
+function observedInterpreterFromIdentity(
+  identity: ProcessIdentity,
+): string | undefined {
+  const argv0 = argv0FromCommandLine(identity.commandLine ?? "");
+  if (!argv0 || /\.pyw?$/i.test(argv0)) return undefined;
+  if (!isAbsolute(argv0)) return undefined;
+  return fileExists(argv0) ? argv0 : undefined;
+}
+
+/**
  * The live environment of a pid we can still PROVE is the process we identified.
  *
  * Reading `/proc/<pid>/environ` from a bare number is not enough: between the port
@@ -1758,7 +1800,14 @@ function resolveLaunchCommand(
   const firstUnquoted = first.trim().replace(/^["']+/, "").replace(/["']+$/, "");
   const looksLikeScript = /\.pyw?$/i.test(firstUnquoted);
   if (looksLikeScript) {
-    const python = findComfyuiPython(config.comfyuiPath ?? undefined, argv);
+    // #1654: the interpreter the OS observed THIS server running under outranks the
+    // layout resolution — a guess that prefers `<root>/.venv` over `<root>/venv`
+    // whenever both exist is how a restart relaunched an empty environment and left
+    // the server down. The observation was captured corroborated against the
+    // server's own argv, so it IS the environment the healthy process imports from.
+    const python =
+      info.observedInterpreter ??
+      findComfyuiPython(config.comfyuiPath ?? undefined, argv);
     if (!python) return null;
     // sys.argv[0] can be RELATIVE (the standard Windows portable launcher runs
     // `python ComfyUI\main.py` from the portable root). We force cwd to
@@ -1832,7 +1881,11 @@ function resolveLaunchCommand(
     // against, so the relaunch never depends on a wrong/undefined working
     // directory. Only an UNANCHORED relative script leaves cwd unset — the
     // refuse-safe preflight (#476/#426) rejects that case before any stop.
-    const exe = liveCwdScript ? liveCwdPython! : python;
+    // The OBSERVED interpreter (#1654) outranks both layout-derived pythons: it is
+    // the environment this exact process was seen running under, while the other
+    // two are install-layout inferences that cannot tell a working `venv` from an
+    // empty `.venv` sitting beside it.
+    const exe = info.observedInterpreter ?? (liveCwdScript ? liveCwdPython! : python);
     const cwd = liveCwdScript ? info.liveCwd : anchor;
     return { exe, args: [script, ...rest], cwd };
   }
@@ -2660,6 +2713,15 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     err.identityAmbiguous = true;
     throw err;
   }
+  // #1654: preserve the interpreter the healthy process is RUNNING under, from the
+  // same corroborated OS observation that bound the pid — captured now, while the
+  // process is alive, for the same reason `liveCwd` is. The relaunch prefers it
+  // over the install-layout guess, which picks `.venv` over `venv` whenever both
+  // exist regardless of which environment the server actually imports from.
+  const observedInterpreter =
+    !desktop && corroboration.kind === "confirmed"
+      ? observedInterpreterFromIdentity(corroboration.identity)
+      : undefined;
   const startedAt = desktop
     ? undefined
     : corroboration.kind === "confirmed"
@@ -2715,6 +2777,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     osArgv,
     osArgvExact,
     osCommandLine,
+    observedInterpreter,
     isDesktopApp: desktop,
     desktopExePath: desktopExe,
     liveCwd,


### PR DESCRIPTION
## Root cause

On a Stability Matrix install containing both `ComfyUI/.venv` and `ComfyUI/venv`, `restart_comfyui(action:"restart")` stopped the healthy server and relaunched it with the empty `.venv/Scripts/python.exe` (no torch/sqlalchemy → exit 1 at `import sqlalchemy`, server left down).

When the server's `sys.argv[0]` is a script (`main.py`), `resolveLaunchCommand` resolved the interpreter purely by **install layout** (`findComfyuiPython` → `resolveComfyuiPython` → `candidatesIn`), whose candidate order prefers `<root>/.venv` over `<root>/venv` whenever both exist. That order is only a preference, never authority — it cannot tell a working `venv` from an empty `.venv` sitting beside it, and it ignored the one observation that settles the question: the OS command line of the very process being restarted, whose argv[0] is the interpreter that process is actually running under.

## Fix

`gatherProcessInfo` already reads the port owner's OS identity and **corroborates it against the server's own argv** (`resolveCorroboratedIdentity`) to bind the pid — so the command line it holds provably describes *this* server. The fix:

- `src/services/process-control.ts`
  - New `ProcessInfo.observedInterpreter`: argv[0] of the corroborated OS command line, captured at gather-time while the process is alive (same known-good moment as `liveCwd`/`liveEnv`). Accepted only as an **absolute, existing, non-script** path — a bare/relative argv[0] (`python`) names no verifiable file, and a shebang-launched server has the *script* as argv[0], which must never be adopted as the interpreter. Same acceptance rule as live-interpreter's tier 2.
  - `resolveLaunchCommand` now prefers `observedInterpreter` over both layout-derived interpreters (the canonical-base one and the live-cwd one). When no observation exists, the pre-existing layout resolution stands unchanged.
  - The refuse-safe preflight (`assessRelaunch`) is untouched and still validates the resolved exe/script on disk **before** anything is stopped — so a relaunch that cannot be validated still refuses before the stop, exactly as the issue asks.

No torch/sqlalchemy import probe was added: the selected interpreter is no longer a layout *candidate* to validate — it is the environment the healthy process was observed importing from, corroborated against the server's own argv. A subprocess probe would add seconds and new failure modes without adding evidence.

## Verification

- `npm ci` — clean.
- `npm run build` (`tsc`, covers `src/__tests__`) — clean.
- New tests in `src/__tests__/services/restart-launcher-env.test.ts` (`restart_comfyui — the interpreter the HEALTHY server runs wins (#1654)`):
  - the issue shape: both venvs on disk, layout prefers the empty `.venv`, OS reports the healthy server under `venv` → relaunch spawns the `venv` interpreter (and the Stability Matrix launcher environment is still reconstructed around it);
  - bare `python` argv[0] → falls back to the layout resolution;
  - a script argv[0] is never adopted as the interpreter.
- Targeted vitest, all green:
  - `restart-launcher-env.test.ts` — 66 passed (incl. the 3 new);
  - 10 restart/process-control service suites (`restart-relaunch-lifecycle`, `restart-instance-identity`, `restart-live-first`, `restart-target-anchor`, `restart-posix-port-release`, `process-control`, `desktop-restart`, `remote-restart`, `process-identity-encoding`, `launch-log-capture`) — 183 passed;
  - 7 orchestrator/tool restart suites (`panel-restart-*`, `restart-timeout-target`, `panel-reboot-cache-invalidation`, `process-control-tool`) — 127 passed.
- Tool descriptions unchanged, so `docs:gen` / `check:vocabulary` / `vocab:export --check` are not implicated.

Closes #1654
