### PR TITLE
fix(900): a timed-out clone kills its lingering git tree; an existing husk is refused, not reported installed

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -966,6 +966,83 @@ describe("node-management service", () => {
       ).rejects.toThrow(/could NOT be removed/i);
     });
 
+    it("a TIMED-OUT clone kills the leftover git process tree before cleanup", async () => {
+      // #900 recurrence, observed 2026-08-05 on Windows: execFileSync's timeout
+      // killed the direct `git` child but `git-remote-https`/`index-pack` kept
+      // running with locks on .git/objects/pack/tmp_pack_*, so the removal failed
+      // EBUSY and the husk stayed. The timeout path must kill the whole tree and
+      // only then remove.
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") {
+          cloned = true;
+          // The shape Node's execFileSync throws on timeout: code ETIMEDOUT with
+          // the dead child's pid — the pid whose TREE must be killed.
+          throw Object.assign(new Error("spawnSync git ETIMEDOUT"), {
+            code: "ETIMEDOUT",
+            pid: 4242,
+          });
+        }
+        return ""; // taskkill / pkill succeed
+      }) as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/Failed to clone/);
+
+      // The process-tree kill went out for the timed-out child's pid (taskkill
+      // /T /F on Windows, a pkill children sweep on POSIX).
+      const treeKill = mockedExec.mock.calls.find(
+        (c) => c[0] === "taskkill" || c[0] === "pkill",
+      );
+      expect(treeKill, "expected a process-tree kill for the timed-out git").toBeDefined();
+      expect(treeKill![1]).toContain("4242");
+      // …and the husk itself was removed once nothing held it open.
+      expect(fsCtl.removed).toContain(NODE_DIR_UTILS);
+    });
+
+    it("REFUSES to install over an existing husk instead of reporting success", async () => {
+      // The other half of #900: a husk already sitting in custom_nodes passed
+      // every check — the clone is skipped because "the directory exists", and
+      // the pack verification ran only for directories THIS call created — so a
+      // retry over a husk reported a successful install of nothing. The husk is
+      // not this call's to delete, so the install refuses and names it.
+      stubFetch({ installedBody: {} });
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return true; // left over from an earlier failure
+        return false;
+      });
+      fsCtl.readdirSync = () => [".git"]; // git metadata and nothing else
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") throw new Error("should not clone");
+        return "";
+      }) as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/husk of an install that did not complete/i);
+
+      // No clone ran over it, and the husk — not this call's creation — was left
+      // exactly where it was.
+      expect(
+        mockedExec.mock.calls.some(
+          (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+        ),
+      ).toBe(false);
+      expect(fsCtl.removed).not.toContain(NODE_DIR_UTILS);
+    });
+
     it("throws ProcessControlError on clone fallback when comfyuiPath is unset", async () => {
       config.comfyuiPath = undefined;
       stubFetch({ installedBody: {} });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2285,10 +2285,51 @@ function looksLikeAPack(dir: string): boolean {
 }
 
 /**
+ * Kill a TIMED-OUT git clone's whole process tree, not just the direct child.
+ *
+ * execFileSync's timeout signals only the `git` it spawned. Git's descendants —
+ * `git-remote-https`, `index-pack` — keep running, and on Windows they hold open
+ * locks on `.git/objects/pack/tmp_pack_*`, so the removal below fails EBUSY and
+ * the husk stays put (#900 recurrence, observed 2026-08-05: `spawnSync git
+ * ETIMEDOUT` with the pack tmpfiles still locked). Mirrors the house pattern
+ * (orchestrator/index.ts killProcessTreeCrossPlatform): Windows `taskkill /T /F`
+ * (tree + force); POSIX a best-effort children sweep around the direct signal.
+ */
+function killGitProcessTree(pid: number): void {
+  if (process.platform === "win32") {
+    // No graceful tree-signal exists on Windows; /T /F is the reliable path.
+    execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" });
+    return;
+  }
+  try {
+    execFileSync("pkill", ["-TERM", "-P", String(pid)], { stdio: "ignore" });
+  } catch {
+    // no children / pkill absent — the direct signal below still applies
+  }
+  process.kill(pid, "SIGTERM");
+}
+
+/** Sync sleep for the settle window after a process-tree kill: this cleanup runs
+ *  inside a synchronous catch, so it may not await. Same Atomics.wait idiom as
+ *  download-progress.ts / lora-catalog.ts. */
+function sleepSyncMs(ms: number): void {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // Atomics.wait disallowed here — the retry below just runs a touch early.
+  }
+}
+
+/**
  * Remove a clone directory THIS call created, after the clone failed.
  *
  * Returns a sentence to append to the error — a leftover nobody was told about
  * is how the husk in #900 survived a month.
+ *
+ * `settlingProcesses` says a process-tree kill just ran (the clone timed out):
+ * the OS releases the killed processes' file handles asynchronously, so a
+ * removal that would EBUSY on the spot succeeds a moment later. Retry briefly
+ * before concluding the directory cannot be removed.
  *
  * `alreadyPresent` is a PRECONDITION, not live logic: every call site today sits
  * inside `if (!alreadyPresent)`, so it is always false here and the guard below
@@ -2298,19 +2339,29 @@ function looksLikeAPack(dir: string): boolean {
  * its unreachability is deliberate: an unreachable check that reads like live
  * protection is worse than one that says what it is.
  */
-function discardFailedClone(nodeDir: string, alreadyPresent: boolean): string {
+function discardFailedClone(
+  nodeDir: string,
+  alreadyPresent: boolean,
+  settlingProcesses = false,
+): string {
   if (alreadyPresent) return ""; // precondition — see above; unreachable today
   if (!existsSync(nodeDir)) return ""; // git cleaned up after itself
-  try {
-    rmSync(nodeDir, { recursive: true, force: true });
-    return "";
-  } catch (rmErr) {
-    return (
-      ` NOTE: the partial clone at ${nodeDir} could NOT be removed ` +
-      `(${rmErr instanceof Error ? rmErr.message : String(rmErr)}). ComfyUI will try to ` +
-      `import it on every start and log an error — delete that directory by hand.`
-    );
+  const attempts = settlingProcesses ? 4 : 1;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) sleepSyncMs(250 * attempt);
+    try {
+      rmSync(nodeDir, { recursive: true, force: true });
+      return "";
+    } catch (rmErr) {
+      lastErr = rmErr;
+    }
   }
+  return (
+    ` NOTE: the partial clone at ${nodeDir} could NOT be removed ` +
+    `(${lastErr instanceof Error ? lastErr.message : String(lastErr)}). ComfyUI will try to ` +
+    `import it on every start and log an error — delete that directory by hand.`
+  );
 }
 
 /**
@@ -2413,6 +2464,21 @@ async function cloneCustomNodeFallback(
   const warnings: string[] = [];
   const alreadyPresent = existsSync(nodeDir);
 
+  // A directory that is already there but holds nothing but git metadata is NOT
+  // a pack — it is the husk an earlier failed install left behind (#900). Without
+  // this check the clone below is skipped ("the directory exists") and the call
+  // reports a successful install of nothing. It is also not ours to delete: this
+  // call did not create it, and a directory we did not create is the user's —
+  // so REFUSE, name it, and leave it untouched.
+  if (alreadyPresent && !looksLikeAPack(nodeDir)) {
+    throw new NodeManagementError(
+      `${because}, and custom_nodes/${repoName} already exists but holds nothing but ` +
+        `git metadata — the husk of an install that did not complete, which ComfyUI ` +
+        `cannot import and logs an error for on every start. This call did not create ` +
+        `it, so it was left untouched. Delete ${nodeDir} by hand and retry the install.`,
+    );
+  }
+
   if (!alreadyPresent) {
     // A concrete ref needs the full history reachable; otherwise shallow-clone.
     // `--end-of-options` ensures gitId/nodeDir are never parsed as git options.
@@ -2431,8 +2497,23 @@ async function cloneCustomNodeFallback(
       const e = err as NodeJS.ErrnoException & {
         stdout?: Buffer | string;
         stderr?: Buffer | string;
+        pid?: number;
       };
-      const leftover = discardFailedClone(nodeDir, alreadyPresent);
+      // A TIMEOUT killed only the direct `git` child; its descendants
+      // (git-remote-https, index-pack) may still be running and holding locks on
+      // the partial pack, which is exactly how the #900 husk survived its own
+      // cleanup (EBUSY on .git/objects/pack/tmp_pack_*). Kill the tree first —
+      // best-effort: if the kill itself fails, the removal below still runs and
+      // still discloses what it could not remove.
+      const timedOut = e.code === "ETIMEDOUT";
+      if (timedOut && typeof e.pid === "number") {
+        try {
+          killGitProcessTree(e.pid);
+        } catch {
+          // best-effort — see above
+        }
+      }
+      const leftover = discardFailedClone(nodeDir, alreadyPresent, timedOut);
       throw new NodeManagementError(
         `Failed to clone "${gitId}" into custom_nodes/${repoName}: ${e.message}${leftover}`,
         {


### PR DESCRIPTION
Closes #900.

## What remained after #917

#917 made a failed clone remove its own husk and disclose a removal it could not complete. Two holes remained, both confirmed in the recurrence report on the issue (2026-08-05, Windows 11, comfyui-mcp 0.50.2):

1. **A timed-out clone could not be cleaned up.** `execFileSync`'s timeout kills only the direct `git` child. Its descendants — `git-remote-https`, `index-pack` — kept running with open locks on `.git/objects/pack/tmp_pack_*`, so the `rmSync` cleanup failed `EBUSY` and the `.git`-only husk stayed in `custom_nodes`, unremovable until those processes exited.
2. **Installing over an existing husk reported success.** With the directory already present, the clone was skipped and the pack verification ran only for directories *that call* created — so a retry over a husk returned "cloned it directly into custom_nodes" having installed nothing.

## What changed

- On a clone **timeout** (`err.code === "ETIMEDOUT"`), the timed-out child's whole **process tree is killed** before cleanup runs — `taskkill /PID /T /F` on Windows, a best-effort `pkill -P` children sweep on POSIX, mirroring `killProcessTreeCrossPlatform` in `orchestrator/index.ts`. The kill is best-effort: if it fails, the removal still runs and still discloses what it could not remove.
- `discardFailedClone` gains a bounded settle-and-retry (used only after a tree kill): the OS releases the killed processes' file handles asynchronously, so a removal that would `EBUSY` on the spot succeeds a moment later. Failure after the retries is disclosed exactly as before.
- An install whose target directory **already exists as a husk** (nothing but git metadata) now **refuses loudly**, names the path, and leaves it untouched — this call did not create it, so it is not this call's to delete. The message tells the user to remove it by hand and retry.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/services/node-management.test.ts` — **164 passed** (2 new: the timed-out clone issues a process-tree kill for the child's pid and the husk is removed; an install over an existing husk rejects, never clones, and removes nothing)
- `npx vitest run git-latest-not-a-ref panel-pin-guard comfy-cli` (neighboring suites) — **152 passed**

The ownership guard from #917 is unchanged: a directory this call did not create is never removed — the new refusal path deletes nothing, it refuses.

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-cli)