### PR TITLE
fix(1655): set a listed promoted subgraph widget

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1,0 +1,342 @@
+// #1655 — a widget the panel lists as promoted must be settable.
+//
+// The panel's graph_set_widget can refuse:
+//
+//   Cannot set widget on subgraph node 78: "width" is not a promoted widget
+//   on this subgraph (promoted: width, height, seed, …)
+//
+// That is a listing-vs-lookup contradiction (widgets[] vs host inputs), not a
+// genuine miss. panel_set_widget must resolve the displayed name to the unique
+// inner widget and write it there, then leave the subgraph.
+//
+// These tests drive the SHIPPED handler (and the parse/resolve helpers it uses).
+// A first-write success is untouched. A genuine miss (name not in the listed
+// set) is never retried. An ambiguous or truncated inner mapping is never guessed.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  isContradictoryPromotedWidgetRefusal,
+  matchListedName,
+  parseContradictoryPromotedWidgetRefusal,
+  resolveInnerPromotedTarget,
+} from "../../orchestrator/promoted-widget.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:krea2";
+
+const CONTRADICTORY =
+  `Cannot set widget on subgraph node 78: "width" is not a promoted widget on this subgraph ` +
+  `(promoted: width, height, seed, control_after_generate, steps, cfg, sampler_name, scheduler, denoise, batch_size).`;
+
+const SUBGRAPH = {
+  subgraph_of: { node_id: 78, title: "Krea2" },
+  instance_widgets: { width: 1920, height: 1080, seed: 1, steps: 20 },
+  node_count: 2,
+  nodes: [
+    { id: 76, type: "EmptyLatentImage", widgets: { width: 1920, height: 1080, batch_size: 1 } },
+    { id: 75, type: "KSampler", widgets: { seed: 1, steps: 20, cfg: 1, sampler_name: "euler" } },
+  ],
+};
+
+type Outcome = "contradict" | "ok" | "fail";
+
+function bridge(opts: {
+  firstWrite?: Outcome;
+  remappedWrite?: Outcome;
+  innerWrite?: Outcome;
+  subgraph?: Record<string, unknown> | Error;
+  enterFails?: boolean;
+  exitFails?: boolean;
+}) {
+  const calls: Array<Record<string, unknown>> = [];
+  let writes = 0;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        const which =
+          writes === 1
+            ? (opts.firstWrite ?? "contradict")
+            : Number(cmd.node_id) === 76 || cmd.node_id === "76"
+              ? (opts.innerWrite ?? "ok")
+              : (opts.remappedWrite ?? "contradict");
+        if (which === "contradict") throw new Error(CONTRADICTORY);
+        if (which === "fail") throw new Error("inner write rejected");
+        return { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (opts.subgraph instanceof Error) throw opts.subgraph;
+        return opts.subgraph ?? SUBGRAPH;
+      }
+      if (cmd.cmd === "graph_enter_subgraph") {
+        if (opts.enterFails) throw new Error("could not enter subgraph 78");
+        return { scope: "subgraph", node_id: cmd.node_id };
+      }
+      if (cmd.cmd === "graph_exit_subgraph") {
+        if (opts.exitFails) throw new Error("could not confirm exit");
+        return { scope: "root" };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function setWidget(
+  args: { node_id: number | string; widget: string; value: number | string },
+  opts: Parameters<typeof bridge>[0] = {},
+) {
+  const { b, calls } = bridge(opts);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("parseContradictoryPromotedWidgetRefusal", () => {
+  it("the reporter's error is contradictory — width is listed as promoted", () => {
+    const parsed = parseContradictoryPromotedWidgetRefusal(CONTRADICTORY, "width");
+    expect(parsed).toEqual({
+      nodeId: "78",
+      widget: "width",
+      listed: [
+        "width",
+        "height",
+        "seed",
+        "control_after_generate",
+        "steps",
+        "cfg",
+        "sampler_name",
+        "scheduler",
+        "denoise",
+        "batch_size",
+      ],
+    });
+    expect(isContradictoryPromotedWidgetRefusal(CONTRADICTORY, "width")).toBe(true);
+  });
+
+  it("a genuine miss (name NOT in the listed set) is not contradictory", () => {
+    const text =
+      `Cannot set widget on subgraph node 78: "foo" is not a promoted widget on this subgraph ` +
+      `(promoted: width, height, seed).`;
+    expect(parseContradictoryPromotedWidgetRefusal(text, "foo")).toBeNull();
+    expect(isContradictoryPromotedWidgetRefusal(text, "foo")).toBe(false);
+  });
+
+  it("promoted: none is never contradictory", () => {
+    const text =
+      `Cannot set widget on subgraph node 78: "width" is not a promoted widget on this subgraph ` +
+      `(promoted: none).`;
+    expect(parseContradictoryPromotedWidgetRefusal(text, "width")).toBeNull();
+  });
+
+  it("an unrelated failure is never contradictory", () => {
+    expect(
+      parseContradictoryPromotedWidgetRefusal("No node with id 78 in the current graph", "width"),
+    ).toBeNull();
+  });
+
+  it("a unique case-insensitive listed name still matches", () => {
+    expect(matchListedName("Width", ["width", "height"])).toBe("width");
+    const parsed = parseContradictoryPromotedWidgetRefusal(CONTRADICTORY, "Width");
+    expect(parsed?.widget).toBe("width");
+  });
+});
+
+describe("resolveInnerPromotedTarget", () => {
+  it("maps width to the unique EmptyLatentImage inner node", () => {
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "width")).toEqual({
+      innerNodeId: 76,
+      widget: "width",
+    });
+  });
+
+  it("maps seed to the unique KSampler inner node", () => {
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "seed")).toEqual({
+      innerNodeId: 75,
+      widget: "seed",
+    });
+  });
+
+  it("refuses to guess when two inners share the widget name", () => {
+    const ambiguous = {
+      ...SUBGRAPH,
+      nodes: [
+        { id: 76, widgets: { width: 1920 } },
+        { id: 99, widgets: { width: 512 } },
+      ],
+    };
+    expect(resolveInnerPromotedTarget(ambiguous, "width")).toBeNull();
+  });
+
+  it("refuses to guess from a truncated inner list", () => {
+    expect(resolveInnerPromotedTarget({ ...SUBGRAPH, truncated: true }, "width")).toBeNull();
+  });
+
+  it("returns null when no inner node owns the widget", () => {
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "denoise")).toBeNull();
+  });
+});
+
+describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
+  it("the reporter's case: refuse → get_subgraph → enter → set inner → exit", async () => {
+    const { text, isError, calls } = await setWidget({ node_id: 78, widget: "width", value: 1024 });
+
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_set_widget",
+      "graph_exit_subgraph",
+    ]);
+    expect(calls[0]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
+    expect(calls[3]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
+    expect(text).toMatch(/inner widget this promotion lists: node 76 "width"/);
+    expect(text).not.toMatch(/is not a promoted widget/);
+  });
+
+  it("a healthy write is untouched — one call, no enter", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 3, widget: "steps", value: 20 },
+      { firstWrite: "ok" },
+    );
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+  });
+
+  it("a genuine miss is never retried", async () => {
+    const { b, calls } = bridge({ firstWrite: "ok" });
+    const failing = {
+      ...(b as object),
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push({ ...cmd });
+        throw new Error(
+          `Cannot set widget on subgraph node 78: "foo" is not a promoted widget on this subgraph ` +
+            `(promoted: width, height, seed).`,
+        );
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(failing, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!def) throw new Error("panel_set_widget is not registered");
+    const res = await def.handler({ node_id: 78, widget: "foo", value: 1 } as never, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_get_subgraph");
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("an UNRELATED failure is never retried", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { firstWrite: "fail" },
+    );
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+  });
+
+  it("an ambiguous inner mapping is not guessed", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      {
+        subgraph: {
+          node_count: 2,
+          nodes: [
+            { id: 76, widgets: { width: 1920 } },
+            { id: 99, widgets: { width: 512 } },
+          ],
+        },
+      },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(/is not a promoted widget/);
+    expect(text).toMatch(/did not uniquely identify/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_get_subgraph"]);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("a truncated subgraph read is not treated as unique", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { subgraph: { ...SUBGRAPH, truncated: true } },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(/did not uniquely identify/);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("a failed subgraph read keeps the original refusal", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { subgraph: new Error("Node 78 is not a subgraph") },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(/is not a promoted widget/);
+    expect(text).toMatch(/graph_get_subgraph FAILED/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_get_subgraph"]);
+  });
+
+  it("always exits after a successful inner write, and discloses an exit failure", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { exitFails: true },
+    );
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
+    expect(text).toMatch(/inner widget this promotion lists/);
+    expect(text).toMatch(/panel_exit_subgraph then FAILED/);
+    expect(text).toMatch(/Call panel_exit_subgraph/);
+  });
+
+  it("exits even when the inner write fails, and keeps the original refusal", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { innerWrite: "fail" },
+    );
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_set_widget",
+      "graph_exit_subgraph",
+    ]);
+    expect(text).toMatch(/is not a promoted widget/);
+    expect(text).toMatch(/Tried the inner mapping node 76 "width"/);
+    expect(text).toMatch(/inner write rejected/);
+  });
+
+  it("retries the listed spelling on the wrapper when only the case differed", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "Width", value: 1024 },
+      { remappedWrite: "ok" },
+    );
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_set_widget"]);
+    expect(calls[0]).toMatchObject({ widget: "Width" });
+    expect(calls[1]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
+    expect(text).not.toMatch(/is not a promoted widget/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -65,6 +65,10 @@ import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../servi
 import type { ScopeRepinOutcome } from "./turn-origins.js";
 import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
 import {
+  parseContradictoryPromotedWidgetRefusal,
+  resolveInnerPromotedTarget,
+} from "./promoted-widget.js";
+import {
   clearSwitchHold,
   describeSwitchHold,
   recordSwitchHold,
@@ -10396,9 +10400,100 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // a single revalidation, #338/#458) — that authoritative fetch can outlast
         // the 6000 ms default ack on a large install and return a FALSE timeout.
         // Give the guarded write the bounded refresh ack budget.
-        return ctx.call(
-          { cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value },
-          OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+        const write = (nodeId: unknown, widget: string): Promise<ToolResult> =>
+          ctx.call(
+            { cmd: "graph_set_widget", node_id: nodeId, widget, value },
+            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+          );
+        const first = await write(args.node_id, args.widget as string);
+        if (!first.isError) return first;
+
+        // #1655 — the panel listed this widget as promoted while refusing it as
+        // not promoted. The listing is node.widgets; the write looks up host
+        // inputs. When those disagree, resolve the displayed name to the unique
+        // inner mapping and set it there (the issue's own workaround), then
+        // leave the subgraph so the caller's scope is unchanged.
+        const refusal = parseContradictoryPromotedWidgetRefusal(
+          textOfToolResult(first),
+          args.widget as string,
+        );
+        if (!refusal || String(refusal.nodeId) !== String(args.node_id)) return first;
+
+        if (refusal.widget !== args.widget) {
+          const remapped = await write(args.node_id, refusal.widget);
+          if (!remapped.isError) return remapped;
+          if (
+            !parseContradictoryPromotedWidgetRefusal(
+              textOfToolResult(remapped),
+              refusal.widget,
+            )
+          ) {
+            return remapped;
+          }
+        }
+
+        const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id });
+        if (sub.isError) {
+          return appendToolResultText(
+            first,
+            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
+              `Tried to resolve that name to the inner widget and graph_get_subgraph FAILED: ` +
+              `${textOfToolResult(sub)})`,
+          );
+        }
+        const inner = resolveInnerPromotedTarget(parseToolResultJson(sub), refusal.widget);
+        if (!inner) {
+          return appendToolResultText(
+            first,
+            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
+              `graph_get_subgraph did not uniquely identify an inner node that owns that widget, ` +
+              `so the write was not retried — guessing among several inners, or acting on a ` +
+              `truncated inner list, would target the wrong node.)`,
+          );
+        }
+
+        const entered = await ctx.call(
+          { cmd: "graph_enter_subgraph", node_id: args.node_id },
+          15000,
+        );
+        if (entered.isError) {
+          return appendToolResultText(
+            first,
+            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
+              `Resolved it to inner node ${inner.innerNodeId} but panel_enter_subgraph FAILED: ` +
+              `${textOfToolResult(entered)})`,
+          );
+        }
+
+        const written = await write(inner.innerNodeId, inner.widget);
+        const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+        if (!written.isError) {
+          const via =
+            `\n\n(Applied via the inner widget this promotion lists: node ${inner.innerNodeId} ` +
+            `"${inner.widget}". The panel listed "${refusal.widget}" as promoted while refusing ` +
+            `it as not promoted; the displayed name was resolved to that inner mapping.)`;
+          if (exited.isError) {
+            return appendToolResultText(
+              written,
+              `${via} panel_exit_subgraph then FAILED — the canvas may still be inside the ` +
+                `subgraph. Call panel_exit_subgraph. (${textOfToolResult(exited)})`,
+            );
+          }
+          return appendToolResultText(written, via);
+        }
+        if (exited.isError) {
+          return appendToolResultText(
+            first,
+            `\n\n(Tried the inner mapping node ${inner.innerNodeId} "${inner.widget}" and it ` +
+              `FAILED: ${textOfToolResult(written)} panel_exit_subgraph also FAILED — the ` +
+              `canvas may still be inside the subgraph. Call panel_exit_subgraph. ` +
+              `(${textOfToolResult(exited)}))`,
+          );
+        }
+        return appendToolResultText(
+          first,
+          `\n\n(Tried the inner mapping node ${inner.innerNodeId} "${inner.widget}" and it ` +
+            `FAILED: ${textOfToolResult(written)})`,
         );
       },
     ),

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -1,0 +1,118 @@
+/**
+ * #1655 — a widget the panel LISTS as promoted must be settable.
+ *
+ * `graph_set_widget` on a subgraph wrapper can refuse with:
+ *
+ *   Cannot set widget on subgraph node 78: "width" is not a promoted widget
+ *   on this subgraph (promoted: width, height, seed, …)
+ *
+ * The listing is `node.widgets[].name`. The write looks up host INPUT names /
+ * `_subgraphSlot` aliases. Those two sets disagree for proxyWidgets promotions
+ * (krea2-txt2img-manual node 78: width/height exist as widgets, not as inputs),
+ * so the refusal names the requested widget in its own "promoted:" list.
+ *
+ * Detection matches that contradiction only. A genuine miss ("foo" against
+ * `promoted: width, height`) is left alone. Resolution maps the displayed name
+ * to a UNIQUE inner node+widget from `graph_get_subgraph` — never by guessing
+ * among several inners that share the name, and never from a truncated read.
+ */
+
+export type ContradictoryPromotedWidgetRefusal = {
+  nodeId: string;
+  widget: string;
+  listed: string[];
+};
+
+export type InnerPromotedTarget = {
+  innerNodeId: number | string;
+  widget: string;
+};
+
+const CONTRADICTORY_RE =
+  /Cannot set widget on subgraph node (\S+): "([^"]+)" is not a promoted widget on this subgraph \(promoted: ([^)]+)\)/i;
+
+/** Exact name first; a unique case-insensitive hit is accepted so a listed
+ *  `width` still matches a caller who sent `Width`. Several CI hits refuse. */
+export function matchListedName(wanted: string, listed: readonly string[]): string | null {
+  if (listed.includes(wanted)) return wanted;
+  const ci = listed.filter((n) => n.toLowerCase() === wanted.toLowerCase());
+  return ci.length === 1 ? ci[0] : null;
+}
+
+function parseListed(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed || /^none$/i.test(trimmed)) return [];
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Parse the contradictory refusal. Returns null unless the requested widget
+ * actually appears in the diagnostic's own promoted list — that is the bug.
+ */
+export function parseContradictoryPromotedWidgetRefusal(
+  text: string,
+  requestedWidget?: string,
+): ContradictoryPromotedWidgetRefusal | null {
+  const m = CONTRADICTORY_RE.exec(text);
+  if (!m) return null;
+  const listed = parseListed(m[3]);
+  const fromError = matchListedName(m[2], listed);
+  if (!fromError) return null;
+  if (requestedWidget != null && matchListedName(requestedWidget, listed) == null) {
+    return null;
+  }
+  const widget =
+    requestedWidget != null ? (matchListedName(requestedWidget, listed) ?? fromError) : fromError;
+  return { nodeId: m[1].replace(/[,:]$/, ""), widget, listed };
+}
+
+function widgetNamesOnInner(node: Record<string, unknown>): string[] {
+  const widgets = node.widgets;
+  if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return [];
+  return Object.keys(widgets as Record<string, unknown>).filter((n) => n.length > 0);
+}
+
+function innerNodeId(node: Record<string, unknown>): number | string | null {
+  const id = node.id;
+  if (typeof id === "number" && Number.isFinite(id)) return id;
+  if (typeof id === "string" && id.trim() !== "") return id;
+  return null;
+}
+
+/**
+ * Map a displayed promoted name to the unique inner node that owns a widget
+ * of that name. `graph_get_subgraph` does not ship a reliable promotion
+ * pairing across frontend versions, so uniqueness is the only attribution
+ * we will act on. A truncated inner list cannot prove uniqueness.
+ */
+export function resolveInnerPromotedTarget(
+  subgraph: Record<string, unknown> | null | undefined,
+  displayedWidget: string,
+): InnerPromotedTarget | null {
+  if (!subgraph || typeof subgraph !== "object") return null;
+  if (subgraph.truncated === true) return null;
+  const nodes = subgraph.nodes;
+  if (!Array.isArray(nodes)) return null;
+
+  const hits: InnerPromotedTarget[] = [];
+  for (const raw of nodes) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const node = raw as Record<string, unknown>;
+    const id = innerNodeId(node);
+    if (id == null) continue;
+    const matched = matchListedName(displayedWidget, widgetNamesOnInner(node));
+    if (matched) hits.push({ innerNodeId: id, widget: matched });
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+/** True when the refusal listed `requestedWidget` as promoted. */
+export function isContradictoryPromotedWidgetRefusal(
+  text: string,
+  requestedWidget: string,
+): boolean {
+  return parseContradictoryPromotedWidgetRefusal(text, requestedWidget) != null;
+}


### PR DESCRIPTION
## Summary

`panel_set_widget` on a subgraph wrapper could refuse a widget that its own error listed as promoted:

```
Cannot set widget on subgraph node 78: "width" is not a promoted widget on this subgraph
(promoted: width, height, seed, control_after_generate, steps, cfg, sampler_name, scheduler, denoise, batch_size).
```

The panel lists `node.widgets[].name`. The write looks up host input / `_subgraphSlot` aliases. Those two sets disagree for `proxyWidgets` promotions (bundled `krea2-txt2img-manual` node 78: width/height exist as widgets, not as inputs), so a listed name was unwritable and a high-resolution render could be queued before the intended edit landed.

## Fix

`panel_set_widget` now detects that contradiction only (the requested name must appear in the diagnostic's own `promoted:` list). It then:

1. Resolves the displayed name to the unique inner node+widget from `graph_get_subgraph`.
2. Enters the subgraph, writes that inner widget, and exits so the caller's scope is unchanged.

Not retried:

- A genuine miss (`"foo"` against `promoted: width, height`)
- An unrelated failure
- An ambiguous inner mapping (two inners share the name)
- A truncated inner list (uniqueness cannot be proven)

A unique case-insensitive listed spelling is retried on the wrapper first, so `Width` can still hit listed `width` without entering.

## Tests

`src/__tests__/orchestrator/promoted-widget.test.ts` drives the shipped helper and the shipped `panel_set_widget` handler: reporter case, healthy write untouched, genuine miss, unrelated failure, ambiguous/truncated mapping, enter/exit failure disclosures, case remap.

Fixes #1655
