### PR TITLE
fix(1615): a re-spelled ComfyUI target keeps its self-queue ledger, and the duplicate-fence override says who it is for

### DIFF
--- a/src/__tests__/orchestrator/panel-run-reconnect-respell.test.ts
+++ b/src/__tests__/orchestrator/panel-run-reconnect-respell.test.ts
@@ -1,0 +1,216 @@
+// #1615 — panel_run's duplicate fence refused a post-reconnect scoped preview,
+// and the override it named was documented as not applying to that caller.
+//
+// TWO bug-shaped halves of one report, tested here together because they are the
+// two halves of one refusal the reporter actually hit:
+//
+// (2) QueueMonitor.start() cleared the self-queue ledger on ANY retarget. The
+//     orchestrator retargets on a panel hello, and a hello can re-spell the SAME
+//     server — `127.0.0.1:8188` -> `localhost:8188` is the example start()'s own
+//     docstring gives. Renders still in flight ON THAT SERVER then read as
+//     unattributable, `selfAttributedProven` went false, and the fence refused
+//     every run until the queue drained. The jobs never became foreign; only
+//     their spelling changed.
+//
+// (1) All three places documenting `allow_duplicate` scoped it to "a sweep/batch"
+//     — precisely the case the post-reconnect caller is NOT in. Reading
+//     "only ... (a sweep/batch)", the correct inference is that the escape hatch
+//     belongs to someone else, so the caller stops. That is the reported symptom
+//     ("prevents normal incremental verification after reconnect").
+//
+// The wiring matters as much as the behaviour: the production retarget path in
+// orchestrator/index.ts calls QueueMonitor.stop() ITSELF and only then start(),
+// so these tests drive that exact sequence rather than start() alone.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as unknown as QMPriv;
+
+// Ports nothing listens on: start() opens a real WS, and pointing it at a live
+// ComfyUI would let an actual server mutate state underneath the assertions.
+const ORIGINAL = "http://127.0.0.1:39971";
+const RESPELLED = "http://localhost:39971"; // same server, different spelling
+const ELSEWHERE = "http://127.0.0.1:39972"; // a genuinely different ComfyUI
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function makeCtx(runReply: Record<string, unknown>): PanelToolCtx {
+  const bridge = {
+    send: async () => ({}),
+    push: () => 1,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = makePanelToolCtx(bridge, "test-tab");
+  (ctx as { call: PanelToolCtx["call"] }).call = async () => ({
+    content: [{ type: "text", text: JSON.stringify(runReply) }],
+  });
+  return ctx;
+}
+
+function firstText(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+/** The user's render, queued by US, still running on ComfyUI. */
+function anOwnRenderInFlight(): void {
+  QueueMonitor.markSelfQueued("p-mine");
+  qm.state.runningPromptId = "p-mine";
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 1;
+}
+
+/**
+ * What the watchdog looks like once it is back up on the retargeted URL. start()
+ * resets the liveness clocks and the socket is not really open here, so restore
+ * the observable view the fence reads — the QUESTION under test is what happened
+ * to the ledger, which start() alone decides.
+ */
+function watchdogBackUp(): void {
+  qm.state.connected = true;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+}
+
+/** Exactly what orchestrator/index.ts does on a target change: stop, then start. */
+function orchestratorRetargetsTo(url: string): void {
+  QueueMonitor.stop();
+  QueueMonitor.start(url);
+  watchdogBackUp();
+}
+
+beforeEach(() => {
+  qm.url = ORIGINAL;
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  watchdogBackUp();
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+});
+
+afterEach(() => {
+  QueueMonitor.stop();
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+describe("#1615: a re-spelled retarget must not orphan the self-queue ledger", () => {
+  it("the reporter's case — a hello re-spells the same server, and the scoped preview still queues", async () => {
+    anOwnRenderInFlight();
+    expect(QueueMonitor.snapshot().selfAttributedProven).toBe(true);
+
+    orchestratorRetargetsTo(RESPELLED);
+
+    // The server did not move, so neither did ownership of what is running on it.
+    expect(qm.selfQueuedIds.has("p-mine")).toBe(true);
+    expect(QueueMonitor.snapshot().selfAttributedProven).toBe(true);
+
+    const res = await defByName("panel_run").handler({ to_node_id: 16 }, makeCtx({ queued: true, prompt_id: "p-next" }));
+    expect(firstText(res)).not.toContain("refused to queue");
+  });
+
+  it("a genuine retarget still drops ownership — another ComfyUI's jobs are foreign (#559 intact)", async () => {
+    anOwnRenderInFlight();
+
+    orchestratorRetargetsTo(ELSEWHERE);
+
+    expect(qm.selfQueuedIds.size).toBe(0);
+    expect(qm.lastSelfQueueTs).toBeNull();
+    expect(QueueMonitor.snapshot().selfAttributedProven).toBe(false);
+
+    const res = await defByName("panel_run").handler({ to_node_id: 16 }, makeCtx({ queued: true, prompt_id: "p-next" }));
+    expect(firstText(res)).toContain("refused to queue");
+  });
+
+  it("same origin, DIFFERENT base path is a different ComfyUI behind one proxy — ownership drops", () => {
+    qm.url = "http://127.0.0.1:39971/comfy-a";
+    anOwnRenderInFlight();
+
+    orchestratorRetargetsTo("http://127.0.0.1:39971/comfy-b");
+
+    expect(qm.selfQueuedIds.size).toBe(0);
+    expect(QueueMonitor.snapshot().selfAttributedProven).toBe(false);
+  });
+
+  it("a trailing slash is not a retarget either", () => {
+    anOwnRenderInFlight();
+
+    orchestratorRetargetsTo(`${ORIGINAL}/`);
+
+    expect(qm.selfQueuedIds.has("p-mine")).toBe(true);
+  });
+
+  it("a first start() with no previous target keeps nothing — there is no prior server", () => {
+    qm.url = null;
+    QueueMonitor.markSelfQueued("p-stray");
+
+    QueueMonitor.stop();
+    QueueMonitor.start(ORIGINAL);
+
+    expect(qm.selfQueuedIds.size).toBe(0);
+  });
+});
+
+describe("#1615: the allow_duplicate override names the caller it is actually for", () => {
+  // A caller reading "pass true ONLY to ... (a sweep/batch)" concludes the hatch
+  // is not theirs. These assert the post-reconnect case is named as ordinary in
+  // every place the override is described — the tool description, the parameter
+  // description, and the refusal the caller actually reads.
+  const panelRun = () => defByName("panel_run");
+
+  function allowDuplicateDescription(): string {
+    const field = panelRun().schema.allow_duplicate as { description?: string };
+    return field.description ?? "";
+  }
+
+  it("the parameter description licenses the post-reconnect preview, not just a sweep", () => {
+    const d = allowDuplicateDescription();
+    expect(d).toMatch(/after a reconnect that is the ordinary case/i);
+    expect(d).toMatch(/to_node_id preview/i);
+    // The old wording made sweep/batch the DEFINITION of the override.
+    expect(d).not.toMatch(/only to deliberately queue behind it \(a sweep\/batch\)/i);
+  });
+
+  it("the tool description does not scope the override to a sweep either", () => {
+    const d = panelRun().description;
+    expect(d).toMatch(/to_node_id preview after a reconnect is the ordinary case/i);
+    expect(d).not.toMatch(/only to deliberately stack behind it/i);
+  });
+
+  it("the refusal the caller reads names their own case as the ordinary one", async () => {
+    qm.state.runningPromptId = "p-unaccounted";
+    qm.state.queueRemaining = 1; // in flight, and not provably ours
+
+    const res = await defByName("panel_run").handler({ to_node_id: 16 }, makeCtx({ queued: true }));
+    const text = firstText(res);
+
+    expect(text).toContain("refused to queue");
+    expect(text).toContain("allow_duplicate:true");
+    expect(text).toMatch(/after a reconnect that is the ORDINARY case/);
+    expect(text).toMatch(/scoped to_node_id preview/);
+    // Sweep/batch survives as an example, never as the licence.
+    expect(text).not.toMatch(/If you genuinely intend to stack another render behind it \(a deliberate sweep\/batch\)/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10104,7 +10104,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_run",
-      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the tool builds the nested execution path for you. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, or pass allow_duplicate:true only to deliberately stack behind it. Use this so the render runs on THEIR canvas and they see the result.",
+      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the tool builds the nested execution path for you. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, then pass allow_duplicate:true once you have decided it is fine to run behind what is there — a scoped to_node_id preview after a reconnect is the ordinary case for it, a deliberate sweep/batch the other. Use this so the render runs on THEIR canvas and they see the result.",
       {
         batch_count: z
           .number()
@@ -10124,7 +10124,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .boolean()
           .optional()
           .describe(
-            "Queue even when a render this session cannot account for is already in flight (default false). When work is in flight that this session has no record of queueing — e.g. YOUR OWN earlier render still running after a reconnect, whose record does not survive the restart — panel_run REFUSES to stack a duplicate and names the in-flight prompt instead. Pass true only to deliberately queue behind it (a sweep/batch).",
+            "Queue even when a render this session cannot account for is already in flight (default false). When work is in flight that this session has no record of queueing — e.g. YOUR OWN earlier render still running after a reconnect, whose record does not survive the restart — panel_run REFUSES to stack a duplicate and names the in-flight prompt instead. Pass true once you have LOOKED at what is in flight (queue action:'list') and decided it is fine to run behind it. After a reconnect that is the ordinary case, not an exotic one: you confirmed the in-flight job is your own earlier render or the user's, and you still want the next run — a scoped to_node_id preview, the next step of the task. Deliberately stacking a sweep/batch uses the same override.",
           ),
       },
       async (args: A, ctx) => {
@@ -10195,9 +10195,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `no prompt id) even YOUR OWN earlier render reads as unconfirmable, and queueing now ` +
               `would stack a DUPLICATE behind it (#862). Nothing was queued. Inspect with queue ` +
               `(action:"list"): if the in-flight job is the render you already started, wait for it ` +
-              `and confirm the outcome with get_history instead of re-running it. If you genuinely ` +
-              `intend to stack another render behind it (a deliberate sweep/batch), re-call panel_run ` +
-              `with allow_duplicate:true. If the in-flight job is actually wedged, queue ` +
+              `and confirm the outcome with get_history instead of re-running it. Once you HAVE ` +
+              `looked and decided it is fine to run behind what is there, re-call panel_run with ` +
+              `allow_duplicate:true — after a reconnect that is the ORDINARY case, not an exotic ` +
+              `one: the in-flight job is your own earlier render or the user's, and you still want ` +
+              `the next run (a scoped to_node_id preview, the next step of the task). Deliberately ` +
+              `stacking a sweep/batch uses the same override. If the in-flight job is actually wedged, queue ` +
               `(action:"cancel") with clear_pending:true interrupts it AND drops everything pending.`,
           );
         }

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -32,6 +32,7 @@ import WebSocket from "ws";
 import { logger } from "../utils/logger.js";
 import { getComfyUIAuthHeaders } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { sameOrigin } from "../utils/origin.js";
 
 interface MonitorState {
   connected: boolean;
@@ -124,6 +125,35 @@ export interface QueueSnapshot {
    *  reported depth is fully accounted for — the coarse recent-self-queue
    *  fallback never counts here. */
   selfAttributedProven: boolean;
+}
+
+/**
+ * `new URL(...).pathname` with trailing slashes stripped, "" when unparseable.
+ * Only ever reached for parseable input — `sameComfyTarget` calls `sameOrigin`
+ * first, which rejects everything `new URL` cannot take.
+ */
+function basePathOf(url: string): string {
+  try {
+    return new URL(url).pathname.replace(/\/+$/, "");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * True when `next` names the ComfyUI this monitor is already pointed at, differing
+ * only in SPELLING (#1615) — `http://127.0.0.1:8188` and `http://localhost:8188`
+ * are one server, and a panel hello can re-spell the target without moving it.
+ *
+ * The base path is compared separately because it is not part of an origin, and
+ * two ComfyUI can genuinely sit behind one reverse proxy at /comfy-a and /comfy-b
+ * — collapsing those would be a FALSE identity, the mirror of the bug this fixes.
+ * A null previous target never matches: there is no prior server to have owned
+ * anything on.
+ */
+function sameComfyTarget(prev: string | null, next: string): boolean {
+  if (!prev || !sameOrigin(prev, next)) return false;
+  return basePathOf(prev) === basePathOf(next);
 }
 
 const RECONNECT_MS = 5000;
@@ -223,6 +253,13 @@ class QueueMonitorImpl {
    *  NOT early-return — that left the watchdog permanently disconnected. */
   start(comfyuiUrl: string): void {
     if (this.url === comfyuiUrl && !this.stopped) return; // already live on this URL
+    // #1615 — read BEFORE `this.url` is overwritten below, and before our own
+    // stop() (which leaves the url intact). It has to be captured here rather
+    // than checked at the top, because the production retarget path in
+    // orchestrator/index.ts calls QueueMonitor.stop() ITSELF and only then
+    // start(url): by then `this.stopped` is true, so any early-return guarded on
+    // it would never fire on the one path that matters.
+    const respelledSameTarget = sameComfyTarget(this.url, comfyuiUrl);
     this.stop(); // tear down any prior socket/reconnect timer (also on URL change)
     this.url = comfyuiUrl;
     this.stopped = false;
@@ -239,8 +276,20 @@ class QueueMonitorImpl {
     this.state.lastCompleted = null;
     // Self-queued prompt ids belong to the OLD target — a fresh ComfyUI's jobs are
     // foreign to us until we queue them, so drop the attribution (#559).
-    this.selfQueuedIds.clear();
-    this.lastSelfQueueTs = null;
+    //
+    // #1615 — but ONLY when the target actually moved. A panel hello arriving as
+    // `localhost:8188` while we are live on `127.0.0.1:8188` is a retarget by
+    // string and the same server in fact, and clearing here made every render
+    // STILL IN FLIGHT ON IT unattributable. panel_run's duplicate fence keys on
+    // exactly that ledger (`selfAttributedProven`), so it then refused every run
+    // — including a scoped to_node_id preview — until the queue drained. Those
+    // jobs never became foreign; only their spelling changed. Ownership is a
+    // property of the SERVER, so it survives a re-spelling, and a genuine
+    // retarget still drops it.
+    if (!respelledSameTarget) {
+      this.selfQueuedIds.clear();
+      this.lastSelfQueueTs = null;
+    }
     // Liveness heartbeats belong to the OLD target — reset so a fresh target's
     // stall clock doesn't inherit a stale "alive" (or a stale "dark") reading.
     this.state.lastFrameTs = null;

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -21,8 +21,18 @@
 // issue thread. A comment asserting a caller that does not exist is the same
 // defect as a message describing a check that does not run.
 //
-// If a fence ever does start comparing origins, wire it to `sameOrigin` and say
-// so here — but the wiring must come first, and the sentence second.
+// WIRED, #1615 — and stated only because the wiring landed with it. Nothing else
+// changed: `QueueMonitor.start()` (services/queue-monitor.ts) is the consumer, and
+// it compares the PREVIOUS target against the new one to tell a real retarget from
+// a re-spelling of the same server, so the self-queue ledger survives the latter.
+// It pairs `sameOrigin` with its own base-path check, because a path prefix is not
+// part of an origin and two ComfyUI can share one reverse proxy.
+//
+// panel_run's duplicate fence then reads that ledger through
+// `selfAttributedProven` — the fence itself still compares no origins. The two
+// non-test importers of this module are that one and `comfyui/fetch.ts`. If a
+// third starts comparing origins, wire it to `sameOrigin` and say so here — but
+// the wiring must come first, and the sentence second.
 //
 // WHY THIS IS ITS OWN MODULE. Three loopback notions already exist
 // (`isLoopbackServerUrl`, `port-owner`'s LOOPBACK/WILDCARD split,


### PR DESCRIPTION
## Root cause

Two compounding halves of one report (#1615, refiled from artokun/comfyui-mcp-panel#1127):

1. **A re-spelled target was treated as a retarget.** `QueueMonitor.start()` cleared `selfQueuedIds`/`lastSelfQueueTs` on *any* retarget, and a retarget was decided by string. A panel hello arriving as `http://localhost:8188` while the orchestrator is live on `http://127.0.0.1:8188` is not deduped anywhere (`applyComfyuiUrl` compares `canonComfyuiTargetUrl`, which normalises only the scheme's default port and trailing slashes), so every render still in flight **on that same server** lost its attribution and the duplicate fence refused every `panel_run` until the queue drained.
2. **The remedy told this caller it was for somebody else.** All three sites documenting `allow_duplicate` (parameter description, `panel_run` tool description, refusal text) scoped the override to "a sweep/batch" — the one case a post-reconnect caller is *not* in.

## Fix

This is the re-land of **c0c4279 (#1626)**, which was reverted in **85a3e19 (#1633)** only because it merged on a substitute reviewer while the codex gate was INDETERMINATE (quota). The diff is unchanged from the reviewed, mutation-verified original; it applies cleanly onto current main (2f46ffb) despite the #1630/#1688 drift in `panel-tools.ts` and the #1652 drift in `queue-monitor.ts`.

- `src/services/queue-monitor.ts` — ownership is a property of the server: a re-spelling of the same target (`sameComfyTarget` = `sameOrigin` + separate base-path comparison) no longer drops the self-queue ledger. The base path is compared separately because it is not part of an origin — two ComfyUIs behind one reverse proxy at `/comfy-a` and `/comfy-b` stay distinct (pinned by test). A genuine retarget still drops the ledger; #559's "another ComfyUI's jobs are foreign to us" is unchanged.
- `src/orchestrator/panel-tools.ts` — all three `allow_duplicate` sites now name the post-reconnect scoped `to_node_id` preview as the ordinary use and keep sweep/batch as the other example. No behaviour change.
- `src/utils/origin.ts` — the WIRED paragraph its header asked for.
- `src/__tests__/orchestrator/panel-run-reconnect-respell.test.ts` — 8 tests driving the real `stop()`-then-`start()` sequence.

## Verification (worktree `.worktrees/fix-1615`, against origin/main 2f46ffb)

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/orchestrator/panel-run-reconnect-respell.test.ts` — 8/8 passed
- Neighbors: `panel-tools.test.ts`, `panel-tools-strict-schema.test.ts`, `panel-run-backpressure.test.ts`, `panel-tools-retraction.test.ts`, `deferred-panel-tools.test.ts` — 524/524 passed; `queue-monitor.stall.test.ts` — 11/11 passed
- Mutation re-confirmed on drifted main: breaking the `respelledSameTarget` guard → 3 of the 8 respell tests fail (recipe expected ≥2)
- `npm run docs:gen` — no diff; `npm run check:vocabulary` — OK; `npm run vocab:export -- --check` — OK

## Not claimed

- The reporter's attribution loss may have come from the ordinary orchestrator-restart path instead of the re-spell path — both explain the report and there were no logs. That path can't be fixed in-process (the ledger is in-memory by construction); for it, the wording fix is what unblocks the caller.
- Finding 3 (publish the panel's `unsettledPromptIds()` over the bridge so the fence can ask before refusing) stays PARKED as a two-repo feature under the freeze.
- The codex gate was quota-blocked at original merge time (reset 2026-08-19 20:43 per #1615); this PR re-lands the exact diff that gate is meant to re-check.

Closes #1615
Refs artokun/comfyui-mcp-panel#1127