### PR TITLE
fix(1670): do not report a post-crash 502 as a base-URL misconfiguration

### DIFF
--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -41,6 +41,7 @@ import {
   guardClientFetch,
   isNonJsonResponseError,
   redactUrlForDiagnosis,
+  resetComfyApiRootValidated,
 } from "../../comfyui/json-guard.js";
 
 /** Every response the fake server will give, in order. */
@@ -59,6 +60,7 @@ beforeEach(() => {
   // wiring under test rather than one another's leftovers.
   resetClient();
   resetObjectInfoCache();
+  resetComfyApiRootValidated();
 });
 
 describe("the library's non-2xx path can no longer eat the response (#828)", () => {
@@ -222,6 +224,10 @@ describe("classifyNonJson on an empty body", () => {
       body: "",
     });
     expect(d.kind).toBe("proxy-error");
+    // #1670 — a 502 empty body is an outage, not the SPA-catch-all remedy.
+    expect(d.message).toMatch(/temporary server outage/i);
+    expect(d.message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(d.message).not.toContain("the same catch-all that produced this page");
   });
 
   // Pins the empty branch's POSITION, not just its existence. Moving it above

--- a/src/__tests__/comfyui/json-guard.test.ts
+++ b/src/__tests__/comfyui/json-guard.test.ts
@@ -13,7 +13,7 @@
 // reported as HTML, and a valid-JSON-but-wrong-document 200 is reported as such
 // instead of being handed on as data.
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // The body prefix is diagnostic, but a gateway that REFLECTS the request could
 // put our own ComfyUI credential in it — and the prefix goes into an error the
@@ -27,9 +27,16 @@ import {
   classifyNonJson,
   isNonJsonResponseError,
   looksLikeHtmlParsedAsJson,
+  noteComfyApiRootValidated,
   readComfyJson,
+  resetComfyApiRootValidated,
   rethrowWithJsonDiagnosis,
 } from "../../comfyui/json-guard.js";
+import { getComfyUIBaseUrl } from "../../config.js";
+
+beforeEach(() => {
+  resetComfyApiRootValidated();
+});
 
 const URL_UNDER_TEST = "http://remote.example:8188/api/workflow_templates";
 
@@ -322,6 +329,41 @@ describe("classifyNonJson names what answered instead of ComfyUI (#828)", () => 
     expect(d.message).toContain("/system_stats");
     expect(d.message).toContain("devices");
     expect(d.message).toContain("is not proof");
+  });
+
+  // #1670 — a CUDA crash that takes ComfyUI down surfaces as an empty 502 on
+  // /history and /internal/logs. The SPA-catch-all remedy ("confirm the base
+  // URL is a ComfyUI API root") is the wrong next step: the host answered, and
+  // a 502 empty body is what a proxy returns when the upstream is gone.
+  it("does not prescribe a base-URL check for an empty 502", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/history",
+      status: 502,
+      contentType: "",
+      body: "",
+    });
+    expect(d.kind).toBe("proxy-error");
+    expect(d.message).toContain("EMPTY body");
+    expect(d.message).toMatch(/temporary server outage/i);
+    expect(d.message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(d.message).not.toContain("the same catch-all that produced this page");
+    expect(d.message).not.toContain("really is a ComfyUI API root");
+  });
+
+  it("names a previously-validated root as an outage, not a misconfiguration", () => {
+    noteComfyApiRootValidated(getComfyUIBaseUrl());
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/internal/logs",
+      status: 502,
+      contentType: "",
+      body: "",
+    });
+    expect(d.message).toContain("already served");
+    expect(d.message).toContain("/system_stats");
+    expect(d.message).toContain("not newly misconfigured");
+    expect(d.message).toMatch(/temporary server outage/i);
+    expect(d.message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(d.message).not.toContain("the same catch-all that produced this page");
   });
 });
 

--- a/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
+++ b/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
@@ -1,0 +1,130 @@
+// #1670 — after a CUDA crash, /history and /internal/logs answer HTTP 502 with
+// an EMPTY body. Diagnostics used to append the SPA-catch-all remedy
+// ("Confirm the configured ComfyUI base URL really is a ComfyUI API root")
+// even though the same endpoint had just served /system_stats JSON.
+//
+// These tests drive the SHIPPED tools — get_history (action:"diagnose") and
+// get_system_stats (action:"logs") — through the real client wiring. Mocking
+// classifyNonJson or getHistory would let the wrong next-step survive.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { resetClient } from "../../comfyui/client.js";
+import { resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
+import { registerDiagnosticsTools } from "../../tools/diagnostics.js";
+import { registerSystemStatsTools } from "../../tools/system-stats.js";
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function getHandler(
+  name: string,
+  register: (server: never) => void,
+): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  register(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+function empty502(): Response {
+  return new Response(null, { status: 502, statusText: "Bad Gateway" });
+}
+
+function statsOk(): Response {
+  return new Response(
+    JSON.stringify({
+      system: { comfyui_version: "0.33.1" },
+      devices: [{ name: "cuda:0" }],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/** Route /system_stats to JSON while healthy; everything else is the post-crash 502. */
+function serve(mode: { healthy: boolean }): void {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const href = String(input);
+    if (mode.healthy && href.includes("/system_stats")) return statsOk();
+    return empty502();
+  }) as unknown as typeof fetch;
+}
+
+function expectOutageNotMisconfig(text: string): void {
+  expect(text).toContain("502");
+  expect(text).toContain("EMPTY body");
+  expect(text).toMatch(/temporary server outage/i);
+  expect(text).not.toContain("Confirm the configured ComfyUI base URL");
+  expect(text).not.toContain("the same catch-all that produced this page");
+  expect(text).not.toContain("really is a ComfyUI API root");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+  resetComfyApiRootValidated();
+});
+
+describe("post-CUDA-crash empty 502 is an outage, not a base-URL misconfig (#1670)", () => {
+  it('get_history (action:"diagnose") does not prescribe reconfiguring the base URL', async () => {
+    serve({ healthy: false });
+    const out = await getHandler("get_history", registerDiagnosticsTools)({ action: "diagnose" });
+    expect(out.isError).toBe(true);
+    const text = out.content[0].text;
+    expect(text).toContain("/history");
+    expectOutageNotMisconfig(text);
+  });
+
+  it('get_system_stats (action:"logs") does not prescribe reconfiguring the base URL', async () => {
+    serve({ healthy: false });
+    const out = await getHandler("get_system_stats", registerSystemStatsTools)({ action: "logs" });
+    expect(out.isError).toBe(true);
+    const text = out.content[0].text;
+    expect(text).toContain("/internal/logs");
+    expectOutageNotMisconfig(text);
+  });
+
+  it("a prior successful /system_stats makes the 502 name the previously-working root", async () => {
+    const mode = { healthy: true };
+    serve(mode);
+
+    const stats = await getHandler("get_system_stats", registerSystemStatsTools)({ action: "stats" });
+    expect(stats.isError).not.toBe(true);
+    expect(stats.content[0].text).toContain("0.33.1");
+
+    // Same configured endpoint, now answering empty 502 the way nginx does
+    // after ComfyUI dies on a CUDA illegal-memory-access.
+    mode.healthy = false;
+
+    const diagnose = await getHandler("get_history", registerDiagnosticsTools)({
+      action: "diagnose",
+    });
+    const logs = await getHandler("get_system_stats", registerSystemStatsTools)({
+      action: "logs",
+    });
+
+    for (const out of [diagnose, logs]) {
+      expect(out.isError).toBe(true);
+      const text = out.content[0].text;
+      expectOutageNotMisconfig(text);
+      expect(text).toContain("already served");
+      expect(text).toContain("/system_stats");
+      expect(text).toContain("not newly misconfigured");
+    }
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -23,6 +23,7 @@ import {
   isNonJsonResponseError,
   looksLikeHtmlParsedAsJson,
   NonJsonResponseError,
+  noteComfyApiRootValidated,
   provesNonJsonAnswer,
   readComfyJson,
   redactErrorMessage,
@@ -209,6 +210,10 @@ export async function getSystemStats(): Promise<SystemStats> {
     expectShape: looksLikeSystemStats,
     shapeHint: "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
   });
+  // Shape-valid /system_stats is the in-session proof that this base URL is a
+  // ComfyUI API root. A later empty 502 must not be reported as a misconfigured
+  // URL (#1670).
+  noteComfyApiRootValidated(getComfyUIBaseUrl());
   return stats;
 }
 

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -852,6 +852,42 @@ export function describeStatus(status: number, statusText?: string): string {
   return safe === null ? String(status) : `${status} ${safe}`;
 }
 
+/**
+ * In-session proof that the configured base URL is a ComfyUI API root.
+ *
+ * A later empty 502 on /history or /internal/logs used to append "Confirm the
+ * configured ComfyUI base URL really is a ComfyUI API root" — the SPA-catch-all
+ * remedy — even when /system_stats had just returned JSON on that same root
+ * (#1670). A CUDA crash that takes ComfyUI down looks exactly like that 502,
+ * and sending the operator to reconfigure COMFYUI_URL loses the traceback they
+ * came for.
+ *
+ * Recorded only from a shape-valid /system_stats document. A JSON envelope from
+ * some other service on the host is not this proof.
+ */
+let validatedApiRoot: string | undefined;
+
+function normalizeApiRoot(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+/** Record that this session already got a shape-valid /system_stats from `baseUrl`. */
+export function noteComfyApiRootValidated(baseUrl: string): void {
+  const n = normalizeApiRoot(baseUrl);
+  if (n) validatedApiRoot = n;
+}
+
+/** Test isolation — the note is process-wide, same as the client singleton. */
+export function resetComfyApiRootValidated(): void {
+  validatedApiRoot = undefined;
+}
+
+function wasComfyApiRootValidated(): boolean {
+  return (
+    validatedApiRoot !== undefined && validatedApiRoot === normalizeApiRoot(getComfyUIBaseUrl())
+  );
+}
+
 /** Reason phrases that merely restate their code. Lowercased for comparison. */
 const STANDARD_REASON_PHRASES: ReadonlySet<string> = new Set([
   "ok",
@@ -929,7 +965,9 @@ export function classifyNonJson(args: {
     kind = "proxy-error";
     cause = proxyPage
       ? "a reverse proxy in front of ComfyUI returned its OWN error page (its markers are in the body) — the proxy is up but could not reach, or timed out talking to, ComfyUI itself"
-      : `a gateway-class status (${status}) came back with a non-JSON body; ComfyUI does not normally emit these, so something between you and it most likely did, though this response does not identify what`;
+      : empty
+        ? `a gateway-class status (${status}) came back with an EMPTY body. A reverse proxy typically answers this way when ComfyUI crashed, is restarting, or is otherwise unreachable — a temporary server outage, not a sign that the configured ComfyUI base URL is pointing at the wrong place. This response does not identify which of those happened`
+        : `a gateway-class status (${status}) came back with a non-JSON body; ComfyUI does not normally emit these, so something between you and it most likely did, though this response does not identify what`;
   } else if (authStatus || loginPage) {
     kind = "login";
     cause = loginPage
@@ -995,11 +1033,23 @@ export function classifyNonJson(args: {
         : contentType
           ? `a ${contentType} body that did not parse as JSON`
           : "a body that did not parse as JSON";
+  // A 502/503/504 (or a body-confirmed proxy error page) is not the SPA
+  // catch-all. The catch-all remedy — "confirm the configured base URL is a
+  // ComfyUI API root" — sent operators to reconfigure a working COMFYUI_URL
+  // after a CUDA crash took the server down (#1670). Name the outage; only
+  // HTML/wrong-responder answers still get the base-URL check.
+  const statsCheck = `${redactUrlForDiagnosis(getComfyUIBaseUrl())}/system_stats`;
+  const gatewayOutage = kind === "proxy-error";
+  const nextStep = gatewayOutage
+    ? wasComfyApiRootValidated()
+      ? `This same ComfyUI API root already served ${statsCheck} JSON this session, so the base URL is not newly misconfigured. Treat this as a temporary server outage (crash, restart, or a proxy that cannot reach ComfyUI) and retry after the server is back`
+      : `This is a temporary server outage — ComfyUI crashed, is restarting, or a proxy in front of it could not reach it — not evidence that the configured ComfyUI base URL is pointing at the wrong place. Retry after the server is back; if ${statsCheck} then returns JSON, the base URL was fine`
+    : `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
+      `The check is that ${statsCheck} returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong`;
   const message =
     `${url} answered ${reason} with ${what} where JSON was expected. This means ${cause}. ` +
     `Content-Type: ${contentType || "(none)"}. Body starts: ${bodyPrefix || "(empty)"}. ` +
-    `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
-    `The check is that ${redactUrlForDiagnosis(getComfyUIBaseUrl())}/system_stats returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong` +
+    nextStep +
     // The credential instruction must follow the same evidence rule as the
     // diagnosis above. Only a body-confirmed sign-in page justifies "give it to
     // the gateway"; a bare 401/403 could equally be ComfyUI's own auth layer, and


### PR DESCRIPTION
## Root cause

After a CUDA illegal-memory-access crash, ComfyUI (or the proxy in front of it) answers `/history` and `/internal/logs` with HTTP 502 and an empty body. `classifyNonJson` already labelled that `proxy-error`, then **always** appended the SPA-catch-all remedy:

> Confirm the configured ComfyUI base URL really is a ComfyUI API root

That sentence is for a 200 HTML frontend catch-all. It is not what an empty 502 means, and it is actively wrong when the same endpoint had just served `/system_stats` JSON. The operator is sent to reconfigure a working `COMFYUI_URL` at the exact moment crash diagnostics are needed.

## Fix

- A 502/503/504 (or a body-confirmed proxy error page) is named as a **temporary server outage** (crash, restart, or proxy that cannot reach ComfyUI). The catch-all / "confirm the base URL" clause is no longer attached.
- A successful shape-valid `/system_stats` is recorded in-session. A later 502 on that same root says the URL is not newly misconfigured and to retry after ComfyUI is back.
- HTML/wrong-responder answers still get the existing base-URL check.

## Verification

- `npx vitest run --maxWorkers=4 src/__tests__/comfyui/json-guard.test.ts src/__tests__/comfyui/client-fetch-json-guard.test.ts src/__tests__/comfyui/json-guard-base-url-redaction.test.ts src/__tests__/tools/post-crash-502-not-misconfig.test.ts src/__tests__/comfyui/history-non-json.test.ts src/__tests__/comfyui/system-stats-non-json.test.ts` — 119 passed
- Neighboring suites (html-instead-of-json, diagnose-run, system-stats, get-history-actions, unreachable-status-branches) — 138 passed
- `npx tsc --noEmit` — clean

The shipped-path tests drive `get_history(action:"diagnose")` and `get_system_stats(action:"logs")` through the real client against an empty 502, including the prior-successful-`/system_stats` case.

Fixes #1670
