### PR TITLE
fix(946): upload tools return the subfolder-qualified reference a loader can use

### DIFF
--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -231,7 +231,7 @@ Put a file where ComfyUI (or cloud storage) can read it. Driven by the `action` 
   Absolute path to the local file to upload. REQUIRED for actions "image", "video" and "audio".
 </ParamField>
 <ParamField path="filename" type="string">
-  Two meanings, one per action. actions "image"/"video"/"audio" — OPTIONAL override for the filename in ComfyUI's input/ directory (auto-detected from source_path if omitted). action:"stage" — REQUIRED filename of the EXISTING output/temp asset to re-register (from get_history or get_image action:"list_outputs"), e.g. LTX_video_00001.mp4; its destination name override is `as_filename`, not this field.
+  Two meanings, one per action. actions "image"/"video"/"audio" — OPTIONAL override for the filename in ComfyUI's input/ directory (auto-detected from source_path if omitted). A path prefix (e.g. assets/clip.mp4) places the upload in that SUBFOLDER of input/ — ".." is refused — and the returned filename reference includes the subfolder, since loaders need the qualified path. action:"stage" — REQUIRED filename of the EXISTING output/temp asset to re-register (from get_history or get_image action:"list_outputs"), e.g. LTX_video_00001.mp4; its destination name override is `as_filename`, not this field.
 </ParamField>
 <ParamField path="subfolder" type="string">
   action:"stage" — subfolder the source asset currently lives in, if any.

--- a/src/__tests__/comfyui/cloud-client.test.ts
+++ b/src/__tests__/comfyui/cloud-client.test.ts
@@ -23,6 +23,7 @@ const {
   getSamplers,
   getSchedulers,
   interrupt,
+  uploadImageHttp,
 } = await import("../../comfyui/cloud-client.js");
 
 describe("cloud-client", () => {
@@ -139,5 +140,30 @@ describe("cloud-client", () => {
     await expect(getHistory("abc")).rejects.toMatchObject({
       code: "CLOUD_API_ERROR",
     });
+  });
+
+  // #946 — the twin split: a path in `filename` is a subfolder request, sent
+  // as the form field the API has. The self-hosted client got this fix first;
+  // this twin kept the original defect (the whole path as the multipart
+  // filename) until the split was shared.
+  it("uploadImageHttp splits a path filename into the subfolder form field", async () => {
+    await uploadImageHttp("assets/clip.mp4", Buffer.from("x"), "video/mp4");
+    const form = calls.at(-1)?.init?.body as FormData;
+    expect(form.get("subfolder")).toBe("assets");
+    expect((form.get("image") as File).name).toBe("clip.mp4");
+  });
+
+  it("uploadImageHttp sends NO subfolder field for a plain filename", async () => {
+    await uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4");
+    const form = calls.at(-1)?.init?.body as FormData;
+    expect(form.has("subfolder")).toBe(false);
+    expect((form.get("image") as File).name).toBe("clip.mp4");
+  });
+
+  it("uploadImageHttp refuses a traversal before anything is sent", async () => {
+    await expect(uploadImageHttp("../escape.png", Buffer.from("x"))).rejects.toThrow(
+      /walks outside/,
+    );
+    expect(calls).toHaveLength(0);
   });
 });

--- a/src/__tests__/services/media-upload.test.ts
+++ b/src/__tests__/services/media-upload.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../comfyui/client.js", () => ({
 
 import { config } from "../../config.js";
 import {
+  uploadImageAuto,
   uploadVideoAuto,
   uploadVideoLocal,
   uploadAudioAuto,
@@ -134,6 +135,53 @@ describe("uploadVideoLocal / uploadAudioLocal (filesystem)", () => {
       ValidationError,
     );
     expect(copyFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("upload subfolder propagation (#946 recurrence)", () => {
+  // A filename override carrying a path ("minimax_h3/clip1_end.png") is a
+  // subfolder request: the server stores the file UNDER that subfolder and
+  // answers { name, subfolder }. Dropping the subfolder here handed the caller
+  // a bare name that did not resolve — queuing a loader failed with
+  // FileNotFoundError for input/<name> while the file sat in input/minimax_h3/.
+  it("uploadVideoAuto returns the subfolder alongside the stored name", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "clip1_end.mp4",
+      subfolder: "minimax_h3",
+      type: "input",
+    });
+    const r = await uploadVideoAuto("/src/clip1_end.mp4", "minimax_h3/clip1_end.mp4");
+    expect(r).toEqual({ filename: "clip1_end.mp4", subfolder: "minimax_h3" });
+  });
+
+  it("uploadImageAuto returns the subfolder alongside the stored name", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "frame.png",
+      subfolder: "assets",
+      type: "input",
+    });
+    const r = await uploadImageAuto("/src/frame.png", "assets/frame.png");
+    expect(r).toEqual({ filename: "frame.png", subfolder: "assets" });
+  });
+
+  it("defaults the subfolder to '' when the server omits it", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({ name: "in.png" });
+    const r = await uploadImageAuto("/src/in.png");
+    expect(r).toEqual({ filename: "in.png", subfolder: "" });
+  });
+
+  it("passes the path-shaped override through to the transport, which owns the split", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "clip.mp4",
+      subfolder: "assets",
+      type: "input",
+    });
+    await uploadVideoAuto("/src/clip.mp4", "assets/clip.mp4");
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "assets/clip.mp4",
+      expect.any(Buffer),
+      "video/mp4",
+    );
   });
 });
 

--- a/src/__tests__/tools/image-assets.test.ts
+++ b/src/__tests__/tools/image-assets.test.ts
@@ -513,6 +513,49 @@ describe("upload_image: each action writes to exactly one destination", () => {
     expect(uploadAudioAutoMock).not.toHaveBeenCalled();
     expect(uploadOutputMock).not.toHaveBeenCalled();
   });
+
+  it('action:"image" reports the SUBFOLDER-qualified reference when the upload landed in one (#946)', async () => {
+    // The recurrence: filename "minimax_h3/walter_ropeflow_clip1_end.png"
+    // uploaded fine, but the tool answered with the bare name — which does not
+    // resolve in a loader, because the file sits in input/minimax_h3/. The
+    // reported reference must be the path a loader accepts.
+    uploadImageAutoMock.mockResolvedValue({
+      filename: "walter_ropeflow_clip1_end.png",
+      subfolder: "minimax_h3",
+    });
+    const res = await uploadImage()({
+      action: "image",
+      source_path: "/tmp/a.png",
+      filename: "minimax_h3/walter_ropeflow_clip1_end.png",
+    });
+    const t = text(res);
+    expect(t).toContain("Filename: minimax_h3/walter_ropeflow_clip1_end.png");
+    expect(t).toContain('Use "minimax_h3/walter_ropeflow_clip1_end.png"');
+    expect(t).not.toContain('Use "walter_ropeflow_clip1_end.png"');
+  });
+
+  it('action:"video" keeps the bare reference when there is no subfolder (unchanged)', async () => {
+    uploadVideoAutoMock.mockResolvedValue({ filename: "in.mp4", subfolder: "" });
+    const res = await uploadImage()({ action: "video", source_path: "/tmp/a.mp4" });
+    expect(text(res)).toContain('Use "in.mp4"');
+  });
+
+  it('action:"stage" reports the qualified reference when as_filename carried a path', async () => {
+    stageOutputAsInputMock.mockResolvedValue({
+      filename: "staged.png",
+      subfolder: "assets",
+      type: "input",
+      kind: "image",
+    });
+    const res = await uploadImage()({
+      action: "stage",
+      filename: "out.png",
+      as_filename: "assets/staged.png",
+    });
+    const t = text(res);
+    expect(t).toContain('Use "assets/staged.png"');
+    expect(t).toContain('panel_set_widget the loader\'s widget to "assets/staged.png"');
+  });
 });
 
 describe("per-action requiredness is enforced in the handler and NAMES the field", () => {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -11,7 +11,6 @@ import { logger } from "../utils/logger.js";
 import {
   ComfyUIError,
   ConnectionError,
-  ValidationError,
   WorkflowExecutionError,
 } from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
@@ -1212,34 +1211,9 @@ export async function uploadImageHttp(
 /**
  * Split an upload target into ComfyUI's two fields (#946).
  *
- * `filename` is the caller's whole intent — "clip.mp4" or "assets/clip.mp4" —
- * while ComfyUI's /upload/image wants a bare filename plus a separate
- * `subfolder`. Backslashes count as separators too: a caller on Windows
- * naturally writes "assets\clip.mp4".
- *
- * Traversal is REFUSED rather than sanitised. Silently rewriting "../../x.png"
- * into something safe would upload to a place the caller did not name and then
- * report the name they asked for — a wrong answer dressed as a right one. The
- * caller gets told instead.
+ * The implementation lives in ./upload-target.js so BOTH upload clients can
+ * share it (cloud-client.ts cannot import from here without a circular
+ * import); re-exported so existing imports keep working.
  */
-export function splitUploadTarget(filename: string): { subfolder: string; name: string } {
-  // A TRAILING separator has to be caught before the empty segments are filtered
-  // out: "assets/" would otherwise leave ["assets"], and the directory would be
-  // adopted as the filename — an upload to a name the caller never wrote.
-  const endsInSeparator = /[/\\]\s*$/.test(filename);
-  const parts = filename.split(/[/\\]+/).filter((p) => p !== "" && p !== ".");
-  const name = endsInSeparator ? "" : (parts.pop() ?? "");
-  if (name === "" || name === "..") {
-    throw new ValidationError(
-      `"${filename}" does not name a file to upload — it ends in a path separator or a "..". ` +
-        `Pass a filename, optionally prefixed with a subfolder (e.g. "assets/clip.mp4").`,
-    );
-  }
-  if (parts.some((p) => p === "..")) {
-    throw new ValidationError(
-      `"${filename}" walks outside ComfyUI's input directory with "..". ` +
-        `A subfolder prefix may only go downwards (e.g. "assets/clip.mp4").`,
-    );
-  }
-  return { subfolder: parts.join("/"), name };
-}
+import { splitUploadTarget } from "./upload-target.js";
+export { splitUploadTarget };

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -23,6 +23,7 @@ import {
   isTimeoutAbort,
 } from "./fetch.js";
 import { bodyPrefixOf, describeStatus } from "./json-guard.js";
+import { splitUploadTarget } from "./upload-target.js";
 import { ComfyUIError, ConnectionError, describeFetchFailure } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import type { HistoryEntry } from "./client.js";
@@ -362,11 +363,17 @@ export async function uploadImageHttp(
   data: Buffer,
   mimeType = "image/png",
 ): Promise<{ name: string; subfolder: string; type: string }> {
+  // #946 — same split as client.ts's uploadImageHttp: a `filename` carrying a
+  // path ("assets/clip.mp4") is a subfolder request, and the API takes that as
+  // its own form field. This twin kept the original defect until now — the rot
+  // the header above warns about.
+  const { subfolder, name } = splitUploadTarget(filename);
   const formData = new FormData();
   const blob = new Blob([data], { type: mimeType });
-  formData.append("image", blob, filename);
+  formData.append("image", blob, name);
   formData.append("type", "input");
   formData.append("overwrite", "true");
+  if (subfolder) formData.append("subfolder", subfolder);
   // multipart sets its own Content-Type; skip the JSON header.
   const res = await cloudFetch("/upload/image", {
     method: "POST",

--- a/src/comfyui/upload-target.ts
+++ b/src/comfyui/upload-target.ts
@@ -1,0 +1,42 @@
+import { ValidationError } from "../utils/errors.js";
+
+/**
+ * Split an upload target into ComfyUI's two fields (#946).
+ *
+ * `filename` is the caller's whole intent — "clip.mp4" or "assets/clip.mp4" —
+ * while ComfyUI's /upload/image wants a bare filename plus a separate
+ * `subfolder`. Backslashes count as separators too: a caller on Windows
+ * naturally writes "assets\clip.mp4".
+ *
+ * Traversal is REFUSED rather than sanitised. Silently rewriting "../../x.png"
+ * into something safe would upload to a place the caller did not name and then
+ * report the name they asked for — a wrong answer dressed as a right one. The
+ * caller gets told instead.
+ *
+ * Lives in its own module because BOTH upload clients need it: client.ts (the
+ * self-hosted /upload/image) and cloud-client.ts (the cloud twin) — and
+ * cloud-client cannot import from client.ts without a circular import. The
+ * one time this rule reached only one twin, the other kept the original #946
+ * defect.
+ */
+export function splitUploadTarget(filename: string): { subfolder: string; name: string } {
+  // A TRAILING separator has to be caught before the empty segments are filtered
+  // out: "assets/" would otherwise leave ["assets"], and the directory would be
+  // adopted as the filename — an upload to a name the caller never wrote.
+  const endsInSeparator = /[/\\]\s*$/.test(filename);
+  const parts = filename.split(/[/\\]+/).filter((p) => p !== "" && p !== ".");
+  const name = endsInSeparator ? "" : (parts.pop() ?? "");
+  if (name === "" || name === "..") {
+    throw new ValidationError(
+      `"${filename}" does not name a file to upload — it ends in a path separator or a "..". ` +
+        `Pass a filename, optionally prefixed with a subfolder (e.g. "assets/clip.mp4").`,
+    );
+  }
+  if (parts.some((p) => p === "..")) {
+    throw new ValidationError(
+      `"${filename}" walks outside ComfyUI's input directory with "..". ` +
+        `A subfolder prefix may only go downwards (e.g. "assets/clip.mp4").`,
+    );
+  }
+  return { subfolder: parts.join("/"), name };
+}

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -950,11 +950,16 @@ function jsonAttachmentRefusal(base64: string): JsonRefusal | null {
 /**
  * Upload a local image to ComfyUI via HTTP multipart POST.
  * Falls back to HTTP when COMFYUI_PATH is not available (remote ComfyUI).
+ *
+ * The returned `subfolder` is part of the answer, not a detail: when the
+ * requested `filename` carried a path ("minimax_h3/clip.png"), the server
+ * stores the file UNDER that subfolder and the bare `name` does not resolve
+ * in a loader — only `subfolder/name` does (#946).
  */
 export async function uploadImageAuto(
   sourcePath: string,
   filename?: string,
-): Promise<{ filename: string }> {
+): Promise<{ filename: string; subfolder: string }> {
   const resolvedFilename = filename ?? basename(sourcePath);
   const ext = extname(resolvedFilename).toLowerCase();
   if (!(ext in IMAGE_MIME)) {
@@ -966,7 +971,7 @@ export async function uploadImageAuto(
   const mimeType = IMAGE_MIME[ext] ?? "application/octet-stream";
   logger.info("Uploading image to ComfyUI via HTTP", { sourcePath, resolvedFilename });
   const result = await uploadImageHttp(resolvedFilename, data, mimeType);
-  return { filename: result.name };
+  return { filename: result.name, subfolder: result.subfolder ?? "" };
 }
 
 // ---------------------------------------------------------------------------
@@ -1025,13 +1030,15 @@ async function uploadMediaHttp(
   filename: string | undefined,
   mimeMap: Record<string, string>,
   kind: "video" | "audio",
-): Promise<{ filename: string }> {
+): Promise<{ filename: string; subfolder: string }> {
   const resolvedFilename = filename ?? basename(sourcePath);
   const mimeType = resolveMediaMime(resolvedFilename, mimeMap, kind);
   const data = await nodeReadFile(sourcePath);
   logger.info(`Uploading ${kind} to ComfyUI via HTTP`, { sourcePath, resolvedFilename });
   const result = await uploadImageHttp(resolvedFilename, data, mimeType);
-  return { filename: result.name };
+  // Same contract as uploadImageAuto: the subfolder travels with the name,
+  // because a subfolder upload's bare name is not a usable loader reference.
+  return { filename: result.name, subfolder: result.subfolder ?? "" };
 }
 
 /** Local filesystem copy of a media file into ComfyUI's input/ (needs COMFYUI_PATH). */

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -877,7 +877,7 @@ export function registerImageManagementTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          'Two meanings, one per action. actions "image"/"video"/"audio" — OPTIONAL override for the filename in ComfyUI\'s input/ directory (auto-detected from source_path if omitted). action:"stage" — REQUIRED filename of the EXISTING output/temp asset to re-register (from get_history or get_image action:"list_outputs"), e.g. LTX_video_00001.mp4; its destination name override is `as_filename`, not this field.',
+          'Two meanings, one per action. actions "image"/"video"/"audio" — OPTIONAL override for the filename in ComfyUI\'s input/ directory (auto-detected from source_path if omitted). A path prefix (e.g. assets/clip.mp4) places the upload in that SUBFOLDER of input/ — ".." is refused — and the returned filename reference includes the subfolder, since loaders need the qualified path. action:"stage" — REQUIRED filename of the EXISTING output/temp asset to re-register (from get_history or get_image action:"list_outputs"), e.g. LTX_video_00001.mp4; its destination name override is `as_filename`, not this field.',
         ),
       subfolder: z
         .string()
@@ -948,13 +948,21 @@ export function registerImageManagementTools(server: McpServer): void {
               "the absolute path of the local file to upload",
             );
             const result = await fn(sourcePath, args.filename);
+            // #946 recurrence: when the filename override carried a path, the
+            // file landed in that SUBFOLDER of input/ — and the bare name the
+            // old text returned did not resolve in a loader (FileNotFoundError
+            // on input/<name>). The reference a loader accepts is the
+            // subfolder-qualified path, so that is what we hand back.
+            const reference = result.subfolder
+              ? `${result.subfolder}/${result.filename}`
+              : result.filename;
             return {
               content: [
                 {
                   type: "text" as const,
                   text:
-                    `Uploaded via HTTP.\n\nFilename: ${result.filename}\n\n` +
-                    `Use "${result.filename}" ${nodeHint}.`,
+                    `Uploaded via HTTP.\n\nFilename: ${reference}\n\n` +
+                    `Use "${reference}" ${nodeHint}.`,
                 },
               ],
             };
@@ -981,20 +989,26 @@ export function registerImageManagementTools(server: McpServer): void {
                 : staged.kind === "audio"
                   ? "the audio input in LoadAudio (or similar)"
                   : "the `image` input in LoadImage";
+            // Same #946 rule as the local uploads above: an as_filename with a
+            // path lands in a subfolder, and the loader reference is the
+            // subfolder-qualified path — the bare filename does not resolve.
+            const stagedRef = staged.subfolder
+              ? `${staged.subfolder}/${staged.filename}`
+              : staged.filename;
             return {
               content: [
                 {
                   type: "text" as const,
                   text:
                     `Staged ${staged.kind} output as input via the server API.\n\n` +
-                    `Input filename: ${staged.filename}\n` +
+                    `Input filename: ${stagedRef}\n` +
                     `subfolder: ${staged.subfolder || "(none)"}\n` +
                     `type: ${staged.type}\n\n` +
-                    `Use "${staged.filename}" as ${loaderHint}.\n\n` +
+                    `Use "${stagedRef}" as ${loaderHint}.\n\n` +
                     `NOTE: the open ComfyUI tab's loader dropdown was populated at page-load, ` +
                     `so this just-registered input is not in it yet — call panel_refresh_nodes ` +
                     `first (it re-pulls /object_info so the new file becomes selectable), THEN ` +
-                    `panel_set_widget the loader's widget to "${staged.filename}". ` +
+                    `panel_set_widget the loader's widget to "${stagedRef}". ` +
                     `(panel_set_widget also self-refreshes on a rejected value, so a single ` +
                     `retry after panel_refresh_nodes will always accept it.)`,
                 },


### PR DESCRIPTION
## Root cause

The first #946 fix (shipped in 0.50.3, #985) taught the transport (`uploadImageHttp`) to split a path-shaped `filename` override (`minimax_h3/walter_ropeflow_clip1_end.png`) into ComfyUI's two real fields: bare `name` + `subfolder` form field. That made the upload itself succeed — but the layers above it still dropped `result.subfolder`:

- `uploadImageAuto` / `uploadMediaHttp` returned only `{ filename: result.name }`, and
- the `upload_image` tool then told the caller `Use "walter_ropeflow_clip1_end.png"`.

The file actually lives at `input/minimax_h3/walter_ropeflow_clip1_end.png`, so the returned bare name does not resolve — queuing a loader failed with `FileNotFoundError` for `C:\comfy\input\walter_ropeflow_clip1_end.png` (the reopened report). A misleading, unusable returned name: the upload "succeeded" under a reference that names nothing.

Two adjacent gaps of the same class:

- `action:"stage"` with an `as_filename` carrying a path had the identical bug (`Use "<bare name>"`).
- `cloud-client.ts`'s `uploadImageHttp` — the parallel implementation its own header warns rots this way — never got the split at all and still sent the whole path as the multipart filename (the original #946 defect, still live on the cloud path).

## Fix

- New `src/comfyui/upload-target.ts`: `splitUploadTarget` moved here so **both** upload clients share it (cloud-client can't import from client.ts without a cycle). `client.ts` re-exports it, so existing imports/tests are untouched.
- `cloud-client.ts` `uploadImageHttp` now splits the target and sends the `subfolder` form field, exactly like its twin.
- `uploadImageAuto` / `uploadMediaHttp` return `{ filename, subfolder }` — the subfolder is part of the answer, not a detail.
- `upload_image` (actions `image`/`video`/`audio` and `stage`) reports the reference a loader actually accepts: `subfolder/name` when a subfolder is involved, bare name otherwise. The `filename` parameter description now discloses the subfolder behavior and the `".."` refusal.

Traversal (`..`) remains refused loudly, unchanged — this closes the *disclosure* half: a path-shaped filename is honored as the subfolder request it always was, and the tool now says the name that resolves.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/comfyui src/__tests__/services src/__tests__/tools` — **326 files, 6707 passed, 3 skipped**
- New regression tests:
  - `media-upload.test.ts`: subfolder propagation through `uploadImageAuto`/`uploadVideoAuto`, `''` default, path-shaped override passed through to the transport
  - `image-assets.test.ts`: tool text reports `Use "minimax_h3/walter_ropeflow_clip1_end.png"` (and never the bare name) for image uploads; stage reports the qualified reference in both the `Use` line and the `panel_set_widget` instruction; bare-name behavior unchanged when no subfolder
  - `cloud-client.test.ts`: cloud `uploadImageHttp` sends the subfolder form field / omits it for plain names / refuses traversal before any request
- Tool description changed, so: `npm run docs:gen` (regenerated `docs/tools/assets-images.mdx` — the only real diff), `npm run check:vocabulary` — OK, `npm run vocab:export -- --check` — OK

Closes #946