### PR TITLE
fix(1524): a mid-session MCP drop is met with one bounded reconnect, reported either way

### DIFF
--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -52,6 +52,8 @@ const hoisted = vi.hoisted(() => ({
   /** What `q.mcpServerStatus()` answers, and how many times it was asked. */
   statusPoll: null as null | Array<{ name: string; status: string }>,
   statusPolls: 0,
+  /** Servers the harness was asked to reconnect, in order. */
+  reconnectCalls: [] as string[],
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -71,6 +73,9 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
         if (!hoisted.statusPoll) throw new Error("no status available");
         return hoisted.statusPoll;
       },
+      reconnectMcpServer: async (name: string) => {
+        hoisted.reconnectCalls.push(name);
+      },
     });
   },
 }));
@@ -80,6 +85,7 @@ beforeEach(() => {
   hoisted.lastMcpServers = null;
   hoisted.statusPoll = null;
   hoisted.statusPolls = 0;
+  hoisted.reconnectCalls = [];
 });
 
 const initWith = (mcp_servers?: Array<{ name: string; status: string }>) => ({
@@ -245,8 +251,8 @@ describe("a Claude session that started without an MCP server reports it (#1524)
   });
 });
 
-describe("a server that was still connecting at init gets settled (#1524)", () => {
-  it("reports it when it settled as FAILED", async () => {
+describe("the turn-end watch settles what init could not (#1524)", () => {
+  it("reports a pending-at-init server that settled as FAILED, after trying the reconnect", async () => {
     // The hole an init-only check leaves: `init` is the only MCP report the
     // session pushes, so `pending` there followed by a failure is silent forever
     // — the same six-hour silence, moved a few hundred milliseconds later.
@@ -264,7 +270,11 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
     const notices = noticesOf(events);
     expect(notices).toHaveLength(1);
     expect(notices[0].message).toContain("panel");
-    expect(hoisted.statusPolls).toBe(1);
+    // The one bounded reconnect was tried, and the outcome line quotes the
+    // verdict re-read — so two polls, not one.
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    expect(hoisted.statusPolls).toBe(2);
+    expect(notices[0].message).toMatch(/reconnect did not bring it back/);
   });
 
   it("says nothing when it settled as connected", async () => {
@@ -280,10 +290,15 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
       ]),
     );
     expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.reconnectCalls).toEqual([]);
     expect(hoisted.statusPolls).toBe(1);
   });
 
-  it("re-reads ONCE, not on every turn", async () => {
+  it("watches on EVERY turn end — the mid-session drop has no other signal", async () => {
+    // `init` is the only report the session pushes, so a healthy-init session
+    // that loses a server hours in is invisible unless something asks. The ask
+    // is one control round-trip per completed turn — turn-driven, so it needs
+    // no timer and cannot spam.
     hoisted.statusPoll = [
       { name: "comfyui", status: "connected" },
       { name: "panel", status: "connected" },
@@ -296,14 +311,18 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
       ]),
       3,
     );
-    expect(hoisted.statusPolls).toBe(1);
+    expect(hoisted.statusPolls).toBe(3);
   });
 
-  it("does not poll at all when nothing was pending", async () => {
-    // The re-read is a control round-trip. A healthy session must not pay for it
-    // on every turn it completes.
-    hoisted.statusPoll = [{ name: "comfyui", status: "connected" }];
-    await driveTurns(
+  it("polls a healthy session too — and stays silent while it stays healthy", async () => {
+    // The watch cannot know the toolset thinned without looking, so the healthy
+    // session pays the same one round-trip per turn. What it must NEVER pay is
+    // a false alarm or an unneeded reconnect.
+    hoisted.statusPoll = [
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "connected" },
+    ];
+    const events = await driveTurns(
       { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
       initWith([
         { name: "comfyui", status: "connected" },
@@ -311,13 +330,15 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
       ]),
       2,
     );
-    expect(hoisted.statusPolls).toBe(0);
+    expect(hoisted.statusPolls).toBe(2);
+    expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.reconnectCalls).toEqual([]);
   });
 
   it("stays silent when the poll is unavailable or throws", async () => {
     // `mcpServerStatus()` is an optional Query method. A harness without it
-    // leaves the pending servers unmentioned rather than guessed at — and must
-    // never take the turn stream down with it.
+    // leaves the servers unmentioned rather than guessed at — and must never
+    // take the turn stream down with it.
     hoisted.statusPoll = null; // the mock throws
     const events = await driveTurns(
       { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
@@ -327,6 +348,7 @@ describe("a server that was still connecting at init gets settled (#1524)", () =
       ]),
     );
     expect(noticesOf(events)).toHaveLength(0);
+    expect(hoisted.reconnectCalls).toEqual([]);
     expect(events.filter((e) => e.type === "result")).toHaveLength(1);
   });
 });

--- a/src/__tests__/orchestrator/claude-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/claude-mcp-reconnect.test.ts
@@ -1,0 +1,294 @@
+// #1524, RECOVERY — a mid-session MCP drop is detected at the next turn end and
+// the one bounded reconnect is attempted, with the outcome narrated from the
+// re-read status, never from the attempt.
+//
+// The reported failure: a healthy session lost all 92 panel_* tools hours in.
+// The harness's own reconnect brought `comfyui` back and never retried the
+// in-process panel server, and since `init` is the only MCP report a session
+// PUSHES, nothing host-side ever learned of it. There is no mid-session push
+// to listen for, so the watch ASKS — one mcpServerStatus() poll per turn end —
+// and recovery is the SDK's own verb, reconnectMcpServer(), tried once per
+// down-episode.
+//
+// Harness pattern follows claude-init-mcp-degraded.test.ts: the optional Agent
+// SDK is mocked, the backend is driven through run(), and the canonical
+// AgentEvents are collected. The mock's status answers are SCRIPTED per poll
+// so a scenario can say exactly what the harness reports before and after the
+// reconnect.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+process.env.COMFYUI_MCP_TURN_REGISTRY_DIR = mkdtempSync(join(tmpdir(), "claude-mcp-reconnect-registry-"));
+
+const hoisted = vi.hoisted(() => ({
+  queue: new (class {
+    private buf: unknown[] = [];
+    private waiters: Array<() => void> = [];
+    private closed = false;
+    reset(): void {
+      this.buf = [];
+      this.closed = false;
+    }
+    push(m: unknown): void {
+      this.buf.push(m);
+      for (const w of this.waiters.splice(0)) w();
+    }
+    end(): void {
+      this.closed = true;
+      for (const w of this.waiters.splice(0)) w();
+    }
+    async *iterate(): AsyncGenerator<unknown> {
+      for (;;) {
+        while (this.buf.length) yield this.buf.shift();
+        if (this.closed) return;
+        await new Promise<void>((resolve) => this.waiters.push(resolve));
+      }
+    }
+  })(),
+  /** Poll answers, in order; the LAST one repeats when the script runs out. */
+  statusScript: [] as Array<Array<{ name: string; status: string }>>,
+  polls: 0,
+  /** Servers the harness was asked to reconnect, in order. */
+  reconnectCalls: [] as string[],
+  /** When true the mock query has no reconnectMcpServer at all. */
+  omitReconnect: false,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (arg: { prompt?: AsyncIterable<unknown> }) => {
+    void (async () => {
+      for await (const _ of arg.prompt ?? []) void _;
+    })();
+    const iter = hoisted.queue.iterate();
+    return Object.assign(iter, {
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      interrupt: async () => {},
+      setModel: async () => {},
+      mcpServerStatus: async () => {
+        hoisted.polls += 1;
+        const script = hoisted.statusScript;
+        if (script.length === 0) throw new Error("no status available");
+        return script.length > 1 ? script.shift() : script[0];
+      },
+      ...(hoisted.omitReconnect
+        ? {}
+        : {
+            reconnectMcpServer: async (name: string) => {
+              hoisted.reconnectCalls.push(name);
+            },
+          }),
+    });
+  },
+}));
+
+beforeEach(() => {
+  hoisted.queue.reset();
+  hoisted.statusScript = [];
+  hoisted.polls = 0;
+  hoisted.reconnectCalls = [];
+  hoisted.omitReconnect = false;
+});
+
+const CONNECTED = [
+  { name: "comfyui", status: "connected" },
+  { name: "panel", status: "connected" },
+];
+const PANEL_DOWN = [
+  { name: "comfyui", status: "connected" },
+  { name: "panel", status: "failed" },
+];
+
+const INIT_HEALTHY = {
+  type: "system",
+  subtype: "init",
+  session_id: "00000000-1111-2222-3333-444444444444",
+  model: "claude-test-1",
+  apiKeySource: "none",
+  skills: [],
+  mcp_servers: CONNECTED,
+};
+
+/** A stand-in for the in-process panel server (createSdkMcpServer's shape). */
+const PANEL_SERVER = { type: "sdk", name: "comfyui-panel", instance: {} } as never;
+const COMFYUI_SERVER = { type: "stdio", command: "node", args: [] } as never;
+const DEPS = { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER };
+
+const noticesOf = (events: AgentEvent[]) =>
+  events.filter(
+    (e): e is Extract<AgentEvent, { type: "error" }> =>
+      e.type === "error" && (e as { sessionNotice?: boolean }).sessionNotice === true,
+  );
+
+interface Drive {
+  events: AgentEvent[];
+  /** Push one result message and wait for the run loop to finish with it. */
+  endTurn(): Promise<void>;
+  finish(): Promise<void>;
+}
+
+/** Drives a session turn by turn, so a scenario controls what each poll — one
+ *  per turn end — answers. The run loop is a single consumer, so polls are
+ *  taken from the script in turn order. */
+async function startDrive(init: unknown): Promise<Drive> {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({
+    mcpServers: DEPS.mcpServers as never,
+    systemAppend: "",
+    panelServer: DEPS.panelServer as never,
+  });
+  const events: AgentEvent[] = [];
+  async function* turns(): AsyncGenerator<{ text: string }> {
+    yield { text: "hello" };
+    await new Promise<void>(() => {}); // never submits again
+  }
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: turns() as never })) events.push(ev);
+  })();
+  hoisted.queue.push(init);
+  await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+  let ended = 0;
+  return {
+    events,
+    async endTurn() {
+      ended += 1;
+      hoisted.queue.push({ type: "result", subtype: "success" });
+      await waitFor(() =>
+        expect(events.filter((e) => e.type === "result").length).toBeGreaterThanOrEqual(ended),
+      );
+    },
+    async finish() {
+      hoisted.queue.end();
+      await done;
+    },
+  };
+}
+
+describe("a mid-session MCP drop is met with one bounded reconnect (#1524)", () => {
+  it("a drop the reconnect fixes is narrated once, as fixed", async () => {
+    // The reporter's six-hour outcome, inverted: the poll sees the drop, the
+    // reconnect is tried, the verdict re-read says connected — and the ONLY
+    // line the user gets is the accurate one.
+    hoisted.statusScript = [PANEL_DOWN, CONNECTED];
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn();
+    await drive.finish();
+
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toMatch(/reconnect brought it back/);
+  });
+
+  it("a drop the reconnect does NOT fix is reported once — not fought every turn", async () => {
+    hoisted.statusScript = [PANEL_DOWN]; // every poll answers "failed"
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.finish();
+
+    // One attempt per episode: three turn ends, one reconnect.
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    // One line per episode: the user is told, not spammed.
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toMatch(/reconnect did not bring it back/);
+  });
+
+  it("a server the harness heals itself is credited to the harness, not to us", async () => {
+    // The reporter watched exactly this asymmetry: comfyui came back on the
+    // harness's own reconnect. When OUR poll sees a down server read connected
+    // again without our attempt, the notice says so.
+    hoisted.statusScript = [PANEL_DOWN, PANEL_DOWN, CONNECTED];
+    hoisted.omitReconnect = true; // nothing we could have done — it healed anyway
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn(); // sees the drop, reports it (no reconnect to ask for)
+    await drive.endTurn(); // still down, already reported — silent
+    await drive.endTurn(); // reads connected: self-heal
+    await drive.finish();
+
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(2);
+    expect(notices[0].message).toMatch(/no reconnect to ask for/);
+    expect(notices[1].message).toMatch(/connected again/);
+    expect(notices[1].message).not.toMatch(/reconnect brought/);
+  });
+
+  it("a needs-auth server is reported but never retried", async () => {
+    // Auth waits on the user; an automatic retry claims effort that cannot
+    // land. Reported once, attempted never.
+    hoisted.statusScript = [
+      [
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "needs-auth" },
+      ],
+    ];
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.finish();
+
+    expect(hoisted.reconnectCalls).toEqual([]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toMatch(/cannot clear this status/);
+  });
+
+  it("a second drop after a recovery is a NEW episode, with its own attempt", async () => {
+    hoisted.statusScript = [PANEL_DOWN, CONNECTED, CONNECTED, PANEL_DOWN];
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn(); // poll: drop → reconnect → verdict re-read: back
+    await drive.endTurn(); // poll: healthy — silent
+    await drive.endTurn(); // poll: drop again → reconnect → verdict: still down
+    await drive.finish();
+
+    expect(hoisted.reconnectCalls).toEqual(["panel", "panel"]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(2);
+    expect(notices[0].message).toMatch(/reconnect brought it back/);
+    expect(notices[1].message).toMatch(/reconnect did not bring it back/);
+  });
+
+  it("a session that STARTED without the server gets its owed attempt at the first turn end", async () => {
+    // Init reported the drop (its own notice, immediately); the notice promised
+    // the reconnect outcome, and the first turn end delivers it.
+    hoisted.statusScript = [PANEL_DOWN];
+    const drive = await startDrive({
+      ...INIT_HEALTHY,
+      mcp_servers: PANEL_DOWN,
+    });
+    await drive.endTurn();
+    await drive.finish();
+
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(2);
+    expect(notices[0].message).toMatch(/started without/);
+    expect(notices[1].message).toMatch(/reconnect did not bring it back/);
+  });
+
+  it("an init-degraded server the harness heals before the first turn is reported as back", async () => {
+    hoisted.statusScript = [CONNECTED];
+    const drive = await startDrive({
+      ...INIT_HEALTHY,
+      mcp_servers: PANEL_DOWN,
+    });
+    await drive.endTurn();
+    await drive.finish();
+
+    // It came back on its own — no attempt of ours to credit.
+    expect(hoisted.reconnectCalls).toEqual([]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(2);
+    expect(notices[0].message).toMatch(/started without/);
+    expect(notices[1].message).toMatch(/connected again/);
+  });
+});

--- a/src/__tests__/orchestrator/claude-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/claude-mcp-reconnect.test.ts
@@ -50,8 +50,9 @@ const hoisted = vi.hoisted(() => ({
       }
     }
   })(),
-  /** Poll answers, in order; the LAST one repeats when the script runs out. */
-  statusScript: [] as Array<Array<{ name: string; status: string }>>,
+  /** Poll answers, in order; the LAST one repeats when the script runs out.
+   *  The entry "throw" makes that poll throw (an unreadable status report). */
+  statusScript: [] as Array<Array<{ name: string; status: string }> | "throw">,
   polls: 0,
   /** Servers the harness was asked to reconnect, in order. */
   reconnectCalls: [] as string[],
@@ -74,7 +75,9 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
         hoisted.polls += 1;
         const script = hoisted.statusScript;
         if (script.length === 0) throw new Error("no status available");
-        return script.length > 1 ? script.shift() : script[0];
+        const next = script.length > 1 ? script.shift()! : script[0];
+        if (next === "throw") throw new Error("no status available");
+        return next;
       },
       ...(hoisted.omitReconnect
         ? {}
@@ -290,5 +293,25 @@ describe("a mid-session MCP drop is met with one bounded reconnect (#1524)", () 
     expect(notices).toHaveLength(2);
     expect(notices[0].message).toMatch(/started without/);
     expect(notices[1].message).toMatch(/connected again/);
+  });
+
+  it("an attempt whose verdict cannot be read back claims no outcome (#1228)", async () => {
+    // The reconnect ran but the status re-read that would judge it is
+    // unavailable. The server is still reported — clearing a degradation
+    // nobody checked is the false success to avoid — but "did not come back"
+    // would be a claim nobody checked either, so the notice names the attempt
+    // and stops there.
+    hoisted.statusScript = [PANEL_DOWN, "throw"];
+    const drive = await startDrive(INIT_HEALTHY);
+    await drive.endTurn();
+    await drive.finish();
+
+    expect(hoisted.reconnectCalls).toEqual(["panel"]);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toMatch(/reconnect was attempted/);
+    expect(notices[0].message).toMatch(/could not be read back/);
+    expect(notices[0].message).not.toMatch(/did not bring it back/);
   });
 });

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -185,6 +185,17 @@ describe("unrecoveredMcpNotice — says which dead end this is, and stops", () =
     expect(note).toMatch(/automatic reconnect did not bring it back/);
   });
 
+  it("claims no outcome when the reconnect's verdict could not be read back (#1228)", () => {
+    // "We tried and it failed" is only sayable off the post-attempt status
+    // re-read; when that read is unavailable the notice reports the attempt
+    // without asserting an outcome nobody checked.
+    const note = unrecoveredMcpNotice([{ name: "panel", status: "failed" }], "unverified");
+    expect(note).toContain("panel");
+    expect(note).toMatch(/reconnect was attempted/);
+    expect(note).toMatch(/could not be read back/);
+    expect(note).not.toMatch(/did not bring/);
+  });
+
   it("says when nothing was attempted, and why", () => {
     // "We tried and failed" and "there was nothing to try" are different
     // situations; the reader must not have to guess which one they are in.

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -27,6 +27,9 @@ import { describe, expect, it } from "vitest";
 import {
   degradedMcpNotice,
   inspectMcpServers,
+  reconnectableMcpStatus,
+  recoveredMcpNotice,
+  unrecoveredMcpNotice,
 } from "../../orchestrator/mcp-session-health.js";
 
 const CONFIGURED = ["comfyui", "panel"];
@@ -132,12 +135,14 @@ describe("degradedMcpNotice — states the observation, and stops", () => {
     expect(note).toContain("not reported");
   });
 
-  it("says the loss lasts the session, without promising a restart fixes it", () => {
+  it("says the loss lasts until the server connects, without promising recovery works", () => {
     // Same discipline as NO_PANEL_TOOLS_OVERRIDE: a cause that persists survives
-    // a restart, so "reconnecting restores them" is a claim this cannot make.
+    // a reconnect and a restart alike, so "recovery restores them" is a claim
+    // this cannot make. What it CAN say is what the session itself will do.
     const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
-    expect(note).toMatch(/rest of this session/);
-    expect(note).toMatch(/whether it succeeds depends on why this one did not/);
+    expect(note).toMatch(/until the server connects/);
+    expect(note).toMatch(/reconnect is attempted/);
+    expect(note).toMatch(/[Ww]hether either succeeds depends on why this one did not/);
     expect(note).not.toMatch(/will fix|will restore|restores them/);
   });
 
@@ -147,5 +152,78 @@ describe("degradedMcpNotice — states the observation, and stops", () => {
     // wearing the fix's clothes.
     const note = degradedMcpNotice([{ name: "panel", status: "failed" }]);
     expect(note).not.toMatch(/because|caused by|due to/i);
+  });
+});
+
+describe("reconnectableMcpStatus — which failures an automatic retry can speak to", () => {
+  it("retries the drop shapes", () => {
+    expect(reconnectableMcpStatus("failed")).toBe(true);
+    expect(reconnectableMcpStatus("error")).toBe(true);
+    expect(reconnectableMcpStatus("FAILED")).toBe(true);
+    // Absent from a populated report — the connection died before the server
+    // was advertised — is a drop shape too.
+    expect(reconnectableMcpStatus(null)).toBe(true);
+  });
+
+  it("does not retry what only the user or an explicit switch can change", () => {
+    // needs-auth waits on the user completing auth; disabled is a deliberate
+    // off switch. Retrying either claims effort that cannot land, or overrides
+    // intent.
+    expect(reconnectableMcpStatus("needs-auth")).toBe(false);
+    expect(reconnectableMcpStatus("disabled")).toBe(false);
+  });
+});
+
+describe("unrecoveredMcpNotice — says which dead end this is, and stops", () => {
+  it("is empty when nothing is degraded", () => {
+    expect(unrecoveredMcpNotice([], "reconnect-failed")).toBe("");
+  });
+
+  it("names the failed reconnect when one was tried", () => {
+    const note = unrecoveredMcpNotice([{ name: "panel", status: "failed" }], "reconnect-failed");
+    expect(note).toContain("panel");
+    expect(note).toMatch(/automatic reconnect did not bring it back/);
+  });
+
+  it("says when nothing was attempted, and why", () => {
+    // "We tried and failed" and "there was nothing to try" are different
+    // situations; the reader must not have to guess which one they are in.
+    const notRetriable = unrecoveredMcpNotice(
+      [{ name: "panel", status: "needs-auth" }],
+      "not-retriable",
+    );
+    expect(notRetriable).toMatch(/cannot clear this status/);
+    expect(notRetriable).not.toMatch(/did not bring/);
+    const unsupported = unrecoveredMcpNotice([{ name: "panel", status: "failed" }], "unsupported");
+    expect(unsupported).toMatch(/no reconnect to ask for/);
+    expect(unsupported).not.toMatch(/did not bring/);
+  });
+
+  it("does not promise a new session fixes it", () => {
+    const note = unrecoveredMcpNotice([{ name: "panel", status: "failed" }], "reconnect-failed");
+    expect(note).toMatch(/whether it succeeds depends on why the server is down/);
+    expect(note).not.toMatch(/will fix|will restore/i);
+  });
+});
+
+describe("recoveredMcpNotice — claims only what the status poll reported", () => {
+  it("is empty when nothing came back", () => {
+    expect(recoveredMcpNotice([], true)).toBe("");
+  });
+
+  it("credits the reconnect when the reconnect did it", () => {
+    const note = recoveredMcpNotice(["panel"], true);
+    expect(note).toContain("panel");
+    expect(note).toMatch(/reconnect brought it back/);
+    expect(note).toMatch(/available to the agent/);
+  });
+
+  it("does not take credit for a server the harness healed itself", () => {
+    // The reporter watched `comfyui` come back on the harness's own reconnect
+    // while `panel` stayed down. Claiming that recovery would be the same
+    // dishonesty as claiming the drop was diagnosed.
+    const note = recoveredMcpNotice(["comfyui"], false);
+    expect(note).toMatch(/connected again/);
+    expect(note).not.toMatch(/reconnect brought/);
   });
 });

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -23,7 +23,13 @@ import { logger } from "../utils/logger.js";
 import { errorText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import { loadTurnRegistry, saveTurnRegistry, tombstoneTurn } from "./turn-registry.js";
-import { degradedMcpNotice, inspectMcpServers } from "./mcp-session-health.js";
+import {
+  degradedMcpNotice,
+  inspectMcpServers,
+  reconnectableMcpStatus,
+  recoveredMcpNotice,
+  unrecoveredMcpNotice,
+} from "./mcp-session-health.js";
 import type { DegradedMcpServer } from "./mcp-session-health.js";
 import { randomUUID } from "node:crypto";
 import {
@@ -427,12 +433,17 @@ export class ClaudeBackend implements AgentBackend {
     };
   }
 
-  /** Configured servers still CONNECTING in this session's `init` report (#1524).
-   *  Settled once, at the first turn end, by settlePendingMcpServers(). */
-  private pendingMcpServers: string[] = [];
+  /** MCP servers this run currently knows are DOWN, name → reconnect attempted.
+   *  An episode opens when the `init` report or a turn-end status poll finds a
+   *  configured server unusable (#1524), and closes when a later poll reads it
+   *  connected again — whether our reconnect brought it back or the harness's
+   *  own supervision did. The boolean bounds retries: ONE automatic reconnect
+   *  per episode, so a server that stays down is reported once, not fought on
+   *  every turn. */
+  private mcpDown = new Map<string, boolean>();
 
   /** Say — in the log — that this session does not have servers it was given.
-   *  Shared by the init check and the deferred settle so both report identically. */
+   *  Shared by the init check and the turn-end watch so both report identically. */
   private reportDegradedMcp(
     degraded: readonly DegradedMcpServer[],
     reported: readonly { name: string; status: string }[] | undefined,
@@ -447,40 +458,140 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   /**
-   * Settle the servers that were still connecting at `init` (#1524).
-   *
-   * `init` is the only MCP report the session PUSHES, and server startup does not
-   * block it — so a server that is `pending` there and FAILS a moment later would
-   * otherwise never be mentioned anywhere, which is the same silence this change
-   * exists to end, just moved a few hundred milliseconds later.
-   *
-   * Re-read once per run, at the first turn end: by then a pending server has
-   * settled, and a turn boundary needs no timer and cannot spam. A session that
-   * never takes a turn is never re-read, which is the right trade — there is no
-   * agent work to degrade.
-   *
-   * Best-effort by construction: `mcpServerStatus()` is an optional Query method
-   * (a harness that lacks it, or a poll that throws, leaves the pending servers
-   * unmentioned rather than guessed at).
+   * One best-effort read of the harness's MCP server statuses. `undefined`
+   * means "nothing learned" — a harness without the method, a poll that
+   * throws, or an empty report all land here, and all three must leave the
+   * session exactly as informed as before: silent, never guessed at.
    */
-  private async settlePendingMcpServers(): Promise<AgentEvent | null> {
-    const names = this.pendingMcpServers;
-    if (names.length === 0) return null;
-    // Taking the names IS the once-only guard: the next turn end finds the list
-    // empty and returns before the poll. A re-read on every turn would spend a
-    // control round-trip per turn for a question that is already answered.
-    this.pendingMcpServers = [];
-    let reported: Array<{ name: string; status: string }> | undefined;
+  private async pollMcpStatus(q: Query): Promise<Array<{ name: string; status: string }> | undefined> {
     try {
-      reported = await this.q?.mcpServerStatus?.();
+      const reported = await q.mcpServerStatus?.();
+      return Array.isArray(reported) && reported.length > 0 ? reported : undefined;
     } catch (err) {
       logger.debug(`[claude-backend] mcpServerStatus: ${msgOf(err)}`);
-      return null;
+      return undefined;
     }
-    const { degraded } = inspectMcpServers(names, reported);
-    if (!degraded.length) return null;
-    this.reportDegradedMcp(degraded, reported, this.registrySessionId ?? "", "is running");
-    return { type: "error", sessionNotice: true, message: degradedMcpNotice(degraded) };
+  }
+
+  /**
+   * Watch the toolset for a MID-SESSION drop, and try to bring it back (#1524).
+   *
+   * The reporter's session came up healthy and lost all 92 panel_* tools hours
+   * in: the harness's own reconnect brought `comfyui` back and never retried
+   * the in-process panel server — and since `init` is the only MCP report a
+   * session PUSHES, nothing host-side ever learned of it. There is no
+   * mid-session push to listen for (the SDK's message vocabulary has none), so
+   * the only detection is to ASK: one `mcpServerStatus()` poll per turn end —
+   * turn-driven, so it needs no timer and cannot spam — read against the set
+   * this session was actually given.
+   *
+   * Recovery is the SDK's own verb, `reconnectMcpServer()` ("reconnects a
+   * disconnected or failed MCP server"), bounded to ONE attempt per
+   * down-episode. The attempt is never claimed to have worked on the strength
+   * of the call alone: the status is re-read once and the re-read is what the
+   * notice quotes. `needs-auth` and `disabled` are reported but not retried —
+   * the first waits on the user, the second is a deliberate off switch.
+   *
+   * Best-effort throughout: a harness without these control methods, or a poll
+   * that throws, leaves the session as informed as it was before this existed
+   * — silent — and never takes the turn stream down with it.
+   */
+  private async checkMcpServers(q: Query): Promise<AgentEvent[]> {
+    const names = Object.keys(this.mcpServersForRun() ?? {});
+    if (names.length === 0) return [];
+    let reported = await this.pollMcpStatus(q);
+    if (!reported) return [];
+    const events: AgentEvent[] = [];
+
+    // Attempt the one reconnect each down server is owed BEFORE reporting, so a
+    // drop the reconnect fixes right away is narrated once and accurately,
+    // instead of "gone" followed by "back". Servers just found down (no open
+    // episode) and episodes opened at init (attempt owed to this turn boundary)
+    // are both due; an episode already retried is not.
+    const triable = inspectMcpServers(names, reported).degraded.filter(
+      (d) => this.mcpDown.get(d.name) !== true && reconnectableMcpStatus(d.status),
+    );
+    const attempted = new Set<string>();
+    if (typeof q.reconnectMcpServer === "function") {
+      for (const d of triable) {
+        attempted.add(d.name);
+        this.mcpDown.set(d.name, true); // the attempt is spent, whatever it returns
+        try {
+          await q.reconnectMcpServer(d.name);
+        } catch (err) {
+          logger.debug(`[claude-backend] reconnectMcpServer(${d.name}): ${msgOf(err)}`);
+        }
+      }
+      if (attempted.size > 0) {
+        // The verdict on the attempts: re-read once. A failed re-read keeps the
+        // pre-attempt reading — the servers stay "down" — the safe direction.
+        const after = await this.pollMcpStatus(q);
+        if (after) reported = after;
+      }
+    }
+
+    const degraded = inspectMcpServers(names, reported).degraded;
+    const downNow = new Set(degraded.map((d) => d.name));
+
+    // Episodes that CLOSED: the server reads connected again. An episode our
+    // own attempt just closed says so; one the harness healed on its own
+    // (the reporter watched `comfyui` do exactly this) is reported as what it
+    // is — it came back, and we did not do it.
+    const backByUs: string[] = [];
+    const backOnItsOwn: string[] = [];
+    for (const name of [...this.mcpDown.keys()]) {
+      if (downNow.has(name)) continue;
+      this.mcpDown.delete(name);
+      (attempted.has(name) ? backByUs : backOnItsOwn).push(name);
+    }
+    if (backByUs.length) {
+      logger.info(`[claude-backend] MCP reconnect brought back: ${backByUs.join(", ")}`);
+      events.push({ type: "error", sessionNotice: true, message: recoveredMcpNotice(backByUs, true) });
+    }
+    if (backOnItsOwn.length) {
+      logger.info(`[claude-backend] MCP servers connected again on their own: ${backOnItsOwn.join(", ")}`);
+      events.push({ type: "error", sessionNotice: true, message: recoveredMcpNotice(backOnItsOwn, false) });
+    }
+
+    // Episodes still OPEN that have not been reported yet: a fresh drop whose
+    // reconnect just failed, an init-time episode whose owed attempt failed
+    // (the init notice promised the outcome), and drops there is no attempt
+    // for. One line per server per episode — a server that stays down is not
+    // re-narrated on every turn.
+    const unreported = degraded.filter((d) => attempted.has(d.name) || !this.mcpDown.has(d.name));
+    const failedAttempt = unreported.filter((d) => attempted.has(d.name));
+    const notRetriable = unreported.filter(
+      (d) => !attempted.has(d.name) && !reconnectableMcpStatus(d.status),
+    );
+    const unsupported = unreported.filter(
+      (d) => !attempted.has(d.name) && reconnectableMcpStatus(d.status),
+    );
+    for (const d of unreported) this.mcpDown.set(d.name, true);
+    if (failedAttempt.length) {
+      this.reportDegradedMcp(failedAttempt, reported, this.registrySessionId ?? "", "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(failedAttempt, "reconnect-failed"),
+      });
+    }
+    if (notRetriable.length) {
+      this.reportDegradedMcp(notRetriable, reported, this.registrySessionId ?? "", "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(notRetriable, "not-retriable"),
+      });
+    }
+    if (unsupported.length) {
+      this.reportDegradedMcp(unsupported, reported, this.registrySessionId ?? "", "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(unsupported, "unsupported"),
+      });
+    }
+    return events;
   }
 
   /**
@@ -592,9 +703,9 @@ export class ClaudeBackend implements AgentBackend {
     this.lastResultTurnId = this.turnSeq;
     this.classificationPoisoned = false;
     // #1524 — MCP health is per SESSION. A restart re-runs every connection, so
-    // the previous run's pending set and its "already settled" mark must not
-    // suppress the new session's report.
-    this.pendingMcpServers = [];
+    // the previous run's down-episodes and their "already retried" marks must
+    // not suppress the new session's report or its one reconnect attempt.
+    this.mcpDown.clear();
     this.parkedInterrupted.clear(); // dead session's parks die with it
     this.consumedInterrupted.clear(); // …and its landing history
     this.markerBase = this.lastResultTurnId; // turn markers are run-relative (#728)
@@ -670,13 +781,13 @@ export class ClaudeBackend implements AgentBackend {
         }
         yield streamTurn === undefined ? ev : { ...ev, turn: streamTurn - this.markerBase };
       }
-      // #1524 — settle whatever was still CONNECTING at init, once, at the first
-      // turn end. Placed here rather than in route() because it has to await a
-      // control request, and after the turn's own events so a session notice
-      // never interleaves into the middle of a reply.
+      // #1524 — watch the toolset at every turn end: poll the servers this
+      // session was given, attempt the one reconnect each down server is owed,
+      // and narrate the outcome. Placed here rather than in route() because it
+      // has to await control requests, and after the turn's own events so a
+      // session notice never interleaves into the middle of a reply.
       if (message.type === "result") {
-        const settled = await this.settlePendingMcpServers();
-        if (settled) yield settled;
+        for (const ev of await this.checkMcpServers(q)) yield ev;
       }
     }
   }
@@ -854,11 +965,15 @@ export class ClaudeBackend implements AgentBackend {
           );
           // A server still CONNECTING at init is not a failure — server startup
           // does not block the session, so a slow one is legitimately `pending`
-          // here and connected a moment later. It is not "fine" either: `init` is
-          // the only report the session PUSHES, so a pending server that goes on
-          // to fail would never be mentioned. Remember the names and settle them
-          // at the first turn end (see settlePendingMcpServers).
-          this.pendingMcpServers = health.pending;
+          // here and connected a moment later. It needs no tracking of its own:
+          // the turn-end watch (checkMcpServers) reads every configured server
+          // at each turn boundary, so a pending server that goes on to FAIL
+          // surfaces there as a fresh drop, and one that connects simply never
+          // opens an episode.
+          //
+          // A server already DOWN at init opens its episode now — reported
+          // below, with the reconnect it is owed landing at the first turn end.
+          for (const d of health.degraded) this.mcpDown.set(d.name, false);
           if (health.degraded.length) {
             this.reportDegradedMcp(health.degraded, message.mcp_servers, message.session_id);
             yield { type: "error", sessionNotice: true, message: degradedMcpNotice(health.degraded) };

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -512,6 +512,10 @@ export class ClaudeBackend implements AgentBackend {
       (d) => this.mcpDown.get(d.name) !== true && reconnectableMcpStatus(d.status),
     );
     const attempted = new Set<string>();
+    // Whether the post-attempt status re-read was READ. "Reconnect failed" is
+    // only claimable when it was — otherwise the still-down reading is the
+    // pre-attempt one and the notice must not assert an outcome nobody saw.
+    let verdictRead = true;
     if (typeof q.reconnectMcpServer === "function") {
       for (const d of triable) {
         attempted.add(d.name);
@@ -527,6 +531,7 @@ export class ClaudeBackend implements AgentBackend {
         // pre-attempt reading — the servers stay "down" — the safe direction.
         const after = await this.pollMcpStatus(q);
         if (after) reported = after;
+        else verdictRead = false;
       }
     }
 
@@ -568,11 +573,15 @@ export class ClaudeBackend implements AgentBackend {
     );
     for (const d of unreported) this.mcpDown.set(d.name, true);
     if (failedAttempt.length) {
+      // "Did not bring it back" is claimable only off the post-attempt re-read;
+      // when that re-read could not be read the attempt is reported WITHOUT an
+      // outcome — "did not come back" would be a claim nobody checked (#1228).
+      const why = verdictRead ? "reconnect-failed" : "unverified";
       this.reportDegradedMcp(failedAttempt, reported, this.registrySessionId ?? "", "lost");
       events.push({
         type: "error",
         sessionNotice: true,
-        message: unrecoveredMcpNotice(failedAttempt, "reconnect-failed"),
+        message: unrecoveredMcpNotice(failedAttempt, why),
       });
     }
     if (notRetriable.length) {

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -178,6 +178,9 @@ function namedDegraded(degraded: readonly DegradedMcpServer[]): string {
  *
  *  - `reconnect-failed`: an automatic reconnect was tried and the re-read still
  *    reports the server down;
+ *  - `unverified`: an automatic reconnect was tried but the status re-read that
+ *    would judge it could not be read — so the outcome is not claimed either
+ *    way ("did not come back" would be a claim nobody checked);
  *  - `not-retriable`: the status (`needs-auth`, `disabled`) is not one an
  *    automatic reconnect can clear — nothing was attempted;
  *  - `unsupported`: the harness exposes no reconnect to ask for — nothing
@@ -188,16 +191,18 @@ function namedDegraded(degraded: readonly DegradedMcpServer[]): string {
  */
 export function unrecoveredMcpNotice(
   degraded: readonly DegradedMcpServer[],
-  why: "reconnect-failed" | "not-retriable" | "unsupported",
+  why: "reconnect-failed" | "unverified" | "not-retriable" | "unsupported",
 ): string {
   if (degraded.length === 0) return "";
   const plural = degraded.length > 1;
   const reason =
     why === "reconnect-failed"
       ? `the automatic reconnect did not bring ${plural ? "them" : "it"} back`
-      : why === "not-retriable"
-        ? "an automatic reconnect cannot clear this status, so none was attempted"
-        : "this harness offers no reconnect to ask for";
+      : why === "unverified"
+        ? "an automatic reconnect was attempted, but its outcome could not be read back"
+        : why === "not-retriable"
+          ? "an automatic reconnect cannot clear this status, so none was attempted"
+          : "this harness offers no reconnect to ask for";
   return (
     `MCP ${plural ? "servers" : "server"} ${namedDegraded(degraded)} ${plural ? "are" : "is"} ` +
     `unavailable to the agent — ${reason}. ` +

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -20,10 +20,12 @@
 // panel server (Claude lane) and the stdio `comfyui` child. `route()` already reads
 // that message for the session id and throws the rest away.
 //
-// This module is only the comparison. It says what was observed and nothing more:
-// it does not diagnose WHY a server is missing (still unknown for #1524, and the
-// two candidate causes need different fixes), and it does not promise a restart
-// would help.
+// This module is the comparison and the wording. The comparison says what was
+// observed and nothing more: it does not diagnose WHY a server is missing
+// (still open for #1524, and the two candidate causes need different fixes).
+// The wording carries the recovery story the same way: a reconnect attempt is
+// reported as attempted, its outcome as whatever the re-read status poll said —
+// never as a promise that a restart or reconnect would help.
 
 /** One entry of the `system`/`init` `mcp_servers` report. */
 export interface ReportedMcpServer {
@@ -121,6 +123,21 @@ export function inspectMcpServers(
 const FAILED_STATUSES = new Set(["failed", "needs-auth", "disabled", "error"]);
 
 /**
+ * Whether an automatic reconnect is worth attempting for a degraded status.
+ *
+ * `failed` / `error` / absent-from-the-report are DROP shapes — re-running the
+ * connection can bring the server back. `needs-auth` waits on the user
+ * completing an auth flow and `disabled` is a deliberate off switch: an
+ * automatic retry of the first claims effort that cannot land, and of the
+ * second overrides intent — so neither is retried, only reported.
+ */
+export function reconnectableMcpStatus(status: string | null): boolean {
+  if (status === null) return true;
+  const s = status.trim().toLowerCase();
+  return s === "failed" || s === "error";
+}
+
+/**
  * The line the user sees when a session starts without a server it was given.
  *
  * Scoped the way `NO_PANEL_TOOLS_OVERRIDE` is scoped: it states the observation
@@ -138,9 +155,77 @@ export function degradedMcpNotice(degraded: readonly DegradedMcpServer[]): strin
   const theirTools = degraded.length > 1 ? "Their tools are" : "Its tools are";
   return (
     `This session started without ${degraded.length} of its MCP ${plural}: ${named}. ` +
-    `${theirTools} not available to the agent for the rest of this session, ` +
+    `${theirTools} not available to the agent until the server connects, ` +
     `so anything that needs them will fail or be worked around silently. ` +
-    `Starting a new session (Disconnect → Connect) is what re-runs the connection; ` +
-    `whether it succeeds depends on why this one did not, which this message does not know.`
+    `A reconnect is attempted at the next turn boundary for any of them that can be retried, ` +
+    `and the outcome is reported; starting a new session (Disconnect → Connect) ` +
+    `re-runs the connection from scratch. ` +
+    `Whether either succeeds depends on why this one did not, which this message does not know.`
+  );
+}
+
+/** Format a degraded-server list the way every notice in this module does. */
+function namedDegraded(degraded: readonly DegradedMcpServer[]): string {
+  return degraded
+    .map((d) => (d.status === null ? `\`${d.name}\` (not reported)` : `\`${d.name}\` (${d.status})`))
+    .join(", ");
+}
+
+/**
+ * The line the user sees when a server is down and STAYS down past the
+ * recovery this session can offer (#1524). `why` names exactly which situation
+ * the session is in — the one thing the reader must not have to guess:
+ *
+ *  - `reconnect-failed`: an automatic reconnect was tried and the re-read still
+ *    reports the server down;
+ *  - `not-retriable`: the status (`needs-auth`, `disabled`) is not one an
+ *    automatic reconnect can clear — nothing was attempted;
+ *  - `unsupported`: the harness exposes no reconnect to ask for — nothing
+ *    could be attempted.
+ *
+ * Like `degradedMcpNotice`, it stops at the observation: it does not diagnose
+ * why the server is down and does not promise a new session fixes it.
+ */
+export function unrecoveredMcpNotice(
+  degraded: readonly DegradedMcpServer[],
+  why: "reconnect-failed" | "not-retriable" | "unsupported",
+): string {
+  if (degraded.length === 0) return "";
+  const plural = degraded.length > 1;
+  const reason =
+    why === "reconnect-failed"
+      ? `the automatic reconnect did not bring ${plural ? "them" : "it"} back`
+      : why === "not-retriable"
+        ? "an automatic reconnect cannot clear this status, so none was attempted"
+        : "this harness offers no reconnect to ask for";
+  return (
+    `MCP ${plural ? "servers" : "server"} ${namedDegraded(degraded)} ${plural ? "are" : "is"} ` +
+    `unavailable to the agent — ${reason}. ` +
+    `Anything that needs ${plural ? "their" : "its"} tools will fail or be worked around ` +
+    `silently for the rest of this session. ` +
+    `Starting a new session (Disconnect → Connect) re-runs the connection; ` +
+    `whether it succeeds depends on why the server is down, which this message does not know.`
+  );
+}
+
+/**
+ * The line the user sees when a down server reads CONNECTED again (#1524).
+ * `byReconnect` distinguishes the two honest shapes: the session's own
+ * reconnect attempt landed, or the harness's supervision brought the server
+ * back on its own (the reporter watched `comfyui` do exactly this while
+ * `panel` stayed down). The claim is only ever what a status poll reported —
+ * never that the tools were exercised.
+ */
+export function recoveredMcpNotice(names: readonly string[], byReconnect: boolean): string {
+  if (names.length === 0) return "";
+  const named = names.map((n) => `\`${n}\``).join(", ");
+  const plural = names.length > 1;
+  const how = byReconnect
+    ? `the automatic reconnect brought ${plural ? "them" : "it"} back`
+    : `${plural ? "they are" : "it is"} connected again`;
+  return (
+    `MCP ${plural ? "servers" : "server"} ${named}: ${how} — ` +
+    `${plural ? "their" : "its"} tools are available to the agent. ` +
+    `Anything the agent reported as unreachable while the server was down may be worth another try.`
   );
 }


### PR DESCRIPTION
Closes #1524

## What was already true

#1614 (v0.51.57) made a session that **starts** without an MCP server say so. What it could not cover — and said it could not — is the reporter's actual case: a session that came up **healthy** and lost all 92 `panel_*` tools hours in. `init` is the only MCP report a session pushes, so a mid-session drop on the Claude lane (where `panel` is an in-process `createSdkMcpServer`) was invisible host-side forever, and nothing anywhere attempted a reconnect. The harness re-registered `comfyui` and never retried the in-process panel server; **why it treats the two differently is still unknown**, and this PR does not claim otherwise.

## Root cause

There is no mid-session MCP push to listen for (checked against the installed agent SDK 0.3.197's message vocabulary), so noticing the drop passively was impossible — and the host never asked: after #1614 the status poll ran once per run, only for servers pending at init. Recovery needed two things the code did not do: **ask** (poll the live status) and **act** (the SDK's `reconnectMcpServer()` control verb exists for exactly this — "reconnects a disconnected or failed MCP server" — and nothing called it).

## What changes

`settlePendingMcpServers` (one poll, once per run, pending servers only) becomes `checkMcpServers`, a watch that runs at every turn end:

- **Detection** — one `mcpServerStatus()` poll per completed turn, read against the server set the session was actually given. This deliberately replaces #1614's "re-read once" rule: that rule answered "did the pending server settle", a question with one answer; "is the toolset still whole" does not have one answer, and the per-turn poll is the only honest way to know. It stays turn-driven — no timer, cannot spam.
- **Recovery** — each down server gets ONE `reconnectMcpServer()` attempt per down-episode, bounded so a server that stays down is reported, not fought. The attempt is never claimed on the strength of the call alone: the status is re-read once and the re-read is what the notice quotes.
- **Honesty rules kept** — `needs-auth` / `disabled` are reported but never retried (the first waits on the user, the second is a deliberate off switch). A server the harness heals itself — the reporter watched `comfyui` do exactly this — is credited to the harness, not to us. A harness without the control methods, or a poll that throws, leaves the session exactly as informed as before: silent, and the turn stream never goes down with it. No line diagnoses a cause; #1524 still has that open.

Resulting narration:

| situation | what the user sees |
|---|---|
| healthy session, mid-session drop, reconnect works | one line: the reconnect brought it back |
| drop, reconnect fails | one line: still down, the reconnect did not bring it back, what re-runs the connection (Disconnect → Connect), and that whether it succeeds depends on why it dropped |
| degraded at init | the #1614 line (reworded — the loss now lasts "until the server connects", and the owed attempt is stated), then the outcome line at the first turn end |
| harness heals a down server on its own | one line saying it is connected again — without taking credit |

## Scope

Claude lane only. The codex/gemini lanes drive the canvas through the loopback HTTP MCP (the #1596 territory) and have their own control planes; nothing here touches them. Whether the harness's `mcp_reconnect` actually revives an sdk-type server mid-session could **not** be verified against a live drop — the issue itself notes it is not deterministically reproducible. What is verified is the host-side logic: detection, the bounded attempt, the verdict re-read, and the exact narration of each outcome, against a mocked harness that scripts each answer.

## Verification

- 7 new tests in `claude-mcp-reconnect.test.ts`: reconnect-fixes-drop narrated once as fixed; reconnect-fails reported once and not retried; harness self-heal credited to the harness; `needs-auth` never retried; a second drop after recovery is a new episode with its own attempt; an init-degraded server gets its owed attempt at the first turn end; an init-degraded server the harness heals first is reported as back.
- `claude-init-mcp-degraded.test.ts` updated to the watch semantics — the two tests that pinned "never re-polls" now pin *why* the standing per-turn poll exists.
- `mcp-session-health.test.ts`: new suites for `reconnectableMcpStatus`, `unrecoveredMcpNotice`, `recoveredMcpNotice`; the test that pinned "for the rest of this session" updated, because recovery existing makes that claim false.
- Mutation checks, each grep-confirmed applied: removing the reconnect call kills 4 tests; removing the once-per-episode mark kills 2; removing the verdict re-read kills 2. Suite green again after restore.
- Full suite: 532 files / 10114 tests green (3 skipped, pre-existing); `tsc` build and lint clean.
