### PR TITLE
fix(980): a fence the settling read proved live is reported BOUND, not unrestored

### DIFF
--- a/src/__tests__/orchestrator/fence-matching-uuid.test.ts
+++ b/src/__tests__/orchestrator/fence-matching-uuid.test.ts
@@ -12,6 +12,10 @@
 //
 // So: the refusal does not move, nothing is adopted, and the fence is not written.
 // Only the DIAGNOSIS splits, on evidence that was already in hand and discarded.
+//
+// panel#980 later took the last step: when the settling read the diagnosis prescribes
+// is run and ACCEPTED, with write capability confirmed, the verdict itself flips to
+// BOUND — the gate matrix lives in unconfirmed-matching-fence.test.ts.
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
@@ -89,49 +93,32 @@ describe("#1401 an uncorroborated uuid that MATCHES the fence", () => {
     expect(text).not.toContain("graph tools will keep failing");
   });
 
-  it("says the fence was not re-derived, and names what that rules OUT", async () => {
-    const { text } = await setCurrent();
+  it("reports BOUND: the held fence was PROVEN live, which is what the uuid alone could not say (panel#980)", async () => {
+    // This bridge answers the settling graph read and confirms the write
+    // capability — the measurement #1401's codex review demanded before any
+    // liveness claim: a matching uuid rules OUT "fenced to another instance"
+    // but cannot rule IN liveness. The ACCEPTED stamped read can, so the claim
+    // no longer rests on the comparison alone.
+    const { res, text } = await setCurrent();
+    expect(res.isError ?? false).toBe(false);
+    expect(text).toMatch(/"graph_binding":\s*"bound"/);
     expect(text).toContain("NOT re-derived");
     expect(text).toContain(LIVE);
-    expect(text).toContain("matches the fence this session already holds");
-    expect(text).toContain("DIFFERENT workflow instance");
+    expect(text).toContain("equals the fence this session already holds");
+    expect(text).toContain("ACCEPTED by the panel");
   });
 
-  it("does NOT promise the graph tools work — that is what could not be confirmed", async () => {
-    // codex review: a matching uuid rules OUT "fenced to another instance"; it does
-    // not rule IN liveness, because a stale or background record can carry the right
-    // uuid and still not be the canvas in front of the user. Claiming health here
-    // would be the mirror image of the bug being fixed — turning "could not confirm"
-    // into "is fine" instead of into "is broken".
+  it("assigns no homework the tool already did", async () => {
+    // The settling read was taken by the tool itself (#1473); prescribing it
+    // again would send the caller to re-run a check whose answer they hold.
     const { text } = await setCurrent();
-    expect(text).toContain("NOT a claim that graph tools work");
-    expect(text).not.toMatch(/likely to work|should work|will work/i);
-  });
-
-  it("prescribes a cheap probe FIRST, not a hard refresh", async () => {
-    // A hard refresh throws away the user's canvas state; it must not be the
-    // opening move for a case where the binding is probably fine.
-    const { text } = await setCurrent();
-    const probeAt = text.indexOf("panel_graph_outline");
-    const refreshAt = text.search(/hard[- ]refresh|refresh the ComfyUI tab|F5/i);
-    expect(probeAt, "the probe must be mentioned").toBeGreaterThan(-1);
-    if (refreshAt > -1) expect(probeAt).toBeLessThan(refreshAt);
+    expect(text).not.toContain("call panel_graph_outline");
   });
 
   it("still ADOPTS NOTHING — the fail-closed rule does not move", async () => {
     await setCurrent();
     expect(adopted, "no uncorroborated identity may be written").toBeUndefined();
     expect(stamp).toBe(LIVE); // unchanged, because it already was LIVE
-  });
-
-  it("is still reported as a FAILURE, not as success", async () => {
-    // Softening the DIAGNOSIS must not soften the RESULT: the rebind genuinely
-    // did not happen, and the caller must still see an error rather than a
-    // reassuring success. (The failure path answers as an error result, not the
-    // JSON body the success path returns.)
-    const { res, text } = await setCurrent();
-    expect(res.isError).toBe(true);
-    expect(text).toContain("did NOT restore this session's graph binding");
   });
 });
 

--- a/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
+++ b/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
@@ -5,9 +5,11 @@
 //
 // #1401 had already got the MESSAGE right for this shape: when the panel's reported identity
 // MATCHES the fence the session already holds, it says so, says it is not a claim that graph
-// tools work, and tells the caller to settle it with a graph read. What was left is that it
-// still reported FAILURE — so this takes the advice it gives instead of handing the caller a
-// failure plus homework.
+// tools work, and tells the caller to settle it with a graph read. #1473 took that read
+// itself and put the answer in the reply. What was left (panel#980) is the VERDICT: when the
+// settling read is ACCEPTED and the write-capability probe also says edits are allowed,
+// "did NOT restore the graph binding" is a false negative — so that one shape now reports
+// BOUND, on exactly the gate #1473's discussion scoped.
 //
 // Narrow by design: the probe runs only on the matching-uuid path, where the two remaining
 // possibilities (a reconciliation race vs a stale/background record) are indistinguishable
@@ -44,7 +46,8 @@ function bridge(opts: {
   activeUuid: string;
   /** "ok" passes; "mismatch" is a real fence refusal; "timeout" is an inconclusive failure. */
   graphRead: "ok" | "mismatch" | "timeout";
-  canMutate?: boolean;
+  /** true/false answer the write-capability probe; "unknown" leaves it unanswerable. */
+  canMutate?: boolean | "unknown";
 }) {
   return {
     send: async (cmd: Record<string, unknown>) => {
@@ -88,19 +91,22 @@ function bridge(opts: {
     resolveActiveTabId: () => TAB,
     refreshWorkflowUuid: () => true,
     workflowUuidFor: () => ({ known: true, uuid: SAME_UUID }),
-    tabCanMutateGraph: () => opts.canMutate !== false,
-    tabGraphMutationCapability: () => ({
-      known: true,
-      canMutate: opts.canMutate !== false,
-      ...(opts.canMutate === false ? { because: "capability" as const } : {}),
-    }),
+    tabCanMutateGraph: () => (opts.canMutate === "unknown" ? undefined : opts.canMutate !== false),
+    tabGraphMutationCapability: () =>
+      opts.canMutate === "unknown"
+        ? { known: false }
+        : {
+            known: true,
+            canMutate: opts.canMutate !== false,
+            ...(opts.canMutate === false ? { because: "capability" as const } : {}),
+          },
   } as unknown as PanelToolCtx["bridge"];
 }
 
 async function setTargetCurrent(opts: {
   activeUuid: string;
   graphRead: "ok" | "mismatch" | "timeout";
-  canMutate?: boolean;
+  canMutate?: boolean | "unknown";
 }) {
   const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
@@ -114,28 +120,43 @@ beforeEach(() => {
 });
 
 describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up front (#1473)", () => {
-  it("probes a graph read and reports what it found", async () => {
+  it("reports BOUND when the settling read passes and writes are accepted (panel#980)", async () => {
     const out = await setTargetCurrent({ activeUuid: SAME_UUID, graphRead: "ok" });
 
     // The probe really ran — without this the assertions could pass on a branch that
     // simply stopped failing, which would be a claim rather than a measurement.
     expect(sent).toContain("graph_query");
 
-    // STILL A FAILURE, and that is #1401's reasoned call, not an oversight: "softening the
-    // DIAGNOSIS must not soften the RESULT — the rebind genuinely did not happen." It did
-    // not. What changed is that the caller learns, in this reply, that nothing is broken —
-    // instead of discovering it one call later.
+    // The flip #1473 left open: an ACCEPTED stamped read plus confirmed write capability
+    // is binding health measured directly, so the false-negative failure is gone.
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"graph_binding":\s*"bound"/);
+    expect(out.text).toMatch(/ACCEPTED by the panel/);
+    expect(out.text).toMatch(/did not need to be/);
+    // No residue of the old verdict: neither the failure headline nor the homework.
+    expect(out.text).not.toMatch(/did NOT restore/);
+    expect(out.text).not.toMatch(/call panel_graph_outline/);
+    // The disclosure survives the flip: the rebind itself still did not happen, and the
+    // proof's scope is stated as one read, not a general promise.
+    expect(out.text).toMatch(/nothing was adopted/);
+    expect(out.text).toMatch(/one read a moment ago/);
+  });
+
+  it("stays a FAILURE when the read passes but write capability is UNKNOWN", async () => {
+    // The gate is canMutateNow === true, not "not observed to refuse". An unanswerable
+    // capability probe must not be rounded up to BOUND — that would report mutation
+    // readiness nobody measured.
+    const out = await setTargetCurrent({
+      activeUuid: SAME_UUID,
+      graphRead: "ok",
+      canMutate: "unknown",
+    });
+
+    expect(sent).toContain("graph_query");
     expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/did NOT restore/);
     expect(out.text).toMatch(/CHECKED FOR YOU/);
     expect(out.text).toMatch(/it SUCCEEDED/);
-    expect(out.text).toMatch(/did not reject THAT command/);
-    expect(out.text).toMatch(/evidence of a reconciliation race/);
-    // ONE observation stated as one: no generalisation to every command (codex r2).
-    expect(out.text).toMatch(/not a\s+guarantee about the next command/);
-    expect(out.text).not.toMatch(/READS work/);
-    expect(out.text).toMatch(/Nothing suggests a recovery step is needed/);
-    // And it does not overclaim: the rebind itself is still reported as not having happened.
-    expect(out.text).toMatch(/rebind itself still did not happen/);
   });
 
   it("keeps the failure when the graph read is REFUSED", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11767,7 +11767,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // target write DID happen, so the outcome is DISCLOSED either way — never
         // retracted as if nothing had been applied — but when the graph binding was NOT
         // restored the result is an ERROR, because "your recovery worked" is the one
-        // thing it must never say when it did not. `graph_binding` carries the same
+        // thing it must never say when it did not. The single exception is measured,
+        // not inferred (panel#980, below): a fence the panel just ACCEPTED a stamped
+        // read against, on a tab whose write capability is confirmed, was never
+        // unrestored. `graph_binding` carries the same
         // verdict machine-readably, and `graph_binding_status` the specific cause, so a
         // caller never has to infer four different remedies from one sentence.
         // A stamp is necessary but not sufficient for a graph EDIT — the panel build
@@ -11823,14 +11826,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // So the read is taken here, on the matching-uuid path ONLY, and its ANSWER is put
         // in the message.
         //
-        // THE RESULT STILL REPORTS FAILURE, deliberately, and that is #1401's call not
-        // mine: "softening the DIAGNOSIS must not soften the RESULT — the rebind genuinely
-        // did not happen". It did not. What changes is that the caller no longer has to
-        // discover, one call later, that nothing was wrong: the answer arrives with the
-        // refusal instead of after it. Whether this should become a SUCCESS is a real
-        // product question and a reversal of a reasoned decision, so it is raised on the
-        // issue rather than decided here.
+        // THE RESULT below is decided by what the probe OBSERVED. #1401's call —
+        // "softening the DIAGNOSIS must not soften the RESULT" — still holds for every
+        // outcome but one: panel#980's recurrence showed that a settling read the fence
+        // ACCEPTED, on a session whose write capability is likewise confirmed, is a
+        // false negative wearing #1401's caution (the reporters' mutations succeeded
+        // immediately after the error). That one shape flips to BOUND below, on the
+        // exact gate #1473's discussion scoped — probe passed AND writes accepted.
+        // Every other outcome keeps the failure, with the probe's answer inside it.
         let settledNote = "";
+        let probePassed = false;
         if (fence && fence.binding === "not_recovered" && fence.settleByRead) {
           // WHAT THE PROBE PROVES, AND ONLY THAT (codex).
           //
@@ -11859,6 +11864,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             probeRefused = isWorkflowInstanceMismatch(err);
           }
           if (probeOk) {
+            probePassed = true;
             settledNote =
               // ONE OBSERVATION, STATED AS ONE (codex r2). A passing graph_query proves that
               // read passed this fence just now — not that every command will, and not that
@@ -11878,8 +11884,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run — a ` +
                   `change it.`
                 : ` Nothing suggests a recovery step is needed for the binding; the next graph ` +
                   `command is still the authority.`) +
-              ` (The rebind itself still did not happen, which is why this is reported as a ` +
-              `failure.)`;
+              ` (The rebind itself still did not happen, and with graph EDITS not confirmed ` +
+              `on this tab the result stays a failure.)`;
           } else if (probeRefused === true) {
             settledNote =
               `
@@ -11893,6 +11899,43 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // in either direction.
         }
         if (fence && fence.binding === "not_recovered") {
+          // panel#980 — the flip #1473 left open, on the gate its discussion scoped.
+          // The rebind genuinely did not happen — but on this shape nothing NEEDED
+          // to: the fence this session already holds was just proven live twice over.
+          // The identity the panel reported equals it, and a read stamped with it was
+          // ACCEPTED by the panel — the binding-health question itself, measured
+          // rather than inferred. Reporting that as "did NOT restore the graph
+          // binding" is the false negative the recurrences kept hitting. The write
+          // half is not waved through on the read: BOUND requires canMutateNow ===
+          // true, so a read-only or unknown-capability panel keeps the failure below.
+          if (probePassed && canMutateNow === true) {
+            // fenceStillMatches guarantees a held uuid, but read it defensively: a
+            // missing value must degrade to an unnamed fence, never print "undefined".
+            const heldUuid =
+              fenceRebind && fenceRebind.status === "no_identity" && fenceRebind.before.known
+                ? fenceRebind.before.uuid
+                : undefined;
+            return ok({
+              ...target,
+              graph_binding: "bound",
+              ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
+              note:
+                hint +
+                rebindNote +
+                ` The graph binding was NOT re-derived (the panel's active reply could ` +
+                `not be corroborated, so nothing was adopted) — and it did not need to ` +
+                `be: the identity the panel reported equals the fence this session ` +
+                `already holds${heldUuid ? ` (${heldUuid})` : ""}, and a graph read ` +
+                `stamped with that fence was just run ` +
+                `and ACCEPTED by the panel. That acceptance is the binding-health ` +
+                `question itself, so this session is reported BOUND: graph reads pass ` +
+                `this fence, and the write-fence capability probe reports this tab ` +
+                `accepting edits. The proof is one read a moment ago — if the user ` +
+                `switched tabs in the instant since, the next graph command fails ` +
+                `closed with a fresh instance mismatch, safe and cleared by calling ` +
+                `this again.`,
+            });
+          }
           return fail(
             `panel_set_workflow_target({mode:"current"}) did NOT restore this session's graph ` +
               `binding.\n\nAPPLIED (do not repeat this part): the workflow target is now ` +


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#980

## Root cause

After a ComfyUI restart, `panel_set_workflow_target({mode:"current"})` re-derives the session's command fence from the panel's `workflow_list`. During the post-restart reconciliation window the panel marks its active record `active_confirmed:false`, so corroboration correctly refuses to adopt anything. Two shipped fixes already addressed the message: #1401 (v0.51.7) stopped claiming "graph tools will keep failing" when the reported uuid matches the held fence, and #1473 (v0.51.29) made the tool run the settling graph read itself and report the answer.

What remained — and what the three recurrences on 0.51.54 / 0.51.56 / 0.51.57 kept hitting — is the **verdict**: even when that built-in, fence-stamped read was **accepted** by the panel (the binding-health question answered directly, by measurement), the tool still returned `isError:true` with "did NOT restore this session's graph binding", while the caller's mutations succeeded immediately after. A false-negative verdict on measured evidence.

## Fix

In `src/orchestrator/panel-tools.ts`, on the matching-uuid path only, the result now flips to success with `graph_binding:"bound"` exactly when both halves are **observed**, on the gate #1473's own discussion scoped:

- the settling read (`graph_query fields:"ids" limit:1`, stamped with the held fence) was **accepted** by the panel — the fence naming the live canvas, measured rather than inferred; and
- the tri-state capability probe reports `canMutateNow === true` — so a read-only or unknown-capability panel is never rounded up to `bound`.

Everything else is unchanged and stays a failure, with the probe's answer inside it: refused probe (confirmed wedge), inconclusive probe (timeout claims nothing), differing/absent uuid (certain-failure wording), write capability refused or **unknown**. Nothing is adopted from the uncorroborated reply on any path — the fail-closed rule does not move.

The success note discloses what did and didn't happen: the rebind was NOT re-derived and nothing was adopted; the held fence (uuid named) was proven live by the accepted read; the proof's scope is stated as one read a moment ago, with the fail-closed tab-switch caveat.

## Verification

Worktree gates (`comfyui-mcp/.worktrees/fix-980`, from `origin/main` @ 212132a):

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run` on the 7 fence/probe test files — 61/61 passed
- `npx vitest run src/__tests__/orchestrator` (full orchestrator suite) — **160 files, 2802 tests, all passed**

Tests (`src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts`, `fence-matching-uuid.test.ts`) pin the gate matrix: probe-passed + writes-confirmed → `bound` success; probe-passed + capability **unknown** → still a failure; probe refused → failure with the REFUSED note; inconclusive probe → failure claiming nothing; differing uuid → no probe, hard wording kept; and on every path, no uncorroborated identity is ever adopted.

No tool descriptions changed, so the docs/vocabulary gates are not implicated.