### PR TITLE
release: v0.52.6 — a carried workflow stamp no longer satisfies the agreement gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.6] - 2026-08-19
+
+### MCP
+
+#### Fixed
+- a workflow edit can no longer land silently on the canvas you switched away from: a stamp CARRIED onto a freshly minted tab id is no longer accepted as that tab's advertised identity, so panel_save_workflow and the other active-canvas commands refuse before the socket write and name the documented rebind, instead of passing a gate that compared the carried value against itself (#1775)
+- a pi turn whose session the CLI no longer has drops the dead session id and retries once as a fresh session, instead of failing every turn until you type /new (#1774)
+- three packs whose workflows asked for models their manifests never downloaded now install clean — z-image-xy-plot ships the Q8_0 GGUF its loader actually loads, leaked personal LoRAs are replaced with declared bring-your-own placeholders, and packs:check-models runs as a CI gate instead of never running at all (#1771)
+- adding Lora Loader (LoraManager) from autocomplete names the STRING-socket LoRA Text Loader instead of stalling five seconds and refusing a healthy pack on ComfyUI 1.49+ (#1762)
+- the local-llms docs flag the default :e4b fine-tune as text-only, so nobody picks it expecting the panel to see its own generated images (#1777)
+
+#### Added
+- consult the maintained arena baseline table — model, params, quant, VRAM and score, grouped by 8 GB fit — from the docs without running the benchmark yourself (#1773)
+
+#### Changed
+- the same vision caveat is mirrored into all ten translated local-llms pages, so a non-English reader is warned too (#1779)
+
+
 ## [0.52.5] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.5",
+  "version": "0.52.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.5",
+      "version": "0.52.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.5",
+  "version": "0.52.6",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release cut carrying six PRs: artokun/comfyui-mcp#1775, artokun/comfyui-mcp#1774, artokun/comfyui-mcp#1771, artokun/comfyui-mcp#1773, artokun/comfyui-mcp#1762, artokun/comfyui-mcp#1777, artokun/comfyui-mcp#1779.

**A carried stamp is not evidence about the canvas it is about to touch** — the dispatch-time agreement gate refuses an active-canvas command when the session's stamp and the routed tab's last-advertised identity disagree, but on a same-socket re-hello that mints a new tab id, `carryWorkflowCommandStamp` copies the retiring id's uuid onto the new one, and the session stamp is captured from that same map. The gate's two sides were therefore the same string by construction, guaranteed to agree in exactly the window where the canvas had just changed — so a `panel_save_workflow` could land on the previous canvas, and refusals only began once some later hello finally proved a different identity. A carried stamp is now tracked as such and treated as an absence of evidence: the command is refused before the socket write, typed `dispatched:false`, naming the documented rebind. The provenance clears the moment a hello or a validated refresh proves an identity for the current id, and a carried stamp the live canvas positively confirms is promoted to observed through the identity validator rather than off the refusal's prose — so a rename or save whose hello merely raced the canvas does not strand the session in refusals (#1656).

**Sessions and node adds recover instead of dead-ending** — a resumed pi turn whose session the CLI no longer has (pruned store, different cwd, or a foreign id armed from the panel's hello hint) used to fail every turn until the user typed `/new`; the miss now drops the dead id, re-arms the preamble and re-runs the turn once as a fresh session, which re-persists a valid id for the next one (#1235). And adding `Lora Loader (LoraManager)` from autocomplete no longer waits five seconds and refuses a perfectly healthy pack — the guard was polling `app.widgets` while ComfyUI 1.49+ moved `getCustomWidgets` into the widget store, so the agent was sent to reload instead of being pointed at the STRING-socket LoRA Text Loader it wanted (#1708).

**Packs install what their workflows actually load** — `packs:check-models` had existed for months and was run by nothing, so three packs shipped workflows asking for models their manifests never fetched. The gate itself is fixed first: five of seven reported gaps were false positives from litegraph keeping a dead `widgets_values` string after a widget is promoted to a linked input, and a gate with that error rate cannot be wired into CI. z-image-xy-plot's real defect was in its manifest — it activated Q5_K_S while its `UnetLoaderGGUF` asked for Q8_0, so a fresh install opened straight to a missing-model error. Leaked personal training artifacts are replaced with declared bring-your-own placeholders, and the gate now runs in CI at zero errors across all 57 packs (#1767).

**Docs stop under-describing the default** — the arena baseline table (model, params, quant, VRAM, score, grouped by 8 GB fit) can now be consulted straight from the published docs instead of only by running the benchmark (#792), and `local-llms` flags the default `:e4b` fine-tune as text-only with no vision loop, so nobody selects it expecting the panel to see its own outputs. The caveat is mirrored into all ten translated pages, where a non-English reader was previously left in the warned-about case with no warning (#1768).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
