### PR TITLE
fix(773): search_custom_nodes false-empties on repo-name queries — exact-id fallback now tries the comfyui- prefix

### DIFF
--- a/src/__tests__/services/registry-search.test.ts
+++ b/src/__tests__/services/registry-search.test.ts
@@ -3,6 +3,7 @@ import {
   searchNodes,
   getNodePackDetails,
   extractVersionString,
+  registryIdCandidatesFromQuery,
 } from "../../services/registry-client.js";
 
 const NODES = [
@@ -203,6 +204,122 @@ describe("searchNodes exact-id fallback (#773)", () => {
     expect(results).toEqual([]);
     // Only the window fetch — no /nodes/<id> call for a later page.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #773 recurrence on 0.52.1: "WanVideoWrapper" slugs to "wanvideowrapper",
+  // but the real pack id is "comfyui-wanvideowrapper" — registry ids are
+  // derived from GitHub repo names, and most packs carry the "ComfyUI-" prefix.
+  it("tries the comfyui-prefixed candidate when the bare slug 404s", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/nodes/comfyui-wanvideowrapper")) {
+        return new Response(
+          JSON.stringify({
+            id: "ComfyUI-WanVideoWrapper",
+            name: "WanVideoWrapper",
+            description: "Wan Video diffusion nodes",
+            author: "kijai",
+            repository: "https://github.com/kijai/ComfyUI-WanVideoWrapper",
+            latest_version: { version: "1.0.0" },
+            total_install: 50000,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (/\/nodes\/[^?]+$/.test(url)) {
+        return new Response("not found", { status: 404 });
+      }
+      // The window never contains the pack — that is why the fallback runs.
+      return new Response(JSON.stringify({ nodes: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const results = await searchNodes("WanVideoWrapper");
+    expect(results.map((r) => r.id)).toEqual(["ComfyUI-WanVideoWrapper"]);
+    const detailCalls = fetchMock.mock.calls.map((c) => String(c[0])).filter((u) =>
+      /\/nodes\/[^?]+$/.test(u),
+    );
+    expect(detailCalls).toEqual([
+      expect.stringContaining("/nodes/wanvideowrapper"),
+      expect.stringContaining("/nodes/comfyui-wanvideowrapper"),
+    ]);
+  });
+
+  it("a query already carrying the comfyui- prefix is tried once, not doubled", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (/\/nodes\/[^?]+$/.test(url)) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(JSON.stringify({ nodes: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const results = await searchNodes("comfyui kjnodes");
+    expect(results).toEqual([]);
+    const detailCalls = fetchMock.mock.calls.map((c) => String(c[0])).filter((u) =>
+      /\/nodes\/[^?]+$/.test(u),
+    );
+    expect(detailCalls).toEqual([expect.stringContaining("/nodes/comfyui-kjnodes")]);
+  });
+
+  it("a later candidate still resolves after an earlier candidate fails non-404", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/nodes/sam3")) {
+        return new Response("boom", { status: 500 });
+      }
+      if (url.includes("/nodes/comfyui-sam3")) {
+        return new Response(
+          JSON.stringify({
+            id: "ComfyUI-SAM3",
+            name: "SAM3",
+            description: "Segment anything",
+            author: "someone",
+            repository: "https://github.com/someone/ComfyUI-SAM3",
+            latest_version: "1.0.0",
+            total_install: 100,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ nodes: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const results = await searchNodes("SAM3");
+    expect(results.map((r) => r.id)).toEqual(["ComfyUI-SAM3"]);
+  });
+});
+
+describe("registryIdCandidatesFromQuery", () => {
+  it("offers the bare slug first, then the comfyui-prefixed form", () => {
+    expect(registryIdCandidatesFromQuery("WanVideoWrapper")).toEqual([
+      "wanvideowrapper",
+      "comfyui-wanvideowrapper",
+    ]);
+    expect(registryIdCandidatesFromQuery("impact pack")).toEqual([
+      "impact-pack",
+      "comfyui-impact-pack",
+    ]);
+  });
+
+  it("does not double a prefix the query already carries", () => {
+    expect(registryIdCandidatesFromQuery("comfyui kjnodes")).toEqual(["comfyui-kjnodes"]);
+  });
+
+  it("offers nothing when no usable slug remains", () => {
+    expect(registryIdCandidatesFromQuery("   ")).toEqual([]);
+    expect(registryIdCandidatesFromQuery("!!!")).toEqual([]);
   });
 });
 

--- a/src/services/registry-client.ts
+++ b/src/services/registry-client.ts
@@ -146,8 +146,14 @@ export async function searchNodes(
   // the fallback has no pagination of its own, so it must not answer for a
   // later page (an out-of-window exact match would otherwise surface ON page 2).
   if (lowerQuery && filtered.length === 0 && page === 1) {
-    const candidate = registryIdCandidateFromQuery(query);
-    if (candidate) {
+    const candidates = registryIdCandidatesFromQuery(query);
+    // The candidates are guesses, not one answer: a 404 only rules out THAT id,
+    // so keep trying the rest. A non-404 failure means absence was never
+    // established for that candidate — remember it; if no candidate resolves,
+    // reporting "no matches" would be an unearned negative, so refuse with the
+    // reason instead of returning the empty page.
+    let unresolved: unknown;
+    for (const candidate of candidates) {
       try {
         const details = await getNodePackDetails(candidate);
         logger.info(
@@ -156,28 +162,27 @@ export async function searchNodes(
         );
         return [normalizeSearchResult(details)];
       } catch (err) {
-        // Only an observed 404 establishes "no pack with that id". Anything
-        // else (500, network) means the fallback could not answer — and the
-        // window search cannot establish absence on its own (that is why the
-        // fallback exists), so reporting "no matches" would be an unearned
-        // negative. Refuse with the reason instead.
         const status =
           err instanceof RegistryError
             ? (err.details as { status?: number } | undefined)?.status
             : undefined;
         if (status !== 404) {
-          throw new RegistryError(
-            `Registry search "${query}" matched nothing in the fetched pack window, ` +
-              `and the exact-id fallback for "${candidate}" could not be resolved ` +
-              `(${err instanceof Error ? err.message : String(err)}) — so "no matches" ` +
-              `cannot be confirmed. Retry, or look the pack up directly with ` +
-              `search_custom_nodes (action:"details").`,
-          );
+          unresolved ??= err;
+          continue;
         }
         logger.debug(
           `Registry exact-id fallback for "${query}": no pack with id "${candidate}" (404)`,
         );
       }
+    }
+    if (unresolved !== undefined) {
+      throw new RegistryError(
+        `Registry search "${query}" matched nothing in the fetched pack window, ` +
+          `and the exact-id fallback could not be resolved ` +
+          `(${unresolved instanceof Error ? unresolved.message : String(unresolved)}) — so "no matches" ` +
+          `cannot be confirmed. Retry, or look the pack up directly with ` +
+          `search_custom_nodes (action:"details").`,
+      );
     }
   }
 
@@ -188,18 +193,25 @@ export async function searchNodes(
 }
 
 /**
- * Normalize a free-text query to a candidate Comfy Registry pack id: lowercase,
- * runs of non-alphanumerics collapsed to single hyphens, edges trimmed
- * ("comfyui kjnodes" → "comfyui-kjnodes"). Undefined when nothing usable
- * remains.
+ * Normalize a free-text query to candidate Comfy Registry pack ids, most
+ * literal first: lowercase, runs of non-alphanumerics collapsed to single
+ * hyphens, edges trimmed ("comfyui kjnodes" → "comfyui-kjnodes").
+ *
+ * #773 recurrence (0.52.1): one slug is not enough. Registry ids are derived
+ * from GitHub repo names, and most packs live under a "ComfyUI-" repo prefix —
+ * so "WanVideoWrapper" slugs to "wanvideowrapper" while the real pack is
+ * "comfyui-wanvideowrapper" (same for VideoHelperSuite, SAM3). The endpoint is
+ * case-insensitive but not prefix-insensitive, so the prefixed form is offered
+ * as a second candidate unless the slug already carries it.
  */
-export function registryIdCandidateFromQuery(query: string): string | undefined {
+export function registryIdCandidatesFromQuery(query: string): string[] {
   const slug = query
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  return slug.length > 0 ? slug : undefined;
+  if (slug.length === 0) return [];
+  return slug.startsWith("comfyui-") ? [slug] : [slug, `comfyui-${slug}`];
 }
 
 /** Coerce the registry's object-shaped `latest_version` into a string. */


### PR DESCRIPTION
Closes #773

## Root cause

#834 added an exact-id fallback for the case where the client-side filter (a 100-pack window of a registry with thousands of packs — the upstream `search` param is ignored server-side) matches nothing: the query is slugified and tried against `GET /nodes/{id}`. The recurrence reported on 0.52.1 shows that fallback false-emptying too, because it generates exactly ONE candidate. Registry ids are derived from GitHub repo names and most packs carry a `ComfyUI-` prefix, while users type the bare repo name:

- `WanVideoWrapper` → slug `wanvideowrapper` → 404; real id is `comfyui-wanvideowrapper`
- `VideoHelperSuite` → `videohelpersuite` → 404; real id is `comfyui-videohelpersuite`
- `SAM3` → `sam3` → 404; real id is `comfyui-sam3`

Verified live against api.comfy.org: all three bare slugs 404, all three `comfyui-`-prefixed ids resolve (the endpoint is case-insensitive; `comfyui-wanvideowrapper` 302s to the canonical `ComfyUI-WanVideoWrapper` and fetch follows it). Also verified the fetched 100-pack window contains none of these packs, so the fallback is the only path that can answer.

## Fix

`registryIdCandidateFromQuery` → `registryIdCandidatesFromQuery` in `src/services/registry-client.ts`: returns the bare slug first, then `comfyui-<slug>` (skipped when the slug already carries the prefix, so no doubled request). The fallback loop tries each candidate: a 404 only rules out that id and the next candidate is tried; a non-404 failure is remembered, and if no candidate resolves the search still refuses loudly ("no matches" was never established) rather than returning the empty page — the fail-closed behavior from #834 is preserved.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/services/registry-search.test.ts src/__tests__/tools/registry-search.test.ts` — 34/34 pass (incl. 6 new tests: prefixed-candidate resolution, no-doubled-prefix, later-candidate-resolves-after-earlier-500, candidate-shape unit tests)
- `npx vitest run src/__tests__/tools/registry-surface.test.ts src/__tests__/tools/node-management.test.ts` — 47/47 pass
- Live against api.comfy.org using the built `dist/`: `searchNodes("WanVideoWrapper")` → `ComfyUI-WanVideoWrapper`; `searchNodes("VideoHelperSuite")` → `comfyui-videohelpersuite`; `searchNodes("SAM3")` → `comfyui-sam3` (all previously "No custom nodes found")

No tool-description changes, so docs/vocabulary gates are not implicated.