### PR TITLE
fix(1789): the orchestrator's own /history observation keeps the completion promise panel_run makes — and the rider stops over-promising

### DIFF
--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -23,6 +23,7 @@ import { readFileSync } from "node:fs";
 import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import { registerQueueManagementTools } from "../../tools/queue-management.js";
 
 const indexSrc = (): string =>
   readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
@@ -130,6 +131,52 @@ afterEach(() => {
   qm.url = null;
 });
 
+/**
+ * Drive the REAL `queue` tool with the call the rider just told the agent to
+ * make, and report whether the tool ACCEPTED it.
+ *
+ * This is the assertion the first cut of #1789 was missing, and the gate caught
+ * it: the batch branch printed `queue (action:"status")` with no id, which
+ * queue-management.ts's `requirePromptId` REFUSES — so an agent obeying the
+ * fallback got an error instead of a status, the reported bug's own shape one
+ * level in. A test that only string-matched the rider pinned the broken form.
+ *
+ * The parse is deliberately narrow (exact literal shapes the rider emits) and
+ * THROWS on anything it does not recognise, so a reworded remedy fails loudly
+ * here instead of silently going unchecked.
+ *
+ * `isError` is the only thing read: a reachability failure is a different fact
+ * from a validation refusal, and the local `queue` handler answers both shapes
+ * without a live ComfyUI (verified: `list` and `status`+id return JSON, bare
+ * `status` returns isError "requires `prompt_id`").
+ */
+async function queueCallIsAccepted(call: string): Promise<boolean> {
+  let captured: ((a: Record<string, unknown>) => Promise<{ isError?: boolean }>) | null = null;
+  registerQueueManagementTools({
+    tool: (name: string, _d: unknown, _s: unknown, h: (a: Record<string, unknown>) => Promise<{ isError?: boolean }>) => {
+      if (name === "queue") captured = h;
+    },
+  } as never);
+  if (!captured) throw new Error("the queue tool was not registered");
+  const withId = call.match(/^queue \(action:"([a-z_]+)", prompt_id:"([^"]+)"\)$/);
+  const bare = call.match(/^queue \(action:"([a-z_]+)"\)$/);
+  const args = withId
+    ? { action: withId[1], prompt_id: withId[2] }
+    : bare
+      ? { action: bare[1] }
+      : null;
+  if (!args) throw new Error(`the rider's remedy is in an unrecognised shape: ${call}`);
+  const res = await (captured as (a: Record<string, unknown>) => Promise<{ isError?: boolean }>)(args);
+  return res.isError !== true;
+}
+
+/** The single remedy the rider's [FALLBACK] line tells the agent to run. */
+function fallbackCallIn(text: string): string {
+  const m = text.match(/make ONE check with (queue \(action:"[a-z_]+"(?:, prompt_id:"[^"]+")?\))/);
+  if (!m) throw new Error(`no [FALLBACK] remedy found in the rider:\n${text}`);
+  return m[1];
+}
+
 describe("#1789 — panel_run's rider stops promising more than the code can keep", () => {
   it("keeps the anti-poll instruction AND names one bounded fallback with the prompt id", async () => {
     const res = await defByName("panel_run").handler({}, makeCtx({ queued: true, prompt_id: "p-1789" }));
@@ -155,9 +202,41 @@ describe("#1789 — panel_run's rider stops promising more than the code can kee
     );
     const text = firstText(res);
     expect(text).toContain("[FALLBACK]");
-    // No invented single id when the run queued more than one.
-    expect(text).toContain('queue (action:"status")');
+    // No invented single id when the run queued more than one — and the remedy
+    // is the action that takes none, not a status call with the id left off.
+    expect(text).toContain('queue (action:"list")');
     expect(text).not.toContain('prompt_id:"p-a"');
+    expect(text).not.toContain('queue (action:"status")');
+  });
+
+  // THE POINT OF THE WHOLE FALLBACK: the call it names has to RUN. Both branches,
+  // executed against the real tool rather than string-matched.
+  it("SINGLE run — the remedy the rider prints is ACCEPTED by the queue tool", async () => {
+    const text = firstText(
+      await defByName("panel_run").handler({}, makeCtx({ queued: true, prompt_id: "p-1789" })),
+    );
+    const call = fallbackCallIn(text);
+    expect(call).toBe('queue (action:"status", prompt_id:"p-1789")');
+    expect(await queueCallIsAccepted(call)).toBe(true);
+  });
+
+  it("BATCH — the remedy the rider prints is ACCEPTED by the queue tool", async () => {
+    const text = firstText(
+      await defByName("panel_run").handler(
+        {},
+        makeCtx({ queued: true, prompt_id: "p-a", prompt_ids: ["p-a", "p-b"] }),
+      ),
+    );
+    const call = fallbackCallIn(text);
+    expect(call).toBe('queue (action:"list")');
+    expect(await queueCallIsAccepted(call)).toBe(true);
+  });
+
+  // The guard's own guard: prove queueCallIsAccepted can SAY NO, or the two
+  // assertions above are a rubber stamp. This is the exact call the first cut
+  // shipped.
+  it("…and that acceptance check is not vacuous — the shipped-broken form is REFUSED", async () => {
+    expect(await queueCallIsAccepted('queue (action:"status")')).toBe(false);
   });
 
   it("the UNCORRELATABLE branch is unchanged — it never told the agent to idle", async () => {

--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -1,0 +1,170 @@
+// #1789 — the two things a unit test of the watchdog cannot see.
+//
+// 1. THE CALL SITE. createRunCompletionWatchdog can be perfect and never run.
+//    The watchdog only exists if the orchestrator TEES QueueMonitor's drained
+//    completions into observe() and TICKS it — both inline in the
+//    startPanelOrchestrator closure, which needs a live bridge, agents and a
+//    socket to construct. Same treatment as the other index.ts boundary
+//    wirings (carried-stamp-wiring, agent-identity-wiring,
+//    shared-session-invariant): pinned at source.
+//
+//    The tee is load-bearing in a way a "does observe() appear anywhere" check
+//    would miss: drainCompletions() SPLICES, so calling it a second time for
+//    the watchdog would race the broadcaster and each consumer would see only
+//    part of the burst. The assertion is therefore about the SHAPE — one drain,
+//    both consumers.
+//
+// 2. THE PROMISE. panel_run's rider is what told the reporting agent to stop
+//    looking. It is driven here through the real tool handler, so the fallback
+//    sentence cannot be quietly dropped while the tests stay green.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+
+const indexSrc = (): string =>
+  readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+
+describe("#1789 — the history fallback is WIRED into the orchestrator, not merely available", () => {
+  it("SOURCE: the orchestrator constructs the watchdog against the real journal", () => {
+    const src = indexSrc();
+    expect(src).toContain("createRunCompletionWatchdog({");
+    const start = src.indexOf("createRunCompletionWatchdog({");
+    const block = src.slice(start, start + 1600);
+    // It asks the journal whether the run is still owed a completion…
+    expect(block).toContain("RunCompletions.awaitingCompletion(");
+    // …and delivers through the SAME arrival path the panel's frame uses, so the
+    // completion is correlated, journaled and replayable rather than pushed raw.
+    expect(block).toContain("RunCompletions.record(");
+    expect(block).toContain("flushRunCompletions(");
+  });
+
+  it("SOURCE: QueueMonitor's completions are TEED to the watchdog from the broadcaster's single drain", () => {
+    const src = indexSrc();
+    // Exactly one drain call site — a second one would race the broadcaster.
+    const drains = src.match(/QueueMonitor\.drainCompletions\(\)/g) ?? [];
+    expect(drains).toHaveLength(1);
+    const start = src.indexOf("createQueueStatusBroadcaster(");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 900);
+    expect(block).toContain("QueueMonitor.drainCompletions()");
+    expect(block).toContain("runCompletionWatchdog.observe(");
+  });
+
+  it("SOURCE: the watchdog is ticked on the poll timer, AFTER the drain that feeds it", () => {
+    const src = indexSrc();
+    const start = src.indexOf("const queueStatusTimer = setInterval(");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 700);
+    expect(block).toContain("runCompletionWatchdog.tick()");
+    // Ordering matters: the broadcaster tick is what arms the watchdog, so
+    // expiring first would delay every arm by a whole poll interval.
+    expect(block.indexOf("queueStatusBroadcaster.tick()")).toBeLessThan(
+      block.indexOf("runCompletionWatchdog.tick()"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as unknown as QMPriv;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function makeCtx(runReply: Record<string, unknown>): PanelToolCtx {
+  const bridge = {
+    send: async () => ({}),
+    push: () => 1,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = makePanelToolCtx(bridge, "test-tab");
+  (ctx as { call: PanelToolCtx["call"] }).call = async () => ({
+    content: [{ type: "text", text: JSON.stringify(runReply) }],
+  });
+  return ctx;
+}
+
+function firstText(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  qm.url = "http://127.0.0.1:9999";
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  RunCompletions.reset();
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+describe("#1789 — panel_run's rider stops promising more than the code can keep", () => {
+  it("keeps the anti-poll instruction AND names one bounded fallback with the prompt id", async () => {
+    const res = await defByName("panel_run").handler({}, makeCtx({ queued: true, prompt_id: "p-1789" }));
+    const text = firstText(res);
+
+    // The anti-poll instruction stays PRIMARY — that is what keeps an agent from
+    // burning a turn a second on a two-minute render.
+    expect(text).toContain("do NOT poll queue");
+    expect(text).toContain("Just end your turn now and wait");
+
+    // …but it no longer forbids ever looking. The escape hatch is stated, bounded,
+    // and actionable in ONE call: the prompt id is right there.
+    expect(text).toContain("[FALLBACK]");
+    expect(text).toContain("it cannot be GUARANTEED");
+    expect(text).toContain('queue (action:"status", prompt_id:"p-1789")');
+    expect(text).toContain("One check, not a loop");
+  });
+
+  it("omits a prompt id it cannot name (a batch queued several)", async () => {
+    const res = await defByName("panel_run").handler(
+      {},
+      makeCtx({ queued: true, prompt_id: "p-a", prompt_ids: ["p-a", "p-b"] }),
+    );
+    const text = firstText(res);
+    expect(text).toContain("[FALLBACK]");
+    // No invented single id when the run queued more than one.
+    expect(text).toContain('queue (action:"status")');
+    expect(text).not.toContain('prompt_id:"p-a"');
+  });
+
+  it("the UNCORRELATABLE branch is unchanged — it never told the agent to idle", async () => {
+    const res = await defByName("panel_run").handler({}, makeCtx({ queued: true }));
+    const text = firstText(res);
+    expect(text).toContain("NO prompt id");
+    expect(text).toContain("Do NOT simply idle and wait indefinitely");
+    expect(text).not.toContain("[FALLBACK]");
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -1,0 +1,246 @@
+// #1789 — `panel_run` promised "you WILL be notified … end your turn now and
+// wait", the panel's `executed` frame never arrived, and the agent sat idle
+// through a clean 28.77s render until a human broke the silence.
+//
+// Two halves are pinned here:
+//   1. DELIVERY. The orchestrator already observes every completion on the
+//      monitored ComfyUI (QueueMonitor's 1 Hz /history tail diff). The watchdog
+//      joins that observation to the open panel_run ticket and synthesises the
+//      completion the panel never sent — into the SAME journal, so it is
+//      correlated as the run the agent queued, replayed if no agent takes it,
+//      and acked like any other.
+//   2. THE PROMISE. panel_run's rider no longer forbids ever looking; it names
+//      ONE bounded check with the prompt id.
+//
+// The journal-level tests drive the REAL RunCompletions singleton, so a
+// regression in `awaitingCompletion` (the predicate the whole fallback is gated
+// on) fails here rather than shipping.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createRunCompletionWatchdog,
+  synthesizeCompletionPayload,
+  DEFAULT_SYNTHESIS_GRACE_MS,
+} from "../../orchestrator/run-completion-watchdog.js";
+import { RunCompletions, type CompletionPayload, type RunTicket } from "../../orchestrator/run-completion-journal.js";
+
+const TAB = "tab-1789";
+const CONV = "orchestrator::claude";
+const PID = "d5e14286-b746-4817-9ce5-45fc052b6a8f";
+
+beforeEach(() => RunCompletions.reset());
+afterEach(() => RunCompletions.reset());
+
+/** A watchdog wired to the real journal, with a controllable clock. */
+function makeWatchdog(clock: { t: number }) {
+  const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
+  const wd = createRunCompletionWatchdog({
+    awaiting: (id) => RunCompletions.awaitingCompletion(id),
+    deliver: (payload, ticket) => {
+      delivered.push({ payload, ticket });
+      RunCompletions.record(ticket.tabId, payload, {
+        ...(ticket.conversation !== undefined ? { conversation: ticket.conversation } : {}),
+      });
+    },
+    now: () => clock.t,
+  });
+  return { wd, delivered };
+}
+
+describe("#1789: a completion the panel never reported is filled in from ComfyUI's history", () => {
+  it("synthesises the completion for an open ticket once the grace elapses", () => {
+    const clock = { t: 1_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+
+    wd.observe([{ promptId: PID, status: "success" }]);
+    expect(wd.armedCount()).toBe(1);
+
+    // Inside the grace: stay quiet — the panel's own frame is still the better
+    // one and its reconcile sweep has not even run yet.
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS - 1;
+    wd.tick();
+    expect(delivered).toHaveLength(0);
+
+    clock.t += 2;
+    wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+    expect(delivered[0].ticket.tabId).toBe(TAB);
+    expect(wd.armedCount()).toBe(0);
+  });
+
+  it("the synthesised completion is CORRELATED as the run the agent queued, and reaches an agent", () => {
+    const clock = { t: 2_000_000 };
+    const { wd } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    wd.tick();
+
+    const outstanding = RunCompletions.outstanding(TAB);
+    expect(outstanding).toHaveLength(1);
+    // NOT "foreign"/UNDETERMINED: the agent must be told this is ITS render.
+    expect(outstanding[0].correlation).toEqual({ status: "matched", promptId: PID });
+
+    const seen: CompletionPayload[] = [];
+    const { delivered: n } = RunCompletions.deliverPending(TAB, (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(n).toBe(1);
+    expect(seen[0].run_correlation).toBe("matched");
+    expect(String(seen[0].note)).toContain("finished SUCCESSFULLY");
+  });
+
+  it("stays SILENT when the panel's real frame lands inside the grace", () => {
+    const clock = { t: 3_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    // The panel reports it — the normal path — while the arm is still held.
+    RunCompletions.record(TAB, { kind: "executed", prompt_id: PID, images: [{ filename: "a.png" }] }, { conversation: CONV });
+
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS + 1;
+    wd.tick();
+    expect(delivered).toHaveLength(0);
+    // …and the agent still gets exactly ONE completion: the panel's, with pixels.
+    expect(RunCompletions.outstanding(TAB)).toHaveLength(1);
+    expect(RunCompletions.outstanding(TAB)[0].payload.images).toHaveLength(1);
+  });
+
+  it("stays silent for a run this session never queued (a render the USER started)", () => {
+    const clock = { t: 4_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    // No openRun at all — there is no promise to keep, and waking the agent for
+    // a foreign render is the failure #889/#559 already paid for.
+    wd.observe([{ promptId: "p-foreign", status: "success" }]);
+    expect(wd.armedCount()).toBe(0);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS + 1;
+    wd.tick();
+    expect(delivered).toHaveLength(0);
+  });
+
+  it("stays silent once the run's completion has already been ACKED", () => {
+    const clock = { t: 5_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    const entry = RunCompletions.record(TAB, { kind: "executed", prompt_id: PID }, { conversation: CONV });
+    RunCompletions.deliverPending(TAB, () => true);
+    RunCompletions.ack(entry.token); // the turn that carried it ended
+
+    wd.observe([{ promptId: PID, status: "success" }]);
+    expect(wd.armedCount()).toBe(0); // settled ticket ⇒ nothing is owed
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS + 1;
+    wd.tick();
+    expect(delivered).toHaveLength(0);
+  });
+
+  it("a re-observation does NOT push the deadline out", () => {
+    const clock = { t: 6_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    // A repeated observation every second, forever, must not make the arm
+    // immortal — that would reproduce the very "waits indefinitely" bug.
+    for (let i = 0; i < 60; i++) {
+      clock.t += 1000;
+      wd.observe([{ promptId: PID, status: "success" }]);
+    }
+    wd.tick();
+    expect(delivered).toHaveLength(1);
+  });
+
+  it("a FAILED run is reported as a failure — and NOT as an urgent run_error", () => {
+    const clock = { t: 7_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "error" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    wd.tick();
+    expect(delivered).toHaveLength(1);
+    // `run_error` INTERRUPTS the live turn; a status read out of a history
+    // record a minute later does not warrant that blast radius (#1489).
+    expect(delivered[0].payload.kind).toBe("executed");
+    expect(String(delivered[0].payload.note)).toContain("FAILED");
+    expect(String(delivered[0].payload.note)).toContain("Do NOT report the run as successful");
+  });
+
+  it("a deliver() that throws does not re-fire on every later tick", () => {
+    const clock = { t: 8_000_000 };
+    let calls = 0;
+    const wd = createRunCompletionWatchdog({
+      awaiting: (id) => RunCompletions.awaitingCompletion(id),
+      deliver: () => {
+        calls++;
+        throw new Error("boom");
+      },
+      now: () => clock.t,
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    wd.tick();
+    wd.tick();
+    wd.tick();
+    expect(calls).toBe(1);
+  });
+});
+
+describe("#1789: awaitingCompletion answers 'is this run still owed its notification?'", () => {
+  it("true for a fresh ticket, false once ANY completion for it is journaled", () => {
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    expect(RunCompletions.awaitingCompletion(PID)?.promptId).toBe(PID);
+    RunCompletions.record(TAB, { kind: "executed", prompt_id: PID }, { conversation: CONV });
+    expect(RunCompletions.awaitingCompletion(PID)).toBeUndefined();
+  });
+
+  it("false while the completion is merely HANDED OFF (the journal owns the replay from there)", () => {
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    RunCompletions.record(TAB, { kind: "executed", prompt_id: PID }, { conversation: CONV });
+    RunCompletions.deliverPending(TAB, () => true); // state → handed_off, not acked
+    expect(RunCompletions.awaitingCompletion(PID)).toBeUndefined();
+  });
+
+  it("false for a REUSED prompt id — a synthesised notice could not say WHICH run finished", () => {
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV }); // queued again
+    expect(RunCompletions.ticketFor(PID)?.reused).toBe(true);
+    expect(RunCompletions.awaitingCompletion(PID)).toBeUndefined();
+  });
+
+  it("false for an id with no ticket at all", () => {
+    expect(RunCompletions.awaitingCompletion("nobody-queued-this")).toBeUndefined();
+  });
+});
+
+describe("#1789: the synthesised note claims only what was observed", () => {
+  it("names the prompt id, the delay, and where the images actually are", () => {
+    const payload = synthesizeCompletionPayload(
+      { promptId: PID, status: "success", observedAt: 1000 },
+      { deliveredAt: 1000 + 46_000 },
+    );
+    const note = String(payload.note);
+    expect(note).toContain(PID);
+    expect(note).toContain("46s");
+    expect(note).toContain("the panel never delivered its completion");
+    // It must NOT pretend to carry pixels it never fetched.
+    expect(payload.images).toEqual([]);
+    expect(note).toContain('get_image (action:"list_outputs")');
+    // Machine-readable provenance, so a consumer can tell this from a panel frame.
+    expect(payload.completion_source).toBe("orchestrator-history-watchdog");
+    expect(payload.run_status).toBe("success");
+  });
+
+  it("an INTERRUPTED run is not described as a crash", () => {
+    const note = String(
+      synthesizeCompletionPayload(
+        { promptId: PID, status: "interrupted", observedAt: 0 },
+        { deliveredAt: 45_000 },
+      ).note,
+    );
+    expect(note).toContain("INTERRUPTED");
+    expect(note).toContain("Nothing crashed");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -206,6 +206,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
+import { createRunCompletionWatchdog } from "./run-completion-watchdog.js";
 import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
@@ -6193,10 +6194,47 @@ export async function runPanelOrchestrator(): Promise<void> {
   // `queue_status` frame at most once per second, and ONLY when the state
   // changed, so an idle rig costs the tabs nothing (see
   // services/queue-status-broadcast.ts for the frame shape + throttle contract).
+  // #1789 — KEEP THE PROMISE panel_run MAKES, or find out that we didn't.
+  //
+  // `panel_run` tells the agent "you WILL be notified … end your turn now and
+  // wait". The only producer of that notification is the panel's `executed`
+  // frame; when it never arrives, the run ticket stays open forever and NOTHING
+  // in this process can tell that apart from a render still in flight. The
+  // reported session sat idle after a clean 28.77 s run until a human intervened.
+  //
+  // QueueMonitor already observes EVERY completion on the monitored ComfyUI —
+  // that is what its 1 Hz `/history` tail diff is for (#259) — and that
+  // observation went only to the `queue_status` UI broadcast. This watchdog is
+  // the join: an observed completion whose panel_run ticket is still unanswered
+  // after the grace is synthesised into the SAME journal the real frame uses.
+  // See run-completion-watchdog.ts for why it waits, and why the panel's frame
+  // still wins whenever it is coming.
+  const runCompletionWatchdog = createRunCompletionWatchdog({
+    awaiting: (promptId) => RunCompletions.awaitingCompletion(promptId),
+    deliver: (payload, ticket) => {
+      // The SAME arrival path the panel's frame takes: correlated once, here,
+      // against the ticket that is still open — so the agent is told this is the
+      // run IT queued, and the journal's replay/ack durability covers it too.
+      const entry = RunCompletions.record(ticket.tabId, payload, {
+        ...(ticket.conversation !== undefined ? { conversation: ticket.conversation } : {}),
+      });
+      logger.info(
+        `[panel-orchestrator] tab ${ticket.tabId.slice(0, 8)} synthesised run completion for ${describeCorrelation(entry.correlation)} (the panel never reported it — #1789)`,
+      );
+      flushRunCompletions(ticket.tabId);
+    },
+  });
   const queueStatusBroadcaster = createQueueStatusBroadcaster(
     () => QueueMonitor.snapshot(),
     (frame) => void bridge.push(frame),
-    () => QueueMonitor.drainCompletions(),
+    // TEE, not a second drain: drainCompletions() splices, so the watchdog has
+    // to read the same array the broadcaster is handed rather than call it
+    // again — a second call would race and each consumer would see only half.
+    () => {
+      const completions = QueueMonitor.drainCompletions();
+      runCompletionWatchdog.observe(completions);
+      return completions;
+    },
   );
   // Each tick first refreshes the monitor over HTTP (GET /queue + /history
   // tail): on modern ComfyUI (0.28+) the passive watchdog WS carries no
@@ -6204,7 +6242,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // restores run attribution (#258) and catches runs shorter than the tick
   // (#259). poll() never rejects and self-guards against overlap.
   const queueStatusTimer = setInterval(() => {
-    void QueueMonitor.poll().finally(() => queueStatusBroadcaster.tick());
+    void QueueMonitor.poll().finally(() => {
+      queueStatusBroadcaster.tick();
+      // …and only THEN expire the watchdog's arms: the broadcaster tick is what
+      // feeds it (the drain tee above), so ticking it first would let an
+      // observation sit a whole extra second before it is even armed. #1789.
+      runCompletionWatchdog.tick();
+    });
   }, 1000);
   queueStatusTimer.unref?.();
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -6203,7 +6203,8 @@ export async function runPanelOrchestrator(): Promise<void> {
   // reported session sat idle after a clean 28.77 s run until a human intervened.
   //
   // QueueMonitor already observes EVERY completion on the monitored ComfyUI —
-  // that is what its 1 Hz `/history` tail diff is for (#259) — and that
+  // on the broadcast WS execution events OR its 1 Hz `/history` tail diff, both
+  // funnelling through one recordCompletion (#258/#259) — and that
   // observation went only to the `queue_status` UI broadcast. This watchdog is
   // the join: an observed completion whose panel_run ticket is still unanswered
   // after the grace is synthesised into the SAME journal the real frame uses.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11888,10 +11888,33 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // should have landed, naming the prompt id so it costs a single call.
         // A weaker promise with a stated fallback beats a strong one that fails
         // into an infinite idle.
-        const promptRef = queuedIds.length === 1 ? `, prompt_id:"${queuedIds[0]}"` : "";
+        // THE REMEDY MUST BE A CALL THAT ACTUALLY RUNS (gate NO-SHIP on the first
+        // cut of this fix). Naming no id for a batch was right — inventing one
+        // would point the agent at a single arbitrary member — but the remedy it
+        // left behind, `queue (action:"status")` with no id, is REFUSED by the
+        // tool: queue-management.ts's requirePromptId throws on an absent
+        // prompt_id, so the agent that obeyed this fallback got an error instead
+        // of a status. That is the reported bug's own shape, one level in: a
+        // rider promising something the code declines to do. Verified live
+        // against the real handler — `status` + id and bare `list` both return
+        // JSON; bare `status` returns isError with "requires `prompt_id`".
+        //
+        // So the two branches get the call that fits what they can name:
+        //   • exactly one id  → status on THAT run, the precise answer;
+        //   • a batch         → list, which takes no id and shows whether any of
+        //                       them are still in flight (get_history settles the
+        //                       outcomes once they are not).
+        const fallbackCheck =
+          queuedIds.length === 1
+            ? `queue (action:"status", prompt_id:"${queuedIds[0]}")`
+            : `queue (action:"list")`;
+        const fallbackTail =
+          queuedIds.length === 1
+            ? ""
+            : ` (this run queued ${queuedIds.length} prompts, so the check is the queue as a whole; get_history settles the outcome of any that are no longer in flight)`;
         const note = correlatable
           ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or get_image (action:\"list_outputs\"). Just end your turn now and wait for the result to be delivered to you." +
-            `\n[FALLBACK] That notification is journaled and replayed if an agent is not there to take it, and the orchestrator will fill one in from ComfyUI's history if the panel never reports the finish — but it cannot be GUARANTEED, so do not wait forever on it. If nothing has arrived LONG after this render should have finished (roughly twice the time you expect it to take), make ONE check with queue (action:"status"${promptRef}) instead of idling indefinitely. One check, not a loop — and not before then.`
+            `\n[FALLBACK] That notification is journaled and replayed if an agent is not there to take it, and the orchestrator will fill one in from ComfyUI itself — its execution event or its history record — if the panel never reports the finish. But it cannot be GUARANTEED, so do not wait forever on it. If nothing has arrived LONG after this render should have finished (roughly twice the time you expect it to take), make ONE check with ${fallbackCheck} instead of idling indefinitely${fallbackTail}. One check, not a loop — and not before then.`
           : "\n\n[IMPORTANT] The run was queued, but the panel reported NO prompt id for it, so a completion event CANNOT be correlated back to this run — its outcome will be reported to you as UNDETERMINED. Do NOT simply idle and wait indefinitely: end your turn, and if nothing arrives, confirm the outcome with get_history (action:\"list\") before acting on it.";
         // Backpressure note. A backlog is only alarming when it's a job we did NOT
         // queue (possibly foreign/stuck). Deliberately batching renders — a sweep,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11870,8 +11870,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // panel forwarded no `prompt_id` — a later completion can only be reported as
         // UNDETERMINED, so telling the agent to idle and wait would park it on a
         // promise we can't keep. Say so and point at the verification path instead.
+        // #1789 — …AND HONEST ABOUT WHAT "AUTOMATICALLY" RESTS ON. The old text
+        // forbade polling outright on the strength of `correlatable`, which
+        // proves only that a completion COULD be recognised — never that one
+        // will arrive. The producer is the panel's `executed` frame, and a
+        // session that lost it sat idle through a clean 28.77s render until a
+        // human intervened, because the one behaviour that would have caught it
+        // in seconds is the one this rider had banned.
+        //
+        // Delivery is now genuinely stronger (the orchestrator fills in from its
+        // own /history observation — run-completion-watchdog.ts), but it is
+        // still not a guarantee this tool can prove at queue time: the watchdog
+        // sees nothing when the monitored ComfyUI is not the one this run went
+        // to, or cannot be polled. So the anti-poll instruction stays PRIMARY —
+        // it is what keeps an agent from burning a turn a second — and it is
+        // paired with a bounded escape hatch: ONE check, long after the render
+        // should have landed, naming the prompt id so it costs a single call.
+        // A weaker promise with a stated fallback beats a strong one that fails
+        // into an infinite idle.
+        const promptRef = queuedIds.length === 1 ? `, prompt_id:"${queuedIds[0]}"` : "";
         const note = correlatable
-          ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or get_image (action:\"list_outputs\"). Just end your turn now and wait for the result to be delivered to you."
+          ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or get_image (action:\"list_outputs\"). Just end your turn now and wait for the result to be delivered to you." +
+            `\n[FALLBACK] That notification is journaled and replayed if an agent is not there to take it, and the orchestrator will fill one in from ComfyUI's history if the panel never reports the finish — but it cannot be GUARANTEED, so do not wait forever on it. If nothing has arrived LONG after this render should have finished (roughly twice the time you expect it to take), make ONE check with queue (action:"status"${promptRef}) instead of idling indefinitely. One check, not a loop — and not before then.`
           : "\n\n[IMPORTANT] The run was queued, but the panel reported NO prompt id for it, so a completion event CANNOT be correlated back to this run — its outcome will be reported to you as UNDETERMINED. Do NOT simply idle and wait indefinitely: end your turn, and if nothing arrives, confirm the outcome with get_history (action:\"list\") before acting on it.";
         // Backpressure note. A backlog is only alarming when it's a job we did NOT
         // queue (possibly foreign/stuck). Deliberately batching renders — a sweep,

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1015,6 +1015,44 @@ export class RunCompletionJournalImpl {
     return [...this.entries.values()].filter((e) => e.key === key);
   }
 
+  /**
+   * #1789 — is this run STILL owed the completion `panel_run` promised it?
+   *
+   * `openRun` succeeding only proves we could RECOGNISE a completion if one
+   * arrived; it never proved one WOULD. The panel's `agent_event` frame is the
+   * sole producer, so every way that frame can be lost (a missed
+   * `execution_success` the panel's own reconcile also missed, a muted/blinded
+   * feed, a send the socket accepted and the bridge dropped, a panel unmounted
+   * mid-render) ends with an open ticket that nothing will ever answer — and
+   * NOTHING in this process could tell that state apart from "still rendering".
+   * This predicate is what makes it nameable, so the orchestrator's own
+   * /history observation can fill in (see run-completion-watchdog.ts).
+   *
+   * Deliberately conservative — it answers "no completion for this run has been
+   * seen AT ALL", never "delivery is late":
+   *  • no ticket, or a ticket whose ack already settled it ⇒ not owed;
+   *  • ANY journaled entry naming this prompt id (pending OR handed off) ⇒ not
+   *    owed: a completion did arrive and the journal's own replay owns it from
+   *    there;
+   *  • an already-acked (tab, run, generation) memo ⇒ not owed, which covers the
+   *    window where the entry has been deleted but the ticket outlives it.
+   * A `reused` id is NOT owed either: it stands for more than one run, so a
+   * synthesised completion for it could not honestly name which one finished.
+   */
+  awaitingCompletion(promptId: string): RunTicket | undefined {
+    const ticket = this.tickets.get(promptId);
+    if (!ticket || ticket.settled || ticket.reused) return undefined;
+    for (const entry of this.entries.values()) {
+      if (entry.correlation.status !== "unidentified" && entry.correlation.promptId === promptId) {
+        return undefined;
+      }
+    }
+    if (this.delivered.has(deliveredKey(this.ownerOf(ticket), promptId, ticket.seq))) {
+      return undefined;
+    }
+    return ticket;
+  }
+
   /** Is ANY completion still undelivered anywhere? The orchestrator's
    *  self-restart gate reads this: the journal is in-memory, so restarting while
    *  an entry is outstanding would silently drop a render result the agent was

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -17,11 +17,15 @@
 // cleanly, `/history` had it, and the agent — having been told in so many words
 // not to poll — sat idle until a human broke the silence.
 //
-// AND THE ORCHESTRATOR ALREADY SAW IT FINISH. QueueMonitor keeps its own socket
-// and a 1 Hz `GET /history` tail diff precisely so it can observe completions
-// the panel-driven path never reports (#258/#259) — including runs queued from
-// the browser. Those observations went to ONE consumer, the `queue_status` UI
-// broadcast, and were dropped on the floor. The completion this session was
+// AND THE ORCHESTRATOR ALREADY SAW IT FINISH. QueueMonitor observes a finish on
+// EITHER of two channels, both funnelling through its own recordCompletion: the
+// broadcast WS `execution_success`/`execution_error`/`execution_interrupted`
+// frames, and a 1 Hz `GET /history` tail diff that catches what modern ComfyUI
+// scopes to the queuing client only, including runs shorter than a poll tick
+// (#258/#259) and runs queued from the browser. Which channel saw it is not
+// knowable downstream, so nothing here names one. Those observations went to ONE
+// consumer, the `queue_status` UI broadcast, and were dropped on the floor. The
+// completion this session was
 // promised was in the orchestrator's hands and thrown away.
 //
 // This module is the join, and only the join:
@@ -36,10 +40,19 @@
 // carries the output images, the duration and the metadata; ours carries a
 // terminal status and a pointer. The normal path lands within a second or two,
 // and the panel's OWN recovery sweep re-reconciles every 20 s, so a grace
-// comfortably past both lets the real frame win every time it is coming. When
-// the synthesised entry is still `pending` at that moment the journal COALESCES
-// the real payload onto it (record()), so the late-but-working case costs the
-// agent nothing at all — not even an extra turn.
+// comfortably past both lets the real frame win every time it is coming. Past
+// the grace there are exactly two shapes, and NEITHER loses anything — stated
+// precisely, because the coalescing one is the narrower case, not the general
+// one (gate finding):
+//   • nothing took the synthesised entry (no live agent at that instant), so it
+//     is still `pending` — the journal COALESCES the real payload onto it
+//     (record()), and the agent sees ONE turn, with the images. This is the only
+//     path on which the extra turn disappears.
+//   • an agent DID take it, so the entry is `handed_off` or acked — the real
+//     frame then arrives on its own, still correlated `matched`, flagged a
+//     possible repeat, and NEVER discarded. Cost: one extra turn. That is the
+//     standing trade this journal is built on (a duplicate beats a loss), and it
+//     is the price of the grace being finite rather than a downgrade.
 //
 // WHAT IT DELIBERATELY IS NOT. It is not a poller for runs nobody queued, not a
 // second delivery channel, and not a claim that ComfyUI is reachable: when the
@@ -96,8 +109,11 @@ export interface RunCompletionWatchdog {
  * Compose the synthesised completion payload.
  *
  * Every claim in it is one the orchestrator actually observed. It does NOT say
- * "here is your image" — we have the terminal status from `/history`, not the
- * outputs — and it does not say the panel is broken, only that its completion
+ * "here is your image" — a CompletionEvent carries a prompt id, a terminal
+ * status and a timestamp, never outputs — and it does not name WHICH channel
+ * saw the finish, because recordCompletion is fed by both the WS execution
+ * events and the /history diff and does not record which one won. It does not
+ * say the panel is broken, only that its completion
  * never arrived here. Naming the delay is what lets the agent tell this apart
  * from a fresh render finishing now.
  *
@@ -105,7 +121,7 @@ export interface RunCompletionWatchdog {
  * than `run_error`: run_error INTERRUPTS the live turn and front-queues "your
  * run just ERRORED, diagnose it", which is the right blast radius for a live
  * failure the panel reported and the wrong one for a status this watchdog read
- * out of a history record possibly a minute later. The note states the failure
+ * out of a terminal record possibly a minute later. The note states the failure
  * plainly and names the tool that reads the detail.
  */
 export function synthesizeCompletionPayload(
@@ -122,7 +138,7 @@ export function synthesizeCompletionPayload(
   const next =
     armed.status === "success"
       ? `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
-        `status from ComfyUI's history, not its images. Fetch them with get_image (action:"list_outputs") ` +
+        `status, not its images. Fetch them with get_image (action:"list_outputs") ` +
         `or get_history for this prompt id before describing or using the result.`
       : armed.status === "interrupted"
         ? `Nothing crashed; it did not run to completion. Re-queue it if the cancellation was unintended.`
@@ -137,8 +153,8 @@ export function synthesizeCompletionPayload(
     run_status: armed.status,
     note:
       `The render you queued (prompt ${armed.promptId}) ${outcome}, but the panel never delivered its ` +
-      `completion event, so this notice was synthesised by the orchestrator from ComfyUI's own history ` +
-      `about ${waitedS}s after the run finished. ${next}`,
+      `completion event, so this notice was synthesised by the orchestrator from ComfyUI itself — its ` +
+      `execution event or its history record — about ${waitedS}s after the run finished. ${next}`,
   };
 }
 
@@ -205,7 +221,7 @@ export function createRunCompletionWatchdog({
         logger.warn(
           `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
             (at - entry.observedAt) / 1000,
-          )}s ago and the panel NEVER reported its completion — synthesising one from ComfyUI's history so the agent that was told to end its turn and wait is not left idle (#1789)`,
+          )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
         );
         try {
           deliver(synthesizeCompletionPayload(entry, { deliveredAt: at }), ticket);

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -1,0 +1,224 @@
+// #1789 — the completion `panel_run` PROMISED, delivered by the orchestrator's
+// own eyes when the panel's never arrives.
+//
+// THE PROMISE AND WHO KEEPS IT. `panel_run` returns "[IMPORTANT] You will be
+// notified automatically … Just end your turn now and wait." Exactly one
+// mechanism can keep that: the panel observes ComfyUI's `execution_success`,
+// composes an `executed` agent_event and sends it over the bridge. Everything
+// downstream of that frame is already durable (run-completion-journal.ts) —
+// correlated once, journaled, replayed until the turn that carried it ends.
+//
+// WHAT WAS UNGUARDED IS UPSTREAM OF IT. If the frame is never SENT, nothing in
+// this process notices. `openRun` returning true — which is the entire test the
+// rider's promise is gated on — proves only that a completion could be
+// RECOGNISED, never that one will arrive. So an open ticket that will be
+// answered and one that never will were the same observation, and the reported
+// failure is the second one: the render finished in 28.77 s, ComfyUI logged it
+// cleanly, `/history` had it, and the agent — having been told in so many words
+// not to poll — sat idle until a human broke the silence.
+//
+// AND THE ORCHESTRATOR ALREADY SAW IT FINISH. QueueMonitor keeps its own socket
+// and a 1 Hz `GET /history` tail diff precisely so it can observe completions
+// the panel-driven path never reports (#258/#259) — including runs queued from
+// the browser. Those observations went to ONE consumer, the `queue_status` UI
+// broadcast, and were dropped on the floor. The completion this session was
+// promised was in the orchestrator's hands and thrown away.
+//
+// This module is the join, and only the join:
+//   observe()  — a QueueMonitor completion whose prompt id has an UNANSWERED
+//                panel_run ticket is armed with the time we saw it.
+//   tick()     — once the grace has elapsed, ask AGAIN. Still unanswered ⇒ the
+//                panel is never going to report it: synthesise the completion
+//                from what ComfyUI told us and hand it to the same journal the
+//                real frame would have used.
+//
+// WHY A GRACE RATHER THAN IMMEDIATELY. The panel's frame is the better one — it
+// carries the output images, the duration and the metadata; ours carries a
+// terminal status and a pointer. The normal path lands within a second or two,
+// and the panel's OWN recovery sweep re-reconciles every 20 s, so a grace
+// comfortably past both lets the real frame win every time it is coming. When
+// the synthesised entry is still `pending` at that moment the journal COALESCES
+// the real payload onto it (record()), so the late-but-working case costs the
+// agent nothing at all — not even an extra turn.
+//
+// WHAT IT DELIBERATELY IS NOT. It is not a poller for runs nobody queued, not a
+// second delivery channel, and not a claim that ComfyUI is reachable: when the
+// monitor is pointed elsewhere or cannot poll, it observes nothing and this does
+// nothing — the same silence as before, which is why the rider also stopped
+// promising more than this can keep.
+
+import { logger } from "../utils/logger.js";
+import type { CompletionStatus } from "../services/queue-monitor.js";
+import type { CompletionPayload, RunTicket } from "./run-completion-journal.js";
+
+/** One completion QueueMonitor observed, held until its grace expires. */
+interface ArmedCompletion {
+  promptId: string;
+  status: CompletionStatus;
+  /** Monotonic-ish ms (the injected clock) when WE observed the finish. */
+  observedAt: number;
+}
+
+export interface RunCompletionWatchdogDeps {
+  /** The still-unanswered ticket for this run, or undefined. Asked TWICE — once
+   *  to arm, once at expiry — because the whole point is the state changing in
+   *  between (the panel's real frame landing). */
+  awaiting: (promptId: string) => RunTicket | undefined;
+  /** Journal + flush a synthesised completion for `ticket`. */
+  deliver: (payload: CompletionPayload, ticket: RunTicket) => void;
+  /** How long to let the panel's own frame (and its 20 s reconcile sweep) win
+   *  before filling in. */
+  graceMs?: number;
+  now?: () => number;
+}
+
+/**
+ * Longer than the panel's own run-reconcile sweep period (20 s) plus a full
+ * reconcile round trip, so the panel's recovery — which delivers the IMAGES —
+ * is given every chance before we fill in with a pointer.
+ */
+export const DEFAULT_SYNTHESIS_GRACE_MS = 45_000;
+
+/** Cap on armed observations. A run's arm is dropped the moment it expires, so
+ *  this only ever bounds a burst of self-queued renders finishing at once. */
+const MAX_ARMED = 256;
+
+export interface RunCompletionWatchdog {
+  /** Feed QueueMonitor's drained completions in. Never throws. */
+  observe(events: ReadonlyArray<{ promptId: string; status: CompletionStatus }>): void;
+  /** Expire armed observations; synthesise for the ones still unanswered. */
+  tick(): void;
+  /** Diagnostics/tests: how many completions are currently armed. */
+  armedCount(): number;
+}
+
+/**
+ * Compose the synthesised completion payload.
+ *
+ * Every claim in it is one the orchestrator actually observed. It does NOT say
+ * "here is your image" — we have the terminal status from `/history`, not the
+ * outputs — and it does not say the panel is broken, only that its completion
+ * never arrived here. Naming the delay is what lets the agent tell this apart
+ * from a fresh render finishing now.
+ *
+ * A FAILED run is reported through this same non-urgent `executed` shape rather
+ * than `run_error`: run_error INTERRUPTS the live turn and front-queues "your
+ * run just ERRORED, diagnose it", which is the right blast radius for a live
+ * failure the panel reported and the wrong one for a status this watchdog read
+ * out of a history record possibly a minute later. The note states the failure
+ * plainly and names the tool that reads the detail.
+ */
+export function synthesizeCompletionPayload(
+  armed: ArmedCompletion,
+  opts: { deliveredAt: number },
+): CompletionPayload {
+  const waitedS = Math.max(0, Math.round((opts.deliveredAt - armed.observedAt) / 1000));
+  const outcome =
+    armed.status === "success"
+      ? "finished SUCCESSFULLY"
+      : armed.status === "interrupted"
+        ? "was INTERRUPTED (cancelled before it finished)"
+        : "FAILED";
+  const next =
+    armed.status === "success"
+      ? `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
+        `status from ComfyUI's history, not its images. Fetch them with get_image (action:"list_outputs") ` +
+        `or get_history for this prompt id before describing or using the result.`
+      : armed.status === "interrupted"
+        ? `Nothing crashed; it did not run to completion. Re-queue it if the cancellation was unintended.`
+        : `Read the failure with panel_get_errors, or get_history for this prompt id. Do NOT report the ` +
+          `run as successful.`;
+  return {
+    kind: "executed",
+    prompt_id: armed.promptId,
+    images: [],
+    // Machine-readable provenance: this completion was NOT reported by the panel.
+    completion_source: "orchestrator-history-watchdog",
+    run_status: armed.status,
+    note:
+      `The render you queued (prompt ${armed.promptId}) ${outcome}, but the panel never delivered its ` +
+      `completion event, so this notice was synthesised by the orchestrator from ComfyUI's own history ` +
+      `about ${waitedS}s after the run finished. ${next}`,
+  };
+}
+
+export function createRunCompletionWatchdog({
+  awaiting,
+  deliver,
+  graceMs = DEFAULT_SYNTHESIS_GRACE_MS,
+  now = () => Date.now(),
+}: RunCompletionWatchdogDeps): RunCompletionWatchdog {
+  /** promptId → the observation we are holding. FIRST observation wins: a
+   *  re-observation must not push the deadline out (that is how a repeatedly
+   *  re-reported completion would never expire and the agent would wait
+   *  forever — the exact failure being fixed). */
+  const armed = new Map<string, ArmedCompletion>();
+
+  return {
+    observe(events) {
+      for (const ev of events ?? []) {
+        try {
+          const promptId = typeof ev?.promptId === "string" ? ev.promptId.trim() : "";
+          if (!promptId || armed.has(promptId)) continue;
+          // Only runs THIS session queued and is still owed a completion for.
+          // A foreign render (the user pressed Queue Prompt) has no ticket and
+          // was never promised anything, so it must never wake the agent.
+          if (!awaiting(promptId)) continue;
+          armed.set(promptId, { promptId, status: ev.status, observedAt: now() });
+          while (armed.size > MAX_ARMED) {
+            const oldest = armed.keys().next().value;
+            if (oldest === undefined) break;
+            armed.delete(oldest);
+          }
+        } catch (err) {
+          logger.debug(
+            `[run-completion-watchdog] observe skipped an event: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    },
+
+    tick() {
+      if (armed.size === 0) return;
+      const at = now();
+      for (const entry of [...armed.values()]) {
+        if (at - entry.observedAt < graceMs) continue;
+        // Disarm FIRST and unconditionally: whatever happens below, this
+        // observation is spent. Leaving it armed on a throwing deliver() would
+        // re-fire it on every later tick.
+        armed.delete(entry.promptId);
+        let ticket: RunTicket | undefined;
+        try {
+          ticket = awaiting(entry.promptId);
+        } catch (err) {
+          logger.debug(
+            `[run-completion-watchdog] could not re-check prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          continue;
+        }
+        // The panel's own frame landed inside the grace — the normal case, and
+        // the one this must stay quiet for.
+        if (!ticket) continue;
+        // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
+        // only detector of a lost completion was a human noticing the agent had
+        // gone quiet.
+        logger.warn(
+          `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
+            (at - entry.observedAt) / 1000,
+          )}s ago and the panel NEVER reported its completion — synthesising one from ComfyUI's history so the agent that was told to end its turn and wait is not left idle (#1789)`,
+        );
+        try {
+          deliver(synthesizeCompletionPayload(entry, { deliveredAt: at }), ticket);
+        } catch (err) {
+          logger.warn(
+            `[run-completion-watchdog] could not deliver the synthesised completion for prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    },
+
+    armedCount() {
+      return armed.size;
+    },
+  };
+}


### PR DESCRIPTION
Addresses the underlying cause of #1789 — `panel_run` told the agent "you WILL be notified … end your turn now and wait", the notification never came, and the session idled through a clean 28.77 s render until a human broke the silence.

## Where the delivery is lost

The rider's promise is gated on `RunCompletions.openRun(...)` returning true. That proves the orchestrator could **recognise** a completion if one arrived — it never proved one **would**. The sole producer is the panel's `agent_event {kind:"executed"}` frame, and everything downstream of it is already durable (`run-completion-journal.ts`: correlated once, journaled, replayed until the turn that carried it ends). Nothing guarded what is **upstream** of that frame. If it is never sent — a missed `execution_success` the panel's own reconcile also missed, a send the socket accepted and the bridge dropped, a panel unmounted mid-render — the ticket stays open forever and **nothing in this process can tell that state apart from "still rendering"**. That is the taxonomy's class 1 exactly: two states, one indistinguishable observation.

And the orchestrator had already seen the run finish. `QueueMonitor` keeps its own socket plus a 1 Hz `GET /history` tail diff *specifically* to observe completions the panel-driven path never reports (#258/#259), including browser-queued runs. Those observations went to exactly one consumer — the `queue_status` UI broadcast (`index.ts`, `QueueMonitor.drainCompletions()`) — and were dropped on the floor. **The completion this session was promised was in the orchestrator's hands and thrown away.**

## What changed — both directions

**Delivery is stronger.** New `src/orchestrator/run-completion-watchdog.ts` joins the two:

- `observe()` — a drained `QueueMonitor` completion whose prompt id has an **unanswered** `panel_run` ticket is armed with the time we saw it. First observation wins, so a repeatedly re-reported completion cannot become immortal.
- `tick()` — once the grace elapses, ask **again**. Still unanswered ⇒ the panel is never going to report it: synthesise the completion and hand it to the **same journal** the real frame uses, so it is correlated `matched` ("this is the run YOU queued"), replayed if no agent takes it, and acked normally.
- New journal predicate `RunCompletions.awaitingCompletion(promptId)` is what makes "finished and never announced" nameable at all. Deliberately conservative — no ticket / already settled / **any** journaled entry for the id (pending *or* handed off) / an acked memo / a `reused` id ⇒ not owed.
- Grace is 45 s: longer than the panel's own 20 s reconcile sweep, so the panel's frame — which carries the **images** — wins every time it is coming. If it lands while the synthesised entry is still `pending`, `record()` coalesces the real payload onto it and the agent sees one turn, with pixels.
- #1789 item 3: it now logs a **warning** naming the prompt id. Until now the only detector of a lost completion was a human noticing the agent had gone quiet.

**And the promise is honest.** The rider kept its absolutism on the strength of `correlatable`, which is written by code that cannot keep it — the watchdog sees nothing when the monitored ComfyUI is not the one this run went to, or cannot be polled. So the anti-poll instruction stays **primary** (it is what stops an agent burning a turn a second), paired with a bounded escape hatch: `[FALLBACK] … it cannot be GUARANTEED … make ONE check with queue (action:"status", prompt_id:"…") … One check, not a loop — and not before then.` The prompt id is inlined when the run queued exactly one, and omitted rather than invented for a batch. The uncorrelatable branch is untouched — it never told the agent to idle.

A failed run is reported through the same non-urgent `executed` shape, **not** `run_error`: `run_error` interrupts the live turn and front-queues "diagnose it", which is the right blast radius for a live failure the panel reported and the wrong one for a status read out of a history record a minute later (#1489's own argument).

## Refutation — 7 mutations, all killed

Each edit was applied with an anchor script that **refuses on a non-unique match**, and each was confirmed with `git diff --stat` before the run.

| # | mutation | result |
|---|---|---|
| 1 | delete `runCompletionWatchdog.observe(completions)` from the broadcaster's drain tee | 1 failed (call-site test) |
| 2 | delete `runCompletionWatchdog.tick()` from the poll timer | 1 failed |
| 3 | `awaitingCompletion` stops checking journaled entries | 3 failed |
| 4 | `awaitingCompletion` always returns undefined | 6 failed |
| 5 | drop the `[FALLBACK]` clause from the rider | 2 failed |
| 6 | do not disarm before `deliver()` | 2 failed |
| 7 | last-observation-wins instead of first | 1 failed |

The call sites are asserted at **source** level (same treatment as `carried-stamp-wiring` / `agent-identity-wiring`): the tee, the tick, the tick *ordering*, and that `drainCompletions()` has exactly **one** call site — a second one would splice-race the broadcaster and each consumer would see half a burst. Mutations 1 and 2 are the ones a behavioural test is blind to.

## Was the reporter inside a known window?

- **#1615/#1690 (re-spelled target keeps its self-queue ledger)** — no. That ledger (`selfQueuedIds` / `isSelfAttributedProven`) drives `panel_run`'s duplicate **fence** and the backlog note. The reporter's run was accepted and queued, so the fence never fired, and the notification path reads the **journal's tickets**, not that ledger. Not on this path.
- **#1656/#1775 (carried workflow stamp vs. the routed tab's advertisement)** — no. That governs graph reads and the workflow fence, not completion routing.
- **panel #1739 (a re-pended completion re-arms the reconcile sweep)** — plausibly **yes**, and worth naming: it landed in panel **0.15.4**; the reporter was on **0.14.44**. Its recorded symptom is verbatim this one ("successful run, no completion event, manual get_history recovery"). But #1739 requires `sendFrame` to have failed, which I cannot establish from the report, and it is panel-side. The orchestrator-side gap fixed here is unconditional and covers every way the frame is lost, including ones no panel version can recover from.

## Verification

- `tsc --noEmit` clean.
- Full suite: **10,514 passed / 573 files**. Three files failed under full-parallel load (`panel-restart-health-readiness`, `panel-restart-legacy-fallback`, `panel-session-rebind-residuals`) and **all 89 tests in those three pass when run alone** — the known wall-clock load flake, none of them touching anything this PR changes.
- `npm run check:vocabulary` OK; `npm run check:unknown-collapse` OK.
- **Not live-reproduced.** The defect is in the long-lived orchestrator process, which only picks up code on a full restart; the fallback needs a real ComfyUI *plus* a deliberately suppressed panel frame. Every branch is driven against the real `RunCompletions` singleton instead. No GPU was taken and no render was queued.

## Gate

Codex is exhausted until 2026-08-19 20:43 and `claude-gate.mjs` is blocked on the weekly limit, so **this PR is ungated** — the owner gates and merges. Nothing here is panel-visible (no `comfyui-mcp-panel` change), so the Playwright browser suite does not apply.

## Deliberately not done

- No `/history` **output fetching** in the synthesised notice. It carries the terminal status and points at `get_image` / `get_history`; claiming images the orchestrator never read would be exactly the over-claim class this repo keeps paying for.
- No change to the panel repo. #1739 already shipped there; a second recovery layer in the browser would not have helped a session whose frame never left.
- The uncorrelatable rider branch, `run_error` routing, and the journal's dedupe/replay rules are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
