### PR TITLE
fix(1640): bootstrap finds Git for Windows even when the orchestrator's PATH is stale

### DIFF
--- a/src/__tests__/services/trainer-bootstrap.test.ts
+++ b/src/__tests__/services/trainer-bootstrap.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { bootstrapToolkit, resolveGitExecutable } from "../../services/trainer-bootstrap.js";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "trainer-bootstrap-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolveGitExecutable", () => {
+  it("finds git on PATH (win32 name)", () => {
+    const bin = tempDir();
+    const exe = join(bin, "git.exe");
+    writeFileSync(exe, "");
+    expect(resolveGitExecutable({ PATH: bin }, "win32")).toBe(exe);
+  });
+
+  it("finds git on PATH (posix name)", () => {
+    const bin = tempDir();
+    const exe = join(bin, "git");
+    writeFileSync(exe, "");
+    expect(resolveGitExecutable({ PATH: bin }, "linux")).toBe(exe);
+  });
+
+  it("strips quotes around PATH entries", () => {
+    const bin = tempDir();
+    const exe = join(bin, "git.exe");
+    writeFileSync(exe, "");
+    expect(resolveGitExecutable({ PATH: `"${bin}"` }, "win32")).toBe(exe);
+  });
+
+  it("falls back to %ProgramFiles%\\Git when PATH has no git (issue #1640)", () => {
+    const programFiles = tempDir();
+    const exe = join(programFiles, "Git", "cmd", "git.exe");
+    mkdirSync(join(programFiles, "Git", "cmd"), { recursive: true });
+    writeFileSync(exe, "");
+    expect(resolveGitExecutable({ PATH: "", ProgramFiles: programFiles }, "win32")).toBe(exe);
+  });
+
+  it("falls back to %LOCALAPPDATA%\\Programs\\Git (user install)", () => {
+    const localAppData = tempDir();
+    const exe = join(localAppData, "Programs", "Git", "cmd", "git.exe");
+    mkdirSync(join(localAppData, "Programs", "Git", "cmd"), { recursive: true });
+    writeFileSync(exe, "");
+    expect(
+      resolveGitExecutable(
+        { PATH: "", ProgramFiles: tempDir(), "ProgramFiles(x86)": tempDir(), LOCALAPPDATA: localAppData },
+        "win32",
+      ),
+    ).toBe(exe);
+  });
+
+  it("prefers PATH over the install-root fallback", () => {
+    const bin = tempDir();
+    const onPath = join(bin, "git.exe");
+    writeFileSync(onPath, "");
+    const programFiles = tempDir();
+    mkdirSync(join(programFiles, "Git", "cmd"), { recursive: true });
+    writeFileSync(join(programFiles, "Git", "cmd", "git.exe"), "");
+    expect(resolveGitExecutable({ PATH: bin, ProgramFiles: programFiles }, "win32")).toBe(onPath);
+  });
+
+  it("returns undefined on Windows when neither PATH nor the standard roots have git", () => {
+    expect(
+      resolveGitExecutable(
+        { PATH: "", ProgramFiles: tempDir(), "ProgramFiles(x86)": tempDir(), LOCALAPPDATA: tempDir() },
+        "win32",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("never consults the Windows install roots on other platforms", () => {
+    const programFiles = tempDir();
+    mkdirSync(join(programFiles, "Git", "cmd"), { recursive: true });
+    writeFileSync(join(programFiles, "Git", "cmd", "git.exe"), "");
+    expect(resolveGitExecutable({ PATH: "", ProgramFiles: programFiles }, "linux")).toBeUndefined();
+  });
+});
+
+describe("bootstrapToolkit git preflight (issue #1640)", () => {
+  const saved: Record<string, string | undefined> = {};
+  const KEYS = ["PATH", "ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA", "COMFYUI_MCP_DATA_DIR"] as const;
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+      delete saved[key];
+    }
+  });
+
+  it("fails closed with git_not_found and the restart remedy when git is unfindable", async () => {
+    for (const key of KEYS) saved[key] = process.env[key];
+    // An empty PATH with no git anywhere + install roots pointed at empty temp
+    // dirs: the exact world the issue's orchestrator lives in — Git installed
+    // after startup, so the inherited PATH cannot see it.
+    process.env.PATH = tempDir();
+    process.env["ProgramFiles"] = tempDir();
+    process.env["ProgramFiles(x86)"] = tempDir();
+    process.env["LOCALAPPDATA"] = tempDir();
+    process.env.COMFYUI_MCP_DATA_DIR = tempDir();
+
+    const result = await bootstrapToolkit();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error?.code).toBe("git_not_found");
+    if (process.platform === "win32") {
+      expect(result.error?.message).toContain("restart the orchestrator");
+      expect(result.error?.message).toContain("panel_reload is not enough");
+    } else {
+      expect(result.error?.message).toContain("restart");
+    }
+  });
+});

--- a/src/services/trainer-bootstrap.ts
+++ b/src/services/trainer-bootstrap.ts
@@ -10,7 +10,7 @@
 import childProcess from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import {
   AI_TOOLKIT_REF,
   AI_TOOLKIT_REPO,
@@ -81,6 +81,49 @@ function basePython(): string {
 }
 
 /**
+ * Resolve the git executable to spawn. PATH first, then — on Windows — the
+ * standard Git for Windows install roots. The fallback exists because a
+ * long-lived orchestrator started BEFORE Git was installed keeps its
+ * pre-install PATH: panel_reload rebuilds the server but the parent's
+ * environment is inherited, so `spawn("git")` dies with ENOENT even though
+ * Git is on the machine (issue #1640). Returns the ABSOLUTE path so the
+ * spawn below never depends on the stale PATH again.
+ */
+export function resolveGitExecutable(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  const name = platform === "win32" ? "git.exe" : "git";
+  for (const dir of (env.PATH ?? "").split(delimiter).filter(Boolean)) {
+    const candidate = join(dir.replace(/^"|"$/g, ""), name);
+    if (existsSync(candidate)) return candidate;
+  }
+  if (platform !== "win32") return undefined;
+  const roots = [
+    env["ProgramFiles"] ?? "C:\\Program Files",
+    env["ProgramFiles(x86)"],
+    env.LOCALAPPDATA ? join(env.LOCALAPPDATA, "Programs") : undefined,
+  ];
+  for (const root of roots) {
+    if (!root) continue;
+    const candidate = join(root, "Git", "cmd", "git.exe");
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Why no git could be found — spelled out with the remedy (issue #1640). */
+function gitNotFoundMessage(): string {
+  return process.platform === "win32"
+    ? "git is not on this process's PATH and was not found under the standard Git for Windows roots " +
+      "(Program Files\\Git, %LOCALAPPDATA%\\Programs\\Git). If Git was installed AFTER the orchestrator " +
+      "started, panel_reload is not enough — the long-lived parent keeps its pre-install PATH. Fully " +
+      "restart the orchestrator (or reboot), then re-run bootstrap."
+    : "git is not on this process's PATH. If git was installed after the orchestrator started, restart " +
+      "the orchestrator so it inherits the new PATH, then re-run bootstrap.";
+}
+
+/**
  * Bootstrap the native trainer. Steps (each idempotent):
  *  1. clone ai-toolkit @ AI_TOOLKIT_REF (or `git fetch + checkout` an existing clone)
  *  2. create the venv
@@ -93,13 +136,17 @@ export async function bootstrapToolkit(opts: { onLog?: (line: string) => void } 
   const dir = resolveAiToolkitDir();
   const log = opts.onLog;
   try {
+    const git = resolveGitExecutable();
+    if (!git) {
+      return fail(TRAINER_COMMAND.bootstrap, "git_not_found", gitNotFoundMessage());
+    }
     mkdirSync(dir, { recursive: true });
 
     if (!existsSync(join(dir, ".git"))) {
       // Clone into a temp sibling then move in, so a failed clone doesn't leave
       // a half repo at the real path.
       const tmp = `${dir}.clone-${process.pid}`;
-      const r = await stream("git", ["clone", "--recurse-submodules", AI_TOOLKIT_REPO, tmp], undefined, log);
+      const r = await stream(git, ["clone", "--recurse-submodules", AI_TOOLKIT_REPO, tmp], undefined, log);
       if (r.code !== 0) {
         // Clean the failed clone so a retry isn't blocked by its leftovers
         // (codex finding: the stale temp dir made every retry fail instantly).
@@ -111,11 +158,11 @@ export async function bootstrapToolkit(opts: { onLog?: (line: string) => void } 
       rmSync(dir, { recursive: true, force: true });
       renameSync(tmp, dir);
     }
-    let r = await stream("git", ["fetch", "--all"], dir, log);
+    let r = await stream(git, ["fetch", "--all"], dir, log);
     if (r.code !== 0) return fail(TRAINER_COMMAND.bootstrap, "fetch_failed", `git fetch exited ${r.code}`, r.tail);
-    r = await stream("git", ["checkout", AI_TOOLKIT_REF], dir, log);
+    r = await stream(git, ["checkout", AI_TOOLKIT_REF], dir, log);
     if (r.code !== 0) return fail(TRAINER_COMMAND.bootstrap, "checkout_failed", `git checkout ${AI_TOOLKIT_REF} exited ${r.code}`, r.tail);
-    r = await stream("git", ["submodule", "update", "--init", "--recursive"], dir, log);
+    r = await stream(git, ["submodule", "update", "--init", "--recursive"], dir, log);
     if (r.code !== 0) return fail(TRAINER_COMMAND.bootstrap, "submodule_failed", `submodule update exited ${r.code}`, r.tail);
 
     // Invalidate any previous completion marker BEFORE the install steps: a


### PR DESCRIPTION
## Root cause

On Windows, `train_doctor` action:"bootstrap" spawns `git` with the orchestrator's inherited environment (`src/services/trainer-bootstrap.ts`). When Git for Windows is installed AFTER the orchestrator started, the long-lived parent keeps its pre-install PATH — `panel_reload(scope:"orchestrator")` rebuilds the agent/tool server but the parent's environment is inherited unchanged — so every `spawn("git", ...)` died with `spawn git ENOENT`, surfaced as `clone_failed: git clone exited 1`, even though Git was on the machine.

## Fix

- New `resolveGitExecutable()` in `src/services/trainer-bootstrap.ts`: scans PATH (quote-stripped entries, `git.exe` on win32 / `git` elsewhere), then — on Windows only — falls back to the standard Git for Windows install roots (`%ProgramFiles%\Git\cmd\git.exe`, `%ProgramFiles(x86)%\…`, `%LOCALAPPDATA%\Programs\Git\cmd\git.exe`). It returns an ABSOLUTE path, so the spawn no longer depends on the stale PATH at all.
- `bootstrapToolkit` resolves git once up front and uses the resolved path for clone/fetch/checkout/submodule.
- Fail closed when git is truly unfindable: a new `git_not_found` error whose message states the remedy the issue asked for — panel_reload is not enough; fully restart the orchestrator (or reboot) so it inherits the new PATH, then re-run bootstrap.

## Verification

- New `src/__tests__/services/trainer-bootstrap.test.ts` (9 tests): PATH hit (win32/posix), quoted PATH entries, `%ProgramFiles%` fallback, `%LOCALAPPDATA%\Programs` user-install fallback, PATH-beats-fallback priority, undefined when nothing exists, Windows roots never consulted on other platforms, and an end-to-end `bootstrapToolkit` run in a no-git world failing with `git_not_found` + the restart remedy. All pass.
- Gates in the worktree (clean `npm ci` from origin/main):
  - `npm run build` (tsc) — clean
  - `npx vitest run src/__tests__/services/trainer-bootstrap.test.ts` — 9/9 pass
  - `npm test` (full chain: vitest + i18n:check + docs-links/docs-locale + blog checks) — exit 0
  - `npm run check:unknown-collapse` — "0 known site(s), no new collapses" (no new catch sites added)
- No tool descriptions changed, so docs:gen / vocabulary gates are not implicated.

Not verified on a real Windows box with the exact install-after-startup sequence (no such machine here); the fallback logic is covered by unit tests with simulated PATH/install roots.

Closes #1640