### PR TITLE
release: v0.52.13 — the launcher fallback stops stranding and double-serving managed Windows accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.13] - 2026-08-19
+
+### MCP
+
+#### Fixed
+- five ways the launcher fallback could strand or double-serve a user (#1800)
+
+
 ## [0.52.11] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.11",
+  "version": "0.52.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.11",
+      "version": "0.52.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.11",
+  "version": "0.52.13",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.13 from `main` (91b66ee).

Carries #1800 — the five merge-gate P1s in the Windows launcher fallback that #1799 shipped without, all of which hit precisely the managed accounts the fallback exists for:

- `/Create` and `/Run` no longer share a catch, so a task that registers but cannot start *right now* stops getting a duplicate Startup entry (two brokers at every logon).
- The Startup path resolves `%APPDATA%` instead of being built from `homedir()`, so redirected-AppData domain accounts stop getting a folder Explorer never scans.
- Liveness is a real probe against the recorded port and token, not `process.kill(pid, 0)` — a recycled PID used to spawn nothing and leave a dead port, dropping the user back into #1798's loop.
- The pid survives the install's own config write, so second and third installs stop spawning rivals beside a live broker.
- A failing Startup write no longer throws before the broker starts — losing the autostart is survivable, losing the session's broker is the bug.

Note: `release/0.52.12` is in flight on another branch, based on `52b3dc1` (before #1800). This cut is explicitly .13 to avoid colliding with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)