### PR TITLE
fix(1656): a post-switch panel_* command whose stamp no longer names the routed tab's canvas is refused before dispatch

### DIFF
--- a/src/__tests__/services/stamp-target-agreement.test.ts
+++ b/src/__tests__/services/stamp-target-agreement.test.ts
@@ -1,0 +1,235 @@
+// #1656 — after a workflow tab switch, panel graph reads/mutations silently ran on
+// the PREVIOUS canvas: the panel's re-hello moved the routed connection onto the new
+// workflow at once, but the session's workflow stamp is resolved from the caller's
+// address (for the shared scope, the conversation's issue-time workflow — #570/#884
+// deliberately never re-resolve it at dispatch), so it still named the previous one.
+// The panel-side fence was expected to refuse that pairing; it compares against the
+// frontend's LIVE identity, which can lag the switch the hello already reported, and
+// in that window outline/save executed on the prior workflow and returned its
+// uuid/path with no error.
+//
+// The fix is the dispatch-time agreement gate in send(): when the caller's stamp and
+// the routed connection's last-advertised identity are BOTH known and DISAGREE, the
+// command is refused BEFORE the socket write ("workflow instance mismatch", typed
+// dispatched:false), naming the documented rebind. These tests drive the REAL
+// UiBridge over a real socket through exactly that sequence.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+import {
+  UiBridge,
+  dispatchOutcomeOf,
+  requiresStampTargetAgreement,
+} from "../../services/ui-bridge.js";
+import { isScopeAddress } from "../../services/session-scope.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const UUID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const UUID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const TAB_A = "wf:route1:workflows/a-long-filename.json";
+const TAB_B = "wf:route1:workflows/krea2_lora_ab_compare.json";
+const SCOPE = "orchestrator::claude";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+describe("requiresStampTargetAgreement (#1656)", () => {
+  it("gates active-canvas reads AND the active-workflow mutators", () => {
+    expect(requiresStampTargetAgreement({ cmd: "graph_outline" })).toBe(true);
+    expect(requiresStampTargetAgreement({ cmd: "graph_query" })).toBe(true);
+    expect(requiresStampTargetAgreement({ cmd: "graph_add_node" })).toBe(true);
+    // An UNLISTED graph_* command fails closed, like GRAPH_CMD_EFFECT's fallback.
+    expect(requiresStampTargetAgreement({ cmd: "graph_some_future_op" })).toBe(true);
+    expect(requiresStampTargetAgreement({ cmd: "workflow_save" })).toBe(true);
+    expect(requiresStampTargetAgreement({ cmd: "workflow_save_as" })).toBe(true);
+    // A path-less rename/close targets the active workflow — gated.
+    expect(requiresStampTargetAgreement({ cmd: "workflow_rename" })).toBe(true);
+    expect(requiresStampTargetAgreement({ cmd: "workflow_close" })).toBe(true);
+  });
+
+  it("exempts the recovery probe, navigation, canvas-independent ops, and selectored rename/close", () => {
+    // workflow_list is the fence-exempt probe the rebind recovery depends on (#932).
+    expect(requiresStampTargetAgreement({ cmd: "workflow_list" })).toBe(false);
+    expect(requiresStampTargetAgreement({ cmd: "workflow_open", path: "x" })).toBe(false);
+    expect(requiresStampTargetAgreement({ cmd: "workflow_new" })).toBe(false);
+    // #602's canvas-independent set (mirrored from the panel).
+    for (const cmd of [
+      "nodes_search",
+      "nodes_list",
+      "nodes_install",
+      "nodes_queue_status",
+      "graph_update_node",
+      "comfy_reboot",
+      "free_vram",
+    ]) {
+      expect(requiresStampTargetAgreement({ cmd })).toBe(false);
+    }
+    // A selectored rename/close may name a genuinely NON-active workflow; the panel
+    // resolves that precisely, so the server-side gate leaves it to the panel.
+    expect(
+      requiresStampTargetAgreement({ cmd: "workflow_rename", path: "workflows/other.json" } as never),
+    ).toBe(false);
+    expect(
+      requiresStampTargetAgreement({ cmd: "workflow_close", path: "workflows/other.json" } as never),
+    ).toBe(false);
+    expect(requiresStampTargetAgreement({ cmd: "show_media" })).toBe(false);
+    expect(requiresStampTargetAgreement({})).toBe(false);
+  });
+});
+
+describe("dispatch-time stamp/target agreement gate (#1656)", () => {
+  let bridge: UiBridge;
+  let port: number;
+
+  /** The orchestrator's two answers, modelled separately BECAUSE they diverge in
+   *  the bug: the per-tab advertised identity (tabCommandWorkflowUuid, refreshed by
+   *  every hello) and the conversation's issue-time stamp (turnOrigins.stampOf). */
+  const advertised = new Map<string, string>();
+  let sessionStamp: string | undefined;
+
+  /** Every command frame the fake panel receives. */
+  let received: Array<Record<string, unknown>>;
+
+  const hello = (sock: WebSocket, tabId: string) =>
+    sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: tabId,
+        title: tabId,
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+
+  beforeEach(async () => {
+    advertised.clear();
+    sessionStamp = undefined;
+    received = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver((id) =>
+      isScopeAddress(id) ? sessionStamp : advertised.get(id),
+    );
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  function connectPanel(tabId: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      sock.on("open", () => {
+        hello(sock, tabId);
+        resolve(sock);
+      });
+      sock.on("error", reject);
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString());
+        if (msg.rid && msg.cmd) {
+          received.push(msg);
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+        }
+      });
+    });
+  }
+
+  it("dispatches while the session stamp and the tab's advertised identity AGREE", async () => {
+    advertised.set(TAB_A, UUID_A);
+    sessionStamp = UUID_A;
+    const sock = await connectPanel(TAB_A);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_A));
+
+    // bridge.send resolves with the reply's RESULT, not the reply envelope.
+    const res = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE });
+    expect(res).toEqual({ cmd: "graph_outline" });
+    expect(received.map((f) => f.cmd)).toEqual(["graph_outline"]);
+    expect(received[0].workflow_uuid).toBe(UUID_A);
+    sock.close();
+  });
+
+  it("refuses a read AND a mutation after the tab switch the session has not caught up to", async () => {
+    advertised.set(TAB_A, UUID_A);
+    sessionStamp = UUID_A;
+    const sock = await connectPanel(TAB_A);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_A));
+
+    // The user switches the canvas A → B. The panel re-hellos on the SAME socket:
+    // the bridge migrates the connection (and last-active) to the new route, and
+    // the orchestrator records the new advertised identity. The conversation's
+    // issue-time stamp stays A — that is #570's rule, not an oversight.
+    hello(sock, TAB_B);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_B));
+    advertised.delete(TAB_A);
+    advertised.set(TAB_B, UUID_B);
+    received.length = 0;
+
+    // The read the issue reported succeeding on the previous canvas…
+    const readErr = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE }).then(
+      () => null,
+      (err) => err as Error,
+    );
+    expect(readErr).not.toBeNull();
+    expect(readErr!.message).toMatch(/^workflow instance mismatch:/);
+    // …and the save that returned the previous workflow's uuid/path.
+    const saveErr = await bridge.send({ cmd: "workflow_save" }, { tabId: SCOPE }).then(
+      () => null,
+      (err) => err as Error,
+    );
+    expect(saveErr).not.toBeNull();
+    expect(saveErr!.message).toMatch(/^workflow instance mismatch:/);
+
+    // NOTHING reached the panel: the refusal is pre-dispatch, typed so the tool
+    // layer's "nothing was applied" handling keys on the flag, not the text.
+    expect(received).toEqual([]);
+    expect(dispatchOutcomeOf(readErr)).toBe(false);
+    expect(dispatchOutcomeOf(saveErr)).toBe(false);
+    // The remedy is the documented one, and the message carries the stamp in the
+    // shape panel-tools' auto-rebind reads back (issued for workflow instance <uuid>).
+    expect(readErr!.message).toContain(`issued for workflow instance ${UUID_A}`);
+    expect(readErr!.message).toContain('panel_set_workflow_target({mode:"current"})');
+
+    // The recovery probe is EXEMPT — gating it would wedge the rebind that clears
+    // this (panel #932's circularity).
+    const probe = await bridge.send({ cmd: "workflow_list" }, { tabId: SCOPE });
+    expect(probe).toEqual({ cmd: "workflow_list" });
+    expect(received.map((f) => f.cmd)).toEqual(["workflow_list"]);
+
+    // After the documented rebind adopts the live identity, the same calls dispatch.
+    sessionStamp = UUID_B;
+    const after = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE });
+    expect(after).toEqual({ cmd: "graph_outline" });
+    expect(received.map((f) => f.cmd)).toEqual(["workflow_list", "graph_outline"]);
+    expect(received[1].workflow_uuid).toBe(UUID_B);
+    sock.close();
+  });
+
+  it("does NOT fire when either side is unreadable — an unknown is not divergence", async () => {
+    advertised.set(TAB_A, UUID_A);
+    // No session stamp at all: the frame ships unstamped and the PANEL's fence is
+    // the judge (#718), exactly as before this gate existed.
+    sessionStamp = undefined;
+    const sock = await connectPanel(TAB_A);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_A));
+    const res = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE });
+    expect(res).toEqual({ cmd: "graph_outline" });
+    expect(received[0].workflow_uuid).toBeUndefined();
+    sock.close();
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1035,16 +1035,31 @@ describe("UiBridge (multi-tab)", () => {
       expect(after).toMatchObject({ ok: true });
       expect(frames.pop()?.workflow_uuid).toBe(UUID);
 
-      // 4) ISSUE-TIME WINS (codex round 1, P0): if the turn was issued for a
-      //    DIFFERENT workflow than the one the active tab now shows, the frame
-      //    must carry the ISSUE-TIME uuid — the panel (comparing against its
-      //    active workflow) then DECLINES, instead of the stamp silently
-      //    re-aiming the mutation at whatever is on screen.
+      // 4) ISSUE-TIME WINS (codex round 1, P0): a turn issued for a DIFFERENT
+      //    workflow than the one the active tab now shows must never be re-aimed
+      //    at whatever is on screen. Before #1656 the frame shipped carrying the
+      //    ISSUE-TIME uuid and the panel (comparing against its active workflow)
+      //    DECLINED. That decline depended on the panel's live-identity read having
+      //    settled — the window #1656 reports, where it had not and the command ran
+      //    on the previous canvas. The stamp still comes from the SCOPE (issue-time),
+      //    but the divergence it creates is now refused by the BRIDGE, before any
+      //    socket write: the outcome #570 required (never applied to the wrong
+      //    workflow) no longer depends on the timing of the panel's read.
       const TURN_UUID = "33333333-3333-4333-8333-333333333333";
       stamps.set(SHARED_SESSION_SCOPE, TURN_UUID);
-      const reaimed = await bridge.send({ cmd: "graph_add_node" }, { tabId: SHARED_SESSION_SCOPE });
-      expect(reaimed).toMatchObject({ ok: true }); // this mock panel accepts; a real one fences
-      expect(frames.pop()?.workflow_uuid).toBe(TURN_UUID); // NOT the conn's own UUID
+      frames.length = 0; // step 2's read left a frame; what matters is nothing NEW ships
+      const reaimedErr = await bridge
+        .send({ cmd: "graph_add_node" }, { tabId: SHARED_SESSION_SCOPE })
+        .then(
+          () => null,
+          (e) => e as Error,
+        );
+      expect(reaimedErr).not.toBeNull();
+      expect(reaimedErr!.message).toMatch(/^workflow instance mismatch:/);
+      expect(reaimedErr!.message).toContain(TURN_UUID); // the issue-time stamp is named…
+      expect(reaimedErr!.message).toContain(UUID); // …against the tab's advertised identity
+      expect(dispatchOutcomeOf(reaimedErr)).toBe(false);
+      expect(frames).toEqual([]); // nothing reached the switched-to canvas
 
       sock.close();
     });
@@ -2126,7 +2141,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(drove?.tab_id).toBe("phone-7");
   });
 
-  it("STAMPS a dispatched command with the ORIGIN workflow uuid so the panel can fence a post-switch apply (#570 P0)", async () => {
+  it("STAMPS a dispatched command with the ORIGIN workflow uuid — and after a switch the divergence is REFUSED pre-dispatch (#570 P0, #1656)", async () => {
     // The orchestrator maps each tab to its trusted per-instance workflow uuid.
     const uuidByTab: Record<string, string> = { "tmp:A": "uuid-A", "tmp:B": "uuid-B" };
     bridge.setTabWorkflowUuidResolver((tabId) => uuidByTab[tabId]);
@@ -2152,13 +2167,28 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B", enforces_workflow_stamp: true, enforces_workflow_stamp_at_write: true }));
     await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:B")).toBe(true));
 
-    // A late command still ISSUED FOR A (its agent's tab id) must stamp A's uuid — even though
-    // it now resolves onto B's socket — so the panel (showing B) declines to apply it. Stamping
-    // B's uuid would let it cross-apply. The resolver reads the ORIGIN tab, so it stays uuid-A.
+    // A late command still ISSUED FOR A (its agent's tab id) must never land on B's
+    // canvas. Before #1656 the bridge delivered it stamped uuid-A — even though it
+    // resolved onto B's socket — and relied on the panel (showing B) to decline;
+    // stamping B's uuid would have let it cross-apply. The guarantee is unchanged
+    // (no cross-apply, ever) but the refusal moved EARLIER: the bridge can see that
+    // the stamp it would attach (uuid-A) and the identity the routed tab now
+    // advertises (uuid-B) disagree, so it refuses BEFORE the socket write — the
+    // panel's live-identity read no longer has to have settled for the mutation to
+    // be fenced.
     frames.length = 0;
-    await bridge.send({ cmd: "graph_add_node", node: "y" } as never, { tabId: "tmp:A" });
-    await waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
-    expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "y" } as never, { tabId: "tmp:A" })
+      .then(
+        () => null,
+        (e) => e as Error,
+      );
+    expect(err).not.toBeNull();
+    expect(err!.message).toMatch(/^workflow instance mismatch:/);
+    expect(err!.message).toContain("uuid-A");
+    expect(err!.message).toContain("uuid-B");
+    expect(dispatchOutcomeOf(err)).toBe(false); // typed: nothing was transmitted
+    expect(frames).toEqual([]); // and in fact nothing was — B's canvas never saw it
     desktop.close();
   });
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1077,6 +1077,50 @@ export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown }): boolea
   return ACTIVE_WORKFLOW_MUTATORS.has(name);
 }
 
+/** #602 — commands whose execution and reply never reference a canvas (Manager
+ *  registry/server operations, ComfyUI-server controls). Mirrors the panel's
+ *  CANVAS_INDEPENDENT_COMMANDS: a stale stamp/target pairing is irrelevant to
+ *  them, so the dispatch-time agreement gate must not refuse them. */
+const STAMP_TARGET_CANVAS_INDEPENDENT = new Set<string>([
+  "nodes_search",
+  "nodes_list",
+  "nodes_install",
+  "nodes_queue_status",
+  "graph_update_node",
+  "comfy_reboot",
+  "free_vram",
+]);
+
+/** #1656 — commands that read or mutate whichever canvas the routed tab has ACTIVE,
+ *  and therefore may only be dispatched when the session's workflow stamp and the
+ *  tab's reported active workflow AGREE (see the dispatch gate in send()).
+ *
+ *  Mirrors the panel's activeWorkflowFenceApplies as far as the server can evaluate
+ *  it. Exempt, deliberately:
+ *   - canvas-independent server/Manager commands (#602): no canvas to get wrong;
+ *   - workflow_list: the fence-EXEMPT recovery probe — gating it would make the
+ *     documented rebind depend on the fence being already-correct (panel #932's
+ *     circularity), and its handler reads the live binding at execution time, so a
+ *     stale pairing cannot make it report a stale answer;
+ *   - workflow_open / workflow_new: navigation/creation with their own explicit or
+ *     new target — they are how a diverged session re-selects;
+ *   - workflow_rename / workflow_close carrying a path selector: the selector may
+ *     name a genuinely NON-active workflow, which the panel resolves precisely and
+ *     exempts; the server cannot evaluate that, so those stay with the panel's
+ *     fence rather than risk a false refusal of a legitimate background op. */
+export function requiresStampTargetAgreement(cmd: { cmd?: unknown }): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  if (!name) return false;
+  if (STAMP_TARGET_CANVAS_INDEPENDENT.has(name)) return false;
+  if (name === "workflow_list" || name === "workflow_open" || name === "workflow_new") return false;
+  if (name === "workflow_rename" || name === "workflow_close") {
+    const path = (cmd as { path?: unknown }).path;
+    return !(typeof path === "string" && path.trim());
+  }
+  if (name.startsWith("graph_")) return true;
+  return name === "workflow_save" || name === "workflow_save_as";
+}
+
 /**
  * Default reply timeout for a MUTATING command with no explicit timeout.
  *
@@ -4465,6 +4509,47 @@ export class UiBridge {
           false,
         );
         return Promise.reject(capabilityMissing ? markCapabilityRefusal(refusal) : refusal);
+      }
+    }
+    // #1656 — the stamp and the routing target are resolved from DIFFERENT inputs,
+    // and after a tab switch they can name different canvases. Routing follows the
+    // panel's re-hello at once (the migration alias / last-active carry move the
+    // connection onto the NEW canvas), while the stamp is resolved from the
+    // CALLER'S address — for the shared scope, the conversation's issue-time
+    // workflow, which is deliberately never re-resolved at dispatch (#570/#884) and
+    // so still names the PREVIOUS canvas. The panel-side fence is meant to refuse
+    // that pairing, but it compares the stamp against the frontend's LIVE identity,
+    // which can lag the very switch the hello already reported — and in that window
+    // the command executes on the previous canvas instead of being refused
+    // (observed: outline + save ran on the prior workflow after the switch and
+    // returned its uuid/path, with no error).
+    //
+    // This side sees both halves: the session's stamp (the caller-address answer)
+    // and the identity the routed tab last advertised (the canonical-id answer,
+    // refreshed by every hello). When BOTH are known and they DISAGREE, the
+    // command's fence provably does not name the canvas it would land on, so refuse
+    // BEFORE the socket write — nothing is dispatched, and the refusal names the
+    // documented rebind. With a settled panel this changes no outcome (a
+    // mismatched stamp is refused there too); it closes the window in which the
+    // refusal does not happen. An UNREADABLE side is not evidence of divergence:
+    // either value missing keeps the existing behaviour and lets the panel fence
+    // judge. And a caller addressing the connection by its canonical id is skipped
+    // outright — both answers then come from the same lookup and can only agree.
+    if (opts.tabId && opts.tabId !== conn.tabId && requiresStampTargetAgreement(cmd)) {
+      const issuedFor = this.resolveTabWorkflowUuid?.(opts.tabId);
+      const landedOn = this.resolveTabWorkflowUuid?.(conn.tabId);
+      if (issuedFor && landedOn && issuedFor !== landedOn) {
+        return Promise.reject(
+          markDispatched(
+            new Error(
+              `workflow instance mismatch: this command was issued for workflow instance ${issuedFor}, ` +
+                `but the tab it routed to has since reported a different active workflow (${landedOn}). ` +
+                `Nothing was dispatched. Re-target with panel_set_workflow_target({mode:"current"}), ` +
+                `then retry.`,
+            ),
+            false,
+          ),
+        );
       }
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {


### PR DESCRIPTION
## Root cause

After a workflow tab switch, the two halves of "which workflow is this command for" are resolved from **different inputs** and can name different canvases:

- **Routing** follows the panel's re-hello immediately — the same-socket migration alias / last-active carry move the connection onto the *new* canvas.
- **The stamp** attached to the outgoing frame is resolved from the *caller's* address: for the shared session scope that is the conversation's issue-time workflow (`TurnOriginTracker.stampOf`), which is deliberately never re-resolved at dispatch (#570/#884) and so still names the *previous* canvas.

The only check against that divergence was the panel-side fence, which compares the stamp against the frontend's *live* identity — and that read can lag the very switch the hello already reported to the orchestrator. In that window `panel_graph_outline` and `panel_save_workflow({})` executed on the previous workflow and returned its uuid/path, with no error — exactly as reported: the panel had already told the orchestrator the active workflow changed, yet dispatch never compared that knowledge against the session's fence before executing.

## Fix

In `UiBridge.send()` (`src/services/ui-bridge.ts`), before any socket write: when the command is routed onward (scope address, alias, or prefix — anything where the caller's id differs from the resolved connection's canonical id) and both the caller-side stamp and the routed tab's last-advertised identity are known and **disagree**, the command is refused pre-dispatch with a `workflow instance mismatch` error (typed `dispatched:false` — nothing is transmitted) naming the documented recovery, `panel_set_workflow_target({mode:"current"})`.

- The command predicate (`requiresStampTargetAgreement`) mirrors the panel's `activeWorkflowFenceApplies` as far as the server can evaluate it. Exempt: the fence-exempt recovery probe `workflow_list` (gating it would re-create panel #932's circular wedge), navigation (`workflow_open`/`workflow_new`), canvas-independent server/Manager ops (#602's set), and path-selectored `workflow_rename`/`workflow_close` (the panel resolves those targets precisely; the server cannot).
- An unreadable either side is **not** evidence of divergence — existing behavior (panel fences it) is kept.
- With a settled panel this changes no outcome: a mismatched stamp was refused there too. It closes the window in which the refusal did not happen, and the #570 guarantee (a post-switch mutation is never re-aimed or cross-applied) no longer depends on the timing of the panel's live-identity read.
- The refusal keeps the leading `workflow instance mismatch:` token and the `issued for workflow instance <uuid>` phrasing, so the tool layer's existing mismatch handling (incl. the auto-rebind verdict for mutations, which probes the exempt `workflow_list`) applies unchanged.

Two existing ui-bridge tests pinned the old contract ("deliver with the origin stamp so the *panel* can decline"); they now assert the stronger one — the same refusal, issued by the bridge before dispatch, with nothing written to the socket.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean; `npx tsc --noEmit` (includes tests) — clean
- New `src/__tests__/services/stamp-target-agreement.test.ts` (5 tests) drives the real bridge over a real socket through the issue's sequence: switch → outline + save are refused pre-dispatch with nothing delivered, `workflow_list` still passes, and after the rebind the same calls dispatch with the new stamp. Verified it **fails without the fix** (3 tests red with `src/services/ui-bridge.ts` stashed).
- `npx vitest run src/__tests__/services` — 212 files, 4975 passed / 3 skipped
- `npx vitest run src/__tests__/orchestrator` — 159 files, 2779 passed

No tool descriptions changed, so docs/vocabulary gates are not implicated.

Closes #1656
