### PR TITLE
fix(1704): restart_comfyui relaunches the Stability Matrix package venv, not Assets CPython

### DIFF
--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -155,6 +155,12 @@ const SM_GIT_ROOT = join(SM_DATA, "PortableGit");
 const SM_GIT_DIR = join(SM_GIT_ROOT, "cmd");
 const SM_GIT_EXE = join(SM_GIT_DIR, "git.exe");
 const SM_ASSETS_ROOT = join(SM_DATA, "Assets");
+const SM_ASSETS_PY = join(
+  SM_ASSETS_ROOT,
+  "Python",
+  "cpython-3.12.11-windows-x86_64-none",
+  "python.exe",
+);
 const SM_FFMPEG_ROOT = join(SM_ASSETS_ROOT, "ffmpeg");
 const SM_SETTINGS = join(SM_DATA, "settings.json");
 const SM_FFMPEG_DIR = join(SM_FFMPEG_ROOT, "bin");
@@ -727,6 +733,132 @@ describe("restart_comfyui — the interpreter the HEALTHY server runs wins (#165
 
     expect(exe).toBe(SM_PY);
     expect(args).toEqual(SM_ARGV);
+  });
+});
+
+describe("restart_comfyui — Stability Matrix package venv, not Assets CPython (#1704)", () => {
+  // #1704: restart/start launched
+  //   <Data>/Assets/Python/cpython-…/python.exe
+  // instead of the package venv
+  //   <Data>/Packages/ComfyUI/venv/Scripts/python.exe
+  // The Assets interpreter has no sqlalchemy/torch, so the child exits 1 and
+  // leaves ComfyUI down. Happens when this session never observed the
+  // interpreter (ComfyUI started outside, or action:"start" after another
+  // session) AND when the OS names the venv trampoline's BASE interpreter.
+  const SM_PACKAGES = join(SM_DATA, "Packages");
+  const SM_ARGV = [SM_MAIN, "--preview-method", "auto", "--use-sage-attention"];
+
+  function useAssetsVsPackageVenv(): void {
+    mockFindComfyuiPython.mockReturnValue(SM_ASSETS_PY);
+    mockLiveRootFromArgv.mockReturnValue(SM_PKG);
+    mockGetSystemStats.mockResolvedValue({ system: { argv: SM_ARGV } });
+    const roots = [SM_GIT_ROOT, SM_FFMPEG_ROOT, SM_PACKAGES];
+    const existingDirs = new Set<string>();
+    for (const root of roots) {
+      let cur = root;
+      while (cur.length > SM_DATA.length && cur.startsWith(SM_DATA)) {
+        existingDirs.add(cur);
+        cur = dirname(cur);
+      }
+      existingDirs.add(SM_DATA);
+    }
+    // Every ancestor of the Assets CPython (Assets/Python/cpython-…).
+    let cur = dirname(SM_ASSETS_PY);
+    while (cur.length >= SM_DATA.length && cur.startsWith(SM_DATA)) {
+      existingDirs.add(cur);
+      cur = dirname(cur);
+    }
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      if (s === SM_MAIN || s === SM_PY || s === SM_ASSETS_PY) return true;
+      if (existingDirs.has(s)) return true;
+      if (s === SM_GIT_EXE || s === SM_FFMPEG_EXE) return true;
+      return false;
+    });
+  }
+
+  function osReportsInterpreter(commandLine: string): void {
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321 ? { startedAt: "stable-stamp", commandLine } : undefined,
+    );
+  }
+
+  async function restartAndReturnSpawn(): Promise<{
+    exe: string;
+    args: string[];
+  }> {
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const result = await restartComfyUI();
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args] = mockSpawn.mock.calls[0];
+    killSpy.mockRestore();
+    return { exe: String(exe), args: args as string[] };
+  }
+
+  it("relaunches the package venv when the layout/PATH guess is the unused Assets CPython", async () => {
+    // THE additional-reproduction shape: no usable OS interpreter (bare
+    // `python`), layout resolution returns Assets python, package venv exists.
+    useAssetsVsPackageVenv();
+    osReportsInterpreter(`python "${SM_MAIN}" --preview-method auto --use-sage-attention`);
+
+    const { exe, args } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+    expect(exe).not.toBe(SM_ASSETS_PY);
+    expect(args).toEqual(SM_ARGV);
+  });
+
+  it("relaunches the package venv when the OS names the Assets CPython (venv trampoline base)", async () => {
+    // Windows reports ExecutablePath / a CommandLine argv[0] of the BASE
+    // interpreter the venv trampoline loads. Spawning that is the original
+    // report: sqlalchemy missing, exit 1.
+    useAssetsVsPackageVenv();
+    osReportsInterpreter(
+      `"${SM_ASSETS_PY}" "${SM_MAIN}" --preview-method auto --use-sage-attention`,
+    );
+
+    const { exe } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+    expect(exe).not.toBe(SM_ASSETS_PY);
+  });
+
+  it("start uses the package venv when this session has no observed interpreter", async () => {
+    // action:"start" after ComfyUI was started (and stopped) outside this
+    // session — lastProcessInfo has the script argv but no observedInterpreter.
+    useAssetsVsPackageVenv();
+    __processControlTestHooks.setLastProcessInfo({
+      pid: 0,
+      port: 8188,
+      argv: SM_ARGV,
+      isDesktopApp: false,
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) return "";
+      if (/lsof/i.test(cmd)) throw noListener();
+      return "";
+    });
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe] = mockSpawn.mock.calls[0];
+    expect(String(exe)).toBe(SM_PY);
+    expect(String(exe)).not.toBe(SM_ASSETS_PY);
   });
 });
 

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -341,6 +341,106 @@ export function detectStabilityMatrix(
   return null;
 }
 
+/**
+ * Is `p` Stability Matrix's unused Assets CPython (#1704)?
+ *
+ * SM stores the *base* interpreter it created the package venv FROM under
+ * `<Data>/Assets/Python/cpython-…/python.exe`. That tree has no ComfyUI
+ * site-packages (`import sqlalchemy` fails immediately). Windows also reports
+ * this path as `Win32_Process.ExecutablePath` for a venv trampoline, so a
+ * relaunch that treats the OS image as the interpreter picks it by accident.
+ *
+ * Requires the same on-disk corroboration as `detectStabilityMatrix` so a
+ * random `…/Assets/Python/…` tree is never classified as SM.
+ */
+export function isStabilityMatrixAssetsPython(p: string | undefined): boolean {
+  if (!p) return false;
+  const segs = segmentsOf(p);
+  const lower = segs.map((s) => s.toLowerCase());
+  const assets = lower.lastIndexOf("assets");
+  if (assets < 0 || lower[assets + 1] !== "python") return false;
+  // Parent of `Assets` is the Data root. The Assets path itself never walks
+  // through `Packages`, so `detectStabilityMatrix` cannot corroborate it —
+  // require the Packages sibling on disk instead.
+  const dataRoot = segs.slice(0, assets).join(separatorOf(p));
+  if (!dataRoot) return false;
+  return pathExists(joinPath(dataRoot, "Packages"));
+}
+
+/** A PATH name, not a file we can verify — `python`, `python.exe`, `python3`. */
+function isBarePythonName(p: string): boolean {
+  if (/[\\/]/.test(p) || /^[a-zA-Z]:/.test(p)) return false;
+  const base = p.toLowerCase();
+  return (
+    base === "python" ||
+    base === "python.exe" ||
+    base === "python3" ||
+    base === "python3.exe"
+  );
+}
+
+function samePath(a: string, b: string): boolean {
+  const norm = (s: string): string =>
+    s.replace(/[\\/]+$/, "").replace(/[\\/]/g, "/").toLowerCase();
+  return norm(a) === norm(b);
+}
+
+/**
+ * The Stability Matrix *package* interpreter (`<Packages>/<name>/venv`, then
+ * `.venv`) for the install named by `paths`.
+ *
+ * SM's official env is `venv` (not `.venv`, not the Assets CPython). Used as
+ * the relaunch fallback when the OS did not name a usable interpreter, and as
+ * the replacement when the chosen exe is the unused Assets CPython (#1704).
+ */
+export function resolveStabilityMatrixPackagePython(
+  paths: ReadonlyArray<string | undefined>,
+): string | undefined {
+  const sm = detectStabilityMatrix(paths);
+  if (!sm) return undefined;
+  const packagesRoot = joinPath(sm.dataRoot, "Packages");
+  for (const p of paths) {
+    if (!p) continue;
+    for (const ancestor of [p, ...ancestorsOf(p)]) {
+      const parent = dirOf(ancestor);
+      if (!parent || !samePath(parent, packagesRoot)) continue;
+      if (
+        !pathExists(joinPath(ancestor, "main.py")) &&
+        !pathExists(joinPath(ancestor, "main.pyw"))
+      ) {
+        continue;
+      }
+      const py = firstExisting([
+        joinPath(ancestor, "venv", "Scripts", "python.exe"),
+        joinPath(ancestor, "venv", "bin", "python"),
+        joinPath(ancestor, "venv", "bin", "python3"),
+        joinPath(ancestor, ".venv", "Scripts", "python.exe"),
+        joinPath(ancestor, ".venv", "bin", "python"),
+        joinPath(ancestor, ".venv", "bin", "python3"),
+      ]);
+      if (py) return py;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Replace an Assets CPython (or a bare PATH `python`) with the package venv
+ * when this is a Stability Matrix install. Any other observed interpreter is
+ * left alone (#1654 — the process we saw still wins).
+ */
+export function preferStabilityMatrixPackagePython(
+  chosen: string | undefined,
+  paths: ReadonlyArray<string | undefined>,
+): string | undefined {
+  const packagePy = resolveStabilityMatrixPackagePython(paths);
+  if (!packagePy) return chosen;
+  if (!chosen || isBarePythonName(chosen) || isStabilityMatrixAssetsPython(chosen)) {
+    return packagePy;
+  }
+  return chosen;
+}
+
 // ---------------------------------------------------------------------------
 // Opaque launchers — recognized, but NOT reproducible
 // ---------------------------------------------------------------------------

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -43,6 +43,7 @@ import {
 } from "./desktop-launch-args.js";
 import { findComfyuiPython } from "./env-capabilities.js";
 import {
+  preferStabilityMatrixPackagePython,
   readLiveProcessEnv,
   resolveLaunchEnvironment,
   type LaunchEnvInfo,
@@ -1812,10 +1813,14 @@ function resolveLaunchCommand(
     // whenever both exist is how a restart relaunched an empty environment and left
     // the server down. The observation was captured corroborated against the
     // server's own argv, so it IS the environment the healthy process imports from.
+    //
+    // #1704: do NOT return null yet when the layout guess is empty — a Stability
+    // Matrix package venv can still be recovered from the script path even when
+    // this session never observed the interpreter (ComfyUI started outside, or
+    // action:"start" after another session).
     const python =
       info.observedInterpreter ??
       findComfyuiPython(config.comfyuiPath ?? undefined, argv);
-    if (!python) return null;
     // sys.argv[0] can be RELATIVE (the standard Windows portable launcher runs
     // `python ComfyUI\main.py` from the portable root). We force cwd to
     // config.comfyuiPath — the ComfyUI dir that directly holds main.py — so a
@@ -1892,11 +1897,30 @@ function resolveLaunchCommand(
     // the environment this exact process was seen running under, while the other
     // two are install-layout inferences that cannot tell a working `venv` from an
     // empty `.venv` sitting beside it.
-    const exe = info.observedInterpreter ?? (liveCwdScript ? liveCwdPython! : python);
+    //
+    // #1704: Stability Matrix's unused Assets CPython (or a bare PATH `python`
+    // that resolves to it) is never a launch interpreter when the package venv
+    // exists — that tree has no sqlalchemy/torch, so spawning it exits 1 and
+    // leaves ComfyUI down. An observed *package* interpreter is left alone.
+    const rawExe = info.observedInterpreter ?? (liveCwdScript ? liveCwdPython! : python);
     const cwd = liveCwdScript ? info.liveCwd : anchor;
+    const exe = preferStabilityMatrixPackagePython(rawExe, [
+      script,
+      rawExe,
+      cwd,
+      info.liveCwd,
+      info.argv[0],
+    ]);
+    if (!exe) return null;
     return { exe, args: [script, ...rest], cwd };
   }
-  return { exe: first, args: rest };
+  const remapped = preferStabilityMatrixPackagePython(first, [
+    first,
+    ...rest,
+    info.liveCwd,
+    info.argv[0],
+  ]);
+  return { exe: remapped ?? first, args: rest };
 }
 
 /**
@@ -2725,9 +2749,19 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // process is alive, for the same reason `liveCwd` is. The relaunch prefers it
   // over the install-layout guess, which picks `.venv` over `venv` whenever both
   // exist regardless of which environment the server actually imports from.
+  //
+  // #1704: `confirmed` also requires a creation stamp (needed to bind a KILL).
+  // A matching command line still names the interpreter when the stamp is
+  // unreadable — the same observation `install_comfyui(action:"environment")`
+  // already reports — so a server started outside this session is not relaunched
+  // with Stability Matrix's unused Assets CPython.
+  const interpreterIdentity =
+    corroboration.kind === "confirmed"
+      ? corroboration.identity
+      : (osIdentity ?? resolveProcessIdentity(pid));
   const observedInterpreter =
-    !desktop && corroboration.kind === "confirmed"
-      ? observedInterpreterFromIdentity(corroboration.identity)
+    !desktop && interpreterIdentity
+      ? observedInterpreterFromIdentity(interpreterIdentity)
       : undefined;
   const startedAt = desktop
     ? undefined


### PR DESCRIPTION
## What the user now observes

`restart_comfyui` (`action:"restart"` and `action:"start"`) relaunches a Stability Matrix ComfyUI with the **package venv** (`Packages/ComfyUI/venv/Scripts/python.exe`), not Stability Matrix's unused Assets CPython (`Assets/Python/cpython-…/python.exe`). The relaunch can import sqlalchemy/torch and comes back up.

## Root cause

On a Stability Matrix install the healthy process runs under the package venv. The Assets tree is only the *base* interpreter that venv was created from — it has no ComfyUI site-packages. `restart_comfyui` still spawned that Assets CPython when:

1. This session never observed the running interpreter (ComfyUI was started outside the session, or `action:"start"` after another session restarted it). Layout/PATH resolution then picked the bare Assets interpreter.
2. Windows reported the venv trampoline's **base** interpreter (`Win32_Process.ExecutablePath` / CommandLine argv[0] of the Assets CPython) as the process image.

`install_comfyui(action:"environment")` already named the package venv. Restart did not reuse it.

#1654 already prefers a corroborated OS observation of a *package* interpreter over the `.venv` vs `venv` layout guess. That does not help when the observation is missing or is the Assets base.

## Fix

- `preferStabilityMatrixPackagePython` in `launcher-env.ts`: if the chosen exe is the unused Assets CPython (or a bare PATH `python`) and the package venv exists on disk, use the package venv. An observed *package* interpreter is left alone (#1654).
- `resolveLaunchCommand` applies that remapping on both the script-launch path and the interpreter-as-argv[0] path, including `action:"start"` when this session has no `observedInterpreter`.
- `gatherProcessInfo` still records argv[0] of a matching command line even when the creation stamp is unreadable (`confirmed` still requires the stamp to bind a kill).

## Verification

Targeted vitest (`--maxWorkers=4`):

- `restart-launcher-env.test.ts` — 69 passed (incl. 3 new #1704 cases: layout/PATH guess is Assets; OS names Assets; `action:"start"` with no observed interpreter)
- `process-control.test.ts`, `restart-live-first.test.ts`, `restart-relaunch-lifecycle.test.ts`, `desktop-restart.test.ts` — 132 passed

Fixes #1704
