### PR TITLE
fix(1672): unwind call_tool when get_system_stats times out mid-decode

### DIFF
--- a/src/__tests__/tools/system-stats-timeout-unwind.test.ts
+++ b/src/__tests__/tools/system-stats-timeout-unwind.test.ts
@@ -1,0 +1,132 @@
+// #1672 — get_system_stats(action:"stats") during a long VAE/audio decode
+// reported "The operation was aborted due to timeout" and then left the
+// enclosing call_tool cell pending until something killed it. The abort
+// cancelled fetch() after headers, but Response.text() / JSON.parse did not
+// observe it. These tests drive the SHIPPED path (call_tool → get_system_stats
+// → getSystemInfo → getSystemStats → fetch+decode) against a body that never
+// finishes, and assert call_tool settles promptly with a structured timeout.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ToolCatalog } from "../../tools/catalog.js";
+import { registerCompactTools } from "../../tools/compact.js";
+import { registerSystemStatsTools } from "../../tools/system-stats.js";
+import { SYSTEM_STATS_TIMEOUT_MS } from "../../comfyui/client.js";
+import { raceAbort } from "../../comfyui/fetch.js";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => false,
+}));
+
+function textOf(result: { content?: Array<{ type: string; text?: string }> }): string {
+  return (result.content ?? [])
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+/** A Response whose body decode never settles — even after the request abort. */
+function hangingDecodeResponse(): Response {
+  const res = new Response("{}", {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  Object.defineProperty(res, "text", {
+    value: () => new Promise<string>(() => { /* never settles */ }),
+  });
+  return res;
+}
+
+async function shippedCallToolClient(): Promise<Client> {
+  const catalog = new ToolCatalog();
+  registerSystemStatsTools(catalog.asRegistrar());
+  const server = new McpServer({ name: "test-1672", version: "0.0.0" });
+  registerCompactTools(server, catalog);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-1672-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+describe("raceAbort (#1672)", () => {
+  it("rejects as soon as the signal aborts, without waiting for work", async () => {
+    const ctl = new AbortController();
+    let finished = false;
+    const pending = raceAbort(ctl.signal, () => new Promise<string>(() => { /* hang */ }));
+    const raced = Promise.race([
+      pending.then(
+        () => {
+          finished = true;
+          return "resolved";
+        },
+        () => {
+          finished = true;
+          return "rejected";
+        },
+      ),
+      new Promise<"still-pending">((r) => setTimeout(() => r("still-pending"), 20)),
+    ]);
+    ctl.abort(Object.assign(new Error("The operation was aborted due to timeout"), { name: "TimeoutError" }));
+    await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(await raced).toBe("rejected");
+    expect(finished).toBe(true);
+  });
+});
+
+describe("call_tool(get_system_stats) unwinds a decode that ignores abort (#1672)", () => {
+  let restoreTimeout: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    const orig = AbortSignal.timeout.bind(AbortSignal);
+    // Keep every OTHER deadline real; only the stats probe is shortened so
+    // this test can wait for the shipped timer instead of faking the clock
+    // (fake timers break the in-memory MCP pair).
+    const spy = vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) =>
+      orig(ms === SYSTEM_STATS_TIMEOUT_MS ? 40 : ms),
+    );
+    restoreTimeout = () => spy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreTimeout?.();
+    restoreTimeout = undefined;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("settles call_tool promptly with a structured timeout, not a hang", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => hangingDecodeResponse()),
+    );
+
+    const client = await shippedCallToolClient();
+    const started = Date.now();
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "get_system_stats", args: { action: "stats" } },
+    })) as { isError?: boolean; content?: Array<{ type: string; text?: string }> };
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(2_000);
+    expect(res.isError).toBe(true);
+    const body = JSON.parse(textOf(res));
+    expect(body.error).toBe("COMFYUI_HTTP_TIMEOUT");
+    expect(body.message).toMatch(/\/system_stats/);
+    expect(body.message).toMatch(/timeout is not a refusal/);
+    expect(body.message).not.toMatch(/The operation was aborted due to timeout/);
+    expect(body.details).toEqual({
+      endpoint: "/system_stats",
+      timeout_ms: SYSTEM_STATS_TIMEOUT_MS,
+    });
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -13,7 +13,7 @@ import {
   ConnectionError,
   WorkflowExecutionError,
 } from "../utils/errors.js";
-import { comfyuiFetch } from "./fetch.js";
+import { comfyuiFetch, isTimeoutAbort, raceAbort } from "./fetch.js";
 import {
   bodyPrefixOf,
   classifyNonJson,
@@ -196,6 +196,11 @@ function looksLikeSystemStats(body: unknown): boolean {
   return (b.system != null && typeof b.system === "object") || Array.isArray(b.devices);
 }
 
+/** Budget for the /system_stats probe. Short on purpose: this is a liveness
+ *  read, and a ComfyUI mid-decode will not answer in time. Exported so the
+ *  call_tool timeout test can shrink only THIS deadline. */
+export const SYSTEM_STATS_TIMEOUT_MS = 15_000;
+
 export async function getSystemStats(): Promise<SystemStats> {
   if (isCloudMode()) return cloudClient.getSystemStats();
   requireLocalMode("getSystemStats");
@@ -205,16 +210,40 @@ export async function getSystemStats(): Promise<SystemStats> {
   // getComfyUIBaseUrl() carries the same path prefix, so a proxied/prefixed
   // remote resolves identically.
   const url = `${getComfyUIBaseUrl()}/system_stats`;
-  const stats = await fetchComfyJson<SystemStats>(url, {
-    init: { signal: AbortSignal.timeout(15000) },
-    expectShape: looksLikeSystemStats,
-    shapeHint: "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
-  });
-  // Shape-valid /system_stats is the in-session proof that this base URL is a
-  // ComfyUI API root. A later empty 502 must not be reported as a misconfigured
-  // URL (#1670).
-  noteComfyApiRootValidated(getComfyUIBaseUrl());
-  return stats;
+  // The 15s signal used to sit only on `fetch`. Headers arriving before the
+  // deadline left `readComfyJson` (`res.text()` + `JSON.parse`) unbounded, so
+  // the abort fired, the nested call reported "The operation was aborted due
+  // to timeout", and the enclosing call_tool stayed pending until something
+  // killed it (#1672). Race the WHOLE fetch+decode against the same signal.
+  const signal = AbortSignal.timeout(SYSTEM_STATS_TIMEOUT_MS);
+  try {
+    const stats = await raceAbort(signal, () =>
+      fetchComfyJson<SystemStats>(url, {
+        init: { signal },
+        expectShape: looksLikeSystemStats,
+        shapeHint:
+          "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
+      }),
+    );
+    // Shape-valid /system_stats is the in-session proof that this base URL is a
+    // ComfyUI API root. A later empty 502 must not be reported as a misconfigured
+    // URL (#1670). A timeout is not that proof — do not stamp on the abort path.
+    noteComfyApiRootValidated(getComfyUIBaseUrl());
+    return stats;
+  } catch (err) {
+    if (!isTimeoutAbort(err)) throw err;
+    // Structured, not the raw AbortSignal.timeout string: call_tool must
+    // settle with a result the caller can act on, not hang and not dump
+    // "The operation was aborted due to timeout" with no endpoint.
+    throw new ComfyUIError(
+      `No reply from ComfyUI within ${SYSTEM_STATS_TIMEOUT_MS / 1000}s — while requesting ${url} (GET). ` +
+        `Nothing was learned about the server from this — a timeout is not a refusal and not a "not found". ` +
+        `The connection was accepted but the body never finished, which is common while a long decode ` +
+        `occupies the server. The request was aborted; retry after the current job finishes.`,
+      "COMFYUI_HTTP_TIMEOUT",
+      { endpoint: "/system_stats", timeout_ms: SYSTEM_STATS_TIMEOUT_MS },
+    );
+  }
 }
 
 // /object_info is large (~MBs) and slow (300-800 ms) but only changes when

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -255,6 +255,55 @@ export function isTimeoutAbort(err: unknown): boolean {
   return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
 }
 
+function abortReasonOf(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
+  );
+}
+
+/**
+ * Reject as soon as `signal` aborts, even if `work` is still running.
+ *
+ * `AbortSignal.timeout` on `fetch` only cancels the HTTP exchange. Once headers
+ * have arrived, `Response.text()` / `JSON.parse` can keep the caller pending for
+ * as long as the body takes to finish — and a ComfyUI that is mid-decode
+ * (VAEDecodeAudio, a long VAE, …) often accepts `/system_stats` and then stalls
+ * on the body. The abort event IS fired; the decode does not observe it. Racing
+ * the abort against the whole fetch+decode is what lets `call_tool` settle
+ * instead of hanging until the decode ends or the process is killed (#1672).
+ *
+ * The inner promise is attached so a late rejection (the decode finally
+ * noticing the abort) cannot become an unhandledRejection after we already
+ * settled.
+ */
+export function raceAbort<T>(signal: AbortSignal | undefined, work: () => Promise<T>): Promise<T> {
+  if (!signal) return work();
+  if (signal.aborted) return Promise.reject(abortReasonOf(signal));
+  const workPromise = work();
+  workPromise.catch(() => {
+    /* settled via abort, or the then-path below already observed this */
+  });
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(abortReasonOf(signal));
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    workPromise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (err) => {
+        cleanup();
+        reject(err);
+      },
+    );
+  });
+}
+
 /**
  * Say what the ceiling did and did NOT establish.
  *


### PR DESCRIPTION
## Summary

While a long ACE-Step VAEDecodeAudio was running, `get_system_stats(action:"stats")` timed out with `The operation was aborted due to timeout` and left the enclosing `call_tool` cell pending until it was forcibly killed.

The 15s `AbortSignal.timeout` sat only on `fetch`. Once headers arrived, `readComfyJson` (`res.text()` + `JSON.parse`) no longer observed the abort — a busy ComfyUI often accepts `/system_stats` and then stalls on the body.

- `raceAbort` (shared AbortController path) rejects as soon as the signal fires, even if the body decode is still running.

- `getSystemStats` races the whole fetch+decode against the same 15s budget and converts the abort into a structured `ComfyUIError` (`COMFYUI_HTTP_TIMEOUT`) so `call_tool` settles immediately with a result the caller can act on.

Fixes #1672

## Test plan

- [x] `src/__tests__/tools/system-stats-timeout-unwind.test.ts` — `raceAbort` rejects without waiting for hung work; shipped `call_tool` → `get_system_stats` against a body that never finishes settles in <2s with `COMFYUI_HTTP_TIMEOUT` (not the raw abort string, not a hang)

- [x] existing `system-stats` / non-JSON / fetch / compact suites still pass

- [x] `npx tsc --noEmit`
