### PR TITLE
fix(369): containment in a root WE picked is not readership — an unvouched destination is UNCONFIRMED, not "in the right place"

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -592,6 +592,52 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.note).toContain(resolve("/live/ComfyUI/models"));
   });
 
+  // #369, the 0.52.1/panel-0.15.1 recurrence (macOS, Comfy Desktop extra model
+  // paths). Four downloads landed in the install-local models/ tree of a SECOND
+  // install while the connected server's /models/<category> answered EMPTY, and
+  // the tool reported that the directory was one the connected server reads and
+  // that the file should not be moved. ~25 GB.
+  //
+  // The verdict's containment test ran against whatever the models-dir resolver
+  // returned, provenance and all — and that root is the one THIS DOWNLOAD RESOLVED
+  // TO, so the landed file is inside it by construction. The comparison therefore
+  // answers "inside" identically for a correct destination and for a stale second
+  // install: taxonomy #1, two states collapsed into one answer.
+  //
+  // This exercises the WIRING (verifyLandedModel → notVisibleVerdict), not just the
+  // wording helper: the provenance has to be READ from the resolution and PASSED,
+  // and a helper-level test cannot see that argument go missing.
+  it("#369: does NOT claim readership of a root the server never NAMED (0.52.1 recurrence)", async () => {
+    const staleLanded = resolve("/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models/loras/new.safetensors");
+    h.modelsDirSource = "configured-base";
+    h.destModelsDir = "/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models";
+    h.liveListings["loras"] = []; // the reporter's observation: answered, and EMPTY
+    const res = await verifyLandedModel(staleLanded, "loras", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("not-visible");
+    expect(res.note).not.toMatch(/INSIDE the models directory the connected ComfyUI reads/);
+    expect(res.note).not.toMatch(/it is in the right place/);
+    expect(res.note).not.toMatch(/Do NOT move the file/);
+    expect(res.note).toMatch(/UNCONFIRMED/);
+    // Both candidates named, plus the check that tells them apart.
+    expect(res.note).toMatch(/STALE LISTING/);
+    expect(res.note).toMatch(/DIFFERENT INSTALL/);
+    expect(res.note).toMatch(/list_paths/);
+  });
+
+  it("#369: an INFERRED (observed-root) destination gets the same unconfirmed verdict", async () => {
+    // #1562's narrowing again: an interpreter's location is evidence about the
+    // BINARY, not about where the server reads. isLiveAuthoritativeModelsDir()
+    // says yes to `observed-root`; the claim here requires modelsDirNamedByServer.
+    const staleLanded = resolve("/stale/ComfyUI/models/loras/new.safetensors");
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/stale/ComfyUI/models";
+    h.liveListings["loras"] = ["someone-elses.safetensors"];
+    const res = await verifyLandedModel(staleLanded, "loras", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("not-visible");
+    expect(res.note).toMatch(/UNCONFIRMED/);
+    expect(res.note).not.toMatch(/it is in the right place/);
+  });
+
   it("still says MOVE IT when the file is outside the live models root", async () => {
     // The write path itself is outside the live root (no junction involved), so
     // membership cannot vouch for it and the remedy stays "move it". (A write

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -590,6 +590,13 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.note).toMatch(/Do NOT move the file/);
     expect(res.note).not.toMatch(/Move the file into the running server's models tree/);
     expect(res.note).toContain(resolve("/live/ComfyUI/models"));
+    // #369 (0.52.1) — the SERVER named this root, so the note may say so, and must
+    // use the plain wording. If the provenance stops reaching the verdict, this
+    // degrades to the junction phrasing and tells a user with no junction that
+    // their layout is "reached through a link/junction" — prose asserting a
+    // mechanism that is not there.
+    expect(res.note).toMatch(/INSIDE the models directory the connected ComfyUI reads/);
+    expect(res.note).not.toMatch(/link\/junction/);
   });
 
   // #369, the 0.52.1/panel-0.15.1 recurrence (macOS, Comfy Desktop extra model
@@ -651,6 +658,10 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.note).toMatch(/will not be usable/);
     expect(res.note).toMatch(/Move the file into the running server's models tree/);
     expect(res.note).toContain(resolve("/live/ComfyUI/models"));
+    // The SERVER named this root, so naming it as what the server reads is earned —
+    // and it is the sentence that makes the move remedy followable. It must not be
+    // downgraded to the unvouched wording just because the provenance went missing.
+    expect(res.note).toMatch(/The models directory that server reads is/);
   });
 
   it("reports UNKNOWN — never a success — when the file is not on disk at all", async () => {

--- a/src/__tests__/services/placement-stale-listing.test.ts
+++ b/src/__tests__/services/placement-stale-listing.test.ts
@@ -25,6 +25,11 @@ describe("a file inside the server's own models root is not called misplaced", (
     ...BASE,
     verifiedPath: "C:\\ComfyUI\\models\\loras\\example.safetensors",
     liveModelsDir: "C:/ComfyUI/models",
+    // #369 (0.52.1) — the provenance is now REQUIRED for this branch, and this is
+    // #1131's actual setup: the reporter wrote into the connected ComfyUI's own
+    // models root, i.e. one the running server named. Containment against a root
+    // nobody vouched for gets the third verdict instead (below).
+    liveModelsDirNamedByServer: true,
   });
 
   it("never prints the impossible instruction", () => {
@@ -97,6 +102,93 @@ describe("a file inside via a junction keeps the refresh remedy (#369/#870)", ()
 
   it("still reports not-visible — the verdict did not weaken", () => {
     expect(junctioned.liveVisible).toBe("not-visible");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #369, the 0.52.1 recurrence — CONTAINMENT IN A ROOT WE PICKED IS NOT READERSHIP.
+//
+// macOS, two installs under ~/ComfyUI-Installs, the live one a Comfy Desktop
+// server reached through --extra-model-paths-config. Four downloads landed in the
+// install-local models/ tree while the connected server's /models/<category>
+// answered EMPTY; the tool told the user the directory was one the connected
+// server reads and not to move the file. ~25 GB.
+//
+// The containment test ran against whatever resolveModelsDir() returned — which
+// includes a `configured-base`/`observed-root` value the server never named. That
+// is the very root the download resolved to, so the landed file is inside it BY
+// CONSTRUCTION: the comparison answers "inside" for a correct destination and for
+// a stale second install alike (taxonomy #1 — two states, one answer, no way to
+// say unknown).
+// ---------------------------------------------------------------------------
+describe("a root the server never NAMED cannot vouch for the placement (#369)", () => {
+  const unvouched = notVisibleVerdict({
+    ...BASE,
+    verifiedPath: "/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models/loras/example.safetensors",
+    liveModelsDir: "/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models",
+    // Omitted provenance = unknown provenance. Local config / an inference.
+  });
+
+  it("never claims the connected ComfyUI reads that directory", () => {
+    expect(unvouched.note).not.toMatch(/INSIDE the models directory the connected ComfyUI reads/);
+    expect(unvouched.note).not.toMatch(/it is in the right place/);
+    expect(unvouched.note).toMatch(/UNCONFIRMED/);
+  });
+
+  it("does not hand out either remedy as if it were established", () => {
+    // Not the #1131 harm (an unfollowable move instruction)…
+    expect(unvouched.note).not.toMatch(/Move the file into the running server's models tree/);
+    // …and not the #369 harm (a reassurance that the bytes are placed).
+    expect(unvouched.note).not.toMatch(/Do NOT move the file/);
+  });
+
+  it("states BOTH candidate causes and the check that separates them", () => {
+    expect(unvouched.note).toMatch(/STALE LISTING/);
+    expect(unvouched.note).toMatch(/DIFFERENT INSTALL/);
+    expect(unvouched.note).toMatch(/refresh_nodes/);
+    expect(unvouched.note).toMatch(/list_paths/);
+  });
+
+  it("still reports not-visible — the verdict did not weaken", () => {
+    expect(unvouched.liveVisible).toBe("not-visible");
+  });
+
+  it("takes the CONFIDENT branch for the same paths once the server named the root", () => {
+    // Same two paths, one fact different. If this and the case above ever produce
+    // the same note, the provenance stopped being read.
+    const vouched = notVisibleVerdict({
+      ...BASE,
+      verifiedPath: "/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models/loras/example.safetensors",
+      liveModelsDir: "/Users/u/ComfyUI-Installs/ComfyUI/ComfyUI/models",
+      liveModelsDirNamedByServer: true,
+    });
+    expect(vouched.note).toMatch(/it is in the right place/);
+    expect(vouched.note).not.toBe(unvouched.note);
+  });
+
+  it("keeps the junction/extra-root vouching, which carries its own narrowing", () => {
+    // knownInsideLiveRoots comes from isUnderLiveModelRoots, which already refuses
+    // to answer for a root the server did not name — so it stays sufficient, and a
+    // #870 junction must not regress into the unverified branch.
+    const junctioned = notVisibleVerdict({
+      ...BASE,
+      verifiedPath: "E:/StabilityMatrix/models/VAE/example.safetensors",
+      liveModelsDir: "C:/ComfyUI/models",
+      knownInsideLiveRoots: true,
+    });
+    expect(junctioned.note).toMatch(/Do NOT move the file/);
+    expect(junctioned.note).not.toMatch(/UNCONFIRMED/);
+  });
+
+  it("does not present an unvouched root as what the server reads in the MOVE branch", () => {
+    const outside = notVisibleVerdict({
+      ...BASE,
+      verifiedPath: "/home/u/Downloads/example.safetensors",
+      liveModelsDir: "/opt/guessed/models",
+    });
+    expect(outside.note).not.toMatch(/models directory that server reads/);
+    // …but it still names the root, because that is where the bytes are.
+    expect(outside.note).toMatch(/\/opt\/guessed\/models/);
   });
 });
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -19,7 +19,6 @@ import { reportDownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import { modelNotFoundMessage } from "./model-root-scope.js";
 import {
-  resolveModelsDir,
   resolveModelsDirWithBases,
   parseModelsDirFromArgv,
   hasUnresolvableRelativeModelDirFlag,
@@ -1851,17 +1850,39 @@ export async function verifyLandedModel(
         `registers a category serving this file type, this server cannot load it at all.`,
     };
   }
+  // #369 (0.52.1 recurrence) — RESOLVE THE ROOT **WITH** ITS PROVENANCE.
+  //
+  // This used to call `resolveModelsDir()`, which reports the models dir whatever
+  // its `source` — including `configured-base`, the one value a reachable server
+  // never vouched for. The verdict below then compared the landed path against it
+  // and, finding the file inside, told the user the connected ComfyUI READS that
+  // directory. But that root is the very one this download chose, so the file is
+  // inside it BY CONSTRUCTION: the comparison is true for a correct destination and
+  // for a stale second install alike, and cannot tell them apart. On the reporter's
+  // macOS Comfy Desktop pair (two installs under ~/ComfyUI-Installs, the live one
+  // reached through extra_model_paths) that produced "it is in the right place …
+  // Do NOT move the file" for ~25 GB written where the running server never looks.
+  //
+  // So the SOURCE travels with the path, and only a server-NAMED root licenses the
+  // claim. `modelsDirNamedByServer` — not `isLiveAuthoritativeModelsDir` — because
+  // an `observed-root` is INFERRED from where the interpreter lives and is exactly
+  // the inference that lands on the wrong install (#1562).
   let liveModelsDir: string | undefined;
+  let liveModelsDirNamedByServer = false;
   try {
-    liveModelsDir = await resolveModelsDir();
+    const dest = await resolveModelsDirWithBases();
+    liveModelsDir = dest.modelsDir;
+    liveModelsDirNamedByServer = modelsDirNamedByServer(dest.source);
   } catch {
     liveModelsDir = undefined;
+    liveModelsDirNamedByServer = false;
   }
   return {
     verifiedPath,
     ...notVisibleVerdict({
       verifiedPath,
       liveModelsDir,
+      liveModelsDirNamedByServer,
       wanted,
       category,
       baseUrl: getComfyUIBaseUrl(),
@@ -1878,14 +1899,33 @@ export async function verifyLandedModel(
 /**
  * The verdict for a file that is on disk but absent from the live listing (#1131).
  *
- * "Not listed" has TWO causes and they take OPPOSITE remedies. If the file sits
- * UNDER the very models root the server reads, it is not misplaced: the server
- * simply has not re-read that folder yet. ComfyUI caches its loader option lists
- * and invalidates them on the directory's mtime, so a check this soon after the
- * write routinely races it. Telling that user to "move the file into the running
- * server's models tree" names a directory the file is ALREADY in — a remedy that
- * cannot be followed, which is what the reporter received. Only a file OUTSIDE
- * that root is genuinely in the wrong place.
+ * "Not listed" has THREE causes, and the first two take OPPOSITE remedies:
+ *
+ *   INSIDE a root the SERVER NAMED — not misplaced. The server simply has not
+ *     re-read that folder yet: ComfyUI caches its loader option lists and
+ *     invalidates them on the directory's mtime, so a check this soon after the
+ *     write routinely races it. Telling that user to "move the file into the
+ *     running server's models tree" names a directory the file is ALREADY in — a
+ *     remedy that cannot be followed, which is what #1131's reporter received.
+ *
+ *   OUTSIDE that root — genuinely in the wrong place. Move it.
+ *
+ *   INSIDE a root NOBODY VOUCHED FOR — unknown, and it must be SAID (#369, the
+ *     0.52.1 recurrence). This third state used to be folded into the first,
+ *     because the containment test ran against whatever `resolveModelsDir()`
+ *     returned — including a `configured-base`/`observed-root` value the running
+ *     server never named. That root is the one the download itself resolved to, so
+ *     the landed file is inside it BY CONSTRUCTION and the test answers "inside"
+ *     for a correct destination and a stale second install alike. It is the same
+ *     shape as #1603: two states, one indistinguishable answer, and no way to say
+ *     "unknown". The reporter's macOS Comfy Desktop pair got "so it is in the right
+ *     place … Do NOT move the file" for ~25 GB written into an install the running
+ *     server (reached through extra_model_paths) never reads.
+ *
+ * The unverified branch is deliberately NOT the move remedy either: refusing to
+ * assert readership is not evidence of misplacement, and #1131's harm was exactly
+ * an unfollowable move instruction. It states both candidates, orders them by
+ * likelihood, and names the ONE check that separates them.
  *
  * The DECISION lives here rather than at the call site so it is covered by the
  * same tests as the wording; a branch chosen upstream and passed in as a boolean
@@ -1904,17 +1944,65 @@ export function notVisibleVerdict(args: {
    *  outside it, and comparing paths alone would prescribe moving a file that is
    *  already in the right place (#369). */
   knownInsideLiveRoots?: boolean;
+  /** Did the RUNNING SERVER ITSELF name `liveModelsDir` (`modelsDirNamedByServer`
+   *  — its own `--models-directory`/`--base-directory`/argv `main.py` root), or did
+   *  it come from local configuration / an inference the server never vouched for?
+   *  Only the former licenses "the connected ComfyUI reads this directory": the
+   *  path comparison below is against the root THIS DOWNLOAD CHOSE, so it is true
+   *  by construction and cannot distinguish a correct destination from a stale
+   *  install (#369). Omitted ⇒ NOT named, because an unstated provenance is an
+   *  unknown one. */
+  liveModelsDirNamedByServer?: boolean;
 }): { liveVisible: "not-visible"; note: string } {
   const { verifiedPath, liveModelsDir, wanted, category, baseUrl } = args;
   const insideLexically = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
-  const insideLiveRoot = insideLexically || args.knownInsideLiveRoots === true;
+  const rootIsServerNamed = args.liveModelsDirNamedByServer === true;
+  // Containment ALONE is not readership. It counts only when the root it is
+  // measured against came from the server (`rootIsServerNamed`), or when the
+  // caller's canonical membership answer — which applies that same narrowing
+  // itself, and additionally covers live extra roots and in-tree junctions —
+  // already said yes.
+  const insideLiveRoot = (insideLexically && rootIsServerNamed) || args.knownInsideLiveRoots === true;
+  // On disk under the root we resolved, with nothing establishing that the server
+  // reads it. Neither remedy is earned; say so, and name the check that decides.
+  const insideUnverifiedRoot = insideLexically && !insideLiveRoot;
+  if (insideUnverifiedRoot) {
+    return {
+      liveVisible: "not-visible",
+      note:
+        `The file IS on disk at ${verifiedPath}, inside ${liveModelsDir} — the models root this ` +
+        `download resolved to. Whether the connected ComfyUI (${baseUrl}) READS that root is ` +
+        `UNCONFIRMED: the running server never named its own models directory, so this root came ` +
+        `from local configuration (COMFYUI_PATH / the saved default workspace) or was inferred ` +
+        `from where the server's interpreter lives — and the file is inside it either way, ` +
+        `because that is the root the download picked. That server does not list "${wanted}" ` +
+        `under "${category}".\n\n` +
+        `TWO very different things produce exactly this, and only one is a problem:\n` +
+        `  1. a STALE LISTING — ComfyUI caches its loader options and invalidates them on the ` +
+        `directory's mtime, so a check this soon after a write routinely races it; or\n` +
+        `  2. a DIFFERENT INSTALL — the bytes are in a models tree the running server never ` +
+        `scans, which is #369 and is how multi-GB downloads get reported as landed and are ` +
+        `never seen again.\n\n` +
+        `Do not move it on the strength of this message alone, and do not treat it as placed ` +
+        `either. SEPARATE THE TWO: refresh the node/model definitions — install_comfyui ` +
+        `(action:"refresh_nodes"), or the panel's refresh — then re-check with list_local_models. ` +
+        `If it STILL does not appear, it is case 2: list_local_models (action:"list_paths") ` +
+        `reports the roots the running server actually reads — move the file into the one for ` +
+        `"${category}". To make future downloads verifiable, point COMFYUI_PATH at the install ` +
+        `that is actually running, or launch it with an absolute --base-directory.`,
+    };
+  }
   return {
     // Still not VISIBLE — we did not observe it in the listing, and #369 exists
     // because an unobserved placement must not render as confirmed. The verdict
     // is unchanged; what changes is the explanation and the remedy.
     liveVisible: "not-visible",
     note: insideLiveRoot
-      ? (insideLexically
+      ? // The lexical phrasing NAMES the directory as one the server reads, so it may
+        // only be used when the SERVER named that directory. Otherwise the membership
+        // answer is what vouched for the placement (an extra root / a junction), and
+        // the wording that does not attribute the root is the honest one.
+        (insideLexically && rootIsServerNamed
           ? `The file IS on disk at ${verifiedPath}, which is INSIDE the models directory the ` +
             `connected ComfyUI reads (${liveModelsDir}) — so it is in the right place. `
           : `The file IS on disk at ${verifiedPath}, which is inside a models tree the ` +
@@ -1929,7 +2017,18 @@ export function notVisibleVerdict(args: {
       : `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
         `(${baseUrl}) does NOT list "${wanted}" under "${category}" — it will not be ` +
         `usable in a workflow from there.` +
-        (liveModelsDir ? ` The models directory that server reads is ${liveModelsDir}.` : "") +
+        // Same rule as above: name it as WHAT THE SERVER READS only when the server
+        // named it. An unvouched root is still worth printing — it is where the
+        // bytes are — but as the destination this download resolved to, not as a
+        // fact about the server (#369).
+        (liveModelsDir
+          ? rootIsServerNamed
+            ? ` The models directory that server reads is ${liveModelsDir}.`
+            : ` This download resolved its destination root to ${liveModelsDir} from local ` +
+              `configuration — the running server never named its own models directory, so that ` +
+              `is not a confirmed answer for where the file belongs; list_local_models ` +
+              `(action:"list_paths") reports the roots it actually reads.`
+          : "") +
         " Move the file into the running server's models tree (or point COMFYUI_PATH at that install and re-download).",
   };
 }


### PR DESCRIPTION
## The recurrence this fixes

The 2026-08-18T22:51Z comment on #369, on comfyui-mcp **0.52.1** / panel **0.15.1** — i.e. a
build that already contains #794, #1562 and #1679. macOS, two installs under
`~/ComfyUI-Installs/`, the live one a ComfyUI Desktop server reached through
`--extra-model-paths-config`:

> four downloads were written to the install-local `models/` tree while the connected
> server's corresponding `/models/<category>` responses were **empty**, despite `status`
> saying the server listed each file. […] roughly 25 GB was misplaced

and, said precisely in the sibling report two comments earlier:

> `status` **incorrectly said the guessed install-local directory was read by the connected
> server and instructed not to move the file**.

That second sentence is a claim the code makes, and it is the half fixed here.

## Mechanism

`verifyLandedModel` ends at `notVisibleVerdict`, which decides between two opposite remedies
by asking whether the landed file is inside "the models directory the connected ComfyUI
reads". It answered that with

```ts
liveModelsDir = await resolveModelsDir();
const insideLexically = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
```

`resolveModelsDir()` is **provenance-blind** — it is `(await resolveModelsDirWithBases()).modelsDir`
and returns the root whatever its `source`, including `configured-base` and `observed-root`,
the two values a reachable server never vouched for. And that root is *the one this download
resolved to*, so the landed file is inside it **by construction**.

So the comparison is `true` for a correct destination and for a stale second install alike:
its two operands are both the choice we made. It cannot distinguish the case it exists to
distinguish (taxonomy class 1 — two states, one indistinguishable answer, no way to say
*unknown*; and class 3 — a guard that is present, correct in isolation, and compares the
wrong pair). The reporter's four downloads therefore each got

> …which is INSIDE the models directory the connected ComfyUI reads (`…/ComfyUI-Installs/ComfyUI/ComfyUI/models`)
> — so it is in the right place. […] **Do NOT move the file.** Refresh the node/model definitions…

for bytes the running server will never scan. The empty `/models/<category>` listing did not
contradict it, because an empty listing is (correctly, #1147) not disagreement — the *guard*
was silent, and the *report* filled the silence with a guess.

## The change

`src/services/model-resolver.ts`, two edits:

1. **The source travels with the path.** `verifyLandedModel` resolves through
   `resolveModelsDirWithBases()` and passes `modelsDirNamedByServer(dest.source)` into the
   verdict. Deliberately `modelsDirNamedByServer`, not `isLiveAuthoritativeModelsDir`: an
   `observed-root` is *inferred* from where the interpreter lives, and that is exactly the
   inference #1562 narrowed for.

2. **"Unknown" becomes representable.** `notVisibleVerdict` gains a third branch. Containment
   in a **server-named** root keeps the #1131 verdict unchanged ("in the right place, do NOT
   move it, refresh"). Containment in an **unvouched** root now says so:

   > The file IS on disk at …, inside … — the models root this download resolved to. Whether
   > the connected ComfyUI READS that root is **UNCONFIRMED** … That server does not list "…"
   > under "…".
   > TWO very different things produce exactly this, and only one is a problem: 1. a **STALE
   > LISTING** … 2. a **DIFFERENT INSTALL** …
   > Do not move it on the strength of this message alone, and do not treat it as placed
   > either. SEPARATE THE TWO: refresh the node/model definitions … then re-check with
   > `list_local_models`. If it STILL does not appear, it is case 2: `list_local_models
   > (action:"list_paths")` reports the roots the running server actually reads — move the
   > file into the one for "…".

   `list_paths` is named because it is the discriminator the reporter used by hand: on their
   box it correctly showed the shared root while the download went elsewhere.

   The unvouched branch is deliberately **not** the move remedy either. #1131's harm was an
   unfollowable instruction to move a file into the directory it was already in; declining to
   assert readership is not evidence of misplacement. And for the ordinary Windows-portable
   shape (#1374) — correct `COMFYUI_PATH`, server reporting a relative `main.py`, so the root
   is unvouched but right — flipping to "it will not be usable in a workflow from there, move
   it" would be a false failure for a working setup.

`knownInsideLiveRoots` is untouched and still sufficient on its own: it comes from
`isUnderLiveModelRoots`, which applies the same narrowing internally and additionally covers
live extra roots and #870 junctions. The `liveVisible` verdict is unchanged in every branch —
what changes is what the note claims.

## Refutation — what I deleted, and what failed

Baseline green first (78/78 on the two files), then four mutations against it:

| # | mutation | result |
|---|---|---|
| 1 | `insideLiveRoot = insideLexically \|\| knownInsideLiveRoots` (the pre-change line) | **5 failed** — both `verifyLandedModel` integration tests + 3 verdict tests |
| 2 | delete `liveModelsDirNamedByServer,` from the call site | **survived 78/78 at first** — see below |
| 3 | `modelsDirNamedByServer(dest.source)` → `isLiveAuthoritativeModelsDir(dest.source)` | **1 failed** — the `observed-root` case |
| 4 | `insideUnverifiedRoot = false` | **5 failed** |

Mutation 2 is the finding. Dropping the wiring flipped nothing, because
`knownInsideLiveRoots` already answers the healthy case — only the *wording* degraded
silently: a plain server-named root began telling users their layout was "reached through a
link/junction", and the move remedy stopped naming the directory that makes it followable.
That is the "an install line is invisible to tests" shape, and a helper-level test cannot see
an argument go missing. The second commit adds the two call-site assertions; re-running
mutation 2 now fails 2 tests.

Also run: `npm run typecheck` clean, `npm run lint` clean, `npm run check:unknown-collapse`
clean ("0 known site(s), no new collapses"), and the full suite — 10191/10205 passed. The
residue is not mine: `package-hooks > every entry in files exists on disk` fails in a fresh
worktree because `dist/` has not been built (`expected [ 'dist' ] to deeply equal []`), and
`tool-surface-filter` / `vocabulary` were 30s timeouts under load that pass in isolation
(96/97 on a serial re-run of the three files, the one failure being the `dist` one).

## Relationship to #1734

#1734 opened at 04:17Z while this was in flight, and the two overlap at exactly one function.
Its `verifyLandedModel` change sets `liveModelsDir = undefined` for an unvouched root, which
routes that case into the existing **move** branch:

> …the connected ComfyUI does NOT list "…" — it will not be usable in a workflow from there.
> Move the file into the running server's models tree…

with no directory named. For the #1374 Windows-portable shape (correct `COMFYUI_PATH`, server
reports a relative `main.py`) that is a definite failure verdict and an unfollowable remedy
for a download that landed correctly — #1131's harm, on the other side of the same collapse.
The third branch here is what that case needs; the rest of #1734 (redirecting the destination
to a server-named extra root) is complementary and not attempted here. Whichever lands first,
the other should be rebased onto it rather than merged over it.

## Deliberately not done

- **The pre-write guard is untouched.** `assertDestinationVisibleToLiveServer` still fails
  open on an empty listing and an empty candidate tree. That is #1147's maintainer ruling
  ("unaccountable is a proceed-unverified state"), and broadening it is how the guard
  false-refuses fresh and shared trees. This PR makes the *report* honest, not the guard
  stricter.
- **No panel code changed**, so the panel Playwright suite was not run; nothing in
  `comfyui-mcp-panel` references these strings (grepped).
- Gate scripts were not run — `codex exec` is account-exhausted until 2026-08-19 20:43 and
  `claude-gate.mjs` is blocked on the weekly limit, so both would return INDETERMINATE. This
  PR is submitted for an independent reviewer to gate.

The underlying cause of #369 is what this addresses; closing is the maintainer's call.
