### PR TITLE
fix(1567): a new session resumes the downloads its predecessor's death orphaned

### DIFF
--- a/src/__tests__/services/download-adopt-orphans.test.ts
+++ b/src/__tests__/services/download-adopt-orphans.test.ts
@@ -1,0 +1,538 @@
+// #1567 (item 3) — a NEW session AUTO-ADOPTS the downloads its predecessor's death
+// orphaned, instead of leaving the user cancel × N + re-issue × N.
+//
+// A respawned (or crashed) tool session took its in-flight transfers with it but left
+// their records reading "downloading": action:"status" proved each owner dead, and the
+// .partial files were still on disk — everything a resume needs — yet recovery was nine
+// manual cancels and nine manual re-issues for ~48 GB. `adoptOrphanedDownloadJobs` is the
+// recovery the record was always rich enough to perform, and these tests pin both
+// directions: what gets adopted (proven-dead owner + resumable partial + intact URL +
+// local route) and, one refusal at a time, what must be LEFT on the manual path.
+//
+// The model-resolver seam is mocked the way download-jobs.test.ts mocks it (the writer
+// never touches a network or a real models dir), EXCEPT that the real
+// findResumablePartialForLocalDownload / applyHfEndpoint stay live — the partial lookup
+// deriving the writer's cache identity is the thing under test, and mocking it would
+// test the mock.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  resolvers: [] as Array<{ resolve: (p: string) => void; reject: (e: Error) => void; url: string }>,
+  calls: [] as Array<{ url: string; sub?: string; filename?: string }>,
+  routeToManager: false,
+  routeThrows: false,
+  /** URLs resolveDownloadTarget should refuse — models a destination that no
+   *  longer resolves (the re-issue half of adoption must fail closed). */
+  failResolveFor: new Set<string>(),
+}));
+
+vi.mock("../../services/model-resolver.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/model-resolver.js")>(
+    "../../services/model-resolver.js",
+  );
+  return {
+    ...actual,
+    // The route decision adoption stands down on: a Manager-routed session must not
+    // "resume" a local orphan (that would be a fresh server-side dispatch).
+    shouldDispatchDownloadToManager: vi.fn(async () => {
+      if (hoisted.routeThrows) throw new Error("no live server in this test");
+      return hoisted.routeToManager;
+    }),
+    // The writer: never streams. Captures the re-issue arguments and pends until the
+    // test resolves it, exactly like the download-jobs.test.ts harness.
+    downloadModel: vi.fn(
+      (
+        url: string,
+        sub?: string,
+        filename?: string,
+        _auth?: unknown,
+        _dispatch?: boolean,
+        _onResume?: unknown,
+        signal?: AbortSignal,
+        onTrayId?: (trayId: string) => void,
+      ) => {
+        hoisted.calls.push({ url, sub, filename });
+        onTrayId?.(`prog-${url}`);
+        return new Promise<string>((resolve, reject) => {
+          hoisted.resolvers.push({ resolve, reject, url });
+          if (signal) {
+            signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+          }
+        });
+      },
+    ),
+    resolveDownloadTarget: vi.fn(async (url: string, sub: string, filename?: string) => {
+      if (hoisted.failResolveFor.has(url)) throw new Error("models root is gone");
+      const base = filename || String(url).split("/").pop() || "model.safetensors";
+      return { targetDir: `/M/${sub}`, filename: base, targetPath: `/M/${sub}/${base}` };
+    }),
+    // #369 post-landing verification — no live server here, so the honest unknown.
+    verifyLandedModel: vi.fn(async (targetPath: string) => ({
+      verifiedPath: targetPath,
+      liveVisible: "unknown" as const,
+      note: "no live server in this test",
+    })),
+    // The pre-flight listing baseline must not reach a network from a test.
+    liveListingHasEntry: vi.fn(async () => undefined),
+  };
+});
+
+import {
+  adoptOrphanedDownloadJobs,
+  downloadIdFor,
+  listDownloadJobs,
+  resetDownloadJobs,
+} from "../../services/download-jobs.js";
+import {
+  setProgressDir,
+  PERSIST_OWNER,
+  __resetStableRecordsDir,
+} from "../../services/download-progress.js";
+import {
+  findResumablePartial,
+  stagedPartialPathForTarget,
+  stagedPartialPathForUrl,
+  __downloadCacheTestHooks,
+} from "../../services/download-cache.js";
+import { config } from "../../config.js";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join as pathJoin, dirname } from "node:path";
+
+/** A pid guaranteed dead: a child process that already exited (the download-jobs
+ *  test suite's own pattern — the probe must answer ESRCH, not "cannot tell"). */
+const deadPid = (): number => spawnSync(process.execPath, ["-e", ""]).pid;
+
+/** An UNAUTHENTICATED-looking host: no env credential attaches to it, so the
+ *  writer's cache identity for these URLs is the bare URL — letting a test stage
+ *  the partial with the exported one-definition helpers. */
+const URL_X = "https://models.example.invalid/big.safetensors";
+const URL_Y = "https://models.example.invalid/other.safetensors";
+/** The reporter's actual case: a gated HuggingFace URL whose env token folds into
+ *  the cache identity (#467 P1-2), so the bare-URL lookup cannot find its partial. */
+const URL_HF = "https://huggingface.co/org/repo/resolve/main/gated.safetensors";
+
+/** Simulate ANOTHER (dead) session's persisted in-flight record on disk — a
+ *  distinct owner-scoped control-job- file. Mirrors download-jobs.test.ts. */
+function writeForeignJobRecord(
+  dir: string,
+  rec: {
+    id: string;
+    trayId: string;
+    progressId: string;
+    url: string;
+    owner: string;
+    filename?: string;
+    viaManager?: boolean;
+    status?: "downloading" | "done" | "error" | "cancelled";
+    ageMs?: number;
+    pid?: number;
+  },
+): void {
+  const status = rec.status ?? "downloading";
+  writeFileSync(
+    pathJoin(dir, `control-job-${rec.id}-${rec.owner}.json`),
+    JSON.stringify({
+      id: rec.id,
+      trayId: rec.trayId,
+      progressId: rec.progressId,
+      url: rec.url,
+      target_subfolder: "loras",
+      filename: rec.filename,
+      via_manager: rec.viaManager,
+      status,
+      started_at: Date.now(),
+      finished_at: status === "downloading" ? undefined : Date.now(),
+      owner: rec.owner,
+      pid: rec.pid,
+      updated: Date.now() - (rec.ageMs ?? 0),
+    }),
+  );
+}
+
+describe("adoptOrphanedDownloadJobs (#1567 item 3)", () => {
+  let recordDir = "";
+  let cacheDir = "";
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    hoisted.resolvers.length = 0;
+    hoisted.calls.length = 0;
+    hoisted.routeToManager = false;
+    hoisted.routeThrows = false;
+    hoisted.failResolveFor.clear();
+    resetDownloadJobs();
+    saved.COMFYUI_MCP_DATA_DIR = process.env.COMFYUI_MCP_DATA_DIR;
+    saved.COMFYUI_DOWNLOAD_CACHE_DIR = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    saved.HF_ENDPOINT = process.env.HF_ENDPOINT;
+    // A mirror endpoint would rewrite the HF URL and change the staged identity the
+    // authed-partial case derives — pin it away rather than depend on CI's env.
+    delete process.env.HF_ENDPOINT;
+    recordDir = mkdtempSync(pathJoin(tmpdir(), "adopt-records-"));
+    cacheDir = mkdtempSync(pathJoin(tmpdir(), "adopt-cache-"));
+    process.env.COMFYUI_MCP_DATA_DIR = recordDir;
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cacheDir;
+    __resetStableRecordsDir();
+    setProgressDir(recordDir);
+  });
+
+  afterEach(() => {
+    resetDownloadJobs();
+    setProgressDir("");
+    config.huggingfaceToken = undefined;
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    __resetStableRecordsDir();
+    rmSync(recordDir, { recursive: true, force: true });
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  /** Stage a non-zero `.partial` the way the writer names it, for a bare-identity URL. */
+  function stagePartial(url: string, bytes: number): void {
+    const p = stagedPartialPathForUrl(url);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, Buffer.alloc(bytes, 1));
+  }
+
+  it("adopts a proven-dead orphan whose partial is staged — cancel + re-issue collapse into the new session", async () => {
+    const id = "orphan1567x0000001";
+    const owner = "dead-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-1",
+      url: URL_X,
+      owner,
+      filename: "big.safetensors",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    const adopted = await adoptOrphanedDownloadJobs();
+
+    expect(adopted).toHaveLength(1);
+    expect(adopted[0]).toMatchObject({ id, filename: "big.safetensors", resumedBytes: 8192 });
+    // The download was RE-ISSUED with the record's own request…
+    expect(hoisted.calls).toEqual([
+      { url: URL_X, sub: "loras", filename: "big.safetensors" },
+    ]);
+    // …and is tracked as this session's live job…
+    const job = listDownloadJobs().find((j) => j.url === URL_X && j.status === "downloading");
+    expect(job).toBeDefined();
+    // …while the dead owner's record file is gone, replaced by THIS session's
+    // administrative close (durable BEFORE the dead file was removed — #858 order).
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8"),
+    ).toThrow();
+    const ours = JSON.parse(
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${PERSIST_OWNER}.json`), "utf8"),
+    );
+    expect(ours.status).toBe("cancelled");
+    expect(ours.reclaimed_dead).toBe(true);
+  });
+
+  it("leaves a proven-dead orphan with NO staged partial on the manual path — a from-zero restart is a new download, not a recovery", async () => {
+    const id = "orphan1567x0000002";
+    const owner = "dead-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-2",
+      url: URL_X,
+      owner,
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    // No partial staged.
+
+    const adopted = await adoptOrphanedDownloadJobs();
+
+    expect(adopted).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    // Untouched: the record still answers status, and cancel + re-issue still works.
+    expect(
+      JSON.parse(readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8")).status,
+    ).toBe("downloading");
+  });
+
+  it("refuses an orphan whose writer process is still ALIVE — another session's live download is never touched", async () => {
+    const id = "orphan1567x0000003";
+    const owner = "other-live-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-live-3",
+      url: URL_X,
+      owner,
+      ageMs: 10 * 60 * 1000,
+      pid: process.pid, // stale heartbeat, provably-live process
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8"),
+    ).not.toThrow();
+  });
+
+  it("refuses a record with NO writer pid — unprovable is not dead (#761)", async () => {
+    const id = "orphan1567x0000004";
+    const owner = "pre-858-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-unknown-4",
+      url: URL_X,
+      owner,
+      ageMs: 10 * 60 * 1000,
+      // no pid
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+  });
+
+  it("NEVER adopts a remote Manager dispatch — the host may still be fetching, and a 'resume' would be a second dispatch into one destination", async () => {
+    const id = "orphan1567x0000005";
+    const owner = "dead-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-5",
+      url: URL_X,
+      owner,
+      viaManager: true,
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8"),
+    ).not.toThrow();
+  });
+
+  it("refuses a record whose persisted URL lost its query auth — re-issuing a redacted URL fetches a different representation", async () => {
+    // persistDownloadJob strips ?token=… before disk. The trayId hashes the ORIGINAL
+    // URL, so a record whose stored URL no longer hashes to its trayId is exactly
+    // that redacted shape — and must be left for the user rather than re-issued
+    // without its credential.
+    const id = "orphan1567x0000006";
+    const owner = "dead-session";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: "original-urls-tray-id", // ≠ downloadIdFor(rec.url): the stored URL was rewritten
+      progressId: "prog-dead-6",
+      url: URL_X,
+      owner,
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+  });
+
+  it("stands down when a FRESH record for the same id exists — another session already adopted the orphan", async () => {
+    const id = "orphan1567x0000007";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-7",
+      url: URL_X,
+      owner: "dead-session",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    // The adopter's fresh in-flight record for the SAME id (its own owner file).
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-7",
+      url: URL_X,
+      owner: "the-session-that-got-here-first",
+      ageMs: 0,
+      pid: process.pid,
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    // …and the dead record was NOT reclaimed either — stand down means stand down.
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-dead-session.json`), "utf8"),
+    ).not.toThrow();
+  });
+
+  it("ignores terminal records — a finished or cancelled download is not an orphan", async () => {
+    for (const [i, status] of ["done", "cancelled", "error"].entries()) {
+      writeForeignJobRecord(recordDir, {
+        id: `orphan1567x000008${i}`,
+        trayId: downloadIdFor(URL_X),
+        progressId: `prog-term-${i}`,
+        url: URL_X,
+        owner: `dead-session-${i}`,
+        status: status as "done",
+        ageMs: 10 * 60 * 1000,
+        pid: deadPid(),
+      });
+    }
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+  });
+
+  it("stands down entirely on the Manager route — 'resuming' a local orphan server-side is a fresh dispatch, not a resume", async () => {
+    hoisted.routeToManager = true;
+    writeForeignJobRecord(recordDir, {
+      id: "orphan1567x0000009",
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-9",
+      url: URL_X,
+      owner: "dead-session",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+  });
+
+  it("fails closed when the route cannot even be decided — no server answer, no adoption", async () => {
+    hoisted.routeThrows = true;
+    writeForeignJobRecord(recordDir, {
+      id: "orphan1567x0000010",
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-10",
+      url: URL_X,
+      owner: "dead-session",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    await expect(adoptOrphanedDownloadJobs()).resolves.toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+  });
+
+  it("a failed re-issue does not throw and leaves the orphan CLOSED, not wedged", async () => {
+    const id = "orphan1567x0000011";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-dead-11",
+      url: URL_X,
+      owner: "dead-session",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+    hoisted.failResolveFor.add(URL_X);
+
+    const adopted = await adoptOrphanedDownloadJobs();
+
+    expect(adopted).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    // The reclaim already ran (close-before-destroy): the user is left exactly where
+    // the manual path leaves them after a cancel — free to re-issue — never wedged
+    // between "do not re-issue" and "not yours".
+    const ours = JSON.parse(
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${PERSIST_OWNER}.json`), "utf8"),
+    );
+    expect(ours.status).toBe("cancelled");
+    expect(ours.reclaimed_dead).toBe(true);
+  });
+
+  it("finds the partial an ENV-CREDENTIALED download staged — the reporter's actual case (#1567)", async () => {
+    // The cache identity folds the Authorization header in (#467 P1-2), so a gated
+    // download's partial is NOT staged under the bare URL's name. Pin both halves:
+    // the bare lookup misses it, and the adoption lookup — which rebuilds the
+    // headers a re-issue would send now — finds it and resumes.
+    config.huggingfaceToken = "hf-test-token";
+    const authedTarget = __downloadCacheTestHooks.cachePathForUrl(URL_HF, {
+      Authorization: "Bearer hf-test-token",
+    });
+    const staged = stagedPartialPathForTarget(authedTarget);
+    mkdirSync(dirname(staged), { recursive: true });
+    writeFileSync(staged, Buffer.alloc(4096, 1));
+    // The half that made the reporter's partials invisible to the naive lookup:
+    expect(await findResumablePartial(URL_HF)).toBeNull();
+
+    const id = "orphan1567x0000012";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_HF),
+      progressId: "prog-dead-12",
+      url: URL_HF,
+      owner: "dead-session",
+      filename: "gated.safetensors",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+
+    const adopted = await adoptOrphanedDownloadJobs();
+
+    expect(adopted).toHaveLength(1);
+    expect(adopted[0]).toMatchObject({ id, filename: "gated.safetensors", resumedBytes: 4096 });
+    expect(hoisted.calls).toEqual([
+      { url: URL_HF, sub: "loras", filename: "gated.safetensors" },
+    ]);
+  });
+
+  it("adopts ONE of two dead records sharing an id — the second reclaim must not clobber the live replacement's record", async () => {
+    // Two dead sessions each left an in-flight record for the SAME download (same
+    // id). The record snapshot is taken before the loop, so without an explicit
+    // this-pass guard the second record's reclaim would write its administrative
+    // cancel over the replacement job's fresh owner-scoped file.
+    const id = "orphan1567x0000013";
+    for (const owner of ["dead-session-a", "dead-session-b"]) {
+      writeForeignJobRecord(recordDir, {
+        id,
+        trayId: downloadIdFor(URL_X),
+        progressId: "prog-dead-13",
+        url: URL_X,
+        owner,
+        ageMs: 10 * 60 * 1000,
+        pid: deadPid(),
+      });
+    }
+    stagePartial(URL_X, 8192);
+
+    const adopted = await adoptOrphanedDownloadJobs();
+
+    expect(adopted).toHaveLength(1);
+    expect(hoisted.calls).toHaveLength(1);
+    // The replacement job is live and its OWN record still says so — not the
+    // cancelled state a second reclaim would have clobbered it with.
+    const live = listDownloadJobs().find((j) => j.url === URL_X && j.status === "downloading");
+    expect(live).toBeDefined();
+    // The second dead owner's record was left alone (a later pass owns it).
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-dead-session-b.json`), "utf8"),
+    ).not.toThrow();
+  });
+
+  it("WIRING: every new session boots the adoption pass", async () => {
+    // The feature is exactly "the new session adopts" — if boot.ts stops calling
+    // this, every guard above still passes and the recovery silently stops
+    // happening. Assert the call the same way the respawn-orphans suite asserts
+    // its emitter wiring: on the source, comments stripped.
+    const src = readFileSync(new URL("../../boot.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    expect(src).toMatch(/adoptOrphanedDownloadJobs/);
+    expect(src).toMatch(/adoptOrphanedDownloadsOnLoad\(\)/);
+  });
+});

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -18,6 +18,7 @@ import { startHttpServer } from "./transport/http.js";
 import { resolveToolSurfacePolicy } from "./tools/tool-surface-filter.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
+import { adoptOrphanedDownloadJobs } from "./services/download-jobs.js";
 import { checkAndSelfUpdate } from "./services/self-update.js";
 import { tr } from "./i18n/index.js";
 import { banner, labelRows, numberedSteps } from "./i18n/terminal-layout.js";
@@ -70,6 +71,47 @@ function ensurePanelOnLoad(): void {
       }
     })
     .catch(() => {});
+}
+
+/**
+ * #1567 (item 3) — resume the downloads the PREVIOUS session's death orphaned.
+ *
+ * A tool-session respawn (or a crash) kills every transfer that session owned and
+ * leaves their records reading "downloading" forever; recovery used to be cancel
+ * × N + re-issue × N by hand. The new session has everything a resume needs — the
+ * job records and the staged `.partial` files — so it adopts them itself. What gets
+ * adopted and what is deliberately left alone is decided inside
+ * adoptOrphanedDownloadJobs (proven-dead owners only, local route only, resumable
+ * partial required, redacted URLs refused).
+ *
+ * Fire-and-forget, hard-guarded, and never throws — it must never block or crash
+ * startup, mirrors the ensure-panel/self-update pattern. Silent when there is
+ * nothing to adopt: an ordinary boot has no orphans, and a boot line about zero
+ * downloads would be noise on every start.
+ */
+function adoptOrphanedDownloadsOnLoad(): void {
+  void adoptOrphanedDownloadJobs()
+    .then((adopted) => {
+      for (const a of adopted) {
+        logger.info(
+          `Adopted an orphaned download from a dead session (#1567): ` +
+            `${a.filename ?? a.id} — resuming from ${(a.resumedBytes / 1024 / 1024).toFixed(1)} MB ` +
+            `already staged on disk (id ${a.id}, tray ${a.trayId}).` +
+            (a.staleRecordLeft
+              ? ` The dead session's record file could not be deleted (a transient ` +
+                `filesystem error), so action:"status" may keep showing its stale row ` +
+                `for a while — it expires on its own.`
+              : ""),
+        );
+      }
+    })
+    .catch((err) => {
+      logger.warn(
+        `Orphaned-download adoption failed (#1567): ${err instanceof Error ? err.message : String(err)}. ` +
+          `Any downloads a previous session left behind stay on the manual path: ` +
+          `download_model action:"status", then cancel + re-issue each one.`,
+      );
+    });
 }
 
 /**
@@ -581,6 +623,10 @@ async function main() {
   ensurePanelOnLoad();
   // ...and self-check the npm registry for a newer published version (non-blocking).
   selfUpdateOnLoad();
+  // ...and resume any downloads the previous session's death orphaned (non-blocking).
+  // After the server is up deliberately: adoption re-issues real transfers, so it
+  // must not delay or endanger the transport coming up.
+  adoptOrphanedDownloadsOnLoad();
 }
 
 main().catch((err) => {

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1121,8 +1121,12 @@ function cacheDir(): string {
 }
 
 /** #1526 — expose the env-derived cache root so its normalization is testable
- *  without reaching into module internals or touching the filesystem. */
-export const __downloadCacheTestHooks = { cacheDir };
+ *  without reaching into module internals or touching the filesystem.
+ *  #1567 adds `cachePathForUrl` so a test can stage a `.partial` under a SPECIFIC
+ *  header identity (the writer's own derivation) instead of re-implementing the
+ *  hash — a fixture derived from a parallel implementation cannot falsify the
+ *  lookup it feeds (#1370). */
+export const __downloadCacheTestHooks = { cacheDir, cachePathForUrl };
 
 function cacheSizeLimitBytes(): number {
   const raw = Number(process.env.COMFYUI_LRU_CACHE_SIZE_GB ?? "0");
@@ -3438,14 +3442,24 @@ export function stagedPartialPathForUrl(url: string): string {
  * A zero-byte partial reports as absent: resuming from it saves nothing, and calling it
  * resumable would restate this issue's bug in miniature — a claim of retained bytes where
  * there are none.
+ *
+ * `headers` are the representation-affecting request headers the lookup should assume —
+ * the staged name folds them into the cache identity (#467 P1-2), so a download that
+ * streamed WITH auth headers stages its partial under a different name than the bare URL
+ * produces. A caller looking for the partial a re-issued download would resume from must
+ * pass the headers that re-issue would send NOW (see
+ * `findResumablePartialForLocalDownload` in model-resolver, #1567); omitting them keeps
+ * the historical bare-URL behaviour, whose scope the note on `stagedPartialPathForUrl`
+ * states. A miss still means "none found under this identity", never "none exists".
  */
 export async function findResumablePartial(
   url: string | undefined,
+  headers: Record<string, string> = {},
 ): Promise<{ path: string; bytes: number } | null> {
   if (typeof url !== "string" || !url.trim()) return null;
   let candidate: string;
   try {
-    candidate = stagedPartialPathForUrl(url.trim());
+    candidate = stagedPartialPathForTarget(cachePathForUrl(url.trim(), headers));
   } catch {
     return null;
   }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -19,6 +19,7 @@ import { realpath } from "node:fs/promises";
 import { extname, basename, dirname, join } from "node:path";
 import {
   downloadModel,
+  findResumablePartialForLocalDownload,
   liveListingHasEntry,
   managerJobFilename,
   resolveDownloadTarget,
@@ -1654,6 +1655,152 @@ function reclaimDeadPersistedDownload(
     }
   }
   return { reclaimed: true, staleRecordLeft: !removed };
+}
+
+/** One orphan a new session resumed — the report boot logs from. */
+export interface OrphanedDownloadAdoption {
+  /** The DEAD record's public id (the replacement job may key itself differently
+   *  when the destination re-resolves onto another root — the report names the
+   *  record that was adopted, not the new job). */
+  id: string;
+  trayId: string;
+  filename?: string;
+  /** Bytes found staged in the `.partial` the replacement writer resumes from. */
+  resumedBytes: number;
+  /** The replacement writer is running, but the dead owner's record file could not
+   *  be deleted — action:"status" may show its stale row until it expires. Disclosed,
+   *  never hidden (same contract as the cancel path's reclaim). */
+  staleRecordLeft?: boolean;
+}
+
+/**
+ * #1567 (item 3) — AUTO-ADOPT the downloads a dead session left behind.
+ *
+ * A respawned tool session used to find its predecessor's transfers like this:
+ * every record still said "downloading", `action:"status"` correctly proved each
+ * owner dead ("NOT running — the owning process is gone"), and recovery was
+ * cancel × N + re-issue × N — by hand, for a job record plus a `.partial` that
+ * between them already contained everything a resume needs. The reporter did that
+ * dance for nine transfers and ~48 GB.
+ *
+ * This is the recovery the record was always rich enough to perform: run once when
+ * a new session boots, it finds each in-flight record whose writer is PROVEN dead
+ * and whose staged `.partial` a re-issue would resume from, closes the dead record
+ * through the same reviewed reclaim the cancel path uses (#858 — terminal state
+ * durable BEFORE anything is destroyed, dead tray row cleared unless something
+ * live shares it), and re-issues the download. The new writer's own resume
+ * handshake (If-Range against the staged bytes) decides how much of the partial
+ * still counts — adoption never asserts a resume the server did not honour.
+ *
+ * Every guard below REFUSES rather than guesses, and each refusal leaves the record
+ * on the manual cancel + re-issue path exactly as before:
+ *
+ *  - PROVEN dead only (ESRCH). A live or unprovable owner (`undefined`) is never
+ *    touched — absence of evidence is not evidence of absence (#761/#858).
+ *  - Never a Manager dispatch: the server-side fetch may still be running on the
+ *    host, and "adopting" it would be a second dispatch into the same destination
+ *    (the one outcome the proven-dead note exists to prevent).
+ *  - Never from a redacted URL. Persisted records strip query auth before disk, so
+ *    the record's URL can differ from the one that was requested; re-issuing THAT
+ *    would fetch a different (unauthenticated) representation. `trayId` hashes the
+ *    ORIGINAL URL, so `downloadIdFor(rec.url) === rec.trayId` proves the URL
+ *    survived byte-identically; anything else is declined.
+ *  - Never a from-zero restart. The issue's condition is a `.partial` the new
+ *    session can actually resume: without one, automatically beginning a multi-GB
+ *    transfer is a new download, not a recovery — and a miss can also mean the
+ *    partial is keyed under a credential this session no longer holds, which #1378
+ *    makes deliberately unreachable. Either way the record is left for the user.
+ *  - Never twice. A FRESH in-flight record for the same id means another session
+ *    already adopted the orphan; stand down. (Two sessions scanning in the same
+ *    instant can still both pass this check — startDownloadJob's own fresh-foreign
+ *    adoption then makes the loser a read-only observer, and the #467 O_EXCL
+ *    staging bounds the residue to a duplicate transfer, never a corrupt file.
+ *    Best-effort, same contract as #529.)
+ *  - Never on the Manager route: if THIS session would dispatch to the remote
+ *    Manager, "resuming" a local orphan would be a fresh server-side fetch, not a
+ *    resume — so the whole pass stands down when the route (or the server needed
+ *    to decide it) is unavailable.
+ *
+ * Best-effort by construction: a re-issue that fails (destination unresolvable,
+ * server unreachable) is logged and skipped, and the record — already closed as an
+ * administrative cancel by the reclaim — stays exactly where the manual path would
+ * have left it. Never throws: it runs at server boot, which must not fail over a
+ * recovery convenience.
+ */
+export async function adoptOrphanedDownloadJobs(): Promise<OrphanedDownloadAdoption[]> {
+  const adopted: OrphanedDownloadAdoption[] = [];
+  if (!persistedRecordsEnabled()) return adopted;
+  let routeToManager: boolean;
+  try {
+    routeToManager = await shouldDispatchDownloadToManager();
+  } catch {
+    // No live server answer — the route cannot be decided, so no adoption verdict
+    // is safe. Fail closed: the records keep for the next session (or the manual path).
+    return adopted;
+  }
+  if (routeToManager) return adopted;
+
+  const now = Date.now();
+  const records = listPersistedDownloadJobs();
+  // Ids this pass already re-issued. `records` is a SNAPSHOT taken before the loop,
+  // so without this a second dead record for the SAME id (two dead sessions each
+  // left one) would be reclaimed AFTER our replacement job persisted its fresh
+  // record — and the reclaim's administrative-cancel write targets the same
+  // owner-scoped file, clobbering the live "downloading" record until the next
+  // heartbeat. One adoption per id per pass.
+  const adoptedIds = new Set<string>();
+  for (const rec of records) {
+    if (rec.status !== "downloading") continue;
+    if (!rec.owner || rec.owner === PERSIST_OWNER) continue;
+    if (rec.via_manager) continue;
+    if (writerProcessGone(rec) !== true) continue;
+    if (!rec.url || downloadIdFor(rec.url) !== rec.trayId) continue;
+    if (adoptedIds.has(rec.id)) continue;
+    const alreadyAdopted = records.some(
+      (other) =>
+        other !== rec &&
+        other.id === rec.id &&
+        other.status === "downloading" &&
+        now - (other.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+    );
+    if (alreadyAdopted) continue;
+    // unknown-ok: adoption only ever ACTS on a positive answer. "The lookup
+    // failed" and "nothing is staged" both lead to `continue` — the record is
+    // left untouched on the manual cancel + re-issue path, nothing is reclaimed,
+    // destroyed, or re-issued — so collapsing a failed observation into "none
+    // found" can only decline a convenience, never assert a wrong one.
+    const partial = await findResumablePartialForLocalDownload(rec.url).catch(() => null);
+    if (!partial) continue;
+
+    const reclaim = reclaimDeadPersistedDownload(rec);
+    // Lost a race with the probe or the persist — fail closed, touch nothing more.
+    if (!reclaim.reclaimed) continue;
+
+    try {
+      const entry = await startDownloadJob(rec.url, rec.target_subfolder, rec.filename);
+      // A keys-less entry is the READ-ONLY view of another session's fresh writer
+      // (#529): the orphan is adopted, but not by us — let that session's boot log
+      // claim it rather than reporting a writer we do not own.
+      if (entry.keys.length === 0) continue;
+    } catch (err) {
+      logger.warn(
+        `[download] orphaned job ${rec.id} (${rec.filename ?? rec.url}) could not be ` +
+          `re-issued in this session: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Its record is already closed as an administrative cancel; re-issue ` +
+          `download_model action:"download" to retry it.`,
+      );
+      continue;
+    }
+    adopted.push({
+      id: rec.id,
+      trayId: rec.trayId,
+      filename: rec.filename,
+      resumedBytes: partial.bytes,
+      staleRecordLeft: reclaim.staleRecordLeft || undefined,
+    });
+    adoptedIds.add(rec.id);
+  }
+  return adopted;
 }
 
 /**

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -14,7 +14,7 @@ import {
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError, unreachableHostMessage } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { downloadWithCache, probeRemoteModelPayload } from "./download-cache.js";
+import { downloadWithCache, findResumablePartial, probeRemoteModelPayload } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import { modelNotFoundMessage } from "./model-root-scope.js";
@@ -2529,6 +2529,34 @@ function localAuthHeadersFor(
     headers["Authorization"] = `Bearer ${civitaiToken}`;
   }
   return headers;
+}
+
+/**
+ * #1567 (item 3) — the resumable `.partial` a LOCAL writer for `url` would pick up
+ * if the download were re-issued RIGHT NOW, or null when none is found.
+ *
+ * The bare-URL `findResumablePartial(url)` reproduces the writer's staged name only
+ * for an UNAUTHENTICATED download: the cache identity folds in the representation
+ * headers (#467 P1-2), and the common gated case — a CivitAI/HuggingFace token from
+ * the environment, exactly the #1567 reporter's setup — sends one, so its partial
+ * is staged under a name the bare URL never produces and the plain lookup reports
+ * "no partial" for gigabytes that are sitting on disk.
+ *
+ * This wrapper rebuilds the request the local streaming path would make TODAY —
+ * the same HF_ENDPOINT rewrite and the same env-credential header block
+ * `downloadModel` applies, through the same `localAuthHeadersFor` definition, so
+ * the lookup and the writer cannot drift apart — and stats the partial under THAT
+ * identity. Explicit per-request auth (and cloud credentials) are deliberately NOT
+ * reproducible here: a job record keeps no credential, so those partials miss, and
+ * a miss means "none found under the identity a re-issue would use now", never
+ * "none exists".
+ */
+export async function findResumablePartialForLocalDownload(
+  url: string,
+): Promise<{ path: string; bytes: number } | null> {
+  const wasHfUrl = /^https?:\/\/huggingface\.co([/?#]|$)/i.test(url);
+  const rewritten = applyHfEndpoint(url);
+  return findResumablePartial(rewritten, localAuthHeadersFor(rewritten, undefined, wasHfUrl));
 }
 
 /**


### PR DESCRIPTION
## Root cause

Item 3 of #1567 (items 1, 2, 4 already shipped in v0.51.57 via #1613). A tool-session respawn — or any crash — kills every transfer that session owned, but their persisted records keep reading `"downloading"`. `download_model action:"status"` proved each owner dead ("NOT running — the owning process is gone", #1479), yet recovery was **cancel × N + re-issue × N by hand** — the reporter did that for nine transfers and ~48 GB — even though the job records plus the staged `.partial` files already contained everything a resume needs. Dead-owner detection existed; only recovery was missing.

## What changed

A new session now **adopts those orphans itself once at boot** (`adoptOrphanedDownloadJobs`, called fire-and-forget from `boot.ts` after the server is up). For each persisted in-flight record whose writer is **proven dead** (pid answers ESRCH) and whose staged `.partial` a re-issue would resume from, it:

1. closes the dead record through the **existing #858 reclaim** — terminal state durable *before* anything is destroyed, dead tray row cleared unless something live shares it;
2. re-issues the download via `startDownloadJob` — the replacement writer's own If-Range handshake decides how much of the partial still counts, so adoption never asserts a resume the server did not honour.

Every guard refuses rather than guesses, and each refusal leaves the record on the manual cancel + re-issue path exactly as before:

- **proven dead only** — a live or unprovable owner (`undefined`: no pid, probe failed, foreign host) is never touched (#761/#858 semantics);
- **never a Manager dispatch** — the server-side fetch may still be running on the host; "adopting" it would be a second dispatch into one destination;
- **never from a redacted URL** — persisted records strip query auth before disk; `downloadIdFor(rec.url) === rec.trayId` proves the URL survived byte-identically, anything else is declined;
- **never a from-zero restart** — the issue's condition is a resumable `.partial`; without one, an automatic multi-GB transfer is a new download, not a recovery;
- **never twice** — a fresh in-flight record for the same id (or one adopted earlier in this pass) stands the pass down; the residual same-instant cross-process race degrades to the #529 read-only adoption / a bounded duplicate transfer, never a corrupt file;
- **never on the Manager route** — the whole pass stands down when this session would dispatch remotely, or when the route cannot even be decided (no live server answer).

One subtlety worth calling out: the `.partial` lookup had to become **auth-aware**. The cache identity folds representation headers in (#467), so an env-credentialed download — the reporter's exact case, CivitAI token from the env file — stages its partial under a name the bare-URL `findResumablePartial` can never produce. `findResumablePartialForLocalDownload` (model-resolver) rebuilds the request the writer would make *now* (same HF_ENDPOINT rewrite, same env-credential header block, through the same `localAuthHeadersFor` definition, so lookup and writer cannot drift), and `findResumablePartial` gained an optional `headers` parameter (default keeps the historical bare-URL behaviour). A test pins both halves: the bare lookup misses the credentialed partial, the adoption lookup finds it.

## Verification

- `npm ci` — clean
- `npm run build` (`tsc`) — clean
- New suite `src/__tests__/services/download-adopt-orphans.test.ts` — **14/14 pass**: adoption happy path, each refusal (live owner, no pid, Manager dispatch, redacted URL, fresh sibling, terminal records, Manager route, undecidable route), failed-reissue fail-closed, the env-credentialed partial case, two-dead-records-one-id (the second reclaim must not clobber the live replacement's record), and a wiring test pinning the boot call.
- Neighbouring suites: `download-jobs` (92), `download-cancel-partial`, `download-status-proven-dead`, `respawn-orphans-downloads`, `download-progress`, `download-persist-atomic`, `download-persist-contention` (185 total), `model-resolver`/`download-cache`/`storage-download-integrity`/status suites (166), `boot-server-version`/`cli-strings`/`tool-surface-filter` (46) — all pass.
- `npm run check:vocabulary` — OK (tool descriptions unchanged, so `docs:gen`/`vocab:export --check` not implicated).

## Deliberately not in this PR

- **Item 5 (mark dead tray rows in the panel download tray).** The tray renderer lives in the comfyui-mcp-panel repo and cannot probe pids from the browser; dead-owner state would have to flow to it through a bridge channel. Adopted orphans heal their own rows (the reclaim clears the dead row, the new writer supersedes it), so this PR narrows item 5 to rows whose downloads were *not* adopted. Filed as a follow-up rather than half-done here.
- Auto-adopting orphans with **no reachable `.partial`** (from-zero restarts) — left on the manual path per the issue's own condition.

Closes #1567