### PR TITLE
fix(1768): local-llms docs flag the default fine-tune as text-only with no vision loop

### DIFF
--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -285,6 +285,18 @@ The panel's Ollama backend **defaults to `:e4b`** — pick **Ollama (local)**
 in the backend picker and it just works once the model is pulled. No account,
 no API key, no per-token cost.
 
+**Vision caveat: these tags are text-only today.** The current GGUF export
+dropped Gemma 4's multimodal projector
+([#642](https://github.com/artokun/comfyui-mcp/issues/642)), so the default
+driver can't *see* — `get_image (action:"view")` critique loops,
+`get_workflow (action:"from_image")`, and visual comparison are unavailable,
+exactly the "flies blind" row in the [capability
+table](#model-requirements) above. Tool calling, generation, and graph
+management are unaffected. The fix on our side is shipping the `mmproj` with
+the next publish, not retraining. If the vision loop matters to you today,
+pick a vision-capable model per [Model requirements](#model-requirements)
+instead of the default.
+
 **Context window:** the tags ship a **65,536-token** window baked in, and the
 orchestrator defers to it (stock models get 16K). The architecture supports up
 to **128K** (`:e2b`/`:e4b`) and **256K** (`:12b`) — raise it with


### PR DESCRIPTION
## Root cause

`docs/local-llms.mdx` names `artokun/gemma4-comfyui-mcp:e4b` as **the default** panel driver (and the panel Ollama backend default) with no vision caveat, while the same page's capability table warns that a text-only model "flies blind on its own outputs" (`get_image (action:"view")` critique loops, `get_workflow (action:"from_image")`, visual comparison unavailable). A reader following the default landed exactly in the warned-about case without being told. Underlying cause per #642: the current GGUF export dropped Gemma 4's multimodal projector — a publish-side fix (ship `mmproj` on next export), not a retrain.

## Fix

One prose paragraph added directly after the "defaults to `:e4b`" paragraph in the fine-tuned-models section: states the shipped tags are text-only today, names the exact vision features that are unavailable, links #642 and the page's own Model requirements table, notes the `mmproj` publish fix, and points readers who need the vision loop today at a vision-capable model. Prose-only change — no headings, MDX components, or code fences added — so locale structure parity is untouched.

## Verification (worktree `.worktrees/fix-1768`, from origin/main @ 9c0ed02)

- `npm ci` — clean
- `npm run build` (tsc) — clean
- `npm test` (full chain: vitest, i18n:check, check:docs-links, check:docs-locale, check:docs-mdx, check:blog\*, ) — exit 0; docs-locale parity ✓ across all 11 locale mirrors (ar/es/fa/fr/ja/ko/pt-BR/ru/tr/zh/zh-TW)

No tool-description, i18n call-site, or vocabulary changes, so docs:gen / vocab / i18n:build gates are not implicated.

Closes #1768