### PR TITLE
fix(panel#1339): a fence this call REPAIRED is not a fence that was already fine — and the verdict rides in a field

### DIFF
--- a/src/__tests__/orchestrator/fence-repair-vs-already-current.test.ts
+++ b/src/__tests__/orchestrator/fence-repair-vs-already-current.test.ts
@@ -49,20 +49,27 @@ const LIVE_UUID = "55555555-5555-4555-8555-555555555555";
 
 type Fence = { known: false } | { known: true; uuid?: string };
 
-/** The refusal the bridge really mints for this state: `markDispatched(err, false)`
- *  — the typed proof that the frame never reached the socket (ui-bridge.ts). */
-const identityRefusal = (tagged = true): Error => {
+/** The dispatch flag the error carries. `no` is what the bridge really mints for this
+ *  state (`markDispatched(err, false)` — typed proof the frame never reached the
+ *  socket). The other two are the hostile cases: an error whose TEXT satisfies the
+ *  branch's phrase match while the flag says the opposite, or is absent entirely. */
+type Dispatch = "no" | "yes" | "untagged";
+
+const identityRefusal = (dispatch: Dispatch = "no"): Error => {
   const err = new Error(
     `"graph_set_widget" cannot be safely targeted to the active workflow: this workflow has ` +
       `no trusted identity for the panel to fence the command against. Reads and view-only ` +
       `commands still work (graph_outline, graph_query, graph_get_state).`,
   );
-  // `tagged:false` is the hostile case: an error whose TEXT satisfies the branch's
-  // phrase match but which carries no dispatch flag at all.
-  return tagged ? markDispatched(err, false) : err;
+  return dispatch === "untagged" ? err : markDispatched(err, dispatch === "yes");
 };
 
-function bridge(opts: { fence: Fence; activeUuid: string | null | "throw"; tagged?: boolean }) {
+function bridge(opts: {
+  fence: Fence;
+  activeUuid: string | null | "throw";
+  dispatch?: Dispatch;
+  adoptThrows?: boolean;
+}) {
   const b = {
     send: async (cmd: Record<string, unknown>) => {
       if (cmd.cmd === "workflow_list") {
@@ -74,14 +81,19 @@ function bridge(opts: { fence: Fence; activeUuid: string | null | "throw"; tagge
         };
         return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
       }
-      throw identityRefusal(opts.tagged ?? true);
+      throw identityRefusal(opts.dispatch ?? "no");
     },
     push: () => 1,
     canReach: (id: string) => id === TAB,
     isHeadless: () => false,
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => TAB,
-    refreshWorkflowUuid: () => true,
+    // A THROW out of the adoption is `adopt_error`: it can land on either side of the
+    // fence write, so whether the fence moved is genuinely unknown.
+    refreshWorkflowUuid: () => {
+      if (opts.adoptThrows) throw new Error("the fence validator threw mid-write");
+      return true;
+    },
     workflowUuidFor: () => opts.fence,
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
@@ -92,7 +104,8 @@ function bridge(opts: { fence: Fence; activeUuid: string | null | "throw"; tagge
 async function setWidget(opts: {
   fence: Fence;
   activeUuid: string | null | "throw";
-  tagged?: boolean;
+  dispatch?: Dispatch;
+  adoptThrows?: boolean;
 }): Promise<{ text: string; res: ToolResult; fence: Record<string, unknown> | undefined }> {
   const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
@@ -106,8 +119,22 @@ async function setWidget(opts: {
   };
 }
 
-/** THE ONE THIS CALL REPAIRED: no fence on the tab, live canvas has an identity. */
-const REFRESHED = { fence: { known: false } as Fence, activeUuid: LIVE_UUID };
+/** THE ONE THIS CALL REPAIRED, with the prior fence DEFINITIVELY ABSENT.
+ *  `{known: true}` and not `{known: false}` — FenceRead's contract makes the first
+ *  "there is no fence" and the second "the read failed", and mislabelling the second
+ *  as the first is the exact fold this file is about. It is also the read that matches
+ *  the refusal: the bridge raises "no trusted identity" only when the resolver answered
+ *  and answered empty. */
+const REFRESHED = { fence: { known: true } as Fence, activeUuid: LIVE_UUID };
+/** Same `refreshed` verdict, DIFFERENT prior: the read itself failed. */
+const REFRESHED_UNREADABLE_PRIOR = { fence: { known: false } as Fence, activeUuid: LIVE_UUID };
+/** Same `refreshed` verdict, DIFFERENT prior again: a fence naming ANOTHER workflow,
+ *  which the adoption replaced. Reachable when the session is re-bound mid-check. */
+const OTHER_UUID = "99999999-9999-4999-8999-999999999999";
+const REFRESHED_OTHER_PRIOR = {
+  fence: { known: true, uuid: OTHER_UUID } as Fence,
+  activeUuid: LIVE_UUID,
+};
 /** THE ONE IT DID NOT: a fence read back already present and already equal. */
 const ALREADY_CURRENT = { fence: { known: true, uuid: LIVE_UUID } as Fence, activeUuid: LIVE_UUID };
 
@@ -125,7 +152,109 @@ describe("the two states behind one sentence are told apart (panel#1339)", () =>
     expect(fence?.retry_clears_refusal).toBe("yes");
     expect(fence?.next_action).toBe("retry_same_call");
     expect(fence?.workflow_uuid).toBe(LIVE_UUID);
+    expect(fence?.prior_fence).toBe("absent");
   });
+});
+
+// `refreshed` is returned for EVERY prior that is not a known-equal fence, which is
+// three different priors. Only one of them is an absence, and FenceRead's own contract
+// forbids reporting the other two as one ("an absence nobody observed"). The first draft
+// of this fix said "this session had NO fence for it" on all three — the same collapse
+// this PR removes, reintroduced inside its own replacement message.
+describe("a refreshed fence reports the prior it actually observed (panel#1339)", () => {
+  it("ABSENT: the only prior that may be called 'no fence'", async () => {
+    const { text, fence } = await setWidget(REFRESHED);
+    expect(fence?.prior_fence).toBe("absent");
+    expect(fence?.prior_fence_uuid).toBeUndefined();
+    expect(text).toMatch(/this session had NO fence for it/);
+  });
+
+  it("UNREADABLE: the read FAILED, so no absence is claimed", async () => {
+    const { text, fence } = await setWidget(REFRESHED_UNREADABLE_PRIOR);
+    expect(fence?.rebind_status).toBe("refreshed");
+    expect(fence?.prior_fence).toBe("unreadable");
+    // The exact false claim.
+    expect(text).not.toMatch(/had NO fence/);
+    expect(text).toMatch(/prior fence could not be read/);
+    // …and it still says the repair happened, which IS established.
+    expect(text).toMatch(/THIS CALL installed one/);
+  });
+
+  it("PRESENT: a DIFFERENT workflow's fence was replaced, and it says which", async () => {
+    const { text, fence } = await setWidget(REFRESHED_OTHER_PRIOR);
+    expect(fence?.rebind_status).toBe("refreshed");
+    expect(fence?.prior_fence).toBe("present");
+    expect(fence?.prior_fence_uuid).toBe(OTHER_UUID);
+    expect(text).not.toMatch(/had NO fence/);
+    expect(text).toMatch(/named a DIFFERENT workflow/);
+    expect(text).toContain(OTHER_UUID);
+  });
+
+  it("THE FOLD: the three priors are distinguishable in the field", async () => {
+    const priors = await Promise.all(
+      [REFRESHED, REFRESHED_UNREADABLE_PRIOR, REFRESHED_OTHER_PRIOR].map(async (s) =>
+        (await setWidget(s)).fence?.prior_fence,
+      ),
+    );
+    expect(new Set(priors).size).toBe(3);
+  });
+});
+
+describe("a retry is never ORDERED while the write's fate is open (panel#1339)", () => {
+  it("dispatched:yes — no retry order, and no claim that the flag is absent", async () => {
+    // Latent today (the `markDispatched(…, true)` sites mint their own text and never
+    // carry this phrase), but the branch is new code and reproduced the collapse:
+    // a two-way ternary printed "carries no dispatch flag" for a flag that said `true`,
+    // beside `retry_safe:"no"` and an unconditional "RETRY THIS EXACT CALL ONCE".
+    const { text, fence } = await setWidget({ ...REFRESHED, dispatch: "yes" });
+
+    expect(fence?.dispatched).toBe("yes");
+    expect(fence?.retry_safe).toBe("no");
+    // The verdict must not contradict retry_safe.
+    expect(fence?.next_action).toBe("verify_applied_then_decide");
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+    expect(text).not.toMatch(/carries no dispatch flag/);
+    expect(text).not.toMatch(/cannot double-apply/);
+    expect(text).toMatch(/WAS written to the socket/);
+  });
+
+  it("dispatched:unknown — also declines to order one", async () => {
+    const { text, fence } = await setWidget({ ...REFRESHED, dispatch: "untagged" });
+    expect(fence?.retry_safe).toBe("unknown");
+    expect(fence?.next_action).toBe("verify_applied_then_decide");
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+  });
+
+  it("the three dispatch states produce three different verdicts", async () => {
+    const seen = await Promise.all(
+      (["no", "yes", "untagged"] as const).map(async (d) => {
+        const { fence } = await setWidget({ ...REFRESHED, dispatch: d });
+        return `${String(fence?.dispatched)}/${String(fence?.retry_safe)}`;
+      }),
+    );
+    expect(new Set(seen).size).toBe(3);
+  });
+});
+
+describe("adopt_error is the one status that may not claim nothing was repaired", () => {
+  it("a THROW out of the adoption reports fence_repaired_by_this_call:unknown", async () => {
+    // The throw can land on either side of the fence write, so "no" would be a state
+    // nobody observed — the same rule rebindWorkflowFence applies one level down when
+    // it declines to reuse `rejected`.
+    const { fence } = await setWidget({ ...REFRESHED, adoptThrows: true });
+    expect(fence?.rebind_status).toBe("adopt_error");
+    expect(fence?.fence_repaired_by_this_call).toBe("unknown");
+    expect(fence?.retry_clears_refusal).toBe("unknown");
+  });
+
+  it("…and every OTHER tail status still says no", async () => {
+    const { fence } = await setWidget({ fence: { known: false }, activeUuid: "throw" });
+    expect(fence?.rebind_status).not.toBe("adopt_error");
+    expect(fence?.fence_repaired_by_this_call).toBe("no");
+  });
+});
+
+describe("the two states behind one sentence are told apart, continued", () => {
 
   it("already_current: says NOTHING was repaired, and does not order a blind retry", async () => {
     const { text, fence } = await setWidget(ALREADY_CURRENT);
@@ -196,7 +325,7 @@ describe("the retry-safety claim stands on the bridge's typed flag, never on the
     // re-surfaced error can contain. Deciding "it is safe to re-run this mutation"
     // off that match is precisely the move this repo forbids. The word match may
     // choose WHAT TO EXPLAIN; only the bridge's flag may authorise a re-run.
-    const { text, fence } = await setWidget({ ...REFRESHED, tagged: false });
+    const { text, fence } = await setWidget({ ...REFRESHED, dispatch: "untagged" });
 
     expect(fence?.dispatched).toBe("unknown");
     expect(fence?.retry_safe).toBe("unknown");

--- a/src/__tests__/orchestrator/fence-repair-vs-already-current.test.ts
+++ b/src/__tests__/orchestrator/fence-repair-vs-already-current.test.ts
@@ -1,0 +1,279 @@
+// panel#1339 — "panel_set_widget transiently rejects matching re-derived workflow identity".
+//
+// The reporter's call was refused with "this workflow has no trusted identity for the
+// panel to fence the command against", was told the identity "DOES carry an identity
+// (<uuid>) and this session's fence has been re-derived onto it", retried, and it
+// worked. They filed it as a contradiction and read it as a race.
+//
+// It is not a race. The FAILED CALL IS THE REPAIR: on this path `rebindWorkflowFence`
+// adopts, so the refusal installs the fence the retry then succeeds with. What is
+// actually broken is that ONE sentence covered two opposite outcomes:
+//
+//   refreshed        the tab had no fence and THIS CALL installed it → retry
+//   already_current  the fence read back already present and equal, which cannot be
+//                    the fence the command was refused against (the refusal proves
+//                    that one was missing) → nothing was repaired, and the uuid
+//                    quoted belongs to a tab reached during the check
+//
+// and those want opposite next moves. Taxonomy class 1: two distinct states collapsed
+// into one indistinguishable answer.
+//
+// The prose split is half the fix. The half that matters for a PROGRAM is that the
+// verdict must be readable without parsing the sentence — this project's standing rule
+// is that an agent never decides to re-run a mutation by pattern-matching an error
+// message. So the discriminator rides in `structuredContent.panel_fence`, and the
+// "nothing was applied" half of it rests on the BRIDGE'S typed dispatch flag, never on
+// the phrase match that selects the branch.
+
+import { describe, expect, it } from "vitest";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  registerPanelTools,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/niji_holo_impasto.json";
+const LIVE_UUID = "55555555-5555-4555-8555-555555555555";
+
+type Fence = { known: false } | { known: true; uuid?: string };
+
+/** The refusal the bridge really mints for this state: `markDispatched(err, false)`
+ *  — the typed proof that the frame never reached the socket (ui-bridge.ts). */
+const identityRefusal = (tagged = true): Error => {
+  const err = new Error(
+    `"graph_set_widget" cannot be safely targeted to the active workflow: this workflow has ` +
+      `no trusted identity for the panel to fence the command against. Reads and view-only ` +
+      `commands still work (graph_outline, graph_query, graph_get_state).`,
+  );
+  // `tagged:false` is the hostile case: an error whose TEXT satisfies the branch's
+  // phrase match but which carries no dispatch flag at all.
+  return tagged ? markDispatched(err, false) : err;
+};
+
+function bridge(opts: { fence: Fence; activeUuid: string | null | "throw"; tagged?: boolean }) {
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        if (opts.activeUuid === "throw") throw new Error("panel did not answer");
+        const active = {
+          path: "workflows/niji_holo_impasto.json",
+          routing_key: TAB,
+          ...(opts.activeUuid ? { workflow_uuid: opts.activeUuid } : {}),
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      throw identityRefusal(opts.tagged ?? true);
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => opts.fence,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return b;
+}
+
+async function setWidget(opts: {
+  fence: Fence;
+  activeUuid: string | null | "throw";
+  tagged?: boolean;
+}): Promise<{ text: string; res: ToolResult; fence: Record<string, unknown> | undefined }> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler({ node_id: 7, widget: "steps", value: 20 } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    res,
+    fence: (res.structuredContent as { panel_fence?: Record<string, unknown> } | undefined)
+      ?.panel_fence,
+  };
+}
+
+/** THE ONE THIS CALL REPAIRED: no fence on the tab, live canvas has an identity. */
+const REFRESHED = { fence: { known: false } as Fence, activeUuid: LIVE_UUID };
+/** THE ONE IT DID NOT: a fence read back already present and already equal. */
+const ALREADY_CURRENT = { fence: { known: true, uuid: LIVE_UUID } as Fence, activeUuid: LIVE_UUID };
+
+describe("the two states behind one sentence are told apart (panel#1339)", () => {
+  it("refreshed: says THIS CALL installed the fence, and the field says so too", async () => {
+    const { text, fence } = await setWidget(REFRESHED);
+
+    expect(text).toMatch(/THIS CALL installed one/);
+    expect(text).toContain(LIVE_UUID);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+
+    expect(fence).toBeDefined();
+    expect(fence?.rebind_status).toBe("refreshed");
+    expect(fence?.fence_repaired_by_this_call).toBe("yes");
+    expect(fence?.retry_clears_refusal).toBe("yes");
+    expect(fence?.next_action).toBe("retry_same_call");
+    expect(fence?.workflow_uuid).toBe(LIVE_UUID);
+  });
+
+  it("already_current: says NOTHING was repaired, and does not order a blind retry", async () => {
+    const { text, fence } = await setWidget(ALREADY_CURRENT);
+
+    expect(text).toMatch(/THIS CALL REPAIRED NOTHING/);
+    // The claim the reporter read as a contradiction must be gone from THIS state.
+    expect(text).not.toMatch(/this session's fence has been re-derived onto it/);
+    expect(text).not.toMatch(/THIS CALL installed one/);
+    expect(text).toMatch(/CONFIRM THE TARGET BEFORE RETRYING/);
+
+    expect(fence).toBeDefined();
+    expect(fence?.rebind_status).toBe("already_current");
+    expect(fence?.fence_repaired_by_this_call).toBe("no");
+    // Not "yes" and not "no": nothing here establishes whose tab that fence is.
+    expect(fence?.retry_clears_refusal).toBe("unknown");
+    expect(fence?.next_action).toBe("confirm_target_then_retry");
+  });
+
+  it("THE COLLAPSE: the two answers differ in the FIELD, not only in the prose", async () => {
+    // This is the whole defect. Before the fix both states returned the identical
+    // sentence and NO structured half at all, so a caller had exactly one observation
+    // for two opposite situations.
+    const a = await setWidget(REFRESHED);
+    const b = await setWidget(ALREADY_CURRENT);
+
+    expect(a.fence, "the refreshed refusal carries no machine-readable verdict").toBeDefined();
+    expect(b.fence, "the already_current refusal carries no machine-readable verdict").toBeDefined();
+    expect(a.fence?.fence_repaired_by_this_call).not.toBe(b.fence?.fence_repaired_by_this_call);
+    expect(a.fence?.next_action).not.toBe(b.fence?.next_action);
+    expect(a.fence?.rebind_status).not.toBe(b.fence?.rebind_status);
+    // …and a caller reading ONLY the field never has to look at the sentence.
+    expect(a.text).not.toBe(b.text);
+  });
+
+  it("no_identity keeps its remedy, and the field agrees a retry will NOT clear it", async () => {
+    const { text, fence } = await setWidget({ fence: { known: false }, activeUuid: null });
+
+    expect(text).toMatch(/CHECKED, so this is not a guess/);
+    expect(text).toMatch(/panel_open_workflow\(<path>\)/);
+    expect(text).toMatch(/panel_save_workflow/);
+    expect(fence?.rebind_status).toBe("no_identity");
+    expect(fence?.retry_clears_refusal).toBe("no");
+    expect(fence?.next_action).toBe("open_or_save_workflow");
+    expect(fence?.fence_repaired_by_this_call).toBe("no");
+  });
+
+  it("unreadable stays UNKNOWN in the field as well as in the sentence", async () => {
+    const { text, fence } = await setWidget({ fence: { known: false }, activeUuid: "throw" });
+
+    expect(text).toMatch(/the answer is UNKNOWN/);
+    expect(fence?.retry_clears_refusal).toBe("unknown");
+    expect(fence?.next_action).toBe("open_workflow");
+  });
+});
+
+describe("the retry-safety claim stands on the bridge's typed flag, never on the text", () => {
+  it("a TAGGED refusal reports retry_safe:yes and says nothing was applied", async () => {
+    const { text, fence } = await setWidget(REFRESHED);
+
+    expect(fence?.dispatched).toBe("no");
+    expect(fence?.retry_safe).toBe("yes");
+    expect(text).toMatch(/never written to the socket/);
+    expect(text).toMatch(/cannot double-apply/);
+  });
+
+  it("an UNTAGGED error with the same words gets retry_safe:unknown, and no promise", async () => {
+    // The branch is selected by /no trusted identity/i — a phrase any wrapped or
+    // re-surfaced error can contain. Deciding "it is safe to re-run this mutation"
+    // off that match is precisely the move this repo forbids. The word match may
+    // choose WHAT TO EXPLAIN; only the bridge's flag may authorise a re-run.
+    const { text, fence } = await setWidget({ ...REFRESHED, tagged: false });
+
+    expect(fence?.dispatched).toBe("unknown");
+    expect(fence?.retry_safe).toBe("unknown");
+    expect(text).not.toMatch(/cannot double-apply/);
+    expect(text).toMatch(/is NOT established here/);
+  });
+});
+
+describe("explaining the refusal never becomes letting one through", () => {
+  it("every state still REFUSES and still carries the panel's own cause", async () => {
+    const states: Array<{ fence: Fence; activeUuid: string | null | "throw" }> = [
+      REFRESHED,
+      ALREADY_CURRENT,
+      { fence: { known: false }, activeUuid: null },
+      { fence: { known: false }, activeUuid: "throw" },
+    ];
+    for (const state of states) {
+      const { text, res } = await setWidget(state);
+      expect(res.isError).toBe(true);
+      expect(text).toMatch(/^Error:/);
+      expect(text).toMatch(/no trusted identity/);
+    }
+  });
+});
+
+describe("WIRING: the field survives the real MCP transport on an isError result", () => {
+  it("a real Client sees structuredContent.panel_fence on the refusal", async () => {
+    // The reachability claim, and it is NOT covered by #1589's test: that one proves
+    // the SDK forwards `structuredContent` on a SUCCESS. A refusal takes a different
+    // shape (`isError: true`), and a caller that cannot read the field over the wire
+    // is back to parsing the sentence.
+    const server = new McpServer({ name: "fence-1339-test", version: "1.0.0" });
+    registerPanelTools(
+      server,
+      makePanelToolCtx(bridge(ALREADY_CURRENT), TAB, new WorkflowTargetStore()),
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "fence-1339-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const res = await client.callTool({
+        name: "panel_set_widget",
+        arguments: { node_id: 7, widget: "steps", value: 20 },
+      });
+      expect(res.isError).toBe(true);
+      const structured = res.structuredContent as
+        | { panel_fence?: Record<string, unknown> }
+        | undefined;
+      expect(structured?.panel_fence, "the verdict did not survive the MCP round trip").toBeDefined();
+      expect(structured?.panel_fence?.fence_repaired_by_this_call).toBe("no");
+      expect(structured?.panel_fence?.next_action).toBe("confirm_target_then_retry");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("SOURCE: the CALL SITE emits the verdict, and the two statuses are not re-merged", () => {
+    // A behavioural test proves today's build answers correctly. It cannot see an edit
+    // that folds the two branches back into one `||` while leaving a helper that still
+    // compiles, so read the call site itself.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+    const at = src.indexOf("if (isNoTrustedIdentityRefusal(err) && isMutatingGraphCmd(cmd)) {");
+    expect(at, "the no-trusted-identity branch is gone").toBeGreaterThan(0);
+    const body = src.slice(at, at + 8000);
+
+    // The exact shape of the bug.
+    expect(body).not.toMatch(/rebind\.status === "refreshed" \|\| rebind\.status === "already_current"/);
+    // Two separate decisions, each with its own answer…
+    expect(body).toMatch(/rebind\.status === "refreshed"/);
+    expect(body).toMatch(/rebind\.status === "already_current"/);
+    // …and the machine-readable half is produced HERE, not merely available somewhere.
+    expect(body).toContain("failWithFenceDiagnosis");
+    // The retry-safety claim reads the typed flag at this call site.
+    expect(body).toContain("dispatchOutcomeOf(err)");
+  });
+});

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -509,7 +509,20 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
       tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
       resolveActiveTabId: () => [...live][0],
       refreshWorkflowUuid: () => true,
-      workflowUuidFor: () => ({ known: true, uuid: LIVE_UUID }),
+      // panel#1339 — THE HARNESS WAS DESCRIBING A STATE THE BRIDGE CANNOT BE IN, and the
+      // collapsed message is what hid it. This said `{ known: true, uuid: LIVE_UUID }`:
+      // a fence PRESENT on this tab and already equal to the live canvas. But the
+      // refusal above is raised only when `resolveTabWorkflowUuid(tabId)` is EMPTY
+      // (ui-bridge: `hasTrustedStamp` false), and `workflowUuidFor` reads that same
+      // resolver — so a real bridge cannot refuse with "no trusted identity" AND report
+      // a fence for the same tab in the same breath.
+      //
+      // With that shape the rebind returned `already_current`, not `refreshed` — the
+      // opposite state — and the assertions below still passed, because ONE sentence
+      // covered both. The test was pinning the wrong branch and could not tell.
+      // `{ known: true }` is the read that matches the refusal: the fence is definitively
+      // ABSENT (FenceRead's own contract), which is #709's state and yields `refreshed`.
+      workflowUuidFor: () => ({ known: true }),
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
 
@@ -528,6 +541,13 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     expect(text).toMatch(/CHECKED: the live canvas DOES carry an identity/);
     expect(text).toContain(LIVE_UUID);
     expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // panel#1339 — and pin WHICH branch produced that, structurally. Asserting only on
+    // the sentence is how this test silently drifted onto `already_current` above; the
+    // field is the thing that can tell the two apart, so it is what the test reads.
+    expect(
+      (res.structuredContent as { panel_fence?: { rebind_status?: string } } | undefined)
+        ?.panel_fence?.rebind_status,
+    ).toBe("refreshed");
   });
 
   it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7542,16 +7542,23 @@ export function makePanelToolCtx(
       //                    repair. A bare retry is the right move and works because
       //                    of it — which is why it looked "transient": the first call
       //                    did the work and reported failure.
-      //   already_current  the fence read back as ALREADY PRESENT AND EQUAL. It
-      //                    cannot have been that for the tab the command was refused
-      //                    on (the refusal proves that tab's stamp was empty, and
-      //                    currentWorkflowFence reads the same resolver), so this is
-      //                    a fence for a tab this session reached DURING the check —
-      //                    rebindWorkflowFence's own workflow_list round trip is
-      //                    retry-safe, and its retry runs ensureReachable, which can
-      //                    move an orphaned mode:"current" session onto another tab.
-      //                    NOTHING WAS REPAIRED for the caller, and the uuid quoted is
-      //                    not necessarily the one they were refused against.
+      //   already_current  the fence read back as ALREADY PRESENT AND EQUAL. It cannot
+      //                    have been that at dispatch — the refusal is proof the stamp
+      //                    was empty, and currentWorkflowFence reads the same resolver
+      //                    the bridge consulted — so a fence appeared between the two
+      //                    reads, and NOT because of this call: `already_current`
+      //                    returns BEFORE any adoption. Two things produce it and this
+      //                    code cannot tell them apart, which is why it asserts
+      //                    neither: the session was moved onto a DIFFERENT tab while
+      //                    the check ran (rebindWorkflowFence's workflow_list round
+      //                    trip is retry-safe, its retry runs ensureReachable, and
+      //                    `before` is then re-read for the new tab), or a fence for
+      //                    THIS tab was installed in that window by something else (a
+      //                    concurrent rebind, or the panel's own mismatch re-hello,
+      //                    #1043/#932). Either way NOTHING WAS REPAIRED for the caller
+      //                    and the uuid quoted may not be the one they were refused
+      //                    against — so the remedy is to confirm the target, not to
+      //                    name a mechanism nobody measured.
       //
       // Splitting the sentence is half the fix. The other half is that the answer must
       // be readable WITHOUT parsing the sentence: an agent deciding to re-run a
@@ -7630,9 +7637,11 @@ export function makePanelToolCtx(
               `${raw}\n\nCHECKED, and THIS CALL REPAIRED NOTHING: the re-read found a fence that ` +
                 `was ALREADY present and already named the live canvas (${rebind.uuid}). That ` +
                 `cannot be the fence your command was refused against — the refusal is proof ` +
-                `that one was missing — so this session reached a DIFFERENT tab while the check ` +
-                `ran, and ${rebind.uuid} is that tab's identity, not necessarily the one you ` +
-                `asked for. CONFIRM THE TARGET BEFORE RETRYING: ` +
+                `that one was missing — so a fence appeared between the two reads, and not ` +
+                `through this call. It is EITHER a fence for a different tab this session was ` +
+                `moved onto while the check ran, OR one installed for this tab by something ` +
+                `else in that window; nothing here can tell which, so ${rebind.uuid} is not ` +
+                `claimed to be the identity you asked for. CONFIRM THE TARGET BEFORE RETRYING: ` +
                 `panel_set_workflow_target({mode:"current"}) if you mean the canvas that is live ` +
                 `now, or panel_open_workflow(<path>) for the workflow you actually meant; then ` +
                 `re-issue.${nothingApplied} A bare retry is not refused by this message — it is ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -278,6 +278,72 @@ function fail(err: unknown): ToolResult {
   const msg = err instanceof Error ? err.message : String(err);
   return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
 }
+
+/**
+ * panel#1339 — the MACHINE-READABLE half of a `no trusted identity` refusal.
+ *
+ * The prose half of this refusal used ONE sentence for two opposite outcomes
+ * (`refreshed` and `already_current`), so the caller could not tell "answering you
+ * is what installed your fence — retry" from "this call repaired nothing, and the
+ * identity quoted is not necessarily the one you were refused against". Splitting
+ * the sentence fixes the reading; it does not fix the DECIDING, because deciding
+ * from a sentence means an agent re-runs a mutation by pattern-matching an error
+ * message. That is the one thing this project never does. So the discriminator is
+ * carried as a field.
+ *
+ * EVERY field is tri-state on purpose. A boolean here would recreate the exact
+ * collapse this exists to remove: `false` would have to mean both "no" and "we
+ * could not find out", and those demand different next actions.
+ *
+ * `dispatched` is read from the BRIDGE'S OWN typed flag (`dispatchOutcomeOf`), never
+ * from the message text. The predicate that selects this whole branch
+ * (`isNoTrustedIdentityRefusal`) IS a text match, which is fine for choosing what to
+ * explain and unfit for authorising a re-run: any error that merely quotes the phrase
+ * would satisfy it. So the "nothing was applied" claim — the claim a caller would act
+ * on — stands on the typed flag alone, and says `unknown` when the flag is absent.
+ */
+type FenceRepairDiagnosis = {
+  /** Was the mutation written to the panel socket? From the bridge's typed flag only. */
+  dispatched: "no" | "yes" | "unknown";
+  /** May this exact call be re-issued without risking a DOUBLE-APPLY? `yes` only
+   *  when `dispatched` is `no` — i.e. only when the bridge itself said so. */
+  retry_safe: "yes" | "no" | "unknown";
+  /** The read-only re-derivation's own verdict, verbatim, so a caller never has to
+   *  re-derive it from the wording. `check_threw` = the diagnosis itself failed. */
+  rebind_status: WorkflowFenceRebind["status"] | "check_threw";
+  /** THE DISCRIMINATOR. `yes` = this refusal is what installed the fence, so the
+   *  retry works because of it. `no` = nothing was repaired for you. */
+  fence_repaired_by_this_call: "yes" | "no" | "unknown";
+  /** Is a bare re-issue expected to get PAST the fence? Independent of `retry_safe`,
+   *  which only says a re-issue is harmless. */
+  retry_clears_refusal: "yes" | "no" | "unknown";
+  /** The one next call to make. */
+  next_action:
+    | "retry_same_call"
+    | "confirm_target_then_retry"
+    | "open_workflow"
+    | "open_or_save_workflow"
+    | "unknown";
+  /** The live workflow identity the check read, when it read one. */
+  workflow_uuid?: string;
+  /** RAW EVIDENCE, not a verdict: the routing key this session was bound to before and
+   *  after the check. `tab_before === tab_after` does NOT prove the session never
+   *  moved — a move-and-return is invisible to it — which is precisely why
+   *  `retry_clears_refusal` stays `unknown` on the `already_current` path rather than
+   *  being derived from this pair. */
+  tab_before: string;
+  tab_after: string;
+};
+
+/** A refusal that also carries {@link FenceRepairDiagnosis}. The text is unchanged by
+ *  this wrapper: the field is ADDITIVE, so a client that ignores structuredContent
+ *  reads exactly what it read before. */
+function failWithFenceDiagnosis(text: string, diagnosis: FenceRepairDiagnosis): ToolResult {
+  const res = fail(text);
+  res.structuredContent = { panel_fence: diagnosis };
+  return res;
+}
+
 /**
  * #971 — the AMBIGUOUS-rebind refusal, worded so it can be acted on.
  *
@@ -7463,12 +7529,71 @@ export function makePanelToolCtx(
       // The bridge cannot tell them apart — from its side both are "no identity". The
       // orchestrator can, with the same read-only re-derivation the documented recovery
       // performs. So it is measured, once, and the answer names the remedy that fits.
+      // panel#1339 — `refreshed` AND `already_current` ARE NOT THE SAME ANSWER.
+      //
+      // The branch below used to return ONE sentence for both: "the live canvas DOES
+      // carry an identity (<uuid>) and this session's fence has been re-derived onto
+      // it. RETRY THIS EXACT CALL ONCE". The reporter read that as a contradiction —
+      // told the identity had *already* been re-derived, yet refused anyway — and the
+      // two states it covers want opposite next moves:
+      //
+      //   refreshed        the tab had NO fence and THIS CALL installed one, derived
+      //                    from the live canvas. The refusal you are holding is the
+      //                    repair. A bare retry is the right move and works because
+      //                    of it — which is why it looked "transient": the first call
+      //                    did the work and reported failure.
+      //   already_current  the fence read back as ALREADY PRESENT AND EQUAL. It
+      //                    cannot have been that for the tab the command was refused
+      //                    on (the refusal proves that tab's stamp was empty, and
+      //                    currentWorkflowFence reads the same resolver), so this is
+      //                    a fence for a tab this session reached DURING the check —
+      //                    rebindWorkflowFence's own workflow_list round trip is
+      //                    retry-safe, and its retry runs ensureReachable, which can
+      //                    move an orphaned mode:"current" session onto another tab.
+      //                    NOTHING WAS REPAIRED for the caller, and the uuid quoted is
+      //                    not necessarily the one they were refused against.
+      //
+      // Splitting the sentence is half the fix. The other half is that the answer must
+      // be readable WITHOUT parsing the sentence: an agent deciding to re-run a
+      // mutation off matched error prose is how a write gets double-applied. See
+      // FenceRepairDiagnosis — the verdict, and the bridge-owned dispatch flag the
+      // "nothing was applied" claim rests on, ride in structuredContent.
+      //
+      // What does NOT change: every branch still REFUSES. The call really did not
+      // perform the widget write — it performed the repair — and a refusal that
+      // repairs and REPORTS is a different risk from one that repairs and PROCEEDS
+      // (#1646 removed exactly that from the neighbouring branch). Nothing here
+      // auto-continues the mutation.
       if (isNoTrustedIdentityRefusal(err) && isMutatingGraphCmd(cmd)) {
         const raw = err instanceof Error ? err.message : String(err);
+        // The TYPED flag, not the text predicate above: `isNoTrustedIdentityRefusal`
+        // is a phrase match and would fire on anything that merely quotes the phrase.
+        // Only the bridge can say whether the frame reached the socket.
+        const dispatchFlag = dispatchOutcomeOf(err);
+        const dispatched: FenceRepairDiagnosis["dispatched"] =
+          dispatchFlag === false ? "no" : dispatchFlag === true ? "yes" : "unknown";
+        const retrySafe: FenceRepairDiagnosis["retry_safe"] =
+          dispatched === "no" ? "yes" : dispatched === "yes" ? "no" : "unknown";
+        // Stated only when the bridge PROVED it. The old wording promised "nothing was
+        // applied, so a retry cannot double-apply" on the strength of the phrase match.
+        const nothingApplied =
+          dispatched === "no"
+            ? ` Nothing was applied (the bridge reports this frame was never written to the ` +
+              `socket), so re-issuing cannot double-apply.`
+            : ` Whether anything was applied is NOT established here — this refusal carries no ` +
+              `dispatch flag — so do not re-issue on the strength of this message alone.`;
+        const tabBefore = ctx.tabId;
         try {
           const rebind = await rebindWorkflowFence(ctx);
+          const base = {
+            dispatched,
+            retry_safe: retrySafe,
+            rebind_status: rebind.status,
+            tab_before: tabBefore,
+            tab_after: ctx.tabId,
+          } as const;
           if (rebind.status === "no_identity") {
-            return fail(
+            return failWithFenceDiagnosis(
               `${raw}\n\nCHECKED, so this is not a guess: the live canvas was re-read and it ` +
                 `carries no workflow identity either (${rebind.why}). ` +
                 `panel_set_workflow_target({mode:"current"}) will NOT clear this — it chooses ` +
@@ -7477,26 +7602,84 @@ export function makePanelToolCtx(
                 `panel_open_workflow(<path>) on this same workflow; re-opening it is what gives ` +
                 `it an identity. If it has never been saved there is no path to re-open — save ` +
                 `it first with panel_save_workflow, which also gives it a stable identity.`,
+              {
+                ...base,
+                fence_repaired_by_this_call: "no",
+                retry_clears_refusal: "no",
+                next_action: "open_or_save_workflow",
+              },
             );
           }
-          if (rebind.status === "refreshed" || rebind.status === "already_current") {
-            return fail(
-              `${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}) and ` +
-                `this session's fence has been re-derived onto it. RETRY THIS EXACT CALL ONCE — ` +
-                `nothing was applied, so a retry cannot double-apply.`,
+          if (rebind.status === "refreshed") {
+            return failWithFenceDiagnosis(
+              `${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}), this ` +
+                `session had NO fence for it, and THIS CALL installed one — the refusal you are ` +
+                `reading is what repaired it, which is why the same call refused now and ` +
+                `succeeds next. RETRY THIS EXACT CALL ONCE.${nothingApplied}`,
+              {
+                ...base,
+                workflow_uuid: rebind.uuid,
+                fence_repaired_by_this_call: "yes",
+                retry_clears_refusal: "yes",
+                next_action: "retry_same_call",
+              },
+            );
+          }
+          if (rebind.status === "already_current") {
+            return failWithFenceDiagnosis(
+              `${raw}\n\nCHECKED, and THIS CALL REPAIRED NOTHING: the re-read found a fence that ` +
+                `was ALREADY present and already named the live canvas (${rebind.uuid}). That ` +
+                `cannot be the fence your command was refused against — the refusal is proof ` +
+                `that one was missing — so this session reached a DIFFERENT tab while the check ` +
+                `ran, and ${rebind.uuid} is that tab's identity, not necessarily the one you ` +
+                `asked for. CONFIRM THE TARGET BEFORE RETRYING: ` +
+                `panel_set_workflow_target({mode:"current"}) if you mean the canvas that is live ` +
+                `now, or panel_open_workflow(<path>) for the workflow you actually meant; then ` +
+                `re-issue.${nothingApplied} A bare retry is not refused by this message — it is ` +
+                `simply not aimed at anything this check verified.`,
+              {
+                ...base,
+                workflow_uuid: rebind.uuid,
+                fence_repaired_by_this_call: "no",
+                // NOT "yes". A retry would carry the fence this read saw, but nothing
+                // here establishes that it belongs to the tab the caller addressed.
+                retry_clears_refusal: "unknown",
+                next_action: "confirm_target_then_retry",
+              },
             );
           }
           // unreadable / uncorroborated — say so rather than picking a remedy.
-          return fail(
+          return failWithFenceDiagnosis(
             `${raw}\n\nCHECKED, and the answer is UNKNOWN: the live canvas could not be re-read ` +
               `well enough to say whether it has an identity. Try ` +
               `panel_open_workflow(<path>) on the workflow you mean — it is the only recovery ` +
               `that works in BOTH states, because it gives the workflow an identity rather than ` +
               `adopting one that may not exist.`,
+            {
+              ...base,
+              ...(("uuid" in rebind) ? { workflow_uuid: rebind.uuid } : {}),
+              // `adopt_error` is the one status that cannot say which side of the write
+              // it threw on, so it is the one that may not claim "nothing was repaired".
+              fence_repaired_by_this_call: rebind.status === "adopt_error" ? "unknown" : "no",
+              retry_clears_refusal: "unknown",
+              next_action: "open_workflow",
+            },
           );
         } catch {
-          // The diagnosis must never change how the call failed.
-          return fail(raw);
+          // The diagnosis must never change how the call failed — so the TEXT is the
+          // bare cause, exactly as before. The field is still emitted, saying unknown:
+          // a caller that has to distinguish "no field" from "field says unknown" is
+          // back to inferring, which is the defect this fix is about.
+          return failWithFenceDiagnosis(raw, {
+            dispatched,
+            retry_safe: retrySafe,
+            rebind_status: "check_threw",
+            tab_before: tabBefore,
+            tab_after: ctx.tabId,
+            fence_repaired_by_this_call: "unknown",
+            retry_clears_refusal: "unknown",
+            next_action: "unknown",
+          });
         }
       }
       // #1330 — CORROBORATE A FENCE MISMATCH INSTEAD OF LETTING IT REPEAT.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -317,13 +317,25 @@ type FenceRepairDiagnosis = {
   /** Is a bare re-issue expected to get PAST the fence? Independent of `retry_safe`,
    *  which only says a re-issue is harmless. */
   retry_clears_refusal: "yes" | "no" | "unknown";
-  /** The one next call to make. */
+  /** The one next call to make. `verify_applied_then_decide` is what any branch
+   *  degrades to when `dispatched` is not `no`: the fence question may be settled,
+   *  but ordering a re-issue while the original write's fate is open is how a
+   *  mutation gets double-applied. */
   next_action:
     | "retry_same_call"
     | "confirm_target_then_retry"
+    | "verify_applied_then_decide"
     | "open_workflow"
     | "open_or_save_workflow"
     | "unknown";
+  /** WHAT THIS SESSION'S FENCE WAS before the check, as its own tri-state — because
+   *  `refreshed` covers three different priors and only one of them is an absence:
+   *  `absent` = definitively none; `present` = a fence naming a DIFFERENT workflow,
+   *  which the adoption replaced (`prior_fence_uuid` names it); `unreadable` = the
+   *  read failed, so nothing is claimed either way. Folding `unreadable` into
+   *  `absent` is the fold FenceRead's own contract forbids. */
+  prior_fence: "absent" | "present" | "unreadable";
+  prior_fence_uuid?: string;
   /** The live workflow identity the check read, when it read one. */
   workflow_uuid?: string;
   /** RAW EVIDENCE, not a verdict: the routing key this session was bound to before and
@@ -7581,21 +7593,56 @@ export function makePanelToolCtx(
           dispatchFlag === false ? "no" : dispatchFlag === true ? "yes" : "unknown";
         const retrySafe: FenceRepairDiagnosis["retry_safe"] =
           dispatched === "no" ? "yes" : dispatched === "yes" ? "no" : "unknown";
-        // Stated only when the bridge PROVED it. The old wording promised "nothing was
-        // applied, so a retry cannot double-apply" on the strength of the phrase match.
+        // THREE-WAY, because the flag is three-way. A two-way ternary here printed
+        // "this refusal carries no dispatch flag" for a refusal whose flag was
+        // present and said `true` — the same collapse this whole branch exists to
+        // remove, reintroduced one level up (review of this PR). Each arm states the
+        // observation it actually has.
         const nothingApplied =
           dispatched === "no"
             ? ` Nothing was applied (the bridge reports this frame was never written to the ` +
               `socket), so re-issuing cannot double-apply.`
-            : ` Whether anything was applied is NOT established here — this refusal carries no ` +
-              `dispatch flag — so do not re-issue on the strength of this message alone.`;
+            : dispatched === "yes"
+              ? ` CAUTION — the bridge reports this frame WAS written to the socket, so the ` +
+                `mutation may ALREADY have been applied. Do not re-issue it blindly; establish ` +
+                `what landed first (read the node back with panel_query_graph).`
+              : ` Whether anything was applied is NOT established here — this refusal carries no ` +
+                `dispatch flag — so do not re-issue on the strength of this message alone.`;
+        // A retry may only be ORDERED when the bridge proved nothing was written.
+        // Otherwise the instruction contradicts `retry_safe`, which is exactly what a
+        // caller keys on: "RETRY THIS EXACT CALL ONCE" beside `retry_safe:"no"` is a
+        // self-contradictory verdict, and the prose is the half an agent obeys.
+        const mayOrderRetry = dispatched === "no";
+        const retryOrder = mayOrderRetry
+          ? `RETRY THIS EXACT CALL ONCE.`
+          : `The fence is repaired, so the same call should now pass it — but re-issue only ` +
+            `after settling the question below.`;
+        // …and the machine-readable step follows the same rule.
+        const retryAction = (fallback: FenceRepairDiagnosis["next_action"]) =>
+          mayOrderRetry ? fallback : ("verify_applied_then_decide" as const);
         const tabBefore = ctx.tabId;
         try {
           const rebind = await rebindWorkflowFence(ctx);
+          // WHAT WAS THERE BEFORE, reported as the tri-state it is rather than folded
+          // into an absence. `refreshed` is returned for every `before` that is not a
+          // known-equal fence, which is THREE different priors: definitively none, a
+          // read that FAILED, and a fence naming a DIFFERENT workflow that was then
+          // replaced. FenceRead's own contract forbids collapsing the second into the
+          // first ("an absence nobody observed"), and a first draft of this message did
+          // exactly that by saying "this session had NO fence for it" on all three.
+          const priorFence: FenceRepairDiagnosis["prior_fence"] = !rebind.before.known
+            ? "unreadable"
+            : rebind.before.uuid
+              ? "present"
+              : "absent";
           const base = {
             dispatched,
             retry_safe: retrySafe,
             rebind_status: rebind.status,
+            prior_fence: priorFence,
+            ...(rebind.before.known && rebind.before.uuid
+              ? { prior_fence_uuid: rebind.before.uuid }
+              : {}),
             tab_before: tabBefore,
             tab_after: ctx.tabId,
           } as const;
@@ -7618,17 +7665,29 @@ export function makePanelToolCtx(
             );
           }
           if (rebind.status === "refreshed") {
+            // Only what was OBSERVED about the prior fence. Each arm is a different
+            // fact with a different implication, and "no fence" is true for exactly
+            // one of them.
+            const wasBefore =
+              priorFence === "absent"
+                ? `this session had NO fence for it`
+                : priorFence === "present"
+                  ? `this session's fence named a DIFFERENT workflow (${
+                      rebind.before.known ? rebind.before.uuid : ""
+                    }), which has been REPLACED`
+                  : `this session's prior fence could not be read, so whether there was one is ` +
+                    `not claimed here`;
             return failWithFenceDiagnosis(
-              `${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}), this ` +
-                `session had NO fence for it, and THIS CALL installed one — the refusal you are ` +
-                `reading is what repaired it, which is why the same call refused now and ` +
-                `succeeds next. RETRY THIS EXACT CALL ONCE.${nothingApplied}`,
+              `${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}), ` +
+                `${wasBefore}, and THIS CALL installed one derived from that canvas — the ` +
+                `refusal you are reading is what repaired it, which is why the same call ` +
+                `refused now and passes the fence next. ${retryOrder}${nothingApplied}`,
               {
                 ...base,
                 workflow_uuid: rebind.uuid,
                 fence_repaired_by_this_call: "yes",
                 retry_clears_refusal: "yes",
-                next_action: "retry_same_call",
+                next_action: retryAction("retry_same_call"),
               },
             );
           }
@@ -7653,7 +7712,7 @@ export function makePanelToolCtx(
                 // NOT "yes". A retry would carry the fence this read saw, but nothing
                 // here establishes that it belongs to the tab the caller addressed.
                 retry_clears_refusal: "unknown",
-                next_action: "confirm_target_then_retry",
+                next_action: retryAction("confirm_target_then_retry"),
               },
             );
           }
@@ -7683,6 +7742,9 @@ export function makePanelToolCtx(
             dispatched,
             retry_safe: retrySafe,
             rebind_status: "check_threw",
+            // The check threw, so it never reported a `before` — that is not an
+            // absence, it is an unmade observation.
+            prior_fence: "unreadable",
             tab_before: tabBefore,
             tab_after: ctx.tabId,
             fence_repaired_by_this_call: "unknown",


### PR DESCRIPTION
Addresses the underlying cause of artokun/comfyui-mcp-panel#1339 — "panel_set_widget
transiently rejects matching re-derived workflow identity". The symptom was filed against the
panel; the code is here. All three strings in that report have zero occurrences in the panel's
`web/js/` and live in `src/services/ui-bridge.ts` and `src/orchestrator/panel-tools.ts`, and
the refusal is raised pre-dispatch, so no panel code ran on the failing call. The panel issue
is correctly labelled `autopilot:parked`.

## It is not a race, and there is no window

The reporter read the retry as a timing window closing. It is not. **The failed call is the
repair.** On the `no trusted identity` path `panel-tools` calls `rebindWorkflowFence(ctx)` with
adoption enabled (unlike the mismatch branch next door, which #1646 moved to `{adopt:false}`).
It reads the panel's fence-exempt `workflow_list`, corroborates the active record, finds a real
uuid and installs it. The retry then succeeds *because the first call already fixed the fence*.
Nothing settled, nothing flapped.

## The defect: two opposite outcomes, one sentence

```ts
if (rebind.status === "refreshed" || rebind.status === "already_current") {
  return fail(`${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}) and ` +
    `this session's fence has been re-derived onto it. RETRY THIS EXACT CALL ONCE — …`);
}
```

Taxonomy class 1. The two branches mean opposite things and want opposite next moves:

* **`refreshed`** — the tab had **no** fence and *this call installed one*. A bare retry is
  right, and works because of the repair.
* **`already_current`** — the fence read back **already present and already equal**, and
  `already_current` returns *before* any adoption, so this call did not install it. It also
  cannot be the fence the command was refused against: that refusal is raised only when
  `resolveTabWorkflowUuid(tabId)` is empty (ui-bridge `hasTrustedStamp`), and
  `currentWorkflowFence` reads the same resolver. So a fence appeared between the two reads.
  **Two things produce that and this code cannot tell them apart**, so it asserts neither:
  the session was moved onto a different tab mid-check (`rebindWorkflowFence`'s
  `workflow_list` round trip is retry-safe, its retry runs `ensureReachable`, which can move
  an orphaned `mode:"current"` session, and `before` is then re-read for the new tab), or a
  fence for this tab was installed in that window by something else (a concurrent rebind, or
  the panel's own mismatch re-hello, #1043/#932). Either way **nothing was repaired for the
  caller** and the uuid in the message may not be the one they were refused against.

One sentence for both told the reporter the identity "had already been re-derived" — which
reads as *it was fine all along and you were refused anyway*. That is why this was filed as a
contradiction.

## The fix

**1. The prose is split.** `refreshed` now says this call installed the fence and that the
refusal itself is the repair. `already_current` says `THIS CALL REPAIRED NOTHING`, says why the
identity it names may not be the caller's, and asks them to confirm the target
(`panel_set_workflow_target({mode:"current"})` or `panel_open_workflow(<path>)`) before
re-issuing — rather than ordering a blind retry at a tab they never asked for.

**2. The verdict rides in a structured field, because prose is not a decision procedure.**
The standing rule here is that an agent must never re-run a mutation by pattern-matching an
error message. A caller that has to parse the sentence to know whether to retry is still
broken, so the refusal now carries `structuredContent.panel_fence`:

| field | values | what a caller does with it |
|---|---|---|
| `rebind_status` | the re-derivation's own verdict (`refreshed`, `already_current`, `no_identity`, `unreadable`, …, `check_threw`) | branch on it instead of on wording |
| `fence_repaired_by_this_call` | `yes` / `no` / `unknown` | **the discriminator.** `yes` = the refusal you are holding is the repair |
| `retry_safe` | `yes` / `no` / `unknown` | may I re-issue without a double-apply? |
| `retry_clears_refusal` | `yes` / `no` / `unknown` | will re-issuing get past the fence? |
| `next_action` | `retry_same_call`, `confirm_target_then_retry`, `open_workflow`, `open_or_save_workflow`, `unknown` | one machine-selectable step |
| `dispatched` | `no` / `yes` / `unknown` | from the bridge's typed flag |
| `workflow_uuid`, `tab_before`, `tab_after` | evidence | — |

Every field is tri-state on purpose: a boolean would recreate the exact collapse this removes,
with `false` meaning both "no" and "we could not find out".

`refreshed` → `fence_repaired_by_this_call:"yes"`, `retry_clears_refusal:"yes"`,
`next_action:"retry_same_call"`. `already_current` → `"no"`, `"unknown"`,
`"confirm_target_then_retry"`. Note `retry_clears_refusal` is **not** `"yes"` for
`already_current` even though a retry would carry *a* fence: nothing on that path establishes
whose tab that fence belongs to, and `tab_before === tab_after` does not prove the session never
moved (a move-and-return is invisible to a bare id comparison), which is why the field says
`unknown` rather than being derived from that pair.

**3. `retry_safe` stands on the bridge's typed flag, never on the text.** The predicate that
selects this branch, `isNoTrustedIdentityRefusal`, is `/no trusted identity/i` — fine for
choosing *what to explain*, unfit for authorising a re-run, since any error quoting the phrase
satisfies it. The claim now reads `dispatchOutcomeOf(err)` (the bridge's `markDispatched`
symbol) and says `unknown` when the flag is absent — and the prose drops "nothing was applied,
so a retry cannot double-apply" in that case instead of promising it on a word match.

## What deliberately stays a refusal

The call really did not perform the widget write; it performed the repair. Every branch still
returns `isError`, still carries the panel's own cause verbatim, and nothing auto-continues the
mutation. Executing a write against a fence the same request just minted is the shape #1646
removed from the neighbouring branch — a refusal that repairs and *reports* is not the same
risk as one that repairs and *proceeds*.

## A pre-existing test was pinning the wrong branch

`panel-session-rebind-residuals.test.ts`'s `#709/#1331` case set
`workflowUuidFor: () => ({known: true, uuid: LIVE_UUID})` — a fence present and equal — while
its `send` threw the `no trusted identity` refusal for the same tab. A real bridge cannot do
both: that refusal fires only when the resolver is empty, and `workflowUuidFor` reads the same
resolver. So the harness was driving `already_current` while asserting the `refreshed` wording,
**and it passed**, because one sentence covered both. Fixed to `{known: true}` (FenceRead's
"definitively no fence"), which is #709's actual state, and the test now also asserts
`rebind_status === "refreshed"` structurally so it cannot drift back silently.

## Refutation

Each mutation was applied with an explicit `git diff` check first — the file is CRLF on disk
and an LF-anchored substitution silently no-ops on it (the first attempt did exactly that and
was caught by an exit-9 guard, not by a passing test).

| # | mutation | `git diff` confirmed applied | result |
|---|---|---|---|
| 1 | delete `res.structuredContent = …` in `failWithFenceDiagnosis` | `-1 line` | **8 of 10 fail** |
| 2 | re-merge the branches into `refreshed \|\| already_current` | `-1/+1` | **4 fail** (already_current, THE COLLAPSE, transport, SOURCE) |
| 3 | derive `dispatched` from the branch instead of the typed flag (`= "no"`) | `-1/+1` | **1 fails** (the untagged-error case) |
| 4 | `already_current` claims `retry_clears_refusal:"yes"` / `retry_same_call` | `-2/+2` | **3 fail** |
| 5 | revert `panel-tools.ts` to `origin/main` wholesale | index+worktree replaced | **9 of 10 fail** |

The one survivor under (5) is "every state still REFUSES", which is a pre-existing property and
should survive. The suite also asserts the **call site** (`panel_set_widget`'s handler, end to
end) rather than the helper, plus a SOURCE assertion that the two statuses are not re-merged,
and a real `McpServer` + `Client` round trip proving `structuredContent` survives the SDK
transport **on an `isError` result** — #1589's existing wiring test only covers a success.

## Test results

* New file `src/__tests__/orchestrator/fence-repair-vs-already-current.test.ts` — 10/10.
* Neighbouring fence suites (`no-trusted-identity-remedy`, `fence-matching-uuid`,
  `fence-mismatch-corroborates`, `fence-rebind-transient`, `fence-refusal-reason`,
  `fence-trusts-own-reply`, `strip-workflow-parseable-reply`) — 58/58.
* `src/__tests__/orchestrator` — 165 files, 2838 tests, all pass.
* `tsc --noEmit` clean; `check:vocabulary`, `check:unknown-collapse`, `vocab:export --check`
  all OK locally.

## Review round 2 — the replacement message reproduced the collapse it replaced

Two defects the gate found in my OWN new code, both agent-facing, both this PR's own class.
Fixed in 141cd18.

**(a) `refreshed` asserted an absence it never observed.** `refreshed` is returned for every
prior that is not a known-equal fence, which is THREE priors: definitively none, a read that
FAILED, and a fence naming a DIFFERENT workflow that the adoption replaced. My text said "this
session had NO fence for it" for all three — the exact fold `FenceRead`'s own contract
forbids ("an absence nobody observed"). main's wording was true in all three; mine was
strictly stronger and newly false in two. Each prior now gets its own sentence, and the
observation rides in `prior_fence: "absent" | "present" | "unreadable"` (+ `prior_fence_uuid`)
rather than in the wording. The same mislabel in this PR's own fixture is fixed too:
`REFRESHED` was `{known:false}` under the label "no fence on the tab" and is now `{known:true}`,
which is also the read that matches the refusal.

**(b) The `nothingApplied` ternary was two-way over a three-way flag.** A `dispatched:true`
refusal got a sentence claiming the flag was absent, printed beside `retry_safe:"no"` and an
unconditional "RETRY THIS EXACT CALL ONCE" — a four-way self-contradictory verdict, and the
prose is the half an agent obeys. Latent today (the `markDispatched(…, true)` sites mint their
own text and never carry the phrase), but it is new code. Each dispatch state now gets its own
sentence, and **a retry is only ORDERED when the bridge proved nothing was written** — otherwise
`next_action` degrades to the new `verify_applied_then_decide` and the prose stops ordering one.

**(c) Optional, taken:** the `adopt_error` tri-state shipped correct but unpinned — collapsing
it to a bare `"no"` left the suite green. It now has a test.

Four more mutations, each `git diff`-confirmed applied: re-collapse the three priors → 2 fail;
revert `nothingApplied` to two-way → 1 fails; ungate the retry order (`mayOrderRetry = true`) →
2 fail; collapse the `adopt_error` tri-state → 1 fails. Re-running the original re-merge
mutation against the final code still kills 4. Suite is 19/19; the seven neighbouring fence
suites are 88/88.

## Adversarial re-read of my own diff

Commit 4cfb814 exists because of it. My first `already_current` wording asserted "this session
reached a DIFFERENT tab while the check ran" as fact. That is one of two mechanisms that
produce the observation and nothing in this code measures which — the exact "prose overstates
what the code does" class. The message now states what was observed (a fence appeared between
the refusal and the re-read, and not through this call), names both possibilities, and lets the
remedy follow from the observation instead of from a mechanism nobody proved.

## Verified against CURRENT main, not just my base

The CI run on head `141cd18` is an `event=pull_request` run, so `actions/checkout@v4` built
`refs/pull/1740/merge` — this branch merged into the base tip — and all four checks passed.
Main then advanced again ~6 minutes after that run started, and **8 of the 13 commits it gained
touch `panel-tools.ts`**, several of them fence code (#1519, #1650, #1639, panel#1292). A green
check is only green for the main it ran against, so that was re-checked directly rather than
assumed:

* Local test-merge of `origin/main` (8d85be9) into this branch: **no conflicts**.
* `tsc --noEmit` on the merged tree: **clean**.
* `src/__tests__/orchestrator` on the merged tree, serial: **173 files, 2916 tests, all pass**
  — including the eight new suites those commits added (`fenced-read-absent-stamp`,
  `open-content-mismatch-fence`, `current-bind-clears-ambiguity`, …).
* The merge was then discarded; the branch is still the linear `141cd18` that CI signed off.

For reference, the same suite at `141cd18` run serially is 165 files / 2847 tests, all pass —
which is what identifies the earlier parallel-run failures on this box as load, not defects.

## What I did not do

* **No gate script was run** (`codex exec` is account-exhausted until 2026-08-19 20:43 and
  `claude-gate.mjs` is blocked on the weekly limit). Gating and merging are the orchestrator's.
* **No Playwright run.** Nothing here is panel-rendered: the panel emits none of these strings,
  and the refusal is raised before any frame reaches the socket. No `web/js/` file is touched.
* I did not chase *which* orchestrator path left the stamp empty in the first place. The
  scope-addressed stamp comes from `turnOrigins.stampOf` and `resolvedPinOf` can clear it; I
  have evidence for where the message is wrong, not for which of those produced the empty
  stamp, and I am not asserting the second.
* I did not make the refusal auto-continue the mutation, and did not touch the
  `already_current` handling in the #1330 mismatch branch, which is a different (read-only)
  probe.
* I did not touch an adjacent pre-existing inaccuracy: `healed_by_panel` falls into the
  "could not be re-read well enough" tail message, which is wrong for it (the read succeeded;
  the panel repaired the fence underneath). Out of scope here, and the new field at least
  reports `rebind_status:"healed_by_panel"` truthfully where the sentence does not.
* Local full-suite runs on this box show a varying set of unrelated failures (4 in one run, 12
  in the next, none reproducible when the same files are run alone, and identical with
  `panel-tools.ts` reverted to `origin/main`) — this machine is running a dozen agents and the
  logs are full of EISDIR/temp contention. Every one of those files passes when run alone
  (5 files, 111 tests, green), and CI is green on all three OS legs — so they are box load, not
  this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
