### PR TITLE
docs(readme): lead with the demo, as a poster that links to the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # comfyui-mcp — drive ComfyUI with ANY LLM
 
+<p align="center">
+  <a href="https://comfyui-mcp.artokun.io/docs">
+    <img src="docs/images/demo-poster.jpg" width="760"
+         alt="The Agent panel driving ComfyUI end to end — click to watch the demo">
+  </a>
+</p>
+
+<p align="center">
+  <em>The Agent panel driving ComfyUI end to end — reading what is installed locally,
+  wiring the graph, freeing VRAM, and running the render.<br>
+  <a href="https://comfyui-mcp.artokun.io/docs">Watch the 76s demo &rarr;</a></em>
+</p>
+
 **The local-first, agent-native control plane for [ComfyUI](https://github.com/comfyanonymous/ComfyUI)** — an MCP server + live sidebar agent that generates images, video and audio, authors and runs workflows, manages models and custom nodes, and **edits your live ComfyUI graph in natural language**. Bring whatever model you have: **Claude or ChatGPT on your subscription, Gemini on your Google login, a free local model via Ollama (fully offline), or any hosted model over one API key** (DeepSeek, GLM, MiMo, Kimi, GPT, Claude via OpenRouter). Same tools, same panel, every tier — and the built-in [LLM Arena](https://comfyui-mcp.artokun.io/docs/arena) scores them all on real ComfyUI tasks so you know exactly what your model can do. One config targets local installs, LAN, VPS, or Comfy Cloud.
 
 [![npm version](https://img.shields.io/npm/v/comfyui-mcp)](https://www.npmjs.com/package/comfyui-mcp)


### PR DESCRIPTION
Requested by artokun in Discord (`#feature-requests` → "Screenshots of the panel in the Github"): *"Put the video from the doc's homepage on there at the top."*

Verified the instruction came from the owner's Discord ID (`338555182474592257`) rather than trusting the display name.

### The literal version would have shipped an invisible README

Copying the docs hero's `<video>` embed straight across renders as **nothing** on GitHub — the markdown sanitizer strips the tag. Checked against GitHub's own renderer rather than assuming:

```
POST /markdown  →  <video src="...mp4" controls></video>
returned:            <p dir="auto"></p>
```

The `<a><img></a>` form survives that same pass intact, so the README gets the **poster still, linked to the docs page** where the clip actually plays.

### Details

- Reuses `docs/images/demo-poster.jpg` — the same "ComfyUI MCP 100% Local" title card as the docs hero, so both surfaces show the same frame. No new asset committed.
- Sits directly under the H1, above the badges.
- Rendered output confirmed through `POST /markdown`: image, link, caption and `&rarr;` all survive.

### Gate

codex is account-exhausted until 2026-08-19 20:43, so this carries the authorised substitute (`claude-gate.mjs`, an independent adversarial reviewer) — disclosed per the standing condition. Docs-only, no source paths touched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)