### PR TITLE
fix(1798): five ways the launcher fallback could strand or double-serve a user

### DIFF
--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   installPanelLauncher,
@@ -28,10 +29,10 @@ function fixture(): { home: string; source: string } {
 }
 
 describe("panel launcher install", () => {
-  it("installs a stable broker, private token config, and per-user Windows task", () => {
+  it("installs a stable broker, private token config, and per-user Windows task", async () => {
     const { home, source } = fixture();
     const calls: Array<{ file: string; args: readonly string[] }> = [];
-    const paths = installPanelLauncher({
+    const paths = await installPanelLauncher({
       home,
       platform: "win32",
       nodePath: "C:\\Node\\node.exe",
@@ -50,16 +51,16 @@ describe("panel launcher install", () => {
     expect(calls.map((call) => call.args[0])).toEqual(["/Create", "/Run"]);
   });
 
-  it("preserves the authentication token across reinstalls", () => {
+  it("preserves the authentication token across reinstalls", async () => {
     const { home, source } = fixture();
     const exec = (() => undefined) as never;
-    installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
+    await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
     const first = readPanelLauncherConfig(home)?.token;
-    installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
+    await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
     expect(readPanelLauncherConfig(home)?.token).toBe(first);
   });
 
-  it("falls back to a Startup autostart when the scheduled task is DENIED", () => {
+  it("falls back to a Startup autostart when the scheduled task is DENIED", async () => {
     // The failure this covers is not hypothetical: on a machine whose policy or
     // task-store ACL refuses task creation to the user, `schtasks /Create` fails
     // with "ERROR: Access is denied." for ANY task name — a throwaway probe is
@@ -77,7 +78,7 @@ describe("panel launcher install", () => {
     }) as typeof process.stderr.write;
     let paths;
     try {
-      paths = installPanelLauncher({
+      paths = await installPanelLauncher({
       home,
       platform: "win32",
       nodePath: "C:\\Node\\node.exe",
@@ -119,20 +120,73 @@ describe("panel launcher install", () => {
     expect(readPanelLauncherConfig(home)?.token.length).toBeGreaterThanOrEqual(32);
   });
 
-  it("does not start a second broker when the previous one is alive", () => {
+  it("does not start a second broker when one ANSWERS on the recorded port", async () => {
     const { home, source } = fixture();
     const spawned: Array<readonly string[]> = [];
-    installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: (() => undefined) as never });
-    // Claim a live broker by writing OUR pid into the config — process.kill(pid, 0)
-    // succeeds for it, so the fallback must leave it alone rather than start a
-    // rival that fights it for the port.
+    await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
+
+    // A broker that actually answers — the only evidence that justifies skipping
+    // the spawn. Started on a real port with the config's own token.
+    const server = createServer((req, res) => {
+      const ok = req.headers.authorization === `Bearer ${cfg.token}`;
+      res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: false }));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as { port: number }).port;
+    writeFileSync(
+      panelLauncherPaths(home).config,
+      JSON.stringify({ ...cfg, port, pid: process.pid }),
+      "utf8",
+    );
+
+    try {
+      await installPanelLauncher({
+        home,
+        platform: "win32",
+        brokerSource: source,
+        exec: (() => {
+          throw new Error("denied");
+        }) as never,
+        spawnImpl: ((_file: string, args: readonly string[]) => {
+          spawned.push(args);
+          return { unref() {} };
+        }) as never,
+      });
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+    expect(spawned).toEqual([]);
+  });
+
+  it("DOES start one when the pid is alive but nothing answers (recycled pid)", async () => {
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    // Windows recycles pids aggressively across a reboot, so an unrelated
+    // process can be wearing the pid we recorded. Trusting `process.kill(pid, 0)`
+    // meant spawning NOTHING while the config still advertised a dead port — the
+    // panel then reports the launcher as not running and sends the user back to
+    // the install they just ran: #1798's loop, re-entered through its own fix.
     const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
     writeFileSync(
       panelLauncherPaths(home).config,
-      JSON.stringify({ ...cfg, pid: process.pid }),
+      // OUR pid (certainly alive) + a port with no listener.
+      JSON.stringify({ ...cfg, pid: process.pid, port: 9 }),
       "utf8",
     );
-    installPanelLauncher({
+    await installPanelLauncher({
       home,
       platform: "win32",
       brokerSource: source,
@@ -144,12 +198,70 @@ describe("panel launcher install", () => {
         return { unref() {} };
       }) as never,
     });
-    expect(spawned).toEqual([]);
+    expect(spawned).toEqual([[panelLauncherPaths(home).broker, "run"]]);
   });
 
-  it("uninstall removes the Startup fallback, not just the task", () => {
+  it("puts the Startup entry under %APPDATA%, not a manufactured profile path", async () => {
+    // Group Policy "Redirect the Roaming AppData folder" points %APPDATA% at a
+    // share while USERPROFILE stays local — the same managed-domain population
+    // whose policy denies schtasks. Deriving the path from home would create a
+    // folder Explorer never scans and still report success.
     const { home, source } = fixture();
-    const paths = installPanelLauncher({
+    const redirected = join(home, "redirected-appdata");
+    const paths = await installPanelLauncher({
+      home,
+      appData: redirected,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("denied");
+      }) as never,
+      spawnImpl: (() => ({ unref() {} })) as never,
+    });
+    expect(paths.windowsStartup.startsWith(redirected)).toBe(true);
+    expect(existsSync(paths.windowsStartup)).toBe(true);
+    // …and uninstall resolves the SAME root, or it deletes a path the install
+    // never wrote and leaves the real autostart running.
+    uninstallPanelLauncher({
+      home,
+      appData: redirected,
+      platform: "win32",
+      exec: (() => undefined) as never,
+    });
+    expect(existsSync(paths.windowsStartup)).toBe(false);
+  });
+
+  it("a task that registers but cannot RUN right now gets no second autostart", async () => {
+    // /Create and /Run fail for different reasons. An /IT task invoked over a
+    // non-interactive session (OpenSSH, WinRM, a CI service) is created fine and
+    // refuses to run right now — SCHED_E_TASK_NOT_READY. Treating that as "the
+    // account cannot register an autostart" wrote a Startup entry beside the live
+    // task, so every later logon started TWO brokers, both rewriting
+    // launcher.json.
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: ((_file: string, args: readonly string[]) => {
+        if (args[0] === "/Run") throw new Error("The task cannot be run…");
+        return undefined;
+      }) as never,
+      spawnImpl: ((_file: string, args: readonly string[]) => {
+        spawned.push(args);
+        return { unref() {} };
+      }) as never,
+    });
+    // The task IS registered — no duplicate autostart.
+    expect(existsSync(paths.windowsStartup)).toBe(false);
+    // …but this session still needs a broker, since /Run did not give it one.
+    expect(spawned).toEqual([[paths.broker, "run"]]);
+  });
+
+  it("uninstall removes the Startup fallback, not just the task", async () => {
+    const { home, source } = fixture();
+    const paths = await installPanelLauncher({
       home,
       platform: "win32",
       brokerSource: source,
@@ -165,9 +277,9 @@ describe("panel launcher install", () => {
     expect(existsSync(paths.windowsStartup)).toBe(false);
   });
 
-  it("writes a Linux user service and falls back to XDG autostart", () => {
+  it("writes a Linux user service and falls back to XDG autostart", async () => {
     const { home, source } = fixture();
-    const paths = installPanelLauncher({
+    const paths = await installPanelLauncher({
       home,
       platform: "linux",
       nodePath: process.execPath,
@@ -184,7 +296,7 @@ describe("panel launcher install", () => {
 describe("panel launcher broker", () => {
   it("binds loopback and rejects requests without the private bearer token", async () => {
     const { home, source } = fixture();
-    installPanelLauncher({
+    await installPanelLauncher({
       home,
       platform: "win32",
       brokerSource: source,
@@ -210,7 +322,7 @@ describe("panel launcher broker", () => {
 });
 
 describe("native terminal command", () => {
-  it("is fixed and always resolves the latest MCP package", () => {
+  it("is fixed and always resolves the latest MCP package", async () => {
     expect(terminalCommandForPlatform("win32", { ComSpec: "cmd.exe" })).toEqual({
       executable: "cmd.exe",
       args: ["/d", "/k", "npx.cmd -y comfyui-mcp@latest connect"],
@@ -226,7 +338,7 @@ describe("native terminal command", () => {
     });
   });
 
-  it("fails clearly when Linux has no supported graphical terminal", () => {
+  it("fails clearly when Linux has no supported graphical terminal", async () => {
     expect(() => terminalCommandForPlatform("linux", { PATH: "/empty" }, () => false)).toThrow(
       "No supported graphical terminal",
     );
@@ -234,7 +346,7 @@ describe("native terminal command", () => {
 });
 
 describe("launcher paths", () => {
-  it("keeps every mutable launcher artifact under the selected user home", () => {
+  it("keeps every mutable launcher artifact under the selected user home", async () => {
     const { home } = fixture();
     const paths = panelLauncherPaths(home);
     expect(paths.config.startsWith(home)).toBe(true);

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -165,6 +165,165 @@ describe("panel launcher install", () => {
     expect(spawned).toEqual([]);
   });
 
+  it("still finds the live broker on a SECOND install (no pid needed)", async () => {
+    // The previous version of this test hand-wrote `pid: process.pid` into the
+    // config immediately before installing — manufacturing the exact state that
+    // install itself destroys, and so blind by construction to the real bug:
+    // the config write dropped `pid`, the liveness guard required one, and every
+    // install after the first skipped the query and spawned a duplicate broker
+    // beside a live one. Here the config is only ever written by the code under
+    // test (merge-gate P1).
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    const denied = (() => {
+      throw new Error("denied");
+    }) as never;
+    const record = ((_file: string, args: readonly string[]) => {
+      spawned.push(args);
+      return { unref() {} };
+    }) as never;
+
+    await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: denied, spawnImpl: record });
+    const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
+    const server = createServer((req, res) => {
+      const ok = req.headers.authorization === `Bearer ${cfg.token}`;
+      res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: false }));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as { port: number }).port;
+    // Exactly what a live broker publishes: its port and pid, nothing hand-made.
+    writeFileSync(
+      panelLauncherPaths(home).config,
+      JSON.stringify({ ...cfg, port, pid: process.pid }),
+      "utf8",
+    );
+
+    try {
+      spawned.length = 0;
+      await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: denied, spawnImpl: record });
+      expect(spawned, "second install spawned a rival broker").toEqual([]);
+      // …and the install must not have erased the pid for the NEXT one either.
+      expect(readPanelLauncherConfig(home)?.pid).toBe(process.pid);
+      spawned.length = 0;
+      await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: denied, spawnImpl: record });
+      expect(spawned, "third install spawned a rival broker").toEqual([]);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it("the PORT is the evidence — a live broker with no pid recorded still counts", async () => {
+    // The pid is not evidence of anything the query needs: it is the port and
+    // token that get asked. A config carrying a port but no pid — an older
+    // broker, or any write that did not publish one — must not send us spawning
+    // a rival on top of a broker that is plainly answering.
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
+    const server = createServer((req, res) => {
+      const ok = req.headers.authorization === `Bearer ${cfg.token}`;
+      res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: true }));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as { port: number }).port;
+    const { pid: _dropped, ...noPid } = { ...cfg, port } as Record<string, unknown>;
+    writeFileSync(panelLauncherPaths(home).config, JSON.stringify(noPid), "utf8");
+    try {
+      await installPanelLauncher({
+        home,
+        platform: "win32",
+        brokerSource: source,
+        exec: (() => {
+          throw new Error("denied");
+        }) as never,
+        spawnImpl: ((_file: string, args: readonly string[]) => {
+          spawned.push(args);
+          return { unref() {} };
+        }) as never,
+      });
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+    expect(spawned).toEqual([]);
+  });
+
+  it("a stranger on the recycled port is not mistaken for our broker", async () => {
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    const cfg = JSON.parse(readFileSync(panelLauncherPaths(home).config, "utf8"));
+    // 200 + parseable JSON, but not our protocol — ports get recycled and the
+    // next holder may answer anything at all.
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ hello: "some other service" }));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as { port: number }).port;
+    writeFileSync(
+      panelLauncherPaths(home).config,
+      JSON.stringify({ ...cfg, port, pid: process.pid }),
+      "utf8",
+    );
+    try {
+      await installPanelLauncher({
+        home,
+        platform: "win32",
+        brokerSource: source,
+        exec: (() => {
+          throw new Error("denied");
+        }) as never,
+        spawnImpl: ((_file: string, args: readonly string[]) => {
+          spawned.push(args);
+          return { unref() {} };
+        }) as never,
+      });
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+    expect(spawned).toEqual([[panelLauncherPaths(home).broker, "run"]]);
+  });
+
+  it("a /Create failure with the task ALREADY registered adds no second autostart", async () => {
+    // /Create failing does not prove the account cannot register a task: the Task
+    // Scheduler service stopped or set to Manual, RPC unavailable, or a GPO
+    // applied after an earlier successful install all fail while leaving a live
+    // registered task. Writing the Startup entry anyway put it beside that task
+    // and both fired at logon — two brokers racing on launcher.json.
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    const seen: string[] = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: ((_file: string, args: readonly string[]) => {
+        seen.push(String(args[0]));
+        if (args[0] === "/Create") throw new Error("The Task Scheduler service is not available.");
+        return undefined; // /Query succeeds → the task exists
+      }) as never,
+      spawnImpl: ((_file: string, args: readonly string[]) => {
+        spawned.push(args);
+        return { unref() {} };
+      }) as never,
+    });
+    expect(seen).toContain("/Query");
+    expect(existsSync(paths.windowsStartup), "wrote a duplicate autostart").toBe(false);
+  });
+
   it("DOES start one when the pid is alive but nothing answers (recycled pid)", async () => {
     const { home, source } = fixture();
     const spawned: Array<readonly string[]> = [];

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -213,6 +213,35 @@ describe("panel launcher install", () => {
     }
   });
 
+  it("an UNWRITABLE Startup folder still leaves this session with a broker", async () => {
+    // EDR/AppLocker blocking Startup persistence, or Roaming AppData redirected
+    // to an offline share — the same managed accounts whose policy denied the
+    // task in the first place. Unguarded, the write threw before the broker was
+    // started and the session got nothing: #1798's stranding loop moved from the
+    // schtasks line to the Startup line. Losing the autostart is survivable;
+    // losing the broker is the bug this whole path exists to fix.
+    const { home, source } = fixture();
+    const spawned: Array<readonly string[]> = [];
+    // A FILE where the Startup tree needs directories → mkdirSync throws ENOTDIR.
+    const blocked = join(home, "blocked-appdata");
+    writeFileSync(blocked, "not a directory", "utf8");
+    const paths = await installPanelLauncher({
+      home,
+      appData: blocked,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("denied");
+      }) as never,
+      spawnImpl: ((_file: string, args: readonly string[]) => {
+        spawned.push(args);
+        return { unref() {} };
+      }) as never,
+    });
+    expect(existsSync(paths.windowsStartup)).toBe(false);
+    expect(spawned, "install threw before starting a broker").toEqual([[paths.broker, "run"]]);
+  });
+
   it("the PORT is the evidence — a live broker with no pid recorded still counts", async () => {
     // The pid is not evidence of anything the query needs: it is the port and
     // token that get asked. A config carrying a port but no pid — an older

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -392,7 +392,7 @@ async function main() {
     }
     try {
       if (cli.launcherAction === "install") {
-        installPanelLauncher();
+        await installPanelLauncher();
         process.stdout.write(
           `\n${tr("cli.launcher_installed", "✓ ComfyUI MCP panel launcher installed for this user.")}\n` +
             `  ${tr("cli.launcher_installed_note", "MCP itself still starts only when the Agent panel asks for it.")}\n\n`,

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -312,19 +312,40 @@ export async function installPanelLauncher(
             `"${PANEL_LAUNCHER_TASK}" task is already registered — leaving it as the autostart.\n`,
         );
       } else {
-        mkdirSync(dirname(paths.windowsStartup), { recursive: true });
-        writeFileSync(
-          paths.windowsStartup,
-          `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
-          "utf8",
-        );
+        // The Startup write can fail too — EDR/AppLocker blocking Startup
+        // persistence, or a Roaming AppData redirected to an offline share, on
+        // the very same managed accounts whose policy denied the task. Unguarded,
+        // it threw before the broker was started and the session got NOTHING:
+        // #1798's stranding loop relocated from the schtasks line to this one
+        // (merge-gate P1). Losing the autostart is survivable; losing this
+        // session's broker is the bug we are here to fix, so warn and fall
+        // through to it.
+        let autostartPath = "";
+        try {
+          mkdirSync(dirname(paths.windowsStartup), { recursive: true });
+          writeFileSync(
+            paths.windowsStartup,
+            `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
+            "utf8",
+          );
+          autostartPath = paths.windowsStartup;
+        } catch (startupErr) {
+          process.stderr?.write?.(
+            `[comfyui-mcp] could not write the Startup autostart ` +
+              `(${startupErr instanceof Error ? startupErr.message : String(startupErr)}); ` +
+              `MCP will run for this session but will NOT start at the next logon. ` +
+              `Start it by hand with: ${paths.windowsScript}\n`,
+          );
+        }
         // Not silent: the user asked for a launcher and got a different mechanism
         // than the one this tool normally installs, which changes how they would
         // later remove or debug it.
-        process.stderr?.write?.(
-          `[comfyui-mcp] scheduled task refused (${schtasksReason(err)}); ` +
-            `registered a Startup-folder autostart instead: ${paths.windowsStartup}\n`,
-        );
+        if (autostartPath) {
+          process.stderr?.write?.(
+            `[comfyui-mcp] scheduled task refused (${schtasksReason(err)}); ` +
+              `registered a Startup-folder autostart instead: ${autostartPath}\n`,
+          );
+        }
       }
     }
     if (taskRegistered) {

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -51,7 +51,10 @@ export type LauncherPaths = {
   linuxAutostart: string;
 };
 
-export function panelLauncherPaths(home: string = homedir()): LauncherPaths {
+export function panelLauncherPaths(
+  home: string = homedir(),
+  appData: string = roamingAppData({}),
+): LauncherPaths {
   const root = join(home, ".comfyui-mcp");
   const launcherDir = join(root, "launcher");
   return {
@@ -61,9 +64,7 @@ export function panelLauncherPaths(home: string = homedir()): LauncherPaths {
     broker: join(launcherDir, "broker.mjs"),
     windowsScript: join(launcherDir, "start-launcher.cmd"),
     windowsStartup: join(
-      home,
-      "AppData",
-      "Roaming",
+      appData,
       "Microsoft",
       "Windows",
       "Start Menu",
@@ -145,16 +146,41 @@ export type InstallLauncherOptions = {
   /** Injected for the tests, so a fallback case can assert the broker was
    *  started without actually starting one. */
   spawnImpl?: typeof spawn;
+  /**
+   * Roaming AppData root. Defaults to `%APPDATA%` in production and to a path
+   * under `home` whenever the caller overrode `home` (tests, and any call that
+   * is deliberately not talking about the real profile).
+   *
+   * NOT derived from `home` unconditionally: Group Policy "Redirect the Roaming
+   * AppData folder" points `%APPDATA%` at a share while `USERPROFILE` stays
+   * local, so `<home>/AppData/Roaming` is then a directory Explorer never scans.
+   * `mkdirSync(…, {recursive:true})` would happily manufacture it and the
+   * install would report success for an autostart that can never fire — on
+   * precisely the managed domain accounts whose policy denies `schtasks` in the
+   * first place, i.e. the whole population this fallback exists for.
+   */
+  appData?: string;
 };
 
-export function installPanelLauncher(options: InstallLauncherOptions = {}): LauncherPaths {
+/** Roaming AppData for a call: explicit wins, then an overridden home, then the
+ *  real `%APPDATA%`, then the conventional layout. */
+function roamingAppData(opts: { home?: string; appData?: string }): string {
+  if (opts.appData) return opts.appData;
+  if (opts.home) return join(opts.home, "AppData", "Roaming");
+  const env = process.env.APPDATA?.trim();
+  return env || join(homedir(), "AppData", "Roaming");
+}
+
+export async function installPanelLauncher(
+  options: InstallLauncherOptions = {},
+): Promise<LauncherPaths> {
   const home = options.home ?? homedir();
   const platform = options.platform ?? process.platform;
   const nodePath = options.nodePath ?? process.execPath;
   const source = options.brokerSource ?? fileURLToPath(import.meta.url);
   const run = options.exec ?? execFileSync;
   const spawnBroker = options.spawnImpl ?? spawn;
-  const paths = panelLauncherPaths(home);
+  const paths = panelLauncherPaths(home, roamingAppData(options));
   mkdirSync(paths.launcherDir, { recursive: true });
   copyFileSync(source, paths.broker);
 
@@ -168,14 +194,18 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
    * nothing to talk to until the next logon. Shared by the Windows and Linux
    * fallbacks rather than duplicated — they answer the identical question.
    */
-  const startBrokerIfIdle = (): void => {
-    if (previous?.pid) {
-      try {
-        process.kill(previous.pid, 0);
-        return; // still running — a second broker would fight it for the port
-      } catch {
-        // Dead pid: fall through and start a replacement.
-      }
+  const startBrokerIfIdle = async (): Promise<void> => {
+    // POSITIVE EVIDENCE, not a pid. `process.kill(pid, 0)` only proves SOME
+    // process holds that number, and Windows recycles pids aggressively across a
+    // reboot — so an unrelated process wearing our old pid made this skip the
+    // spawn, leaving a dead port in the config and the panel telling the user to
+    // re-run the install they had just run: the #1798 loop, re-entered through
+    // its own fix. `queryPanelLauncher` asks the recorded port, with the recorded
+    // token, whether a broker is actually answering. Anything short of a live
+    // answer means start one (merge-gate P1).
+    if (previous?.pid && previous.port) {
+      const live = (await queryPanelLauncher(home)) as { running?: boolean };
+      if (live.running) return; // a real broker answered — leave it alone
     }
     const child = spawnBroker(nodePath, [paths.broker, "run"], {
       detached: true,
@@ -213,6 +243,16 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
     // and start the broker directly. The Startup folder is user-writable and
     // needs no elevation, which is exactly the constraint the scheduled task
     // could not satisfy.
+    // /Create and /Run get SEPARATE try blocks, because they fail for different
+    // reasons and only one of them means "this account cannot register an
+    // autostart". A created task whose /Run is refused right now — an /IT task
+    // invoked over a non-interactive session (OpenSSH, WinRM, a CI service),
+    // SCHED_E_TASK_NOT_READY — is REGISTERED and will fire at the next logon.
+    // Treating that as a refusal wrote a Startup entry beside the live task, so
+    // every later logon started two brokers, both rewriting launcher.json
+    // (merge-gate P1). It also printed "scheduled task refused" about a task
+    // that plainly exists.
+    let taskRegistered = false;
     try {
       run(
         "schtasks.exe",
@@ -235,7 +275,7 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
         // bad argument, or a denial, which is the one that actually happens.
         { stdio: ["ignore", "ignore", "pipe"] },
       );
-      run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+      taskRegistered = true;
     } catch (err) {
       mkdirSync(dirname(paths.windowsStartup), { recursive: true });
       writeFileSync(
@@ -243,7 +283,6 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
         `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
         "utf8",
       );
-      startBrokerIfIdle();
       // Not silent: the user asked for a launcher and got a different mechanism
       // than the one this tool normally installs, which changes how they would
       // later remove or debug it.
@@ -252,6 +291,17 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
           `registered a Startup-folder autostart instead: ${paths.windowsStartup}\n`,
       );
     }
+    if (taskRegistered) {
+      try {
+        run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+        return paths; // the task is registered AND running it worked
+      } catch {
+        // Registered but not startable right now (non-interactive session). The
+        // autostart is in place for the next logon, so do NOT add a second one —
+        // just get a broker up for THIS session.
+      }
+    }
+    await startBrokerIfIdle();
     return paths;
   }
 
@@ -300,18 +350,23 @@ export function installPanelLauncher(options: InstallLauncherOptions = {}): Laun
         `Exec="${nodePath}" "${paths.broker}" run\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
-    startBrokerIfIdle();
+    await startBrokerIfIdle();
   }
   return paths;
 }
 
-export type UninstallLauncherOptions = Pick<InstallLauncherOptions, "home" | "platform" | "exec">;
+export type UninstallLauncherOptions = Pick<
+  InstallLauncherOptions,
+  "home" | "platform" | "exec" | "appData"
+>;
 
 export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): void {
   const home = options.home ?? homedir();
   const platform = options.platform ?? process.platform;
   const run = options.exec ?? execFileSync;
-  const paths = panelLauncherPaths(home);
+  // Same resolution as install, or uninstall deletes a path the install never
+  // wrote and leaves the real autostart in place.
+  const paths = panelLauncherPaths(home, roamingAppData(options));
   if (platform === "win32") {
     try {
       run("schtasks.exe", ["/End", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -203,7 +203,11 @@ export async function installPanelLauncher(
     // its own fix. `queryPanelLauncher` asks the recorded port, with the recorded
     // token, whether a broker is actually answering. Anything short of a live
     // answer means start one (merge-gate P1).
-    if (previous?.pid && previous.port) {
+    // Keyed on the PORT alone. Gating on a pid as well meant the query never ran
+    // on a second install — this function's own config write used to drop the
+    // pid — so a duplicate broker was spawned beside a live one (merge-gate P1).
+    // The port is what the query actually uses; the pid was never evidence.
+    if (previous?.port) {
       const live = (await queryPanelLauncher(home)) as { running?: boolean };
       if (live.running) return; // a real broker answered — leave it alone
     }
@@ -219,6 +223,12 @@ export async function installPanelLauncher(
       host: "127.0.0.1",
       port: previous?.port ?? 0,
       token: previous?.token ?? randomBytes(32).toString("base64url"),
+      // The running broker's pid is the broker's to publish, not this install's
+      // to erase. Dropping it made the config say "no broker has ever run here"
+      // to every subsequent install (merge-gate P1) — the port and token were
+      // carried over but the pid was not, which is an incoherent record of the
+      // same broker.
+      ...(previous?.pid ? { pid: previous.pid } : {}),
       updated_at: new Date().toISOString(),
     },
     home,
@@ -277,19 +287,45 @@ export async function installPanelLauncher(
       );
       taskRegistered = true;
     } catch (err) {
-      mkdirSync(dirname(paths.windowsStartup), { recursive: true });
-      writeFileSync(
-        paths.windowsStartup,
-        `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
-        "utf8",
-      );
-      // Not silent: the user asked for a launcher and got a different mechanism
-      // than the one this tool normally installs, which changes how they would
-      // later remove or debug it.
-      process.stderr?.write?.(
-        `[comfyui-mcp] scheduled task refused (${schtasksReason(err)}); ` +
-          `registered a Startup-folder autostart instead: ${paths.windowsStartup}\n`,
-      );
+      // A /Create failure does NOT prove this account can never register an
+      // autostart — only that THIS call failed. The Task Scheduler service being
+      // stopped or set to Manual, RPC being unavailable, or a GPO applied after
+      // an earlier successful install all fail here while leaving a registered
+      // task intact. Writing the Startup entry anyway put it beside that task, so
+      // both fired at the next logon and two brokers raced on launcher.json —
+      // the same collapse the /Run branch was split out to avoid, left open on
+      // this branch (merge-gate P1). So ASK whether the task exists.
+      let alreadyRegistered = false;
+      try {
+        run("schtasks.exe", ["/Query", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+        alreadyRegistered = true;
+      } catch {
+        // No such task (or we cannot even query) → the fallback is warranted.
+      }
+      if (alreadyRegistered) {
+        // It IS registered — that task is the autostart. This session may still
+        // need a broker, which the /Run attempt below (and then
+        // startBrokerIfIdle) provides.
+        taskRegistered = true;
+        process.stderr?.write?.(
+          `[comfyui-mcp] schtasks /Create failed (${schtasksReason(err)}), but the ` +
+            `"${PANEL_LAUNCHER_TASK}" task is already registered — leaving it as the autostart.\n`,
+        );
+      } else {
+        mkdirSync(dirname(paths.windowsStartup), { recursive: true });
+        writeFileSync(
+          paths.windowsStartup,
+          `@echo off\r\nstart "" /min "${paths.windowsScript}"\r\n`,
+          "utf8",
+        );
+        // Not silent: the user asked for a launcher and got a different mechanism
+        // than the one this tool normally installs, which changes how they would
+        // later remove or debug it.
+        process.stderr?.write?.(
+          `[comfyui-mcp] scheduled task refused (${schtasksReason(err)}); ` +
+            `registered a Startup-folder autostart instead: ${paths.windowsStartup}\n`,
+        );
+      }
     }
     if (taskRegistered) {
       try {
@@ -673,7 +709,17 @@ export async function queryPanelLauncher(home: string = homedir()): Promise<Reco
         res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
         res.on("end", () => {
           try {
-            resolve({ installed: true, running: res.statusCode === 200, ...JSON.parse(Buffer.concat(chunks).toString("utf8")) });
+            const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+              string,
+              unknown
+            >;
+            // 200 + parseable JSON is not proof it is OUR broker: ports get
+            // recycled, and whoever holds this one next may answer anything.
+            // The body already carries the protocol — check it, or the recycled-
+            // port case this liveness probe exists to kill walks straight back in
+            // (merge-gate). Computed AFTER the spread so the body cannot set it.
+            const running = res.statusCode === 200 && body.protocol === PANEL_LAUNCHER_PROTOCOL;
+            resolve({ installed: true, ...body, running });
           } catch {
             resolve({ ok: false, installed: true, running: false, error: "invalid_response" });
           }


### PR DESCRIPTION
Follow-up to #1799, which merged the fallback before the merge gate had finished with it. The
fallback itself is right; these are the five P1s the gate found in it, across two rounds. Every one
of them is the same shape as the bug #1798 reported — a check that cannot tell apart the case it
cares about — and every one of them could strand or double-serve a user on exactly the managed
Windows machines this fallback exists for.

### Round 1

**One catch for two commands.** `/Create` and `/Run` fail for different reasons, and only `/Create`
failing means "this account cannot register an autostart". An `/IT` task invoked over a
non-interactive session (OpenSSH, WinRM, a CI service) is created fine and refuses to run *right
now* — `SCHED_E_TASK_NOT_READY`. Wrapping both meant that task also got a Startup entry, so every
later logon started **two brokers**, each rewriting `launcher.json`. Separate try blocks now; a
`/Run` failure keeps the registered task and just gets this session a broker.

**A manufactured Startup folder.** `windowsStartup` was built from `homedir()` and ignored
`%APPDATA%`. Group Policy *Redirect the Roaming AppData folder* points `%APPDATA%` at a share while
`USERPROFILE` stays local — i.e. exactly the managed domain accounts whose policy denies `schtasks`
in the first place. `mkdirSync(recursive)` cheerfully created a directory Explorer never scans, the
install reported success, and nothing started at the next logon.

**A pid is not a broker.** `process.kill(pid, 0)` only proves *some* process holds that number, and
Windows recycles pids aggressively across a reboot. With an unrelated process wearing the recorded
pid, the fallback spawned nothing and left a dead port in the config — the panel then reports the
launcher as not running and sends the user back to the install they just ran, which is #1798's loop
re-entered through its own fix. It now asks the recorded port, with the recorded token, whether a
broker actually answers.

### Round 2 — introduced by round 1

**A pid this function itself erased.** The new liveness guard required `previous.pid`, but the
install's own config write did not carry `pid` forward. So the query ran only on the very first
install after a broker recorded one, and every later install spawned a duplicate broker beside a
live one. The pid is preserved now, and the guard keys on the **port** — which is what the query
uses. *The covering test hand-wrote `pid: process.pid` immediately before installing — the exact
state production destroys — so it was blind by construction and 13/13 green proved nothing.* It now
installs twice and three times with the config written only by the code under test.

**A `/Create` failure is not "this account cannot register a task".** Task Scheduler stopped or set
to Manual, RPC unavailable, or a GPO applied after an earlier successful install all fail `/Create`
while leaving a live registered task. The catch wrote the Startup entry regardless, so it sat beside
that task and both fired at logon. It now runs `schtasks /Query` first and keeps the existing task.

Also: `queryPanelLauncher` treated any 200 with parseable JSON as our broker, which re-admits the
recycled-port case the probe exists to kill. The body already carries `protocol` — it is checked,
and computed *after* the spread so a response cannot set its own verdict.

### Verification

Nine mutations, each red: drop the fallback, don't start the broker, swallow schtasks stderr,
uninstall leaves the fallback, spawn when a broker is alive, one catch for both commands,
home-derived Startup path, bare-pid check, drop the pid from the config write, re-require a pid
before querying, write Startup when the task exists, remove the protocol check.

Live against the real `schtasks.exe` on the affected machine (throwaway `home`, stubbed spawn):
the denial still produces a Startup entry plus a broker start, and uninstall removes it.

Suite: 571 files / 10,479 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Round 3 — one more, landed before merge (title says five; it was six)

A third gate round ran after this description was written, and its finding was fixed on this branch
before merge, so the merged commit contains **six** P1 fixes while its title and the section above
say five. Recorded here rather than left to be discovered:

**A failing Startup write cost the session its broker.** The fallback's `mkdirSync`/`writeFileSync`
to the Startup folder was unguarded, so when that write failed the install threw *before*
`startBrokerIfIdle()` and the session got nothing at all — #1798's stranding loop relocated from the
schtasks line to the Startup line, on the same population (EDR/AppLocker blocking Startup
persistence, or Roaming AppData redirected to an offline share). The write is now wrapped, says so,
prints the manual command, and falls through to the broker start.

Verify on `main`: `git show origin/main:src/services/panel-launcher.ts | grep "could not write the
Startup autostart"`.

Provenance note: the gate flagged this line as inherited from #1799 rather than introduced by this
branch's own fixes — so of the six, three were in the original merge, two were introduced by the
fixes for those three, and one was pre-existing and caught while reviewing them.
