### PR TITLE
fix(1697): the progress counter runs at Node's default buffer depth again — 4 MiB measured 0.77x

### DIFF
--- a/src/__tests__/services/download-progress-counter.test.ts
+++ b/src/__tests__/services/download-progress-counter.test.ts
@@ -1,17 +1,20 @@
-// #1697 — the progress-counting Transform in streamUrlToFile must OBSERVE the
-// transfer, never pace it, and never misreport it.
+// #1697 — the progress-counting Transform in streamUrlToFile must never
+// MISREPORT the transfer: the bytes it tallies are exactly the bytes that
+// reached disk, and no row it publishes claims more than the transfer carried.
 //
-// It was constructed with Node's default 16 KiB highWaterMark — the narrowest
-// buffer in a chain whose write stream alone buffers 64 KiB — so every chunk
-// cost a full backpressure circuit. Measured in the issue: 0.35–0.48 MB/s where
-// curl held 12 MB/s on the same link (~25x), a steady ~16 KiB per ~40 ms.
+// This is a counting-arithmetic guard, and it is deliberately independent of the
+// counter's buffer depth — it passes at Node's default and at any explicit
+// highWaterMark, because the counting is per chunk either way. That
+// independence is the point: re-chunking is the thing that could silently break
+// the tally, so the test pushes 128 chunks of 48 KiB (not a multiple of any
+// stage's buffer) through the REAL exported downloadUrlToFile and compares disk
+// bytes against the counter's terminal progress row.
 //
-// Two things are pinned here:
-//   1. the counter's buffer depth is deep enough that it can never be the
-//      narrowest stage again, and bounded so a stalled sink can't grow memory
-//      without limit;
-//   2. counting honesty: through the deep buffer, the bytes the counter tallies
-//      are exactly the bytes that reached disk.
+// It does NOT pin a buffer depth. #1738 briefly added a 4 MiB highWaterMark here
+// on the theory that the default paced the pipeline; a later alternating A/B
+// against a same-round straight pipe measured the opposite (the default is the
+// fastest depth tried, and 4 MiB ran 0.77x unthrottled), so the override was
+// removed. See the comment beside the Transform in download-cache.ts.
 
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -49,7 +52,7 @@ vi.mock("../../services/download-progress.js", async () => {
   };
 });
 
-import { __downloadCacheTestHooks, downloadUrlToFile } from "../../services/download-cache.js";
+import { downloadUrlToFile } from "../../services/download-cache.js";
 
 const fetchMock = vi.fn();
 let tempDir: string;
@@ -84,17 +87,7 @@ afterEach(async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
 
-describe("progress counter buffer depth (#1697)", () => {
-  it("the counter's highWaterMark is deep enough to never pace the pipeline, and bounded", () => {
-    const hwm = __downloadCacheTestHooks.progressCounterHighWaterMark;
-    // Below 1 MiB the counter risks being the narrowest buffer in the chain
-    // again (the regression: 16 KiB vs the write stream's 64 KiB).
-    expect(hwm).toBeGreaterThanOrEqual(1024 * 1024);
-    // Deep, not unbounded: a stalled sink must not be able to buffer the whole
-    // model in memory.
-    expect(hwm).toBeLessThanOrEqual(64 * 1024 * 1024);
-  });
-
+describe("progress counter honesty (#1697)", () => {
   it("counts exactly the bytes that reach disk, across many chunks", async () => {
     // 128 chunks of 48 KiB = 6 MiB — chunk sizes deliberately NOT a multiple of
     // any stage's buffer, so the count survives arbitrary re-chunking.

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1125,17 +1125,8 @@ function cacheDir(): string {
  *  #1567 adds `cachePathForUrl` so a test can stage a `.partial` under a SPECIFIC
  *  header identity (the writer's own derivation) instead of re-implementing the
  *  hash — a fixture derived from a parallel implementation cannot falsify the
- *  lookup it feeds (#1370).
- *  #1697 adds `progressCounterHighWaterMark` (a getter: the constant is declared
- *  further down, beside the pipeline it belongs to) so a test can pin the
- *  progress counter's buffer depth without re-constructing the pipeline. */
-export const __downloadCacheTestHooks = {
-  cacheDir,
-  cachePathForUrl,
-  get progressCounterHighWaterMark() {
-    return PROGRESS_COUNTER_HIGH_WATER_MARK;
-  },
-};
+ *  lookup it feeds (#1370). */
+export const __downloadCacheTestHooks = { cacheDir, cachePathForUrl };
 
 function cacheSizeLimitBytes(): number {
   const raw = Number(process.env.COMFYUI_LRU_CACHE_SIZE_GB ?? "0");
@@ -1332,22 +1323,6 @@ function normalizeEtag(value: string | null | undefined): string | null {
   if (/^[0-9a-f]+$/i.test(s)) s = s.toLowerCase();
   return s;
 }
-
-/** #1697 — buffer depth for the progress-counting Transform in streamUrlToFile.
- *
- *  Without an explicit highWaterMark a Transform inherits Node's 16 KiB default
- *  and becomes the narrowest buffer in the chain (the write stream alone buffers
- *  64 KiB): every chunk then costs a full backpressure circuit (source pause →
- *  transform → sink → drain → resume), and when that circuit crosses a real
- *  network/disk boundary its latency is tens of ms — a 20 GB download measured
- *  0.35–0.48 MB/s while curl held 12 MB/s on the same link (~25x), steady at
- *  ~16 KiB per ~40 ms, the signature of the 16 KiB window pacing the transfer.
- *  The no-progress branch (a straight pipe, no interposed stream) does not
- *  suffer it. A deep buffer lets the counter OBSERVE bytes instead of
- *  rate-limiting them; bounded at 4 MiB so a stalled sink can't grow memory
- *  without limit, and progress honesty is unchanged — counting is per chunk
- *  either way and the tray emit is already time-windowed (400 ms). */
-const PROGRESS_COUNTER_HIGH_WATER_MARK = 4 * 1024 * 1024;
 
 async function streamUrlToFile(
   url: string,
@@ -2340,10 +2315,17 @@ async function streamUrlToFile(
         )
       : undefined;
   emit("downloading", true); // show the row immediately, even before the first chunk
+  // #1697 — deliberately NO explicit highWaterMark: the counter runs at Node's
+  // default, which matches the write stream it feeds (measured in-pipeline on
+  // Node v24: both `writableHighWaterMark` are 16384; 64 KiB is createReadStream's
+  // default, not createWriteStream's). Benchmarked against a same-round straight
+  // pipe over loopback at 512 MiB x 16 rounds, the default is the fastest counter
+  // depth tried (1.16x) and shows no deficit at any rate measured; WIDENING it is
+  // what costs throughput once the source outruns the sink — 4 MiB ran 0.77x the
+  // straight pipe unthrottled and 0.92x at 400 MB/s, with the crossover between
+  // 200 and 400 MB/s. Do not add one back without a fresh alternating A/B in the
+  // regime you care about.
   const counter = new Transform({
-    // #1697 — deep enough that the counter OBSERVES bytes instead of pacing the
-    // pipeline; see PROGRESS_COUNTER_HIGH_WATER_MARK.
-    highWaterMark: PROGRESS_COUNTER_HIGH_WATER_MARK,
     transform(chunk: Buffer, _enc, cb) {
       downloaded += chunk.length;
       // Feed the watchdog FIRST and unconditionally — before the 400 ms throughput


### PR DESCRIPTION
This **corrects** #1738 rather than reverting it wholesale. #1738's honesty test is kept — it is the good part, and it is doing real work. What comes out is the one thing measurement does not support: the explicit `PROGRESS_COUNTER_HIGH_WATER_MARK = 4 MiB` on the progress-counting `Transform` in `streamUrlToFile`.

Nothing here reopens anything. #1697 is closed and stays closed; this only corrects a constant that landed while chasing the underlying cause of #1697.

## The stated premise does not hold

#1738's root-cause paragraph says the counter "became the narrowest buffer in the chain (**the write stream alone buffers 64 KiB**)". Printed inside the live pipeline on Node **v24.16.0**:

```
createWriteStream  writableHighWaterMark = 16384   <- the sink
new Transform({})  writableHighWaterMark = 16384   <- the counter, at its default
createReadStream   readableHighWaterMark = 65536   <- where the 64 KiB number actually comes from
```

64 KiB is `createReadStream`'s default, not `createWriteStream`'s. The counter at its default was never *narrower* than the sink it feeds — it was exactly equal. The "narrowest stage" mechanism has nothing to stand on.

The mechanism does not survive on the other side either: a **512-byte** HWM — 32x *narrower* than the "pathological" default — holds 12.7 MB/s at the reporter's own curl speed, and is the fastest counter arm on loopback. A 16 KiB buffer cannot have paced anything down to 0.35 MB/s.

## The measurements

Rig: the real exported `downloadUrlToFile()` over a loopback server, arms **alternating in one process**, shuffled order per round, each arm normalised to the **same round's** straight pipe (so drift in disk/CPU state cannot favour an arm).

**Unthrottled loopback, 512 MiB x 16 rounds** — ratio to same-round straight pipe:

| counter HWM | ratio |
| --- | --- |
| 512 B | 1.113 |
| **16 KiB (Node default)** | **1.163** |
| 64 KiB | 0.974 |
| 256 KiB | 0.866 |
| 1 MiB | 0.790 |
| **4 MiB (what #1738 shipped)** | **0.770** |

The 4 MiB arm runs **~32% below the default arm**.

**Throttled** — 4 MiB arm's ratio to same-round straight pipe:

| source rate | 4 MiB ratio |
| --- | --- |
| 12 MB/s | 0.999 |
| 80 MB/s | 0.999 |
| 200 MB/s | 0.997 |
| **400 MB/s** | **0.923** |

**The crossover sits between 200 and 400 MB/s.** Below it the buffer depth is invisible — the source is the constraint and every arm is at parity. Above it, a deep counter buffer starts costing throughput.

An independent single alternating A/B on this rig (3 rounds, 512 MiB, separate harness driving the same topology `fetch -> Readable.fromWeb -> counter -> createWriteStream`) reproduces it: **default 1.140**, **4 MiB 0.764**.

## Both prior sessions measured correctly

This is worth stating plainly, because it looks like a contradiction and is not one. **Neither session blundered.** Session B's null result at ~80 MB/s and Session A's regression at ~390 MB/s are *both right* — they sat on opposite sides of the crossover. At 80 MB/s the 4 MiB arm really is at parity (0.999); at ~390 MB/s it really is down ~8%. Two correct measurements in two different throughput regimes, reported honestly. The disagreement was never about rigor; it was about which regime each rig happened to be in, which nobody had named yet.

The same generosity applies to #1738 itself. The author did careful work: the issue's symptom was real, the pipeline reasoning was legible and specific enough to be *falsifiable*, and the honesty test they wrote is a genuinely good test. It is only the numeric premise underneath the constant that turned out to be wrong.

## What this PR does

- **Removes the explicit `highWaterMark`** from the counter `Transform`, restoring pre-#1738 behaviour (Node's default). It is not re-tuned to a different magic number: the default shows **no deficit against a straight pipe at any rate measured**, so there is no throughput case for raising it. (64 KiB was the largest depth that never charged anything, but it never beat the default either — so the honest choice is simply not to override.)
- **Deletes `PROGRESS_COUNTER_HIGH_WATER_MARK`** and the `progressCounterHighWaterMark` test hook that existed only to pin it. `__downloadCacheTestHooks` goes back to `{ cacheDir, cachePathForUrl }`.
- **Keeps the honesty test** (`counts exactly the bytes that reach disk, across many chunks`). Verified by measurement, not assumption: with the constant set to 16 KiB the honesty test still passes, so it is a genuine *constant-independent* guard on the counter's arithmetic — 128 x 48 KiB through the real progress path, asserting disk bytes == counter tally == terminal progress row, with no row over-counting. Chunk size is deliberately not a multiple of any stage's buffer, so re-chunking cannot hide a drift.
- **Drops the buffer-depth guard test.** It pinned the disputed number (it fails `expected 16384 to be >= 1048576` the moment the constant is lowered) and its comment restated the false 64 KiB premise. With the override gone, the counter and its sink are both Node defaults by construction, so there is no longer an invariant a test could falsify — the guard would assert nothing.
- **Corrects the prose.** The comment block above the constant and the test file's header both asserted the 64 KiB premise and the pacing mechanism. Grepped tree-wide; those two sites were the only ones. The replacement comment beside the `Transform` records why the default is deliberate, names the measured direction, and tells the next reader not to add a value back without a fresh alternating A/B in the regime they care about.

## Verification

- `src/__tests__/services/` — **216 files, 5068 passed**, 3 skipped.
- Download suites specifically (`download-progress-counter`, `download-cache`, `download-cache-failclosed`, `download-retry`) — **4 files, 144 passed**. The honesty test passes with the constant gone.
- `tsc --noEmit` (this repo's `npm run lint`) — clean.
- `check:vocabulary` — OK, 1664 files scanned, no live references to dead names.

## What is still open

The underlying cause of #1697 — the reporter's 0.35-0.48 MB/s against curl's 12 MB/s on the same link — is **not** explained by buffer depth, and this PR does not claim to explain it. Removing a constant that measured 0.77x is worth doing on its own merits, but the original symptom needs a fresh look with the pacing hypothesis off the table. Flagging that explicitly so it is not quietly assumed handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
