### PR TITLE
fix(1671): recover panel_restart_comfyui when the crash takes the bridge offline

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-bridge-offline.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-bridge-offline.test.ts
@@ -1,0 +1,326 @@
+// #1671: panel_restart_comfyui cannot recover when a crash takes the panel
+// bridge offline. The confirmation card used to be the only path, so a CUDA
+// 502 / dead tab answered "the panel could not be reached to ask" and left
+// the recovery command depending on the component that had just disappeared.
+//
+// The shipped path now falls back to the headless managed restart of the
+// configured local process when:
+//   - confirm is UNREACHABLE (the card never appeared)
+//   - ComfyUI is not healthy (down, or ambiguous like an empty-body 502)
+//   - the target is a known local boot instance
+// Confirmation and busy-queue stay: an explicit decline still does not
+// restart; a still-healthy server still does not auto-restart (#1332); a
+// readable busy queue still refuses without force:true.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remoteMode: { value: false },
+  configBase: { value: null as string | null },
+  restart: vi.fn(async () => ({ stopped: true, started: true, ready: true, message: "restarted" })),
+  getQueueVerified: vi.fn(async () => {
+    throw new Error("fetch failed");
+  }),
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isRemoteMode: () => hoisted.remoteMode.value || actual.isRemoteMode(),
+    getComfyUIBaseUrl: () => hoisted.configBase.value ?? actual.getComfyUIBaseUrl(),
+  };
+});
+
+vi.mock("../../services/process-control.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/process-control.js")>();
+  return { ...actual, restartComfyUI: hoisted.restart };
+});
+
+vi.mock("../../comfyui/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
+  return { ...actual, getQueueVerified: hoisted.getQueueVerified };
+});
+
+vi.mock("../../services/instance-witness.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../services/instance-witness.js")>()),
+  acquireInstanceWitness: async () => undefined,
+}));
+
+import {
+  buildPanelToolDefs,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { config, getBootLocalComfyUIBaseUrl } from "../../config.js";
+
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const text = (res: ToolResult): string =>
+  res.content.find((c) => c.type === "text")!.text as string;
+const parse = (res: ToolResult): Record<string, unknown> => JSON.parse(text(res));
+
+function restartTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def;
+}
+
+/** The crash: confirmation cannot be asked, and the tab handshake is gone. */
+function makeOfflineCtx(opts?: {
+  confirm?: "yes" | "no" | "unreachable";
+  /** Last-known handshake Origin — undefined models a tab that is truly gone. */
+  serverOrigin?: string | undefined;
+  tabIsLocal?: boolean;
+}): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
+  const sends: Array<Record<string, unknown>> = [];
+  const ctx = {
+    call: async () => {
+      throw new Error("ctx.call must not be used by the restart handler");
+    },
+    confirm: async () => opts?.confirm ?? "unreachable",
+    ensureReachable: () => {},
+    bridge: {
+      send: async (cmd: Record<string, unknown>) => {
+        sends.push(cmd);
+        throw new Error("panel tab is not open");
+      },
+      tabOrigin: () => undefined,
+      tabServerOrigin: () => opts?.serverOrigin,
+      tabIsLocal: () => opts?.tabIsLocal ?? false,
+      canReach: () => false,
+    } as unknown as PanelToolCtx["bridge"],
+    tabId: "dead-tab",
+    panelConnectionIdentity: () => undefined,
+    awaitPostRestartReachable: async () => false,
+    tabCanMutateGraph: () => false,
+  } as unknown as PanelToolCtx;
+  return { ctx, sends };
+}
+
+function scriptProbe(samples: Array<"healthy" | "down" | "unknown">): void {
+  let i = 0;
+  __panelToolsTestHooks.setHealthProbe(async () => samples[Math.min(i++, samples.length - 1)]);
+}
+
+/**
+ * Decline window must never see healthy (that folds into #1332 / recovered).
+ * After the decline window, observeRecovery needs an immediate down→up —
+ * leftover "unknown" samples on a 50ms Windows timer would eat the budget.
+ */
+function scriptCrashThenRecover(decline: "unknown" | "down"): void {
+  const started = Date.now();
+  let recoverySamples = 0;
+  __panelToolsTestHooks.setHealthProbe(async () => {
+    // 80ms covers the 40ms decline window plus timer slop.
+    if (Date.now() - started < 80) return decline;
+    recoverySamples++;
+    return recoverySamples < 2 ? "down" : "healthy";
+  });
+}
+
+beforeEach(() => {
+  hoisted.remoteMode.value = false;
+  hoisted.configBase.value = null;
+  hoisted.restart.mockClear();
+  hoisted.restart.mockResolvedValue({ stopped: true, started: true, ready: true, message: "restarted" });
+  hoisted.getQueueVerified.mockReset();
+  hoisted.getQueueVerified.mockRejectedValue(new Error("fetch failed"));
+  config.comfyuiRestartCommand = undefined;
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 400,
+    intervalMs: 5,
+    probeTimeoutMs: 5,
+  });
+  __panelToolsTestHooks.setDeclineProbeTiming({
+    windowMs: 40,
+    intervalMs: 5,
+    probeTimeoutMs: 5,
+  });
+});
+
+afterEach(() => {
+  config.comfyuiRestartCommand = undefined;
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setDeclineProbeTiming(null);
+  hoisted.remoteMode.value = false;
+  hoisted.configBase.value = null;
+});
+
+describe("panel_restart_comfyui — crash takes the panel bridge offline (#1671)", () => {
+  it("the issue: empty-body 502 (ambiguous) + dead tab → headless restart, not a 'could not be reached' dead-end", async () => {
+    // Decline window samples 502-class unknown; recovery then observes down→up.
+    scriptCrashThenRecover("unknown");
+    const { ctx, sends } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(o.rebooting).toBe(true);
+    expect(o.server_ready).toBe(true);
+    expect(o.confirmed_cycle).toBe(true);
+    expect(String(o.note)).toMatch(/panel bridge was offline/i);
+    expect(String(o.note)).toMatch(/headless managed restart/i);
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("ECONNREFUSED crash (down for the whole decline window) also recovers through the headless path", async () => {
+    scriptCrashThenRecover("down");
+    const { ctx, sends } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(o.server_ready).toBe(true);
+    expect(String(o.note)).toMatch(/panel bridge was offline/i);
+  });
+
+  it("#1332 preserved: UNREACHABLE + still-HEALTHY does NOT auto-restart", async () => {
+    scriptProbe(["healthy"]);
+    const { ctx, sends } = makeOfflineCtx();
+
+    const t = text(await restartTool().handler({}, ctx));
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(t).toMatch(/did NOT dispatch a restart/);
+    expect(t).toMatch(/could not be reached to ask/);
+    expect(t).toMatch(/server is reachable now/);
+    expect(t).toMatch(/restart_comfyui/);
+  });
+
+  it("confirmation safeguard: an EXPLICIT decline while down does NOT restart", async () => {
+    scriptProbe(["down", "down", "down", "down", "down", "down"]);
+    const { ctx, sends } = makeOfflineCtx({ confirm: "no" });
+
+    const t = text(await restartTool().handler({}, ctx));
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(t).toMatch(/ComfyUI is DOWN|ComfyUI appears to be DOWN/i);
+    expect(t).not.toMatch(/panel bridge was offline/i);
+  });
+
+  it("busy-queue safeguard: a readable busy queue refuses without force — nothing was stopped", async () => {
+    hoisted.getQueueVerified.mockResolvedValue({
+      queue_running: [{}],
+      queue_pending: [],
+    } as never);
+    scriptProbe(["unknown", "unknown", "unknown", "unknown", "unknown", "unknown"]);
+    const { ctx, sends } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(o.refused).toBe(true);
+    expect(String(o.note)).toMatch(/in progress or queued/);
+    expect(String(o.note)).toMatch(/force:true/);
+  });
+
+  it("force:true restarts even with a readable busy queue", async () => {
+    hoisted.getQueueVerified.mockResolvedValue({
+      queue_running: [{}],
+      queue_pending: [],
+    } as never);
+    scriptCrashThenRecover("unknown");
+    const { ctx } = makeOfflineCtx();
+
+    const res = await restartTool().handler({ force: true }, ctx);
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    expect(parse(res).server_ready).toBe(true);
+  });
+
+  it("unreadable queue on an already-unhealthy server is the crash — restart proceeds (not a refuse)", async () => {
+    hoisted.getQueueVerified.mockRejectedValue(new Error("HTTP 502"));
+    scriptCrashThenRecover("unknown");
+    const { ctx } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    expect(parse(res).server_ready).toBe(true);
+  });
+
+  it("a proven-different panel origin does NOT restart the configured server", async () => {
+    scriptProbe(["unknown", "unknown", "unknown", "unknown", "unknown", "unknown"]);
+    const { ctx, sends } = makeOfflineCtx({
+      serverOrigin: "http://127.0.0.1:9999",
+      tabIsLocal: true,
+    });
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(o.refused).toBe(true);
+    expect(String(o.note)).toMatch(/did NOT dispatch a restart/);
+    expect(String(o.note)).toMatch(/Do NOT reach for restart_comfyui/);
+  });
+
+  it("preflight failure refuses BEFORE anything is stopped — unrelaunchable process is not killed", async () => {
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: false,
+      reason: "Resolved ComfyUI script does not exist on disk: main.py",
+    }));
+    scriptProbe(["unknown", "unknown", "unknown", "unknown", "unknown", "unknown"]);
+    const { ctx } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(o.refused).toBe(true);
+    expect(String(o.note)).toMatch(/Refusing to restart ComfyUI/);
+    expect(String(o.note)).toMatch(/main\.py/);
+  });
+
+  it("COMFYUI_RESTART_COMMAND skips the failing preflight and runs the configured command", async () => {
+    config.comfyuiRestartCommand = "docker restart comfyui";
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: false,
+      reason: "Resolved ComfyUI script does not exist on disk: main.py",
+    }));
+    scriptCrashThenRecover("unknown");
+    const { ctx, sends } = makeOfflineCtx();
+
+    const res = await restartTool().handler({}, ctx);
+    const o = parse(res);
+
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(String(o.note)).toMatch(/COMFYUI_RESTART_COMMAND/);
+  });
+
+  it("REMOTE mode does not invent a local process to kill", async () => {
+    hoisted.remoteMode.value = true;
+    scriptProbe(["down", "down", "down", "down", "down", "down"]);
+    const { ctx } = makeOfflineCtx();
+
+    const t = text(await restartTool().handler({}, ctx));
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(t).toMatch(/ComfyUI is DOWN|ComfyUI appears to be DOWN/i);
+  });
+
+  it("does not claim graph-tools ready when the tab never came back — #654 honesty on this path too", async () => {
+    scriptCrashThenRecover("unknown");
+    const { ctx } = makeOfflineCtx();
+
+    const o = parse(await restartTool().handler({}, ctx));
+    expect(o.server_ready).toBe(true);
+    expect(o.ready).toBe(false);
+    expect(o.graph_tools_ready).toBe(false);
+    expect(o.panel_tab_reconnected).toBe("unknown");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2047,6 +2047,46 @@ function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   return loopbackProbeUrl(base);
 }
 
+/**
+ * #1671 — the configured LOCAL boot instance, when that is a known loopback
+ * process this orchestrator can account for without a live panel tab.
+ *
+ * `captureRebootHealthBase` requires a live tab handshake. After a crash that
+ * takes the panel bridge offline that proof is gone — the tab is the component
+ * that disappeared. The configured boot URL is still known, and it is the same
+ * target `restart_comfyui` would act on. Returning it is NOT a claim that the
+ * vanished tab fronted this instance; callers must still refuse a proven
+ * mismatch (see offlineRestartHealthBase).
+ */
+function configuredBootRestartBase(): string | null {
+  if (isCloudMode() || isRemoteMode()) return null;
+  const bootBase = getBootLocalComfyUIBaseUrl();
+  if (!bootBase || !isLoopbackOrigin(bootBase)) return null;
+  const base = bootBase.replace(/\/+$/, "");
+  if (!sameHttpBase(getComfyUIBaseUrl(), base)) return null;
+  return loopbackProbeUrl(base);
+}
+
+/**
+ * #1671 — which base, if any, a panel-offline crash recovery may restart.
+ *
+ * Prefer a still-provable tab binding. If the tab is gone, fall back to the
+ * configured boot instance UNLESS the last-known handshake Origin proves the
+ * panel was on a DIFFERENT server (#851/#1593: never restart the wrong one).
+ */
+function offlineRestartHealthBase(ctx: PanelToolCtx): string | null {
+  const bound = captureRebootHealthBase(ctx);
+  if (bound != null && sameHttpBase(getComfyUIBaseUrl(), bound)) return bound;
+  const observed = ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null;
+  const verdict = classifyRestartFallbackTarget({
+    headlessBase: getComfyUIBaseUrl(),
+    panelBase: bound,
+    observedOrigin: observed,
+  });
+  if (verdict.kind === "different") return null;
+  return configuredBootRestartBase();
+}
+
 let healthProbeOverride:
   | ((base: string | null, timeoutMs: number) => Promise<boolean | ProbeStatus>)
   | null = null;
@@ -13269,7 +13309,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_restart_comfyui",
-      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead, or set COMFYUI_RESTART_COMMAND to the exact command that restarts the instance (e.g. `docker restart <container>`): the restart then runs through that command (the busy guard above still applies) instead of needing the launch path.",
+      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. If a crash takes the panel bridge offline so the confirmation card cannot be shown, this tool falls back to a headless restart of the configured local process (or COMFYUI_RESTART_COMMAND) instead of depending on the dead bridge — it still refuses a readable busy queue without force:true, and still refuses when a relaunch cannot be proven. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead, or set COMFYUI_RESTART_COMMAND to the exact command that restarts the instance (e.g. `docker restart <container>`): the restart then runs through that command (the busy guard above still applies) instead of needing the launch path.",
       { force: z.boolean().optional() },
       async ({ force }, ctx) => {
         // Whole-handler budget (#536): confirm + dispatch + readiness — INCLUDING
@@ -13335,6 +13375,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               `and I'll re-ask. ${fallback}`,
           );
         }
+        // #1671 — set when the confirmation card was UNREACHABLE and ComfyUI is
+        // not healthy: the crash took the panel bridge offline, so recovery
+        // must not depend on asking that bridge. The headless path below runs
+        // instead. An explicit decline, a still-healthy server, and remote/
+        // cloud keep the existing reports (confirmation + busy-queue stay).
+        let recoverWithoutPanel = false;
         if (decision !== "yes") {
           // #742: NEVER claim "not restarted" while the server is actually DOWN —
           // and NEVER declare a loss from ONE probe (codex gate): a genuinely
@@ -13403,7 +13449,20 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               clearSessionRestartDispatchIfSame(ctx, declineHeldToken);
             }
           }
-          if (outcome.status === "down") {
+          // #1671: the recovery command must not depend on the component a crash
+          // takes offline. UNREACHABLE + not-healthy (down, or ambiguous — the
+          // reporter's empty-body HTTP 502) on a LOCAL target falls through to
+          // the headless restart. An explicit decline still reports and does
+          // NOT restart (confirmation). A still-healthy server still does not
+          // auto-restart (#1332). Remote/cloud have no local process to cycle.
+          const crashTookBridgeOffline =
+            decision === "unreachable" &&
+            (outcome.status === "down" || outcome.status === "ambiguous") &&
+            !isRemoteMode() &&
+            !isCloudMode();
+          if (crashTookBridgeOffline) {
+            recoverWithoutPanel = true;
+          } else if (outcome.status === "down") {
             const secs = Math.max(1, Math.round(outcome.waited_ms / 1000));
             if (boundToRestartTarget) {
               // r4: causation may be named ONLY against a RECORDED restart
@@ -13451,7 +13510,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 "manually if it is down, then reload the panel tab so it reconnects.",
             );
           }
-          if (outcome.status === "recovered" && boundToRestartTarget) {
+          if (recoverWithoutPanel) {
+            // Fall through to the headless path once runHeadlessManagedRestart
+            // is defined. Do not claim the server is reachable, and do not ask
+            // the dead panel to reboot it.
+          } else if (outcome.status === "recovered" && boundToRestartTarget) {
             // r14: the recovery CLAIM ("a restart initiated earlier appears to
             // have completed") passes the SAME causation gate as the DOWN
             // report — a session-held, bound-confirmed record, recent, and
@@ -13472,29 +13535,40 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 : "Cancelled — no new restart was dispatched. ComfyUI was briefly " +
                     "unreachable but is healthy again.",
             );
+          } else {
+            // #1332 — the reporter's exact string, and it was FALSE. They accepted the
+            // restart, ComfyUI restarted (a fresh startup in the server log), and this
+            // said it had not — because the restart dropped the socket the answer had to
+            // travel back on, and a transport failure used to arrive here as "no".
+            //
+            // The probes above already refuse to claim "not restarted" while the server
+            // is DOWN. This is the remaining case: the server is HEALTHY, which is
+            // equally true of "nothing happened" and of "it restarted and came back".
+            // With an explicit decline we know which; without one we do not, and the
+            // sentence must stop asserting it.
+            const fallback =
+              decision === "unreachable"
+                ? " " +
+                  restartTimeoutFallbackAdvice({
+                    headlessBase: getComfyUIBaseUrl(),
+                    panelBase: declineBootBase,
+                    observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
+                  })
+                : "";
+            return ok(
+              decision === "unreachable"
+                ? "This call did NOT dispatch a restart. Whether ComfyUI restarted for some " +
+                    "other reason cannot be told from here: the panel could not be reached to " +
+                    "ask for confirmation — the question never appeared — so no decision was " +
+                    "made either way, and the server is reachable now, which looks the same " +
+                    "whether it never went down or went down and came back. If you asked for a " +
+                    "restart and one has already happened, this is that transport loss, not a " +
+                    "cancellation. Check the ComfyUI log for a fresh startup line before " +
+                    "restarting again." +
+                    fallback
+                : "Cancelled — ComfyUI was not restarted.",
+            );
           }
-          // #1332 — the reporter's exact string, and it was FALSE. They accepted the
-          // restart, ComfyUI restarted (a fresh startup in the server log), and this
-          // said it had not — because the restart dropped the socket the answer had to
-          // travel back on, and a transport failure used to arrive here as "no".
-          //
-          // The probes above already refuse to claim "not restarted" while the server
-          // is DOWN. This is the remaining case: the server is HEALTHY, which is
-          // equally true of "nothing happened" and of "it restarted and came back".
-          // With an explicit decline we know which; without one we do not, and the
-          // sentence must stop asserting it.
-          return ok(
-            decision === "unreachable"
-              ? "This call did NOT dispatch a restart. Whether ComfyUI restarted for some " +
-                  "other reason cannot be told from here: the panel could not be reached to " +
-                  "ask for confirmation — the question never appeared — so no decision was " +
-                  "made either way, and the server is reachable now, which looks the same " +
-                  "whether it never went down or went down and came back. If you asked for a " +
-                  "restart and one has already happened, this is that transport loss, not a " +
-                  "cancellation. Check the ComfyUI log for a fresh startup line before " +
-                  "restarting again."
-              : "Cancelled — ComfyUI was not restarted.",
-          );
         }
         // Heal an orphaned session onto the live tab FIRST, then bind the reboot dispatch
         // to that ONE tab id (no await between capture and dispatch, so JS run-to-
@@ -13505,11 +13579,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // Run the HEADLESS managed restart (restartComfyUI) from inside this tool and
         // report its outcome against OUR OWN independent boot-endpoint observation
         // (never restartComfyUI's self-reported readiness, which a first-healthy
-        // no-op would flunk). Shared by two call sites that must not dispatch the tab
-        // reboot: the legacy no-endpoint fallback below (#425), and a configured
-        // COMFYUI_RESTART_COMMAND (panel#1262). Both require a BOUND-CONFIRMED local
-        // target: restartComfyUI acts on the orchestrator's GLOBAL config target, so
-        // it may run only when the bound tab provably fronts our own boot instance.
+        // no-op would flunk). Shared by three call sites that must not dispatch the
+        // tab reboot: the legacy no-endpoint fallback below (#425), a configured
+        // COMFYUI_RESTART_COMMAND (panel#1262), and #1671 crash recovery when the
+        // panel bridge is already gone. restartComfyUI acts on the orchestrator's
+        // GLOBAL config target, so the first two require a BOUND-CONFIRMED local
+        // tab; #1671 may also use the configured boot instance when the tab is gone.
         const runHeadlessManagedRestart = async (args: {
           healthBase: string;
           preRestartPanelIdentity: { generation: number; tabSessionId: string } | undefined;
@@ -13686,6 +13761,119 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                     : `but it did NOT become healthy within ${Math.round(recovery.waited_ms / 1000)}s — verify with get_system_stats (action:"health") / panel_node_queue_status before assuming it restarted.`),
           });
         };
+        // #1671: panel-offline crash recovery. The confirmation card could not
+        // be shown because the bridge is gone, and ComfyUI is not healthy
+        // (down, or an empty-body 502). Restart the configured local process
+        // through the same headless path the Manager-missing and
+        // COMFYUI_RESTART_COMMAND cases already use. Do NOT send comfy_reboot
+        // — that is the dead bridge. A readable busy queue still refuses
+        // without force:true; an unreadable queue on an already-unhealthy
+        // server is the crash, not "idle", and is not a reason to refuse.
+        // A proven-different panel origin, or a process we cannot relaunch,
+        // fails with the true cause instead of claiming success.
+        if (recoverWithoutPanel) {
+          const healthBase = offlineRestartHealthBase(ctx);
+          if (healthBase == null || !sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              refused: true,
+              note:
+                "This call did NOT dispatch a restart. The panel could not be reached to " +
+                "ask for confirmation (the crash took the panel bridge offline) and I " +
+                "cannot identify a local ComfyUI process I can account for, so I will " +
+                "not stop a server I cannot prove I can bring back. Nothing was " +
+                "stopped. " +
+                restartRefusalHandoffAdvice({
+                  headlessBase: getComfyUIBaseUrl(),
+                  panelBase: captureRebootHealthBase(ctx),
+                  observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
+                }),
+            });
+          }
+          if (force !== true) {
+            let busyCount: number | null = null;
+            try {
+              const queue = await getQueueVerified();
+              busyCount = queue.queue_running.length + queue.queue_pending.length;
+            } catch {
+              // Unreadable queue + already-unhealthy server is the crash itself.
+              // Unlike the configured-command YES path, "cannot check" is not a
+              // reason to refuse: the generation that might have been running
+              // is the one that took the bridge down.
+              busyCount = null;
+            }
+            if (busyCount != null && busyCount !== 0) {
+              return ok({
+                rebooting: false,
+                ready: false,
+                confirmed_cycle: false,
+                refused: true,
+                note:
+                  `Refusing to restart ComfyUI: ${busyCount} generation(s) are in progress ` +
+                  "or queued, and a restart ABORTS them. The panel could not be reached " +
+                  "to ask, so nothing was stopped. Wait for the queue to drain, or retry " +
+                  "with force:true ONLY if the user explicitly confirms they want to kill " +
+                  "the running generation.",
+              });
+            }
+          }
+          const configuredCmd = config.comfyuiRestartCommand;
+          if (!configuredCmd) {
+            const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
+            if (!preflight.ok) {
+              return ok({
+                rebooting: false,
+                ready: false,
+                confirmed_cycle: false,
+                refused: true,
+                note:
+                  "The panel could not be reached to ask for confirmation (the crash " +
+                  "took the panel bridge offline). Refusing to restart ComfyUI: " +
+                  `${preflight.reason} A restart from here would STOP ComfyUI and ` +
+                  "nothing would bring it back automatically, so it was refused " +
+                  "BEFORE anything was stopped. Restart it from whatever launches it, " +
+                  "or set COMFYUI_RESTART_COMMAND to the exact command that restarts " +
+                  "the instance.",
+              });
+            }
+          }
+          const postHealthBase = offlineRestartHealthBase(ctx);
+          if (postHealthBase == null || !sameHttpBase(healthBase, postHealthBase)) {
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              refused: true,
+              note:
+                "Refusing to restart ComfyUI: the ComfyUI target changed while the " +
+                "offline recovery was being prepared, so I can no longer confirm the " +
+                "headless restart would act on the instance this session accounts for. " +
+                "Nothing was stopped.",
+            });
+          }
+          return runHeadlessManagedRestart({
+            healthBase,
+            preRestartPanelIdentity: ctx.panelConnectionIdentity?.(),
+            why:
+              "The panel could not be reached to ask for confirmation (the crash took " +
+              "the panel bridge offline)",
+            mechanism: configuredCmd
+              ? "the configured restart command"
+              : "the headless managed restart (kill + relaunch)",
+            noteHealthyLead: configuredCmd
+              ? "The panel bridge was offline after the crash, so the restart ran " +
+                "through COMFYUI_RESTART_COMMAND; ComfyUI"
+              : "The panel bridge was offline after the crash, so the restart ran " +
+                "through the headless managed restart; ComfyUI",
+            noteRanLead: configuredCmd
+              ? "The panel bridge was offline after the crash, so the restart ran " +
+                "through COMFYUI_RESTART_COMMAND (not a panel confirmation card)"
+              : "The panel bridge was offline after the crash, so the restart ran " +
+                "through the headless managed restart (not a panel confirmation card)",
+          });
+        }
         // panel#1262: A CONFIGURED RESTART COMMAND REPLACES THE TAB REBOOT.
         //
         // On an externally-managed local install (a container, a systemd unit, a


### PR DESCRIPTION
## Root cause

`panel_restart_comfyui` could only dispatch a restart after a panel confirmation card. After a CUDA illegal-memory-access crash, two things fail together:

1. The panel bridge is gone, so `confirm` returns `unreachable`.
2. ComfyUI answers empty-body HTTP 502. The health probe classifies any HTTP response as `unknown` (not `down`), so the decline recheck ends `ambiguous`.

That combination fell through to the #1332 healthy-looking copy: *"This call did NOT dispatch a restart… the panel could not be reached to ask… the server is reachable now."* The 502 is not a reachable ComfyUI, and the recovery command depended on the component the crash had just taken offline.

Related panel work (#654 tab-reconnect honesty, #404 confirm-card bound) is already on main and is not re-implemented here. This is the orchestrator recovery when the bridge is already gone.

## Fix

When the confirmation card is **unreachable** and ComfyUI is **not healthy** (`down`, or `ambiguous` like a 502), `panel_restart_comfyui` falls through to the existing headless managed restart of the configured local process (the same `runHeadlessManagedRestart` path #425 and panel#1262 already use). It does **not** send `comfy_reboot` on the dead bridge.

Safeguards kept:

- An **explicit decline** still reports and does not restart.
- A **still-healthy** server still does not auto-restart (#1332). The #1332 copy now also names `restart_comfyui` when that tool aims at the same instance.
- A **readable busy queue** still refuses without `force:true`.
- An **unreadable** queue on an already-unhealthy server is the crash, not a reason to refuse.
- A **proven-different** panel origin still refuses (#851/#1593).
- An **unrelaunchable** process still refuses before anything is stopped (#742). `COMFYUI_RESTART_COMMAND` remains the escape hatch.
- Remote/cloud still have no local process to cycle.

If the vanished tab's binding cannot be proven, the fallback uses the configured boot instance — the same target `restart_comfyui` would act on — and says so. `ready` / `graph_tools_ready` stay false until the tab is actually back (#654).

## Verification

- New: `src/__tests__/orchestrator/panel-restart-bridge-offline.test.ts` (12 tests) — the issue's 502 + dead-tab shape; ECONNREFUSED crash; #1332 healthy-unreachable preserved; explicit decline; busy-queue refuse; force override; unreadable-queue proceeds; proven-different origin; preflight refuse; `COMFYUI_RESTART_COMMAND`; remote untouched; #654 reconnect honesty.
- Targeted on current `origin/main`: the new file plus `panel-restart-cancel-truth`, `confirm-unreachable-is-not-a-decline`, `panel-restart-legacy-fallback`, `panel-restart-configured-command` — 84 passed.

Fixes #1671
