### PR TITLE
fix(1229): a too-old note with a current disk pack prescribes restart + hard-refresh, not a no-op sync

### DIFF
--- a/src/__tests__/services/panel-version-gap.test.ts
+++ b/src/__tests__/services/panel-version-gap.test.ts
@@ -124,6 +124,81 @@ describe("the rebind failure message carries the version gap (#1043)", () => {
     expect(body).toMatch(/if \(!v\?\.tooOld\) return ""/);
   });
 
+  // ── #1229: disk already current → sync is a no-op remedy ────────────────────
+  //
+  // The reporter's pack on disk was 0.14.37 while the session ran 0.11.38:
+  // ComfyUI-Manager had updated the pack in place after ComfyUI started, and
+  // ComfyUI keeps serving the web assets it registered at startup. Every
+  // affected tool reply prescribed `sync` — a no-op there — and the reporter
+  // had to run a full pack-version investigation to learn that. The remedy for
+  // a stale SERVED bundle is restart + hard-refresh, never a sync.
+
+  it("the too-old note checks the ON-DISK version before prescribing a sync", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("function panelTooOldNote");
+    const end = src.indexOf("\n}", src.indexOf("if (!v?.tooOld) return \"\"", start));
+    const body = src.slice(start, end);
+
+    // The disk read must come from the same proof machinery the write gate
+    // uses (#774): a version re-read NOW from the observed install dir, never
+    // a recorded one trusted on its own.
+    expect(body).toContain("verifiedPanelDiskVersion()");
+    // …and it must run BEFORE the sync remedy is rendered, so the remedy can
+    // be overridden. Asserted on order, not just presence: a disk check added
+    // after the return would be dead code that still passes a grep. The search
+    // starts AT the disk check because the neverAdvertised branch above (#1560)
+    // legitimately names the sync remedy first — it is deliberately weaker and
+    // its remedy is not the one this override governs.
+    const diskCheck = body.indexOf("verifiedPanelDiskVersion()");
+    const syncRemedy = body.indexOf('panel_action:"sync"', diskCheck);
+    expect(diskCheck).toBeGreaterThan(-1);
+    expect(syncRemedy).toBeGreaterThan(diskCheck);
+  });
+
+  it("a disk version that clears the floor renders DO NOT SYNC, restart + hard-refresh", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("function panelTooOldNote");
+    const end = src.indexOf("\n}", src.indexOf("if (!v?.tooOld) return \"\"", start));
+    const body = src.slice(start, end);
+
+    // The override fires only on positive proof: the disk version parses and
+    // meets the minimum. An unproven disk state must fall through to the sync
+    // remedy, which is correct for a pack that really is behind.
+    expect(body).toMatch(/SEMVER_RE\.test\(disk\) && compareSemver\(disk, v\.needed\) >= 0/);
+    // The note names what is on disk, says a sync changes nothing, and gives
+    // the remedy that actually works for the reporter's exact trap — including
+    // that a hard-refresh ALONE does not, which they verified the hard way.
+    expect(body).toContain("${disk}");
+    expect(body).toMatch(/DO NOT SYNC THE PANEL/);
+    expect(body).toMatch(/Restart ComfyUI so it serves \$\{disk\}/);
+    expect(body).toMatch(/HARD-REFRESH/);
+    expect(body).toMatch(/a hard refresh ALONE does not fix this/);
+  });
+
+  it("a missing disk reading re-primes in the background, never awaited", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("function panelTooOldNote");
+    const end = src.indexOf("\n}", src.indexOf("if (!v?.tooOld) return \"\"", start));
+    const body = src.slice(start, end);
+    // Same pattern as resolveStaleBundleSkew (#973): building an error message
+    // must not block on I/O, and the retry an agent reliably makes is what
+    // renders the corrected note.
+    expect(body).toMatch(/void primePanelBase\(\)/);
+    expect(body).not.toMatch(/await primePanelBase\(\)/);
+  });
+
   // ── #1560: a panel too old to help is also too old to say so ────────────────
 
   it("a panel that NEVER advertised a version is reported as never-advertised", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -55,6 +55,12 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
+import { SEMVER_RE } from "../services/ui-bridge.js";
+import { compareSemver } from "../services/self-update.js";
+import {
+  primePanelBase,
+  verifiedPanelDiskVersion,
+} from "../services/panel-workspace.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
 import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
@@ -4721,6 +4727,48 @@ WORTH CHECKING — THE PANEL'S VERSION IS UNKNOWN HERE: this session's panel has
       );
     }
     if (!v?.tooOld) return "";
+    // #1229 — IS THE INSTALL EVEN BEHIND, OR ONLY WHAT COMFYUI IS SERVING?
+    //
+    // This branch compares the RUNNING panel against the minimum and concludes
+    // "pack is out of date" — but the reporter's pack on disk was 0.14.37 while
+    // the session ran 0.11.38: ComfyUI-Manager had updated the pack IN PLACE
+    // after ComfyUI started, and ComfyUI keeps serving the web assets it
+    // registered at startup. Prescribing `sync` there is a no-op remedy — the
+    // disk already clears the floor — and it cost the reporter a full
+    // pack-version investigation to discover that. The actual fix is a RESTART
+    // plus a hard-refresh, and a hard-refresh ALONE provably does not work,
+    // because the new assets are registered server-side at startup, not re-read
+    // from disk on reload.
+    //
+    // Same proof discipline as resolveStaleBundleSkew (#774): only a disk
+    // version re-read NOW from the observed install dir may override the update
+    // advice. Anything unproven — no observation, an unparseable version, or a
+    // disk version genuinely below the floor — falls through to the sync remedy
+    // unchanged, which is correct for a pack that really is behind.
+    const disk = verifiedPanelDiskVersion()?.trim();
+    if (!disk) {
+      // The observation is missing or stale (most often the live-base
+      // resolution lapsed and this refusal is the first thing to ask in a
+      // while). Refresh it in the background — never awaited, since building
+      // an error message must not block on I/O — so a retry can answer.
+      void primePanelBase().catch(() => {});
+    }
+    if (disk && SEMVER_RE.test(disk) && compareSemver(disk, v.needed) >= 0) {
+      return (
+        `
+
+WHY THIS READ WAS NEEDED AT ALL: this session's RUNNING panel is ${v.version}, ` +
+        `and a panel only reports the new workflow's identity ON THE REPLY from ` +
+        `${v.needed} onwards — but DO NOT SYNC THE PANEL: the pack ON DISK is ` +
+        `${disk}, which already meets ${v.needed}, so a sync would change nothing. ` +
+        `What is stale is what ComfyUI is SERVING: the pack was updated after ` +
+        `ComfyUI started, and ComfyUI keeps serving the web assets it registered ` +
+        `at startup. Restart ComfyUI so it serves ${disk}, then HARD-REFRESH the ` +
+        `browser tab (Ctrl+Shift+R) — a hard refresh ALONE does not fix this, ` +
+        `because the assets are registered server-side at startup, not re-read ` +
+        `from disk on reload.`
+      );
+    }
     return (
       `
 


### PR DESCRIPTION
## Root cause

`panelTooOldNote` in `src/orchestrator/panel-tools.ts` compared the **running** panel's version against the minimum and, on `tooOld`, unconditionally prescribed `install_comfyui(action:"panel", panel_action:"sync")`. But the reporter's pack **on disk** was 0.14.37 while the session ran 0.11.38: ComfyUI-Manager had updated the pack in place after ComfyUI started, and ComfyUI keeps serving the web assets it registered at startup. A sync there is a no-op — disk already clears the floor — and following the advice cost the reporter a full pack-version investigation. The remedy that actually works for a stale *served* bundle is a ComfyUI restart plus a hard browser refresh (the reporter verified a hard refresh alone does NOT fix it, because the assets are registered server-side at startup).

## Fix

In the `tooOld` branch, before rendering the sync remedy, re-read the on-disk panel version with the same proof machinery the write gate uses (#774): `verifiedPanelDiskVersion()` re-reads the version NOW from the observed install dir and only returns it when the observation still describes the tree the live server serves. When that fresh disk version parses as semver and meets the minimum, the note instead says: DO NOT SYNC — the pack on disk (X) already meets the minimum; what is stale is what ComfyUI is serving; restart ComfyUI so it serves X, then HARD-REFRESH the tab, and a hard refresh alone does not fix this.

Fail-closed discipline is unchanged: no observation, an unparseable version, or a disk version genuinely below the floor all fall through to the original sync remedy, which is correct for a pack that really is behind. A missing observation kicks off a background `primePanelBase()` (never awaited — building an error message must not block on I/O) so a retry can answer.

## Verification

- `npm ci` — clean
- `npm run build` (tsc) — clean
- Full `npm test` chain (vitest 538 files / 10195 passed, plus i18n, docs-links, docs-locale, docs-mdx, blog checks) — exit 0
- New tests in `src/__tests__/services/panel-version-gap.test.ts` pin: the disk check uses `verifiedPanelDiskVersion()` and runs before the sync remedy; a disk version clearing the floor renders the DO-NOT-SYNC restart + hard-refresh note; a missing disk reading re-primes in the background without awaiting.

Closes artokun/comfyui-mcp-panel#1229