### PR TITLE
feat(report): stamp WHICH LLM filed a panel bug report, mechanically

### DIFF
--- a/src/__tests__/orchestrator/agent-identity-wiring.test.ts
+++ b/src/__tests__/orchestrator/agent-identity-wiring.test.ts
@@ -1,0 +1,113 @@
+// WHICH LLM FILED THE REPORT — the orchestrator half of the channel.
+//
+// report_issue stamps the reporting model into the issue body, but it can only
+// read what the orchestrator published, and it runs in a DIFFERENT PROCESS: the
+// comfyui MCP subprocess, which knows nothing about panels, backends or chips.
+// Two wires make it work, and either one missing fails silently — reports keep
+// filing, just anonymously, which is indistinguishable from "nobody filed any":
+//
+//   1. the identity file's path reaches the subprocess in its spawn env, on BOTH
+//      spawn lanes (the Claude lane's buildMcpServers and the HTTP lane's
+//      makeHttpBackendMcpServers);
+//   2. the orchestrator republishes the identity at TURN DISPATCH.
+//
+// Both live inline in the orchestrator's start closure, so — like the other
+// index.ts boundary guards (shared-session-invariant.test.ts,
+// ask-answer-journal.test.ts) — the wiring is pinned at source level while the
+// behaviour underneath is driven by agent-identity.test.ts against the real
+// module.
+//
+// The lane check is not ceremony: this file already carries two written-up
+// incidents of a spawn variable forwarded on one lane and not the other
+// (COMFYUI_MCP_TOOL_PRESET in panel-secrets.ts, the #547/#884 download stamp),
+// and the Claude lane — the DEFAULT backend — is the one that got missed both
+// times.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const indexSrc = (): string =>
+  readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+
+/** The source of one inline arrow-function/object block, by its opening line. */
+function blockAfter(src: string, opener: string, endMarker: string): string {
+  const start = src.indexOf(opener);
+  expect(start, `opener not found: ${opener}`).toBeGreaterThan(-1);
+  const end = src.indexOf(endMarker, start);
+  expect(end, `end marker not found after ${opener}: ${endMarker}`).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe("agent identity reaches the MCP subprocess (both spawn lanes)", () => {
+  it("SOURCE: the HTTP lane (codex/gemini/ollama/…) forwards the identity path", () => {
+    const lane = blockAfter(
+      indexSrc(),
+      "const makeHttpBackendMcpServers = (tabId: string",
+      "// Live-graph panel_* tools for THIS tab",
+    );
+    expect(lane).toContain("...agentIdentityEnv(tabId)");
+    // Keyed by the same agent key the lane already self-scopes downloads with —
+    // one agent, one identity file, no cross-provider bleed when several
+    // backends are live at once (#884).
+    expect(lane).toContain("COMFYUI_MCP_TAB: tabId");
+  });
+
+  it("SOURCE: the CLAUDE lane forwards it too — the one that gets missed", () => {
+    const lane = blockAfter(
+      indexSrc(),
+      "const buildMcpServers = (agentKey?: string)",
+      "const manager = new PanelAgentManager",
+    );
+    expect(lane).toContain("...agentIdentityEnv(agentKey)");
+  });
+
+  it("SOURCE: the path is derived ONCE, from the bridge port and the agent key", () => {
+    const src = indexSrc();
+    // Port-scoped for the reason SessionStore is: the agent key carries no port,
+    // so two ComfyUI instances on one machine would otherwise stamp each other's
+    // model onto each other's reports.
+    expect(src).toContain("agentIdentityPath(bridgePort, agentKey)");
+    // …and no lane builds its own path expression.
+    expect(src.match(/agentIdentityPath\(/g)?.length).toBe(2); // the derivation + the publish
+  });
+});
+
+describe("the identity is republished at TURN DISPATCH", () => {
+  it("SOURCE: onTurn publishes on 'working', not on 'done'", () => {
+    const handler = blockAfter(indexSrc(), "onTurn: (key, state) => {", "onThinking:");
+    // "working" fires at dispatch — before the backend starts the turn, and so
+    // before any tool that turn calls. Publishing on "done" would be too late
+    // for the report the turn itself files.
+    expect(handler).toContain('if (state === "working") republishAgentIdentity(key)');
+  });
+
+  it("SOURCE: it reads THE CHIPS — the same expression the panel is sent as `current`", () => {
+    const src = indexSrc();
+    const publisher = blockAfter(
+      src,
+      "function republishAgentIdentity(key: string): void {",
+      "function pushModels(",
+    );
+    const chips = "manager.modelOverrideFor(";
+    // pushModels sends the panel `modelOverrideFor(key) ?? currentModelFor(backend)`
+    // as the chip's `current`. The stamp must name what the picker shows, not a
+    // second notion of "the model" that can drift from it.
+    expect(publisher).toContain(chips);
+    expect(publisher).toContain("currentModelFor(backend)");
+    expect(blockAfter(src, "function pushModels(panelTabId: string): void {", "\n  }")).toContain(
+      chips,
+    );
+  });
+
+  it("SOURCE: a failed write is not remembered as published", () => {
+    const publisher = blockAfter(
+      indexSrc(),
+      "function republishAgentIdentity(key: string): void {",
+      "function pushModels(",
+    );
+    // The dedupe cache exists to skip redundant writes, not to latch a failure:
+    // caching the fingerprint unconditionally would let one transient EPERM
+    // suppress every later publish for that agent, for the life of the process.
+    expect(publisher).toContain("if (publishAgentIdentity(");
+  });
+});

--- a/src/__tests__/orchestrator/agent-identity-wiring.test.ts
+++ b/src/__tests__/orchestrator/agent-identity-wiring.test.ts
@@ -99,15 +99,19 @@ describe("the identity is republished at TURN DISPATCH", () => {
     );
   });
 
-  it("SOURCE: a failed write is not remembered as published", () => {
+  it("SOURCE: the publish is UNCONDITIONAL — no cache can suppress a rewrite", () => {
     const publisher = blockAfter(
       indexSrc(),
       "function republishAgentIdentity(key: string): void {",
       "function pushModels(",
     );
-    // The dedupe cache exists to skip redundant writes, not to latch a failure:
-    // caching the fingerprint unconditionally would let one transient EPERM
-    // suppress every later publish for that agent, for the life of the process.
-    expect(publisher).toContain("if (publishAgentIdentity(");
+    // A "skip when unchanged" cache made the write conditional on a belief about
+    // the FILE that this process cannot hold: delete the file underneath a live
+    // orchestrator and every later report from that agent files unattributed,
+    // for the life of the process. What it saved was ~100 bytes once per turn,
+    // on a path that is already standing up an LLM turn.
+    expect(publisher).toContain("publishAgentIdentity(agentIdentityPath(bridgePort, key)");
+    expect(publisher).not.toMatch(/fingerprint|lastPublished/);
+    expect(publisher).not.toMatch(/\breturn;/);
   });
 });

--- a/src/__tests__/services/agent-identity.test.ts
+++ b/src/__tests__/services/agent-identity.test.ts
@@ -1,0 +1,184 @@
+// The cross-process AGENT IDENTITY channel — which LLM is driving the panel
+// agent, published by the orchestrator and read by report_issue in the comfyui
+// MCP subprocess (services/agent-identity.ts).
+//
+// What these pin is the failure mode the channel exists to prevent: a report
+// attributed to the WRONG model, or attributed at all when we do not actually
+// know. Every "we don't know" input — no env var, no file, corrupt file, a
+// payload with no backend — must read as undefined and leave the body untouched,
+// because a body that says nothing is honest and a body that names the wrong
+// model is not.
+
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AGENT_IDENTITY_ENV,
+  agentIdentityPath,
+  agentLabel,
+  formatAgentIdentity,
+  publishAgentIdentity,
+  readAgentIdentity,
+  stampAgentIdentity,
+} from "../../services/agent-identity.js";
+
+const DIR = mkdtempSync(join(tmpdir(), "cmcp-agent-identity-"));
+const saved = process.env[AGENT_IDENTITY_ENV];
+const savedData = process.env.COMFYUI_MCP_DATA_DIR;
+
+afterEach(() => {
+  if (saved === undefined) delete process.env[AGENT_IDENTITY_ENV];
+  else process.env[AGENT_IDENTITY_ENV] = saved;
+  if (savedData === undefined) delete process.env.COMFYUI_MCP_DATA_DIR;
+  else process.env.COMFYUI_MCP_DATA_DIR = savedData;
+  try {
+    rmSync(DIR, { recursive: true, force: true });
+    mkdirSync(DIR, { recursive: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("agentIdentityPath", () => {
+  it("is keyed by BOTH the bridge port and the agent key", () => {
+    process.env.COMFYUI_MCP_DATA_DIR = DIR;
+    const a = agentIdentityPath(9180, "orchestrator::claude");
+    const b = agentIdentityPath(9190, "orchestrator::claude");
+    const c = agentIdentityPath(9180, "orchestrator::ollama");
+    // Two ComfyUI instances on one machine share the agent key (it carries no
+    // port — see session-store.ts), so a port-less path would have one
+    // instance's identity stamped onto the other instance's reports.
+    expect(a).not.toBe(b);
+    // Two providers live at once (#884) is the ordinary case, not an edge one.
+    expect(a).not.toBe(c);
+  });
+
+  it("reduces the agent key to a filename-safe token", () => {
+    process.env.COMFYUI_MCP_DATA_DIR = DIR;
+    const p = agentIdentityPath(9180, "orchestrator::claude");
+    expect(p.endsWith("identity-9180-orchestrator_claude.json")).toBe(true);
+    // `::` is the ordinary separator, but nothing downstream validates a backend
+    // id, so a path separator arriving in a key must not escape the directory.
+    const evil = agentIdentityPath(9180, "../../etc/passwd");
+    expect(evil.includes("..")).toBe(false);
+  });
+});
+
+describe("publish → read round trip", () => {
+  it("round-trips the chips and stamps a write time", () => {
+    const p = join(DIR, "identity.json");
+    expect(publishAgentIdentity(p, { backend: "ollama", model: "gemma3:4b", effort: "low" })).toBe(
+      true,
+    );
+    const got = readAgentIdentity(p);
+    expect(got?.backend).toBe("ollama");
+    expect(got?.model).toBe("gemma3:4b");
+    expect(got?.effort).toBe("low");
+    expect(typeof got?.updated).toBe("number");
+  });
+
+  it("republishing replaces the previous identity (a live model switch)", () => {
+    const p = join(DIR, "identity.json");
+    publishAgentIdentity(p, { backend: "claude", model: "claude-opus-4-5" });
+    publishAgentIdentity(p, { backend: "claude", model: "claude-haiku-4-5" });
+    // setModel does not restart the session, so the SECOND value is the one the
+    // running turn uses — reading a stale first write would attribute the report
+    // to the model the user switched away from.
+    expect(readAgentIdentity(p)?.model).toBe("claude-haiku-4-5");
+  });
+
+  it("reads from the env var by default", () => {
+    const p = join(DIR, "identity.json");
+    publishAgentIdentity(p, { backend: "kimi", model: "kimi-k2-thinking" });
+    process.env[AGENT_IDENTITY_ENV] = p;
+    expect(readAgentIdentity()?.backend).toBe("kimi");
+  });
+
+  it("does NOT age out — a long turn is still the turn that is running", () => {
+    const p = join(DIR, "identity.json");
+    // An hour-old write. The identity is published when a turn STARTS, and a
+    // turn can run for hours before its agent files a report; a TTL here would
+    // silently drop attribution for exactly the longest sessions.
+    writeFileSync(
+      p,
+      JSON.stringify({ backend: "codex", model: "gpt-5.6", updated: Date.now() - 3_600_000 }),
+      "utf8",
+    );
+    expect(readAgentIdentity(p)?.model).toBe("gpt-5.6");
+  });
+});
+
+describe("an unknown identity stays unknown", () => {
+  it("returns undefined for no env var, a missing file, garbage, or no backend", () => {
+    delete process.env[AGENT_IDENTITY_ENV];
+    expect(readAgentIdentity()).toBeUndefined(); // every non-panel spawn
+    expect(readAgentIdentity(join(DIR, "nope.json"))).toBeUndefined();
+
+    const bad = join(DIR, "bad.json");
+    writeFileSync(bad, "{not json", "utf8");
+    expect(readAgentIdentity(bad)).toBeUndefined();
+
+    // A torn/partial write, or a future writer that changed the shape: no
+    // backend means we cannot name the provider, so we name nothing.
+    for (const payload of ["null", '"claude"', "[]", "{}", '{"backend":"   "}', '{"model":"x"}']) {
+      const f = join(DIR, "shape.json");
+      writeFileSync(f, payload, "utf8");
+      expect(readAgentIdentity(f), payload).toBeUndefined();
+    }
+  });
+
+  it("survives a non-string model/effort without inventing one", () => {
+    const f = join(DIR, "types.json");
+    writeFileSync(f, JSON.stringify({ backend: "grok", model: 42, effort: {} }), "utf8");
+    const got = readAgentIdentity(f);
+    expect(got?.backend).toBe("grok");
+    expect(got?.model).toBeUndefined();
+    expect(got?.effort).toBeUndefined();
+  });
+});
+
+describe("stampAgentIdentity", () => {
+  const identity = { backend: "ollama", model: "gemma3:4b", effort: "low" };
+
+  it("names the provider AND the model, and says it was not self-reported", () => {
+    const out = stampAgentIdentity("It broke.", identity);
+    expect(out).toContain("It broke.");
+    expect(out).toContain("ollama");
+    expect(out).toContain("gemma3:4b");
+    // The value of the line is that a reader can trust it the way they trust the
+    // version line — so it has to say who put it there.
+    expect(out).toContain("not self-reported");
+    // Machine-readable form for after-the-fact analysis across many issues.
+    expect(out).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b effort=low -->");
+  });
+
+  it("is idempotent — a retry or a pasted prior report never double-stamps", () => {
+    const once = stampAgentIdentity("It broke.", identity);
+    expect(stampAgentIdentity(once, identity)).toBe(once);
+    // Including when a DIFFERENT identity would be appended: the body already
+    // carries an attribution, and appending a second one leaves the reader with
+    // two answers and no way to pick.
+    expect(stampAgentIdentity(once, { backend: "claude", model: "claude-opus-4-5" })).toBe(once);
+  });
+
+  it("passes the body through untouched when there is no identity", () => {
+    expect(stampAgentIdentity("It broke.", undefined)).toBe("It broke.");
+  });
+
+  it("states an unreported model rather than omitting the field", () => {
+    const out = stampAgentIdentity("b", { backend: "pi" });
+    expect(out).toContain("_unreported_");
+    expect(out).toContain("model=unknown");
+    // A provider with no model chip and a report filed before this shipped are
+    // different facts; dropping the field silently makes them read the same.
+    expect(formatAgentIdentity({ backend: "pi" })).toContain("unreported");
+  });
+});
+
+describe("agentLabel", () => {
+  it("is per-PROVIDER, so the label set stays bounded", () => {
+    expect(agentLabel({ backend: "ollama", model: "gemma3:4b" })).toBe("agent:ollama");
+    expect(agentLabel({ backend: "ollama", model: "qwen3:30b" })).toBe("agent:ollama");
+  });
+});

--- a/src/__tests__/services/agent-identity.test.ts
+++ b/src/__tests__/services/agent-identity.test.ts
@@ -153,13 +153,36 @@ describe("stampAgentIdentity", () => {
     expect(out).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b effort=low -->");
   });
 
-  it("is idempotent — a retry or a pasted prior report never double-stamps", () => {
+  it("stamps a body that QUOTES another issue's stamp — with THIS model (gate P1)", () => {
+    // Quoting a related issue is ordinary agent behaviour, and every stamped
+    // issue in the tracker carries the marker as quotable text. Treating that
+    // marker as "already stamped" filed the report under the QUOTED model's
+    // name, inside a sentence vouching the attribution is mechanical — the
+    // exact mis-attribution this module exists to prevent.
+    const quoting =
+      "Related to #1234, whose body reads:\n" +
+      "> Filed from the ComfyUI panel by **claude** · model `claude-opus-5`\n" +
+      "> <!-- reporter-agent: backend=claude model=claude-opus-5 -->";
+    const out = stampAgentIdentity(quoting, identity);
+    expect(out).toContain("gemma3:4b");
+    expect(out.trimEnd().endsWith("-->")).toBe(true);
+    // EXACTLY ONE live marker, and it is this report's: an analysis pass
+    // counting attributions across the tracker cannot read a quotation as a
+    // second reporter.
+    expect(out.match(/<!-- reporter-agent:/g)?.length).toBe(1);
+    expect(out).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b effort=low -->");
+    // The quoted line survives, readable, as a quotation.
+    expect(out).toContain("<!-- quoted-reporter-agent: backend=claude model=claude-opus-5 -->");
+  });
+
+  it("has no 'already stamped' shortcut — the stamp is always this call's", () => {
+    // Nothing in a body can establish that WE stamped it; the one caller passes
+    // the raw argument and forwards the result, so a double-stamp is not
+    // reachable. Stamping unconditionally is what makes suppression impossible.
     const once = stampAgentIdentity("It broke.", identity);
-    expect(stampAgentIdentity(once, identity)).toBe(once);
-    // Including when a DIFFERENT identity would be appended: the body already
-    // carries an attribution, and appending a second one leaves the reader with
-    // two answers and no way to pick.
-    expect(stampAgentIdentity(once, { backend: "claude", model: "claude-opus-4-5" })).toBe(once);
+    const twice = stampAgentIdentity(once, { backend: "claude", model: "claude-opus-4-5" });
+    expect(twice).toContain("claude-opus-4-5");
+    expect(twice.match(/<!-- reporter-agent:/g)?.length).toBe(1);
   });
 
   it("passes the body through untouched when there is no identity", () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -144,6 +144,11 @@ import { tryInstallRetiredNameRedirect } from "../tools/retired-redirect.js";
 import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import {
+  AGENT_IDENTITY_ENV,
+  agentIdentityPath,
+  publishAgentIdentity,
+} from "../services/agent-identity.js";
+import {
   buildComfyuiMcpEnv,
   comfyuiSecretKeys,
   onComfyuiSecretsChanged,
@@ -2117,6 +2122,16 @@ export async function runPanelOrchestrator(): Promise<void> {
   // tools don't saturate the backend's tool budget and make codex silently drop
   // the panel_* HTTP-MCP tools (overridable via COMFYUI_MCP_TOOL_MODE=full).
   const httpLaneComfyToolMode = resolveHttpLaneComfyToolMode();
+  // WHICH LLM IS DRIVING THIS AGENT — pointed at the file the orchestrator
+  // republishes on every turn dispatch (see the onTurn handler). report_issue
+  // reads it in the subprocess and stamps the model into the issue body, so a
+  // report can be judged against the model that wrote it instead of being
+  // attributed by asking the model itself (which answers with a guess). BOTH
+  // spawn lanes need it: the HTTP lane below and the Claude lane's
+  // buildMcpServers() — a var forwarded on only one of them is the recurring
+  // defect this file already carries two separate warnings about.
+  const agentIdentityEnv = (agentKey: string | undefined): Record<string, string> =>
+    agentKey ? { [AGENT_IDENTITY_ENV]: agentIdentityPath(bridgePort, agentKey) } : {};
   // #788 — `toolMode: null` OMITS the key entirely, which is NOT the same as
   // passing "compact": a pre-baked value is read downstream as a caller-explicit
   // pin and outranks per-model auto-selection, so the Ollama-family backends
@@ -2143,6 +2158,8 @@ export async function runPanelOrchestrator(): Promise<void> {
         // downloads resolved to nobody and the owning conversation stalled).
         // `tabId` here IS the agent key (the scope address the lane binds).
         COMFYUI_MCP_TAB: tabId,
+        // …and the same key addresses this agent's published identity.
+        ...agentIdentityEnv(tabId),
       }),
     },
     // Live-graph panel_* tools for THIS tab over the loopback HTTP MCP.
@@ -2446,6 +2463,9 @@ export async function runPanelOrchestrator(): Promise<void> {
         // child stamps its own COMFYUI_MCP_TAB into each progress row, and the
         // settle path resolves an agent-key-shaped stamp directly.
         ...(agentKey ? { COMFYUI_MCP_TAB: agentKey } : {}),
+        // Which LLM is driving this agent, for report_issue's stamp (see
+        // agentIdentityEnv). Same key, same reason it is keyed by agent.
+        ...agentIdentityEnv(agentKey),
         // Local mode → enables download_model, apply_manifest (installer packs),
         // and model scans so the agent installs the right way instead of curl.
         ...(comfyuiPath ? { COMFYUI_PATH: comfyuiPath } : forceRemoteEnv()),
@@ -2542,6 +2562,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       // #884 P0 — the turn ended: release its routing pin so idle-time scope
       // resolution follows the active tab again (the next turn re-pins).
       if (state === "done") turnOrigins.turnEnded(key);
+      // Publish WHICH LLM this turn runs on, for report_issue's stamp. Here
+      // because "working" fires at DISPATCH — before the backend starts the
+      // turn, and therefore before any tool the turn calls — so the file the
+      // subprocess reads always describes the turn doing the reporting. A
+      // spawn-time env var could not: setModel is live and never respawns, so
+      // it would stamp reports with the model the user switched AWAY from.
+      if (state === "working") republishAgentIdentity(key);
       pushToConversation(key, { type: "turn", state });
     },
     // Live extended-thinking token count → "thinking… (N)" indicator.
@@ -3449,6 +3476,35 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (reg) return openAiKeyProviderModel(reg); // glm / kimi / moonshot
     if (backend === "copilot") return copilotModel;
     return model;
+  }
+  /**
+   * Publish WHICH LLM is driving an agent, so report_issue can stamp it into the
+   * issue body from the comfyui MCP subprocess (services/agent-identity.ts).
+   *
+   * Read from THE CHIPS — the same expression pushModels() sends the panel as
+   * `current`, so the stamp names exactly what the picker shows rather than a
+   * second, drifting notion of "the model". The alternative was asking the model
+   * to name itself in the report, which is a guess: the ENVIRONMENT block has
+   * never carried the model at all, only `Backend:`.
+   *
+   * Called on every turn dispatch; the last-published value is remembered per key
+   * so an unchanged identity costs no write.
+   */
+  const lastPublishedIdentity = new Map<string, string>();
+  function republishAgentIdentity(key: string): void {
+    const backend = backendOf(key);
+    const identity = {
+      backend,
+      model: manager.modelOverrideFor(key) ?? currentModelFor(backend),
+      effort: manager.currentEffortFor(key),
+    };
+    const fingerprint = JSON.stringify(identity);
+    if (lastPublishedIdentity.get(key) === fingerprint) return;
+    // Only remember it as published if the write actually landed — otherwise a
+    // single failed write would suppress every later attempt for this key.
+    if (publishAgentIdentity(agentIdentityPath(bridgePort, key), identity)) {
+      lastPublishedIdentity.set(key, fingerprint);
+    }
   }
   function pushModels(panelTabId: string): void {
     const backend = backendForTab(panelTabId);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3487,24 +3487,22 @@ export async function runPanelOrchestrator(): Promise<void> {
    * to name itself in the report, which is a guess: the ENVIRONMENT block has
    * never carried the model at all, only `Backend:`.
    *
-   * Called on every turn dispatch; the last-published value is remembered per key
-   * so an unchanged identity costs no write.
+   * Called on every turn dispatch, and it WRITES every time. A dedupe cache
+   * ("skip when the identity is unchanged") was here and is deliberately gone:
+   * it made the write conditional on a belief about the FILE that this process
+   * has no way to hold — delete the file underneath a live orchestrator and the
+   * cache suppresses the rewrite for the rest of the process's life, leaving
+   * every later report from that agent unattributed (fallback merge gate, a
+   * dropped P2). The thing it saved is ~100 bytes once per turn, on a path that
+   * is already standing up an LLM turn.
    */
-  const lastPublishedIdentity = new Map<string, string>();
   function republishAgentIdentity(key: string): void {
     const backend = backendOf(key);
-    const identity = {
+    publishAgentIdentity(agentIdentityPath(bridgePort, key), {
       backend,
       model: manager.modelOverrideFor(key) ?? currentModelFor(backend),
       effort: manager.currentEffortFor(key),
-    };
-    const fingerprint = JSON.stringify(identity);
-    if (lastPublishedIdentity.get(key) === fingerprint) return;
-    // Only remember it as published if the write actually landed — otherwise a
-    // single failed write would suppress every later attempt for this key.
-    if (publishAgentIdentity(agentIdentityPath(bridgePort, key), identity)) {
-      lastPublishedIdentity.set(key, fingerprint);
-    }
+    });
   }
   function pushModels(panelTabId: string): void {
     const backend = backendForTab(panelTabId);

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2571,6 +2571,15 @@ export class PanelAgentManager {
     return this.modelByKey.get(tabId);
   }
 
+  /** The reasoning effort this key runs at — its picker override when set, else
+   *  the shared default. Unlike {@link modelOverrideFor} this folds the default
+   *  in, because there is no second source to fall back to: the caller (the
+   *  orchestrator publishing the agent's identity for report_issue) wants the
+   *  value in force, not whether it was overridden. */
+  currentEffortFor(tabId: string): Effort | undefined {
+    return this.effortFor(tabId);
+  }
+
   private makeAgent(tabId: string): PanelAgent {
     // Inject the toggle-selected backend (Codex) when provided; otherwise the
     // PanelAgent constructor defaults to ClaudeBackend (existing behavior).

--- a/src/services/agent-identity.ts
+++ b/src/services/agent-identity.ts
@@ -52,9 +52,23 @@ export interface AgentIdentity {
   updated?: number;
 }
 
-/** Machine-readable marker line. Doubles as the idempotency guard: a body that
- *  already carries one is never stamped twice. */
+/** Machine-readable marker: the form an analysis pass greps for. */
 const STAMP_MARKER = "<!-- reporter-agent:";
+
+/**
+ * What a marker becomes when it arrives INSIDE a caller's body — i.e. quoted
+ * from some other issue, which is ordinary agent behaviour ("related to #1234,
+ * whose body reads: …"). Every stamped issue in the tracker carries the marker
+ * as quotable text, so a body that already contains one says nothing about who
+ * is filing THIS report.
+ *
+ * An earlier version treated any marker as proof this body was already stamped
+ * and returned it untouched — which filed the report under the QUOTED model's
+ * name, in a sentence explicitly vouching that the attribution is mechanical.
+ * That is the exact harm this module exists to prevent, arriving through its own
+ * guard (fallback merge gate, P1).
+ */
+const QUOTED_MARKER = "<!-- quoted-reporter-agent:";
 
 /**
  * Where the identity for one agent lives.
@@ -146,11 +160,20 @@ export function formatAgentIdentity(identity: AgentIdentity): string {
  * NOT the model's own claim about itself — a reader comparing report quality
  * across models has to be able to trust it the way they trust the version line.
  *
- * Idempotent: a body that already carries the marker is returned unchanged, so a
- * retry (or an agent that pasted a previous report) cannot double-stamp.
+ * ALWAYS appended when the identity is known. There is no "already stamped"
+ * shortcut, because nothing in the body can establish that: the only marker a
+ * caller's text can carry is one QUOTED from another issue, and skipping on it
+ * files the report under someone else's model. The one caller passes the raw
+ * argument and forwards the stamped result, so a body cannot reach here twice.
+ *
+ * A quoted marker is REWRITTEN as it passes through, so exactly one live marker
+ * survives and it is this report's — an analysis pass counting `reporter-agent`
+ * across the tracker can never read a quotation as a second reporter. The quoted
+ * line stays readable; only its machine prefix changes.
  */
 export function stampAgentIdentity(body: string, identity: AgentIdentity | undefined): string {
-  if (!identity || body.includes(STAMP_MARKER)) return body;
+  if (!identity) return body;
+  body = body.replaceAll(STAMP_MARKER, QUOTED_MARKER);
   const machine = [
     `backend=${identity.backend}`,
     identity.model ? `model=${identity.model}` : "model=unknown",

--- a/src/services/agent-identity.ts
+++ b/src/services/agent-identity.ts
@@ -167,8 +167,10 @@ export function formatAgentIdentity(identity: AgentIdentity): string {
  * argument and forwards the stamped result, so a body cannot reach here twice.
  *
  * A quoted marker is REWRITTEN as it passes through, so exactly one live marker
- * survives and it is this report's — an analysis pass counting `reporter-agent`
- * across the tracker can never read a quotation as a second reporter. The quoted
+ * survives and it is this report's — an analysis pass counting the full
+ * `<!-- reporter-agent:` literal across the tracker can never read a quotation as
+ * a second reporter (a looser grep for `reporter-agent` still matches the quoted
+ * form, by design — it stays findable). The quoted
  * line stays readable; only its machine prefix changes.
  */
 export function stampAgentIdentity(body: string, identity: AgentIdentity | undefined): string {

--- a/src/services/agent-identity.ts
+++ b/src/services/agent-identity.ts
@@ -1,0 +1,172 @@
+// Cross-process AGENT IDENTITY channel — WHICH LLM is driving the panel agent.
+//
+// A bug report filed from the panel is written by whichever model the user has
+// selected in the provider/model chips: Claude Opus, a hosted Kimi, a local
+// gemma. Report QUALITY tracks that choice, so a report that does not name the
+// model cannot be judged — a thin, wrong or hallucinated issue looks exactly
+// like a careful one until you know what wrote it.
+//
+// It CANNOT be self-reported. Asking a model which model it is returns a guess
+// (they routinely name a sibling, or the model they were distilled from), and
+// the agent's ENVIRONMENT block never carried the model at all — only
+// `Backend:`. So the ORCHESTRATOR, which owns the chips and therefore the fact,
+// publishes it, and report_issue reads it back.
+//
+// The transport is the one download-progress.ts already established, with the
+// direction reversed: that channel is the comfyui MCP subprocess writing rows
+// for the orchestrator to read; this one is the orchestrator writing a single
+// small JSON for the subprocess to read. No socket, no new HTTP surface, and —
+// like that channel — it no-ops entirely when the env var is unset, i.e. for
+// every non-panel use of the MCP (plain stdio, CLI, tests).
+//
+// WHY A FILE AND NOT THE SPAWN ENV: the model is live-switchable. `setModel`
+// deliberately does NOT restart the session (panel-agent.ts), so a value baked
+// into the child's env at spawn goes stale the moment the user changes the chip
+// — and would then stamp reports with a model that did not write them, which is
+// worse than stamping nothing. The orchestrator republishes at every turn
+// dispatch instead, so the file always describes the turn that is running.
+//
+// There is deliberately NO staleness cutoff on a read: the identity is written
+// when a turn STARTS, and a turn can legitimately run for an hour before its
+// agent files a report. Ageing the file out would drop exactly the long
+// sessions most worth attributing.
+
+import { mkdirSync, renameSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** Env var naming the identity file for THIS agent's MCP subprocess. Absent for
+ *  every non-panel spawn, which is what makes the whole channel opt-in. */
+export const AGENT_IDENTITY_ENV = "COMFYUI_MCP_AGENT_IDENTITY";
+
+/** The chips, as facts: what the orchestrator dispatched the current turn with. */
+export interface AgentIdentity {
+  /** Provider chip — the backend id (`claude`, `codex`, `ollama`, `kimi`, …). */
+  backend: string;
+  /** Model chip — the model this turn runs on. Absent when the provider exposes
+   *  no model selection at all. */
+  model?: string;
+  /** Effort chip, for the providers that have one. */
+  effort?: string;
+  /** Epoch ms of the write. Diagnostic only — never used to expire a read. */
+  updated?: number;
+}
+
+/** Machine-readable marker line. Doubles as the idempotency guard: a body that
+ *  already carries one is never stamped twice. */
+const STAMP_MARKER = "<!-- reporter-agent:";
+
+/**
+ * Where the identity for one agent lives.
+ *
+ * Keyed by the BRIDGE PORT as well as the agent key for the same reason
+ * SessionStore is (session-store.ts): the agent key is `orchestrator::<backend>`
+ * and carries no port, so two ComfyUI instances on one machine would otherwise
+ * write each other's identity — and a report would name the other instance's
+ * model.
+ */
+export function agentIdentityPath(port: number | string, agentKey: string): string {
+  const dir = join(
+    process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp"),
+    "agents",
+  );
+  // Agent keys contain `::` and could in principle contain anything else a
+  // backend id allows; reduce to a filename-safe token rather than trusting it.
+  const safe = agentKey.replace(/[^A-Za-z0-9_-]+/g, "_").slice(0, 80) || "agent";
+  return join(dir, `identity-${port}-${safe}.json`);
+}
+
+/**
+ * Publish the identity for one agent. Best-effort: a failure here must never
+ * break a turn — the cost of not writing it is an unstamped report, which is
+ * where we were before.
+ *
+ * Written tmp-then-rename so a reader in the subprocess can never observe a
+ * half-written file (Node's rename replaces an existing destination on Windows
+ * too, which is where this runs most).
+ */
+export function publishAgentIdentity(path: string, identity: AgentIdentity): boolean {
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const tmp = `${path}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify({ ...identity, updated: Date.now() }), "utf8");
+    renameSync(tmp, path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the published identity, or undefined when there is none to read: no env
+ * var (every non-panel spawn), no file yet, unreadable, unparseable, or parsed
+ * to something without a backend. Every one of those means "we do not know what
+ * model this is", and an unknown must stay unstamped rather than be guessed at.
+ */
+export function readAgentIdentity(
+  path: string | undefined = process.env[AGENT_IDENTITY_ENV],
+): AgentIdentity | undefined {
+  if (!path) return undefined;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (!raw || typeof raw !== "object") return undefined;
+    const rec = raw as Record<string, unknown>;
+    const backend = typeof rec.backend === "string" ? rec.backend.trim() : "";
+    if (!backend) return undefined;
+    const str = (v: unknown): string | undefined => {
+      const s = typeof v === "string" ? v.trim() : "";
+      return s ? s.slice(0, 120) : undefined;
+    };
+    return {
+      backend: backend.slice(0, 60),
+      model: str(rec.model),
+      effort: str(rec.effort),
+      updated: typeof rec.updated === "number" ? rec.updated : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Human form for the report line: `kimi · model kimi-k2-thinking · effort high`. */
+export function formatAgentIdentity(identity: AgentIdentity): string {
+  const parts = [`**${identity.backend}**`];
+  // "model unknown" is stated rather than omitted: a provider that exposes no
+  // model chip is a different fact from a report filed before this shipped, and
+  // silently dropping the field makes those two read identically.
+  parts.push(identity.model ? `model \`${identity.model}\`` : "model _unreported_");
+  if (identity.effort) parts.push(`effort \`${identity.effort}\``);
+  return parts.join(" · ");
+}
+
+/**
+ * Append the identity block to an issue body.
+ *
+ * The wording says who stamped it, because the whole point is that this line is
+ * NOT the model's own claim about itself — a reader comparing report quality
+ * across models has to be able to trust it the way they trust the version line.
+ *
+ * Idempotent: a body that already carries the marker is returned unchanged, so a
+ * retry (or an agent that pasted a previous report) cannot double-stamp.
+ */
+export function stampAgentIdentity(body: string, identity: AgentIdentity | undefined): string {
+  if (!identity || body.includes(STAMP_MARKER)) return body;
+  const machine = [
+    `backend=${identity.backend}`,
+    identity.model ? `model=${identity.model}` : "model=unknown",
+    ...(identity.effort ? [`effort=${identity.effort}`] : []),
+  ].join(" ");
+  return (
+    `${body.replace(/\s+$/, "")}\n\n---\n` +
+    `Filed from the ComfyUI panel by ${formatAgentIdentity(identity)} ` +
+    `— stamped by comfyui-mcp from the panel's provider/model selection, not self-reported.\n` +
+    `${STAMP_MARKER} ${machine} -->\n`
+  );
+}
+
+/** The label that makes the filed issues filterable by provider on GitHub
+ *  (`label:agent:ollama`). The MODEL stays in the body — one label per provider
+ *  is a bounded set, one per model is not. */
+export function agentLabel(identity: AgentIdentity): string {
+  return `agent:${identity.backend}`;
+}

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA } from "./report-issue.js";
 
 const noSleep = async () => {};
@@ -504,5 +507,102 @@ describe("#937: every intake request carries a named User-Agent", () => {
     // The poll is a separate request and would be judged by the WAF separately.
     expect(seen.length).toBeGreaterThan(1);
     expect(seen[1]["User-Agent"]).toBe(REPORT_UA);
+  });
+});
+
+// ── WHICH LLM FILED IT ───────────────────────────────────────────────────────
+// The panel can be driven by anything from a frontier model to a local 4B, and
+// report quality follows. The orchestrator publishes the provider/model chips to
+// a file (services/agent-identity.ts) and the handler stamps them into the body
+// it actually SENDS — the worker pins that body verbatim into the created issue
+// (triage.ts: `sanitized.body = opts.report.body`), so the body is the one
+// channel that reaches the issue without a worker deploy.
+//
+// These drive the REGISTERED HANDLER, not the stamping helper: a helper that
+// works and a call site that never runs it is the same defect as no helper at
+// all, and the body/labels the handler forwards are what a reader ends up
+// judging the report by.
+describe("report_issue stamps the reporting model (mechanical, not self-reported)", () => {
+  const IDENTITY_DIR = mkdtempSync(join(tmpdir(), "cmcp-report-identity-"));
+  const identityFile = join(IDENTITY_DIR, "identity.json");
+  const savedEnv = process.env.COMFYUI_MCP_AGENT_IDENTITY;
+
+  const publish = (identity: Record<string, unknown>) => {
+    writeFileSync(identityFile, JSON.stringify(identity), "utf8");
+    process.env.COMFYUI_MCP_AGENT_IDENTITY = identityFile;
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (savedEnv === undefined) delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
+    else process.env.COMFYUI_MCP_AGENT_IDENTITY = savedEnv;
+  });
+  afterAll(() => {
+    try {
+      rmSync(IDENTITY_DIR, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  /** The submit payload the handler actually put on the wire. */
+  async function submittedPayload(args: Record<string, unknown>) {
+    const spy = vi.fn(async (_url: string, _init: RequestInit) =>
+      res({ state: "CLOSED", payload: { issue: { number: 7, url: "https://gh/7" } }, url: "https://gh/7" }),
+    );
+    vi.stubGlobal("fetch", spy);
+    const out = await callTool(args);
+    const init = spy.mock.calls[0]?.[1] as RequestInit | undefined;
+    return { payload: init ? (JSON.parse(init.body as string) as Record<string, unknown>) : undefined, out };
+  }
+
+  it("sends the model in the body and the provider as a label", async () => {
+    publish({ backend: "ollama", model: "gemma3:4b", effort: "low" });
+    const { payload } = await submittedPayload({ title: "t", body: "It broke." });
+    const body = payload?.body as string;
+    expect(body).toContain("It broke.");
+    // The exact model is the whole point — "ollama" alone cannot distinguish a
+    // 4B from a 235B, which is the comparison this exists to enable.
+    expect(body).toContain("gemma3:4b");
+    expect(body).toContain("not self-reported");
+    expect(payload?.labels).toContain("agent:ollama");
+  });
+
+  it("keeps the caller's labels alongside the provider label", async () => {
+    publish({ backend: "kimi", model: "kimi-k2-thinking" });
+    const { payload } = await submittedPayload({ title: "t", body: "b", labels: ["bug"] });
+    expect(payload?.labels).toEqual(expect.arrayContaining(["bug", "agent:kimi"]));
+  });
+
+  it("changes NOTHING when no identity was published (every non-panel spawn)", async () => {
+    delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
+    const { payload } = await submittedPayload({ title: "t", body: "It broke.", labels: ["bug"] });
+    // Byte-identical, not merely "contains": a plain stdio/CLI report has no
+    // panel behind it, so there is no model to name and nothing to append.
+    expect(payload?.body).toBe("It broke.");
+    expect(payload?.labels).toEqual(["bug"]);
+  });
+
+  it("never stamps a THIRD-PARTY tracker", async () => {
+    publish({ backend: "ollama", model: "gemma3:4b" });
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { json } = await callTool({ title: "t", body: "It broke.", repo: "someone/their-node", labels: ["bug"] });
+    // The prefilled URL is what the user posts to someone else's repo. Our
+    // provider telemetry is not their business, and `agent:ollama` is a label
+    // their repo has never heard of.
+    const url = new URL(json.url as string);
+    expect(url.searchParams.get("body")).toBe("It broke.");
+    expect(url.searchParams.get("labels")).toBe("bug");
+  });
+
+  it("stamps the PREFILLED fallback for our repos too", async () => {
+    publish({ backend: "claude", model: "claude-opus-4-5" });
+    // no_file and the worker-unreachable fallback share this URL — a report that
+    // arrives by the fallback path is no less in need of attribution.
+    const { json } = await callTool({ title: "t", body: "It broke.", no_file: true });
+    const url = new URL(json.url as string);
+    expect(url.searchParams.get("body")).toContain("claude-opus-4-5");
+    expect(url.searchParams.get("labels")).toBe("agent:claude");
   });
 });

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach, afterAll } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA } from "./report-issue.js";
+import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA, WORKER_MAX_BODY_LEN } from "./report-issue.js";
 
 const noSleep = async () => {};
 
@@ -598,6 +598,31 @@ describe("report_issue stamps the reporting model (mechanical, not self-reported
     // panel behind it, so there is no model to name and nothing to append.
     expect(payload?.body).toBe("It broke.");
     expect(payload?.labels).toEqual(["bug"]);
+  });
+
+  it("an oversized body keeps its stamp — the worker would have cut it off", async () => {
+    publish({ backend: "ollama", model: "gemma3:4b" });
+    const huge = "x".repeat(WORKER_MAX_BODY_LEN + 5_000);
+    const { payload } = await submittedPayload({ title: "t", body: huge });
+    const body = payload?.body as string;
+    // The worker truncates at 60k BEFORE filing, and the stamp is last — so the
+    // attribution would vanish server-side on exactly the longest reports, with
+    // nothing anywhere saying it had been there.
+    expect(body.length).toBeLessThanOrEqual(WORKER_MAX_BODY_LEN);
+    expect(body).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b -->");
+    expect(body).toContain("trimmed to keep the reporting-agent stamp");
+    // The caller's own text is still nearly all of it — this trims by the
+    // stamp's width, it does not summarize.
+    expect(body.length).toBeGreaterThan(WORKER_MAX_BODY_LEN - 1_000);
+  });
+
+  it("leaves an oversized body ALONE when there is no identity to protect", async () => {
+    delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
+    const huge = "x".repeat(WORKER_MAX_BODY_LEN + 5_000);
+    const { payload } = await submittedPayload({ title: "t", body: huge });
+    // No stamp to save, so the worker's own truncation is the only one that
+    // should ever apply. Trimming here would drop the caller's text for nothing.
+    expect(payload?.body).toBe(huge);
   });
 
   it("never stamps a THIRD-PARTY tracker", async () => {

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -568,6 +568,23 @@ describe("report_issue stamps the reporting model (mechanical, not self-reported
     expect(payload?.labels).toContain("agent:ollama");
   });
 
+  it("a body QUOTING another issue's stamp is still filed under THIS model (gate P1)", async () => {
+    publish({ backend: "ollama", model: "gemma3:4b" });
+    const { payload } = await submittedPayload({
+      title: "t",
+      body:
+        "Related to #1234, whose body reads:\n" +
+        "> <!-- reporter-agent: backend=claude model=claude-opus-5 -->",
+    });
+    const body = payload?.body as string;
+    // Quoting a related issue is ordinary agent behaviour. Reading the quoted
+    // marker as "already stamped" filed the report asserting claude-opus-5 wrote
+    // it — while the label on the same issue said agent:ollama.
+    expect(body).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b -->");
+    expect(body.match(/<!-- reporter-agent:/g)?.length).toBe(1);
+    expect(payload?.labels).toContain("agent:ollama");
+  });
+
   it("keeps the caller's labels alongside the provider label", async () => {
     publish({ backend: "kimi", model: "kimi-k2-thinking" });
     const { payload } = await submittedPayload({ title: "t", body: "b", labels: ["bug"] });

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -616,6 +616,31 @@ describe("report_issue stamps the reporting model (mechanical, not self-reported
     expect(body.length).toBeGreaterThan(WORKER_MAX_BODY_LEN - 1_000);
   });
 
+  it("…and keeps it when the oversized body QUOTES stamps (gate P1, round 3)", async () => {
+    publish({ backend: "ollama", model: "gemma3:4b", effort: "high" });
+    // The previous test's body was marker-free, so it could not see this at all:
+    // stamping also REWRITES each quoted marker (+7 chars), so budgeting the
+    // stamp's width against the raw text put the shipped body 7·n OVER the cap —
+    // and the worker cuts the tail, which is the stamp. Blind by construction is
+    // how a covering test ships the bug it covers.
+    for (const markers of [1, 88]) {
+      const quote = "> <!-- reporter-agent: backend=claude model=opus -->\n".repeat(markers);
+      const { payload } = await submittedPayload({
+        title: "t",
+        body: `Related to #1234:\n${quote}${"LOG\n".repeat(20_000)}`,
+      });
+      const body = payload?.body as string;
+      expect(body.length, `markers=${markers}`).toBeLessThanOrEqual(WORKER_MAX_BODY_LEN);
+      // Present AND terminated: a marker cut mid-token is not an attribution.
+      expect(body, `markers=${markers}`).toContain(
+        "<!-- reporter-agent: backend=ollama model=gemma3:4b effort=high -->",
+      );
+      expect(body, `markers=${markers}`).toContain("Filed from the ComfyUI panel");
+      // Still exactly one live marker: the quoted ones stayed neutralized.
+      expect(body.match(/<!-- reporter-agent:/g)?.length, `markers=${markers}`).toBe(1);
+    }
+  });
+
   it("leaves an oversized body ALONE when there is no identity to protect", async () => {
     delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
     const huge = "x".repeat(WORKER_MAX_BODY_LEN + 5_000);

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { detectInstallMode } from "../services/self-update.js";
+import { agentLabel, readAgentIdentity, stampAgentIdentity } from "../services/agent-identity.js";
 
 // Issue reporting. For OUR repos (comfyui-mcp / comfyui-mcp-panel) this FILES the
 // issue through the async AI-triage Worker: submit (with the reporter's versions)
@@ -499,10 +500,31 @@ export function registerReportIssueTools(server: McpServer): void {
     async (args) => {
       try {
         const repo = normalizeRepo(args.repo);
-        const prefilledUrl = buildIssueUrl(repo, args.title, args.body, args.labels);
+        const ours = isOurRepo(repo);
+        // WHICH LLM WROTE THIS REPORT. Published by the orchestrator from the
+        // panel's provider/model chips (services/agent-identity.ts) and read
+        // here, in the subprocess the reporting agent's tools run in — NOT asked
+        // of the model, which cannot reliably name itself and was never told its
+        // own model in the first place (the ENVIRONMENT block carries only
+        // `Backend:`). Report quality varies enormously across the providers the
+        // panel can drive, and until this line existed there was no way to tell a
+        // thin report from a local 4B model apart from a thin report from a
+        // frontier one.
+        //
+        // OUR repos only: someone else's tracker is not the place for our
+        // provider telemetry, and a prefilled `agent:*` label would be a label
+        // their repo has never heard of. Absent identity (every non-panel spawn:
+        // plain stdio, CLI, tests) changes nothing — body and labels pass
+        // through as before.
+        const identity = ours ? readAgentIdentity() : undefined;
+        const body = stampAgentIdentity(args.body, identity);
+        const labels = identity
+          ? Array.from(new Set([...(args.labels ?? []), agentLabel(identity)]))
+          : args.labels;
+        const prefilledUrl = buildIssueUrl(repo, args.title, body, labels);
 
         // Third-party (or explicitly disabled): prefilled link only, as before.
-        if (!isOurRepo(repo) || args.no_file) {
+        if (!ours || args.no_file) {
           return jsonResult({
             url: prefilledUrl,
             repo,
@@ -539,8 +561,8 @@ export function registerReportIssueTools(server: McpServer): void {
             clientKey,
             repoName,
             title: args.title,
-            body: args.body,
-            labels: args.labels,
+            body,
+            labels,
             reporterVersions,
             timeoutMs,
             maxPolls,

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -474,9 +474,24 @@ export function normalizeReportedVersion(
  * The identity stamp is the LAST thing in the body, so an oversized report — a
  * pasted log, the diff the report-bug skill asks for — would have its
  * attribution cut off server-side, silently, and precisely on the reports with
- * the most in them. Trim the caller's own text by the stamp's width instead: the
- * worker was going to cut that tail anyway, so the content lost is the same
+ * the most in them. Trim the caller's own text by what the stamp costs instead:
+ * the worker was going to cut that tail anyway, so the content lost is the same
  * either way, and the attribution survives.
+ *
+ * MEASURE THE BODY THAT SHIPS, never a stand-in for it. The first version
+ * budgeted `stampAgentIdentity("")` — the stamp's own width — and trimmed the
+ * caller's RAW text to fit. But stamping also rewrites every quoted marker the
+ * body carries (`<!-- reporter-agent:` → `<!-- quoted-reporter-agent:`, +7 chars
+ * each), so a body quoting other issues came out 7·n OVER the cap and the worker
+ * cut off the very stamp this exists to protect — 88 quoted markers removed it
+ * outright (round-3 merge gate, P1). The covering test was marker-free, so it
+ * passed either way: blind by construction to the one interaction that mattered.
+ *
+ * So the loop below asks the real question — "how long is the body I am about to
+ * send?" — and shortens by the actual overflow. One correction is provably
+ * enough (removing the overflow can only reduce the number of markers retained,
+ * so the expansion cannot grow), and the bound is there so a future change to
+ * the stamp cannot turn this into a spin.
  *
  * Exported for the covering test — nothing else calls it.
  */
@@ -490,9 +505,17 @@ export function fitUnderWorkerCap(
   const note = "\n\n…[trimmed to keep the reporting-agent stamp]";
   // Measure the stamp against THIS identity rather than assuming a width — the
   // model name is provider-supplied and unbounded in principle.
-  const stampWidth = stampAgentIdentity("", identity).length;
-  const room = WORKER_MAX_BODY_LEN - stampWidth - note.length;
-  return room > 0 ? body.slice(0, room) + note : note;
+  let room = WORKER_MAX_BODY_LEN - stampAgentIdentity("", identity).length - note.length;
+  for (let i = 0; i < 8 && room > 0; i++) {
+    const candidate = body.slice(0, room) + note;
+    const shipped = stampAgentIdentity(candidate, identity).length;
+    if (shipped <= WORKER_MAX_BODY_LEN) return candidate;
+    room -= shipped - WORKER_MAX_BODY_LEN;
+  }
+  // Nothing of the caller's text fits alongside the stamp. Keeping the note
+  // alone is the honest outcome: a report that says it was trimmed, correctly
+  // attributed, beats a full one attributed to nobody.
+  return note;
 }
 
 export function registerReportIssueTools(server: McpServer): void {

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -467,6 +467,34 @@ export function normalizeReportedVersion(
   return asVersionToken(trimmed);
 }
 
+/**
+ * The intake worker truncates a submitted body at 60_000 chars (index.ts:
+ * MAX_BODY_LEN) before anything is stored or filed.
+ *
+ * The identity stamp is the LAST thing in the body, so an oversized report — a
+ * pasted log, the diff the report-bug skill asks for — would have its
+ * attribution cut off server-side, silently, and precisely on the reports with
+ * the most in them. Trim the caller's own text by the stamp's width instead: the
+ * worker was going to cut that tail anyway, so the content lost is the same
+ * either way, and the attribution survives.
+ *
+ * Exported for the covering test — nothing else calls it.
+ */
+export const WORKER_MAX_BODY_LEN = 60_000;
+
+export function fitUnderWorkerCap(
+  body: string,
+  identity: Parameters<typeof stampAgentIdentity>[1],
+): string {
+  if (!identity || stampAgentIdentity(body, identity).length <= WORKER_MAX_BODY_LEN) return body;
+  const note = "\n\n…[trimmed to keep the reporting-agent stamp]";
+  // Measure the stamp against THIS identity rather than assuming a width — the
+  // model name is provider-supplied and unbounded in principle.
+  const stampWidth = stampAgentIdentity("", identity).length;
+  const room = WORKER_MAX_BODY_LEN - stampWidth - note.length;
+  return room > 0 ? body.slice(0, room) + note : note;
+}
+
 export function registerReportIssueTools(server: McpServer): void {
   server.tool(
     "report_issue",
@@ -517,7 +545,7 @@ export function registerReportIssueTools(server: McpServer): void {
         // plain stdio, CLI, tests) changes nothing — body and labels pass
         // through as before.
         const identity = ours ? readAgentIdentity() : undefined;
-        const body = stampAgentIdentity(args.body, identity);
+        const body = stampAgentIdentity(fitUnderWorkerCap(args.body, identity), identity);
         const labels = identity
           ? Array.from(new Set([...(args.labels ?? []), agentLabel(identity)]))
           : args.labels;


### PR DESCRIPTION
A bug report filed from the panel is written by whichever model is selected in the
provider/model chips — Claude Opus, a hosted Kimi, a local gemma — and report quality
tracks that choice closely. Nothing in the filed issue said which, so a thin or wrong
report from a 4B model was indistinguishable from one from a frontier model, and the
question "are the bad reports coming from the non-SOTA backends?" could not be asked at
all, let alone across a batch of issues.

It cannot be self-reported. A model asked to name itself answers with a guess, and the
agent's ENVIRONMENT block never carried the model in the first place — only `Backend:`.
So the **orchestrator**, which owns the chips, publishes the fact, and `report_issue`
reads it back.

## What lands in the issue

```
Filed from the ComfyUI panel by **ollama** · model `gemma3:4b` · effort `low` — stamped by
comfyui-mcp from the panel's provider/model selection, not self-reported.
<!-- reporter-agent: backend=ollama model=gemma3:4b effort=low -->
```

…plus an `agent:<provider>` label, so the issues are filterable on GitHub. The **body** is
the channel that works today with no worker deploy: the intake worker pins the submitted
body verbatim into the created issue (`triage.ts` — `sanitized.body = opts.report.body`),
while an unknown top-level payload field would be silently dropped. Per-**provider** label,
not per-model — one label per provider is a bounded set, one per model is not; the exact
model stays in the body.

## How it gets there

`src/services/agent-identity.ts` is the transport `download-progress.ts` already
established, with the direction reversed: the orchestrator writes a small per-agent JSON,
the comfyui MCP subprocess reads it. No socket, no new HTTP surface, and it no-ops
entirely when the env var is unset — every non-panel spawn (plain stdio, CLI, tests) sends
a byte-identical body and label set to before.

**Why a file and not the spawn env.** `setModel` is live and deliberately does not restart
the session, so a value baked in at spawn goes stale the moment the user changes the chip —
and would then attribute reports to the model they switched *away* from, which is worse
than saying nothing. It is republished at **turn dispatch**: `"working"` fires before the
backend starts the turn, and therefore before any tool that turn calls. That is also why a
read has **no staleness cutoff** — a turn can legitimately run for an hour before it files,
and ageing the file out would drop attribution for exactly the longest sessions.

Both spawn lanes forward the path — the HTTP lane and the Claude lane, the one missed by
both prior incidents this file is annotated with. The path is port-scoped for the reason
`SessionStore` is: the agent key carries no port, so two ComfyUI instances on one machine
would otherwise stamp each other's model onto each other's reports.

Third-party trackers are untouched: our provider telemetry is not their business, and
`agent:ollama` is a label their repo has never heard of.

## Verification

**Mutation, on the wires and not just the helpers** — each of these turns the suite red:
cutting the Claude lane's env, cutting the HTTP lane's env, moving the publish to `"done"`,
latching a failed write into the dedupe cache, dropping the body stamp, dropping the label,
and inverting the stamp guard.

**Live, on the rig** — a real orchestrator on its own bridge port, driven over the real
panel bridge protocol, with a real Claude turn calling `report_issue` (`no_file:true`, so
nothing was filed):

```
--- identity at dispatch --- {"backend":"claude","model":"claude-opus-5","updated":…}
--- tool calls --- ["ToolSearch","mcp__comfyui__report_issue"]
--- agent reply ---
https://github.com/artokun/comfyui-mcp/issues/new?title=LIVE+CHECK…&body=…%0A---%0AFiled+from+the+ComfyUI+panel+by+**claude**+%C2%B7+model+%60claude-opus-5%60+…+not+self-reported.%0A%3C%21--+reporter-agent%3A+backend%3Dclaude+model%3Dclaude-opus-5+--%3E&labels=agent%3Aclaude
```

…and the same real built `dist/index.js` spawned as the MCP child both ways: with an
identity published (stamped, `agent:ollama` label) and without one (body and labels
byte-identical to the caller's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
