### PR TITLE
fix(1297): a self-nested panel_call_tool unwraps once or names the correct shape

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -563,6 +563,126 @@ describe("OllamaBackend", () => {
     expect(events.filter((e) => e.type === "result")).toHaveLength(1);
   });
 
+  it("unwraps a router-self-nested panel_call_tool envelope instead of refusing the real call (#1297)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_focus_node", description: "Focus a node in the canvas." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              // the malformed shape from the issue: the model wrapped the real
+              // call in a second panel_call_tool envelope.
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments: { name: "panel_call_tool", args: { name: "panel_focus_node", args: { node_id: 3 } } },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "focused." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "focus node 3" }));
+    // the inner call ran exactly as spelled out — name and args unwrapped once
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_focus_node", arguments: { node_id: 3 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+    const toolMsg = chatRequests[1].messages.find((m) => m.role === "tool");
+    const content = String(toolMsg?.content);
+    // the recovery is disclosed, and the correct shape is taught for next time
+    expect(content).toContain("Recovered a nested panel_call_tool envelope");
+    expect(content).toContain('panel_call_tool {"name": "panel_focus_node"');
+    expect(content).toContain("result-of-panel_focus_node");
+    expect(content).not.toContain("Unknown panel tool");
+  });
+
+  it("a router self-call WITHOUT a real nested panel tool is refused with the correct shape (#1297)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_focus_node", description: "Focus a node in the canvas." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              // nested envelope names a tool that does not exist — fail closed.
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments: { name: "panel_call_tool", args: { name: "panel_nope" } },
+                },
+              },
+              // bare self-call with no envelope at all
+              { function: { name: "panel_call_tool", arguments: { name: "panel_list_tools" } } },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "sorry" }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "do the thing" }));
+    expect(panelCall).not.toHaveBeenCalled();
+    const toolMsgs = chatRequests[1].messages.filter((m) => m.role === "tool").map((m) => String(m.content));
+    expect(toolMsgs).toHaveLength(2);
+    for (const content of toolMsgs) {
+      expect(content).toContain("is this router itself, not a panel tool");
+      expect(content).toContain('panel_call_tool {"name": "<panel tool>", "args": {...}}');
+      expect(content).not.toContain("Unknown panel tool");
+    }
+  });
+
+  it("panel_call_tool without a name field says what is missing instead of 'Unknown panel tool '''", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_focus_node", description: "Focus a node in the canvas." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [{ function: { name: "panel_call_tool", arguments: { args: { node_id: 3 } } } }],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "sorry" }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "focus node 3" }));
+    expect(panelCall).not.toHaveBeenCalled();
+    const toolMsg = chatRequests[1].messages.find((m) => m.role === "tool");
+    const content = String(toolMsg?.content);
+    expect(content).toContain('panel_call_tool requires a "name" field');
+    expect(content).toContain("panel_list_tools");
+  });
+
   it("the model sees exactly six tools", async () => {
     const { client: comfy } = fakeMcpClient(COMFY_META);
     const { client: panel } = fakeMcpClient([{ name: "panel_focus_node", description: "x" }]);

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -782,11 +782,54 @@ export class OllamaBackend implements AgentBackend {
       }
       if (name === "panel_call_tool") {
         if (!this.panel) return { text: "panel tools are unavailable in this session.", isError: true };
-        const wanted = typeof args.name === "string" ? args.name : typeof args.tool_name === "string" ? (args.tool_name as string) : "";
+        let wanted = typeof args.name === "string" ? args.name : typeof args.tool_name === "string" ? (args.tool_name as string) : "";
+        let inner: unknown = args.args ?? args.arguments ?? {};
+        // #1297 — ROUTER SELF-NESTING: a malformed call wraps the real invocation
+        // in a second router envelope (panel_call_tool {"name": "panel_call_tool",
+        // "args": {"name": "<tool>", "args": {...}}}). The old reply — "Unknown
+        // panel tool 'panel_call_tool'" — was doubly unhelpful: the name IS known
+        // (it is this router itself), and the answer discarded a call whose inner
+        // tool and args were fully spelled out. Peek one envelope deep: when it
+        // carries a real panel tool, unwrap it and run exactly that; otherwise
+        // refuse with the correct shape. ONE level only — a deeper nest fails
+        // closed through the same refusal.
+        let unwrapped = false;
+        if (wanted === "panel_call_tool" || wanted === "panel_list_tools" || wanted === "panel_describe_tool") {
+          let peek: unknown = inner;
+          if (typeof peek === "string") {
+            try {
+              peek = peek.trim() ? JSON.parse(peek) : {};
+            } catch {
+              // Not parseable JSON — cannot be a nested envelope, so fall through
+              // to the self-call refusal below rather than guessing.
+              peek = undefined;
+            }
+          }
+          const nested = peek !== null && typeof peek === "object" && !Array.isArray(peek) ? (peek as Record<string, unknown>) : undefined;
+          const nestedName = nested && typeof nested.name === "string" ? nested.name : "";
+          if (wanted === "panel_call_tool" && nested && this.panelTools.some((t) => t.name === nestedName)) {
+            wanted = nestedName;
+            inner = nested.args ?? nested.arguments ?? {};
+            unwrapped = true;
+          } else {
+            return {
+              text:
+                `'${wanted}' is this router itself, not a panel tool — the router cannot run its own ` +
+                `panel_list_tools / panel_describe_tool / panel_call_tool. Pass the inner tool directly: ` +
+                `panel_call_tool {"name": "<panel tool>", "args": {...}}. Use panel_list_tools to see the tools.`,
+              isError: true,
+            };
+          }
+        }
+        if (!wanted) {
+          return {
+            text: `panel_call_tool requires a "name" field naming the panel tool to run: {"name": "<panel tool>", "args": {...}}. Use panel_list_tools to see the tools.`,
+            isError: true,
+          };
+        }
         if (!this.panelTools.some((t) => t.name === wanted)) {
           return { text: `Unknown panel tool '${wanted}'. Use panel_list_tools.`, isError: true };
         }
-        let inner = args.args ?? args.arguments ?? {};
         if (typeof inner === "string") {
           try {
             inner = inner.trim() ? (JSON.parse(inner) as Record<string, unknown>) : {};
@@ -810,7 +853,13 @@ export class OllamaBackend implements AgentBackend {
         if (res.isError) {
           logger.warn(`[ollama-backend] panel tool '${wanted}' returned isError: ${textOf(res).slice(0, 300)}`);
         }
-        return { text: textOf(res), isError: !!res.isError };
+        const resultText = textOf(res);
+        return {
+          text: unwrapped
+            ? `Recovered a nested panel_call_tool envelope by unwrapping it once; call panel_call_tool {"name": "${wanted}", "args": {...}} directly next time.\n\n${resultText}`
+            : resultText,
+          isError: !!res.isError,
+        };
       }
       // FORGIVING DIRECT DISPATCH — small models routinely call an inner tool
       // by its bare name instead of going through the router. If the name is a


### PR DESCRIPTION
## Root cause

The Ollama-family agent backends (ollama, grok-direct, kimi, copilot, chatgpt-oauth — all sharing `OllamaBackend.dispatch`) expose the live-canvas surface through a three-tool router: `panel_list_tools` / `panel_describe_tool` / `panel_call_tool`. When a model malforms an invocation by nesting the router inside itself — `panel_call_tool {"name": "panel_call_tool", "args": {"name": "<tool>", "args": {...}}}` — the dispatch answered `Unknown panel tool 'panel_call_tool'. Use panel_list_tools.` That reply was doubly unhelpful: the name IS known (it is the router itself), and it discarded a call whose inner tool and args were fully spelled out, forcing a recovery turn mid-repair (artokun/comfyui-mcp-panel#1297).

## Fix (`src/orchestrator/ollama-backend.ts`, `panel_call_tool` branch only)

- If `name` is one of the router's own three tools, peek exactly one envelope deep: when it carries a real panel tool, unwrap once and run exactly that tool with exactly those args, disclosing the recovery in the result text (`Recovered a nested panel_call_tool envelope ... call ... directly next time`).
- Otherwise (no nested envelope, or a nested name that is not a real panel tool) fail closed: `'panel_call_tool' is this router itself, not a panel tool — ... Pass the inner tool directly: panel_call_tool {"name": "<panel tool>", "args": {...}}`. A deeper nest fails closed through the same refusal.
- A missing/non-string `name` now gets `panel_call_tool requires a "name" field ...` instead of `Unknown panel tool ''`.

## Verification

- New tests in `src/__tests__/orchestrator/ollama-backend.test.ts`: (1) the exact envelope from the issue unwraps and the panel client receives the inner call with the #325 timeout; (2) self-calls without a real nested tool are refused with the correct shape and never reach the panel client; (3) a missing name field names the missing field.
- `npm ci` ✓ · `npm run build` (tsc) ✓ · targeted file: 49/49 ✓ · full vitest: **555 files, 10372 passed, 3 skipped, 0 failed** ✓ (two earlier full runs each showed one different load-contention flake — `tool-surface-filter`/`vocabulary` 30s timeouts and a `panel-restart` assertion — each passing in a standalone re-run and untouched by this diff)
- `npm run check:unknown-collapse` ✓ (the new catch falls through to the refusal with a comment, no silent collapse)
- `npm run i18n:check`, `check:docs-links`, `check:docs-locale`, `check:docs-mdx`, `check:blog*` all ✓ (no tool-description, trFor, or docs changes)

Closes artokun/comfyui-mcp-panel#1297