### PR TITLE
fix(1697): the download progress counter observes bytes instead of pacing them

### DIFF
--- a/src/__tests__/services/download-progress-counter.test.ts
+++ b/src/__tests__/services/download-progress-counter.test.ts
@@ -1,0 +1,129 @@
+// #1697 — the progress-counting Transform in streamUrlToFile must OBSERVE the
+// transfer, never pace it, and never misreport it.
+//
+// It was constructed with Node's default 16 KiB highWaterMark — the narrowest
+// buffer in a chain whose write stream alone buffers 64 KiB — so every chunk
+// cost a full backpressure circuit. Measured in the issue: 0.35–0.48 MB/s where
+// curl held 12 MB/s on the same link (~25x), a steady ~16 KiB per ~40 ms.
+//
+// Two things are pinned here:
+//   1. the counter's buffer depth is deep enough that it can never be the
+//      narrowest stage again, and bounded so a stalled sink can't grow memory
+//      without limit;
+//   2. counting honesty: through the deep buffer, the bytes the counter tallies
+//      are exactly the bytes that reached disk.
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    huggingfaceToken: undefined as string | undefined,
+    civitaiApiToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    isRemoteMode: () => !config.comfyuiPath,
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
+  };
+});
+
+/** Every progress row the counter publishes. Recorded through a module mock
+ *  because the real reporter writes to COMFYUI_MCP_PROGRESS_DIR, which is read
+ *  from the environment at import time (same seam download-retry.test.ts uses). */
+const progressRows = vi.hoisted(
+  () => [] as Array<{ status: string; downloaded: number; total?: number }>,
+);
+vi.mock("../../services/download-progress.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/download-progress.js")>(
+    "../../services/download-progress.js",
+  );
+  return {
+    ...actual,
+    reportDownloadProgress: (p: { status: string; downloaded: number; total?: number }) => {
+      progressRows.push({ status: p.status, downloaded: p.downloaded, total: p.total });
+    },
+  };
+});
+
+import { __downloadCacheTestHooks, downloadUrlToFile } from "../../services/download-cache.js";
+
+const fetchMock = vi.fn();
+let tempDir: string;
+
+/** A 200 response whose body arrives as MANY chunks (the counter's per-chunk
+ *  path), with an honest Content-Length so the completion check has something
+ *  authoritative to verify against. */
+function chunkedResponse(chunks: Buffer[]): Response {
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(new Uint8Array(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-length": String(total), "content-type": "application/octet-stream" },
+  });
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "comfyui-mcp-counter-test-"));
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  progressRows.length = 0;
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("progress counter buffer depth (#1697)", () => {
+  it("the counter's highWaterMark is deep enough to never pace the pipeline, and bounded", () => {
+    const hwm = __downloadCacheTestHooks.progressCounterHighWaterMark;
+    // Below 1 MiB the counter risks being the narrowest buffer in the chain
+    // again (the regression: 16 KiB vs the write stream's 64 KiB).
+    expect(hwm).toBeGreaterThanOrEqual(1024 * 1024);
+    // Deep, not unbounded: a stalled sink must not be able to buffer the whole
+    // model in memory.
+    expect(hwm).toBeLessThanOrEqual(64 * 1024 * 1024);
+  });
+
+  it("counts exactly the bytes that reach disk, across many chunks", async () => {
+    // 128 chunks of 48 KiB = 6 MiB — chunk sizes deliberately NOT a multiple of
+    // any stage's buffer, so the count survives arbitrary re-chunking.
+    const chunks = Array.from({ length: 128 }, (_, i) => Buffer.alloc(48 * 1024, i % 251));
+    const total = chunks.reduce((n, c) => n + c.length, 0);
+    fetchMock.mockResolvedValueOnce(chunkedResponse(chunks));
+
+    const target = join(tempDir, "model.bin");
+    await downloadUrlToFile(
+      "https://example.com/models/counter.bin",
+      target,
+      {},
+      undefined,
+      {},
+      { id: "counter-test", name: "counter.bin", attempt: 1 },
+      "", // no payload validation — this is about byte counting, not classification
+    );
+
+    const onDisk = await readFile(target);
+    expect(onDisk.length).toBe(total);
+    expect(onDisk.equals(Buffer.concat(chunks))).toBe(true);
+
+    // The counter's terminal row tallies exactly what landed — no drift between
+    // observed and written bytes.
+    const done = progressRows.find((r) => r.status === "done");
+    expect(done).toBeDefined();
+    expect(done!.downloaded).toBe(total);
+    // No row ever claims MORE than the transfer carried.
+    for (const row of progressRows) expect(row.downloaded).toBeLessThanOrEqual(total);
+    expect(progressRows.some((r) => r.status === "error")).toBe(false);
+  });
+});

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1125,8 +1125,17 @@ function cacheDir(): string {
  *  #1567 adds `cachePathForUrl` so a test can stage a `.partial` under a SPECIFIC
  *  header identity (the writer's own derivation) instead of re-implementing the
  *  hash — a fixture derived from a parallel implementation cannot falsify the
- *  lookup it feeds (#1370). */
-export const __downloadCacheTestHooks = { cacheDir, cachePathForUrl };
+ *  lookup it feeds (#1370).
+ *  #1697 adds `progressCounterHighWaterMark` (a getter: the constant is declared
+ *  further down, beside the pipeline it belongs to) so a test can pin the
+ *  progress counter's buffer depth without re-constructing the pipeline. */
+export const __downloadCacheTestHooks = {
+  cacheDir,
+  cachePathForUrl,
+  get progressCounterHighWaterMark() {
+    return PROGRESS_COUNTER_HIGH_WATER_MARK;
+  },
+};
 
 function cacheSizeLimitBytes(): number {
   const raw = Number(process.env.COMFYUI_LRU_CACHE_SIZE_GB ?? "0");
@@ -1323,6 +1332,22 @@ function normalizeEtag(value: string | null | undefined): string | null {
   if (/^[0-9a-f]+$/i.test(s)) s = s.toLowerCase();
   return s;
 }
+
+/** #1697 — buffer depth for the progress-counting Transform in streamUrlToFile.
+ *
+ *  Without an explicit highWaterMark a Transform inherits Node's 16 KiB default
+ *  and becomes the narrowest buffer in the chain (the write stream alone buffers
+ *  64 KiB): every chunk then costs a full backpressure circuit (source pause →
+ *  transform → sink → drain → resume), and when that circuit crosses a real
+ *  network/disk boundary its latency is tens of ms — a 20 GB download measured
+ *  0.35–0.48 MB/s while curl held 12 MB/s on the same link (~25x), steady at
+ *  ~16 KiB per ~40 ms, the signature of the 16 KiB window pacing the transfer.
+ *  The no-progress branch (a straight pipe, no interposed stream) does not
+ *  suffer it. A deep buffer lets the counter OBSERVE bytes instead of
+ *  rate-limiting them; bounded at 4 MiB so a stalled sink can't grow memory
+ *  without limit, and progress honesty is unchanged — counting is per chunk
+ *  either way and the tray emit is already time-windowed (400 ms). */
+const PROGRESS_COUNTER_HIGH_WATER_MARK = 4 * 1024 * 1024;
 
 async function streamUrlToFile(
   url: string,
@@ -2316,6 +2341,9 @@ async function streamUrlToFile(
       : undefined;
   emit("downloading", true); // show the row immediately, even before the first chunk
   const counter = new Transform({
+    // #1697 — deep enough that the counter OBSERVES bytes instead of pacing the
+    // pipeline; see PROGRESS_COUNTER_HIGH_WATER_MARK.
+    highWaterMark: PROGRESS_COUNTER_HIGH_WATER_MARK,
     transform(chunk: Buffer, _enc, cb) {
       downloaded += chunk.length;
       // Feed the watchdog FIRST and unconditionally — before the 400 ms throughput


### PR DESCRIPTION
## Root cause

`streamUrlToFile` has two branches. The no-progress branch is a straight `pipeline(nodeStream, fileStream)`. The progress branch inserts a byte-counting `Transform` between them — constructed with no stream options, so it inherited Node's default non-object-mode `highWaterMark` of **16 KiB**, the narrowest buffer in the chain (`createWriteStream` alone buffers 64 KiB). Every chunk then cost a full backpressure circuit (source pause → transform → sink → drain → resume). On the reporter's machine (macOS, Node via npx, 12 MB/s link) that circuit cost ~40 ms: a steady **~16 KiB per ~40 ms = 0.35–0.48 MB/s** on a 20 GB download where curl held 12 MB/s on the same link — the ~25x gap. The panel always attaches a progress row, so every user-facing download took the slow branch while internal/cache downloads took the fast one.

## Fix

The counter now gets an explicit, deep, **bounded** buffer (`PROGRESS_COUNTER_HIGH_WATER_MARK = 4 MiB`), so it *observes* bytes instead of pacing them. Progress honesty is unchanged — counting is per chunk either way, and the tray emit is already time-windowed (400 ms). The bound means a stalled sink can buffer at most 4 MiB, not the whole model.

- `src/services/download-cache.ts` — the one-line fix plus the reasoned constant; the constant is exposed via `__downloadCacheTestHooks` (a lazy getter — it's declared further down the module) so the regression test doesn't reconstruct the pipeline.
- `src/__tests__/services/download-progress-counter.test.ts` — pins the buffer depth (≥ 1 MiB so the counter can never be the narrowest stage again; ≤ 64 MiB so it stays bounded), and verifies counting honesty end-to-end: 128 chunks × 48 KiB through the real `downloadUrlToFile` progress path, asserting disk bytes == counter tally == terminal progress row, with no row ever over-counting. The pin test fails without the fix; both pass with it.

## Verification — and an honest caveat

**I could NOT reproduce the 25x gap on my machine**, so this fix is verified by construction and by guard test, not by a measured before/after on the affected environment. Live A/B against the issue's own URL (100 MB range, real `fetch` → `Readable.fromWeb` → counter → `createWriteStream` to disk, Node v24.16.0, Windows, fast link):

```
straight-pipe    : 79.70 MB/s  (100.0 MB in 1.3s)
counter-default  : 76.57 MB/s  (100.0 MB in 1.3s)   <- pre-fix shape: no slowdown HERE
counter-4MiB-hwm : 87.08 MB/s  (100.0 MB in 1.1s)   <- the fix: no regression
```

On a low-RTT, high-bandwidth link the pipeline never stays full long enough for the 16 KiB buffer to become the pacer — consistent with the diagnosis, which requires a per-circuit latency (network RTT + disk) of tens of ms to bite. The reporter's measurement (a steady 16 KiB per ~40 ms) is exactly the signature of the default HWM pacing the transfer. The fix removes the one stage whose buffer was 4x narrower than every other stage's, so the counter structurally cannot be the chokepoint regardless of link latency. It is the same change the issue author proposed but could not measure.

The issue also flagged `Readable.fromWeb(res.body)` per-chunk overhead as a secondary suspect if the HWM change doesn't close the full gap. On Node 24 that wrapper showed no measurable cost here (76 MB/s through it); left untouched — if the reporter still sees a gap after this, that's the next place to look.

## Gates (worktree on `origin/main`)

- `npm ci` — clean
- `npm run build` (`tsc`) — clean, exit 0 (run twice: pre- and post-rebase)
- `npm test` (full chain, exit code captured) — 10,216 passed / 3 skipped; the only failures across two full runs were 30 s **timeout** flakes (zero assertion failures) in three suites unrelated to this change: `gen-changelog-dedupe`, `tool-surface-filter`, `vocabulary`. All three pass in isolation on this branch; `gen-changelog-dedupe` is inherently load-sensitive (every case takes 14–45 s against the 30 s timeout — it spins up git fixtures — and this machine was running other heavy jobs). All download suites pass: `download-progress-counter` (new), `download-cache`, `download-cache-failclosed`, `download-retry` — 145/145. The new pin test fails when the fix is reverted.

Closes #1697
