### PR TITLE
fix(1798): a Windows account that cannot create scheduled tasks still gets a launcher

### DIFF
--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -57,6 +57,112 @@ describe("panel launcher install", () => {
     const first = readPanelLauncherConfig(home)?.token;
     installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
     expect(readPanelLauncherConfig(home)?.token).toBe(first);
+  });
+
+  it("falls back to a Startup autostart when the scheduled task is DENIED", () => {
+    // The failure this covers is not hypothetical: on a machine whose policy or
+    // task-store ACL refuses task creation to the user, `schtasks /Create` fails
+    // with "ERROR: Access is denied." for ANY task name — a throwaway probe is
+    // refused identically. The install had already written every file it needed
+    // and then threw, so the panel's Connect button kept sending the user to an
+    // install that could not succeed on that account.
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    const execOpts: Array<{ stdio?: unknown }> = [];
+    const warnings: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown) => {
+      warnings.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    let paths;
+    try {
+      paths = installPanelLauncher({
+      home,
+      platform: "win32",
+      nodePath: "C:\\Node\\node.exe",
+      brokerSource: source,
+      exec: ((_file: string, _args: readonly string[], opts: { stdio?: unknown }) => {
+        execOpts.push(opts);
+        const err = new Error("Command failed: schtasks.exe /Create …") as Error & {
+          stderr: string;
+        };
+        err.stderr = "ERROR: Access is denied.\r\n";
+        throw err;
+      }) as never,
+      spawnImpl: ((_file: string, args: readonly string[]) => {
+        spawned.push(args);
+        return { unref() {} };
+      }) as never,
+      });
+    } finally {
+      process.stderr.write = realWrite;
+    }
+
+    // The TOOL's own reason, not our paraphrase of it. Piping schtasks' stderr
+    // is what makes this possible: with stdio "ignore" the only text available
+    // was "Command failed: schtasks.exe …", which cannot tell a denial apart
+    // from a bad argument or a missing binary.
+    expect(warnings.join("")).toContain("Access is denied");
+    // Pinned at the CALL, not just at the message: a fake exec carries a
+    // `.stderr` no matter what stdio was requested, so asserting only on the
+    // rendered warning cannot tell piped from swallowed — the real binary can.
+    expect(execOpts[0]?.stdio).toEqual(["ignore", "ignore", "pipe"]);
+    // A per-user autostart, which needs no elevation — the exact constraint the
+    // scheduled task could not satisfy.
+    expect(paths.windowsStartup).toContain("Startup");
+    expect(readFileSync(paths.windowsStartup, "utf8")).toContain(paths.windowsScript);
+    // …and the broker starts NOW, or the install "succeeds" while leaving the
+    // panel with nothing to talk to until the next logon.
+    expect(spawned).toEqual([[paths.broker, "run"]]);
+    // The install must not throw: everything the launcher needs now exists.
+    expect(readPanelLauncherConfig(home)?.token.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("does not start a second broker when the previous one is alive", () => {
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: (() => undefined) as never });
+    // Claim a live broker by writing OUR pid into the config — process.kill(pid, 0)
+    // succeeds for it, so the fallback must leave it alone rather than start a
+    // rival that fights it for the port.
+    const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
+    writeFileSync(
+      panelLauncherPaths(home).config,
+      JSON.stringify({ ...cfg, pid: process.pid }),
+      "utf8",
+    );
+    installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("denied");
+      }) as never,
+      spawnImpl: ((_file: string, args: readonly string[]) => {
+        spawned.push(args);
+        return { unref() {} };
+      }) as never,
+    });
+    expect(spawned).toEqual([]);
+  });
+
+  it("uninstall removes the Startup fallback, not just the task", () => {
+    const { home, source } = fixture();
+    const paths = installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("denied");
+      }) as never,
+      spawnImpl: (() => ({ unref() {} })) as never,
+    });
+    expect(readFileSync(paths.windowsStartup, "utf8")).toContain(paths.windowsScript);
+    uninstallPanelLauncher({ home, platform: "win32", exec: (() => undefined) as never });
+    // Removing only the task would leave exactly the accounts that needed the
+    // fallback with a launcher that survives every uninstall.
+    expect(existsSync(paths.windowsStartup)).toBe(false);
   });
 
   it("writes a Linux user service and falls back to XDG autostart", () => {

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -43,6 +43,9 @@ export type LauncherPaths = {
   config: string;
   broker: string;
   windowsScript: string;
+  /** Windows fallback autostart, for accounts that may not create scheduled
+   *  tasks. The Startup folder is per-user and needs no elevation. */
+  windowsStartup: string;
   macPlist: string;
   linuxService: string;
   linuxAutostart: string;
@@ -57,6 +60,17 @@ export function panelLauncherPaths(home: string = homedir()): LauncherPaths {
     config: join(root, "launcher.json"),
     broker: join(launcherDir, "broker.mjs"),
     windowsScript: join(launcherDir, "start-launcher.cmd"),
+    windowsStartup: join(
+      home,
+      "AppData",
+      "Roaming",
+      "Microsoft",
+      "Windows",
+      "Start Menu",
+      "Programs",
+      "Startup",
+      "comfyui-mcp-launcher.cmd",
+    ),
     macPlist: join(home, "Library", "LaunchAgents", `${PANEL_LAUNCHER_LABEL}.plist`),
     linuxService: join(home, ".config", "systemd", "user", "comfyui-mcp-launcher.service"),
     linuxAutostart: join(home, ".config", "autostart", "comfyui-mcp-launcher.desktop"),
@@ -102,12 +116,35 @@ function xml(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
+/**
+ * Why a service manager refused, as a single line fit for a CLI message.
+ *
+ * `execFileSync` throws an Error whose `stderr` holds the tool's own words
+ * ("ERROR: Access is denied."), but only when the caller piped it; the generic
+ * `message` is just the command line, which tells the user nothing they can act
+ * on. Prefer the tool's reason and fall back to the message.
+ */
+function schtasksReason(err: unknown): string {
+  const stderr = (err as { stderr?: unknown })?.stderr;
+  const text =
+    typeof stderr === "string"
+      ? stderr
+      : stderr && typeof (stderr as Buffer).toString === "function"
+        ? (stderr as Buffer).toString("utf8")
+        : "";
+  const line = text.split(/\r?\n/).find((l) => l.trim().length > 0);
+  return line?.trim() || (err instanceof Error ? err.message : String(err));
+}
+
 export type InstallLauncherOptions = {
   home?: string;
   platform?: NodeJS.Platform;
   nodePath?: string;
   brokerSource?: string;
   exec?: typeof execFileSync;
+  /** Injected for the tests, so a fallback case can assert the broker was
+   *  started without actually starting one. */
+  spawnImpl?: typeof spawn;
 };
 
 export function installPanelLauncher(options: InstallLauncherOptions = {}): LauncherPaths {
@@ -116,11 +153,36 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
   const nodePath = options.nodePath ?? process.execPath;
   const source = options.brokerSource ?? fileURLToPath(import.meta.url);
   const run = options.exec ?? execFileSync;
+  const spawnBroker = options.spawnImpl ?? spawn;
   const paths = panelLauncherPaths(home);
   mkdirSync(paths.launcherDir, { recursive: true });
   copyFileSync(source, paths.broker);
 
   const previous = readPanelLauncherConfig(home);
+
+  /**
+   * Start the broker unless the previous one is still alive.
+   *
+   * Every fallback path needs this: without a service manager nothing else will
+   * start the broker, so the install would "succeed" and leave the panel with
+   * nothing to talk to until the next logon. Shared by the Windows and Linux
+   * fallbacks rather than duplicated — they answer the identical question.
+   */
+  const startBrokerIfIdle = (): void => {
+    if (previous?.pid) {
+      try {
+        process.kill(previous.pid, 0);
+        return; // still running — a second broker would fight it for the port
+      } catch {
+        // Dead pid: fall through and start a replacement.
+      }
+    }
+    const child = spawnBroker(nodePath, [paths.broker, "run"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref?.();
+  };
   writePanelLauncherConfig(
     {
       protocol: PANEL_LAUNCHER_PROTOCOL,
@@ -138,24 +200,58 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
       `@echo off\r\n"${nodePath}" "${paths.broker}" run\r\n`,
       "utf8",
     );
-    run(
-      "schtasks.exe",
-      [
-        "/Create",
-        "/F",
-        "/SC",
-        "ONLOGON",
-        "/IT",
-        "/RL",
-        "LIMITED",
-        "/TN",
-        PANEL_LAUNCHER_TASK,
-        "/TR",
-        `"${paths.windowsScript}"`,
-      ],
-      { stdio: "ignore" },
-    );
-    run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+    // A scheduled task is the preferred registration, but it is NOT available to
+    // every account: creating one can be denied outright by machine policy or by
+    // the ACL on the task store, and the denial has nothing to do with this task
+    // in particular (a throwaway probe task is refused identically). On such a
+    // machine the install used to throw here, having already written every file
+    // it needed, and the panel's Connect button kept telling the user to run an
+    // install that could never succeed.
+    //
+    // So Windows now gets the same shape Linux has had all along: try the
+    // service manager, and when it refuses, fall back to a per-user autostart
+    // and start the broker directly. The Startup folder is user-writable and
+    // needs no elevation, which is exactly the constraint the scheduled task
+    // could not satisfy.
+    try {
+      run(
+        "schtasks.exe",
+        [
+          "/Create",
+          "/F",
+          "/SC",
+          "ONLOGON",
+          "/IT",
+          "/RL",
+          "LIMITED",
+          "/TN",
+          PANEL_LAUNCHER_TASK,
+          "/TR",
+          `"${paths.windowsScript}"`,
+        ],
+        // NOT "ignore" (codex-taxonomy class 1): schtasks reports WHY it refused
+        // on stderr, and swallowing it left the CLI printing a bare "Command
+        // failed: schtasks.exe …" — indistinguishable from a missing binary, a
+        // bad argument, or a denial, which is the one that actually happens.
+        { stdio: ["ignore", "ignore", "pipe"] },
+      );
+      run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+    } catch (err) {
+      mkdirSync(dirname(paths.windowsStartup), { recursive: true });
+      writeFileSync(
+        paths.windowsStartup,
+        `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
+        "utf8",
+      );
+      startBrokerIfIdle();
+      // Not silent: the user asked for a launcher and got a different mechanism
+      // than the one this tool normally installs, which changes how they would
+      // later remove or debug it.
+      process.stderr?.write?.(
+        `[comfyui-mcp] scheduled task refused (${schtasksReason(err)}); ` +
+          `registered a Startup-folder autostart instead: ${paths.windowsStartup}\n`,
+      );
+    }
     return paths;
   }
 
@@ -204,19 +300,7 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
         `Exec="${nodePath}" "${paths.broker}" run\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
-    let previousStillRunning = false;
-    if (previous?.pid) {
-      try {
-        process.kill(previous.pid, 0);
-        previousStillRunning = true;
-      } catch {
-        previousStillRunning = false;
-      }
-    }
-    if (!previousStillRunning) {
-      const child = spawn(nodePath, [paths.broker, "run"], { detached: true, stdio: "ignore" });
-      child.unref();
-    }
+    startBrokerIfIdle();
   }
   return paths;
 }
@@ -239,6 +323,10 @@ export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): 
     } catch {
       // Already absent is the desired end state.
     }
+    // …and the fallback autostart, which is what an account that could not
+    // create the task actually has. Removing only the task would leave those
+    // users with a launcher that keeps coming back after every uninstall.
+    rmSync(paths.windowsStartup, { force: true });
   } else if (platform === "darwin") {
     try {
       run("launchctl", ["bootout", `gui/${process.getuid?.() ?? 0}`, paths.macPlist], { stdio: "ignore" });


### PR DESCRIPTION
Fixes #1798.

Clicking **Connect** told the user to run `npx comfyui-mcp@latest launcher install`, and on the
reporting account that command could never succeed. `schtasks.exe /Create` fails with
**`ERROR: Access is denied.`** — and a throwaway probe task is refused identically, with the real
task absent beforehand and the shell non-elevated, so it is machine policy or the task-store ACL.
Not a name collision, not this task, and not something retrying can fix.

```
schtasks /Create /F /SC ONLOGON /IT /RL LIMITED /TN "cmcp-probe-delete-me" /TR "cmd /c echo hi"
ERROR: Access is denied.
```

Two things compounded it:

1. **No Windows fallback.** The win32 branch treated `schtasks` as mandatory and threw — even
   though `broker.mjs`, `start-launcher.cmd` and `launcher.json` (with its token) had *all* been
   written successfully by that point. Only the autostart registration was missing.
2. **The reason was swallowed.** Both `schtasks` calls ran with `stdio: "ignore"`, so the CLI
   could print only `Command failed: schtasks.exe …` — indistinguishable from a bad argument or a
   missing binary. That is why it read as "nothing happens", and why the echoed command's unquoted
   task name looks like the bug when it isn't (args are passed as an array).

## The fix

Linux has had the answer all along — when `systemctl --user` fails it writes an XDG autostart entry
*and* spawns the broker directly. Windows now does the same:

- `schtasks /Create` + `/Run` wrapped in try/catch;
- on refusal, a **Startup-folder** entry (`%APPDATA%\…\Start Menu\Programs\Startup\comfyui-mcp-launcher.cmd`)
  — user-writable, no elevation, which is exactly the constraint the scheduled task could not meet;
- an immediate broker start, because otherwise the install "succeeds" and leaves the panel with
  nothing to talk to until the next logon;
- both fallbacks now share one `startBrokerIfIdle` — they answer the identical question, and
  neither may start a rival for the port;
- `launcher uninstall` removes the Startup entry too, or the accounts that *needed* the fallback
  keep a launcher that survives every uninstall;
- `schtasks` stderr is piped and its first line surfaced, so a denial says `ERROR: Access is denied.`

## Verification

**Live, against the real `schtasks.exe` on the affected machine** (throwaway `home`, stubbed spawn,
nothing written to the real profile):

```
[comfyui-mcp] scheduled task refused (ERROR: Access is denied.); registered a Startup-folder
autostart instead: …\Start Menu\Programs\Startup\comfyui-mcp-launcher.cmd
--- broker spawn --- [["…\\.comfyui-mcp\\launcher\\broker.mjs","run"]]
PASS — real denial fell back to a Startup autostart + broker start
PASS — uninstall removed the fallback
```

And the whole user-facing chain confirmed by hand on that machine: broker → `POST /v1/ensure-running`
→ orchestrator → bridge on 9180 → panel connected → agent turn answered.

**Mutations, all five red:** no fallback (rethrow), don't start the broker, swallow schtasks stderr,
uninstall leaves the fallback, spawn even when a broker is alive. The stderr one *survived* at first
— an injected `exec` carries a `.stderr` no matter what stdio was requested, so asserting on the
rendered warning could not tell piped from swallowed. The assertion moved to the **call options**,
which the real binary is actually governed by.

Suite: 571 files / 10,472 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
