### PR TITLE
fix(1710): opening a save-as copy rebinds dest identity so save and the promoted prompt stick

### DIFF
--- a/src/__tests__/orchestrator/open-identity-normalization.test.ts
+++ b/src/__tests__/orchestrator/open-identity-normalization.test.ts
@@ -1,0 +1,237 @@
+// #1710 — opening a save-as copy bound the dest tab, then save refused because
+// extra.comfyui_mcp still named the source, and outline showed an empty promoted
+// prompt the dest file still held.
+//
+// Tests drive panel_open_workflow / panel_save_workflow. Dest file comes through
+// the same userdata read those handlers use.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const destByKey = new Map<string, Record<string, unknown>>();
+
+vi.mock("../../services/userdata-library.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/userdata-library.js")>();
+  return {
+    ...actual,
+    userdataFetch: async (route: string) => {
+      for (const [key, graph] of destByKey) {
+        if (route.includes(encodeURIComponent(key)) || route.includes(key)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(graph),
+          } as Response;
+        }
+      }
+      throw new Error(`no dest fixture for ${route}`);
+    },
+  };
+});
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+
+const TAB = "wf:workflows/copy.json";
+const DEST = "workflows/copy.json";
+const SOURCE = "workflows/source.json";
+const DEST_UUID = "77777777-7777-4777-8777-777777777777";
+const SOURCE_UUID = "11111111-1111-4111-8111-111111111111";
+const PROMPT = "a cinematic portrait of a woman in gold light";
+
+const IDENTITY_PROVEN =
+  `workflow_open RAN and the canvas IS bound to ${DEST} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded, and every node that was loaded is on it with ` +
+  `the same id and type, and nothing extra appeared — no node was lost. What differs is per-node ` +
+  `fields. You are on the right workflow. You are NOT on the wrong workflow: ${DEST} IS the ` +
+  `active one. This reply carries NO fence refresh.`;
+
+const STAMP_REFUSAL =
+  `REFUSED to save: the canvas about to overwrite "${DEST}" is stamped as belonging to ` +
+  `"${SOURCE}" (extra.comfyui_mcp.workflow_path), which is a different workflow that still ` +
+  `exists. Writing it would replace that file's content with a graph that does not belong to it.`;
+
+function destGraph(prompt: string) {
+  return {
+    nodes: [
+      {
+        id: 78,
+        type: "FLUX",
+        properties: { proxyWidgets: [["12", "text"]] },
+        widgets_values: [prompt],
+        widgets_values_named: { text: prompt },
+      },
+      { id: 12, type: "CLIPTextEncode", widgets_values: [prompt], widgets_values_named: { text: prompt } },
+    ],
+    links: [],
+    extra: { comfyui_mcp: { workflow_path: DEST, workflow_uuid: DEST_UUID } },
+  };
+}
+
+function liveGraph(opts: { extraPath: string; prompt: string }) {
+  return {
+    nodes: [
+      {
+        id: 78,
+        type: "FLUX",
+        properties: { proxyWidgets: [["12", "text"]] },
+        widgets_values: [opts.prompt],
+        widgets_values_named: { text: opts.prompt },
+      },
+      {
+        id: 12,
+        type: "CLIPTextEncode",
+        widgets_values: [opts.prompt],
+        widgets_values_named: { text: opts.prompt },
+      },
+    ],
+    links: [],
+    extra: { comfyui_mcp: { workflow_path: opts.extraPath, workflow_uuid: SOURCE_UUID } },
+  };
+}
+
+type Mode = "open" | "save";
+
+function bridge(opts: {
+  live: Record<string, unknown>;
+  saveFirst?: "refuse" | "ok";
+}) {
+  const calls: Array<Record<string, unknown>> = [];
+  let stamp: string | undefined = SOURCE_UUID;
+  let saves = 0;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "workflow_list") {
+        const active = { path: DEST, routing_key: `wf:${DEST}`, workflow_uuid: DEST_UUID };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(IDENTITY_PROVEN);
+      if (cmd.cmd === "graph_query") {
+        return { ids: [78, 12], node_count: 2 };
+      }
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: opts.live, node_count: 2 };
+      }
+      if (cmd.cmd === "graph_load") {
+        return { loaded: true };
+      }
+      if (cmd.cmd === "workflow_save") {
+        saves += 1;
+        if (opts.saveFirst === "refuse" && saves === 1) throw new Error(STAMP_REFUSAL);
+        return { saved: true, workflow: DEST };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "copy", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push({ cmd: `adopt:${uuid}` });
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls, stampOf: () => stamp };
+}
+
+beforeEach(() => {
+  destByKey.clear();
+  destByKey.set("workflows/copy.json", destGraph(PROMPT));
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+afterEach(() => {
+  destByKey.clear();
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+async function run(mode: Mode, live: Record<string, unknown>, saveFirst?: "refuse" | "ok") {
+  const { b, calls, stampOf } = bridge({ live, saveFirst });
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const name = mode === "open" ? "panel_open_workflow" : "panel_save_workflow";
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  const args = mode === "open" ? { path: DEST } : {};
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+    stamp: stampOf(),
+    loaded: calls.find((c) => c.cmd === "graph_load")?.graph as Record<string, unknown> | undefined,
+  };
+}
+
+describe("panel_open_workflow rebinds dest identity after frontend normalization (#1710)", () => {
+  it("the reporter's case: dest nodes, source extra, empty promoted prompt — open succeeds", async () => {
+    const { text, isError, calls, stamp, loaded } = await run(
+      "open",
+      liveGraph({ extraPath: SOURCE, prompt: "" }),
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toContain("graph_serialize");
+    expect(calls.map((c) => c.cmd)).toContain("graph_load");
+    expect(stamp).toBe(DEST_UUID);
+    expect(text).toMatch(/identity_rebound/);
+    expect(text).toMatch(/Restored/);
+    expect(loaded?.extra).toMatchObject({
+      comfyui_mcp: { workflow_path: DEST, workflow_uuid: DEST_UUID },
+    });
+    const flux = (loaded?.nodes as Array<Record<string, unknown>>)?.find((n) => n.id === 78);
+    expect(flux?.widgets_values).toEqual([PROMPT]);
+    expect(flux?.widgets_values_named).toEqual({ text: PROMPT });
+  });
+
+  it("does not restamp when a non-empty live widget disagrees with dest — #1639 stays closed", async () => {
+    const { isError, calls, stamp } = await run(
+      "open",
+      liveGraph({ extraPath: SOURCE, prompt: "the SOURCE prompt still on the previous graph" }),
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_load");
+    expect(stamp).toBe(SOURCE_UUID);
+  });
+});
+
+describe("panel_save_workflow restamps dest extra then retries (#1710)", () => {
+  it("the reporter's save refusal becomes a save after dest identity is rebound", async () => {
+    const { text, isError, calls, stamp, loaded } = await run(
+      "save",
+      liveGraph({ extraPath: SOURCE, prompt: "" }),
+      "refuse",
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(2);
+    expect(calls.map((c) => c.cmd)).toContain("graph_load");
+    expect(stamp).toBe(DEST_UUID);
+    expect(text).toMatch(/saved/i);
+    expect(loaded?.extra).toMatchObject({
+      comfyui_mcp: { workflow_path: DEST },
+    });
+  });
+
+  it("keeps the refusal when dest content is not what is on the canvas", async () => {
+    const { isError, calls } = await run(
+      "save",
+      liveGraph({ extraPath: SOURCE, prompt: "the SOURCE prompt still on the previous graph" }),
+      "refuse",
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(1);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_load");
+  });
+});

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -1,0 +1,260 @@
+// #1710 — a save-as copy opens onto the right node set, then save refuses
+// because extra.comfyui_mcp still names the SOURCE, and outline shows empty
+// promoted widgets the dest file still carries.
+//
+// Two levels stay separate:
+//   presentation (order/size/named-vs-positional widgets) is not identity
+//   a NON-EMPTY live widget that disagrees with dest is not dest's graph
+//     (#1639: the previous workflow still answering under the old stamp)
+
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export function normalizeWorkflowPath(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+/g, "/");
+  if (!normalized || /^(?:tmp:|wf:)/i.test(normalized)) return null;
+  return normalized;
+}
+
+export function workflowFromSerializeReply(reply: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(reply)) return null;
+  if (Array.isArray(reply.nodes)) return reply;
+  const wf = reply.workflow;
+  if (isPlainObject(wf) && Array.isArray(wf.nodes)) return wf;
+  return null;
+}
+
+export function extraWorkflowPath(graph: unknown): string | null {
+  if (!isPlainObject(graph)) return null;
+  const extra = isPlainObject(graph.extra) ? graph.extra : null;
+  const meta = extra && isPlainObject(extra.comfyui_mcp) ? extra.comfyui_mcp : null;
+  return typeof meta?.workflow_path === "string" && meta.workflow_path ? meta.workflow_path : null;
+}
+
+export function extraStampDisagrees(graph: unknown, destPath: string): boolean {
+  const stamped = normalizeWorkflowPath(extraWorkflowPath(graph));
+  const dest = normalizeWorkflowPath(destPath);
+  if (!stamped || !dest) return false;
+  return stamped !== dest;
+}
+
+export function isEmptyWidgetValue(v: unknown): boolean {
+  if (v == null) return true;
+  if (v === "") return true;
+  if (Array.isArray(v)) return v.length === 0 || v.every(isEmptyWidgetValue);
+  if (isPlainObject(v)) {
+    const vals = Object.values(v);
+    return vals.length === 0 || vals.every(isEmptyWidgetValue);
+  }
+  return false;
+}
+
+function namedWidgets(node: Record<string, unknown>): Record<string, unknown> | null {
+  if (isPlainObject(node.widgets_values_named)) return node.widgets_values_named;
+  if (isPlainObject(node.widgets_values)) return node.widgets_values;
+  return null;
+}
+
+function valuesDiffer(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return false;
+  try {
+    return JSON.stringify(a) !== JSON.stringify(b);
+  } catch {
+    return true;
+  }
+}
+
+function nodeIdentityKey(node: unknown): string | null {
+  if (!isPlainObject(node) || node.id == null || typeof node.type !== "string") return null;
+  return `${String(node.id)}\0${node.type}`;
+}
+
+export function nodeIdentitySet(graph: unknown): Set<string> | null {
+  if (!isPlainObject(graph) || !Array.isArray(graph.nodes)) return null;
+  const keys = new Set<string>();
+  for (const raw of graph.nodes) {
+    const key = nodeIdentityKey(raw);
+    if (key == null || keys.has(key)) return null;
+    keys.add(key);
+  }
+  return keys;
+}
+
+export function nodeIdentitiesMatch(a: unknown, b: unknown): boolean {
+  const left = nodeIdentitySet(a);
+  const right = nodeIdentitySet(b);
+  if (!left || !right || left.size !== right.size || left.size === 0) return false;
+  for (const key of left) if (!right.has(key)) return false;
+  return true;
+}
+
+/** True when dest has a NON-EMPTY widget live already holds as a different value. */
+export function liveSemanticWidgetsDisagree(live: unknown, dest: unknown): boolean {
+  if (!isPlainObject(live) || !isPlainObject(dest)) return true;
+  if (!Array.isArray(live.nodes) || !Array.isArray(dest.nodes)) return true;
+  const liveById = new Map<string, Record<string, unknown>>();
+  for (const raw of live.nodes) {
+    if (isPlainObject(raw) && raw.id != null) liveById.set(String(raw.id), raw);
+  }
+  for (const raw of dest.nodes) {
+    if (!isPlainObject(raw) || raw.id == null) continue;
+    const liveNode = liveById.get(String(raw.id));
+    if (!liveNode) return true;
+    if (nodeWidgetsDisagree(liveNode, raw)) return true;
+  }
+  return false;
+}
+
+function nodeWidgetsDisagree(liveNode: Record<string, unknown>, destNode: Record<string, unknown>): boolean {
+  const destNamed = namedWidgets(destNode);
+  if (destNamed) {
+    const liveMap = namedWidgets(liveNode) ?? {};
+    for (const [key, destVal] of Object.entries(destNamed)) {
+      const liveVal = liveMap[key];
+      if (isEmptyWidgetValue(liveVal)) continue;
+      if (valuesDiffer(liveVal, destVal)) return true;
+    }
+    return false;
+  }
+  if (!Array.isArray(destNode.widgets_values)) return false;
+  const destWv = destNode.widgets_values;
+  const liveWv = Array.isArray(liveNode.widgets_values) ? liveNode.widgets_values : [];
+  for (let i = 0; i < destWv.length; i++) {
+    if (isEmptyWidgetValue(liveWv[i])) continue;
+    if (valuesDiffer(liveWv[i], destWv[i])) return true;
+  }
+  return false;
+}
+
+function nodeNeedsPromotedRestore(
+  liveNode: Record<string, unknown>,
+  destNode: Record<string, unknown>,
+): boolean {
+  const destNamed = namedWidgets(destNode);
+  if (destNamed) {
+    const liveMap = namedWidgets(liveNode) ?? {};
+    for (const [key, destVal] of Object.entries(destNamed)) {
+      if (!isEmptyWidgetValue(destVal) && isEmptyWidgetValue(liveMap[key])) return true;
+    }
+  }
+  if (Array.isArray(destNode.widgets_values)) {
+    const liveWv = Array.isArray(liveNode.widgets_values) ? liveNode.widgets_values : [];
+    for (let i = 0; i < destNode.widgets_values.length; i++) {
+      if (!isEmptyWidgetValue(destNode.widgets_values[i]) && isEmptyWidgetValue(liveWv[i])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function destHasEmptyLivePromotedWidgets(live: unknown, dest: unknown): boolean {
+  if (!isPlainObject(live) || !isPlainObject(dest)) return false;
+  if (!Array.isArray(live.nodes) || !Array.isArray(dest.nodes)) return false;
+  const liveById = new Map<string, Record<string, unknown>>();
+  for (const raw of live.nodes) {
+    if (isPlainObject(raw) && raw.id != null) liveById.set(String(raw.id), raw);
+  }
+  for (const raw of dest.nodes) {
+    if (!isPlainObject(raw) || raw.id == null) continue;
+    const liveNode = liveById.get(String(raw.id));
+    if (liveNode && nodeNeedsPromotedRestore(liveNode, raw)) return true;
+  }
+  return false;
+}
+
+export function shouldRebindOpenIdentity(input: {
+  live: unknown;
+  dest: unknown;
+  destPath: string;
+}): boolean {
+  if (!nodeIdentitiesMatch(input.live, input.dest)) return false;
+  if (liveSemanticWidgetsDisagree(input.live, input.dest)) return false;
+  return (
+    extraStampDisagrees(input.live, input.destPath) ||
+    destHasEmptyLivePromotedWidgets(input.live, input.dest)
+  );
+}
+
+function restoreEmptyPromotedWidgets(
+  liveNode: Record<string, unknown>,
+  destNode: Record<string, unknown>,
+): boolean {
+  let restored = false;
+  const destNamed = namedWidgets(destNode);
+  if (destNamed) {
+    const liveNamed = { ...(namedWidgets(liveNode) ?? {}) };
+    let namedChanged = false;
+    for (const [key, destVal] of Object.entries(destNamed)) {
+      if (!isEmptyWidgetValue(destVal) && isEmptyWidgetValue(liveNamed[key])) {
+        liveNamed[key] = destVal;
+        namedChanged = true;
+      }
+    }
+    if (namedChanged) {
+      restored = true;
+      if (isPlainObject(liveNode.widgets_values_named) || isPlainObject(destNode.widgets_values_named)) {
+        liveNode.widgets_values_named = liveNamed;
+      }
+      if (isPlainObject(liveNode.widgets_values) || isPlainObject(destNode.widgets_values)) {
+        liveNode.widgets_values = {
+          ...(isPlainObject(liveNode.widgets_values) ? liveNode.widgets_values : {}),
+          ...liveNamed,
+        };
+      }
+    }
+  }
+  if (Array.isArray(destNode.widgets_values)) {
+    const destWv = destNode.widgets_values;
+    const liveWv = Array.isArray(liveNode.widgets_values) ? [...liveNode.widgets_values] : [];
+    let positionalChanged = false;
+    for (let i = 0; i < destWv.length; i++) {
+      if (!isEmptyWidgetValue(destWv[i]) && isEmptyWidgetValue(liveWv[i])) {
+        liveWv[i] = destWv[i];
+        positionalChanged = true;
+      }
+    }
+    if (positionalChanged) {
+      liveNode.widgets_values = liveWv;
+      restored = true;
+    }
+  }
+  return restored;
+}
+
+export function patchOpenIdentity(
+  live: Record<string, unknown>,
+  dest: Record<string, unknown>,
+  destPath: string,
+  destUuid?: string,
+): { graph: Record<string, unknown>; restoredWidgets: number } {
+  const graph = structuredClone(live) as Record<string, unknown>;
+  const extra = isPlainObject(graph.extra) ? { ...graph.extra } : {};
+  const meta = isPlainObject(extra.comfyui_mcp) ? { ...extra.comfyui_mcp } : {};
+  meta.workflow_path = destPath;
+  if (destUuid) meta.workflow_uuid = destUuid;
+  extra.comfyui_mcp = meta;
+  graph.extra = extra;
+
+  const destById = new Map<string, Record<string, unknown>>();
+  if (Array.isArray(dest.nodes)) {
+    for (const raw of dest.nodes) {
+      if (isPlainObject(raw) && raw.id != null) destById.set(String(raw.id), raw);
+    }
+  }
+  let restoredWidgets = 0;
+  if (Array.isArray(graph.nodes)) {
+    for (const raw of graph.nodes) {
+      if (!isPlainObject(raw) || raw.id == null) continue;
+      const destNode = destById.get(String(raw.id));
+      if (destNode && restoreEmptyPromotedWidgets(raw, destNode)) restoredWidgets += 1;
+    }
+  }
+  return { graph, restoredWidgets };
+}
+
+export function isStampMismatchSaveRefusal(text: string): boolean {
+  return /stamped as belonging to/i.test(text) && /extra\.comfyui_mcp\.workflow_path/i.test(text);
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -74,6 +74,13 @@ import {
   resolveInnerPromotedTarget,
 } from "./promoted-widget.js";
 import {
+  isPlainObject,
+  isStampMismatchSaveRefusal,
+  patchOpenIdentity,
+  shouldRebindOpenIdentity,
+  workflowFromSerializeReply,
+} from "./open-identity-normalization.js";
+import {
   clearSwitchHold,
   describeSwitchHold,
   recordSwitchHold,
@@ -4425,6 +4432,87 @@ function identityClaimedContentUnverifiedNote(detail: string): string {
   );
 }
 
+type OpenIdentityRebind =
+  | { status: "rebound"; destPath: string; destUuid?: string; restoredWidgets: number }
+  | { status: "skipped" };
+
+/**
+ * #1710 — restamp extra.comfyui_mcp onto the dest the tab is already bound to,
+ * and copy dest-file promoted widgets onto any live empty slots.
+ *
+ * Fail-closed: dest file unreadable, node-set mismatch, or a non-empty live
+ * widget that disagrees with dest (#1639 previous graph) leaves extra alone.
+ */
+async function tryRebindConfirmedOpenIdentity(
+  ctx: PanelToolCtx,
+  destPath: string,
+): Promise<OpenIdentityRebind> {
+  let live: Record<string, unknown> | null = null;
+  try {
+    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+    live = workflowFromSerializeReply(parseToolResultJson(serialized));
+  } catch {
+    return { status: "skipped" };
+  }
+  if (!live) return { status: "skipped" };
+
+  let dest: Record<string, unknown>;
+  try {
+    dest = await readWorkflowFromPath(destPath);
+  } catch {
+    return { status: "skipped" };
+  }
+  if (!shouldRebindOpenIdentity({ live, dest, destPath })) return { status: "skipped" };
+
+  const destUuid = await activeWorkflowUuidForPath(ctx, destPath);
+  const { graph, restoredWidgets } = patchOpenIdentity(live, dest, destPath, destUuid);
+  const loaded = await ctx.call({ cmd: "graph_load", graph }, 30000);
+  if (loaded.isError) return { status: "skipped" };
+  if (destUuid) refreshWorkflowUuid(ctx, { workflow_uuid: destUuid });
+  return { status: "rebound", destPath, destUuid, restoredWidgets };
+}
+
+async function activeWorkflowUuidForPath(ctx: PanelToolCtx, destPath: string): Promise<string | undefined> {
+  try {
+    const list = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
+    if (!list) return undefined;
+    if (readOpenActiveAgainstTarget(list.active, destPath, list.active_confirmed) !== "same") {
+      return undefined;
+    }
+    return responseWorkflowUuid(list.active);
+  } catch {
+    return undefined;
+  }
+}
+
+async function activeSavedPath(ctx: PanelToolCtx): Promise<string | undefined> {
+  try {
+    const list = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
+    const path = isPlainObject(list?.active) ? list.active.path : undefined;
+    return typeof path === "string" && path ? path : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function openedIdentityReboundResult(
+  destPath: string,
+  rebound: Extract<OpenIdentityRebind, { status: "rebound" }>,
+): ToolResult {
+  return ok({
+    opened: { path: destPath },
+    identity_rebound: true,
+    restored_promoted_widgets: rebound.restoredWidgets,
+    note:
+      `Opened ${destPath}. Frontend-normalized presentation/widget fields differed after load; ` +
+      `extra.comfyui_mcp.workflow_path/workflow_uuid were rebound to this workflow so a later ` +
+      `save will not refuse a source-stamp mismatch.` +
+      (rebound.restoredWidgets > 0
+        ? ` Restored ${rebound.restoredWidgets} empty promoted widget value(s) from the saved graph.`
+        : ""),
+  });
+}
+
 function identityClaimedButLiveGraphUnchangedNote(ctx: PanelToolCtx): string {
   const fence = currentWorkflowFence(ctx);
   const fenceTxt =
@@ -4446,6 +4534,7 @@ function identityClaimedButLiveGraphUnchangedNote(ctx: PanelToolCtx): string {
 async function clearFenceOnIdentityProvenOpen(
   ctx: PanelToolCtx,
   res: ToolResult,
+  requestedPath?: string,
 ): Promise<{ res: ToolResult; repaired: boolean }> {
   const text = toolResultText(res);
   // ONLY the class that states identity was proven. The UNPROVEN verdict ("could not
@@ -4455,6 +4544,15 @@ async function clearFenceOnIdentityProvenOpen(
 
   const canvas = await probeLiveGraphUnderCurrentFence(ctx);
   if (canvas.status === "answered") {
+    // #1710 — the old stamp still answering is ALSO what a save-as copy looks
+    // like: dest tab, dest nodes, extra.comfyui_mcp still naming the source.
+    // Confirm dest file content before touching extra (#1639 stays fail-closed).
+    if (requestedPath) {
+      const rebound = await tryRebindConfirmedOpenIdentity(ctx, requestedPath);
+      if (rebound.status === "rebound") {
+        return { res: openedIdentityReboundResult(requestedPath, rebound), repaired: true };
+      }
+    }
     return { res: appendToolResultText(res, identityClaimedButLiveGraphUnchangedNote(ctx)), repaired: false };
   }
   if (canvas.status === "unanswered") {
@@ -6144,7 +6242,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       if (!/workflow_open RAN/i.test(toolResultText(res))) return res;
       const probe = await observeActiveAfterOpen(ctx, path);
       if (probe.status !== "different") {
-        const cleared = await clearFenceOnIdentityProvenOpen(ctx, res);
+        const cleared = await clearFenceOnIdentityProvenOpen(ctx, res, path);
         // #1560 — the probe's SILENCE, reported. Suppressed when the fence was in fact
         // repaired: that re-derivation is itself a `workflow_list` round trip, so a
         // success there proves the channel answered and the note would contradict the
@@ -12651,9 +12749,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (ctx.awaitReachable && !(await ctx.awaitReachable())) {
           return noReachableTabFail(args.name ? "workflow_save_as" : "workflow_save", ctx);
         }
-        const res = args.name
-          ? await ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)
-          : await ctx.call({ cmd: "workflow_save" }, 15000);
+        const saveOnce = () =>
+          args.name
+            ? ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)
+            : ctx.call({ cmd: "workflow_save" }, 15000);
+        let res = await saveOnce();
+        // #1710 — dest tab + dest nodes, extra still stamped as the save-as SOURCE.
+        // Rebind extra to the confirmed dest, then retry the same save once.
+        if (res.isError && isStampMismatchSaveRefusal(toolResultText(res))) {
+          const destPath = await activeSavedPath(ctx);
+          if (destPath) {
+            const rebound = await tryRebindConfirmedOpenIdentity(ctx, destPath);
+            if (rebound.status === "rebound") {
+              const retried = await saveOnce();
+              if (!retried.isError) res = retried;
+            }
+          }
+        }
         if (res.isError) return res;
         // #1045 — a SAVE-AS replaces the active workflow instance: the canvas is
         // now the NEW file, with its own identity, while this session's command


### PR DESCRIPTION
Fixes #1710

Opening a save-as copy bound the dest tab, but extra.comfyui_mcp still named the source. panel_open_workflow returned unknown because frontend-normalized presentation/widget fields differed, panel_save_workflow then refused the dest file, and panel_graph_outline showed an empty promoted prompt the dest file still held.

After this change, when the live node set matches the dest file and no non-empty live widget disagrees with dest, the orchestrator rebinds extra.comfyui_mcp.workflow_path/workflow_uuid to dest, restores empty promoted widgets from the saved graph, and retries save. #1639 stays fail-closed: a previous graph whose widgets still disagree is not restamped.
