### PR TITLE
fix(1447): plugin .mcp.json launches via a warm-path wrapper instead of bare npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ plugin/
     job-complete-notify.mjs # Job completion notification via temp files
   scripts/                 # Background scripts
     monitor-progress.mjs   # Real-time WebSocket progress monitor
+    launch-server.mjs      # MCP server launcher — prefers a global install over cold `npx` (#1447)
 ```
 
 ---

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,9 +1,8 @@
 {
   "comfyui": {
-    "command": "npx",
+    "command": "node",
     "args": [
-      "-y",
-      "comfyui-mcp",
+      "${CLAUDE_PLUGIN_ROOT}/scripts/launch-server.mjs",
       "--full"
     ],
     "env": {

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * #1447 — plugin MCP server launcher.
+ *
+ * The plugin's .mcp.json used to be `npx -y comfyui-mcp --full` directly. On a
+ * cold npx cache that downloads the whole ~900 MB dependency tree INSIDE the
+ * client's MCP handshake timeout; the client kills the attempt, nothing is
+ * persisted, and every retry pays the full cost again (the measured `_npx`
+ * cache timestamped to a manual run, never to a client attempt).
+ *
+ * This wrapper is the warm path: when `comfyui-mcp` is installed globally
+ * (`npm install -g comfyui-mcp`), it resolves `<npm root -g>/comfyui-mcp/
+ * dist/index.js` and runs it with this same node — sub-second start, no
+ * registry round-trip, and a killed handshake cannot discard an install that
+ * already happened. With no global install it falls back to the original
+ * `npx -y comfyui-mcp` behaviour, so the plugin works identically for anyone
+ * who never installs globally.
+ *
+ * STDIO IS THE MCP TRANSPORT. Everything the child says on stdout/stderr is
+ * the protocol — the wrapper inherits stdio verbatim and must never write to
+ * stdout itself. Diagnostics (there is exactly one, a spawn failure) go to
+ * stderr via console.error.
+ *
+ * Import-safe: nothing here runs on import. The resolution decisions are pure
+ * exports so the tests can call the real thing instead of reimplementing it
+ * (the #1385 lesson — a test of a copy is a test of nothing).
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** `npm root -g` is normally ~100 ms; 5 s bounds a wedged npm without hanging the handshake. */
+const NPM_ROOT_TIMEOUT_MS = 5000;
+
+/**
+ * `npm root -g` stdout → the global install's entry point, or null when the
+ * output is unusable or the install is absent/incomplete (no dist/index.js).
+ * null is not an error here — it means "take the npx path".
+ */
+export function globalEntry(npmRootStdout, { exists = existsSync } = {}) {
+  const root = typeof npmRootStdout === "string" ? npmRootStdout.trim() : "";
+  if (!root) return null;
+  const entry = join(root, "comfyui-mcp", "dist", "index.js");
+  return exists(entry) ? entry : null;
+}
+
+/**
+ * Tokens the shell form may contain. The fallback's args come from the
+ * plugin's own .mcp.json (today: `--full`), never from user input — but a
+ * shell command is string concatenation, so anything outside this alphabet
+ * (whitespace, quotes, metacharacters) is REFUSED rather than passed through
+ * to be silently misparsed.
+ */
+const SHELL_SAFE_TOKEN = /^[A-Za-z0-9@._~:/=-]+$/;
+
+/**
+ * The spawn spec for the resolved server. `extraArgs` are the plugin's own
+ * args from .mcp.json (`--full`), forwarded to whichever server runs so the
+ * manifest stays the declarative source of how the server is started.
+ *
+ * With an entry point we spawn node directly — no shell, no shim resolution.
+ *
+ * The npx fallback differs by platform:
+ *  - POSIX: spawn npx with an args array, no shell.
+ *  - Windows: npx is npx.cmd, which Node refuses to spawn without a shell
+ *    since the 18.20.2/20.12.2 bat-file fix — but `shell` + an args array
+ *    triggers DEP0190 (args are concatenated UNESCAPED, and Node warns every
+ *    launch). So the Windows spec is one pre-validated command string instead:
+ *    same concatenation, but every token is checked against SHELL_SAFE_TOKEN
+ *    first, so what the shell parses is exactly what was written.
+ */
+export function serverSpec(entry, extraArgs, { platform = process.platform, node = process.execPath } = {}) {
+  if (entry) return { command: node, args: [entry, ...extraArgs], shell: false };
+  const npxArgs = ["-y", "comfyui-mcp", ...extraArgs];
+  if (platform !== "win32") return { command: "npx", args: npxArgs, shell: false };
+  for (const token of ["npx", ...npxArgs]) {
+    if (!SHELL_SAFE_TOKEN.test(token)) {
+      throw new Error(`[comfyui-mcp launcher] refusing to pass unsafe shell token to npx: ${JSON.stringify(token)}`);
+    }
+  }
+  return { command: ["npx", ...npxArgs].join(" "), args: [], shell: true };
+}
+
+/** Ask npm where global packages live. String-command form on Windows for the
+ *  same DEP0190 reason as serverSpec; the command is a fixed literal, so there
+ *  is nothing to inject. Resolves null on any failure — the npx fallback is
+ *  the original behaviour, so a failed probe degrades to exactly what the
+ *  plugin did before this wrapper existed. */
+function probeGlobalRoot() {
+  const isWin = process.platform === "win32";
+  return new Promise((resolve) => {
+    execFile(
+      isWin ? "npm root -g" : "npm",
+      isWin ? [] : ["root", "-g"],
+      { shell: isWin, timeout: NPM_ROOT_TIMEOUT_MS },
+      (error, stdout) => resolve(error ? null : stdout),
+    );
+  });
+}
+
+function run(spec) {
+  const child = spawn(spec.command, spec.args, { stdio: "inherit", shell: spec.shell });
+
+  // The client kills the WRAPPER when it shuts the server down; without
+  // forwarding, the real server would be orphaned holding stdio. Killing the
+  // child on signal makes its `exit` fire, which is what exits the wrapper.
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(sig, () => child.kill(sig));
+  }
+
+  child.on("exit", (code, signal) => {
+    // A signal death has no code; 1 keeps the client from reading it as clean.
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+  child.on("error", (err) => {
+    // Honest failure, loudly: a server that never started must not look like
+    // one that exited cleanly. stderr, never stdout — see the header.
+    console.error(`[comfyui-mcp launcher] failed to start ${spec.command}: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const extraArgs = process.argv.slice(2);
+  const entry = globalEntry(await probeGlobalRoot());
+  run(serverSpec(entry, extraArgs));
+}

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -1,0 +1,132 @@
+// #1447 — the plugin's .mcp.json ran `npx -y comfyui-mcp --full` directly, so a
+// cold npx cache downloaded the whole dependency tree inside the client's MCP
+// handshake timeout; the kill discarded the partial install and every retry
+// paid full price again. The fix is a launcher (plugin/scripts/launch-server.mjs)
+// that prefers a globally installed comfyui-mcp (warm, sub-second) and falls
+// back to the original npx invocation when there isn't one.
+//
+// The decisions are exercised against the REAL exports — the launcher is
+// import-safe by design, so importing it here is also the proof that importing
+// it spawns nothing.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const launcher = await import("../../../plugin/scripts/launch-server.mjs");
+const { globalEntry, serverSpec } = launcher as {
+  globalEntry: (stdout: unknown, opts?: { exists?: (p: string) => boolean }) => string | null;
+  serverSpec: (
+    entry: string | null,
+    extraArgs: string[],
+    opts?: { platform?: string; node?: string },
+  ) => { command: string; args: string[]; shell: boolean };
+};
+
+const mcpJson = (): { comfyui: { command: string; args: string[] } } =>
+  JSON.parse(readFileSync(new URL("../../../plugin/.mcp.json", import.meta.url), "utf8"));
+
+describe("launch-server global resolution (#1447)", () => {
+  it("resolves the global entry point when the install is present", () => {
+    const entry = globalEntry("/usr/local/lib/node_modules\n", { exists: () => true });
+    expect(entry).toMatch(/node_modules[\\/]comfyui-mcp[\\/]dist[\\/]index\.js$/);
+  });
+
+  it("returns null — the npx path — when npm output is unusable", () => {
+    for (const bad of [null, undefined, "", "  \n", 42]) {
+      expect(globalEntry(bad, { exists: () => true })).toBeNull();
+    }
+  });
+
+  it("returns null when the global install is absent or lacks dist/index.js", () => {
+    expect(globalEntry("/usr/local/lib/node_modules", { exists: () => false })).toBeNull();
+  });
+
+  it("checks for the entry under the probed root, not a hardcoded prefix", () => {
+    let checked = "";
+    globalEntry("C:\\Users\\u\\AppData\\Roaming\\npm", {
+      exists: (p: string) => {
+        checked = p;
+        return false;
+      },
+    });
+    expect(checked).toMatch(/^C:[\\/]Users[\\/]u[\\/]AppData[\\/]Roaming[\\/]npm[\\/]/);
+  });
+});
+
+describe("launch-server spawn spec (#1447)", () => {
+  it("warm path: spawns node on the resolved entry, no shell", () => {
+    const spec = serverSpec("/global/node_modules/comfyui-mcp/dist/index.js", ["--full"], {
+      platform: "linux",
+      node: "/usr/bin/node",
+    });
+    expect(spec).toEqual({
+      command: "/usr/bin/node",
+      args: ["/global/node_modules/comfyui-mcp/dist/index.js", "--full"],
+      shell: false,
+    });
+  });
+
+  it("fallback is exactly the pre-fix invocation, with the plugin's args preserved", () => {
+    const spec = serverSpec(null, ["--full"], { platform: "linux" });
+    expect(spec.command).toBe("npx");
+    expect(spec.args).toEqual(["-y", "comfyui-mcp", "--full"]);
+    expect(spec.shell).toBe(false);
+  });
+
+  it("fallback on Windows is one validated command string — no DEP0190, no unsafe tokens", () => {
+    // Node refuses to spawn npx.cmd without a shell since the 18.20.2/20.12.2
+    // bat-file fix, and shell + an args array warns DEP0190 on every launch
+    // (args are concatenated unescaped). So the Windows spec concatenates
+    // itself, after validating every token.
+    const spec = serverSpec(null, ["--full"], { platform: "win32" });
+    expect(spec).toEqual({ command: "npx -y comfyui-mcp --full", args: [], shell: true });
+    // …and it refuses loudly rather than letting a shell metacharacter through.
+    expect(() => serverSpec(null, ["--full; rm -rf /"], { platform: "win32" })).toThrow(
+      /unsafe shell token/,
+    );
+    expect(() => serverSpec(null, ['--name "x"'], { platform: "win32" })).toThrow(
+      /unsafe shell token/,
+    );
+    // POSIX keeps the args array and no shell at all.
+    expect(serverSpec(null, [], { platform: "darwin" })).toEqual({
+      command: "npx",
+      args: ["-y", "comfyui-mcp"],
+      shell: false,
+    });
+  });
+});
+
+describe("plugin/.mcp.json (#1447)", () => {
+  it("launches the wrapper via the plugin root, not npx", () => {
+    const cfg = mcpJson().comfyui;
+    expect(cfg.command).toBe("node");
+    expect(cfg.args[0]).toBe("${CLAUDE_PLUGIN_ROOT}/scripts/launch-server.mjs");
+  });
+
+  it("still starts the server in --full mode", () => {
+    expect(mcpJson().comfyui.args).toContain("--full");
+  });
+
+  it("the wrapper is import-safe — side effects sit behind the main guard", () => {
+    // The dynamic import at the top of this file is the behavioural half: had
+    // main() run, the test process would have spawned an npx install. This
+    // pins the source shape that makes the import safe.
+    const src = readFileSync(
+      new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url),
+      "utf8",
+    );
+    expect(src).toMatch(/import\.meta\.url === pathToFileURL\(process\.argv\[1\]\)\.href/);
+    expect(src).toMatch(/if \(isMain\) \{/);
+  });
+
+  it("the wrapper never writes to stdout — stdio is the MCP transport", () => {
+    const src = readFileSync(
+      new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url),
+      "utf8",
+    );
+    expect(src).not.toMatch(/console\.log\(/);
+    expect(src).not.toMatch(/process\.stdout\.write\(/);
+    // stdio must be inherited verbatim, or the handshake frames never reach the client.
+    expect(src).toMatch(/stdio: "inherit"/);
+  });
+});


### PR DESCRIPTION
## Root cause

`plugin/.mcp.json` invoked `npx -y comfyui-mcp --full` directly. On a cold npx cache that downloads the whole ~900 MB dependency tree *inside* the client's MCP handshake timeout; the client kills the attempt mid-install, nothing is persisted to `_npx`, and every retry pays the full cost again — so the loop never converges. The issue thread measured all of this (922 MB / 215 packages default install; the reporter's global-install workaround starts in 0.48 s).

The thread also established what the fix is **not**: `--omit=optional` is tree-wide and strips sharp's `@img/sharp-*` platform binary (the slim tree dies in `sharp/dist/utility.mjs` before `initialize`), and moving the agent backends to optional peer deps is a distribution/product decision that was deliberately parked, not a bug fix to slip in. This PR does not touch packaging.

## Fix

Point `.mcp.json` at a launcher shipped with the plugin — `plugin/scripts/launch-server.mjs` — instead of bare `npx`:

- **Warm path:** resolves `npm root -g` → `<root>/comfyui-mcp/dist/index.js` and runs it with the current node when a global install exists. Sub-second start, no registry round-trip, and a killed handshake cannot discard an install that already happened. This is the reporter's documented workaround, now automatic: anyone who has done `npm install -g comfyui-mcp` gets it; everyone else is unaffected.
- **Fallback:** no global install → the exact pre-change invocation, `npx -y comfyui-mcp --full`. A failed probe (no npm, wedged npm, 5 s timeout) degrades to precisely what the plugin did before this change.
- **Transport hygiene:** stdio is inherited verbatim — stdio *is* the MCP protocol — and the wrapper never writes to stdout. Exit codes are propagated; SIGINT/SIGTERM/SIGHUP are forwarded to the child so a client shutdown cannot orphan the server.
- **Windows:** `npx` is `npx.cmd`, which Node refuses to spawn without a shell (18.20.2/20.12.2 bat-file fix) — but `shell` + an args array trips DEP0190 every launch and concatenates args unescaped. The Windows spec is therefore one pre-validated command string: every token is checked against a safe alphabet first, and anything else is *refused loudly* rather than passed to a shell to be misparsed.

The decisions (`globalEntry`, `serverSpec`) are pure exports so tests call the real thing; the script is import-safe behind a main guard.

## Verification

- `npx vitest run src/__tests__/scripts/launch-server.test.ts` — **11/11 passed** (resolution, spawn specs per platform, unsafe-token refusal, `.mcp.json` shape, import-safety, no-stdout-writes).
- Live end-to-end on this machine (Windows, global install present): spawned the launcher, sent a real MCP `initialize` — **handshake first byte in 1365 ms**, no DEP0190, no stdout pollution. The same probe against bare `npx` on a cold cache is the failure mode in the issue.
- Full gate in the worktree: `npm ci` (278 packages) → `npm run build` → full `npm test` chain: **vitest 577 files / 10639 passed / 4 skipped**, then `i18n:check`, `check:docs-links`, `check:docs-locale` (all 12 locales), `check:docs-mdx` (311 files), `check:blog`, `check:blog-packs`, `check:blog-stale`, `check:blog-structure` — all green.

## Not in scope (from the issue thread, still true)

- The ~77% of install weight that is the orchestrator's agent backends (`@openai/codex`, `@anthropic-ai/claude-agent-sdk`, `cloudflared`, cloud SDKs) leaving the default install via optional **peer** deps — a product/distribution decision, still parked.
- Teaching `describeBrokenInstall` (#1318) to distinguish a deliberately-minimal install from a damaged one — only needed if that split ever lands.
- Pinning the spec in `.mcp.json` — moves the cold cost onto every release rather than removing it.

Closes #1447