### PR TITLE
release: v0.52.3 — a workflow mismatch is reported, never silently adopted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.3] - 2026-08-19
+
+### MCP
+
+#### Fixed
+- a workflow-instance mismatch is diagnosed read-only, so a refused edit can no longer re-aim the fence onto the live canvas the caller did not name (#1646)
+- free_vram on a frozen tab is settled against the ComfyUI server itself instead of left outcome-unknown (#1249)
+- a Manager reboot whose loopback witness saw the down-up cycle reports the restart confirmed, not unconfirmed (#1642)
+- bootstrap finds git in the Git for Windows install roots when the orchestrator's PATH predates the install, and says a full restart is required when git is truly absent (#1640)
+- node_pack scaffold/publish adopt the live workspace install_comfyui already detected instead of refusing that no local install is configured (#1653)
+- apply_manifest stops refusing junctioned model folders, so a StabilityMatrix install resolves every model category (#870)
+- a re-spelled ComfyUI target keeps its self-queue ledger, so a post-reconnect scoped preview is not refused as a duplicate (#1615)
+
+
 ## [0.52.2] - 2026-08-18
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.2",
+      "version": "0.52.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying seven fixes: artokun/comfyui-mcp#1718, artokun/comfyui-mcp#1713, artokun/comfyui-mcp#1714, artokun/comfyui-mcp#1717, artokun/comfyui-mcp#1720, artokun/comfyui-mcp#1625, artokun/comfyui-mcp#1690.

**A refused edit stays refused** — the workflow fence answered a mismatch by adopting the live canvas, so every later mutation in the sequence was accepted against the workflow the caller never named: the wrong-graph corruption the fence exists to prevent, delivered as recovery. The mismatch is now diagnosed read-only and reported as diverged; the fence moves only on a deliberate rebind (#1646).

**Operations report what actually happened** — `free_vram` on a frozen tab is settled against the ComfyUI server itself rather than left as an outcome-unknown mutation the tool warns not to retry (#1249), and a Manager reboot whose loopback witness observed the down-up cycle reports the restart confirmed instead of unconfirmed on every healthy comeback (#1642).

**Local installs are found instead of denied** — `apply_manifest` no longer refuses junctioned model folders, so a StabilityMatrix layout resolves every category rather than only the ones backed by real directories (#870); `node_pack` scaffold/publish adopt the live workspace `install_comfyui` already detected instead of claiming nothing is configured (#1653); and training bootstrap resolves git from the Git for Windows install roots when the orchestrator's PATH predates the install, saying a full restart is required when git is genuinely absent (#1640).

**Reconnects keep their history** — a ComfyUI target re-spelled by a panel hello (`127.0.0.1` to `localhost`) keeps its self-queue ledger, so a post-reconnect scoped preview is no longer refused as a duplicate until the queue drains; the duplicate-fence override now names that case in all three places it is documented (#1615).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
