### PR TITLE
fix(1656): a CARRIED workflow stamp is not the routed tab's advertisement — the agreement gate stops being satisfied by the carry

### DIFF
--- a/src/__tests__/orchestrator/carried-stamp-corroboration.test.ts
+++ b/src/__tests__/orchestrator/carried-stamp-corroboration.test.ts
@@ -1,0 +1,121 @@
+// #1656 — the OTHER half: a carried stamp that the live canvas CONFIRMS must stop
+// being treated as inherited, or the fix is worse than the bug.
+//
+// The dispatch gate refuses an active-canvas command while the routed tab's stamp is
+// one CARRIED onto a new tab id by a same-socket re-hello that could not resolve an
+// identity. That window is entered by a rename/save whose hello merely RACED the
+// canvas identity — where the canvas is in fact the very workflow the caller named.
+// Left alone, the session would keep refusing edits to a canvas the panel agrees is
+// correct, and the reporter of #1330 has already shown what that costs (14 refusals).
+//
+// So the read-only mismatch probe carries the repair. When the corroborated
+// `workflow_list` says the LIVE canvas is the same instance the fence already names,
+// that is an observation of the tab under its CURRENT id: the value is confirmed and
+// the provenance is promoted from inherited to observed, through the orchestrator's
+// validator (reachability + origin-bound uuid shape), never off the refusal's prose.
+//
+// It is NOT the retarget #1646 removed. The uuid written is the one this branch has
+// just established EQUALS the fence in force, so nothing is re-aimed — the DIVERGED
+// case (live canvas is a different workflow) still adopts nothing at all.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:route1:workflows/krea2_lora_ab_compare.json";
+const CARRIED_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OTHER_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+/** The bridge's #1656 refusal, verbatim in shape: pre-dispatch, typed dispatched:false,
+ *  and carrying the stamp in the form panel-tools reads back. */
+const carriedRefusal = (): Error =>
+  markDispatched(
+    new Error(
+      `workflow instance mismatch: this command was issued for workflow instance ${CARRIED_UUID}, ` +
+        `and the tab it routed to has not re-established its workflow identity since it ` +
+        `re-registered under a new id — the uuid it currently carries (${CARRIED_UUID}) was ` +
+        `inherited from the tab id it replaced, so it is not evidence about the canvas now ` +
+        `mounted there. Nothing was dispatched. Re-target with ` +
+        `panel_set_workflow_target({mode:"current"}), then retry.`,
+    ),
+    false,
+  );
+
+function harness(liveUuid: string) {
+  /** Every uuid handed to the orchestrator's validator by this call. */
+  const refreshed: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        const active = {
+          path: "workflows/krea2_lora_ab_compare.json",
+          routing_key: TAB,
+          workflow_uuid: liveUuid,
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      throw carriedRefusal();
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      refreshed.push(uuid);
+      return true;
+    },
+    // The session's fence — the carried uuid the command was issued for.
+    workflowUuidFor: () => ({ known: true, uuid: CARRIED_UUID }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge: b, refreshed };
+}
+
+async function connect(liveUuid: string): Promise<{
+  text: string;
+  res: ToolResult;
+  refreshed: string[];
+}> {
+  const { bridge, refreshed } = harness(liveUuid);
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_connect");
+  if (!def) throw new Error("panel_connect is not registered");
+  const res: ToolResult = await def.handler(
+    { from_node: 1, from_slot: 0, to_node: 2, to_slot: 0 } as never,
+    ctx,
+  );
+  return { text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "), res, refreshed };
+}
+
+describe("#1656 — a carried stamp the live canvas CONFIRMS is corroborated, not left inherited", () => {
+  it("promotes the provenance when workflow_list names the SAME instance", async () => {
+    const { text, refreshed } = await connect(CARRIED_UUID);
+    // The corroboration ran, and it wrote back exactly the uuid already in force —
+    // so no target moved; only the evidence behind it did.
+    expect(refreshed).toEqual([CARRIED_UUID]);
+    // The verdict is unchanged: still the transient reading, still one informed retry.
+    expect(text).toMatch(/TRANSIENT/);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // And the refusal itself is preserved — the call still fails.
+    expect(text).toMatch(/workflow instance mismatch/);
+  });
+
+  it("adopts NOTHING when the live canvas is a DIFFERENT workflow (#1646 stands)", async () => {
+    const { text, refreshed } = await connect(OTHER_UUID);
+    expect(refreshed).toEqual([]);
+    expect(text).toMatch(/DIFFERENT workflow/);
+    expect(text).toContain(OTHER_UUID);
+    // The fence stays on the workflow the caller named, so later edits keep being
+    // refused rather than landing on the other canvas.
+    expect(text).toMatch(/The fence is unchanged/);
+  });
+});

--- a/src/__tests__/orchestrator/carried-stamp-corroboration.test.ts
+++ b/src/__tests__/orchestrator/carried-stamp-corroboration.test.ts
@@ -12,11 +12,15 @@
 // `workflow_list` says the LIVE canvas is the same instance the fence already names,
 // that is an observation of the tab under its CURRENT id: the value is confirmed and
 // the provenance is promoted from inherited to observed, through the orchestrator's
-// validator (reachability + origin-bound uuid shape), never off the refusal's prose.
+// identity validator, never off the refusal's prose.
 //
-// It is NOT the retarget #1646 removed. The uuid written is the one this branch has
-// just established EQUALS the fence in force, so nothing is re-aimed — the DIVERGED
-// case (live canvas is a different workflow) still adopts nothing at all.
+// It goes through `corroborateTabStamp`, NOT `refreshWorkflowUuid` — and the difference
+// is the whole safety argument. `refreshWorkflowUuid` WRITES a stamp (and a
+// conversation's issue-time stamp with it), which is precisely the retarget #1646
+// removed from this probe. `corroborateTabStamp` writes no stamp at all: the
+// orchestrator re-checks that the uuid ALREADY equals the tab's current stamp and
+// refuses outright when it does not, so the only thing it can change is a provenance
+// bit. The DIVERGED case — live canvas is a different workflow — reaches neither.
 
 import { describe, expect, it } from "vitest";
 
@@ -49,8 +53,10 @@ const carriedRefusal = (): Error =>
   );
 
 function harness(liveUuid: string) {
-  /** Every uuid handed to the orchestrator's validator by this call. */
-  const refreshed: string[] = [];
+  /** Every uuid offered to the provenance-only corroborator by this call. */
+  const corroborated: string[] = [];
+  /** Every uuid handed to the RETARGETING fence write — must stay empty here. */
+  const retargeted: string[] = [];
   const b = {
     send: async (cmd: Record<string, unknown>) => {
       if (cmd.cmd === "workflow_list") {
@@ -68,8 +74,15 @@ function harness(liveUuid: string) {
     isHeadless: () => false,
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => TAB,
+    // The RETARGETING write. It must never be reached by a read-only mismatch probe.
     refreshWorkflowUuid: (_tabId: string, uuid: string) => {
-      refreshed.push(uuid);
+      retargeted.push(uuid);
+      return true;
+    },
+    // The provenance-only promotion. The real implementation refuses unless the uuid
+    // already equals the tab's stamp; this records what it was offered.
+    corroborateTabStamp: (_tabId: string, uuid: string) => {
+      corroborated.push(uuid);
       return true;
     },
     // The session's fence — the carried uuid the command was issued for.
@@ -77,15 +90,16 @@ function harness(liveUuid: string) {
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];
-  return { bridge: b, refreshed };
+  return { bridge: b, corroborated, retargeted };
 }
 
 async function connect(liveUuid: string): Promise<{
   text: string;
   res: ToolResult;
-  refreshed: string[];
+  corroborated: string[];
+  retargeted: string[];
 }> {
-  const { bridge, refreshed } = harness(liveUuid);
+  const { bridge, corroborated, retargeted } = harness(liveUuid);
   const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_connect");
   if (!def) throw new Error("panel_connect is not registered");
@@ -93,15 +107,21 @@ async function connect(liveUuid: string): Promise<{
     { from_node: 1, from_slot: 0, to_node: 2, to_slot: 0 } as never,
     ctx,
   );
-  return { text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "), res, refreshed };
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    res,
+    corroborated,
+    retargeted,
+  };
 }
 
 describe("#1656 — a carried stamp the live canvas CONFIRMS is corroborated, not left inherited", () => {
   it("promotes the provenance when workflow_list names the SAME instance", async () => {
-    const { text, refreshed } = await connect(CARRIED_UUID);
-    // The corroboration ran, and it wrote back exactly the uuid already in force —
-    // so no target moved; only the evidence behind it did.
-    expect(refreshed).toEqual([CARRIED_UUID]);
+    const { text, corroborated, retargeted } = await connect(CARRIED_UUID);
+    // The corroboration ran, offering exactly the uuid already in force — and the
+    // RETARGETING write was not reached at all, so no fence moved.
+    expect(corroborated).toEqual([CARRIED_UUID]);
+    expect(retargeted).toEqual([]);
     // The verdict is unchanged: still the transient reading, still one informed retry.
     expect(text).toMatch(/TRANSIENT/);
     expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
@@ -110,8 +130,9 @@ describe("#1656 — a carried stamp the live canvas CONFIRMS is corroborated, no
   });
 
   it("adopts NOTHING when the live canvas is a DIFFERENT workflow (#1646 stands)", async () => {
-    const { text, refreshed } = await connect(OTHER_UUID);
-    expect(refreshed).toEqual([]);
+    const { text, corroborated, retargeted } = await connect(OTHER_UUID);
+    expect(corroborated).toEqual([]);
+    expect(retargeted).toEqual([]);
     expect(text).toMatch(/DIFFERENT workflow/);
     expect(text).toContain(OTHER_UUID);
     // The fence stays on the workflow the caller named, so later edits keep being

--- a/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
+++ b/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
@@ -1,0 +1,91 @@
+// #1656 — the CALL SITES for the carried-stamp provenance.
+//
+// The behaviour lives in UiBridge.send()'s agreement gate and is driven over a real
+// socket in services/carried-stamp-agreement.test.ts. That suite installs the
+// predicate itself, so it stays green if production never installs one — and an
+// uninstalled predicate is defined to mean "proven", i.e. the exact pre-#1656
+// behaviour with the bug intact. Four one-line wirings decide whether the fix runs at
+// all, and every one of them is invisible to a behavioural test:
+//
+//   1. the hello handler RECORDING that a carry happened,
+//   2. the hello handler CLEARING it when this hello proves an identity,
+//   3. the validated-refresh path CLEARING it (the documented way out), and
+//   4. `bridge.setCarriedTabStampPredicate(...)` being called at all.
+//
+// The hello handler is inline in the orchestrator start function, so — as with the
+// other index.ts boundary guards (shared-session-invariant.test.ts,
+// agent-identity-wiring.test.ts) — the wiring is pinned at source level.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const indexSrc = (): string =>
+  readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+const bridgeSrc = (): string =>
+  readFileSync(new URL("../../services/ui-bridge.ts", import.meta.url), "utf8");
+
+describe("#1656 — carried-stamp provenance is WIRED, not merely available", () => {
+  it("SOURCE: the orchestrator installs the predicate on the bridge", () => {
+    const src = indexSrc();
+    expect(src).toContain("bridge.setCarriedTabStampPredicate(");
+    // …and it answers from the provenance set, resolved through panelTabOf exactly
+    // like the uuid resolver beside it (an agent-key address must give the same
+    // verdict as the bare tab id).
+    const start = src.indexOf("bridge.setCarriedTabStampPredicate(");
+    const block = src.slice(start, start + 400);
+    expect(block).toContain("panelTabOf(tabId)");
+    expect(block).toContain("tabStampCarried.has(");
+    // A scope address is the conversation's issue-time stamp, never a tab
+    // advertisement, so it can never be "carried".
+    expect(block).toContain("isScopeAddress(tabId)");
+  });
+
+  it("SOURCE: the hello handler records the carry and clears it on a proven identity", () => {
+    const src = indexSrc();
+    const start = src.indexOf("if (migratedFrom && migratedFrom !== panelTab) {");
+    expect(start, "migration block not found").toBeGreaterThan(-1);
+    const end = src.indexOf("Record this tab's trusted per-workflow COMMAND STAMP", start);
+    expect(end, "post-migration anchor not found").toBeGreaterThan(start);
+    const block = src.slice(start, end);
+    // The carry's RETURN VALUE decides the provenance — not a re-derivation of what
+    // the carry "ought" to have done.
+    expect(block).toMatch(/if \(carryWorkflowCommandStamp\(tabCommandWorkflowUuid, migratedFrom, panelTab\)\)/);
+    expect(block).toContain("tabStampCarried.add(panelTab)");
+    // The retiring id keeps no provenance entry, exactly as it keeps no stamp.
+    expect(block).toContain("tabStampCarried.delete(migratedFrom)");
+
+    // The stamp-recording branch below the block clears the provenance: an identity
+    // this tab advertised under THIS id supersedes anything inherited.
+    const setIdx = src.indexOf("tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);");
+    expect(setIdx, "hello stamp-set not found").toBeGreaterThan(-1);
+    expect(src.slice(setIdx, setIdx + 300)).toContain("tabStampCarried.delete(panelTab)");
+  });
+
+  it("SOURCE: a VALIDATED refresh clears the provenance — the documented rebind is the way out", () => {
+    const src = indexSrc();
+    const setIdx = src.indexOf("tabCommandWorkflowUuid.set(panelTab, identity.uuid);");
+    expect(setIdx, "refresh stamp-set not found").toBeGreaterThan(-1);
+    expect(src.slice(setIdx, setIdx + 400)).toContain("tabStampCarried.delete(panelTab)");
+  });
+
+  it("SOURCE: the gate consults the predicate, and the recovery probe stays exempt", () => {
+    const src = bridgeSrc();
+    // The gate reads provenance for the CONNECTION's canonical id — the tab the
+    // frame would actually land on — not for the caller's address.
+    expect(src).toContain("this.isCarriedTabStamp?.(conn.tabId) === true");
+    // The refusal is pre-dispatch and typed, like #1682's.
+    const idx = src.indexOf("if (issuedFor && landedOn && carried) {");
+    expect(idx, "carried refusal branch not found").toBeGreaterThan(-1);
+    const branch = src.slice(idx, idx + 1200);
+    expect(branch).toContain("markDispatched(");
+    expect(branch).toContain("has not re-established its workflow identity");
+    expect(branch).toContain('panel_set_workflow_target({mode:"current"})');
+    // It sits INSIDE requiresStampTargetAgreement's guard, so workflow_list /
+    // workflow_open / workflow_new / canvas-independent ops are untouched and the
+    // rebind that clears this state is not gated on the state being already correct
+    // (panel #932's circularity).
+    const gate = src.indexOf("requiresStampTargetAgreement(cmd)) {");
+    expect(gate).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(idx);
+  });
+});

--- a/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
+++ b/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
@@ -4,13 +4,16 @@
 // socket in services/carried-stamp-agreement.test.ts. That suite installs the
 // predicate itself, so it stays green if production never installs one — and an
 // uninstalled predicate is defined to mean "proven", i.e. the exact pre-#1656
-// behaviour with the bug intact. Four one-line wirings decide whether the fix runs at
-// all, and every one of them is invisible to a behavioural test:
+// behaviour with the bug intact. Six wirings decide whether the fix runs at all and
+// whether it stays safe, and every one of them is invisible to a behavioural test:
 //
 //   1. the hello handler RECORDING that a carry happened,
 //   2. the hello handler CLEARING it when this hello proves an identity,
-//   3. the validated-refresh path CLEARING it (the documented way out), and
-//   4. `bridge.setCarriedTabStampPredicate(...)` being called at all.
+//   3. the validated-refresh path CLEARING it (the documented way out),
+//   4. `bridge.setCarriedTabStampPredicate(...)` being called at all,
+//   5. `bridge.setTabStampCorroborator(...)` refusing any uuid that does not ALREADY
+//      match — the guarantee that the self-healing path cannot retarget a session, and
+//   6. the read-only mismatch probe calling the corroborator and NOT the fence write.
 //
 // The hello handler is inline in the orchestrator start function, so — as with the
 // other index.ts boundary guards (shared-session-invariant.test.ts,
@@ -66,6 +69,37 @@ describe("#1656 — carried-stamp provenance is WIRED, not merely available", ()
     const setIdx = src.indexOf("tabCommandWorkflowUuid.set(panelTab, identity.uuid);");
     expect(setIdx, "refresh stamp-set not found").toBeGreaterThan(-1);
     expect(src.slice(setIdx, setIdx + 400)).toContain("tabStampCarried.delete(panelTab)");
+  });
+
+  it("SOURCE: the corroborator is installed, and it can only promote a MATCHING value", () => {
+    const src = indexSrc();
+    expect(src).toContain("bridge.setTabStampCorroborator(");
+    const start = src.indexOf("bridge.setTabStampCorroborator(");
+    const block = src.slice(start, start + 1400);
+    // The uuid is validated exactly like every other identity acceptance — never a
+    // bare string off a reply.
+    expect(block).toContain("workflowIdentityParts({");
+    // THE SAFETY ARGUMENT, enforced here rather than trusted from the caller: a uuid
+    // that does not ALREADY equal this tab's stamp is refused, so nothing can be
+    // retargeted through this path.
+    expect(block).toContain("if (tabCommandWorkflowUuid.get(panelTab) !== identity.uuid) return false;");
+    // …and the only write it performs is the provenance bit.
+    expect(block).toContain("tabStampCarried.delete(panelTab)");
+    expect(block).not.toContain("tabCommandWorkflowUuid.set(");
+    expect(block).not.toContain("turnOrigins.setStamp(");
+  });
+
+  it("SOURCE: the read-only mismatch probe corroborates, and never RETARGETS", () => {
+    const toolsSrc = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf8",
+    );
+    const idx = toolsSrc.indexOf('if (before.known && before.uuid === uuid) {');
+    expect(idx, "already_current branch not found").toBeGreaterThan(-1);
+    const branch = toolsSrc.slice(idx, toolsSrc.indexOf('return { status: "already_current"', idx));
+    expect(branch).toContain("corroborateTabStamp(ctx, uuid)");
+    // #1646 — the fence-writing call must never appear on this branch.
+    expect(branch).not.toContain("refreshWorkflowUuid(");
   });
 
   it("SOURCE: the gate consults the predicate, and the recovery probe stays exempt", () => {

--- a/src/__tests__/services/carried-stamp-agreement.test.ts
+++ b/src/__tests__/services/carried-stamp-agreement.test.ts
@@ -1,0 +1,272 @@
+// #1656 (recurrence on 0.52.3, which already carries #1682's dispatch gate) —
+// during an `Untitled` → saved-name instance transition six graph mutations
+// returned normal success payloads, none of them persisted, and only the SEVENTH
+// was refused by the instance fence.
+//
+// WHY THE EXISTING GATE WAS SATISFIED. #1682 refuses an active-canvas command
+// when "the session's stamp and the routed tab's LAST-ADVERTISED identity are
+// both known and disagree". The value it reads as the tab's last-advertised
+// identity is `tabCommandWorkflowUuid.get(conn.tabId)` — and on the same-socket
+// re-hello that mints the new tab id (a workflow switch, or the tmp: → wf:
+// transition a save/rename performs), `carryWorkflowCommandStamp` COPIES the
+// retiring id's uuid onto the new id and only overwrites it `if (newIdentity)`.
+// So in the window where the hello could not resolve an identity, the "advertised
+// identity" of the new canvas is the PREVIOUS canvas's uuid.
+//
+// That is not merely "sometimes equal". The conversation's issue-time stamp is
+// captured FROM the same map at user-message time
+// (`turnOrigins.recordForMid(mid, tabCommandWorkflowUuid.get(tab), tab)`), so the
+// carry copies the exact string the session stamp was derived from onto the tab
+// the command will land on. The two sides of the agreement gate are then EQUAL BY
+// CONSTRUCTION, precisely in the window where the canvas changed — the gate is
+// guaranteed to pass exactly when it is needed. The seventh mutation was refused
+// because by then a hello had finally resolved a real identity for the new canvas.
+//
+// These tests drive the REAL UiBridge over a real socket, and use the REAL
+// `carryWorkflowCommandStamp` the orchestrator's hello handler calls, with the
+// resolver wired the way `orchestrator/index.ts` wires it.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+import { UiBridge, dispatchOutcomeOf } from "../../services/ui-bridge.js";
+import { isScopeAddress } from "../../services/session-scope.js";
+import { carryWorkflowCommandStamp } from "../../orchestrator/session-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/** The Untitled instance's per-instance uuid — the one the turn was issued for. */
+const UUID_UNTITLED = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+/** The identity the saved canvas eventually advertises. */
+const UUID_SAVED = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const TAB_UNSAVED = "tmp:11111111-1111-4111-8111-111111111111";
+const TAB_SAVED = "wf:route1:workflows/krea2_lora_ab_compare.json";
+const SCOPE = "orchestrator::claude";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+describe("#1656 recurrence — a CARRIED stamp is not the routed tab's advertised identity", () => {
+  let bridge: UiBridge;
+  let port: number;
+
+  /** The orchestrator's `tabCommandWorkflowUuid`. */
+  const advertised = new Map<string, string>();
+  /** The orchestrator's carried-provenance set (tab ids whose current stamp was
+   *  carried from a retired id and never re-proven for THIS id). */
+  const carried = new Set<string>();
+  /** The conversation's issue-time stamp (`turnOrigins.stampOf`). */
+  let sessionStamp: string | undefined;
+
+  let received: Array<Record<string, unknown>>;
+
+  const hello = (sock: WebSocket, tabId: string) =>
+    sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: tabId,
+        title: tabId,
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+
+  beforeEach(async () => {
+    advertised.clear();
+    carried.clear();
+    sessionStamp = undefined;
+    received = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver((id) =>
+      isScopeAddress(id) ? sessionStamp : advertised.get(id),
+    );
+    bridge.setCarriedTabStampPredicate((id) => (isScopeAddress(id) ? false : carried.has(id)));
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  function connectPanel(tabId: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      sock.on("open", () => {
+        hello(sock, tabId);
+        resolve(sock);
+      });
+      sock.on("error", reject);
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString());
+        if (msg.rid && msg.cmd) {
+          received.push(msg);
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+        }
+      });
+    });
+  }
+
+  /** The orchestrator's hello handler, for the identity half only: carry the
+   *  retiring id's stamp onto the new one, then overwrite it IF this hello
+   *  resolved a trusted identity. Uses the production `carryWorkflowCommandStamp`. */
+  function orchestratorHello(migratedFrom: string, panelTab: string, newIdentity?: string): void {
+    if (carryWorkflowCommandStamp(advertised, migratedFrom, panelTab)) carried.add(panelTab);
+    else carried.delete(panelTab);
+    carried.delete(migratedFrom);
+    if (newIdentity) {
+      advertised.set(panelTab, newIdentity);
+      carried.delete(panelTab);
+    }
+  }
+
+  it("refuses an active-canvas mutation whose only agreement comes from the CARRY", async () => {
+    advertised.set(TAB_UNSAVED, UUID_UNTITLED);
+    // The turn's stamp is captured FROM the same map (turnOrigins.recordForMid).
+    sessionStamp = advertised.get(TAB_UNSAVED);
+    const sock = await connectPanel(TAB_UNSAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_UNSAVED));
+
+    // The Untitled workflow is saved under a name: the panel re-hellos on the SAME
+    // socket under a wf:<path> id, and THIS hello lands before the canvas identity
+    // is readable, so it carries no workflow_uuid (#1331's window).
+    hello(sock, TAB_SAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_SAVED));
+    orchestratorHello(TAB_UNSAVED, TAB_SAVED, undefined);
+    received.length = 0;
+
+    // The carry made the two sides equal — by construction, not by observation.
+    expect(advertised.get(TAB_SAVED)).toBe(UUID_UNTITLED);
+    expect(sessionStamp).toBe(UUID_UNTITLED);
+    expect(carried.has(TAB_SAVED)).toBe(true);
+
+    for (const cmd of ["graph_connect", "graph_set_widget", "graph_outline", "workflow_save"]) {
+      const err = await bridge.send({ cmd }, { tabId: SCOPE }).then(
+        () => null,
+        (e) => e as Error,
+      );
+      expect(err, `${cmd} must not be dispatched onto an unproven canvas`).not.toBeNull();
+      expect(err!.message).toMatch(/^workflow instance mismatch:/);
+      // The refusal says WHY: the agreement is unproven, not observed.
+      expect(err!.message).toContain("has not re-established its workflow identity");
+      expect(err!.message).toContain('panel_set_workflow_target({mode:"current"})');
+      expect(dispatchOutcomeOf(err)).toBe(false);
+    }
+    // NOTHING reached the panel — the six "successful" mutations of the report.
+    expect(received).toEqual([]);
+    sock.close();
+  });
+
+  it("keeps the recovery probe and navigation dispatchable so the rebind is not circular", async () => {
+    advertised.set(TAB_UNSAVED, UUID_UNTITLED);
+    sessionStamp = advertised.get(TAB_UNSAVED);
+    const sock = await connectPanel(TAB_UNSAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_UNSAVED));
+    hello(sock, TAB_SAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_SAVED));
+    orchestratorHello(TAB_UNSAVED, TAB_SAVED, undefined);
+    received.length = 0;
+
+    for (const cmd of ["workflow_list", "workflow_open", "workflow_new", "nodes_search"]) {
+      await expect(bridge.send({ cmd }, { tabId: SCOPE })).resolves.toEqual({ cmd });
+    }
+    expect(received.map((f) => f.cmd)).toEqual([
+      "workflow_list",
+      "workflow_open",
+      "workflow_new",
+      "nodes_search",
+    ]);
+
+    // The documented rebind proves an identity for THIS tab id, which clears the
+    // carried provenance — and the same mutations then dispatch normally.
+    advertised.set(TAB_SAVED, UUID_SAVED);
+    carried.delete(TAB_SAVED);
+    sessionStamp = UUID_SAVED;
+    received.length = 0;
+    await expect(bridge.send({ cmd: "graph_connect" }, { tabId: SCOPE })).resolves.toEqual({
+      cmd: "graph_connect",
+    });
+    expect(received[0].workflow_uuid).toBe(UUID_SAVED);
+    sock.close();
+  });
+
+  it("leaves a PROVEN agreement dispatching — the carry is the only thing withdrawn", async () => {
+    advertised.set(TAB_UNSAVED, UUID_UNTITLED);
+    sessionStamp = advertised.get(TAB_UNSAVED);
+    const sock = await connectPanel(TAB_UNSAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_UNSAVED));
+
+    // Same transition, but this hello DOES resolve the identity — and it is the
+    // same instance (a save/rename keeps the per-instance uuid). Nothing changes:
+    // the agreement is observed, so the command dispatches.
+    hello(sock, TAB_SAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_SAVED));
+    orchestratorHello(TAB_UNSAVED, TAB_SAVED, UUID_UNTITLED);
+    received.length = 0;
+    expect(carried.has(TAB_SAVED)).toBe(false);
+
+    await expect(bridge.send({ cmd: "graph_connect" }, { tabId: SCOPE })).resolves.toEqual({
+      cmd: "graph_connect",
+    });
+    expect(received[0].workflow_uuid).toBe(UUID_UNTITLED);
+    sock.close();
+  });
+
+  it("still refuses a plain DISAGREEMENT with #1682's message, carry or not", async () => {
+    advertised.set(TAB_UNSAVED, UUID_UNTITLED);
+    sessionStamp = UUID_UNTITLED;
+    const sock = await connectPanel(TAB_UNSAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_UNSAVED));
+    hello(sock, TAB_SAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_SAVED));
+    orchestratorHello(TAB_UNSAVED, TAB_SAVED, UUID_SAVED);
+    received.length = 0;
+
+    const err = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE }).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(`issued for workflow instance ${UUID_UNTITLED}`);
+    expect(err!.message).toContain(`different active workflow (${UUID_SAVED})`);
+    expect(received).toEqual([]);
+    sock.close();
+  });
+});
+
+describe("#1656 — carryWorkflowCommandStamp reports whether it CARRIED", () => {
+  it("is true only when the retiring id's stamp was actually copied forward", () => {
+    const stamps = new Map<string, string>([["tmp:old", UUID_UNTITLED]]);
+    expect(carryWorkflowCommandStamp(stamps, "tmp:old", "wf:new")).toBe(true);
+    expect(stamps.get("wf:new")).toBe(UUID_UNTITLED);
+    expect(stamps.has("tmp:old")).toBe(false);
+  });
+
+  it("is false when the new id already holds its OWN (newer) evidence", () => {
+    const stamps = new Map<string, string>([
+      ["tmp:old", UUID_UNTITLED],
+      ["wf:new", UUID_SAVED],
+    ]);
+    expect(carryWorkflowCommandStamp(stamps, "tmp:old", "wf:new")).toBe(false);
+    expect(stamps.get("wf:new")).toBe(UUID_SAVED);
+  });
+
+  it("is false when the retiring id had no stamp to carry", () => {
+    const stamps = new Map<string, string>();
+    expect(carryWorkflowCommandStamp(stamps, "tmp:old", "wf:new")).toBe(false);
+    expect(stamps.has("wf:new")).toBe(false);
+  });
+});

--- a/src/__tests__/services/carried-stamp-agreement.test.ts
+++ b/src/__tests__/services/carried-stamp-agreement.test.ts
@@ -170,6 +170,35 @@ describe("#1656 recurrence — a CARRIED stamp is not the routed tab's advertise
     sock.close();
   });
 
+  // THE BUG ITSELF, on the same code path. An uninstalled predicate is defined to mean
+  // "proven", which is precisely the pre-#1656 gate: it sees two equal uuids and calls
+  // that agreement. Same sockets, same carry, same commands — and every one of them
+  // reaches the panel, stamped with the PREVIOUS canvas's uuid. Six accepted mutations
+  // and a seventh refusal is what that looks like from the caller's side.
+  it("BASELINE (predicate absent = pre-#1656): the very same sequence DISPATCHES", async () => {
+    bridge.setCarriedTabStampPredicate(() => false);
+    advertised.set(TAB_UNSAVED, UUID_UNTITLED);
+    sessionStamp = advertised.get(TAB_UNSAVED);
+    const sock = await connectPanel(TAB_UNSAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_UNSAVED));
+    hello(sock, TAB_SAVED);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_SAVED));
+    orchestratorHello(TAB_UNSAVED, TAB_SAVED, undefined);
+    received.length = 0;
+
+    for (const cmd of ["graph_connect", "graph_set_widget", "workflow_save"]) {
+      await expect(bridge.send({ cmd }, { tabId: SCOPE })).resolves.toEqual({ cmd });
+    }
+    expect(received.map((f) => f.cmd)).toEqual([
+      "graph_connect",
+      "graph_set_widget",
+      "workflow_save",
+    ]);
+    // …carrying the RETIRED tab's uuid as this command's target.
+    expect(received.every((f) => f.workflow_uuid === UUID_UNTITLED)).toBe(true);
+    sock.close();
+  });
+
   it("keeps the recovery probe and navigation dispatchable so the rebind is not circular", async () => {
     advertised.set(TAB_UNSAVED, UUID_UNTITLED);
     sessionStamp = advertised.get(TAB_UNSAVED);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1780,6 +1780,14 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Set from each hello's trusted identity; #716 lets a successful explicit
   // open/re-pin refresh it between hellos.
   const tabCommandWorkflowUuid = new Map<string, string>();
+  // #1656 — WHO said so, for the entries above. A tab id in this set holds a stamp that
+  // was CARRIED from the tab id a same-socket re-hello retired and has NOT been proven
+  // under its current id. The value is still used to stamp frames (#1331 — an absent
+  // stamp is the unrecoverable half), but the dispatch-time agreement gate may not read
+  // it as this tab's own advertisement: the conversation's issue-time stamp is captured
+  // from this very map, so a carry makes that gate's two sides identical by construction
+  // in exactly the window where the canvas changed.
+  const tabStampCarried = new Set<string>();
   const scopeAgentKeyOf = (scopeId: string): string =>
     scopeId === SHARED_SESSION_SCOPE ? sharedKeyFor(defaultBackend) : scopeId;
   // #884 — each shared conversation's last message origin (tab + workflow uuid),
@@ -3113,6 +3121,10 @@ export async function runPanelOrchestrator(): Promise<void> {
           reason: identityReason(tabId, origin, workflowUuid, bridge.resolveFailure?.(tabId)),
         };
       tabCommandWorkflowUuid.set(panelTab, identity.uuid);
+      // A VALIDATED refresh (an explicit open / panel_set_workflow_target({mode:"current"})
+      // / a save reply's workflow_uuid) is an observation about this tab id — it is the
+      // documented way out of the carried state (#1656).
+      tabStampCarried.delete(panelTab);
       // #716/#884 — an explicit, VALIDATED open/re-pin from the shared agent is
       // the agent deliberately moving its turn to another workflow: refresh
       // that CONVERSATION's issue-time stamp too, so its subsequent edits
@@ -3122,6 +3134,15 @@ export async function runPanelOrchestrator(): Promise<void> {
       return true;
     },
   );
+  // #1656 — the provenance half of the same answer. A SCOPE address never carries: its
+  // stamp is the conversation's issue-time value, not a tab advertisement. A real tab id
+  // is resolved through panelTabOf exactly like the resolver above, so an agent-key
+  // address and the bare tab id give the same verdict.
+  bridge.setCarriedTabStampPredicate((tabId) => {
+    if (isScopeAddress(tabId)) return false;
+    const t = panelTabOf(tabId);
+    return t ? tabStampCarried.has(t) : false;
+  });
 
   // ── Local-agent VRAM pause during generation ────────────────────────────
   // On a single-GPU box the local chat model and ComfyUI fight for VRAM:
@@ -3927,7 +3948,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         //
         // If THIS hello does resolve an identity, the `set` below overwrites what
         // we carried — new evidence always wins over old.
-        carryWorkflowCommandStamp(tabCommandWorkflowUuid, migratedFrom, panelTab);
+        if (carryWorkflowCommandStamp(tabCommandWorkflowUuid, migratedFrom, panelTab)) {
+          // Inherited, not proven — see tabStampCarried.
+          tabStampCarried.add(panelTab);
+        } else {
+          // The new id kept its OWN entry (newer evidence) or there was nothing to
+          // carry; either way nothing was inherited onto it here.
+          tabStampCarried.delete(panelTab);
+        }
+        tabStampCarried.delete(migratedFrom);
         logger.info(
           `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — routing state carried; the shared session continues (#884)`,
         );
@@ -3967,6 +3996,9 @@ export async function runPanelOrchestrator(): Promise<void> {
       // it on equality, which is the only test that decides authorization.
       if (newIdentity) {
         tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);
+        // THIS tab, under THIS id, just advertised an identity — whatever was inherited
+        // is superseded by an observation (#1656).
+        tabStampCarried.delete(panelTab);
       }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3143,6 +3143,31 @@ export async function runPanelOrchestrator(): Promise<void> {
     const t = panelTabOf(tabId);
     return t ? tabStampCarried.has(t) : false;
   });
+  // #1656 — and the way OUT of the carried state that does not move anything. The
+  // fence-mismatch probe reads the live canvas with workflow_list; when the corroborated
+  // active record names the instance this tab's stamp ALREADY holds, the inherited value
+  // has been confirmed by an observation of the tab under its CURRENT id.
+  //
+  // The equality test is the whole safety argument, and it is enforced HERE rather than
+  // trusted from the caller: no stamp is written, no conversation stamp is touched, and a
+  // uuid that does not already match is REFUSED outright. So this can never retarget a
+  // session — which is exactly why it is not routed through refreshWorkflowUuid (#1646:
+  // a read-only diagnosis that re-points the fence is the corruption the fence exists to
+  // prevent, delivered as recovery).
+  bridge.setTabStampCorroborator((tabId, workflowUuid) => {
+    const panelTab = scopeToRealTab(tabId);
+    if (!panelTab) return false;
+    // Same validator as every other identity acceptance: server-observed origin +
+    // the uuid's shape/origin binding. Never a bare string from a reply.
+    const identity = workflowIdentityParts({
+      workflowUuid,
+      origin: bridge.tabServerOrigin(tabId),
+    });
+    if (!identity) return false;
+    if (tabCommandWorkflowUuid.get(panelTab) !== identity.uuid) return false;
+    tabStampCarried.delete(panelTab);
+    return true;
+  });
 
   // ── Local-agent VRAM pause during generation ────────────────────────────
   // On a single-GPU box the local chat model and ComfyUI fight for VRAM:

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4793,6 +4793,19 @@ function responseWorkflowUuid(value: unknown): string | undefined {
 }
 
 /** Refresh only the bridge-owned command stamp, never caller data. */
+/** #1656 — tell the orchestrator that a live read confirmed the routed tab's CURRENT
+ *  stamp, so a value inherited on a same-socket re-hello stops being treated as
+ *  inherited. Never throws, and can never move a fence (see the bridge method). */
+function corroborateTabStamp(ctx: PanelToolCtx, workflowUuid: string): boolean {
+  const fn = (ctx.bridge as unknown as { corroborateTabStamp?: unknown }).corroborateTabStamp;
+  if (typeof fn !== "function") return false;
+  try {
+    return (fn as (t: string, u: string) => boolean).call(ctx.bridge, ctx.tabId, workflowUuid) === true;
+  } catch {
+    return false;
+  }
+}
+
 function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
   const uuid = responseWorkflowUuid(value);
   const refresh = (ctx.bridge as unknown as { refreshWorkflowUuid?: unknown }).refreshWorkflowUuid;
@@ -5458,18 +5471,15 @@ async function rebindWorkflowFence(
     // identity would leave the session refusing edits to a canvas the panel agrees is
     // the right one: the fix would be worse than the bug.
     //
-    // This is NOT the retarget #1646 removed. The value written is `uuid`, which this
-    // branch has just established EQUALS the fence already in force, so no target
-    // changes and no later edit is re-aimed — only the provenance of an identical
-    // value is promoted from inherited to observed. It goes through the orchestrator's
-    // validator (reachability + the origin-bound uuid shape), never off parsed prose,
-    // and a refusal or a throw is swallowed: this is corroboration, and a diagnostic
+    // This is NOT the retarget #1646 removed, and deliberately not `refreshWorkflowUuid`
+    // either — that one WRITES a stamp (and a conversation's issue-time stamp with it).
+    // `corroborateTabStamp` can only promote the provenance of a uuid the orchestrator
+    // has itself confirmed already equals the tab's current stamp; it writes no stamp and
+    // refuses outright when the values differ, so no target changes and no later edit is
+    // re-aimed. The uuid still goes through the orchestrator's identity validator, never
+    // off parsed prose, and the result is ignored: this is corroboration, and a diagnostic
     // must never replace the outcome it is describing.
-    try {
-      refreshWorkflowUuid(ctx, active);
-    } catch {
-      /* corroboration only — the verdict below is unchanged either way */
-    }
+    corroborateTabStamp(ctx, uuid);
     return { status: "already_current", uuid, before };
   }
   // #1646 — a READ-ONLY probe never moves the fence: the live canvas naming a

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5446,7 +5446,32 @@ async function rebindWorkflowFence(
   // "already current" requires a KNOWN prior fence equal to the live uuid. An
   // UNKNOWN prior fence must not short-circuit the adoption: we would be claiming
   // the stamp already matched without ever having read it.
-  if (before.known && before.uuid === uuid) return { status: "already_current", uuid, before };
+  if (before.known && before.uuid === uuid) {
+    // #1656 — THE FENCE DOES NOT MOVE HERE, BUT THE EVIDENCE DOES.
+    //
+    // Reaching this line means the panel's own corroborated workflow_list says the
+    // LIVE canvas is this very instance. If the routed tab's stamp was one CARRIED
+    // onto a new tab id by a same-socket re-hello that could not resolve an identity,
+    // that carried value has now been confirmed by an observation of the tab under its
+    // CURRENT id — so the dispatch-time agreement gate must stop treating it as
+    // inherited. Without this, a rename/save whose hello merely RACED the canvas
+    // identity would leave the session refusing edits to a canvas the panel agrees is
+    // the right one: the fix would be worse than the bug.
+    //
+    // This is NOT the retarget #1646 removed. The value written is `uuid`, which this
+    // branch has just established EQUALS the fence already in force, so no target
+    // changes and no later edit is re-aimed — only the provenance of an identical
+    // value is promoted from inherited to observed. It goes through the orchestrator's
+    // validator (reachability + the origin-bound uuid shape), never off parsed prose,
+    // and a refusal or a throw is swallowed: this is corroboration, and a diagnostic
+    // must never replace the outcome it is describing.
+    try {
+      refreshWorkflowUuid(ctx, active);
+    } catch {
+      /* corroboration only — the verdict below is unchanged either way */
+    }
+    return { status: "already_current", uuid, before };
+  }
   // #1646 — a READ-ONLY probe never moves the fence: the live canvas naming a
   // DIFFERENT workflow is reported, not adopted. Only a deliberate rebind
   // (panel_set_workflow_target, open/new) may replace the fence — a mismatch

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -581,16 +581,32 @@ export class SessionStore {
  *
  * Extracted and CALLED by the hello handler rather than inlined, so the tests exercise the
  * function production runs instead of a re-implementation of what it ought to do.
+ *
+ * RETURNS whether it actually carried (#1656). "CARRYING CANNOT WIDEN AUTHORIZATION" was
+ * true of the ONE authorizer that existed when it was written: the panel's
+ * `stamp === live active uuid` test, which judges the carried value against the canvas
+ * actually mounted. #1682 then added a SECOND authorizer -- the orchestrator's
+ * dispatch-time agreement gate -- which reads this same map as "the identity the routed
+ * tab last ADVERTISED". A carried entry was advertised by the tab that was RETIRED, so
+ * for that gate the sentence stops holding: the conversation's issue-time stamp is
+ * captured from this very map (`turnOrigins.recordForMid(mid, stamps.get(tab), tab)`),
+ * so a carry makes the gate's two sides equal BY CONSTRUCTION exactly in the window
+ * where the canvas changed. Callers therefore have to be able to tell a CARRIED stamp
+ * from a PROVEN one, and only a proven one may satisfy an agreement check. The carry
+ * itself is unchanged -- #1331 still needs it, so the frame keeps its stamp and the
+ * panel's own fence keeps judging it.
  */
 export function carryWorkflowCommandStamp(
   stamps: Map<string, string>,
   migratedFrom: string,
   panelTab: string,
-): void {
+): boolean {
   const carried = stamps.get(migratedFrom);
   // An entry already recorded for the new id is NEWER evidence than anything held under
   // the old one, so it wins.
-  if (carried !== undefined && !stamps.has(panelTab)) stamps.set(panelTab, carried);
+  const didCarry = carried !== undefined && !stamps.has(panelTab);
+  if (didCarry) stamps.set(panelTab, carried as string);
   // The old id is still retired: a straggler command addressed to it must not resolve.
   stamps.delete(migratedFrom);
+  return didCarry;
 }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1540,6 +1540,8 @@ export class UiBridge {
    *  is not wired (tests/embedders): treated as PROVEN, which is exactly the pre-#1656
    *  behaviour. */
   private isCarriedTabStamp: ((tabId: string) => boolean) | null = null;
+  /** #1656 — orchestrator-injected: see {@link corroborateTabStamp}. */
+  private corroborateTabStampFn: ((tabId: string, workflowUuid: string) => boolean) | null = null;
   /** #884 P0 — orchestrator-injected: the tab a conversation's IN-FLIGHT turn is
    *  PINNED to (string), `null` when the turn's origin is ambiguous (refuse), or
    *  undefined when no turn is in flight (fall back to active-tab resolution).
@@ -5022,6 +5024,33 @@ export class UiBridge {
    *  gate is forbidden to accept it as evidence about the routed tab's canvas. */
   setCarriedTabStampPredicate(fn: (tabId: string) => boolean): void {
     this.isCarriedTabStamp = fn;
+  }
+
+  /** #1656 — inject the CORROBORATION half: "the live canvas was read and it is this
+   *  instance". Deliberately NOT `refreshWorkflowUuid`. That one WRITES a stamp (and a
+   *  conversation's issue-time stamp with it), which is a retarget the read-only mismatch
+   *  probe must never perform (#1646); this one may only promote the PROVENANCE of a value
+   *  that already matches, and the orchestrator's implementation refuses outright when it
+   *  does not match. Nothing it can do changes which workflow anything is fenced to. */
+  setTabStampCorroborator(fn: (tabId: string, workflowUuid: string) => boolean): void {
+    this.corroborateTabStampFn = fn;
+  }
+
+  /**
+   * #1656 — record that the routed tab's CURRENT stamp has been confirmed by a live read
+   * of the canvas, so a value that was inherited on a same-socket re-hello stops being
+   * treated as inherited by the dispatch-time agreement gate.
+   *
+   * Returns whether the corroboration was accepted. Never throws: this is a diagnostic
+   * running inside a refusal path, and a diagnostic must never replace the outcome it is
+   * describing.
+   */
+  corroborateTabStamp(tabId: string, workflowUuid: string): boolean {
+    try {
+      return this.corroborateTabStampFn?.(tabId, workflowUuid) === true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1526,6 +1526,20 @@ export class UiBridge {
    *  to (the generation-bound-command leak: the server can't retract a frame already
    *  delivered to the browser, but the browser can decline to APPLY a stale one). */
   private resolveTabWorkflowUuid: ((tabId: string) => string | undefined) | null = null;
+  /** #1656 — orchestrator-injected: is this tab's CURRENT stamp one that was CARRIED
+   *  from a tab id the same socket retired (carryWorkflowCommandStamp), rather than one
+   *  the tab itself has proven under this id?
+   *
+   *  The stamp map answers "what uuid is on this tab" but not "who said so", and the two
+   *  are different facts. On a same-socket re-hello that mints a new tab id — a workflow
+   *  switch, or the tmp: -> wf: transition of a save/rename — the retiring id's uuid is
+   *  copied onto the new id and overwritten only if THAT hello resolved an identity. When
+   *  it did not, the value sitting on the new tab id was advertised by a tab that no longer
+   *  exists, about a canvas that is no longer mounted. The dispatch-time agreement gate
+   *  below must not read it as this tab's advertisement. Absent predicate = the mechanism
+   *  is not wired (tests/embedders): treated as PROVEN, which is exactly the pre-#1656
+   *  behaviour. */
+  private isCarriedTabStamp: ((tabId: string) => boolean) | null = null;
   /** #884 P0 — orchestrator-injected: the tab a conversation's IN-FLIGHT turn is
    *  PINNED to (string), `null` when the turn's origin is ambiguous (refuse), or
    *  undefined when no turn is in flight (fall back to active-tab resolution).
@@ -4610,9 +4624,36 @@ export class UiBridge {
     // either value missing keeps the existing behaviour and lets the panel fence
     // judge. And a caller addressing the connection by its canonical id is skipped
     // outright — both answers then come from the same lookup and can only agree.
+    //
+    // #1656 (recurrence) — the gate above compares two VALUES and calls equality
+    // "agreement". That inference is only sound when the routed tab's value is
+    // something THAT TAB advertised. `carryWorkflowCommandStamp` copies the retiring
+    // id's uuid onto the new id on every same-socket re-hello that mints one, and the
+    // hello handler overwrites it only `if (newIdentity)`. Its docstring's promise —
+    // "carrying cannot widen authorization" — was written about the PANEL's fence,
+    // which tests the carried value against the live canvas; this gate instead treats
+    // it as an observation about the new canvas, and there the promise fails. Worse
+    // than "may agree": the conversation's issue-time stamp is captured from that same
+    // map (`turnOrigins.recordForMid(mid, tabCommandWorkflowUuid.get(tab), tab)`), so a
+    // carry makes both sides the SAME STRING by construction — the gate is guaranteed
+    // to pass in exactly the window where the canvas changed, and starts refusing only
+    // once some later hello finally proves a different identity. That is the reported
+    // shape verbatim: six mutations accepted onto the previous canvas, the seventh
+    // refused.
+    //
+    // So a CARRIED stamp is not agreement, it is an absence of evidence about a canvas
+    // this command is about to read or mutate — and #570's rule for that is to refuse
+    // the dispatch, because a delivered frame cannot be retracted. Deliberately narrow:
+    // only the commands requiresStampTargetAgreement() already covers (workflow_list,
+    // workflow_open/new, canvas-independent ops and path-selectored rename/close stay
+    // exempt, so the documented rebind is reachable and clears this by proving an
+    // identity for the tab's CURRENT id), and only while the carry is unproven — the
+    // instant any hello or validated reply establishes an identity for this tab id, the
+    // provenance flips to proven and nothing about the pre-#1656 behaviour changes.
     if (opts.tabId && opts.tabId !== conn.tabId && requiresStampTargetAgreement(cmd)) {
       const issuedFor = this.resolveTabWorkflowUuid?.(opts.tabId);
       const landedOn = this.resolveTabWorkflowUuid?.(conn.tabId);
+      const carried = this.isCarriedTabStamp?.(conn.tabId) === true;
       if (issuedFor && landedOn && issuedFor !== landedOn) {
         return Promise.reject(
           markDispatched(
@@ -4621,6 +4662,21 @@ export class UiBridge {
                 `but the tab it routed to has since reported a different active workflow (${landedOn}). ` +
                 `Nothing was dispatched. Re-target with panel_set_workflow_target({mode:"current"}), ` +
                 `then retry.`,
+            ),
+            false,
+          ),
+        );
+      }
+      if (issuedFor && landedOn && carried) {
+        return Promise.reject(
+          markDispatched(
+            new Error(
+              `workflow instance mismatch: this command was issued for workflow instance ${issuedFor}, ` +
+                `and the tab it routed to has not re-established its workflow identity since it ` +
+                `re-registered under a new id — the uuid it currently carries (${landedOn}) was ` +
+                `inherited from the tab id it replaced, so it is not evidence about the canvas now ` +
+                `mounted there. Nothing was dispatched. Re-target with ` +
+                `panel_set_workflow_target({mode:"current"}), then retry.`,
             ),
             false,
           ),
@@ -4958,6 +5014,14 @@ export class UiBridge {
   ): void {
     this.resolveTabWorkflowUuid = fn;
     this.refreshTabWorkflowUuid = refresh ?? null;
+  }
+
+  /** #1656 — inject the stamp-PROVENANCE predicate (see {@link isCarriedTabStamp}).
+   *  Separate from the resolver on purpose: the resolver's value is still used to STAMP
+   *  the frame (a carried stamp is better than none — #1331), and only the agreement
+   *  gate is forbidden to accept it as evidence about the routed tab's canvas. */
+  setCarriedTabStampPredicate(fn: (tabId: string) => boolean): void {
+    this.isCarriedTabStamp = fn;
   }
 
   /**


### PR DESCRIPTION
The underlying cause of #1656 (recurrence on 0.52.3, which already carries #1682's
dispatch gate): a stamp the routed tab **inherited** was read as a stamp the routed tab
**advertised**, and the two are different facts.

## Why the existing fence was satisfied

#1682 refuses an active-canvas command when "the session's stamp and the routed tab's
LAST-ADVERTISED identity are both known and disagree". The value it reads for the second
half is `tabCommandWorkflowUuid.get(conn.tabId)`.

On the same-socket re-hello that mints a new tab id — a workflow switch, or the
`tmp:` → `wf:<path>` re-key a first save/rename performs — `carryWorkflowCommandStamp`
copies the **retiring** id's uuid onto the new id, and the hello handler overwrites it
only `if (newIdentity)`. So while a hello has not resolved an identity, the "advertised
identity" of the new canvas is the *previous* canvas's uuid.

That is not "sometimes equal". The conversation's issue-time stamp is captured from the
same map at user-message time:

```ts
turnOrigins.recordForMid(userMid, tabCommandWorkflowUuid.get(event.tab_id), event.tab_id);
```

so the carry copies the exact string the session stamp was derived from onto the tab the
command will land on. **The gate's two sides are equal by construction, precisely in the
window where the canvas changed** — it is guaranteed to pass exactly when it is needed,
and starts refusing only once some later hello finally proves a different identity. That
is the reported shape verbatim: six mutations accepted onto the previous canvas, the
seventh refused.

`carryWorkflowCommandStamp`'s own docstring promises "CARRYING CANNOT WIDEN
AUTHORIZATION". That was true of the one authorizer that existed when it was written —
the panel's `stamp === live active uuid` test, which judges the carried value against the
canvas actually mounted. #1682 added a second authorizer that reads the same value as an
*observation about the new canvas*, and there the promise stops holding. A later change
invalidated an earlier one's stated premise; this PR restores it.

Taxonomy: class 1 (CARRIED and ADVERTISED collapse into one indistinguishable value) on
top of class 2 (identity survives the re-key that should have invalidated it).

## Mechanism

* `carryWorkflowCommandStamp` now **returns whether it carried**. The carry itself is
  unchanged — #1331 still needs it, so the frame keeps its stamp and the panel's own
  fence keeps judging it.
* The orchestrator keeps that provenance per tab id (`tabStampCarried`) and clears it the
  moment a hello or a validated refresh proves an identity **for the current id**.
* `UiBridge.send()`'s agreement gate treats a carried stamp as an *absence of evidence*
  about the canvas it is about to read or mutate, and refuses **before the socket write**
  (`workflow instance mismatch: … has not re-established its workflow identity …`, typed
  `dispatched:false`), naming the documented rebind. `#570`'s rule for an unprovable
  target: a delivered frame cannot be retracted, so refuse the dispatch.

### The self-healing half, so the fix is not worse than the bug

The same window is entered by a rename/save whose hello merely **raced** the canvas
identity — where the canvas *is* the workflow the caller named (the panel's own note:
a first save and a Save-As "re-key the route while the instance — and therefore the uuid
— is the same object it always was"). Left alone the session would refuse edits to a
canvas the panel agrees is correct; #1330 measured that cost at 14 refusals.

So the read-only mismatch probe carries the repair. When the corroborated `workflow_list`
says the live canvas is the instance the fence already names, that is an observation of
the tab under its **current** id, and the provenance is promoted from inherited to
observed.

It goes through a new `bridge.setTabStampCorroborator`, **not** `refreshWorkflowUuid` —
and the difference is the whole safety argument. `refreshWorkflowUuid` writes a stamp
(and a conversation's issue-time stamp with it): that is the retarget #1646 removed from
this probe, and `panel-tools.test.ts`'s "nothing to change, so nothing is claimed to have
changed" invariant caught my first cut doing exactly that. The corroborator writes **no
stamp at all**: the orchestrator re-validates the uuid (server-observed origin + shape)
and **refuses unless it already equals the tab's current stamp**, so the only thing it
can change is a provenance bit. No input can retarget a session through it. The
`diverged` case reaches neither call.

## What is still allowed

* Everything, whenever the tab's identity is **proven** under its current id — the normal
  case. The instant a hello or a validated refresh lands, provenance flips and behaviour
  is byte-identical to before this PR.
* Tabs that never migrated: no carry, no flag, no change.
* Inside the gate the exemptions are #1682's, untouched: `workflow_list` (the recovery
  probe — so `panel_set_workflow_target({mode:"current"})` is reachable and is not gated
  on the state it repairs, panel #932's circularity), `workflow_open` / `workflow_new`,
  the #602 canvas-independent set, and path-selectored `workflow_rename` / `workflow_close`.
* Callers addressing the connection by its canonical id: the gate's outer guard
  (`opts.tabId !== conn.tabId`) is unchanged, so the loopback-MCP-by-tab-id path is
  untouched.
* The refusal keeps the `issued for workflow instance <uuid>` shape panel-tools' fence
  diagnosis parses, so it classifies as `stamped` (this session HAS an identity) and not
  as the opposite-remedy `unstamped` case.

## Refutation — 9 mutations, every one killed, each diff confirmed before running

| # | mutation | result |
|---|---|---|
| M1 | disable the carried refusal branch in the gate | 2 fail — incl. the frames reaching the panel |
| M2 | delete `bridge.setCarriedTabStampPredicate(...)` | 1 fail (**source-only** — the behavioural suite stayed green, which is the point) |
| M3 | drop `tabStampCarried.add(panelTab)` in the hello handler | 1 fail (source-only) |
| M4 | make `carryWorkflowCommandStamp` always return `false` | 2 fail |
| M5 | stop clearing the flag when a hello proves an identity | 1 fail (source-only) |
| M6 | delete the corroboration call from `already_current` | 1 fail |
| M7 | delete `bridge.setTabStampCorroborator(...)` | 1 fail (source-only) |
| M8 | delete the corroborator's equality guard | 1 fail (source-only) |
| M9 | swap the corroborator back to `refreshWorkflowUuid` | 3 fail, incl. the pre-existing #1339 invariant |

M2/M3/M5/M7/M8 are the ones that matter for the "helper-only tests" trap: they are
one-line wirings that no behavioural test can see (an uninstalled predicate is *defined*
to mean "proven", i.e. the pre-#1656 behaviour with the bug intact), so
`carried-stamp-wiring.test.ts` pins them at source level, the way
`shared-session-invariant.test.ts` and `agent-identity-wiring.test.ts` already do for this
file. After each mutation `git diff` was read to confirm it applied (CRLF repo — every
edit went through an explicit newline-normalising patcher, never `$`-anchored perl).

## Test evidence

* `src/__tests__/services/carried-stamp-agreement.test.ts` — 8 tests driving the **real**
  `UiBridge` over **real** sockets with the **real** `carryWorkflowCommandStamp`, resolver
  wired the way `orchestrator/index.ts` wires it. Includes a **BASELINE test that pins the
  bug**: with the predicate absent (= pre-#1656) the identical sequence dispatches all
  three commands, stamped with the retired tab's uuid.
* `src/__tests__/orchestrator/carried-stamp-corroboration.test.ts` — the self-healing half
  and its limit: corroborated on a matching live uuid, and *nothing* offered to either
  call when the live canvas is a different workflow.
* `src/__tests__/orchestrator/carried-stamp-wiring.test.ts` — the six call sites.
* Full suite on this branch: **10 421 passed**. Three files failed in the parallel run and
  all three passed alone (a different three on an earlier full run) — machine-load flakes,
  not a delta. `tsc --noEmit`, `check:vocabulary` (1680 files) and `check:unknown-collapse`
  all clean.

## Live reproduction / browser gate

**Not reproduced against a live browser.** The window needs a same-socket re-hello whose
hello has not yet resolved a canvas identity, which is a race I could not force
deterministically from outside. What is driven for real is the whole server half — real
bridge, real sockets, real carry helper — plus the baseline test that shows the pre-fix
gate dispatching on that exact input.

**No panel file changes**, and no change to the wire frame's shape — only whether a frame
is written at all. The panel's Playwright suite therefore cannot observe this change, and
I did not run it; saying so explicitly rather than implying coverage I do not have.

## Scope — what I deliberately did NOT do

* Did not touch the carry (#1331) or the panel's fence. The stamp still ships; only the
  orchestrator's "these agree, therefore dispatch" inference is withdrawn.
* Did not add per-tab or per-workflow session state — sessions stay orchestrator-scoped.
* Did not chase the panel-side half. The recurrence was filed on panel **0.14.44** with
  0.15.4 current, and several later panel fixes bear on it (0.15.1 "a stale-canvas tab can
  no longer persist its graph over another file", #1268 widget-write verification, #1272
  connect-throw verification, #1267b Save-As capture, and open draft #1391 for #1389's
  stale-ROUTE half, which is the other way a command can land somewhere the caller did not
  name). Those are separate work; this PR fixes the orchestrator-side gate only, and I am
  not claiming it is the whole of the reporter's session.

## Gate

Codex was unavailable (account exhausted until 2026-08-19 20:43) and `claude-gate.mjs` is
blocked on the weekly limit, so **this PR carries no independent adversarial gate** — the
owner gates and merges it. I did not self-gate; a self-review reads its own guard as
obviously right, which is the defect class this change is an instance of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
