### PR TITLE
release: v0.52.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.12] - 2026-08-19
+
+_No user-facing changes._
+
+
 ## [0.52.11] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.11",
+  "version": "0.52.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.11",
+      "version": "0.52.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.11",
+  "version": "0.52.12",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Patch release **v0.52.12**. Includes #1798/#1799 (Windows account that cannot create scheduled tasks still gets a launcher).

Do **not** squash-merge. Rebase-merge or merge-commit so the version tag stays aligned.