### PR TITLE
fix(1519): a fenced graph READ is diagnosed, and a missing stamp is not a wrong one

### DIFF
--- a/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
+++ b/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
@@ -176,6 +176,20 @@ describe("a fenced graph READ is diagnosed, and a missing stamp is not a wrong o
     expect(adopted).toEqual([]);
   });
 
+  it("NO IDENTITY, but the session HAS a stamp: the verdict does not claim the session lacks one", async () => {
+    // The same probe result reached from the other shape. "carries no workflow
+    // identity EITHER" would be false here — this session is fenced to STALE — and a
+    // verdict that describes the caller's state wrongly is the class of claim this
+    // whole issue is about.
+    fence = { known: true, uuid: STALE };
+    const text = await outline({ issuedFor: STALE, liveUuid: null });
+
+    expect(text).toMatch(/no workflow identity of its own/);
+    expect(text).not.toMatch(/no workflow identity either/);
+    expect(text).toMatch(/will NOT clear this/);
+    expect(adopted).toEqual([]);
+  });
+
   it("PINNED: naming mode:\"current\" also discloses that it releases the pin", async () => {
     // mode:"current" is the right remedy for a missing stamp AND it silently drops a
     // pin. A caller who followed it to fix a read would lose their target and find

--- a/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
+++ b/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
@@ -1,0 +1,267 @@
+// #1519 — a live graph READ refused by the workflow fence said nothing about how to fix it,
+// and the two states behind that refusal are not the same state.
+//
+// The reporter's session resumed onto a different workflow and the first live-canvas read
+// came back
+//
+//   workflow instance mismatch: this command carries no workflow-instance stamp, and the
+//   active canvas reports 2b3f4684-…. Nothing was applied.
+//
+// MEASURED on main before this change: that sentence was the ENTIRE tool result. The
+// corroboration #1330 added is gated on `isMutatingGraphCmd`, so a READ refused by the very
+// same fence fell through every branch of the catch and the panel's raw refusal was
+// surfaced verbatim — no verdict, no remedy. The reporter found
+// `panel_set_workflow_target({mode:"current"})` themselves; that discovery is the report.
+//
+// TWO REFUSALS, NOT ONE — the part these assertions exist to pin. `isWorkflowInstanceMismatch`
+// matches both of the panel's states and they have OPPOSITE remedies:
+//
+//   "carries no workflow-instance stamp"  → no identity at all. Nothing was compared.
+//                                           Deriving a fence from the live canvas fixes it.
+//   "issued for workflow instance <uuid>" → an identity the canvas disagrees with. Deriving
+//                                           a fence from the live canvas ABANDONS the
+//                                           workflow the caller named (the retarget #1646
+//                                           removed for cause).
+//
+// So each case asserts its OWN remedy AND asserts the other case's remedy is absent. A
+// verdict that merely mentioned rebinding would satisfy a one-sided test while re-collapsing
+// the two states, which is the defect this issue is about.
+//
+// THE FENCE IS NOT MOVED. Every case asserts `refreshWorkflowUuid` was never called: the probe
+// is the read-only one, the refusal still fails the call, and the caller decides.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const LIVE = "2b3f4684-b7e7-495b-a7a1-f40439e35e0a"; // what the canvas reports
+const STALE = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"; // a fence that has gone stale
+
+let listCalls: number;
+let adopted: string[];
+let fence: { known: boolean; uuid?: string };
+
+/** A self-corroborating workflow_list reply: the active record also appears in the
+ *  open-workflow list flagged active, which is what corroboration requires. */
+function settled(uuid: string | null): Record<string, unknown> {
+  const active: Record<string, unknown> = {
+    path: "workflows/a.json",
+    routing_key: TAB,
+    ...(uuid ? { workflow_uuid: uuid } : {}),
+  };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+/**
+ * `issuedFor` — what the panel's refusal states: a uuid (the WRONG-stamp wording) or
+ * `null` (the MISSING-stamp wording). `liveUuid` — what workflow_list reports for the
+ * live canvas, `null` for a canvas that has no identity of its own. `probeRefused` —
+ * a build predating panel #759 that fences the recovery probe too.
+ */
+function bridge(opts: { issuedFor: string | null; liveUuid: string | null; probeRefused?: boolean }) {
+  const refusal =
+    `workflow instance mismatch: ` +
+    (opts.issuedFor
+      ? `this command was issued for workflow instance ${opts.issuedFor}`
+      : `this command carries no workflow-instance stamp`) +
+    `, and the active canvas reports ${LIVE}. Nothing was applied.`;
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        // A build predating panel #759 fences the recovery probe too. It must
+        // surface its own refusal, NOT re-enter the diagnosis that called it.
+        if (opts.probeRefused) throw new Error(refusal);
+        return settled(opts.liveUuid);
+      }
+      throw new Error(refusal);
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      adopted.push(uuid);
+      return true;
+    },
+    workflowUuidFor: () => fence,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+/** Drive a real READ tool (panel_graph_outline) through the real ctx.call path. */
+async function outline(
+  opts: { issuedFor: string | null; liveUuid: string | null; probeRefused?: boolean },
+  store = new WorkflowTargetStore(),
+): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, store);
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
+  if (!def) throw new Error("panel_graph_outline is not registered");
+  const res: ToolResult = await def.handler({} as never, ctx);
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+/** The remedy that is right ONLY for an absent stamp. */
+const REBIND = /panel_set_workflow_target\(\{mode:"current"\}\) derives this session's fence/;
+/** The remedy that is right ONLY for a wrong stamp. */
+const CHOOSE = /to read the workflow you issued for, bring it back with panel_open_workflow/;
+
+beforeEach(() => {
+  listCalls = 0;
+  adopted = [];
+  fence = { known: true, uuid: undefined }; // definitively NOT fenced — #1519's state
+});
+
+describe("a fenced graph READ is diagnosed, and a missing stamp is not a wrong one (#1519)", () => {
+  it("MISSING STAMP: says the stamp was absent and names the rebind that mints one", async () => {
+    const text = await outline({ issuedFor: null, liveUuid: LIVE });
+
+    // The live canvas really was re-read — without this every assertion below could
+    // be satisfied by a message that never consulted the panel.
+    expect(listCalls).toBeGreaterThan(0);
+
+    expect(text).toMatch(/CHECKED/);
+    expect(text).toMatch(/MISSING stamp rather than a wrong one/);
+    expect(text).toMatch(REBIND);
+    expect(text).toContain(LIVE);
+    // The panel's own refusal is preserved verbatim — it is the evidence.
+    expect(text).toContain("carries no workflow-instance stamp");
+    // The OTHER state's remedy must not appear: there is no workflow this read was
+    // "issued for", so telling the caller to bring one back is a fabricated target.
+    expect(text).not.toMatch(CHOOSE);
+    // The call still FAILS, and the fence was not moved.
+    expect(text.startsWith("Error:")).toBe(true);
+    expect(adopted).toEqual([]);
+  });
+
+  it("WRONG STAMP: names the choice between two real workflows, and NOT the mint-a-stamp rebind", async () => {
+    // The collapse this branch must not make. A session that HAS an identity and a
+    // canvas that disagrees is a different fact, and mode:"current" abandons the
+    // workflow the caller named rather than repairing anything.
+    fence = { known: true, uuid: STALE };
+    const text = await outline({ issuedFor: STALE, liveUuid: LIVE });
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(text).toMatch(/WRONG stamp, not a missing one/);
+    expect(text).toMatch(CHOOSE);
+    expect(text).not.toMatch(REBIND);
+    // It names BOTH identities, which is the fact the caller has to choose between.
+    expect(text).toContain(STALE);
+    expect(text).toContain(LIVE);
+    // And it discloses what re-targeting costs, rather than presenting it as repair.
+    expect(text).toMatch(/re-points every later EDIT/);
+    expect(adopted).toEqual([]);
+  });
+
+  it("NO IDENTITY ANYWHERE: says the rebind will NOT clear it, and sends the caller to re-open", async () => {
+    // #1331's lesson, applied to the read path: when the live canvas has no identity
+    // either, mode:"current" reports success while the read keeps failing.
+    const text = await outline({ issuedFor: null, liveUuid: null });
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(text).toMatch(/will NOT clear this/);
+    expect(text).toMatch(/panel_open_workflow\(<path>\)/);
+    expect(text).toMatch(/panel_save_workflow/);
+    // The remedy that cannot work here must not be offered as one.
+    expect(text).not.toMatch(REBIND);
+    expect(adopted).toEqual([]);
+  });
+
+  it("PINNED: naming mode:\"current\" also discloses that it releases the pin", async () => {
+    // mode:"current" is the right remedy for a missing stamp AND it silently drops a
+    // pin. A caller who followed it to fix a read would lose their target and find
+    // out by editing the wrong workflow later.
+    const store = new WorkflowTargetStore();
+    store.set(TAB, { mode: "pinned", path: "workflows/b.json", filename: "b.json" });
+    const text = await outline({ issuedFor: null, liveUuid: LIVE }, store);
+
+    expect(text).toMatch(REBIND);
+    expect(text).toMatch(/PINNED to b\.json/);
+    expect(text).toMatch(/RELEASES that pin/);
+    expect(text).toMatch(/panel_open_workflow\("workflows\/b\.json"\)/);
+    expect(adopted).toEqual([]);
+  });
+
+  it("UNSTATED SHAPE: a refusal that names neither state gets NO remedy invented for it", async () => {
+    // The third answer. A panel wording this cannot classify is not evidence for
+    // either state, and guessing one would be the collapse in the other direction.
+    const ctx = makePanelToolCtx(
+      {
+        send: async (cmd: Record<string, unknown>) => {
+          if (cmd.cmd === "workflow_list") {
+            listCalls += 1;
+            return settled(LIVE);
+          }
+          throw new Error("workflow instance mismatch: this command targets a different workflow");
+        },
+        push: () => 1,
+        canReach: (id: string) => id === TAB,
+        isHeadless: () => false,
+        tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+        resolveActiveTabId: () => TAB,
+        refreshWorkflowUuid: (_t: string, u: string) => {
+          adopted.push(u);
+          return true;
+        },
+        workflowUuidFor: () => fence,
+        tabCanMutateGraph: () => true,
+        tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+      } as unknown as PanelToolCtx["bridge"],
+      TAB,
+      new WorkflowTargetStore(),
+    );
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
+    if (!def) throw new Error("panel_graph_outline is not registered");
+    const res: ToolResult = await def.handler({} as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(text).toMatch(/is NOT known from here/);
+    expect(text).not.toMatch(REBIND);
+    expect(text).not.toMatch(CHOOSE);
+    expect(adopted).toEqual([]);
+  });
+});
+
+describe("the #1519 diagnosis cannot re-enter itself, and changes no other path", () => {
+  it("a panel that FENCES the recovery probe surfaces its refusal instead of recursing", async () => {
+    // The probe this branch runs is `workflow_list`, which flows back through the same
+    // catch. A build predating panel #759 fences it too — the branch is keyed on the
+    // `graph_` prefix precisely so that reply cannot re-enter the diagnosis. Bounded
+    // recursion would show up here as an exploding call count (or a hang), not as
+    // wrong wording.
+    const text = await outline({ issuedFor: null, liveUuid: LIVE, probeRefused: true });
+
+    expect(listCalls).toBeLessThanOrEqual(4); // one read + at most the #1292 rechecks
+    expect(text).toMatch(/UNKNOWN/);
+    expect(text).toContain("carries no workflow-instance stamp");
+    expect(adopted).toEqual([]);
+  }, 20000);
+
+  it("a MUTATION refused by the same fence keeps its own #1330 verdict", async () => {
+    // The control. The mutation branch runs first and is untouched: its wording says
+    // NOT APPLIED, which is the claim a read must not make and a write must.
+    fence = { known: true, uuid: STALE };
+    const ctx = makePanelToolCtx(
+      bridge({ issuedFor: STALE, liveUuid: LIVE }),
+      TAB,
+      new WorkflowTargetStore(),
+    );
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_connect");
+    if (!def) throw new Error("panel_connect is not registered");
+    const res: ToolResult = await def.handler({ from_node_id: 1, to_node_id: 2 } as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(text).toMatch(/NOT applied — nothing changed/);
+    expect(text).not.toMatch(/no graph data was read/);
+    expect(adopted).toEqual([]);
+  });
+});

--- a/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
+++ b/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
@@ -231,6 +231,88 @@ describe("a fenced graph READ is diagnosed, and a missing stamp is not a wrong o
   });
 });
 
+describe("classified against the panel's REAL wording, not the fixture's short form", () => {
+  // The short refusal above is the one #1519 was filed with. A current panel says more:
+  // since 0.11.83 (`workflowInstanceMismatchMessage`) it appends its own remedy line,
+  // and that line names BOTH exits as interchangeable —
+  //
+  //   Re-target with panel_set_workflow_target({mode:"current"}), or re-select the
+  //   intended workflow with panel_open_workflow, then retry.
+  //
+  // which is right for the panel (it "observed only that the two identities differ")
+  // and is exactly the collapse this branch resolves. Transcribed verbatim from
+  // comfyui-mcp-panel@v0.15.3 so the classification is checked against the shape it
+  // will actually meet, and so the extra prose cannot flip the regexes.
+  const REAL = (compared: string): string =>
+    `workflow instance mismatch: ${compared}. Nothing was applied.\n\n` +
+    `That is the comparison, not the cause — the panel observed only that the two ` +
+    `identities differ. It can mean the workflow was switched or replaced after the ` +
+    `command was issued, that this session's fence was never established or could not ` +
+    `be refreshed, or that the identity could not be read at all.\n\n` +
+    `Re-target with panel_set_workflow_target({mode:"current"}), or re-select the ` +
+    `intended workflow with panel_open_workflow, then retry. If NO panel tab is ` +
+    `connected, neither will help and the connection is the thing to fix — ` +
+    `panel_graph_outline reports connectivity directly.`;
+
+  async function outlineRaw(refusal: string): Promise<string> {
+    const ctx = makePanelToolCtx(
+      {
+        send: async (cmd: Record<string, unknown>) => {
+          if (cmd.cmd === "workflow_list") {
+            listCalls += 1;
+            return settled(LIVE);
+          }
+          throw new Error(refusal);
+        },
+        push: () => 1,
+        canReach: (id: string) => id === TAB,
+        isHeadless: () => false,
+        tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+        resolveActiveTabId: () => TAB,
+        refreshWorkflowUuid: (_t: string, u: string) => {
+          adopted.push(u);
+          return true;
+        },
+        workflowUuidFor: () => fence,
+        tabCanMutateGraph: () => true,
+        tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+      } as unknown as PanelToolCtx["bridge"],
+      TAB,
+      new WorkflowTargetStore(),
+    );
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
+    if (!def) throw new Error("panel_graph_outline is not registered");
+    const res: ToolResult = await def.handler({} as never, ctx);
+    return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+  }
+
+  it("the full MISSING-stamp refusal is still classified as missing", async () => {
+    const text = await outlineRaw(
+      REAL(`this command carries no workflow-instance stamp, and the active canvas reports ${LIVE}`),
+    );
+    expect(text).toMatch(/MISSING stamp rather than a wrong one/);
+    expect(text).toMatch(REBIND);
+    expect(text).not.toMatch(CHOOSE);
+    expect(adopted).toEqual([]);
+  });
+
+  it("the full WRONG-stamp refusal is still classified as wrong", async () => {
+    fence = { known: true, uuid: STALE };
+    const text = await outlineRaw(
+      REAL(
+        `this command was issued for workflow instance ${STALE}, and the active canvas reports ${LIVE}`,
+      ),
+    );
+    expect(text).toMatch(/WRONG stamp, not a missing one/);
+    expect(text).toMatch(CHOOSE);
+    // The panel offered mode:"current" here as an equal option. This side, having
+    // measured which state it is, does NOT — it says what re-targeting costs instead.
+    expect(text).not.toMatch(REBIND);
+    expect(text).toMatch(/re-points every later EDIT/);
+    expect(adopted).toEqual([]);
+  });
+});
+
 describe("the #1519 diagnosis cannot re-enter itself, and changes no other path", () => {
   it("a panel that FENCES the recovery probe surfaces its refusal instead of recursing", async () => {
     // The probe this branch runs is `workflow_list`, which flows back through the same

--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -41,12 +41,20 @@ function switchGuardError(cmd = "graph_outline"): Error {
 }
 
 let attempts: number;
+/** Every command name this fixture was asked to send, in order. `attempts` counts
+ *  ALL of them, which is not the same question as "was the command under test
+ *  re-issued?": a refusal may cost a read-only DIAGNOSIS round trip (#1519 reads
+ *  `workflow_list` to say which fence state a mismatch is). Keep the two apart so
+ *  a retry assertion is made about the retry. */
+let sent: string[];
 
 /** Fails the first `failures` sends with the switch guard, then succeeds. */
 function bridgeFailing(failures: number, err: () => Error = switchGuardError) {
   attempts = 0;
+  sent = [];
   return {
-    send: async () => {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(typeof cmd?.cmd === "string" ? cmd.cmd : "");
       attempts += 1;
       if (attempts <= failures) throw err();
       return { ok: true, nodes: [] };
@@ -131,7 +139,13 @@ describe("#1027: the other refusals keep their own handling", () => {
     );
     const res = await ctx.call({ cmd: "graph_outline" });
     expect(res.isError).toBe(true);
-    expect(attempts).toBe(1);
+    // Asserted about the READ itself, which is what "not retried" means here: the
+    // stamp names a workflow that is no longer active and waiting cannot change
+    // that, so re-issuing it would report the same thing one round trip later.
+    // #1519 does spend one READ-ONLY `workflow_list` to say WHICH fence state the
+    // mismatch is — a diagnosis, not a re-issue — so it is counted separately
+    // rather than folded into a bare send count that cannot tell them apart.
+    expect(sent.filter((c) => c === "graph_outline")).toEqual(["graph_outline"]);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7651,10 +7651,14 @@ export function makePanelToolCtx(
                   `(${live}) — through the panel's own repair, not this check. ${RETRY_IS_FREE}`
                 : probe.status === "already_current"
                   ? shape === "unstamped"
-                    ? `\n\nCHECKED, and the two sides disagree about this session's state: its ` +
-                      `fence NOW names the live canvas (${live}), yet this command reached the ` +
-                      `panel carrying no stamp at all — so the identity was established, or ` +
-                      `re-advertised, after this command went out. ${RETRY_IS_FREE}`
+                    ? // The COMPARISON, not a cause — the panel's own discipline. An
+                      // identity established between dispatch and this read explains
+                      // it, and so does this session having been re-bound onto another
+                      // tab in between; neither was witnessed, so neither is asserted.
+                      `\n\nCHECKED, and the two readings disagree: this session's fence NOW ` +
+                      `names the live canvas (${live}), yet this command reached the panel ` +
+                      `carrying no stamp at all. What produced that gap was not observed from ` +
+                      `here. ${RETRY_IS_FREE}`
                     : `\n\nCHECKED: this session's fence already names the live canvas ` +
                       `(${live}), so it was not the stale side and the disagreement is gone by ` +
                       `the time it was looked at. ${RETRY_IS_FREE} If it refuses again with the ` +
@@ -7662,17 +7666,27 @@ export function makePanelToolCtx(
                       `panel_open_workflow is the way to settle which one you mean.`
                   : probe.status === "diverged"
                     ? shape === "unstamped"
-                      ? `\n\nCHECKED, and this is a MISSING stamp rather than a wrong one: this ` +
-                        `session holds no workflow identity, so nothing was compared — the read ` +
-                        `was refused for arriving bare. The live canvas DOES have one ` +
+                      ? // Says only what the panel reported and what the probe read. It
+                        // does NOT assert that this session holds no fence right now:
+                        // `diverged` is also reached with a fence naming some third
+                        // workflow, and that reading was never taken.
+                        `\n\nCHECKED, and this is a MISSING stamp rather than a wrong one: the ` +
+                        `panel refused it for arriving with NO stamp, so no two identities were ` +
+                        `compared — this is not the case where you are pointed at another ` +
+                        `workflow. The live canvas DOES have an identity ` +
                         `(${live}). Nothing was adopted here; this check is read-only and the ` +
                         `fence is unchanged. RECOVERY: ` +
                         `panel_set_workflow_target({mode:"current"}) derives this session's ` +
                         `fence from the live canvas, after which this read carries a stamp and ` +
                         `runs.${pinNote}`
                       : shape === "stamped"
-                        ? `\n\nCHECKED, and this session was NOT re-pointed: it is fenced to ` +
-                          `${stamped} and the live canvas is a DIFFERENT workflow (${live}). ` +
+                        ? // "was issued for", not "is fenced to": the uuid comes from the
+                          // panel's account of what the COMMAND carried, and the session's
+                          // fence may have moved since. The mutation branch above words
+                          // it the same way for the same reason.
+                          `\n\nCHECKED, and this session was NOT re-pointed: this command was ` +
+                          `issued for ${stamped} and the live canvas is a DIFFERENT workflow ` +
+                          `(${live}). ` +
                           `This is a WRONG stamp, not a missing one, so the two exits are not ` +
                           `interchangeable: to read the workflow you issued for, bring it back ` +
                           `with panel_open_workflow; to read the live canvas instead, re-target ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -906,6 +906,27 @@ function isMutatingGraphCmd(cmd: Record<string, unknown>): boolean {
   return MUTATING_GRAPH_EDIT_CMDS.has(name);
 }
 
+/**
+ * #1519 — a graph command the panel FENCES that does not mutate the canvas.
+ *
+ * The panel's `activeWorkflowFenceApplies` fences every `graph_*` command, reads
+ * included, and exempts the recovery probe `workflow_list`
+ * (`commandIsCanvasTargetless`, panel #759). So "fenced, and not a mutation" is
+ * exactly the `graph_*` names that are not in MUTATING_GRAPH_EDIT_CMDS — derived
+ * from that one allowlist rather than kept as a second one, so a newly added edit
+ * command cannot drift into being classified as a read.
+ *
+ * The `graph_` prefix is load-bearing for a second reason: the diagnosis this
+ * gates runs `workflow_list`, which flows back through this same catch. Keying on
+ * the prefix keeps the probe OUT of the branch that launched it, so a panel that
+ * fences the probe too (a build predating the #759 exemption) surfaces its own
+ * refusal instead of recursing.
+ */
+function isFencedGraphRead(cmd: Record<string, unknown>): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  return name.startsWith("graph_") && !MUTATING_GRAPH_EDIT_CMDS.has(name);
+}
+
 /** True when an error is a TRANSIENT transport/reconnect drop (the tab went away
  *  or was replaced), NOT a genuine command error or a live-but-frozen reply
  *  timeout. Deliberately EXCLUDES "did not reply within N ms" (a backgrounded/
@@ -7530,6 +7551,138 @@ export function makePanelToolCtx(
             `(${probeErr instanceof Error ? probeErr.message : String(probeErr)})`;
         }
         return fail(`${name} was NOT applied — nothing changed. ${raw}${verdict}`);
+      }
+      // #1519 — THE SAME REFUSAL ON A READ, AND AN ABSENT STAMP IS NOT A WRONG ONE.
+      //
+      // The reporter's session resumed onto a different workflow and the very first
+      // live-canvas read came back
+      //
+      //   workflow instance mismatch: this command carries no workflow-instance
+      //   stamp, and the active canvas reports 2b3f4684-…. Nothing was applied.
+      //
+      // Measured on current main before this branch existed: that text is the ENTIRE
+      // tool result. The corroboration above is gated on `isMutatingGraphCmd`, so a
+      // READ refused by the very same fence fell through every branch here and the
+      // panel's raw refusal was surfaced verbatim — no verdict, no remedy. The
+      // reporter had to find `panel_set_workflow_target({mode:"current"})` on their
+      // own, which is the whole content of the report. #1480's guard already extends
+      // its diagnosis to reads "on purpose: `panel_graph_outline` refusing was half
+      // of the reported dead end"; this is the same reasoning for the stamp fence.
+      //
+      // TWO REFUSALS, NOT ONE. `isWorkflowInstanceMismatch` matches both of the
+      // panel's states, and they are different facts with OPPOSITE remedies:
+      //
+      //   "carries no workflow-instance stamp"  → this session has NO workflow
+      //       identity. Nothing was compared; the command was refused for arriving
+      //       bare. Deriving a fence from the live canvas is what fixes it.
+      //   "issued for workflow instance <uuid>" → this session HAS an identity and
+      //       the canvas disagrees with it. Deriving a fence from the live canvas
+      //       ABANDONS the workflow the caller named — the right move only if that
+      //       is what they meant.
+      //
+      // Collapsing them would hand the second case the first case's remedy, which is
+      // the retarget #1646 removed for cause. So the shape is read from the panel's
+      // own words and, when it matches NEITHER wording, the answer is UNKNOWN and is
+      // said to be — never guessed into one of the two.
+      //
+      // Read from the REFUSAL, never from `cmd.workflow_uuid`: the stamp is applied
+      // downstream of here, so that field is undefined at this point for BOTH states
+      // (the trap that silently disabled #1330's transient branch one block up).
+      //
+      // NOTHING IS ADOPTED. The probe is the same read-only one (`adopt:false`), so
+      // this reports which state it found and the fence moves only on an explicit
+      // rebind. The refusal itself is preserved verbatim and the call still fails.
+      if (isWorkflowInstanceMismatch(err) && isFencedGraphRead(cmd)) {
+        const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
+        const raw = err instanceof Error ? err.message : String(err);
+        const stamped = /issued for workflow instance ([0-9a-f-]{36})/i.exec(raw)?.[1] ?? null;
+        const unstamped = /carries no workflow-instance stamp/i.test(raw);
+        // Three-valued on purpose. A panel whose wording matches neither is not
+        // evidence for either state, and this branch must not manufacture one.
+        const shape: "unstamped" | "stamped" | "unstated" = unstamped
+          ? "unstamped"
+          : stamped
+            ? "stamped"
+            : "unstated";
+        // Naming `mode:"current"` to a PINNED session is naming something that also
+        // RELEASES the pin. Say so where it applies rather than letting the caller
+        // discover it by losing their target.
+        const pin = ctx.workflowTarget?.get(ctx.tabId);
+        const pinNote =
+          pin?.mode === "pinned" && pin.path
+            ? ` NOTE: this session is PINNED to ${pin.filename ?? pin.path}, and mode:"current" ` +
+              `RELEASES that pin. To keep it, bring that workflow back to the canvas with ` +
+              `panel_open_workflow(${JSON.stringify(pin.path)}) and retry instead.`
+            : "";
+        const RETRY_IS_FREE =
+          `RETRY THIS EXACT CALL ONCE — this is a read, so re-issuing it cannot double-apply ` +
+          `anything.`;
+        let verdict: string;
+        try {
+          const probe = await rebindWorkflowFence(ctx, { adopt: false });
+          const live = "uuid" in probe ? probe.uuid : null;
+          verdict =
+            probe.status === "no_identity"
+              ? `\n\nCHECKED, so this is not a guess: the live canvas was re-read and it carries ` +
+                `no workflow identity either (${probe.why}). ` +
+                `panel_set_workflow_target({mode:"current"}) will NOT clear this — it chooses ` +
+                `WHICH workflow to fence against and cannot mint an identity for one that has ` +
+                `none, so it reports success while this read keeps being refused. RECOVERY: ` +
+                `panel_open_workflow(<path>) on this same workflow; re-opening it is what gives ` +
+                `it an identity. If it has never been saved there is no path to re-open — save ` +
+                `it first with panel_save_workflow, which also gives it a stable identity.`
+              : probe.status === "healed_by_panel"
+                ? `\n\nCHECKED, and the answer CHANGED while it was being read: the panel ` +
+                  `re-advertised its identity and this session's fence moved to the live canvas ` +
+                  `(${live}) — through the panel's own repair, not this check. ${RETRY_IS_FREE}`
+                : probe.status === "already_current"
+                  ? shape === "unstamped"
+                    ? `\n\nCHECKED, and the two sides disagree about this session's state: its ` +
+                      `fence NOW names the live canvas (${live}), yet this command reached the ` +
+                      `panel carrying no stamp at all — so the identity was established, or ` +
+                      `re-advertised, after this command went out. ${RETRY_IS_FREE}`
+                    : `\n\nCHECKED: this session's fence already names the live canvas ` +
+                      `(${live}), so it was not the stale side and the disagreement is gone by ` +
+                      `the time it was looked at. ${RETRY_IS_FREE} If it refuses again with the ` +
+                      `same pair, the two identities are genuinely disagreeing and ` +
+                      `panel_open_workflow is the way to settle which one you mean.`
+                  : probe.status === "diverged"
+                    ? shape === "unstamped"
+                      ? `\n\nCHECKED, and this is a MISSING stamp rather than a wrong one: this ` +
+                        `session holds no workflow identity, so nothing was compared — the read ` +
+                        `was refused for arriving bare. The live canvas DOES have one ` +
+                        `(${live}). Nothing was adopted here; this check is read-only and the ` +
+                        `fence is unchanged. RECOVERY: ` +
+                        `panel_set_workflow_target({mode:"current"}) derives this session's ` +
+                        `fence from the live canvas, after which this read carries a stamp and ` +
+                        `runs.${pinNote}`
+                      : shape === "stamped"
+                        ? `\n\nCHECKED, and this session was NOT re-pointed: it is fenced to ` +
+                          `${stamped} and the live canvas is a DIFFERENT workflow (${live}). ` +
+                          `This is a WRONG stamp, not a missing one, so the two exits are not ` +
+                          `interchangeable: to read the workflow you issued for, bring it back ` +
+                          `with panel_open_workflow; to read the live canvas instead, re-target ` +
+                          `deliberately with panel_set_workflow_target({mode:"current"}) — that ` +
+                          `also re-points every later EDIT in this session, which is why it is ` +
+                          `never done for you off a refusal.${pinNote}`
+                        : `\n\nCHECKED, and the live canvas reports ${live}. Which side is ` +
+                          `stale is NOT known from here: this panel's refusal states neither ` +
+                          `that the command was unstamped nor which instance it was issued ` +
+                          `for, so no remedy is named for it — read panel_list_workflows (the ` +
+                          `panel exempts it from this fence) and decide which workflow you mean.`
+                    : `\n\nCHECKED, but the live canvas could not be established ` +
+                      `(${probe.status}), so the answer is UNKNOWN and the fence is unchanged. ` +
+                      `Try panel_list_workflows — the panel exempts that read from this fence ` +
+                      `(it is the recovery probe) — and re-select the workflow you mean with ` +
+                      `panel_open_workflow.`;
+        } catch (probeErr) {
+          // A diagnosis must never change how the call failed.
+          verdict =
+            `\n\nCHECKED, and the check itself threw, so the live canvas is UNKNOWN — this ` +
+            `refusal stands on its own terms and the fence is unchanged. ` +
+            `(${probeErr instanceof Error ? probeErr.message : String(probeErr)})`;
+        }
+        return fail(`${name} was refused before it ran — no graph data was read. ${raw}${verdict}`);
       }
       // #1480 — NAME A REMEDY THE TAB CAN ACTUALLY ACCEPT.
       //

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7633,8 +7633,12 @@ export function makePanelToolCtx(
           const live = "uuid" in probe ? probe.uuid : null;
           verdict =
             probe.status === "no_identity"
+              // Worded without reference to the session's own side, because this
+              // state is reachable from BOTH shapes: an unstamped session and a
+              // stamped one can each face a canvas with no readable identity, and
+              // "no identity EITHER" would be false for the second.
               ? `\n\nCHECKED, so this is not a guess: the live canvas was re-read and it carries ` +
-                `no workflow identity either (${probe.why}). ` +
+                `no workflow identity of its own (${probe.why}). ` +
                 `panel_set_workflow_target({mode:"current"}) will NOT clear this — it chooses ` +
                 `WHICH workflow to fence against and cannot mint an identity for one that has ` +
                 `none, so it reports success while this read keeps being refused. RECOVERY: ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7560,14 +7560,24 @@ export function makePanelToolCtx(
       //   workflow instance mismatch: this command carries no workflow-instance
       //   stamp, and the active canvas reports 2b3f4684-…. Nothing was applied.
       //
-      // Measured on current main before this branch existed: that text is the ENTIRE
-      // tool result. The corroboration above is gated on `isMutatingGraphCmd`, so a
-      // READ refused by the very same fence fell through every branch here and the
-      // panel's raw refusal was surfaced verbatim — no verdict, no remedy. The
-      // reporter had to find `panel_set_workflow_target({mode:"current"})` on their
-      // own, which is the whole content of the report. #1480's guard already extends
-      // its diagnosis to reads "on purpose: `panel_graph_outline` refusing was half
-      // of the reported dead end"; this is the same reasoning for the stamp fence.
+      // Measured on current main before this branch existed: the panel's refusal IS
+      // the entire tool result. The corroboration above is gated on
+      // `isMutatingGraphCmd`, so a READ refused by the very same fence fell through
+      // every branch here and this side added nothing at all. #1480's guard already
+      // extends its diagnosis to reads "on purpose: `panel_graph_outline` refusing
+      // was half of the reported dead end"; this is the same reasoning for the stamp
+      // fence.
+      //
+      // What the panel says on its own is NOT nothing, and the difference is the
+      // point. Since panel 0.11.83 its refusal ends "Re-target with
+      // panel_set_workflow_target({mode:"current"}), or re-select the intended
+      // workflow with panel_open_workflow, then retry" — both exits, offered as
+      // interchangeable, with nothing said about which one this refusal calls for.
+      // That is right for the panel, which by design "observed only that the two
+      // identities differ" and refuses to infer a cause; it is not enough for the
+      // caller, and in the #1331 state the first of the two cannot work at all — it
+      // reports success while the read keeps failing. Only this side can take the
+      // read that decides, so this side takes it.
       //
       // TWO REFUSALS, NOT ONE. `isWorkflowInstanceMismatch` matches both of the
       // panel's states, and they are different facts with OPPOSITE remedies:


### PR DESCRIPTION
A fenced graph **READ** is refused and the orchestrator adds nothing to it, so the two states behind that refusal reach the caller as one. This addresses the underlying cause of #1519.

## What I measured first

Driving `panel_graph_outline` through the real `ctx.call` path on `origin/main@a649ff7`, against a panel that refuses the unstamped command, the **entire tool result** is:

```
Error: workflow instance mismatch: this command carries no workflow-instance stamp,
and the active canvas reports 2b3f4684-…. Nothing was applied.
```

That is verbatim what #1519 was filed with. #1330's corroboration is gated on `isMutatingGraphCmd`, so a READ refused by the very same fence falls through every branch of the catch and **this side adds nothing at all**. #1480's guard already extends its diagnosis to reads "on purpose: `panel_graph_outline` refusing was half of the reported dead end"; this is the same reasoning for the stamp fence.

**What the panel says on its own is not nothing, and the difference is the point.** Reading `workflowInstanceMismatchMessage` on `comfyui-mcp-panel@origin/main` rather than the short form quoted in the report: since panel **0.11.83** the refusal ends

> Re-target with `panel_set_workflow_target({mode:"current"})`, or re-select the intended workflow with `panel_open_workflow`, then retry.

Both exits, offered as interchangeable, with nothing said about which one this refusal calls for. That is correct *for the panel* — by design it "observed only that the two identities differ" and refuses to infer a cause — and it is exactly the collapse below. In the #1331 state the first of the two cannot work at all: it reports success while the read keeps failing. Only the orchestrator can take the read that decides, so it takes it.

## Mechanism

`isWorkflowInstanceMismatch` matches **two** panel states with **opposite** remedies:

| the panel said | what it means | what fixes it |
| --- | --- | --- |
| `carries no workflow-instance stamp` | this session has **no** identity; nothing was compared | derive a fence from the live canvas |
| `issued for workflow instance <uuid>` | this session **has** an identity the canvas disagrees with | choose which workflow you meant — deriving from the live canvas **abandons** the one you named |

Collapsing them hands the second case the first case's remedy, which is the retarget #1646 removed for cause. So the shape is read from the panel's own words, each state names only its own remedy, and a wording matching **neither** is reported as unknown rather than guessed into one of the two.

Read from the **refusal**, never from `cmd.workflow_uuid`: the stamp is applied downstream of the catch, so that field is `undefined` for *both* states — the trap that silently disabled #1330's transient branch one block up.

Also handled: the live canvas having no identity **of its own** (#1331's lesson — `mode:"current"` reports success while the read keeps failing, so it is not offered), an unreadable probe (says UNKNOWN), and a **pinned** session (naming `mode:"current"` also discloses that it releases the pin, with the `panel_open_workflow` alternative).

## What this does NOT do

- **No position on the open design question** recorded in `ui-bridge.ts` — whether an unstamped read should be *admitted*. Nothing about what is dispatched, or about the panel's fence, changes.
- **Nothing is adopted.** The probe is the read-only `rebindWorkflowFence({adopt:false})`; the refusal still fails the call; the fence moves only on an explicit rebind.
- The mutation path is untouched (a control test pins its distinct `NOT applied — nothing changed` wording).

## Refutations I ran

Each one is a deletion, run against the new suite:

1. **Disable the branch** (`if (false && …)`) → **6 of 7 fail** (of the suite as it stood then). The survivor is the mutation-path control, which correctly stays green.
2. **Collapse absent and stamped into one state** (hard-code `shape = "unstamped"`) → **3 fail**: the WRONG-STAMP case, the UNSTATED case, and the WRONG-STAMP case driven from the panel's full real message. The anti-collapse property is what the assertions are made of — each case asserts its own remedy *and* asserts the other case's remedy is absent, so a verdict that merely mentioned rebinding cannot pass.
3. **Remove the re-entrancy guard** (drop the `graph_` prefix from `isFencedGraphRead`) → the diagnosis re-enters itself through its own `workflow_list` probe and **the vitest worker dies with a fatal error**. The guard is load-bearing; a panel predating the #759 probe exemption is the input that reaches it.
4. **Re-add `workflow instance mismatch` to the transient classifier** (which really does re-issue the read) → the corrected `switch-guard-retry` assertion still fails, so that harness change tightened the test rather than loosening it.

The classifier is also driven against the panel's **full message transcribed verbatim from v0.15.3**, both shapes — so the extra prose (which itself names both remedies) cannot flip the regexes. And the `no_identity` verdict is driven from *both* shapes: it is reachable from a stamped session too, so it says "no workflow identity **of its own**" rather than "either", which would be false for that half.

`switch-guard-retry.test.ts` needed a harness correction: its fixture counted **all** sends, so the diagnosis round trip read as a retry of the command under test. Its own prose asserts the first thing ("an instance mismatch is NOT retried"), so the fixture now records *which* command it was asked to send and the assertion is made about `graph_outline` itself.

## Cost

One read-only `workflow_list` on an already-failed read (plus the existing #1292 rechecks only when corroboration fails) — the same trade the mutation path has made since #1330: one informed round trip instead of N blind ones.

## Verification

- `tsc --noEmit` clean; `npm run build` clean.
- `npm run check:vocabulary`, `npm run check:unknown-collapse`, `npm run vocab:export -- --check`, `node scripts/asset-counts.mjs --check` — all pass locally.
- Full `vitest run`: the new file and `switch-guard-retry` are green. Unrelated failures on this loaded Windows box (`gen-changelog-dedupe`, `turn-watchdog`, `tool-surface-filter`, `vocabulary`, `training-jobs`) are all 30s wall-clock timeouts and pass in isolation; none import `panel-tools`. Leaving those to CI.
- **Not run:** the panel Playwright suite — this change is orchestrator-side only and renders nothing in the sidebar, so there is no panel-visible behaviour to cover.

## Gate

codex was unavailable (account exhausted until 2026-08-19); this PR is left for an independent adversarial review rather than self-gated. I did not run any gate script and did not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
