### PR TITLE
fix(1642): a Manager reboot the loopback witness saw cycle reports the confirmed restart

### DIFF
--- a/src/__tests__/services/restart-instance-identity.test.ts
+++ b/src/__tests__/services/restart-instance-identity.test.ts
@@ -25,6 +25,7 @@ import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: true },
+  base: { value: "http://127.0.0.1:8188" },
   fetchMock: vi.fn(),
   resetClient: vi.fn(),
   resetObjectInfoCache: vi.fn(),
@@ -49,7 +50,7 @@ vi.mock("node:os", async (importOriginal) => {
 
 vi.mock("../../config.js", () => ({
   config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
-  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIBaseUrl: () => hoisted.base.value,
   getComfyUIAuthHeaders: () => ({}),
   getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => hoisted.remoteMode.value,
@@ -121,6 +122,7 @@ const BASE_ARGV = ["python", "main.py", "--port", "8188"];
 
 beforeEach(() => {
   hoisted.remoteMode.value = true;
+  hoisted.base.value = "http://127.0.0.1:8188";
   hoisted.fetchMock.mockReset();
   hoisted.resetClient.mockClear();
   hoisted.resetObjectInfoCache.mockClear();
@@ -193,6 +195,9 @@ describe("#871 — the argv comparison is fenced by the instance, not the endpoi
     expect(res.message).not.toMatch(/launch arguments/i);
     expect(res.message).not.toContain("--other-agents-flag");
     expect(res.message).toContain("ComfyUI is healthy now");
+    // #1642: a close stamped BEFORE the dispatch is no evidence of our cycle.
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("unconfirmed");
   });
 
   it("compares normally when the witness dies AFTER the dispatch — consistent with our own reboot", async () => {
@@ -232,6 +237,77 @@ describe("#871 — the argv comparison is fenced by the instance, not the endpoi
     expect(res.message).toContain("--new-flag");
   });
 
+  it("#1642: a witness that died AFTER the dispatch on a LOOPBACK endpoint confirms the restart", async () => {
+    // The issue's report: the Manager reboot completed and the health probe
+    // found ComfyUI healthy, yet the flow answered started:false /
+    // startup:"unconfirmed". On loopback the witness close after the dispatch
+    // is the down→up the readiness poll cannot see, so the verdict is now the
+    // confirmed restart that actually happened.
+    hoisted.getSystemStats.mockImplementation(async () => ({
+      system: { argv: [...BASE_ARGV] },
+    }));
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        return new Response("", { status: 200 });
+      }
+      if (path === "/system_stats") {
+        hoisted.witness.closedAt ??= Date.now() + 5000;
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.stopped).toBe(true);
+    expect(res.started).toBe(true);
+    expect(res.ready).toBe(true);
+    expect(res.startup).toBe("confirmed");
+    expect(res.message).toContain("CONFIRMED");
+    expect(res.message).toContain("ComfyUI is healthy now");
+    // We launched nothing of ours, so ownership is never claimed even here.
+    expect(res.listener_ownership).toBe("unconfirmed");
+  });
+
+  it("#1642: the same witness drop on a REMOTE endpoint stays unconfirmed", async () => {
+    // Past the first hop a close proves nothing (tunnels hiccup, proxies idle
+    // out), so a dropped witness must NOT upgrade the verdict there — the
+    // conservative reading the confirmed branch is scoped away from.
+    hoisted.base.value = "http://remote.example:8188";
+    hoisted.getSystemStats.mockImplementation(async () => ({
+      system: { argv: [...BASE_ARGV] },
+    }));
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        return new Response("", { status: 200 });
+      }
+      if (path === "/system_stats") {
+        hoisted.witness.closedAt ??= Date.now() + 5000;
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("unconfirmed");
+    expect(res.message).toContain("not directly observed");
+  });
+
   it("compares normally when the witness never dies — the instance provably never went away", async () => {
     // A Manager that accepts the request and does nothing leaves the witness
     // open: both readings are then provably one instance's, and UNCHANGED is
@@ -245,6 +321,10 @@ describe("#871 — the argv comparison is fenced by the instance, not the endpoi
 
     expect(res.ready).toBe(true);
     expect(res.message).toContain("launch arguments are UNCHANGED");
+    // #1642: an OPEN witness means the instance provably never went away — no
+    // cycle to confirm, so the verdict must stay unconfirmed.
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("unconfirmed");
   });
 
   it("declines the comparison when no witness could be acquired at all", async () => {
@@ -265,6 +345,9 @@ describe("#871 — the argv comparison is fenced by the instance, not the endpoi
     expect(findCall((p) => p === "/v2/manager/reboot")).toBeDefined();
     expect(res.message).not.toMatch(/launch arguments/i);
     expect(res.message).toContain("ComfyUI is healthy now");
+    // #1642: no witness at all — nothing observed the cycle.
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("unconfirmed");
   });
 });
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -56,6 +56,7 @@ import {
   type ListenerOwnership,
   type SupervisorRelaunch,
 } from "./listener-ownership.js";
+import { isLoopbackServerUrl } from "./local-vram.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
 import {
   parseListenerPidFromNetstat,
@@ -348,10 +349,14 @@ interface StartupReadinessResult {
  *                         could not be mapped, so our process cannot be shown to be
  *                         the listener (the #449 shape);
  *                       • ready:true, Manager reboot — the server is up but no cycle
- *                         was observed, which is EVERY Manager reboot: that path
- *                         watches for a healthy probe, never for a down→up, so an
- *                         accepted request in front of a server that never restarted
- *                         looks identical to a successful one.
+ *                         was observed. That is every Manager reboot whose witness
+ *                         stayed open, dropped on a REMOTE endpoint, or could not be
+ *                         acquired at all: the readiness poll alone only certifies a
+ *                         healthy answer, never a down→up, so an accepted request in
+ *                         front of a server that never restarted looks identical to a
+ *                         successful one. On a LOOPBACK endpoint a witness that closed
+ *                         after the dispatch IS the observed down→up and the verdict is
+ *                         "confirmed" instead (#1642).
  *                     A caller composing its own message MUST check `ready` before
  *                     saying anything about the server being up.
  *   "not-attempted" — this call never launched or rebooted anything (a refusal, or
@@ -4016,6 +4021,57 @@ async function restartViaManagerRebootDispatch(
         )
       : "";
 
+  // #1642: the readiness poll alone can never see a cycle — it certifies that
+  // SOMETHING healthy answers now, which is why every Manager reboot used to
+  // land on `started:false, startup:"unconfirmed"` no matter how cleanly the
+  // server came back (the issue's exact report). But since #871 this path holds
+  // the instance WITNESS across the dispatch, and on a LOOPBACK endpoint that
+  // witness supplies the down→up the poller cannot: a socket on this machine
+  // has no tunnel to hiccup and no proxy to idle out (instance-witness.ts's
+  // reasons a close is inconclusive are all off-loopback), so its close AFTER
+  // the dispatch is the instance that accepted the reboot going away, and the
+  // healthy probe is the successor answering. That is precisely the positive
+  // evidence the rounds-7/8 ruling below says `started` requires, so this
+  // branch returns the confirmed verdict the fields below must withhold.
+  //
+  // Scoped to loopback on purpose: past the first hop a close still proves
+  // nothing, so a remote endpoint keeps the unconfirmed verdict even with a
+  // dropped witness. A loopback REVERSE PROXY could in principle drop the
+  // client connection while its origin never cycled — the substitution edge
+  // the witness module already declines to cover, not a reason to deny every
+  // plain local install the confirmation its reboot earned. The strict `>`
+  // boundary is the same one the argv fence uses: a same-millisecond stamp is
+  // ambiguous (event-delivery slack), and ambiguous declines.
+  const witnessSawTheCycle =
+    witness !== undefined &&
+    witnessClosedAt !== undefined &&
+    witnessClosedAt > dispatchedAt &&
+    isLoopbackServerUrl(anchoredBase);
+  if (witnessSawTheCycle) {
+    return {
+      stopped: true,
+      started: true,
+      ready: true,
+      startup: "confirmed",
+      readiness,
+      message:
+        (reboot.acked
+          ? "The ComfyUI-Manager reboot request was acknowledged."
+          : `A ComfyUI-Manager reboot was dispatched but not acknowledged (${reboot.note ?? "no reply"}).`) +
+        ` ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
+        "restart, CONFIRMED: the instance that accepted the reboot dropped the " +
+        "connection this call was holding open across the dispatch (the down), " +
+        "and the same endpoint answers healthy again (the up)." +
+        argvNote +
+        // #1647: same disclosure as every other branch — an inferred
+        // supervision is stated whatever the probes saw.
+        (context.supervisionNote ? ` ${context.supervisionNote}` : ""),
+      // This path still launched nothing of ours — a supervisor cycled the
+      // process — so the listener is never ours to claim, confirmed or not.
+      listener_ownership: unclassifiedOwnership(),
+    };
+  }
+
   return {
     stopped: true,
     // THE FIELDS MUST AGREE WITH THE SENTENCE (codex gate rounds 7 and 8). A message
@@ -4029,7 +4085,9 @@ async function restartViaManagerRebootDispatch(
     // demonstrably existed and only its attribution was uncertain. HERE this call
     // spawned nothing at all, and an acknowledged Manager request can be a no-op —
     // so there is no positive evidence that this call started anything, and
-    // `started` is exactly the claim that it did.
+    // `started` is exactly the claim that it did. (#1642: when the loopback witness
+    // DID supply that evidence — the observed down→up — the confirmed branch above
+    // has already returned; this return is the unobserved case only.)
     //
     // The fear that drove the earlier choice — that `false` reads as a failed
     // restart — is answered by the fields beside it rather than by overstating this


### PR DESCRIPTION
## Root cause

The ComfyUI-Manager reboot path (`restartViaManagerRebootDispatch` in `src/services/process-control.ts`) certifies success with a readiness poll only. A poll can prove *something healthy answers now* — it can never prove a down→up cycle happened, so every Manager reboot whose server came back healthy returned `stopped:true, started:false, ready:true, startup:"unconfirmed"`, exactly the report in #1642 ("restart completes and the server is healthy, but the flow reports unconfirmed").

The verdict check misreads because it ignores evidence the path already holds: since #871 an **instance witness** (a WebSocket held open across the call, which dies with the instance that accepted it) spans the dispatch. It was only ever consulted for the launch-argument comparison, never for the startup verdict — the `StartupConfirmation` doc even stated "no cycle was observed, which is EVERY Manager reboot".

## Fix

When the witness **closed after the dispatch** on a **loopback** endpoint and the readiness probe then finds the server healthy, the down→up *was* observed: a socket on this machine has no tunnel to hiccup and no proxy to idle out (the witness module's own reasons a close is inconclusive are all off-loopback). That combination now returns `started:true, startup:"confirmed"` with a message stating what was observed.

Deliberately unchanged (still `started:false, startup:"unconfirmed"`):
- remote endpoints with a dropped witness (past the first hop a close proves nothing),
- a witness still open (the instance provably never cycled — a no-op reboot),
- a witness closed *before* the dispatch, or no witness at all,
- `listener_ownership` (this path launches nothing of ours, confirmed or not).

The strict `closedAt > dispatchedAt` boundary matches the existing argv fence: a same-millisecond stamp is ambiguous, and ambiguous declines.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npx vitest run src/__tests__/services/restart-instance-identity.test.ts` — 11/11 pass, including two new #1642 tests (loopback witness-close-after-dispatch → `started:true`/`startup:"confirmed"`; same drop on a remote base → stays `unconfirmed`) and new pins on the three other witness states
- `npm run check:unknown-collapse` — `0 known site(s), no new collapses`
- Full `npm test` chain — 533–535/536 files green; the 1–3 failing files (`vocabulary.test.ts` import timeout, `training-jobs.test.ts`, `panel-restart-legacy-fallback.test.ts`) are parallel-load flakes on this Windows box: each passes standalone, none executes the changed code (the panel-fallback suite stubs `restartComfyUI` entirely)
- Tool descriptions untouched, so `docs:gen` / `check:vocabulary` / `vocab:export --check` are not implicated

## Follow-up (not in this PR)

The issue's added comment describes a second variant where `panel_restart_comfyui` reported the panel transport unreachable and the confirmation card never appeared — that failure lives on the panel/transport side and is not addressed here.

Closes #1642