### PR TITLE
fix(1646): a workflow-instance mismatch is checked read-only — the fence moves only on an explicit rebind

### DIFF
--- a/src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts
+++ b/src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts
@@ -12,10 +12,14 @@
 // while a new unsaved workflow was materialising, and nothing in the refusal separated
 // that from "you are genuinely pointed at another workflow".
 //
-// THE FENCE IS NOT WEAKENED AND NOTHING IS AUTO-APPLIED. The refusal still stands; what
-// changes is that the orchestrator now performs the same read-only re-derivation the
-// documented recovery performs, and reports WHICH of the two states it found. One
-// informed retry replaces fourteen blind ones.
+// THE FENCE IS NOT WEAKENED, NOTHING IS AUTO-APPLIED — AND (#1646) THE PROBE IS
+// READ-ONLY. The refusal still stands; the orchestrator re-reads the live canvas and
+// reports WHICH of the two states it found. What it no longer does is adopt: the first
+// version re-derived the fence onto the live canvas when the two genuinely differed,
+// so the caller's NEXT mutations were silently re-pointed at the canvas the refusal
+// had named as the wrong one. The fence now moves only on an explicit rebind
+// (panel_set_workflow_target({mode:"current"}) or a successful open). One informed
+// retry replaces fourteen blind ones.
 //
 // Recommending a retry is safe here specifically because the panel checks the fence
 // BEFORE running the handler — "Nothing was applied" is structural, not an echoed claim.
@@ -103,7 +107,7 @@ describe("a fenced mutation is corroborated before the caller retries blindly (#
     // satisfied by a message that never consulted the panel at all.
     expect(listCalls).toBeGreaterThan(0);
 
-    expect(text).toMatch(/AUTO-REBIND: ATTEMPTED/);
+    expect(text).toMatch(/CHECKED/);
     expect(text).toMatch(/TRANSIENT/);
     expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
     // The instruction that actually saves the 14 calls.
@@ -111,19 +115,45 @@ describe("a fenced mutation is corroborated before the caller retries blindly (#
     // The refusal itself is preserved verbatim — the comparison is the evidence.
     expect(text).toContain(STAMP);
     expect(text).toMatch(/NOT applied — nothing changed/);
+    // The transient probe must not have touched the fence either.
+    expect(stamp).toBe(STAMP);
   });
 
-  it("GENUINELY DIFFERENT: the fence is re-derived and the caller is told which", async () => {
+  it("GENUINELY DIFFERENT: the fence is NOT re-pointed, and the caller is told which (#1646)", async () => {
     // Not the reporter's case, and it must not be described as transient — telling an
     // agent to retry into a different workflow is how an edit lands on the wrong graph.
+    // #1646: the first version of this check RE-DERIVED the fence onto the live canvas
+    // here, so every later mutation in the same sequence was accepted against the OTHER
+    // tab. The probe now reports the divergence and leaves the fence exactly as it was.
     stamp = STAMP;
     const text = await connect(OTHER);
 
     expect(listCalls).toBeGreaterThan(0);
-    expect(text).toMatch(/RE-DERIVED onto the live canvas/);
+    expect(text).toMatch(/NOT re-pointed/);
     expect(text).toContain(OTHER);
+    expect(text).toContain(STAMP);
+    // Both deliberate recoveries are named; the move is never made for the caller.
     expect(text).toMatch(/panel_open_workflow/);
+    expect(text).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
     expect(text).not.toMatch(/TRANSIENT/);
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // THE assertion this issue exists for: the fence still names the workflow the
+    // command was issued for, so a later edit in the same sequence is refused
+    // rather than mutating the other canvas.
+    expect(stamp, "the probe never adopted the live canvas's identity").toBe(STAMP);
+  });
+
+  it("a later mutation after a GENUINE mismatch is still refused against the original target", async () => {
+    // The reported corruption, end to end: open/routing raced, the first mutation
+    // mismatched, and the auto-rebind then ACCEPTED the following edits against the
+    // wrong canvas. With the fence preserved, the next mutation fails the same way.
+    stamp = STAMP;
+    await connect(OTHER);
+    const second = await connect(OTHER);
+
+    expect(second).toMatch(/NOT applied — nothing changed/);
+    expect(second).toMatch(/NOT re-pointed/);
+    expect(stamp).toBe(STAMP);
   });
 
   it("UNREADABLE: promises nothing, because nothing was established", async () => {
@@ -132,10 +162,11 @@ describe("a fenced mutation is corroborated before the caller retries blindly (#
     // loop this issue is about — with our encouragement this time.
     const text = await connect(null);
 
-    expect(text).toMatch(/did NOT succeed/);
+    expect(text).toMatch(/could not be established/);
     expect(text).toMatch(/a bare retry will fail the same way/);
     expect(text).not.toMatch(/TRANSIENT/);
     expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+    expect(stamp).toBe(STAMP);
   });
 
   it("the fence still REFUSES — this discloses, it never applies", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4262,6 +4262,10 @@ function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
 export type WorkflowFenceRebind =
   /** Read the live identity; it differed from the stamp and has REPLACED it. */
   | { status: "refreshed"; uuid: string; before: FenceRead }
+  /** #1646 — a READ-ONLY probe (`adopt:false`) found the live identity differs
+   *  from the fence and deliberately did NOT adopt it: a mismatch diagnosis
+   *  must never re-point mutation routing on its own authority. */
+  | { status: "diverged"; uuid: string; before: FenceRead }
   /** Read the live identity; the stamp already named it. Nothing to repair. */
   | { status: "already_current"; uuid: string; before: FenceRead }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
@@ -4625,7 +4629,10 @@ NOTE: an API-format load CAN re-mint the canvas workflow instance. If your next 
   );
 }
 
-async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
+async function rebindWorkflowFence(
+  ctx: PanelToolCtx,
+  opts?: { adopt?: boolean },
+): Promise<WorkflowFenceRebind> {
   const tabAtStart = ctx.tabId;
   let before = currentWorkflowFence(ctx);
   // `before` describes the tab we are ABOUT to compare against — but ctx.call can
@@ -4723,6 +4730,12 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
   // UNKNOWN prior fence must not short-circuit the adoption: we would be claiming
   // the stamp already matched without ever having read it.
   if (before.known && before.uuid === uuid) return { status: "already_current", uuid, before };
+  // #1646 — a READ-ONLY probe never moves the fence: the live canvas naming a
+  // DIFFERENT workflow is reported, not adopted. Only a deliberate rebind
+  // (panel_set_workflow_target, open/new) may replace the fence — a mismatch
+  // diagnosis that re-pointed the session on its own authority routed the
+  // caller's NEXT edits onto the very canvas the refusal named as the wrong one.
+  if (opts?.adopt === false) return { status: "diverged", uuid, before };
   // refreshWorkflowUuid routes through the orchestrator's validator, which
   // re-checks reachability and the uuid's shape/origin binding. A `false` here is
   // a REFUSAL, not a no-op, so it gets its own status rather than being reported
@@ -4877,6 +4890,22 @@ function describeFenceRebind(
       `(#803).`
     : "";
   switch (r.status) {
+    case "diverged":
+      // #1646 — produced ONLY by a read-only probe (`adopt:false`), which the
+      // mismatch diagnosis uses; the deliberate rebinds this renderer serves
+      // never pass it. Handled anyway, because an unhandled union member would
+      // silently render as `undefined` — say exactly what happened if a future
+      // caller ever routes one here.
+      return {
+        binding: "not_recovered",
+        note:
+          ` The live canvas is a DIFFERENT workflow instance (${r.uuid}) than this session's ` +
+          `fence, and it was deliberately NOT adopted — a diagnosis must never re-point ` +
+          `mutation routing on its own.` +
+          (r.before.known && r.before.uuid ? ` The fence still names ${r.before.uuid}.` : "") +
+          `\n\nWHAT TO DO: re-open the workflow you mean with panel_open_workflow, or re-target ` +
+          `the live canvas deliberately by calling this tool with mode:"current".`,
+      };
     case "refreshed":
       return {
         binding: okBinding,
@@ -7247,9 +7276,16 @@ export function makePanelToolCtx(
       // because nothing in the refusal distinguishes "the canvas really is a different
       // workflow" from "the identity flipped for a moment while you were building".
       //
-      // The fence is NOT weakened and nothing is auto-applied. This performs the same
-      // read-only re-derivation the documented recovery performs, then says which of the
-      // two states was found. One informed retry replaces fourteen blind ones.
+      // The fence is NOT weakened, nothing is auto-applied, and — #1646 — the
+      // probe is READ-ONLY. The first version of this check re-derived the fence
+      // onto the live canvas when the two genuinely differed ("AUTO-REBIND"), so
+      // every later mutation in the caller's sequence was silently re-pointed at
+      // the very canvas the refusal had just named as the wrong one — the exact
+      // corruption the fence exists to prevent, delivered as recovery. Now the
+      // check says which of the two states it found and the fence moves ONLY on
+      // an explicit rebind: panel_set_workflow_target({mode:"current"}) or a
+      // successful open. Until then every write stays refused against the target
+      // the caller actually named. One informed retry replaces fourteen blind ones.
       //
       // Safe to recommend a retry because a fence refusal is checked BEFORE the handler
       // runs — "Nothing was applied" is structural here, not an echoed claim.
@@ -7267,32 +7303,46 @@ export function makePanelToolCtx(
         )?.[1] ?? null;
         let verdict: string;
         try {
-          const rebind = await rebindWorkflowFence(ctx);
+          const probe = await rebindWorkflowFence(ctx, { adopt: false });
           verdict =
-            rebind.status === "already_current" && stamped && rebind.uuid === stamped
-              ? `\n\nAUTO-REBIND: ATTEMPTED, and the live canvas now reports the SAME workflow ` +
-                `instance this command carried (${stamped}) — nothing needed repairing. The ` +
-                `mismatch was TRANSIENT: the identity flipped and settled back, which happens ` +
-                `while a new unsaved workflow is still materialising. RETRY THIS EXACT CALL ONCE. ` +
-                `Nothing was applied, so a retry cannot double-apply, and re-issuing the whole ` +
-                `build would duplicate the work that already succeeded.`
-              : rebind.status === "already_current"
-                ? `\n\nAUTO-REBIND: ATTEMPTED; the fence already named the live canvas ` +
-                  `(${rebind.uuid}), so it was not the stale side. Retry once — if it refuses ` +
+            probe.status === "already_current" && stamped && probe.uuid === stamped
+              ? `\n\nCHECKED: the live canvas now reports the SAME workflow instance this ` +
+                `command carried (${stamped}), so the mismatch was TRANSIENT: the identity ` +
+                `flipped and settled back, which happens while a new unsaved workflow is still ` +
+                `materialising. RETRY THIS EXACT CALL ONCE. Nothing was applied, so a retry ` +
+                `cannot double-apply, and re-issuing the whole build would duplicate the work ` +
+                `that already succeeded.`
+              : probe.status === "already_current"
+                ? `\n\nCHECKED: the session's fence already names the live canvas ` +
+                  `(${probe.uuid}), so it was not the stale side. Retry once — if it refuses ` +
                   `again with the same pair, the two identities are genuinely disagreeing and ` +
                   `panel_open_workflow is the way to settle which one you mean.`
-                : rebind.status === "refreshed"
-                  ? `\n\nAUTO-REBIND: ATTEMPTED and the fence was RE-DERIVED onto the live canvas ` +
-                    `(now ${rebind.uuid}). Retry once. If you meant the EARLIER workflow, re-select ` +
-                    `it with panel_open_workflow first — this session now points at the live one.`
-                  : `\n\nAUTO-REBIND: ATTEMPTED and did NOT succeed (${rebind.status}), so the fence ` +
-                    `is unchanged and a bare retry will fail the same way. Re-select the workflow ` +
-                    `you mean with panel_open_workflow, then retry.`;
-        } catch (rebindErr) {
+                : probe.status === "diverged"
+                  ? `\n\nCHECKED, and this session was NOT re-pointed: the live canvas is a ` +
+                    `DIFFERENT workflow (${probe.uuid}) than the one this command was issued ` +
+                    `for${stamped ? ` (${stamped})` : ""}. The fence is unchanged, so later ` +
+                    `edits in this sequence keep being refused rather than landing on the ` +
+                    `wrong canvas. WHAT TO DO: to edit the workflow you issued for, bring it ` +
+                    `back with panel_open_workflow; to follow the live canvas instead, ` +
+                    `re-target deliberately with panel_set_workflow_target({mode:"current"}). ` +
+                    `Either way the move is explicit — it is never made for you off a refused ` +
+                    `mutation.`
+                  : probe.status === "healed_by_panel"
+                    ? `\n\nCHECKED, and the answer CHANGED while it was being read: the panel ` +
+                      `re-advertised its identity and this session's fence moved to the live ` +
+                      `canvas (${probe.uuid}) — through the panel's own repair, not this ` +
+                      `check. If you meant the EARLIER workflow, re-select it with ` +
+                      `panel_open_workflow before any further edits; they now target the live one.`
+                    : `\n\nCHECKED, but the live canvas could not be established ` +
+                      `(${probe.status}), so the fence is unchanged and a bare retry will fail ` +
+                      `the same way. Re-select the workflow you mean with panel_open_workflow, ` +
+                      `then retry.`;
+        } catch (probeErr) {
           // Never let the diagnosis fail the call differently than it already failed.
           verdict =
-            `\n\nAUTO-REBIND: ATTEMPTED and threw, so the fence state is UNKNOWN — this refusal ` +
-            `stands on its own terms. (${rebindErr instanceof Error ? rebindErr.message : String(rebindErr)})`;
+            `\n\nCHECKED, and the check itself threw, so the live canvas is UNKNOWN — this ` +
+            `refusal stands on its own terms and the fence is unchanged. ` +
+            `(${probeErr instanceof Error ? probeErr.message : String(probeErr)})`;
         }
         return fail(`${name} was NOT applied — nothing changed. ${raw}${verdict}`);
       }


### PR DESCRIPTION
## Root cause

The #1330 corroboration in `src/orchestrator/panel-tools.ts` answered a refused mutation's workflow-instance mismatch by calling `rebindWorkflowFence(ctx)` — and when the live canvas **genuinely differed** from the uuid the command carried, it **adopted** the live identity (`AUTO-REBIND … RE-DERIVED onto the live canvas`). Every later mutation in the caller's sequence was then stamped with — and accepted against — the other canvas: exactly the wrong-workflow corruption the fence exists to prevent, delivered as recovery.

#1682 (shipped) made the mismatch refuse **earlier** (pre-dispatch, when stamp and routed tab disagree) — but that refusal carries the same `workflow instance mismatch … issued for workflow instance <uuid>` shape, so it flows into this same branch, which then undid the protection one level up by re-deriving the fence onto the live canvas. #1688 (shipped) touched only the `panel_set_workflow_target` verdict wording. Neither closed the auto-rebind-on-mismatch path this issue is about.

## Fix

- `rebindWorkflowFence` gains `opts?: { adopt?: boolean }` (default keeps today's behavior). With `adopt: false`, a corroborated live identity that differs from the current fence is returned as a new `diverged` status — reported, **not** adopted.
- The mismatch diagnosis now probes with `{ adopt: false }`:
  - **Transient** (live canvas settled back to the stamped uuid): unchanged — one informed `RETRY THIS EXACT CALL ONCE`, nothing adopted.
  - **Genuinely different**: the refusal says the session was **NOT re-pointed**, names both identities, and names the two deliberate recoveries — `panel_open_workflow` for the workflow the caller issued for, or `panel_set_workflow_target({mode:"current"})` to follow the live canvas. The fence is unchanged, so later edits in the sequence keep being refused against the original target instead of mutating the other tab.
  - **Unreadable / healed-under-us**: stated honestly, no blind retry advice.
- `describeFenceRebind` gains a defensive `diverged` case so the new union member can never render as `undefined`.
- Deliberate rebinds (`panel_set_workflow_target({mode:"current"})`, open/new) still adopt — that is their documented purpose.

## Verification

- `src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts` updated: the GENUINELY DIFFERENT case now asserts the fence is **not** adopted (`stamp` stays the issued-for uuid) and that a **second** mutation in the same sequence is still refused against the original target — the reported corruption path, end to end.
- Gates (worktree off fresh origin/main): `npm ci` ✓ · `npm run build` (tsc) ✓ · targeted vitest 5/5 ✓ · full `npm test` chain (vitest suite + i18n + docs gates) exit 0 ✓ · `npm run check:unknown-collapse` ✓ (0 known sites, no new collapses) · `npm run lint` ✓

Closes #1646