### PR TITLE
feat(1400): check_runtime consults the panel-proven frontend virtual registry

### DIFF
--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -29,7 +29,7 @@ import { WebSocket } from "ws";
 /** Panel version the mock advertises (#1384). Kept in step with the product's own derived
  *  fence minimum by src/__tests__/scripts/knowledge-parity-mock-version.test.ts — a raised
  *  floor fails that test instead of silently refusing every graph write in the smoke. */
-const MOCK_PANEL_VERSION = "0.15.10";
+const MOCK_PANEL_VERSION = "0.15.11";
 /** A well-formed workflow uuid, so the per-command stamp fence has something to fence on. */
 // MOCK_WORKFLOW_UUID is imported above — it belongs with the executors that answer with it.
 

--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -29,7 +29,7 @@ import { WebSocket } from "ws";
 /** Panel version the mock advertises (#1384). Kept in step with the product's own derived
  *  fence minimum by src/__tests__/scripts/knowledge-parity-mock-version.test.ts — a raised
  *  floor fails that test instead of silently refusing every graph write in the smoke. */
-const MOCK_PANEL_VERSION = "0.13.0";
+const MOCK_PANEL_VERSION = "0.15.10";
 /** A well-formed workflow uuid, so the per-command stamp fence has something to fence on. */
 // MOCK_WORKFLOW_UUID is imported above — it belongs with the executors that answer with it.
 

--- a/scripts/knowledge-parity-mock-graph.mjs
+++ b/scripts/knowledge-parity-mock-graph.mjs
@@ -193,6 +193,12 @@ export function makeGraph() {
     // things, and a populated one is simply invented. The unknown-command error names the
     // harness, which is the honest answer here.
     graph_select_nodes: ({ node_ids }) => ({ selected: node_ids }),
+    // #1400 — the orchestrator pulls this on every hello once its minimum-version
+    // table covers the command; a mock advertising a current version but answering
+    // "unknown command" is the harness lie #1384 exists to catch. The real reply
+    // shape with the honest content for this mock: its registry proves nothing
+    // virtual.
+    graph_get_virtual_types: () => ({ ok: true, virtual_types: [], virtual_type_count: 0 }),
     set_todo: ({ items }) => ({ ok: true, count: (items || []).length }),
     ask_user: (m) => (m.options && m.options[0] && m.options[0].label) || "yes",
   };

--- a/src/__tests__/services/frontend-virtual-types.test.ts
+++ b/src/__tests__/services/frontend-virtual-types.test.ts
@@ -1,0 +1,252 @@
+// #1400 — the frontend-virtual-types channel: orchestrator → spawned MCP child.
+//
+// `check_runtime` runs in the spawned stdio child, which has no bridge; the
+// frontend's virtual-node registry (what the panel proved via
+// `graph_get_virtual_types`) reaches it through this file channel in the shared
+// progress dir. The transport discipline (change-only writes, heartbeat,
+// pid-liveness + freshness, bounded read, atomic rename) is the sibling
+// panel-origin-channel's, deliberately — half of it is reused as code, and the
+// tests below pin the half that is this channel's own: the payload shape, the
+// origin matching, and the fail-closed reads.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FRONTEND_VIRTUAL_TYPES_FILE,
+  FRONTEND_VIRTUAL_TYPES_HEARTBEAT_MS,
+  FRONTEND_VIRTUAL_TYPES_MAX_AGE_MS,
+  frontendVirtualTypesFor,
+  publishFrontendVirtualTypes,
+  resetPublishedFrontendVirtualTypes,
+} from "../../services/frontend-virtual-types.js";
+import { CONTROL_PREFIX, listTargetChangeRequests } from "../../services/download-progress.js";
+
+const ORIGIN = "http://127.0.0.1:8188";
+const VIRTUALS = ["Label (rgthree)", "Fast Groups Bypasser (rgthree)", "Fast Groups Muter (rgthree)"];
+
+let dir = "";
+const savedEnv = process.env.COMFYUI_MCP_PROGRESS_DIR;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-virtuals-"));
+  // The CHILD's view of the channel: the orchestrator hands it this dir in the
+  // spawn env (COMFYUI_MCP_PROGRESS_DIR).
+  process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  resetPublishedFrontendVirtualTypes();
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  else process.env.COMFYUI_MCP_PROGRESS_DIR = savedEnv;
+  rmSync(dir, { recursive: true, force: true });
+  resetPublishedFrontendVirtualTypes();
+});
+
+describe("frontend-virtual-types channel", () => {
+  it("carries the types the orchestrator published for the asked origin", () => {
+    publishFrontendVirtualTypes(dir, [{ origin: ORIGIN, types: VIRTUALS }]);
+    expect([...frontendVirtualTypesFor(ORIGIN)].sort()).toEqual([...VIRTUALS].sort());
+  });
+
+  it("matches loopback SPELLINGS of the same server (#1175)", () => {
+    // The panel's handshake Origin says 127.0.0.1; the child's COMFYUI_URL says
+    // localhost. One server — a spelling comparison would silently disable the
+    // whole feature in the most common install.
+    publishFrontendVirtualTypes(dir, [{ origin: ORIGIN, types: VIRTUALS }]);
+    expect(frontendVirtualTypesFor("http://localhost:8188").size).toBe(VIRTUALS.length);
+  });
+
+  it("answers NOTHING for an origin nobody proved — a different server is not this one", () => {
+    publishFrontendVirtualTypes(dir, [{ origin: ORIGIN, types: VIRTUALS }]);
+    expect(frontendVirtualTypesFor("http://192.0.2.10:8188").size).toBe(0);
+    expect(frontendVirtualTypesFor("http://127.0.0.1:8288").size).toBe(0);
+  });
+
+  it("reads nothing when there is no channel — a plain MCP server", () => {
+    delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("reads nothing when nothing has been published yet", () => {
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("reads nothing from a mid-write or corrupt file", () => {
+    writeFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), '{"entries": [{"origin": "http://127.');
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("drops a disconnected origin's entry — level-triggered, like the sibling channel", () => {
+    publishFrontendVirtualTypes(dir, [{ origin: ORIGIN, types: VIRTUALS }]);
+    publishFrontendVirtualTypes(dir, []);
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("filters a junk payload down to plausible type names", () => {
+    // The answer ultimately comes from page JS. Non-strings, empties and
+    // absurdly long names are not types a healthy panel sent.
+    publishFrontendVirtualTypes(dir, [
+      { origin: ORIGIN, types: ["GetNode", 42, null, "", "x".repeat(301)] as never },
+    ]);
+    expect([...frontendVirtualTypesFor(ORIGIN)]).toEqual(["GetNode"]);
+  });
+
+  it("ignores entries with a non-string origin", () => {
+    writeFileSync(
+      join(dir, FRONTEND_VIRTUAL_TYPES_FILE),
+      JSON.stringify({
+        entries: [{ origin: 42, types: VIRTUALS }, { origin: ORIGIN, types: ["GetNode"] }],
+        updated: Date.now(),
+        pid: process.pid,
+      }),
+    );
+    expect([...frontendVirtualTypesFor(ORIGIN)]).toEqual(["GetNode"]);
+  });
+
+  it("survives an unwritable directory instead of throwing into the poll tick", () => {
+    expect(() =>
+      publishFrontendVirtualTypes(join(dir, "nope", "\0bad"), [{ origin: ORIGIN, types: VIRTUALS }]),
+    ).not.toThrow();
+  });
+});
+
+// The progress dir is shared with the download tray and the target-change
+// control channel. This file must be invisible to both, and the only thing
+// making that true is its name.
+describe("the channel file cannot be mistaken for a download row or a request", () => {
+  it("carries the control prefix pollDownloads filters on", () => {
+    expect(FRONTEND_VIRTUAL_TYPES_FILE.startsWith(CONTROL_PREFIX)).toBe(true);
+  });
+
+  it("is not read as a pending target-change request", () => {
+    publishFrontendVirtualTypes(dir, [{ origin: ORIGIN, types: VIRTUALS }]);
+    expect(listTargetChangeRequests(dir)).toEqual([]);
+  });
+});
+
+// ── Staleness across the publisher's death ───────────────────────────────────
+//
+// A record that outlives its orchestrator would keep exempting types nobody is
+// still observing. The read therefore gates on the publisher being alive AND the
+// record being fresh — the sibling channel's discipline, pinned here because
+// this channel's failure mode is a classification, not a sentence.
+
+/** A pid that is definitely NOT running (see panel-origin-channel.test.ts). */
+function deadPid(): number {
+  const done = spawnSync(process.execPath, ["-e", "0"]);
+  if (typeof done.pid !== "number") throw new Error("could not obtain a dead pid");
+  return done.pid;
+}
+
+function writeRecord(record: unknown): void {
+  writeFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), JSON.stringify(record));
+}
+
+describe("frontend-virtual-types channel — staleness", () => {
+  const entries = [{ origin: ORIGIN, types: VIRTUALS }];
+
+  it("ignores a record whose publisher is gone", () => {
+    writeRecord({ entries, updated: Date.now(), pid: deadPid() });
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("ignores a record with NO pid", () => {
+    writeRecord({ entries, updated: Date.now() });
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("ignores a stale record even when the pid is alive (pid reuse)", () => {
+    writeRecord({ entries, updated: Date.now() - FRONTEND_VIRTUAL_TYPES_MAX_AGE_MS - 1, pid: process.pid });
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("ignores a record stamped in the FUTURE", () => {
+    writeRecord({ entries, updated: Date.now() + 60_000, pid: process.pid });
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(0);
+  });
+
+  it("accepts a live, fresh record", () => {
+    // The direction that must keep working: a suite that only asserted rejection
+    // could pass with the reader hard-wired to empty.
+    writeRecord({ entries, updated: Date.now(), pid: process.pid });
+    expect(frontendVirtualTypesFor(ORIGIN).size).toBe(VIRTUALS.length);
+  });
+
+  it("the heartbeat stays comfortably inside the age limit", () => {
+    expect(FRONTEND_VIRTUAL_TYPES_HEARTBEAT_MS * 2).toBeLessThanOrEqual(
+      FRONTEND_VIRTUAL_TYPES_MAX_AGE_MS,
+    );
+  });
+});
+
+describe("frontend-virtual-types channel — heartbeat", () => {
+  const entries = [{ origin: ORIGIN, types: VIRTUALS }];
+
+  it("does NOT rewrite an unchanged map on every tick", () => {
+    const now = Date.now();
+    publishFrontendVirtualTypes(dir, entries, now);
+    const first = readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8");
+    publishFrontendVirtualTypes(dir, entries, now + 700);
+    publishFrontendVirtualTypes(dir, entries, now + 1_400);
+    expect(readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8")).toBe(first);
+  });
+
+  it("DOES refresh an unchanged map once the heartbeat is due", () => {
+    const now = Date.now();
+    publishFrontendVirtualTypes(dir, entries, now);
+    const first = JSON.parse(readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8"));
+    publishFrontendVirtualTypes(dir, entries, now + FRONTEND_VIRTUAL_TYPES_HEARTBEAT_MS);
+    const second = JSON.parse(readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8"));
+    expect(second.updated).toBeGreaterThan(first.updated);
+    expect(second.entries).toEqual(first.entries);
+  });
+
+  it("does not rewrite when only the ORDER or duplication changed", () => {
+    const now = Date.now();
+    publishFrontendVirtualTypes(dir, entries, now);
+    const first = readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8");
+    publishFrontendVirtualTypes(
+      dir,
+      [{ origin: ORIGIN, types: [...VIRTUALS].reverse().concat(VIRTUALS[0]) }],
+      now + 700,
+    );
+    expect(readFileSync(join(dir, FRONTEND_VIRTUAL_TYPES_FILE), "utf-8")).toBe(first);
+  });
+});
+
+// The pull and the publish run inside the orchestrator's own startup closures,
+// which no test can construct. What CAN be pinned is that both sit where the
+// panel lifecycle drives them — the hello handler and the 700ms tick — the
+// property a future edit is most likely to break (mirrors the #1415 wiring
+// assertions in child-panel-origin-drift.test.ts).
+describe("#1400 WIRING: the orchestrator pulls on hello and publishes on the poll tick", () => {
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(HERE, "../../orchestrator/index.ts"), "utf8");
+
+  it("pulls the tab's virtual registry on hello, keyed by the handshake origin", () => {
+    const hello = src.indexOf('bridge.onPanelMessage = (event) => {');
+    expect(hello).toBeGreaterThan(-1);
+    const body = src.slice(hello, hello + 20_000);
+    expect(body).toMatch(/pullFrontendVirtualTypes\(/);
+    // tabServerOrigin is the SERVER-OBSERVED handshake origin; tabOrigin is the
+    // spoofable hello claim. The pull must key on the former (the #756 trust
+    // model) — a tab annotates only the server it provably fronts.
+    expect(src).toMatch(/bridge\.tabServerOrigin\(tabId\)/);
+  });
+
+  it("publishes inside pollDownloads, scoped to origins a tab still fronts", () => {
+    const open = src.indexOf("const pollDownloads = () => {");
+    const close = src.indexOf("const downloadTimer = setInterval(pollDownloads, 700);");
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    const body = src.slice(open, close);
+    expect(body).toMatch(/publishFrontendVirtualTypes\(\s*progressDir,/);
+    expect(body).toMatch(/connectedServerOrigins\(\)/);
+    // …and nowhere else, so this test is asking about the only call site.
+    expect(src.split("publishFrontendVirtualTypes(").length - 1).toBe(1);
+  });
+});

--- a/src/__tests__/services/runtime-virtual-nodes.test.ts
+++ b/src/__tests__/services/runtime-virtual-nodes.test.ts
@@ -192,16 +192,88 @@ describe("a Get/Set bus node is not an unknown runtime (#1400)", () => {
     expect(r.usesApiNodes).toBe(true);
   });
 
-  it("rgthree's canvas-only nodes are still UNKNOWN — cautious, and deliberately so", async () => {
-    // The rest of #1400's population (Label, Fast Groups Bypasser/Muter) is NOT covered.
-    // The converter does not strip them, so nothing here can prove they never execute, and
-    // guessing "free" is a guess with someone's money on it. Recorded as a test so the gap
-    // is a decision rather than an oversight.
+  it("rgthree's canvas-only nodes are still UNKNOWN without panel proof — cautious, and deliberately so", async () => {
+    // The rest of #1400's population (Label, Fast Groups Bypasser/Muter) is not in the
+    // converter's list, so with no connected panel's registry to consult (this deps set
+    // has no getFrontendVirtualTypes — the plain-MCP-server case) the doubt is preserved.
+    // Recorded as a test so the gap is a decision rather than an oversight. The WITH-panel
+    // half is the describe block below.
     const r = await checkWorkflowRuntime(
       graphOf("KSampler", "Fast Groups Bypasser (rgthree)"),
       depsWith({ KSampler: KSAMPLER }),
     );
     expect(r.runtime).toBe("unknown");
     expect(r.unknownNodes).toEqual(["Fast Groups Bypasser (rgthree)"]);
+  });
+});
+
+// #1400 — the parked half, landed: when a panel IS connected, the orchestrator pulls the
+// frontend's own virtual registry (`graph_get_virtual_types` — the registered classes whose
+// probe instances carry `isVirtualNode === true`, the flag ComfyUI's serializer reads) and
+// republishes it to this process. The classifier consults it UNDER THE SAME def-first rule
+// as the static set: only a type the server does NOT register can be exempted.
+describe("the panel-proven virtual registry is consulted (#1400)", () => {
+  const RGTHREE_VIRTUALS = ["Label (rgthree)", "Fast Groups Bypasser (rgthree)", "Fast Groups Muter (rgthree)"];
+  function depsWithVirtuals(objectInfo: Record<string, unknown>, virtuals: readonly string[]) {
+    return {
+      getObjectInfo: async () => objectInfo,
+      getFrontendVirtualTypes: () => new Set(virtuals),
+    } as never;
+  }
+
+  it("THE PARKED CASE: rgthree canvas-only nodes are local once the frontend proves them virtual", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", ...RGTHREE_VIRTUALS),
+      depsWithVirtuals({ KSampler: KSAMPLER }, RGTHREE_VIRTUALS),
+    );
+    expect(r.runtime).toBe("local");
+    expect(r.usesApiNodes).toBe(false);
+    expect(r.unknownNodes).toEqual([]);
+  });
+
+  it("a type the panel did NOT prove stays unknown — partial proof does not leak", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "Label (rgthree)", "SomeUninstalledPackNode"),
+      depsWithVirtuals({ KSampler: KSAMPLER }, RGTHREE_VIRTUALS),
+    );
+    expect(r.runtime).toBe("unknown");
+    expect(r.unknownNodes).toEqual(["SomeUninstalledPackNode"]);
+  });
+
+  it("a REGISTERED api node whose name is in the virtual set is still classified — the def-first rule", async () => {
+    // The #1396 codex P1 applies to the new source identically: the panel's answer exempts
+    // only what the server does not register. A backend node — possibly PAID — that shares
+    // a name with a proven-virtual type is examined, never skipped.
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "Label (rgthree)"),
+      depsWithVirtuals(
+        { KSampler: KSAMPLER, "Label (rgthree)": { ...API_NODE, name: "Label (rgthree)" } },
+        RGTHREE_VIRTUALS,
+      ),
+    );
+    expect(r.runtime).toBe("mixed");
+    expect(r.usesApiNodes).toBe(true);
+    expect(r.apiNodes).toContain("Label (rgthree)");
+  });
+
+  it("panel-proven virtuals leave the DENOMINATOR too — one API node beside them is 'api', not 'mixed'", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("FluxProImageNode", ...RGTHREE_VIRTUALS),
+      depsWithVirtuals({ FluxProImageNode: API_NODE }, RGTHREE_VIRTUALS),
+    );
+    expect(r.runtime).toBe("api");
+    expect(r.usesApiNodes).toBe(true);
+  });
+
+  it("a throwing source is 'no proof', never a failed classification", async () => {
+    const deps = {
+      getObjectInfo: async () => ({ KSampler: KSAMPLER }),
+      getFrontendVirtualTypes: () => {
+        throw new Error("channel exploded");
+      },
+    } as never;
+    const r = await checkWorkflowRuntime(graphOf("KSampler", "Label (rgthree)"), deps);
+    expect(r.runtime).toBe("unknown");
+    expect(r.unknownNodes).toEqual(["Label (rgthree)"]);
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -29,9 +29,16 @@ import {
   startUiBridge,
   isLoopbackBindHost,
   isMirrorSafeFrameType,
+  isUnknownCommandReply,
+  isPanelCmdUnsupportedError,
   SESSION_EPOCH,
   type UiBridge,
 } from "../services/ui-bridge.js";
+import { canonicalOrigin } from "../utils/origin.js";
+import {
+  publishFrontendVirtualTypes,
+  type FrontendVirtualTypesEntry,
+} from "../services/frontend-virtual-types.js";
 import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } from "../services/secure-bridge.js";
 import { judgeHelloRetarget, canonComfyuiTargetUrl } from "../services/hello-retarget.js";
 import { startQuickTunnel } from "../services/tunnel.js";
@@ -1968,6 +1975,59 @@ export async function runPanelOrchestrator(): Promise<void> {
   // mirror-image lie: claiming to be a build we are not running.
   const mcpVersionRunning = MCP_VERSION_RUNNING;
   let latestPanelVersion: string | undefined;
+
+  // #1400 — the frontend VIRTUAL-node registry each connected canvas-owning tab
+  // has PROVEN (its `graph_get_virtual_types` answer: the registered classes that
+  // set `isVirtualNode === true`, the flag ComfyUI's own serializer reads to keep
+  // a node out of the prompt). The headless `check_runtime` in the spawned tool
+  // servers cannot see a browser registry, so each hello pulls this and the poll
+  // tick republishes it through the progress-dir channel the children read
+  // (services/frontend-virtual-types.ts).
+  //
+  // Keyed by the tab's SERVER-OBSERVED handshake origin (bridge.tabServerOrigin),
+  // NEVER the hello's client-supplied comfyui_url claim — page JS can write the
+  // claim but cannot forge the browser's Origin header (the #756 trust model), so
+  // a tab can only annotate the server it provably fronts. A failed or refused
+  // pull keeps the PREVIOUS answer for the origin; only an ok:true reply
+  // replaces it, so a transient error never erases known-good proof.
+  const frontendVirtualTypesByOrigin = new Map<string, string[]>();
+  // Panel versions that PROVED they lack the command (an Unknown-command reply or
+  // the proactive too-old refusal), so an old panel is asked once per process,
+  // not once per hello. Keyed by version, not tab: a panel UPDATE keeps the tab
+  // but moves the version, and must be asked again.
+  const virtualTypesUnsupportedPanelVersions = new Set<string>();
+
+  async function pullFrontendVirtualTypes(tabId: string, panelVersion?: string): Promise<void> {
+    // A headless (mobile/mirror) client fronts no canvas registry.
+    if (bridge.isCurrentHeadless(tabId)) return;
+    if (panelVersion && virtualTypesUnsupportedPanelVersions.has(panelVersion)) return;
+    const origin = bridge.tabServerOrigin(tabId);
+    // No proven handshake origin → the answer would be keyed on a claim. Skip:
+    // an unkeyed registry is not evidence about any server.
+    if (!origin) return;
+    try {
+      const reply = (await bridge.send({ cmd: "graph_get_virtual_types" }, { tabId })) as
+        | { ok?: boolean; virtual_types?: unknown }
+        | undefined;
+      // ok:false (the panel could not read its own registry) or a malformed
+      // answer keeps the previous entry rather than replacing it with nothing.
+      if (reply?.ok !== true || !Array.isArray(reply.virtual_types)) return;
+      const types = reply.virtual_types.filter(
+        (t): t is string => typeof t === "string" && t !== "",
+      );
+      frontendVirtualTypesByOrigin.set(canonicalOrigin(origin) ?? origin, types);
+    } catch (err) {
+      // A panel that predates the command is a STABLE fact for this process —
+      // remember the version and stop re-asking on every hello. Any other
+      // failure (timeout, mid-restart socket drop) is transient: the previous
+      // answer stands and the next hello retries.
+      if (isPanelCmdUnsupportedError(err, "graph_get_virtual_types") ||
+          isUnknownCommandReply(err instanceof Error ? err.message : String(err))) {
+        if (panelVersion) virtualTypesUnsupportedPanelVersions.add(panelVersion);
+      }
+    }
+  }
+
   let panelSystemAppend = resolvePanelPersona();
   // Set once the manager exists so a later refresh (after a ComfyUI restart) feeds
   // the freshly-gathered env into newly-spawned agents too — Claude reads
@@ -3697,6 +3757,13 @@ export async function runPanelOrchestrator(): Promise<void> {
         latestPanelVersion = helloPanelVer;
         void refreshEnvCapabilities();
       }
+      // #1400 — pull this tab's proven frontend-virtual registry for the
+      // check_runtime channel. On EVERY hello, not just the first: a page reload
+      // is how a pack's frontend JS arrives or leaves, and the reload re-hellos.
+      void pullFrontendVirtualTypes(
+        panelTab,
+        typeof helloPanelVer === "string" && helloPanelVer ? helloPanelVer : undefined,
+      );
       // #236 — THE VOCABULARY HANDSHAKE, at the handshake.
       //
       // `describeVocabularySkew` and the hash it compares have existed, fully
@@ -5794,6 +5861,22 @@ export async function runPanelOrchestrator(): Promise<void> {
     // the child must never quote a panel that has since disconnected. Writes only
     // when the set changed.
     publishConnectedPanelOrigins(progressDir, bridge.connectedServerOrigins());
+    // #1400 — the same level-triggered discipline for the frontend-virtual
+    // registry: republish the CURRENT map, scoped to origins a connected tab
+    // actually fronts, so a disconnected tab's entry drops out of the channel
+    // within one tick rather than exempting types for a page that is gone.
+    {
+      const fronted = new Set(
+        bridge
+          .connectedServerOrigins()
+          .map((o) => canonicalOrigin(o) ?? o),
+      );
+      const virtualEntries: FrontendVirtualTypesEntry[] = [];
+      for (const [origin, types] of frontendVirtualTypesByOrigin) {
+        if (fronted.has(origin)) virtualEntries.push({ origin, types });
+      }
+      publishFrontendVirtualTypes(progressDir, virtualEntries);
+    }
     let files: string[] = [];
     try {
       files = readdirSync(progressDir).filter((f) => f.endsWith(".json"));

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -5,9 +5,10 @@ import type {
   WorkflowJSON,
 } from "../comfyui/types.js";
 import { FRONTEND_ONLY_NODE_TYPES } from "./workflow-converter.js";
+import { frontendVirtualTypesFor } from "./frontend-virtual-types.js";
 import { getObjectInfo } from "../comfyui/client.js";
 import { enqueueWorkflow } from "./workflow-executor.js";
-import { config } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
 import { ValidationError } from "../utils/errors.js";
 
 /**
@@ -46,11 +47,21 @@ export interface ApiNodesDeps {
       extra_data?: Record<string, unknown>;
     },
   ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
+  /** #1400 — the node types a connected panel has PROVEN frontend-virtual on the
+   *  ComfyUI this process targets (its registered classes set `isVirtualNode ===
+   *  true`, the flag ComfyUI's own serializer reads to keep a node out of the
+   *  prompt). The headless classifier cannot see the frontend's registry, so the
+   *  orchestrator pulls it over the panel bridge and republishes it through the
+   *  progress-dir channel (services/frontend-virtual-types.ts). Optional: absent
+   *  (a plain MCP server with no panel, a stale record) means "no proof", and
+   *  the classification keeps its cautious pre-#1400 "unknown" for those types. */
+  getFrontendVirtualTypes?: () => ReadonlySet<string>;
 }
 
 const defaultDeps: ApiNodesDeps = {
   getObjectInfo,
   enqueue: enqueueWorkflow,
+  getFrontendVirtualTypes: () => frontendVirtualTypesFor(getComfyUIBaseUrl()),
 };
 
 /** True if a node definition is a hosted partner/API node. */
@@ -392,6 +403,22 @@ export async function checkWorkflowRuntime(
 ): Promise<WorkflowRuntime> {
   const classTypes = extractWorkflowClassTypes(graph);
   const objectInfo = await deps.getObjectInfo();
+  // #1400 — the SECOND source of frontend-only proof, alongside the static
+  // FRONTEND_ONLY_NODE_TYPES: the types a connected panel observed this
+  // frontend's registry prove virtual (`isVirtualNode === true` on the
+  // registered class — covering third-party virtual nodes like rgthree's Label /
+  // Fast Groups toggles that no static list may name). Read ONCE per call; an
+  // absent/unreadable channel is an empty set, and a type it names is still
+  // classified from its /object_info def whenever the server registers one (the
+  // def-first rule below applies to both sources identically).
+  let frontendVirtual: ReadonlySet<string>;
+  try {
+    frontendVirtual = deps.getFrontendVirtualTypes?.() ?? new Set();
+  } catch {
+    // A broken source is "no proof", never a failure of the classification it
+    // was only narrowing.
+    frontendVirtual = new Set();
+  }
   const apiNodes: string[] = [];
   const externalApiNodes: string[] = [];
   const externalProviders: string[] = [];
@@ -423,8 +450,9 @@ export async function checkWorkflowRuntime(
     //
     // Absence from /object_info is not a heuristic for "virtual", it is the definition:
     // the frontend registers these, the backend does not. So a REGISTERED node of the same
-    // name is a real node and is classified as one.
-    if (!def && FRONTEND_ONLY_NODE_TYPES.has(ct)) continue;
+    // name is a real node and is classified as one. The #1400 panel-observed set is
+    // consulted under the SAME rule: it exempts only what the server does not register.
+    if (!def && (FRONTEND_ONLY_NODE_TYPES.has(ct) || frontendVirtual.has(ct))) continue;
     if (!def) {
       unknownNodes.push(ct);
       continue;
@@ -445,7 +473,7 @@ export async function checkWorkflowRuntime(
   // otherwise a workflow of one KSampler plus three Notes reads as 1-of-4 API and reports
   // "mixed" when it is entirely local.
   const virtualCount = classTypes.filter(
-    (ct) => !objectInfo[ct] && FRONTEND_ONLY_NODE_TYPES.has(ct),
+    (ct) => !objectInfo[ct] && (FRONTEND_ONLY_NODE_TYPES.has(ct) || frontendVirtual.has(ct)),
   ).length;
   const classifiable = classTypes.length - unknownNodes.length - virtualCount;
   let runtime: "local" | "api" | "mixed" | "unknown";

--- a/src/services/frontend-virtual-types.ts
+++ b/src/services/frontend-virtual-types.ts
@@ -1,0 +1,202 @@
+// The frontend's VIRTUAL-node registry, ORCHESTRATOR → spawned MCP child (#1400).
+//
+// `check_runtime` (checkWorkflowRuntime, services/api-nodes.ts) classifies a
+// workflow's node types against the connected server's /object_info. A type
+// absent from /object_info is reported in `unknownNodes` and collapses the
+// verdict to "unknown" — cautious by design, because such a type COULD be a paid
+// node the server does not expose. But the caution is wrong for a type that can
+// never execute at all: a frontend-only VIRTUAL node (KJNodes' Get/Set bus,
+// rgthree's Label / Fast Groups toggles, …). #1372/#1564 exempted the names the
+// converter already knew; the owner declined a list of third-party names — a
+// list goes stale silently and then reads as authoritative.
+//
+// The authority is the FRONTEND's LiteGraph registry: a type whose registered
+// class sets `isVirtualNode === true` is skipped by ComfyUI's own serializer and
+// never reaches the backend. The panel (comfyui-mcp-panel, the one process that
+// CAN see that registry) proves it per type by probe-constructing the class, and
+// serves it as the `graph_get_virtual_types` bridge command. The orchestrator
+// pulls that answer on each panel hello and republishes it here, into the
+// progress dir every spawned comfyui tool server already shares
+// (COMFYUI_MCP_PROGRESS_DIR — the same plumbing as panel-origin-channel.ts,
+// whose read/liveness/write helpers this module reuses so the two channels
+// cannot drift). A child has no bridge; a file it can read is the whole channel.
+//
+// Entries are keyed by the tab's SERVER-OBSERVED handshake origin (UiBridge's
+// tabServerOrigin), never the client-supplied hello claim — page JS can write
+// the claim, it cannot forge the browser's Origin header (the #756 trust model).
+// The reader matches its own target with sameOrigin (utils/origin.ts), so
+// 127.0.0.1 and localhost spellings of one server are one entry (#1175).
+//
+// LEVEL-TRIGGERED like the sibling channel: the orchestrator republishes the
+// CURRENT map on its 700ms poll tick, keyed to origins a connected tab actually
+// fronts. A tab that goes away drops its entry within one tick, so a stale set
+// stops exempting almost immediately. The record also carries the publisher's
+// pid + a heartbeat, and the reader requires BOTH (see panel-origin-channel.ts
+// for why each alone leaves a hole): a crashed orchestrator's record expires
+// instead of exempting forever.
+//
+// ## What a wrong or stale answer could do, stated rather than implied
+//
+// The classifier checks /object_info FIRST: a type the server registers is
+// classified from its def, and this set is never consulted for it — a stale or
+// even hostile entry cannot move a REGISTERED (possibly paid) node. What an
+// entry moves is only a type ABSENT from /object_info, from "unknown" to
+// skipped. Such a type cannot execute on that server at all (an unregistered
+// class_type is rejected at /prompt), so it cannot bill: the worst a stale entry
+// produces is "local" for a workflow that is actually BROKEN (its pack removed),
+// which fails loudly at queue time and is a runnability answer, not the
+// cost answer this tool exists to give. The fail-closed direction is preserved.
+//
+// No-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — a plain (non-panel)
+// MCP server keeps the pre-#1400 "unknown" exactly as before.
+
+import { join } from "node:path";
+import {
+  publisherAlive,
+  readChannelFile,
+  writeChannelPayload,
+} from "./panel-origin-channel.js";
+import { sameOrigin } from "../utils/origin.js";
+
+/** File name inside the progress dir. The `control-` prefix is load-bearing:
+ *  pollDownloads and listTargetChangeRequests both filter on it, so this file is
+ *  never mistaken for a download row or a target-change request (same contract
+ *  as PANEL_ORIGINS_FILE). */
+export const FRONTEND_VIRTUAL_TYPES_FILE = "control-frontend-virtual-types.json";
+
+/** Refresh cadence for an UNCHANGED map, so a reader can tell "still true" from
+ *  "nobody has touched this since the orchestrator died". Mirrors the sibling
+ *  channel's 30s heartbeat against the same 700ms tick. */
+export const FRONTEND_VIRTUAL_TYPES_HEARTBEAT_MS = 30_000;
+
+/** How stale a record may be before the reader stops trusting it (4x the
+ *  heartbeat, mirroring the sibling channel: the cost of expiring a good record
+ *  is a cautious "unknown", but flapping would be worse). */
+export const FRONTEND_VIRTUAL_TYPES_MAX_AGE_MS = 120_000;
+
+/** Defensive bounds on a payload that ultimately comes from page JS. The honest
+ *  answer is a few dozen short type names; anything past these is not something
+ *  a healthy panel sent. */
+const MAX_TYPES_PER_ORIGIN = 512;
+const MAX_TYPE_CHARS = 300;
+
+export interface FrontendVirtualTypesEntry {
+  /** The SERVER-OBSERVED handshake origin of the tab that proved these types. */
+  origin: string;
+  /** Type names whose registered class the panel proved `isVirtualNode === true`. */
+  types: string[];
+}
+
+/** Read at CALL time, not at module load: a test can point the channel at a temp
+ *  dir, and nothing in production changes it after spawn anyway. */
+function channelFile(dir?: string): string | null {
+  const base = dir ?? process.env.COMFYUI_MCP_PROGRESS_DIR ?? "";
+  return base ? join(base, FRONTEND_VIRTUAL_TYPES_FILE) : null;
+}
+
+/** Last payload written by THIS process (change-only writes), and when. */
+let lastPublished: string | null = null;
+let lastWriteAt = 0;
+
+/**
+ * Orchestrator side: publish the CURRENT virtual-registry map — one entry per
+ * origin a connected tab fronts and has answered `graph_get_virtual_types` for.
+ * Level-triggered: callers pass the whole live map every tick, and an origin
+ * whose tab disconnected drops out of the file within that tick.
+ *
+ * Best-effort: a failed write leaves the child on the previous record, which the
+ * freshness check expires — the classifier falls back to "unknown", never to a
+ * fabricated "virtual".
+ */
+export function publishFrontendVirtualTypes(
+  dir: string,
+  entries: readonly FrontendVirtualTypesEntry[],
+  now: number = Date.now(),
+): void {
+  const file = channelFile(dir);
+  if (!file) return;
+  // What actually gets published: validated, bounded, deduped, ordered — the
+  // change-key and the payload are both built from THIS, so they cannot
+  // disagree, and a hostile-sized answer is cut to the defensive bounds before
+  // it can reach the classifier.
+  const published = entries
+    .filter((e) => e && typeof e.origin === "string" && e.origin !== "")
+    .map((e) => ({
+      origin: e.origin,
+      types: [
+        ...new Set(
+          (Array.isArray(e.types) ? e.types : []).filter(
+            (t): t is string =>
+              typeof t === "string" && t !== "" && t.length <= MAX_TYPE_CHARS,
+          ),
+        ),
+      ]
+        .sort()
+        .slice(0, MAX_TYPES_PER_ORIGIN),
+    }))
+    .sort((a, b) => (a.origin < b.origin ? -1 : a.origin > b.origin ? 1 : 0));
+  const key = JSON.stringify(published);
+  const changed = key !== lastPublished;
+  const heartbeatDue = now - lastWriteAt >= FRONTEND_VIRTUAL_TYPES_HEARTBEAT_MS;
+  if (!changed && !heartbeatDue) return;
+  const payload = JSON.stringify({ entries: published, updated: now, pid: process.pid });
+  // A failed write leaves the PRIOR complete record in place; do NOT record this
+  // as published, so the next tick retries (the sibling channel's rule).
+  if (!writeChannelPayload(dir, file, payload)) return;
+  lastPublished = key;
+  lastWriteAt = now;
+}
+
+/** Test/shutdown hook: forget what this process last published, so the next
+ *  publish writes unconditionally. */
+export function resetPublishedFrontendVirtualTypes(): void {
+  lastPublished = null;
+  lastWriteAt = 0;
+}
+
+/**
+ * Child side: the virtual types a connected panel proved for the ComfyUI at
+ * `targetOrigin` (this process's own ComfyUI base URL — matching is alias-aware
+ * via sameOrigin). An EMPTY SET — never an error — when there is no channel (a
+ * plain MCP server), no live/fresh record, no entry for this origin, or the
+ * payload is unreadable: "no proof" is the cautious answer, and the classifier's
+ * pre-#1400 behaviour is the fallback every one of those shares.
+ */
+export function frontendVirtualTypesFor(
+  targetOrigin: string | undefined,
+  now: number = Date.now(),
+): ReadonlySet<string> {
+  const out = new Set<string>();
+  const file = channelFile();
+  if (!file || !targetOrigin) return out;
+  try {
+    const raw = JSON.parse(readChannelFile(file)) as {
+      entries?: unknown;
+      updated?: unknown;
+      pid?: unknown;
+    };
+    if (!Array.isArray(raw?.entries)) return out;
+    // A record whose publisher is gone describes a registry nobody is still
+    // observing. Both checks, per the sibling channel: liveness catches the
+    // death, freshness catches a reused pid.
+    if (!publisherAlive(raw.pid)) return out;
+    const updated = typeof raw.updated === "number" ? raw.updated : 0;
+    // `updated > now` (a clock step, or a future-dated write) is NOT freshness
+    // evidence — without this it would read as maximally fresh, forever.
+    if (updated > now || now - updated > FRONTEND_VIRTUAL_TYPES_MAX_AGE_MS) return out;
+    for (const entry of raw.entries as Array<{ origin?: unknown; types?: unknown }>) {
+      if (!entry || typeof entry.origin !== "string" || !entry.origin) continue;
+      if (!sameOrigin(entry.origin, targetOrigin)) continue;
+      for (const t of Array.isArray(entry.types) ? entry.types : []) {
+        if (typeof t === "string" && t !== "" && t.length <= MAX_TYPE_CHARS) out.add(t);
+        if (out.size >= MAX_TYPES_PER_ORIGIN) break;
+      }
+      // One origin match is the answer; a second entry for the same server would
+      // be a publisher bug, and first-wins is at least DETERMINISTIC about it.
+      break;
+    }
+    return out;
+  } catch {
+    return out;
+  }
+}

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -153,6 +153,59 @@ function tempPathFor(file: string): string {
   return `${file}.${process.pid}-${publishSeq++}-${entropy}.tmp`;
 }
 
+/**
+ * Write `payload` to `file` atomically; returns whether it LANDED.
+ *
+ * Write-then-rename, NOT an in-place rewrite. `writeFileSync(file, …)`
+ * truncates and refills, so a child reading during that window sees a
+ * partial record, fails to parse, and answers [] — dropping every live
+ * origin at exactly the moment it is formatting the error those origins
+ * explain (review r2). A rename makes readers see the old record or the new
+ * one, never a torn one.
+ *
+ * Same shape as persistDownloadJob (download-progress.ts), including its
+ * reason for retrying: on Windows a reader briefly holding the target open
+ * makes rename fail transiently. On persistent failure the PRIOR complete
+ * record is left untouched and the temp dropped — the next tick retries, so
+ * this self-heals rather than degrading to a torn write.
+ *
+ * Exported for the sibling control channel (frontend-virtual-types.ts, #1400):
+ * one atomic-write implementation, so the two cannot drift apart.
+ */
+export function writeChannelPayload(dir: string, file: string, payload: string): boolean {
+  try {
+    mkdirSync(dir, { recursive: true });
+    const tmp = tempPathFor(file);
+    let renamed = false;
+    try {
+      writeFileSync(tmp, payload);
+      for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
+        try {
+          renameSync(tmp, file);
+          renamed = true;
+        } catch {
+          /* transient (e.g. Windows sharing violation) — retry */
+        }
+      }
+    } finally {
+      // In a `finally`, so a THROWING write is cleaned up too. With the removal
+      // sitting after the loop instead, a `writeFileSync` that failed partway —
+      // a full disk is the ordinary cause — left its partial temp behind and
+      // added another on every tick thereafter (review r3).
+      if (!renamed) {
+        try {
+          rmSync(tmp, { force: true });
+        } catch {
+          /* ignore — a stray .tmp is not the channel file and is never read */
+        }
+      }
+    }
+    return renamed;
+  } catch {
+    return false; // retried on the next tick
+  }
+}
+
 /** Refresh the record at least this often even when the set is UNCHANGED, so a
  *  reader can tell "still true" from "nobody has touched this since the
  *  orchestrator died". 30s against a 700ms tick is ~2 writes a minute — the
@@ -183,8 +236,11 @@ const MAX_CHANNEL_BYTES = 64 * 1024;
  * already parked, inside the error path, forever. (Written the other way first,
  * with a comment claiming the fstat covered it. It did not.) Undefined on
  * Windows, where the case does not arise, so it falls back to 0.
+ *
+ * Exported for the sibling control channel (frontend-virtual-types.ts, #1400):
+ * one bounded-read implementation, so the two cannot drift apart.
  */
-function readChannelFile(file: string): string {
+export function readChannelFile(file: string): string {
   const fd = openSync(file, readFlags());
   try {
     const stat = fstatSync(fd);
@@ -213,8 +269,9 @@ function readChannelFile(file: string): string {
  *  `process.kill(pid, 0)` sends no signal — it only asks. EPERM means the pid
  *  exists but belongs to another user, which still answers "alive". Anything
  *  unreadable answers false, because this gates a claim and an unanswerable
- *  question must not grant it. */
-function publisherAlive(pid: unknown): boolean {
+ *  question must not grant it. Exported for the sibling control channel
+ *  (frontend-virtual-types.ts, #1400). */
+export function publisherAlive(pid: unknown): boolean {
   if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
@@ -265,51 +322,13 @@ export function publishConnectedPanelOrigins(
     updated: now,
     pid: process.pid,
   });
-  try {
-    mkdirSync(dir, { recursive: true });
-    // Write-then-rename, NOT an in-place rewrite. `writeFileSync(file, …)`
-    // truncates and refills, so a child reading during that window sees a
-    // partial record, fails to parse, and answers [] — dropping every live
-    // origin at exactly the moment it is formatting the error those origins
-    // explain (review r2). A rename makes readers see the old record or the new
-    // one, never a torn one.
-    //
-    // Same shape as persistDownloadJob (download-progress.ts), including its
-    // reason for retrying: on Windows a reader briefly holding the target open
-    // makes rename fail transiently. On persistent failure the PRIOR complete
-    // record is left untouched and the temp dropped — the next tick retries, so
-    // this self-heals rather than degrading to a torn write.
-    const tmp = tempPathFor(file);
-    let renamed = false;
-    try {
-      writeFileSync(tmp, payload);
-      for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
-        try {
-          renameSync(tmp, file);
-          renamed = true;
-        } catch {
-          /* transient (e.g. Windows sharing violation) — retry */
-        }
-      }
-    } finally {
-      // In a `finally`, so a THROWING write is cleaned up too. With the removal
-      // sitting after the loop instead, a `writeFileSync` that failed partway —
-      // a full disk is the ordinary cause — left its partial temp behind and
-      // added another on every tick thereafter (review r3).
-      if (!renamed) {
-        try {
-          rmSync(tmp, { force: true });
-        } catch {
-          /* ignore — a stray .tmp is not the channel file and is never read */
-        }
-      }
-    }
-    if (!renamed) return; // do NOT record it as published; the next tick retries
-    lastPublished = key;
-    lastWriteAt = now;
-  } catch {
-    // ignore — retried on the next tick
-  }
+  // The atomic write lives in writeChannelPayload (shared with the sibling
+  // frontend-virtual-types channel, #1400); a false return means the PRIOR
+  // complete record was left in place, so do NOT record this as published —
+  // the next tick retries.
+  if (!writeChannelPayload(dir, file, payload)) return;
+  lastPublished = key;
+  lastWriteAt = now;
 }
 
 /** Test/shutdown hook: forget what this process last published, so the next

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -292,6 +292,13 @@ export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
   // "graph_resize_node" (detected 0.11.21) — update … to ≥0.11.4`. Tabled, it quotes
   // the true minimum and the #392 proactive gate rejects the first call pre-dispatch.
   graph_resize_node: "0.11.25",
+  // #1400 — the panel serving its frontend's VIRTUAL-type registry ships in the
+  // panel release carrying the `graph_get_virtual_types` executor. The entry is
+  // deliberately on the LOW side of whatever that release turns out to be: the
+  // only caller (the orchestrator's hello-time pull) degrades silently on an
+  // unknown-command reply, so a too-low floor can never produce a wrong verdict —
+  // it just lets an old panel answer "Unknown command", which the pull swallows.
+  graph_get_virtual_types: "0.15.10",
 };
 
 /**
@@ -843,6 +850,10 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_serialize",
   // Reads the tab's own /object_info and returns it. Touches nothing.
   "graph_get_object_info",
+  // #1400: reads the tab's LiteGraph class registry and probe-constructs
+  // provenance-clean classes off-graph. Touches no canvas; idempotent — safe to
+  // re-dispatch after a socket drop (the orchestrator pulls it on every hello).
+  "graph_get_virtual_types",
   "graph_outline",
   "graph_get_errors",
   "graph_get_state",
@@ -907,6 +918,9 @@ export const GRAPH_CMD_EFFECT: Readonly<Record<string, GraphCmdEffect>> = {
   // ---- inert: reads -------------------------------------------------------
   graph_serialize: "inert",
   graph_get_object_info: "inert",
+  // #1400 — a registry query, not a canvas one: it describes the page's node
+  // CLASSES, and no workflow's content or identity rides on it.
+  graph_get_virtual_types: "inert",
   graph_outline: "inert",
   graph_get_errors: "inert",
   graph_get_state: "inert",
@@ -1087,6 +1101,10 @@ const STAMP_TARGET_CANVAS_INDEPENDENT = new Set<string>([
   "nodes_install",
   "nodes_queue_status",
   "graph_update_node",
+  // #1400 — reads the GLOBAL LiteGraph registry, never a canvas, and the
+  // orchestrator pulls it at hello, where no workflow stamp exists to agree
+  // with. Mirrors the panel's CANVAS_INDEPENDENT_COMMANDS entry.
+  "graph_get_virtual_types",
   "comfy_reboot",
   "free_vram",
 ]);

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -298,7 +298,7 @@ export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
   // only caller (the orchestrator's hello-time pull) degrades silently on an
   // unknown-command reply, so a too-low floor can never produce a wrong verdict —
   // it just lets an old panel answer "Unknown command", which the pull swallows.
-  graph_get_virtual_types: "0.15.10",
+  graph_get_virtual_types: "0.15.11",
 };
 
 /**


### PR DESCRIPTION
Closes #1400. Companion: **artokun/comfyui-mcp-panel#1441** (the panel half — merge order: panel first, and the `BRIDGE_CMD_MIN_PANEL_VERSION` entry here must match the release that ships it, see below).

## Root cause

`check_runtime` classifies a workflow's node class_types against `/object_info` and reports anything absent as `unknown` — the deliberate "could be a paid node the server doesn't expose" doubt. #1372/#1564 exempted the types the converter already knew never reach the backend (natives + the Get/Set bus), but the rgthree canvas-only half (`Label`, `Fast Groups Bypasser/Muter`) stayed `unknown`: a static list of third-party names was declined, and the principled discriminator — the frontend's own registry — is invisible to the classifier, which runs headless in the spawned tool server with no bridge.

## What changes

The signal the parked comment identified and proved — `isVirtualNode === true` on the registered class, the exact flag ComfyUI's serializer reads — now travels to the classifier:

1. **Panel** (companion PR): new `graph_get_virtual_types` bridge command answers with the registered types *proven* virtual (probe-constructed class instances carrying the flag; backend-provenance classes never probed; anything unproven omitted — fail closed).
2. **Orchestrator** pulls it on every panel hello (`pullFrontendVirtualTypes`), keyed by the tab's **server-observed handshake origin** — never the spoofable `hello.comfyui_url` claim (the #756 trust model). Only an `ok:true` reply replaces a previous answer, so a transient error never erases known-good proof. A panel that predates the command is asked once per process, not once per hello.
3. **Channel**: the poll tick republishes the current map into the progress dir every spawned child already shares — level-triggered like the #1415 panel-origin channel, whose bounded-read / pid-liveness / atomic-write helpers are now shared code rather than a second copy. A disconnected tab's entry drops within one tick; a dead orchestrator's record expires.
4. **Classifier** (`checkWorkflowRuntime`): a type absent from `/object_info` that the panel proved virtual is exempted **under the same def-first rule** as the static set — a registered, possibly-paid node sharing a virtual type's name is still classified from its def.

Fail closed in every direction: no panel, old panel, dead orchestrator, stale record, or unreadable registry all yield the pre-#1400 `unknown`. And a wrong entry can only exempt a type *absent* from `/object_info`, which cannot execute on that server at all — so the money direction never moves.

## Gates

- `npm ci`, `npm run build` — clean.
- **Full `npm test` chain — exit 0: 578/578 test files, 10668 passed, 4 skipped** (vitest + i18n:check + docs-links/locale/mdx + blog gates). First run failed exactly one place: the #1384 knowledge-parity ratchet caught the new `BRIDGE_CMD_MIN_PANEL_VERSION` entry as designed — `MOCK_PANEL_VERSION` raised to 0.15.10 and the mock now implements `graph_get_virtual_types` with the real reply shape.
- New tests: `frontend-virtual-types.test.ts` (24: round-trip, loopback alias matching #1175, staleness/pid/future-dated reads, junk filtering, level-triggered blanking, heartbeat discipline, control-prefix invisibility, source-level wiring pins for the hello pull and the poll-tick publish) + 5 new classifier tests in `runtime-virtual-nodes.test.ts` (the parked rgthree case now `local` WITH panel proof; unproven types stay `unknown`; def-first wins over the virtual set; denominator arithmetic; a throwing source is "no proof"). The pre-existing pin that rgthree types stay `unknown` WITHOUT a panel still holds and its comment now names the with-panel half.
- **Mutation check**: removing the classifier's `frontendVirtual` exemption → 3 tests RED; restored → 19/19.
- No tool-description changes (the documented `unknown` contract is unchanged), so docs:gen/vocab/docs-locale gates are not triggered; i18n untouched (no new call-site strings).
- Live-server verification NOT done here — the panel side is unmerged; the contract is pinned by the channel + classifier tests on this side and the panel's own unit suite on the other.

## Version note

`BRIDGE_CMD_MIN_PANEL_VERSION.graph_get_virtual_types = "0.15.10"` assumes the companion panel PR ships in the next panel release. The entry is deliberately on the low side of whatever that release is: the only caller degrades silently on an unknown-command reply, so a low floor can never produce a wrong verdict — but if the command ships later than 0.15.10, raise the entry before this merges.
