### PR TITLE
feat(1167): MiniMax H3 local-video skill citing official prompting guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,6 +768,15 @@ All notable changes to this project are documented here. This project adheres to
   the free local-weights nodes from the paid Hailuo API nodes. Enhancement — do not
   merge until another agent reviews.
 
+### Fixed
+
+- **MiniMax H3 skill load path (#1167 / #1801).** `plugin/skills/minimax-h3-video/SKILL.md`
+  no longer tells the agent to `panel_load_workflow` / `run_template` a Template
+  Library basename. Core `video_minimax_h3_*` graphs open from the frontend
+  Template Library, or from Comfy-Org/workflow_templates via `save_workflow` then
+  `panel_load_workflow path:`. `run_template` is named only as "won't work until
+  a pack exists."
+
 ## [0.52.13] - 2026-08-19
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,13 +759,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Added
+
+- **`minimax-h3-video` plugin skill (#1167).** Local MiniMax H3 (Hailuo) T2V/I2V/R2V
+  in ComfyUI — Comfy-Org INT8 pack, turbo LoRAs, 15 s stereo clips — with a
+  `#1155` `## Sources` block that **links** MiniMax's official prompting guides
+  rather than copying them (Community License includes Documentation). Distinguishes
+  the free local-weights nodes from the paid Hailuo API nodes. Enhancement — do not
+  merge until another agent reviews.
+
 ## [0.52.13] - 2026-08-19
 
 ### MCP
 
 #### Fixed
 - five ways the launcher fallback could strand or double-serve a user (#1800)
-
 
 ## [0.52.11] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**37 MCP tools** | **40 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **56 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**37 MCP tools** | **41 AI skills** (Flux · WAN · LTX 2.3 video · MiniMax H3 · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **56 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -136,7 +136,7 @@ This package also ships as a **Claude Code plugin**, providing slash commands, s
 
 ### Built-in skills
 
-40 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, the **launch/performance-flags** matrix, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
+41 skills total — model-family guides (Flux, WAN, LTX 2.3, MiniMax H3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, the **launch/performance-flags** matrix, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
 
 > **Installer packs.** [`packs/`](packs/) bundles 13 one-command ComfyUI setups — ANIMA, Ideogram 4, LTX-2.3, ERNIE, WAN (animate / longer-videos / transparent), Qwen (image / image-edit), Z-Image (turbo / base / xy-plot) and artokun-flow (WAN Animate — replace / animate). Each is a manifest of custom nodes + model URLs + workflow that drives both `apply_manifest` and generated `install-windows.bat` / `install-runpod.sh`, with CI that validates every model link + payload size. See [`packs/README.md`](packs/README.md).
 

--- a/docs/local-vs-comfy-cloud.mdx
+++ b/docs/local-vs-comfy-cloud.mdx
@@ -44,7 +44,7 @@ ElevenLabs without owning a GPU.
 ## What this project offers
 
 `comfyui-mcp` is an MCP server plus a sidebar agent that drives **your** ComfyUI
-install — local, LAN, VPS, or RunPod. 37 MCP tools, 40 model-specific skills,
+install — local, LAN, VPS, or RunPod. 37 MCP tools, 41 model-specific skills,
 and a panel agent that edits your live graph in natural language.
 
 The structural difference is **where the reasoning comes from**. This project is

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 40 AI skills, 11 slash commands, 4 autonomous agents, and 3 hooks on top of the 37 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 41 AI skills, 11 slash commands, 4 autonomous agents, and 3 hooks on top of the 37 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 40 AI skills — and growing
+## 41 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,
@@ -27,6 +27,7 @@ and failure-mode guidance:
 | `wan-t2v-video` / `wan-flf-video` | WAN 2.x text-to-video and first-last-frame workflows |
 | `wan-scail-replacement` | SCAIL-2 in-video character replacement — reference-framing→scale rule, tuning and compositing pitfalls |
 | `ltxv2-video` | LTX-2.3 (and LTX-2 19B) — GGUF UNet, distilled model, camera-control LoRAs, two-stage upscaling, kornia fix |
+| `minimax-h3-video` | MiniMax H3 (Hailuo) local T2V/I2V/R2V — Comfy-Org INT8, turbo LoRAs, 15 s stereo clips; cites MiniMax's official prompting guides |
 | `qwen-txt2img` / `qwen-image-edit` | Qwen-Image generation and instruction-based editing |
 | `z-image-txt2img` | Z-Image Turbo workflows |
 | `ideogram-ultra` | Ideogram 4 — open-weight text-to-image, area prompting, logos / posters / readable text |

--- a/plugin/skills/minimax-h3-video/SKILL.md
+++ b/plugin/skills/minimax-h3-video/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: minimax-h3-video
+description: Build MiniMax H3 (Hailuo) local video workflows — native T2V/I2V/R2V nodes, Comfy-Org INT8 weights, turbo LoRAs for 8GB VRAM, 15-second stereo-audio clips, and the official MiniMax prompting guides (cite by link, do not copy).
+globs:
+  - "**/*.json"
+---
+
+# MiniMax H3 (Hailuo) — local video
+
+This skill teaches the **local-weights** MiniMax H3 path in ComfyUI. It is the
+pilot for `#1155` (Official vs Empirical sources) because MiniMax publishes a
+real prompting guide. **Cite that guide by URL. Do not copy it into this repo.**
+
+## Two products, two cost models — pick one
+
+They share a brand and **must not be mixed**.
+
+| Path | Nodes | Cost | VRAM | When |
+|---|---|---|---|---|
+| **Local weights** (this skill) | `MiniMaxH3ImageToVideo`, `MiniMaxH3ReferenceToVideo`, `EmptyMiniMaxH3LatentAV`, `MiniMaxH3SigmaShift`, `MiniMaxH3MemoryEfficientSageAttentionPatch` | Free after download | Yes — INT8 + turbo LoRA is the 8 GB story | User wants 4–15 s stereo clips on their GPU |
+| **Partner API** | `MinimaxHailuo03TextToVideoNode`, `MinimaxHailuo03FirstLastFrameNode`, `MinimaxHailuo03ReferenceNode`, `MinimaxTextToVideoNode`, `MinimaxImageToVideoNode`, `MinimaxHailuoVideoNode` | Paid per generation | None | User has a MiniMax / Hailuo API key and does not want local weights |
+
+API nodes do not take `MiniMaxH3SigmaShift` or Sage-attention patches. Local
+nodes do not spend API credits. If the user asked for Hailuo *cloud*, stop and
+use the API nodes + their key; do not download 40 GB of weights.
+
+`MiniMaxH3Director` is a **third-party** pack (`muse-collective-26/MiniMaxH3-Director`),
+not core. Do not require it for T2V / I2V / R2V.
+
+## License — cite, do not copy
+
+Local weights and MiniMax's own documentation sit under the
+[MiniMax H3 Community License](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE).
+`Materials` includes the Documentation. The agreement's Applicable Territory
+**excludes the United States, the EU, the UK, and South Korea**. This skill
+does **not** reproduce MiniMax's `skills/h3-prompt-writing/` SKILL.md or the
+prompting-guide prose. Linking to a public URL is the `#1155` requirement.
+
+This is not legal advice. Tell a US/EU/UK/KR user that the *local* path is
+territory-restricted and that the **paid API** is a separate product under
+MiniMax platform terms.
+
+## Prefer the Comfy-Org template over hand-wiring
+
+ComfyUI ≥ **0.30.0** (templates in the 0.33 line). Template Library → Video:
+
+| Mode | Template | Diffusion file |
+|---|---|---|
+| T2V / I2V / FL2VA | `video_minimax_h3_t2v.json` / `video_minimax_h3_i2v.json` | `minimax_h3_fl2va_pruned_int8_convrot.safetensors` |
+| R2V (omni-reference) | `video_minimax_h3_r2v.json` | `minimax_h3_ref2va_pruned_int8_convrot.safetensors` |
+
+Load with `panel_load_workflow` or `enqueue_workflow` `action:"run_template"`.
+Then retarget widgets. Hand-building the subgraph is slower and easy to get wrong.
+
+Comfy tutorial (wiring, not MiniMax's prompt formula):
+https://docs.comfy.org/tutorials/video/minimax/minimax-h3
+
+## Models (Comfy-Org INT8 pack)
+
+All from `huggingface.co/Comfy-Org/MiniMax-H3`. Download with
+`download_model` `action:"download"`.
+
+| File | Folder | Role |
+|---|---|---|
+| `minimax_h3_fl2va_pruned_int8_convrot.safetensors` | `diffusion_models/` | T2V / I2V / first-last-frame |
+| `minimax_h3_ref2va_pruned_int8_convrot.safetensors` | `diffusion_models/` | R2V only — **different UNet** |
+| `qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` | `text_encoders/` | Qwen3-VL-32B encoder, `CLIPLoader` **type=`minimax`** |
+| `minimax_h3_video_vae_fp16.safetensors` | `vae/` | Visual VAE |
+| `minimax_h3_audio_vae_fp32.safetensors` | `vae/` | Stereo audio VAE (32 kHz) |
+
+### Turbo LoRAs (4–8 steps instead of ~20)
+
+The Comfy-Org T2V template already switches these on with `turbo_mode`:
+
+| Steps | File | Source |
+|---|---|---|
+| 8 | `minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors` | `lightx2v/Minimax-h3-Turbo` |
+| 4 | `minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors` | `Comfy-Org/MiniMax-H3` `loras/` |
+
+Kijai conversions live at `Kijai/MiniMax-H3_comfy` (`loras/`) and experimental
+W4A8 at `Kijai/MiniMax-H3-experimental`. Same job (low-step / low-VRAM). Prefer
+the Comfy-Org / lightx2v filenames the template already names; only switch to a
+Kijai file if that is what is on disk.
+
+4-step is faster and softer; **6–8 steps** is the usual sharpness compromise.
+
+## Output spec
+
+| Knob | Value |
+|---|---|
+| Duration | 4–15 seconds |
+| Frame rate | **24 fps** (`CreateVideo.fps`) |
+| Audio | Native stereo, decoded by the audio VAE, muxed in `CreateVideo` |
+| Short edge | 768 px native; cap **768×1344**, multiple of **32** |
+| Preview size | `ResolutionSelector` megapixels **0.4** → 864×480 at 16:9 |
+| Full 768p | megapixels **~0.98** → **1344×768** at 16:9 |
+
+Duration → frame `length` (Comfy-Org template math, 17-frame blocks):
+
+```
+max(5, round(seconds * 24)) + (5 - (max(5, round(seconds * 24)) % 17)) % 17
+```
+
+That is the `17k+5` grid. Do not invent a WAN-style `4n+1` length.
+
+## Node graph (local T2V / I2V)
+
+From the Comfy-Org T2V subgraph (core nodes, not the Markdown notes):
+
+```
+ResolutionSelector (aspect, megapixels, multiple=32) → width, height
+
+UNETLoader (fl2va int8)
+  ├─ LoraLoaderModelOnly (turbo LoRA) ─┐
+  └────────────────────────────────────┤ ComfySwitchNode (turbo_mode)
+                                       ▼
+                         BasicGuider + BasicScheduler + KSamplerSelect(res_multistep)
+                                       ▼
+CLIPLoader (type=minimax, qwen3vl 32b) → MiniMaxH3ImageToVideo
+VAELoader (video vae) ─────────────────→   prompt, width, height, length
+optional first_frame / last_frame ─────→   → CONDITIONING + LATENT
+                                       ▼
+                         SamplerCustomAdvanced → LATENT
+                                       ├─ VAEDecode (video vae) → IMAGE
+                                       └─ VAEDecodeAudio (audio vae) → AUDIO
+                                       ▼
+                         CreateVideo (fps=24) → SaveVideo
+```
+
+`MiniMaxH3ImageToVideo` **is** T2V when both image sockets are empty, I2V with
+`first_frame`, FL2VA with both frames. Do not add a second T2V-only node.
+
+R2V replaces the UNet with **ref2va** and the conditioner with
+`MiniMaxH3ReferenceToVideo`. Do not load fl2va into an R2V graph.
+
+### Local-only helpers
+
+| Node | Role |
+|---|---|
+| `EmptyMiniMaxH3LatentAV` | Empty audio-video latent when you are not using `MiniMaxH3ImageToVideo`'s built-in latent |
+| `MiniMaxH3SigmaShift` | Flow-matching shift on the local UNet |
+| `MiniMaxH3MemoryEfficientSageAttentionPatch` | Core Sage patch; or KJNodes `Patch Sage Attention KJ` (`sage_attention=auto`) between `UNETLoader` and `BasicGuider` |
+
+Sage roughly doubles speed. H3 has mixed dtypes — console lines about falling
+back to pytorch attention on some layers are expected.
+
+## Sampler defaults (Comfy-Org template)
+
+| Mode | Sampler | Scheduler | Steps |
+|---|---|---|---|
+| Base (no turbo) | `res_multistep` | `simple` | **20** |
+| Turbo on | `res_multistep` | `simple` | **4–8** (template default turbo steps widget) |
+
+Guider is `BasicGuider` (CFG-distilled checkpoint — do not crank CFG). Seed via
+`RandomNoise`.
+
+## Prompting — read the vendor guide, do not paste it here
+
+Write the prompt **in the MiniMax H3 node**, not a generic `CLIPTextEncode`.
+
+**Official MiniMax guides** (read these; do not copy them into graphs as a
+system prompt dump):
+
+- T2VA / I2VA / FL2VA / L2VA:
+  https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md
+- Full-reference / R2V:
+  https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md
+- Vendor skill (install separately if the user wants it — we do not bundle it):
+  https://github.com/MiniMax-AI/MiniMax-H3 (`npx skills add … --skill h3-prompt-writing`)
+
+H3-Context-IR (the hosted prompt rewriter) is **not** in the open weights.
+Local ComfyUI has no IR node. Either write the structured prompt yourself from
+the guide, or call MiniMax's Context-IR API and paste `content.prompt` into the
+local node.
+
+Comfy-Org's own template notes (safe to follow, not MiniMax docs):
+
+1. One block covering **look, scene, timed shots, camera, and audio** (dialogue,
+   SFX, score).
+2. Time shots (`[0s-1.5s] Shot 1: …`).
+3. R2V: name each input in connection order (`<Picture 1>`, `<Video 1>`,
+   `<Audio 1>`) and say what job each one does (identity, motion, voice).
+4. R2V caps (vendor model card, not a guess): ≤9 images, ≤3 videos, ≤3 audio
+   clips, ≤12 files mixed; each AV clip 2–15 s.
+
+## 15-second clips and chaining
+
+One H3 shot is **at most ~15 s**. Longer pieces are concatenated clips, not a
+bigger `length`.
+
+1. Generate clip N (up to 15 s).
+2. Confirm the file with `get_image` `action:"list_outputs"` (`kind:"video"`) —
+   video nodes often skip `/history`.
+3. Stage the last frame (or the whole clip) with `upload_image` `action:"stage"`.
+4. Clip N+1: `MiniMaxH3ImageToVideo.first_frame` = last frame of N, **or** R2V
+   with `<Video 1>` as a continuation reference.
+5. Concat with ffmpeg (`director` skill) or an editor.
+
+This is **not** WAN Pusa (`video-extend`). Pusa LoRAs and `flowmatch_pusa` do
+not apply to H3.
+
+## VRAM
+
+| Card | Practical setup |
+|---|---|
+| **24 GB+** | INT8 fl2va + Qwen3-VL + both VAEs; 1344×768; 10–15 s; Sage optional |
+| **12–16 GB** | Same INT8 pack; drop megapixels toward 0.4–0.6; turbo LoRA on; Sage |
+| **8 GB** | INT8 + turbo LoRA + Sage + short preview (0.2–0.4 MP, 4–6 s). Minutes per clip. Kijai W4A8 if INT8 still OOMs. |
+
+Always `clear_vram` before switching to H3 from WAN / LTX / a checkpoint.
+
+## Gotchas
+
+- **`CLIPLoader` type must be `minimax`.** `qwen_image` / `flux` will load the
+  wrong encoder layout.
+- **fl2va vs ref2va.** T2V/I2V templates on ref2va (or R2V on fl2va) are garbage
+  or a load error.
+- **Turbo off, 4 steps.** The switch defaults off and base steps are 20. Four
+  steps without the LoRA is mush.
+- **API node in a local graph.** Costs money and ignores the UNet you downloaded.
+- **WAN frame math.** H3 is 24 fps and `17k+5`, not 16 fps `4n+1`.
+- **Verify video on disk**, then stage — never guess `input/` paths.
+- **ffmpeg** is required for `CreateVideo` / `SaveVideo` / `VHS_VideoCombine`.
+- Desktop/Cloud ComfyUI lags nightly. Missing `MiniMaxH3*` nodes → update to
+  ≥0.30.0 (0.33 templates) before hunting custom packs.
+
+## See also
+
+- `video-extend` — WAN Pusa temporal continuation (different family)
+- `director` — multi-clip concat after you have 15 s H3 shots
+- `prompt-engineering` — generic CLIP syntax; **H3 does not use it**
+- `triton-sageattention` — installing Sage on Windows
+
+No bundled `packs/minimax-h3-*` installer yet. Use the Comfy-Org templates +
+`download_model` against `Comfy-Org/MiniMax-H3`.
+
+## Sources
+
+- **Official:** MiniMax prompting guides https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md (T2VA/I2VA/FL2VA/L2VA) and https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md (full-reference / R2V); vendor repo https://github.com/MiniMax-AI/MiniMax-H3; ComfyUI tutorial + templates https://docs.comfy.org/tutorials/video/minimax/minimax-h3 (wiring, duration grid, INT8 filenames). MiniMax's own `skills/h3-prompt-writing` is linked, not copied — Community License includes Documentation.
+- **Empirical:** local vs partner-API node split and 8 GB turbo-LoRA note from issue #1167 / the reporter's rig; Sage mixed-dtype fallback from the Comfy tutorial; chaining last-frame→next-clip from observed ComfyUI I/O (stage + list_outputs), not a vendor extender.

--- a/plugin/skills/minimax-h3-video/SKILL.md
+++ b/plugin/skills/minimax-h3-video/SKILL.md
@@ -42,15 +42,42 @@ MiniMax platform terms.
 
 ## Prefer the Comfy-Org template over hand-wiring
 
-ComfyUI ≥ **0.30.0** (templates in the 0.33 line). Template Library → Video:
+ComfyUI ≥ **0.30.0** (templates in the 0.33 line). These are **core**
+`comfyui-workflow-templates` graphs in the frontend **Template Library →
+Video**, not installer packs and not custom-node `example_workflows`:
 
-| Mode | Template | Diffusion file |
-|---|---|---|
-| T2V / I2V / FL2VA | `video_minimax_h3_t2v.json` / `video_minimax_h3_i2v.json` | `minimax_h3_fl2va_pruned_int8_convrot.safetensors` |
-| R2V (omni-reference) | `video_minimax_h3_r2v.json` | `minimax_h3_ref2va_pruned_int8_convrot.safetensors` |
+| Mode | Template Library card | File | Diffusion file |
+|---|---|---|---|
+| T2V / I2V / FL2VA | MiniMax H3: Text to Video / Image to Video | `video_minimax_h3_t2v.json` / `video_minimax_h3_i2v.json` | `minimax_h3_fl2va_pruned_int8_convrot.safetensors` |
+| R2V (omni-reference) | MiniMax H3: Reference to Video | `video_minimax_h3_r2v.json` | `minimax_h3_ref2va_pruned_int8_convrot.safetensors` |
 
-Load with `panel_load_workflow` or `enqueue_workflow` `action:"run_template"`.
-Then retarget widgets. Hand-building the subgraph is slower and easy to get wrong.
+`list_packs action:"list_templates"` will **not** list them.
+`enqueue_workflow action:"run_template"` will **not** resolve
+`video_minimax_h3_t2v` / `_i2v` / `_r2v` — that action only loads bundled
+installer packs, and there is no `packs/minimax-h3-*` yet. Do not call it
+until a pack exists. `panel_load_workflow` needs `pack:`, a disk `path:`, or
+an inline UI `graph` — a Template Library basename is none of those.
+
+**Load path that actually works:**
+
+1. **Preferred.** Ask the user to open **Template Library → Video → MiniMax H3:
+   Text to Video** (or Image to Video / Reference to Video). Pick the local
+   `video_minimax_h3_*` cards, **not** the `api_minimax_h3_*` paid partner
+   templates.
+2. **Agent, no UI click.** Fetch the UI JSON from
+   https://github.com/Comfy-Org/workflow_templates/blob/main/templates/video_minimax_h3_t2v.json
+   (or `_i2v` / `_r2v`; raw.githubusercontent.com is the same files), save it
+   with `save_workflow action:"save"` `filename:"video_minimax_h3_t2v.json"`,
+   then `panel_load_workflow path:"video_minimax_h3_t2v.json"`. Same pattern as
+   `video-extend` (stage on disk, then `path:`). Do not pass the GitHub URL as
+   `path:` or `pack:`.
+
+After it lands, retarget the **subgraph's exposed widgets** (prompt, duration,
+`turbo_mode`, megapixels). Official T2V/I2V graphs wrap
+`MiniMaxH3ImageToVideo` inside a subgraph (`type` is a UUID). Do not flatten
+that interior unless you are hand-building.
+
+Hand-building the subgraph is slower and easy to get wrong.
 
 Comfy tutorial (wiring, not MiniMax's prompt formula):
 https://docs.comfy.org/tutorials/video/minimax/minimax-h3
@@ -231,8 +258,11 @@ Always `clear_vram` before switching to H3 from WAN / LTX / a checkpoint.
 - `prompt-engineering` — generic CLIP syntax; **H3 does not use it**
 - `triton-sageattention` — installing Sage on Windows
 
-No bundled `packs/minimax-h3-*` installer yet. Use the Comfy-Org templates +
-`download_model` against `Comfy-Org/MiniMax-H3`.
+No bundled `packs/minimax-h3-*` installer yet — that is why
+`enqueue_workflow action:"run_template"` cannot load these graphs. Use the
+Template Library (or the GitHub fetch → `save_workflow` →
+`panel_load_workflow path:` path above) + `download_model` against
+`Comfy-Org/MiniMax-H3`.
 
 ## Sources
 

--- a/plugin/skills/model-registry/SKILL.md
+++ b/plugin/skills/model-registry/SKILL.md
@@ -70,6 +70,22 @@ Comfy-Org repackages everything: `huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repac
 | Qwen-Image-Edit 2511 Lightning LoRA | `huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning` | `loras/` |
 | Qwen-Image 2512 Turbo LoRA | `huggingface.co/Wuli-art/Qwen-Image-2512-Turbo-LoRA` | `loras/` |
 
+## MiniMax H3 video (see `minimax-h3-video` skill)
+
+Comfy-Org INT8 pack: `huggingface.co/Comfy-Org/MiniMax-H3`. Local weights are
+under the MiniMax H3 Community License (territory-restricted). Prefer the
+filenames the Comfy-Org templates already name.
+
+| File | Source | Target |
+|---|---|---|
+| `minimax_h3_fl2va_pruned_int8_convrot.safetensors` | `huggingface.co/Comfy-Org/MiniMax-H3/resolve/main/diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors` | `diffusion_models/` |
+| `minimax_h3_ref2va_pruned_int8_convrot.safetensors` | same repo, `diffusion_models/` | `diffusion_models/` |
+| `qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` | same repo, `text_encoders/` | `text_encoders/` |
+| `minimax_h3_video_vae_fp16.safetensors` | same repo, `vae/` | `vae/` |
+| `minimax_h3_audio_vae_fp32.safetensors` | same repo, `vae/` | `vae/` |
+| `minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors` | `huggingface.co/lightx2v/Minimax-h3-Turbo/resolve/main/minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors` | `loras/` |
+| `minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors` | `huggingface.co/Comfy-Org/MiniMax-H3/resolve/main/loras/minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors` | `loras/` |
+
 ## Z-Image (see `z-image-txt2img` skill)
 
 | File | Source | Target |

--- a/src/__tests__/orchestrator/minimax-h3-skill.test.ts
+++ b/src/__tests__/orchestrator/minimax-h3-skill.test.ts
@@ -58,4 +58,25 @@ describe("the minimax-h3-video skill is the #1155 official-guide pilot (#1167)",
     expect(SKILL).not.toMatch(/subject_definitions/);
     expect(SKILL).not.toMatch(/integrated_multimodal_description/);
   });
+
+  it("does not teach run_template as the Comfy-Org template load path (#1801 review)", () => {
+    // Core templates are invisible to list_templates / run_template and are not
+    // a panel_load_workflow pack/path/graph. The old sentence claimed they were.
+    expect(SKILL).not.toMatch(
+      /Load with `panel_load_workflow` or `enqueue_workflow` `action:"run_template"`/,
+    );
+    expect(SKILL).toMatch(/Template Library → Video/);
+    expect(SKILL).toContain(
+      "https://github.com/Comfy-Org/workflow_templates/blob/main/templates/video_minimax_h3_t2v.json",
+    );
+    expect(SKILL).toMatch(/list_templates/);
+    expect(SKILL).toMatch(/will \*\*not\*\* list them/);
+    const mentions = [...SKILL.matchAll(/run_template/g)];
+    expect(mentions.length).toBeGreaterThan(0);
+    for (const m of mentions) {
+      const at = m.index ?? 0;
+      const around = SKILL.slice(Math.max(0, at - 220), at + 180);
+      expect(around).toMatch(/will \*\*not\*\*|Do not call it until a pack exists|cannot load/i);
+    }
+  });
 });

--- a/src/__tests__/orchestrator/minimax-h3-skill.test.ts
+++ b/src/__tests__/orchestrator/minimax-h3-skill.test.ts
@@ -59,9 +59,10 @@ describe("the minimax-h3-video skill is the #1155 official-guide pilot (#1167)",
     expect(SKILL).not.toMatch(/integrated_multimodal_description/);
   });
 
-  it("does not teach run_template as the Comfy-Org template load path (#1801 review)", () => {
-    // Core templates are invisible to list_templates / run_template and are not
-    // a panel_load_workflow pack/path/graph. The old sentence claimed they were.
+  it('does not teach enqueue_workflow (action:"run_template") as the Comfy-Org template load path (#1801 review)', () => {
+    // Core templates are invisible to list_templates /
+    // enqueue_workflow (action:"run_template") and are not a
+    // panel_load_workflow pack/path/graph. The old sentence claimed they were.
     expect(SKILL).not.toMatch(
       /Load with `panel_load_workflow` or `enqueue_workflow` `action:"run_template"`/,
     );
@@ -71,7 +72,7 @@ describe("the minimax-h3-video skill is the #1155 official-guide pilot (#1167)",
     );
     expect(SKILL).toMatch(/list_templates/);
     expect(SKILL).toMatch(/will \*\*not\*\* list them/);
-    const mentions = [...SKILL.matchAll(/run_template/g)];
+    const mentions = [...SKILL.matchAll(/action:"run_template"/g)];
     expect(mentions.length).toBeGreaterThan(0);
     for (const m of mentions) {
       const at = m.index ?? 0;

--- a/src/__tests__/orchestrator/minimax-h3-skill.test.ts
+++ b/src/__tests__/orchestrator/minimax-h3-skill.test.ts
@@ -1,0 +1,61 @@
+// #1167 — MiniMax H3 is the first bundled skill with a real vendor prompting
+// guide, so it is the #1155 pilot: Official must be a MiniMax URL, Empirical
+// must say what was inferred, and we must not ship a copy of MiniMax's own
+// skills/h3-prompt-writing (Community License includes Documentation).
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+
+const SKILL_URL = new URL("../../../plugin/skills/minimax-h3-video/SKILL.md", import.meta.url);
+const SKILL = existsSync(SKILL_URL)
+  ? readFileSync(SKILL_URL, "utf-8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n")
+  : "";
+
+function sourcesSection(markdown: string): string {
+  const headingAt = markdown.search(/^## Sources[ \t]*$/m);
+  expect(headingAt, "missing ## Sources heading").toBeGreaterThan(-1);
+  const from = markdown.slice(headingAt);
+  const nextHeading = from.slice("## Sources".length).search(/\n## /);
+  return nextHeading === -1 ? from : from.slice(0, "## Sources".length + nextHeading);
+}
+
+describe("the minimax-h3-video skill is the #1155 official-guide pilot (#1167)", () => {
+  it("is bundled at plugin/skills/minimax-h3-video/SKILL.md", () => {
+    expect(existsSync(SKILL_URL)).toBe(true);
+  });
+
+  it("is a loadable skill — frontmatter name matches its directory", () => {
+    expect(SKILL).toMatch(/^---\nname: minimax-h3-video\n/);
+    expect(SKILL).toMatch(/\ndescription: .+/);
+  });
+
+  it("cites MiniMax's official prompting guides by URL, not none found", () => {
+    const sources = sourcesSection(SKILL);
+    expect(sources).toContain("**Official:**");
+    expect(sources).toContain("**Empirical:**");
+    expect(sources).toContain(
+      "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md",
+    );
+    expect(sources).toContain(
+      "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md",
+    );
+    expect(sources).toContain("https://github.com/MiniMax-AI/MiniMax-H3");
+    expect(sources).not.toMatch(/\*\*Official:\*\*\s*none found/i);
+  });
+
+  it("teaches the local-weights path and names the paid API nodes so they are not mixed", () => {
+    expect(SKILL).toContain("MiniMaxH3ImageToVideo");
+    expect(SKILL).toContain("MiniMaxH3ReferenceToVideo");
+    expect(SKILL).toContain("EmptyMiniMaxH3LatentAV");
+    expect(SKILL).toContain("MiniMaxH3SigmaShift");
+    expect(SKILL).toContain("MinimaxHailuo03TextToVideoNode");
+    expect(SKILL).toMatch(/must not be mixed/);
+  });
+
+  it("points at MiniMax's own skill instead of copying the licensed prompting prose", () => {
+    expect(SKILL).toMatch(/cite by link|linked, not copied|Do not copy/i);
+    expect(SKILL).toContain("h3-prompt-writing");
+    // These headings exist only in MiniMax's licensed prompting guides / SKILL.md.
+    expect(SKILL).not.toMatch(/subject_definitions/);
+    expect(SKILL).not.toMatch(/integrated_multimodal_description/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the bundled `minimax-h3-video` skill requested in #1167 — the #1155 pilot for a skill that can cite a **real official prompting guide**.

**Enhancement — do not merge until another agent reviews.**

This is original ComfyUI wiring guidance. MiniMax's prompting-guide prose and their `skills/h3-prompt-writing` SKILL.md are **linked, not copied** (Community License includes Documentation; Applicable Territory excludes US/EU/UK/KR).

### What the skill teaches

- **Local-weights path** (the reporter's request): `MiniMaxH3ImageToVideo` / `MiniMaxH3ReferenceToVideo`, Comfy-Org INT8 pack, turbo LoRAs (4–8 steps), 15 s native-stereo clips, Sage, 8 GB VRAM notes.
- **Not the paid API path**: names `MinimaxHailuo03*` / Hailuo partner nodes so they are not mixed into a local graph.
- **Official Sources**: MiniMax T2VA/R2V prompting guides on HuggingFace + vendor GitHub + Comfy-Org tutorial/templates.
- **Empirical Sources**: API-vs-local node split and turbo-LoRA 8 GB note from #1167; chaining last-frame → next clip via `upload_image` stage.

Asset counts 40 → 41 skills. `model-registry` gains the Comfy-Org H3 filenames.

## Test plan

- [x] `vitest run` on `minimax-h3-skill.test.ts`, `skill-source-citations.test.ts`, `skill-authoring-limits.test.ts` (265 tests)
- [ ] Reviewer: confirm Official URLs resolve and that the skill does not paste MiniMax's licensed guide
- [ ] Reviewer: confirm local vs API node split matches a live `/object_info` if ComfyUI ≥ 0.30 is available

Closes #1167