### PR TITLE
fix(1702): report a non-ASCII CIVITAI_API_TOKEN as a credential fault, not a network outage

### DIFF
--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -192,6 +192,42 @@ describe("civitai request error surfacing (distinct failure modes)", () => {
     );
   });
 
+  it("a non-ASCII CIVITAI_API_TOKEN is a credential fault, not a network outage (#1702)", async () => {
+    // Node's fetch rejects a non-ASCII Authorization header with TypeError
+    // *before* any socket opens. The suite-wide fetch stub would hide that
+    // throw, so this case drives the real platform fetch — the same path
+    // download_model action:"download_civitai" hits.
+    vi.unstubAllGlobals();
+    const nonAsciiToken = "token日本語";
+    try {
+      const probe = await fetch("https://example.invalid", {
+        headers: { Authorization: `Bearer ${nonAsciiToken}` },
+      }).then(
+        () => undefined,
+        (e: unknown) => e,
+      );
+      expect(probe).toBeInstanceOf(TypeError);
+      expect((probe as TypeError).message).toMatch(/ByteString|greater than 255/i);
+
+      config.civitaiApiToken = nonAsciiToken;
+      let err: unknown;
+      try {
+        await resolveCivitaiModelVersion(3223074);
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(ModelError);
+      const me = err as ModelError;
+      expect(me.message).not.toMatch(/unreachable|check connectivity/i);
+      expect(me.message).toMatch(/credential|CIVITAI_API_TOKEN/i);
+      expect((me.details as { network?: boolean } | undefined)?.network).not.toBe(true);
+      expect((me.details as { credential?: boolean } | undefined)?.credential).toBe(true);
+    } finally {
+      vi.stubGlobal("fetch", fetchMock);
+    }
+  });
+
   it("2xx that is NOT JSON (bot-gate/interstitial) → distinct non-JSON error, not a garbage empty", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -146,6 +146,19 @@ function transportError(err: unknown, url: string): ModelError | null {
     );
   }
   if (err instanceof TypeError) {
+    // A malformed Authorization header (e.g. CIVITAI_API_TOKEN pasted with
+    // non-ASCII characters) ALSO rejects as TypeError, but it is a LOCAL
+    // credential-config fault, not a connectivity fault. Labelling it
+    // "unreachable / check connectivity" sends the caller down the wrong
+    // diagnostic path.
+    if (/ByteString|greater than 255|Invalid header|invalid header/i.test(err.message)) {
+      return new ModelError(
+        `CivitAI credential is invalid: the API token contains characters that ` +
+          `cannot be sent in an HTTP header (non-ASCII). Re-enter CIVITAI_API_TOKEN as the raw ASCII ` +
+          `token — no quotes, no "Bearer " prefix, no label or translated text. (raw: ${err.message})`,
+        { url, credential: true },
+      );
+    }
     return new ModelError(
       `CivitAI is unreachable (network error: ${err.message}) — ` +
         `check connectivity and try again.`,


### PR DESCRIPTION
## Root cause

`download_model action:"download_civitai"` built `Authorization: Bearer <token>` from `CIVITAI_API_TOKEN`. Node `fetch` rejects a non-ASCII header value with `TypeError` (`Cannot convert argument to a ByteString … greater than 255`) *before* any socket opens.

`transportError()` mapped **any** `TypeError` to a connectivity failure (`network: true`, "CivitAI is unreachable — check connectivity"). That assumption holds for `TypeError: fetch failed` (DNS/TLS/connection), but an invalid header throws the same type. The agent then diagnosed an outage instead of a bad token.

## Fix

Classify the invalid-header `TypeError` as a credential fault before the network branch. A genuine `TypeError: fetch failed` is unchanged.

Not in this PR (separate, save-time): `panel_request_secret` still accepts a non-ASCII `CIVITAI_API_TOKEN` and reports a successful read-back. The download now tells the user to re-enter the token instead of blaming the network.

## Verification

- `npx vitest run src/__tests__/services/civitai-resolver.test.ts --maxWorkers=4` — 52 passed
- New case drives shipped `resolveCivitaiModelVersion` (the function `download_civitai` uses for the reporter's `/api/v1/model-versions/…` request) with a non-ASCII token on the real Node `fetch`. Asserts `MODEL_ERROR` is a credential fault, not `network: true` / "check connectivity". Existing `TypeError: fetch failed` case still reads as unreachable.

Fixes #1702
