### PR TITLE
fix(1217): panel_show_media's mid-command drop now settles with a re-issue, not an unverifiable check

### DIFF
--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -377,3 +377,95 @@ describe("#646 workflow navigation has a reader too", () => {
     expect(block).not.toMatch(/workflow_open|workflow_new/);
   });
 });
+
+
+// ===========================================================================
+// panel#1217 — a media card was told to "verify that it applied", and nothing
+// can.
+//
+// `panel_show_media` was interrupted by a mobile tab disconnect after dispatch
+// and got the DEFAULT branch: "Verify that it applied before retrying, rather
+// than re-issuing it blindly". That is the same defect shape as #952 and #646 —
+// a check named that cannot hold the answer. The panel's chat has no read-back,
+// so no tool can say whether the card painted; and the warning against retrying
+// is backwards here, because a duplicate media card is the one duplicate that
+// costs the user nothing (no GPU time, no answer owed). The honest settlement
+// is to re-issue and disclose the possible repeat.
+// ===========================================================================
+describe("#1217 show_media gets a remedy that can actually settle it", () => {
+  const MEDIA = { short: "mobile-c", cmd: "show_media" };
+
+  it("does NOT fall to the generic default — that is the reported defect", () => {
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).not.toMatch(/Verify that it applied/);
+    expect(msg).not.toMatch(/a retry may apply it twice/);
+    // And none of the other branches' readers — none of them can see the chat.
+    expect(msg).not.toMatch(/queue action:"list"/);
+    expect(msg).not.toMatch(/panel_query_graph/);
+    expect(msg).not.toMatch(/panel_list_workflows/);
+  });
+
+  it("says WHY it is unverifiable instead of pretending a check exists", () => {
+    // Same honesty as the interactive branch: name the missing reader, so the
+    // caller stops looking for one.
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).toMatch(/chat cannot be read back/);
+  });
+
+  it("makes re-issuing the settlement, and says what a duplicate costs", () => {
+    // The property that distinguishes show_media from ask_user: the retry is
+    // safe, not merely unavoidable. The cost comparison is what lets the agent
+    // reason instead of memorise — a run would cost GPU time, a question would
+    // be owed an answer, a media card asks for neither.
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).toMatch(/Re-issue the same panel_show_media/);
+    expect(msg).toMatch(/shows the same media twice|same media twice/);
+    expect(msg).toMatch(/GPU time/);
+    expect(msg).toMatch(/answer owed/);
+  });
+
+  it("discloses the duplicate instead of hiding it — suppression is keyed to the dead socket", () => {
+    // The retry runs fresh (the dedupe ledger does not carry across the
+    // reconnect), so if the original DID paint, the user sees two. Said plainly,
+    // with what to tell the user — the same disclosure the interactive branch
+    // makes, inverted: there it is the reason NOT to retry, here it is the
+    // price OF the retry.
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).toMatch(/keyed to the socket that dropped/);
+    expect(msg).toMatch(/may see two/);
+    expect(msg).toMatch(/not new content/);
+  });
+
+  it("offers the zero-duplicate route: ask the user first", () => {
+    // The one observer of the panel's chat that always exists is the person
+    // looking at it.
+    expect(midCommandVerifyClause("show_media")).toMatch(/ask the user whether it appeared/);
+  });
+
+  it("the applied half names the media, not a generic write", () => {
+    // "the panel may have applied it (for a run, ComfyUI may already be
+    // rendering)" describes a render; for show_media the thing that may have
+    // happened is the card painting.
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).toMatch(/media may already be on screen/);
+    expect(msg).not.toMatch(/ComfyUI may already be rendering/);
+  });
+
+  it("still reports OUTCOME UNKNOWN and the tab, like every other branch", () => {
+    const msg = midCommandDisconnectMessage(MEDIA);
+    expect(msg).toMatch(/disconnected mid-command \("show_media"\)/);
+    expect(msg).toMatch(/OUTCOME UNKNOWN/);
+    expect(msg).toContain("mobile-c");
+  });
+
+  it("show_media is NOT classified as interactive — the advice differs for a reason", () => {
+    // An ask card and a media card share the missing reader, but the remedies
+    // are opposites (retry endangers one, settles the other). If these
+    // classifiers ever merge, one of them gets the other's advice.
+    expect(isInteractiveCommand("show_media")).toBe(false);
+    const media = midCommandVerifyClause("show_media");
+    const ask = midCommandVerifyClause("ask_user");
+    expect(media).not.toBe(ask);
+    expect(media).not.toMatch(/will NOT reach you/);
+  });
+});

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -65,8 +65,11 @@ export function isInteractiveCommand(cmd: string): boolean {
  *    identical after a blueprint save, so both graph readers show what they showed
  *    before and prove nothing (codex review).
  *  • a CLIPBOARD write (`graph_copy_nodes`) — nothing can read the clipboard, and
- *    the graph is unchanged. This is the one interrupted write where re-issuing is
- *    the right answer: a second copy of the same nodes is the same clipboard.
+ *    the graph is unchanged. Re-issuing is the right answer: a second copy of the
+ *    same nodes is the same clipboard.
+ *  • a MEDIA display (`show_media`) — nothing can read the chat back either, but
+ *    re-issuing is safe in a different way: a duplicate media card costs the user
+ *    nothing, so the retry IS the settlement (panel#1217).
  *  • anything else — say to verify without naming tools that may not apply.
  *    Naming a plausible-but-wrong check is what this fix exists to remove; doing
  *    it again in the default branch would be the same defect with a different tool.
@@ -88,10 +91,22 @@ const LIBRARY_COMMANDS = new Set<string>(["graph_save_subgraph"]);
 
 /** Writes the CLIPBOARD, which nothing in the tool surface can read (codex review).
  *  Copying leaves the graph identical, so a canvas read is no evidence at all —
- *  but unlike everything else here, re-issuing is harmless: a second copy of the
+ *  but re-issuing is harmless: a second copy of the
  *  same nodes produces the same clipboard. That makes "just do it again" the
  *  correct advice rather than a dangerous one. */
 const CLIPBOARD_COMMANDS = new Set<string>(["graph_copy_nodes"]);
+
+/** Media display into the panel's chat (`show_media`, panel#1217). Like the
+ *  interactive branch, nothing in the tool surface can READ BACK whether the
+ *  card painted — the chat has no reader — so the interrupted command is
+ *  unverifiable. Unlike the interactive branch, a blind retry is not dangerous:
+ *  the source file is unchanged, so re-issuing either paints the card that
+ *  never landed or shows the same media twice, and a duplicate media card asks
+ *  nothing of the user — no GPU time (a run), no answer owed (a question).
+ *  That makes "re-issue, and say the repeat may appear" the honest settlement
+ *  rather than the generic "verify first", which names a check that cannot
+ *  exist. */
+const MEDIA_COMMANDS = new Set<string>(["show_media"]);
 
 /** The four active-workflow mutators. A canvas read cannot see these — they change
  *  which workflows exist or are open, not what is on the current graph. Mirrors
@@ -206,6 +221,18 @@ export function midCommandVerifyClause(cmd: string): string {
       `clipboard, so a retry here costs nothing and settles it.`
     );
   }
+  if (MEDIA_COMMANDS.has(cmd)) {
+    return (
+      `Nothing in the tool surface can check that — the panel's chat cannot be read back, ` +
+      `so you cannot see whether the card painted. Re-issue the same panel_show_media on the ` +
+      `current connection: the source file is unchanged, so the retry either paints the card ` +
+      `that never landed or shows the same media twice — and a duplicate media card asks ` +
+      `nothing of the user, unlike a second render (GPU time) or a second question card (an ` +
+      `answer owed). Retry suppression is keyed to the socket that dropped, so the retry runs ` +
+      `fresh and the user may see two; if it appears twice, tell them the repeat is the retry, ` +
+      `not new content. If even that is unwanted, ask the user whether it appeared first.`
+    );
+  }
   if (cmd.startsWith("graph_")) {
     return (
       `Verify with a graph READ before retrying — panel_query_graph on the node(s) this ` +
@@ -228,9 +255,12 @@ export function midCommandVerifyClause(cmd: string): string {
 /** The full OUTCOME UNKNOWN sentence for a mid-command disconnect. */
 export function midCommandDisconnectMessage(opts: { short: string; cmd: string }): string {
   const interactive = isInteractiveCommand(opts.cmd);
+  const media = MEDIA_COMMANDS.has(opts.cmd);
   const applied = interactive
     ? `the command was already sent, so the card may already be on screen`
-    : `the command was already sent, so the panel may have applied it (for a run, ComfyUI may already be rendering)`;
+    : media
+      ? `the command was already sent, so the media may already be on screen in the panel's chat`
+      : `the command was already sent, so the panel may have applied it (for a run, ComfyUI may already be rendering)`;
   return (
     `panel tab ${opts.short} disconnected mid-command ("${opts.cmd}") — OUTCOME UNKNOWN: ` +
     `${applied}. ${midCommandVerifyClause(opts.cmd)}`


### PR DESCRIPTION
## Root cause

When a panel tab disconnects after `show_media` was already written to the socket, the bridge rejects with the OUTCOME UNKNOWN message from `midCommandDisconnectMessage` (src/services/mid-command-remedy.ts). `show_media` fell to the DEFAULT branch — "Verify that it applied before retrying, rather than re-issuing it blindly" — which names a check that cannot exist: nothing in the tool surface can read the panel's chat back, so the agent was told to verify with no tool able to verify, and warned off the one action (re-issue) that is actually safe. This is the same defect shape as panel#952 (interactive cards) and panel#646 (graph writes), now fixed for media cards. Reported in artokun/comfyui-mcp-panel#1217; the message is built orchestrator-side, so the fix lives here.

## Fix

A new MEDIA branch in `midCommandVerifyClause`/`midCommandDisconnectMessage` for `show_media`:

- Says WHY it is unverifiable (the panel's chat cannot be read back) instead of pretending a check exists.
- Makes re-issuing the settlement: the source file is unchanged, so the retry either paints the card that never landed or shows the same media twice — and a duplicate media card asks nothing of the user, unlike a second render (GPU time) or a second question card (an answer owed). Retry suppression is keyed to the socket that dropped, so the retry runs fresh; the message discloses the possible duplicate and what to tell the user, and offers the zero-duplicate route (ask the user whether it appeared).
- The applied half names the media ("the media may already be on screen in the panel's chat"), not a generic write.

Verified against the bridge: `show_media` is not in `BRIDGE_READONLY_CMDS` (so it does take the mutating mid-command path) and not in `RETRY_TOKEN_CMDS` (no `retry_of` token is minted for it, so plain re-issue advice does not conflict with the #694 token hint).

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npm test` — full chain (vitest + i18n/docs/blog checks) exit 0
- `npx vitest run src/__tests__/services/mid-command-remedy.test.ts` — 41/41 pass, including the 8 new #1217 tests
- `npm run check:vocabulary` — OK (1556 files)
- `npm run vocab:export -- --check` — OK (ledger matches)

Closes artokun/comfyui-mcp-panel#1217