### PR TITLE
fix(1804): one-arg panelLauncherPaths keeps windowsStartup under the passed home

### DIFF
--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -539,5 +539,9 @@ describe("launcher paths", () => {
     const paths = panelLauncherPaths(home);
     expect(paths.config.startsWith(home)).toBe(true);
     expect(paths.broker.startsWith(home)).toBe(true);
+    // The one that escaped: a one-arg call must NOT resolve the Startup entry
+    // to the real user's %APPDATA%, or a sandboxed caller writes a persistent
+    // autostart outside the home it chose.
+    expect(paths.windowsStartup.startsWith(home)).toBe(true);
   });
 });

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -53,7 +53,10 @@ export type LauncherPaths = {
 
 export function panelLauncherPaths(
   home: string = homedir(),
-  appData: string = roamingAppData({}),
+  // Derive from `home`, not the process environment: a caller passing only a
+  // home (test harness, sandbox, per-user install) must get every artifact
+  // under that home, not a Startup entry in the REAL user's %APPDATA%.
+  appData: string = roamingAppData({ home }),
 ): LauncherPaths {
   const root = join(home, ".comfyui-mcp");
   const launcherDir = join(root, "launcher");


### PR DESCRIPTION
## Root cause

`panelLauncherPaths(home)` defaulted its `appData` parameter to `roamingAppData({})`, which reads the **process environment's real `%APPDATA%`** when no home/appData is given to that helper. A caller passing only a fake/override `home` (test harness, sandbox, per-user install) got `config` and `broker` under that home but `windowsStartup` pointing into the real user's Startup folder — a persistent autostart entry outside the directory the caller chose. The guard test titled *"keeps every mutable launcher artifact under the selected user home"* asserted `config` and `broker` but never `windowsStartup`, so it could not see the violation. Latent: no current caller invokes it one-arg on the write path (install/uninstall always pass `roamingAppData(options)` explicitly, unchanged here).

## Fix

- `src/services/panel-launcher.ts`: the `appData` default is now `roamingAppData({ home })` — derived from the same `home` argument — with a comment explaining why the environment fallback does not belong here.
- `src/__tests__/services/panel-launcher.test.ts`: the existing guard test now asserts `windowsStartup.startsWith(home)` alongside `config` and `broker`.

## Verification

- Red-check: with only the test change applied to pre-fix code, the extended test **fails** (`windowsStartup` resolved to the real `C:\Users\...\AppData\Roaming\...\Startup`).
- Green: `npx vitest run src/__tests__/services/panel-launcher.test.ts` — 18/18 pass.
- Gates in worktree: `npm ci` OK, `npm run build` (tsc) clean, full `npm test` chain exit 0 (includes vitest suite, docs/locale/blog checks).
- No tool descriptions, no docs/*.mdx, no i18n keys touched — vocabulary/docs-gen gates not implicated.

Closes #1804