### PR TITLE
fix(docs): drop unsupported fa from the Mintlify language switcher

### DIFF
--- a/design/writing-blog-posts.md
+++ b/design/writing-blog-posts.md
@@ -194,6 +194,14 @@ and try splitting it.
 
 `docs/<locale>/` mirrors five entry pages. When adding or regenerating one:
 
+**Mintlify language codes are a closed enum.** `navigation.languages[].language` must be a
+code their schema accepts (`https://www.mintlify.com/docs.json`). An unknown code fails the
+**entire** production build and leaves the previous deploy up — that is how the site froze
+on the Korean pilot after Persian (`fa`) was added. `fa` is a real BCP-47 tag and a real
+panel locale; it is not a Mintlify language. Keep `docs/fa/*.mdx` in git; do not put `fa`
+back in the switcher until their schema lists it. `check:docs-links` now rejects an
+unsupported code.
+
 **Never translate:** fenced code (including comments inside it), inline backticks (flags, env
 vars, paths, tool names, `action` values, JSON keys), MDX component names and props, URLs, the
 target half of a link, `icon:` tokens, or frontmatter *keys*.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -385,26 +385,6 @@
             ]
           }
         ]
-      },
-      {
-        "language": "fa",
-        "tabs": [
-          {
-            "tab": "راهنماها",
-            "groups": [
-              {
-                "group": "شروع به کار",
-                "pages": [
-                  "fa/index",
-                  "fa/quickstart",
-                  "fa/installation",
-                  "fa/panel",
-                  "fa/troubleshooting"
-                ]
-              }
-            ]
-          }
-        ]
       }
     ]
   },

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -25,6 +25,18 @@ const DOCS = path.join(ROOT, 'docs');
 
 const cfg = JSON.parse(fs.readFileSync(path.join(DOCS, 'docs.json'), 'utf8'));
 
+// Mintlify's docs.json schema enum for navigation.languages[].language.
+// Measured 2026-08-18 from https://www.mintlify.com/docs.json — `fa` is NOT in it.
+// An unsupported code fails the whole production build and leaves the last good
+// deploy up (Korean-only, after #1577, once `fa` landed in #9b241e0).
+const MINTLIFY_LANGUAGES = new Set([
+  "en", "cn", "zh", "zh-Hans", "zh-Hant", "zh-CN", "zh-TW",
+  "es", "fr", "fr-CA", "fr-ca", "ja", "jp", "ja-jp", "ja-JP",
+  "pt", "pt-BR", "de", "ko", "it", "ru", "ro", "cs", "id",
+  "ar", "tr", "hi", "sv", "no", "da", "lv", "nl", "uk", "vi",
+  "pl", "uz", "he", "ca", "fi", "hu",
+]);
+
 /** Every page path the navigation references, wherever it is nested. */
 function navPages(node, out = []) {
   if (Array.isArray(node)) {
@@ -112,6 +124,17 @@ console.log(`pages in navigation: ${listed.length}`);
 console.log(`anchor-only links (not checked): ${anchorOnly.length}`);
 
 let failures = 0;
+const langCodes = (cfg.navigation?.languages ?? [])
+  .map((l) => l?.language)
+  .filter((c) => typeof c === "string");
+const badLangs = langCodes.filter((c) => !MINTLIFY_LANGUAGES.has(c));
+if (badLangs.length) {
+  failures += badLangs.length;
+  console.error(
+    `\n✗ ${badLangs.length} language code(s) Mintlify's docs.json schema does not accept — this fails the production build:`,
+  );
+  for (const c of badLangs) console.error(`    ${c}`);
+}
 if (missing.length) {
   failures += missing.length;
   console.error(`\n✗ ${missing.length} navigation entr(ies) with no file — these 404 from the sidebar:`);


### PR DESCRIPTION
The docs site auto-deployed until the Korean pilot, then froze. That is a **failed production build**, not a dead webhook.

**Cause (measured against Mintlify's live schema, 2026-08-18).**
`navigation.languages[].language` is a closed enum on `https://www.mintlify.com/docs.json`. `fa` is not in it. `ko`, `ja`, `zh`, `zh-TW`, `pt-BR`, `tr`, `ar`, … are.

`9b241e0` added Persian to the switcher. Every later docs push — including the blog audit — has been building a schema-invalid `docs.json`. Mintlify keeps the last successful deploy, which is why:

- `/docs/ko/*` is live (the last good build)
- `/docs/ja`, `/zh`, `/fr`, … 404
- the WAN post still has the pre-audit `(2026 Guide)` title
- `Mintlify Deployment: skipped` on GitHub is still a preview check and is not the signal

**Fix.** Remove `fa` from the switcher. Leave `docs/fa/*.mdx` in git — it is a real panel locale; Mintlify just will not accept it as a language until their schema lists it. `check:docs-links` now fails the build if anyone puts an unsupported code back.

Merging this should be enough for auto-deploy to resume, because `docs.json` is the file Mintlify actually builds.
