### PR TITLE
feat(792): consult the arena baseline table without running it

### DIFF
--- a/benchmarks/arena-baseline.json
+++ b/benchmarks/arena-baseline.json
@@ -1,0 +1,35 @@
+{
+  "gpu": "cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync",
+  "source": "Published 4090 leaderboard (`docs/images/arena-leaderboard-*.svg`, recorded 2026-07-09). These runs predate version stamping and the 0.50 tool-surface consolidation (#726); VRAM and quantization were not probed, so those cells stay em-dash rather than guessed. Absolute scores are not comparable to a current-surface run.",
+  "scenarios": [
+    "health",
+    "models",
+    "registry",
+    "queue",
+    "generate",
+    "precision",
+    "breakfix",
+    "provenance",
+    "multiout",
+    "pipeline"
+  ],
+  "leaderboard": [
+    { "model": "google/gemini-3.1-pro-preview", "tier": "SoTA", "total": 20, "max": 20 },
+    { "model": "anthropic/claude-opus-4.8", "tier": "SoTA", "total": 20, "max": 20 },
+    { "model": "openai/gpt-5.5", "tier": "SoTA", "total": 20, "max": 20 },
+    { "model": "z-ai/glm-5.1", "tier": "B-tier", "total": 19, "max": 20 },
+    { "model": "moonshotai/kimi-k2.5", "tier": "B-tier", "total": 19, "max": 20 },
+    { "model": "xiaomi/mimo-v2.5", "tier": "SoTA", "total": 19, "max": 20 },
+    { "model": "deepseek/deepseek-v3.2", "tier": "B-tier", "total": 17, "max": 20 },
+    { "model": "minimax/minimax-m3", "tier": "B-tier", "total": 17, "max": 20 },
+    { "model": "x-ai/grok-4.3", "tier": "SoTA", "total": 15, "max": 20 },
+    { "model": "artokun/gemma4-comfyui-mcp:e4b", "tier": "local", "total": 14, "max": 20 },
+    { "model": "qwen3:4b", "tier": "local", "total": 13, "max": 20 },
+    { "model": "artokun/gemma4-comfyui-mcp:12b", "tier": "local", "total": 13, "max": 20 },
+    { "model": "gemma4:e4b", "tier": "local", "total": 12, "max": 20 },
+    { "model": "qwen3:8b", "tier": "local", "total": 11, "max": 20 },
+    { "model": "gemma4:e2b", "tier": "local", "total": 8, "max": 20 },
+    { "model": "artokun/gemma4-comfyui-mcp:e2b", "tier": "local", "total": 4, "max": 20 },
+    { "model": "llama3.1:8b", "tier": "local", "total": 2, "max": 20 }
+  ]
+}

--- a/docs/arena.mdx
+++ b/docs/arena.mdx
@@ -95,7 +95,39 @@ actionable (#792):
 <img className="block dark:hidden" src="./images/arena-leaderboard-light.svg" alt="ComfyUI LLM Arena leaderboard" />
 <img className="hidden dark:block" src="./images/arena-leaderboard-dark.svg" alt="ComfyUI LLM Arena leaderboard" />
 
-14 models, best-of-3 on the top cluster. The headline findings:
+Consultable without running the ladder. Resident VRAM is the model's footprint while it is loaded (Ollama `/api/ps`), not remaining headroom — ComfyUI shares the same card. Params/Quant come from `/api/show`. Hosted endpoints have no equivalent; those cells stay `—`, never guessed.
+
+These runs were recorded before version stamping (or could not read their package version). Absolute scores move when the tool surface changes — do not compare them to a current-surface run as if they were one ladder.
+
+Hardware: cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync.
+
+Published 4090 leaderboard (`docs/images/arena-leaderboard-*.svg`, recorded 2026-07-09). These runs predate version stamping and the 0.50 tool-surface consolidation (#726); VRAM and quantization were not probed, so those cells stay em-dash rather than guessed. Absolute scores are not comparable to a current-surface run.
+
+**VRAM not recorded — hosted models, or runs from before the VRAM axis**
+
+| Model | Tier | Params | Quant | VRAM | Score |
+| --- | --- | --- | --- | --- | --- |
+| `google/gemini-3.1-pro-preview` | SoTA | — | — | — | 20/20 |
+| `anthropic/claude-opus-4.8` | SoTA | — | — | — | 20/20 |
+| `openai/gpt-5.5` | SoTA | — | — | — | 20/20 |
+| `z-ai/glm-5.1` | B-tier | — | — | — | 19/20 |
+| `moonshotai/kimi-k2.5` | B-tier | — | — | — | 19/20 |
+| `xiaomi/mimo-v2.5` | SoTA | — | — | — | 19/20 |
+| `deepseek/deepseek-v3.2` | B-tier | — | — | — | 17/20 |
+| `minimax/minimax-m3` | B-tier | — | — | — | 17/20 |
+| `x-ai/grok-4.3` | SoTA | — | — | — | 15/20 |
+| `artokun/gemma4-comfyui-mcp:e4b` | local | — | — | — | 14/20 |
+| `qwen3:4b` | local | — | — | — | 13/20 |
+| `artokun/gemma4-comfyui-mcp:12b` | local | — | — | — | 13/20 |
+| `gemma4:e4b` | local | — | — | — | 12/20 |
+| `qwen3:8b` | local | — | — | — | 11/20 |
+| `gemma4:e2b` | local | — | — | — | 8/20 |
+| `artokun/gemma4-comfyui-mcp:e2b` | local | — | — | — | 4/20 |
+| `llama3.1:8b` | local | — | — | — | 2/20 |
+
+Replace `benchmarks/arena-baseline.json` with a current-surface `arena-results.json` and re-run `node scripts/arena-baseline.mjs` to refresh this table. A run that recorded resident VRAM groups itself into **Fits 8 GB**.
+
+17 models, best-of-3 on the top cluster. The headline findings:
 
 - **gemini-3.1-pro-preview is the only model that's perfect every run** (20-20-20).
 - claude-opus-4.8 and gpt-5.5 both reach 20 but dropped a point in other runs.

--- a/scripts/arena-baseline.mjs
+++ b/scripts/arena-baseline.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Render the published community baseline table (#792 ask 3).
+//
+//   node scripts/arena-baseline.mjs
+//   node scripts/arena-baseline.mjs path/to/arena-results.json
+//   ARENA_VRAM_CAP_GIB=12 node scripts/arena-baseline.mjs
+//
+// Default input is benchmarks/arena-baseline.json — replace that file with a
+// current-surface arena-results.json (VRAM/quant stamped) when a fresh ladder
+// lands. The docs page embeds this function's output verbatim.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCommunityBaseline } from "./arena-report.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const path = process.argv[2] ?? join(ROOT, "benchmarks", "arena-baseline.json");
+const cap = Number(process.env.ARENA_VRAM_CAP_GIB ?? 8);
+const data = JSON.parse(readFileSync(path, "utf8"));
+process.stdout.write(buildCommunityBaseline(data, { capGiB: cap }));

--- a/scripts/arena-graphic.mjs
+++ b/scripts/arena-graphic.mjs
@@ -9,6 +9,7 @@
 // names its tier in ink.
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { graphicAxisHint } from "./arena-report.mjs";
 
 const resultsPath = process.argv[2] ?? join(process.cwd(), "arena-results", "arena-results.json");
 const data = JSON.parse(readFileSync(resultsPath, "utf8"));
@@ -88,9 +89,11 @@ function render(mode) {
     const runs = m.runs?.totals;
     const range = runs && runs.length > 1 ? `${Math.min(...runs)}–${Math.max(...runs)}` : null;
     const name = m.model.length > 34 ? `${m.model.slice(0, 33)}…` : m.model;
+    const hint = graphicAxisHint(m);
+    const sub = hint ? `${m.tier ?? "local"} · ${hint}` : (m.tier ?? "local");
     parts.push(
       `<text x="${PAD}" y="${cy - 1}" font-size="12.5" font-weight="600" fill="${c.inkPrimary}">${esc(name)}</text>`,
-      `<text x="${PAD}" y="${cy + 12}" font-size="10" fill="${c.inkSecondary}">${esc(m.tier ?? "local")}</text>`,
+      `<text x="${PAD}" y="${cy + 12}" font-size="10" fill="${c.inkSecondary}">${esc(sub)}</text>`,
       // track + bar: thin mark, 4px rounded DATA end only (square baseline end)
       `<rect x="${plotX}" y="${cy - BAR_H / 2}" width="${plotW}" height="${BAR_H}" fill="${c.track}"/>`,
       `<path d="M ${plotX} ${cy - BAR_H / 2} H ${plotX + w - 4} a 4 4 0 0 1 4 4 v ${BAR_H - 8} a 4 4 0 0 1 -4 4 H ${plotX} Z" fill="${color}"/>`,

--- a/scripts/arena-report.mjs
+++ b/scripts/arena-report.mjs
@@ -13,6 +13,10 @@
 // Plus the methodology guard: a scenario where EVERY model failed after
 // reaching for the same wrong tool reads as OUR description bug, not a
 // field-wide capability gap (#557/#654 precedent) — flagged, never asserted.
+//
+// Ask 3 is the published community baseline: buildCommunityBaseline renders a
+// consultable table (grouped by card capacity when VRAM was recorded) from
+// benchmarks/arena-baseline.json, which docs/arena.mdx embeds verbatim.
 
 /** Resident VRAM as "GiB" with one decimal, or null when unknown. */
 export function vramLabel(bytes) {
@@ -102,6 +106,107 @@ export function axisCell(entry, axis) {
     return one ? `${one} GiB` : "—";
   }
   return entry[axis] ?? "—";
+}
+
+const GIB = 1024 * 1024 * 1024;
+
+/**
+ * Whether an entry's measured resident VRAM fits a card of `capGiB`.
+ * `true` / `false` only when VRAM was recorded as one condition; `null` when
+ * it was never recorded or the best-of range mixed two different footprints
+ * — unknown is not a fit.
+ */
+export function fitsVramCap(entry, capGiB) {
+  if (!entry || entry.mixedAxes?.includes("vram")) return null;
+  const bytes = entry.vramResidentBytes;
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return null;
+  if (typeof capGiB !== "number" || !Number.isFinite(capGiB) || capGiB <= 0) return null;
+  return bytes <= capGiB * GIB;
+}
+
+/**
+ * Partition a leaderboard by card capacity. Order inside each group is the
+ * input order (already ranked). Unknown VRAM is its own group so an 8 GB
+ * reader never has an unmeasured row presented as a fit.
+ */
+export function communityBaselineGroups(leaderboard, capGiB) {
+  const fits = [];
+  const over = [];
+  const unknown = [];
+  for (const m of leaderboard ?? []) {
+    const fit = fitsVramCap(m, capGiB);
+    if (fit === true) fits.push(m);
+    else if (fit === false) over.push(m);
+    else unknown.push(m);
+  }
+  return { fits, over, unknown };
+}
+
+/** Second-line hint for the leaderboard graphic: params/quant/VRAM when known. */
+export function graphicAxisHint(entry) {
+  const bits = [];
+  for (const axis of ["params", "quant", "vram"]) {
+    const cell = axisCell(entry, axis);
+    if (cell !== "—") bits.push(cell);
+  }
+  return bits.join(" · ");
+}
+
+function scoreCell(m) {
+  const totals = m.runs?.totals;
+  if (Array.isArray(totals) && totals.length > 1) {
+    return `${m.total}/${m.max} (best of ${totals.length}: ${Math.min(...totals)}–${Math.max(...totals)})`;
+  }
+  return `${m.total}/${m.max}`;
+}
+
+function baselineRows(entries) {
+  return entries.map(
+    (m) =>
+      `| \`${m.model}\` | ${m.tier ?? "local"} | ${axisCell(m, "params")} | ${axisCell(m, "quant")} | ${axisCell(m, "vram")} | ${scoreCell(m)} |`,
+  );
+}
+
+function versionCaveat(board) {
+  const versions = [...new Set(board.map((m) => m.mcpVersion).filter(Boolean))];
+  const unversioned = board.some((m) => !m.mcpVersion);
+  if (versions.length === 1 && !unversioned) {
+    return `Recorded with comfyui-mcp v${versions[0]} — scores are only directly comparable within the same comfyui-mcp version.`;
+  }
+  if (!versions.length) {
+    return "These runs were recorded before version stamping (or could not read their package version). Absolute scores move when the tool surface changes — do not compare them to a current-surface run as if they were one ladder.";
+  }
+  return `⚠️ This baseline mixes recordings (versions ${versions.map((v) => `v${v}`).join(", ")}${unversioned ? " and unversioned runs — recorded before version stamping, or whose own version could not be read" : ""}) — do NOT compare scores across them directly.`;
+}
+
+/**
+ * Compact community baseline (#792 ask 3): a table someone can consult
+ * without running the arena. Groups by card capacity when VRAM was recorded
+ * (default 8 GB — the reporter's question) and leaves unmeasured rows in
+ * their own group rather than guessing them into a fit.
+ */
+export function buildCommunityBaseline(data, opts = {}) {
+  const capGiB = opts.capGiB ?? 8;
+  const board = data.leaderboard ?? [];
+  const { fits, over, unknown } = communityBaselineGroups(board, capGiB);
+  const header = "| Model | Tier | Params | Quant | VRAM | Score |";
+  const sep = "| --- | --- | --- | --- | --- | --- |";
+  const md = [];
+  md.push(
+    "Consultable without running the ladder. Resident VRAM is the model's footprint while it is loaded (Ollama `/api/ps`), not remaining headroom — ComfyUI shares the same card. Params/Quant come from `/api/show`. Hosted endpoints have no equivalent; those cells stay `—`, never guessed.",
+    "",
+  );
+  md.push(versionCaveat(board), "");
+  if (data.gpu) md.push(`Hardware: ${data.gpu}.`, "");
+  if (data.source) md.push(data.source, "");
+  const section = (title, rows) => {
+    if (!rows.length) return;
+    md.push(`**${title}**`, "", header, sep, ...baselineRows(rows), "");
+  };
+  section(`Fits ${capGiB} GB (resident VRAM ${capGiB} GiB or under)`, fits);
+  section(`Needs more than ${capGiB} GB`, over);
+  section("VRAM not recorded — hosted models, or runs from before the VRAM axis", unknown);
+  return `${md.join("\n")}\n`;
 }
 
 const nudgesOf = (m) => m.results.reduce((s, r) => s + (r.nudges ?? 0), 0);

--- a/src/__tests__/arena-report.test.ts
+++ b/src/__tests__/arena-report.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 // @ts-expect-error plain-JS module under scripts/, no type declarations
-import { axisCell, buildArenaReport, mergeRunAxes, suspectScenarioLines, vramLabel } from "../../scripts/arena-report.mjs";
+import { axisCell, buildArenaReport, buildCommunityBaseline, fitsVramCap, graphicAxisHint, mergeRunAxes, suspectScenarioLines, vramLabel } from "../../scripts/arena-report.mjs";
 
 function entry(over: Record<string, unknown>) {
   return {
@@ -424,5 +424,90 @@ describe("a best-of range must not display ONE condition it did not all run unde
     expect(md).toContain("| mixed |"); // the quant cell
     expect(md).toContain("5.0–6.0 GiB");
     expect(md).toContain("not tied");
+  });
+});
+
+describe("community baseline (#792 ask 3)", () => {
+  const GIB = 1024 * 1024 * 1024;
+  const ROOT = join(__dirname, "..", "..");
+
+  it("groups a measured 8 GB-or-under model as a fit and prints the same VRAM cell the report uses", () => {
+    const small = entry({
+      model: "gemma4:e4b",
+      params: "4B",
+      quant: "Q4_K_M",
+      vramResidentBytes: Math.round(6.3 * GIB),
+      total: 14,
+      max: 20,
+      mcpVersion: "0.52.4",
+    });
+    const md = buildCommunityBaseline({ gpu: "RTX 3070", leaderboard: [small] }, { capGiB: 8 });
+    expect(fitsVramCap(small, 8)).toBe(true);
+    expect(md).toContain("| Model | Tier | Params | Quant | VRAM | Score |");
+    expect(md).toContain(axisCell(small, "vram"));
+    expect(md).toContain(axisCell(small, "quant"));
+    expect(md).toContain("`gemma4:e4b`");
+    expect(md).toMatch(new RegExp(`Fits 8 GB[\\s\\S]*${axisCell(small, "vram").replace(".", "\\.")}`));
+    expect(md).toContain("v0.52.4");
+    expect(md).toContain("RTX 3070");
+  });
+
+  it("does not list a model that needs more VRAM as a fit, and never guesses unmeasured VRAM into Fits", () => {
+    const big = entry({ model: "big:70b", vramResidentBytes: 12 * GIB, total: 16, max: 20 });
+    const tiny = entry({ model: "tiny:1b", vramResidentBytes: 3 * GIB, total: 8, max: 20 });
+    const hosted = entry({ model: "openai/gpt-5.5", tier: "SoTA", total: 20, max: 20 });
+    const md = buildCommunityBaseline({ leaderboard: [big, tiny, hosted] }, { capGiB: 8 });
+    const [fitsPart, afterFits] = md.split("**Needs more than 8 GB**");
+    const [overPart, unknownPart] = afterFits.split("**VRAM not recorded");
+    expect(fitsPart).toContain("`tiny:1b`");
+    expect(fitsPart).not.toContain("`big:70b`");
+    expect(fitsPart).not.toContain("`openai/gpt-5.5`");
+    expect(overPart).toContain("`big:70b`");
+    expect(overPart).not.toContain("`tiny:1b`");
+    expect(unknownPart).toContain("`openai/gpt-5.5`");
+    expect(unknownPart).toMatch(/\| `openai\/gpt-5.5` \| SoTA \| — \| — \| — \|/);
+    expect(fitsVramCap(hosted, 8)).toBeNull();
+    expect(fitsVramCap({ mixedAxes: ["vram"], vramResidentBytes: 4 * GIB }, 8)).toBeNull();
+  });
+
+  it("the published arena page embeds the table rendered from the committed baseline JSON", () => {
+    const data = JSON.parse(readFileSync(join(ROOT, "benchmarks", "arena-baseline.json"), "utf8"));
+    const table = buildCommunityBaseline(data, { capGiB: 8 });
+    const page = readFileSync(join(ROOT, "docs", "arena.mdx"), "utf8").replace(/\r\n/g, "\n");
+    expect(page).toContain(table.trim());
+    expect(table).toContain("| Params | Quant | VRAM | Score |");
+    for (const m of data.leaderboard) {
+      expect(table).toContain(`\`${m.model}\``);
+      expect(table).toContain(axisCell(m, "vram"));
+    }
+  });
+
+  it("graphicAxisHint names only recorded axes", () => {
+    const measured = entry({ params: "4B", quant: "Q4_K_M", vramResidentBytes: 4 * GIB });
+    expect(graphicAxisHint(measured)).toBe(`${axisCell(measured, "params")} · ${axisCell(measured, "quant")} · ${axisCell(measured, "vram")}`);
+    expect(graphicAxisHint(entry({}))).toBe("");
+  });
+});
+
+describe("arena graphic VRAM hint (#792)", () => {
+  const GIB = 1024 * 1024 * 1024;
+  const GRAPHIC = join(__dirname, "..", "..", "scripts", "arena-graphic.mjs");
+
+  it("prints the VRAM cell on the row when results recorded it", () => {
+    const row = {
+      model: "gemma4:e4b",
+      tier: "local",
+      total: 14,
+      max: 20,
+      quant: "Q4_K_M",
+      vramResidentBytes: Math.round(6.3 * GIB),
+    };
+    const dir = mkdtempSync(join(tmpdir(), "arena-graphic-"));
+    writeFileSync(join(dir, "arena-results.json"), JSON.stringify({ gpu: "RTX 3070", leaderboard: [row] }));
+    const r = spawnSync(process.execPath, [GRAPHIC, join(dir, "arena-results.json")], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    const svg = readFileSync(join(dir, "arena-leaderboard-light.svg"), "utf8");
+    expect(svg).toContain(axisCell(row, "vram"));
+    expect(svg).toContain(axisCell(row, "quant"));
   });
 });


### PR DESCRIPTION
#792 ask 3 — the published community baseline.

VRAM, quantization, attempted-tool recording, and version stamping already landed in #842 / #880. What was still missing is a table someone can consult without running the ladder.

This ships that table:

- `buildCommunityBaseline` renders Model / Params / Quant / VRAM / Score from `benchmarks/arena-baseline.json`
- Rows with a measured resident VRAM group into **Fits 8 GB** or **Needs more than 8 GB**; unmeasured rows stay in their own group (never guessed into a fit)
- `docs/arena.mdx` embeds that output verbatim (test-gated so the page cannot drift from the JSON)
- The leaderboard graphic now names Params/Quant/VRAM on a row when the run recorded them

This is not a current-surface hardware run. The committed numbers are the already-published 4090 ladder (2026-07-09). Those runs predate the VRAM/quant probes and the 0.50 tool-surface change, so those cells are em-dash and the table says so. Drop a current-surface `arena-results.json` on `benchmarks/arena-baseline.json` and `node scripts/arena-baseline.mjs` refreshes the page.

Does not close #792 — asks 1–2 and the methodology caveat are already on main; this is the doc-surface slice of ask 3.
