### PR TITLE
feat(802): panel_show_media stage:true stages oversized local files outside served dirs

### DIFF
--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -10,7 +10,7 @@
 // oversized fixtures are real files above the cap.
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
@@ -235,6 +235,8 @@ describe("panel_show_media: an oversized file NOT under a root is refused with a
     expect(text).toContain(inDir);
     expect(text).toMatch(/Copy or move it/);
     expect(text).toContain("panel_show_media");
+    // #802 — the refusal also names the opt-in one-call remedy.
+    expect(text).toContain("stage:true");
   });
 
   it("does not blame the file's location when the roots could not be resolved", async () => {
@@ -258,6 +260,82 @@ describe("panel_show_media: an oversized file NOT under a root is refused with a
     expect(text).toContain("REMOTE ComfyUI");
     expect(text).not.toMatch(/Copy or move it/);
     expect(text).toContain('type: "input"');
+  });
+});
+
+// #802 — with stage:true the caller opts into the orchestrator copying an
+// oversized OUTSIDE file into <output>/_panel_staged and displaying the copy
+// by reference. These cover the WIRING; the staging mechanics and their
+// failure modes are pinned in comfy-view-ref.test.ts.
+describe("panel_show_media: stage:true stages an oversized outside file (#802)", () => {
+  it("copies the file under _panel_staged and forwards a ref to the COPY", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigVideoOutside, stage: true } }]);
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("viewRef");
+    expect(items[0].viewRef).toMatchObject({
+      subfolder: "_panel_staged",
+      type: "output",
+    });
+    const ref = items[0].viewRef as { filename: string };
+    expect(ref.filename).toMatch(/^\d+-reference\.mp4$/);
+    // The copy exists, is the full file, and the ORIGINAL was left alone.
+    expect(statSync(join(outDir, "_panel_staged", ref.filename)).size).toBe(OVERSIZE);
+    expect(statSync(bigVideoOutside).size).toBe(OVERSIZE);
+  });
+
+  it("discloses the write, its location, and that the copy persists", async () => {
+    const { res } = await showMedia([{ source: { path: bigVideoOutside, stage: true } }]);
+    const text = textOf(res);
+    expect(text).toContain("COPIED");
+    expect(text).toContain("_panel_staged");
+    expect(text).toMatch(/persists/);
+    expect(text).toContain("NOT sent the bytes");
+  });
+
+  it("without stage the same file is still refused — the write stays opt-in", async () => {
+    const before = existsSync(join(outDir, "_panel_staged"))
+      ? readdirSync(join(outDir, "_panel_staged")).length
+      : 0;
+    const { res, calls } = await showMedia([{ source: { path: bigVideoOutside } }]);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const after = existsSync(join(outDir, "_panel_staged"))
+      ? readdirSync(join(outDir, "_panel_staged")).length
+      : 0;
+    expect(after).toBe(before);
+  });
+
+  it("a staging failure falls through to the refusal WITH the reason attached", async () => {
+    state.remote = true;
+    const { res, calls } = await showMedia([{ source: { path: bigVideoOutside, stage: true } }]);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const text = textOf(res);
+    expect(text).toContain("Staging WAS requested");
+    expect(text).toContain("REMOTE");
+  });
+
+  it("stage:true does not copy a file that is already servable by reference", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigVideoUnderRoot, stage: true } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    // The ORIGINAL location's ref — not a staged copy.
+    expect(items[0].viewRef).toEqual({
+      filename: "reference.mp4",
+      subfolder: "takes",
+      type: "output",
+    });
+  });
+
+  it("stage:true is ignored for a file small enough to inline", async () => {
+    const { res, calls } = await showMedia([{ source: { path: smallImage, stage: true } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("image");
+    expect(String(items[0].dataUrl)).toMatch(/^data:image\/png;base64,/);
   });
 });
 

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -7,7 +7,7 @@
 // it needs to be, so the tests below assert the REASON, not just the outcome.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -76,6 +76,8 @@ const {
   oversizedInlineRefusal,
   forwardedByReferenceNote,
   unverifiedViewRefNote,
+  stageFileIntoServedDir,
+  stagedForDisplayNote,
 } = await import("../../services/comfy-view-ref.js");
 
 let root: string;
@@ -518,5 +520,157 @@ describe("unverifiedViewRefNote (#941)", () => {
     const note = unverifiedViewRefNote(many);
     expect(note).toMatch(/…and 4 more/);
     expect(note).not.toContain("f11.png");
+  });
+});
+
+// #802 — the parked half of the original report: the `outside` verdict used to
+// end in "copy the file yourself". stageFileIntoServedDir does that copy for a
+// caller who explicitly opted in (stage:true), into <output>/_panel_staged,
+// and the tests below pin the things that make it safe to offer: it is a
+// disclosed, never-overwriting, size-checked write — and it fails closed.
+describe("stageFileIntoServedDir (#802)", () => {
+  it("copies an outside file under _panel_staged and returns a ref to the COPY", async () => {
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    writeFileSync(src, "video-bytes");
+    const res = await stageFileIntoServedDir(src);
+    expect(res.status).toBe("staged");
+    if (res.status !== "staged") return;
+    expect(res.ref.type).toBe("output");
+    expect(res.ref.subfolder).toBe("_panel_staged");
+    // Timestamped name, original basename preserved, and the copy really is
+    // the file — the by-reference route shows the copy, so it must BE it.
+    expect(res.ref.filename).toMatch(/^\d+-clip\.mp4$/);
+    expect(readFileSync(res.stagedPath, "utf8")).toBe("video-bytes");
+    expect(res.stagedPath).toBe(join(outDir, "_panel_staged", res.ref.filename));
+    // The ORIGINAL was not modified or moved.
+    expect(readFileSync(src, "utf8")).toBe("video-bytes");
+  });
+
+  it("staging the same file twice never overwrites the first copy", async () => {
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const first = await stageFileIntoServedDir(src);
+    const second = await stageFileIntoServedDir(src);
+    expect(first.status).toBe("staged");
+    expect(second.status).toBe("staged");
+    if (first.status !== "staged" || second.status !== "staged") return;
+    expect(second.ref.filename).not.toBe(first.ref.filename);
+    expect(existsSync(first.stagedPath)).toBe(true);
+    expect(existsSync(second.stagedPath)).toBe(true);
+  });
+
+  it("refuses to stage a file that is ALREADY under the output directory", async () => {
+    const inside = touch(join(outDir, "clip.mp4"));
+    const res = await stageFileIntoServedDir(inside);
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("ALREADY under");
+    // No duplicate may have been deposited.
+    expect(existsSync(join(outDir, "_panel_staged"))).toBe(false);
+  });
+
+  it("fails closed on a REMOTE target — a copy made here would be unreachable", async () => {
+    state.remote = true;
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await stageFileIntoServedDir(src);
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("REMOTE");
+    expect(existsSync(join(outDir, "_panel_staged"))).toBe(false);
+  });
+
+  it("fails closed on ComfyUI Cloud", async () => {
+    state.cloud = true;
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await stageFileIntoServedDir(src);
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("Cloud");
+  });
+
+  it("fails, rather than throwing, when the output directory cannot be resolved", async () => {
+    state.outputError = "the server did not answer /system_stats";
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await stageFileIntoServedDir(src);
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("could not be resolved");
+    expect(res.reason).toContain("the server did not answer /system_stats");
+  });
+
+  it("refuses a file over the per-file staging cap and copies nothing", async () => {
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await stageFileIntoServedDir(src, { maxFileBytes: 0 });
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("per-file staging cap");
+    expect(existsSync(join(outDir, "_panel_staged"))).toBe(false);
+  });
+
+  it("refuses when the staging folder would pass the total cap, and names the folder", async () => {
+    mkdirSync(join(outDir, "_panel_staged"), { recursive: true });
+    writeFileSync(join(outDir, "_panel_staged", "old.mp4"), "x".repeat(64));
+    const src = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await stageFileIntoServedDir(src, { maxDirBytes: 16 });
+    expect(res.status).toBe("failed");
+    if (res.status !== "failed") return;
+    expect(res.reason).toContain("total cap");
+    expect(res.reason).toContain("_panel_staged");
+  });
+});
+
+describe("oversizedInlineRefusal — the outside branch names staging (#802)", () => {
+  const base = {
+    path: "/refs/clip.mp4",
+    sizeBytes: 72 * 1024 * 1024,
+    capBytes: 20 * 1024 * 1024,
+    kind: "video" as const,
+  };
+
+  it("offers stage:true as the one-call remedy, disclosed as a persistent disk write", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    expect(msg).toContain("stage:true");
+    expect(msg).toContain("/c/output/_panel_staged");
+    // The write's cost is stated where it is offered, not buried.
+    expect(msg).toMatch(/disk write/);
+    expect(msg).toContain("PERSISTS");
+  });
+
+  it("does NOT offer staging to a remote caller, who it cannot help", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "remote", reason: "this session targets a REMOTE ComfyUI on a different host" },
+    });
+    expect(msg).not.toContain("stage:true");
+  });
+});
+
+describe("stagedForDisplayNote (#802)", () => {
+  const item = {
+    path: "/refs/clip.mp4",
+    stagedPath: "/c/output/_panel_staged/1724000000000-clip.mp4",
+    sizeBytes: 72 * 1024 * 1024,
+    kind: "video" as const,
+    ref: { filename: "1724000000000-clip.mp4", subfolder: "_panel_staged", type: "output" as const },
+  };
+
+  it("discloses the write, its location, and that the copy PERSISTS", () => {
+    const note = stagedForDisplayNote([item], 20 * 1024 * 1024);
+    expect(note).toContain("COPIED");
+    expect(note).toContain("stage:true");
+    expect(note).toContain("/refs/clip.mp4");
+    expect(note).toContain(item.stagedPath);
+    expect(note).toMatch(/real filesystem WRITE/);
+    expect(note).toMatch(/persists/);
+    expect(note).toContain("_panel_staged");
+  });
+
+  it("never claims the panel displayed anything, and says the bytes were not sent", () => {
+    const note = stagedForDisplayNote([item], 20 * 1024 * 1024);
+    expect(note).toContain("NOT sent the bytes");
+    expect(note).toContain("in its reply above");
+    expect(note).not.toMatch(/was displayed to the user/i);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -38,8 +38,11 @@ import {
   forwardedByReferenceNote,
   oversizedInlineRefusal,
   resolveServableViewRef,
+  stageFileIntoServedDir,
+  stagedForDisplayNote,
   unverifiedViewRefNote,
   type ForwardedByReference,
+  type StagedForDisplay,
   type UnverifiedViewRef,
   type ViewRefProbe,
 } from "../services/comfy-view-ref.js";
@@ -15636,14 +15639,22 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_show_media",
-      "Display one or more images or videos directly in the panel chat. Use this whenever the user asks to SEE or SHOW a file — a disk path you composited/downloaded/generated (absolute path on the orchestrator host) OR a ComfyUI output ref ({ filename, subfolder?, type? }). Items are rendered as media cards in the agent chat area; supply optional captions. Max 8 items per call. NEVER describe an image with emoji or text placeholders — call this tool instead.",
+      "Display one or more images or videos directly in the panel chat. Use this whenever the user asks to SEE or SHOW a file — a disk path you composited/downloaded/generated (absolute path on the orchestrator host) OR a ComfyUI output ref ({ filename, subfolder?, type? }). Items are rendered as media cards in the agent chat area; supply optional captions. Max 8 items per call. A path item OVER the 20 MB inline cap that is not under any directory ComfyUI serves can still be shown by passing stage:true on that item — the orchestrator COPIES it into <output>/_panel_staged (an opt-in, persistent disk write; 512 MB per-file and 2 GB total caps) and displays the copy by reference. NEVER describe an image with emoji or text placeholders — call this tool instead.",
       {
         items: z
           .array(
             z.object({
               source: z.union([
                 // Absolute file path on the orchestrator host
-                z.object({ path: z.string().min(1) }),
+                z.object({
+                  path: z.string().min(1),
+                  stage: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                      "OPT-IN for a file over the 20 MB inline cap that is NOT under any directory ComfyUI serves: the orchestrator COPIES it into <output>/_panel_staged (a real disk write — caps 512 MB per file, 2 GB total staged; the copy persists until someone deletes it) and displays the copy by reference. Ignored for files already servable or small enough to inline.",
+                    ),
+                }),
                 // ComfyUI /view ref
                 z.object({
                   filename: z.string().min(1),
@@ -15660,7 +15671,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       async (args: A, ctx) => {
         const items = args.items as Array<{
           source:
-            | { path: string }
+            | { path: string; stage?: boolean }
             | { filename: string; subfolder?: string; type?: string };
           caption?: string;
         }>;
@@ -15704,6 +15715,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const resolved: Array<Record<string, unknown>> = [];
         /** Oversized items that took the /view reference route instead (#648). */
         const forwarded: ForwardedByReference[] = [];
+        /** Oversized items the caller opted into staging into a served dir (#802). */
+        const stagedItems: StagedForDisplay[] = [];
         // #941 — /view references handed to a BROWSER panel, whose rendering this
         // process never observes. Collected so the reply can say what "painted"
         // does and does not establish.
@@ -15777,6 +15790,42 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 });
                 forwarded.push({ path: p, sizeBytes: stat.size, kind, ref: servable.ref });
                 continue;
+              }
+              // #802 — the reference route needs the file to ALREADY sit under a
+              // served directory. With stage:true the caller has opted into the
+              // one remaining move: the orchestrator copies it into
+              // <output>/_panel_staged and forwards a ref to the COPY. Opt-in
+              // because it is a real disk write; the copy and its persistence
+              // are disclosed in the reply, and any staging failure falls
+              // through to the ordinary refusal with the reason attached.
+              if (src.stage === true) {
+                const staged = await stageFileIntoServedDir(p);
+                if (staged.status === "staged") {
+                  resolved.push({
+                    kind: "viewRef",
+                    viewRef: staged.ref,
+                    filename: staged.ref.filename,
+                    caption: item.caption,
+                  });
+                  stagedItems.push({
+                    path: p,
+                    stagedPath: staged.stagedPath,
+                    sizeBytes: stat.size,
+                    kind,
+                    ref: staged.ref,
+                  });
+                  continue;
+                }
+                return fail(
+                  oversizedInlineRefusal({
+                    path: p,
+                    sizeBytes: stat.size,
+                    capBytes: MAX_BYTES,
+                    kind,
+                    resolution: servable,
+                  }) +
+                    `\nStaging WAS requested (stage:true) but could not be done: ${staged.reason}`,
+                );
               }
               return fail(
                 oversizedInlineRefusal({
@@ -15880,6 +15929,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           res.content.push({
             type: "text",
             text: forwardedByReferenceNote(forwarded, MAX_BYTES),
+          });
+        }
+        // #802 — staged items took the same reference route, but the reference
+        // points at a COPY this process wrote into the user's output directory.
+        // That write, its location, and its persistence must be disclosed.
+        if (stagedItems.length > 0 && !res.isError) {
+          res.content.push({
+            type: "text",
+            text: stagedForDisplayNote(stagedItems, MAX_BYTES),
           });
         }
         // #941 — a forwarded /view reference is DISPATCHED, not displayed. Probe a

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -50,8 +50,16 @@
 // names the directories it actually checked rather than claiming no directory
 // could serve the file.
 
-import { realpath } from "node:fs/promises";
-import { basename, dirname, relative, resolve, sep } from "node:path";
+import { constants as fsConstants } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readdir,
+  realpath,
+  rm,
+  stat,
+} from "node:fs/promises";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { isCloudMode, isRemoteMode } from "../config.js";
 import { resolveInputDir, resolveOutputDir } from "./output-dir.js";
 
@@ -330,6 +338,267 @@ export async function resolveServableViewRef(
   return { status: "outside", checked: roots };
 }
 
+// ---- opt-in staging into a served directory (#802) --------------------------
+//
+// The `outside` verdict used to end in "copy the file yourself". Staging does
+// that copy FOR the caller — and it is deliberately OPT-IN (panel_show_media's
+// stage:true), because it is a filesystem WRITE into the user's ComfyUI output
+// directory made as a side effect of a display call. The default behaviour is
+// unchanged: a refusal that names the manual remedy.
+//
+// The staged copy lands in <output>/_panel_staged/ with a timestamped name, so
+// a repeat staging never overwrites an earlier copy, and the copies PERSIST —
+// no automatic cleanup, because every lifecycle this codebase has tried for
+// shared temp files has raced a reader that had not finished (#1152). The
+// reply discloses the write and where the copies live; deleting them is the
+// user's call, not ours.
+
+/** Subfolder of ComfyUI's output directory that staged copies are written to. */
+export const STAGED_SUBFOLDER = "_panel_staged";
+
+/** Per-file staging cap — a guardrail on disk use, not the transport limit. */
+export const STAGE_MAX_FILE_BYTES = 512 * 1024 * 1024; // 512 MB
+
+/** Total cap on the staging folder, so repeated staging cannot grow without bound. */
+export const STAGE_MAX_DIR_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
+
+export type StageIntoServedDirResult =
+  | { status: "staged"; ref: ComfyServableRef; stagedPath: string }
+  | { status: "failed"; reason: string };
+
+/**
+ * Copy a LOCAL file into <output>/_panel_staged/ so ComfyUI can serve it over
+ * /view, and return the ref for the COPY.
+ *
+ * Never throws: like the resolver above, every step is an operation that can
+ * fail, and a staging failure must come back as a reason the caller can report,
+ * not as a transport error. Fails CLOSED on the copy itself — COPYFILE_EXCL
+ * (never overwrite), and a size check after the copy with the partial file
+ * removed when it does not match, so a raced or truncated copy is never
+ * forwarded as if it were the file the caller asked to show.
+ */
+export async function stageFileIntoServedDir(
+  absPath: string,
+  opts?: { maxFileBytes?: number; maxDirBytes?: number },
+): Promise<StageIntoServedDirResult> {
+  const maxFileBytes = opts?.maxFileBytes ?? STAGE_MAX_FILE_BYTES;
+  const maxDirBytes = opts?.maxDirBytes ?? STAGE_MAX_DIR_BYTES;
+  try {
+    // Same guard as the resolver, and first for the same reason: on a remote or
+    // cloud target a copy made HERE would land on a machine ComfyUI cannot see.
+    if (isCloudMode()) {
+      return {
+        status: "failed",
+        reason:
+          "this session targets ComfyUI Cloud — a copy made on this machine would not be reachable by that server",
+      };
+    }
+    if (isRemoteMode()) {
+      return {
+        status: "failed",
+        reason:
+          "this session targets a REMOTE ComfyUI on a different host — a copy made on this machine would not be reachable by that server",
+      };
+    }
+
+    let outputDir: string;
+    try {
+      outputDir = await resolveOutputDir();
+    } catch (err) {
+      return {
+        status: "failed",
+        reason: `ComfyUI's output directory could not be resolved (${errText(err)})`,
+      };
+    }
+    if (typeof outputDir !== "string" || outputDir.length === 0) {
+      return {
+        status: "failed",
+        reason: "ComfyUI's output directory resolved to an empty value",
+      };
+    }
+    const root = await canonical(resolve(outputDir));
+    if (!root.resolved) {
+      return {
+        status: "failed",
+        reason: `ComfyUI's output directory (${outputDir}) could not be canonicalised (${root.why ?? "unknown error"})`,
+      };
+    }
+
+    const file = await canonical(resolve(absPath));
+    if (!file.resolved) {
+      return {
+        status: "failed",
+        reason: `the file's real location could not be resolved (${file.why ?? "unknown error"})`,
+      };
+    }
+    if (isStrictlyInside(file.path, root.path)) {
+      // The caller stages only files it believes are outside every served
+      // directory; finding the file INSIDE the output root means that belief
+      // is stale, and copying it under a second name would deposit a duplicate
+      // the user never asked for.
+      return {
+        status: "failed",
+        reason:
+          "the file is ALREADY under ComfyUI's output directory, so it needs no staging — call panel_show_media with the same path again (it should take the by-reference route) and do NOT pass stage",
+      };
+    }
+
+    const srcStat = await stat(file.path);
+    if (!srcStat.isFile()) {
+      return { status: "failed", reason: `not a regular file: ${absPath}` };
+    }
+    if (srcStat.size > maxFileBytes) {
+      return {
+        status: "failed",
+        reason:
+          `the file is ${mb(srcStat.size)}, over the ${mb(maxFileBytes)} per-file staging cap — ` +
+          `staging is for ordinary oversized media, not unbounded disk use; copy it under a served directory yourself if it really must be shown`,
+      };
+    }
+
+    const stagingDir = join(root.path, STAGED_SUBFOLDER);
+    // Total-usage guardrail. Entries that vanish or refuse a stat between the
+    // readdir and here are simply not counted — undercounting a transient is
+    // fine; this cap exists to stop unbounded growth, not to audit the folder.
+    let stagedBytes = 0;
+    try {
+      for (const entry of await readdir(stagingDir)) {
+        try {
+          stagedBytes += (await stat(join(stagingDir, entry))).size;
+        } catch {
+          // unknown-ok: an entry that disappeared mid-scan contributes nothing
+          // to current usage; the guardrail tolerates the undercount.
+        }
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        return {
+          status: "failed",
+          reason: `the staging folder (${stagingDir}) could not be read (${errText(err)})`,
+        };
+      }
+      // ENOENT: nothing staged yet — usage is zero.
+    }
+    if (stagedBytes + srcStat.size > maxDirBytes) {
+      return {
+        status: "failed",
+        reason:
+          `the staging folder (${stagingDir}) already holds ${mb(stagedBytes)} and this ${mb(srcStat.size)} file would pass the ${mb(maxDirBytes)} total cap — ` +
+          `ask the user to clear out old staged copies, then retry`,
+      };
+    }
+
+    await mkdir(stagingDir, { recursive: true });
+
+    // Timestamped so staging the same basename twice never collides; the retry
+    // loop covers two calls landing in the same millisecond.
+    const base = basename(file.path);
+    let stagedPath = "";
+    let stagedName = "";
+    let copied = false;
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < 3 && !copied; attempt++) {
+      stagedName =
+        attempt === 0
+          ? `${Date.now()}-${base}`
+          : `${Date.now()}-${attempt}-${base}`;
+      stagedPath = join(stagingDir, stagedName);
+      try {
+        await copyFile(file.path, stagedPath, fsConstants.COPYFILE_EXCL);
+        copied = true;
+      } catch (err) {
+        lastErr = err;
+        if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") break;
+      }
+    }
+    if (!copied) {
+      return {
+        status: "failed",
+        reason: `the copy into ${stagingDir} failed (${errText(lastErr)}) — the original file was not modified`,
+      };
+    }
+
+    // The copy must BE the file: a source rewritten mid-copy, or a truncated
+    // write, must not be forwarded as if it were what the caller asked to show.
+    const dstStat = await stat(stagedPath);
+    if (dstStat.size !== srcStat.size) {
+      await rm(stagedPath, { force: true }).catch(() => {
+        // unknown-ok: the partial copy is already rejected; failing to remove
+        // it leaves harmless scratch, and masking the real failure (the size
+        // mismatch) with a cleanup error would misreport what went wrong.
+      });
+      return {
+        status: "failed",
+        reason:
+          `the staged copy came out ${mb(dstStat.size)} against a ${mb(srcStat.size)} source — the file may have changed while it was being copied; ` +
+          `the partial copy was removed and nothing was forwarded`,
+      };
+    }
+
+    const problem = refShapeProblem(stagedName, STAGED_SUBFOLDER);
+    if (problem) {
+      await rm(stagedPath, { force: true }).catch(() => {
+        // unknown-ok: same as above — the ref rejection is the failure that
+        // matters; leftover scratch is disclosed by the folder's existence.
+      });
+      return {
+        status: "failed",
+        reason: `the staged ref was rejected by the shape check (${problem}) — the copy was removed and nothing was forwarded`,
+      };
+    }
+
+    return {
+      status: "staged",
+      ref: { filename: stagedName, subfolder: STAGED_SUBFOLDER, type: "output" },
+      stagedPath,
+    };
+  } catch (err) {
+    return {
+      status: "failed",
+      reason: `staging failed (${errText(err)}) — the original file was not modified`,
+    };
+  }
+}
+
+/** One item that was staged into a served directory and forwarded by reference. */
+export type StagedForDisplay = {
+  /** The original path the caller passed. */
+  path: string;
+  /** The copy the panel was pointed at. */
+  stagedPath: string;
+  sizeBytes: number;
+  kind: "image" | "video";
+  ref: ComfyServableRef;
+};
+
+/**
+ * What the agent is told about items that took the staging route (#802).
+ *
+ * The disclosure is the point: staging is a real filesystem WRITE into the
+ * user's ComfyUI output directory, and the copies PERSIST. The note states the
+ * write, where it landed, that nothing cleans it up, and — as with every
+ * reference route — that this process forwarded a reference and did not
+ * observe the panel displaying anything.
+ */
+export function stagedForDisplayNote(
+  items: StagedForDisplay[],
+  capBytes: number,
+): string {
+  const one = items.length === 1;
+  const lines = items.map((it) => {
+    return `  - ${it.ref.filename} (${mb(it.sizeBytes)}, ${it.kind}) — copied from ${it.path} to ${it.stagedPath}`;
+  });
+  return (
+    `NOTE — ${one ? "1 item was" : `${items.length} items were`} over the ${mb(capBytes)} inline cap and ${one ? "was" : "were"} STAGED, ` +
+    `because stage:true was passed: the orchestrator COPIED ${one ? "the file" : "each file"} into a directory ComfyUI serves ` +
+    `and sent the panel a /view reference to the copy (that route has no size limit):\n${lines.join("\n")}\n` +
+    `That was a real filesystem WRITE, done only because stage:true opted in. The ${one ? "copy persists" : "copies persist"} — ` +
+    `nothing cleans ${one ? "it" : "them"} up automatically; ${one ? "it lives" : "they live"} in the ${STAGED_SUBFOLDER} folder ` +
+    `above and the user can delete that folder when done. Say so if you mention the file's location.\n` +
+    `You were NOT sent the bytes of ${one ? "this file" : "these files"}. Whether the panel displayed ${one ? "it" : "them"} is in its reply above, not here.`
+  );
+}
+
 const mb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 
 /**
@@ -386,12 +655,20 @@ export function oversizedInlineRefusal(opts: {
     const list = resolution.checked
       .map((r) => `    - ${r.kind}: ${r.dir}`)
       .join("\n");
+    const outputDir = resolution.checked.find((r) => r.kind === "output")?.dir;
+    // Staging is named FIRST because it is the one remedy that is a single
+    // retried call — but it is disclosed as the disk write it is, caps and
+    // persistence included, so choosing it is an informed choice (#802).
+    const staging = outputDir
+      ? `  1. Retry THIS call with stage:true on the item — the orchestrator will COPY the file into ${outputDir}${outputDir.endsWith("/") || outputDir.endsWith("\\") ? "" : "/"}${STAGED_SUBFOLDER} and display the copy by reference. That is a real disk write (caps: ${mb(STAGE_MAX_FILE_BYTES)} per file, ${mb(STAGE_MAX_DIR_BYTES)} total staged) and the copy PERSISTS until someone deletes it.\n`
+      : "";
     return (
       `${head}\n` +
       `This file is not under any directory this ComfyUI serves. Checked:\n${list}\n` +
       `What you can do:\n` +
-      `  1. Copy or move it under one of the directories above (a subfolder is fine) and call panel_show_media again with the NEW path. ${seeItYourself}\n` +
-      `  2. Ask the user to move it, or to open it themselves; it is on the machine they are at.`
+      staging +
+      `  ${staging ? "2" : "1"}. Copy or move it under one of the directories above (a subfolder is fine) and call panel_show_media again with the NEW path. ${seeItYourself}\n` +
+      `  ${staging ? "3" : "2"}. Ask the user to move it, or to open it themselves; it is on the machine they are at.`
     );
   }
 


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#802

## Root cause

`panel_show_media` inlines local files as base64 data URLs, capped at 20 MB. Since #648, an oversized file **already under** a ComfyUI-served directory is forwarded as a `/view` reference (no cap on that route) — but a file **outside** every served directory dead-ended at a refusal whose only remedy was a manual `cp`. That half was deliberately parked: the fix is a disk write into the user's ComfyUI directories, so it ships here as an explicit opt-in, exactly the shape the issue thread converged on.

## What changed

- New optional `stage: true` on `panel_show_media` path items. When a path item is over the 20 MB inline cap and provably **not** under any served directory, the orchestrator copies it into `<output>/_panel_staged/` and forwards a `/view` reference to the **copy** (the by-reference route has no size limit).
- Bounded and fail-closed: 512 MB per-file cap, 2 GB total cap on the staging folder, timestamped names + `COPYFILE_EXCL` (never overwrites), and a post-copy size check — a mismatched copy is deleted and refused, never forwarded.
- Disclosure: the reply note states the orchestrator made a real filesystem write, where the copy landed, that copies **persist** (no automatic cleanup — every temp-file lifecycle this codebase has tried has raced a reader, #1152), and that the agent was not sent the bytes.
- The `outside` refusal now names `stage:true` as the one-call remedy, with the write's cost (caps, persistence) stated where it's offered. Default behaviour, the 20 MB inline cap, and the servable/remote/unknown routing are unchanged. Remote/cloud sessions refuse staging with the reason attached.

## Verification

- `src/__tests__/services/comfy-view-ref.test.ts`: +12 tests (staged ref shape + copy integrity, no-overwrite on repeat, already-inside refusal, remote/cloud refusal, unresolvable output dir, per-file and total caps, refusal wording, disclosure note) — 47/47 pass.
- `src/__tests__/orchestrator/panel-show-media-oversized.test.ts`: +6 wiring tests (stage copies and forwards a ref to the copy; disclosure in reply; no-`stage` stays a refusal and writes nothing; staging failure falls through to the refusal with the reason; servable files never copied; small files still inline) — 25/25 pass.
- Full gate chain in the worktree: `npm ci`, `npm run build` (tsc clean), full `npm test` (vitest + i18n:check + docs links/locale/mdx + blog checks) exit 0, `docs:gen` (no content diff — panel tools aren't in generated reference pages), `check:vocabulary` OK, `vocab:export --check` OK, `check:unknown-collapse` 0 new collapses (the two `.catch` sites carry reasoned `// unknown-ok:` waivers).

## Deliberately not done

- No automatic cleanup of `_panel_staged/` — lifecycle timing is a design decision (#1152 raced exactly this); the copies and their persistence are disclosed instead.
- The 20 MB inline cap is unchanged; staging relocates the file so ComfyUI serves it, it does not enlarge the inline path.