### PR TITLE
fix(1767): clean the three packs whose workflows outran their manifests, and make packs:check-models a CI gate

### DIFF
--- a/.github/workflows/packs.yml
+++ b/.github/workflows/packs.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/validate-manifests.mjs"
       - "scripts/test-packs.sh"
       - "scripts/check-model-urls.mjs"
+      - "scripts/check-pack-models.mjs"
       - "src/services/manifest.ts"
       - ".github/workflows/packs.yml"
   pull_request:
@@ -17,6 +18,7 @@ on:
       - "scripts/validate-manifests.mjs"
       - "scripts/test-packs.sh"
       - "scripts/check-model-urls.mjs"
+      - "scripts/check-pack-models.mjs"
       - "src/services/manifest.ts"
       - ".github/workflows/packs.yml"
 
@@ -58,6 +60,9 @@ jobs:
 
       - name: Dry-run install scripts (offline, git/curl stubbed)
         run: bash scripts/test-packs.sh
+
+      - name: Workflows only reference models their manifest downloads
+        run: npm run packs:check-models
 
       - name: Validate model URLs + payload sizes (network, no full downloads)
         run: node scripts/check-model-urls.mjs

--- a/packs/ltx-2.3-xy-plot/pack.yaml
+++ b/packs/ltx-2.3-xy-plot/pack.yaml
@@ -16,9 +16,20 @@ notes:
   - Run the generated installer from your ComfyUI root.
   - Sliced + un-bypassed from the LTX-2.3 ULTRA workflow.
   - Needs the kornia fix (fix-ltxvideo-kornia.sh) if ComfyUI-LTXVideo's pyramid import breaks.
+  - >-
+    Bring your own trained LTX-2.3 LoRAs. This pack installs NO subject LoRAs —
+    the two "easy loraNames" selectors ship the placeholders
+    YOUR-LTX-LORA-a/b.safetensors, which are the two axes of the comparison grid.
+    Drop your own .safetensors into models/loras/ and pick them there. The
+    detailer and distill LoRAs the graph also loads ARE downloaded by this pack.
 post_install:
   - Restart ComfyUI, load workflow.json.
+  - >-
+    Set the two "easy loraNames" nodes to your own trained LoRAs — until you do,
+    they point at YOUR-LTX-LORA-a/b.safetensors placeholders and ComfyUI will
+    report them missing.
+# Declared external so packs:check-models knows they're intentionally not shipped.
+# Placeholders, not real weights — see the "bring your own" note above (#1767).
 external_models:
-  - Paulie-Walnuts-LTX23_000004250.safetensors
-  - Paulie-Walnuts-LTX23_000008000.safetensors
-  - paulie-walnuts-ltx23-03.safetensors
+  - YOUR-LTX-LORA-a.safetensors
+  - YOUR-LTX-LORA-b.safetensors

--- a/packs/ltx-2.3-xy-plot/workflow.json
+++ b/packs/ltx-2.3-xy-plot/workflow.json
@@ -2750,7 +2750,7 @@
         "secondTabWidth": 65
       },
       "widgets_values": [
-        "Paulie Walnuts sitting at Satriale's in a beige bomber jacket. He raises his right hand with a flat palm in a \"stop\" gesture and says, \"that was different, Chrissy was shot. That was a paranormal event.\"\n"
+        "A man sitting in a diner booth in a beige bomber jacket. He raises his right hand with a flat palm in a \"stop\" gesture and says, \"that was different, my cousin was shot. That was a paranormal event.\"\n"
       ],
       "color": "#009933",
       "bgcolor": "#353"
@@ -5720,7 +5720,7 @@
         "secondTabWidth": 65
       },
       "widgets_values": [
-        "Paulie Walnuts sitting at Satriale's in a beige bomber jacket. He raises his right hand with a flat palm in a \"stop\" gesture and says, \"that was different, Chrissy was shot. That was a paranormal event.\"\n"
+        "A man sitting in a diner booth in a beige bomber jacket. He raises his right hand with a flat palm in a \"stop\" gesture and says, \"that was different, my cousin was shot. That was a paranormal event.\"\n"
       ],
       "color": "#009933",
       "bgcolor": "#353"
@@ -5851,7 +5851,7 @@
         }
       },
       "widgets_values": [
-        "Paulie-Walnuts-LTX23_000004250.safetensors",
+        "YOUR-LTX-LORA-b.safetensors",
         1,
         1
       ],
@@ -6508,7 +6508,7 @@
         }
       },
       "widgets_values": [
-        "Paulie-Walnuts-LTX23_000008000.safetensors"
+        "YOUR-LTX-LORA-a.safetensors"
       ]
     },
     {
@@ -6546,7 +6546,7 @@
         }
       },
       "widgets_values": [
-        "paulie-walnuts-ltx23-03.safetensors"
+        "YOUR-LTX-LORA-b.safetensors"
       ]
     },
     {
@@ -6799,7 +6799,7 @@
         }
       },
       "widgets_values": [
-        "Paulie-Walnuts-LTX23_000004250.safetensors",
+        "YOUR-LTX-LORA-a.safetensors",
         1,
         1
       ],

--- a/packs/z-image-xy-plot/install-runpod.sh
+++ b/packs/z-image-xy-plot/install-runpod.sh
@@ -38,6 +38,6 @@ clone "RES4LYF" "https://github.com/ClownsharkBatwing/RES4LYF"
 echo "-------- models --------"
 grab "models/text_encoders/Qwen3-4B-UD-Q6_K_XL.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/Qwen3-4B-UD-Q6_K_XL.gguf"
 grab "models/vae/z-image-ae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/ae.safetensors"
-grab "models/unet/z_image_turbo-Q5_K_S.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q5_K_S.gguf"
+grab "models/unet/z_image_turbo-Q8_0.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q8_0.gguf"
 
 echo "DONE. Restart ComfyUI, then load workflow.json."

--- a/packs/z-image-xy-plot/install-windows.bat
+++ b/packs/z-image-xy-plot/install-windows.bat
@@ -28,7 +28,7 @@ call :clone "RES4LYF" "https://github.com/ClownsharkBatwing/RES4LYF"
 echo -------- models --------
 call :grab "models\text_encoders\Qwen3-4B-UD-Q6_K_XL.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/Qwen3-4B-UD-Q6_K_XL.gguf"
 call :grab "models\vae\z-image-ae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/ae.safetensors"
-call :grab "models\unet\z_image_turbo-Q5_K_S.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q5_K_S.gguf"
+call :grab "models\unet\z_image_turbo-Q8_0.gguf" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q8_0.gguf"
 
 echo DONE. Restart ComfyUI, then load workflow.json.
 pause

--- a/packs/z-image-xy-plot/manifest.yaml
+++ b/packs/z-image-xy-plot/manifest.yaml
@@ -5,15 +5,19 @@
 # Mirror base: https://huggingface.co/Aitrepreneur/FLX/resolve/main
 # Official Z-Image Turbo weights: https://huggingface.co/Tongyi-MAI/Z-Image-Turbo
 #
-# GGUF QUANT TIER: the installer prompts Q5_K_S (GPUs <8GB, recommended) /
-# Q6_K (8-12GB) / Q8_0 (12-16GB+) for the Z-Image Turbo UNet. This manifest ships
-# the Q5_K_S tier active (matches the pack's <8GB target); the bundled workflow
-# selects z_image_turbo-Q8_0.gguf, so uncomment the Q8_0 line below to match it
-# exactly, or just pick your tier's GGUF in the UnetLoaderGGUF node after install.
+# GGUF QUANT TIER: the installer prompts Q5_K_S (GPUs <8GB) / Q6_K (8-12GB) /
+# Q8_0 (12-16GB+, best quality) for the Z-Image Turbo UNet. This manifest ships
+# the Q8_0 tier active, which is what the bundled workflow's UnetLoaderGGUF
+# selects and what every other z-image-* pack ships. Until #1767 this pack alone
+# activated Q5_K_S while the workflow asked for Q8_0, so a fresh install opened
+# to a missing-model error. To run a smaller tier, comment the Q8_0 line below,
+# uncomment the tier you want, and pick it in the UnetLoaderGGUF node.
 #
 # This pack compares USER-TRAINED Z-Image LoRAs on an XY grid. The LoRAs the
-# workflow references (e.g. Margot-Robbie-Z3_*.safetensors) are user-supplied and
-# are NOT downloaded here — drop your own trained LoRAs into models/loras/.
+# workflow references (the YOUR-LORA-*.safetensors placeholders, declared in
+# pack.yaml external_models) are user-supplied and are NOT downloaded here —
+# drop your own trained LoRAs into models/loras/ and select them in the
+# "easy loraNames" nodes.
 
 pip: []
 
@@ -39,15 +43,15 @@ models:
   - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/ae.safetensors
     local_path: vae/z-image-ae.safetensors
 
-  # --- Diffusion UNet (UnetLoaderGGUF) — Q5_K_S tier active (<8GB, recommended) ---
-  - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q5_K_S.gguf
-    local_path: unet/z_image_turbo-Q5_K_S.gguf
-  # Q6_K tier (8-12GB) — uncomment to use, comment the Q5_K_S line above
+  # --- Diffusion UNet (UnetLoaderGGUF) — Q8_0 tier active (matches the workflow) ---
+  - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q8_0.gguf
+    local_path: unet/z_image_turbo-Q8_0.gguf
+  # Q5_K_S tier (<8GB) — uncomment to use, comment the Q8_0 line above
+  # - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q5_K_S.gguf
+  #   local_path: unet/z_image_turbo-Q5_K_S.gguf
+  # Q6_K tier (8-12GB) — uncomment to use, comment the Q8_0 line above
   # - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q6_K.gguf
   #   local_path: unet/z_image_turbo-Q6_K.gguf
-  # Q8_0 tier (12-16GB+, best quality; matches the bundled workflow selection)
-  # - url: https://huggingface.co/Aitrepreneur/FLX/resolve/main/z_image_turbo-Q8_0.gguf
-  #   local_path: unet/z_image_turbo-Q8_0.gguf
 
   # --- Upscalers (in the installer's shared Turbo bundle; NOT used by this
   #     XY-plot comparison workflow — uncomment if you want them) ---

--- a/packs/z-image-xy-plot/pack.yaml
+++ b/packs/z-image-xy-plot/pack.yaml
@@ -22,16 +22,20 @@ notes:
   - >-
     Bring your own trained LoRAs. This pack installs NO LoRAs — drop your trained
     Z-Image LoRA .safetensors into models/loras/, then pick them in the workflow's
-    "easy loraNames" selector nodes to compare them on the XY grid.
+    "easy loraNames" selector nodes to compare them on the XY grid. The five
+    selectors ship the placeholders YOUR-LORA-step1000/1500/2000/2500 and
+    YOUR-LORA-final.safetensors; ComfyUI reports those missing until you replace
+    them, which is expected.
   - >-
     Need to train a Z-Image LoRA first? See the anima-lora-trainer skill (Citron's
     local kohya trainer) or an ai-toolkit-based trainer; export the resulting
     .safetensors into models/loras/.
   - >-
-    GGUF quant tier - the upstream installer prompts Q5_K_S (<8GB, recommended) /
-    Q6_K (8-12GB) / Q8_0 (12-16GB+). The manifest ships Q5_K_S active; the bundled
-    workflow defaults to z_image_turbo-Q8_0.gguf, so either uncomment the Q8_0 tier
-    in manifest.yaml or just select your installed GGUF in the UnetLoaderGGUF node.
+    GGUF quant tier - the upstream installer prompts Q5_K_S (<8GB) / Q6_K
+    (8-12GB) / Q8_0 (12-16GB+). The manifest ships Q8_0 active, matching the
+    bundled workflow's UnetLoaderGGUF and every other z-image-* pack. For a
+    smaller tier, swap the commented line in manifest.yaml and select your
+    installed GGUF in the UnetLoaderGGUF node.
   - >-
     The text encoder loads via CLIPLoaderGGUF with type "lumina2"; the VAE is
     z-image-ae.safetensors. Both are downloaded by this pack.
@@ -47,3 +51,11 @@ post_install:
   - >-
     Load workflow.json, then set each "easy loraNames" node to one of your trained
     LoRAs in models/loras/ to populate the comparison grid.
+# Declared external so packs:check-models knows they're intentionally not shipped.
+# Placeholders, not real weights — see the "bring your own" note above (#1767).
+external_models:
+  - YOUR-LORA-step1000.safetensors
+  - YOUR-LORA-step1500.safetensors
+  - YOUR-LORA-step2000.safetensors
+  - YOUR-LORA-step2500.safetensors
+  - YOUR-LORA-final.safetensors

--- a/packs/z-image-xy-plot/workflow.json
+++ b/packs/z-image-xy-plot/workflow.json
@@ -613,7 +613,7 @@
         }
       },
       "widgets_values": [
-        "01margott_W_000001000.safetensors",
+        "YOUR-LORA-step1000.safetensors",
         1,
         1
       ],
@@ -1146,7 +1146,7 @@
         }
       },
       "widgets_values": [
-        "01margott_W_000001000.safetensors",
+        "YOUR-LORA-step1500.safetensors",
         1,
         1
       ]
@@ -1734,7 +1734,7 @@
         }
       },
       "widgets_values": [
-        "01margott_W_000001000.safetensors",
+        "YOUR-LORA-step2000.safetensors",
         1,
         1
       ]
@@ -2464,7 +2464,7 @@
         }
       },
       "widgets_values": [
-        "01margott_W_000001000.safetensors",
+        "YOUR-LORA-step2500.safetensors",
         1,
         1
       ]
@@ -3121,7 +3121,7 @@
         }
       },
       "widgets_values": [
-        "01margott_W_000001000.safetensors",
+        "YOUR-LORA-final.safetensors",
         1,
         1
       ]
@@ -4254,7 +4254,7 @@
         }
       },
       "widgets_values": [
-        "Margot-Robbie-Z3_000001000.safetensors"
+        "YOUR-LORA-step1000.safetensors"
       ]
     },
     {
@@ -4292,7 +4292,7 @@
         }
       },
       "widgets_values": [
-        "Margot-Robbie-Z3_000001500.safetensors"
+        "YOUR-LORA-step1500.safetensors"
       ]
     },
     {
@@ -4330,7 +4330,7 @@
         }
       },
       "widgets_values": [
-        "Margot-Robbie-Z3_000002000.safetensors"
+        "YOUR-LORA-step2000.safetensors"
       ]
     },
     {
@@ -4368,7 +4368,7 @@
         }
       },
       "widgets_values": [
-        "Margot-Robbie-Z3_000002500.safetensors"
+        "YOUR-LORA-step2500.safetensors"
       ]
     },
     {
@@ -4406,7 +4406,7 @@
         }
       },
       "widgets_values": [
-        "Margot-Robbie-Z3.safetensors"
+        "YOUR-LORA-final.safetensors"
       ]
     },
     {
@@ -4445,7 +4445,7 @@
         "ttNnodeVersion": "1.0.0"
       },
       "widgets_values": [
-        "margot robbie cyberpunk portrait, neon rim-lights, rain-soaked city backdrop, vivid colors, photoreal.\n"
+        "a woman cyberpunk portrait, neon rim-lights, rain-soaked city backdrop, vivid colors, photoreal.\n"
       ],
       "color": "#232",
       "bgcolor": "#353"

--- a/scripts/check-pack-models.mjs
+++ b/scripts/check-pack-models.mjs
@@ -13,7 +13,7 @@
 // Dead downloads (provided but never referenced) are reported as warnings only.
 
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
+import { join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
@@ -33,9 +33,37 @@ const SENTINELS = new Set(["none", "undefined", "null", ""]);
 const SELF_MANAGING = /(^DownloadAndLoad)|Preprocessor$|RIFE|InsightFace/i;
 const isSelfManaging = (type) => SELF_MANAGING.test(String(type || ""));
 
+// Widget names that are unambiguous MODEL selectors on every node exposing them.
+// Kept in sync by hand with ASSET_WIDGET_NAMES in src/services/workflow-converter.ts
+// (this script is standalone .mjs and deliberately does not import from src/).
+// Deliberately excludes enum-shaped "_name" widgets (sampler_name, scheduler)
+// and generic media names, for the same reasons the converter excludes them.
+const ASSET_WIDGET_NAMES = new Set([
+  "ckpt_name",
+  "unet_name",
+  "vae_name",
+  "lora_name",
+  "clip_name",
+  "clip_name1",
+  "clip_name2",
+  "clip_name3",
+  "clip_name4",
+  "control_net_name",
+  "controlnet_name",
+  "style_model_name",
+  "gligen_name",
+  "hypernetwork_name",
+  "clip_vision_name",
+  "model_path",
+  "diffusion_model",
+]);
+
 function packDirs() {
   const arg = process.argv[2];
-  if (arg) return [join(repoRoot, arg)];
+  // resolve(), not join(): an ABSOLUTE arg must be honoured as-is so the test
+  // suite can point the gate at a synthetic pack outside the repo. A relative
+  // arg still resolves against repoRoot exactly as before.
+  if (arg) return [resolve(repoRoot, arg)];
   return readdirSync(packsRoot)
     .map((n) => join(packsRoot, n))
     .filter((p) => statSync(p).isDirectory() && existsSync(join(p, "manifest.yaml")));
@@ -65,6 +93,55 @@ function providedFiles(manifest) {
   return out;
 }
 
+/** How many model-extension strings a widgets_values tree holds (same shape test
+ *  `record` applies, so the two can never disagree about what counts). */
+function countModelStrings(v) {
+  if (Array.isArray(v)) return v.reduce((n, x) => n + countModelStrings(x), 0);
+  if (v && typeof v === "object") return Object.values(v).reduce((n, x) => n + countModelStrings(x), 0);
+  if (typeof v !== "string") return 0;
+  if (SENTINELS.has(v.toLowerCase())) return 0;
+  return MODEL_EXT.test(v) ? 1 : 0;
+}
+
+/**
+ * How many of this node's MODEL widget slots are fed by a link instead of by
+ * their stored widget value.
+ *
+ * When a widget is promoted to an input and connected, litegraph keeps the old
+ * string in `widgets_values` forever, but `graphToPrompt` builds that input from
+ * the LINK — the stored string is dead and ComfyUI never loads it. Five
+ * `LoraLoader`s in z-image-xy-plot and two in ltx-2.3-xy-plot are exactly this:
+ * a stale filename from before the author wired up the `easy loraNames`
+ * selectors. Counting them as live references made the gate report seven
+ * missing models that no install can ever miss.
+ *
+ * The reference itself is NOT lost by skipping them: the link resolves back to
+ * a selector node (`easy loraNames`, through Reroutes) whose own widget value is
+ * scanned on its own turn, so the gap is still reported — against the node that
+ * actually supplies the value.
+ *
+ * `input.link == null` matters: a widget can be promoted to an input and left
+ * UNCONNECTED, and then its stored value is still what ComfyUI loads. Dropping
+ * that check would turn every promoted-but-dangling model widget into a blind
+ * spot.
+ *
+ * RESIDUAL RISK, stated rather than hidden: the caller decides by arity, so a
+ * node whose linked slot happens to hold a NON-model string (never set to a real
+ * file before promotion) under-counts here, and a second model widget typed in
+ * on the same node could be skipped with it. That shape does not occur in any of
+ * the 57 bundled packs — measured, all 7 link-fed model slots hold model strings
+ * — and closing it properly needs object_info, which this script deliberately
+ * does not load.
+ */
+function linkedAssetWidgetCount(node) {
+  let n = 0;
+  for (const input of node.inputs || []) {
+    if (!input || !input.widget || input.link == null) continue;
+    if (ASSET_WIDGET_NAMES.has(String(input.widget.name))) n++;
+  }
+  return n;
+}
+
 // Model files referenced by a workflow's loader nodes. We scan widgets_values
 // (the value ComfyUI actually loads) for strings ending in a model extension —
 // NOT node.properties.models, which is a download hint that is often stale.
@@ -88,7 +165,21 @@ function referencedFiles(workflow) {
     else record(v, node);
   };
   if (Array.isArray(workflow.nodes)) {
-    for (const node of workflow.nodes) walk(node.widgets_values, node);
+    for (const node of workflow.nodes) {
+      // `widgets_values` is POSITIONAL and this script has no object_info, so it
+      // cannot map a slot index back to a widget name. It can still decide the
+      // question safely by ARITY: if every model-extension string on the node is
+      // accounted for by a linked model widget, all of them are link-supplied.
+      //
+      // When the counts DISAGREE the node is ambiguous (e.g. a DualCLIPLoader
+      // with clip_name1 linked and clip_name2 typed in) and we scan it in full.
+      // That direction is deliberate: an ambiguous node yields a false POSITIVE
+      // the author can silence explicitly, whereas guessing would yield a false
+      // NEGATIVE — a genuinely missing model, silently unreported.
+      const modelStrings = countModelStrings(node.widgets_values);
+      if (modelStrings > 0 && modelStrings <= linkedAssetWidgetCount(node)) continue;
+      walk(node.widgets_values, node);
+    }
   } else {
     // API/prompt-format workflow: { "<id>": { class_type, inputs } }. Scan only
     // scalar input values (link references are [nodeId, slot] arrays, but a

--- a/src/__tests__/packs/check-models-is-wired.test.ts
+++ b/src/__tests__/packs/check-models-is-wired.test.ts
@@ -1,0 +1,69 @@
+// #1767 — `packs:check-models` existed for months and was run by NOTHING: not
+// CI, not the release workflow. Three packs shipped workflows referencing weights
+// their manifest never downloaded, and the gate that would have caught it sat
+// unexecuted in package.json.
+//
+// Wiring a gate in is a one-line change that no helper-level test can see, so
+// this file asserts on the WIRING itself: the step exists, it invokes the script
+// that actually exists, and the workflow's `paths` filter includes the gate's own
+// source — otherwise editing the gate would not run the gate.
+
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const GATE_SCRIPT = "scripts/check-pack-models.mjs";
+const NPM_SCRIPT = "packs:check-models";
+
+type Workflow = {
+  on?: { push?: { paths?: string[] }; pull_request?: { paths?: string[] } };
+  jobs?: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+};
+
+const workflowPath = join(repoRoot, ".github", "workflows", "packs.yml");
+const workflow = parse(readFileSync(workflowPath, "utf8")) as Workflow;
+const steps = Object.values(workflow.jobs ?? {}).flatMap((j) => j.steps ?? []);
+const runLines = steps.map((s) => s.run ?? "").join("\n");
+
+describe("#1767 the packs gate is actually executed", () => {
+  it("parses packs.yml into steps to scan (guards a vacuous pass)", () => {
+    expect(steps.length).toBeGreaterThan(0);
+    // Sanity: the sibling gates this workflow already ran are still here, so a
+    // parse that silently produced the wrong shape cannot look like a pass.
+    expect(runLines).toContain("packs:validate");
+  });
+
+  it("the gate script it invokes exists on disk", () => {
+    expect(existsSync(join(repoRoot, GATE_SCRIPT))).toBe(true);
+  });
+
+  it("package.json still defines the npm script CI calls", () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    expect(pkg.scripts?.[NPM_SCRIPT]).toBeDefined();
+    // The npm script must point at the file above, or the two drift apart.
+    expect(pkg.scripts?.[NPM_SCRIPT]).toContain("check-pack-models.mjs");
+  });
+
+  it("a packs.yml step runs it", () => {
+    expect(runLines).toContain(`npm run ${NPM_SCRIPT}`);
+  });
+
+  // The defect this pins: a gate whose own source is missing from `paths` is
+  // skipped by the very change most likely to break it.
+  it.each(["push", "pull_request"] as const)("the %s paths filter includes the gate's own source", (event) => {
+    const paths = workflow.on?.[event]?.paths;
+    expect(paths, `on.${event}.paths is missing`).toBeDefined();
+    expect(paths).toContain(GATE_SCRIPT);
+  });
+
+  it("the paths filter also covers the pack files the gate reads", () => {
+    for (const event of ["push", "pull_request"] as const) {
+      expect(workflow.on?.[event]?.paths).toContain("packs/**");
+    }
+  });
+});

--- a/src/__tests__/scripts/check-pack-models.test.ts
+++ b/src/__tests__/scripts/check-pack-models.test.ts
@@ -1,0 +1,168 @@
+// #1767 — packs:check-models is now a CI gate, so its false-positive rate is no
+// longer cosmetic: a gate that cries wolf gets deleted, and a gate that stays
+// quiet on a real gap ships a broken pack.
+//
+// The defect that motivated this file: when a widget is promoted to an input and
+// connected, litegraph keeps the old string in `widgets_values` forever, but
+// `graphToPrompt` builds that input from the LINK. The stored string is dead.
+// Seven `LoraLoader` slots across two shipped packs were exactly this, and the
+// gate reported all seven as missing models that no install can ever miss.
+//
+// The tests below fix BOTH directions. The negative half (a dead slot stays
+// quiet) is the fix; the positive half (an ambiguous node still fails, the link
+// SOURCE is still caught) is what stops the fix from becoming a silencer.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts", "check-pack-models.mjs");
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "packmodels-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Write a synthetic one-pack fixture. `manifest` lists what the pack downloads. */
+function pack(nodes: unknown[], provided: string[] = [], packYaml = "") {
+  const p = join(dir, "fixture");
+  mkdirSync(p, { recursive: true });
+  writeFileSync(
+    join(p, "manifest.yaml"),
+    `name: fixture\nmodels:\n${provided.map((f) => `  - url: https://example.invalid/${f}\n    local_path: loras/${f}\n`).join("") || "  []\n"}`,
+  );
+  writeFileSync(join(p, "pack.yaml"), `name: fixture\nworkflow: workflow.json\n${packYaml}`);
+  writeFileSync(join(p, "workflow.json"), JSON.stringify({ nodes }));
+  return p;
+}
+
+/** Run the gate against a fixture. The MESSAGE is part of the contract — a
+ *  developer who cannot tell which node fired will reach for the allow-list. */
+function run(fixture: string) {
+  try {
+    const out = execFileSync(process.execPath, [SCRIPT, fixture], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status: number; stdout: string; stderr: string };
+    return { code: err.status, out: (err.stdout ?? "") + (err.stderr ?? "") };
+  }
+}
+
+/** A LoraLoader whose `lora_name` widget was promoted to an input. `link` null
+ *  means promoted-but-UNCONNECTED, which still reads its widget value. */
+const loraLoader = (id: number, widgetValue: string, link: number | null) => ({
+  id,
+  type: "LoraLoader",
+  mode: 0,
+  widgets_values: [widgetValue, 1, 1],
+  inputs: [
+    { name: "model", type: "MODEL", link: 1 },
+    { name: "clip", type: "CLIP", link: 2 },
+    { name: "lora_name", type: "COMBO", widget: { name: "lora_name" }, link },
+  ],
+});
+
+describe("#1767 a widget slot fed by a link is DEAD, not a reference", () => {
+  it("stays quiet on the exact shape that shipped in z-image-xy-plot", () => {
+    // Five LoraLoaders carrying a stale filename, every lora_name link-fed.
+    const nodes = [86, 91, 99, 113, 129].map((id) =>
+      loraLoader(id, "01margott_W_000001000.safetensors", 100 + id),
+    );
+    const r = run(pack(nodes));
+    expect(r.out).not.toContain("01margott_W_000001000.safetensors");
+    expect(r.code).toBe(0);
+  });
+
+  it("DOES fail when the promoted widget is not connected", () => {
+    // Same node, link: null. The widget value is what ComfyUI loads, so a gap
+    // here is real. This is the pair that proves the fix keys on the LINK and
+    // not merely on "lora_name was promoted".
+    const r = run(pack([loraLoader(91, "unobtainable.safetensors", null)]));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("unobtainable.safetensors");
+    expect(r.out).toContain("LoraLoader#91");
+  });
+
+  it("still catches the value at the LINK SOURCE, so no coverage is lost", () => {
+    // The real reference lives on the selector node that feeds the link. This is
+    // why skipping the dead slot loses nothing: the gap is still reported, just
+    // against the node that actually supplies the value.
+    const nodes = [
+      loraLoader(91, "stale-and-dead.safetensors", 153),
+      { id: 92, type: "easy loraNames", mode: 0, widgets_values: ["really-missing.safetensors"], inputs: [] },
+    ];
+    const r = run(pack(nodes));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("really-missing.safetensors");
+    expect(r.out).toContain("easy loraNames#92");
+    expect(r.out).not.toContain("stale-and-dead.safetensors");
+  });
+
+  it("a satisfied link source is clean end to end", () => {
+    const nodes = [
+      loraLoader(91, "stale-and-dead.safetensors", 153),
+      { id: 92, type: "easy loraNames", mode: 0, widgets_values: ["shipped.safetensors"], inputs: [] },
+    ];
+    const r = run(pack(nodes, ["shipped.safetensors"]));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("no live gaps");
+  });
+});
+
+describe("#1767 the fix must not become a silencer", () => {
+  it("an AMBIGUOUS node still fails — more model strings than linked slots", () => {
+    // clip_name1 is link-fed, clip_name2 is typed in. The script has no
+    // object_info and cannot tell which slot is which, so it must report BOTH
+    // rather than guess and hide a genuinely missing model.
+    const nodes = [
+      {
+        id: 7,
+        type: "DualCLIPLoader",
+        mode: 0,
+        widgets_values: ["fed-by-link.safetensors", "typed-in-and-missing.safetensors", "ltxv"],
+        inputs: [{ name: "clip_name1", type: "COMBO", widget: { name: "clip_name1" }, link: 55 }],
+      },
+    ];
+    const r = run(pack(nodes));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("typed-in-and-missing.safetensors");
+  });
+
+  it("a linked input that is NOT a model selector suppresses nothing", () => {
+    // The shape wan-animate ships: positive_prompt is link-fed while the node
+    // also carries a real, live text-encoder filename in widgets_values.
+    const nodes = [
+      {
+        id: 65,
+        type: "WanVideoTextEncodeCached",
+        mode: 0,
+        widgets_values: ["umt5-xxl-enc-bf16.safetensors", "some prompt"],
+        inputs: [{ name: "positive_prompt", type: "STRING", widget: { name: "positive_prompt" }, link: 9 }],
+      },
+    ];
+    const r = run(pack(nodes));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("umt5-xxl-enc-bf16.safetensors");
+  });
+
+  it("a plain unpromoted loader gap still fails", () => {
+    const nodes = [{ id: 10, type: "UnetLoaderGGUF", mode: 0, widgets_values: ["absent-Q8_0.gguf"], inputs: [] }];
+    const r = run(pack(nodes));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("absent-Q8_0.gguf");
+    expect(r.out).toContain("UnetLoaderGGUF#10");
+  });
+
+  it("external_models still downgrades a declared gap to clean", () => {
+    const nodes = [{ id: 1, type: "LoraLoader", mode: 0, widgets_values: ["YOUR-LORA-final.safetensors", 1, 1], inputs: [] }];
+    const r = run(pack(nodes, [], "external_models:\n  - YOUR-LORA-final.safetensors\n"));
+    expect(r.code).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #1767.

`packs:check-models` has existed for months and was run by **nothing** — not CI, not the release workflow. Wiring it in is the durable fix; cleaning what it finds is the precondition. Both are here.

Investigating first changed the shape of the bug in three ways, so the diff is not what the issue asked for.

## 1. Five of the seven reported gaps were the gate's own false positives

When a widget is promoted to an input and connected, litegraph keeps the old string in `widgets_values` forever, but `graphToPrompt` builds that input from the **link** — the stored string is dead and ComfyUI never loads it. Five `LoraLoader`s in `z-image-xy-plot` and two in `ltx-2.3-xy-plot` are exactly this, carrying a stale filename from before the author wired up the `easy loraNames` selectors:

```
LoraLoader#91.lora_name <= Reroute#93 -> easy loraNames#92 wv=["Margot-Robbie-Z3_000001000.safetensors"]
```

`01margott_W_000001000.safetensors` — reported on 5 nodes — is never loaded by any install. A gate with a 5-in-7 false-positive rate cannot be wired into CI, so the gate is fixed first.

**No coverage is lost.** Each dead slot's link resolves back (through Reroutes) to a selector node whose own widget value is scanned on its own turn, so the gap is still reported — against the node that actually supplies the value. Traced for all 7; one of the tests pins it.

The script has no `object_info` and cannot map a positional slot back to a widget name, so it decides by **arity** and refuses to guess: only when every model string on a node is accounted for by a linked model widget are they all treated as link-supplied. A node where the counts disagree is scanned in full — a false positive can be silenced explicitly, a false negative ships a broken pack. Measured across all 57 packs: 9 nodes have a linked widget plus a model string, 7 unambiguous, and the 2 ambiguous ones (`WanVideoTextEncodeCached` with `positive_prompt` linked) are real live values already in their manifests, untouched by the rule.

## 2. z-image-xy-plot's real defect was in its manifest, not its workflow

All 13 sibling `z-image-*` packs ship the **Q8_0** tier active and select Q8_0. This pack alone activated Q5_K_S while its `UnetLoaderGGUF` asked for Q8_0, so a fresh install opened straight to a missing-model error — and `pack.yaml` documented the workaround instead of fixing it. The manifest now ships Q8_0, the byte-identical URL 12 other packs already download (HEAD 200; all three tier URLs verified). This also clears the mirror-image `downloads Q5_K_S but no loader references it` warning.

Fixing the workflow instead would have diverged this pack from its whole family.

## 3. wan-pusa-extend needed no change — the issue was wrong about it

The issue called this "the straightforward case — both files are ordinary public weights that the manifest simply omits." They are not omitted; both sit on `mode: 2` (**bypassed**) alternative nodes:

| node | why it's bypassed |
|---|---|
| `CLIPLoader#48` → `umt5_xxl_fp16.safetensors` | superseded by `umt5-xxl-enc-bf16.safetensors`, the WanVideoWrapper-native encoder the pack **does** ship |
| `WanVideoTinyVAELoader#118` → `taew2_1.safetensors` | optional preview VAE |

The gate already classifies both correctly as warnings. Adding `umt5_xxl_fp16.safetensors` would download ~11 GB that nothing active loads — a bloat regression, not a fix. **No change made.**

## The decision the issue asked for on the two LoRA sets

Re-authoring against public weights, as the issue suggested, is **not possible**: both packs compare successive checkpoints of *one* training run (`_000001000`, `_000001500`, `_000002000`, `_000002500`, final), and no public weight set has that shape. Both packs are bring-your-own-LoRA by design — `z-image-xy-plot` already said so in its notes, `ltx-2.3-xy-plot` did not, and now does.

So the leaked personal artifacts are replaced with self-documenting placeholders and declared in `pack.yaml` `external_models`, the mechanism that already existed for a reviewed intentional gap:

- `Margot-Robbie-Z3*` (5 live selectors) → `YOUR-LORA-step1000/1500/2000/2500`, `YOUR-LORA-final`
- `01margott_W_*` (5 dead slots) → the placeholder each one's link actually supplies, so the JSON reads consistently
- `Paulie-Walnuts-LTX23*` → `YOUR-LTX-LORA-a/b`

The example prompts naming the same two people are neutralized so the shipped graph is coherent for a BYOL user. (The first pass missed `Chrissy` in the ltx dialogue; the gate caught it and it is now scrubbed too — see the gate section.) `ltx-2.3-xy-plot` also drops a now-unnecessary `external_models` entry (`Paulie-Walnuts-LTX23_000004250`, which only ever appeared on the two dead slots).

Note this makes the gate's pass on real pack data independent of the gate fix — cleaning the dead slots means pack data no longer exercises the dead-slot path. That is deliberate: the unit test is the pin, not shipped stale data that a future maintainer would break by tidying.

## Verified by mutation, not by green

| mutation | result |
|---|---|
| remove the dead-slot skip in `check-pack-models.mjs` | **3 of 8** gate tests fail |
| remove the `npm run packs:check-models` step from `packs.yml` | wiring test fails |
| remove `scripts/check-pack-models.mjs` from the `paths` filters | 2 wiring tests fail |

Each mutation was asserted to have actually applied before running, and reverted after.

- `packs:check-models`: **7 errors → 0** across all 57 packs
- `packs:validate`: green; `packs:gen` regenerated the two installers (the Q8_0 tier swap is the only functional line)
- targeted suites: 12 files / 155 tests green
- full suite: 10,426 tests green (3 timeout flakes under concurrent load; all 103 tests in those files pass in isolation, none touch this diff)
- **real CI**: the `packs` job passed with the new step executing `node scripts/check-pack-models.mjs` on ubuntu — wiring proven in CI, not just locally

The `paths` filter now includes the gate's own source — otherwise editing the gate would not run the gate.

## Gate

**Verdict: SHIP.**

codex was unavailable (the account is exhausted until 2026-08-19 20:43, measured on both the wrapper and `codex exec` directly); gated by an independent adversarial review instead — a fresh session that never saw this reasoning, handed only the diff and told to refute. Disclosing the substitution is the condition it was accepted under.

It worked the repo's seven-class defect taxonomy by executing rather than reading, and independently re-derived the load-bearing claims:

- **Two states collapsing** — measured all 3475 links across 57 packs: minimum link id is **1**, zero links with id `0`, so "unconnected" (`link == null`) cannot collapse with "connected to link 0".
- **Arity blind spot** — it built the adversarial input (2 linked asset widgets, 1 typed model string → node skipped) and confirmed it is real, that the code comment already discloses it, and that incidence in the repo is **zero** (all 7 skipped nodes are 1:1 `lora_name` on `LoraLoader`).
- **Mutation coverage** — 5 mutations, all killed, including two I had not tried (`resolve`→`join`, ignoring `ASSET_WIDGET_NAMES`).
- **Prose vs code** — verified "what every other z-image-* pack ships" and ltx's "the detailer and distill LoRAs ARE downloaded by this pack" against the manifests.

Worth recording: its CI-step mutation **first read as survived** because CRLF line endings ate its `perl` anchors, so the deletion never applied. It caught that itself and re-ran with the deletion verified against the file, where it died. A mutation that never applied is indistinguishable from one that survived unless you check that it landed.

**Post-gate delta, disclosed:** the gate listed as a *non-finding* that two `Chrissy` strings survived my likeness scrub in the ltx prompt dialogue. Not a correctness defect, but it made the PR text above inaccurate, so I scrubbed them (`Chrissy` → `my cousin`, 2 strings in `packs/ltx-2.3-xy-plot/workflow.json`) after the SHIP verdict. That is the only change since the gated tree: pack prompt prose, no code. Re-verified after it — `packs:check-models` 0 errors, `packs:validate` clean, no installer drift, 79 pack/script tests green.

The gate's other non-finding — a non-array `node.inputs` throws a `TypeError` — I left deliberately: it fails **closed** (non-zero exit turns CI red) on a shape litegraph does not emit, and changing it post-gate would alter code behaviour for no user-visible gain.

## Not done

- No browser/Playwright run: this touches pack data, a standalone node script and CI config. Nothing here renders in the panel.
- `docs/blog/z-image-comfyui.mdx:265` claims "there's no Q6_K on the mirror". That is stale — Q6_K returns HTTP 200. Left alone as an unrelated docs bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

