### PR TITLE
fix(1669): degrade panel_search_nodes when Manager cache mappings return HTTP 500

### DIFF
--- a/src/__tests__/orchestrator/panel-search-nodes-manager-500.test.ts
+++ b/src/__tests__/orchestrator/panel-search-nodes-manager-500.test.ts
@@ -1,0 +1,62 @@
+// #1669 — panel_search_nodes must not fail the whole search on a Manager
+// cache-mappings HTTP 500.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { buildPanelToolDefs, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { setFetchMappingsForTests } from "../../services/manager-node-search.js";
+
+afterEach(() => setFetchMappingsForTests(undefined));
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+describe("panel_search_nodes (#1669 mappings 500)", () => {
+  it("still returns packs when the panel fail()s cache mappings HTTP 500", async () => {
+    setFetchMappingsForTests(async (mode) => {
+      if (mode === "cache") {
+        throw new Error("Manager customnode/getmappings?mode=cache: HTTP 500");
+      }
+      return {
+        "https://github.com/someone/ComfyUI-SolAttn": [
+          ["SolAttnPatch"],
+          { title: "SolAttn", description: "patch" },
+        ],
+      };
+    });
+    const ctx = {
+      call: async () => ({
+        isError: true,
+        content: [{ type: "text", text: "Error: Manager customnode/getmappings?mode=cache: HTTP 500" }],
+      }),
+    } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_search_nodes").handler({ query: "SolAttnPatch" }, ctx);
+    expect(res.isError).toBeUndefined();
+    const text = res.content.map((c) => ("text" in c ? c.text : "")).join("");
+    expect(text).toMatch(/SolAttn/);
+    expect(text).toMatch(/Manager outage/i);
+    expect(text).not.toMatch(/does not exist/i);
+    const body = JSON.parse(text) as { count: number; requested_mode: string };
+    expect(body.count).toBe(1);
+    expect(body.requested_mode).toBe("remote");
+  });
+
+  it("forwards a healthy panel search unchanged", async () => {
+    const ctx = {
+      call: async (cmd: Record<string, unknown>) => ({
+        content: [{ type: "text", text: JSON.stringify(cmd) }],
+      }),
+    } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_search_nodes").handler({ query: "kjnodes", limit: 5 }, ctx);
+    const body = JSON.parse(res.content.map((c) => ("text" in c ? c.text : "")).join("")) as {
+      cmd: string;
+      query: string;
+      limit: number;
+    };
+    expect(body).toMatchObject({ cmd: "nodes_search", query: "kjnodes", limit: 5 });
+  });
+});

--- a/src/__tests__/services/manager-node-search.test.ts
+++ b/src/__tests__/services/manager-node-search.test.ts
@@ -1,0 +1,185 @@
+// #1669 — panel_search_nodes failed the whole search when Manager's
+// `customnode/getmappings?mode=cache` answered HTTP 500. A 500 is a Manager
+// outage on one source, not a missing pack. searchNodesViaMappings must keep
+// searching (remote/local) or name the outage.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isManagerMappingsServerError,
+  managerMappingsOutageResult,
+  parseNodeMappings,
+  searchNodesViaMappings,
+  searchPanelNodes,
+  setFetchMappingsForTests,
+  type FetchMappings,
+} from "../../services/manager-node-search.js";
+
+afterEach(() => setFetchMappingsForTests(undefined));
+
+const CACHE_500 = new Error("Manager customnode/getmappings?mode=cache: HTTP 500");
+
+const CATALOGUE = {
+  "https://github.com/someone/ComfyUI-SolAttn": [
+    ["SolAttnPatch"],
+    { title: "SolAttn", description: "Sage-attention patch node" },
+  ],
+  "https://github.com/ltdrdata/ComfyUI-Impact-Pack": [
+    ["ImpactSomething"],
+    { title: "ComfyUI-Impact-Pack", description: "impact pack" },
+  ],
+};
+
+function fetchByMode(table: Partial<Record<string, unknown | Error>>): FetchMappings {
+  return async (mode) => {
+    const row = table[mode];
+    if (row instanceof Error) throw row;
+    if (row !== undefined) return row;
+    throw new Error(`Manager customnode/getmappings?mode=${mode}: HTTP 500`);
+  };
+}
+
+describe("isManagerMappingsServerError", () => {
+  it("matches the reported panel error text", () => {
+    expect(isManagerMappingsServerError(CACHE_500)).toBe(true);
+    expect(
+      isManagerMappingsServerError({
+        isError: true,
+        content: [{ type: "text", text: `Error: ${CACHE_500.message}` }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat 403, 404, or a no-match as a mappings 500", () => {
+    expect(isManagerMappingsServerError(new Error("Manager customnode/getmappings: HTTP 403"))).toBe(false);
+    expect(isManagerMappingsServerError(new Error("Manager customnode/getmappings: HTTP 404"))).toBe(false);
+    expect(isManagerMappingsServerError({ count: 0, results: [] })).toBe(false);
+  });
+});
+
+describe("searchNodesViaMappings (#1669)", () => {
+  it("keeps searching when cache mappings return HTTP 500", async () => {
+    const res = await searchNodesViaMappings({
+      query: "SolAttnPatch",
+      fetchMappings: fetchByMode({
+        cache: CACHE_500,
+        remote: CATALOGUE,
+      }),
+    });
+    expect(res.count).toBe(1);
+    expect(res.results[0]?.id).toContain("SolAttn");
+    expect(res.requested_mode).toBe("remote");
+    expect(res.degraded_from).toBe("cache");
+    expect(res.message).toMatch(/Manager outage/i);
+    expect(res.message).not.toMatch(/does not exist|not found|missing pack/i);
+  });
+
+  it("names an all-modes 500 as a Manager outage, not a missing pack", async () => {
+    const res = await searchNodesViaMappings({
+      query: "SolAttnPatch",
+      fetchMappings: fetchByMode({
+        cache: CACHE_500,
+        remote: new Error("Manager customnode/getmappings?mode=remote: HTTP 500"),
+        local: new Error("Manager customnode/getmappings?mode=local: HTTP 502"),
+      }),
+    });
+    expect(res.manager_outage).toBe(true);
+    expect(res.supported).toBe(false);
+    expect(res.count).toBe(0);
+    expect(res.results).toEqual([]);
+    expect(res.message).toMatch(/Manager outage/i);
+    expect(res.message).not.toMatch(/does not exist|not found|missing pack/i);
+    expect(res.reason).toMatch(/HTTP 50/);
+  });
+
+  it("does not retry when cache succeeds", async () => {
+    const seen: string[] = [];
+    const res = await searchNodesViaMappings({
+      query: "impact",
+      fetchMappings: async (mode) => {
+        seen.push(mode);
+        if (mode !== "cache") throw new Error("should not be asked");
+        return CATALOGUE;
+      },
+    });
+    expect(seen).toEqual(["cache"]);
+    expect(res.count).toBe(1);
+    expect(res.degraded_from).toBeUndefined();
+    expect(res.manager_outage).toBeUndefined();
+  });
+
+  it("propagates a non-5xx mappings error from the first mode", async () => {
+    await expect(
+      searchNodesViaMappings({
+        query: "x",
+        fetchMappings: fetchByMode({
+          cache: new Error("Manager customnode/getmappings?mode=cache: HTTP 403"),
+        }),
+      }),
+    ).rejects.toThrow(/HTTP 403/);
+  });
+});
+
+describe("searchPanelNodes (#1669)", () => {
+  it("degrades to mappings search when the panel fail()s a cache 500", async () => {
+    const out = await searchPanelNodes({
+      query: "SolAttnPatch",
+      panelSearch: async () => ({
+        isError: true,
+        content: [{ type: "text", text: `Error: ${CACHE_500.message}` }],
+      }),
+      fetchMappings: fetchByMode({ cache: CACHE_500, remote: CATALOGUE }),
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.count).toBe(1);
+    expect(out.value.results[0]?.title).toBe("SolAttn");
+  });
+
+  it("degrades when the panel throws the same 500", async () => {
+    const out = await searchPanelNodes({
+      query: "SolAttnPatch",
+      panelSearch: async () => {
+        throw CACHE_500;
+      },
+      fetchMappings: fetchByMode({ cache: CACHE_500, local: CATALOGUE }),
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.requested_mode).toBe("local");
+    expect(out.value.count).toBe(1);
+  });
+
+  it("passes a successful panel result through", async () => {
+    const panel = { count: 1, results: [{ id: "a", title: "A", description: "" }] };
+    const out = await searchPanelNodes({
+      query: "A",
+      panelSearch: async () => panel,
+      fetchMappings: async () => {
+        throw new Error("fallback must not run");
+      },
+    });
+    expect(out).toEqual({ via: "panel", value: panel });
+  });
+});
+
+describe("parseNodeMappings / outage copy", () => {
+  it("uses the repo-URL key as id, never the display title", () => {
+    const res = parseNodeMappings(CATALOGUE, "SolAttn", 15);
+    expect(res.results[0]?.id).toBe("https://github.com/someone/ComfyUI-SolAttn");
+    expect(res.results[0]?.title).toBe("SolAttn");
+  });
+
+  it("matches a node CLASS name in the mappings first array", () => {
+    // The reporter searched SolAttnPatch — a class_type, not a pack title.
+    const res = parseNodeMappings(CATALOGUE, "SolAttnPatch", 15);
+    expect(res.count).toBe(1);
+    expect(res.results[0]?.id).toContain("SolAttn");
+  });
+
+  it("outage copy names Manager, not a missing pack", () => {
+    const res = managerMappingsOutageResult("SolAttnPatch", CACHE_500);
+    expect(res.manager_outage).toBe(true);
+    expect(res.message).toMatch(/Manager outage/);
+    expect(res.message).not.toMatch(/does not exist/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -48,6 +48,7 @@ import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import { nodesInstallCommandArgs } from "../services/node-management.js";
+import { searchPanelNodes } from "../services/manager-node-search.js";
 import { isPanelAnsweredError } from "../services/panel-answered.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
@@ -12848,9 +12849,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_search_nodes",
-      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager.",
+      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager. If Manager's cache mappings endpoint returns HTTP 5xx, this retries remote/local and still searches; a remaining 5xx is a Manager outage, not proof the pack is missing.",
       { query: z.string().describe("Search text, e.g. 'kjnodes', 'controlnet', 'ipadapter'."), limit: z.number().int().min(1).max(40).optional().describe("Max results to return, 1-40 (default 15). Requests above 40 are refused; the panel also clamps to 40 and discloses limit_cap.") },
-      async (args: A, ctx) => ctx.call({ cmd: "nodes_search", query: args.query, limit: args.limit }, 20000),
+      async (args: A, ctx) => {
+        // #1669 — the panel asks getmappings?mode=cache and used to fail the
+        // whole search on HTTP 500. Degrade: retry remote/local, or name the
+        // 500 as a Manager outage (not a missing pack).
+        const query = String(args.query ?? "");
+        const limit = typeof args.limit === "number" ? args.limit : undefined;
+        const out = await searchPanelNodes({
+          panelSearch: () => ctx.call({ cmd: "nodes_search", query, limit }, 20000),
+          query,
+          limit,
+        });
+        return out.via === "panel" ? (out.value as ToolResult) : ok(out.value);
+      },
     ),
     def(
       "panel_list_nodes",

--- a/src/services/manager-node-search.ts
+++ b/src/services/manager-node-search.ts
@@ -1,0 +1,236 @@
+import { getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
+import { detectManagerApi, managerApiPrefixFor, type ManagerMode } from "./node-management.js";
+
+/** Same cap as panel_search_nodes / the panel's SEARCH_LIMIT_CAP (#1287). */
+export const SEARCH_LIMIT_CAP = 40;
+
+export type MappingsMode = ManagerMode;
+
+export interface NodeSearchHit {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface NodeSearchResult {
+  count: number;
+  results: NodeSearchHit[];
+  catalogue_size?: number;
+  limit_cap?: number;
+  /** Mode that actually produced the catalogue, when we had to leave cache. */
+  requested_mode?: MappingsMode;
+  degraded_from?: "cache";
+  manager_outage?: boolean;
+  supported?: boolean;
+  query?: string;
+  reason?: string;
+  message?: string;
+}
+
+export type FetchMappings = (mode: MappingsMode) => Promise<unknown>;
+
+const MODES: MappingsMode[] = ["cache", "remote", "local"];
+
+let fetchMappingsOverride: FetchMappings | undefined;
+
+/** Test seam — restore with `undefined` in afterEach. */
+export function setFetchMappingsForTests(fn: FetchMappings | undefined): void {
+  fetchMappingsOverride = fn;
+}
+
+function queryTerms(query: string): string[] {
+  return String(query ?? "")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function matchesAllTerms(hay: string, terms: string[]): boolean {
+  return terms.every((t) => hay.includes(t));
+}
+
+function extractText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === "object") {
+    const rec = value as { content?: Array<{ text?: string }>; message?: unknown };
+    if (Array.isArray(rec.content)) {
+      return rec.content.map((c) => (typeof c?.text === "string" ? c.text : "")).join("\n");
+    }
+    if (typeof rec.message === "string") return rec.message;
+  }
+  return "";
+}
+
+/** HTTP 5xx from Manager's getmappings — a Manager outage, not a missing pack. */
+export function isManagerMappingsServerError(value: unknown): boolean {
+  const text = extractText(value);
+  return /getmappings/i.test(text) && /HTTP\s*5\d\d\b/.test(text);
+}
+
+export function catalogueSize(data: unknown): number {
+  if (Array.isArray(data)) return data.length;
+  if (data && typeof data === "object") return Object.keys(data).length;
+  return 0;
+}
+
+/**
+ * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into
+ * `{ count, results:[{id,title,description}] }`. Mirrors the panel parser
+ * (array or repo-key map). `id` is cnr/reference or the map key — never title.
+ */
+export function parseNodeMappings(data: unknown, query: string, limit?: number): NodeSearchResult {
+  const terms = queryTerms(query);
+  const out: NodeSearchHit[] = [];
+  const push = (id: unknown, title: unknown, desc: unknown, classNames?: unknown) => {
+    if (id == null || id === "") return;
+    const idStr = String(id);
+    const titleStr = title == null ? idStr : String(title);
+    const descStr = String(desc ?? "").slice(0, 160);
+    const classes = Array.isArray(classNames) ? classNames.map(String).join(" ") : "";
+    const hay = `${idStr} ${titleStr} ${descStr} ${classes}`.toLowerCase();
+    if (matchesAllTerms(hay, terms)) {
+      out.push({ id: idStr, title: titleStr, description: descStr });
+    }
+  };
+  if (Array.isArray(data)) {
+    for (const p of data) {
+      if (!p || typeof p !== "object") continue;
+      const pack = p as {
+        id?: unknown;
+        reference?: unknown;
+        title?: unknown;
+        title_aux?: unknown;
+        description?: unknown;
+        nodename?: unknown;
+      };
+      push(pack.id ?? pack.reference ?? pack.title, pack.title ?? pack.title_aux, pack.description, pack.nodename);
+    }
+  } else if (data && typeof data === "object") {
+    for (const [key, val] of Object.entries(data as Record<string, unknown>)) {
+      const classes = Array.isArray(val) && Array.isArray(val[0]) ? val[0] : undefined;
+      const meta = Array.isArray(val) ? val[1] : val;
+      const m =
+        meta && typeof meta === "object"
+          ? (meta as { id?: unknown; reference?: unknown; title?: unknown; title_aux?: unknown; description?: unknown })
+          : {};
+      push(m.id ?? m.reference ?? key, m.title ?? m.title_aux, m.description, classes);
+    }
+  }
+  const requested = Number(limit) || 15;
+  const max = Math.min(requested, SEARCH_LIMIT_CAP);
+  const result: NodeSearchResult = {
+    count: out.length,
+    results: out.slice(0, max),
+    catalogue_size: catalogueSize(data),
+  };
+  if (requested > SEARCH_LIMIT_CAP) result.limit_cap = SEARCH_LIMIT_CAP;
+  return result;
+}
+
+export function managerMappingsOutageResult(query: string, err: unknown): NodeSearchResult {
+  const reason = extractText(err) || "ComfyUI-Manager mappings HTTP 500";
+  return {
+    supported: false,
+    manager_outage: true,
+    count: 0,
+    results: [],
+    query: query == null ? "" : String(query),
+    reason,
+    message:
+      "Node-registry search could not complete: ComfyUI-Manager's mappings endpoint is " +
+      "returning HTTP 5xx. That is a Manager outage, not proof this pack is missing. " +
+      "Retry after Manager recovers, or search with search_custom_nodes action:\"search\" " +
+      "(queries api.comfy.org directly, not through Manager).",
+  };
+}
+
+async function defaultFetchMappings(mode: MappingsMode): Promise<unknown> {
+  const base = getComfyUIBaseUrl();
+  const api = await detectManagerApi(base);
+  const path = `${managerApiPrefixFor(api)}/customnode/getmappings?mode=${encodeURIComponent(mode)}`;
+  const res = await comfyuiFetch(`${base}${path}`);
+  if (!res.ok) {
+    throw Object.assign(new Error(`Manager customnode/getmappings?mode=${mode}: HTTP ${res.status}`), {
+      status: res.status,
+    });
+  }
+  return res.json();
+}
+
+function resolveFetch(fn?: FetchMappings): FetchMappings {
+  return fn ?? fetchMappingsOverride ?? defaultFetchMappings;
+}
+
+/**
+ * Search installable packs via Manager getmappings.
+ *
+ * Cache is tried first (what the panel asks for). An HTTP 5xx from that
+ * endpoint is a Manager outage on one source, not a missing pack: retry
+ * remote, then local. If every mode 5xxs, return a structured outage —
+ * never throw a "not found" and never fail the whole search.
+ */
+export async function searchNodesViaMappings(opts: {
+  query: string;
+  limit?: number;
+  fetchMappings?: FetchMappings;
+}): Promise<NodeSearchResult> {
+  const fetchMappings = resolveFetch(opts.fetchMappings);
+  let lastErr: unknown;
+  let data: unknown;
+  let usedMode: MappingsMode | undefined;
+  let sawServerError = false;
+
+  for (const mode of MODES) {
+    try {
+      data = await fetchMappings(mode);
+      usedMode = mode;
+      break;
+    } catch (err) {
+      lastErr = err;
+      if (isManagerMappingsServerError(err)) {
+        sawServerError = true;
+        continue;
+      }
+      if (sawServerError) continue;
+      throw err;
+    }
+  }
+
+  if (usedMode === undefined) {
+    return managerMappingsOutageResult(opts.query, lastErr);
+  }
+
+  const parsed = parseNodeMappings(data, opts.query, opts.limit);
+  if (usedMode === "cache") return parsed;
+  return {
+    ...parsed,
+    requested_mode: usedMode,
+    degraded_from: "cache",
+    message:
+      `ComfyUI-Manager's cache mappings endpoint returned HTTP 5xx; searched via ` +
+      `mode=${usedMode} instead. That 500 is a Manager outage on the cache source, ` +
+      `not proof the pack is missing.`,
+  };
+}
+
+/**
+ * Panel nodes_search first. If the panel surfaces a mappings HTTP 5xx
+ * (throw or fail() ToolResult), degrade to searchNodesViaMappings.
+ */
+export async function searchPanelNodes(opts: {
+  panelSearch: () => Promise<unknown>;
+  query: string;
+  limit?: number;
+  fetchMappings?: FetchMappings;
+}): Promise<{ via: "panel"; value: unknown } | { via: "fallback"; value: NodeSearchResult }> {
+  try {
+    const value = await opts.panelSearch();
+    if (!isManagerMappingsServerError(value)) return { via: "panel", value };
+    return { via: "fallback", value: await searchNodesViaMappings(opts) };
+  } catch (err) {
+    if (!isManagerMappingsServerError(err)) throw err;
+    return { via: "fallback", value: await searchNodesViaMappings(opts) };
+  }
+}


### PR DESCRIPTION
## Root cause

`panel_search_nodes` forwards `nodes_search` to the panel. The panel asks ComfyUI-Manager for `customnode/getmappings?mode=cache` and used to propagate HTTP 500 as a hard tool error:

`Error: Manager customnode/getmappings?mode=cache: HTTP 500`

That failed the whole search. A 500 is a Manager outage on one source, not proof the pack is missing — and there is no `mode` fallback, so node discovery stopped even though `remote` / `local` can still answer.

## Fix

- New `searchNodesViaMappings`: try `cache`, then `remote`, then `local`. A 5xx is retryable; a first-mode 403 still propagates.
- If every mode 5xxs, return a structured `manager_outage` result that names the Manager outage and does **not** read as "pack not found".
- `panel_search_nodes` still prefers the panel. When the panel `fail()`s or throws that mappings 500, it degrades to the fallback and still searches.
- Class names from the mappings first array are part of the haystack so a query like `SolAttnPatch` can match.

## Verification

- `npx vitest run --maxWorkers=4 src/__tests__/services/manager-node-search.test.ts src/__tests__/orchestrator/panel-search-nodes-manager-500.test.ts` — 14 passed
- `npx tsc --noEmit` — clean

Fixes #1669
