### PR TITLE
fix(1701): a download-complete event now means the dest file exists

### DIFF
--- a/src/__tests__/services/download-done-before-dest.test.ts
+++ b/src/__tests__/services/download-done-before-dest.test.ts
@@ -1,0 +1,136 @@
+// #1701 — the tray announced "Model download transfer completed" for
+// t5xxl_flux1_int8_convrot.safetensors while download_model action:"status"
+// still said downloading and dest did not exist.
+//
+// The orchestrator raises that event from the first progress row with
+// status "done" (#547). streamUrlToFile used to emit that row when the
+// CACHE write finished — then Windows spent minutes COPYing the file
+// into models/text_encoders/. Status still said downloading because
+// the job only commits done at the dest rename (onLanded).
+//
+// Drive the real downloadModel (the local writer download_model uses).
+// Hold the copy-materialize mid-flight. A "done" row during that hold
+// is the reported false completion.
+
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { waitFor } from "../helpers/wait-for.js";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    huggingfaceToken: undefined as string | undefined,
+    civitaiApiToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    isRemoteMode: () => !config.comfyuiPath,
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
+  };
+});
+
+const progressRows = vi.hoisted(
+  () => [] as Array<{ status: string; downloaded?: number }>,
+);
+const destAtDone = vi.hoisted(() => ({
+  path: "",
+  existed: [] as boolean[],
+  check: (_p: string): boolean => false,
+}));
+
+vi.mock("../../services/download-progress.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/download-progress.js")>(
+    "../../services/download-progress.js",
+  );
+  return {
+    ...actual,
+    reportDownloadProgress: (p: { status: string; downloaded?: number }) => {
+      progressRows.push({ status: p.status, downloaded: p.downloaded });
+      if (p.status === "done") destAtDone.existed.push(destAtDone.check(destAtDone.path));
+    },
+  };
+});
+
+import { config } from "../../config.js";
+import { downloadCacheFs } from "../../services/download-cache.js";
+import { downloadModel } from "../../services/model-resolver.js";
+import { setDownloadRetryPolicyForTests } from "../../services/download-retry.js";
+
+const fetchMock = vi.fn();
+let tempDir: string;
+
+function okResponse(body: string): Response {
+  return new Response(body, { status: 200, statusText: "OK" });
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "comfyui-mcp-1701-"));
+  process.env.COMFYUI_DOWNLOAD_CACHE_DIR = join(tempDir, "cache");
+  delete process.env.COMFYUI_LRU_CACHE_SIZE_GB;
+  config.comfyuiPath = join(tempDir, "comfy");
+  config.huggingfaceToken = undefined;
+  config.civitaiApiToken = undefined;
+  destAtDone.path = "";
+  destAtDone.existed = [];
+  destAtDone.check = (p) => p !== "" && existsSync(p);
+  progressRows.length = 0;
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  setDownloadRetryPolicyForTests({ maxAttempts: 1, stallTimeoutMs: 0 });
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+  delete process.env.COMFYUI_LRU_CACHE_SIZE_GB;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("a done progress row means dest exists (#1701)", () => {
+  it("does not emit done while the dest copy is still in flight", async () => {
+    const filename = "t5xxl_flux1_int8_convrot.safetensors";
+    const dest = join(tempDir, "comfy", "models", "text_encoders", filename);
+    destAtDone.path = dest;
+
+    let releaseCopy!: () => void;
+    const copyHeld = new Promise<void>((r) => {
+      releaseCopy = r;
+    });
+    let copyEntered = false;
+    const realCopy = downloadCacheFs.copyFile.bind(downloadCacheFs);
+    vi.spyOn(downloadCacheFs, "link").mockRejectedValue(
+      Object.assign(new Error("cross-device link"), { code: "EXDEV" }),
+    );
+    vi.spyOn(downloadCacheFs, "copyFile").mockImplementation(async (src, destPath, mode) => {
+      copyEntered = true;
+      await copyHeld;
+      return realCopy(src, destPath, mode);
+    });
+
+    fetchMock.mockResolvedValueOnce(okResponse("T5XXL-PAYLOAD-BYTES"));
+
+    const pending = downloadModel(
+      "https://huggingface.co/org/repo/resolve/main/t5xxl_flux1_int8_convrot.safetensors",
+      "text_encoders",
+      filename,
+    );
+
+    await waitFor(() => copyEntered);
+    expect(existsSync(dest)).toBe(false);
+    expect(progressRows.some((r) => r.status === "done")).toBe(false);
+
+    releaseCopy();
+    const landed = await pending;
+    expect(landed).toBe(dest);
+    await expect(readFile(dest, "utf-8")).resolves.toBe("T5XXL-PAYLOAD-BYTES");
+
+    expect(progressRows.some((r) => r.status === "done")).toBe(true);
+    expect(destAtDone.existed.length).toBeGreaterThan(0);
+    expect(destAtDone.existed.every(Boolean)).toBe(true);
+  });
+});

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2350,7 +2350,14 @@ async function streamUrlToFile(
     await assertModelPayload(await currentStagedBaseline());
     if (resumable) await safeRm(validatorSidecar);
     bytesPerSec = 0;
-    emit("done", true);
+    // #1701 — bytes arriving at THIS path is not a landed destination. This
+    // function writes the cache `.partial` or a materialize temp; dest is
+    // renamed later (and on Windows that rename is often a multi-GB COPY).
+    // The orchestrator treats the first "done" row as "transfer completed"
+    // (#547), which is how the tray announced t5xxl_flux1_int8_convrot.safetensors
+    // while action:"status" still said downloading and dest did not exist.
+    // Keep the row at 100% downloading; the caller that lands dest emits done.
+    emit("downloading", true);
     return responseContentType;
   } catch (err) {
     // On a user cancel (#515) the abort left a resumable .partial on disk. Do NOT emit
@@ -3222,6 +3229,38 @@ async function evictLruIfNeeded(): Promise<void> {
   }
 }
 
+/** Publish a terminal "done" row only when `destPath` is already a non-empty file.
+ *
+ *  #1701 — the orchestrator wakes the agent from the first "done" row. Emitting
+ *  that before dest exists is the false completion. Callers that have just
+ *  landed dest use this; a missing/empty dest stays silent. */
+async function reportProgressDoneIfLanded(
+  progress: ProgressMeta | undefined,
+  destPath: string,
+): Promise<void> {
+  if (!progress) return;
+  let size = 0;
+  try {
+    const st = await downloadCacheFs.stat(destPath);
+    if (!st.isFile() || st.size <= 0) return;
+    size = st.size;
+  } catch {
+    return;
+  }
+  reportDownloadProgress(
+    {
+      id: progress.id,
+      name: progress.name,
+      attempt: progress.attempt,
+      downloaded: size,
+      total: size,
+      bytes_per_sec: 0,
+      status: "done",
+    },
+    true,
+  );
+}
+
 export async function downloadUrlToFile(
   url: string,
   targetPath: string,
@@ -3231,10 +3270,11 @@ export async function downloadUrlToFile(
   progress?: ProgressMeta,
   modelExt = extname(targetPath),
   signal?: AbortSignal,
-  /** See streamUrlToFile: when true the caller owns the terminal "error" row. The
+  /** See streamUrlToFile: when true the caller owns the terminal rows. The
    *  cache-unavailable fallback in downloadWithCache passes true because
-   *  downloadModel already publishes exactly one row when the whole call throws;
-   *  emitting here as well would write that outcome twice (#470/#547). */
+   *  downloadModel already publishes exactly one error row when the whole call
+   *  throws, and because this API is writing a TEMP — a "done" here would
+   *  fire the #1701 completion before dest exists (#470/#547/#1701). */
   deferErrorRow = false,
   /** See DownloadCacheOptions.callerAuth (#1635). */
   callerAuth = false,
@@ -3257,6 +3297,9 @@ export async function downloadUrlToFile(
     false,
     callerAuth,
   );
+  // This API's target IS dest (except the fallback, which defers). streamUrlToFile
+  // no longer claims "done" itself (#1701).
+  if (!deferErrorRow) await reportProgressDoneIfLanded(progress, targetPath);
 }
 
 export async function downloadWithCache(
@@ -3337,6 +3380,9 @@ export async function downloadWithCache(
       options.signal,
       options.onLanded,
     );
+    // Dest exists (onLanded already committed the job). This is the first honest
+    // "done" — downloadModel emits another after its own dest stat, which is fine.
+    await reportProgressDoneIfLanded(options.progress, options.targetPath);
     await evictLruIfNeeded();
     return {
       targetPath: options.targetPath,
@@ -3390,6 +3436,7 @@ export async function downloadWithCache(
       // any backup-cleanup await) — commits "done" with no landed→return window; the
       // signal also aborts the Windows swap after the backup move (#515).
       await renameTempOverDestination(tmp, options.targetPath, options.onLanded, options.signal);
+      await reportProgressDoneIfLanded(options.progress, options.targetPath);
     } catch (e) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw e;


### PR DESCRIPTION
Fixes #1701

The panel announced `Model download transfer completed` for `t5xxl_flux1_int8_convrot.safetensors` while `download_model action:\"status\"` still said downloading and dest did not exist.

Root cause: `streamUrlToFile` emitted a terminal `done` progress row when the **cache** write finished. The orchestrator treats that first `done` row as the completion event (#547). On Windows the dest landing is often a multi-GB COPY from cache, so the event fired minutes before dest existed and before `onLanded` committed the job record to `done`.

#1574 already hedges when the job record still says downloading. That does not stop the event from claiming completion, and a long dest copy is not persist lag.

This change:
- keeps the tray at 100% `downloading` until dest has actually landed
- emits `done` only after dest is a non-empty file
- so the completion event, `action:\"status\"`, and the dest path agree

Test drives real `downloadModel` (the local writer `download_model` uses), holds the copy-materialize mid-flight, and asserts no `done` row exists until dest does.