### PR TITLE
release: v0.52.2 — a new session picks up the downloads a dead one dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.2] - 2026-08-18
+
+### MCP
+
+#### Fixed
+- a new session resumes the downloads its predecessor's death orphaned (#1567)
+- upload tools return the subfolder-qualified reference a loader can use (#946)
+- stop shipping a preset library nothing reads (#1597)
+- search_custom_nodes tries the comfyui-prefixed registry id, so repo-name queries like WanVideoWrapper no longer false-empty (#773)
+- automatic previews stop at a per-conversation budget instead of compounding a Codex rollout without bound (#1516)
+- a fence the settling read proved live is reported BOUND, not unrestored (#980)
+- a download destination is judged by the one observation that produced it (#1371)
+
+
 ## [0.52.1] - 2026-08-17
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.1",
+      "version": "0.52.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying seven fixes: artokun/comfyui-mcp#1694, artokun/comfyui-mcp#1693, artokun/comfyui-mcp#1692, artokun/comfyui-mcp#1691, artokun/comfyui-mcp#1689, artokun/comfyui-mcp#1688, artokun/comfyui-mcp#1687.

**Interrupted work resumes instead of vanishing** — when a session dies mid-download, the next session now resumes the transfers its predecessor orphaned rather than leaving them stranded (#1567). Alongside that, a fence the settling read proved live is reported BOUND instead of unrestored (#980), and a download destination is judged by the one observation that produced it — not a later, weaker one (#1371).

**References that resolve** — the upload tools return the subfolder-qualified reference a loader can actually use (#946), and `search_custom_nodes` falls back to the comfyui-prefixed registry id, so repo-name queries like WanVideoWrapper no longer false-empty (#773).

**Bounded behaviour, honest surface** — automatic previews stop at a per-conversation budget instead of compounding a Codex rollout without bound (#1516), and the preset library nothing reads is no longer shipped (#1597).

🤖 Generated with [Claude Code](https://claude.com/claude-code)