### PR TITLE
docs: the 0.52.7 changelog names #1784, which shipped in the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,6 +768,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - panel_save_workflow corroborates a fence refusal so a save-only retry self-heals (#1782)
+- the widened fence arm must not adopt refusals that merely quote it (#1784)
 
 
 ## [0.52.6] - 2026-08-19


### PR DESCRIPTION
Found while driving #1783 to a terminal state.

**The gap.** `release/0.52.7` was cut at `aa3efcb` (11:04Z), before #1784 merged
to main at 11:27Z. GitHub squash-merged the version bump *on top of* #1784, so
the tag `v0.52.7` (`9d8827a`) does contain the fix — confirmed in the published
artifact, where `package/dist/orchestrator/panel-tools.js:7077` carries the
discriminator form:

```js
(isFencedActiveWorkflowMutator(cmd) &&
    !isCapabilityRefusal(err) &&
    !isNoTrustedIdentityRefusal(err))
```

The changelog entry could not have known: `gen-changelog` ran during `npm version`
on a branch where `4037ad6` did not yet exist.

**Why it will not self-correct.** `describe --tags` makes the next release's range
`v0.52.7..HEAD`, and `git merge-base --is-ancestor 4037ad6 v0.52.7` is true — so
`4037ad6` is excluded from that range and from every later one. The fix would stay
absent from the record permanently.

Docs only. No source or test change.
