### PR TITLE
fix(1778): a fence-refused workflow save corroborates like a fenced graph edit

### DIFF
--- a/src/__tests__/orchestrator/fenced-save-corroborates.test.ts
+++ b/src/__tests__/orchestrator/fenced-save-corroborates.test.ts
@@ -37,7 +37,11 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
-import { markDispatched } from "../../services/ui-bridge.js";
+import {
+  isCapabilityRefusal,
+  markCapabilityRefusal,
+  markDispatched,
+} from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "wf:route1:workflows/krea2_lora_ab_compare.json";
@@ -59,7 +63,60 @@ const fenceRefusal = (): Error =>
     false,
   );
 
-function harness(liveUuid: string) {
+// ── The two LOOK-ALIKES, quoted from the bridge's own templates ───────────────
+//
+// Both are minted by the SAME `"<cmd>" cannot be safely targeted to the active
+// workflow` reject in ui-bridge, both are `dispatched:false`, and both carry the
+// literal words "workflow instance mismatch" inside the `readsNote` that describes
+// what a DIFFERENT command would get. `isWorkflowInstanceMismatch` is an unanchored
+// phrase match, so it fires on both — which is why the new arm needs discriminators
+// the `graph_*` arm gets for free from the #1401 branch sitting above it.
+
+/** `capabilityMissing` — the panel does not enforce the fence contract a write needs.
+ *  Typed with the bridge's own symbol marker. NEITHER a retry NOR a rebind can add
+ *  the missing capability (#709), so appending that suffix contradicts the refusal. */
+const capabilityRefusal = (): Error =>
+  markCapabilityRefusal(
+    markDispatched(
+      new Error(
+        `"workflow_save" cannot be safely targeted to the active workflow: panel tab ` +
+          `${TAB} does not recheck workflow targeting at the graph write boundary after ` +
+          `asynchronous work (detected panel 0.11.40; a graph WRITE needs panel 0.11.62+, ` +
+          `the first build that rechecks the fence after an await). Update the panel and ` +
+          `hard-refresh the browser tab. WHETHER GRAPH READS STILL WORK IS NOT KNOWN FROM ` +
+          `HERE, and is not claimed: a read carries this session's stamp (${CARRIED_UUID}), ` +
+          `and this tab's panel runs it only while that stamp still names the ACTIVE canvas ` +
+          `— a comparison only the panel can make. If the workflow was switched or replaced ` +
+          `after this session bound to it, graph_outline / graph_query are refused with ` +
+          `"workflow instance mismatch" as well; if it was not, they work. Try ` +
+          `panel_list_workflows — the panel exempts that read from this fence (it is the ` +
+          `recovery probe), though a build predating the exemption fences it too. Non-graph ` +
+          `tools are unaffected.`,
+      ),
+      false,
+    ),
+  );
+
+/** The #1331 state: the fence contract IS advertised, but the workflow has no identity
+ *  to fence against. NOT capability-marked — the panel is fine, the canvas is not — so
+ *  the discriminating phrase is the only thing that separates it. And the separation
+ *  matters: "a mismatch may clear by itself, this never does". */
+const noTrustedIdentityRefusal = (): Error =>
+  markDispatched(
+    new Error(
+      `"workflow_save" cannot be safely targeted to the active workflow: this workflow has ` +
+        `no trusted identity for the panel to fence the command against. GRAPH READS ARE ` +
+        `REFUSED TOO, for this same missing stamp: this tab's panel enforces the ` +
+        `per-command fence and refuses an UNSTAMPED command rather than fail open, so ` +
+        `graph_outline / graph_query answer "workflow instance mismatch: this command ` +
+        `carries no workflow-instance stamp" as well. Try panel_list_workflows — the panel ` +
+        `exempts that read from this fence (it is the recovery probe), though a build ` +
+        `predating the exemption fences it too. Non-graph tools are unaffected.`,
+    ),
+    false,
+  );
+
+function harness(liveUuid: string, refusal: () => Error = fenceRefusal) {
   /** Every uuid offered to the provenance-only corroborator — the self-heal. */
   const corroborated: string[] = [];
   /** Every uuid handed to the RETARGETING fence write — must stay empty (#1646). */
@@ -77,7 +134,7 @@ function harness(liveUuid: string) {
         };
         return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
       }
-      throw fenceRefusal();
+      throw refusal();
     },
     push: () => 1,
     canReach: (id: string) => id === TAB,
@@ -103,6 +160,7 @@ async function runTool(
   tool: string,
   args: Record<string, unknown>,
   liveUuid: string,
+  refusal: () => Error = fenceRefusal,
 ): Promise<{
   text: string;
   res: ToolResult;
@@ -110,7 +168,7 @@ async function runTool(
   retargeted: string[];
   sent: string[];
 }> {
-  const { bridge, corroborated, retargeted, sent } = harness(liveUuid);
+  const { bridge, corroborated, retargeted, sent } = harness(liveUuid, refusal);
   const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === tool);
   if (!def) throw new Error(`${tool} is not registered`);
@@ -186,6 +244,59 @@ describe("#1778 — a fenced workflow SAVE corroborates like a fenced graph edit
     expect(corroborated).toEqual([CARRIED_UUID]);
     expect(text).toMatch(/CHECKED/);
     expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+  });
+
+  it("does NOT hijack a CAPABILITY refusal that merely quotes the phrase", async () => {
+    // The bridge's capability refusal names "workflow instance mismatch" inside its
+    // readsNote, to say what a graph READ would get. The phrase match cannot tell that
+    // apart from the fence actually having refused — for `graph_*` the ordering above
+    // hides it, and these four have nothing above them.
+    const raw = capabilityRefusal();
+    // The fixture is only meaningful if it really does trip the phrase match; assert
+    // that, or this test could pass for the wrong reason.
+    expect(/workflow instance mismatch/i.test(raw.message)).toBe(true);
+    expect(isCapabilityRefusal(raw)).toBe(true);
+
+    const { text, corroborated, sent } = await runTool(
+      "panel_save_workflow",
+      {},
+      CARRIED_UUID,
+      capabilityRefusal,
+    );
+
+    // No probe: there is no fence state to corroborate, and the round trip is wasted.
+    expect(sent).not.toContain("workflow_list");
+    expect(corroborated).toEqual([]);
+    // The capability branch's verbatim surfacing, not #1330's verdict.
+    expect(text).not.toMatch(/CHECKED/);
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // #709: neither a retry nor a rebind can add the missing capability, so the
+    // suffix that orders one must not be appended three lines after the refusal
+    // says so.
+    expect(text).toMatch(/cannot be safely targeted to the active workflow/);
+  });
+
+  it("does NOT hand a NO-TRUSTED-IDENTITY refusal the mismatch remedy", async () => {
+    // The pair the repo forbids conflating: a mismatch may clear by itself, this
+    // never does. Answering it with "retry once, the fence already names the live
+    // canvas" is the wrong half.
+    const raw = noTrustedIdentityRefusal();
+    expect(/workflow instance mismatch/i.test(raw.message)).toBe(true);
+    expect(isCapabilityRefusal(raw)).toBe(false); // the marker cannot separate this one
+
+    const { text, corroborated, sent } = await runTool(
+      "panel_save_workflow",
+      {},
+      CARRIED_UUID,
+      noTrustedIdentityRefusal,
+    );
+
+    expect(sent).not.toContain("workflow_list");
+    expect(corroborated).toEqual([]);
+    expect(text).not.toMatch(/CHECKED/);
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // The refusal's own words survive, which is where the real remedy lives.
+    expect(text).toMatch(/no trusted identity/);
   });
 
   it("CONTROL: a canvas-INDEPENDENT command is left alone", async () => {

--- a/src/__tests__/orchestrator/fenced-save-corroborates.test.ts
+++ b/src/__tests__/orchestrator/fenced-save-corroborates.test.ts
@@ -1,0 +1,203 @@
+// #1778 — panel_save_workflow was fence-refused WITHOUT corroborating, so a
+// save-only retry loop never self-healed.
+//
+// Split out of #1656, where an independent gate constructed the case and a control run
+// proved it pre-dates that fix. The panel fences far more than `graph_*`:
+// `activeWorkflowFenceApplies` covers everything that is not canvas-targetless /
+// workflow_open / workflow_new, which includes the four ACTIVE-workflow mutators
+// workflow_save, workflow_save_as, workflow_rename and workflow_close.
+//
+// Orchestrator-side, both halves of the repair read their scope off the `graph_` prefix
+// instead: `isMutatingGraphCmd` is an allowlist of `graph_*` names and `isFencedGraphRead`
+// requires the prefix outright. So a fence refusal on `workflow_save` matched NEITHER,
+// fell all the way through to the generic `dispatched:false` wrapper, and fired no probe
+// at all — which means `rebindWorkflowFence`'s `corroborateTabStamp` (#1656, the
+// promotion that lets a CARRIED-but-confirmed stamp dispatch) never ran.
+//
+// Measured on the reporter's rig, one session, one stamp: `panel_graph_outline` was
+// refused, probed, corroborated, and its retry went through; `panel_save_workflow({})`
+// was refused with an EMPTY corroboration every time. A caller that only ever retries
+// the save therefore stays refused indefinitely — until it happens to issue some
+// unrelated `graph_*` call, or takes the remedy the refusal names.
+//
+// NOTHING IS WRITTEN BY EITHER STATE. The fence is checked pre-dispatch and the refusal
+// is typed `dispatched:false`, so the cost is a stuck loop and a wasted turn, not data —
+// which is also what makes "retry this exact call once" safe to say here.
+//
+// The generic wrapper's prose was the second, smaller half: it guesses "the tab may be
+// disconnected, still reconnecting … or the binding is stale". In this state the tab is
+// connected and routing fine; what is stale is the stamp. Reaching the real branch
+// retires that guess as a side effect, and this file pins that too.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:route1:workflows/krea2_lora_ab_compare.json";
+const CARRIED_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OTHER_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+/** The fence refusal in the shape the bridge mints it: PRE-dispatch, typed
+ *  `dispatched:false`, and stating both sides of the comparison it performed. */
+const fenceRefusal = (): Error =>
+  markDispatched(
+    new Error(
+      `workflow instance mismatch: this command was issued for workflow instance ` +
+        `${CARRIED_UUID}, and the tab it routed to has not re-established its workflow ` +
+        `identity since it re-registered under a new id — the uuid it currently carries ` +
+        `(${CARRIED_UUID}) was inherited from the tab id it replaced, so it is not evidence ` +
+        `about the canvas now mounted there. Nothing was dispatched. Re-target with ` +
+        `panel_set_workflow_target({mode:"current"}), then retry.`,
+    ),
+    false,
+  );
+
+function harness(liveUuid: string) {
+  /** Every uuid offered to the provenance-only corroborator — the self-heal. */
+  const corroborated: string[] = [];
+  /** Every uuid handed to the RETARGETING fence write — must stay empty (#1646). */
+  const retargeted: string[] = [];
+  /** Which commands the panel was actually asked to run. */
+  const sent: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        const active = {
+          path: "workflows/krea2_lora_ab_compare.json",
+          routing_key: TAB,
+          workflow_uuid: liveUuid,
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      throw fenceRefusal();
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      retargeted.push(uuid);
+      return true;
+    },
+    corroborateTabStamp: (_tabId: string, uuid: string) => {
+      corroborated.push(uuid);
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: CARRIED_UUID }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge: b, corroborated, retargeted, sent };
+}
+
+async function runTool(
+  tool: string,
+  args: Record<string, unknown>,
+  liveUuid: string,
+): Promise<{
+  text: string;
+  res: ToolResult;
+  corroborated: string[];
+  retargeted: string[];
+  sent: string[];
+}> {
+  const { bridge, corroborated, retargeted, sent } = harness(liveUuid);
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === tool);
+  if (!def) throw new Error(`${tool} is not registered`);
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    res,
+    corroborated,
+    retargeted,
+    sent,
+  };
+}
+
+describe("#1778 — a fenced workflow SAVE corroborates like a fenced graph edit", () => {
+  it("probes and corroborates when the live canvas confirms the carried stamp", async () => {
+    const { text, corroborated, retargeted, sent } = await runTool(
+      "panel_save_workflow",
+      {},
+      CARRIED_UUID,
+    );
+
+    // THE FIX. Before it, the save refusal fired no probe at all: `workflow_list` was
+    // never sent and `corroborateTabStamp` was never offered anything, so the session
+    // kept refusing a canvas the panel agrees is the right one and a save-only retry
+    // loop could not converge. Both assertions fail when the widened gate is reverted.
+    expect(sent).toContain("workflow_list");
+    expect(corroborated).toEqual([CARRIED_UUID]);
+    // Read-only, exactly as for a graph edit: the RETARGETING write is not reached.
+    expect(retargeted).toEqual([]);
+
+    // The refusal is still a refusal — nothing is auto-applied, nothing auto-continues.
+    expect(text).toMatch(/workflow instance mismatch/);
+    // …and it now carries the verdict that makes the retry informed rather than blind.
+    expect(text).toMatch(/CHECKED/);
+    expect(text).toMatch(/TRANSIENT/);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // Structural, not echoed: the fence is checked before the handler runs, so the
+    // file was NOT written and the retry cannot double-apply.
+    expect(text).toMatch(/NOT applied — nothing changed/);
+
+    // The second half of #1778: the generic wrapper's guess is retired. The tab is
+    // connected and routing fine here — only the stamp is stale — so "may be
+    // disconnected / still reconnecting" was describing a state that did not exist.
+    expect(text).not.toMatch(/may be disconnected/);
+    expect(text).not.toMatch(/still reconnecting after a restart\/reload/);
+  });
+
+  it("adopts NOTHING when the live canvas is a DIFFERENT workflow (#1646 stands)", async () => {
+    const { text, corroborated, retargeted } = await runTool(
+      "panel_save_workflow",
+      {},
+      OTHER_UUID,
+    );
+    // A save must never be re-pointed onto the canvas its own refusal named as the
+    // wrong one — that would write the caller's graph over another workflow's file.
+    expect(corroborated).toEqual([]);
+    expect(retargeted).toEqual([]);
+    expect(text).toMatch(/DIFFERENT workflow/);
+    expect(text).toContain(OTHER_UUID);
+    expect(text).toMatch(/The fence is unchanged/);
+  });
+
+  it("covers the whole fenced set, not just the reported command (rename)", async () => {
+    // The gap is not about `panel_save_workflow`; it is about the orchestrator reading
+    // this branch's scope off the `graph_` prefix while the panel reads it off the
+    // fence. `workflow_rename` refused against the ACTIVE canvas is the same state.
+    const { text, corroborated, sent } = await runTool(
+      "panel_rename_workflow",
+      { name: "renamed" },
+      CARRIED_UUID,
+    );
+    expect(sent).toContain("workflow_list");
+    expect(corroborated).toEqual([CARRIED_UUID]);
+    expect(text).toMatch(/CHECKED/);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+  });
+
+  it("CONTROL: a canvas-INDEPENDENT command is left alone", async () => {
+    // The widening is an explicit list, not "everything that is not graph_". The panel
+    // exempts canvas-independent Manager/server ops from this fence entirely, so a
+    // refusal quoting the phrase for one of them is not a fence state this branch may
+    // claim to have diagnosed — it must fall through to the generic handling.
+    const { bridge, corroborated, sent } = harness(CARRIED_UUID);
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await ctx.call({ cmd: "manager_getlist" }, 5000);
+    expect(res.isError).toBe(true);
+    expect(sent).not.toContain("workflow_list");
+    expect(corroborated).toEqual([]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8390,9 +8390,37 @@ export function makePanelToolCtx(
       // refused PRE-dispatch exactly as a graph edit is, so every claim this branch
       // makes — "NOT applied", the read-only probe, the retry advice — holds for them
       // verbatim. See isFencedWorkflowMutator.
+      //
+      // THE PHRASE IS NOT THE STATE, AND TWO OTHER REFUSALS QUOTE IT (gate, P1).
+      // `isWorkflowInstanceMismatch` is an unanchored `/workflow instance mismatch/i`,
+      // and the bridge's own capability refusal embeds those exact words in its
+      // `readsNote` — "graph_outline / graph_query are refused with «workflow instance
+      // mismatch» as well" — to describe what a DIFFERENT command would get. Its
+      // `why` clause carries the second look-alike, `no trusted identity`. Both are
+      // minted by the same `cannot be safely targeted` reject, both are
+      // `dispatched:false`, and both would satisfy the phrase match.
+      //
+      // For `graph_*` that never surfaced, by ordering rather than by design: the
+      // #1401 branch above catches `no trusted identity` for a mutating graph edit
+      // first. These four have no such branch above them, so the widening alone would
+      // have HIJACKED both states and answered each with the other's remedy — the
+      // precise conflation `isNoTrustedIdentityRefusal`'s docstring forbids ("a
+      // mismatch may clear by itself, this never does"), and for the capability state
+      // it would re-append the futile retry/rebind suffix #709 exists to suppress,
+      // three lines after the refusal says rebinding cannot help.
+      //
+      // So the new arm carries the discriminators the old one got from ordering. Both
+      // are TYPED-or-explicit, never a second reading of the same prose:
+      // `isCapabilityRefusal` is the bridge's own symbol marker, and
+      // `isNoTrustedIdentityRefusal` matches the distinct phrase the mismatch refusal
+      // never contains. Scoped to THIS arm on purpose — `isMutatingGraphCmd` keeps its
+      // exact prior behaviour, so nothing about the graph path moves here.
       if (
         isWorkflowInstanceMismatch(err) &&
-        (isMutatingGraphCmd(cmd) || isFencedWorkflowMutator(cmd))
+        (isMutatingGraphCmd(cmd) ||
+          (isFencedWorkflowMutator(cmd) &&
+            !isCapabilityRefusal(err) &&
+            !isNoTrustedIdentityRefusal(err)))
       ) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
         const raw = err instanceof Error ? err.message : String(err);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1077,6 +1077,58 @@ function isFencedGraphRead(cmd: Record<string, unknown>): boolean {
   return name.startsWith("graph_") && !MUTATING_GRAPH_EDIT_CMDS.has(name);
 }
 
+/**
+ * #1778 — THE FOUR FENCED COMMANDS THAT ARE NOT `graph_*`.
+ *
+ * The panel's `activeWorkflowFenceApplies` does not key on the `graph_` prefix at
+ * all: it fences everything that is not canvas-TARGETLESS, `workflow_open` or
+ * `workflow_new`. Alongside every `graph_*` that covers the four ACTIVE-workflow
+ * mutators — `workflow_save`, `workflow_save_as`, `workflow_rename`,
+ * `workflow_close` — which the panel's own comment names explicitly ("workflow_save*
+ * ignore any path, so they are ALWAYS active").
+ *
+ * Orchestrator-side both repair branches for that refusal WERE keyed on the prefix:
+ * `isMutatingGraphCmd`'s allowlist holds only `graph_*` names, and `isFencedGraphRead`
+ * requires the prefix outright. So these four matched NEITHER. A fence refusal on
+ * `workflow_save` fell past both, past the routing/capability branches, and landed in
+ * the generic `dispatched:false` wrapper — which fires no probe, so
+ * `rebindWorkflowFence`'s `corroborateTabStamp` (#1656, the promotion that lets a
+ * CARRIED-but-confirmed stamp dispatch) never ran.
+ *
+ * That is the reported dead end. In the same session, on the same stamp,
+ * `panel_graph_outline` probed, corroborated and its retry went through, while
+ * `panel_save_workflow({})` was refused with an EMPTY corroboration every time — so a
+ * caller whose loop only retries the save never self-heals. Nothing is written by
+ * either state (the refusal is pre-dispatch, `dispatched:false`), so the cost is a
+ * stuck loop, not data.
+ *
+ * EXPLICIT LIST, deliberately NOT "every non-`graph_` command". Most non-graph
+ * commands the orchestrator sends are canvas-INDEPENDENT Manager/server ops that the
+ * panel exempts from this fence (`CANVAS_INDEPENDENT_COMMANDS`, #602); a negation rule
+ * would claim a fence repair for commands this fence can never raise. Mirrors the
+ * MUTATING_GRAPH_EDIT_CMDS maintenance model — keep in sync with the panel's
+ * `activeWorkflowFenceApplies`.
+ *
+ * `workflow_rename`/`workflow_close` are listed even though the panel EXEMPTS them
+ * when their selector resolves to a genuinely non-active workflow: the exemption
+ * means no refusal is raised in that case, so this predicate is simply never
+ * consulted for it. When one of them IS refused, it was targeting the active canvas —
+ * exactly the state this repairs.
+ */
+const FENCED_WORKFLOW_MUTATOR_CMDS = new Set<string>([
+  "workflow_save",
+  "workflow_save_as",
+  "workflow_rename",
+  "workflow_close",
+]);
+
+/** #1778 — a non-`graph_*` command the panel's active-workflow fence still covers, so
+ *  its refusal deserves the same read-only corroboration a fenced graph edit gets. */
+function isFencedWorkflowMutator(cmd: Record<string, unknown>): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  return FENCED_WORKFLOW_MUTATOR_CMDS.has(name);
+}
+
 /** True when an error is a TRANSIENT transport/reconnect drop (the tab went away
  *  or was replaced), NOT a genuine command error or a live-but-frozen reply
  *  timeout. Deliberately EXCLUDES "did not reply within N ms" (a backgrounded/
@@ -8328,7 +8380,20 @@ export function makePanelToolCtx(
       //
       // Safe to recommend a retry because a fence refusal is checked BEFORE the handler
       // runs — "Nothing was applied" is structural here, not an echoed claim.
-      if (isWorkflowInstanceMismatch(err) && isMutatingGraphCmd(cmd)) {
+      //
+      // #1778 — and the same is true of the four workflow mutators the panel fences
+      // identically. `isMutatingGraphCmd` alone read this branch's scope off the
+      // `graph_` allowlist rather than off the fence, so `workflow_save` /
+      // `workflow_save_as` / `workflow_rename` / `workflow_close` fell through to the
+      // generic dispatched:false wrapper: no probe, no `corroborateTabStamp`, and a
+      // caller retrying only the save stayed refused forever. They are mutations
+      // refused PRE-dispatch exactly as a graph edit is, so every claim this branch
+      // makes — "NOT applied", the read-only probe, the retry advice — holds for them
+      // verbatim. See isFencedWorkflowMutator.
+      if (
+        isWorkflowInstanceMismatch(err) &&
+        (isMutatingGraphCmd(cmd) || isFencedWorkflowMutator(cmd))
+      ) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
         const raw = err instanceof Error ? err.message : String(err);
         // The uuid the command CARRIED, read from the panel's own refusal rather than


### PR DESCRIPTION
Fixes #1778.

## The gap

The panel's `activeWorkflowFenceApplies` does **not** key on the `graph_` prefix. It fences everything that is not canvas-*targetless*, `workflow_open` or `workflow_new` — which, alongside every `graph_*`, covers the four ACTIVE-workflow mutators the panel's own comment names explicitly: `workflow_save`, `workflow_save_as`, `workflow_rename`, `workflow_close` ("workflow_save\* ignore any path, so they are ALWAYS active").

Orchestrator-side, both halves of the repair read their scope off the prefix instead:

- `isMutatingGraphCmd` is an allowlist holding only `graph_*` names (#1330 branch);
- `isFencedGraphRead` requires the prefix outright (#1519 branch).

So a fence refusal on `workflow_save` matched **neither**. It fell past those, past the root-uuid / capability / routing-ambiguity branches, and landed in the generic `dispatchOutcomeOf(err) === false` wrapper — which fires no probe at all. That means `rebindWorkflowFence`'s `corroborateTabStamp` (#1656 — the promotion that lets a CARRIED-but-confirmed stamp start dispatching again) **never ran**.

In the reporter's session, on one stamp: `panel_graph_outline` was refused, probed, corroborated, and its retry went through. `panel_save_workflow({})` was refused with an **empty corroboration**, every time. A caller whose loop only ever retries the save therefore never self-heals — until it happens to issue some unrelated `graph_*` call, or takes the remedy named in the refusal text.

Not destructive: the fence is checked pre-dispatch and the refusal is typed `dispatched:false`, so nothing was written and a retry cannot double-apply. The cost was a stuck loop and a wasted turn, not data.

## The fix

Name the four fenced non-graph mutators explicitly (`isFencedWorkflowMutator`) and admit them to the #1330 corroboration branch. They are mutations refused PRE-dispatch exactly as a graph edit is, so every claim that branch makes holds for them verbatim — "NOT applied — nothing changed", the READ-ONLY probe, and the retry advice.

`#1646 stands`: the probe is still `adopt:false`. A live canvas that names a **different** workflow is reported, never adopted — for a save that matters more than for an edit, since a re-pointed save would write the caller's graph over another workflow's file. `corroborateTabStamp` (provenance only) is reached; `refreshWorkflowUuid` (the retargeting write) is not.

**An explicit list, deliberately not "everything that is not `graph_`"** — see the scope section below for why the wider fenced set is not admitted. A control test pins the boundary: `manager_getlist` (canvas-independent, `CANVAS_INDEPENDENT_COMMANDS`, #602) quoting the same phrase still falls through to generic handling, probing nothing.

`workflow_rename`/`workflow_close` are listed even though the panel exempts them when their selector resolves to a **deterministically** non-active workflow — in that case no refusal is raised at all, so the predicate is never consulted. It is *not* claimed that a refused rename/close was therefore targeting the active canvas: a `path` resolving to no open workflow is fenced too, since the exemption requires a positive resolution. Such a call gets one informed retry instead of the generic wrapper's guess; both refuse, so the cost of being wrong there is a round trip, not a wrong target.

### The phrase is not the state (second commit, from the gate)

`isWorkflowInstanceMismatch` is an **unanchored** `/workflow instance mismatch/i`, and two other refusals quote those exact words:

- the bridge's **capability** refusal embeds them in its `readsNote`, to describe what a *different* command would get;
- the **no-trusted-identity** refusal (#1331) carries them the same way.

Both are minted by the same `"<cmd>" cannot be safely targeted to the active workflow` reject and both are `dispatched:false`, so both satisfied the phrase match. For `graph_*` that never surfaced — by ordering rather than by design: the #1401 branch catches `no trusted identity` for a mutating graph edit first. These four have nothing above them, so the widening **alone** would have hijacked both states and answered each with the other's remedy: the retry/rebind suffix #709 exists to suppress, appended three lines after the refusal says rebinding cannot add the missing capability; and #1330's "retry once" handed to a state whose own docstring says "a mismatch may clear by itself, this never does".

So the new arm carries the discriminators the old one got from ordering — `isCapabilityRefusal` (the bridge's typed symbol marker) and `isNoTrustedIdentityRefusal` (the distinct phrase a mismatch refusal never contains). Scoped to the new arm only, so `isMutatingGraphCmd` keeps its exact prior behaviour.

## Answering "check whether other non-`graph_*` targeted commands share the gap"

They do — but the fenced set outside the prefix is **wider than four**, and the round-2 gate was right to push on my first wording. `CANVAS_INDEPENDENT_COMMANDS` holds only seven names, so `activeWorkflowFenceApplies` also fences `ask_user`, `ui_render`, `training_*`, `civitai_*` and others.

Those are deliberately **not** admitted. This branch's claims are about a MUTATION of the active canvas — "NOT applied — nothing changed", a read-only re-read of that canvas, a retry that cannot double-apply — and the four are exactly the set for which all three are true. They mirror ui-bridge's own `ACTIVE_WORKFLOW_MUTATORS` (#570 P0c), which is the list to keep the new predicate in sync with. A negation rule would have been wrong in both directions.

**Deliberately not changed, two things:**

1. The #1401 `no trusted identity` branch is gated on `isMutatingGraphCmd` too, so it has the same *shape* of gap for these four. Left alone: different refusal, its probe **adopts** rather than being read-only, and it was neither reported nor reproduced. Widening an adopting rebind onto the save path off an unreproduced hypothesis is not a trade worth making under the freeze. (This PR makes those four fall through to the generic wrapper for that state, exactly as before — it does not make it worse.)
2. `graph_*` mutations *already* hijack the capability refusal through the same unanchored phrase match — pre-existing, untouched here, and worth a separate look. Anchoring `isWorkflowInstanceMismatch` would fix it globally but changes the graph path, which is out of scope for a P3.

## Verification

**Verified by deleting the fix, twice.**

Reverting the widened gate to bare `isMutatingGraphCmd(cmd)` fails 3 of the tests, and the failure output is the reported symptom byte for byte:

```
expected 'Error: workflow_save could not be dis…' to match /DIFFERENT workflow/
+ Received:
"Error: workflow_save could not be dispatched to this session's panel tab — nothing was
 applied. The tab may be disconnected, still reconnecting after a restart/reload, or the
 session's binding is stale (e.g. another workflow tab is now active). …"
```

Reverting the two discriminators fails exactly the two tests that pin them. The CONTROL test (canvas-independent command) correctly survives both mutations.

The tests drive the **real** `panel_save_workflow` / `panel_rename_workflow` tool defs through the real `ctx.call` path, with a bridge that mints each refusal via the bridge's own `markDispatched` / `markCapabilityRefusal` — so they exercise the production call site, not a helper. Each look-alike fixture first asserts that it really does trip `/workflow instance mismatch/i`, so neither test can pass vacuously.

- `npx vitest run src/__tests__/orchestrator/fenced-save-corroborates.test.ts` — 6 passed
- `npx vitest run src/__tests__/orchestrator src/__tests__/services` — **402 files / 8089 tests passed**, 3 skipped
- `npm run lint` (`tsc --noEmit`) — clean

**Browser coverage:** none was run, and none applies. This is orchestrator-side TypeScript only; no panel source is touched and nothing the sidebar renders changes. What changes is the probe behaviour and text of an MCP tool result.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead, via `.claude/autopilot/claude-gate.mjs`. Disclosed as required.

- **Round 1 — NO-SHIP.** Two P1s, both real and both the same class: the unanchored phrase match cannot distinguish the fence refusing from another refusal *quoting* the fence. Fixed in `ccb60b7`, with a test per finding.
- **Round 2 — SHIP.** Re-gated after the fix. The reviewer enumerated every producer of `/workflow instance mismatch/i` that can reach this catch, forced the probe to fail (`unreadable`, no corroboration), fenced `workflow_list` itself to check the branch cannot recurse (one probe, no loop), and independently killed all three mutations. It raised two comment-only prose inaccuracies, both correct and both fixed in the third commit — the fenced set outside the prefix is wider than four, and a refused rename/close does not prove an active target. Neither changed behaviour.

## Note for the maintainer

A parallel worker claimed this issue in `.worktrees/wt-1778` (branch `fix/1778-save-fence-corroborate`) and began writing a test there mid-run. I relocated to my own worktree and left theirs exactly as I found it. If a competing PR appears, it and this one are solving the same defect — close whichever is second.
