### PR TITLE
fix(1695): panel_set_widget summarizes long previous/new echo strings

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -8,6 +8,7 @@
 // identical set.
 
 import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -250,6 +251,98 @@ describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
   it("keeps the ack bounded (never Infinity) so a genuinely dead tab still fails", () => {
     expect(Number.isFinite(REFRESH_ACK_MS)).toBe(true);
     expect(REFRESH_ACK_MS).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe("panel-tools: panel_set_widget echo summary (#1695)", () => {
+  // #1695: a code-mode script that batches panel_set_widget calls accumulates
+  // every nested reply in the OUTER tool result; each reply echoes the previous
+  // and new widget values verbatim, so two long prompts per call overflow the
+  // outer budget ("Output exceeded the available model context and was
+  // truncated") even though every mutation succeeded. Long strings are now
+  // echoed as {chars, sha256, preview} by default, with `echo: "full"` opting
+  // back into the verbatim reply.
+  const LONG = "a pretty elaborate prompt, ".repeat(100); // 2700 chars
+  const sha256 = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+
+  async function runSetWidget(
+    args: Record<string, unknown>,
+    reply: unknown,
+  ): Promise<ToolResult> {
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 6, widget: "text", value: "x", ...args },
+      {
+        call: async () =>
+          typeof reply === "object" && reply !== null && "isError" in reply
+            ? reply
+            : { content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }] },
+      } as unknown as PanelToolCtx,
+    );
+    return res as ToolResult;
+  }
+
+  const setReply = (previous: unknown, value: unknown) => ({
+    set: { node_id: 6, widget: "text", previous, value },
+  });
+
+  it("summarizes long string previous/value as {chars, sha256, preview} by default", async () => {
+    const res = await runSetWidget({}, setReply(LONG, LONG + "v2"));
+    expect(res.isError).toBeUndefined();
+    const payload = JSON.parse(res.content[0].text!) as Record<string, any>;
+    expect(payload.set.node_id).toBe(6);
+    expect(payload.set.previous).toMatchObject({
+      chars: LONG.length,
+      sha256: sha256(LONG),
+    });
+    expect(payload.set.value.chars).toBe(LONG.length + 2);
+    expect(payload.set.value.sha256).toBe(sha256(LONG + "v2"));
+    // The preview is a disclosed PREFIX of the real value, never a rewrite.
+    expect((LONG + "v2").startsWith(payload.set.value.preview.slice(0, -1))).toBe(true);
+    expect(payload.set.value.preview.endsWith("…")).toBe(true);
+    // The way back to the full strings is named in the reply itself.
+    expect(payload.echo).toBe("summary");
+    expect(payload.echo_full).toContain('echo: "full"');
+  });
+
+  it("leaves short values verbatim and adds no echo rider", async () => {
+    const res = await runSetWidget({}, setReply("old", "new"));
+    const payload = JSON.parse(res.content[0].text!) as Record<string, any>;
+    expect(payload.set.previous).toBe("old");
+    expect(payload.set.value).toBe("new");
+    expect(payload.echo).toBeUndefined();
+    expect(payload.echo_full).toBeUndefined();
+  });
+
+  it("echo: \"full\" returns long strings verbatim", async () => {
+    const res = await runSetWidget({ echo: "full" }, setReply(LONG, LONG));
+    const payload = JSON.parse(res.content[0].text!) as Record<string, any>;
+    expect(payload.set.previous).toBe(LONG);
+    expect(payload.set.value).toBe(LONG);
+    expect(payload.echo).toBeUndefined();
+  });
+
+  it("leaves non-string values (numbers, booleans) untouched", async () => {
+    const res = await runSetWidget({ widget: "steps" }, setReply(20, 30));
+    const payload = JSON.parse(res.content[0].text!) as Record<string, any>;
+    expect(payload.set.previous).toBe(20);
+    expect(payload.set.value).toBe(30);
+    expect(payload.echo).toBeUndefined();
+  });
+
+  it("passes an error result through untouched", async () => {
+    const err = {
+      isError: true as const,
+      content: [{ type: "text" as const, text: "Error: widget not found" }],
+    };
+    const res = await runSetWidget({}, err);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toBe("Error: widget not found");
+  });
+
+  it("passes a reply with no `set` envelope through untouched", async () => {
+    const reply = { ok: true, note: "no set envelope" };
+    const res = await runSetWidget({}, reply);
+    expect(res.content[0].text).toBe(JSON.stringify(reply, null, 2));
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -24,7 +24,7 @@
 // so parity is automatic — neither path reimplements a tool.
 
 import { z } from "zod";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 // #873 — the operator's tool-surface policy also governs the panel surface.
 import {
   resolveToolSurfacePolicy,
@@ -2884,6 +2884,62 @@ function appendToolResultText(res: ToolResult, extra: string): ToolResult {
   const content = [...res.content];
   content[idx] = { type: "text", text: `${block.text}${extra}` };
   return { ...res, content };
+}
+
+// ---- #1695: bound the panel_set_widget previous/new echo --------------------
+//
+// Code-mode clients (Codex `functions.exec`) batch several panel_set_widget
+// calls into one script, and the OUTER tool result accumulates every nested
+// reply. Each reply echoes the previous and new widget values verbatim; two
+// long CLIPTextEncode prompts per call push the aggregate past the client's
+// tool-result budget ("Output exceeded the available model context and was
+// truncated") even though every mutation succeeded — and the truncation can
+// hide exactly the per-call status the caller needs. The echo is confirmation,
+// not transport (a read-back belongs to panel_query_graph), so a long string
+// value is summarized server-side as { chars, sha256, preview }: the hash keeps
+// the confirmation verifiable, the preview keeps it legible, and `echo: "full"`
+// opts back into the verbatim reply.
+//
+// Server-side on purpose — the echo is produced by the panel frontend, and an
+// old panel keeps echoing verbatim no matter what a new one would do (the same
+// reason fitQueryGraphReply re-fits here, #807).
+const SET_WIDGET_ECHO_SUMMARY_THRESHOLD = 1000;
+const SET_WIDGET_ECHO_PREVIEW_CHARS = 160;
+
+function summarizeSetWidgetEcho(res: ToolResult, full: boolean): ToolResult {
+  if (full || res.isError) return res;
+  const payload = parseToolResultJson(res);
+  const set = payload?.set;
+  if (!payload || !set || typeof set !== "object" || Array.isArray(set)) return res;
+  const record = set as Record<string, unknown>;
+  const summarize = (v: unknown): unknown => {
+    if (typeof v !== "string" || v.length <= SET_WIDGET_ECHO_SUMMARY_THRESHOLD) return v;
+    return {
+      chars: v.length,
+      sha256: createHash("sha256").update(v, "utf8").digest("hex"),
+      preview: `${v.slice(0, SET_WIDGET_ECHO_PREVIEW_CHARS)}…`,
+    };
+  };
+  const previous = summarize(record.previous);
+  const value = summarize(record.value);
+  // Nothing crossed the threshold — return the reply untouched rather than
+  // dressing up an unfitted payload as a fitted one.
+  if (previous === record.previous && value === record.value) return res;
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  const fitted = {
+    ...payload,
+    set: { ...record, previous, value },
+    echo: "summary",
+    echo_full:
+      'Long string values were summarized as {chars, sha256, preview} so batched calls do not overflow the outer tool result; the mutation was applied. Re-call with echo: "full" for the verbatim strings, or read the live value back with panel_query_graph.',
+  };
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: JSON.stringify(fitted, null, 2) } : c,
+    ),
+  };
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -10588,7 +10644,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_widget",
-      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted).",
+      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value (a string longer than 1000 chars is echoed as {chars, sha256, preview} so batched calls stay inside the outer tool-result budget — pass `echo: \"full\"` for the verbatim string). Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted).",
       {
         node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
@@ -10600,6 +10656,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .boolean()
           .optional()
           .describe("Set true to clear the widget to an empty string (\"\"). Escape hatch for when a client cannot carry an empty-string `value` through tool-arg JSON. Overrides `value`."),
+        echo: z
+          .enum(["summary", "full"])
+          .optional()
+          .describe(
+            "How to echo the previous/new values back. 'summary' (default) replaces a string longer than 1000 chars with {chars, sha256, preview} — the mutation is applied either way. 'full' returns the verbatim strings.",
+          ),
       },
       async (args: A, ctx) => {
         // Distinguish "value present but empty" from "value absent" by key
@@ -10616,10 +10678,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // a single revalidation, #338/#458) — that authoritative fetch can outlast
         // the 6000 ms default ack on a large install and return a FALSE timeout.
         // Give the guarded write the bounded refresh ack budget.
-        const write = (nodeId: unknown, widget: string): Promise<ToolResult> =>
-          ctx.call(
-            { cmd: "graph_set_widget", node_id: nodeId, widget, value },
-            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+        // #1695: summarize the previous/new echo of every successful write
+        // (direct, remapped, or inner-subgraph) before anything else touches
+        // it — long prompts batched in one code-mode script otherwise overflow
+        // the outer tool result even though the mutations succeeded. Applied
+        // to the raw success reply so a later appendToolResultText disclosure
+        // (which makes the text no longer parse as JSON) cannot dodge it.
+        const echoFull = args.echo === "full";
+        const write = async (nodeId: unknown, widget: string): Promise<ToolResult> =>
+          summarizeSetWidgetEcho(
+            await ctx.call(
+              { cmd: "graph_set_widget", node_id: nodeId, widget, value },
+              OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+            ),
+            echoFull,
           );
         const first = await write(args.node_id, args.widget as string);
         if (!first.isError) return first;


### PR DESCRIPTION
## Root cause

A code-mode (Codex `functions.exec`) script that batches several `panel_set_widget` calls accumulates every nested reply in the OUTER tool result. Each reply echoed the `set.previous`/`set.value` strings verbatim, so two long CLIPTextEncode prompts per call pushed the aggregate past the client's tool-result budget — "Output exceeded the available model context and was truncated" — even though every mutation succeeded, and the truncation hid the per-call status the caller needed.

The accumulation happens client-side (Codex), so the fixable surface here is the reply itself. The verbatim echo is produced by the panel frontend; an orchestrator-side fitter is the defense that also works against older panel versions (the same rationale as `fitQueryGraphReply`, #807).

## Fix

- New `summarizeSetWidgetEcho()` in `src/orchestrator/panel-tools.ts`: on a successful `panel_set_widget` reply, any string `previous`/`value` longer than 1000 chars is replaced with `{chars, sha256, preview}` (160-char prefix). The reply then carries `echo: "summary"` plus an `echo_full` note naming the two ways back to the full strings (`echo: "full"`, or a `panel_query_graph` read-back).
- New opt-in arg `echo: "summary" | "full"` (default summary); `full` returns the verbatim strings as before.
- Applied inside the handler's `write()` wrapper, so all three success paths (direct, #1655 promoted-widget remap, inner-subgraph write) are covered, and it runs on the raw reply before any `appendToolResultText` disclosure makes the text unparseable.
- Fail-closed passthrough: short values, non-string values, error replies, and replies without a `set` envelope are returned untouched — an unfitted payload is never dressed up as a fitted one.

Per-call mutation status is preserved: only the two long string fields shrink; the `set` envelope (node_id, widget) and `isError` are unchanged.

## Verification

- 6 new tests in `src/__tests__/orchestrator/panel-tools.test.ts` (#1695 describe): default summarization with matching sha256/prefix preview, short-value passthrough with no rider, `echo: "full"` verbatim, non-string passthrough, error passthrough, no-`set`-envelope passthrough.
- `npm run build` (tsc): clean.
- `npx vitest run src/__tests__/orchestrator/panel-tools.test.ts`: 343/343 pass; promoted-widget + strict-schema suites: 158/158.
- Full `npm test`: 10311 passed, 3 skipped, 4 failed — all 4 are 30s timeouts in unrelated load-sensitive suites (`tool-surface-filter.test.ts`, `vocabulary.test.ts`); both files pass 94/94 in isolation in 6.8s. Post-vitest chain run explicitly: `i18n:check`, `check:docs-links`, `check:docs-locale`, `check:docs-mdx`, `check:blog`, `check:blog-packs`, `check:blog-stale`, `check:blog-structure` — all exit 0.
- Tool description changed, so: `npm run docs:gen` produced byte-identical docs (panel tools are not in the generated core-tool reference; only CRLF churn, reverted), `npm run check:vocabulary` OK, `npm run vocab:export -- --check` OK. No `docs/*.mdx` touched, so no locale-mirror changes.

Closes #1695