### PR TITLE
release: v0.52.14 — handshake instructions, MiniMax H3 skill, plugin warm-path launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.14] - 2026-08-19
+
 ### Added
 
 - **`minimax-h3-video` plugin skill (#1167).** Local MiniMax H3 (Hailuo) T2V/I2V/R2V
@@ -776,6 +778,17 @@ All notable changes to this project are documented here. This project adheres to
   Template Library, or from Comfy-Org/workflow_templates via `save_workflow` then
   `panel_load_workflow path:`. `run_template` is named only as "won't work until
   a pack exists."
+
+### MCP
+
+#### Added
+- MiniMax H3 local-video skill citing official prompting guides (#1801)
+- canonical flows at MCP initialize (call order, async handles, pre-flight, trust) (#1805)
+
+#### Fixed
+- plugin .mcp.json launches via a warm-path wrapper instead of bare npx (#1807)
+- one-arg panelLauncherPaths keeps windowsStartup under the passed home (#1806)
+
 
 ## [0.52.13] - 2026-08-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.13",
+  "version": "0.52.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.13",
+      "version": "0.52.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.13",
+  "version": "0.52.14",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.14 from `main` (d702e54).

Carries:

- #1805 — canonical flows at MCP initialize (call order, async handles, pre-flight, trust)
- #1801 / #1167 — MiniMax H3 local-video skill citing official prompting guides
- #1806 — one-arg `panelLauncherPaths` keeps `windowsStartup` under the passed home
- #1807 / #1447 — plugin `.mcp.json` launches via a warm-path wrapper instead of bare `npx`

Do **not** squash-merge. Merge-commit (keeps the `v0.52.14` tag on the version commit). Tag is local; push `v0.52.14` after merge.