### PR TITLE
fix(401): environment no longer reports packages missing off the Homebrew base python

### DIFF
--- a/src/__tests__/services/env-capabilities-argv-contradiction.test.ts
+++ b/src/__tests__/services/env-capabilities-argv-contradiction.test.ts
@@ -64,7 +64,7 @@ function statsPayload(argv: string[]): unknown {
  * same python banner the server reports — the venv/base pair the version check cannot
  * tell apart.
  */
-function probeSays(triton: boolean, sage: boolean): void {
+function probeSays(triton: boolean, sage: boolean, torch?: boolean): void {
   execFileMock.mockImplementation(
     (
       _file: string,
@@ -72,11 +72,16 @@ function probeSays(triton: boolean, sage: boolean): void {
       _opts: unknown,
       cb: (e: Error | null, stdout: string, stderr: string) => void,
     ) => {
+      const torchLine =
+        torch === undefined
+          ? ""
+          : `torch ${torch ? "True" : "False"}\ntorch_version ${torch ? "2.4.0" : ""}\n`;
       cb(
         null,
         `python 3.13.12 (main, Feb 12 2026, 00:38:53) [MSC v.1944 64 bit (AMD64)]\n` +
           `triton ${triton ? "True" : "False"}\n` +
-          `sageattention ${sage ? "True" : "False"}\n`,
+          `sageattention ${sage ? "True" : "False"}\n` +
+          torchLine,
         "",
       );
       return { on: () => undefined };
@@ -148,6 +153,26 @@ describe("contradictedPackage (pure)", () => {
     expect(contradictedPackage({ triton: "not-installed", sageattention: "installed" }, proven)).toBeUndefined();
     expect(contradictedPackage({ triton: "installed", sageattention: "unknown" }, proven)).toBeUndefined();
     expect(contradictedPackage(undefined, proven)).toBeUndefined();
+  });
+
+  it("flags a probe that finds no torch while /system_stats reports pytorch", () => {
+    expect(
+      contradictedPackage(
+        { triton: "not-installed", sageattention: "not-installed", torch: "not-installed" },
+        new Set(),
+        "2.12.1",
+      ),
+    ).toBe("torch");
+  });
+
+  it("does not flag an honest unknown torch, even when the server reports pytorch", () => {
+    expect(
+      contradictedPackage(
+        { triton: "not-installed", sageattention: "not-installed", torch: "unknown" },
+        new Set(),
+        "2.12.1",
+      ),
+    ).toBeUndefined();
   });
 });
 
@@ -257,5 +282,43 @@ describe("gatherEnvCapabilities — a contradicted probe cannot state ANY negati
     });
 
     expect(caps.sageattention).toBe("not-installed");
+  });
+
+  it("voids Triton when the probe has no torch but /system_stats reports pytorch (#401)", async () => {
+    // 0.52.1: Homebrew base, versions agree, no --use-sage-attention to contradict
+    // anything, and the ENVIRONMENT banner said Triton is not installed. The
+    // server's own pytorch_version is the observation that discredits the source.
+    comfyuiFetchMock.mockImplementation(async (url: string) => {
+      if (String(url).includes("/system_stats")) {
+        return {
+          ok: true,
+          json: async () => ({
+            system: {
+              os: "darwin",
+              python_version: "3.12.13 (main, Feb 12 2026) [Clang 17.0.0]",
+              comfyui_version: "0.27.0",
+              pytorch_version: "2.12.1",
+              embedded_python: false,
+              argv: ["python", "main.py"],
+            },
+            devices: [{ name: "Apple M4 Max", type: "mps" }],
+          }),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    });
+    probeSays(false, false, false);
+
+    const caps = await gatherEnvCapabilities({
+      comfyuiUrl: "http://127.0.0.1:8188",
+      statsTimeoutMs: 50,
+      tritonTimeoutMs: 50,
+    });
+
+    expect(caps.torch).toBe("2.12.1");
+    expect(caps.triton).toBe("unknown");
+    expect(caps.triton).not.toBe("not-installed");
+    expect(caps.sageattention).toBe("unknown");
+    expect(caps.sageattention).not.toBe("not-installed");
   });
 });

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -6,11 +6,14 @@ import { join, sep } from "node:path";
 import {
   argv0FromCommandLine,
   commandLineMatchesArgv,
+  interpreterFromVenvHints,
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
   getLaunchedInterpreterRecord,
   observeLiveServerProcess,
   resolveLiveInterpreter,
+  venvHintsFromEnvironBuffer,
+  venvHintsFromProcArgs2,
 } from "../../services/live-interpreter.js";
 
 /** ComfyUI Desktop's real shape, as measured on the machine that filed #401. */
@@ -427,5 +430,103 @@ describe("observeLiveServerProcess — the OS image survives a relative argv[0] 
         readIdentity: () => ({ commandLine: "python main.py", executablePath: exe }),
       }),
     ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #401 recurrence 0.52.1 — macOS Homebrew / Python.app re-exec.
+//
+// argv[0] is the BASE interpreter (it exists; versions match the venv by
+// construction). The venv path survives only in the process environment.
+// Probing argv[0] reports torch/Triton missing while /system_stats shows them.
+// ---------------------------------------------------------------------------
+describe("venv env hints recover the interpreter Python.app hid (#401)", () => {
+  it("reads only the two venv keys out of a Linux environ buffer", () => {
+    const buf = Buffer.from(
+      ["PATH=/usr/bin", "VIRTUAL_ENV=/opt/comfy/.venv", "SECRET=do-not-keep", "__PYVENV_LAUNCHER__=/opt/comfy/.venv/bin/python", ""].join(
+        "\0",
+      ),
+    );
+    expect(venvHintsFromEnvironBuffer(buf)).toEqual({
+      pyvenvLauncher: "/opt/comfy/.venv/bin/python",
+      virtualEnv: "/opt/comfy/.venv",
+    });
+  });
+
+  it("parses kern.procargs2 envp after argc/argv padding", () => {
+    const argv = ["/opt/homebrew/Cellar/python@3.12/Python.app/Contents/MacOS/Python", "main.py"];
+    const env = [
+      "HOME=/Users/a",
+      "__PYVENV_LAUNCHER__=/Users/a/ComfyUI/.venv/bin/python",
+      "VIRTUAL_ENV=/Users/a/ComfyUI/.venv",
+    ];
+    const argc = Buffer.alloc(4);
+    argc.writeInt32LE(argv.length);
+    const parts = [
+      argc,
+      Buffer.from("/opt/homebrew/bin/python3\0"),
+      Buffer.from("\0"),
+      ...argv.map((a) => Buffer.from(a + "\0")),
+      Buffer.from("\0"),
+      ...env.map((e) => Buffer.from(e + "\0")),
+      Buffer.from("\0"),
+    ];
+    expect(venvHintsFromProcArgs2(Buffer.concat(parts))).toEqual({
+      pyvenvLauncher: "/Users/a/ComfyUI/.venv/bin/python",
+      virtualEnv: "/Users/a/ComfyUI/.venv",
+    });
+  });
+
+  it("prefers an existing __PYVENV_LAUNCHER__ over VIRTUAL_ENV", async () => {
+    const launcher = await makeExe("venv-python");
+    const venvRoot = join(dir, "other-venv");
+    expect(
+      interpreterFromVenvHints({
+        pyvenvLauncher: launcher,
+        virtualEnv: venvRoot,
+      }),
+    ).toBe(launcher);
+  });
+
+  it("reconstructs python from VIRTUAL_ENV when the launcher path is gone", async () => {
+    const bin = join(dir, ".venv", process.platform === "win32" ? "Scripts" : "bin");
+    await mkdir(bin, { recursive: true });
+    const exe = join(bin, process.platform === "win32" ? "python.exe" : "python");
+    await writeFile(exe, "", "utf-8");
+    expect(interpreterFromVenvHints({ virtualEnv: join(dir, ".venv") })).toBe(exe);
+  });
+
+  it("probes the venv python even when argv[0] is a real Homebrew base", async () => {
+    const homebrew = await makeExe("homebrew-python");
+    const venvPy = await makeExe("venv-python");
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py"],
+      findPid: () => 77,
+      readIdentity: () => ({
+        commandLine: `${homebrew} main.py`,
+        venvPython: venvPy,
+        startedAt: "t1",
+      }),
+    });
+    expect(res).toEqual({ python: venvPy, source: "process-table", pid: 77 });
+    expect(res?.python).not.toBe(homebrew);
+  });
+
+  it("falls back to argv[0] when the venv hint names nothing on disk", async () => {
+    const homebrew = await makeExe("homebrew-python");
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py"],
+      findPid: () => 77,
+      readIdentity: () => ({
+        commandLine: `${homebrew} main.py`,
+        venvPython: join(dir, "gone-venv-python"),
+        startedAt: "t1",
+      }),
+    });
+    expect(res).toEqual({ python: homebrew, source: "process-table", pid: 77 });
   });
 });

--- a/src/__tests__/services/venv-hint-corroboration.test.ts
+++ b/src/__tests__/services/venv-hint-corroboration.test.ts
@@ -106,6 +106,27 @@ describe("VIRTUAL_ENV may only displace argv[0] when the venv says argv[0] is it
     expect(interpreterFromVenvHints({ pyvenvLauncher: launcher }, argv0)).toBe(launcher);
   });
 
+  it("REFUSES to displace an argv[0] that is itself a venv interpreter", async () => {
+    // On POSIX a venv's bin/python is a SYMLINK to the base it was built from, so
+    // resolving argv[0] collapses it onto that base — and a second venv built from
+    // the same interpreter then records exactly that path as its `executable`, so
+    // the two compare EQUAL and the base check licenses the override. Symlinks are
+    // not available on this platform, so the collapsed state is expressed directly:
+    // the stale venv names argv[0] itself as its base, which is what the comparison
+    // sees after resolution on the platforms where this code runs.
+    //
+    // The guard answers the question without going through paths at all: argv[0]
+    // has its own pyvenv.cfg, so it is already a venv interpreter and there is no
+    // base interpreter to recover from.
+    const running = await makeVenv("comfy-venv", await makeExe("shared-base-python"));
+    const argv0 = join(running, BIN, PY);
+    const stale = await makeVenv("other-venv", argv0);
+
+    // Sanity: without the guard this is precisely the corroborated shape.
+    expect(venvBaseInterpreters(stale)).toContain(argv0);
+    expect(interpreterFromVenvHints({ virtualEnv: stale }, argv0)).toBeUndefined();
+  });
+
   it("reads the base interpreter a real pyvenv.cfg records", async () => {
     const base = await makeExe("base-python");
     const venv = await makeVenv("v", base);

--- a/src/__tests__/services/venv-hint-corroboration.test.ts
+++ b/src/__tests__/services/venv-hint-corroboration.test.ts
@@ -1,28 +1,35 @@
-// A stale VIRTUAL_ENV must not be allowed to re-file #401.
+// `VIRTUAL_ENV` must never displace a usable argv[0] (#401).
 //
-// The 0.52.1 fix recovers the interpreter from the process's OWN environment, which
-// is right for `__PYVENV_LAUNCHER__` — CPython writes it during this process's macOS
-// framework re-exec, so it describes THIS interpreter. `VIRTUAL_ENV` is different in
-// kind: `activate` exports it and every child inherits it whatever interpreter that
-// child turns out to be. Measured:
+// The 0.52.1 fix recovers the interpreter from the process's OWN environment. That is
+// right for `__PYVENV_LAUNCHER__` — CPython writes it during this process's macOS
+// framework re-exec, so it describes THIS interpreter. `VIRTUAL_ENV` is a statement
+// about the SHELL: `activate` exports it and every descendant inherits it whatever
+// interpreter it runs.
 //
-//   $ VIRTUAL_ENV=/tmp/ve401 python -c "import sys,os; print(sys.executable)"
-//   sys.executable = C:\Users\A\miniconda3\python.exe     <- what it really imports
-//   VIRTUAL_ENV    = /tmp/ve401                           <- an unrelated venv
+// A first attempt licensed it by asking whether the venv's `pyvenv.cfg` named argv[0]
+// as its base. That answers "was this venv built FROM argv[0]?", which is NOT "is this
+// process running IN that venv?" — and they come apart precisely when argv[0] is the
+// system python, because every stock venv records exactly that interpreter as its
+// base. Measured on Ubuntu 24.04:
 //
-// So letting it displace a usable argv[0] would report packages off an interpreter
-// the server never loaded — the original bug, newly reachable on a machine that
-// never had it. These tests pin the asymmetry.
+//     VIRTUAL_ENV=/tmp/ve402 /usr/bin/python3 main.py
+//     sys.executable                = /usr/bin/python3      <- NOT inside ve402
+//     readlink -f /usr/bin/python3  = /usr/bin/python3.14
+//     /tmp/ve402/pyvenv.cfg         executable = /usr/bin/python3.14   <- "matches"
+//
+// So the rule is positional: argv[0] wins whenever it is usable, and `VIRTUAL_ENV` is
+// consulted only when argv[0] gave us nothing probeable. These tests pin that, and in
+// particular pin the base-vs-venv shape that the path comparison let through.
 
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   interpreterFromVenvHints,
   observeLiveServerProcess,
-  venvBaseInterpreters,
 } from "../../services/live-interpreter.js";
 import { TRITON_PROBE_SOURCE } from "../../services/env-capabilities.js";
 
@@ -38,20 +45,19 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-/** Build a venv on disk whose pyvenv.cfg names `base` as the interpreter it was
- *  created from — the real layout, as measured on a `python -m venv` result. */
+/** A venv on disk, with the `pyvenv.cfg` a real `python -m venv` writes. */
 async function makeVenv(name: string, base?: string): Promise<string> {
   const root = join(dir, name);
   await mkdir(join(root, BIN), { recursive: true });
-  const exe = join(root, BIN, PY);
-  await writeFile(exe, "", "utf-8");
+  await writeFile(join(root, BIN, PY), "", "utf-8");
   if (base) {
+    const sep = IS_WIN ? "\\" : "/";
     await writeFile(
       join(root, "pyvenv.cfg"),
       [
-        `home = ${base.slice(0, base.lastIndexOf(IS_WIN ? "\\" : "/"))}`,
+        `home = ${base.slice(0, base.lastIndexOf(sep))}`,
         "include-system-site-packages = false",
-        "version = 3.12.13",
+        "version = 3.14.4",
         `executable = ${base}`,
       ].join("\n"),
       "utf-8",
@@ -60,8 +66,7 @@ async function makeVenv(name: string, base?: string): Promise<string> {
   return root;
 }
 
-/** An interpreter in its OWN directory, the way a real base install sits — so a
- *  test can never pass merely because two fixtures share a parent. */
+/** An interpreter in its OWN directory, the way a real base install sits. */
 async function makeExe(name: string): Promise<string> {
   const home = join(dir, `${name}-home`);
   await mkdir(home, { recursive: true });
@@ -70,129 +75,135 @@ async function makeExe(name: string): Promise<string> {
   return p;
 }
 
-describe("VIRTUAL_ENV may only displace argv[0] when the venv says argv[0] is its base", () => {
+describe("VIRTUAL_ENV never displaces a usable argv[0]", () => {
+  it("REFUSES when argv[0] is the SYSTEM PYTHON the venv was built from (gate P0)", async () => {
+    // The shape that defeated the pyvenv.cfg comparison: the process really is
+    // running the base interpreter, and the inherited venv legitimately records that
+    // same interpreter as its base. Nothing about the paths distinguishes this from
+    // the case the override was meant for.
+    const systemPython = await makeExe("python3");
+    const inherited = await makeVenv("some-other-venv", systemPython);
+
+    expect(interpreterFromVenvHints({ virtualEnv: inherited }, systemPython)).toBeUndefined();
+  });
+
   it("REFUSES a venv the running interpreter has nothing to do with", async () => {
-    // The activated-shell case: ComfyUI launched by explicit absolute path, while an
-    // unrelated venv is active in the environment it inherited.
     const argv0 = await makeExe("real-comfy-python");
     const stale = await makeVenv("some-other-venv", await makeExe("unrelated-base"));
 
     expect(interpreterFromVenvHints({ virtualEnv: stale }, argv0)).toBeUndefined();
   });
 
-  it("ACCEPTS the venv whose pyvenv.cfg names argv[0] as its base", async () => {
-    // The macOS Python.app shape: argv[0] IS the base this venv was built from.
-    const base = await makeExe("homebrew-base-python");
-    const venv = await makeVenv("comfy-venv", base);
+  it("REFUSES when argv[0] is itself a venv interpreter", async () => {
+    const running = await makeVenv("comfy-venv", await makeExe("shared-base"));
+    const argv0 = join(running, BIN, PY);
+    const stale = await makeVenv("other-venv", argv0);
 
-    expect(interpreterFromVenvHints({ virtualEnv: venv }, base)).toBe(join(venv, BIN, PY));
+    expect(interpreterFromVenvHints({ virtualEnv: stale }, argv0)).toBeUndefined();
   });
 
-  it("uses the hint when there is no usable argv[0] to contradict it", async () => {
-    // A bare `python` argv[0] names no file we can probe, so the hint is the only
-    // observation available and is strictly better than nothing.
+  it("uses the hint when argv[0] gave us nothing probeable", async () => {
+    // A bare `python`, a relative spelling, or a path that no longer exists — the
+    // hint displaces nothing here and beats returning undefined.
     const venv = await makeVenv("comfy-venv", await makeExe("some-base"));
 
     expect(interpreterFromVenvHints({ virtualEnv: venv }, undefined)).toBe(join(venv, BIN, PY));
     expect(interpreterFromVenvHints({ virtualEnv: venv }, "python")).toBe(join(venv, BIN, PY));
+    expect(interpreterFromVenvHints({ virtualEnv: venv }, join(dir, "gone"))).toBe(
+      join(venv, BIN, PY),
+    );
   });
 
   it("leaves __PYVENV_LAUNCHER__ unconditional — CPython wrote it for THIS process", async () => {
-    // The framework re-exec case must keep working even though argv[0] (the base)
-    // is unrelated to the launcher path by construction.
+    // The macOS framework re-exec: argv[0] is the base and IS usable, but the
+    // launcher is a statement about this interpreter, so it still wins.
     const launcher = await makeExe("venv-python");
     const argv0 = await makeExe("framework-base-python");
 
     expect(interpreterFromVenvHints({ pyvenvLauncher: launcher }, argv0)).toBe(launcher);
   });
+});
 
-  it("REFUSES to displace an argv[0] that is itself a venv interpreter", async () => {
-    // On POSIX a venv's bin/python is a SYMLINK to the base it was built from, so
-    // resolving argv[0] collapses it onto that base — and a second venv built from
-    // the same interpreter then records exactly that path as its `executable`, so
-    // the two compare EQUAL and the base check licenses the override. Symlinks are
-    // not available on this platform, so the collapsed state is expressed directly:
-    // the stale venv names argv[0] itself as its base, which is what the comparison
-    // sees after resolution on the platforms where this code runs.
-    //
-    // The guard answers the question without going through paths at all: argv[0]
-    // has its own pyvenv.cfg, so it is already a venv interpreter and there is no
-    // base interpreter to recover from.
-    const running = await makeVenv("comfy-venv", await makeExe("shared-base-python"));
-    const argv0 = join(running, BIN, PY);
-    const stale = await makeVenv("other-venv", argv0);
+describe("the resolver keeps argv[0] when the environment names another venv", () => {
+  const ARGV = ["main.py", "--port", "8188"];
 
-    // Sanity: without the guard this is precisely the corroborated shape.
-    expect(venvBaseInterpreters(stale)).toContain(argv0);
-    expect(interpreterFromVenvHints({ virtualEnv: stale }, argv0)).toBeUndefined();
+  const observe = (commandLine: string, venvHints: Record<string, string>) =>
+    observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ARGV,
+      findPid: () => 4242,
+      readIdentity: () => ({
+        commandLine,
+        argv: commandLine.split(" "),
+        argvFidelity: "exact",
+        venvHints,
+      }),
+    });
+
+  it("does NOT hand back an inherited venv's python (#401 must not recur)", async () => {
+    const systemPython = await makeExe("python3");
+    const inherited = await makeVenv("inherited-venv", systemPython);
+
+    const res = observe(`${systemPython} main.py --port 8188`, { virtualEnv: inherited });
+
+    // Without the positional rule this returns join(inherited, BIN, PY) — a venv the
+    // server never imported from, reported through the trusted process-table tier.
+    expect(res?.python).toBe(systemPython);
+    expect(res?.source).toBe("process-table");
   });
 
-  it("reads the base interpreter a real pyvenv.cfg records", async () => {
-    const base = await makeExe("base-python");
-    const venv = await makeVenv("v", base);
-    expect(venvBaseInterpreters(venv)).toContain(base);
-    expect(venvBaseInterpreters(join(dir, "not-a-venv"))).toEqual([]);
+  it("still recovers the venv when argv[0] is not probeable", async () => {
+    const venv = await makeVenv("comfy-venv", await makeExe("base"));
+
+    const res = observe(`python main.py --port 8188`, { virtualEnv: venv });
+
+    expect(res?.python).toBe(join(venv, BIN, PY));
   });
 });
 
-describe("the resolver keeps argv[0] when the environment's venv is stale", () => {
-  const ARGV = ["main.py", "--port", "8188"];
+describe("the venv hints are actually WIRED to the OS read", () => {
+  // The gate's supporting finding: deleting the production line that attaches
+  // `venvHints` left 5165/5165 green, because every test injects them through the
+  // `readIdentity` seam. A behavioural test cannot reach it here — `venvHintsFromPid`
+  // short-circuits on Windows and needs a live foreign process elsewhere — so the
+  // call site is asserted on the SOURCE, which is the only thing that can see it.
+  const src = readFileSync(
+    new URL("../../services/live-interpreter.ts", import.meta.url),
+    "utf-8",
+  );
 
-  it("does NOT hand back an unrelated venv's python (#401 must not recur)", async () => {
-    const argv0 = await makeExe("comfy-python");
-    const stale = await makeVenv("stale-venv", await makeExe("unrelated-base"));
-
-    const res = observeLiveServerProcess({
-      port: 8188,
-      remote: false,
-      serverArgv: ARGV,
-      findPid: () => 4242,
-      readIdentity: () => ({
-        commandLine: `${argv0} main.py --port 8188`,
-        argv: [argv0, ...ARGV],
-        argvFidelity: "exact",
-        venvHints: { virtualEnv: stale },
-      }),
-    });
-
-    // Without the corroboration this returns join(stale, BIN, PY) — a venv the
-    // server never imported from, reported as trusted.
-    expect(res?.python).toBe(argv0);
+  it("routes every readProcessIdentity return through withVenvPython", () => {
+    const body = src.slice(
+      src.indexOf("export function readProcessIdentity("),
+      src.indexOf("export function readProcessArgv0("),
+    );
+    expect(body).not.toBe("");
+    // Windows, Linux and the macOS `ps` paths each build an identity, plus the
+    // unparsed-`ps` fallback: all of them must attach the hints.
+    const attached = body.match(/withVenvPython\(/g) ?? [];
+    expect(attached.length).toBeGreaterThanOrEqual(4);
+    // and no return path may construct an identity object directly
+    expect(body).not.toMatch(/return\s*\{\s*commandLine/);
   });
 
-  it("still recovers the venv when argv[0] is the base it was built from", async () => {
-    const base = await makeExe("homebrew-base");
-    const venv = await makeVenv("comfy-venv", base);
-
-    const res = observeLiveServerProcess({
-      port: 8188,
-      remote: false,
-      serverArgv: ARGV,
-      findPid: () => 4242,
-      readIdentity: () => ({
-        commandLine: `${base} main.py --port 8188`,
-        argv: [base, ...ARGV],
-        argvFidelity: "exact",
-        venvHints: { virtualEnv: venv },
-      }),
-    });
-
-    expect(res?.python).toBe(join(venv, BIN, PY));
-    expect(res?.source).toBe("process-table");
+  it("resolves the hints where argv[0] is known, not behind the OS read", () => {
+    const resolver = src.slice(src.indexOf("export function observeLiveServerProcess("));
+    expect(resolver).toContain("interpreterFromVenvHints(identity.venvHints, argv0)");
   });
 });
 
 describe("the capability probe never imports torch", () => {
   // A NEGATIVE guarantee, so it is asserted on the source: no behavioural test can
-  // notice a future edit that quietly puts the import back, and the cost of that
-  // edit is not a slow probe but a SILENT one. `probeTritonSage` runs under a 5s
-  // budget and CPython block-buffers stdout when it is a pipe, so a torch import
-  // that overruns takes the already-computed triton/sageattention lines down with
-  // it and every answer degrades to "unknown".
+  // notice a future edit that puts the import back, and the cost of that edit is not
+  // a slow probe but a SILENT one. `probeTritonSage` runs under a 5s budget and
+  // CPython block-buffers stdout when it is a pipe, so a torch import that overruns
+  // takes the already-computed triton/sageattention lines down with it and every
+  // answer degrades to "unknown".
   //
-  // Measured on an RTX box, warm: `import torch` 1.89s (38% of the whole budget),
-  // `importlib.metadata.version('torch')` 0.043s — and both return the identical
-  // string "2.10.0+cu130".
+  // Measured on an RTX box, warm: `import torch` 1.89s (38% of the whole budget)
+  // against 0.043s for `importlib.metadata.version('torch')` — and both return the
+  // identical string "2.10.0+cu130".
   it("reads the version from dist metadata, not from the module", () => {
     expect(TRITON_PROBE_SOURCE).toContain("importlib.metadata");
     expect(TRITON_PROBE_SOURCE).toContain("md.version('torch')");
@@ -203,7 +214,6 @@ describe("the capability probe never imports torch", () => {
   it("still answers triton and sageattention without consulting torch", () => {
     expect(TRITON_PROBE_SOURCE).toContain("u.find_spec('triton')");
     expect(TRITON_PROBE_SOURCE).toContain("u.find_spec('sageattention')");
-    // find_spec, not import: locating a module must not execute it.
     expect(TRITON_PROBE_SOURCE).not.toContain("__import__('triton')");
   });
 });

--- a/src/__tests__/services/venv-hint-corroboration.test.ts
+++ b/src/__tests__/services/venv-hint-corroboration.test.ts
@@ -1,0 +1,188 @@
+// A stale VIRTUAL_ENV must not be allowed to re-file #401.
+//
+// The 0.52.1 fix recovers the interpreter from the process's OWN environment, which
+// is right for `__PYVENV_LAUNCHER__` — CPython writes it during this process's macOS
+// framework re-exec, so it describes THIS interpreter. `VIRTUAL_ENV` is different in
+// kind: `activate` exports it and every child inherits it whatever interpreter that
+// child turns out to be. Measured:
+//
+//   $ VIRTUAL_ENV=/tmp/ve401 python -c "import sys,os; print(sys.executable)"
+//   sys.executable = C:\Users\A\miniconda3\python.exe     <- what it really imports
+//   VIRTUAL_ENV    = /tmp/ve401                           <- an unrelated venv
+//
+// So letting it displace a usable argv[0] would report packages off an interpreter
+// the server never loaded — the original bug, newly reachable on a machine that
+// never had it. These tests pin the asymmetry.
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  interpreterFromVenvHints,
+  observeLiveServerProcess,
+  venvBaseInterpreters,
+} from "../../services/live-interpreter.js";
+import { TRITON_PROBE_SOURCE } from "../../services/env-capabilities.js";
+
+const IS_WIN = process.platform === "win32";
+const BIN = IS_WIN ? "Scripts" : "bin";
+const PY = IS_WIN ? "python.exe" : "python";
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "venv-hint-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Build a venv on disk whose pyvenv.cfg names `base` as the interpreter it was
+ *  created from — the real layout, as measured on a `python -m venv` result. */
+async function makeVenv(name: string, base?: string): Promise<string> {
+  const root = join(dir, name);
+  await mkdir(join(root, BIN), { recursive: true });
+  const exe = join(root, BIN, PY);
+  await writeFile(exe, "", "utf-8");
+  if (base) {
+    await writeFile(
+      join(root, "pyvenv.cfg"),
+      [
+        `home = ${base.slice(0, base.lastIndexOf(IS_WIN ? "\\" : "/"))}`,
+        "include-system-site-packages = false",
+        "version = 3.12.13",
+        `executable = ${base}`,
+      ].join("\n"),
+      "utf-8",
+    );
+  }
+  return root;
+}
+
+/** An interpreter in its OWN directory, the way a real base install sits — so a
+ *  test can never pass merely because two fixtures share a parent. */
+async function makeExe(name: string): Promise<string> {
+  const home = join(dir, `${name}-home`);
+  await mkdir(home, { recursive: true });
+  const p = join(home, name);
+  await writeFile(p, "", "utf-8");
+  return p;
+}
+
+describe("VIRTUAL_ENV may only displace argv[0] when the venv says argv[0] is its base", () => {
+  it("REFUSES a venv the running interpreter has nothing to do with", async () => {
+    // The activated-shell case: ComfyUI launched by explicit absolute path, while an
+    // unrelated venv is active in the environment it inherited.
+    const argv0 = await makeExe("real-comfy-python");
+    const stale = await makeVenv("some-other-venv", await makeExe("unrelated-base"));
+
+    expect(interpreterFromVenvHints({ virtualEnv: stale }, argv0)).toBeUndefined();
+  });
+
+  it("ACCEPTS the venv whose pyvenv.cfg names argv[0] as its base", async () => {
+    // The macOS Python.app shape: argv[0] IS the base this venv was built from.
+    const base = await makeExe("homebrew-base-python");
+    const venv = await makeVenv("comfy-venv", base);
+
+    expect(interpreterFromVenvHints({ virtualEnv: venv }, base)).toBe(join(venv, BIN, PY));
+  });
+
+  it("uses the hint when there is no usable argv[0] to contradict it", async () => {
+    // A bare `python` argv[0] names no file we can probe, so the hint is the only
+    // observation available and is strictly better than nothing.
+    const venv = await makeVenv("comfy-venv", await makeExe("some-base"));
+
+    expect(interpreterFromVenvHints({ virtualEnv: venv }, undefined)).toBe(join(venv, BIN, PY));
+    expect(interpreterFromVenvHints({ virtualEnv: venv }, "python")).toBe(join(venv, BIN, PY));
+  });
+
+  it("leaves __PYVENV_LAUNCHER__ unconditional — CPython wrote it for THIS process", async () => {
+    // The framework re-exec case must keep working even though argv[0] (the base)
+    // is unrelated to the launcher path by construction.
+    const launcher = await makeExe("venv-python");
+    const argv0 = await makeExe("framework-base-python");
+
+    expect(interpreterFromVenvHints({ pyvenvLauncher: launcher }, argv0)).toBe(launcher);
+  });
+
+  it("reads the base interpreter a real pyvenv.cfg records", async () => {
+    const base = await makeExe("base-python");
+    const venv = await makeVenv("v", base);
+    expect(venvBaseInterpreters(venv)).toContain(base);
+    expect(venvBaseInterpreters(join(dir, "not-a-venv"))).toEqual([]);
+  });
+});
+
+describe("the resolver keeps argv[0] when the environment's venv is stale", () => {
+  const ARGV = ["main.py", "--port", "8188"];
+
+  it("does NOT hand back an unrelated venv's python (#401 must not recur)", async () => {
+    const argv0 = await makeExe("comfy-python");
+    const stale = await makeVenv("stale-venv", await makeExe("unrelated-base"));
+
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ARGV,
+      findPid: () => 4242,
+      readIdentity: () => ({
+        commandLine: `${argv0} main.py --port 8188`,
+        argv: [argv0, ...ARGV],
+        argvFidelity: "exact",
+        venvHints: { virtualEnv: stale },
+      }),
+    });
+
+    // Without the corroboration this returns join(stale, BIN, PY) — a venv the
+    // server never imported from, reported as trusted.
+    expect(res?.python).toBe(argv0);
+  });
+
+  it("still recovers the venv when argv[0] is the base it was built from", async () => {
+    const base = await makeExe("homebrew-base");
+    const venv = await makeVenv("comfy-venv", base);
+
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ARGV,
+      findPid: () => 4242,
+      readIdentity: () => ({
+        commandLine: `${base} main.py --port 8188`,
+        argv: [base, ...ARGV],
+        argvFidelity: "exact",
+        venvHints: { virtualEnv: venv },
+      }),
+    });
+
+    expect(res?.python).toBe(join(venv, BIN, PY));
+    expect(res?.source).toBe("process-table");
+  });
+});
+
+describe("the capability probe never imports torch", () => {
+  // A NEGATIVE guarantee, so it is asserted on the source: no behavioural test can
+  // notice a future edit that quietly puts the import back, and the cost of that
+  // edit is not a slow probe but a SILENT one. `probeTritonSage` runs under a 5s
+  // budget and CPython block-buffers stdout when it is a pipe, so a torch import
+  // that overruns takes the already-computed triton/sageattention lines down with
+  // it and every answer degrades to "unknown".
+  //
+  // Measured on an RTX box, warm: `import torch` 1.89s (38% of the whole budget),
+  // `importlib.metadata.version('torch')` 0.043s — and both return the identical
+  // string "2.10.0+cu130".
+  it("reads the version from dist metadata, not from the module", () => {
+    expect(TRITON_PROBE_SOURCE).toContain("importlib.metadata");
+    expect(TRITON_PROBE_SOURCE).toContain("md.version('torch')");
+    expect(TRITON_PROBE_SOURCE).not.toContain("__import__('torch')");
+    expect(TRITON_PROBE_SOURCE).not.toMatch(/^\s*import torch\b/m);
+  });
+
+  it("still answers triton and sageattention without consulting torch", () => {
+    expect(TRITON_PROBE_SOURCE).toContain("u.find_spec('triton')");
+    expect(TRITON_PROBE_SOURCE).toContain("u.find_spec('sageattention')");
+    // find_spec, not import: locating a module must not execute it.
+    expect(TRITON_PROBE_SOURCE).not.toContain("__import__('triton')");
+  });
+});

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -105,6 +105,7 @@ import {
   resolveLiveComfyUIBase,
   resolveLiveServerRoot,
   resolveRootInterpreter,
+  torchVersionsAgree,
 } from "../../services/workspace-env.js";
 
 async function tmpDir(): Promise<string> {
@@ -1255,6 +1256,150 @@ describe("getEnvironment", () => {
     }
   });
 
+  it("untrusts a process-table hit that has no torch while /system_stats reports pytorch (#401)", async () => {
+    // 0.52.1 recurrence: macOS Homebrew base marked trusted (versions agree with
+    // the venv by construction), pip answers, none of torch/vision/audio are
+    // there, while the reachable server's /system_stats reports PyTorch 2.12.1.
+    // Reporting that as "not installed" is the same false capability as Triton.
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    try {
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "darwin",
+          python_version: "3.12.13",
+          comfyui_version: "0.27.0",
+          pytorch_version: "2.12.1",
+          embedded_python: false,
+          argv: [],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 88 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version") && !args.includes("pip")) {
+          return { stdout: "Python 3.12.13\n" };
+        }
+        if (args.includes("pip")) {
+          return Object.assign(new Error("Command failed: exit 1"), {
+            stdout: "",
+            stderr: "WARNING: Package(s) not found: torch, torchvision, torchaudio, xformers, numpy, transformers, diffusers, comfyui-frontend-package\n",
+          });
+        }
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.running_instance.pytorch_version).toBe("2.12.1");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/none of torch/i);
+      expect(env.local.python_probe_reason).toMatch(/2\.12\.1/);
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("untrusts a process-table hit whose torch disagrees with /system_stats", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    try {
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "darwin",
+          python_version: "3.12.13",
+          comfyui_version: "0.27.0",
+          pytorch_version: "2.12.1",
+          embedded_python: false,
+          argv: [],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 89 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version") && !args.includes("pip")) {
+          return { stdout: "Python 3.12.13\n" };
+        }
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.4.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI pytorch/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still reports packages when the probed torch matches /system_stats", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    try {
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "darwin",
+          python_version: "3.12.13",
+          comfyui_version: "0.27.0",
+          pytorch_version: "2.12.1+cpu",
+          embedded_python: false,
+          argv: [],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 90 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version") && !args.includes("pip")) {
+          return { stdout: "Python 3.12.13\n" };
+        }
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.12.1\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("2.12.1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a failed pip query as a torch contradiction", async () => {
+    // uv venvs often have no pip. Silence is "we could not tell", not "torch is absent".
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    try {
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "darwin",
+          python_version: "3.12.13",
+          pytorch_version: "2.12.1",
+          embedded_python: false,
+          argv: [],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 91 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version") && !args.includes("pip")) {
+          return { stdout: "Python 3.12.13\n" };
+        }
+        if (args.includes("pip")) return new Error("No module named pip");
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.note).toMatch(/pip did not answer at all/);
+      expect(env.local.python_probe_reason).not.toMatch(/none of torch/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("never trusts anything for a REMOTE server (#401 / #433 round 3)", async () => {
     const dir = await tmpDir();
     const rootB = join(dir, "B");
@@ -1291,6 +1436,19 @@ describe("getEnvironment", () => {
   });
 });
 
+
+describe("torchVersionsAgree (#401)", () => {
+  it("treats local suffixes as the same build", () => {
+    expect(torchVersionsAgree("2.12.1", "2.12.1+cpu")).toBe(true);
+    expect(torchVersionsAgree("2.12.1+cu130", "2.12.1")).toBe(true);
+  });
+
+  it("rejects a different version, and never agrees on a missing side", () => {
+    expect(torchVersionsAgree("2.11.0", "2.12.1")).toBe(false);
+    expect(torchVersionsAgree("2.12.1", undefined)).toBe(false);
+    expect(torchVersionsAgree(undefined, "2.12.1")).toBe(false);
+  });
+});
 
 describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
   it("returns the absolute dir of an absolute main.py", () => {

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -378,6 +378,31 @@ export function findComfyuiPython(
 }
 
 /**
+ * The exact python source the capability probe runs. Exported so a test can assert
+ * on the SOURCE: the guarantee that matters most here is a NEGATIVE one — that we
+ * never import torch inside a 5s budget — and no behavioural assertion can notice a
+ * future edit that quietly puts the import back.
+ */
+export const TRITON_PROBE_SOURCE = [
+  "import importlib.util as u, sys",
+  "print('python', ' '.join(sys.version.split()))",
+  "print('triton', u.find_spec('triton') is not None)",
+  "print('sageattention', u.find_spec('sageattention') is not None)",
+  "ts = u.find_spec('torch')",
+  "print('torch', ts is not None)",
+  "tv = ''",
+  "if ts is not None:",
+  "    try:",
+  "        import importlib.metadata as md",
+  "        tv = md.version('torch')",
+  "    except Exception:",
+  // torch present but with no dist-info (a hand-copied tree). "installed" still
+  // stands; only the version comparison is skipped.
+  "        tv = ''",
+  "print('torch_version', tv)",
+].join("\n");
+
+/**
  * Probe whether triton + sageattention are importable in the ComfyUI python.
  * Best-effort, hard ~5s timeout. Returns one tri-state per package:
  *   installed | not-installed | unknown
@@ -409,18 +434,26 @@ export function probeTritonSage(
     // not just a major.minor one (#401 review).
     // torch is the 0.52.1 discriminator: a venv and its Homebrew/uv base share a
     // python banner, but only the venv has the torch /system_stats reports.
-    const code =
-      "import importlib.util as u,sys;" +
-      "print('python', ' '.join(sys.version.split()));" +
-      "print('triton', u.find_spec('triton') is not None);" +
-      "print('sageattention', u.find_spec('sageattention') is not None);" +
-      "ts=u.find_spec('torch');" +
-      "print('torch', ts is not None);" +
-      "print('torch_version', (ts and getattr(__import__('torch'), '__version__', '')) or '')";
+    //
+    // The version comes from DIST METADATA, never `import torch`. Importing torch
+    // initializes CUDA/MPS and loads a stack of native libraries: measured at 1.89s
+    // warm on a local NVMe RTX box, i.e. 38% of this probe's entire 5s budget, and
+    // multiples of that cold or on a network-mounted venv. Blowing the budget is not
+    // a partial loss — CPython block-buffers stdout when it is a pipe, so the kill
+    // discards the triton/sageattention lines that had ALREADY been computed, and
+    // the caller's `if (!out.trim())` branch reports everything as "unknown". That
+    // would degrade a working `Triton: installed` to unknown on exactly the
+    // heavy-CUDA machines #401 is about. `importlib.metadata.version` returns the
+    // identical string ("2.10.0+cu130" both ways, measured) for 43ms.
+    //
+    // Written with real newlines because the metadata lookup needs a try/except,
+    // which has no inline form. `-u` keeps stdout unbuffered so that if the child
+    // is killed anyway, the lines printed before the kill still reach us.
+    const code = TRITON_PROBE_SOURCE;
     let done = false;
     const child = execFile(
       pythonExe,
-      ["-c", code],
+      ["-u", "-c", code],
       { timeout: timeoutMs, windowsHide: true },
       (err, stdout) => {
         if (done) return;

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -21,7 +21,7 @@ import { join } from "node:path";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
 import { isForceRemoteFlagSet } from "../config.js";
-import { resolveComfyuiPython, pythonVersionsAgree } from "./workspace-env.js";
+import { resolveComfyuiPython, pythonVersionsAgree, torchVersionsAgree } from "./workspace-env.js";
 import { resolveLiveInterpreter } from "./live-interpreter.js";
 import { parsePyproject } from "./node-authoring.js";
 import { detectInstallMode } from "./self-update.js";
@@ -387,10 +387,16 @@ export function findComfyuiPython(
 export function probeTritonSage(
   pythonExe: string | undefined,
   timeoutMs = 5000,
-): Promise<{ triton: TriState; sageattention: TriState; pythonVersion?: string }> {
+): Promise<{
+  triton: TriState;
+  sageattention: TriState;
+  torch: TriState;
+  torchVersion?: string;
+  pythonVersion?: string;
+}> {
   return new Promise((resolve) => {
     if (!pythonExe) {
-      resolve({ triton: "unknown", sageattention: "unknown" });
+      resolve({ triton: "unknown", sageattention: "unknown", torch: "unknown" });
       return;
     }
     // Print a clear per-package marker so we can tell which imported, even if one
@@ -401,11 +407,16 @@ export function probeTritonSage(
     // Print the FULL `sys.version` banner (single line) — the same string
     // /system_stats reports — so the caller can spot a build/compiler disagreement,
     // not just a major.minor one (#401 review).
+    // torch is the 0.52.1 discriminator: a venv and its Homebrew/uv base share a
+    // python banner, but only the venv has the torch /system_stats reports.
     const code =
       "import importlib.util as u,sys;" +
       "print('python', ' '.join(sys.version.split()));" +
       "print('triton', u.find_spec('triton') is not None);" +
-      "print('sageattention', u.find_spec('sageattention') is not None)";
+      "print('sageattention', u.find_spec('sageattention') is not None);" +
+      "ts=u.find_spec('torch');" +
+      "print('torch', ts is not None);" +
+      "print('torch_version', (ts and getattr(__import__('torch'), '__version__', '')) or '')";
     let done = false;
     const child = execFile(
       pythonExe,
@@ -417,7 +428,7 @@ export function probeTritonSage(
         // Spawn failure (ENOENT) or non-import error with no output → unknown.
         const out = (stdout || "").toString();
         if (!out.trim()) {
-          resolve({ triton: "unknown", sageattention: "unknown" });
+          resolve({ triton: "unknown", sageattention: "unknown", torch: "unknown" });
           return;
         }
         const read = (name: string): TriState => {
@@ -426,12 +437,15 @@ export function probeTritonSage(
           return m[1] === "True" ? "installed" : "not-installed";
         };
         const pyMatch = out.match(/^python\s+(.+)$/m);
+        const torchVer = out.match(/^torch_version\s+(\S+)/m)?.[1];
         // If python ran but errored AFTER printing partial output, still trust
         // whatever lines we got; missing lines stay "unknown".
         void err;
         resolve({
           triton: read("triton"),
           sageattention: read("sageattention"),
+          torch: read("torch"),
+          torchVersion: torchVer || undefined,
           pythonVersion: pyMatch ? pyMatch[1].trim() : undefined,
         });
       },
@@ -439,7 +453,7 @@ export function probeTritonSage(
     child.on?.("error", () => {
       if (done) return;
       done = true;
-      resolve({ triton: "unknown", sageattention: "unknown" });
+      resolve({ triton: "unknown", sageattention: "unknown", torch: "unknown" });
     });
   });
 }
@@ -509,12 +523,31 @@ export function packagesProvenByServerArgv(
  * when it carried no information at all.
  */
 export function contradictedPackage(
-  probe: { triton: TriState; sageattention: TriState } | undefined,
+  probe:
+    | {
+        triton: TriState;
+        sageattention: TriState;
+        torch?: TriState;
+        torchVersion?: string;
+      }
+    | undefined,
   proven: Set<"triton" | "sageattention">,
-): "triton" | "sageattention" | undefined {
+  serverTorch?: string,
+): "triton" | "sageattention" | "torch" | undefined {
   if (!probe) return undefined;
   for (const pkg of proven) {
     if (probe[pkg] === "not-installed") return pkg;
+  }
+  // /system_stats.pytorch_version is what the RUNNING server imported. A probe
+  // that finds no torch — or a different build — is looking at the base
+  // interpreter, not the venv. Python versions agree in that case by
+  // construction, so this is the discriminator the version check cannot be
+  // (#401 recurrence, 0.52.1). An honest "unknown" (we could not ask) is not
+  // a contradiction.
+  const reported = serverTorch?.trim();
+  if (reported) {
+    if (probe.torch === "not-installed") return "torch";
+    if (probe.torchVersion && !torchVersionsAgree(probe.torchVersion, reported)) return "torch";
   }
   return undefined;
 }
@@ -771,11 +804,15 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   // RAW sys.version banner — caps.python is truncated to major.minor for DISPLAY, so
   // the contradiction check needs the untruncated string (#401 review).
   let statsPythonRaw: string | undefined;
+  // RAW pytorch_version — caps.torch is cleaned for DISPLAY; contradiction needs
+  // the string the server actually reported (#401 recurrence, 0.52.1).
+  let statsTorchRaw: string | undefined;
   if (stats) {
     applyStats(caps, stats);
     statsArgv = stats.system?.argv;
     statsCwd = stats.system?.cwd;
     statsPythonRaw = stats.system?.python_version?.trim() || undefined;
+    statsTorchRaw = stats.system?.pytorch_version?.trim() || undefined;
     statsEmbedded =
       typeof stats.system?.embedded_python === "boolean"
         ? stats.system.embedded_python
@@ -846,7 +883,7 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   // The genuinely observed positives survive anyway: the argv-proven flag is re-applied
   // immediately below, and the ComfyUI-log markers after it.
   const provenByArgv = packagesProvenByServerArgv(statsArgv);
-  const contradicted = contradictedPackage(ts, provenByArgv);
+  const contradicted = contradictedPackage(ts, provenByArgv, statsTorchRaw);
   if (contradicted) {
     logger.info(
       "Discarding this interpreter's capability results entirely: it contradicts the running ComfyUI's own launch flags",

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -27,7 +27,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readlinkSync } from "node:fs";
-import { isAbsolute, resolve as pathResolve } from "node:path";
+import { isAbsolute, join, resolve as pathResolve } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
 import { logger } from "./../utils/logger.js";
@@ -242,6 +242,18 @@ export interface ProcessIdentity {
    * that does not depend on WHEN it is read.
    */
   parentPid?: number;
+  /**
+   * The interpreter implied by the process's OWN environment, when that names a
+   * file we can probe. On macOS a venv python is a symlink into the Homebrew
+   * framework; Python.app re-execs and `ps` then reports the BASE interpreter as
+   * argv[0]. The original venv path survives as `__PYVENV_LAUNCHER__` (CPython's
+   * framework hook) or `VIRTUAL_ENV`. Those are observations of the running
+   * process, not layout guesses (#401 recurrence, 0.52.1).
+   *
+   * Only those two keys are read; the rest of the environment is discarded and
+   * never logged.
+   */
+  venvPython?: string;
 }
 
 /**
@@ -307,14 +319,14 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
       const executablePath = out.match(/^EXE=(.*)$/m)?.[1]?.trim();
       const commandLine = out.match(/^CMD=([\s\S]*)$/m)?.[1]?.trim();
       if (!startedAt && !commandLine) return undefined;
-      return {
+      return withVenvPython(pid, {
         commandLine: commandLine || undefined,
         argv: commandLine ? tokenizeCommandLine(commandLine) : undefined,
         argvFidelity: "exact",
         executablePath: executablePath || undefined,
         startedAt: startedAt || undefined,
         parentPid,
-      };
+      });
     }
     if (platform() === "linux") {
       // argv entries are "\u0000"-separated; rejoin them as a command line.
@@ -345,14 +357,14 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
         /* not ours to read → undefined, and the caller falls back to argv[0] */
       }
       if (!commandLine && !startedAt) return undefined;
-      return {
+      return withVenvPython(pid, {
         commandLine: commandLine || undefined,
         argv: argv.length > 0 ? argv : undefined,
         argvFidelity: "exact",
         executablePath: executablePath || undefined,
         startedAt,
         parentPid,
-      };
+      });
     }
     const out = execFileSync(
       "ps",
@@ -364,14 +376,20 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
     const m = out.match(
       /^\s*(\d+)\s+(\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+([\s\S]*)$/,
     );
-    if (!m) return { commandLine: out, argv: tokenizeCommandLine(out), argvFidelity: "flattened" };
-    return {
+    if (!m) {
+      return withVenvPython(pid, {
+        commandLine: out,
+        argv: tokenizeCommandLine(out),
+        argvFidelity: "flattened",
+      });
+    }
+    return withVenvPython(pid, {
       parentPid: parsePid(m[1]),
       startedAt: m[2].replace(/\s+/g, " "),
       commandLine: m[3].trim(),
       argv: tokenizeCommandLine(m[3].trim()),
       argvFidelity: "flattened",
-    };
+    });
   } catch {
     return undefined;
   }
@@ -381,6 +399,110 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
 export function readProcessArgv0(pid: number): string | undefined {
   const cmd = readProcessIdentity(pid)?.commandLine;
   return cmd ? argv0FromCommandLine(cmd) : undefined;
+}
+
+/**
+ * The two process-env keys that name the venv the process is actually importing
+ * from. Everything else in the environment is discarded here — we never want a
+ * capability probe to carry secrets just to recover an interpreter.
+ */
+export interface VenvEnvHints {
+  pyvenvLauncher?: string;
+  virtualEnv?: string;
+}
+
+/** Pull only `__PYVENV_LAUNCHER__` and `VIRTUAL_ENV` out of `KEY=VALUE` entries. */
+export function venvHintsFromEnvEntries(entries: Iterable<string>): VenvEnvHints {
+  const out: VenvEnvHints = {};
+  for (const raw of entries) {
+    if (raw.startsWith("__PYVENV_LAUNCHER__=")) {
+      const v = raw.slice("__PYVENV_LAUNCHER__=".length).trim();
+      if (v) out.pyvenvLauncher = v;
+    } else if (raw.startsWith("VIRTUAL_ENV=")) {
+      const v = raw.slice("VIRTUAL_ENV=".length).trim();
+      if (v) out.virtualEnv = v;
+    }
+    if (out.pyvenvLauncher && out.virtualEnv) break;
+  }
+  return out;
+}
+
+/** Linux `/proc/<pid>/environ` is NUL-separated `KEY=VALUE`. */
+export function venvHintsFromEnvironBuffer(buf: Buffer): VenvEnvHints {
+  return venvHintsFromEnvEntries(buf.toString("utf8").split("\0"));
+}
+
+/**
+ * macOS `kern.procargs2.<pid>`: int32 argc, exec path, argv[argc], then envp.
+ * Padding NULs sit between the exec path and argv, and between argv and envp.
+ * We only need the env keys; argv is already read from `ps`.
+ */
+export function venvHintsFromProcArgs2(buf: Buffer): VenvEnvHints {
+  if (buf.length < 8) return {};
+  const argc = buf.readInt32LE(0);
+  if (argc < 0 || argc > 4096) return {};
+  let i = 4;
+  const nextNul = (from: number): number => {
+    const at = buf.indexOf(0, from);
+    return at < 0 ? buf.length : at;
+  };
+  // Skip the exec path and the padding that follows it.
+  i = nextNul(i) + 1;
+  while (i < buf.length && buf[i] === 0) i++;
+  const strings: string[] = [];
+  while (i < buf.length) {
+    const end = nextNul(i);
+    if (end === i) {
+      i++;
+      continue;
+    }
+    strings.push(buf.toString("utf8", i, end));
+    i = end + 1;
+  }
+  return venvHintsFromEnvEntries(strings.slice(Math.max(0, argc)));
+}
+
+/**
+ * Reconstruct the venv interpreter the PROCESS recorded. `__PYVENV_LAUNCHER__`
+ * is the original argv[0] CPython saved before the macOS framework re-exec;
+ * `VIRTUAL_ENV` is the activate-script / uv equivalent. Either is an observation
+ * of the running process. Layout guesses do not belong here.
+ */
+export function interpreterFromVenvHints(hints: VenvEnvHints): string | undefined {
+  const launcher = hints.pyvenvLauncher;
+  if (launcher && isAbsolute(launcher) && existsSync(launcher)) return pathResolve(launcher);
+  const venv = hints.virtualEnv;
+  if (!venv || !isAbsolute(venv)) return undefined;
+  const candidates = IS_WIN
+    ? [join(venv, "Scripts", "python.exe"), join(venv, "python.exe")]
+    : [join(venv, "bin", "python"), join(venv, "bin", "python3")];
+  for (const c of candidates) {
+    if (existsSync(c)) return pathResolve(c);
+  }
+  return undefined;
+}
+
+function venvPythonFromPid(pid: number): string | undefined {
+  try {
+    if (IS_WIN) return undefined;
+    if (platform() === "linux") {
+      return interpreterFromVenvHints(venvHintsFromEnvironBuffer(readFileSync(`/proc/${pid}/environ`)));
+    }
+    const buf = execFileSync("sysctl", ["-b", `kern.procargs2.${pid}`], {
+      timeout: 8000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    if (!Buffer.isBuffer(buf) || buf.length === 0) return undefined;
+    return interpreterFromVenvHints(venvHintsFromProcArgs2(buf));
+  } catch {
+    return undefined;
+  }
+}
+
+function withVenvPython(pid: number, identity: ProcessIdentity): ProcessIdentity {
+  const venvPython = venvPythonFromPid(pid);
+  if (venvPython) identity.venvPython = venvPython;
+  return identity;
 }
 
 /**
@@ -593,6 +715,15 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
 
   // Tier 2 — the OS process table, correlated against the server's own argv.
   if (!commandLineMatchesArgv(identity?.commandLine, opts.serverArgv)) return undefined;
+
+  // Prefer the venv the process itself recorded. After a macOS Python.app re-exec,
+  // argv[0] is the Homebrew/framework BASE interpreter — it exists, versions match
+  // the venv by construction, and probing it reports torch/Triton missing while
+  // /system_stats shows they are there (#401 recurrence, 0.52.1).
+  const fromEnv = identity?.venvPython;
+  if (fromEnv && isAbsolute(fromEnv) && existsSync(fromEnv)) {
+    return { python: fromEnv, source: "process-table", pid, image };
+  }
 
   const argv0 = argv0FromCommandLine(identity?.commandLine ?? "");
   // A relative or bare argv[0] ("python", "./python") does not identify a file we

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -470,16 +470,22 @@ export function venvHintsFromProcArgs2(buf: Buffer): VenvEnvHints {
   return venvHintsFromEnvEntries(strings.slice(Math.max(0, argc)));
 }
 
-/** Normalize a path for comparison: resolve symlinks where we can, and fold case
- *  and separators on Windows. */
+/** Fold case and separators so two spellings of one path compare equal. */
+function literal(p: string): string {
+  const out = pathResolve(p).replace(/\\/g, "/");
+  return IS_WIN ? out.toLowerCase() : out;
+}
+
+/** `literal`, plus symlink resolution where the filesystem allows it. Both forms
+ *  are compared, because either one alone gives a wrong answer: unresolved misses a
+ *  base install reached through a symlinked prefix, and resolved collapses a venv's
+ *  `bin/python` onto the base it links to. */
 function canonical(p: string): string {
-  let out = p;
   try {
-    out = realpathSync(p);
+    return literal(realpathSync(p));
   } catch {
-    out = pathResolve(p);
+    return literal(p);
   }
-  return IS_WIN ? out.toLowerCase().replace(/\\/g, "/") : out;
 }
 
 /**
@@ -551,17 +557,41 @@ export function interpreterFromVenvHints(
   if (!found) return undefined;
   // Nothing usable to contradict → the hint is the only observation we have.
   if (!argv0 || !isAbsolute(argv0) || !existsSync(argv0)) return pathResolve(found);
-  // argv[0] is usable. Only let the venv displace it if the venv says argv[0] is
-  // its base — otherwise this is an inherited VIRTUAL_ENV and argv[0] is right.
-  // `executable` is the base interpreter itself, so an exact match settles it.
+
+  // argv[0] is ALREADY a venv interpreter → there is nothing to recover, so the
+  // environment gets no say. This override exists for one situation only: argv[0]
+  // came back as a BASE interpreter (the macOS framework re-exec) and the venv it
+  // belongs to survives just in the environment. When argv[0] names a venv python,
+  // that story cannot apply, and any VIRTUAL_ENV pointing elsewhere is inherited.
+  //
+  // This is also what closes a hole the base comparison below cannot: on POSIX a
+  // venv's `bin/python` is a SYMLINK to its base, so resolving argv[0] collapses it
+  // onto that base — and two venvs built from one interpreter would then corroborate
+  // each other. Checking for argv[0]'s own `pyvenv.cfg` asks the question directly
+  // instead of inferring it from paths.
+  if (existsSync(join(argv0, "..", "..", "pyvenv.cfg"))) {
+    logger.info("Ignoring VIRTUAL_ENV: argv[0] is itself a venv interpreter", {
+      virtualEnv: venv,
+      argv0,
+    });
+    return undefined;
+  }
+
+  // Otherwise let the venv displace argv[0] only if the venv says argv[0] is its
+  // base. `executable` is the base interpreter itself, so an exact match settles it.
   // `home` is the DIRECTORY that interpreter lives in, so argv[0] must sit directly
   // in it — a prefix test would accept anything anywhere beneath a shared bin dir
   // (`/usr/bin`), which is far too weak to license overriding argv[0].
-  const target = canonical(argv0);
-  const targetDir = target.slice(0, target.lastIndexOf("/"));
+  //
+  // Compared BOTH as written and as resolved: a base install reached through a
+  // symlinked prefix (`/opt/homebrew/opt/python@3.12` → `../Cellar/...`) would
+  // otherwise fail to match the spelling `pyvenv.cfg` recorded.
+  const targets = new Set([canonical(argv0), literal(argv0)]);
+  const dirsOf = (p: string): string => p.slice(0, p.lastIndexOf("/"));
+  for (const t of [...targets]) targets.add(dirsOf(t));
   const corroborated = venvBaseInterpreters(venv)
-    .map(canonical)
-    .some((b) => b === target || b === targetDir);
+    .flatMap((b) => [canonical(b), literal(b)])
+    .some((b) => targets.has(b));
   if (corroborated) return pathResolve(found);
   logger.info("Ignoring VIRTUAL_ENV: it is not the venv argv[0] is the base of", {
     virtualEnv: venv,

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -26,7 +26,7 @@
 // should be added here as tier 0 — it works for remote servers too.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readlinkSync } from "node:fs";
+import { existsSync, readFileSync, readlinkSync, realpathSync } from "node:fs";
 import { isAbsolute, join, resolve as pathResolve } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
@@ -254,6 +254,14 @@ export interface ProcessIdentity {
    * never logged.
    */
   venvPython?: string;
+  /**
+   * The RAW venv hints, uninterpreted. Carried separately from `venvPython` because
+   * `VIRTUAL_ENV` can only be judged against argv[0], and argv[0] is chosen in
+   * `observeLiveServerProcess`, not here. Resolving at the decision point is what
+   * keeps the corroboration reachable — behind the OS read it would be invisible to
+   * every caller that injects a `readIdentity` seam.
+   */
+  venvHints?: VenvEnvHints;
 }
 
 /**
@@ -462,13 +470,76 @@ export function venvHintsFromProcArgs2(buf: Buffer): VenvEnvHints {
   return venvHintsFromEnvEntries(strings.slice(Math.max(0, argc)));
 }
 
+/** Normalize a path for comparison: resolve symlinks where we can, and fold case
+ *  and separators on Windows. */
+function canonical(p: string): string {
+  let out = p;
+  try {
+    out = realpathSync(p);
+  } catch {
+    out = pathResolve(p);
+  }
+  return IS_WIN ? out.toLowerCase().replace(/\\/g, "/") : out;
+}
+
+/**
+ * The BASE interpreter a venv was built from, as the venv itself records it.
+ *
+ * `pyvenv.cfg` is written at creation time and names the interpreter that created
+ * it — `executable` (the full path, CPython 3.11+) and `home` (its directory).
+ * Measured on a real venv:
+ *
+ *     home = C:\Users\A\miniconda3
+ *     executable = C:\Users\A\miniconda3\python.exe
+ *
+ * This is what lets us tell a venv that argv[0] is the base OF from a venv that
+ * merely happens to be named in the environment.
+ */
+export function venvBaseInterpreters(venvRoot: string): string[] {
+  try {
+    const cfg = readFileSync(join(venvRoot, "pyvenv.cfg"), "utf-8");
+    const out: string[] = [];
+    const exe = cfg.match(/^\s*executable\s*=\s*(.+)$/m)?.[1]?.trim();
+    if (exe) out.push(exe);
+    const home = cfg.match(/^\s*home\s*=\s*(.+)$/m)?.[1]?.trim();
+    if (home) out.push(home);
+    return out;
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Reconstruct the venv interpreter the PROCESS recorded. `__PYVENV_LAUNCHER__`
  * is the original argv[0] CPython saved before the macOS framework re-exec;
- * `VIRTUAL_ENV` is the activate-script / uv equivalent. Either is an observation
- * of the running process. Layout guesses do not belong here.
+ * `VIRTUAL_ENV` is the activate-script / uv equivalent.
+ *
+ * The two are NOT equally trustworthy, and treating them as if they were is its own
+ * #401. `__PYVENV_LAUNCHER__` is set by CPython itself, during this process's own
+ * re-exec, so it describes THIS interpreter. `VIRTUAL_ENV` is set by `activate` and
+ * then INHERITED by every child regardless of which interpreter that child is —
+ * measured:
+ *
+ *     $ VIRTUAL_ENV=/tmp/ve401 python -c "import sys,os; print(sys.executable)"
+ *     sys.executable = C:\Users\A\miniconda3\python.exe     <- what it really imports
+ *     VIRTUAL_ENV    = /tmp/ve401                           <- an unrelated venv
+ *
+ * So a server launched by explicit absolute path from a shell with some other venv
+ * active would be probed against that other venv — reporting `Triton: not installed`
+ * off an interpreter the server never loaded, which is the original bug verbatim.
+ *
+ * `VIRTUAL_ENV` may therefore only OVERRIDE a usable argv[0] when the venv's own
+ * `pyvenv.cfg` names argv[0] as the base it was built from. That is exactly the
+ * macOS Python.app re-exec case (argv[0] IS the framework base of this venv), and
+ * exactly not the stale-inheritance case. When there is no usable argv[0] to
+ * contradict, the hint is better than nothing and is used as before.
  */
-export function interpreterFromVenvHints(hints: VenvEnvHints): string | undefined {
+export function interpreterFromVenvHints(
+  hints: VenvEnvHints,
+  /** argv[0] of the process, when it is an absolute path that exists. Supplied only
+   *  to corroborate `VIRTUAL_ENV`; it never affects `__PYVENV_LAUNCHER__`. */
+  argv0?: string,
+): string | undefined {
   const launcher = hints.pyvenvLauncher;
   if (launcher && isAbsolute(launcher) && existsSync(launcher)) return pathResolve(launcher);
   const venv = hints.virtualEnv;
@@ -476,32 +547,51 @@ export function interpreterFromVenvHints(hints: VenvEnvHints): string | undefine
   const candidates = IS_WIN
     ? [join(venv, "Scripts", "python.exe"), join(venv, "python.exe")]
     : [join(venv, "bin", "python"), join(venv, "bin", "python3")];
-  for (const c of candidates) {
-    if (existsSync(c)) return pathResolve(c);
-  }
+  const found = candidates.find((c) => existsSync(c));
+  if (!found) return undefined;
+  // Nothing usable to contradict → the hint is the only observation we have.
+  if (!argv0 || !isAbsolute(argv0) || !existsSync(argv0)) return pathResolve(found);
+  // argv[0] is usable. Only let the venv displace it if the venv says argv[0] is
+  // its base — otherwise this is an inherited VIRTUAL_ENV and argv[0] is right.
+  // `executable` is the base interpreter itself, so an exact match settles it.
+  // `home` is the DIRECTORY that interpreter lives in, so argv[0] must sit directly
+  // in it — a prefix test would accept anything anywhere beneath a shared bin dir
+  // (`/usr/bin`), which is far too weak to license overriding argv[0].
+  const target = canonical(argv0);
+  const targetDir = target.slice(0, target.lastIndexOf("/"));
+  const corroborated = venvBaseInterpreters(venv)
+    .map(canonical)
+    .some((b) => b === target || b === targetDir);
+  if (corroborated) return pathResolve(found);
+  logger.info("Ignoring VIRTUAL_ENV: it is not the venv argv[0] is the base of", {
+    virtualEnv: venv,
+    argv0,
+  });
   return undefined;
 }
 
-function venvPythonFromPid(pid: number): string | undefined {
+function venvHintsFromPid(pid: number): VenvEnvHints | undefined {
   try {
     if (IS_WIN) return undefined;
     if (platform() === "linux") {
-      return interpreterFromVenvHints(venvHintsFromEnvironBuffer(readFileSync(`/proc/${pid}/environ`)));
+      return venvHintsFromEnvironBuffer(readFileSync(`/proc/${pid}/environ`));
     }
     const buf = execFileSync("sysctl", ["-b", `kern.procargs2.${pid}`], {
       timeout: 8000,
       maxBuffer: 2 * 1024 * 1024,
     });
     if (!Buffer.isBuffer(buf) || buf.length === 0) return undefined;
-    return interpreterFromVenvHints(venvHintsFromProcArgs2(buf));
+    return venvHintsFromProcArgs2(buf);
   } catch {
     return undefined;
   }
 }
 
+/** Attach the raw venv hints. Deliberately does NOT resolve them: `VIRTUAL_ENV` is
+ *  only meaningful next to argv[0], which the resolver picks. */
 function withVenvPython(pid: number, identity: ProcessIdentity): ProcessIdentity {
-  const venvPython = venvPythonFromPid(pid);
-  if (venvPython) identity.venvPython = venvPython;
+  const hints = venvHintsFromPid(pid);
+  if (hints && (hints.pyvenvLauncher || hints.virtualEnv)) identity.venvHints = hints;
   return identity;
 }
 
@@ -716,21 +806,32 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
   // Tier 2 — the OS process table, correlated against the server's own argv.
   if (!commandLineMatchesArgv(identity?.commandLine, opts.serverArgv)) return undefined;
 
-  // Prefer the venv the process itself recorded. After a macOS Python.app re-exec,
-  // argv[0] is the Homebrew/framework BASE interpreter — it exists, versions match
-  // the venv by construction, and probing it reports torch/Triton missing while
-  // /system_stats shows they are there (#401 recurrence, 0.52.1).
-  const fromEnv = identity?.venvPython;
-  if (fromEnv && isAbsolute(fromEnv) && existsSync(fromEnv)) {
-    return { python: fromEnv, source: "process-table", pid, image };
-  }
-
-  const argv0 = argv0FromCommandLine(identity?.commandLine ?? "");
   // A relative or bare argv[0] ("python", "./python") does not identify a file we
   // can probe — the process's cwd is not ours. Only an absolute path that exists
   // is usable; anything else is honestly unknown as an INTERPRETER. The OS image
   // still travels with the result for the weaker anchor question (#1374).
-  if (argv0 && isAbsolute(argv0) && existsSync(argv0)) {
+  const rawArgv0 = argv0FromCommandLine(identity?.commandLine ?? "");
+  const argv0 =
+    rawArgv0 && isAbsolute(rawArgv0) && existsSync(rawArgv0) ? rawArgv0 : undefined;
+
+  // Prefer the venv the process itself recorded. After a macOS Python.app re-exec,
+  // argv[0] is the Homebrew/framework BASE interpreter — it exists, versions match
+  // the venv by construction, and probing it reports torch/Triton missing while
+  // /system_stats shows they are there (#401 recurrence, 0.52.1).
+  //
+  // Resolved HERE, with argv[0] in hand, because `VIRTUAL_ENV` is only meaningful
+  // beside it: inherited from an activating shell, it names a venv this process may
+  // have nothing to do with, and letting that displace a good argv[0] would re-file
+  // #401 on machines that never had it. `venvPython` remains honoured when a caller
+  // supplied one directly.
+  const fromEnv = identity?.venvHints
+    ? interpreterFromVenvHints(identity.venvHints, argv0)
+    : identity?.venvPython;
+  if (fromEnv && isAbsolute(fromEnv) && existsSync(fromEnv)) {
+    return { python: fromEnv, source: "process-table", pid, image };
+  }
+
+  if (argv0) {
     return { python: argv0, source: "process-table", pid, image };
   }
   return { pid, image };

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -26,7 +26,7 @@
 // should be added here as tier 0 — it works for remote servers too.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readlinkSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, readlinkSync } from "node:fs";
 import { isAbsolute, join, resolve as pathResolve } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
@@ -470,50 +470,6 @@ export function venvHintsFromProcArgs2(buf: Buffer): VenvEnvHints {
   return venvHintsFromEnvEntries(strings.slice(Math.max(0, argc)));
 }
 
-/** Fold case and separators so two spellings of one path compare equal. */
-function literal(p: string): string {
-  const out = pathResolve(p).replace(/\\/g, "/");
-  return IS_WIN ? out.toLowerCase() : out;
-}
-
-/** `literal`, plus symlink resolution where the filesystem allows it. Both forms
- *  are compared, because either one alone gives a wrong answer: unresolved misses a
- *  base install reached through a symlinked prefix, and resolved collapses a venv's
- *  `bin/python` onto the base it links to. */
-function canonical(p: string): string {
-  try {
-    return literal(realpathSync(p));
-  } catch {
-    return literal(p);
-  }
-}
-
-/**
- * The BASE interpreter a venv was built from, as the venv itself records it.
- *
- * `pyvenv.cfg` is written at creation time and names the interpreter that created
- * it — `executable` (the full path, CPython 3.11+) and `home` (its directory).
- * Measured on a real venv:
- *
- *     home = C:\Users\A\miniconda3
- *     executable = C:\Users\A\miniconda3\python.exe
- *
- * This is what lets us tell a venv that argv[0] is the base OF from a venv that
- * merely happens to be named in the environment.
- */
-export function venvBaseInterpreters(venvRoot: string): string[] {
-  try {
-    const cfg = readFileSync(join(venvRoot, "pyvenv.cfg"), "utf-8");
-    const out: string[] = [];
-    const exe = cfg.match(/^\s*executable\s*=\s*(.+)$/m)?.[1]?.trim();
-    if (exe) out.push(exe);
-    const home = cfg.match(/^\s*home\s*=\s*(.+)$/m)?.[1]?.trim();
-    if (home) out.push(home);
-    return out;
-  } catch {
-    return [];
-  }
-}
 
 /**
  * Reconstruct the venv interpreter the PROCESS recorded. `__PYVENV_LAUNCHER__`
@@ -542,62 +498,63 @@ export function venvBaseInterpreters(venvRoot: string): string[] {
  */
 export function interpreterFromVenvHints(
   hints: VenvEnvHints,
-  /** argv[0] of the process, when it is an absolute path that exists. Supplied only
-   *  to corroborate `VIRTUAL_ENV`; it never affects `__PYVENV_LAUNCHER__`. */
+  /** argv[0] of the process, when it is an absolute path that exists. Its presence
+   *  DISQUALIFIES `VIRTUAL_ENV`; it never affects `__PYVENV_LAUNCHER__`. */
   argv0?: string,
 ): string | undefined {
+  // `__PYVENV_LAUNCHER__` is written by CPython during THIS process's own macOS
+  // framework re-exec, to preserve the `sys.executable` it started with. It is a
+  // statement about this interpreter, so it is authoritative.
   const launcher = hints.pyvenvLauncher;
   if (launcher && isAbsolute(launcher) && existsSync(launcher)) return pathResolve(launcher);
+
   const venv = hints.virtualEnv;
   if (!venv || !isAbsolute(venv)) return undefined;
-  const candidates = IS_WIN
-    ? [join(venv, "Scripts", "python.exe"), join(venv, "python.exe")]
-    : [join(venv, "bin", "python"), join(venv, "bin", "python3")];
-  const found = candidates.find((c) => existsSync(c));
-  if (!found) return undefined;
-  // Nothing usable to contradict → the hint is the only observation we have.
-  if (!argv0 || !isAbsolute(argv0) || !existsSync(argv0)) return pathResolve(found);
 
-  // argv[0] is ALREADY a venv interpreter → there is nothing to recover, so the
-  // environment gets no say. This override exists for one situation only: argv[0]
-  // came back as a BASE interpreter (the macOS framework re-exec) and the venv it
-  // belongs to survives just in the environment. When argv[0] names a venv python,
-  // that story cannot apply, and any VIRTUAL_ENV pointing elsewhere is inherited.
+  // `VIRTUAL_ENV` is a statement about the SHELL, not about this process. `activate`
+  // exports it and every descendant inherits it whatever interpreter it happens to
+  // run, so it can never establish which python is executing.
   //
-  // This is also what closes a hole the base comparison below cannot: on POSIX a
-  // venv's `bin/python` is a SYMLINK to its base, so resolving argv[0] collapses it
-  // onto that base — and two venvs built from one interpreter would then corroborate
-  // each other. Checking for argv[0]'s own `pyvenv.cfg` asks the question directly
-  // instead of inferring it from paths.
-  if (existsSync(join(argv0, "..", "..", "pyvenv.cfg"))) {
-    logger.info("Ignoring VIRTUAL_ENV: argv[0] is itself a venv interpreter", {
+  // An earlier revision tried to license it by checking the venv's `pyvenv.cfg`
+  // against argv[0] — "was this venv built FROM argv[0]?". That is a different
+  // question from "is this process running IN that venv?", and the two come apart
+  // exactly where it matters. Measured on Ubuntu 24.04 (gate round 1):
+  //
+  //     $ VIRTUAL_ENV=/tmp/ve402 /usr/bin/python3 main.py
+  //     sys.executable            = /usr/bin/python3        <- NOT in ve402
+  //     readlink -f /usr/bin/python3 = /usr/bin/python3.14
+  //     /tmp/ve402/pyvenv.cfg     executable = /usr/bin/python3.14   <- matches
+  //
+  // Every stock `python -m venv` records the base it was built from, so a system
+  // python launching ComfyUI "corroborates" any venv on the machine. That check
+  // re-filed #401 on configurations `main` handles correctly today. Comparing paths
+  // cannot answer this; there is no path fact that distinguishes the two cases.
+  //
+  // So the rule is positional, not evidential: `VIRTUAL_ENV` is consulted ONLY when
+  // argv[0] gave us nothing to probe (a bare `python`, a relative spelling, a path
+  // that no longer exists). Then it displaces nothing and is strictly better than
+  // the `undefined` we would otherwise return. Whenever argv[0] IS usable it wins,
+  // because it is an observation of the process rather than of the shell.
+  //
+  // The macOS Homebrew case this feature exists for is unaffected: that is a
+  // framework re-exec, which sets `__PYVENV_LAUNCHER__` above. And when neither
+  // hint applies, the interpreter stays argv[0] and the caller's /system_stats
+  // contradiction check discredits the probe — reporting Triton as UNKNOWN, which
+  // is what #401 asked for ("a false `not installed` ... is worse than saying
+  // nothing at all").
+  if (argv0 && isAbsolute(argv0) && existsSync(argv0)) {
+    logger.info("Ignoring VIRTUAL_ENV: it describes the shell, and argv[0] is usable", {
       virtualEnv: venv,
       argv0,
     });
     return undefined;
   }
 
-  // Otherwise let the venv displace argv[0] only if the venv says argv[0] is its
-  // base. `executable` is the base interpreter itself, so an exact match settles it.
-  // `home` is the DIRECTORY that interpreter lives in, so argv[0] must sit directly
-  // in it — a prefix test would accept anything anywhere beneath a shared bin dir
-  // (`/usr/bin`), which is far too weak to license overriding argv[0].
-  //
-  // Compared BOTH as written and as resolved: a base install reached through a
-  // symlinked prefix (`/opt/homebrew/opt/python@3.12` → `../Cellar/...`) would
-  // otherwise fail to match the spelling `pyvenv.cfg` recorded.
-  const targets = new Set([canonical(argv0), literal(argv0)]);
-  const dirsOf = (p: string): string => p.slice(0, p.lastIndexOf("/"));
-  for (const t of [...targets]) targets.add(dirsOf(t));
-  const corroborated = venvBaseInterpreters(venv)
-    .flatMap((b) => [canonical(b), literal(b)])
-    .some((b) => targets.has(b));
-  if (corroborated) return pathResolve(found);
-  logger.info("Ignoring VIRTUAL_ENV: it is not the venv argv[0] is the base of", {
-    virtualEnv: venv,
-    argv0,
-  });
-  return undefined;
+  const candidates = IS_WIN
+    ? [join(venv, "Scripts", "python.exe"), join(venv, "python.exe")]
+    : [join(venv, "bin", "python"), join(venv, "bin", "python3")];
+  const found = candidates.find((c) => existsSync(c));
+  return found ? pathResolve(found) : undefined;
 }
 
 function venvHintsFromPid(pid: number): VenvEnvHints | undefined {

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1249,6 +1249,33 @@ export function pythonVersionsAgree(a: string | undefined, b: string | undefined
   return true;
 }
 
+/**
+ * Do two torch version strings describe the same install?
+ *
+ * `/system_stats.pytorch_version` (e.g. "2.12.1" or "2.11.0.dev20260123+cu130")
+ * is what the RUNNING server imported. A pip/import probe reports
+ * `torch.__version__` from whichever interpreter we asked. Compare the version
+ * token and ignore local suffixes (`+cu130`, `+cpu`): those are the same build
+ * with a different local tag, not a different install.
+ *
+ * CONTRADICTION check only — agreement does not prove identity. A Homebrew
+ * base and its venv share a python banner, but only the venv has torch
+ * (#401 recurrence, 0.52.1).
+ */
+export function torchVersionsAgree(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  const norm = (v: string): string =>
+    v
+      .replace(/^torch\s+/i, "")
+      .split("+")[0]!
+      .split(/\s/)[0]!
+      .trim()
+      .toLowerCase();
+  const na = norm(a);
+  const nb = norm(b);
+  return na.length > 0 && na === nb;
+}
+
 /** A bundle root may contain its actual server in `ComfyUI/`; do not confuse a
  * nested independent checkout with that bundle layout. */
 function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefined): boolean {
@@ -1702,7 +1729,43 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     if (trusted && probeExe) {
       const probed = await probePipPackages(probeExe, KEY_PACKAGES);
       pkgs = probed.packages;
-      if (Object.keys(pkgs).length > 0) {
+      // A venv and its base interpreter report the SAME sys.version, so the
+      // version check above cannot tell them apart. /system_stats.pytorch_version
+      // can: the running server imported that torch. A probe that finds none (or a
+      // different build) is looking at the wrong environment — typically the
+      // Homebrew/uv BASE python after the process table lost the venv context
+      // (#401 recurrence, 0.52.1). Absence only counts when pip actually answered.
+      const serverTorch = running.pytorch_version?.trim();
+      const torchContradiction =
+        serverTorch &&
+        (probed.ran && !pkgs.torch
+          ? "absent"
+          : pkgs.torch && !torchVersionsAgree(pkgs.torch, serverTorch)
+            ? "version"
+            : undefined);
+      if (torchContradiction) {
+        trusted = false;
+        const observedAs = groundTruth?.source ?? "process-table";
+        reason =
+          torchContradiction === "absent"
+            ? `the observed interpreter (${observedAs}) has none of torch while ` +
+              `the running ComfyUI reports pytorch ${serverTorch} — this is the base ` +
+              `interpreter, not the venv the server imports from. Refusing to attribute ` +
+              `its packages to the server`
+            : `the observed interpreter (${observedAs}) reports torch ${pkgs.torch}, ` +
+              `which does not match the running ComfyUI pytorch ${serverTorch} — ` +
+              `refusing to attribute its packages to the server`;
+        local.python_probe_trusted = false;
+        local.python_probe_reason = reason;
+        local.note = [
+          local.note,
+          `Package versions omitted: ${reason}, so reporting them would be a false ` +
+            `capability report (#401). Start ComfyUI through restart_comfyui (action:"start"), or run it ` +
+            `locally where this process can read its command line, for an accurate report.`,
+        ]
+          .filter(Boolean)
+          .join(" ");
+      } else if (Object.keys(pkgs).length > 0) {
         local.packages = pkgs;
       } else {
         // An absent `packages` field otherwise reads identically to the deliberate


### PR DESCRIPTION
## Why

`install_comfyui(action:"environment")` and the ENVIRONMENT banner still reported torch / Triton as missing after the earlier #401 fixes. The 0.52.1 recurrence is macOS + Homebrew: the process-table probe sees the **base** interpreter (Python.app re-execs; `ps` argv[0] is `/opt/homebrew/.../Python`), marks it trusted because the venv reports the same `sys.version`, then `pip show` finds none of torch/torchvision/torchaudio — while the reachable server's `/system_stats` already reports PyTorch 2.12.1.

That is the same harmful false negative as the original report: an agent treats "not installed" as fact and disables working acceleration.

## What changed

**Recover the venv the process itself recorded.** After argv correlation, prefer `__PYVENV_LAUNCHER__` (CPython's macOS framework hook) or `$VIRTUAL_ENV/bin/python` from the live process environment over argv[0]. Those are observations, not layout guesses. argv[0] remains the fallback when the hint is missing or the path is gone.

**Refuse a trusted package list that contradicts `/system_stats`.** A venv and its base share a python banner, so the version check cannot tell them apart. If the probe's pip/import says torch is absent (or a different build) while the server reports `pytorch_version`, the source is discredited: `python_probe_trusted` is false, `packages` is omitted, and Triton/SageAttention negatives become `unknown`. A failed pip query (uv venvs often have no pip) is still "we could not tell", not "torch is absent".

## Tests

- `live-interpreter.test.ts` — parse Linux environ / `kern.procargs2`, prefer the launcher python over a real Homebrew argv[0]
- `workspace-env.test.ts` — getEnvironment untrusts a process-table hit with no torch (or the wrong torch) when `/system_stats` reports pytorch; matching torch still reports packages; a failed pip query is not a contradiction
- `env-capabilities-argv-contradiction.test.ts` — ENVIRONMENT banner voids Triton when the probe has no torch but the server reports pytorch

`tsc --noEmit` clean. Targeted vitest 173/173.

Fixes #401
