### PR TITLE
fix(1249): free_vram on a frozen tab is settled server-side, not left unverifiable

### DIFF
--- a/src/__tests__/orchestrator/free-vram-frozen-tab.test.ts
+++ b/src/__tests__/orchestrator/free-vram-frozen-tab.test.ts
@@ -1,0 +1,239 @@
+// #1249 — panel_free_vram on a FROZEN canvas tab. The command is a purely
+// server-side operation (the panel's handler is a plain POST /free), yet the
+// tool treated the tab's ack as the only source of truth: a reply timeout left
+// the caller with "MUTATES … may have been applied" and no way to verify
+// recovery — the tool even warns against retrying, so recovery could never be
+// confirmed.
+//
+// The settle: when the tab PROVABLY fronts the orchestrator's local boot
+// instance (the captureRebootHealthBase gate), issue /free DIRECTLY and verify
+// on the server's own answer, reading /system_stats around it for the VRAM
+// counters. /free is idempotent, so the copy the frozen tab may still execute
+// when it wakes cannot double-apply — the hazard that bars this path for every
+// other mutation does not exist for this one command. Every case that cannot
+// be verified returns the original outcome-unknown UNTOUCHED.
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+
+/** The orchestrator's immutable boot endpoint — what the direct /free aims at. */
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+/** The bridge's canonical no-reply for a MUTATING command, verbatim from a live
+ *  UiBridge against a frozen tab (the exact string the issue reports). */
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+let sent: string[] = [];
+
+function bridge(opts: {
+  reply: "timeout" | "acked-error" | "acked-error-timeout-worded" | "ok";
+  /** What the captureRebootHealthBase gate sees: is this a server-trusted local
+   *  tab whose handshake origin matches the boot instance? */
+  local?: boolean;
+  origin?: string | null;
+}): PanelToolCtx["bridge"] {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd !== "free_vram") return { ok: true };
+      if (opts.reply === "ok") return { freed: true, unload_models: true, free_memory: true };
+      if (opts.reply === "acked-error") {
+        // The panel's OWN verdict: /free answered non-OK and the tab SAID so.
+        throw new Error("Failed to free VRAM: 500 Internal Server Error — OOM in unload");
+      }
+      if (opts.reply === "acked-error-timeout-worded") {
+        // An ACKED panel error quoting the bridge's canonical timeout sentence
+        // verbatim — text is NOT the discriminator (#1468 round 2); the missing
+        // markReplyTimeout tag is the difference that actually exists.
+        throw new Error(
+          `Panel tab ${TAB} did not reply to "free_vram" within 15000 ms — the ComfyUI tab ` +
+            `may be backgrounded or frozen. Reported by the executor: /free answered 503.`,
+        );
+      }
+      throw markReplyTimeout(ackTimeout("free_vram", 15000));
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    // The direct-path gate reads the SERVER-OBSERVED handshake origin and the
+    // token-less-loopback provenance, never the spoofable hello.comfyui_url.
+    tabIsLocal: () => opts.local ?? true,
+    tabServerOrigin: () =>
+      opts.origin === undefined ? BOOT_BASE : (opts.origin ?? undefined),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function run(
+  opts: Parameters<typeof bridge>[0],
+): Promise<{ text: string; isError: boolean }> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
+  if (!def) throw new Error("panel_free_vram is not registered");
+  const res: ToolResult = await def.handler({} as never, ctx);
+  return { text: textOf(res), isError: res.isError === true };
+}
+
+/** The scripted server-side /free outcomes a test can inject. */
+const DIRECT_OK = {
+  ok: true,
+  before: [{ name: "cuda:0", vram_total: 16_000, vram_free: 2_000 }],
+  after: [{ name: "cuda:0", vram_total: 16_000, vram_free: 15_000 }],
+};
+const DIRECT_OK_NO_STATS = { ok: true, before: null, after: null };
+const DIRECT_FAIL = { ok: false, reason: "POST http://127.0.0.1:8188/free answered HTTP 500" };
+
+let directCalls: string[] = [];
+
+beforeEach(() => {
+  sent = [];
+  directCalls = [];
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setFreeVramDirect(null);
+});
+
+describe("panel_free_vram on a frozen tab is settled server-side (#1249)", () => {
+  it("issues /free directly and reports the verified outcome when the tab fronts the local server", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "timeout" });
+
+    // The tab was asked exactly once — nothing was re-dispatched through it.
+    expect(sent).toEqual(["free_vram"]);
+    // The direct path aimed at the PROVEN base, not a spoofable hello URL.
+    expect(directCalls).toEqual([BOOT_BASE]);
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).toMatch(/"verified": "server-side"/);
+    expect(out.text).toMatch(/"acknowledged": false/);
+    // The observed counters, not a claimed delta.
+    expect(out.text).toMatch(/"vram_before"/);
+    expect(out.text).toMatch(/"vram_after"/);
+    // The disclosure says what happened and why the queued tab copy is harmless.
+    expect(out.text).toMatch(/never acknowledged/);
+    expect(out.text).toMatch(/idempotent/);
+  });
+
+  it("says the 2xx — not a measured delta — is the verification when /system_stats does not answer", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async () => DIRECT_OK_NO_STATS);
+    const out = await run({ reply: "timeout" });
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/"vram_before"/);
+    expect(out.text).toMatch(/no VRAM counters are reported/);
+  });
+
+  it("returns the outcome-unknown UNTOUCHED when the tab is not a server-trusted local tab", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "timeout", local: false });
+
+    // The gate refused: no direct /free was ever attempted at an unproven server.
+    expect(directCalls).toEqual([]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).not.toMatch(/server-side/);
+  });
+
+  it("returns the outcome-unknown UNTOUCHED when the tab's handshake origin is a DIFFERENT instance", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "timeout", origin: "http://127.0.0.1:8288" });
+
+    // Freeing the BOOT server and reporting it as this command's success would
+    // be a wrong-target success — worse than the honest unknown being fixed.
+    expect(directCalls).toEqual([]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+  });
+
+  it("keeps the outcome UNKNOWN — and names what was tried — when the direct /free also fails", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async () => DIRECT_FAIL);
+    const out = await run({ reply: "timeout" });
+
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).toMatch(/server-side fallback also could not reach/);
+    expect(out.text).toMatch(/HTTP 500/);
+    expect(out.text).toMatch(/UNVERIFIED/);
+  });
+
+  it("does NOT re-issue behind an ACKED executor error — the panel already said what failed", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "acked-error" });
+
+    expect(sent).toEqual(["free_vram"]);
+    expect(directCalls).toEqual([]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/Failed to free VRAM: 500/);
+  });
+
+  it("does NOT settle an acked error that merely QUOTES the timeout sentence (#1468 round 2)", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "acked-error-timeout-worded" });
+
+    // Not markReplyTimeout-tagged, so the settle must not fire on the text.
+    expect(directCalls).toEqual([]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/\/free answered 503/);
+  });
+
+  it("passes a normal acknowledgement through unchanged", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      directCalls.push(base);
+      return DIRECT_OK;
+    });
+    const out = await run({ reply: "ok" });
+
+    expect(directCalls).toEqual([]);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/server-side/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -721,6 +721,11 @@ export const __panelToolsTestHooks = {
   ): void {
     declineProbeTimingOverride = timing;
   },
+  /** Inject a fake #1249 server-side /free so the frozen-tab settle can be
+   *  driven without real HTTP. null restores the live freeVramDirect. */
+  setFreeVramDirect(fn: ((base: string) => Promise<FreeVramDirectOutcome>) | null): void {
+    freeVramDirectOverride = fn;
+  },
   /** Direct access to the #742 decline recheck loop so its hard-deadline
    *  guarantee (codex gate r2) can be unit-tested with a custom deadline. */
   probeDeclineRecovery,
@@ -2411,6 +2416,186 @@ async function settleExitSubgraphAfterAckTimeout(
     };
   }
   return timedOut;
+}
+
+// ---- panel_free_vram: verifiable when the canvas tab is frozen (#1249) -----
+// `free_vram` is a purely SERVER-SIDE operation — the panel's handler is a plain
+// `POST /free` against the ComfyUI the tab fronts — yet the tool treated the
+// frozen tab's ACK as the only source of truth: a reply timeout left the caller
+// with "MUTATES … may have been applied" and no way to verify recovery. The
+// settle below takes the path the tab was only proxying: when the tab PROVABLY
+// fronts the orchestrator's local boot instance (the captureRebootHealthBase
+// gate — loopback, server-trusted, handshake-origin-matched), issue /free
+// DIRECTLY and read /system_stats around it.
+//
+// Why re-issuing is safe HERE and nowhere else on the timeout path: /free is
+// IDEMPOTENT. Unloading already-unloaded models and freeing an already-empty
+// cache is a no-op, so the copy the frozen tab may still execute when it wakes
+// cannot double-apply — the exact hazard the bridge's "do not blind-retry"
+// disclosure guards against for every other mutation does not exist for this
+// one command. This is a per-command exception, argued per command; it is NOT a
+// precedent for settling other mutations this way.
+
+/** Per-request bound for the direct /free + /system_stats round-trips, so a
+ *  wedged server degrades to the honest outcome-unknown instead of hanging the
+ *  tool call. ComfyUI applies /free synchronously before answering, so a large
+ *  unload can take seconds — 10s matches the bound probeComfyEndpoint callers
+ *  already pay on this same server. */
+const FREE_VRAM_DIRECT_TIMEOUT_MS = 10_000;
+
+/** The VRAM counters of one /system_stats device entry, read when present. */
+interface VramDeviceSample {
+  name?: string;
+  vram_total?: number;
+  vram_free?: number;
+}
+
+/** GET `${base}/system_stats` and return its device VRAM counters, or null when
+ *  the read cannot answer (unreachable, non-2xx, non-ComfyUI body). Never
+ *  throws: an unreadable stat is "no numbers", never evidence in either
+ *  direction — the POST's own status is what certifies the free. */
+async function readVramDevices(
+  base: string,
+  timeoutMs: number,
+): Promise<VramDeviceSample[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  timer.unref?.();
+  try {
+    const res = await comfyuiFetch(`${base}/system_stats`, {
+      signal: controller.signal,
+      redirect: "manual",
+    });
+    if (res.status < 200 || res.status >= 300) return null;
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return null; // 2xx but not JSON — up, but not a /system_stats we trust
+    }
+    if (!looksLikeSystemStats(body)) return null;
+    const devices = (body as { devices?: unknown }).devices;
+    if (!Array.isArray(devices)) return null;
+    return devices.map((d) => {
+      const dev = (d ?? {}) as Record<string, unknown>;
+      const sample: VramDeviceSample = {};
+      if (typeof dev.name === "string") sample.name = dev.name;
+      if (typeof dev.vram_total === "number") sample.vram_total = dev.vram_total;
+      if (typeof dev.vram_free === "number") sample.vram_free = dev.vram_free;
+      return sample;
+    });
+  } catch {
+    return null; // unreachable/timed out — no numbers to report
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface FreeVramDirectOutcome {
+  ok: boolean;
+  /** Failure detail when !ok (HTTP status / transport error), already worded
+   *  for the caller. Absent on success. */
+  reason?: string;
+  before?: VramDeviceSample[] | null;
+  after?: VramDeviceSample[] | null;
+}
+
+/** Issue ComfyUI's /free DIRECTLY against a proven-local base and read the
+ *  VRAM counters around it. Never throws — every failure is a value, so the
+ *  settle can degrade to the honest outcome-unknown instead of masking the
+ *  original timeout behind a new error. */
+async function freeVramDirect(base: string): Promise<FreeVramDirectOutcome> {
+  const before = await readVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FREE_VRAM_DIRECT_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const res = await comfyuiFetch(`${base}/free`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ unload_models: true, free_memory: true }),
+      signal: controller.signal,
+      redirect: "manual",
+    });
+    if (res.status < 200 || res.status >= 300) {
+      return { ok: false, reason: `POST ${base}/free answered HTTP ${res.status}` };
+    }
+  } catch (err) {
+    const msg = controller.signal.aborted
+      ? `POST ${base}/free did not answer within ${FREE_VRAM_DIRECT_TIMEOUT_MS} ms`
+      : `POST ${base}/free failed: ${err instanceof Error ? err.message : String(err)}`;
+    return { ok: false, reason: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+  const after = await readVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
+  return { ok: true, before, after };
+}
+
+/** Test injection for the direct server-side /free, so the settle can be
+ *  driven without real HTTP. null restores the live path. */
+let freeVramDirectOverride: ((base: string) => Promise<FreeVramDirectOutcome>) | null = null;
+
+/**
+ * After an ack timeout on `free_vram`, settle the outcome against the one
+ * channel a frozen tab cannot block: the ComfyUI server itself.
+ *
+ * Returns the timeout UNTOUCHED in every case where nothing was verified —
+ * no provable local server (remote/cloud tab, ambiguous origin, untrusted
+ * socket), or a direct /free that itself failed. #1473's rule: an unknown
+ * answer claims nothing in either direction, and the bridge's original
+ * outcome-unknown disclosure is already the honest verdict there.
+ */
+async function settleFreeVramAfterAckTimeout(
+  ctx: PanelToolCtx,
+  timedOut: ToolResult,
+): Promise<ToolResult> {
+  // The same gate the restart certification uses: null unless the tab PROVABLY
+  // fronts THIS orchestrator's local boot instance (loopback + server-trusted +
+  // handshake-origin match). Without that proof a direct /free could aim at a
+  // DIFFERENT server than the one the tab was asked to free — reporting that as
+  // this command's success would be the wrong-target success the gate exists to
+  // prevent, which is worse than the honest unknown being fixed.
+  const base = captureRebootHealthBase(ctx);
+  if (!base) return timedOut;
+  const direct = await (freeVramDirectOverride ?? freeVramDirect)(base);
+  if (!direct.ok) {
+    // The tab never answered AND the server-side path failed. The outcome stays
+    // unknown — say so, and name what was tried, without claiming either way.
+    const text = timedOut.content?.find((c) => c.type === "text")?.text ?? "";
+    return {
+      ...timedOut,
+      content: [
+        {
+          type: "text",
+          text:
+            `${text}\n\nThe server-side fallback also could not reach ComfyUI's /free ` +
+            `(${direct.reason ?? "no detail"}), so whether VRAM was freed remains UNVERIFIED — ` +
+            `check with get_system_stats (action:"health") once the server answers.`,
+        },
+      ],
+    };
+  }
+  const statsNote =
+    direct.before != null && direct.after != null
+      ? "vram_before/vram_after are the server's own /system_stats counters around the free."
+      : "The /system_stats read around it did not answer, so no VRAM counters are reported — the 2xx from /free is the verification, not a measured delta.";
+  return ok({
+    freed: true,
+    unload_models: true,
+    free_memory: true,
+    acknowledged: false,
+    verified: "server-side",
+    via: `POST ${base}/free`,
+    ...(direct.before != null ? { vram_before: direct.before } : {}),
+    ...(direct.after != null ? { vram_after: direct.after } : {}),
+    note:
+      `The panel tab never acknowledged (frozen or backgrounded), so the free was issued ` +
+      `DIRECTLY to the ComfyUI server this tab provably fronts — the same /free endpoint the ` +
+      `panel would have called — and the server confirmed it. /free is idempotent: if the tab's ` +
+      `queued copy still executes when the tab wakes, it is a no-op, so nothing was applied ` +
+      `twice. ${statsNote}`,
+  });
 }
 
 // ---- panel_install_node: accepted-but-never-enqueued (#1129) ---------------
@@ -13582,9 +13767,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_free_vram",
-      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory.",
+      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory. If the panel tab is frozen and cannot acknowledge, the free is instead issued DIRECTLY to the ComfyUI server and verified there (same /free, idempotent) whenever the tab provably fronts the local server — otherwise the outcome is reported unknown rather than claimed.",
       {},
-      async (_args, ctx) => ctx.call({ cmd: "free_vram" }, 15000),
+      async (_args, ctx) => {
+        const res = await ctx.call({ cmd: "free_vram" }, 15000);
+        // #1249 — ONLY a no-reply is settled server-side. An acked executor error
+        // (the panel's own "Failed to free VRAM: …") is a reply the bridge
+        // received and relayed; it already says what failed, and re-issuing from
+        // out here would fire a second mutation behind a verdict the caller was
+        // given. A tagged reply-timeout is the one case where nothing answered.
+        if (!isReplyTimeoutResult(res)) return res;
+        return settleFreeVramAfterAckTimeout(ctx, res);
+      },
     ),
     def(
       "panel_show_media",


### PR DESCRIPTION
## Root cause

`panel_free_vram` routed a purely **server-side** operation — the panel's `free_vram` handler is a plain `POST /free` against the ComfyUI the tab fronts — through the frontend tab and treated the tab's acknowledgement as the only source of truth. When the canvas tab was frozen/backgrounded (e.g. a stalled Krea2 sampling step), the 15 s reply window expired with the mutation already delivered, and the bridge's honest "MUTATES … may have been applied — do not blind-retry" disclosure left the caller with no way to ever verify whether VRAM was freed (artokun/comfyui-mcp-panel#1249).

## Fix

On a **bridge-tagged reply timeout only** (`isReplyTimeoutResult` — an acked executor error still passes through untouched, even one quoting the timeout sentence), the tool now settles the outcome against the one channel a frozen tab cannot block: the ComfyUI server itself.

- Gated on `captureRebootHealthBase(ctx)` — the same proof the restart certification uses (loopback boot instance, server-trusted local tab, handshake-Origin match). Without that proof a direct `/free` could aim at a **different** server than the tab was asked to free; that case returns the original outcome-unknown verdict **untouched** (remote/cloud tabs, ambiguous origins, untrusted sockets all degrade honestly).
- With the proof, the tool issues the identical `POST /free` **directly** and reads `/system_stats` around it, reporting `vram_before`/`vram_after` when observed. The server's 2xx — not a measured delta — is the verification, and says so when the stats read doesn't answer.
- **Why re-issuing is safe here and nowhere else on the timeout path:** `/free` is idempotent. The copy the frozen tab may still execute when it wakes is a no-op, so the double-apply hazard the bridge's disclosure guards against does not exist for this one command. The code comment argues this per-command and explicitly disclaims it as precedent.
- If the direct `/free` itself fails, the outcome stays UNKNOWN and the reply names the failed fallback — no claim in either direction.

## Verification

- New `src/__tests__/orchestrator/free-vram-frozen-tab.test.ts` (8 tests, all passing): verified server-side success with VRAM counters; 2xx-without-stats wording; gate refusals (non-local tab, different-origin tab) returning the timeout untouched with **no** direct attempt; failed fallback keeping the outcome UNVERIFIED; acked executor errors (including timeout-worded ones) never re-issued; normal ack passthrough.
- Gates in the worktree: `npm ci` ✓ · `npm run build` (tsc) ✓ · `npm run check:unknown-collapse` ✓ (0 known sites, no new collapses) · `npm run check:vocabulary` ✓ · `npm run vocab:export -- --check` ✓ · `npm run docs:gen` ✓ (regenerated output identical to committed docs) · full `npm test` chain ✓ exit 0 (10169 tests; a first run flaked two unrelated load-sensitive tests — `training-jobs` reconcile timing and a 30 s `vocabulary` catalog timeout — both pass in isolation and the rerun was green).

Closes artokun/comfyui-mcp-panel#1249
