### PR TITLE
fix(panel#1292): recover the turn pin before mode:current claims bound

### DIFF
--- a/src/__tests__/orchestrator/current-bind-clears-ambiguity.test.ts
+++ b/src/__tests__/orchestrator/current-bind-clears-ambiguity.test.ts
@@ -1,0 +1,302 @@
+// panel#1292 — `panel_set_workflow_target({mode:"current"})` reported
+// `graph_binding:"bound"` from the workflow-instance fence, then the next
+// `panel_graph_outline` / `panel_set_todo` failed because the turn-origin pin
+// was still `null` (`issued from multiple workflows at once`).
+//
+// Same class as panel#888, which only fixed `mode:"pinned"`. Two holes:
+//   1. Same-batch siblings start while the pin is still null, even if the bind
+//      later recovers it.
+//   2. `bound` can be emitted from the fence even when `repinScopeToActive`
+//      declined.
+//
+// Contract: after this tool reports `graph_binding:"bound"`, `resolvedPinOf`
+// for that conversation is a live tab, not `null`. Tests drive the shipped
+// UiBridge + panel-tools + TurnOriginTracker path — not a source-text grep.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import { SHARED_SESSION_SCOPE } from "../../services/session-scope.js";
+import {
+  TurnOriginTracker,
+  makeScopeRepinHandler,
+  makeScopeTargetResolver,
+} from "../../orchestrator/turn-origins.js";
+import { buildPanelToolDefs, makePanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const SCOPE_KEY = `${SHARED_SESSION_SCOPE}::claude`;
+const TAB_A = "wf:tab-one:workflows/a.json";
+const TAB_B = "wf:tab-two:workflows/b.json";
+const TAB_C = "wf:tab-three:workflows/c.json";
+const PATH_A = "workflows/a.json";
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join("\n");
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close→rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(port: number, tabId: string, title: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: tabId,
+          title,
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function autoReply(sock: WebSocket, tag: string, path: string): void {
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString());
+    if (!msg.rid || !msg.cmd) return;
+    if (msg.cmd === "workflow_list") {
+      sock.send(
+        JSON.stringify({
+          rid: msg.rid,
+          ok: true,
+          result: {
+            active: {
+              path,
+              routing_key: `wf:${path}`,
+              workflow_uuid: UUID,
+              active: true,
+            },
+            workflows: [
+              {
+                path,
+                routing_key: `wf:${path}`,
+                workflow_uuid: UUID,
+                active: true,
+              },
+            ],
+          },
+        }),
+      );
+      return;
+    }
+    sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { from: tag, cmd: msg.cmd } }));
+  });
+}
+
+describe("panel#1292 mode:'current' recovers the turn pin before claiming bound", () => {
+  let bridge: UiBridge;
+  let port: number;
+  let tracker: TurnOriginTracker;
+  let tabBackends: Map<string, string>;
+
+  beforeEach(async () => {
+    ({ bridge, port } = await startBridge());
+    bridge.setTabWorkflowUuidResolver(() => UUID);
+    tabBackends = new Map();
+    const backendOfKey = (key: string): string =>
+      key.includes("::") ? key.slice(key.lastIndexOf("::") + 2) : "claude";
+    const backendForTab = (tab: string): string => tabBackends.get(tab) ?? "claude";
+    tracker = new TurnOriginTracker({
+      backendForTab,
+      backendOfKey,
+      uuidOfTab: () => UUID,
+      liveTabOf: (tab) => bridge.liveTabIdFor(tab),
+      warn: () => {},
+    });
+    const scopeAgentKeyOf = (scopeId: string): string =>
+      scopeId === SHARED_SESSION_SCOPE ? SCOPE_KEY : scopeId;
+    bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker, scopeAgentKeyOf }));
+    bridge.setScopeRepinHandler(
+      makeScopeRepinHandler({
+        bridge,
+        tracker,
+        scopeAgentKeyOf,
+        backendForTab,
+        backendOfKey,
+        info: () => {},
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  async function pinAmbiguous(tabs: string[]): Promise<void> {
+    tabs.forEach((tab, i) => {
+      tracker.recordForMid(`m-${i}`, UUID, tab);
+      tracker.onSeen(SCOPE_KEY, `m-${i}`);
+    });
+    await waitFor(() => expect(tracker.pinOf(SCOPE_KEY)).toBeNull());
+  }
+
+  function tools() {
+    const defs = buildPanelToolDefs();
+    const ctx = makePanelToolCtx(bridge, SCOPE_KEY, new WorkflowTargetStore());
+    return {
+      ctx,
+      setTarget: defs.find((d) => d.name === "panel_set_workflow_target")!,
+      outline: defs.find((d) => d.name === "panel_graph_outline")!,
+      setTodo: defs.find((d) => d.name === "panel_set_todo")!,
+    };
+  }
+
+  it("same-batch panel_graph_outline does not fail ambiguous while mode:current recovers the pin", async () => {
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    autoReply(a, "tab-a", PATH_A);
+    autoReply(b, "tab-b", "workflows/b.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    a.send(JSON.stringify({ type: "user_message", text: "from a" }));
+    await waitFor(() => expect(bridge.resolveActiveScopeTab()).toBe(TAB_A));
+    await pinAmbiguous([TAB_A, TAB_B]);
+
+    const { ctx, setTarget, outline } = tools();
+    // Outline first: it hits the null pin, then waits for the bind in this batch.
+    const outlineP = outline.handler({}, ctx);
+    const bindP = setTarget.handler({ mode: "current" }, ctx);
+    const [outlineRes, bindRes] = await Promise.all([outlineP, bindP]);
+
+    expect(tracker.resolvedPinOf(SCOPE_KEY), "the bind must recover the turn pin").toBe(TAB_A);
+    expect(bridge.canReach(SCOPE_KEY)).toBe(true);
+    expect(outlineRes.isError, textOf(outlineRes as ToolResult)).toBeFalsy();
+    expect(textOf(outlineRes as ToolResult)).not.toContain("issued from multiple workflows at once");
+    const bindText = textOf(bindRes as ToolResult);
+    if (bindText.includes('"graph_binding": "bound"') || bindText.includes('"graph_binding":"bound"')) {
+      expect(typeof tracker.resolvedPinOf(SCOPE_KEY)).toBe("string");
+      expect(tracker.resolvedPinOf(SCOPE_KEY)).not.toBeNull();
+    }
+    expect(bindRes.isError, bindText).toBeFalsy();
+    a.close();
+    b.close();
+  });
+
+  it("same-batch panel_set_todo rides the same recovery", async () => {
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    autoReply(a, "tab-a", PATH_A);
+    autoReply(b, "tab-b", "workflows/b.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    a.send(JSON.stringify({ type: "user_message", text: "from a" }));
+    await waitFor(() => expect(bridge.resolveActiveScopeTab()).toBe(TAB_A));
+    await pinAmbiguous([TAB_A, TAB_B]);
+
+    const { ctx, setTarget, setTodo } = tools();
+    const todoP = setTodo.handler({ items: [{ text: "x", status: "pending" }] }, ctx);
+    const bindP = setTarget.handler({ mode: "current" }, ctx);
+    const [todoRes, bindRes] = await Promise.all([todoP, bindP]);
+
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBe(TAB_A);
+    expect(todoRes.isError, textOf(todoRes as ToolResult)).toBeFalsy();
+    expect(bindRes.isError, textOf(bindRes as ToolResult)).toBeFalsy();
+    a.close();
+    b.close();
+  });
+
+  it("does not emit graph_binding bound when the turn pin stays null", async () => {
+    // Active tab belongs to another backend; this conversation has two eligible
+    // tabs, so mode:"current" cannot name one — the #1077 stuck case.
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    const c = await connectPanel(port, TAB_C, "c");
+    autoReply(a, "tab-a", PATH_A);
+    autoReply(b, "tab-b", "workflows/b.json");
+    autoReply(c, "tab-c", "workflows/c.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(3));
+    tabBackends.set(TAB_B, "codex");
+    b.send(JSON.stringify({ type: "user_message", text: "from b" }));
+    await waitFor(() => expect(bridge.resolveActiveScopeTab()).toBe(TAB_B));
+    await pinAmbiguous([TAB_A, TAB_C]);
+
+    const { ctx, setTarget, outline } = tools();
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    const bindText = textOf(bindRes as ToolResult);
+
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBeNull();
+    expect(bindText).not.toMatch(/"graph_binding":\s*"bound"/);
+    expect(bindText).toMatch(/pin was NOT moved|turn routing|issued from multiple workflows/i);
+
+    const outlineRes = await outline.handler({}, ctx);
+    expect(outlineRes.isError).toBe(true);
+    expect(textOf(outlineRes as ToolResult)).toContain("issued from multiple workflows at once");
+    a.close();
+    b.close();
+    c.close();
+  });
+
+  it("a graph call with no bind in flight still refuses the null pin (does not hang)", async () => {
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    autoReply(a, "tab-a", PATH_A);
+    autoReply(b, "tab-b", "workflows/b.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    await pinAmbiguous([TAB_A, TAB_B]);
+
+    const { ctx, outline } = tools();
+    const started = Date.now();
+    const outlineRes = await outline.handler({}, ctx);
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(outlineRes.isError).toBe(true);
+    expect(textOf(outlineRes as ToolResult)).toContain("issued from multiple workflows at once");
+    a.close();
+    b.close();
+  });
+
+  it("after bound, resolvedPinOf is a live tab — sequential follow-up also routes", async () => {
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    autoReply(a, "tab-a", PATH_A);
+    autoReply(b, "tab-b", "workflows/b.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    a.send(JSON.stringify({ type: "user_message", text: "from a" }));
+    await waitFor(() => expect(bridge.resolveActiveScopeTab()).toBe(TAB_A));
+    await pinAmbiguous([TAB_A, TAB_B]);
+
+    const { ctx, setTarget, outline } = tools();
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    const bindText = textOf(bindRes as ToolResult);
+    expect(bindRes.isError, bindText).toBeFalsy();
+    expect(typeof tracker.resolvedPinOf(SCOPE_KEY)).toBe("string");
+    expect(bridge.canReach(tracker.resolvedPinOf(SCOPE_KEY) as string)).toBe(true);
+    if (bindText.includes("graph_binding")) {
+      expect(bindText).toMatch(/"graph_binding":\s*"bound"/);
+    }
+
+    const outlineRes = await outline.handler({}, ctx);
+    expect(outlineRes.isError, textOf(outlineRes as ToolResult)).toBeFalsy();
+    a.close();
+    b.close();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12339,7 +12339,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Hold the send() wait BEFORE the first await so a same-batch sibling
           // that already hit the null pin waits instead of minting #884.
           if (recoveringScope) ctx.bridge.beginScopeRecovery?.(before);
-          const tryRebind = (): ToolResult | undefined => {
+          const tryRebind = (deferIfNoTabs: boolean): ToolResult | undefined => {
             try {
               // mode:"current" is THE explicit scope-recovery consent (#884 gate 3)
               // — the only caller that may escape a DEAD scope pin (a healthy pin
@@ -12379,6 +12379,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   !/multiple|last active|pass tab_id/i.test(msg);
               }
               if (!noTabsConnected) return fail(ambiguousRebindGuidance(ctx, err));
+              // The first pass is BEFORE awaitReachable. Deferring here skipped the
+              // wait, so a tab that reconnects mid-call (#474) was never adopted.
+              if (!deferIfNoTabs) return undefined;
               deferredBind = true;
               rebindNote =
                 " No panel tab is connected yet — cleared the stale binding; this session will " +
@@ -12391,19 +12394,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           try {
             // panel#1292 hole 1 — recover the turn pin SYNCHRONOUSLY, before
             // awaitReachable yields to same-batch siblings.
-            const failed = tryRebind();
+            const failed = tryRebind(false);
             if (failed) return failed;
             // Give an in-flight reconnect (a ComfyUI restart / panel reload still
             // settling) a brief chance to bind immediately, since this IS the recovery
             // signal the agent reaches for in exactly that window (#474). awaitReachable
             // rebinds via ensureReachable when a tab is (re)connected.
-            if (!deferredBind && ctx.awaitReachable) await ctx.awaitReachable();
+            if (ctx.awaitReachable) await ctx.awaitReachable();
             // A first attempt that found no canvas (or a dead pin that is still
             // dead after the wait) gets one more recovery now that a tab may exist.
             const pinStillDead =
               typeof ctx.bridge.canReach === "function" && !ctx.bridge.canReach(ctx.tabId);
-            if (!deferredBind && !currentModeTurnRepinned && pinStillDead) {
-              const failed2 = tryRebind();
+            if (!currentModeTurnRepinned && pinStillDead) {
+              const failed2 = tryRebind(true);
               if (failed2) return failed2;
             }
           } finally {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12329,63 +12329,85 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         let rebindNote = "";
         let deferredBind = false;
         let fenceRebind: WorkflowFenceRebind | undefined;
+        // panel#1292 — a scope ctx stays scope-bound, so ctx.tabId never changes
+        // on a successful turn-pin recovery. Track that separately from the
+        // real-tab rebind note below.
+        let currentModeTurnRepinned = false;
         if (mode === "current" && ctx.rebindToActiveTab) {
           const before = ctx.tabId;
-          // Give an in-flight reconnect (a ComfyUI restart / panel reload still
-          // settling) a brief chance to bind immediately, since this IS the recovery
-          // signal the agent reaches for in exactly that window (#474). awaitReachable
-          // rebinds via ensureReachable when a tab is (re)connected.
-          if (ctx.awaitReachable) await ctx.awaitReachable();
+          const recoveringScope = isScopeAddress(before);
+          // Hold the send() wait BEFORE the first await so a same-batch sibling
+          // that already hit the null pin waits instead of minting #884.
+          if (recoveringScope) ctx.bridge.beginScopeRecovery?.(before);
+          const tryRebind = (): ToolResult | undefined => {
+            try {
+              // mode:"current" is THE explicit scope-recovery consent (#884 gate 3)
+              // — the only caller that may escape a DEAD scope pin (a healthy pin
+              // still stays put; see rebindToActiveTab's double gate).
+              const rebind = ctx.rebindToActiveTab!({ scopeRecoveryConsent: true });
+              // #1077 Finding 2 — a scope repin that declined now says WHY.
+              if (rebind?.repinRefusal && !/pin was NOT moved/.test(rebindNote)) {
+                rebindNote += ` The session pin was NOT moved: ${rebind.repinRefusal}.`;
+              }
+              if (rebind?.rebound) currentModeTurnRepinned = true;
+            } catch (err) {
+              // #474: with 2+ live tabs the rebind is AMBIGUOUS — fail so the user picks.
+              // But with ZERO tabs connected (the "Connected: none" window right after a
+              // restart/reload where the old tmp: tab is gone) the recovery call must NOT
+              // hard-fail: clear the stale binding and record the current-mode intent so
+              // the session binds onto the tab the moment one reconnects, instead of
+              // stranding the agent with no way to recover.
+              const live = typeof ctx.bridge.tabs === "function" ? ctx.bridge.tabs() : undefined;
+              let noTabsConnected: boolean;
+              if (Array.isArray(live)) {
+                // Count only INTERACTIVE (canvas-owning) tabs: a headless-only reconnect is
+                // NOT a usable graph binding, so it defers (binds once a real canvas tab
+                // connects) rather than failing as if a tab were pickable. Call isHeadless
+                // THROUGH the bridge (it reads `this.conns`) — a detached reference would
+                // lose `this` and throw "reading 'conns'" (the same #478 unbound-method bug).
+                const isHeadlessTab = (id: string): boolean =>
+                  typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
+                const interactive = live.filter((t) => !isHeadlessTab(t.tab_id));
+                noTabsConnected = interactive.length === 0;
+              } else {
+                // No tab enumeration — classify by the resolve error: only "nothing
+                // connected" defers; an AMBIGUOUS multi-tab error must still fail so the
+                // user picks (never silently defer a routable-but-ambiguous session).
+                const msg = err instanceof Error ? err.message : String(err ?? "");
+                noTabsConnected =
+                  /no panel connected|not reachable|connected:\s*none|no connected tab/i.test(msg) &&
+                  !/multiple|last active|pass tab_id/i.test(msg);
+              }
+              if (!noTabsConnected) return fail(ambiguousRebindGuidance(ctx, err));
+              deferredBind = true;
+              rebindNote =
+                " No panel tab is connected yet — cleared the stale binding; this session will " +
+                "follow (bind onto) the tab as soon as one reconnects. Retry your graph tool in a " +
+                "moment; if nothing reconnects shortly, ask the user to refresh (reload) the ComfyUI " +
+                "browser tab, which reconnects the Agent panel after a restart (not an install issue).";
+            }
+            return undefined;
+          };
           try {
-            // completes the rebind if awaitReachable didn't. mode:"current" is
-            // THE explicit scope-recovery consent (#884 gate 3) — the only
-            // caller that may escape a DEAD scope pin (a healthy pin still
-            // stays put; see rebindToActiveTab's double gate).
-            const rebind = ctx.rebindToActiveTab({ scopeRecoveryConsent: true });
-            // #1077 Finding 2 — a scope repin that declined now says WHY, and
-            // this is where the user reads it. The refusal used to be a bare
-            // boolean, so a session stuck in the one state that repeats forever
-            // (the active tab belongs to another backend's conversation while
-            // this one has several eligible tabs) saw no difference from a
-            // healthy pin being correctly left alone.
-            if (rebind?.repinRefusal) {
-              rebindNote += ` The session pin was NOT moved: ${rebind.repinRefusal}.`;
+            // panel#1292 hole 1 — recover the turn pin SYNCHRONOUSLY, before
+            // awaitReachable yields to same-batch siblings.
+            const failed = tryRebind();
+            if (failed) return failed;
+            // Give an in-flight reconnect (a ComfyUI restart / panel reload still
+            // settling) a brief chance to bind immediately, since this IS the recovery
+            // signal the agent reaches for in exactly that window (#474). awaitReachable
+            // rebinds via ensureReachable when a tab is (re)connected.
+            if (!deferredBind && ctx.awaitReachable) await ctx.awaitReachable();
+            // A first attempt that found no canvas (or a dead pin that is still
+            // dead after the wait) gets one more recovery now that a tab may exist.
+            const pinStillDead =
+              typeof ctx.bridge.canReach === "function" && !ctx.bridge.canReach(ctx.tabId);
+            if (!deferredBind && !currentModeTurnRepinned && pinStillDead) {
+              const failed2 = tryRebind();
+              if (failed2) return failed2;
             }
-          } catch (err) {
-            // #474: with 2+ live tabs the rebind is AMBIGUOUS — fail so the user picks.
-            // But with ZERO tabs connected (the "Connected: none" window right after a
-            // restart/reload where the old tmp: tab is gone) the recovery call must NOT
-            // hard-fail: clear the stale binding and record the current-mode intent so
-            // the session binds onto the tab the moment one reconnects, instead of
-            // stranding the agent with no way to recover.
-            const live = typeof ctx.bridge.tabs === "function" ? ctx.bridge.tabs() : undefined;
-            let noTabsConnected: boolean;
-            if (Array.isArray(live)) {
-              // Count only INTERACTIVE (canvas-owning) tabs: a headless-only reconnect is
-              // NOT a usable graph binding, so it defers (binds once a real canvas tab
-              // connects) rather than failing as if a tab were pickable. Call isHeadless
-              // THROUGH the bridge (it reads `this.conns`) — a detached reference would
-              // lose `this` and throw "reading 'conns'" (the same #478 unbound-method bug).
-              const isHeadlessTab = (id: string): boolean =>
-                typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
-              const interactive = live.filter((t) => !isHeadlessTab(t.tab_id));
-              noTabsConnected = interactive.length === 0;
-            } else {
-              // No tab enumeration — classify by the resolve error: only "nothing
-              // connected" defers; an AMBIGUOUS multi-tab error must still fail so the
-              // user picks (never silently defer a routable-but-ambiguous session).
-              const msg = err instanceof Error ? err.message : String(err ?? "");
-              noTabsConnected =
-                /no panel connected|not reachable|connected:\s*none|no connected tab/i.test(msg) &&
-                !/multiple|last active|pass tab_id/i.test(msg);
-            }
-            if (!noTabsConnected) return fail(ambiguousRebindGuidance(ctx, err));
-            deferredBind = true;
-            rebindNote =
-              " No panel tab is connected yet — cleared the stale binding; this session will " +
-              "follow (bind onto) the tab as soon as one reconnects. Retry your graph tool in a " +
-              "moment; if nothing reconnects shortly, ask the user to refresh (reload) the ComfyUI " +
-              "browser tab, which reconnects the Agent panel after a restart (not an install issue).";
+          } finally {
+            if (recoveringScope) ctx.bridge.endScopeRecovery?.(before);
           }
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
@@ -12396,6 +12418,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // DIFFERENT workflows. In the middle of a wedge whose entire question
             // was whether the retarget did anything, it read as a no-op.
             rebindNote = ` Rebound this session from tab ${shortTabId(before)} onto the active tab ${shortTabId(ctx.tabId)}.`;
+          }
+          if (currentModeTurnRepinned) {
+            rebindNote +=
+              ` This session's turn routing was AMBIGUOUS (a reconnect delivered messages from ` +
+              `several workflows at once) and is now pinned to the active tab, so graph tools ` +
+              `will resolve deterministically.`;
           }
         }
         // PIN: bind to the EXACT open-workflow identity from the authoritative
@@ -12593,6 +12621,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const fence = fenceRebind
           ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause)
           : undefined;
+        // panel#1292 hole 2 — `graph_binding:"bound"` is a fence verdict, not a
+        // statement that the turn-origin pin was recovered. A null pin still
+        // mints the #884 refusal on the next scope-addressed graph call.
+        const turnPinStillAmbiguous = (): boolean =>
+          isScopeAddress(ctx.tabId) &&
+          typeof ctx.bridge.resolveFailure === "function" &&
+          ctx.bridge.resolveFailure(ctx.tabId) === "ambiguous";
+        const refuseBoundWhileAmbiguous = (): ToolResult =>
+          fail(
+            `panel_set_workflow_target({mode:"current"}) did NOT restore this session's turn ` +
+              `routing.\n\nAPPLIED (do not repeat this part): the workflow target is now ` +
+              `mode:"current"${rebindNote ? `.${rebindNote}` : "."}\n\nNOT APPLIED: the ` +
+              `workflow-instance fence could be described as bound, but the turn-origin pin ` +
+              `is still ambiguous, so the next graph call would fail with "issued from ` +
+              `multiple workflows at once". Name a workflow with ` +
+              `panel_set_workflow_target({mode:"pinned", path:...}) or wait for the next ` +
+              `single-origin message.`,
+          );
         // #1473 — TAKE THE ADVICE THIS MESSAGE GIVES, instead of assigning it as homework.
         //
         // The reporter restarted ComfyUI, called this, was told the binding was NOT
@@ -12694,10 +12740,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               fenceRebind && fenceRebind.status === "no_identity" && fenceRebind.before.known
                 ? fenceRebind.before.uuid
                 : undefined;
+            if (turnPinStillAmbiguous()) return refuseBoundWhileAmbiguous();
             return ok({
               ...target,
               graph_binding: "bound",
               ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
+              ...(currentModeTurnRepinned ? { turn_routing: "repinned" } : {}),
               note:
                 hint +
                 rebindNote +
@@ -12732,12 +12780,17 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             : scopeRepin && typeof scopeRepin === "object" && scopeRepin.reason
               ? ` NOTE — the workflow target was set, but this session's turn routing was NOT re-pinned: ${scopeRepin.reason}.`
               : "";
+        if (fence?.binding === "bound" && turnPinStillAmbiguous()) {
+          return refuseBoundWhileAmbiguous();
+        }
         return ok({
           ...target,
           ...(deferredBind ? { deferred: true } : {}),
           ...(fence ? { graph_binding: fence.binding } : {}),
           ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
-          ...(typeof scopeRepin === "string" ? { turn_routing: "repinned" } : {}),
+          ...(typeof scopeRepin === "string" || currentModeTurnRepinned
+            ? { turn_routing: "repinned" }
+            : {}),
           note: hint + rebindNote + (fence?.note ?? "") + scopeRepinNote,
         });
       },

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1536,6 +1536,17 @@ export class UiBridge {
    *  panel_set_workflow_target({mode:"current"}) consent). Returns the tab it
    *  repinned to, or undefined when nothing is resolvable. */
   private scopeRepinHandler: ((scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome) | null = null;
+  /**
+   * panel#1292 — an in-flight `mode:"current"` bind that is recovering a null
+   * turn pin. Same-batch siblings (`panel_graph_outline`, `panel_set_todo`)
+   * start while the pin is still ambiguous; `send()` waits here instead of
+   * minting the #884 refusal the bind is about to clear. Ref-counted so two
+   * overlapping binds on one scope do not drop the wait early.
+   */
+  private scopeRecovery = new Map<
+    string,
+    { count: number; done: Promise<void>; finish: () => void }
+  >();
   /** #884 — orchestrator-injected: normalize a hello's raw `backend` value the
    *  same way the orchestrator does (unknown/absent → the default backend), so
    *  the backend-qualified scope-buffer replay matches the conversation the
@@ -3278,6 +3289,52 @@ export class UiBridge {
     return this.scopeRepinHandler?.(scopeId, workflowPath);
   }
 
+  /**
+   * panel#1292 — mark that this scope's turn pin is being recovered. `send()`
+   * waits for {@link endScopeRecovery} before minting the mixed-origin refusal
+   * so a same-batch sibling can ride the bind rather than lose the race.
+   */
+  beginScopeRecovery(scopeId: string): void {
+    const rec = this.scopeRecovery.get(scopeId);
+    if (rec) {
+      rec.count += 1;
+      return;
+    }
+    let finish!: () => void;
+    const done = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    this.scopeRecovery.set(scopeId, { count: 1, done, finish });
+  }
+
+  /** panel#1292 — the matching close for {@link beginScopeRecovery}. */
+  endScopeRecovery(scopeId: string): void {
+    const rec = this.scopeRecovery.get(scopeId);
+    if (!rec) return;
+    rec.count -= 1;
+    if (rec.count > 0) return;
+    rec.finish();
+    this.scopeRecovery.delete(scopeId);
+  }
+
+  /**
+   * Wait for an in-flight scope recovery, or (if none is registered yet) yield
+   * once so a same-tick bind can register. Always returns: the caller retries
+   * `resolveTarget` and throws the original refusal if the pin is still null.
+   */
+  private awaitScopePinRecovery(scopeId: string): Promise<void> {
+    const rec = this.scopeRecovery.get(scopeId);
+    if (rec) return rec.done;
+    return Promise.resolve().then(() => {
+      const rec2 = this.scopeRecovery.get(scopeId);
+      if (rec2) return rec2.done;
+      return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => {
+        const rec3 = this.scopeRecovery.get(scopeId);
+        if (rec3) return rec3.done;
+      });
+    });
+  }
+
   /** #884 — inject the hello-backend normalizer (see the field doc). */
   setHelloBackendNormalizer(fn: (raw: unknown) => string): void {
     this.helloBackendNormalizer = fn;
@@ -4208,28 +4265,46 @@ export class UiBridge {
     }
   }
 
-  send(cmd: BridgeCommand, opts: { tabId?: string; timeoutMs?: number; onDispatchedRid?: (rid: string) => void } = {}): Promise<unknown> {
+  async send(cmd: BridgeCommand, opts: { tabId?: string; timeoutMs?: number; onDispatchedRid?: (rid: string) => void } = {}): Promise<unknown> {
     // #357: read (idempotent) ops get a more tolerant default so a busy-but-alive
     // panel main thread (e.g. Preview3D loading a large FBX) isn't declared frozen;
     // mutating ops keep the tight default. An explicit opts.timeoutMs always wins.
     const timeoutMs = opts.timeoutMs ?? defaultBridgeTimeoutMs(cmd.cmd);
     let conn: Conn;
-    try {
-      conn = this.resolveTarget(opts.tabId);
-    } catch (err) {
-      // Offline target: buffer a finished-render delivery for reconnect instead of
-      // failing, so the agent's "here's your image" isn't lost while the phone is away.
-      if (opts.tabId && UiBridge.isMailboxable(cmd)) {
-        this.storeMailbox(opts.tabId, cmd);
-        return Promise.resolve({ ok: true, mailboxed: true });
+    // panel#1292 — a mixed-origin pin is decided once per batch, but
+    // `mode:"current"` is the advertised recovery and may be running in THIS
+    // same batch. Wait for that recovery once before minting the refusal;
+    // `canReach` stays sync (it swallows the throw) so the wait is send-only.
+    let waitedForScopeRecovery = false;
+    for (;;) {
+      try {
+        conn = this.resolveTarget(opts.tabId);
+        break;
+      } catch (err) {
+        if (
+          !waitedForScopeRecovery &&
+          isRoutingAmbiguity(err) &&
+          opts.tabId &&
+          isScopeAddress(opts.tabId)
+        ) {
+          await this.awaitScopePinRecovery(opts.tabId);
+          waitedForScopeRecovery = true;
+          continue;
+        }
+        // Offline target: buffer a finished-render delivery for reconnect instead of
+        // failing, so the agent's "here's your image" isn't lost while the phone is away.
+        if (opts.tabId && UiBridge.isMailboxable(cmd)) {
+          this.storeMailbox(opts.tabId, cmd);
+          return { ok: true, mailboxed: true };
+        }
+        // resolveTarget threw BEFORE any socket write — no tab could be routed to (no
+        // connected tab / ambiguous / multiple / not reachable), so nothing was
+        // transmitted. Tag the rejection with the AUTHORITATIVE typed flag
+        // dispatched:false so a caller classifies "nothing applied" categorically (reboot
+        // readiness; the mutating-command rebind hint, panel #442) — never by
+        // string-matching a message whose text a post-dispatch executor error could quote.
+        throw markDispatched(err instanceof Error ? err : new Error(String(err)), false);
       }
-      // resolveTarget threw BEFORE any socket write — no tab could be routed to (no
-      // connected tab / ambiguous / multiple / not reachable), so nothing was
-      // transmitted. Tag the rejection with the AUTHORITATIVE typed flag
-      // dispatched:false so a caller classifies "nothing applied" categorically (reboot
-      // readiness; the mutating-command rebind hint, panel #442) — never by
-      // string-matching a message whose text a post-dispatch executor error could quote.
-      return Promise.reject(markDispatched(err instanceof Error ? err : new Error(String(err)), false));
     }
     // #236 — proactively gate a command this exact connection has already proven
     // unsupported (see Conn.unsupportedCmds), instead of dispatching it again just


### PR DESCRIPTION
## Why

Follow-through from [panel#1292](https://github.com/artokun/comfyui-mcp-panel/issues/1292). The refusal is minted in this repo, not the panel.

`panel_set_workflow_target({mode:"current"})` reported `graph_binding: "bound"` from the workflow-instance fence, then the next `panel_graph_outline` / `panel_set_todo` failed with:

```
no connected tab can be chosen … issued from multiple workflows at once
```

Same class as panel#888 / MCP 0.50.81, which only fixed `mode:"pinned"`. Two holes on current `main`:

1. Same-batch siblings start while the turn-origin pin is still `null`, even if the bind later recovers it (`await awaitReachable()` yielded before `repinScopeToActive`).
2. `graph_binding: "bound"` is a fence verdict. It can be emitted even when `repinScopeToActive` declined, so the next scope-addressed graph call still hits the #884 refusal.

## What

- Recover the turn pin **synchronously** at the start of `mode:"current"`, before any await, and hold a scope-recovery latch so in-flight `send()` waits instead of minting the mixed-origin refusal.
- `UiBridge.send()` retries `resolveTarget` once after that latch (or a same-tick yield). `canReach` stays sync.
- Do not emit `graph_binding: "bound"` while `resolveFailure(scope)` is still `"ambiguous"`. Fail and name the pinned-mode / next-single-origin recovery instead.

## Tests

`src/__tests__/orchestrator/current-bind-clears-ambiguity.test.ts` drives the shipped `UiBridge` + `panel_set_workflow_target` / `panel_graph_outline` / `panel_set_todo` + `TurnOriginTracker` path:

- same-batch outline / set_todo ride the recovery
- declined current-mode bind does not claim `bound`
- a lone graph call with no bind still refuses quickly
- after `bound`, `resolvedPinOf` is a live tab

Does not merge or release.
