### PR TITLE
fix(1778): panel_save_workflow corroborates a fence refusal so a save-only retry self-heals

### DIFF
--- a/src/__tests__/orchestrator/save-fence-corroborate.test.ts
+++ b/src/__tests__/orchestrator/save-fence-corroborate.test.ts
@@ -1,0 +1,189 @@
+// #1778 — panel_save_workflow is fence-refused without corroborating, so a save-only
+// retry loop never self-heals.
+//
+// When a command is refused by the workflow-instance fence, graph reads
+// (isFencedGraphRead) and graph mutations (isMutatingGraphCmd) fire a read-only
+// probe: workflow_list corroborates the instance the fence already holds, the
+// first call still fails, and a retry dispatches. panel_save_workflow({}) is
+// neither a graph_* command nor in MUTATING_GRAPH_EDIT_CMDS, so neither probe
+// branch fires. The save handler then returns at `if (res.isError) return res`
+// with the generic "tab may be disconnected" wrapper and an empty corroboration.
+// A caller that only retries the save stays refused indefinitely.
+//
+// Same safety as #1656's graph probe: corroborateTabStamp, never refreshWorkflowUuid.
+// A matching live uuid is the self-heal; a diverged canvas stays refused (#1646).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:route1:workflows/krea2_lora_ab_compare.json";
+const CARRIED_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OTHER_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const carriedRefusal = (): Error =>
+  markDispatched(
+    new Error(
+      `workflow instance mismatch: this command was issued for workflow instance ${CARRIED_UUID}, ` +
+        `and the tab it routed to has not re-established its workflow identity since it ` +
+        `re-registered under a new id — the uuid it currently carries (${CARRIED_UUID}) was ` +
+        `inherited from the tab id it replaced, so it is not evidence about the canvas now ` +
+        `mounted there. Nothing was dispatched. Re-target with ` +
+        `panel_set_workflow_target({mode:"current"}), then retry.`,
+    ),
+    false,
+  );
+
+function harness(liveUuid: string) {
+  const corroborated: string[] = [];
+  const retargeted: string[] = [];
+  /** Commands that actually reached a success reply — the dispatch the retry must earn. */
+  const dispatched: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        const active = {
+          path: "workflows/krea2_lora_ab_compare.json",
+          routing_key: TAB,
+          workflow_uuid: liveUuid,
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      // Models the real agreement gate: a carried stamp stays refused until the
+      // live canvas CONFIRMS it. Corroboration is the only thing that flips this.
+      const proven = corroborated.includes(CARRIED_UUID) && liveUuid === CARRIED_UUID;
+      if (!proven) throw carriedRefusal();
+      dispatched.push(typeof cmd.cmd === "string" ? cmd.cmd : "");
+      if (cmd.cmd === "workflow_save" || cmd.cmd === "workflow_save_as") {
+        return { saved: true, workflow: "x", workflow_uuid: CARRIED_UUID, routing_key: TAB };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      retargeted.push(uuid);
+      return true;
+    },
+    corroborateTabStamp: (_tabId: string, uuid: string) => {
+      corroborated.push(uuid);
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: CARRIED_UUID }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge: b, corroborated, retargeted, dispatched };
+}
+
+type Harness = ReturnType<typeof harness>;
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+async function callTool(
+  h: Harness,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; res: ToolResult }> {
+  const ctx = makePanelToolCtx(h.bridge, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return { text: textOf(res), res };
+}
+
+describe("#1778 panel_save_workflow corroborates a fence refusal, so a save-only retry self-heals", () => {
+  it("CONTROL: panel_graph_outline in this state probes, corroborates, and a retry dispatches", async () => {
+    // The path the reporter already had: a fenced graph READ self-heals. If this
+    // fails, the harness is wrong — not the save gap.
+    const h = harness(CARRIED_UUID);
+    const first = await callTool(h, "panel_graph_outline");
+    expect(h.corroborated).toEqual([CARRIED_UUID]);
+    expect(h.retargeted).toEqual([]);
+    expect(first.res.isError).toBe(true);
+    expect(h.dispatched).toEqual([]);
+
+    const second = await callTool(h, "panel_graph_outline");
+    expect(second.res.isError).toBeFalsy();
+    expect(h.dispatched).toContain("graph_outline");
+  });
+
+  it("a matching live uuid is corroborated, and a save-only retry then dispatches", async () => {
+    const h = harness(CARRIED_UUID);
+    const first = await callTool(h, "panel_save_workflow");
+
+    // The probe ran and offered the uuid already in force — that is the self-heal.
+    expect(h.corroborated).toEqual([CARRIED_UUID]);
+    // The RETARGETING write is not reached on the refusal: the fence does not move.
+    expect(h.retargeted).toEqual([]);
+    expect(first.res.isError).toBe(true);
+    expect(first.text).toMatch(/workflow instance mismatch/);
+    expect(first.text).toMatch(/CHECKED/);
+    expect(first.text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // The generic dispatched:false wrapper is the misleading one: the tab is
+    // connected; what is stale is the stamp. The probe must replace it.
+    expect(first.text).not.toMatch(/tab may be disconnected/);
+    // Nothing was written — the first save never dispatched.
+    expect(h.dispatched).toEqual([]);
+
+    // The reporter's loop: retry the SAME save, no graph_* in between.
+    const second = await callTool(h, "panel_save_workflow");
+    expect(second.res.isError).toBeFalsy();
+    expect(h.dispatched).toContain("workflow_save");
+  });
+
+  it("Save-As on the same path corroborates too — it is the same tool, a different cmd", async () => {
+    const h = harness(CARRIED_UUID);
+    const first = await callTool(h, "panel_save_workflow", { name: "copy" });
+    expect(h.corroborated).toEqual([CARRIED_UUID]);
+    expect(first.res.isError).toBe(true);
+    expect(h.dispatched).toEqual([]);
+
+    const second = await callTool(h, "panel_save_workflow", { name: "copy" });
+    expect(second.res.isError).toBeFalsy();
+    expect(h.dispatched).toContain("workflow_save_as");
+  });
+
+  it("a path-less rename shares the gap and is covered by the same probe", async () => {
+    // requiresStampTargetAgreement gates rename/close without a path the same way
+    // it gates save. Widening the probe to the active-workflow mutators, not just
+    // workflow_save, is what keeps that from becoming the next recurrence.
+    const h = harness(CARRIED_UUID);
+    const first = await callTool(h, "panel_rename_workflow", { name: "renamed" });
+    expect(h.corroborated).toEqual([CARRIED_UUID]);
+    expect(first.res.isError).toBe(true);
+    expect(h.dispatched).toEqual([]);
+
+    const second = await callTool(h, "panel_rename_workflow", { name: "renamed" });
+    expect(second.res.isError).toBeFalsy();
+    expect(h.dispatched).toContain("workflow_rename");
+  });
+
+  it("adopts NOTHING when the live canvas is a DIFFERENT workflow (#1646 stands)", async () => {
+    const h = harness(OTHER_UUID);
+    const first = await callTool(h, "panel_save_workflow");
+    expect(h.corroborated).toEqual([]);
+    expect(h.retargeted).toEqual([]);
+    expect(first.res.isError).toBe(true);
+    expect(first.text).toMatch(/DIFFERENT workflow/);
+    expect(first.text).toContain(OTHER_UUID);
+    expect(h.dispatched).toEqual([]);
+
+    // A save-only retry cannot smuggle the write onto the other canvas.
+    const second = await callTool(h, "panel_save_workflow");
+    expect(second.res.isError).toBe(true);
+    expect(h.dispatched).toEqual([]);
+    expect(h.retargeted).toEqual([]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1077,6 +1077,27 @@ function isFencedGraphRead(cmd: Record<string, unknown>): boolean {
   return name.startsWith("graph_") && !MUTATING_GRAPH_EDIT_CMDS.has(name);
 }
 
+/**
+ * #1778 — a fenced command that is neither a graph edit nor a graph read.
+ *
+ * `workflow_save` / `workflow_save_as` / `workflow_rename` / `workflow_close`
+ * require a workflow stamp (`requiresWorkflowStampEnforcement`) and the
+ * dispatch gate refuses them the same way it refuses a graph_* command. They
+ * are not in MUTATING_GRAPH_EDIT_CMDS and they do not start with `graph_`, so
+ * neither existing probe branch fires. The save handler then returns at
+ * `if (res.isError) return res` with the generic "tab may be disconnected"
+ * wrapper and an empty corroboration, so a save-only retry never self-heals.
+ *
+ * Derived from the stamp-enforcement classifier minus the `graph_` prefix, so
+ * a newly added active-workflow mutator cannot drift out. The prefix is still
+ * load-bearing for the same reason as `isFencedGraphRead`: the diagnosis runs
+ * `workflow_list`, which must not re-enter this branch.
+ */
+function isFencedActiveWorkflowMutator(cmd: Record<string, unknown>): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  return !name.startsWith("graph_") && requiresWorkflowStampEnforcement(cmd);
+}
+
 /** True when an error is a TRANSIENT transport/reconnect drop (the tab went away
  *  or was replaced), NOT a genuine command error or a live-but-frozen reply
  *  timeout. Deliberately EXCLUDES "did not reply within N ms" (a backgrounded/
@@ -8328,7 +8349,17 @@ export function makePanelToolCtx(
       //
       // Safe to recommend a retry because a fence refusal is checked BEFORE the handler
       // runs — "Nothing was applied" is structural here, not an echoed claim.
-      if (isWorkflowInstanceMismatch(err) && isMutatingGraphCmd(cmd)) {
+      //
+      // #1778 — the same refusal on workflow_save / save_as / rename / close. Those
+      // carry a workflow target but are not graph_*, so neither isMutatingGraphCmd
+      // nor isFencedGraphRead was true and the call fell through to the generic
+      // dispatched:false wrapper: no probe, no corroborateTabStamp, and a
+      // "tab may be disconnected" line that is false here (the tab is connected;
+      // what is stale is the stamp). Widening this branch is the self-heal.
+      if (
+        isWorkflowInstanceMismatch(err) &&
+        (isMutatingGraphCmd(cmd) || isFencedActiveWorkflowMutator(cmd))
+      ) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
         const raw = err instanceof Error ? err.message : String(err);
         // The uuid the command CARRIED, read from the panel's own refusal rather than


### PR DESCRIPTION
## Summary

`panel_save_workflow({})` refused by the workflow-instance fence never corroborated, so a save-only retry loop stayed refused until some other `graph_*` call happened to probe.

Graph reads (`isFencedGraphRead`) and graph mutations (`isMutatingGraphCmd`) already fire the read-only `workflow_list` probe: matching live uuid is corroborated (not retargeted), the first call still fails, and a retry dispatches. Save is neither `graph_*` nor in `MUTATING_GRAPH_EDIT_CMDS`, so both branches missed it. The handler then returned at `if (res.isError) return res` with the generic "tab may be disconnected" wrapper — false here: the tab is connected; what is stale is the stamp.

The same probe now covers the active-workflow mutators (`workflow_save` / `save_as` / `rename` / `close`), derived from `requiresWorkflowStampEnforcement` rather than restated. A matching live uuid self-heals on retry; a diverged canvas stays refused (`#1646`). Nothing is auto-applied: the refusal is pre-dispatch (`dispatched:false`).

## Test plan

- [x] `src/__tests__/orchestrator/save-fence-corroborate.test.ts` drives `panel_save_workflow` (and Save-As / path-less rename) through the real `ctx.call` path
  - CONTROL: `panel_graph_outline` already probes, corroborates, retry dispatches
  - matching live uuid: first save fails with CHECKED / RETRY, corroborates, no "tab may be disconnected"; retry dispatches `workflow_save`
  - diverged canvas: no corroboration, no retarget, retry still refused
- [x] Related fence suites still green: carried-stamp-corroboration, fence-mismatch-corroborates, fenced-read-absent-stamp, save-as-fence, fence-trusts-own-reply, panel-retry-identity, open-identity-normalization

Fixes #1778
