### PR TITLE
fix(1235): a pi resume-miss drops the dead session id and retries the turn fresh

### DIFF
--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -492,6 +492,63 @@ describe("PiBackend turns", () => {
     expect(events[0]).toMatchObject({ type: "session", sessionId: "sess-existing" });
   });
 
+  // #1235 — a resumed turn whose session pi no longer has ("No session found
+  // matching '<id>'": pruned store, different cwd/home, or a foreign id armed
+  // from the panel's hello.resume hint) must drop the dead id and re-run the
+  // turn ONCE as a fresh session — the pre-fix behavior failed every turn until
+  // the user typed /new.
+  it("self-heals a resume-miss: drops the dead id and retries the turn fresh (#1235)", async () => {
+    hoisted.script.push(
+      { stdout: [], stderr: "Error: No session found matching 'dead-id'", exit: 1 },
+      { stdout: [header("fresh-id"), delta("Recovered"), END], exit: 0 },
+    );
+    const backend = new PiBackend({ cwd: workDir, systemAppend: "PERSONA" });
+    const events = await collect(backend.run({ resume: "dead-id", channel: channelOf([{ text: "hi" }]) }));
+
+    // The miss produced NO error/failed result — the retry's success is the
+    // turn's single terminal outcome.
+    expect(events.some((e) => e.type === "error")).toBe(false);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: true, subtype: "end_turn", turn: 1 },
+    ]);
+    // The retry ran FRESH (no --session), re-armed the suppressed preamble, and
+    // re-sent the user's message.
+    expect(hoisted.spawns.length).toBe(2);
+    expect(hoisted.spawns[0]!.args[hoisted.spawns[0]!.args.indexOf("--session") + 1]).toBe("dead-id");
+    expect(hoisted.spawns[1]!.args).not.toContain("--session");
+    expect(hoisted.spawns[1]!.args.at(-1)).toContain("PERSONA");
+    expect(hoisted.spawns[1]!.args.at(-1)).toContain("hi");
+    // The fresh session's id replaced the dead one, so the NEXT turn resumes it.
+    expect(events.some((e) => e.type === "session" && (e as { sessionId: string }).sessionId === "fresh-id")).toBe(true);
+  });
+
+  it("a resume-miss whose FRESH retry also fails surfaces the retry's error once (#1235)", async () => {
+    hoisted.script.push(
+      { stdout: [], stderr: "Error: No session found matching 'dead-id'", exit: 1 },
+      { stdout: [], stderr: "boom: quota exceeded", exit: 7 },
+    );
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ resume: "dead-id", channel: channelOf([{ text: "hi" }]) }));
+    // Exactly one retry (no loop), and the surfaced failure is the FRESH
+    // attempt's — the more accurate cause.
+    expect(hoisted.spawns.length).toBe(2);
+    const err = events.find((e) => e.type === "error") as { message: string };
+    expect(err.message).toContain("code 7");
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "error", turn: 1 },
+    ]);
+  });
+
+  it("a FRESH turn failing with the miss text is NOT retried (nothing was resumed)", async () => {
+    hoisted.script.push({ stdout: [], stderr: "Error: No session found matching 'x'", exit: 1 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    expect(hoisted.spawns.length).toBe(1);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "error", turn: 1 },
+    ]);
+  });
+
   it("maps a credential-looking failure to provider-setup guidance", async () => {
     hoisted.script.push({ stdout: [], stderr: "no provider configured: set an API key", exit: 1 });
     const backend = new PiBackend({ cwd: workDir });

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -357,11 +357,23 @@ export class PiBackend implements AgentBackend {
    *  tool_call events, the session header reveals the resumable id. Exit 0 commits
    *  the accumulated text + a successful result; a non-zero exit (or spawn
    *  failure) surfaces an error + failed result. Exactly one terminal result per
-   *  turn (PanelAgent's gate depends on it). */
+   *  turn (PanelAgent's gate depends on it).
+   *
+   *  RESUME-MISS SELF-HEAL (artokun/comfyui-mcp-panel#1235): a RESUMED turn that
+   *  dies with pi's "No session found matching '<id>'" has a dead resume target
+   *  (pruned session store, different cwd/home, a foreign id armed from the
+   *  panel's hello.resume hint). Retrying the SAME resume would fail every turn
+   *  forever — the panel's `/new` workaround exists precisely because nothing
+   *  dropped the dead id. So drop it and re-run THIS turn once as a fresh
+   *  session (isRetry guards against a loop); the new header re-persists a valid
+   *  id up the stack. The claude/codex equivalents self-heal in PanelAgent's
+   *  catch (#277); pi yields error EVENTS instead of throwing, so the heal lives
+   *  here. */
   private async *runTurn(
     turn: NeutralTurn,
     cwd: string,
     onActivity?: () => void,
+    isRetry = false,
   ): AsyncGenerator<AgentEvent> {
     let text = promptText(turn.text);
     // System blocks, in order: the heavy panel preamble (FIRST fresh turn only)
@@ -560,6 +572,9 @@ export class PiBackend implements AgentBackend {
 
     let settled = false;
     let exitFallback: ReturnType<typeof setTimeout> | null = null;
+    // Set by settle() when the failure IS the resume-miss: the dead id is dropped
+    // and this turn re-runs once as a fresh session (see the runTurn docstring).
+    let resumeMiss = false;
     const settle = (code: number | null, spawnErr?: Error) => {
       if (settled) return;
       settled = true;
@@ -585,20 +600,26 @@ export class PiBackend implements AgentBackend {
         push({ type: "result", ok: false, subtype: "timeout" });
       } else if (spawnErr || code !== 0) {
         const stderrTail = stripAnsi(errOut).trim().split(/\r?\n/).slice(-3).join(" ").trim();
-        const authish = looksLikeAuthFailure(stderrTail + finalText);
-        // #948 — pi's own text says "please run /login", which in a chat panel
-        // reads as "type this here" and sends the user somewhere it cannot work.
-        // Every path that passes the child's words through is qualified, not just
-        // the auth one: a non-auth failure can name a slash command too.
-        const message = spawnErr
-          ? /ENOENT/i.test(spawnErr.message)
-            ? "pi CLI (`pi`) could not be launched — it may have been uninstalled. Reinstall from https://pi.dev and reconnect."
-            : `pi failed to start: ${spawnErr.message}`
-          : authish
-            ? providerAuthRemedy("pi", stderrTail)
-            : `pi exited with code ${code}.${stderrTail ? ` ${qualifySlashCommands(stderrTail, "pi")}` : ""}`;
-        push({ type: "error", message });
-        push({ type: "result", ok: false, subtype: "error" });
+        if (!spawnErr && resuming && !isRetry && /no session found matching/i.test(stderrTail)) {
+          // RESUME-MISS (#1235): drop the dead id and retry fresh below — push NO
+          // error/result, so the turn's single terminal event comes from the retry.
+          resumeMiss = true;
+        } else {
+          const authish = looksLikeAuthFailure(stderrTail + finalText);
+          // #948 — pi's own text says "please run /login", which in a chat panel
+          // reads as "type this here" and sends the user somewhere it cannot work.
+          // Every path that passes the child's words through is qualified, not just
+          // the auth one: a non-auth failure can name a slash command too.
+          const message = spawnErr
+            ? /ENOENT/i.test(spawnErr.message)
+              ? "pi CLI (`pi`) could not be launched — it may have been uninstalled. Reinstall from https://pi.dev and reconnect."
+              : `pi failed to start: ${spawnErr.message}`
+            : authish
+              ? providerAuthRemedy("pi", stderrTail)
+              : `pi exited with code ${code}.${stderrTail ? ` ${qualifySlashCommands(stderrTail, "pi")}` : ""}`;
+          push({ type: "error", message });
+          push({ type: "result", ok: false, subtype: "error" });
+        }
       } else {
         if (finalText) push({ type: "assistant", text: finalText });
         push({ type: "result", ok: true, subtype: "end_turn" });
@@ -646,6 +667,17 @@ export class PiBackend implements AgentBackend {
         this.turnActive = false;
         this.interrupted = false;
       }
+    }
+
+    if (resumeMiss) {
+      // The dead resume id must NEVER be retried, and the fresh session needs the
+      // panel preamble a resume suppresses. The retried turn re-reads both.
+      logger.warn(
+        `[pi-backend] resume target ${this.piSessionId} is gone (pi: no session found matching) — dropping it and retrying the turn as a fresh session (#1235)`,
+      );
+      this.piSessionId = null;
+      this.needsSystemPreamble = !!this.deps.systemAppend;
+      yield* this.runTurn(turn, cwd, onActivity, true);
     }
   }
 


### PR DESCRIPTION
## Root cause

Reported in artokun/comfyui-mcp-panel#1235: switching to the pi backend (or any resume of a pi session pi no longer has) failed every turn with

> pi exited with code 1. No session found matching '019fc985-…'

until the user worked around it with `/new`. The dead resume id was never dropped, so each subsequent turn re-attempted the same `--session <dead-id>` and failed identically. The id can go stale several ways: pi's session store pruned, the orchestrator relaunched under a different cwd/home (the reporter runs it under a nologin user), or a foreign/stale id armed from the panel's `hello.resume` last-resort hint.

The claude/codex equivalents of this condition self-heal in PanelAgent's stream-error catch (#277: "No conversation found with session ID" / "no rollout found for thread id" → drop the id, restart fresh, replay the message). That catch never fires for pi, because the pi backend yields error **events** instead of throwing — so the heal has to live in the pi backend.

## Fix

In `PiBackend.runTurn()` (src/orchestrator/pi-backend.ts): when a **resumed** turn exits non-zero and stderr carries pi's "No session found matching" text, push no error/result, drop the dead session id, re-arm the suppressed system preamble, and re-run the same turn **once** as a fresh session (`isRetry` guards against a loop). The fresh run's session header re-persists a valid id up the stack, so the next turn resumes normally. If the fresh retry also fails, its (more accurate) error is what surfaces.

## Verification

- `npx vitest run src/__tests__/orchestrator/pi-backend.test.ts` — 34/34 pass, including 3 new tests: self-heal success path (fresh retry carries the preamble + user text, new session id re-emitted, no error event), retry-also-fails surfaces the retry's error exactly once, and a **fresh** turn failing with the miss text is not retried.
- `npm run build` (tsc) clean.
- Full `npm test` chain: 10427 passed; 4 failures were load-induced 30s timeouts in the unrelated `tools/vocabulary.test.ts` (machine under heavy parallel load — transform alone took 864s); that file passes standalone in 3.8s (57/57). The remaining chain gates (`i18n:check`, `check:docs-links`, `check:docs-locale`, `check:docs-mdx`, `check:blog*`) all pass.

Closes artokun/comfyui-mcp-panel#1235