### PR TITLE
fix(1415): list_templates honors COMFYUI_MCP_HTTP_TIMEOUT_S instead of aborting at 8s

### DIFF
--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -258,8 +258,7 @@ describe("comfyuiFetch bounds a call that brought no budget", () => {
     expect((spy.mock.calls.at(-1)![1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
-  // The caller's own budget is the informed one — 8s for the template listing,
-  // and so on. Ours must never shorten or replace it.
+  // The caller's own budget is the informed one. Ours must never shorten or replace it.
   it("NEVER overrides a caller's own signal", async () => {
     const mine = AbortSignal.timeout(5_000);
     const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));

--- a/src/__tests__/services/skill-generator-timeout.test.ts
+++ b/src/__tests__/services/skill-generator-timeout.test.ts
@@ -3,8 +3,8 @@
 //
 // The reporter named action:"list" and action:"skill_list", but neither can hang:
 // both are synchronous local filesystem enumeration with no network and no await.
-// The pack catalog's one live-server action (list_templates) already carries
-// AbortSignal.timeout(8000).
+// The pack catalog's one live-server action (list_templates) is bounded by
+// comfyuiFetch's COMFYUI_MCP_HTTP_TIMEOUT_S ceiling.
 //
 // The actual unbounded path on that tool is action:"generate_skill", which
 // reaches GitHub and api.comfy.org — and all three of those calls were a bare

--- a/src/__tests__/tools/template-index-timeout.test.ts
+++ b/src/__tests__/tools/template-index-timeout.test.ts
@@ -1,0 +1,76 @@
+// #1415 — the configured template read must let COMFYUI_MCP_HTTP_TIMEOUT_S
+// govern it.
+//
+// `comfyuiFetch` applies its configurable ceiling ONLY to callers that passed no
+// signal (`init.signal ?? defaultComfyTimeoutSignal()`). A hard-coded
+// `AbortSignal.timeout(8000)` at the call site therefore always wins, and a user
+// who raised the timeout for a slow remote still had this one read aborted at 8s
+// — the setting silently did nothing here.
+//
+// WHY THIS IS A SEPARATE FILE, AND NOT A TIMING TEST. A real-timer version (a
+// 50ms configured budget against a slower stub) passed alone and failed in the
+// full suite: the outcome depended on when the stub was scheduled relative to a
+// timer that had already fired, which is not the claim. The claim is structural:
+// THIS CALL SITE PASSES NO SIGNAL, so the configured ceiling is what applies.
+// Asserting that directly needs comfyuiFetch itself mocked, which must not leak
+// into the behaviour tests next door.
+
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiApiKey: undefined, huggingfaceToken: undefined, civitaiApiToken: undefined },
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const seen: Array<{ url: string; init: RequestInit | undefined }> = [];
+
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/fetch.js")>();
+  return {
+    ...actual,
+    comfyuiFetch: async (input: string | URL | Request, init?: RequestInit) => {
+      seen.push({ url: String(input), init });
+      return new Response(JSON.stringify({ core: [{ name: "t" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  };
+});
+
+import { registerSkillsAccessTools } from "../../tools/skills-access.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function handler(): Handler {
+  const tools: Array<{ name: string; handler: Handler }> = [];
+  const server = {
+    tool: (name: string, _d: string, _s: z.ZodRawShape, h: Handler) => {
+      tools.push({ name, handler: h });
+    },
+  };
+  registerSkillsAccessTools(server as never);
+  const t = tools.find((x) => x.name === "list_packs");
+  if (!t) throw new Error("list_packs not registered");
+  return t.handler;
+}
+
+describe('list_packs action:"list_templates" — the configured timeout governs', () => {
+  it("passes NO signal of its own, so comfyuiFetch's configurable ceiling applies", async () => {
+    seen.length = 0;
+
+    const res = await handler()({ action: "list_templates" });
+
+    expect(res.isError).toBeFalsy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("http://127.0.0.1:8188/api/workflow_templates");
+    // The whole finding in one assertion: any signal here overrides the user's
+    // setting, because comfyuiFetch only fills one in when the caller passed none.
+    expect(seen[0].init?.signal).toBeUndefined();
+  });
+});

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -228,8 +228,8 @@ function describeComfyFetchFailure(err: unknown, target: string, method: string)
  * fix bounded three calls, and this bounds the rest.
  *
  * DELIBERATELY GENEROUS. Every caller that knows its own budget already passes a
- * signal (8s for the template listing, and so on) and keeps it — `init.signal`
- * always wins. This value only has to be shorter than "forever" and longer than
+ * signal and keeps it — `init.signal` always wins. This value only has to be
+ * shorter than "forever" and longer than
  * any healthy request: `/object_info` on a large custom-node install is
  * legitimately slow, and a ceiling that fires on a working server would be a
  * worse bug than the one being fixed.

--- a/src/services/skill-generator.ts
+++ b/src/services/skill-generator.ts
@@ -74,8 +74,9 @@ function githubHeaders(): Record<string, string> {
  * shape: not a failure that was mis-described, but no answer at all.
  *
  * Every other network path on that tool is already bounded (the live-server
- * template listing carries AbortSignal.timeout(8000); comfyuiFetch callers pass
- * their own). These three were the gap.
+ * template listing goes through comfyuiFetch, which applies
+ * COMFYUI_MCP_HTTP_TIMEOUT_S; other comfyuiFetch callers pass their own). These
+ * three were the gap.
  *
  * Generous by default — a cold GitHub API call over a slow link is legitimately
  * slow, and a timeout that fires on a working connection would be its own bug.

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -586,9 +586,11 @@ async function listWorkflowTemplatesAction(): Promise<ToolText> {
   // symptom, from a session where the panel bridge was connected and this
   // headless address was not. comfyuiFetch names the target on a network throw,
   // and it is the same auth path every other ComfyUI call uses.
-  const res = await comfyuiFetch(url, {
-    signal: AbortSignal.timeout(8000),
-  });
+  //
+  // NO SIGNAL (#1415). comfyuiFetch applies COMFYUI_MCP_HTTP_TIMEOUT_S only
+  // when the caller passed none. A hard-coded AbortSignal.timeout(8000) always
+  // won, so raising the env for a slow remote still aborted this read at 8s.
+  const res = await comfyuiFetch(url);
   if (!res.ok) {
     // A NON-2xx may still be an HTML proxy/login page — say which, instead
     // of blaming a possibly-fine ComfyUI version (#828).


### PR DESCRIPTION
## What

`list_packs` `action:"list_templates"` now honors `COMFYUI_MCP_HTTP_TIMEOUT_S` instead of always aborting at 8s.

## Why

`comfyuiFetch` applies its configurable ceiling only when the caller passed no signal. This call site passed `AbortSignal.timeout(8000)`, so a user who raised the env for a slow remote still had a healthy index answering at 9s aborted at 8 — the setting silently did nothing here.

This is the freeze-appropriate slice named when #1600 closed, lifted onto current main without the discarded panel-origin retry. **Does not close #1415**: the tunnel / loopback-only routing half (panel bridge command + child→bridge transport) is still parked.

## Test

- Structural: `list_templates` drives the shipped handler and asserts the call passes **no** signal, so `comfyuiFetch`'s ceiling is the one that applies. Isolated file so the `comfyuiFetch` mock cannot leak into the neighbouring behaviour tests.
- Not a real-timer test: the first version of this (50ms budget vs a slower stub) passed alone and failed in the suite.

```
npx vitest run --maxWorkers=4 src/__tests__/tools/template-index-timeout.test.ts src/__tests__/tools/skills-access.test.ts src/__tests__/tools/html-instead-of-json.test.ts src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
```

98 related tests green (8 files).
