### PR TITLE
fix(1700): panel_remove_mcp + panel_reload drops the removed server

### DIFF
--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -49,6 +49,8 @@ const hoisted = vi.hoisted(() => ({
   })(),
   /** The mcpServers object the backend actually handed the SDK. */
   lastMcpServers: null as Record<string, unknown> | null,
+  lastForkSession: undefined as boolean | undefined,
+  lastResume: undefined as string | undefined,
   /** What `q.mcpServerStatus()` answers, and how many times it was asked. */
   statusPoll: null as null | Array<{ name: string; status: string }>,
   statusPolls: 0,
@@ -57,8 +59,13 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (arg: { prompt?: AsyncIterable<unknown>; options?: { mcpServers?: Record<string, unknown> } }) => {
+  query: (arg: {
+    prompt?: AsyncIterable<unknown>;
+    options?: { mcpServers?: Record<string, unknown>; forkSession?: boolean; resume?: string };
+  }) => {
     hoisted.lastMcpServers = arg.options?.mcpServers ?? null;
+    hoisted.lastForkSession = arg.options?.forkSession;
+    hoisted.lastResume = arg.options?.resume;
     void (async () => {
       for await (const _ of arg.prompt ?? []) void _;
     })();
@@ -83,6 +90,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 beforeEach(() => {
   hoisted.queue.reset();
   hoisted.lastMcpServers = null;
+  hoisted.lastForkSession = undefined;
+  hoisted.lastResume = undefined;
   hoisted.statusPoll = null;
   hoisted.statusPolls = 0;
   hoisted.reconnectCalls = [];
@@ -350,5 +359,80 @@ describe("the turn-end watch settles what init could not (#1524)", () => {
     expect(noticesOf(events)).toHaveLength(0);
     expect(hoisted.reconnectCalls).toEqual([]);
     expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+  });
+});
+
+describe("a forked resume uses THIS run's MCP set, not the session-recorded one (#1700)", () => {
+  const MAGIC = { type: "stdio", command: "npx", args: ["-y", "@21st-dev/magic"] } as never;
+
+  it("hands the SDK forkSession plus the post-remove server set", async () => {
+    // The reporter's case: magic was removed from config, then panel_reload
+    // resumed the old session. A plain resume restores the recorded MCP set, so
+    // magic stayed failed. The shipped backend must fork AND pass the current
+    // deps (no magic) so the replacement session cannot relaunch it.
+    const events: AgentEvent[] = [];
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({
+      mcpServers: { comfyui: COMFYUI_SERVER } as never,
+      systemAppend: "",
+      panelServer: PANEL_SERVER,
+    });
+    async function* idle(): AsyncGenerator<{ text: string }> {
+      await new Promise<void>(() => {});
+    }
+    const done = (async () => {
+      for await (const ev of backend.run({
+        channel: idle() as never,
+        resume: "sess-with-magic",
+        forkSession: true,
+      })) {
+        events.push(ev);
+      }
+    })();
+    hoisted.queue.push(
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+    );
+    await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+    hoisted.queue.end();
+    await done;
+
+    expect(hoisted.lastResume).toBe("sess-with-magic");
+    expect(hoisted.lastForkSession).toBe(true);
+    expect(hoisted.lastMcpServers && Object.keys(hoisted.lastMcpServers).sort()).toEqual([
+      "comfyui",
+      "panel",
+    ]);
+    expect(hoisted.lastMcpServers).not.toHaveProperty("magic");
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("a plain resume does not set forkSession — that is the bug's shape", async () => {
+    const events: AgentEvent[] = [];
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({
+      mcpServers: { comfyui: COMFYUI_SERVER, magic: MAGIC } as never,
+      systemAppend: "",
+    });
+    async function* idle(): AsyncGenerator<{ text: string }> {
+      await new Promise<void>(() => {});
+    }
+    const done = (async () => {
+      for await (const ev of backend.run({
+        channel: idle() as never,
+        resume: "sess-with-magic",
+      })) {
+        events.push(ev);
+      }
+    })();
+    hoisted.queue.push(initWith([{ name: "comfyui", status: "connected" }]));
+    await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+    hoisted.queue.end();
+    await done;
+
+    expect(hoisted.lastResume).toBe("sess-with-magic");
+    expect(hoisted.lastForkSession).toBeUndefined();
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -21,6 +21,7 @@ import {
   buildPanelToolDefs,
   makePanelToolCtx,
   registerPanelTools,
+  setApplyMcpReload,
   __openWorkflowTestHooks,
   __panelToolsTestHooks,
   __panelRunTestHooks,
@@ -1713,6 +1714,41 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
     expect(res.isError).toBeUndefined();
     const text = (res.content[0] as { text: string }).text;
     expect(text).not.toMatch(/does NOT reload/i);
+  });
+
+  it("panel_reload (orchestrator scope) schedules the in-process MCP respawn (#1700)", async () => {
+    // The frontend soft_reload only drops the websocket; without this hook the
+    // live agent keeps the MCP set it was spawned with. Drive the REAL tool.
+    const keys: string[] = [];
+    setApplyMcpReload((key) => {
+      keys.push(key);
+    });
+    try {
+      const store = new WorkflowTargetStore();
+      const { bridge } = methodIsHeadlessBridge(["only-live-tab"]);
+      const ctx = makePanelToolCtx(bridge, "orphaned-tab", store);
+      const res = await defByName("panel_reload").handler({}, ctx);
+      expect(res.isError).toBeUndefined();
+      expect(keys).toEqual([ctx.tabId]);
+    } finally {
+      setApplyMcpReload(undefined);
+    }
+  });
+
+  it("panel_reload (frontend scope) does NOT schedule an MCP respawn (#1700)", async () => {
+    const keys: string[] = [];
+    setApplyMcpReload((key) => {
+      keys.push(key);
+    });
+    try {
+      const store = new WorkflowTargetStore();
+      const { bridge } = methodIsHeadlessBridge(["only-live-tab"]);
+      const ctx = makePanelToolCtx(bridge, "orphaned-tab", store);
+      await defByName("panel_reload").handler({ scope: "frontend" }, ctx);
+      expect(keys).toEqual([]);
+    } finally {
+      setApplyMcpReload(undefined);
+    }
   });
 
   it("panel_set_workflow_target recovery filters isHeadless bound, not detached (#478 sibling site)", async () => {

--- a/src/__tests__/orchestrator/remove-mcp-stale-session.test.ts
+++ b/src/__tests__/orchestrator/remove-mcp-stale-session.test.ts
@@ -1,0 +1,191 @@
+// #1700 — panel_remove_mcp + panel_reload left the removed server in the
+// resumed session's MCP set, and the panel kept reporting it as failed.
+//
+// Two stacked facts:
+//   1. panel_reload's frontend soft_reload only drops the websocket (this pack's
+//      /reload is a 503). The live agent is not replaced, so it keeps the MCP
+//      set it was spawned with.
+//   2. Even a replacement that RESUMES the session restores the MCP set recorded
+//      WITH that session, ignoring the freshly-read ~/.claude.json.
+//
+// The shipped fix: panel_reload({scope:"orchestrator"}) calls
+// restartForMcpConfig, which respawns via makeMcpServers() (re-read) AND forks
+// so the SDK cannot restore the old set.
+//
+// These tests drive the REAL remove + the REAL manager restart. A fake expected
+// server list would pass with the spawn still handing the old set.
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import { readFileSync } from "node:fs";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+let readUserMcpServers: typeof import("../../services/user-mcp-config.js").readUserMcpServers;
+let removeUserMcpServer: typeof import("../../services/user-mcp-config.js").removeUserMcpServer;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+  ({ readUserMcpServers, removeUserMcpServer } = await import("../../services/user-mcp-config.js"));
+});
+
+const CLAUDE_JSON = {
+  mcpServers: {
+    magic: { type: "stdio", command: "npx", args: ["-y", "@21st-dev/magic"] },
+    codegraph: { type: "http", url: "http://127.0.0.1:9999" },
+  },
+};
+
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runs: BackendStartOptions[] = [];
+  autoComplete = true;
+  private releaseTurn: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runs.push(opts);
+    yield { type: "session", sessionId: "sess-with-magic" };
+    for await (const turn of opts.channel) {
+      void turn;
+      if (!this.autoComplete) {
+        await new Promise<void>((resolve) => {
+          this.releaseTurn = resolve;
+        });
+        this.releaseTurn = null;
+      }
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  release(): void {
+    const r = this.releaseTurn;
+    this.releaseTurn = null;
+    r?.();
+  }
+
+  async interrupt(): Promise<void> {
+    this.release();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const prevClaudeJson = process.env.COMFYUI_MCP_CLAUDE_JSON;
+
+beforeEach(() => {
+  const dir = mkdtempSync(join(tmpdir(), "remove-mcp-1700-"));
+  const path = join(dir, ".claude.json");
+  writeFileSync(path, JSON.stringify(CLAUDE_JSON, null, 2));
+  process.env.COMFYUI_MCP_CLAUDE_JSON = path;
+});
+
+afterEach(() => {
+  if (prevClaudeJson === undefined) delete process.env.COMFYUI_MCP_CLAUDE_JSON;
+  else process.env.COMFYUI_MCP_CLAUDE_JSON = prevClaudeJson;
+});
+
+describe("panel_remove_mcp + forked respawn drops the removed server (#1700)", () => {
+  it("restartForMcpConfig re-reads the config and forks so magic is gone", async () => {
+    const mcpNames: string[][] = [];
+    const backend = new RecordingBackend();
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+      makeMcpServers: () => {
+        const inherited = readUserMcpServers();
+        mcpNames.push(Object.keys(inherited));
+        return { comfyui: { type: "stdio", command: "node" }, ...inherited } as never;
+      },
+    } as never);
+
+    manager.send("orchestrator::claude", "hello");
+    await waitFor(() => backend.runs.length >= 1);
+
+    expect(readUserMcpServers().magic).toBeDefined();
+    expect(removeUserMcpServer("magic")).toBe(true);
+    expect(readUserMcpServers().magic).toBeUndefined();
+    expect(Object.keys(readUserMcpServers()).sort()).toEqual(["codegraph"]);
+
+    await waitFor(() => manager.restartForMcpConfig("orchestrator::claude") === "applied");
+    await waitFor(() => backend.runs.length >= 2);
+
+    const replacement = backend.runs[1];
+    expect(replacement.resume, "conversation continues").toBe("sess-with-magic");
+    expect(replacement.forkSession, "must fork so the SDK does not restore magic").toBe(true);
+    const lastRead = mcpNames.at(-1) ?? [];
+    expect(lastRead).not.toContain("magic");
+    expect(lastRead).toContain("codegraph");
+  });
+
+  it("a credential-style restartForMcpEnv does NOT fork — env change keeps the session", async () => {
+    const backend = new RecordingBackend();
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+    } as never);
+
+    manager.send("tab-env", "hello");
+    await waitFor(() => backend.runs.length >= 1);
+    await waitFor(() => manager.restartForMcpEnv("tab-env") === "applied");
+    await waitFor(() => backend.runs.length >= 2);
+    expect(backend.runs[1].resume).toBe("sess-with-magic");
+    expect(backend.runs[1].forkSession).toBeUndefined();
+  });
+
+  it("mid-turn panel_reload path stays scheduled until idle, then forks", async () => {
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+    } as never);
+
+    manager.send("tab-busy", "hello");
+    await waitFor(() => backend.runs.length >= 1);
+    expect(manager.restartForMcpConfig("tab-busy")).toBe("scheduled");
+    expect(backend.runs).toHaveLength(1);
+
+    backend.autoComplete = true;
+    backend.release();
+    await waitFor(() => backend.runs.length >= 2);
+    expect(backend.runs[1].forkSession).toBe(true);
+  });
+});
+
+describe("panel_reload is wired to the forked MCP respawn (#1700)", () => {
+  it("index.ts binds setApplyMcpReload to manager.restartForMcpConfig", () => {
+    const src = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+    expect(src).toMatch(/setApplyMcpReload\(\(key\) => \{\s*manager\.restartForMcpConfig\(key\);/s);
+  });
+});

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -205,6 +205,14 @@ export interface ModelChoice {
 export interface BackendStartOptions {
   /** Resume an existing session/thread by id. */
   resume?: string;
+  /**
+   * Resume into a NEW session id that keeps conversation history but takes the
+   * CURRENT MCP server set (#1700). A plain `resume` restores the MCP set
+   * recorded with that session, so panel_add_mcp / panel_remove_mcp would not
+   * take effect. Honored by Claude (`forkSession: true`); other backends ignore
+   * it. Distinct from `rewindAnchor`, which also forks but drops later turns.
+   */
+  forkSession?: boolean;
   /** Fork the conversation at this anchor — honored only if `forkAtAnchor`. */
   rewindAnchor?: string | null;
   /** Model id (provider-specific). */

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -630,9 +630,17 @@ export class ClaudeBackend implements AgentBackend {
     // Rewind: fork the conversation at the anchor (resume up to that message, then
     // branch into a new session id) so everything after it is dropped. A null
     // anchor means "fresh session" (handled by clearing resume below).
+    //
+    // #1700 — a plain `resume` restores the MCP server set recorded WITH that
+    // session, so a panel_remove_mcp that re-read ~/.claude.json still launched
+    // the deleted server (and kept reporting it as failed). `forkSession`
+    // without an anchor keeps history but applies THIS run's mcpServers.
+    const resumeTarget = opts.sessionId ?? resume;
     const rewindOpts = rewindAnchor
-      ? { resume: opts.sessionId ?? resume, resumeSessionAt: rewindAnchor, forkSession: true }
-      : null;
+      ? { resume: resumeTarget, resumeSessionAt: rewindAnchor, forkSession: true }
+      : opts.forkSession && resumeTarget
+        ? { resume: resumeTarget, forkSession: true }
+        : null;
     return {
       model,
       permissionMode: "bypassPermissions",

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -127,6 +127,7 @@ import {
   makePanelToolCtx,
   resolvePinTarget,
   secretSavedReply,
+  setApplyMcpReload,
   RETRY_TOKEN_CMDS,
 } from "./panel-tools.js";
 import {
@@ -2640,6 +2641,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Let refreshEnvCapabilities() feed a freshly-gathered env block into agents
   // spawned after a ComfyUI restart/reconnect.
   liveManager = manager;
+  // #1700 — panel_reload({scope:"orchestrator"}) must fork-respawn so a
+  // panel_remove_mcp / panel_add_mcp is not lost to the resumed session's
+  // recorded MCP set. The tool itself lives in the panel MCP and cannot
+  // reach the manager except through this hook.
+  setApplyMcpReload((key) => {
+    manager.restartForMcpConfig(key);
+  });
 
   // #468 — let the journal pull a still-unread completion back off an agent's
   // queue when it has to WEAKEN that completion's correlation (a reused prompt
@@ -6380,6 +6388,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     unsubscribeSecrets();
     unsubscribeAgentSecrets();
+    setApplyMcpReload(undefined);
     await manager.stopAll();
     // Dispose the readiness-probe backends (kills each Codex/Gemini CLI child).
     for (const pb of probeBackends.values()) {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -532,6 +532,9 @@ export class PanelAgent {
   /** Set by requestRewind() to fork the session on the next (re)start. `anchor`
    *  is the assistant UUID to resume up to (drop everything after); null = fresh. */
   private pendingRewind: { anchor: string | null } | null = null;
+  /** #1700 — next start resumes history into a NEW session so the current
+   *  mcpServers (re-read from ~/.claude.json) replace the session-recorded set. */
+  private pendingForkOnResume = false;
   /** Captured from the session's init message; enables resume across restarts. */
   sessionId: string | null = null;
   /** #1516 — cumulative AUTOMATIC previews committed to turns of the CURRENT
@@ -678,6 +681,7 @@ export class PanelAgent {
     // A rewind deliberately DROPS everything after the anchor (the edited message
     // arrives separately), so the interrupted turn's text must NOT be re-queued.
     this.inFlight = null;
+    this.pendingForkOnResume = false; // rewind owns the next start's fork shape
     // The dropped turn may have been carrying a run completion — that is news,
     // not conversation, so hand it back for replay rather than rewinding it away
     // (#468).
@@ -693,6 +697,12 @@ export class PanelAgent {
     const wake = this.waiting;
     this.waiting = null;
     wake?.();
+  }
+
+  /** #1700 — next start resumes history into a NEW session so the current
+   *  mcpServers replace the set recorded with the old session. */
+  requestForkOnResume(): void {
+    this.pendingForkOnResume = true;
   }
 
   /**
@@ -1765,6 +1775,9 @@ export class PanelAgent {
       // session instead of starting clean. (requestRewind(null) clears sessionId;
       // this also suppresses the resumeSessionId fallback.)
       const resume = rewind?.anchor === null ? undefined : (this.sessionId ?? resumeSessionId);
+      // Consume once: a later self-restart must not keep forking unless asked again.
+      const forkSession = this.pendingForkOnResume && !!resume && !rewind?.anchor;
+      this.pendingForkOnResume = false;
       const startedAt = Date.now();
       // Set below if the backend fails because the resume target is gone; keeps a
       // recoverable resume-miss from counting toward the give-up threshold.
@@ -1796,6 +1809,7 @@ export class PanelAgent {
           model: this.model,
           ...(this.effort ? { effort: this.effort } : {}),
           ...(resume ? { resume } : {}),
+          ...(forkSession ? { forkSession: true } : {}),
           sessionId: this.sessionId,
           rewindAnchor: rewind?.anchor ?? null,
           // LIVENESS: re-arm the freeze watchdog on ANY sign the backend is alive —
@@ -2510,6 +2524,9 @@ export class PanelAgentManager {
    *  an optional nudge to enqueue after the resumed agent comes back (e.g. "retry
    *  the download"). Applied at the next idle so the saving turn finishes first. */
   private pendingMcpRestart = new Map<string, string | null>();
+  /** #1700 — tabs whose pending MCP restart must FORK the session so the
+   *  freshly-read MCP server set replaces the session-recorded one. */
+  private pendingForkOnRestart = new Set<string>();
   /** #1429 — tabs whose queued MCP-restart nudge is a RETARGET nudge, mapped to
    *  the EARLIEST address they were stranded on. Two jobs: it tells a retarget
    *  nudge apart from a per-request retry nudge (#164, which must never be
@@ -2791,6 +2808,18 @@ export class PanelAgentManager {
     // as its own and overwrite it — the exact #164 erasure, one step removed.
     this.pendingRetargetFrom.delete(key);
     return this.applyPendingRestarts(key);
+  }
+
+  /**
+   * #1700 — respawn this conversation so panel_add_mcp / panel_remove_mcp take
+   * effect. Same coalesced at-idle replacement as restartForMcpEnv, but the
+   * replacement FORKS: a plain resume would restore the MCP set recorded with
+   * the old session (the reporter's `magic` server stayed failed after reload).
+   * makeMcpServers() re-reads ~/.claude.json on the new spawn.
+   */
+  restartForMcpConfig(key: string, nudge?: string): McpEnvRestartOutcome {
+    if (this.agents.has(key)) this.pendingForkOnRestart.add(key);
+    return this.restartForMcpEnv(key, nudge);
   }
 
   /** Rebuild a live agent because its PROVIDER credential rotated (#278): keyed
@@ -3078,6 +3107,7 @@ export class PanelAgentManager {
     if (!agent || agent.isStopped) {
       this.pendingEffortRestart.delete(tabId);
       this.pendingMcpRestart.delete(tabId);
+      this.pendingForkOnRestart.delete(tabId);
       this.pendingRetargetFrom.delete(tabId);
       // #1567 — this restart is being dropped, so it will never deliver an armed watch,
       // and there is no longer a session whose transfers a hold could protect.
@@ -3144,8 +3174,12 @@ export class PanelAgentManager {
     this.pendingEffortRestart.delete(tabId);
     this.pendingMcpRestart.delete(tabId);
     this.pendingRetargetFrom.delete(tabId);
-    const carried = this.restartAgentResume(tabId, agent, finalNudge);
-    const reasons = [wantEffort ? "effort" : null, wantMcp ? "comfyui-mcp-env" : null]
+    const forkSession = this.pendingForkOnRestart.delete(tabId);
+    const carried = this.restartAgentResume(tabId, agent, finalNudge, { forkSession });
+    const reasons = [
+      wantEffort ? "effort" : null,
+      wantMcp ? (forkSession ? "mcp-config" : "comfyui-mcp-env") : null,
+    ]
       .filter(Boolean)
       .join("+");
     logger.info(
@@ -3178,10 +3212,15 @@ export class PanelAgentManager {
    *  model/effort/mcpServers), resuming the conversation and carrying over any
    *  unsent queued messages. `nudge`, if given, is enqueued after the carried-over
    *  messages so the resumed agent auto-continues. Returns how many were carried. */
-  private restartAgentResume(tabId: string, oldAgent: PanelAgent, nudge?: string): number {
+  private restartAgentResume(
+    tabId: string,
+    oldAgent: PanelAgent,
+    nudge?: string,
+    spawnOpts?: { forkSession?: boolean },
+  ): number {
     const resume = oldAgent.sessionId ?? undefined;
     const pending = oldAgent.takePending();
-    const fresh = this.spawn(tabId, resume); // new agent owns the tab now
+    const fresh = this.spawn(tabId, resume, spawnOpts); // new agent owns the tab now
     for (const item of pending) {
       fresh.send(item.text, {
         images: item.images,
@@ -3297,8 +3336,9 @@ export class PanelAgentManager {
     return true;
   }
 
-  private spawn(tabId: string, resume?: string): PanelAgent {
+  private spawn(tabId: string, resume?: string, spawnOpts?: { forkSession?: boolean }): PanelAgent {
     const agent = this.makeAgent(tabId);
+    if (spawnOpts?.forkSession) agent.requestForkOnResume();
     this.agents.set(tabId, agent);
     logger.info(
       `[panel-orchestrator] spawning agent for tab ${tabId.slice(0, 8)}${resume ? " (resume)" : ""} (${this.agents.size} active)`,
@@ -3504,6 +3544,7 @@ export class PanelAgentManager {
       this.pendingMcpRestart.set(newKey, this.pendingMcpRestart.get(oldKey)!);
       this.pendingMcpRestart.delete(oldKey);
     }
+    if (this.pendingForkOnRestart.delete(oldKey)) this.pendingForkOnRestart.add(newKey);
     // #1567 — the mark and the hold classify that same queued restart, so they travel with
     // it. Left behind, the renamed tab's credential respawn stops being one this may wait
     // for, and fires into whatever downloads are running under the new key.
@@ -3782,6 +3823,7 @@ export class PanelAgentManager {
     const durableCleared = this.opts.sessionStore ? this.opts.sessionStore.clear(tabId) : true;
     this.pendingEffortRestart.delete(tabId); // a reset supersedes any deferred restart
     this.pendingMcpRestart.delete(tabId);
+    this.pendingForkOnRestart.delete(tabId);
     this.pendingRetargetFrom.delete(tabId); // #1429 — nothing queued, nothing to classify
     // Drop this key's picker override so a provider switch (which reset()s the old
     // key) can't carry the old provider's model/effort into the new backend's spawn.
@@ -3839,6 +3881,7 @@ export class PanelAgentManager {
   async stopAll(): Promise<void> {
     this.pendingEffortRestart.clear();
     this.pendingMcpRestart.clear();
+    this.pendingForkOnRestart.clear();
     // #1567 — no restart is owed any more, so nothing may be held for one. The poll timer is
     // unref'd, but a shutdown that leaves it running would keep re-entering
     // applyPendingRestarts against agents this method is in the middle of stopping.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -186,6 +186,15 @@ import { sliceWorkflow } from "../services/workflow-slicer.js";
 import { validateA2UISpecServer } from "../services/a2ui-spec.js";
 import type { UiWorkflow } from "../comfyui/types.js";
 
+/** #1700 — orchestrator wires this so panel_reload can fork-respawn the agent
+ *  with a freshly-read MCP set. Unset in tests that only exercise the tool. */
+let applyMcpReload: ((agentKey: string) => void) | undefined;
+
+/** Bind (or clear) the in-process MCP-config respawn used by panel_reload. */
+export function setApplyMcpReload(fn: ((agentKey: string) => void) | undefined): void {
+  applyMcpReload = fn;
+}
+
 /** Treat these as an affirmative answer to a yes/no confirm card (destructive-op
  *  gate). Deliberately BROAD/lenient — a false "no" only SKIPS a destructive op, so
  *  erring toward "not yes" is safe. NEVER use this for the adult-consent gate: a
@@ -11652,6 +11661,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
         const scope = (args.scope as string) ?? "orchestrator";
+        // #1700 — the frontend soft_reload only drops the websocket (this pack's
+        // /reload is a 503). The live agent keeps the MCP set it was spawned
+        // with, and a plain resume restores the session-recorded set anyway.
+        // Schedule a forked in-process respawn so makeMcpServers() re-reads
+        // ~/.claude.json and the replacement session is NOT the old MCP set.
+        if (scope === "orchestrator") applyMcpReload?.(ctx.tabId);
         const res = await ctx.call({ cmd: "soft_reload", scope }, 15000);
         // #765 — the agent reads this result as its last context before the
         // reload, and again after the resume, so it is the place to state what


### PR DESCRIPTION
Fixes #1700

## What the user now observes

After `panel_remove_mcp` then `panel_reload` (orchestrator scope), the respawned session no longer starts with the removed server and the panel stops reporting it as failed. `panel_list_mcp` and the live session agree.

## Why it was broken

`panel_reload` only forwarded `soft_reload` to the frontend. On this pack that POST is a 503, so the websocket reconnects and the **same** agent keeps running with the MCP set it was spawned with.

Even a replacement that **resumes** the Claude session restores the MCP set recorded with that session, so a freshly-read `~/.claude.json` (magic already gone) was ignored. A full Disconnect → Connect started clean because it did not resume.

## Fix

Orchestrator-scope `panel_reload` now calls `restartForMcpConfig`: respawn via `makeMcpServers()` (re-reads the user config) **and** `forkSession` so the SDK applies this run's server set instead of the session-recorded one. Conversation history is kept. Credential/env respawns still plain-resume.

## Tests

- Real `panel_remove_mcp` against a temp Claude config, then `restartForMcpConfig`: replacement run is a fork, inherited names no longer include the removed server.
- Real `panel_reload` handler schedules that respawn (frontend scope does not).
- Real `ClaudeBackend.run({ resume, forkSession: true })` hands the SDK `forkSession` plus the current mcpServers (no removed name).
