### PR TITLE
docs(i18n): French remaining guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -320,8 +320,29 @@
                 "pages": [
                   "fr/index",
                   "fr/quickstart",
+                  "fr/using-tools",
+                  "fr/local-vs-comfy-cloud",
                   "fr/installation",
+                  "fr/roadmap"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "fr/configuration",
+                  "fr/remote-connector",
+                  "fr/cloud-deployment",
+                  "fr/docker",
+                  "fr/self-hosted-relay",
+                  "fr/concepts",
+                  "fr/plugin",
                   "fr/panel",
+                  "fr/apps",
+                  "fr/mobile",
+                  "fr/third-party-hosts",
+                  "fr/backends",
+                  "fr/local-llms",
+                  "fr/arena",
                   "fr/troubleshooting"
                 ]
               }

--- a/docs/fr/apps.mdx
+++ b/docs/fr/apps.mdx
@@ -1,0 +1,267 @@
+---
+title: "Apps (micro-apps)"
+description: "Transformez un workflow en app en un clic : un manifeste, un formulaire d'exécution exposé, et un instantané de prompt API dans lequel les valeurs sont patchées à chaque exécution. Convertissez dans le panneau, lancez depuis le panneau, le téléphone ou un agent, et publiez dans un registre public."
+icon: "layout-grid"
+---
+
+Une **app** est un workflow empaqueté pour des exécutions en un clic **sans
+canevas**. C'est un répertoire sur votre machine qui contient quatre choses :
+
+| Fichier | Ce que c'est |
+|---|---|
+| `manifest.json` | nom, description, `appMode {inputs, outputs}`, `deps`, `hideWorkflow`, `published` |
+| `prompt.json` | l'instantané de prompt au **format API** — les valeurs y sont patchées à chaque exécution |
+| `workflow.json` | le graphe UI litegraph — **absent** quand `hideWorkflow` est défini |
+| `thumbnail.png` | illustration de carte facultative |
+
+Les bundles vivent sous le répertoire utilisateur de ComfyUI à
+`<user>/comfyui-mcp-panel/apps/<app-id>/` — volontairement **pas** le
+répertoire des workflows, pour qu'une app masquée ne apparaisse jamais dans
+le navigateur de workflows.
+
+```
+workflow ⇄ convert (panel) ⇄ app bundle on disk ⇄ run form ⇄ patch snapshot ⇄ ComfyUI queue
+                                    ⇅
+                        publish / install ⇄ public registry
+```
+
+La raison pour laquelle les apps existent comme leur propre couche : le
+canevas est la mauvaise interface pour *exécuter* un workflow auquel vous
+faites déjà confiance. Un formulaire avec cinq champs étiquetés est la
+bonne, et c'est la seule interface qu'un téléphone ou un agent puisse
+piloter du tout.
+
+<Note>
+  Il y a **une** implémentation de stockage et d'exécution — les routes HTTP
+  du pack du panneau (`/comfyui_mcp_panel/apps/*`). Le panneau bureau,
+  l'onglet Apps mobile, et les outils MCP `apps_*` en sont tous des clients,
+  donc une app se comporte de façon identique d'où que vous la lanciez.
+</Note>
+
+## Prérequis
+
+Les apps sont servies par le **pack du panneau** (`comfyui-mcp-panel`), pas
+par le serveur MCP tout seul. Si le pack sur votre ComfyUI précède la
+fonctionnalité, `apps` avec `action:"list"` échoue avec un message explicite
+*« the panel pack on this ComfyUI predates the Apps feature »* — mettez à
+jour le pack et redémarrez ComfyUI.
+
+## Convertir un workflow en app
+
+Dans le panneau, le bouton de barre d'outils **Apps** (à côté de Civitai)
+ouvre la grille d'apps. Convertir le workflow ouvert fait trois choses :
+
+1. **Importe la config mode APP de ComfyUI** si le workflow en porte déjà
+   une, et sinon choisit les entrées et sorties **heuristiquement** (widgets
+   de prompt, seeds, réglages de sampler ; nœuds de classe `SaveImage` comme
+   sorties). Les entrées mode APP importées sont honorées sur **n'importe
+   quel** type de nœud, donc les endpoints de nœuds personnalisés survivent
+   à la conversion.
+2. **Analyse les dépendances** — les modèles et packs de nœuds
+   personnalisés dont le graphe a besoin — dans `manifest.deps`.
+3. **Prend un instantané du prompt** au format API. Les valeurs de widgets
+   au moment de la conversion deviennent le `default` de formulaire de
+   chaque entrée.
+
+Chaque entrée de `appMode.inputs` porte `nodeId`, `widget`, `label`, et un
+`kind` parmi `text`, `number`, `combo`, `toggle`, `image`, ou `model` ; les
+combos portent aussi `choices`. C'est ce dont le formulaire d'exécution se
+rend — sur le bureau et sur mobile.
+
+### Masquer le workflow
+
+`hideWorkflow` retire entièrement `workflow.json` du bundle, donc le graphe
+n'est pas remis à qui exécute ou installe l'app.
+
+<Warning>
+  **`hideWorkflow` est de l'obfuscation, jamais de la sécurité.** Le prompt
+  API reste visible à quiconque exécute l'app via le `/history` propre de
+  ComfyUI, et les modèles et nœuds personnalisés que l'app installe
+  révèlent les dépendances du graphe. Traitez-le comme « ne pas encombrer
+  mon navigateur de workflows », pas comme une protection pour un graphe
+  que vous ne pouvez pas vous permettre de laisser fuiter.
+</Warning>
+
+## Exécuter une app
+
+Une exécution patche vos valeurs de formulaire dans l'instantané stocké et
+met le résultat en file. Les clés de patch sont `"<nodeId>.<widget>"` — par
+exemple `{"6.text": "a cat", "3.seed": 42}`. La clé se coupe seulement sur
+le **premier** point, donc les noms de widgets qui contiennent eux-mêmes des
+points (piles LoRA, `lora_1.model`) restent intacts.
+
+Le patch est **strict** : une clé qui adresse un nœud ou une entrée qui
+n'existe pas dans l'instantané est une erreur dure, pas un saut silencieux.
+Un raté veut dire que le manifeste a dérivé de l'instantané, et échouer
+fort vaut mieux que d'exécuter avec des valeurs périmées. Les entrées que
+vous omettez gardent leurs défauts du moment de la conversion.
+
+L'exécution renvoie un `prompt_id` ; sondez-le pour le statut
+(`pending` → `running` → `done`, ou `unknown` si ComfyUI n'en a jamais
+entendu parler) et pour les sorties regroupées sous chaque nœud de sortie.
+
+### Exécuter sur un pod RunPod
+
+Le chemin **Exécuter sur RunPod** du panneau réutilise le même moteur de
+patch en mode **dry** : le panneau demande le prompt patché *sans* le
+mettre en file localement, pousse les dépendances épinglées vers le pod, et
+met le prompt en file là-bas à la place.
+
+<Warning>
+  Les apps avec une **entrée image** refusent de s'exécuter sur un pod. Les
+  envois atterrissent sur le ComfyUI **local**, que le pod ne peut pas
+  atteindre — donc le panneau refuse honnêtement plutôt que de mettre en
+  file une exécution qui échouerait sur un fichier manquant.
+</Warning>
+
+## Publier et Explorer
+
+L'onglet **Explorer** du panneau est un registre public (un Cloudflare
+Worker adossé à D1 + R2) avec des listes tendances / nouveaux / plus
+étoilés et une recherche. Tendances = `stars * 3 + runs` sur 7 jours.
+Publier envoie le bundle — manifeste, prompt, workflow sauf s'il est
+masqué, vignette — sous une identité de créateur à clé sha256.
+
+Installer depuis Explorer affiche d'abord une **boîte de dialogue de
+consentement aux dépendances** : les `deps` d'une app sont *signalées*,
+jamais installées en silence. Rien n'installe un modèle ou un pack de
+nœuds personnalisés sur votre machine parce que vous avez appuyé sur une
+carte.
+
+<Note>
+  `pricing_json` et `hosted_only` existent dans le schéma du manifeste et
+  sont transmis tels quels, mais rien ne les lit. Ils réservent de la place
+  pour une phase de monétisation uniquement conçue — il n'y a aucun
+  comportement d'app payante aujourd'hui.
+</Note>
+
+## L'outil MCP `apps`
+
+Un outil avec cinq actions, toutes de minces proxies au-dessus de l'API
+Apps du panneau. C'est la surface **sans canevas** : ce que l'appli mobile
+et un agent piloté directement utilisent. Il est sur la liste blanche
+`call_tool` de l'orchestrateur — `list`/`get`/`run_status` sont en lecture
+seule, et `run` porte la même posture de risque que `enqueue_workflow`
+(il met en file un job que l'utilisateur a explicitement lancé).
+
+| Action | Effet |
+|---|---|
+| `action:"list"` | Lister chaque app enregistrée sur ce ComfyUI — chaque entrée est le manifeste complet plus `has_workflow` / `has_prompt` / `has_thumbnail`. Aucun autre paramètre. Lecture seule. |
+| `action:"get"` | Le manifeste + les faits du bundle d'une app par id. `appMode.inputs` est le formulaire d'exécution. Lecture seule. |
+| `action:"run"` | Patcher `values` dans l'instantané et le mettre en file. Renvoie `prompt_id`. |
+| `action:"run_status"` | Sonder une exécution par `prompt_id` : `status` plus les sorties de l'exécution (réfs de fichiers image/vidéo par nœud de sortie, sorties texte). Lecture seule. |
+| `action:"import"` | Installer une app depuis le registre public sur ce ComfyUI. |
+
+### Paramètres
+
+`action` est le seul paramètre exigé par le schéma — chaque action a besoin
+d'un sous-ensemble différent, donc le reste est optionnel dans le schéma et
+leur présence est imposée par le gestionnaire, qui nomme le champ qui
+manque.
+
+| Action | Paramètre | Type | Notes |
+|---|---|---|---|
+| `get` | `app_id` | `string` (uuid), requis | depuis `action:"list"` |
+| `run` | `app_id` | `string` (uuid), requis | |
+| | `values` | `object`, optionnel | clés `"<nodeId>.<widget>"` ; les clés inconnues échouent fort |
+| `run_status` | `app_id` | `string` (uuid), requis | |
+| | `prompt_id` | `string`, requis | doit correspondre à `^[0-9a-zA-Z-]{1,64}$` |
+| `import` | `registry_url` | `string` (URL), requis | doit être le registre par défaut ou une origine en liste blanche |
+| | `app_id` | `string` (uuid), requis | l'uuid de l'app du **registre** |
+| | `slug` | `string`, optionnel | enregistré dans les métadonnées locales |
+| | `version` | `integer`, optionnel | enregistré dans les métadonnées locales |
+
+La contrainte de forme de `prompt_id` est imposée **deux fois** — à la
+frontière du schéma et encore à l'intérieur du gestionnaire — parce que
+l'id est interpolé dans un chemin d'URL. Un « prompt id » en forme de
+traversée ne doit jamais atteindre le constructeur d'URL même si un appelant
+contourne le schéma.
+
+Pour la référence de schéma générée par outil, voir
+[Outils Apps](/docs/tools/apps).
+
+### Importer depuis le registre
+
+`action:"import"` récupère le bundle du registre côté serveur et le crée
+comme une app locale. L'**id du registre devient l'id local**, donc
+réimporter une app que vous avez déjà signale un conflit d'id plutôt que de
+la dupliquer. La vignette vit à un endpoint de registre séparé et est
+récupérée et transmise séparément, donc une app installée garde son
+illustration de carte.
+
+Les dépendances ne sont **pas** installées. L'outil renvoie les `deps` du
+manifeste pour que l'appelant puisse les signaler et laisser l'utilisateur
+les installer délibérément.
+
+<Warning>
+  `registry_url` est une liste blanche, pas une URL libre. La récupération
+  se fait **sur le serveur**, donc une URL arbitraire serait une primitive
+  SSRF — adresses loopback ou LAN, ou une URL publique qui redirige vers
+  l'une d'elles. Seul le registre public par défaut est accepté sauf si
+  l'opérateur met en liste blanche des origines supplémentaires via
+  `COMFYUI_MCP_REGISTRY_URLS` (séparées par des virgules, prévu pour le
+  dev/la préprod). Les redirections sont refusées net plutôt que suivies.
+</Warning>
+
+## Limites et validation
+
+Des choses que vous pouvez vraiment rencontrer :
+
+| Limite | Valeur | Où |
+|---|---|---|
+| Bundle / prompt JSON | 16 Mo | plus spacieux qu'un graphe simple parce qu'un prompt peut porter des images en base64 |
+| Vignette | 5 Mo | décodée et validée **avant** que quoi que ce soit soit écrit, pour qu'une mauvaise vignette ne puisse pas laisser un bundle à moitié créé derrière |
+| Nom de l'app | 120 caractères | tronqué |
+| Description | 4000 caractères | tronqué |
+| `choices` de combo | 200 entrées | tronqué |
+| Récupération du registre | 16 Mo, 30 s | vérifié sur le `content-length` déclaré **et** les octets réels |
+
+Validation que vous remarquerez :
+
+- **Les ids d'app doivent être des uuid.** Tout le reste est rejeté avant
+  qu'un chemin soit construit, et le chemin de bundle résolu est
+  revérifié pour rester sous la racine des apps.
+- **Un prompt doit être au format API** — clés d'id de nœud numériques,
+  chaque nœud un objet `{class_type, inputs}`. Les graphes au format UI
+  sont rejetés.
+- **Un workflow UI est requis sauf si `hideWorkflow`** est défini.
+- **Créer une app qui existe déjà** est un conflit, pas un écrasement.
+- **Les mises à jour partielles de manifeste sont vraiment partielles.**
+  Publier ou masquer une app n'envoie que ses propres champs et
+  n'effacera pas votre nom, description, ou `appMode`.
+- **Les clés de manifeste inconnues sont abandonnées**, sauf les champs
+  pass-through réservés, donc une machine plus ancienne ignore les champs
+  qu'elle ne comprend pas au lieu d'échouer.
+
+La racine des apps est remplaçable avec `COMFYUI_MCP_APPS_DIR` (surtout
+pour les tests) ; par défaut elle est dérivée du propre répertoire
+utilisateur de ComfyUI, donc elle survit aux installations portables.
+
+## Sur le téléphone
+
+L'appli mobile livre un vrai onglet **Apps** — pas un aperçu. Il a deux
+moitiés :
+
+- **Mes apps** — les apps installées sur votre machine, listées via le
+  pont avec `action:"list"`. Appuyer sur l'une ouvre un formulaire
+  d'exécution généré, la met en file avec `action:"run"`, et sonde
+  `action:"run_status"` toutes les 2 s (borné à 30 minutes) jusqu'à ce
+  que les sorties s'affichent.
+- **Explorer** — le registre public, frappé **directement en HTTPS** depuis
+  le téléphone (pas de saut de pont, donc la navigation marche avant que
+  vous ayez appairé). Installer va dans l'autre sens : la machine récupère
+  le bundle elle-même via `action:"import"`.
+
+C'est la chose la plus claire que le téléphone peut faire et que le chat
+ne peut pas — exécuter un vrai workflow, avec de vraies entrées, sans
+canevas nulle part en vue.
+
+## Voir aussi
+
+- [Outils Apps](/docs/tools/apps) — la référence de schéma générée par outil
+- [Panneau latéral](/docs/fr/panel) — où les apps sont converties, publiées
+  et explorées
+- [Appli mobile](/docs/fr/mobile) — l'onglet Apps dans son contexte
+- [Pods RunPod](/docs/tools/runpod) — le pod que le chemin « Exécuter sur
+  RunPod » cible
+- [Feuille de route](/docs/fr/roadmap)

--- a/docs/fr/arena.mdx
+++ b/docs/fr/arena.mdx
@@ -1,0 +1,139 @@
+---
+title: "Arène des LLM"
+description: "Évaluez N'IMPORTE QUEL LLM agent sur de vraies tâches ComfyUI — local (Ollama), hébergé (OpenRouter/DeepSeek/GLM/MiMo), ou frontier. Chaque score est vérifié contre le serveur ComfyUI, pas les prétentions du modèle. Une commande, des rapports prêts à partager."
+icon: "trophy"
+---
+
+L'**Arène des LLM ComfyUI** répond à une question honnêtement : *ce modèle
+peut-il vraiment piloter ComfyUI ?* Pas « a-t-il l'air confiant » — le
+résultat de chaque scénario est **vérifié contre le serveur ComfyUI
+lui-même** (historique des jobs, paramètres du graphe exécuté, vrais
+fichiers de sortie et leurs tailles en pixels). Elle tourne sur le même
+[routeur d'outils compact](/docs/fr/local-llms) que le panneau et les
+clients MCP utilisent, donc un score d'arène prédit le comportement réel
+de l'agent.
+
+```bash
+npm run arena          # scores the default local field via Ollama
+```
+
+## L'échelle de tâches
+
+Dix scénarios, trois paliers de difficulté, PASS = 2 (fait et vérifié par
+le serveur), PARTIAL = 1 (bonne famille d'outils, résultat incomplet),
+FAIL = 0 — max **20** :
+
+| Palier | Scénario | Ce qu'il prouve |
+| --- | --- | --- |
+| Basics | `health` · `models` · `registry` · `queue` | découverte d'outils + tâches à un seul appel |
+| Gauntlet | `generate` (rendu asynchrone + sondage) · `precision` (les steps/taille exacts atterrissent dans le graphe exécuté) · `breakfix` (échec volontaire → diagnostiquer → récupérer) · `provenance` (trouver le registre d'assets, le re-rendre via generate_image (action:"regenerate") avec un override) | chaînes multi-sauts, fidélité des paramètres, récupération d'erreurs |
+| Crucible | `multiout` (UN graphe qui enregistre des sorties 512px + 1024px — vérifié en lisant les en-têtes PNG) · `pipeline` (img2img en deux étapes chaîné via `upload_image (action:"stage")`) | composition de graphe brute — aucun template ne couvre ça |
+
+Les égalités se départagent sur **coups de pouce → tours d'outils → temps
+écoulé**, donc un modèle qui cloue une tâche du premier coup se classe
+au-dessus d'un qui a pataugé jusqu'au même score.
+
+## Apportez votre propre modèle
+
+L'arène parle deux dialectes — Ollama local et tout ce qui est compatible
+OpenAI :
+
+```bash
+# Local models (Ollama)
+ARENA_MODELS="gemma4:e4b,qwen3:4b" npm run arena
+
+# Any hosted model — one OpenRouter key covers most of the market
+ARENA_API=openai ARENA_BASE_URL=https://openrouter.ai/api/v1 \
+ARENA_API_KEY=sk-or-... ARENA_TIER=B-tier \
+ARENA_MODELS="deepseek/deepseek-v3.2,z-ai/glm-5.1,xiaomi/mimo-v2.5" \
+npm run arena
+
+# Direct providers work too (any /v1/chat/completions endpoint):
+#   DeepSeek:  ARENA_BASE_URL=https://api.deepseek.com/v1
+#   vLLM/LM Studio: point ARENA_BASE_URL at your server
+```
+
+Les résultats **fusionnent entre les invocations** (lancez un modèle à la
+fois si vous voulez) dans `arena-results/` : un JSON, les transcriptions
+complètes par scénario, et un `arena-report.md` prêt à partager. Générez
+le graphique du classement avec :
+
+```bash
+node scripts/arena-graphic.mjs    # light + dark SVGs from your own results
+```
+
+Boutons utiles : `ARENA_TIER` étiquette les modèles d'une exécution (SoTA /
+B-tier / local) ; `ARENA_OUT` redirige la sortie ; `ARENA_MAX_ROUNDS` et
+`ARENA_SCENARIO_TIMEOUT_MS` bornent les modèles qui s'emballent ;
+`COMFYUI_DEFAULT_CHECKPOINT` épingle le checkpoint de rendu (faites-le si
+votre dossier de checkpoints commence par un modèle non-txt2img).
+
+**Prérequis** : un ComfyUI en cours d'exécution avec un checkpoint txt2img
+(SD 1.5 suffit — les scénarios sont vérifiés sur le contenu, pas la
+qualité), `npm run build` une fois, et soit Ollama soit une clé API.
+
+## Ce que chaque exécution enregistre
+
+Au-delà du score, chaque entrée du classement porte les axes qui rendent
+un résultat actionnable (#792) :
+
+- **Quantification et taille en paramètres** (Ollama `/api/show`) et
+  **VRAM résidente** (`/api/ps`, échantillonné pendant que le modèle est
+  encore chargé) — donc « que peut vraiment faire tourner ma carte 8 Go,
+  et un q4 suffit-il ? » est répondable depuis le tableau. Faire passer
+  le même modèle en q4 / q8 / fp16 dans l'échelle montre où le score
+  chute vraiment. Ces champs sont vides quand la sonde ne peut pas
+  répondre (les endpoints hébergés n'ont pas d'équivalent) — jamais
+  devinés.
+- **La version de comfyui-mcp**, tamponnée sur chaque entrée dont
+  l'exécution a pu la lire (une exécution qui ne peut pas lire sa propre
+  version de paquet est enregistrée *sans version*, exactement comme une
+  exécution d'avant le tamponnage). Les scores absolus bougent quand la
+  surface d'outils change, donc le rapport signale tout classement qui
+  mélange des versions (ou des exécutions sans version) comme **non
+  directement comparable**.
+- **Chaque outil que le modèle a tendu la main** sur un échec, pas
+  seulement ceux qui ont réussi. Quand 2+ modèles échouent le même
+  scénario après avoir choisi le même mauvais outil (et qu'aucune
+  exécution réussie ne l'a utilisé), le rapport signale un **scénario
+  suspect** — une sélection fausse sur tout le champ est un suspect de
+  *description* d'outil, pas un trou de capacité (précédent : #557/#654,
+  où c'était notre propre libellé, pas les modèles, qui était faux).
+  Vérifiez la description avant de faire confiance aux scores de ce
+  scénario.
+
+## Classement actuel
+
+<img className="block dark:hidden" src="/images/arena-leaderboard-light.svg" alt="Classement de l'Arène des LLM ComfyUI" />
+<img className="hidden dark:block" src="/images/arena-leaderboard-dark.svg" alt="Classement de l'Arène des LLM ComfyUI" />
+
+14 modèles, meilleur-de-3 sur le cluster du haut. Les constats en tête :
+
+- **gemini-3.1-pro-preview est le seul modèle parfait à chaque
+  exécution** (20-20-20).
+- claude-opus-4.8 et gpt-5.5 atteignent tous les deux 20 mais ont perdu
+  un point dans d'autres exécutions.
+- **Le B-tier n'est qu'à un point du frontier** — GLM-5.1 (19-19-19, le
+  modèle le plus régulier du champ), Kimi-k2.5 et MiMo-v2.5 à 19 — pour
+  une petite fraction du prix frontier.
+- Les petits modèles locaux passent les bases et des parties du gauntlet
+  mais calent sur la composition de graphe du crucible ; llama3.1:8b ne
+  peut pas du tout tenir le format d'outils.
+
+Nous aimerions des exécutions communautaires de modèles que nous n'avons
+pas couverts — postez votre `arena-report.md` (et le graphique) dans une
+[discussion GitHub](https://github.com/artokun/comfyui-mcp/discussions) ou
+une issue, avec votre GPU + les tags de modèle pour que les résultats
+soient comparables.
+
+## Test fumée du panneau
+
+Un score d'arène prouve le pilotage d'outils headless ; `npm run smoke:panel`
+prouve que le même modèle survit au **panneau latéral en direct**
+(flux, filtrage des tours, le routeur à 6 outils sur le pont). Il lance
+un orchestrateur isolé par modèle sur son propre port et pilote un vrai
+tour :
+
+```bash
+SMOKE_MODELS="gemma4:e4b,xiaomi/mimo-v2.5" npm run smoke:panel
+```

--- a/docs/fr/backends.mdx
+++ b/docs/fr/backends.mdx
@@ -1,0 +1,334 @@
+---
+title: "Backends / fournisseurs"
+description: "L'agent du panneau tourne sur N'IMPORTE QUEL LLM : Claude, ChatGPT, Gemini, Grok, Kimi ou GLM sur votre propre abonnement/forfait, un modèle local gratuit via Ollama / LM Studio / llama.cpp (aucun compte), ou n'importe quel modèle hébergé via un endpoint compatible OpenAI. Comment le port AgentBackend neutre vis-à-vis du fournisseur, le sélecteur, et la matrice des fonctionnalités marchent."
+icon: "shuffle"
+---
+
+L'agent du [panneau latéral](/docs/fr/panel) est **agnostique vis-à-vis du
+fournisseur**. Choisissez **Claude**, **ChatGPT**, **Gemini**, ou
+**Ollama (local)** et l'agent correspondant tourne en arrière-plan — les
+abonnements n'ont pas besoin de clé API, et les modèles locaux n'ont besoin
+d'aucun compte. Le backend Ollama parle aussi **n'importe quel endpoint
+compatible OpenAI** (OpenRouter, DeepSeek, GLM, MiMo, vLLM, LM Studio),
+donc « apportez votre propre modèle » couvre tout, d'un 4B gratuit sur
+votre propre GPU jusqu'au frontier. Tous les fournisseurs partagent les
+mêmes outils de canevas en direct, la même connaissance des modèles, les
+mêmes chargements de workflow en une fois, le même garde-fou sur les coûts.
+L'[Arène des LLM](/docs/fr/arena) les note tous sur de vraies tâches
+ComfyUI.
+
+```
+panel (pick a provider) ⇄ loopback bridge ⇄ orchestrator (Claude · ChatGPT · Gemini · any LLM) ⇄ your graph
+```
+
+## Choisissez un fournisseur, pas un port
+
+Le panneau affiche un **sélecteur de fournisseur** — des puces Claude /
+ChatGPT / Gemini / Antigravity / Grok / Kimi / GLM / Ollama / LM Studio /
+llama.cpp / OpenRouter / Endpoint personnalisé (les fournisseurs
+expérimentaux comme Copilot apparaissent derrière le commutateur
+expérimental). En cliquer une connecte ce fournisseur sur le seul
+orchestrateur partagé (un port de pont sert tous les fournisseurs ; chaque
+onglet du panneau choisit son fournisseur lors de la poignée de main).
+L'URL du pont vit sous **Avancé** pour les orchestrateurs gérés par
+l'utilisateur.
+
+Changer de fournisseur **démarre une nouvelle conversation** — les
+conversations ne sont pas partagées entre fournisseurs — et le panneau
+poste une note système qui le dit. Le placeholder de la zone de rédaction
+suit le backend actif (« Demandez à Claude… » / « Demandez à Ollama… »).
+
+## Se connecter (une fois par fournisseur — ou pas du tout)
+
+- **Claude** — `claude` (ou `claude setup-token`) — OAuth claude.ai
+  (abonnement).
+- **ChatGPT (Codex)** — `codex login` — connexion ChatGPT (abonnement) ;
+  passe par l'app-server Codex.
+- **ChatGPT (OAuth direct)** — aucune étape supplémentaire si vous avez
+  déjà lancé `codex login` : le backend `chatgpt` réutilise
+  `~/.codex/auth.json` et parle à ChatGPT directement (pas de processus
+  Codex). Si l'accusé dit que le fichier d'auth manque, lancez
+  `codex login` une fois.
+- **Gemini** — `gemini` — connexion Google. Notez que la connexion Google
+  individuelle gratuite a été retirée le 2026-06-18 : le backend CLI Gemini
+  a maintenant besoin d'une `GEMINI_API_KEY` ou d'un compte
+  entreprise/Code Assist. Abonnés individuels : utilisez **Antigravity**
+  ci-dessous.
+- **Antigravity (abonnement Google)** — installez le CLI Antigravity
+  officiel depuis [antigravity.google](https://antigravity.google), lancez
+  `agy` une fois et terminez la connexion Google (forfaits AI Pro/Ultra et
+  gratuits). Le backend pilote `agy -p` par tour avec la continuité de
+  conversation `--continue`, lit le catalogue de modèles en direct depuis
+  `agy models`, et branche les outils MCP ComfyUI + panneau via un
+  `.agents/mcp_config.json` d'espace de travail sûr à fusionner. Capacités
+  réduites par conception (pas de flux d'événements machine-readable
+  documenté) : le texte de la réponse finale arrive en flux, mais il n'y a
+  pas de progression par outil ni d'entrée image. La continuité de
+  conversation utilise `agy --continue` (la dernière conversation du
+  compte), donc lancez UN seul onglet antigravity à la fois — un second
+  onglet, ou une session `agy` interactive dans un terminal, peut voler
+  le fil. `COMFYUI_MCP_ANTIGRAVITY_MODEL` épingle un modèle,
+  `COMFYUI_MCP_ANTIGRAVITY_PATH` pointe vers une installation hors
+  standard.
+- **Grok** — installez le CLI Grok (xAI / Grok Build) et lancez `grok` une
+  fois pour vous connecter ; le backend le pilote en mode ACP. Le panneau
+  propose aussi une ligne de connexion OAuth dans le panneau quand Grok
+  n'est pas prêt.
+- **Kimi (recommandé)** — installez le [CLI Kimi Code](https://moonshotai.github.io/kimi-code/)
+  et lancez `kimi login` (flux device-code) ; le backend réutilise cette
+  connexion depuis `~/.kimi-code/credentials/kimi-code.json` (le chemin
+  héritage `~/.kimi` est encore lu en repli). Ça utilise votre
+  **abonnement Kimi Code** et c'est la façon préférée de lancer Kimi —
+  moins cher et à limites plus hautes que la clé Moonshot au jeton
+  ci-dessous. Définissez `KIMI_API_KEY` à la place seulement pour le CI /
+  l'usage sans CLI, ou `KIMI_CODE_HOME` pour pointer vers un répertoire
+  d'identifiants non par défaut (`KIMI_SHARE_DIR` est encore honoré pour
+  quiconque a défini l'ancien nom). La connexion OAuth dans le panneau
+  est aussi proposée.
+- **GLM** — définissez `ZAI_API_KEY` (Z.AI Coding Plan ; `GLM_API_KEY` /
+  `ZHIPUAI_API_KEY` aussi acceptées). Pas de CLI.
+- **Kimi K3 (Moonshot)** — l'**alternative au jeton** quand vous n'avez
+  pas d'abonnement Kimi Code (préférez le chemin **Kimi** ci-dessus si
+  vous en avez un). Définissez `MOONSHOT_API_KEY` depuis
+  [platform.kimi.ai](https://platform.kimi.ai/console/api-keys). Pas de
+  CLI. C'est la clé **plateforme** Moonshot (modèle par défaut `kimi-k3`,
+  base `https://api.moonshot.ai/v1`) — distincte du fournisseur **Kimi**
+  ci-dessus, qui est l'abonnement de code Kimi Code. Remplacez le modèle
+  avec `COMFYUI_MCP_MOONSHOT_MODEL` et la base avec
+  `COMFYUI_MCP_MOONSHOT_BASE_URL`.
+- **MiniMax** — définissez `MINIMAX_API_KEY` depuis
+  [platform.minimax.io](https://platform.minimax.io/console/api-keys). Pas
+  de CLI. Le modèle par défaut est `MiniMax-M3` et la base par défaut est
+  l'endpoint global `https://api.minimax.io/v1` (compatible OpenAI, auth
+  Bearer simple). Pour la région Chine, définissez
+  `COMFYUI_MCP_MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. Remplacez
+  le modèle avec `COMFYUI_MCP_MINIMAX_MODEL`.
+- **Copilot (expérimental)** — connectez-vous depuis la ligne de
+  fournisseur expérimental du panneau. Éteint par défaut ; activez d'abord
+  les backends expérimentaux dans Réglages.
+- **Ollama (local)** — pas de connexion. Installez Ollama et tirez un
+  modèle capable d'appeler des outils (`ollama pull gemma4:e4b`). Pour un
+  modèle **hébergé** à la place, définissez `COMFYUI_MCP_OLLAMA_API=openai`,
+  `COMFYUI_MCP_OLLAMA_BASE_URL` (par ex. `https://openrouter.ai/api/v1`),
+  et une clé API (`COMFYUI_MCP_OLLAMA_API_KEY` / `OPENROUTER_API_KEY`).
+- **Endpoint personnalisé** — pas de flux de connexion. Pointez-le vers
+  n'importe quel `/v1` compatible OpenAI (vLLM, DeepSeek, Together, Azure,
+  un llama-server distant) dans Réglages → Endpoint personnalisé ; ajoutez
+  une clé API là si le serveur en a besoin (saisie masquée, stockée 0600
+  par l'orchestrateur). Voir
+  [LLM locaux → Endpoint personnalisé](/docs/fr/local-llms#endpoint-personnalisé-tout-serveur-compatible-openai).
+
+### État de préparation à la connexion et prise en main
+
+Chaque puce de fournisseur se dégrade HONNÊTEMENT quand elle n'est pas
+prête : l'accusé de connexion vous dit l'étape manquante exacte
+(« Définissez ZAI_API_KEY… », « lancez `codex login`… », « Connectez-vous
+depuis la ligne expérimentale… ») au lieu d'échouer à votre premier
+message — et un fournisseur dont les identifiants apparaissent plus tard
+passe à prêt au prochain Connecter sans redémarrage.
+
+Le panneau détecte l'état de préparation de chaque fournisseur au moment
+de **Connecter** — un CLI dans le `PATH` plus une connexion sur disque
+pour les fournisseurs par abonnement, un binaire présent pour Ollama (un
+démon arrêté se dégrade proprement à la connexion). Vous n'avez pas à
+deviner quel fournisseur est configuré :
+
+- Une **carte de prise en main** n'apparaît que lorsque **aucun**
+  fournisseur n'est prêt, avec l'étape de configuration unique par
+  fournisseur (pour Ollama c'est une installation + un pull de modèle,
+  pas une connexion).
+- Si le fournisseur enregistré n'est pas utilisable, le panneau **bascule
+  automatiquement vers un fournisseur prêt** (votre préférence
+  enregistrée est restaurée une fois que vous l'avez configuré).
+- La ligne d'un fournisseur non prêt devient une action **« configurer »**
+  qui amorce une invite de configuration vers l'agent qui marche.
+
+## Comment chaque fournisseur est piloté
+
+L'orchestrateur dépend d'un port **`AgentBackend`** neutre vis-à-vis du
+fournisseur (injection de dépendances). Chaque fournisseur est un
+adaptateur :
+
+| | Claude | ChatGPT (Codex) | Gemini | Ollama / n'importe quel LLM |
+|---|---|---|---|---|
+| Pilote | Claude Agent SDK — session persistante en flux | `codex app-server` JSON-RPC | `gemini --acp` (Agent Client Protocol) | HTTP direct — Ollama `/api/chat` ou n'importe quel `/v1/chat/completions` compatible OpenAI ; le backend possède toute la boucle agentique |
+| Auth | OAuth claude.ai | connexion ChatGPT | connexion Google | aucune (local) / clé bearer (hébergé) |
+| Outils de canevas en direct | serveur MCP SDK in-process | MCP streamable-HTTP loopback | MCP streamable-HTTP loopback | le [routeur à 6 outils](/docs/fr/local-llms) sur le même MCP loopback |
+| MCP `comfyui` headless | in-process | stdio déclaré en config | stdio déclaré en config | sous-processus stdio en mode compact derrière le routeur |
+
+Les définitions d'outils `panel_*` vivent dans **une seule liste
+partagée**, enregistrée sur chaque chemin, donc la surface de canevas en
+direct (y compris le filtrage de confirmation destructrice pour
+`panel_clear` / `panel_restart_comfyui`) est identique entre fournisseurs.
+La parité est automatique — aucun chemin ne réimplémente un outil. Le
+backend Ollama/n'importe-quel-LLM enveloppe en plus les deux surfaces
+d'outils derrière six outils routeur pour que les petits modèles ne se
+noient pas dans les schémas — voir
+[LLM locaux et autres agents](/docs/fr/local-llms).
+
+## Matrice des fonctionnalités
+
+Un descripteur de fonctionnalités par backend laisse le panneau **se
+dégrader proprement** sur les fonctionnalités qu'un fournisseur ne peut
+pas faire :
+
+| Fonctionnalité | Claude | ChatGPT (Codex) | Gemini | Ollama / n'importe quel LLM |
+|---|---|---|---|---|
+| Canal persistant (pousser des tours dans le temps) | ✅ | ✅ (fil + `turn/start`) | ✅ | ✅ (historique en mémoire) |
+| Deltas en flux | ✅ | ✅ | ✅ | ✅ (NDJSON / SSE) |
+| Interrompre en cours de tour | ✅ | ✅ (`turn/interrupt`) | ✅ (`session/cancel`) | ✅ (abandon de requête) |
+| Retour en arrière de conversation (forker à un tour) | ✅ `forkSession` | ⚠️ désactivé | ⚠️ désactivé | ⚠️ désactivé |
+| Outils MCP in-process | ✅ | ❌ | ❌ | ❌ (routeur au-dessus de clients MCP) |
+| Énumération des modèles | ✅ | ✅ (`config/read`) | catalogue statique | ✅ (`/api/tags` ou `/models`) |
+| Vision (entrée image) | ✅ | ✅ | ✅ | ❌ (dépend du modèle ; éteint pour l'instant) |
+| Entrée audio | ❌ | ❌ | ❌ | ✅ Ollama (vérifié) · ⚠️ autres (non vérifié) |
+| Commandes slash du fournisseur | ✅ | ❌ | ❌ | ❌ |
+
+### Entrée audio — quels backends, honnêtement
+
+L'agent peut piloter les outils audio de ComfyUI sur chaque backend.
+**Entendre** un fichier audio est plus étroit, et le tableau ci-dessus est
+volontairement conservateur parce qu'une pièce jointe abandonnée en
+silence est pire qu'une refusée :
+
+- **Ollama (le backend `ollama`, `/api/chat` natif) — pris en charge,
+  vérifié en capacité, et vérifié de bout en bout.** L'audio voyage dans
+  le tableau `images[]`, qui est le propre porteur d'audio d'Ollama plutôt
+  qu'un hack. Confirmé en direct contre un Ollama local avec
+  `gemma4:e2b`, qui a transcrit un vrai WAV.
+  - **Par modèle, pas par fournisseur.** Avant d'envoyer quoi que ce soit,
+    le backend demande à `POST /api/show` si *ce* modèle signale la
+    capacité `audio`. S'il ne le fait pas, la pièce jointe est refusée
+    par nom, la liste de capacités signalée est citée, et on vous dit
+    quels modèles peuvent entendre (`ollama pull gemma4:e2b` /
+    `gemma4:e4b` / `nemotron3:33b`). Notez que `GET /api/tags` renvoie
+    aussi un tableau `capabilities` et ce n'est **pas** la même réponse
+    — le même modèle n'y signalait pas d'audio et en signalait depuis
+    `/api/show` — donc seul `/api/show` est consulté.
+  - La capacité est revérifiée à chaque tour qui porte de l'audio, parce
+    qu'un tag Ollama est mutable : `ollama pull` peut remplacer les
+    poids sous le même nom, et un verdict en cache pourrait survivre au
+    modèle qu'il décrivait.
+- **LM Studio / llama.cpp / OpenRouter / GLM / Kimi / Moonshot / MiniMax /
+  Copilot / endpoints personnalisés compatibles OpenAI — tenté, PAS
+  vérifié en capacité.** Tous parlent `/v1/chat/completions`, qui n'a
+  aucun endpoint de capacité à interroger, donc l'audio est envoyé comme
+  une partie de contenu `input_audio` et on vous dit, à ce tour, que la
+  livraison est **non confirmée** : *« Je ne peux pas confirmer que le
+  modèle les reçoit vraiment — si la réponse ne reflète pas ce qu'il y a
+  dans le fichier, il ne l'a pas entendu. »* Refuser à la place
+  refuserait l'audio à chaque endpoint qui n'a simplement pas d'API de
+  capacité ; un garde qui ne peut pas tourner n'est pas un verdict. La
+  forme `input_audio` elle-même a été vérifiée contre l'endpoint
+  compatible OpenAI d'Ollama ; qu'un hôte tiers *donné* l'honore n'est
+  pas quelque chose que nous pouvons vérifier, et nous ne le prétendons
+  pas.
+- **Claude, ChatGPT (Codex), Codex CLI, Gemini, Grok, Antigravity, pi** —
+  pas d'entrée audio dans ce build. Joindre de l'audio est refusé avant
+  que le tour soit construit, et vous et le modèle en êtes informés, en
+  nommant le fournisseur et ce qui marcherait à la place.
+
+  Sur Gemini/Grok c'est une omission volontaire plutôt qu'un trou de
+  protocole : ACP *définit* bien un ContentBlock `audio`, mais il exige
+  que l'agent annonce d'abord une capacité de prompt `audio`, et aucun
+  des deux CLI n'a été observé le faire. Un chemin d'envoi qui ne peut
+  jamais être exercé, dont le mode d'échec est une pièce jointe dont
+  l'utilisateur n'est jamais informé qu'elle n'est pas arrivée, est pire
+  qu'un refus honnête — donc il n'est pas livré.
+
+Le commutateur **Aveugle** concerne les *pixels* : il retient les images
+et ne **retient pas** l'audio.
+
+L'application d'Aveugle atteint aussi les **outils natifs** de l'agent,
+pas seulement la surface MCP comfyui : le backend Claude intégré tourne
+avec une barrière PreToolUse qui refuse ses propres `Read`/`WebFetch` sur
+le contenu image (fichiers raster par extension *et* octets magiques,
+PDF, sorties de notebook, et URL `/view` de ComfyUI) dès qu'Aveugle est
+activé — lu en direct à chaque appel, donc un commutateur en cours de
+session lie le tout prochain appel d'outil. Les voies API/locales
+(famille Ollama, GLM, Kimi, endpoints personnalisés) ne portent que
+notre surface d'outils, donc le nettoyage MCP les couvre entièrement.
+Les **voies CLI** (Codex, Gemini, Grok, Antigravity, pi, Copilot)
+exécutent leurs propres binaires d'agent dont les outils de fichiers
+intégrés nous ne pouvons pas accrocher — activer Aveugle là-bas poste
+un avertissement visible qui dit exactement ça, plutôt que d'impliquer
+une garantie que nous ne pouvons pas tenir.
+
+#### Comment un fichier audio arrive sur un tour
+
+L'orchestrateur accepte l'audio sur une trame `message` du panneau de
+deux façons :
+
+```jsonc
+{ "type": "message", "text": "what key is this in?",
+  "audio":  [{ "filename": "song.mp3", "type": "input" }],   // preferred
+  "images": [{ "filename": "song.mp3", "type": "input" }] }  // also routed to audio
+```
+
+La seconde forme existe parce qu'un build de panneau qui ne connaît que
+`images` remettrait autrement un fichier audio à une partie de contenu
+vision. Tout ce qui a une extension audio est déplacé automatiquement
+vers le chemin audio — y compris les formats que nous ne savons pas
+encoder (`.wma`, `.mid`, `.aiff`), donc vous obtenez « convertissez-le
+en l'un de… » plutôt qu'une erreur d'image.
+
+Envoyer le même fichier dans **les deux** tableaux (comme le fait
+l'exemple ci-dessus) est sûr : une réf est identifiée par nom de fichier
++ sous-dossier + type, donc elle est livrée une fois et compte une fois
+contre la limite de deux pièces jointes par tour. Elle n'est pas prise
+pour un second fichier puis refusée pour ne pas tenir.
+
+<Note>
+Un **contrôle de zone de rédaction** pour choisir un fichier audio vit
+dans le panneau (`comfyui-mcp-panel`), qui est un dépôt séparé — cette
+partie n'est pas dans cette version. En attendant qu'elle atterrisse, le
+contrat filaire ci-dessus est ce qu'un client envoie, et la route est
+exercée de bout en bout depuis le côté orchestrateur.
+</Note>
+
+Seul le chemin Ollama natif ci-dessus est vérifié de bout en bout, et
+c'est le seul où « ce modèle peut entendre » est établi plutôt que
+supposé. Le chemin compatible OpenAI est une tentative honnête avec une
+réserve honnête ; tout le reste de cette section décrit un refus, pas
+une capacité.
+
+Le **retour en arrière de conversation** (forker le chat vers un tour
+passé) est réservé à Claude ; le retour en arrière **code/graphe**
+(`/revert`, double Échap, instantanés par tour) marche sur chaque
+backend parce qu'il vit dans l'orchestrateur, pas le fournisseur.
+
+## Effort de raisonnement lors d'un changement
+
+Le sélecteur d'effort/modèle est **par fournisseur**. Un effort choisi
+survit à un changement de fournisseur en se mappant au niveau valide le
+plus proche pour le backend cible (le panneau et les backends de
+l'orchestrateur font le même mapping) :
+
+- **Claude :** `low` · `medium` · `high` · `xhigh` · `max`
+- **ChatGPT (Codex) :** `none` · `minimal` · `low` · `medium` · `high` ·
+  `xhigh` · `max` · `ultra` (`max` / `ultra` sur les modèles de classe
+  GPT-5.6)
+- **Gemini / Ollama :** pas d'échelle d'effort visible — le sélecteur
+  est caché.
+
+## Parité des connaissances et des coûts
+
+Parce que seul Claude peut charger des skills natives, l'expertise
+bundlée est publiée comme un outil MCP que n'importe quel backend peut
+appeler — `list_packs`, dont les actions couvrent les skills
+(`skill_list`, `skill_read`), les packs d'installation (`list`,
+`read_workflow`) et les templates du serveur (`list_templates`) — plus
+le garde-fou GPU-local-vs-API-payante (`action: "check_runtime"`) et
+`panel_load_workflow` en une fois. Voir
+[Skills, packs et coût d'exécution](/docs/tools/skills-knowledge).
+
+## Voir aussi
+
+- [Panneau latéral](/docs/fr/panel) — l'UX complète du panneau
+- [LLM locaux et autres agents](/docs/fr/local-llms) — le routeur à 6
+  outils, les exigences de modèle, la mise en place Hermes/OpenClaw/Copilot
+- [Arène des LLM](/docs/fr/arena) — notez VOTRE modèle sur de vraies
+  tâches ComfyUI
+- [Skills, packs et coût d'exécution](/docs/tools/skills-knowledge) — les
+  outils de parité + de coût
+- Doc de conception : [`design/agent-backend-injection.md`](https://github.com/artokun/comfyui-mcp/blob/main/design/agent-backend-injection.md)

--- a/docs/fr/cloud-deployment.mdx
+++ b/docs/fr/cloud-deployment.mdx
@@ -1,0 +1,265 @@
+---
+title: "Déploiement cloud (RunPod)"
+description: "Déployez, connectez, surveillez et arrêtez un pod GPU cloud pour ComfyUI sans quitter le panneau agent — déploiement en un geste, un commutateur d'hôte local⇄pod honnête, l'état coût/GPU en direct, et l'arrêt automatique à l'inactivité. Ou pilotez un pod existant en une commande."
+icon: "cloud"
+---
+
+Vous n'avez pas de GPU local — ou vous en voulez un plus gros à la demande ?
+Déployez ComfyUI sur un **pod GPU cloud** et pilotez-le en langage naturel
+depuis l'agent qui tourne sur **votre** machine, sur votre propre abonnement
+Claude ou ChatGPT.
+
+<Note>
+Le pod ne sert que **ComfyUI + Manager + l'UI du panneau agent**. Le cerveau
+de l'agent (l'[orchestrateur du panneau](/docs/fr/panel)) tourne **en local
+sur votre machine** sur votre propre abonnement — donc un pod cloud ne brûle
+jamais d'heures GPU sur le LLM, et aucune clé API ni connexion d'agent ne
+touche jamais la machine. Voir
+[Topologie](#topologie--où-tourne-lagent).
+</Note>
+
+## Modèle en un clic (le chemin le plus rapide)
+
+L'image préconstruite démarre **prête à être pilotée par le panneau agent** —
+ComfyUI + [Agent Panel](https://github.com/artokun/comfyui-mcp-panel) +
+ComfyUI-Manager v2 sont intégrés, aucune configuration :
+
+[![Deploy on RunPod](https://img.shields.io/badge/Deploy_on-RunPod-673AB7?style=for-the-badge)](https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b)
+
+1. Cliquez sur **Deploy on RunPod** et choisissez un GPU (une RTX 5090 /
+   n'importe quelle carte Blackwell ou Ada marche — l'image livre torch
+   cu128).
+2. Gardez les défauts du modèle : port HTTP **3000** exposé et un volume
+   réseau monté sur **`/workspace`**.
+3. Attendez que le pod soit prêt. Une page « ComfyUI is starting… » à
+   rafraîchissement automatique sert jusqu'à ce qu'il soit prêt (~30–60 s
+   d'init ComfyUI).
+
+Puis sautez à [Se connecter depuis votre machine](#se-connecter-depuis-votre-machine).
+
+## Le déployer et le contrôler depuis le panneau agent (v0.44+)
+
+Depuis **comfyui-mcp 0.44**, vous n'avez plus à toucher à la console RunPod
+ni à lancer une commande CLI — le [panneau agent](/docs/fr/panel) a un
+**panneau de contrôle RunPod** qui déploie, connecte, surveille et arrête un
+pod pour vous, et la même feuille de contrôle se livre dans
+l'[appli mobile](/docs/fr/mobile).
+
+1. **Définissez votre clé une fois.** Dans la carte **Clés API** du panneau,
+   collez votre `RUNPOD_API_KEY`. Elle est stockée côté serveur dans
+   `~/.comfyui-mcp/.env` — jamais dans le navigateur.
+2. **Ouvrez le panneau de contrôle RunPod** depuis le bouton d'hôte dans la
+   barre d'outils du panneau (il affiche **🟢 Local · votre machine** au
+   départ).
+3. **Déployez ou connectez.** Appuyez sur **Déployer** pour un pod en un
+   geste (il passe par le lien de déploiement du modèle et se rabat entre
+   types de GPU / COMMUNITY→SECURE quand la capacité est serrée), ou
+   choisissez un pod existant **par nom** dans le menu déroulant et
+   **Connecter**.
+4. **Surveillez-le en direct.** La carte d'état montre GPU / VRAM / temps de
+   fonctionnement / **$·h** et un compte à rebours d'**arrêt automatique à
+   l'inactivité**, et le bouton d'hôte bascule vers
+   **🔵 RunPod · `<pod>` · GPU · $/h** — donc où un rendu s'exécute n'est
+   jamais ambigu. L'agent installe vos nœuds personnalisés + LoRA et
+   télécharge vos modèles sur le pod, pour que vous ayez une **parité
+   exacte du canevas** avec votre machine locale.
+5. **Revenez en local et arrêtez.** **Utiliser local** redirige le rendu
+   vers votre propre machine instantanément ; **Arrêter** éteint le pod.
+   L'arrêt automatique à l'inactivité (`RUNPOD_IDLE_STOP_MINUTES`, défaut
+   15 ; ne compte que pendant que vous rendez vraiment sur le pod) est le
+   filet de sécurité des coûts si vous oubliez.
+
+**Interrupteur homme mort (v0.47+).** L'arrêt automatique à l'inactivité
+vit dans le processus comfyui-mcp — si ce processus meurt (crash, laptop
+fermé), le filet mourait avec lui et le pod facturait pour toujours. Les
+pods **créés via le connecteur** portent maintenant un chien de garde côté
+pod : tant que comfyui-mcp s'occupe du pod il envoie un battement toutes
+les quelques secondes ; si les battements s'arrêtent, le pod **s'arrête
+lui-même** (ne se termine jamais — votre `/workspace` survit) après une
+période de grâce (45 min après le démarrage sans battement, puis 20 min
+entre les battements ; `RUNPOD_DEADMAN_BOOT_GRACE_S` /
+`RUNPOD_DEADMAN_BEAT_GRACE_S`). « S'occuper » survit à **Utiliser local**
+et **Ne plus surveiller** — ceux-là ne changent que ce que l'UI montre ;
+le chien de garde ne se déclenche que lorsque comfyui-mcp lui-même a
+disparu (ou que le pod sort). Le chien de garde arrête le pod avec la
+**clé API au périmètre du pod que RunPod injecte automatiquement dans
+chaque pod** — votre clé de compte ne quitte jamais votre machine, et il
+n'y a rien à désactiver côté identifiants. Laissez-le désarmé avec
+`deadman:false` sur `runpod` / `action: "create"` (ou `RUNPOD_DEADMAN=0`),
+ou `DEADMAN_DISABLE=1` comme env du pod. Les pods déployés depuis la
+console ne portent jamais le jeton de battement, et les déploiements de
+modèle personnalisé (`RUNPOD_TEMPLATE_ID`) le laissent **éteint** par
+défaut — passez `deadman:true` seulement si cette image livre notre chien
+de garde.
+
+<Note>
+Nouveau dans la location de GPU pour ComfyUI ? Le blog parcourt tout le
+flux de bout en bout :
+[Exécuter ComfyUI sur un GPU cloud loué](/docs/blog/runpod-comfyui).
+</Note>
+
+Le reste de cette page est le **chemin manuel / CLI** — toujours
+entièrement pris en charge, et ce que le panneau de contrôle pilote sous
+le capot.
+
+## Se connecter depuis votre machine
+
+Une fois le pod prêt, récupérez son URL de proxy publique (RunPod → votre
+pod → l'endpoint HTTP **:3000**, par ex.
+`https://<pod-id>-3000.proxy.runpod.net`) et lancez **une commande** sur
+votre laptop :
+
+```bash
+npx -y comfyui-mcp@latest connect https://<pod-id>-3000.proxy.runpod.net
+```
+
+Pour un **pod HTTPS distant**, `connect` ouvre automatiquement un **tunnel
+`wss://` chiffré sécurisé** (via Cloudflare) vers le pont de l'agent sur
+votre machine et remet cette URL au panneau du pod pour vous — donc la
+page HTTPS du pod atteint l'agent avec **aucune invite navigateur, rien à
+copier, dans n'importe quel navigateur**. Pour un ComfyUI **local** il
+utilise le pont loopback `ws://127.0.0.1:9180` en clair. Dans les deux cas
+l'agent — et votre connexion Claude/ChatGPT — ne tourne que sur **votre**
+machine ; rien n'est installé sur le pod.
+
+Pour finir, avec `connect` toujours en cours sur votre propre machine,
+ouvrez le ComfyUI du pod dans votre navigateur, ouvrez la barre latérale
+**Agent**, et cliquez sur **Connecter**.
+
+Pilotez maintenant le graphe en langage naturel.
+
+<Note>
+**Pourquoi un tunnel ?** Une page de pod est servie en `https://`, et les
+navigateurs bloquent une page sécurisée qui ouvrirait une socket `ws://`
+non sécurisée vers votre machine (contenu mixte / Private Network Access).
+Le tunnel donne au pont une URL `wss://` à TLS valide — filtrée par un
+jeton aléatoire par session — pour que ça marche partout sans invite.
+</Note>
+
+<Note>
+Si le pod est derrière une auth, définissez `COMFYUI_AUTH_TOKEN` (plus
+éventuellement `COMFYUI_AUTH_HEADER` / `COMFYUI_AUTH_SCHEME`) sur la
+commande `connect` locale. Pour un pod précédé de **Cloudflare Access**,
+créez un **jeton de service** Access et définissez
+`CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` — les deux voyagent sur
+chaque requête ComfyUI (HTTP + le WebSocket du surveillant de file), donc
+le connecteur passe la barrière pendant que la page de connexion humaine
+reste debout pour les navigateurs.
+</Note>
+
+### Tout garder sur votre machine (pas de Cloudflare)
+
+Vous préférez ne pas router le pont par Cloudflare ? Atteignez le pod via
+votre propre **redirection de port SSH** pour que la page soit une origine
+loopback (`ws://` en clair marche, pas de tunnel) :
+
+```bash
+ssh <pod-ssh> -L 3000:localhost:3000   # grab the SSH command from RunPod → Connect
+npx -y comfyui-mcp@latest connect http://localhost:3000
+```
+
+Puis ouvrez **http://localhost:3000**. Ou connectez-vous à l'URL https
+directe du pod mais forcez le pont loopback en clair avec
+**`--insecure-bridge`** (vous arrangez alors votre propre chemin pour que
+la page du pod atteigne `ws://127.0.0.1:9180`).
+
+Vous voulez une **alternative auto-hébergée et stable** au quick tunnel
+Cloudflare par défaut — votre propre domaine, pas de nom d'hôte éphémère,
+propriété complète de ce saut — au lieu de l'un ou l'autre ci-dessus ?
+Voir [Relais auto-hébergé](/docs/fr/self-hosted-relay).
+
+## Topologie : où tourne l'agent
+
+```
+  YOUR LAPTOP                                   CLOUD GPU POD (RunPod)
+  ┌───────────────────────────┐                ┌───────────────────────────────────┐
+  │ npx comfyui-mcp connect …  │  HTTP/WS  ───▶ │ nginx :3000 ─▶ ComfyUI :3001        │
+  │  └─ panel orchestrator     │                │   ├─ Manager v2 (--enable-manager) │
+  │     (Claude/ChatGPT Agent  │ ◀───  events   │   └─ Agent Panel (sidebar)         │
+  │      SDK on YOUR sub)      │                │                                     │
+  └───────────────────────────┘                └───────────────────────────────────┘
+```
+
+Le pod livre volontairement **aucun agent Node.js, aucun Agent SDK, et
+aucun client LLM** — ils brûleraient des heures GPU pour rien. La boucle
+de raisonnement vit sur votre machine ; le pod est un backend ComfyUI
+pur. C'est le même [modèle de pilotage distant](/docs/fr/panel) que le
+panneau agent local utilise, juste avec ComfyUI sur un GPU cloud au lieu
+de localhost.
+
+## Ce qui persiste (et ce qui ne persiste pas)
+
+L'image est optimisée pour un **arrêt/démarrage rapide**. Le logiciel
+lourd — ComfyUI, son venv, Manager v2 — est intégré à l'image immuable et
+tourne depuis `/opt/ComfyUI`, tandis que `custom_nodes` vit sur le volume
+`/workspace` (lien symbolique) pour que vos installations persistent. Un
+redémarrage à chaud ne fait aucune installation/sync/graine complète et
+relance juste ComfyUI.
+
+| Quoi | Où ça vit | Survivre à un redémarrage ? |
+|------|----------------|---------------------|
+| Modèles (y compris les téléchargements Manager) | volume `/workspace/models` | **Oui** |
+| Workflows + réglages ComfyUI + config Manager | volume `/workspace/user` | **Oui** |
+| Entrées / sorties | volume `/workspace/input`, `/output` | **Oui** |
+| **Nœuds personnalisés** (installations agent/Manager) | volume `/workspace/custom_nodes` (lien symbolique) | **Oui** |
+| Installation ComfyUI + venv + Manager | image `/opt/ComfyUI` | Re-tiré avec l'image |
+
+<Note>
+**Les nœuds personnalisés installés à l'exécution survivent à un
+redémarrage.** `custom_nodes` est lié symboliquement à
+`/workspace/custom_nodes` ; à chaque démarrage les nœuds intégrés de
+l'image (panneau agent + builtins) y sont semés/rafraîchis (donc une mise
+à jour d'image livre un panneau actuel pendant que vos propres nœuds sont
+conservés), et les dépendances Python de chaque nœud sont réinstallées
+dans le venv depuis un **cache pip persistant** sur le volume — rapide
+après la première fois. Les modèles persistent aussi. Pour intégrer un
+nœud afin qu'il n'ait aucun travail au démarrage, ajoutez-le au
+`Dockerfile` et reconstruisez l'image (ci-dessous).
+</Note>
+
+## Construire et déployer votre propre image
+
+Le modèle en un clic est l'image préconstruite. Une **image préconstruite
+allégée** — le même ComfyUI + panneau agent + Manager, mais sans les extras
+donneurs optionnels (`runpod-uploader`/`croc`/`app-manager`) ni le
+checkpoint SDXL de spotcheck intégré, construite en continu en CI — est
+aussi publique à
+[`ghcr.io/artokun/comfyui-mcp-runpod:cu128-lean`](https://github.com/artokun/comfyui-mcp/pkgs/container/comfyui-mcp-runpod)
+si vous voulez juste pointer un modèle RunPod vers quelque chose sans
+construire quoi que ce soit vous-même.
+
+Pour la personnaliser — épingler des versions, intégrer des nœuds
+personnalisés supplémentaires, changer la disposition des modèles —
+construisez et poussez la vôtre depuis
+[`docker/runpod/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/runpod) :
+
+```bash
+cd docker/runpod
+docker build -t <your-registry>/comfyui-mcp-runpod:cu128 .
+docker push     <your-registry>/comfyui-mcp-runpod:cu128
+```
+
+Aucun GPU n'est nécessaire au moment de la construction. Créez ensuite un
+**modèle de pod** RunPod pointé vers votre image avec le **port HTTP 3000**
+exposé et un **volume réseau sur `/workspace`**.
+
+Le [`docker/runpod/README.md`](https://github.com/artokun/comfyui-mcp/blob/main/docker/runpod/README.md)
+est la référence de construction complète — le Dockerfile multi-étapes, les
+drapeaux de lancement ComfyUI exacts, le mapping de volume
+`extra_model_paths.yaml`, la barrière d'installation distante de Manager,
+les variables d'environnement, et les compromis taille/épingle.
+
+## Autres cibles cloud
+
+Le flux `connect` n'est pas spécifique à RunPod — il marche contre
+**n'importe quel** ComfyUI joignable qui sert le panneau agent (un autre
+hôte cloud, un VPS, une machine sur votre LAN). Pointez `connect` vers son
+URL et basculez le commutateur d'orchestrateur externe :
+
+```bash
+npx -y comfyui-mcp@latest connect https://your-comfyui.example.com
+```
+
+Pour exposer **comfyui-mcp lui-même** comme un serveur MCP hébergé et
+authentifié (plutôt que de déployer ComfyUI), voir
+[Connecteur distant / hébergé](/docs/fr/remote-connector).

--- a/docs/fr/concepts.mdx
+++ b/docs/fr/concepts.mdx
@@ -1,0 +1,99 @@
+---
+title: "Comment ça fonctionne"
+description: "Le modèle derrière les outils — transports, l'API ComfyUI-Manager, et les modes local/distant/cloud."
+icon: "diagram-project"
+---
+
+## Le modèle mental
+
+ComfyUI MCP est une couche mince et bien décrite au-dessus d'une **instance
+ComfyUI en cours d'exécution**. La plupart des outils parlent à cette
+instance via son API HTTP/WebSocket, donc ils marchent de la même façon que
+ComfyUI soit local, distant (`--comfyui-url`), ou
+[Comfy Cloud](https://cloud.comfy.org) (`COMFYUI_API_KEY`).
+
+<Steps>
+  <Step title="Génération et workflows → API HTTP ComfyUI">
+    `generate_image`, `enqueue_workflow`, file/historique/stats-système, et les
+    outils de création de workflows appellent `/prompt`, `/queue`, `/history`,
+    `/object_info`, etc. de ComfyUI. La mise en file est lancer-et-oublier : vous
+    obtenez un `prompt_id` tout de suite et les résultats arrivent via une
+    notification de fin. En mode cloud, un `cloud-client` alternatif dispatche
+    les mêmes opérations vers `cloud.comfy.org` via `X-API-Key`.
+  </Step>
+  <Step title="Nœuds personnalisés et modèles → ComfyUI-Manager (HTTP), avec un repli sous-processus">
+    L'installation/mise à jour/instantané/bisect de nœuds et les installations
+    de dépendances de workflows préfèrent l'API HTTP de
+    [ComfyUI-Manager](https://github.com/Comfy-Org/ComfyUI-Manager) (donc elles
+    marchent aussi contre des instances distantes), avec un repli sur
+    `cm-cli` / `git` / `pip`/`uv` contre une installation locale là où l'API
+    ne peut pas faire le travail.
+  </Step>
+  <Step title="Installation et opérations système de fichiers → local seulement">
+    Installer ComfyUI, mettre à jour le cœur, supprimer des fichiers de
+    modèles, lire les logs du serveur, et lister le répertoire de sortie
+    opèrent sur le système de fichiers local. Ils exigent un `COMFYUI_PATH`
+    connu et renvoient une erreur claire en mode distant ou cloud.
+  </Step>
+  <Step title="WebSocket → local + distant, pas cloud">
+    Les notifications de fin de job s'attachent au WebSocket de ComfyUI là où
+    c'est disponible. Comfy Cloud n'a pas de WebSocket — le surveillant de
+    jobs retombe sur son chemin de sondage HTTP existant.
+  </Step>
+</Steps>
+
+<Note>
+  Règle empirique : tout ce qui **lit ou exécute** le serveur connecté marche
+  dans n'importe quel mode ; tout ce qui **installe du logiciel ou touche des
+  fichiers sur disque** a besoin d'une installation locale. La matrice
+  complète de parité fonctionnelle est dans
+  [Configuration → Modes de déploiement](/docs/fr/configuration#modes-de-déploiement).
+</Note>
+
+## Auto-réparation : le chien de garde file/rendu
+
+Une étape de sampler haute résolution coincée laissait autrefois l'agent
+empiler des jobs derrière un rendu zombie qu'il ne pouvait ni voir ni tuer.
+Trois gardes au mieux de leur capacité ferment ce trou, pour que l'agent
+arrête de remettre en file à l'aveugle derrière un rendu coincé :
+
+- **Rétropression** — `panel_run` ajoute un QUEUE WARNING à son résultat
+  quand un rendu tourne déjà, pour que l'agent n'empile pas derrière.
+- **Détection de blocage** — un WebSocket passif vers ComfyUI suit le
+  prompt / nœud / progression en cours ; une étape qui cesse d'avancer
+  au-delà du seuil
+  ([`COMFYUI_MCP_STALL_S`](/docs/fr/configuration#orchestrateur-du-panneau-et-le-pont),
+  défaut 180 s) ajoute en tête une note STALL/BACKLOG d'une ligne au
+  prochain tour de l'agent.
+- **Annulation qui escalade** — `queue` (action:"cancel") interrompt,
+  **vérifie** que le job s'est vraiment arrêté (dans
+  [`COMFYUI_MCP_INTERRUPT_S`](/docs/fr/configuration#surveillance-des-jobs),
+  défaut 30 s), puis escalade vers `/free` et signale le rendu WEDGED (en
+  suggérant `restart_comfyui`) s'il ne meurt toujours pas ;
+  `clear_pending` abandonne tous les jobs en attente dans le même appel.
+
+Tout est fail-safe : si le WebSocket du chien de garde ne s'ouvre jamais,
+rien ne change. L'agent peut aussi raisonner sur les couleurs d'une image
+sans aller-retour vision via `get_image (action:"analyze_color")` (palette
+dominante, stats moyenne + luminance, vérifications de contraste).
+
+## Catégories d'outils
+
+<CardGroup cols={2}>
+  <Card title="Génération d'images" icon="image" href="/docs/tools/image-generation" />
+  <Card title="Exécution de workflows" icon="play" href="/docs/tools/workflow-execution" />
+  <Card title="Création de workflows" icon="pen-ruler" href="/docs/tools/workflow-authoring" />
+  <Card title="Bibliothèque de workflows" icon="folder-open" href="/docs/tools/workflow-library" />
+  <Card title="Assets et images" icon="images" href="/docs/tools/assets-images" />
+  <Card title="Modèles" icon="box" href="/docs/tools/models" />
+  <Card title="Nœuds personnalisés" icon="puzzle" href="/docs/tools/custom-nodes" />
+  <Card title="Nœuds API" icon="cloud" href="/docs/tools/api-nodes" />
+  <Card title="Installation et environnement" icon="wrench" href="/docs/tools/install-environment" />
+  <Card title="Contrôle de processus" icon="power" href="/docs/tools/process-control" />
+  <Card title="Défauts, stats et skills" icon="sliders" href="/docs/tools/defaults-stats-skills" />
+</CardGroup>
+
+<Info>
+  La Référence des outils est générée à partir des schémas d'outils MCP en
+  direct (`npm run docs:gen`), donc elle ne dérive jamais du code.
+</Info>

--- a/docs/fr/configuration.mdx
+++ b/docs/fr/configuration.mdx
@@ -1,0 +1,435 @@
+---
+title: "Configuration"
+description: "Variables d'environnement, transports et ciblage de la connexion."
+icon: "gear"
+---
+
+Toute la configuration passe par des variables d'environnement (définies dans le
+bloc `env` du serveur dans `~/.claude/settings.json`) ou des drapeaux CLI.
+Priorité pour la cible ComfyUI :
+`--comfyui-url` / `COMFYUI_URL` → `COMFYUI_HOST`/`COMFYUI_PORT` → détection
+automatique.
+
+## Modes de déploiement
+
+`comfyui-mcp` fonctionne dans l'un des trois modes, auto-sélectionné depuis
+l'environnement :
+
+| Mode | Déclencheur | FS local ? | Contrôle de processus ? | WebSocket ? |
+| --- | --- | --- | --- | --- |
+| **Local** | défaut | oui | oui | oui |
+| **Distant** | `--comfyui-url` / `COMFYUI_URL` pointe vers un hôte non-loopback | non | non | oui |
+| **Cloud** | `COMFYUI_API_KEY` est défini (cible Comfy Cloud) | non | non | non (sondage HTTP) |
+
+Les outils qui exigent une installation locale (`restart_comfyui` avec
+`action: "start"` / `apply_manifest` / `list_local_models` (`action:"remove"`) /
+`get_image (action:"list_outputs")` / etc.)
+renvoient une erreur claire en mode distant ou cloud. En modes distant et cloud
+le serveur saute la détection automatique locale de `COMFYUI_PATH` pour qu'une
+installation locale obsolète ne puisse pas absorber silencieusement les envois
+ou les téléchargements de modèles que l'agent destine à la vraie cible —
+définissez `COMFYUI_PATH` explicitement si vous voulez mélanger.
+
+## Connexion
+
+<ParamField path="COMFYUI_URL" type="string">
+  URL complète de l'instance ComfyUI, par ex. `https://my-comfy.example.com`.
+  Équivalent au drapeau CLI `--comfyui-url`. Prend le pas sur hôte/port et saute
+  la détection automatique du port. Un **préfixe de chemin est conservé** (par
+  ex. `https://host/comfyapi`) pour que les instances derrière un reverse-proxy
+  soient routées correctement. Quand l'hôte n'est pas en loopback (tout sauf
+  `127.0.0.1` / `localhost` / `::1` / `0.0.0.0`), le serveur entre en **mode
+  distant** et saute la détection automatique de `COMFYUI_PATH`.
+</ParamField>
+<ParamField path="COMFYUI_HOST" type="string" default="127.0.0.1">
+  Hôte du serveur ComfyUI.
+</ParamField>
+<ParamField path="COMFYUI_PORT" type="number">
+  Port du serveur ComfyUI. Auto-détecté (8188, puis 8000) quand il n'est pas
+  défini.
+</ParamField>
+<ParamField path="COMFYUI_SSL" type="boolean" default="false">
+  Utiliser `https`/`wss` au lieu de `http`/`ws`.
+</ParamField>
+<ParamField path="COMFYUI_PATH" type="string">
+  Chemin absolu vers l'installation ComfyUI locale. Auto-détecté depuis les
+  emplacements courants quand il n'est pas défini (supprimé en modes
+  distant/cloud). Requis par les outils uniquement locaux (installer/gérer les
+  nœuds, supprimer des modèles, lire les logs, lister les fichiers de sortie).
+</ParamField>
+
+## Distant derrière un reverse proxy / passerelle API
+
+Pour un ComfyUI auto-hébergé exposé sous un préfixe de chemin et/ou sa propre
+couche d'auth (une route nginx, une passerelle API, un bord SSO) — ce n'est
+**pas** Comfy Cloud :
+
+- `COMFYUI_URL` **conserve un préfixe de chemin** (par ex. `https://host/comfyapi`),
+  donc les requêtes sont routées dessous au lieu de frapper `/prompt`,
+  `/system_stats`, … à la racine.
+- Les variables `COMFYUI_AUTH_*` attachent un en-tête d'auth générique à
+  **chaque** requête ComfyUI (les appels HTTP directs et la bibliothèque
+  client/WebSocket sous-jacente). C'est indépendant du mode cloud, donc une
+  instance authentifiée par passerelle n'est jamais lue à tort comme Comfy Cloud.
+
+<ParamField path="COMFYUI_AUTH_TOKEN" type="string">
+  Jeton d'auth pour un ComfyUI auto-hébergé derrière une passerelle. Quand il
+  est défini, envoyé sur chaque requête ComfyUI. Jamais journalisé.
+</ParamField>
+<ParamField path="COMFYUI_AUTH_HEADER" type="string" default="Authorization">
+  Nom de l'en-tête qui porte le jeton, par ex. `X-API-Key`.
+</ParamField>
+<ParamField path="COMFYUI_AUTH_SCHEME" type="string" default="Bearer for Authorization, else none">
+  Préfixe de schéma sur la valeur du jeton, par ex. `Bearer`, `Token`.
+</ParamField>
+<ParamField path="CF_ACCESS_CLIENT_ID" type="string">
+  Client ID du **jeton de service** Cloudflare Access. À définir avec
+  `CF_ACCESS_CLIENT_SECRET` pour atteindre un ComfyUI précédé de Cloudflare
+  Access — les deux sont envoyés (sous `CF-Access-Client-Id` /
+  `CF-Access-Client-Secret`) sur **chaque** requête ComfyUI (HTTP et le
+  WebSocket du surveillant de file), pour que le connecteur passe la barrière
+  Access au lieu d'obtenir la page de connexion interactive. Additif à
+  `COMFYUI_AUTH_TOKEN` ; les deux prennent effet si les deux sont définis.
+  Jamais journalisé.
+</ParamField>
+<ParamField path="CF_ACCESS_CLIENT_SECRET" type="string">
+  Client Secret du jeton de service Cloudflare Access (la paire de
+  `CF_ACCESS_CLIENT_ID`). Envoyé seulement quand **les deux** sont définis —
+  un jeton à moitié configuré est ignoré. Jamais journalisé.
+</ParamField>
+
+```bash
+# Authorization: Bearer <token>, requests under /comfyapi
+COMFYUI_URL=https://gateway.example.com/comfyapi COMFYUI_AUTH_TOKEN=<token> npx -y comfyui-mcp@latest
+# custom header: X-API-Key: <token>
+COMFYUI_URL=https://gateway.example.com/comfyapi COMFYUI_AUTH_HEADER=X-API-Key COMFYUI_AUTH_TOKEN=<token> npx -y comfyui-mcp@latest
+# ComfyUI behind Cloudflare Access — pass a service token (keeps the human sign-in page up)
+COMFYUI_URL=https://comfy.example.com CF_ACCESS_CLIENT_ID=<id>.access CF_ACCESS_CLIENT_SECRET=<secret> npx -y comfyui-mcp@latest
+```
+
+## Comfy Cloud
+
+Définir `COMFYUI_API_KEY` bascule le serveur en **mode cloud** : toutes les
+primitives adossées à HTTP (mise en file, historique, stats système, file,
+view, upload) sont routées vers `cloud.comfy.org` en HTTPS avec
+l'authentification `X-API-Key` ; les outils WebSocket et FS-local/processus
+lèvent une erreur `CLOUD_UNSUPPORTED` claire. Architecture et dispatcher
+`cloud-client` contribués à l'origine par
+[@picoSols](https://github.com/picoSols).
+
+<Note>
+  **Comfy-Org livre un [outillage agent officiel](https://docs.comfy.org/agent-tools)** — Comfy Cloud MCP (bêta publique) et le Comfy In-App Agent (alpha privée), tous deux maintenus par l'équipe Comfy et tous deux exécutés sur Comfy Cloud. Si vous ne ciblez que Comfy Cloud, c'est probablement le bon choix ; voir [Local vs. Comfy Cloud](/docs/fr/local-vs-comfy-cloud). Le mode cloud de `comfyui-mcp` ci-dessous convient le mieux quand vous voulez un seul MCP pour le local / le distant / le cloud, ou que vous en avez besoin aujourd'hui (il est MIT et se livre maintenant).
+</Note>
+
+<ParamField path="COMFYUI_API_KEY" type="string">
+  Clé API Comfy Cloud. Quand elle est définie, le serveur entre en mode cloud
+  et parle à l'URL cloud configurée au lieu d'un ComfyUI local. Jamais
+  journalisée.
+</ParamField>
+<ParamField path="COMFYUI_CLOUD_URL" type="string" default="https://cloud.comfy.org">
+  Remplacer l'endpoint Comfy Cloud (surtout pour les tests / la préprod).
+</ParamField>
+
+## Jetons
+
+<ParamField path="CIVITAI_API_TOKEN" type="string">
+  Jeton API CivitAI. Utilisé pour les téléchargements gated/early-access.
+  Envoyé comme en-tête bearer (jamais dans les URL).
+</ParamField>
+<ParamField path="HUGGINGFACE_TOKEN" type="string">
+  Jeton HuggingFace pour des limites de débit de recherche/téléchargement plus
+  élevées.
+</ParamField>
+<ParamField path="HF_ENDPOINT" type="string">
+  Endpoint miroir HuggingFace pour les régions à réseau restreint (par ex.
+  `https://hf-mirror.com`). Toutes les URL d'API et de téléchargement
+  `huggingface.co` sont réécrites vers cet hôte ; votre `HUGGINGFACE_TOKEN`
+  voyage toujours pour les dépôts gated. La variable de facto standard — la
+  même que `huggingface_hub` honore.
+</ParamField>
+<ParamField path="CIVITAI_ENABLED" type="string">
+  Définir à `0` pour désactiver entièrement l'accès Civitai (régions où
+  civitai.com est injoignable). Les outils Civitai initiés par l'utilisateur
+  échouent vite avec un message clair « disabled by config » au lieu de
+  rester bloqués ; les recherches de provenance en arrière-plan ne font
+  rien, silencieusement.
+</ParamField>
+<ParamField path="GITHUB_TOKEN" type="string">
+  Jeton GitHub utilisé par la génération de skills et les récupérations de
+  métadonnées de nœuds pour éviter les limites de débit.
+</ParamField>
+<ParamField path="COMFY_API_KEY" type="string">
+  Clé API comfy.org transmise aux nœuds API hébergés via la charge utile
+  `extra_data` de `/prompt`. Si la variable d'environnement n'est pas
+  définie, la clé est lue depuis `~/.comfy-api-key` (contenu du fichier
+  trimé ; `chmod 600` recommandé) — pratique pour les installations
+  headless qui gardent les secrets hors des listes d'environnement/processus.
+</ParamField>
+<ParamField path="REGISTRY_ACCESS_TOKEN" type="string">
+  Clé API Comfy Registry utilisée par `node_pack` (`action: "publish"`) pour
+  publier un pack de nœuds. Passée à comfy-cli via l'environnement, jamais
+  placée dans les arguments ou les logs.
+</ParamField>
+
+## Comportement
+
+<ParamField path="COMFYUI_WORKFLOWS_DIR" type="string" default="~/.comfyui-mcp/workflows">
+  Répertoire parcouru pour les workflows `*.json`. Chacun devient un outil
+  d'exécution auto-chargé.
+</ParamField>
+<ParamField path="LOG_LEVEL" type="string" default="info">
+  Verbosité des logs : `debug`, `info`, `warn`, `error`.
+</ParamField>
+
+## Téléchargements de modèles
+
+<ParamField path="COMFYUI_DOWNLOAD_CACHE_DIR" type="string" default="~/.comfyui-mcp/cache">
+  Cache adressé par contenu pour les téléchargements de modèles. Les
+  téléchargements répétés ou concurrents de la même URL réutilisent le
+  fichier en cache ; le chemin de modèle cible est matérialisé via un
+  hardlink (repli sur la copie).
+</ParamField>
+<ParamField path="COMFYUI_LRU_CACHE_SIZE_GB" type="number" default="0">
+  Taille max du cache de téléchargement en Go. `0` désactive l'éviction ;
+  au-dessus de la limite, les fichiers en cache les moins récemment utilisés
+  sont supprimés après qu'un téléchargement se termine.
+</ParamField>
+
+## Supervision des processus (installations locales)
+
+S'applique à `restart_comfyui` (actions `start` et `restart`) quand
+comfyui-mcp gère un processus ComfyUI local.
+
+<ParamField path="COMFYUI_STARTUP_CHECK_INTERVAL_S" type="number" default="1">
+  Secondes entre les sondes de disponibilité après le lancement de ComfyUI.
+</ParamField>
+<ParamField path="COMFYUI_STARTUP_CHECK_MAX_TRIES" type="number" default="60">
+  Nombre maximal de sondes de disponibilité avant de signaler que le
+  démarrage n'est pas confirmé. Avec l'intervalle par défaut de 1 s, c'est
+  un budget d'environ 60 s. Il a été relevé de 20 parce que ComfyUI avec un
+  jeu normal de nœuds personnalisés met régulièrement plus de 20 s à
+  répondre à `/system_stats` sur un démarrage à froid, et le budget plus
+  court signalait un démarrage non confirmé quelques instants avant qu'une
+  instance saine soit prête.
+
+  Épuiser le budget veut dire que le démarrage **n'est pas encore confirmé**
+  — pas qu'il a échoué.
+</ParamField>
+<ParamField path="COMFYUI_ALWAYS_RESTART" type="boolean" default="false">
+  Quand c'est activé, un processus ComfyUI qui se termine de façon inattendue
+  est redémarré automatiquement. Un `restart_comfyui` volontaire avec
+  `action: "stop"` n'est jamais redémarré.
+</ParamField>
+<ParamField path="COMFYUI_RESTART_MAX_ATTEMPTS" type="number" default="3">
+  Nombre maximal de redémarrages automatiques autorisés dans la fenêtre de
+  redémarrage avant d'abandonner.
+</ParamField>
+<ParamField path="COMFYUI_RESTART_WINDOW_S" type="number" default="60">
+  Fenêtre glissante (secondes) sur laquelle les tentatives de redémarrage
+  automatique sont comptées.
+</ParamField>
+
+## Orchestrateur du panneau et le pont
+
+La barre latérale [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel)
+est pilotée par l'**orchestrateur du panneau** — un processus d'arrière-plan
+qui possède un pont WebSocket loopback et exécute une session autonome Claude
+Agent SDK par onglet du panneau sur votre **abonnement Claude** (sans clés
+API). Le pack du panneau le démarre automatiquement au chargement de ComfyUI,
+donc vous ne lancez normalement rien à la main — voir
+[Panneau latéral](/docs/fr/panel). Pour le lancer vous-même :
+
+```bash
+npx -y comfyui-mcp@latest connect
+```
+
+<ParamField path="COMFYUI_MCP_PANEL_ORCHESTRATOR" type="boolean" default="false">
+  Lancer l'orchestrateur du panneau au lieu d'un serveur MCP (identique à
+  `--panel-orchestrator`).
+</ParamField>
+<ParamField path="COMFYUI_MCP_PANEL_MODEL" type="string" default="claude-opus-5">
+  Modèle pour les agents de panneau en arrière-plan.
+</ParamField>
+<ParamField path="COMFYUI_MCP_BRIDGE_PORT" type="number" default="9180">
+  Port loopback du pont WebSocket du panneau que l'**orchestrateur du
+  panneau** possède (défaut **9180**).
+</ParamField>
+<ParamField path="COMFYUI_MCP_STALL_S" type="number" default="180">
+  Seuil d'alerte de rendu bloqué (secondes) pour le chien de garde
+  file/rendu de l'orchestrateur : un job en cours dont le nœud/la
+  progression n'a plus avancé depuis aussi longtemps est signalé comme
+  bloqué, et une note STALL/BACKLOG d'une ligne est ajoutée en tête du
+  prochain tour de l'agent. Les étapes vidéo sont légitimement lentes, donc
+  le défaut est élevé. Borné à **15–3600 s**. Le réglage **Alerte de rendu
+  bloqué (secondes)** du panneau (Réglages → Comfy MCP Agent → Général)
+  le remplace **en direct** via une trame de pont `set_config` — aucune
+  reconnexion nécessaire — et prend le pas sur cette valeur d'environnement.
+</ParamField>
+
+### Pont sécurisé (piloter un pod distant ou cloud)
+
+Quand `connect <url>` cible un ComfyUI **https distant** (par ex. un pod
+RunPod), la page HTTPS du panneau du pod ne peut pas ouvrir une socket
+`ws://127.0.0.1` en clair vers le pont sur votre machine — les navigateurs
+la bloquent (contenu mixte / Private Network Access). L'orchestrateur passe
+automatiquement à un tunnel `wss://` sécurisé pour que ça marche sans
+invite, dans n'importe quel navigateur. Voir
+[Déploiement cloud](/docs/fr/cloud-deployment) pour le parcours complet et
+[Relais auto-hébergé](/docs/fr/self-hosted-relay) pour faire tourner votre
+propre infrastructure de tunnel au lieu du quick tunnel cloudflared par
+défaut.
+
+<ParamField path="COMFYUI_MCP_INSECURE_BRIDGE" type="boolean" default="false">
+  Forcer le pont loopback `ws://` en clair même en pilotant une cible https
+  distante, au lieu de passer automatiquement à un tunnel sécurisé. À
+  utiliser si vous atteignez le pod via votre propre redirection de port SSH
+  (donc sa page est déjà une origine loopback) et que vous ne voulez pas de
+  dépendance Cloudflare. Identique à `--insecure-bridge`.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TUNNEL_BACKEND" type="string" default="cloudflared">
+  Quel backend de pont sécurisé utiliser pour une cible distante :
+  `cloudflared` (défaut — un quick tunnel éphémère, zéro configuration) ou
+  `relay` (appeler un [relais auto-hébergé](/docs/fr/self-hosted-relay) que
+  vous opérez, pour un domaine stable et aucune dépendance à un quick tunnel
+  tiers). Ne prend effet que lorsque le mode sécurisé est actif (cible https
+  distante, pas `COMFYUI_MCP_INSECURE_BRIDGE`).
+</ParamField>
+<ParamField path="COMFYUI_MCP_RELAY_URL" type="string">
+  L'URL `wss://` de votre relais. Requis quand
+  `COMFYUI_MCP_TUNNEL_BACKEND=relay`.
+</ParamField>
+<ParamField path="COMFYUI_MCP_RELAY_KEY" type="string">
+  Secret partagé facultatif qui filtre qui peut ouvrir une session sur votre
+  relais (`?key=`), indépendant du jeton de pont par session. Pertinent
+  seulement en mode relais, et seulement si votre déploiement de relais
+  définit `RELAY_ACCESS_KEY`.
+</ParamField>
+
+## Surveillance des jobs
+
+Les notifications de fin pour les jobs mis en file sont suivies par un
+surveillant (WebSocket là où c'est disponible, sondage HTTP sinon).
+
+<ParamField path="COMFYUI_JOB_TIMEOUT_S" type="number" default="1800">
+  Secondes maximales pendant lesquelles le surveillant attend qu'un job se
+  termine avant d'abandonner. Relevez-le pour de très longs rendus vidéo ou
+  des workflows multi-étapes lourds. (Le job lui-même continue de tourner
+  dans ComfyUI — seule la notification de fin est abandonnée.)
+</ParamField>
+<ParamField path="COMFYUI_JOB_POLL_INTERVAL_S" type="number" default="2">
+  Secondes entre les sondages HTTP de l'historique pendant qu'un job est
+  surveillé.
+</ParamField>
+<ParamField path="COMFYUI_MCP_INTERRUPT_S" type="number" default="30">
+  Fenêtre d'honneur de l'annulation (secondes) pour `queue`
+  (action:"cancel") : combien de temps attendre qu'une interruption arrête
+  vraiment le job en cours avant d'escalader (vers `/free`, puis signaler le
+  rendu WEDGED). ComfyUI ne vérifie le drapeau d'interruption qu'entre les
+  nœuds/étapes, donc une seule étape de plusieurs minutes ne l'honorera pas
+  tout de suite — cette attente est ce qui détecte un vrai coinçage.
+</ParamField>
+
+## Restreindre la surface d'outils
+
+Pour un déploiement **hébergé** — un Open WebUI partagé, un frontend d'équipe
+— l'opérateur n'est pas la personne qui invite. Les variables de préréglage /
+autorisation / refus d'outils retiennent les outils du modèle entièrement :
+un outil retenu n'est jamais enregistré, donc il est absent de `tools/list`,
+absent de `call_tool`, et le modèle n'apprend jamais qu'il existe. La liste
+d'autorisation d'actions est le compagnon plus étroit pour un outil qui doit
+rester visible : l'outil reste enregistré, mais une action non listée est
+rejetée avant que son gestionnaire ne tourne.
+
+<ParamField path="COMFYUI_MCP_TOOL_PRESET" type="string">
+  `safe` — tout sauf les outils qui changent la machine ou la bibliothèque
+  de modèles. Installer, supprimer et redémarrer sont retenus. **Le rendu
+  marche encore, et aussi ce qui vient avec** : mettre des générations en
+  file, `list_api_nodes` (nœuds partenaires hébergés qui dépensent des
+  crédits PAYANTS), et `report_issue` (dépose une issue GitHub publique).
+  Utilisez `readonly` si les utilisateurs d'un frontend partagé ne doivent
+  pas pouvoir dépenser ni publier.
+  `readonly` — inspection seulement : aucun rendu mis en file, rien
+  d'écrit, rien de dépensé.
+  Les deux retiennent aussi toute la surface `panel_*`, qui pilote un
+  canevas partagé en direct.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_DENY" type="string">
+  Noms d'outils séparés par des virgules à retenir, par ex.
+  `restart_comfyui,download_model`. Un `*` final correspond à une famille :
+  `train_*`. Appliqué par-dessus tout préréglage **et** par-dessus une
+  liste d'autorisation.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_ALLOW" type="string">
+  Liste d'autorisation séparée par des virgules. Quand elle est définie, la
+  surface est **exactement** ces outils — tout ce qui n'est pas nommé est
+  retenu même si aucune règle de refus ne le mentionne. Utilisez-la pour
+  réadmettre des outils individuels au-delà d'un préréglage :
+  `COMFYUI_MCP_TOOL_PRESET=safe` plus
+  `COMFYUI_MCP_TOOL_ALLOW=panel_graph_outline,panel_query_graph`.
+
+  Seul un **nom exact** réadmet un outil au-delà d'un préréglage. Un glob
+  (`list_*`) resserre la surface comme n'importe quelle autre entrée mais
+  ne peut pas rouvrir ce qu'un préréglage a fermé — sinon `ALLOW=list_*`
+  réadmettrait `list_packs`, dont l'action `install_deps` installe et
+  exécute du code tiers, et `ALLOW=*` rendrait chaque préréglage inerte.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_ACTION_ALLOW" type="string">
+  Paires exactes `tool:action` séparées par des virgules. Quand c'est
+  défini, chaque appel d'outil portant un champ `action` doit correspondre
+  à l'une de ces paires ; les outils portant une action omis de la liste
+  ne peuvent dispatcher aucune action. Ça restreint les outils consolidés
+  dont le nom seul ne révèle plus le rayon d'action — par exemple,
+  autoriser l'inspection de la file et une annulation ciblée sans aussi
+  autoriser les modifications de file ou un effacement global :
+
+  `queue:list,queue:status,queue:cancel,enqueue_workflow:enqueue`
+
+  Associez ceci à `COMFYUI_MCP_TOOL_ALLOW` pour borner les deux dimensions.
+  Les règles sont exactes ; les jokers sont rejetés pour qu'une action
+  nouvellement ajoutée ne puisse pas devenir autorisée après une mise à
+  jour.
+</ParamField>
+
+```bash A hosted deployment that cannot install or restart anything
+COMFYUI_MCP_TOOL_PRESET=safe npx comfyui-mcp@latest --http --host 0.0.0.0 --port 9100
+```
+
+```bash A generation operator that can inspect, enqueue, and cancel—but not install or clear queues
+COMFYUI_MCP_TOOL_ALLOW=get_system_stats,get_history,create_workflow,enqueue_workflow,queue \
+COMFYUI_MCP_TOOL_ACTION_ALLOW=get_system_stats:stats,get_system_stats:logs,get_system_stats:health,get_history:list,get_history:diagnose,create_workflow:create,create_workflow:modify,create_workflow:validate,create_workflow:node_info,enqueue_workflow:enqueue,queue:list,queue:status,queue:cancel \
+npx comfyui-mcp@latest
+```
+
+<Warning>
+  C'est une frontière contre le **modèle** et les personnes qui l'invitent —
+  pas contre celui qui définit l'environnement, qui peut simplement le
+  retirer, et pas un substitut pour tenir une partie non de confiance hors
+  de l'hôte ComfyUI.
+
+  Une mauvaise configuration **refuse de démarrer** plutôt que de démarrer
+  sans restriction : un nom de préréglage inconnu, ou une variable qui est
+  définie mais vide (un `${VAR}` non développé dans un fichier compose),
+  s'arrête avec la raison. Arriver avec une surface d'outils complète alors
+  que vous croyez qu'elle est restreinte est pire que de n'avoir aucun
+  filtre du tout.
+</Warning>
+
+## Transport
+
+Le serveur parle **stdio** par défaut (ce que Claude Code attend). Il peut
+aussi servir le transport **streamable-HTTP** pour les configurations
+distantes / multi-clients.
+
+<ParamField path="MCP_TRANSPORT" type="string" default="stdio">
+  `stdio` ou `http`. Drapeaux équivalents : `--stdio`, `--http`.
+</ParamField>
+<ParamField path="MCP_HOST" type="string" default="127.0.0.1">
+  Hôte de liaison HTTP (avec `--http`). Drapeau : `--host`.
+</ParamField>
+<ParamField path="MCP_PORT" type="number" default="9100">
+  Port de liaison HTTP (avec `--http`). Drapeau : `--port`.
+</ParamField>
+
+```bash Run the HTTP transport
+npx comfyui-mcp@latest --http --host 0.0.0.0 --port 9100 --comfyui-url https://my-comfy.example.com
+```

--- a/docs/fr/docker.mdx
+++ b/docs/fr/docker.mdx
@@ -1,0 +1,120 @@
+---
+title: "Docker et Compose"
+description: "Faites tourner ComfyUI comme un service docker-compose et connectez-y comfyui-mcp — et pourquoi comfyui-mcp lui-même n'est jamais un service compose."
+icon: "docker"
+---
+
+## comfyui-mcp est stdio — il ne peut pas être un service compose
+
+`comfyui-mcp` est un **serveur MCP stdio**. Il n'a pas de port et n'expose
+rien sur le réseau : le client MCP (Claude Code, Cursor, un pont MCP, …)
+**le lance comme un processus enfant** et lui parle via stdin/stdout.
+
+Donc dans un `docker-compose.yml`, un service `comfyui-mcp` est une impasse
+— il démarrerait, n'aurait personne à qui parler, et sortirait. Ça piège
+presque tout le monde qui branche ComfyUI dans compose, parce qu'un fichier
+compose correct a l'air de « manquer » un service. Ce n'est pas le cas : ce
+que vous composez, c'est **ComfyUI**, et le serveur MCP tourne là où tourne
+votre client MCP, en atteignant ComfyUI en HTTP simple via `COMFYUI_URL`.
+
+<Note>
+  La commande `npx` qui lance le serveur exige **Node.js >= 22** sur la
+  machine (ou le conteneur) qui l'exécute — le principal piège des images de
+  base allégées.
+</Note>
+
+## Les deux formes de déploiement
+
+<CardGroup cols={2}>
+  <Card title="npx local + ComfyUI local" icon="laptop">
+    Le défaut. ComfyUI tourne directement sur votre machine ; le client MCP
+    lance `npx -y comfyui-mcp@latest`, qui détecte automatiquement
+    l'installation locale et son port. Aucune config nécessaire. Voir
+    [Installation](/docs/fr/installation).
+  </Card>
+  <Card title="npx local + ComfyUI dockerisé / distant" icon="docker">
+    ComfyUI tourne dans un conteneur (ou sur un autre hôte) ; le client MCP
+    lance encore `comfyui-mcp` en local, pointé vers lui avec `COMFYUI_URL`
+    (ou `--comfyui-url`). Une URL non-loopback met le serveur en **mode
+    distant** : tous les outils HTTP marchent — y compris l'installation de
+    nœuds personnalisés, qui passe par l'API HTTP de ComfyUI-Manager. Les
+    outils qui ont besoin du système de fichiers ou d'un processus local
+    (installer ComfyUI lui-même, les opérations comfy-cli, lire les logs,
+    supprimer des fichiers de modèles) renvoient une erreur claire.
+  </Card>
+</CardGroup>
+
+## Exemple : ComfyUI dans docker-compose
+
+Un exemple prêt à l'emploi vit dans le dépôt à
+[`docker/compose/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/compose)
+— ComfyUI comme service (NVIDIA par défaut, variante AMD/ROCm commentée),
+montages bind pour les modèles et les sorties, et la config client dans les
+commentaires d'en-tête :
+
+```yaml
+services:
+  comfyui:
+    image: yanwk/comfyui-boot:cu130-slim-v2   # community image; :rocm for AMD
+    ports:
+      - "8188:8188"
+    volumes:
+      - ./storage/models:/root/ComfyUI/models
+      - ./storage/custom_nodes:/root/ComfyUI/custom_nodes
+      - ./storage/input:/root/ComfyUI/input
+      - ./storage/output:/root/ComfyUI/output
+      - ./storage/user:/root/ComfyUI/user
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+Puis pointez votre client MCP vers le conteneur. Sur l'**hôte** (le cas
+courant — Claude Code sur la même machine), utilisez le port publié :
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "command": "npx",
+      "args": ["-y", "comfyui-mcp@latest"],
+      "env": {
+        "COMFYUI_URL": "http://localhost:8188"
+      }
+    }
+  }
+}
+```
+
+Si le client MCP tourne **à l'intérieur d'un autre service compose** sur le
+même réseau (par ex. un pont MCP-vers-HTTP devant Open WebUI), utilisez le
+**nom du service compose**, pas `localhost` :
+
+```
+COMFYUI_URL=http://comfyui:8188
+```
+
+Dans cette disposition, c'est le service pont qui lance `comfyui-mcp`, donc
+son image doit contenir Node.js >= 22 avec le serveur lançable via
+`npx -y comfyui-mcp@latest`. Les ponts sont des logiciels tiers — configurez
+le vôtre d'après sa propre doc ; le fichier compose d'exemple a une
+ébauche commentée.
+
+## Notes AMD / ROCm
+
+- Utilisez le tag d'image `yanwk/comfyui-boot:rocm` et décommentez le
+  passage ROCm dans l'exemple — les morceaux que les gens manquent :
+  `devices: [/dev/kfd, /dev/dri]`, `group_add: [video]`,
+  `security_opt: [seccomp:unconfined]`.
+- `comfyui-mcp` lui-même n'a **aucune dépendance GPU/CUDA** — les hôtes
+  ROCm sont entièrement pris en charge. Le
+  [panneau agent](/docs/fr/panel) est une **extension ComfyUI**, pas un
+  service, et il est optionnel quand un frontend externe est votre surface.
+- [`docker/runpod/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/runpod)
+  dans ce dépôt est une **image cloud RunPod orientée CUDA** (voir
+  [Déploiement cloud](/docs/fr/cloud-deployment)), pas une image ComfyUI
+  à usage général — les utilisateurs AMD ne devraient pas commencer là.

--- a/docs/fr/local-llms.mdx
+++ b/docs/fr/local-llms.mdx
@@ -1,0 +1,493 @@
+---
+title: "LLM locaux et autres agents"
+description: "Prise en charge de première classe pour Hermes Agent, OpenClaw et Copilot CLI — plus n'importe quel client MCP sur un modèle local (Ollama) ou hébergé. Mise en place en une commande, et un mode d'outils compact qui réduit ~200 schémas d'outils en 3 méta-outils."
+icon: "microchip"
+---
+
+comfyui-mcp est un serveur MCP stdio standard, donc **n'importe quel agent
+capable de MCP peut le piloter** — pas seulement Claude Code. Cette page
+couvre les harnais que nous prenons en charge de première classe
+(**Hermes Agent, OpenClaw, Copilot CLI**), ce que votre modèle doit
+apporter, et le **mode d'outils compact** qui rend les petits modèles /
+locaux viables.
+
+## Exigences de modèle
+
+Soyez honnête avec vous-même sur le modèle que vous apportez. La spec
+minimale pour l'expérience *complète* est un modèle avec **appel d'outils
++ réflexion + vision** :
+
+| Capacité | Sans elle |
+| --- | --- |
+| **Appel d'outils** (function calling natif) | **Ne marchera pas.** Chaque action comfyui-mcp est un appel d'outil. L'appel d'outils émulé par prompt dans certains harnais tourne techniquement, mais la fiabilité s'effondre — traitez-le comme non pris en charge. |
+| **Réflexion / raisonnement** | Marche, dégradé. Les chaînes multi-étapes (choisir l'outil → récupérer le schéma → construire les args → se remettre des erreurs) deviennent nettement moins bonnes ; attendez-vous à ce que l'agent ait besoin de relances/coups de pouce. |
+| **Vision** | Marche, dégradé. L'agent peut générer mais ne peut pas *voir* — les boucles de critique `get_image (action:"view")`, `get_workflow (action:"from_image")`, et les comparaisons visuelles sont indisponibles, donc il vole à l'aveugle sur ses propres sorties. |
+
+Les modèles hébergés qui tiennent la spec complète changent chaque mois —
+vérifiez la fiche modèle de votre fournisseur pour les trois capacités
+plutôt que de vous fier à une liste. Mi-2026 : **Xiaomi MiMo-V2.5**
+(vision + outils + long contexte) tient la spec complète à bon marché ;
+les modèles de classe **DeepSeek-V3.x / GLM / MiniMax** ont un appel
+d'outils + réflexion solides mais les variantes texte seulement perdent
+la boucle vision ; les petits modèles locaux (ci-dessous) gardent en
+général l'appel d'outils et lâchent le reste.
+
+## Mode d'outils compact
+
+La surface complète fait 37 outils avec de riches schémas JSON (~200 Ko,
+environ 50k jetons, par `tools/list`). La plupart des harnais non-Claude
+injectent chaque schéma enregistré tout droit dans le contexte du modèle
+— très bien pour les modèles frontier, fatal pour un local 4B. Le **mode
+d'outils compact** n'enregistre que **trois méta-outils** et garde le
+vrai catalogue derrière eux :
+
+| Méta-outil | Ce qu'il fait |
+| --- | --- |
+| `list_tools` | Catalogue léger en jetons : chaque nom d'outil + un résumé d'une ligne, groupé par catégorie. Prend en charge les filtres `category` et `search`. |
+| `describe_tool` | Description complète + JSON Schema d'un outil, récupéré seulement quand c'est nécessaire. |
+| `call_tool` | Exécute n'importe quel outil catalogué : `{"name": "generate_image", "args": {...}}`. Renvoie exactement ce que l'outil sous-jacent renvoie. |
+
+La boucle du modèle est : `list_tools` → choisir → `describe_tool` →
+`call_tool`. Les schémas entrent dans le contexte un outil à la fois. Les
+méta-outils sont volontairement indulgents envers les bizarreries des
+petits modèles : `args` peut être un objet **ou** une chaîne encodée en
+JSON, les alias de champs courants (`tool_name`, `arguments`) sont
+acceptés, et les erreurs de validation reviennent avec le schéma attendu
+pour que le modèle puisse se corriger au lieu de mourir sur une erreur de
+protocole opaque.
+
+Le compact est **opt-in** — la surface directe est le défaut, donc un
+petit modèle a besoin de l'un de ceux-ci (le drapeau l'emporte sur la
+variable d'environnement) :
+
+```bash
+npx -y comfyui-mcp --compact
+# or
+COMFYUI_MCP_TOOL_MODE=compact npx -y comfyui-mcp
+```
+
+Le défaut convient aux harnais de modèles frontier (Claude Code / Cursor /
+Claude Desktop), dont les clients gèrent bien les longues listes d'outils.
+`--full` est encore accepté et est maintenant un no-op.
+
+### Auto-sélection : calée sur le modèle, pas le fournisseur
+
+Dans les backends LLM locaux du panneau (Ollama / LM Studio / llama.cpp /
+compatible OpenAI), quand **vous n'avez pas choisi de mode**, le *modèle*
+en choisit un :
+
+- un modèle dont l'id porte un nombre de paramètres à **70B** ou plus
+  (`llama3.3:70b`, `gpt-oss:120b`, `mixtral:8x22b`) obtient la surface
+  **complète** ;
+- tout ce qui est plus petit reste **compact** ;
+- un id de modèle sans nombre de paramètres lisible
+  (`moonshotai/kimi-k2.5`) est traité comme **inconnu**, pas comme petit,
+  et obtient le repli compact documenté.
+
+« Ollama ⇒ compact » serait faux dans les deux sens — un modèle local 70B
+tient la surface complète et serait inutilement estropié, et certains
+petits modèles hébergés veulent le compact. Donc le signal est le modèle.
+
+**Votre choix l'emporte toujours, dans les deux sens.**
+`COMFYUI_MCP_TOOL_MODE=full` force la surface complète sur un modèle 4B ;
+`COMFYUI_MCP_TOOL_MODE=compact` force le routeur sur un 405B.
+L'auto-sélection ne comble que le trou où rien n'a été choisi.
+
+Le seuil de 70B est volontairement conservateur : c'est le seul chiffre
+que quiconque a réellement affirmé sur cet axe, donc rien n'est promu sur
+une devinette. `COMFYUI_MCP_FULL_SURFACE_MIN_PARAMS_B=30` l'abaisse si
+vous voulez trouver où est vraiment le plafond de votre matériel.
+
+Le **prompt système suit le mode**. Le prompt compact dit au modèle qu'il
+a six outils et route ComfyUI via `call_tool` ; quand la surface complète
+est sélectionnée c'est simplement faux, donc le prompt mode complet dit
+que les outils ComfyUI sont annoncés directement et garde la description
+du routeur pour `panel_*` seulement. Auto-sélectionner le complet tout en
+niant que les outils existent serait pire que le défaut qu'il a remplacé.
+
+Le mode actif **et sa raison** sont imprimés sur la ligne de prêt du
+backend, par ex. `Tool mode: compact — chosen for this MODEL: "qwen3:4b" is ~4B
+parameters, below the 70B full-surface threshold…`, pour que le levier ne
+soit plus jamais invisible.
+
+<Note>
+Cette auto-sélection couvre la voie LLM locale du panneau. La voie HTTP
+Codex / Gemini / Grok / Copilot reste épinglée au compact pour une autre
+raison — leurs propres budgets d'outils évinceraient autrement les outils
+`panel_*` — et le défaut du serveur MCP autonome est inchangé.
+</Note>
+
+## Entrée audio
+
+**Sur le backend `ollama` (`/api/chat` natif)**, l'audio n'atteint le
+modèle que là où le modèle signale réellement qu'il peut entendre. Avant
+d'envoyer, le backend demande à `POST /api/show` les capacités de ce
+modèle :
+
+```bash
+ollama pull gemma4:e2b      # capabilities: completion, vision, audio, tools, thinking
+```
+
+Si le modèle sélectionné n'a pas la capacité `audio`, la pièce jointe est
+**refusée à voix haute** — avec la liste de capacités que le serveur a
+signalée et une commande pull pour un modèle qui peut entendre — plutôt
+que d'être abandonnée dans la requête où le modèle répondrait depuis
+votre seul texte. Il en va de même pour un fichier qui n'est pas un
+format audio, ou qui est présent mais de zéro octet.
+
+Livrer les octets n'est pas tout à fait tout le travail. Mesuré en direct
+contre `gemma4:e2b` : avec le WAV démontrablement dans le contexte (555
+jetons de prompt, `/api/show` signalant `audio`), le modèle a quand même
+répondu *« I do not have the capability to transcribe audio — my functions are limited to operating
+ComfyUI »*. Le prompt système du panneau le présente comme un opérateur de
+graphe et un petit modèle se raisonne hors d'un sens qu'il a réellement.
+Donc un tour dont l'audio a été vérifié en capacité et attaché porte
+aussi une courte note qui dit au modèle que l'audio est là et qu'il
+devrait répondre depuis ce qu'il entend. Avec cette note le même modèle
+a transcrit correctement quatre fois sur quatre.
+
+**Sur les backends compatibles OpenAI** (LM Studio, llama.cpp, OpenRouter,
+personnalisé) il n'y a aucun endpoint de capacité à interroger. L'audio
+est envoyé comme une partie de contenu `input_audio` et le tour porte une
+ligne explicite *« I cannot confirm the model actually receives them »*.
+Refuser refuserait l'audio à chaque endpoint qui n'a simplement pas d'API
+de capacité ; un garde qui ne peut pas tourner n'est pas un verdict —
+mais ce n'est pas non plus une confirmation, et le libellé le dit.
+
+Voir [Backends → Entrée audio](/docs/fr/backends#entrée-audio--quels-backends-honnêtement)
+pour ce que fait chaque autre fournisseur.
+
+## Mise en place en une commande
+
+`comfyui-mcp setup <agent>` écrit l'entrée du serveur dans le propre
+fichier de config du harnais (en fusionnant avec ce qui s'y trouve déjà
+— serveurs existants, commentaires dans le YAML, tout est conservé) :
+
+```bash
+npx -y comfyui-mcp setup hermes     # → ~/.hermes/config.yaml      (compact by default)
+npx -y comfyui-mcp setup openclaw   # → ~/.openclaw/openclaw.json  (compact by default)
+npx -y comfyui-mcp setup copilot    # → ~/.copilot/mcp-config.json (full by default)
+```
+
+Drapeaux : `--compact` / `--full` remplacent le défaut par agent,
+`--comfyui-url <url>` embarque votre cible ComfyUI (locale, LAN, ou URL
+de proxy RunPod), `--dry-run` affiche la config fusionnée au lieu de
+l'écrire.
+
+## Hermes Agent
+
+```bash
+npx -y comfyui-mcp setup hermes --comfyui-url http://127.0.0.1:8188
+```
+
+ce qui produit ceci dans `~/.hermes/config.yaml` (ajoutez-le à la main si
+vous préférez) :
+
+```yaml
+mcp_servers:
+  comfyui:
+    command: "npx"
+    args: ["-y", "comfyui-mcp", "--compact"]
+    env:
+      COMFYUI_URL: "http://127.0.0.1:8188"
+```
+
+Rechargez avec `/reload-mcp` (ou redémarrez Hermes). Hermes préfixe les
+outils, donc le modèle voit `mcp_comfyui_list_tools`,
+`mcp_comfyui_describe_tool`, et `mcp_comfyui_call_tool` — trois
+définitions dans le contexte au lieu de deux cents.
+
+<Note>
+Sur un modèle frontier (via Nous Portal / OpenRouter) vous pouvez relancer
+setup avec `--full` et éventuellement utiliser la liste d'autorisation
+`tools.include` propre à Hermes. Le compact est le bon défaut pour tout
+ce qui est plus petit.
+</Note>
+
+Hermes livre aussi une *skill* `comfyui` bundlée qui pilote ComfyUI en
+REST brut depuis des scripts Python. Ça marche, mais ça précède ce
+serveur — le chemin MCP vous donne la création/validation de workflows,
+la gestion des modèles + nœuds personnalisés, les packs d'installation,
+le contrôle de file, et l'auto-diagnostic. Désactivez la skill si
+l'agent continue d'y tendre la main au lieu des outils MCP.
+
+## OpenClaw
+
+```bash
+npx -y comfyui-mcp setup openclaw
+```
+
+ce qui produit ceci dans `~/.openclaw/openclaw.json` :
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "command": "npx",
+      "args": ["-y", "comfyui-mcp", "--compact"],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+Redémarrez la passerelle OpenClaw pour qu'elle prenne en compte le
+serveur. La doc d'OpenClaw recommande de garder le nombre d'outils MCP
+bas — c'est exactement à ça que sert le mode compact, et pourquoi c'est
+le défaut ici.
+
+## Copilot CLI
+
+```bash
+npx -y comfyui-mcp setup copilot
+# or use Copilot's own command:
+copilot mcp add comfyui -- npx -y comfyui-mcp
+```
+
+ce qui produit ceci dans `~/.copilot/mcp-config.json` :
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "comfyui-mcp"],
+      "env": {},
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Copilot CLI tourne des modèles frontier, donc setup se met par défaut à
+la surface d'outils **complète** (passez `--compact` si vous routez
+Copilot vers un plus petit modèle). Vérifiez-le avec `/mcp show` à
+l'intérieur de `copilot`.
+
+## Nos modèles locaux fine-tunés (gratuits, recommandés)
+
+Si vous voulez faire tourner l'agent **en local gratuitement**, commencez
+ici. Nous avons fine-tuné la famille Gemma 4 spécifiquement pour
+comfyui-mcp : entraîné en QLoRA sur **1 055 trajectoires d'usage d'outils
+vérifiées par le serveur** synthétisées contre un ComfyUI en direct —
+couvrant la **surface complète de 178 outils** (113 MCP + 65 outils
+panneau) — donc le modèle connaît cette suite d'outils exacte nativement
+au lieu de la rencontrer à froid.
+
+```bash
+# 1. Install Ollama (once):  https://ollama.com/download
+# 2. Pull the size that fits your GPU:
+ollama pull artokun/gemma4-comfyui-mcp:e4b     # default — ~3.5 GB VRAM at q4
+ollama pull artokun/gemma4-comfyui-mcp:12b     # ~8 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:e2b     # smallest — ~2 GB VRAM (see caveat)
+```
+
+**Mesuré, pas promis** — les scores de l'[Arène des LLM](/docs/fr/arena)
+sur la vraie échelle à 10 scénarios (meilleur de 3, chaque résultat
+vérifié contre un serveur ComfyUI en direct, RTX 4090) :
+
+| Tag | VRAM (q4) | Score d'arène | vs. d'origine |
+|---|---|---|---|
+| `:e4b` | ~3,5 Go | **14/20** (13–14) — meilleur modèle local que nous ayons testé | gemma4:e4b d'origine : 12/20 |
+| `:12b` | ~8 Go | 13/20 (12–13) | 12b d'origine non benchmarké |
+| `:e2b` (v2) | ~2 Go | 10/20 (7–10) | gemma4:e2b d'origine : 8/20 |
+
+Chaque palier bat maintenant sa base d'origine. Le réentraînement `:e2b`
+v2 (entraînement double vue : appels d'outils directs ET l'enveloppe
+routeur déployée) a corrigé la régression de format `call_tool` de la v1
+— zéro enveloppe malformée sur les exécutions de verdict. Le guide de
+taille tient : `:e4b` est le meilleur compromis (seulement ~1,5 Go de
+plus que e2b et +4 à l'arène) ; `:e2b` est maintenant un choix légitime
+pour une VRAM serrée ; `:12b` achète de la stabilité sur les longues
+tâches multi-étapes, pas un score brut.
+
+| Tag | Base | VRAM (q4) | Notes |
+| --- | --- | --- | --- |
+| `:e4b` | Gemma 4 E4B | ~3,5 Go | **Le défaut** — meilleur équilibre taille/qualité |
+| `:e2b` | Gemma 4 E2B | ~2 Go | Réfléchit verbeusement — autorisez un `max_tokens` généreux (≥512) |
+| `:12b` | Gemma 4 12B | ~8 Go | Palier le plus solide |
+
+Le backend Ollama du panneau **se met par défaut à `:e4b`** — choisissez
+**Ollama (local)** dans le sélecteur de backend et ça marche une fois le
+modèle tiré. Pas de compte, pas de clé API, pas de coût au jeton.
+
+**Fenêtre de contexte :** les tags livrent une fenêtre de **65 536
+jetons** intégrée, et l'orchestrateur s'y fie (les modèles d'origine
+obtiennent 16K). L'architecture tient jusqu'à **128K** (`:e2b`/`:e4b`)
+et **256K** (`:12b`) — relevez-la avec
+`COMFYUI_MCP_OLLAMA_NUM_CTX=131072` si vous avez la VRAM (le cache KV
+grandit avec la fenêtre). Si l'agent commence à « oublier » en cours de
+conversation, surveillez le log de l'orchestrateur : il avertit quand un
+tour remplit ≥85 % de la fenêtre. Poids, adaptateurs LoRA, et le pipeline
+d'entraînement sont ouverts :
+[`artokun/gemma4-comfyui-mcp`](https://huggingface.co/artokun/gemma4-comfyui-mcp)
+(jeu de données :
+[`artokun/comfyui-mcp-trajectories`](https://huggingface.co/datasets/artokun/comfyui-mcp-trajectories)).
+
+## LM Studio
+
+Le panneau parle LM Studio nativement : choisissez **LM Studio** dans le
+sélecteur de backend et l'orchestrateur pilote son serveur local
+(`http://127.0.0.1:1234/v1`, remplaçable par
+`COMFYUI_MCP_LMSTUDIO_HOST`). La mise en place tient en deux clics :
+installez depuis [lmstudio.ai](https://lmstudio.ai), puis
+**Developer → Start Server** avec un **modèle capable d'appeler des
+outils** chargé. Le sélecteur de modèle reflète ce que le serveur
+propose ; sans défaut défini, le premier modèle servi est adopté
+automatiquement. L'orchestrateur gère le **cycle de vie complet** sans
+intervention : il démarre automatiquement le serveur au besoin, charge
+votre modèle en JIT, libère sa VRAM pendant qu'un rendu ComfyUI tourne
+(le chat est retenu et répondu quand le rendu se termine), décharge le
+modèle sortant lors d'un changement de modèle, et relâche tout quand
+vous passez à un autre fournisseur.
+
+Nos GGUF fine-tunés marchent ici aussi — cherchez
+`artokun/gemma4-comfyui-mcp` dans le téléchargeur de modèles de LM Studio
+et prenez un `model-q4_k_m.gguf`. Attendez-vous à la même pause de
+chargement à froid JIT au premier message qu'Ollama a (30 s+ est
+normal).
+
+## llama.cpp (llama-server)
+
+Vous lancez du `llama.cpp` brut ? Choisissez **llama.cpp** dans le
+sélecteur de backend — l'orchestrateur pilote l'endpoint compatible
+OpenAI de `llama-server` (`http://127.0.0.1:8080/v1`, remplaçable par
+`COMFYUI_MCP_LLAMACPP_HOST`) :
+
+```bash
+llama-server -m gemma4-comfyui-mcp-e2b.Q4_K_M.gguf -c 16384
+```
+
+Notes du terrain : le contexte est un **drapeau de lancement** (`-c`) —
+l'agent avertit si le serveur tourne sous 16K (la charge utile des
+outils en a besoin). L'appel d'outils est activé par défaut dans les
+builds actuels ; **les builds plus anciens ont besoin de `--jinja`** (le
+panneau détecte un serveur incapable d'outils à la connexion et le dit
+exactement). Le seul modèle chargé est adopté automatiquement — aucun
+choix nécessaire.
+
+Sur une machine à un seul GPU, un llama-server **local** (ou llama-swap
+devant) rejoint la même passation de VRAM qu'Ollama et LM Studio :
+pendant qu'un rendu ComfyUI tourne, votre chat est retenu et répondu dès
+que le rendu se termine. Comme llama-server n'a pas d'API de déchargement
+(et llama-swap échange les modèles en amont à la demande), la passation
+est retenue seulement — rien n'est explicitement déchargé ou réchauffé.
+Un `COMFYUI_MCP_LLAMACPP_HOST` **distant** est le GPU de quelqu'un
+d'autre et n'est jamais filtré. La passation est activée par défaut pour
+les trois backends locaux ; désactivez-la avec
+`COMFYUI_MCP_PAUSE_LOCAL_ON_GEN=0` (l'héritage
+`COMFYUI_MCP_OLLAMA_PAUSE_ON_GEN=0` est encore honoré).
+
+## Endpoint personnalisé (tout serveur compatible OpenAI)
+
+Tout ce qui parle `/v1/chat/completions` — vLLM, DeepSeek, Together,
+Azure OpenAI, un llama-server sur une autre machine, la passerelle de
+votre entreprise — se branche comme le fournisseur **Endpoint
+personnalisé** :
+
+1. Réglages ComfyUI → **Comfy MCP Agent → Endpoint personnalisé** →
+   définissez l'**URL de base de l'endpoint** (incluez le `/v1`, par ex.
+   `http://192.168.1.20:8000/v1`).
+2. Si le serveur a besoin d'une clé : **Définir la clé API…** — une
+   saisie masquée ; la clé est stockée `0600` par l'orchestrateur dans
+   `~/.comfyui-mcp`, jamais dans les réglages ComfyUI ni le chat.
+3. Choisissez **Endpoint personnalisé** dans le sélecteur de backend et
+   Connecter.
+
+La liste de modèles vient de `/v1/models` du serveur ; les serveurs à un
+seul modèle sont adoptés automatiquement, ou définissez un id de
+**Modèle par défaut** explicitement pour les endpoints qui ne listent
+pas de modèles. Trappe d'échappement env : `COMFYUI_MCP_CUSTOM_BASE_URL`,
+`COMFYUI_MCP_CUSTOM_MODEL`, `COMFYUI_MCP_CUSTOM_API_KEY`. Le modèle doit
+prendre en charge l'**appel d'outils**.
+
+## Ollama et modèles locaux — l'Arène des LLM
+
+N'importe quel harnais MCP qui parle à Ollama (ou à un endpoint
+compatible OpenAI) peut piloter le mode compact avec un modèle local.
+Deux harnais reproductibles se livrent dans le dépôt :
+`npm run test:local-llm` (vérification rapide d'un seul modèle) et
+`node scripts/llm-arena.mjs` — l'**Arène des LLM ComfyUI**, qui fait
+passer un champ de modèles par un jeu de tâches identique contre un
+ComfyUI *en direct* et vérifie chaque résultat contre le serveur, jamais
+les prétentions du modèle.
+
+Scores du palier local sur l'échelle complète à 10 scénarios (RTX 4090,
+ComfyUI 0.27, température 0 — voir la [page Arène](/docs/fr/arena) pour
+l'échelle de tâches et le classement tous paliers y compris les modèles
+frontier et hébergés) :
+
+| Modèle | Taille | Score /20 |
+| --- | --- | --- |
+| `qwen3:4b` | 2,6 Go | **13** |
+| `gemma4:e4b` | 9,6 Go | **12** |
+| `qwen3:8b` | 5,2 Go | **11** |
+| `gemma4:e2b` | 7,2 Go | **8** |
+| `llama3.1:8b` | 4,9 Go | **2** |
+| `gemma3` (toute taille) | — | ❌ pas d'appel d'outils natif — non pris en charge |
+
+À retenir : la classe qwen3/gemma4 passe solidement les tâches à un
+seul outil (santé, modèles installés, recherche registre, file) et
+ramasse des points sur les paliers plus durs, mais la composition de
+graphe multi-étapes (un graphe avec deux sorties en tuyau, un pipeline
+img2img en deux étapes préparé) reste du territoire frontier/B-tier.
+La discipline de format d'outils de llama3.1:8b s'effondre sur ce
+catalogue (il hallucine des noms d'outils et imprime du JSON d'appel
+d'outil comme du texte). Gemma 4 a livré le function calling natif sur
+toute la famille (Ollama ≥ v0.20) ; `e4b` ou plus grand est le meilleur
+compromis.
+
+Rappelez-vous l'échelle de capacités ci-dessus : ces petits modèles
+gardent l'appel d'outils mais ont une vision et une réflexion limitées
+ou nulles, donc ils peuvent générer et gérer des workflows mais ne
+peuvent pas critiquer visuellement les résultats.
+
+## Le panneau latéral sur un modèle local
+
+L'[agent du panneau](/docs/fr/panel) gagne un **backend Ollama** à côté
+de Claude / ChatGPT / Gemini : choisissez **Ollama (local)** dans le
+sélecteur de backend et l'orchestrateur pilote votre graphe en direct
+avec un modèle local — pas de compte, pas de clé API, entièrement hors
+ligne. Le modèle voit le routeur à 6 outils (les 3 méta-outils comfyui
+compacts plus `panel_list_tools` / `panel_describe_tool` /
+`panel_call_tool` pour le canevas en direct), donc même un modèle 4B
+n'est pas noyé dans les schémas. Modèle par défaut :
+**`artokun/gemma4-comfyui-mcp:e4b`** — [notre fine-tune
+gemma4](#nos-modèles-locaux-fine-tunés-gratuits-recommandés), entraîné
+sur cette suite d'outils exacte (remplace le `gemma4:e4b` d'origine,
+précédent meilleur de l'Arène) ; remplacez-le avec
+`COMFYUI_MCP_OLLAMA_MODEL` ou le sélecteur de modèle du panneau, qui
+liste ce que vous avez tiré en local. Attendez-vous à des compromis
+honnêtes face aux backends frontier : des tours plus lents (surtout le
+premier, pendant que le modèle charge), pas de vision, pas de retour en
+arrière de conversation.
+
+## Ce que vous obtenez (et n'obtenez pas)
+
+N'importe quel client MCP obtient la **surface d'outils complète** —
+génération, création de workflows, modèles, nœuds personnalisés, file,
+diagnostics — dans l'un ou l'autre mode d'outils. Les **extras du
+plugin** Claude Code (skills, commandes slash, hooks, packs
+d'installation, l'agent du panneau latéral) sont des fonctionnalités du
+plugin et ne voyagent pas vers les autres harnais. Le catalogue
+`list_tools` est conçu pour porter assez d'orientation pour que les
+agents sans cette couche de connaissance puissent encore se retrouver.
+
+## Dépannage
+
+- **Le modèle appelle `call_tool` avec un `args` stringifié** — pris en
+  charge ; le serveur parse automatiquement les chaînes encodées en JSON.
+- **Le modèle invente des noms d'outils** — les noms inconnus
+  renvoient des suggestions de proches correspondances plus un pointeur
+  vers `list_tools`.
+- **Paramètres faux/manquants** — l'erreur inclut le JSON Schema de
+  l'outil ; les modèles capables se corrigent à la tentative suivante.
+- **Le modèle répond depuis le catalogue sans rien exécuter** — un mode
+  d'échec connu des petits modèles ; donnez-lui un coup de pouce
+  (« les entrées du catalogue sont des noms d'outils, pas des données —
+  lance l'outil avec call_tool »).
+- **ComfyUI injoignable** — le mode compact ne change que
+  *l'enregistrement* des outils ; la config de connexion est identique à
+  toutes les autres mises en place (voir
+  [Configuration](/docs/fr/configuration)).

--- a/docs/fr/local-vs-comfy-cloud.mdx
+++ b/docs/fr/local-vs-comfy-cloud.mdx
@@ -1,0 +1,149 @@
+---
+title: "Local vs. agent Comfy Cloud"
+description: "L'In-App Agent et le Comfy Cloud MCP de Comfy-Org tournent sur Comfy Cloud ; comfyui-mcp tourne sur votre propre installation ComfyUI, avec n'importe quel LLM — Claude ou ChatGPT sur votre abonnement existant, ou un modèle local gratuit via Ollama sans compte ni réseau. Une comparaison honnête de quand utiliser lequel, y compris les cas où Comfy Cloud est la meilleure réponse."
+icon: "scale-balanced"
+---
+
+Si vous hésitez entre l'outillage agent officiel de Comfy-Org et ce projet, la
+version courte est qu'**ils résolvent des problèmes différents** — et pour un
+bon nombre de personnes l'option officielle est le bon choix. Cette page pose
+les deux honnêtement pour que vous puissiez choisir une fois et passer à autre
+chose.
+
+<Note>
+Comfy-Org livre vite, et les statuts ci-dessous datent de **juillet 2026**.
+Vérifiez [docs.comfy.org/agent-tools](https://docs.comfy.org/agent-tools) pour
+l'état actuel avant de traiter quoi que ce soit ici comme acquis.
+</Note>
+
+## La réponse en une ligne
+
+**Pas de GPU local, ou vous voulez zéro configuration ?** Utilisez Comfy Cloud.
+C'est first-party, c'est maintenu par l'équipe qui construit ComfyUI, et vous
+n'avez pas à penser aux pilotes, à la VRAM ou aux téléchargements de modèles.
+
+**Vous faites déjà tourner ComfyUI sur votre propre machine ?** C'est pour ça
+que ce projet existe. Votre GPU est déjà payé, vos modèles sont déjà sur
+disque, et votre abonnement Claude ou ChatGPT couvre déjà le raisonnement.
+
+## Ce que propose Comfy-Org
+
+La page [Agent Tools](https://docs.comfy.org/agent-tools) de Comfy-Org liste
+trois produits pertinents :
+
+| Produit | Ce que c'est | Statut (juil. 2026) |
+|---|---|---|
+| **Comfy Cloud MCP** | Serveur MCP hébergé ; la génération tourne sur les GPU Comfy Cloud | en bêta publique |
+| **Comfy In-App Agent** | Agent piloté par le chat à l'intérieur de Comfy Cloud, qui construit et édite votre graphe | en alpha privée |
+| **Comfy Local MCP** | Serveur MCP local first-party qui pilote votre propre installation ComfyUI | en test privé ; pas encore disponible publiquement |
+
+Comfy Cloud MCP est vraiment bon dans ce qu'il fait : il expose le moteur
+ComfyUI via MCP, se connecte en OAuth depuis Claude Code, Claude Desktop et
+Codex, et vous donne un accès géré à des modèles comme Kling, Veo, Seedance,
+Flux et ElevenLabs sans posséder de GPU.
+
+## Ce que propose ce projet
+
+`comfyui-mcp` est un serveur MCP plus un agent de barre latérale qui pilote
+**votre** installation ComfyUI — locale, LAN, VPS ou RunPod. 37 outils MCP,
+39 skills spécifiques aux modèles, et un agent de panneau qui édite votre
+graphe en direct en langage naturel.
+
+La différence structurelle, c'est **d'où vient le raisonnement**. Ce projet
+est agnostique vis-à-vis du fournisseur : les mêmes outils et le même panneau
+tournent sur Claude, ChatGPT, Gemini, Grok ou Kimi avec un abonnement que vous
+payez déjà, sur n'importe quel endpoint compatible OpenAI, ou sur un modèle
+local gratuit via Ollama, LM Studio ou llama.cpp — sans compte et sans aucun
+réseau sortant.
+
+## Face à face
+
+| | Comfy Cloud (In-App Agent / Cloud MCP) | comfyui-mcp |
+|---|---|---|
+| La génération tourne sur | les GPU Comfy Cloud | Votre GPU (ou votre VPS / pod RunPod) |
+| Exige un compte Comfy | Oui | Non |
+| Fonctionne entièrement hors ligne | Non | Oui, avec un modèle local |
+| Modèle de raisonnement | Fourni par le service | **Le vôtre** — n'importe quel LLM, y compris local gratuit |
+| Modèle de coût | Crédits cloud | Votre abonnement existant, ou 0 $ en local |
+| Vos images/prompts quittent la machine | Oui | Seulement si vous choisissez un LLM hébergé |
+| Gère vos nœuds personnalisés et fichiers de modèles | N/A (environnement géré) | Oui — installe les nœuds, télécharge les modèles |
+| Disponibilité | Cloud MCP en bêta publique ; agent en alpha privée | Disponible maintenant |
+| Support first-party | Oui | Projet communautaire |
+
+## Choisissez Comfy Cloud si…
+
+- Vous n'avez pas de GPU, ou le vôtre est trop petit pour les modèles que vous
+  voulez
+- Vous voulez que ça marche sans configuration ni maintenance
+- Vous préférez acheter des crédits plutôt que de gérer CUDA, la VRAM et les
+  téléchargements de checkpoints
+- Votre équipe est déjà sur Comfy Cloud et vous voulez un seul vendeur et une
+  seule facture
+- Vous voulez un support first-party des gens qui construisent ComfyUI
+
+Ce sont de bonnes raisons. Si plusieurs s'appliquent à vous, arrêtez de lire
+et allez utiliser [Comfy Cloud](https://comfy.org/) — vous passerez un meilleur
+moment.
+
+## Choisissez comfyui-mcp si…
+
+- **Vous avez déjà un GPU.** Vous l'avez payé ; les crédits cloud sont une
+  deuxième facture pour du calcul que vous possédez déjà.
+- **Votre travail ne peut pas quitter la machine.** Matériel client sous NDA,
+  données d'entraînement sous licence, tout ce que vous ne pouvez pas envoyer.
+  Avec un modèle local, rien ne part.
+- **Vous voulez utiliser l'abonnement LLM que vous avez déjà.** Votre forfait
+  Claude ou ChatGPT couvre déjà le raisonnement — pas de second compteur pour
+  l'agent.
+- **Vous le voulez gratuit, ou vous le voulez hors ligne.** Ollama, LM Studio
+  et llama.cpp tournent sans compte et sans réseau. Voir
+  [LLM locaux](/docs/fr/local-llms).
+- **Votre installation est le point.** Vos nœuds personnalisés, vos LoRA,
+  votre collection de checkpoints. L'agent
+  [installe les nœuds et télécharge les modèles](/docs/tools/models) dans
+  l'installation que vous utilisez vraiment.
+- **Vous voulez choisir le modèle.** Les LLM sont meilleurs à des choses
+  différentes ; l'[Arène des LLM](/docs/fr/arena) les note sur de vraies
+  tâches ComfyUI pour que vous puissiez choisir sur des preuves. Voir
+  [Backends](/docs/fr/backends).
+
+## « Le MCP local officiel ne rendra-t-il pas ceci redondant ? »
+
+Question légitime, et elle vaut d'être tranchée de face plutôt que de faire
+semblant.
+
+Comfy Local MCP est un **pilote first-party pour une installation locale**, et
+quand il sortira ce sera un bon. Mais c'est une couche différente de ce
+projet : il connecte un agent à ComfyUI, là où `comfyui-mcp` apporte aussi
+l'agent, le backend neutre vis-à-vis du fournisseur qui le fait tourner sur
+onze fournisseurs et runtimes locaux, l'UI de barre latérale, les skills
+spécifiques aux modèles, et la gestion des nœuds/modèles.
+
+La lecture honnête : si tout ce que vous voulez est « laisser Claude Code
+parler à mon ComfyUI local », l'outillage first-party finira par couvrir ça,
+et vous devriez probablement l'utiliser. Si vous voulez apporter votre propre
+modèle — y compris un local gratuit — et que l'agent vive à l'intérieur de
+ComfyUI et gère l'installation elle-même, c'est le vide que ce projet existe
+pour combler.
+
+Ils se composent aussi. Ce projet peut aussi cibler Comfy Cloud (définissez
+`COMFYUI_API_KEY` — voir [Déploiement cloud](/docs/fr/cloud-deployment)), donc
+une seule config couvre une installation locale, une machine LAN, un VPS et
+Comfy Cloud.
+
+## Pour commencer
+
+<CardGroup cols={2}>
+  <Card title="Démarrage rapide" icon="rocket" href="/docs/fr/quickstart">
+    Serveur MCP qui tourne contre votre ComfyUI local en environ une minute.
+  </Card>
+  <Card title="LLM locaux" icon="microchip" href="/docs/fr/local-llms">
+    Entièrement hors ligne sur Ollama, LM Studio ou llama.cpp — sans compte.
+  </Card>
+  <Card title="Backends" icon="shuffle" href="/docs/fr/backends">
+    Claude, ChatGPT, Gemini, Grok, Kimi, ou n'importe quel endpoint compatible OpenAI.
+  </Card>
+  <Card title="Panneau agent" icon="window" href="/docs/fr/panel">
+    L'agent de barre latérale qui pilote votre graphe en direct.
+  </Card>
+</CardGroup>

--- a/docs/fr/mobile.mdx
+++ b/docs/fr/mobile.mdx
@@ -1,0 +1,73 @@
+---
+title: "Appli mobile (bêta)"
+description: "ComfyUI-MCP Mobile — discutez avec votre agent ComfyUI depuis votre téléphone. Appairez avec le QR code du panneau agent et pilotez générations, workflows et modèles depuis n'importe où sur votre réseau. Maintenant en bêta fermée sur Android et iOS."
+icon: "mobile"
+---
+
+<Note>
+**Rejoindre la bêta.** L'appli mobile ComfyUI-MCP est en bêta fermée —
+installez un build pour votre plateforme :
+
+- **Android** — [Firebase App Distribution](https://appdistribution.firebase.dev/i/27a5cccde72ffb42)
+- **iOS** — [TestFlight](https://testflight.apple.com/join/ws65s4a2)
+</Note>
+
+L'appli mobile est un frontend natif téléphone du même agent qui alimente le
+[panneau latéral](/docs/fr/panel). Elle se connecte au pont de
+l'orchestrateur du panneau, donc tout ce que le panneau peut faire —
+générer des images, exécuter et inspecter des workflows, changer de modèles
+— est disponible depuis votre téléphone, avec le ComfyUI de votre bureau qui
+fait le travail.
+
+## Appairage
+
+L'appli parle à l'hôte de l'agent via le pont du panneau, donc vous
+appairez une fois et vous y êtes :
+
+1. Installez et lancez [comfyui-mcp](/docs/fr/quickstart) avec le
+   [panneau agent](/docs/fr/panel) sur votre bureau.
+2. Dans les **Réglages** de ComfyUI, activez
+   **« Contrôle via l'appli mobile (bêta) »** — c'est **éteint par défaut**,
+   et le bouton d'appairage reste caché jusqu'à ce que vous l'activiez.
+3. Ouvrez le panneau et cliquez sur le bouton **QR** dans son en-tête pour
+   afficher le **QR d'appairage**.
+4. Dans l'appli mobile, appuyez sur **Scanner le QR du panneau** — ou
+   collez l'URL du pont (`ws://…?token=…`) à la main.
+
+Le QR encode une URL lander dont les données d'appairage voyagent dans le
+fragment d'URL, donc l'hôte et le jeton ne quittent jamais vos appareils.
+L'appli enregistre aussi le deep link `comfyui-mcp://pair` pour le bouton
+**Ouvrir dans l'appli** du lander.
+
+<Note>
+Le téléphone et le bureau ont besoin d'un chemin réseau entre eux — le même
+LAN dans le cas simple, ou un [relais sécurisé](/docs/fr/self-hosted-relay) /
+[déploiement cloud](/docs/fr/cloud-deployment) quand l'hôte n'est pas
+directement joignable.
+</Note>
+
+## Ce qu'il y a dans l'appli
+
+- **Chat agent** — la même conversation que vous auriez dans la barre
+  latérale du panneau, depuis votre téléphone.
+- **Sélecteur de modèle** — catalogue de modèles en direct depuis
+  l'orchestrateur ; changez de modèle en cours de session.
+- **Navigation Civitai** — chercher des modèles et des créateurs, j'aime et
+  favoris.
+- **Contrôle à distance** — mirorer l'onglet du panneau bureau et vérifier
+  les diagnostics de workflow en déplacement.
+
+## Retours
+
+Les retours de bêta et les rapports de bugs sont les bienvenus sur
+[Discord](https://discord.gg/cW9arBhzCu) ou le
+[tracker d'issues](https://github.com/artokun/comfyui-mcp/issues).
+
+## Voir aussi
+
+- [Panneau latéral](/docs/fr/panel) — l'agent dans ComfyUI auquel l'appli
+  s'appaire
+- [Déploiement cloud](/docs/fr/cloud-deployment) — piloter un pod ComfyUI
+  distant
+- [Relais auto-hébergé](/docs/fr/self-hosted-relay) — posséder le chemin du
+  pont sécurisé

--- a/docs/fr/plugin.mdx
+++ b/docs/fr/plugin.mdx
@@ -1,0 +1,135 @@
+---
+title: "Plugin Claude Code"
+description: "comfyui-mcp est un plugin Claude Code complet : 39 skills IA, 11 commandes slash, 4 agents autonomes, et 3 hooks par-dessus les 37 outils MCP — une expertise ComfyUI qui grandit à chaque version."
+icon: "puzzle-piece"
+---
+
+`comfyui-mcp` n'est pas seulement un serveur MCP — il se livre comme un
+**plugin Claude Code** complet. Installer le plugin donne à Claude une
+connaissance experte, spécifique aux modèles, de ComfyUI pour qu'il choisisse
+le bon sampler, CFG, résolution et fichiers de modèles sans essais-erreurs.
+
+```bash
+# In Claude Code
+/plugin marketplace add artokun/comfyui-mcp
+/plugin install comfy
+```
+
+## 39 skills IA — et ça grandit
+
+Les skills sont des documents de connaissance soignés que Claude charge à la
+demande. Chaque famille de modèles reçoit des paramètres de génération, des
+graphes de nœuds, des URL de téléchargement de modèles soignées, et un guide
+des modes d'échec :
+
+| Skill | Ce que Claude apprend |
+|---|---|
+| `flux-txt2img` | Flux.1 Dev/Schnell + Flux 2 Klein — pièges BF16 vs FP8, câblage dual-CLIP, choix de VAE |
+| `wan-t2v-video` / `wan-flf-video` | Workflows WAN 2.x texte-vers-vidéo et première-dernière-image |
+| `wan-scail-replacement` | Remplacement de personnage in-video SCAIL-2 — règle cadrage-de-référence→échelle, pièges de réglage et de compositing |
+| `ltxv2-video` | LTX-2.3 (et LTX-2 19B) — UNet GGUF, modèle distillé, LoRA de contrôle caméra, upscale en deux étapes, correctif kornia |
+| `qwen-txt2img` / `qwen-image-edit` | Génération Qwen-Image et édition par instruction |
+| `z-image-txt2img` | Workflows Z-Image Turbo |
+| `ideogram-ultra` | Ideogram 4 — texte-vers-image open-weight, prompting par zones, logos / posters / texte lisible |
+| `ernie-image` | ERNIE-Image — texte-vers-image rapide, rendu de texte multilingue précis, tourne sous 8 Go de VRAM |
+| `anima-base` | ANIMA 1.0 — modèle anime/illustration ~2B, tags Danbooru + langage naturel, inpainting anime, sous 6 Go de VRAM |
+| `anima-lora-trainer` | Entraîner des LoRA anime personnalisés — trainer Gradio kohya `sd-scripts`, sous 6 Go de VRAM |
+| `ai-toolkit-trainer` | Entraîner des LoRA WAN 2.2 + Z-Image personnalisés (personnes / styles / mouvement) — ostris AI-Toolkit, local ou RunPod |
+| `installer-packs` | Utiliser, construire et dériver des packs d'installation en une commande — et inviter les utilisateurs à contribuer de nouveaux packs en amont |
+| `panel-node-pack-sync` | Garder le pack de nœuds du panneau latéral aligné avec l'orchestrateur après une mise à jour — détection de décalage de version, une épingle de version dont on avertit plutôt que de l'écraser, et une synchro dont le résultat est relu depuis le disque |
+| `model-compatibility` | Quelle paire VAE/CLIP/text-encoder va avec quelle architecture — la source n°1 des workflows cassés |
+| `model-registry` | URL de téléchargement soignées + répertoires cibles pour chaque modèle que les skills référencent — grandit à chaque version |
+| `civitai` | Boucle native découverte Civitai → téléchargement local / câblage / génération via `download_model` `action:"search_civitai"` intégré (pas de clé, pas de serveur supplémentaire) ; le [Civitai MCP](https://mcp.civitai.com/mcp) officiel est un add-on de surface communautaire optionnel, pas bundlé |
+| `comfyui-core` | Sémantique de file, d'historique et d'API |
+| `comfyui-node-registry` | Création + publication de packs de nœuds personnalisés sur le Comfy Registry |
+| `comfyui-frontend-extensions` | Création d'extensions frontend v1/v2 (onglets de barre latérale, widgets) |
+| `rgthree` | Configurer rgthree-comfy — bascules de groupe Fast Groups Bypasser/Muter (nœuds frontend-only absents de `/object_info`, réglés via les PROPERTIES du nœud pas les widgets), empilement Power Lora Loader, bus Context |
+| `director` | Direction de scène multi-plans pour les pipelines vidéo |
+| `prompt-engineering` | Prompting spécifique à l'architecture (langage naturel vs tags) |
+| `troubleshooting` | OOM, nœuds manquants, dérive de version — arbres de diagnostic |
+| `comfyui-launch-flags` | La matrice des drapeaux de lancement VRAM/attention/cache/perf — `--reserve-vram`, `--novram`+`--cache-none`, `--use-sage-attention` vs `--use-pytorch-cross-attention` (Z-Image), plus les notes de pile d'accélération Blackwell/RTX 5000 |
+
+De nouvelles skills arrivent à chaque version — générées depuis les packs
+populaires du registre via l'outil intégré `list_packs`
+(`action: "generate_skill"`), puis soignées par un humain.
+
+**Essayez la connaissance avant de brancher quoi que ce soit** — chaque skill
+est un fichier markdown simple, utile tout seul. Le plus largement applicable
+est
+[`prompt-engineering`](https://github.com/artokun/comfyui-mcp/blob/main/plugin/skills/prompt-engineering/SKILL.md)
+— la limite de 77 jetons de CLIP et le découpage `BREAK`, la syntaxe de
+poids, et la stratégie par architecture (pourquoi Flux veut du langage
+naturel et pas de prompt négatif tandis que SD1.5 veut des tags). Lisez-le
+dans le navigateur, ou collez-le dans le contexte de n'importe quel agent
+comme prompt système — aucun ComfyUI, MCP ni installation requis. Quand
+vous connectez le plugin complet, les agents chargent les mêmes fichiers
+automatiquement (`list_packs` avec `action: "skill_read"`).
+
+### Recherche Civitai — intégrée
+
+`download_model` `action:"search_civitai"` cherche sur Civitai nativement
+(API REST publique, pas de clé, pas de serveur supplémentaire) : mot-clé +
+filtres `types` + `base_models` (« un LoRA **Flux** »), SFW seulement par
+défaut, et chaque résultat renvoie le `model_version_id` que
+`action:"download_civitai"` prend directement — plus les **mots déclencheurs**
+du modèle pour le prompt. Parce que c'est un outil de première classe, ça
+marche sur **chaque backend**, y compris les petits modèles locaux derrière
+le routeur compact. La skill `civitai` enseigne toute la passation
+découverte → téléchargement → génération.
+
+**Clé API optionnelle.** La recherche n'en a besoin d'aucune.
+`CIVITAI_API_TOKEN` déverrouille les téléchargements gated/early-access et
+les résultats de recherche gated — une seule variable alimente à la fois
+la recherche et le téléchargement.
+
+**Optionnel : le Civitai MCP officiel.** Pour la surface communautaire
+au-delà de chercher→installer (parcourir les images d'exemple + leurs
+paramètres de génération, publier, collections), associez le
+[serveur distant officiel](https://mcp.civitai.com/mcp) de Civitai —
+plus auto-bundlé, ajoutez-le une fois :
+
+```bash
+claude mcp add --transport http civitai https://mcp.civitai.com/mcp \
+  --header "Authorization: Bearer YOUR_CIVITAI_API_KEY"
+```
+
+## 11 commandes slash
+
+`/comfy:gen` (générer depuis un prompt), `/comfy:debug` (diagnostiquer un
+workflow en échec), `/comfy:install` (installer des packs de nœuds),
+`/comfy:viz` (workflow → Mermaid), `/comfy:batch`, `/comfy:compare`,
+`/comfy:convert`, `/comfy:gallery`, `/comfy:recipe`, `/comfy:director`,
+`/comfy:node-skill`.
+
+## 4 agents autonomes
+
+- **comfy-explorer** — plonge dans le source d'un pack de nœuds pour le
+  documenter
+- **comfy-researcher** — énoncé de problème → recommandations de packs
+  classées
+- **comfy-debugger** — trouve la cause racine des workflows en échec depuis
+  l'historique + les logs
+- **comfy-optimizer** — réglage VRAM et vitesse pour un GPU donné
+
+## Le panneau latéral — pas de clés API
+
+<Note>
+  Le panneau latéral se livre comme son propre pack, **sur le Comfy Registry
+  et dans ComfyUI-Manager sous `comfyui-agent-panel`** — cherchez-le là et
+  choisissez **Latest**, pas Nightly. Guide complet :
+  [Panneau latéral](/docs/fr/panel).
+</Note>
+
+La barre latérale [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel)
+exécute un agent autonome sur votre **abonnement Claude** (pas de
+facturation API au jeton). Installez le pack, ouvrez l'onglet Agent, et
+cliquez sur **Connecter** — il démarre l'[orchestrateur du
+panneau](/docs/fr/configuration) à la demande ; demandez-lui une image, un
+workflow ou une modification et il travaille contre votre ComfyUI.
+
+## Hooks
+
+Trois hooks gardent les sessions de génération serrées : **vérifications
+VRAM pré-vol** avant de mettre un workflow en file, **notifications de fin
+de job**, et **avertissements d'enregistrement** avant les opérations
+destructrices.

--- a/docs/fr/remote-connector.mdx
+++ b/docs/fr/remote-connector.mdx
@@ -1,0 +1,173 @@
+---
+title: "Connecteur distant / hébergé"
+description: "Exposez comfyui-mcp comme un serveur MCP Streamable-HTTP authentifié et joignable publiquement — ajoutez-le aux Connecteurs personnalisés de Claude Desktop ou à n'importe quel client distant, une seule commande."
+icon: "globe"
+---
+
+`comfyui-mcp` parle le même transport MCP **Streamable-HTTP** que les
+connecteurs hébergés (par exemple le Custom Connector propre de Comfy,
+`cloud.comfy.org/mcp`). En une commande il tourne comme un serveur
+authentifié par jeton derrière un tunnel HTTPS public, pour que vous puissiez
+l'ajouter à **Claude Desktop → Connectors** ou l'appeler en headless depuis
+n'importe où.
+
+<Note>
+C'est opt-in. Le transport `stdio` par défaut (et le `--http` en clair sur
+loopback) se comporte exactement comme avant — ouvert et local. L'auth et le
+tunnel ne s'activent que lorsque vous définissez un jeton ou passez
+`--tunnel`.
+</Note>
+
+<Note>
+**Vous cherchez plutôt à piloter un pod ComfyUI distant (par ex. RunPod) avec
+le panneau agent ?** C'est une fonctionnalité différente — voir
+[Déploiement cloud](/docs/fr/cloud-deployment). Cette page concerne
+l'exposition du **serveur MCP comfyui-mcp lui-même** à des clients distants
+comme Claude Desktop ; elle ne touche ni ComfyUI ni le pont du panneau.
+Les deux se trouvent utiliser un quick tunnel cloudflared sous le capot, ce
+qui est la façon la plus facile de les confondre.
+</Note>
+
+## Tunnel en une commande
+
+```bash
+npx -y comfyui-mcp@latest --tunnel
+```
+
+Cela fait quatre choses :
+
+1. Force le transport HTTP (`MCP_TRANSPORT=http`).
+2. Génère un jeton d'auth aléatoire fort si vous n'en avez pas défini un.
+3. Démarre un quick tunnel [cloudflared](https://github.com/cloudflare/cloudflared)
+   vers le port MCP local.
+4. Affiche un bloc prêt à coller : l'URL publique `https://…/mcp`, le jeton,
+   et un extrait de connecteur Claude Desktop.
+
+La sortie ressemble à :
+
+```text
+════════════════════════════════════════════════════════════════════
+ ComfyUI MCP — Remote / Hosted Connector is LIVE
+════════════════════════════════════════════════════════════════════
+ Public MCP URL : https://shiny-otter-1234.trycloudflare.com/mcp
+ Auth token     : 9f2c…<redacted>
+ ...
+════════════════════════════════════════════════════════════════════
+```
+
+<Warning>
+Laissez le terminal ouvert. Un **quick tunnel** cloudflared est éphémère —
+son URL change à chaque lancement et il se ferme quand le processus se
+termine. Pour un nom d'hôte stable, lancez votre propre
+[tunnel cloudflared nommé](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+pointé vers le port HTTP local à la place.
+</Warning>
+
+### cloudflared n'est pas installé ?
+
+`cloudflared` se livre comme une dépendance optionnelle. Si le binaire est
+introuvable, le serveur continue de tourner en local et affiche un guide
+d'installation :
+
+```bash
+npm install -g cloudflared          # cross-platform
+brew install cloudflared            # macOS
+winget install cloudflare.cloudflared  # Windows
+```
+
+Puis relancez avec `--tunnel`.
+
+## L'ajouter à Claude Desktop
+
+Ouvrez **Claude Desktop → Settings → Connectors → Add custom connector** et
+remplissez :
+
+| Champ  | Valeur |
+|--------|-------|
+| Name   | `ComfyUI` |
+| URL    | l'URL `https://…/mcp` affichée |
+| Header | `X-API-Key: <token>` (ou `Authorization: Bearer <token>`) |
+
+Enregistrez, puis activez le connecteur dans une conversation. Les outils
+ComfyUI apparaissent exactement comme pour le serveur stdio local.
+
+## Config headless / programmatique
+
+Tout client MCP qui prend en charge un serveur Streamable-HTTP distant
+marche. Fournissez l'URL et l'en-tête d'auth :
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "url": "https://shiny-otter-1234.trycloudflare.com/mcp",
+      "headers": { "X-API-Key": "<token>" }
+    }
+  }
+}
+```
+
+Les deux formes d'en-tête sont acceptées sur **chaque** requête vers `/mcp` :
+
+```bash
+# X-API-Key (matches Comfy Cloud's convention)
+curl -H "X-API-Key: <token>" https://…/mcp
+
+# Authorization: Bearer
+curl -H "Authorization: Bearer <token>" https://…/mcp
+```
+
+## Mise en place manuelle (apportez votre propre tunnel / proxy)
+
+Si vous préférez gérer l'endpoint public vous-même, lancez le transport HTTP
+avec un jeton fixe et placez-le derrière votre propre reverse proxy, tunnel
+ou VPN :
+
+```bash
+COMFYUI_MCP_HTTP_TOKEN=my-long-random-secret \
+  npx -y comfyui-mcp@latest --http --host 0.0.0.0 --port 9100
+```
+
+Puis pointez votre tunnel/proxy vers `http://127.0.0.1:9100/mcp`.
+
+<Warning>
+Se lier à un hôte non-loopback (par ex. `0.0.0.0`) **sans** jeton est un
+**échec dur** — le serveur refuse de démarrer plutôt que d'exposer un
+endpoint `/mcp` ouvert hors de la machine. Définissez
+`COMFYUI_MCP_HTTP_TOKEN` (recommandé), utilisez `--tunnel`, ou liez un hôte
+loopback. Si vous voulez vraiment un endpoint ouvert (par ex. derrière
+votre propre proxy authentifiant), optez-y explicitement avec
+`--allow-unauthenticated-non-loopback` (env `COMFYUI_MCP_ALLOW_UNAUTH=1`),
+ce qui rétrograde l'échec en avertissement.
+</Warning>
+
+## Référence d'auth
+
+| Réglage | Effet |
+|---------|--------|
+| `COMFYUI_MCP_HTTP_TOKEN` | Jeton secret partagé exigé sur `/mcp`. Non défini → l'endpoint est ouvert. |
+| `--token <value>` | Identique à la variable d'environnement ; le drapeau CLI l'emporte sur la variable. |
+| `--tunnel` / `MCP_TUNNEL=1` | Forcer HTTP, auto-générer un jeton s'il n'est pas défini, ouvrir un tunnel cloudflared. |
+| `--http` / `MCP_TRANSPORT=http` | Transport HTTP sans tunnel (l'auth s'applique encore si un jeton est défini). |
+| `--host`, `--port` | Adresse de liaison (défaut `127.0.0.1:9100`). |
+| `--allow-unauthenticated-non-loopback` / `COMFYUI_MCP_ALLOW_UNAUTH=1` | Opter pour un `/mcp` OUVERT sur un hôte non-loopback. Sans ça, cette combinaison est un échec dur au démarrage. |
+
+Les jetons sont comparés en temps constant, et la barrière est appliquée sur
+chaque méthode HTTP (`POST`/`GET`/`DELETE`) à l'endpoint MCP. Lier un hôte
+non-loopback sans jeton est refusé au démarrage sauf si la trappe ci-dessus
+est définie.
+
+## Feuille de route : OAuth
+
+L'auth d'aujourd'hui est un **jeton secret partagé manuel** (Bearer /
+`X-API-Key`), qui couvre à la fois le chemin headless et le Custom Connector
+de Claude Desktop. Un flux de connexion **OAuth** complet dans le navigateur
+(comme le connecteur hébergé de Comfy) est un suivi prévu — c'est un
+changement plus lourd et il n'est pas requis pour se connecter manuellement.
+
+## Voir aussi
+
+- [Déploiement cloud](/docs/fr/cloud-deployment) — piloter un pod ComfyUI
+  distant avec le panneau agent (un tunnel différent, un but différent)
+- [Configuration](/docs/fr/configuration) — la référence complète des
+  variables d'environnement

--- a/docs/fr/roadmap.mdx
+++ b/docs/fr/roadmap.mdx
@@ -1,0 +1,195 @@
+---
+title: "Feuille de route"
+description: "Ce qui est livré, ce qui se construit, ce qui vient ensuite — et ce que nous avons décidé de ne pas construire, avec le raisonnement. Ordonné par priorité, pas par date."
+icon: "map"
+---
+
+## Ce que cela couvre
+
+**Tout le projet, pas un seul dépôt.** comfyui-mcp, ce sont plusieurs pièces
+qui se livrent séparément et se versionnent indépendamment :
+
+| Pièce | Dépôt | Ce que c'est |
+|---|---|---|
+| **Serveur MCP + plugin** | [`comfyui-mcp`](https://github.com/artokun/comfyui-mcp) | les outils et l'orchestrateur — le plan de contrôle |
+| **Panneau** | [`comfyui-mcp-panel`](https://github.com/artokun/comfyui-mcp-panel) | la barre latérale agent à l'intérieur de ComfyUI |
+| **Appli mobile** | [`comfyui-mcp-mobile`](https://github.com/artokun/comfyui-mcp-mobile) | chat, file, LoRA et miroir d'onglet bureau |
+| **Relais** | [`comfyui-mcp-relay`](https://github.com/artokun/comfyui-mcp-relay) | Worker Cloudflare pour un pont distant `wss://` stable |
+
+Les éléments ci-dessous sont étiquetés par pièce quand ça compte. Tout est
+planifié comme un seul produit même s'il atterrit à quatre endroits.
+
+<Warning>
+  Les numéros de version dans [Comment on en est arrivé là](#comment-on-en-est-arrivé-là)
+  sont ceux du **serveur MCP**. Le panneau et l'appli mobile portent leurs
+  propres lignes de version, sans rapport — le panneau 0.9.x n'est pas « en
+  retard » sur le serveur v0.44. Ne les comparez pas.
+</Warning>
+
+## Comment lire cette page
+
+**Il n'y a aucune date sur cette page, et c'est volontaire.**
+
+Ce projet livre vite et réordonne souvent — l'arc RunPod a sauté la file en
+une seule semaine. Une feuille de route avec des trimestres dessus serait
+fausse en quelques jours, et une mauvaise date est pire qu'aucune date : elle
+transforme un plan en une promesse que personne n'a faite.
+
+Donc cette page s'engage sur **l'ordre, pas le calendrier**. « Ensuite » veut
+dire le suivant dans la file, pas le mois prochain. Si quelque chose ici
+compte pour vous, dites-le sur [Discord](https://discord.gg/cW9arBhzCu) — ce
+que les gens font vraiment au quotidien fait monter les choses dans cette
+liste bien plus fiablement que la taille de la demande.
+
+La section la plus utile est probablement la dernière.
+**[Non prévu](#non-prévu)** dit ce que nous avons décidé *contre* et pourquoi,
+pour que vous puissiez arrêter d'attendre.
+
+---
+
+## Livré
+
+Tout ici marche aujourd'hui et est couvert par la doc.
+
+| Domaine | Ce que vous obtenez |
+|---|---|
+| **Agent dans ComfyUI** | Le panneau place un agent à côté de votre canevas — il lit le graphe, édite les nœuds, exécute des workflows et explique les échecs. Voir [Panneau](/docs/fr/panel). |
+| **Apportez votre propre modèle** | Claude, ChatGPT/Codex, Gemini, Antigravity, Grok, Kimi, GLM, Ollama, LM Studio, llama.cpp, OpenRouter, ou un endpoint personnalisé — un sélecteur, un orchestrateur. Voir [Backends](/docs/fr/backends). |
+| **Modèles locaux** | Fonctionnement entièrement local via Ollama / LM Studio / llama.cpp, y compris les petits modèles. Voir [LLM locaux](/docs/fr/local-llms). |
+| **Création de workflows** | Construire, patcher, découper, valider et verrouiller des workflows depuis le langage naturel ; importer depuis les métadonnées d'une image. |
+| **Modèles et nœuds personnalisés** | Chercher, installer et réparer des packs de nœuds ; trouver et télécharger des modèles — y compris déterminer quels modèles un workflow manque et quelle quantification tient dans votre VRAM. |
+| **Navigateur Civitai** | Parcourir images, vidéos et modèles dans le panneau, filtrer par modèle de base et créateur, et tirer un workflow tout droit sur le canevas. |
+| **Appli mobile** | Discuter avec l'agent, surveiller la file, parcourir les LoRA, et mirorer un onglet bureau pour piloter votre machine depuis votre téléphone. Voir [Mobile](/docs/fr/mobile). |
+| **Apps (micro-apps)** | Transformer un workflow en app en un clic avec un vrai formulaire : convertir et publier dans le panneau, l'exécuter en local ou sur un pod, installer les apps des autres depuis le registre public — et lancer les mêmes apps depuis l'onglet Apps du téléphone ou un agent via les outils `apps_*`. Voir [Apps](/docs/fr/apps). |
+| **Distant et cloud** | Pointer le panneau vers un ComfyUI distant, un relais auto-hébergé, ou Comfy Cloud. Voir [Connecteur distant](/docs/fr/remote-connector). |
+| **Pods RunPod** | Créer, se connecter à et arrêter des pods RunPod depuis le panneau, avec des défauts sûrs pour la facturation et un indicateur d'hôte honnête. |
+| **Entraînement LoRA (local)** | LoRA de personnages sur FLUX.1-dev, pilotés par l'agent via les outils `train_*` dans un conteneur Docker GPU — jeu de données en entrée, `.safetensors` dans `models/loras/` en sortie. |
+
+## En cours de construction
+
+Activement en cours. Ce sont les choses les plus susceptibles de bouger
+ensuite.
+
+| Élément | Où ça en est |
+|---|---|
+| **Entraînement LoRA sur pods RunPod** | Le transport est arrivé ; le travail de suivi continue sur le périmètre de l'arrêt à l'inactivité et un chemin natif sans Docker pour les machines sans Docker. |
+| **Entraînement au-delà des LoRA de personnages** | Flux style, curseur et édition, et des modèles de base au-delà de FLUX.1-dev. La couche de config a été construite pour s'élargir ; les flux ne sont pas encore écrits. |
+
+## Ensuite
+
+En file et spécifiés, pas commencés. Ordonnés.
+
+| Élément | Pourquoi c'est ici |
+|---|---|
+| **Aperçus honnêtes dans l'appli mobile** | L'onglet **Entraînement** est encore une UI de placeholder inerte — six cartes qui se lisent comme une fonctionnalité livrée et ont déjà induit les gens à demander où ça en est. Soit l'étiqueter clairement, soit le cacher — le correctif le moins cher de cette liste. (L'onglet **Apps** était l'autre moitié de cet élément et est maintenant réel ; voir [Apps](/docs/fr/apps).) |
+| **Entraînement mobile** | Brancher l'onglet Entraînement mobile sur le trainer qui marche déjà. Le dur est fait ; c'est surtout de la plomberie, et ça retire l'élément ci-dessus. |
+| **Disposition tablette** | Du vrai travail responsive, sans glamour. Ça vaut le coup une fois que les écrans ci-dessus ont quelque chose qui mérite d'être montré. |
+
+## À l'étude
+
+Souhaité, mais bloqué sur une question de conception plutôt que sur l'effort.
+Aucun engagement.
+
+### Sessions multi-utilisateurs
+
+Laisser quelqu'un d'autre se connecter à *votre* session et piloter *votre*
+machine — déboguer à deux un workflow cassé, ou un studio partagé.
+
+Ça vaut d'être précis sur le bloqueur, parce que ce n'est pas celui qui saute
+aux yeux : **le transport existe déjà.** L'appairage, le fan-out de sockets et
+l'auth par session ont tous été construits pour le miroir téléphone-bureau,
+qui est la même plomberie.
+
+Ce qui manque, c'est un **modèle de confiance**. Qui a le droit de piloter ?
+Que peuvent-ils voir de votre canevas, de votre historique, de votre système
+de fichiers ? Comment révoquer l'accès de quelqu'un en cours d'exécution ?
+Ces questions ont besoin d'une réponse avant que quoi que ce soit soit
+construit — livrer une réponse à moitié conçue sur le GPU de quelqu'un
+d'autre, c'est comme ça qu'on fait du mal aux gens.
+
+---
+
+## Non prévu
+
+Décidé contre, avec le raisonnement, pour que personne n'attende dessus. Pas
+permanent — un bon argument rouvre n'importe lequel — mais rien ici n'est en
+file.
+
+### Dates et jalons numérotés par version
+
+Voir [le haut de cette page](#comment-lire-cette-page). L'ordre, pas le
+calendrier.
+
+### Contrôle uniquement vocal (lunettes connectées, casques)
+
+Piloter l'agent de bureau à la voix depuis des lunettes revient régulièrement,
+et la plomberie réutiliserait surtout le transport de miroir.
+
+La raison pour laquelle ce n'est pas en file, c'est qu'une surface uniquement
+vocale **n'a pas de canevas**. Il n'y a pas d'aperçu à jeter un œil, aucun
+moyen de résoudre *« utilise l'autre LoRA »* quand deux sont chargés, et
+aucune annulation visible quand l'agent fait la mauvaise chose à votre
+graphe. Ce sont les vrais problèmes, et ajouter un micro n'en résout aucun.
+Tant qu'il n'y a pas de réponse, ça se livrerait comme une démo sur laquelle
+il est désagréable de s'appuyer.
+
+### Montre connectée
+
+Tout ce qui précède s'applique, sur un écran plus petit avec un budget
+d'énergie plus serré. Personne n'a encore décrit un travail qu'elle ferait
+mieux que le téléphone déjà.
+
+### Un service hébergé qui exécute ComfyUI pour vous
+
+Ce projet est un **plan de contrôle local-first**. Il se connecte à votre
+ComfyUI — sur votre machine, votre boîtier distant, votre pod, ou Comfy Cloud
+— et il ne veut ni vos fichiers ni vos prompts. Faire de l'inférence à votre
+place est un produit différent avec un modèle de confiance différent, et ce
+n'est pas celui-ci.
+
+---
+
+## Comment on en est arrivé là
+
+L'arc jusqu'ici, pour le contexte de là où se situent les prochains éléments.
+C'est volontairement grossier — pour ce qui a changé dans une version
+précise, voir le [Changelog](/docs/changelog).
+
+<Note>
+  Les versions publiques commencent à **v0.2.0**. Il n'y a pas de v0.0.1 ni
+  de v0.1.x — les deux premières semaines de travail ont atterri tout droit
+  sur `main` avant que le paquet soit publié, à partir du commit initial du
+  **2026-02-15**.
+</Note>
+
+Les versions montrées sont celles du **serveur MCP** — le panneau et l'appli
+mobile se versionnent séparément, et les ères ci-dessous décrivent le projet
+dans son ensemble.
+
+| Ère | Versions du serveur | De quoi il s'agissait |
+|---|---|---|
+| **Le serveur MCP**<br/>Fév. 2026 | v0.2 – v0.3 | L'idée d'origine : piloter ComfyUI depuis un agent. Génération d'images, analyse de workflows, un convertisseur de workflow UI→API, visualisation hiérarchique, skills de modèles, et le passage des exécutions bloquantes à une file non bloquante avec progression en arrière-plan et contrôle de processus. |
+| **Période calme**<br/>Mars – avr. 2026 | v0.3.x | Trois commits de fonctionnalités en deux mois. ComfyUI distant via HTTP, expansion des sous-graphes/composants dans le convertisseur, support HTTPS/WSS. Du terrain, pas des gros titres. |
+| **Environnement et cycle de vie**<br/>Mai 2026 | v0.4 – v0.8 | Le faire survivre aux vraies installations : vérification/échafaudage de nœuds personnalisés avec CI, installations épinglées à une ref git, auth pour les modèles gated et privés, manifests d'environnement déclaratifs, fournisseurs de stockage cloud, conversion d'images côté serveur, et découverte de skills de nœuds en cache. Le panneau intégré a été conçu à la fin de cette période. |
+| **L'ère du panneau**<br/>Juin 2026 | v0.9 – v0.22 | Le plus gros mois en volume (~102 commits de fonctionnalités). L'agent a emménagé *dans* ComfyUI à côté du canevas, a gagné plusieurs fournisseurs, et a développé l'infrastructure pour tourner n'importe où : packs d'installation en un clic, une image RunPod, un pont `wss://` sécurisé avec un relais opt-in, et la visibilité du raisonnement en direct. |
+| **Portée et profondeur**<br/>Juil. 2026 | v0.23 – v0.44 | Deux directions à la fois. **Portée :** l'appli mobile, le miroir d'onglet bureau, le navigateur Civitai, plus de fournisseurs (Antigravity, GLM, Kimi), et le mode d'outils compact pour que les petits modèles locaux puissent piloter les outils. **Profondeur :** l'Arène des LLM, les pods RunPod first-party avec des défauts sûrs pour la facturation, l'entraînement LoRA, et la résolution des modèles manquants qui tient compte de votre VRAM. |
+
+Deux choses que ce tableau ne vous dira pas. Le rythme est inégal exprès —
+deux mois de calme au printemps, puis ~180 commits de fonctionnalités en
+juin et juillet. Et l'ordre n'a jamais été fixé d'avance : RunPod et
+l'entraînement ont tous les deux sauté la file parce qu'ils se sont avérés
+compter plus que ce qui était nominalement ensuite. C'est la raison
+principale pour laquelle cette page ne porte aucune date.
+
+## Quelque chose manque ?
+
+Si vous attendez quelque chose qui n'est pas listé, ou si l'un des appels
+« non prévu » a l'air faux pour la façon dont vous travaillez vraiment,
+ouvrez une issue sur
+[GitHub](https://github.com/artokun/comfyui-mcp/issues) ou dites-le sur
+[Discord](https://discord.gg/cW9arBhzCu).
+
+Les demandes qui décrivent **ce que vous essayez de faire** sont bien plus
+utiles que celles qui nomment une fonctionnalité — plusieurs éléments de
+cette page sont ordonnés comme ils le sont parce que quelqu'un a expliqué sa
+journée, pas parce qu'il a demandé le plus fort.

--- a/docs/fr/self-hosted-relay.mdx
+++ b/docs/fr/self-hosted-relay.mdx
@@ -1,0 +1,81 @@
+---
+title: "Relais de pont sécurisé auto-hébergé (entreprise)"
+description: "Possédez la boucle entière : faites tourner votre propre relais pour le pont wss:// sécurisé au lieu de dépendre d'un service tiers — pour la résidence des données, la conformité, ou une exigence sans dépendance externe."
+icon: "building-columns"
+---
+
+Quand [`connect`](/docs/fr/cloud-deployment) pilote un pod HTTPS distant,
+comfyui-mcp a besoin d'un chemin `wss://` à TLS valide depuis le panneau
+navigateur du pod jusqu'au pont de l'agent sur votre machine (un `ws://` en
+clair depuis une page `https://` est bloqué par le navigateur). Par défaut
+c'est un **quick tunnel cloudflared** — zéro configuration, mais éphémère
+(un nouveau nom d'hôte aléatoire à chaque lancement).
+
+Pour les organisations qui ont besoin de **posséder ce chemin de bout en
+bout** — le canal de contrôle ne transite jamais par un tiers, un domaine
+fixe pour les règles de pare-feu/audit, ou aucune dépendance à un service
+hors de votre infrastructure — comfyui-mcp prend en charge le routage du
+pont sécurisé via un relais **que vous opérez**, à la place du quick tunnel
+par défaut.
+
+<Note>
+L'implémentation de référence est open source :
+**[artokun/comfyui-mcp-relay](https://github.com/artokun/comfyui-mcp-relay)**
+— un Cloudflare Worker + Durable Object, sous licence MIT, marqué comme
+modèle GitHub pour que vous puissiez cliquer sur **Use this template** et
+avoir votre propre copie en quelques secondes. Forkez-le, déployez-le tel
+quel, ou adaptez-le à n'importe quelle infrastructure capable de WebSocket
+que votre organisation fait déjà tourner — le README documente le protocole
+filaire, le cycle de vie des sessions, et les compromis de conception
+(multiplexage, auth, hibernation) en entier.
+</Note>
+
+## Pourquoi auto-héberger
+
+- **Résidence des données / conformité** — le pont transporte les appels
+  d'outils et les opérations de graphe (pas les octets d'image, qui circulent
+  pod↔navigateur directement), mais certaines organisations ont quand même
+  besoin que ce canal de contrôle reste à l'intérieur d'une infrastructure
+  qu'elles opèrent.
+- **Aucune dépendance d'exécution tierce** — un endpoint fixe et possédé au
+  lieu de s'appuyer sur la disponibilité d'un relais externe.
+- **Règles de pare-feu / audit** — un domaine stable que vous contrôlez est
+  plus facile à mettre en liste blanche et à journaliser qu'un nom d'hôte
+  éphémère qui change à chaque session.
+
+## Comment ça s'assemble
+
+Les deux côtés du pont appellent **vers l'extérieur** — personne n'a besoin
+d'un port entrant ouvert nulle part. Le travail de votre relais est d'apparier
+un orchestrateur (qui tourne sur la machine d'un utilisateur) avec les
+connexions du panneau navigateur sur le pod qu'il pilote, et de faire
+circuler les octets entre eux ; il n'a jamais besoin de comprendre le
+protocole d'appels d'outils propre à comfyui-mcp qui voyage par-dessus.
+
+Une fois un relais déployé, pointer comfyui-mcp vers lui tient en quelques
+variables d'environnement :
+
+```bash
+export COMFYUI_MCP_TUNNEL_BACKEND=relay
+export COMFYUI_MCP_RELAY_URL=wss://your-relay.internal.example.com
+# optional: a shared secret gating who can open a session on your relay at all
+export COMFYUI_MCP_RELAY_KEY=your-shared-deploy-secret
+```
+
+Avec `COMFYUI_MCP_TUNNEL_BACKEND` non défini, comfyui-mcp continue d'utiliser
+le comportement de quick-tunnel éphémère par défaut — c'est entièrement
+opt-in.
+
+## Déployer l'implémentation de référence
+
+```bash
+gh repo create your-org/your-relay --template artokun/comfyui-mcp-relay --clone
+cd your-relay
+npm install
+wrangler login
+npm run deploy
+```
+
+Voir **[artokun/comfyui-mcp-relay](https://github.com/artokun/comfyui-mcp-relay)**
+pour le README complet — le protocole filaire, le modèle d'auth, et les
+étapes de déploiement.

--- a/docs/fr/third-party-hosts.mdx
+++ b/docs/fr/third-party-hosts.mdx
@@ -1,0 +1,240 @@
+---
+title: "Hôtes tiers"
+description: "Construisez votre propre frontend (panneau Blender, extension navigateur, une autre appli) sur le même protocole d'appairage que l'appli mobile — un agent, un contexte partagé, un client mince. Les formes de messages, les endpoints, les invariants de sécurité, et un prompt à coller pour qu'un LLM échafaude votre adaptateur."
+icon: "plug"
+---
+
+Le panneau agent, l'[appli mobile](/docs/fr/mobile), et tout outil qui
+s'appaire à une session en cours parlent **un petit protocole WebSocket**
+vers l'écouteur d'appairage de l'orchestrateur. Un **hôte tiers** est
+n'importe quel client que vous construisez sur ce protocole — un panneau
+Blender, une extension navigateur, un CLI, un autre éditeur — qui
+**s'attache à un onglet bureau en direct et pilote sa session d'agent**.
+Même agent, même contexte, pas de second processus Claude Code, rien de
+plus à installer pour l'utilisateur.
+
+<Note>
+C'est exactement la surface sur laquelle l'appli mobile est construite. Si
+vous pouvez ouvrir un WebSocket et envoyer du JSON, vous pouvez construire
+un hôte.
+</Note>
+
+## Comment ça marche
+
+<Steps>
+<Step title="Le bureau écoute déjà">
+Quand le panneau agent est ouvert, l'orchestrateur fait tourner un
+**écouteur d'appairage filtré par jeton** sur le LAN (voir
+[Endpoints](#endpoints)). Chaque onglet de panneau ouvert est un **onglet
+bureau** avec un `tab_id` stable et une session d'agent en direct.
+</Step>
+<Step title="Votre hôte se connecte avec le jeton d'appairage">
+Ouvrez un WebSocket vers l'URL d'appairage avec le jeton dans la query
+string. Sans jeton valide la connexion est refusée — l'appairage est toute
+la frontière de sécurité.
+</Step>
+<Step title="Lister et s'attacher à un onglet">
+Envoyez `list_tabs` pour découvrir les onglets bureau ouverts, puis
+`attach_tab` pour en mirorer un. Votre hôte **reçoit maintenant l'activité
+de cet onglet** (en flux) et peut **le piloter**.
+</Step>
+<Step title="Piloter la session partagée">
+Envoyez des trames `user_message`. Tant que vous êtes attaché, le serveur
+les route vers l'**onglet miroré** — donc votre message entre dans la
+*même* conversation que l'agent de bureau. C'est ce qui en fait « un
+agent, un contexte partagé » plutôt qu'une seconde session.
+</Step>
+</Steps>
+
+## Endpoints
+
+L'écouteur d'appairage est dérivé du port du pont (`COMFYUI_MCP_BRIDGE_PORT`,
+défaut **9180**) :
+
+| Port | Rôle |
+|---|---|
+| `bridge` (9180) | Le pont UI panneau ⇄ orchestrateur (la propre connexion du bureau). |
+| `bridge + 1` (9181) | La surface HTTP-MCP `panel_*` — **pas** ce protocole. |
+| **`bridge + 2` (9182)** | **L'écouteur d'appairage / contrôle à distance auquel vous vous connectez.** Filtré par jeton, lié sur `0.0.0.0` (joignable sur le LAN). |
+
+**URL d'appairage :**
+
+```
+ws://<desktop-machine-ip>:9182/?token=<PAIR_TOKEN>
+```
+
+- Le jeton est soit **épinglé** par l'utilisateur via
+  `COMFYUI_MCP_PAIR_TOKEN` (appairage toujours actif) soit **frappé par
+  session** et remis via le flux QR / appairage du panneau. Votre hôte
+  l'obtient de la même façon que l'appli mobile : l'utilisateur l'appaire
+  une fois.
+- **Lié au LAN par défaut**, mais l'exposition publique est intégrée quand
+  l'utilisateur la demande : la fenêtre d'appairage du panneau propose un
+  mode **Internet** qui ouvre un quick tunnel cloudflared chiffré, et les
+  entreprises peuvent le router via un relais auto-hébergé
+  (`COMFYUI_MCP_TUNNEL_BACKEND=relay`). Le jeton le filtre dans les deux
+  cas.
+
+## Formes de messages
+
+Toutes les trames sont des objets JSON avec un `type`. Les trames
+requête/réponse portent un `cid` (id de corrélation) que vous choisissez,
+répété sur la réponse correspondante.
+
+### Entrant — hôte → orchestrateur
+
+| `type` | Champs | Effet |
+|---|---|---|
+| `hello` | `tab_id`, `headless: true` | Enregistrer votre connexion. Les hôtes tiers sont des clients **headless** (pas de canevas propre). |
+| `list_tabs` | `cid` | Demander les onglets bureau ouverts. |
+| `attach_tab` | `cid`, `target_tab_id` | Mirorer + piloter cet onglet bureau. Valide seulement pour un onglet bureau **réel, non-headless**. |
+| `detach_tab` | — | Arrêter de mirorer/piloter ; votre saisie revient à votre propre session (vide). |
+| `user_message` | `text` (+ vos champs de message habituels) | Un tour dans la conversation de l'onglet **miroré**. Tamponné par le serveur vers l'onglet attaché. |
+
+Tout autre événement de panneau que vous envoyez tant que vous êtes attaché
+est de même routé vers l'onglet miroré.
+
+### Sortant — orchestrateur → hôte
+
+| `type` | Champs | Signification |
+|---|---|---|
+| `tab_list` | `cid`, `tabs[]` | Réponse à `list_tabs` : les onglets bureau attachables. |
+| `tab_attached` | `cid`, `tab_id`, `ok`, `error?` | Réponse à `attach_tab`. `ok:false` + `error` si la cible est périmée/headless. |
+| `mailbox_flush` | trames tamponnées | Rejeu de tout ce que l'onglet a produit pendant que vous n'aviez pas de connexion en direct. |
+
+Plus l'activité agent en direct de l'onglet miroré (réponses en flux, statut,
+cartes), que votre hôte rend.
+
+<Warning>
+**`attach_tab` est autoritaire — vous ne pouvez pas forger la cible.** Le
+serveur écrase tout `tab_id` que vous mettez sur une trame sortante avec
+l'onglet auquel vous vous êtes réellement attaché. Un hôte ne peut jamais
+piloter qu'un onglet auquel il s'est explicitement attaché. C'est
+volontaire ; voir ci-dessous.
+</Warning>
+
+## Invariants de sécurité — un hôte DOIT les préserver
+
+Ce sont les garanties qui rendent l'appairage sûr. Construire un hôte qui
+les respecte est tout le contrat ; un hôte qui essaie de les contourner est
+exactement ce que l'écouteur est conçu pour rejeter.
+
+<Note>
+Préserver ces invariants n'est pas une contrainte sur votre hôte — c'*est*
+la fonctionnalité. Ils empêchent un client de détourner une session à
+laquelle il ne s'est jamais appairé.
+</Note>
+
+1. **Barrière de jeton.** L'écouteur refuse toute connexion sans un jeton
+   d'appairage valide (`verifyClient`). Ne construisez jamais un flux qui
+   livre ou embarque le jeton automatiquement — l'utilisateur appairé, une
+   fois, délibérément.
+2. **Tamponnage autoritaire de `attach_tab`.** Le serveur, pas le client,
+   décide quel onglet vos trames ciblent. Ne vous fiez pas au `tab_id`
+   fourni par le client pour le routage ; attachez d'abord, puis envoyez.
+3. **Cibles non-headless seulement.** Vous pouvez vous attacher à un vrai
+   onglet bureau, jamais à un autre client headless (vous ne pouvez pas
+   mirorer un autre téléphone/hôte).
+4. **Un onglet à la fois.** S'attacher à B abandonne votre abonnement à A.
+   Modélisez un seul miroir actif par connexion.
+5. **Genre de socket épinglé.** Le genre d'une connexion (headless vs
+   bureau) est fixé à son premier `hello` ; n'essayez pas de le basculer
+   pour échapper aux gardes de prise de contrôle.
+
+## Client de référence minimal
+
+```js
+const token = "<PAIR_TOKEN>";            // obtained via the user's pair flow
+const ws = new WebSocket(`ws://192.168.1.50:9182/?token=${token}`);
+let cid = 0;
+
+ws.onopen = () => {
+  ws.send(JSON.stringify({ type: "hello", tab_id: "myhost:" + crypto.randomUUID(), headless: true }));
+  ws.send(JSON.stringify({ type: "list_tabs", cid: ++cid }));
+};
+
+ws.onmessage = (ev) => {
+  const m = JSON.parse(ev.data);
+  if (m.type === "tab_list") {
+    // pick a desktop tab and attach to it
+    const target = m.tabs[0]?.tab_id;
+    if (target) ws.send(JSON.stringify({ type: "attach_tab", cid: ++cid, target_tab_id: target }));
+  } else if (m.type === "tab_attached" && m.ok) {
+    // now you're driving that tab's session
+    ws.send(JSON.stringify({ type: "user_message", text: "Add a KSampler and wire it up." }));
+  } else {
+    // render streamed agent activity for the mirrored tab
+    console.log("from session:", m);
+  }
+};
+```
+
+## Apprendre à un LLM à construire votre adaptateur
+
+Collez le prompt ci-dessous dans Claude, ChatGPT, ou votre agent de code
+pour qu'il échafaude un adaptateur d'hôte pour votre plateforme. Il porte
+le contrat de protocole complet, donc le modèle n'a pas à deviner.
+
+```text Copy this into your LLM
+You are building a THIRD-PARTY HOST ("adapter") for comfyui-mcp. A host connects
+to a running comfyui-mcp orchestrator over WebSocket, attaches to a live desktop
+"tab", and drives that tab's agent session — same agent, shared context, no second
+session. Build the adapter for THIS platform: <describe your platform, e.g. a
+Blender sidebar panel / a Chrome extension / a Neovim plugin>.
+
+CONNECTION
+- WebSocket to:  ws://<desktop-ip>:9182/?token=<PAIR_TOKEN>
+  (port = bridge port + 2; bridge default 9180. Token is provided by the user via
+  their pairing flow — NEVER hardcode, embed, or auto-provision it.)
+- On open, send:  {"type":"hello","tab_id":"<your-unique-id>","headless":true}
+
+DISCOVER + ATTACH
+- Send {"type":"list_tabs","cid":1}; you receive {"type":"tab_list","cid":1,"tabs":[...]}.
+- Send {"type":"attach_tab","cid":2,"target_tab_id":"<a tab_id from tab_list>"};
+  you receive {"type":"tab_attached","cid":2,"tab_id":"...","ok":true|false,"error"?}.
+  Only real, non-headless desktop tabs are attachable.
+
+DRIVE
+- Send {"type":"user_message","text":"..."} to post a turn into the ATTACHED tab's
+  conversation. The server routes it to the mirrored tab automatically.
+- Send {"type":"detach_tab"} to stop.
+
+RENDER
+- After attaching you receive the mirrored tab's live activity (streamed agent
+  replies, status, interactive cards) and a {"type":"mailbox_flush"} replay of
+  anything produced while you were disconnected. Render these in your UI.
+
+SECURITY — these are non-negotiable; preserve every one:
+1. Only connect with a user-provided pair token; never embed or auto-ship it.
+2. Never assume you can target a tab you did not attach_tab to — the server stamps
+   the target authoritatively; trust tab_attached.ok, don't spoof tab_id.
+3. Attach only to non-headless desktop tabs; never to another headless client.
+4. One active attachment per connection (attaching to a new tab drops the old).
+5. Do not try to change your connection's kind after the first hello.
+
+DELIVERABLE
+- A minimal, working adapter for the platform above: connect → list → attach →
+  send a user_message → render streamed replies → detach. Handle reconnects and
+  the mailbox_flush replay. Keep the pairing/token handling explicit and
+  user-driven.
+```
+
+## Enregistrer votre intégration
+
+Vous avez construit quelque chose ? **Enregistrez-le** pour qu'il puisse
+être listé et pour que nous puissions vous signaler les changements de
+protocole avant qu'ils se livrent :
+
+<Card title="Enregistrer un hôte tiers" icon="plug" href="https://github.com/artokun/comfyui-mcp/issues/new?template=third-party-host.yml">
+Ouvrez le modèle d'enregistrement sur GitHub — nom, plateforme, dépôt, et
+contre quelle version de protocole vous avez construit.
+</Card>
+
+<Note>
+**Stabilité :** les trames ci-dessus sont celles sur lesquelles l'appli
+mobile se livre, mais ce n'est pas encore un contrat figé et versionné —
+lisez le source
+([`src/services/ui-bridge.ts`](https://github.com/artokun/comfyui-mcp/blob/main/src/services/ui-bridge.ts))
+comme autorité, et enregistrez votre hôte pour être prévenu quand les
+formes bougent.
+</Note>

--- a/docs/fr/using-tools.mdx
+++ b/docs/fr/using-tools.mdx
@@ -1,0 +1,594 @@
+---
+title: "Utiliser les outils"
+description: "Ce que sont les outils, pourquoi vous n'en appelez jamais un vous-même, et que faire quand l'un d'eux dit non. Écrit pour des personnes, pas pour des ingénieurs."
+icon: "hand-pointer"
+---
+
+La [Référence des outils](/docs/tools/image-generation) liste tout ce que ce projet
+peut faire, sous la forme que l'IA lit. Cette page est la version pour vous.
+
+<Note>
+  Rien ici ne vous demande d'écrire du code, de taper du JSON ou d'apprendre une
+  API. Si vous avez déjà demandé à quelqu'un « ouvre mon workflow portrait et
+  monte les steps à 30 », vous connaissez déjà l'interface.
+</Note>
+
+## Un outil est une chose que l'agent peut faire, pas une chose que vous tapez
+
+À lui seul, un modèle de chat ne peut produire que du texte. Il peut décrire un
+workflow ; il ne peut pas en ouvrir un.
+
+Un **outil** est une action précise et nommée que nous donnons au modèle pour
+qu'il atteigne réellement votre ComfyUI — charger un fichier, mettre un rendu
+en file, installer un pack de nœuds, regarder l'image qui est sortie. Le modèle
+n'a pas le droit d'inventer ces actions. Il reçoit un menu fixe, et chaque
+entrée du menu dit exactement ce dont elle a besoin.
+
+**Vous ne choisissez jamais dans ce menu.** Vous dites ce que vous voulez, avec
+les mots qui viennent naturellement, et l'agent choisit.
+
+| Vous dites | Il exécute discrètement |
+| --- | --- |
+| « Qu'est-ce que j'ai d'enregistré ? » | `get_workflow` with `action: "list"` |
+| « Ouvre celui du portrait et dis-moi ce qu'il fait » | `get_workflow` with `action: "list"`, then `action: "analyze"` |
+| « Fais-moi un renard rouge dans la neige » | `generate_image` (the `image` job) |
+| « C'est fini ? » | `queue` (the `list` job) |
+| « Ça a échoué et je ne comprends pas pourquoi » | `get_history` (the `diagnose` job) |
+| « La moitié des nœuds sont rouges » | `list_packs` (the `install_deps` job) |
+| « Je n'ai plus d'espace disque, qu'est-ce qui est gros ? » | `list_local_models` |
+
+Remarquez la deuxième ligne : une phrase, deux outils, dans un ordre que vous
+n'aviez pas à connaître. C'est tout l'intérêt de l'arrangement. On n'attend pas
+de vous que vous sachiez que trouver un fichier et le lire sont deux opérations
+distinctes.
+
+<Tip>
+  Vous pouvez être aussi vague que vous voulez. « Quelque chose est cassé » est
+  un parfaitement bon début — l'agent commencera par
+  `get_system_stats (action:"health")` et affinera. Être précis va plus vite,
+  mais ce n'est jamais obligatoire.
+</Tip>
+
+### Alors, à quoi sert tout ce JSON dans les pages de référence ?
+
+Chaque page d'outil montre un bloc comme celui-ci :
+
+```json
+{
+  "tool": "generate_image",
+  "arguments": {
+    "prompt": "a red fox in deep snow, golden hour, sharp focus",
+    "steps": 30
+  }
+}
+```
+
+C'est la transcription de ce que l'agent a envoyé, pas une instruction pour
+vous. Vous avez dit « fais-moi un renard rouge dans la neige, et mets un peu
+plus de détail » ; c'est ce qui est sorti de l'autre côté.
+
+Savoir en lire un vaut le coup, pour deux raisons : quand vous voulez vérifier
+que l'agent vous a compris, et quand quelque chose tourne mal et que vous le
+décrivez à quelqu'un d'autre. Ça ne vaut pas la peine de l'apprendre par cœur.
+
+## Les outils viennent de deux endroits
+
+Il y a deux surfaces, et elles existent parce qu'elles répondent à des
+questions différentes.
+
+<CardGroup cols={2}>
+  <Card title="Le panneau latéral" icon="window-maximize">
+    Vit **à l'intérieur de ComfyUI**, dans l'onglet Agent. Ses outils
+    (`panel_*`) agissent sur le graphe que vous regardez maintenant — le
+    canevas réel, avec vos modifications non enregistrées dessus.
+  </Card>
+  <Card title="Un client extérieur" icon="terminal">
+    Claude Desktop, Claude Code, un éditeur, votre téléphone. Ses outils
+    agissent sur le **serveur** : fichiers sur disque, file de jobs, modèles,
+    packs de nœuds, le processus ComfyUI lui-même.
+  </Card>
+</CardGroup>
+
+La scission porte vraiment sur le mot « ceci ». Quand vous dites « ajoute un
+LoRA à **ceci** », le panneau sait ce qu'est « ceci », parce qu'il voit votre
+écran. Un client extérieur ne le peut pas — il faut lui donner un nom de
+fichier.
+
+Le panneau s'occupe donc de choses comme :
+
+- lire le graphe devant vous (`panel_graph_outline`)
+- l'exécuter, exactement comme si vous aviez appuyé sur Queue Prompt
+  (`panel_run`)
+- câbler un nœud, changer un widget, vous dire pourquoi un nœud est devenu
+  rouge (`panel_add_node`, `panel_set_widget`, `panel_get_errors`)
+- charger un workflow entier sur le canevas, ou enregistrer ce qui s'y trouve
+  (`panel_load_workflow`, `panel_save_workflow`)
+
+Et un client extérieur s'occupe de générer une image de zéro, de gérer
+les modèles et les packs de nœuds, de parcourir les fichiers enregistrés, et
+de redémarrer ComfyUI.
+
+<Tip>
+  **Si vous débutez, utilisez le panneau.** C'est une seule installation, il
+  est juste à côté de votre graphe, et il n'a pas besoin d'une appli séparée.
+  Voir [le guide du panneau](/docs/fr/panel) pour le mettre en place. Ajoutez
+  un client extérieur plus tard, quand vous voudrez impliquer l'agent dans des
+  choses qui ne sont pas un canevas.
+</Tip>
+
+Ce ne sont pas des rivaux — le panneau parle au même serveur en dessous, et
+une session peut utiliser les deux. Quelqu'un qui édite un graphe sur son
+bureau pendant qu'un téléphone pilote la même session, c'est une chose prise
+en charge, pas un hack.
+
+## Un outil, plusieurs tâches
+
+Vous remarquerez que certains outils prennent une `action` :
+
+```json
+{ "tool": "workspace", "arguments": { "action": "get" } }
+```
+
+Ça a l'air cryptique, et ça ne l'est pas. `workspace` est un sujet — *de
+quelle installation ComfyUI parle-t-on* — et `action` dit quelle question vous
+posez sur ce sujet : le lire, changer le défaut, lister ce qui est disponible.
+
+Ça se lit exactement comme la parole ordinaire, où le verbe et l'objet sont
+des mots séparés :
+
+| Vous dites | Action |
+| --- | --- |
+| « Quel ComfyUI j'utilise ? » | `get` |
+| « Utilise toujours celui de mon disque D » | `set_default` |
+| « Quelles installations tu vois ? » | `list` |
+
+### Rien n'a été retiré
+
+Cette forme est assez récente, et on la lit facilement comme une réduction de
+capacité. Ce n'est pas le cas, et la confusion vaut d'être écartée tout de
+suite, parce qu'elle est déjà apparue.
+
+Il y avait autrefois un outil par question — un nom pour lire un workspace, un
+autre pour le régler, un autre pour les lister. Ces noms ont disparu, et si
+vous regardez le nombre d'outils vous le verrez chuter, nettement.
+
+Ce qui s'est réellement passé, c'est que des outils liés ont été **fusionnés**,
+pas supprimés :
+
+| The old name | The same thing today |
+| --- | --- |
+| `get_workspace` | `workspace` with `action: "get"` |
+| `get_queue` | `queue` with `action: "list"` |
+| `apps_run_status` | `apps` with `action: "run_status"` |
+| `install_workflow_dependencies` | `list_packs` with `action: "install_deps"` |
+| `list_workflows` | `get_workflow` with `action: "list"` |
+| `analyze_workflow` | `get_workflow` with `action: "analyze"` |
+| `validate_workflow` | `create_workflow` with `action: "validate"` |
+
+Même code en dessous, même comportement, mêmes réponses. Seule l'étiquette
+devant a changé.
+
+La raison, c'est que le menu était devenu assez long pour faire du mal. La
+description complète de chaque outil doit être remise au modèle avant qu'il
+puisse choisir, et passé une certaine taille le choix lui-même se dégrade —
+les plus petits modèles en particulier se mettent à prendre un voisin
+plausible au lieu du bon. Moins d'outils, plus larges, avec une `action`
+claire, corrige ça de façon mesurable. Ça veut aussi dire que le modèle
+dépense son attention sur votre demande plutôt que sur la lecture d'un
+catalogue.
+
+Vous ne devriez rien remarquer de tout cela. Vous n'avez jamais tapé l'ancien
+nom non plus ; vous disiez « quel ComfyUI j'utilise ? », et ça marche encore.
+
+<Note>
+  Si un guide plus ancien ou la mémoire propre d'un modèle tend la main vers
+  un nom qui n'existe plus, vous obtenez une erreur précise qui nomme le
+  remplaçant plutôt qu'un « unknown tool » vide — par exemple : *removed in
+  0.49.0. Call workspace (action:"get") instead.* L'agent peut en général se
+  corriger et réessayer sans que vous fassiez quoi que ce soit.
+</Note>
+
+## Demander quelque chose de différent
+
+Chaque page d'outil liste des paramètres — `max_chars`, `limit`, `depth`,
+`fields`. C'est une question légitime de savoir où vous êtes censé les taper,
+et la réponse honnête est : nulle part. Il n'y a pas de boîte de réglages pour
+`max_chars`, parce que ce n'est pas un réglage. C'est un argument que
+**l'agent** remplit, à neuf, chaque fois qu'il appelle l'outil.
+
+Ça ne vous laisse pas dehors. Ça change l'allure du contrôle :
+
+<Note>
+  Vous ne réglez pas un paramètre. Vous en demandez un — dans la même phrase
+  que vous alliez écrire de toute façon.
+</Note>
+
+### Deux façons de demander
+
+Les deux marchent. Elles échouent différemment, et c'est la seule raison de
+connaître les deux.
+
+| | Ça sonne comme | Atteignez-le quand |
+| --- | --- | --- |
+| **Simple** | « Lis le nœud 42 en détail — juste ce nœud, pas tout le graphe. » | Commencez toujours ici. C'est ce que les gens tapent vraiment, et ça marche en général. |
+| **Explicite** | « Utilise `panel_query_graph` avec `ids` [42] et `max_chars` 20000. » | Le modèle s'est déjà trompé une fois et vous ne voulez lui laisser aucune marge. |
+
+Nommer l'outil et l'argument n'est pas la forme *correcte* — c'est la forme
+*contraignante*. Gardez-la pour le nouvel essai.
+
+### Quand la réponse est coupée
+
+Les longues lectures sont plafonnées pour qu'un graphe énorme ne puisse pas
+avaler toute la conversation. Deux plafonds différents peuvent arrêter la même
+lecture — le nombre de nœuds listés (`limit`) et le budget de caractères
+(`max_chars`) — et relever celui qui n'était pas le problème ne change rien,
+ce qui se lit exactement comme si le nouvel essai avait échoué.
+
+On n'attend pas de vous que vous trouviez lequel. Sur un fichier enregistré,
+la note **nomme le levier qui s'est déclenché et écarte l'autre**, en toutes
+lettres :
+
+> … truncated at 40 of 300 by `limit`=40 — raise `limit` up to 200, or narrow with `types`/`where`/`ids`/`depth`. `max_chars` is not the constraint here.
+
+Et quand le levier est déjà à son plafond, elle le dit au lieu de vous
+renvoyer le relever encore, parce qu'il ne reste plus rien à relever.
+
+<Note>
+  Sur le canevas en direct (`panel_query_graph`) la même lecture est exécutée
+  par la propre copie de ce moteur dans le panneau, qui n'a pas encore rattrapé
+  ce libellé. Si une note là-bas nomme un argument et que le relever ne change
+  rien, essayez l'autre avant de conclure que l'outil est cassé.
+</Note>
+
+L'agent est censé lire sa propre note et réessayer tout seul. Quand il ne le
+fait pas, vous êtes le repli, et c'est cette phrase :
+
+> Ça a été tronqué — lis la note et relance la même requête, en relevant la
+> limite qu'elle nomme.
+
+### Où sont les murs
+
+Voici les chiffres pour les deux outils qui lisent un graphe avec un budget —
+`panel_query_graph` (le canevas en direct) et `get_workflow` avec
+`action: "query"` (un fichier enregistré) :
+
+| Argument | Défaut | Le plus que vous puissiez demander |
+| --- | --- | --- |
+| `max_chars` | 12000 | 60000 |
+| `limit` (nœuds listés) | 40 | 200 |
+
+Sur ces deux outils, demander au-delà d'un plafond est rejeté comme un
+argument invalide plutôt que discrètement arrondi vers le bas, donc l'agent
+le sait tout de suite et peut se corriger. Les chiffres ne sont pas
+universels non plus : plusieurs autres outils prennent un `max_chars` et
+fixent leur propre plafond, indiqué dans la description de cet outil.
+
+### La portée l'emporte sur le budget
+
+Relever le plafond est la deuxième chose à essayer, pas la première. Sur un
+workflow de 600 nœuds, un plus gros budget vous achète surtout plus des
+mauvais nœuds, et enterrer la réponse parmi des centaines d'éléments hors
+sujet dégrade la réponse même quand elle tient techniquement.
+
+Réduisez d'abord, avec les mots qui viennent naturellement :
+
+| Vous dites | Ce que ça réduit à |
+| --- | --- |
+| « Regarde juste les nœuds 42 et 43. » | ces ids seulement |
+| « Qu'est-ce qui alimente le sampler ? » | le côté amont d'un nœud |
+| « …seulement deux sauts en arrière. » | une distance bornée à partir de là |
+| « Combien de chaque type de nœud il y a ici ? » | des comptes au lieu d'une liste |
+
+Puis, si c'est encore coupé, élargissez.
+
+## Quand il dit non
+
+Un outil qui refuse n'est en général pas un bug. La plupart des refus sont un
+garde-fou qui s'est déclenché parce que l'appel aurait fait quelque chose que
+vous n'avez pas demandé.
+
+### « Il a refusé et je ne sais pas pourquoi »
+
+Vous verrez du texte en langage clair plutôt qu'une stack trace — quelque
+chose qui nomme ce qu'il n'a pas voulu faire et quoi faire à la place. Lisez
+ça comme l'agent qui est prudent, pas coincé. Refus honnêtes courants :
+
+- **Il ne peut pas dire de quel workflow vous parlez.** Plus d'un onglet est
+  ouvert, ou le graphe n'a pas encore d'identité enregistrée. Enregistrez-le,
+  ou dites lequel.
+- **Ça écraserait quelque chose.** Demandez un nouveau nom de fichier et il
+  continuera.
+- **La chose n'est vraiment pas là.** Un fichier de modèle, un pack de nœuds,
+  un serveur en cours d'exécution.
+
+Si un refus se lit comme du non-sens plutôt que de la prudence, ça vaut d'être
+signalé — demandez à l'agent de le déposer, et il joindra les détails de
+votre configuration pour vous.
+
+### « Ce panneau est trop ancien »
+
+Le refus le plus courant qui a une vraie correction. Ça se lit à peu près
+comme :
+
+> This ComfyUI-MCP panel is too old for *"…"* — update the ComfyUI-MCP panel, then reconnect.
+
+Le panneau latéral et ce serveur sont des pièces séparées qui se livrent
+séparément, donc l'un peut retarder sur l'autre. Quand le serveur demande
+quelque chose que le panneau installé ne peut pas faire en sécurité, il
+refuse plutôt que de deviner — un vieux panneau qui ne peut pas confirmer
+*quel* workflow reçoit une commande pourrait appliquer votre modification au
+mauvais onglet, donc on le limite aux lectures jusqu'à ce qu'il soit mis à
+jour.
+
+La correction tient en trois étapes, et **la troisième est celle que les gens
+sautent** :
+
+<Steps>
+  <Step title="Mettre à jour le panneau">
+    Demandez à l'agent de le mettre à jour (`install_comfyui(action:'panel', panel_action:'update')`), ou faites-le
+    depuis ComfyUI-Manager, où il est listé sous `comfyui-agent-panel`.
+  </Step>
+  <Step title="Redémarrer ComfyUI">
+    La mise à jour ne redémarre rien toute seule. Demandez à l'agent, ou
+    redémarrez-le vous-même.
+  </Step>
+  <Step title="Forcer le rechargement de l'onglet navigateur de ComfyUI">
+    **Ctrl+Shift+R** (**Cmd+Shift+R** sur un Mac). Votre navigateur a l'ancien
+    code du panneau en cache, et un redémarrage seul ne le délogera pas.
+    Sautez cette étape et le même message revient tout de suite, ce qui donne
+    l'impression que la mise à jour a échoué alors que ce n'est pas le cas.
+  </Step>
+</Steps>
+
+### « Aucun panneau connecté »
+
+Problème différent, message d'allure similaire. Ça veut dire que l'agent
+extérieur ne trouve pas l'onglet navigateur de votre ComfyUI. C'est presque
+toujours l'un de :
+
+- ComfyUI n'est ouvert dans aucun navigateur — ouvrez-le et regardez l'onglet
+  Agent dans la barre latérale.
+- ComfyUI vient d'être redémarré, ou vous avez rechargé l'onglet. Ça coupe la
+  connexion. **Rechargez l'onglet ComfyUI** et elle revient tout de suite.
+- L'onglet Agent est ouvert mais n'a jamais été connecté. Le panneau
+  s'attache quand vous choisissez un fournisseur et cliquez sur **Connecter**,
+  jamais au chargement, donc un onglet fraîchement ouvert qui n'affiche rien
+  est l'état ordinaire plutôt qu'une panne.
+- Le panneau n'est pas encore installé. Voir [le guide du panneau](/docs/fr/panel).
+
+Le message sépare ça en deux groupes pour vous — il distingue « connecté plus
+tôt et coupé » de « rien n'est encore connecté ». Il n'allait pas plus loin,
+et il le dit plutôt que de choisir une cause qu'il n'a aucun moyen
+d'observer. Un onglet qui s'est déjà connecté prouve que le panneau est
+installé et fonctionnait, donc recharger l'onglet ComfyUI est la première
+chose à essayer et souvent la seule ; si le rechargement ne le ramène pas,
+traitez-le comme le second groupe et descendez les vérifications ci-dessus.
+
+## Quand il ne dit rien
+
+L'échec le plus dur est celui qui ne contient aucune erreur. L'agent n'appelle
+pas d'outil, ne refuse pas, ne se plaint pas. Il se contente de parler : il
+décrit ce que votre workflow contient probablement, ou propose de vous écrire
+un script. Ça sonne utile, et il n'a jamais rien regardé.
+
+Trois situations complètement différentes produisent ce même comportement, et
+d'où vous êtes assis elles sont indiscernables :
+
+<CardGroup cols={3}>
+  <Card title="Absent" icon="circle-minus">
+    Votre client n'a jamais reçu les outils. Ils ne sont pas dans la liste
+    qu'il remet au modèle, donc il n'y a rien à appeler.
+  </Card>
+  <Card title="Bloqué" icon="hand">
+    Votre client a les outils et n'autorise pas le modèle à les exécuter.
+    L'appel est arrêté à l'intérieur de votre client.
+  </Card>
+  <Card title="Pas demandé" icon="eye-slash">
+    Tout fonctionne. La chose que vous vouliez existe sous un nom qui n'est
+    jamais apparu, donc personne n'y a tendu la main.
+  </Card>
+</CardGroup>
+
+Les remèdes pointent dans trois directions différentes, et deux d'entre eux
+sont activement nuisibles si vous vous trompez : réinstaller ce qui est déjà
+installé, ou relâcher des permissions qui n'étaient jamais le problème. Donc
+le premier geste n'est pas de réparer quoi que ce soit. C'est de découvrir
+dans lequel vous êtes.
+
+### Deux questions qui les distinguent
+
+Demandez à l'agent, en mots simples :
+
+<Steps>
+  <Step title="Demandez ce qu'il peut voir">
+    > Quels outils as-tu de comfyui-mcp ? Liste juste les noms.
+
+    Une liste de quelques dizaines de noms est normale et saine — c'est la
+    surface directe, qui est le défaut depuis 0.50.0.
+
+    **Trois noms** — `list_tools`, `describe_tool`, `call_tool` — c'est
+    *aussi* normal et sain. C'est le [mode compact](#si-vous-utilisez-un-petit-modèle-local),
+    que vous obtenez en passant `--compact`, et que les petits modèles locaux
+    sélectionnent encore automatiquement. Le reste du catalogue est à un
+    appel `list_tools` de distance, donc demandez-lui de l'exécuter et vous
+    verrez la vraie liste. Ni l'une ni l'autre de ces réponses ne veut dire
+    que quelque chose est retenu.
+
+    **Aucun nom du tout**, ou « Je n'ai aucun outil pour ComfyUI », écarte le
+    troisième cas et rien d'autre. Ça ne veut **pas** dire absent. Une
+    politique de permissions peut retenir les outils de la liste montrée au
+    modèle, donc un serveur installé, connecté et fonctionnel produit
+    exactement cette réponse. Absent et bloqué sont indiscernables à cette
+    étape, et c'est la branche qui a coûté des jours à un utilisateur —
+    d'être sûr que c'était le câblage.
+
+    Une vérification affine, et ce n'est pas quelque chose que l'agent peut
+    voir : **ouvrez la propre liste de serveurs MCP de votre client** — l'endroit
+    où il montre quels serveurs il a connectés, qui est une liste différente
+    des outils qu'il remet au modèle.
+
+    - **comfyui-mcp n'y est pas, ou s'affiche en échec** → **absent**. Un
+      problème de câblage côté client, pas une panne du panneau ou du
+      serveur. Ça se scinde encore en deux — jamais câblé, ou un hôte qui
+      ne peut pas les tenir du tout — et la liste
+      [ci-dessous](#doù-vient-habituellement-chaque-réponse) les distingue.
+    - **Il est là et connecté, et le modèle ne liste toujours rien** → les
+      outils ont atteint votre client. Où ils se sont arrêtés ensuite reste
+      ouvert : ils peuvent être retenus du modèle par une règle de
+      permission, ou le modèle peut simplement avoir échoué ou refusé de les
+      lister, ce qui a exactement le même aspect d'ici. Ne **commencez pas**
+      à relâcher des permissions sur ça seul.
+
+      Si cette liste de serveurs montre aussi **quels outils elle a pris de
+      comfyui-mcp**, ça tranche : des outils listés là mais pas par le modèle
+      veulent dire que le modèle est le problème, pas vos permissions ;
+      aucun listé là veut dire qu'ils sont filtrés avant que le modèle les
+      voie jamais. Si votre client ne montre pas ça — et beaucoup ne le
+      font pas — rien de ce qui vous est accessible ne distingue les deux
+      ici, et l'étape 2 est la meilleure chance, parce qu'un refus revient
+      en mots.
+  </Step>
+  <Step title="Demandez-lui d'essayer, et de rapporter mot pour mot">
+    > Maintenant appelle celui que tu utiliserais pour la chose qui ne
+    > marche pas, et colle exactement ce qui revient — y compris toute
+    > erreur. Ne contourne pas.
+
+    Deux détails de cette phrase font le travail.
+
+    **L'outil que tu utiliserais pour la chose qui ne marche pas**,
+    spécifiquement. Les règles de permission sont en général écrites par
+    outil, donc un autre outil qui réussit ne prouve rien sur celui qui
+    vous intéresse — c'est précisément comme ça qu'un blocage se cache.
+    Si c'est le canevas qui n'est pas lu, le test doit être une lecture
+    de canevas.
+
+    **Ne contourne pas.** Tout le mode d'échec est un agent qui contourne
+    discrètement un obstacle au lieu de le nommer, et laissé à lui-même
+    il le refera.
+
+    - **Un vrai résultat** — cet outil marche. Vous êtes dans le troisième
+      cas.
+    - **« Ça a été refusé » / « non autorisé » / « j'ai besoin d'une
+      permission »** — **bloqué**, à l'intérieur de votre client. Celui-ci
+      est concluant : l'agent a demandé et s'est vu refuser.
+    - **« Je n'ai pas cet outil »** — absent *ou* bloqué, encore. Un outil
+      retenu et un outil manquant ont le même aspect depuis le siège du
+      modèle, donc n'agissez pas là-dessus tout seul : ramenez-le à la
+      liste de serveurs de l'étape 1, et si cette liste ne montre pas non
+      plus les outils par serveur, alors rien de ce que vous pouvez
+      atteindre ne sépare les deux et le prochain geste honnête est de
+      demander sur le tracker d'issues plutôt que de commencer à changer
+      des réglages.
+    - **Encore de la prose, toujours aucun appel** — demandez carrément :
+      *« As-tu appelé un outil ? Si non, pourquoi pas ? »* Un agent qui
+      esquive deux fois contourne en général quelque chose qu'il n'a pas
+      mentionné.
+  </Step>
+</Steps>
+
+### Ce que nous voyons d'ici, et ce que nous ne voyons pas
+
+<Warning>
+  Quand votre client refuse un appel d'outil, cet appel ne quitte jamais
+  votre client. Rien n'atteint ce serveur, donc rien n'apparaît dans son
+  journal et aucune erreur n'est produite nulle part où nous pouvons
+  l'atteindre. Nous ne pouvons pas détecter un blocage, et nous ne ferons
+  pas semblant : toute page ou message prétendant vous dire « votre client
+  a bloqué ceci » serait en train de deviner.
+</Warning>
+
+Le même fait coupe dans l'autre sens, et c'est la partie qui induit les gens
+en erreur : un journal silencieux n'est pas la preuve que rien n'a été
+tenté. Absent, bloqué, et jamais-demandé ont tous l'air d'un silence d'ici.
+
+C'est pourquoi les deux questions ci-dessus sont le vrai diagnostic. Elles
+marchent parce qu'elles demandent au seul participant qui *était* dans la
+pièce — votre agent — de dire ce qu'il a essayé, et lui refusent l'option de
+contourner la réponse.
+
+### D'où vient habituellement chaque réponse
+
+**Bloqué — les propres règles de permission de votre client.** Dans Claude
+Code, c'est le bloc `permissions` de `settings.json` (`~/.claude/settings.json`,
+ou le `.claude/settings.json` du projet) ; les outils MCP y apparaissent sous
+leurs noms avec espace de noms, `mcp__comfyui__<tool>`. Une liste `allow`
+stricte qui ne les mentionne jamais arrête chaque appel avant qu'il soit
+envoyé. C'est le cas qui a coûté plusieurs jours à un utilisateur : les
+outils avaient l'air de marcher, précisément parce que les erreurs qu'il
+cherchait ne pouvaient jamais apparaître.
+
+**Absent, et réparable — jamais câblé.** Le client parle MCP mais n'a jamais
+été informé de ce serveur, ou l'a été et l'entrée est fausse. C'est le cas
+courant et c'est une modification de config ; voir
+[Démarrage rapide](/docs/fr/quickstart) pour l'entrée que votre client attend.
+
+**Absent, et non réparable — un hôte sans aucun client MCP.** Certains agents
+ne parlent pas MCP, et aucune quantité de configuration n'y change rien.
+`pi` en est un : il a ses propres outils shell-et-éditeur intégrés et aucun
+client MCP, donc on ne peut pas lui remettre les nôtres quoi d'autre soit
+installé. Le panneau le dit clairement quand vous le choisissez —
+*« pi n'a aucun outil ComfyUI (pas de MCP) »*. Cette ligne est la réponse,
+pas un symptôme à déboguer ; la correction est de choisir un autre backend.
+
+**L'un ou l'autre — quelque chose assis au milieu.** Une passerelle, un
+proxy ou un routeur qui transporte votre trafic MCP peut ne faire passer
+qu'une partie de la surface. Si le catalogue et ce qui s'exécute vraiment
+ne sont pas d'accord, suspectez le milieu.
+
+### Si c'est le troisième cas
+
+Alors rien n'était cassé et personne n'a mal configuré quoi que ce soit : une
+capacité existait et vous n'aviez aucun moyen de le découvrir. C'est notre
+échec plutôt que le vôtre, et ça vaut de nous le dire — demandez à l'agent
+de le déposer et il joindra votre configuration pour vous. Une fonctionnalité
+que personne ne peut trouver est, d'où vous êtes assis, une fonctionnalité
+que nous n'avons pas livrée.
+
+## Si vous utilisez un petit modèle local
+
+Remettre le menu entier à un modèle coûte beaucoup de lecture avant qu'il
+dise un mot. Sur un grand modèle hébergé, ça va. Sur un petit modèle qui
+tourne sur votre propre machine, c'est souvent la différence entre ça marche
+et ça ne marche pas.
+
+Donc par défaut l'agent reçoit **trois** outils au lieu de l'ensemble
+complet : un pour parcourir le catalogue, un pour consulter un seul outil en
+détail, et un pour l'exécuter. Il récupère ce dont il a besoin, au moment où
+il en a besoin, plutôt que de tout lire d'avance.
+
+Vous n'avez rien à faire pour l'obtenir — c'est le défaut. Les contrôles
+existent si vous les voulez :
+
+```bash
+# force the small three-tool mode
+npx -y comfyui-mcp --compact
+
+# or hand the model everything at once
+npx -y comfyui-mcp --full
+```
+
+L'un ou l'autre peut aussi se régler avec `COMFYUI_MCP_TOOL_MODE=compact` ou
+`COMFYUI_MCP_TOOL_MODE=full`.
+
+Le compromis, c'est quelques allers-retours de plus avant la première vraie
+action, en échange d'un modèle à qui il reste de la place pour réfléchir. Les
+gros modèles sont en général plus à l'aise avec `--full`. Voir
+[les LLM locaux](/docs/fr/local-llms) pour quels modèles tiennent le coup avec
+quoi.
+
+## Où aller ensuite
+
+<CardGroup cols={2}>
+  <Card title="Démarrage rapide" icon="rocket" href="/docs/fr/quickstart">
+    Installez-le et générez votre première image.
+  </Card>
+  <Card title="Le panneau latéral" icon="window-maximize" href="/docs/fr/panel">
+    L'agent dans ComfyUI, et ce qu'il peut faire à votre canevas.
+  </Card>
+  <Card title="Référence des outils" icon="book" href="/docs/tools/image-generation">
+    Chaque outil, avec des exemples concrets de ce à quoi ressemble un vrai appel.
+  </Card>
+  <Card title="Dépannage" icon="wrench" href="/docs/fr/troubleshooting">
+    Quand ce n'est pas un refus et que quelque chose est vraiment cassé.
+  </Card>
+</CardGroup>

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -672,6 +672,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
       },
       {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `get_workspace` | `workspace` with `action: \"get\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
+      },
+      {
         path: "src/tools/retired-redirect.ts",
         context: '"Tool get_workspace not found"',
         why: "A verbatim quotation of MEASURED output: the three-row table in that module's header records what each call path actually answered on 0.49.0 for an already-retired name, which is the evidence the module exists at all. Quoting the SDK's bare 404 is the opposite of instructing anyone to call the name — it is the defect being removed. Deliberately the ONLY mention left in that file: the surrounding prose was reworded to say 'a name the 0.49.0 slices had already retired', and its test file derives the name from this ledger rather than spelling it, so this exemption covers one quoted line instead of seven comments. Pinned to the quotation because a quotation is the part least likely to be reworded — and if it IS reworded the gate should fire.",
@@ -735,6 +740,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         path: "docs/zh/using-tools.mdx",
         context: "| `get_queue` | `queue` with `action: \"list\"` |",
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
+      },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `get_queue` | `queue` with `action: \"list\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
       },
     ],
   },
@@ -928,6 +938,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         path: "docs/zh/using-tools.mdx",
         context: "| `apps_run_status` | `apps` with `action: \"run_status\"` |",
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
+      },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `apps_run_status` | `apps` with `action: \"run_status\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
       },
     ],
   },
@@ -1184,6 +1199,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         path: "docs/zh/using-tools.mdx",
         context: '| `install_workflow_dependencies` | `list_packs` with `action: "install_deps"` |',
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
+      },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: '| `install_workflow_dependencies` | `list_packs` with `action: "install_deps"` |',
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
       },
     ],
   },
@@ -1499,6 +1519,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         context: "| `validate_workflow` | `create_workflow` with `action: \"validate\"` |",
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
       },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `validate_workflow` | `create_workflow` with `action: \"validate\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
+      },
     ],
   },
   {
@@ -1551,6 +1576,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         context: "| `list_workflows` | `get_workflow` with `action: \"list\"` |",
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
       },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `list_workflows` | `get_workflow` with `action: \"list\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
+      },
     ],
   },
   {
@@ -1592,6 +1622,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         path: "docs/zh/using-tools.mdx",
         context: "| `analyze_workflow` | `get_workflow` with `action: \"analyze\"` |",
         why: "Same migration table as docs/using-tools.mdx, Simplified Chinese translation. Cells stay English.",
+      },
+      {
+        path: "docs/fr/using-tools.mdx",
+        context: "| `analyze_workflow` | `get_workflow` with `action: \"analyze\"` |",
+        why: "Same migration table as docs/using-tools.mdx, French translation. Cells stay English.",
       },
     ],
   },


### PR DESCRIPTION
Same shape as ko/ja (#1722) and zh (#1724): the remaining 16 **guide** pages for French, nav matching English's two groups (Démarrage / Configuration).

Does not translate tools/, blog/, or changelog/. Does not add `fa`.

`using-tools` migration table cells stay English; `allowedIn` rows added for `docs/fr/using-tools.mdx`.

**Gates (local):** `check:docs-locale fr`, `check:docs-links`, `check:docs-mdx` pass.
