### PR TITLE
release: v0.52.1 — a mid-session MCP drop reconnects, and a stale stamp is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,27 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.1] - 2026-08-17
+
+### MCP
+
+#### Added
+- Grok 4.6 is now in the Agent Panel catalog (#1494)
+
+#### Fixed
+- re-delivered multi-workflow events inherit the established origin instead of wedging scope routing (#1685)
+- a timed-out clone's lingering git tree is killed so cleanup can remove the husk, and an existing husk is refused rather than reported installed (#1684)
+- a mid-session MCP drop is met with one bounded reconnect, reported either way (#1681)
+- a post-switch panel_* command whose stamp no longer names the routed tab's canvas is refused before dispatch (#1682)
+- restart relaunches the interpreter the healthy server was observed running under (#1680)
+- a landed file the core listing contractually omits is unconfirmed, never "not-visible" (#1679)
+- an unreadable parent PID degrades to a disclosed Desktop restart (#1677)
+- training runs no longer trip the hard stall floor while the server stays alive (#1676)
+- download_model action:"cancel" no longer asserts a live heartbeat it never probed (#1675)
+- resolve list_paths through the live root the OS can see (#1629)
+- Blind gates the Claude backend's native Read/WebFetch with a PreToolUse deny hook (#1643)
+
+
 ## [0.52.0] - 2026-08-17
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Patch release of everything merged after v0.52.0. Purpose: get the already-fixed bugs into a published version so reports stop coming in for work that already landed on main.

**The headline fixes**

- **#1524 / #1681** — a mid-session MCP drop is met with one bounded reconnect, reported either way. A respawned session no longer sits with zero panel tools and a success-looking notice.
- **#1656 / #1682** — a post-switch `panel_*` command whose stamp no longer names the routed tab's canvas is refused before dispatch.
- **#1641 / #1643** — Blind gates the Claude backend's native `Read`/`WebFetch` with a PreToolUse deny hook.

**Also in this cut**

- a landed file the core listing contractually omits is unconfirmed, never "not-visible" (#369 / #1679)
- restart relaunches the interpreter the healthy server was observed running under (#1654 / #1680)
- training runs no longer trip the hard stall floor while the server stays alive (#1652 / #1676)
- `download_model` `action:"cancel"` no longer asserts a live heartbeat it never probed (#1644 / #1675)
- an unreadable parent PID degrades to a disclosed Desktop restart (#1647 / #1677)
- a timed-out clone's lingering git tree is killed, and an existing husk is refused (#900 / #1684)
- re-delivered multi-workflow events inherit the established origin (#1001 / #1685)
- `list_paths` resolves through the live root the OS can see (#1621 / #1629)
- Grok 4.6 is now in the Agent Panel catalog (#1494)

After merge: tag `v0.52.1` on the merge commit and push. `release.yml` publishes npm + GitHub; `mcp-registry.yml` publishes the MCP Registry listing.
