### PR TITLE
fix(1788): a PINNED extra-paths target says so when the running server reads a different config

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -580,6 +580,38 @@ describe("pre-write: a SERVER-NAMED extra model root wins over an unvouched prim
     expect(h.fetchCalls).toEqual([]);
   });
 
+  // #1788 — the same report, one release later, on `ipadapter`: a CUSTOM category
+  // that no ComfyUI core folder list contains. The redirect must be keyed on the
+  // config's OWN keys, never on a known-category set: a hardcoded set would leave
+  // every custom category (ipadapter, instantid, ultralytics, the categories custom
+  // node packs register) writing into the unvouched primary while loras worked.
+  it.each(["ipadapter", "instantid", "ultralytics", "clip_vision"])(
+    "redirects the CUSTOM category %s exactly like a core one (#1788)",
+    async (category) => {
+      const sharedRoot = resolve(`/shared/models/${category}`);
+      h.liveExtraRoots = {
+        authoritative: true,
+        roots: [{ category, dir: sharedRoot, group: "desktop" }],
+      };
+      await expect(resolveModelSubfolderPreferServer(category)).resolves.toBe(sharedRoot);
+    },
+  );
+
+  it("post-write: a landed ipadapter file under the named extra root verifies VISIBLE (#1788)", async () => {
+    const sharedIpadapter = resolve("/shared/models/ipadapter");
+    h.liveExtraRoots = {
+      authoritative: true,
+      roots: [{ category: "ipadapter", dir: sharedIpadapter, group: "desktop" }],
+    };
+    h.liveListings["ipadapter"] = ["ip-adapter-faceid_sdxl.bin"];
+    const res = await verifyLandedModel(
+      resolve(sharedIpadapter, "ip-adapter-faceid_sdxl.bin"),
+      "ipadapter",
+      { attempts: 1, retryMs: 0 },
+    );
+    expect(res.liveVisible).toBe("visible");
+  });
+
   it("does NOT redirect a category the config does not map", async () => {
     await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBe(
       resolve("/comfy/models/loras"),

--- a/src/__tests__/services/extra-paths-root-guard.test.ts
+++ b/src/__tests__/services/extra-paths-root-guard.test.ts
@@ -286,6 +286,52 @@ describe("inferred root revalidation at the point of use", () => {
     expect(script.consumed).toBe(4);
   });
 
+  // #1788 — the divergence disclosure compares a PINNED config path against every file
+  // the running server loads. That comparison is realpath-collapsed on purpose: here the
+  // harmful direction is the false NEGATIVE, i.e. telling a user their edit is inert when
+  // it lands in the very file the server reads. Scripted realpathSync so it is proven on
+  // every platform (a real file symlink needs privileges on Windows).
+  it("pinned config: a realpath ALIAS of the server's own config is not called inert", async () => {
+    const liveRoot = await trackTmp();
+    await writeFile(join(liveRoot, "main.py"), "# comfyui\n", "utf-8");
+    const serverCfg = join(liveRoot, "instance-model-paths.yaml");
+    await writeFile(serverCfg, "live:\n  ipadapter: D:/shared/ipadapter\n", "utf-8");
+    const aliasDir = await trackTmp();
+    const alias = join(aliasDir, "alias.yaml");
+    await writeFile(alias, "live:\n  ipadapter: D:/shared/ipadapter\n", "utf-8");
+    script.realpath[alias] = serverCfg;
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: ["python", join(liveRoot, "main.py"), "--extra-model-paths-config", serverCfg],
+      },
+    });
+
+    const added = await addExtraPath({ configPath: alias, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("pinned config: a path that is NOT an alias of any server config IS called inert", async () => {
+    // The control for the test above: without it, a disclosure that never fires at all
+    // would pass it just as well.
+    const liveRoot = await trackTmp();
+    await writeFile(join(liveRoot, "main.py"), "# comfyui\n", "utf-8");
+    const serverCfg = join(liveRoot, "instance-model-paths.yaml");
+    await writeFile(serverCfg, "live:\n  ipadapter: D:/shared/ipadapter\n", "utf-8");
+    const other = join(await trackTmp(), "unrelated.yaml");
+    await writeFile(other, "local:\n  vae: D:/vae\n", "utf-8");
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: ["python", join(liveRoot, "main.py"), "--extra-model-paths-config", serverCfg],
+      },
+    });
+
+    const added = await addExtraPath({ configPath: other, category: "vae", path: "D:/vae2" });
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+    expect(added.message).not.toMatch(/Restart ComfyUI to apply it/);
+    expect(added.message).toContain(serverCfg);
+  });
+
   it("live root: a SYMLINKED main.py resolves to the real install root (platform-independent)", async () => {
     // ComfyUI reads the implicit config next to os.path.realpath(__file__). Scripted
     // realpathSync stands in for a symlink so this runs everywhere, including on a

--- a/src/__tests__/services/extra-paths-root-guard.test.ts
+++ b/src/__tests__/services/extra-paths-root-guard.test.ts
@@ -332,6 +332,60 @@ describe("inferred root revalidation at the point of use", () => {
     expect(added.message).toContain(serverCfg);
   });
 
+  // #1788 gate round 1, P1. The realpath collapse above is DEAD exactly when the pinned
+  // file does not exist yet — `realpathSync` throws on an absent path, so the comparison
+  // silently degraded to the lexical one it was added to fix. And "does not exist yet" is
+  // the ORDINARY state here: pinning a config is how a caller creates it. A junctioned
+  // ComfyUI root therefore had the very file the server reads declared inert. The
+  // aliasing lives in the PARENT, so the parent is what must be resolved.
+  it("pinned config: a not-yet-created file under a JUNCTIONED root is not called inert", async () => {
+    const realRoot = await trackTmp();
+    await writeFile(join(realRoot, "main.py"), "# comfyui\n", "utf-8");
+    const aliasRoot = await trackTmp();
+    // A junction: two spellings of ONE directory. Scripted so it runs without the
+    // privileges a real Windows junction needs; identity-mapping the real root keeps
+    // both sides of the comparison in the same spelling the argv resolution produced.
+    script.realpath[aliasRoot] = realRoot;
+    script.realpath[realRoot] = realRoot;
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(realRoot, "main.py")] },
+    });
+
+    const pinned = join(aliasRoot, "extra_model_paths.yaml");
+    expect(existsSync(pinned)).toBe(false); // the case that used to break it
+    const added = await addExtraPath({ configPath: pinned, category: "vae", path: "D:/vae" });
+
+    // It IS the server's implicit config, under another name for the same directory.
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(
+      false,
+    );
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+    // The pin is still honoured — the write went to the spelling the caller gave. (With
+    // a REAL junction that pathname and the server's are one file; the scripted alias
+    // here models only the realpath answer, so the two directories stay distinct on
+    // disk and the assertion is about the pin, not about the junction.)
+    expect(existsSync(pinned)).toBe(true);
+  });
+
+  it("pinned config: a not-yet-created file under an UNRELATED root still IS called inert", async () => {
+    // The control. Without it, a comparison that had simply stopped firing would pass
+    // the junction case above just as well.
+    const realRoot = await trackTmp();
+    await writeFile(join(realRoot, "main.py"), "# comfyui\n", "utf-8");
+    const elsewhere = await trackTmp();
+    script.realpath[realRoot] = realRoot;
+    script.realpath[elsewhere] = elsewhere;
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(realRoot, "main.py")] },
+    });
+
+    const pinned = join(elsewhere, "extra_model_paths.yaml");
+    expect(existsSync(pinned)).toBe(false);
+    const added = await addExtraPath({ configPath: pinned, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+    expect(added.message).not.toMatch(/Restart ComfyUI to apply it/);
+  });
+
   it("live root: a SYMLINKED main.py resolves to the real install root (platform-independent)", async () => {
     // ComfyUI reads the implicit config next to os.path.realpath(__file__). Scripted
     // realpathSync stands in for a symlink so this runs everywhere, including on a

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1150,6 +1150,26 @@ describe("#1788 — a PINNED target discloses that the running server reads else
     expect(added.message).toMatch(/Restart ComfyUI to apply it/);
   });
 
+  it("says NOTHING for the second value of ONE nargs='+' flag occurrence", async () => {
+    // `--extra-model-paths-config` is argparse `nargs="+"`, so ONE occurrence can carry
+    // SEVERAL files and ComfyUI loads them all. The sibling test above spells the flag
+    // twice; this spells it once with two values, which is a different argv shape and a
+    // different parser path. Both must count as configs the server reads.
+    const liveRoot = await trackTmp();
+    await writeFile(join(liveRoot, "main.py"), "# comfyui\n", "utf-8");
+    const first = await liveConfigAt(liveRoot, "first.yaml");
+    const second = await liveConfigAt(liveRoot, "second.yaml");
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: ["python", join(liveRoot, "main.py"), "--extra-model-paths-config", first, second],
+      },
+    });
+
+    const added = await addExtraPath({ configPath: second, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
   it("says NOTHING about the implicit <root>/extra_model_paths.yaml that does not exist YET", async () => {
     // Pinning it is how a user CREATES it; the next restart then loads it. Calling that
     // edit inert would be exactly backwards.

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1178,6 +1178,26 @@ describe("#1788 — a PINNED target discloses that the running server reads else
     expect(added.message).toMatch(/Restart ComfyUI to apply it/);
   });
 
+  // Real symlinks need privileges/Developer Mode on Windows; skipped rather than
+  // silently passing, so it can never read as a vacuous confirmation.
+  it.skipIf(!CAN_SYMLINK)(
+    "says NOTHING when the pinned path is a SYMLINK to a config the server loads",
+    async () => {
+      // The harmful direction for THIS comparison is the false negative: telling a user
+      // their edit is inert when it lands in the very file the server reads. A lexical
+      // compare says these two spellings differ; they are one file.
+      const liveRoot = await trackTmp();
+      const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+      await liveServer(liveRoot, serverCfg);
+      const alias = join(await trackTmp(), "alias.yaml");
+      symlinkSync(serverCfg, alias, "file");
+
+      const added = await addExtraPath({ configPath: alias, category: "vae", path: "D:/vae" });
+      expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+      expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+    },
+  );
+
   it("remove_path carries the disclosure too (an inert removal is equally a no-op)", async () => {
     const appData = await trackTmp();
     process.env.APPDATA = appData;

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1198,6 +1198,57 @@ describe("#1788 — a PINNED target discloses that the running server reads else
     },
   );
 
+  // #1788 gate round 1, P1. Removing the promise from the headline `message` was not
+  // enough: `summarize` appends "Restart ComfyUI after editing this file so startup path
+  // registration is rebuilt." to EVERY answer. That is the same promise in different
+  // words — different enough that the `/Restart ComfyUI to apply it/` assertions above
+  // never saw it — and an agent reads `notes` and acts on it. So the payload contained
+  // both "restarting will not apply this" and "restart to apply this".
+  it("withdraws the generic restart INSTRUCTION from notes too, not just the message", async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ComfyUI-Shared/models/ipadapter",
+    });
+
+    // Nothing in the whole payload may still instruct a restart to apply this edit.
+    expect(added.notes.some((n) => /Restart ComfyUI after editing this file/.test(n))).toBe(
+      false,
+    );
+    expect(JSON.stringify(added)).not.toMatch(/Restart ComfyUI after editing/);
+    // …and the disclosure that replaces it is still there.
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+  });
+
+  it("KEEPS the generic restart instruction when the pin is not inert", async () => {
+    // The control: the note is withdrawn for divergence specifically, not deleted.
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const added = await addExtraPath({ configPath: serverCfg, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /Restart ComfyUI after editing this file/.test(n))).toBe(true);
+  });
+
+  it("list_paths withdraws it too (a READ of an inert file must not instruct a restart)", async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const listed = await listExtraPaths({ target: "desktop" });
+    expect(listed.notes.some((n) => /Restart ComfyUI after editing this file/.test(n))).toBe(
+      false,
+    );
+  });
+
   it("remove_path carries the disclosure too (an inert removal is equally a no-op)", async () => {
     const appData = await trackTmp();
     process.env.APPDATA = appData;

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1202,6 +1202,50 @@ describe("#1788 — a PINNED target discloses that the running server reads else
     expect(added.message).toMatch(/Restart ComfyUI to apply it/);
   });
 
+  // Gate round 2 test gap: the test above exercises the SINGLE-flag arm, where an
+  // unresolvable relative value means there is no server config at all. The
+  // multi-flag arm computes completeness differently — `unlocatable` is filled from
+  // flags 2..n — and forcing `complete: true` there killed no test. That is the shape
+  // that matters most: a FIRST flag we can resolve makes everything downstream look
+  // proven, while the second names a file we cannot see and may well be the pinned one.
+  it("says NOTHING when a LATER relative flag is unlocatable, even though the FIRST resolved", async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    // Absolute first (resolves), relative second (does not — no server cwd reported).
+    await liveServer(liveRoot, serverCfg, "relative-second.yaml");
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ipadapter",
+    });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("DOES speak when every one of several flags resolved (the control for the gap above)", async () => {
+    // Same multi-flag shape, but nothing is unlocatable — the set is complete, so the
+    // pinned file's absence from it really is evidence. Without this, a disclosure that
+    // had simply stopped firing for multi-flag servers would pass the test above.
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const first = await liveConfigAt(liveRoot, "first.yaml");
+    const second = await liveConfigAt(liveRoot, "second.yaml");
+    await liveServer(liveRoot, first, second);
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ipadapter",
+    });
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+    expect(added.message).not.toMatch(/Restart ComfyUI to apply it/);
+    expect(added.message).toContain(second);
+  });
+
   it("says NOTHING when the server is UNREACHABLE (the pin is all there is)", async () => {
     const appData = await trackTmp();
     process.env.APPDATA = appData;

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1019,6 +1019,180 @@ describe("a reachable server with NO --extra-model-paths-config is still authori
   });
 });
 
+describe("#1788 — a PINNED target discloses that the running server reads elsewhere", () => {
+  // The report: on ComfyUI Desktop, `list_local_models action:"add_path" target:"desktop"`
+  // wrote %APPDATA%/ComfyUI/extra_models_config.yaml and answered "Added … Restart
+  // ComfyUI to apply it", while `action:"list_paths"` on the same tool had already named
+  // the DIFFERENT file the running server was launched with. The write target is the
+  // documented escape hatch and stays where the caller pinned it — what changes is that
+  // the answer stops promising an effect the running server will never see.
+
+  /** A reachable server launched from `root`/main.py with the given config flags. */
+  async function liveServer(root: string, ...flags: string[]): Promise<void> {
+    await writeFile(join(root, "main.py"), "# comfyui\n", "utf-8");
+    const argv = ["python", join(root, "main.py")];
+    for (const f of flags) argv.push("--extra-model-paths-config", f);
+    mockGetSystemStats.mockResolvedValue({ system: { argv } });
+  }
+
+  async function liveConfigAt(dir: string, name: string): Promise<string> {
+    const cfg = join(dir, name);
+    await writeFile(cfg, "live:\n  ipadapter: D:/ComfyUI-Shared/models/ipadapter\n", "utf-8");
+    return cfg;
+  }
+
+  it('add_path target:"desktop" still writes the pinned file but refuses to promise a restart applies it', async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ComfyUI-Shared/models/ipadapter",
+    });
+
+    // The escape hatch is intact: the bytes landed exactly where the caller pinned.
+    expect(added.path).toBe(join(appData, "ComfyUI", "extra_models_config.yaml"));
+    expect(added.changed).toBe(true);
+    expect(existsSync(added.path)).toBe(true);
+    // …and the answer says the running server does not read it.
+    expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+    expect(added.notes.join(" ")).toContain(serverCfg);
+    expect(added.message).not.toMatch(/Restart ComfyUI to apply it/);
+    expect(added.message).toMatch(/does NOT read/);
+    expect(added.message).toContain(serverCfg);
+  });
+
+  it('list_paths target:"desktop" carries the same disclosure (the READ was never wrong, only silent)', async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const listed = await listExtraPaths({ target: "desktop" });
+    expect(listed.path).toBe(join(appData, "ComfyUI", "extra_models_config.yaml"));
+    expect(listed.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(true);
+  });
+
+  it("says NOTHING when the pinned file IS the one the server was launched with", async () => {
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+
+    const added = await addExtraPath({
+      configPath: serverCfg,
+      category: "loras",
+      path: "D:/loras",
+    });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("says NOTHING when the pinned file is the SECOND --extra-model-paths-config (not just the first)", async () => {
+    // The guard must compare the pinned path against EVERY config the server loads.
+    // Comparing only the primary resolution — the first flag — would call a live file
+    // inert, which is the same wrong-pair defect one level out.
+    const liveRoot = await trackTmp();
+    const first = await liveConfigAt(liveRoot, "first.yaml");
+    const second = await liveConfigAt(liveRoot, "second.yaml");
+    await liveServer(liveRoot, first, second);
+
+    const added = await addExtraPath({ configPath: second, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("says NOTHING about the implicit <root>/extra_model_paths.yaml that does not exist YET", async () => {
+    // Pinning it is how a user CREATES it; the next restart then loads it. Calling that
+    // edit inert would be exactly backwards.
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+    const implicit = join(liveRoot, "extra_model_paths.yaml");
+    expect(existsSync(implicit)).toBe(false);
+
+    const added = await addExtraPath({ configPath: implicit, category: "vae", path: "D:/vae" });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("says NOTHING when a RELATIVE flag leaves the server's config set INCOMPLETE", async () => {
+    // The server names a config this process cannot locate, so the pinned file's absence
+    // from what we CAN name is not evidence the server does not read it. Unknown stays
+    // unknown — never a confident "it does not read this".
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    await liveServer(liveRoot, "relative-cfg.yaml");
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ipadapter",
+    });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("says NOTHING when the server is UNREACHABLE (the pin is all there is)", async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ipadapter",
+    });
+    expect(added.path).toBe(join(appData, "ComfyUI", "extra_models_config.yaml"));
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("says NOTHING when the server's tree is not proven to be this machine's", async () => {
+    // Reachable, but its main.py does not resolve here (container/WSL/another host). The
+    // absolute flag value would name a same-spelled file on ITS disk; nothing is proven.
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "python",
+          join(await trackTmp(), "not-mounted", "main.py"),
+          "--extra-model-paths-config",
+          "/srv/comfy/extra.yaml",
+        ],
+      },
+    });
+
+    const added = await addExtraPath({
+      target: "desktop",
+      category: "ipadapter",
+      path: "D:/ipadapter",
+    });
+    expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+    expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+  });
+
+  it("remove_path carries the disclosure too (an inert removal is equally a no-op)", async () => {
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const liveRoot = await trackTmp();
+    const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+    await liveServer(liveRoot, serverCfg);
+    await addExtraPath({ target: "desktop", category: "vae", path: "D:/vae" });
+
+    const removed = await removeExtraPath({ target: "desktop", category: "vae", path: "D:/vae" });
+    expect(removed.changed).toBe(true);
+    expect(removed.message).not.toMatch(/Restart ComfyUI to apply it/);
+    expect(removed.message).toMatch(/does NOT read/);
+  });
+});
+
 describe("expandVars — single-pass %VAR% scanner (no placeholder round-trip)", () => {
   const VAR = "CMCP_EXPAND_TEST_VAR";
   const oldValue = process.env[VAR];

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -58,6 +59,49 @@ const CAN_SYMLINK = (() => {
     return true;
   } catch {
     return false;
+  }
+})();
+
+/**
+ * The 8.3 short spelling of a path, or undefined when this volume does not generate one.
+ * `Scripting.FileSystemObject.ShortPath` is the only reliable way to ask Windows for it;
+ * when 8.3 generation is disabled (`fsutil 8dot3name`, the default on some volumes) it
+ * answers with the LONG path, which is the signal to skip rather than assert nothing.
+ */
+function shortPathOf(target: string, kind: "GetFile" | "GetFolder"): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  try {
+    const quoted = target.replace(/'/g, "''");
+    const out = execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(New-Object -ComObject Scripting.FileSystemObject).${kind}('${quoted}').ShortPath`,
+      ],
+      { encoding: "utf-8", windowsHide: true, timeout: 30_000 },
+    ).trim();
+    if (!out || out.toLowerCase() === target.toLowerCase()) return undefined;
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Does this machine generate 8.3 aliases in tmpdir at all? Probed once, like CAN_SYMLINK,
+ *  so the tests below SKIP on a volume with 8dot3name disabled instead of passing
+ *  vacuously against a path that was never short. */
+const CAN_SHORT_PATH = (() => {
+  if (process.platform !== "win32") return false;
+  let dir: string | undefined;
+  try {
+    dir = mkdtempSync(join(tmpdir(), "comfyui-1788-a-very-long-install-name-"));
+    return shortPathOf(dir, "GetFolder") !== undefined;
+  } catch {
+    return false;
+  } finally {
+    if (dir) rmSync(dir, { recursive: true, force: true });
   }
 })();
 
@@ -1246,6 +1290,77 @@ describe("#1788 — a PINNED target discloses that the running server reads else
     const listed = await listExtraPaths({ target: "desktop" });
     expect(listed.notes.some((n) => /Restart ComfyUI after editing this file/.test(n))).toBe(
       false,
+    );
+  });
+
+  // GATE ROUND 2, P1 — `fs.realpathSync` collapses junctions but does NOT expand a
+  // Windows 8.3 short name; only `.native` asks the OS (this repo already uses `.native`
+  // for exactly that in panel-installer.ts and node-dev.ts). With the JS binding, pinning
+  // the server's OWN config by its short spelling emitted "the running ComfyUI does NOT
+  // read …\AVERYL~1\instance.yaml" for a file it demonstrably reads — a confident wrong
+  // negative replacing harmless silence, on the platform this was reported from.
+  describe.runIf(process.platform === "win32")("Windows 8.3 short names", () => {
+    it.skipIf(!CAN_SHORT_PATH)(
+      "says NOTHING when the server's own config is pinned by its 8.3 short spelling",
+      async () => {
+        const liveRoot = await trackTmp();
+        const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+        await liveServer(liveRoot, serverCfg);
+        const short = shortPathOf(serverCfg, "GetFile");
+        expect(short).toBeDefined();
+        expect(short!.toLowerCase()).not.toBe(serverCfg.toLowerCase());
+
+        const added = await addExtraPath({
+          configPath: short!,
+          category: "ipadapter",
+          path: "D:/ipadapter",
+        });
+        expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+        expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+      },
+    );
+
+    it.skipIf(!CAN_SHORT_PATH)(
+      "says NOTHING for the not-yet-created implicit yaml under an 8.3 directory",
+      async () => {
+        // Both failing channels at once: the leaf does not exist (so the collapse falls
+        // to the PARENT) and the parent is spelled 8.3 (so only `.native` expands it).
+        const liveRoot = await trackTmp();
+        const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+        await liveServer(liveRoot, serverCfg);
+        const shortDir = shortPathOf(liveRoot, "GetFolder");
+        expect(shortDir).toBeDefined();
+        const pinned = join(shortDir!, "extra_model_paths.yaml");
+        expect(existsSync(join(liveRoot, "extra_model_paths.yaml"))).toBe(false);
+
+        const added = await addExtraPath({ configPath: pinned, category: "vae", path: "D:/vae" });
+        expect(added.notes.some((n) => /does not read this file/.test(n))).toBe(false);
+        expect(added.message).toMatch(/Restart ComfyUI to apply it/);
+      },
+    );
+
+    it.skipIf(!CAN_SHORT_PATH)(
+      "still DOES flag an unrelated file under the same 8.3 directory (no over-collapsing)",
+      async () => {
+        // The control. Without it, a disclosure that had stopped firing entirely would
+        // pass both tests above — expanding short names must not collapse two distinct
+        // files in one directory into each other.
+        const liveRoot = await trackTmp();
+        const serverCfg = await liveConfigAt(liveRoot, "instance-model-paths.yaml");
+        await liveServer(liveRoot, serverCfg);
+        const shortDir = shortPathOf(liveRoot, "GetFolder");
+        expect(shortDir).toBeDefined();
+
+        const added = await addExtraPath({
+          configPath: join(shortDir!, "unrelated.yaml"),
+          category: "vae",
+          path: "D:/vae",
+        });
+        expect(added.notes.some((n) => /RUNNING ComfyUI does not read this file/.test(n))).toBe(
+          true,
+        );
+        expect(added.message).not.toMatch(/Restart ComfyUI to apply it/);
+      },
     );
   });
 

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -453,6 +453,32 @@ interface ResolvedTarget {
   createParents: boolean;
   /** Set for an inferred root — re-proved before every read and every write. */
   guard?: GuardedRoot;
+  /** Every config file the RUNNING server loads, when this resolution was anchored to
+   *  that server. Only a `complete` set can support the #1788 divergence disclosure —
+   *  a path's ABSENCE from a partial set is not evidence the server does not read it. */
+  liveLoaded?: LiveLoadedConfigs;
+  /** Set ONLY when the caller PINNED a file (`target`/`config_path`) and the running
+   *  server was proven to read a DIFFERENT, completely-enumerated set of configs — i.e.
+   *  this edit cannot affect the running server. Structured, never re-parsed from the
+   *  note: the mutation messages key on this field to stop promising "Restart ComfyUI
+   *  to apply it" for a file no ComfyUI will read (#1788). */
+  divergesFromLive?: { serverPaths: string[] };
+}
+
+/**
+ * The config files the RUNNING ComfyUI loads, established from ONE /system_stats
+ * snapshot. ComfyUI's set is exactly: every `--extra-model-paths-config` it was launched
+ * with, PLUS `<its own main.py root>/extra_model_paths.yaml`.
+ *
+ * `complete: false` means this process could NOT name them all — a RELATIVE
+ * `--extra-model-paths-config` with no reported server cwd resolves only against the
+ * SERVER's working directory. In that state a file's absence from `paths` says nothing
+ * about whether the server reads it, so no caller may conclude divergence from it. Same
+ * rule the rest of this file runs on: "could not determine" is never "determined not".
+ */
+interface LiveLoadedConfigs {
+  paths: string[];
+  complete: boolean;
 }
 
 function standaloneConfigPath(): Omit<ResolvedTarget, "target"> {
@@ -753,6 +779,10 @@ function implicitLiveTarget(
     serverResolved: true,
     createParents: false, // the root is proven; only the YAML itself may be missing
     guard: { path: liveRoot, identity: seen.identity, source: "live-root" },
+    // With no flag at all this IS the server's whole set. With an UNRESOLVABLE relative
+    // flag there is a second file we cannot name, so the set is incomplete and a pinned
+    // path's absence from it concludes nothing.
+    liveLoaded: { paths: [path], complete: unresolvableFlag === undefined },
   };
 }
 
@@ -802,9 +832,11 @@ async function resolveTargetPathPreferServer(
   opts: ExtraPathOptions = {},
   allowUnprovenLocalListFallback = false,
 ): Promise<ResolvedTarget & { serverResolved: boolean }> {
-  // Explicit config_path or an explicit non-auto target: honor the caller.
+  // Explicit config_path or an explicit non-auto target: honor the caller — and then
+  // say so honestly when the running server reads somewhere else (#1788). The write
+  // target is UNCHANGED by that check; only the reporting is.
   if (opts.configPath || (opts.target && opts.target !== "auto")) {
-    return { ...resolveTargetPath(opts), serverResolved: false };
+    return await notePinnedDivergence({ ...resolveTargetPath(opts), serverResolved: false });
   }
 
   const snapshot = await getLiveServerSnapshot(); // remote/unreachable → reachable:false
@@ -1095,6 +1127,17 @@ async function resolveTargetPathPreferServer(
   } catch {
     // No static guess available — the server-resolved path stands on its own.
   }
+  // The COMPARISON set for the #1788 divergence disclosure — deliberately NOT the
+  // `alsoLoaded` display list. Two differences, both load-bearing:
+  //   • the implicit `<root>/extra_model_paths.yaml` is included even when it does not
+  //     exist yet. Pinning it is how a user CREATES it, and the next restart then loads
+  //     it — calling that edit inert would be exactly backwards.
+  //   • `unlocatable` relative flags make the set INCOMPLETE, so a pinned path's absence
+  //     proves nothing and no divergence may be claimed.
+  const liveLoadedPaths = [serverConfig, ...alsoLoaded];
+  if (implicitConfig && !liveLoadedPaths.some((p) => samePath(p, implicitConfig))) {
+    liveLoadedPaths.push(implicitConfig);
+  }
   const isDesktop = looksLikeDesktopConfig(serverConfig);
   if (isDesktopGeneratedConfig(serverConfig)) {
     notes.push(
@@ -1108,6 +1151,75 @@ async function resolveTargetPathPreferServer(
     serverResolved: true,
     // The live server told us this file, so its directory exists by construction.
     createParents: true,
+    liveLoaded: { paths: liveLoadedPaths, complete: unlocatable.length === 0 },
+  };
+}
+
+/**
+ * #1788 — a PINNED target (`target: "desktop"` / `"standalone"` / an explicit
+ * `config_path`) deliberately bypasses the live resolution above: it is the documented
+ * escape hatch, and it must keep writing exactly where the caller said.
+ *
+ * What it must NOT keep doing is reporting that edit as though the running server will
+ * pick it up. The reporter called `list_local_models action:"add_path" target:"desktop"`
+ * on ComfyUI Desktop; the static heuristic wrote
+ * `%APPDATA%/ComfyUI/extra_models_config.yaml` and answered "Added … Restart ComfyUI to
+ * apply it", while the very same tool's `action:"list_paths"` had already reported the
+ * DIFFERENT file the running server was launched with. Two code paths, one question,
+ * two answers — and only the one that was right said so. Every live-anchored branch
+ * above pushes a divergence note when the STATIC guess would have differed; the pinned
+ * branch, which is the direction that actually loses data, pushed none.
+ *
+ * So: still write where the caller pinned, but ASK the same canonical resolver what the
+ * running server reads and disclose the divergence. Deliberately conservative — it can
+ * only ever ADD a note:
+ *   • the resolver is re-entered with NO pin, so this is the ONE canonical live
+ *     resolution, not a second copy of it that could drift (one level of recursion only:
+ *     `{}` cannot re-enter this branch);
+ *   • anything short of `serverResolved` proof — unreachable, remote, an unproven tree,
+ *     the #764 display fallbacks — yields NO note. Silence is the honest answer to "we
+ *     could not establish what the server reads";
+ *   • an INCOMPLETE loaded set yields no note either (see LiveLoadedConfigs);
+ *   • a pinned path that IS one of the server's configs yields no note — a caller
+ *     pinning the second `--extra-model-paths-config` file is editing a live one.
+ */
+async function notePinnedDivergence(
+  pinned: ResolvedTarget & { serverResolved: boolean },
+): Promise<ResolvedTarget & { serverResolved: boolean }> {
+  // Reachability is checked FIRST, before any resolution work. Without a reachable
+  // local server no note is possible, and the full resolution is not free: it stats the
+  // caller's own guarded root, and that root's TOCTOU revalidation counts every stat it
+  // takes (#648). Burning one there to learn nothing would turn a stable root into a
+  // spurious "REPLACED while this call was running" refusal.
+  //
+  // This is a second /system_stats read, and it is deliberately only a GATE — the inner
+  // resolution takes its own authoritative snapshot. A server that stops or starts
+  // between the two can therefore only ever SUPPRESS the note (gate says unreachable, or
+  // the inner call finds nothing proven); it can never manufacture one from a state the
+  // resolver did not itself observe.
+  if (!(await getLiveServerSnapshot()).reachable) return pinned;
+  let live: (ResolvedTarget & { serverResolved: boolean }) | undefined;
+  try {
+    live = await resolveTargetPathPreferServer({});
+  } catch {
+    return pinned; // the server established nothing — the pin is all there is
+  }
+  if (!live.serverResolved) return pinned;
+  const loaded = live.liveLoaded;
+  if (!loaded?.complete) return pinned;
+  if (loaded.paths.some((p) => samePath(p, pinned.path))) return pinned;
+  return {
+    ...pinned,
+    notes: [
+      ...pinned.notes,
+      `WARNING: the RUNNING ComfyUI does not read this file. You pinned it explicitly ` +
+        `(target/config_path), so it was selected by the local heuristic, not from the ` +
+        `server; the connected server reports it loads ${loaded.paths.join(", ")}. An ` +
+        `edit here does NOT reach the running server — restarting will not apply it. ` +
+        `Omit target/config_path to act on the config the running server actually reads, ` +
+        `or pass config_path with one of the paths above.`,
+    ],
+    divergesFromLive: { serverPaths: loaded.paths },
   };
 }
 
@@ -1339,6 +1451,22 @@ async function writeConfigFile(
   await writeFile(path, stringifyYaml(raw, { lineWidth: 0 }), "utf-8");
 }
 
+/**
+ * What a mutation's headline `message` must say when the file was PINNED and the running
+ * server provably reads elsewhere (#1788). Built from the STRUCTURED `divergesFromLive`
+ * field, never from re-reading a note: "Restart ComfyUI to apply it" is a promise about
+ * an effect, and it was being made for a file no running ComfyUI reads.
+ */
+function inertEditSuffix(resolved: ResolvedTarget): string {
+  const d = resolved.divergesFromLive;
+  if (!d) return "";
+  return (
+    ` WARNING: the running ComfyUI does NOT read ${resolved.path} — it loads ` +
+    `${d.serverPaths.join(", ")}. Restarting will NOT apply this change; you pinned this ` +
+    `file with target/config_path. Omit those to edit the config the running server reads.`
+  );
+}
+
 export async function addExtraPath(
   opts: ExtraPathMutationOptions,
 ): Promise<ExtraPathMutationResult> {
@@ -1376,12 +1504,16 @@ export async function addExtraPath(
     resolved.serverResolved,
     existedBefore || changed,
   );
+  const inert = inertEditSuffix(resolved);
   return {
     ...info,
     changed,
-    message: changed
-      ? `Added ${nextPath} to ${groupName}.${category}. Restart ComfyUI to apply it.`
-      : `${nextPath} is already present in ${groupName}.${category}.`,
+    message:
+      (changed
+        ? inert
+          ? `Added ${nextPath} to ${groupName}.${category}.`
+          : `Added ${nextPath} to ${groupName}.${category}. Restart ComfyUI to apply it.`
+        : `${nextPath} is already present in ${groupName}.${category}.`) + inert,
   };
 }
 
@@ -1418,11 +1550,15 @@ export async function removeExtraPath(
     resolved.serverResolved,
     existedBefore || changed,
   );
+  const inert = inertEditSuffix(resolved);
   return {
     ...info,
     changed,
-    message: changed
-      ? `Removed ${removePath} from ${groupName}.${category}. Restart ComfyUI to apply it.`
-      : `${removePath} was not present in ${groupName}.${category}.`,
+    message:
+      (changed
+        ? inert
+          ? `Removed ${removePath} from ${groupName}.${category}.`
+          : `Removed ${removePath} from ${groupName}.${category}. Restart ComfyUI to apply it.`
+        : `${removePath} was not present in ${groupName}.${category}.`) + inert,
   };
 }

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -382,6 +382,33 @@ function samePath(a: string, b: string): boolean {
   }
 }
 
+/**
+ * Do these two spellings name the SAME config file? Used only by the #1788 divergence
+ * disclosure, where the harmful direction is the opposite of `samePath`'s.
+ *
+ * `samePath` is deliberately lexical, and its false negatives are safe there: they demote
+ * a root from "explicit" to "inferred", i.e. more checking. Here a false negative would
+ * declare a file the server DOES read to be inert and tell the user their edit will not
+ * apply — a confident wrong answer on a correct action. A junction, an 8.3 short name, or
+ * a UNC-vs-mapped-drive spelling of one file is ordinary on the platform this was
+ * reported from, so the comparison is collapsed through `realpath` as well.
+ *
+ * `realpath` is best-effort: a path that does not exist yet (the implicit
+ * `<root>/extra_model_paths.yaml` a caller is about to create) simply falls back to its
+ * lexical form, which is what `samePath` already compared.
+ */
+function sameConfigFile(a: string, b: string): boolean {
+  if (samePath(a, b)) return true;
+  const real = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  };
+  return samePath(real(a), real(b));
+}
+
 function standaloneRoot(): {
   root: string;
   source: StandaloneRootSource;
@@ -455,7 +482,13 @@ interface ResolvedTarget {
   guard?: GuardedRoot;
   /** Every config file the RUNNING server loads, when this resolution was anchored to
    *  that server. Only a `complete` set can support the #1788 divergence disclosure —
-   *  a path's ABSENCE from a partial set is not evidence the server does not read it. */
+   *  a path's ABSENCE from a partial set is not evidence the server does not read it.
+   *
+   *  INVARIANT, relied on by `notePinnedDivergence`: this field is set ONLY by a branch
+   *  that also reports `serverResolved: true`. Its presence is therefore the proof that
+   *  the running server — not a local heuristic, not a #764 display fallback — named
+   *  these files. A branch that sets it without that anchoring would turn a guess into a
+   *  confident "the running ComfyUI does not read your file". */
   liveLoaded?: LiveLoadedConfigs;
   /** Set ONLY when the caller PINNED a file (`target`/`config_path`) and the running
    *  server was proven to read a DIFFERENT, completely-enumerated set of configs — i.e.
@@ -1135,7 +1168,7 @@ async function resolveTargetPathPreferServer(
   //   • `unlocatable` relative flags make the set INCOMPLETE, so a pinned path's absence
   //     proves nothing and no divergence may be claimed.
   const liveLoadedPaths = [serverConfig, ...alsoLoaded];
-  if (implicitConfig && !liveLoadedPaths.some((p) => samePath(p, implicitConfig))) {
+  if (implicitConfig && !liveLoadedPaths.some((p) => sameConfigFile(p, implicitConfig))) {
     liveLoadedPaths.push(implicitConfig);
   }
   const isDesktop = looksLikeDesktopConfig(serverConfig);
@@ -1204,10 +1237,16 @@ async function notePinnedDivergence(
   } catch {
     return pinned; // the server established nothing — the pin is all there is
   }
-  if (!live.serverResolved) return pinned;
+  // `liveLoaded` IS the proof of anchoring: only the two server-anchored branches
+  // produce it (see its declaration), and it is the predicate this decision actually
+  // needs — the complete set of files the running server reads. An additional
+  // `serverResolved` check beside it was redundant by construction: a mutation deleting
+  // it killed zero tests, because no input can make the two disagree. An untestable
+  // guard is not defence in depth, it is an unpinned claim, so the invariant lives on
+  // the field's contract where a future branch has to read it.
   const loaded = live.liveLoaded;
   if (!loaded?.complete) return pinned;
-  if (loaded.paths.some((p) => samePath(p, pinned.path))) return pinned;
+  if (loaded.paths.some((p) => sameConfigFile(p, pinned.path))) return pinned;
   return {
     ...pinned,
     notes: [

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -393,12 +393,23 @@ function samePath(a: string, b: string): boolean {
  * a UNC-vs-mapped-drive spelling of one file is ordinary on the platform this was
  * reported from, so the comparison is collapsed through `realpath` as well.
  *
- * `realpath` on the FILE is not enough, and the gap is not academic: `realpathSync`
- * throws on a path that does not exist, and "does not exist yet" is the ordinary state
- * here — the implicit `<root>/extra_model_paths.yaml` a caller is about to CREATE. In
- * that state the file-level collapse silently degrades to the lexical compare it was
- * added to fix, so a junctioned `COMFYUI_PATH` naming the very file the server reads was
- * declared inert (gate round 1, P1, reproduced with a real Windows junction).
+ * WHICH realpath is load-bearing, and the previous version of this comment was simply
+ * WRONG about it: `fs.realpathSync` collapses junctions and symlinks but does NOT expand
+ * a Windows 8.3 short name — only `fs.realpathSync.native` asks the OS and gets back the
+ * long, real-case path. This repo already learned that (`panel-installer.ts`,
+ * `node-dev.ts` both use `.native` for exactly this). With the JS binding, pinning the
+ * server's OWN config by its short spelling produced "the running ComfyUI does NOT read
+ * `…\AVERYL~1\instance.yaml`" for a file it demonstrably reads (gate round 2, P1) —
+ * the disqualifying direction, on the platform this was reported from. `.native` first,
+ * with the JS binding as a fallback so an environment where the native call is
+ * unavailable still collapses junctions rather than nothing.
+ *
+ * `realpath` on the FILE is not enough either, and that gap is not academic: it throws
+ * on a path that does not exist, and "does not exist yet" is the ordinary state here —
+ * the implicit `<root>/extra_model_paths.yaml` a caller is about to CREATE. In that
+ * state the file-level collapse silently degrades to the lexical compare it was added to
+ * fix, so a junctioned `COMFYUI_PATH` naming the very file the server reads was declared
+ * inert (gate round 1, P1, reproduced with a real Windows junction).
  *
  * So resolve the DIRECTORY and rejoin the basename when the file itself does not
  * resolve. The aliasing that matters lives in the parent — a junctioned/symlinked
@@ -408,17 +419,32 @@ function samePath(a: string, b: string): boolean {
  */
 function sameConfigFile(a: string, b: string): boolean {
   if (samePath(a, b)) return true;
-  const real = (p: string): string => {
+  /** Canonicalize one path, or `undefined` if it cannot be resolved at all. `.native`
+   *  is FIRST and is the only binding that expands a Windows 8.3 short name; the JS
+   *  binding is a fallback that still collapses junctions/symlinks. Returning
+   *  `undefined` rather than the input keeps "could not resolve" distinguishable from
+   *  "resolved to itself", so the caller can try the parent instead of silently
+   *  comparing an unresolved path against a resolved one. */
+  const canon = (p: string): string | undefined => {
+    try {
+      return realpathSync.native(p);
+    } catch {
+      // Native unavailable, or the path is absent/unreadable — try the JS binding.
+    }
     try {
       return realpathSync(p);
     } catch {
-      // The file is absent/unreadable — resolve its directory instead.
+      return undefined;
     }
-    try {
-      return join(realpathSync(dirname(p)), basename(p));
-    } catch {
-      return p;
-    }
+  };
+  const real = (p: string): string => {
+    const direct = canon(p);
+    if (direct !== undefined) return direct;
+    // Absent/unreadable — and absent is the ORDINARY state, since pinning a config is
+    // how a caller creates it. The aliasing lives in the parent, so resolve the
+    // directory and rejoin the basename.
+    const parent = canon(dirname(p));
+    return parent === undefined ? p : join(parent, basename(p));
   };
   return samePath(real(a), real(b));
 }

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -1,7 +1,7 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir, platform } from "node:os";
-import { dirname, join, isAbsolute, resolve } from "node:path";
+import { basename, dirname, join, isAbsolute, resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { config, isRemoteMode } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
@@ -393,15 +393,29 @@ function samePath(a: string, b: string): boolean {
  * a UNC-vs-mapped-drive spelling of one file is ordinary on the platform this was
  * reported from, so the comparison is collapsed through `realpath` as well.
  *
- * `realpath` is best-effort: a path that does not exist yet (the implicit
- * `<root>/extra_model_paths.yaml` a caller is about to create) simply falls back to its
- * lexical form, which is what `samePath` already compared.
+ * `realpath` on the FILE is not enough, and the gap is not academic: `realpathSync`
+ * throws on a path that does not exist, and "does not exist yet" is the ordinary state
+ * here — the implicit `<root>/extra_model_paths.yaml` a caller is about to CREATE. In
+ * that state the file-level collapse silently degrades to the lexical compare it was
+ * added to fix, so a junctioned `COMFYUI_PATH` naming the very file the server reads was
+ * declared inert (gate round 1, P1, reproduced with a real Windows junction).
+ *
+ * So resolve the DIRECTORY and rejoin the basename when the file itself does not
+ * resolve. The aliasing that matters lives in the parent — a junctioned/symlinked
+ * install root, an 8.3 short name, a mapped drive — and the parent of a config a caller
+ * can write to normally exists. Only when even the parent does not resolve does this
+ * fall back to the lexical form, i.e. to exactly what `samePath` already compared.
  */
 function sameConfigFile(a: string, b: string): boolean {
   if (samePath(a, b)) return true;
   const real = (p: string): string => {
     try {
       return realpathSync(p);
+    } catch {
+      // The file is absent/unreadable — resolve its directory instead.
+    }
+    try {
+      return join(realpathSync(dirname(p)), basename(p));
     } catch {
       return p;
     }
@@ -662,6 +676,18 @@ function summarize(
    * be reported as `exists: false` about a file we had just finished reading.
    */
   exists = false,
+  /**
+   * Set when this file was PINNED and the running server provably reads elsewhere
+   * (#1788). The headline `message` is not the only place that promised an effect: the
+   * generic "Restart ComfyUI after editing this file" note below is appended to EVERY
+   * summary, and it is the same promise in different words — different enough that the
+   * `message`-level assertions did not see it (gate round 1, P1). An agent reads `notes`
+   * and acts on it, so the promise is withdrawn HERE too, keyed on the same structured
+   * observation `inertEditSuffix` uses rather than on re-read prose. Nothing is lost:
+   * the divergence warning already in `extraNotes` states what a restart will and will
+   * not do, so the two can never disagree.
+   */
+  divergesFromLive?: { serverPaths: string[] },
 ): ExtraPathsConfigInfo {
   const groups: ExtraPathGroup[] = [];
   for (const [name, value] of Object.entries(raw)) {
@@ -682,7 +708,9 @@ function summarize(
             : "Standalone/manual installs use extra_model_paths.yaml in the ComfyUI root.",
         ]),
     "Categories are generic ComfyUI search-path keys, so model folders and custom_nodes can both be represented when supported by the running ComfyUI build.",
-    "Restart ComfyUI after editing this file so startup path registration is rebuilt.",
+    ...(divergesFromLive
+      ? []
+      : ["Restart ComfyUI after editing this file so startup path registration is rebuilt."]),
   ];
   return { target, path, exists, groups, notes };
 }
@@ -1284,6 +1312,7 @@ async function readExtraPathsConfig(
     resolved.notes,
     resolved.serverResolved,
     exists,
+    resolved.divergesFromLive,
   );
 }
 
@@ -1542,6 +1571,7 @@ export async function addExtraPath(
     resolved.notes,
     resolved.serverResolved,
     existedBefore || changed,
+    resolved.divergesFromLive,
   );
   const inert = inertEditSuffix(resolved);
   return {
@@ -1588,6 +1618,7 @@ export async function removeExtraPath(
     resolved.notes,
     resolved.serverResolved,
     existedBefore || changed,
+    resolved.divergesFromLive,
   );
   const inert = inertEditSuffix(resolved);
   return {


### PR DESCRIPTION
Closes #1788.

The report has two halves. **Only one of them still needed code.**

---

## Half 1 — the download landed in the install-local `models/ipadapter`: already shipped

The obvious hypothesis was a hardcoded category set that omits `ipadapter`. **Refuted by
execution, not by reading.** `getLiveExtraModelRoots` enumerates the config's OWN keys
(`readGroup` skips only `base_path`/`is_default`), and the redirect's only category filter is
`NON_MODEL_EXTRA_CATEGORIES = {"custom_nodes"}`. A probe on the reporter's exact shape —
unvouched primary, absolute `--extra-model-paths-config`, `ipadapter` — redirects
`…/ComfyUI-Installs/ComfyUI/ComfyUI/models/ipadapter` → `…/ComfyUI-Shared/models/ipadapter`,
and verifies VISIBLE post-write.

The real reason is duller: **the reporter runs comfyui-mcp 0.52.0.**
`git merge-base --is-ancestor 0580637 v0.52.3` → no; `v0.52.4` → yes. #1734 first shipped in
**v0.52.4**, four patch releases after the reporter's build. `ipadapter` was never a special
case, because the mechanism is keyed on the live config.

It is also none of the three follow-ups recorded on #1734 — not the `.find()` first-match (one
group, one mapping), not the current-contents read (the config predates the download), not the
`verified_root` stamp (on 0.52.0 the file never reached the extra root at all).

No product change here. What this PR adds is four permanent cases in
`download-live-destination.test.ts` (`ipadapter`, `instantid`, `ultralytics`, `clip_vision`)
plus a post-write `verifyLandedModel` case, because nothing pinned category-agnosticism and a
later "only these categories" narrowing would have shipped silently. Gating off the #1734
redirect (`if (false && argvNamesConfig && …)`, diff confirmed) kills all four new cases plus
three originals — so they pin the shipped mechanism rather than decorating it.

## Half 2 — `add_path target:"desktop"` edited an inactive YAML and promised a restart would apply it

`list_paths` "correctly identified the right root" and `add_path target:"desktop"` did not —
the sharpest clue in the report, and it points at a different function.
`resolveTargetPathPreferServer` short-circuits on an explicit `target`/`config_path`:

```ts
if (opts.configPath || (opts.target && opts.target !== "auto")) {
  return { ...resolveTargetPath(opts), serverResolved: false };
}
```

so `target:"desktop"` returned the static `%APPDATA%/ComfyUI/extra_models_config.yaml` with
`notes: []`, wrote it, and answered **"Added … Restart ComfyUI to apply it"** for a file the
running Desktop server does not read. Note the asymmetry that was actually there: every
*live-anchored* branch already pushes a divergence note when the static guess would have
differed; the pinned branch — the direction that actually loses the user's edit — pushed none.

**The pin stays.** It is the documented escape hatch (the schema says in so many words: *"Use
standalone/desktop (or config_path) to deliberately target a file the running server does not
read"*), and the bytes still land exactly where the caller said. What changes is that the
answer stops promising an effect. The pinned branch re-enters the **same canonical resolver**
with no pin (one level; `{}` cannot re-enter the branch — no second copy of the resolution to
drift) and discloses divergence in `notes` and in the mutation `message`, keyed on a structured
`divergesFromLive` field, never on re-parsed prose. `removeExtraPath` and `listExtraPaths` get
it too.

It can only ever ADD a note. Silence — never a confident negative — for: an unreachable or
remote server; a tree not proven to be this machine's; the #764 display fallbacks; an
**incomplete** config set; and a pin naming any config the server loads, **including the second
`--extra-model-paths-config`** and the not-yet-created implicit `<root>/extra_model_paths.yaml`
(pinning that is how you create it).

A cheap reachability gate runs before any resolution work: the full resolution stats the
caller's guarded root, and that root's #648 TOCTOU revalidation counts every stat — burning one
there to learn nothing turned a stable root into a spurious "REPLACED while this call was
running". The gate is a gate only; the inner call takes its own authoritative snapshot, so a
server starting or stopping between the two can suppress the note, never manufacture one.

---

## Gate record — 3 rounds, 3 NO-SHIP/SHIP transitions, every finding fixed rather than argued with

**codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead** — `.claude/autopilot/claude-gate.mjs`, a fresh reviewer that never
saw the implementing session's reasoning. Disclosing the substitution is the condition it was
accepted under. Both rounds ran the code rather than reading it, and both P1s below were
reproduced on this real Windows box before a line was written.

### Round 1 — NO-SHIP, 2 × P1

1. **`sameConfigFile`'s realpath collapse was dead exactly where it mattered.** `realpathSync`
   throws on a path that does not exist, and "does not exist yet" is the ORDINARY state here —
   pinning a config is how a caller CREATES it. So the collapse added to survive
   junctions/8.3/mapped drives silently degraded to the lexical compare it was added to fix,
   and a junctioned `COMFYUI_PATH` naming the very file the server reads was declared inert.
   Reproduced with a real Windows junction. Fixed: resolve the **parent directory** and rejoin
   the basename when the file itself does not resolve.
2. **Withdrawing the promise from `message` left it standing in `notes`.** `summarize` appends
   *"Restart ComfyUI after editing this file so startup path registration is rebuilt."* to every
   answer — the same promise in different words, different enough that the
   `/Restart ComfyUI to apply it/` assertions never saw it. The payload carried both "restarting
   will not apply this" and "restart to apply this", and an agent reads `notes`. Fixed: keyed on
   the same structured `divergesFromLive`, threaded through all three `summarize` call sites.

### Round 2 — NO-SHIP, 1 × P1

3. **Only `realpathSync.native` expands a Windows 8.3 short name.** The JS binding follows
   junctions and symlinks but returns a short name unchanged — a distinction this repo had
   already encoded in `panel-installer.ts` and `node-dev.ts`, and which this function's own
   docblock *claimed* to handle while the code did not. Measured: for a temp dir whose 8.3 alias
   is `COE80~65`, `realpathSync` returns `…\COE80~65\INSTAN~1.YAM` unchanged while `.native`
   returns the long path — so pinning the server's OWN config by its short spelling emitted "the
   running ComfyUI does NOT read …" for a file it demonstrably reads. Fixed: `.native` first for
   both the file and the parent step, JS binding as fallback. Three Windows-only tests, **skipped
   rather than vacuously passing** when the volume has 8dot3name generation disabled.

### Round 3 — **SHIP**

> "Nothing material. Verified by execution, not reading."

Worked all seven taxonomy classes with the specific thing checked named for each; ran the
absolute-first/relative-second argv, repeated occurrences and `nargs='+'`; probed 8.3 short
names, a `subst` mapped drive, absent-file-via-parent and a 447-char path on this real Windows
box. Deleting the `notePinnedDivergence` call kills 8 tests — reachable.

It reported **one surviving mutation out of 11**: forcing `complete: true` on the *multi-flag*
`liveLoaded` branch killed zero tests. It executed that argv shape and confirmed the code
suppresses correctly, so it called it a test gap, not a defect, and not a ship blocker. **Fixed
anyway** in `df9f970`, because an unpinned discriminator is one refactor away from becoming a
defect: the existing INCOMPLETE test drives the SINGLE-flag arm (`implicitLiveTarget`,
`unresolvableFlag`), while the multi-flag arm computes completeness from `unlocatable`, filled
only from flags 2..n. Two opposed tests now cover it — absolute-first + unlocatable-second must
stay silent, absolute-first + absolute-second must speak — and forcing `complete: true` kills
the first.

Two round-3 prose nits, both non-blocking and left as-is: the message says the server "loads"
the implicit `extra_model_paths.yaml` when it does not exist yet (ComfyUI gates on
`os.path.isfile`, though the suggested remedy is still right), and a comment says the root guard
"counts every stat it takes" when `assertRootIntact` compares dev/ino.

## Refutation — mutations, every diff confirmed applied

Anchors asserted unique, and an empty diff refuses rather than measuring nothing (an early
battery silently applied **none** of them — a heredoc had eaten the escapes — and the refusal
caught it).

| mutation | tests killed |
|---|---|
| delete the disclosure at the **call site** | 4 |
| delete the structured `divergesFromLive` the message keys on | 3 |
| compare only the primary resolution, not every loaded config | 2 |
| make the config comparison lexical again | 1 |
| delete the reachability gate | 2 (the #648 root-guard ordinals) |
| drop the `complete` requirement | 1 |
| drop the not-yet-created implicit yaml from the set | 1 |
| delete the **parent-directory** realpath fallback (round 1 fix) | 1 |
| make the restart note unconditional again (round 2 fix) | 2 |
| stop threading `divergesFromLive` to `summarize` (the wiring, not the helper) | 2 |
| force `complete: true` on the multi-flag arm (round 3 gap) | 1 |

## CI

`tsc --noEmit` clean; `vitest run` **571 files / 10527 tests green**; `check:vocabulary` (1694
files, no live dead names), `check:unknown-collapse` (0 collapses), `vocab:export --check`,
`asset-counts --check`, `i18n:check` and all `check:docs-*` / `check:blog-*` gates pass.

## Deliberately not done

- **No change to where a pinned target writes.** "Prefer the server's config" or "refuse" would
  delete the documented escape hatch; the defect was the false promise, not the destination.
- **`isDesktopGeneratedConfig` not widened.** The reporter says Desktop regenerated their live
  instance YAML, but the report never gives that file's path or header, and inventing a regex
  from prose is the wrong-pair defect this PR exists to fix. The existing
  `Comfy Desktop/…/shared_model_paths.yaml` warning is unchanged.
- **No panel-rendered surface changes** (`src/services/extra-paths.ts` and tests only), so the
  Playwright browser gate does not apply. It was not run and no such coverage is implied.
- **No model weights downloaded** — the destination resolution is asserted directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
