### PR TITLE
fix(369): a download goes to the extra model root the SERVER named, not an unvouched install

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -905,8 +905,15 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
   // file — and the verdict STILL claimed "it is in the right place … Do NOT
   // move the file", because resolveModelsDir() returned that same configured/
   // inferred root and the lexical containment check against it passes for any
-  // file the download itself just wrote there. Only a root the SERVER NAMED may
-  // anchor the refresh remedy; anything else keeps the move remedy.
+  // file the download itself just wrote there.
+  //
+  // #1735 settled what REPLACES that claim, and it is not the move remedy: this
+  // state is the THIRD one (inside a root nobody vouched for), so the verdict says
+  // UNCONFIRMED, names both candidates — stale listing vs. different install — and
+  // names the ONE check that separates them. Asserting the move remedy here would
+  // re-import #1131's harm: on the ordinary Windows-portable shape this file landed
+  // exactly right, and "move it" with no destination is an instruction nobody can
+  // follow. These expectations are read off what main actually emits.
   it.each(["configured-base", "observed-root", "base-anchored"] as const)(
     "#369 (0.52.1): a not-listed file under a root the server never named is NOT called 'in the right place' (%s)",
     async (source) => {
@@ -918,7 +925,17 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
       expect(res.liveVisible).toBe("not-visible");
       expect(res.note).not.toMatch(/in the right place/);
       expect(res.note).not.toMatch(/Do NOT move the file/);
-      expect(res.note).toMatch(/Move the file/);
+      // The honest third answer, not either remedy (#1735).
+      expect(res.note).toMatch(/UNCONFIRMED/);
+      expect(res.note).toMatch(/STALE LISTING/);
+      expect(res.note).toMatch(/DIFFERENT INSTALL/);
+      expect(res.note).toMatch(/list_local_models \(action:"list_paths"\)/);
+      // Not the unfollowable move instruction — the destination is unknown here, so
+      // there is no tree to name, and #1131's reporter got exactly that sentence.
+      expect(res.note).not.toMatch(/Move the file into the running server's models tree/);
+      // It must still NAME the root the bytes are in: that is where the user looks,
+      // and a verdict that withholds it is not actionable either.
+      expect(res.note).toContain(resolve("/stale/ComfyUI/models"));
       // …and it must not name the unvouched root as "the models directory that
       // server reads" — that assertion is the false claim being fixed.
       expect(res.note).not.toMatch(/models directory (the connected ComfyUI|that server) reads/);

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -135,6 +135,7 @@ vi.mock("node:fs/promises", () => ({
 import {
   currentLiveModelsRoot,
   resolveModelSubfolderPreferServer,
+  resolveModelSubfolderWithLiveRoot,
   verifyLandedModel,
 } from "../../services/model-resolver.js";
 import { ModelError } from "../../utils/errors.js";
@@ -533,6 +534,114 @@ describe("pre-write: a destination the LIVE server does not read from is refused
   });
 });
 
+describe("pre-write: a SERVER-NAMED extra model root wins over an unvouched primary (#369, 0.52.1)", () => {
+  // The 0.52.1 reports: ComfyUI Desktop launched with an ABSOLUTE
+  // --extra-model-paths-config whose base_path is the shared models root, while the
+  // primary models root could only be INFERRED (or came from stale local config).
+  // Every listing-based guard fails open on an empty tree by design, so the write
+  // landed in the install-local / non-running tree the server never reads. The
+  // server's own command line had already named the right root — use it.
+  const sharedVae = resolve("/shared/models/vae");
+  const configPath = resolve("/live/ComfyUI/extra_models_config.yaml");
+
+  beforeEach(() => {
+    // The Desktop shape: primary root NOT server-named, argv names the config,
+    // and that config maps the target category to the shared root.
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/comfy/models";
+    h.snapshotArgv = [resolve("/live/ComfyUI/main.py"), "--extra-model-paths-config", configPath];
+    h.liveExtraRoots = {
+      authoritative: true,
+      roots: [{ category: "vae", dir: sharedVae, group: "desktop" }],
+    };
+  });
+
+  it("downloads into the extra root the server's --extra-model-paths-config names", async () => {
+    const res = await resolveModelSubfolderWithLiveRoot("vae");
+    expect(res.targetDir).toBe(sharedVae);
+    // The mid-flight swap check compares PRIMARY roots; a redirected destination
+    // has no honest value to bind, so it must report none.
+    expect(res.liveRootAtResolve).toBeUndefined();
+  });
+
+  it("keeps the nested remainder under the extra root", async () => {
+    await expect(resolveModelSubfolderPreferServer("vae/sub")).resolves.toBe(
+      resolve("/shared/models/vae/sub"),
+    );
+  });
+
+  it("never runs the stale-install disagreement guard against a server-named destination", async () => {
+    // This evidence WOULD refuse the unvouched primary (a populated tree the server
+    // does not list). The redirect decides first, so the guard is moot and the
+    // server is never even asked.
+    h.onDisk = { vae: ["stale.safetensors"] };
+    h.liveListings["vae"] = ["someone-elses.safetensors"];
+    await expect(resolveModelSubfolderPreferServer("vae")).resolves.toBe(sharedVae);
+    expect(h.fetchCalls).toEqual([]);
+  });
+
+  it("does NOT redirect a category the config does not map", async () => {
+    await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBe(
+      resolve("/comfy/models/loras"),
+    );
+  });
+
+  it("does NOT redirect when the argv flag value is RELATIVE (cannot locate the server's file)", async () => {
+    h.snapshotArgv = [resolve("/live/ComfyUI/main.py"), "--extra-model-paths-config", "extra.yaml"];
+    await expect(resolveModelSubfolderPreferServer("vae")).resolves.toBe(
+      resolve("/comfy/models/vae"),
+    );
+  });
+
+  it("does NOT redirect on a non-authoritative read of the live config", async () => {
+    h.liveExtraRoots = { authoritative: false, roots: [{ category: "vae", dir: sharedVae }] };
+    await expect(resolveModelSubfolderPreferServer("vae")).resolves.toBe(
+      resolve("/comfy/models/vae"),
+    );
+  });
+
+  it("does NOT redirect into a CODE category (custom_nodes is never a download destination)", async () => {
+    const sharedCustomNodes = resolve("/shared/models/custom_nodes");
+    h.liveExtraRoots = {
+      authoritative: true,
+      roots: [{ category: "custom_nodes", dir: sharedCustomNodes, group: "desktop" }],
+    };
+    await expect(resolveModelSubfolderPreferServer("custom_nodes")).resolves.toBe(
+      resolve("/comfy/models/custom_nodes"),
+    );
+  });
+
+  it("keeps the primary root when the SERVER NAMED it (live-root needs no redirect)", async () => {
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    await expect(resolveModelSubfolderPreferServer("vae")).resolves.toBe(
+      resolve("/live/ComfyUI/models/vae"),
+    );
+  });
+
+  it("post-write: a landed file under the server-named extra root verifies VISIBLE", async () => {
+    // The other half of the 0.52.1 report: the file landed where the server's
+    // config says it reads, the server lists it — yet the verdict stayed
+    // "unconfirmed" because the PRIMARY root was unvouched. The argv-named config
+    // vouches for the extra root independently, so the listing is decisive.
+    const landed = resolve("/shared/models/vae/new.safetensors");
+    h.liveListings["vae"] = ["new.safetensors"];
+    const res = await verifyLandedModel(landed, "vae", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("visible");
+    expect(res.note).toBeUndefined();
+  });
+
+  it("post-write control: WITHOUT an argv-named config, the same extra root still vouches NOTHING", async () => {
+    // The auto-loaded config beside an INFERRED main.py inherits the inference —
+    // it is not a statement by the server, so the listing stays untieable.
+    h.snapshotArgv = [resolve("/live/ComfyUI/main.py")];
+    const landed = resolve("/shared/models/vae/new.safetensors");
+    h.liveListings["vae"] = ["new.safetensors"];
+    const res = await verifyLandedModel(landed, "vae", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("unknown");
+    expect(res.note).toMatch(/not named by the running server/);
+  });
+});
 describe("currentLiveModelsRoot — only a LIVE-AUTHORITATIVE answer (#369)", () => {
   it("returns the root when the models dir came from the running server", async () => {
     h.modelsDirSource = "observed-root";
@@ -789,6 +898,43 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.liveVisible).toBe("unknown");
     expect(res.note).toMatch(/inferred from where the server's interpreter lives/);
     expect(res.note).toMatch(/already listed that name before this download/);
+  });
+
+  // #369, the 0.52.1 report: a download landed in a stale second install whose
+  // root the server never named, the listing (correctly) did not contain the
+  // file — and the verdict STILL claimed "it is in the right place … Do NOT
+  // move the file", because resolveModelsDir() returned that same configured/
+  // inferred root and the lexical containment check against it passes for any
+  // file the download itself just wrote there. Only a root the SERVER NAMED may
+  // anchor the refresh remedy; anything else keeps the move remedy.
+  it.each(["configured-base", "observed-root", "base-anchored"] as const)(
+    "#369 (0.52.1): a not-listed file under a root the server never named is NOT called 'in the right place' (%s)",
+    async (source) => {
+      const staleLanded = resolve("/stale/ComfyUI/models/loras/new.safetensors");
+      h.modelsDirSource = source;
+      h.destModelsDir = "/stale/ComfyUI/models";
+      h.liveListings["loras"] = ["something-else.safetensors"]; // answered; ours absent
+      const res = await verifyLandedModel(staleLanded, "loras", { attempts: 2, retryMs: 0 });
+      expect(res.liveVisible).toBe("not-visible");
+      expect(res.note).not.toMatch(/in the right place/);
+      expect(res.note).not.toMatch(/Do NOT move the file/);
+      expect(res.note).toMatch(/Move the file/);
+      // …and it must not name the unvouched root as "the models directory that
+      // server reads" — that assertion is the false claim being fixed.
+      expect(res.note).not.toMatch(/models directory (the connected ComfyUI|that server) reads/);
+    },
+  );
+
+  it("#369 (0.52.1): a root the server NAMED keeps the refresh remedy on a listing miss", async () => {
+    // The control: gating the remedy on modelsDirNamedByServer must not take the
+    // #1131 fix away from a correctly-placed file whose listing is merely stale.
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.liveListings["loras"] = ["something-else.safetensors"];
+    const res = await verifyLandedModel(target, "loras", { attempts: 2, retryMs: 0 });
+    expect(res.liveVisible).toBe("not-visible");
+    expect(res.note).toMatch(/it is in the right place/);
+    expect(res.note).toMatch(/Do NOT move the file/);
   });
 
   it("DOES confirm a re-download into a LIVE-AUTHORITATIVE root even though the name pre-existed", async () => {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -21,6 +21,7 @@ import { modelNotFoundMessage } from "./model-root-scope.js";
 import {
   resolveModelsDirWithBases,
   parseModelsDirFromArgv,
+  parseExtraModelPathsConfigsFromArgvRaw,
   hasUnresolvableRelativeModelDirFlag,
   isLiveAuthoritativeModelsDir,
   modelsDirNamedByServer,
@@ -1349,29 +1350,53 @@ export async function isUnderLiveModelRoots(
   // "visible" and gives it the qualified note instead. That is the right trade:
   // the note names the file, the root, and the remedy, whereas the false positive
   // is silent and the user discovers it at queue time.
-  if (!modelsDirNamedByServer(dest.source)) return { inRoots: undefined };
+  //
+  // One exception (#369, the 0.52.1 reports): an extra model root is vouched for by
+  // the server's OWN command line when argv carries an ABSOLUTE
+  // --extra-model-paths-config — that statement is independent of how the PRIMARY
+  // root was derived, and a download redirected onto such a root
+  // (resolveModelSubfolderWithLiveRoot) must be able to confirm here, or the file
+  // lands exactly where the server reads and is STILL reported unconfirmed. With no
+  // argv-named config the extra roots may come from the auto-loaded config beside
+  // an INFERRED main.py — that inherits the inference and vouches for nothing, so
+  // the early UNKNOWN stands. The unvouched primary still cannot support a
+  // NEGATIVE answer below: unknown stays unknown, never "outside the live roots".
+  const primaryNamed = modelsDirNamedByServer(dest.source);
+  if (
+    !primaryNamed &&
+    !parseExtraModelPathsConfigsFromArgvRaw(dest.snapshot.argv).some((p) => isAbsolute(p))
+  ) {
+    return { inRoots: undefined };
+  }
   const liveRoot = resolve(dest.modelsDir);
+
+  let extra: Awaited<ReturnType<typeof getLiveExtraModelRoots>> | undefined;
+  try {
+    extra = await getLiveExtraModelRoots(dest.snapshot);
+  } catch {
+    extra = undefined;
+  }
+  const wantCat = (category ?? "").trim().toLowerCase();
 
   // A negative answer is only honest when everything it rests on could actually be
   // canonicalized; otherwise say UNKNOWN rather than accuse a correct placement.
   let fullyCanonical = target.ok;
-  const primary = await canon(dest.modelsDir);
-  fullyCanonical = fullyCanonical && primary.ok;
-  if (under(primary)) return { inRoots: true, liveRoot };
+  if (primaryNamed) {
+    const primary = await canon(dest.modelsDir);
+    fullyCanonical = fullyCanonical && primary.ok;
+    if (under(primary)) return { inRoots: true, liveRoot };
+  }
 
-  let extra: Awaited<ReturnType<typeof getLiveExtraModelRoots>>;
-  try {
-    extra = await getLiveExtraModelRoots(dest.snapshot);
-  } catch {
-    return { inRoots: undefined, liveRoot };
+  if (extra?.authoritative) {
+    for (const r of extra.roots) {
+      if (wantCat && String(r.category ?? "").trim().toLowerCase() !== wantCat) continue;
+      const rc = await canon(r.dir);
+      fullyCanonical = fullyCanonical && rc.ok;
+      if (under(rc)) return { inRoots: true, liveRoot };
+    }
   }
-  const wantCat = (category ?? "").trim().toLowerCase();
-  for (const r of extra.roots) {
-    if (wantCat && String(r.category ?? "").trim().toLowerCase() !== wantCat) continue;
-    const rc = await canon(r.dir);
-    fullyCanonical = fullyCanonical && rc.ok;
-    if (under(rc)) return { inRoots: true, liveRoot };
-  }
+  if (!primaryNamed) return { inRoots: undefined, liveRoot };
+  if (!extra) return { inRoots: undefined, liveRoot };
   // The live roots are known and this path is in none of them.
   if (!extra.authoritative) return { inRoots: undefined, liveRoot };
   return { inRoots: fullyCanonical ? false : undefined, liveRoot };
@@ -2116,28 +2141,89 @@ export async function resolveModelSubfolderWithLiveRoot(
   const { modelsDir, baseDirs, snapshot, source } = await resolveModelsDirWithBases({
     targetCategory: escapes ? "" : categoryOf(normalizedSub),
   });
-  const modelsRoot = resolve(modelsDir);
-  const targetDir = resolve(modelsRoot, raw);
+  let modelsRoot = resolve(modelsDir);
+  let targetDir = resolve(modelsRoot, raw);
   if (targetDir !== modelsRoot && !targetDir.startsWith(modelsRoot + sep)) {
     throw new ModelError(`Refusing to write outside the models directory: ${raw}`);
   }
-  // The root did NOT come from the running server (it could not tell us where it
-  // lives, so we fell back to local config). Before writing, check the one thing
-  // that can still expose a stale-install destination: the server's own listing for
-  // this category. #369 shipped 4.88 GB into a directory the live ComfyUI had never
-  // heard of; refusing here costs nothing and saves the transfer.
-  await assertDestinationVisibleToLiveServer(modelsRoot, raw, source, snapshot);
+  // #369 (the 0.52.1 reports) — a root the SERVER NAMED beats our best inference.
+  //
+  // When the primary root came from local configuration or from an INFERRED live
+  // root, every guard below can do no better than fail OPEN on an empty tree
+  // (#1147's deliberate trade: an empty listing contradicts nothing), so a stale
+  // second install received the write whenever its evidence was silent — the
+  // 0.52.1 reports had gigabytes land in the non-running install while the
+  // connected Desktop server's models lived in the shared root its
+  // --extra-model-paths-config declares (the very root list_paths shows).
+  //
+  // That config flag is the server's OWN command line naming a root it reads this
+  // category from — a statement, not an inference — so it outranks the unvouched
+  // primary and the download goes THERE instead. The gate is deliberately the
+  // exact evidence: an ABSOLUTE --extra-model-paths-config in argv (a relative
+  // one cannot be located from this process and fails closed, per extra-paths),
+  // an AUTHORITATIVE read of it, and a MODEL category (never custom_nodes — a
+  // download must not become a Python import). Anything less keeps the existing
+  // resolution and its corroboration guards untouched.
+  const serverNamedPrimary = modelsDirNamedByServer(source);
+  let redirectedToExtraRoot = false;
+  if (!serverNamedPrimary && snapshot.reachable && !isRemoteMode()) {
+    const category = categoryOf(normalizedSub).toLowerCase();
+    const argvNamesConfig = parseExtraModelPathsConfigsFromArgvRaw(snapshot.argv).some(
+      (p) => isAbsolute(p),
+    );
+    if (argvNamesConfig && category && !NON_MODEL_EXTRA_CATEGORIES.has(category)) {
+      const extra = await getLiveExtraModelRoots(snapshot);
+      const namedRoot = extra.authoritative
+        ? extra.roots.find((r) => r.category.trim().toLowerCase() === category)
+        : undefined;
+      if (namedRoot) {
+        const extraRoot = resolve(namedRoot.dir);
+        const redirected = resolve(extraRoot, subfolderRemainder(normalizedSub));
+        if (redirected !== extraRoot && !redirected.startsWith(extraRoot + sep)) {
+          throw new ModelError(`Refusing to write outside the models directory: ${raw}`);
+        }
+        logger.info(
+          `Downloading into the extra model root the connected server named for "${category}" ` +
+            `(${extraRoot}) instead of the unvouched primary root (${modelsRoot}) — the root the ` +
+            `server's --extra-model-paths-config declares is where it actually reads (#369).`,
+        );
+        modelsRoot = extraRoot;
+        targetDir = redirected;
+        redirectedToExtraRoot = true;
+      }
+    }
+  }
+  if (!redirectedToExtraRoot) {
+    // The root did NOT come from the running server (it could not tell us where it
+    // lives, so we fell back to local config). Before writing, check the one thing
+    // that can still expose a stale-install destination: the server's own listing for
+    // this category. #369 shipped 4.88 GB into a directory the live ComfyUI had never
+    // heard of; refusing here costs nothing and saves the transfer. (A server-named
+    // primary is not skipped here either — the guard itself decides, because a named
+    // root that does not EXIST locally, e.g. a container-side --models-directory,
+    // still gets the cheap check. Only the REDIRECTED destination is exempt: the
+    // server's own config named it, so disagreeing with our inference is moot.)
+    await assertDestinationVisibleToLiveServer(modelsRoot, raw, source, snapshot);
+  }
   // Path-string containment (above) is not enough: an EXISTING symlink somewhere
   // between modelsRoot and targetDir could redirect the real write OUTSIDE the
   // models dir. Because THIS resolver is the single canonical write-target for
   // every local download (startDownloadJob keying AND downloadModel's write), the
   // guard belongs here — co-located with the resolution the write actually uses —
   // so it can never diverge from a caller's separate pre-validation (e.g.
-  // apply_manifest resolving the root a second time; #490 codex review).
+  // apply_manifest resolving the root a second time; #490 codex review). Runs on
+  // the REDIRECTED root too: its code-root veto is what keeps a malicious or
+  // miswritten extra-paths entry from turning this into a write into custom_nodes.
   await assertNoEscapingSymlinkAncestor(modelsRoot, targetDir, raw, baseDirs, snapshot);
   return {
     targetDir,
-    liveRootAtResolve: isLiveAuthoritativeModelsDir(source) ? modelsRoot : undefined,
+    // A redirected destination is bound to the EXTRA root, but the writer's
+    // mid-flight swap check compares PRIMARY roots (currentLiveModelsRoot), so
+    // there is no honest value to bind here — leave it unknown, exactly like any
+    // other non-server-named primary. The post-write check still verifies the
+    // landed file against the connected server.
+    liveRootAtResolve:
+      !redirectedToExtraRoot && isLiveAuthoritativeModelsDir(source) ? modelsRoot : undefined,
   };
 }
 


### PR DESCRIPTION
> **Rebased onto `main` after #1735 merged.** Two sessions independently opened rival PRs on the
> same report; the comparative gate ruled SHIP BOTH, with one hunk of this PR dropped. #1735 landed
> first (`3b98b01`), and this branch is now that base plus the two hunks the gate kept. See
> **"What was dropped, and why"** below.

## Root cause (the 0.52.1 recurrence)

`resolveModelsDirWithBases` picks the download destination from launch argv, the live install root,
or — when neither resolves — local configuration (`COMFYUI_PATH` / saved workspace). When only local
config or an INFERRED root is available, the pre-write guards (#1371, #1562) can only refuse on
POSITIVE disagreement and deliberately fail open on an empty tree (#1147). So on the 0.52.1
reporters' setups — ComfyUI Desktop launched with `--extra-model-paths-config` whose `base_path` is
the shared models root — `download_model` kept writing into the install-local / non-running second
install's `models/` tree while `list_local_models(action:"list_paths")` correctly showed the shared
root the server's own config declares.

Gigabytes landed in a tree the connected server does not read: the macOS report is four downloads,
~25 GB, into the non-running install; the Windows report is the install-local root while the shared
root is where models actually live.

## Fix (`src/services/model-resolver.ts`) — the two hunks this PR ships

- **`resolveModelSubfolderWithLiveRoot` (the redirect)** — when the primary models root is not one
  the server named (`modelsDirNamedByServer` is false) and argv carries an ABSOLUTE
  `--extra-model-paths-config` whose authoritative read maps the target MODEL category, the download
  goes to that server-named extra root instead. That flag is the server's own command line naming a
  root it reads — a statement, not an inference. Relative config values (unlocatable from this
  process), non-authoritative reads, missing category mappings, and code categories (`custom_nodes`)
  never redirect; a server-named primary is kept as before. The symlink/code-root veto still runs
  against the redirected root.
- **`isUnderLiveModelRoots` (the exception)** — roots from an argv-named config vouch for membership
  independently of the primary root's provenance, so a file landed there can verify `visible`.
  Without an argv-named config the early UNKNOWN stands: the auto-loaded config beside an INFERRED
  `main.py` inherits the inference and vouches for nothing. The unvouched primary still cannot
  support a NEGATIVE answer.

These two are the ONLY change here that moves the bytes. Probed on the Desktop shape (unvouched
primary plus an absolute `--extra-model-paths-config` mapping `loras`), the destination moves from
`…/ComfyUI-Installs/ComfyUI/ComfyUI/models/loras` to `…/ComfyUI-Shared/models/loras`.

## What was dropped, and why

The original branch also changed **`verifyLandedModel`** to set `liveModelsDir = undefined` for an
unvouched root, so the post-write verdict would fall through to the "move it" remedy instead of
claiming "it is in the right place — Do NOT move the file". **That hunk is dropped**; `main` keeps
#1735's `liveModelsDir = dest.modelsDir` + `liveModelsDirNamedByServer`.

The gate probed the dropped hunk against the #1374 input state (`source: "observed-root"`, root
correct, no `--extra-model-paths-config`, listing answered but stale). It emits a definite failure
verdict plus an instruction nobody can follow — *"it will not be usable in a workflow from there.
Move the file into the running server's models tree…"* with **no directory named**, because
`liveModelsDir` had just been suppressed. For the ordinary Windows-portable shape that is a false
failure on a download that landed exactly right, and it re-imports the exact harm #1131 was opened
about.

#1735 resolves that state properly: it is a THIRD case — inside a root nobody vouched for — so the
verdict says UNCONFIRMED, names both candidates (stale listing vs. different install), names the one
check that separates them, and still names the root the bytes are in. Both PRs were right about the
false assurance; only #1735's answer is followable.

Consequently the three `it.each(["configured-base","observed-root","base-anchored"])` cases in
`download-live-destination.test.ts` were re-pointed. They asserted `toMatch(/Move the file/)` — the
wording the dropped hunk produced. They now assert what `main` actually emits, read off a real run:
`UNCONFIRMED`, `STALE LISTING`, `DIFFERENT INSTALL`, `list_local_models (action:"list_paths")`, the
ABSENCE of `Move the file into the running server's models tree`, and the PRESENCE of the root the
file is in.

## Verification (on the rebased tree)

- `src/__tests__/services/` — **213 files, 5049 passed, 3 skipped, 0 failed.**
- `tsc --noEmit` — clean. `check:unknown-collapse` — clean (0 known sites, no new collapses).
- **Mutation, redirect hunk**: gating the redirect block off ⇒ **3 failures** (`downloads into the
  extra root the server's --extra-model-paths-config names`, `keeps the nested remainder under the
  extra root`, `never runs the stale-install disagreement guard against a server-named destination`).
- **Mutation, `isUnderLiveModelRoots` exception**: reverting to the plain
  `if (!primaryNamed) return { inRoots: undefined }` ⇒ **1 failure** (`post-write: a landed file
  under the server-named extra root verifies VISIBLE`). A second red in `training-jobs.test.ts` on
  that run was a 4.8 s timing test under concurrent load; it passes alone on the restored tree.

Both kept hunks are therefore still pinned by tests after the rebase.

## Known-open, recorded by the gate — NOT addressed here

Filed as follow-ups so they are not lost with this branch:

1. **Two config groups mapping one category** — the redirect takes `.find()`'s first match silently.
   A probe with two groups routed a download to an `a111` NAS root. It should refuse, or rank, rather
   than pick.
2. **`getLiveExtraModelRoots` reads the config's CURRENT contents**, not the contents at server
   start. A root added since launch can now *pick* the destination, not merely *authorise* one — the
   running server may not have read it yet.
3. **A redirected `visible` stamps `verified_root` with the unvouched primary** the file is not in
   (`model-resolver.ts:1788`).

## Deliberately unchanged

- The fail-open-on-empty-listing design of the pre-write guard (#1147's ruling) — with no
  server-named extra root and silent listings, an unvouched destination still proceeds, and the
  post-write report (now #1735's) is honest about it.
- `isLiveAuthoritativeModelsDir`'s wider meaning for its other callers.

Together with #1735 this addresses the underlying cause of #369; leaving that issue open until both
are on `main` and the placement has been confirmed on a real Desktop pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
