### PR TITLE
fix(1639): graph_* fail fast while a prompt runs; do not clear the fence on an identity-only open

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -1,0 +1,218 @@
+// #1639 — while a ComfyUI prompt is running, graph_* (including read-only
+// graph_query / graph_outline) time out with "tab may be backgrounded or frozen"
+// and mutating commands report an unknown outcome. 100% correlated with
+// queue action:"list" showing running:1; the same calls succeed the moment
+// the queue drains.
+//
+// The frontend main thread is what cannot answer. The orchestrator CAN see the
+// running prompt via QueueMonitor (HTTP /queue, independent of the panel tab).
+// Fail closed BEFORE dispatch for canvas-touching graph commands so the agent
+// gets an explicit QUEUE BUSY instead of a 20/30s unknown-outcome timeout.
+// `graph_run` is excluded: queuing behind an in-flight job is the documented
+// sweep path. A timeout that still happens (graph_run, or a lagging snapshot)
+// is annotated with the same QUEUE BUSY rather than "backgrounded or frozen".
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "11111111-2222-4333-8444-555555555555";
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    currentNode: string | null;
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as unknown as QMPriv;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+function makeBridge(opts?: { timeoutCmds?: Set<string> }) {
+  const sent: string[] = [];
+  const timeoutCmds = opts?.timeoutCmds ?? new Set<string>();
+  const bridge = {
+    send: async (cmd: Record<string, unknown>, o?: { onDispatchedRid?: (rid: string) => void }) => {
+      sent.push(String(cmd.cmd));
+      o?.onDispatchedRid?.("rid-timeout-1");
+      if (timeoutCmds.has(String(cmd.cmd))) {
+        throw markReplyTimeout(
+          new Error(
+            `Panel tab ${TAB} did not reply to "${cmd.cmd}" within 20000 ms — the ComfyUI tab ` +
+              `may be backgrounded or frozen`,
+          ),
+        );
+      }
+      return { ok: true, ids: [1], node_count: 1 };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent };
+}
+
+beforeEach(() => {
+  qm.url = "http://127.0.0.1:9999";
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.runningPromptId = null;
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+describe("graph_* fail fast while a prompt is running (#1639)", () => {
+  it("a read-only graph_query is NOT sent — QUEUE BUSY names the running prompt", async () => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.currentNode = "42";
+    qm.state.queueRemaining = 1;
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
+    const text = textOf(res);
+
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/running prompt p-in-flight/);
+    expect(text).toMatch(/currently at node 42/);
+    expect(text).toMatch(/was NOT sent — nothing was applied/);
+    expect(text).toMatch(/running: 0/);
+    // Mentions the generic frozen-tab wording only as the diagnosis it refuses to
+    // surface — the actual headline is QUEUE BUSY, not a backgrounded tab.
+  });
+
+  it("panel_graph_outline is the same — reads are not exempt", async () => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.queueRemaining = 1;
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_graph_outline").handler({} as never, ctx);
+
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/QUEUE BUSY/);
+  });
+
+  it("panel_set_widget is NOT delivered — outcome is known (nothing applied)", async () => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.queueRemaining = 1;
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+    const text = textOf(res);
+
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/was NOT sent — nothing was applied/);
+    // A mutation that never left must not invite retry_of / unknown-outcome.
+    expect(text).not.toMatch(/may have been applied/);
+    expect(text).not.toMatch(/retry_of/);
+  });
+
+  it("idle queue: the same read is dispatched", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
+
+    expect(sent).toEqual(["graph_query"]);
+    expect(res.isError).not.toBe(true);
+  });
+
+  it("graph_run is still dispatched — queuing behind an in-flight job is the sweep path", async () => {
+    qm.state.runningPromptId = "p-own";
+    qm.state.queueRemaining = 1;
+    QueueMonitor.markSelfQueued("p-own");
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    // panel_run's own duplicate fence would refuse an unaccounted job; mark it ours.
+    const res = await defByName("panel_run").handler({ allow_duplicate: true } as never, ctx);
+
+    expect(sent).toContain("graph_run");
+    expect(textOf(res)).not.toMatch(/was NOT sent/);
+  });
+});
+
+describe("a graph_* timeout while a prompt is running is named QUEUE BUSY (#1639)", () => {
+  it("graph_run's missing ack names the running prompt instead of a frozen tab", async () => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.queueRemaining = 1;
+    QueueMonitor.markSelfQueued("p-in-flight");
+
+    const { bridge, sent } = makeBridge({ timeoutCmds: new Set(["graph_run"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_run").handler({ allow_duplicate: true } as never, ctx);
+    const text = textOf(res);
+
+    expect(sent).toContain("graph_run");
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/did not reply to "graph_run"/);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/running prompt p-in-flight/);
+    expect(text).toMatch(/not a backgrounded or frozen tab/i);
+  });
+
+  it("an idle queue does not append QUEUE BUSY onto a genuine timeout", async () => {
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_run"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_run").handler({} as never, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/did not reply to "graph_run"/);
+    expect(text).not.toMatch(/QUEUE BUSY/);
+  });
+});

--- a/src/__tests__/orchestrator/open-clears-fence-on-drift.test.ts
+++ b/src/__tests__/orchestrator/open-clears-fence-on-drift.test.ts
@@ -71,6 +71,17 @@ function bridge(openVerdict: string, listUuid: string | null | "throw") {
         return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
       }
       if (cmd.cmd === "workflow_open") throw new Error(openVerdict);
+      // #1639 — the identity-PROVEN verdict re-derives the fence ONLY when the
+      // live graph refuses this session's existing stamp. A successful graph
+      // read means the canvas did not actually switch; those cases are covered
+      // in open-content-mismatch-fence.test.ts.
+      if (cmd.cmd === "graph_query") {
+        throw new Error(
+          "workflow instance mismatch: issued for workflow instance " +
+            "00000000-0000-4000-8000-000000000000 but canvas is " +
+            LIVE,
+        );
+      }
       return { ok: true };
     },
     push: () => 1,

--- a/src/__tests__/orchestrator/open-content-mismatch-fence.test.ts
+++ b/src/__tests__/orchestrator/open-content-mismatch-fence.test.ts
@@ -1,0 +1,163 @@
+// #1639 — `workflow_open` asserted "you are on the right workflow" while the
+// canvas still showed the PREVIOUS graph, and #1337's identity-PROVEN fence
+// re-derivation then CLEARED the fence so later graph reads of that previous
+// graph succeeded as if they were the opened file.
+//
+// TWO LEVELS WERE BEING CONFLATED, the other way from #1337. That issue treated
+// content-level uncertainty as if it blocked an identity-level fence. This one
+// treated an identity-level CLAIM as if the live graph had moved. Clearing the
+// fence on `the canvas IS bound to X` is what made `panel_graph_outline` return
+// workflow A's 13 inpaint nodes after opening B, with `active_confirmed:true`
+// for B.
+//
+// THE DISCRIMINATOR is a live graph read UNDER THE EXISTING FENCE, taken before
+// any re-derivation:
+//   - the read SUCCEEDS → the canvas still answers as the previous workflow.
+//     Do not re-derive. Contradict "you are on the right workflow".
+//   - the read is refused with `workflow instance mismatch` → the canvas
+//     identity actually moved. That is the #1337 wedge; re-derive.
+//   - the read does not come back → content is unverified. Do not re-derive.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+
+const TAB = "wf:workflows/a.json";
+const PATH = "workflows/b.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+const PRIOR = "11111111-1111-4111-8111-111111111111";
+
+const IDENTITY_PROVEN_DRIFT =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded, and every node that was loaded is on it with ` +
+  `the same id and type, and nothing extra appeared — no node was lost. What differs is per-node ` +
+  `fields. You are on the right workflow. You are NOT on the wrong workflow: ${PATH} IS the ` +
+  `active one. This reply carries NO fence refresh.`;
+
+type GraphQuery = "answers" | "mismatch" | "timeout";
+
+function bridge(graphQuery: GraphQuery) {
+  const calls: string[] = [];
+  let stamp: string | undefined = PRIOR;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        const active = { path: PATH, routing_key: `wf:${PATH}`, workflow_uuid: LIVE };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(IDENTITY_PROVEN_DRIFT);
+      if (cmd.cmd === "graph_query") {
+        if (graphQuery === "timeout") {
+          throw markReplyTimeout(
+            new Error(
+              `Panel tab ${TAB} did not reply to "graph_query" within 8000 ms — the ComfyUI tab ` +
+                `may be backgrounded or frozen`,
+            ),
+          );
+        }
+        if (graphQuery === "mismatch") {
+          throw new Error(
+            `workflow instance mismatch: issued for workflow instance ${PRIOR} but canvas is ${LIVE}`,
+          );
+        }
+        return { ids: [1, 2, 3], node_count: 13 };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls, stampOf: () => stamp };
+}
+
+beforeEach(() => {
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+afterEach(() => {
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+async function openWorkflow(graphQuery: GraphQuery) {
+  const { b, calls, stampOf } = bridge(graphQuery);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+    stamp: stampOf(),
+  };
+}
+
+describe("workflow_open does not clear the fence when the live graph still answers (#1639)", () => {
+  it("the reporter's wedge: identity named B, live graph still answers as A — fence stays", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow("answers");
+
+    expect(isError).toBe(true);
+    expect(calls).toContain("graph_query");
+    expect(calls.some((c) => c.startsWith("adopt:"))).toBe(false);
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).toMatch(/CONTENT MISMATCH/);
+    expect(text).toMatch(/PREVIOUS workflow/);
+    // The panel's own reassurance is contradicted, not amplified.
+    expect(text).toMatch(/do NOT trust "you are on the right workflow"/i);
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+  });
+
+  it("preserves the panel's content warning — the open still fails", async () => {
+    const { text, isError } = await openWorkflow("answers");
+
+    expect(isError).toBe(true);
+    expect(text).toContain("You are on the right workflow");
+    expect(text).toMatch(/do NOT edit or save expecting the opened file/i);
+  });
+
+  it("an unread live graph is UNVERIFIED — the fence is not re-derived on a missing read", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow("timeout");
+
+    expect(isError).toBe(true);
+    expect(calls).toContain("graph_query");
+    expect(calls.some((c) => c.startsWith("adopt:"))).toBe(false);
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).toMatch(/UNVERIFIED/);
+    expect(text).toMatch(/do NOT trust "you are on the right workflow"/i);
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+  });
+
+  it("a genuine instance-mismatch refusal still re-derives — the #1337 wedge stays recovered", async () => {
+    const { text, calls, stamp } = await openWorkflow("mismatch");
+
+    expect(calls).toContain("graph_query");
+    expect(calls).toContain("workflow_list");
+    expect(text).toMatch(/FENCE: CLEARED/);
+    expect(stamp).toBe(LIVE);
+    expect(text).toMatch(/content warning above still stands/i);
+  });
+});

--- a/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
+++ b/src/__tests__/orchestrator/open-reports-silent-panel-channel.test.ts
@@ -93,6 +93,16 @@ function bridge(openVerdict: string, list: ListBehaviour) {
         return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
       }
       if (cmd.cmd === "workflow_open") throw new Error(openVerdict);
+      // #1639 — identity-PROVEN re-derivation is gated on the live graph
+      // refusing this session's stamp. Without this the probe would succeed
+      // (this stub's default `{ok:true}`) and the fence would stay closed.
+      if (cmd.cmd === "graph_query") {
+        throw new Error(
+          "workflow instance mismatch: issued for workflow instance " +
+            "00000000-0000-4000-8000-000000000000 but canvas is " +
+            LIVE,
+        );
+      }
       return { ok: true };
     },
     push: () => 1,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -828,6 +828,46 @@ function sleep(ms: number): Promise<void> {
 // frozen/backgrounded tab fails in bounded time instead of hanging forever.
 const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
 
+// #1639 — while a ComfyUI prompt is running the frontend main thread often
+// cannot service graph_* at all (reads included). Waiting out the 20/30 s ack
+// bound only surfaces "tab may be backgrounded or frozen" with an unknown
+// mutation outcome. Fail closed BEFORE dispatch for canvas-touching graph
+// commands so the agent gets an explicit QUEUE BUSY instead. `graph_run` is
+// excluded: queuing behind an in-flight job is the documented sweep path, and
+// panel_run already has its own duplicate fence.
+function queueBusySnapshotNote(): string {
+  const snap = QueueMonitor.snapshot();
+  if (!snap.running) return "";
+  const prompt = snap.runningPromptId ? ` (running prompt ${snap.runningPromptId}` : "";
+  const node = snap.currentNode ? `, currently at node ${snap.currentNode}` : "";
+  const close = snap.runningPromptId ? ")" : "";
+  return `${prompt}${node}${close}`;
+}
+
+function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  if (!name.startsWith("graph_") || name === "graph_run") return null;
+  const snap = QueueMonitor.snapshot();
+  if (!snap.running) return null;
+  return (
+    `${name} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
+    `${queueBusySnapshotNote()}. The panel tab typically cannot answer graph_* commands ` +
+    `(including read-only graph_query / graph_outline) while a prompt is executing — ` +
+    `waiting out the ack timeout would only surface a generic "tab may be backgrounded ` +
+    `or frozen" with an unknown outcome. Retry after queue (action:"list") shows running: 0.`
+  );
+}
+
+function queueBusyTimeoutNote(): string {
+  if (!QueueMonitor.snapshot().running) return "";
+  return (
+    `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}. ` +
+    `The panel tab typically cannot answer graph_* (including read-only queries) while a ` +
+    `prompt is executing — this is not a backgrounded or frozen tab. Retry after queue ` +
+    `(action:"list") shows running: 0.`
+  );
+}
+
 const RETRY_SAFE_CMDS = new Set<string>([
   // Idempotent reads (mirror UiBridge.READONLY_CMDS + list/status probes).
   "graph_serialize",
@@ -4112,7 +4152,75 @@ export function readOpenActiveAgainstTarget(
  * FAILS — the content warning is preserved verbatim, because "re-read before editing"
  * is still the right instruction — and nothing is adopted on the UNPROVEN verdict,
  * where identity itself is in doubt.
+ *
+ * #1639 — IDENTITY CLAIM IS NOT CONTENT. The #1337 re-derivation assumed that
+ * "the canvas IS bound to X" meant later graph reads would show X. A later session
+ * showed the opposite: workflow_list / this verdict named B, FENCE: CLEARED, and
+ * both panel_graph_outline and panel_query_graph then returned the PREVIOUS
+ * workflow as ordinary successes. Clearing the fence on an identity claim is what
+ * turns a wrong-graph read into a trusted one. So this path now probes the live
+ * graph UNDER THE EXISTING FENCE first:
+ *   - the read SUCCEEDS → the canvas still answers as the previous workflow.
+ *     Do not re-derive. Contradict "you are on the right workflow".
+ *   - the read is refused with `workflow instance mismatch` → the canvas identity
+ *     actually moved. That is the #1337 wedge; re-derive as before.
+ *   - the read does not come back → content is unverified. Do not re-derive.
  */
+type LiveGraphUnderFence =
+  | { status: "answered" }
+  | { status: "mismatch_refused" }
+  | { status: "unanswered"; detail: string };
+
+async function probeLiveGraphUnderCurrentFence(ctx: PanelToolCtx): Promise<LiveGraphUnderFence> {
+  // `fields:"ids", limit:1` is the cheapest shape that still has to pass the
+  // instance fence — we only need whether the canvas STILL ACCEPTS this session's
+  // stamp, not the graph itself.
+  let res: ToolResult;
+  try {
+    res = await ctx.call({ cmd: "graph_query", fields: "ids", limit: 1 }, 8000);
+  } catch (err) {
+    if (isWorkflowInstanceMismatch(err)) return { status: "mismatch_refused" };
+    return { status: "unanswered", detail: err instanceof Error ? err.message : String(err) };
+  }
+  if (!res?.isError) return { status: "answered" };
+  const text = toolResultText(res);
+  if (isWorkflowInstanceMismatch(text)) return { status: "mismatch_refused" };
+  // An acked executor error still means the fence passed — the canvas is the
+  // one this session was already bound to.
+  if (isPanelAnsweredResult(res)) return { status: "answered" };
+  return { status: "unanswered", detail: text };
+}
+
+function identityClaimedContentUnverifiedNote(detail: string): string {
+  const busy = queueBusyTimeoutNote();
+  return (
+    `\n\nFENCE: NOT cleared (live graph unread). The panel asserted the canvas IS bound to the ` +
+    `requested workflow, but a live graph read did not come back (${detail || "no reason was reported"}), ` +
+    `so content is UNVERIFIED. Identity-matched is not content-matched: do NOT trust ` +
+    `"you are on the right workflow" / "You are NOT on the wrong workflow". Do NOT edit or save ` +
+    `expecting the opened file. Retry the graph read (panel_graph_outline) once the tab answers.` +
+    busy
+  );
+}
+
+function identityClaimedButLiveGraphUnchangedNote(ctx: PanelToolCtx): string {
+  const fence = currentWorkflowFence(ctx);
+  const fenceTxt =
+    fence.known && fence.uuid
+      ? `under this session's existing fence (${fence.uuid})`
+      : `without being refused by a workflow-instance fence`;
+  return (
+    `\n\nFENCE: NOT cleared (live graph still answers). CONTENT MISMATCH: the panel asserted the ` +
+    `canvas IS bound to the requested workflow, but a live graph read still answers ${fenceTxt} — ` +
+    `the graph on screen is the PREVIOUS workflow, not the one just opened. That is the failure ` +
+    `the fence exists to prevent: clearing it here would let later reads of this graph succeed ` +
+    `as if they were the opened file. Do NOT trust "you are on the right workflow" / ` +
+    `"You are NOT on the wrong workflow". Do NOT edit or save expecting the opened file. ` +
+    `Read the graph (panel_graph_outline) to see what is actually open, then retry ` +
+    `panel_open_workflow or panel_load_workflow if the canvas did not switch.`
+  );
+}
+
 async function clearFenceOnIdentityProvenOpen(
   ctx: PanelToolCtx,
   res: ToolResult,
@@ -4122,6 +4230,14 @@ async function clearFenceOnIdentityProvenOpen(
   // prove that the active canvas was rebound") must keep failing closed: re-deriving a
   // fence onto a canvas we cannot identify is how an edit lands on the wrong graph.
   if (!/the canvas IS bound to/i.test(text)) return { res, repaired: false };
+
+  const canvas = await probeLiveGraphUnderCurrentFence(ctx);
+  if (canvas.status === "answered") {
+    return { res: appendToolResultText(res, identityClaimedButLiveGraphUnchangedNote(ctx)), repaired: false };
+  }
+  if (canvas.status === "unanswered") {
+    return { res: appendToolResultText(res, identityClaimedContentUnverifiedNote(canvas.detail)), repaired: false };
+  }
 
   let note: string;
   // #1560 — reported STRUCTURALLY, never re-read out of the sentence below. The caller
@@ -7432,6 +7548,11 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
+      // #1639 — a running prompt freezes the tab's graph_* channel. Refuse
+      // BEFORE dispatch so a mutation is known-not-applied rather than
+      // delivered-into-a-frozen-tab with a 20/30s unknown-outcome timeout.
+      const blocked = graphCmdBlockedByRunningPrompt(cmd);
+      if (blocked) return fail(blocked);
       const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid));
       // panel#1097 — a guard-domain command that SUCCEEDS is the evidence that the
       // switch is over, whichever attempt lands it. Without this an ordinary
@@ -7534,7 +7655,7 @@ export function makePanelToolCtx(
           // Leaving it unmarked fails closed (nothing is settled, no false success)
           // but silently switches the settle off for a real sequence, which is the
           // kind of gap that reads as "the fix does not work" much later.
-          return carryReplyTimeoutMark(err2, fail(err2));
+          return carryReplyTimeoutMark(err2, fail(`${err2 instanceof Error ? err2.message : String(err2)}${queueBusyTimeoutNote()}`));
         }
       }
       // #442 defect 4: a MUTATING command (deliberately excluded from RETRY_SAFE_CMDS)
@@ -7969,11 +8090,13 @@ export function makePanelToolCtx(
         return carryReplyTimeoutMark(
           err,
           fail(
-            `${cause}\n\nTo retry this exact mutation, re-issue identical args plus retry_of:"${dispatchedRid}"; otherwise call normally.`,
+            `${cause}\n\nTo retry this exact mutation, re-issue identical args plus retry_of:"${dispatchedRid}"; otherwise call normally.` +
+              queueBusyTimeoutNote(),
           ),
         );
       }
-      return carryReplyTimeoutMark(err, fail(err));
+      const timeoutCause = err instanceof Error ? err.message : String(err);
+      return carryReplyTimeoutMark(err, fail(`${timeoutCause}${queueBusyTimeoutNote()}`));
     }
   };
   /**


### PR DESCRIPTION
## Summary

Two related panel-reliability defects from a long sequential-render session.

**A. `graph_*` (including reads) time out while a prompt is running.** The panel tab's JS thread cannot answer `graph_set_widget` / `graph_query` / `graph_outline` while ComfyUI is executing. Waiting out the 20/30s ack bound only surfaced "tab may be backgrounded or frozen" with an unknown mutation outcome. QueueMonitor already knows a prompt is running (HTTP `/queue`, independent of the tab).

- Canvas-touching `graph_*` commands now refuse **before dispatch** with an explicit `QUEUE BUSY` (running prompt named). Outcome is known: nothing was applied.
- `graph_run` is excluded so a sweep can still queue behind an in-flight job (`panel_run`'s duplicate fence is unchanged).
- Timeouts that still happen (e.g. `graph_run`) are annotated with the same `QUEUE BUSY` instead of implying a frozen/backgrounded tab.

**B. `workflow_open` asserted "you are on the right workflow" while the canvas still showed the previous graph.** The identity-PROVEN verdict (`the canvas IS bound to X`) cleared the fence via `workflow_list` even when a live graph read still answered under the previous stamp. Later `panel_graph_outline` / `panel_query_graph` then returned the **old** graph as ordinary successes — the exact failure the fence exists to prevent.

A live `graph_query` now gates that re-derivation:

- read **succeeds** → canvas did not switch. Fence stays. Content mismatch named. Do not trust "you are on the right workflow".
- read refused with `workflow instance mismatch` → canvas identity actually moved. `#1337` recovery is unchanged.
- read does not come back → content unverified. Fence stays.

Fixes #1639

## Test plan

- [x] `src/__tests__/orchestrator/graph-read-during-render.test.ts` — fail-fast reads/mutations while running; `graph_run` still dispatches; timeout annotated QUEUE BUSY; idle queue unchanged
- [x] `src/__tests__/orchestrator/open-content-mismatch-fence.test.ts` — live graph still answering does not clear the fence; unread graph is UNVERIFIED; instance-mismatch still re-derives (#1337)
- [x] Existing `#1337` / `#1560` / `#887` open-workflow suites still pass (graph_query mismatch stubbed so the identity-moved path remains covered)
- [x] `npx tsc --noEmit`
