### PR TITLE
release: v0.52.15 — Qwen Code backend, app-mode tool, staged media, Fast Groups matchTitle honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.15] - 2026-08-19
+
+### MCP
+
+#### Added
+- Qwen Code CLI as an Agent Panel backend over ACP (#1813)
+- panel_configure_app_mode — set App Mode inputs, outputs, and default mode (#1809)
+- panel_show_media stage:true stages oversized outside files into a served dir (#1810)
+
+#### Fixed
+- matchTitle on Fast Groups no longer pretends the toggle list rebuilt (#1814)
+
+
 ## [0.52.14] - 2026-08-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.14",
+  "version": "0.52.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.14",
+      "version": "0.52.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.14",
+  "version": "0.52.15",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.15 from `main` (4b108e2).

Carries:

- #1813 / #1417 — Qwen Code CLI as an Agent Panel backend over ACP
- #1809 / #1709 — `panel_configure_app_mode`
- #1810 / #802 — `panel_show_media stage:true`
- #1814 / #1808 — matchTitle on Fast Groups no longer pretends the toggle list rebuilt

Do **not** squash-merge. Merge-commit (keeps the `v0.52.15` tag on the version commit). Tag is local; push `v0.52.15` after merge.

Held out: #1817 (`graph_get_virtual_types` min panel version still 0.15.10; wait for panel v0.15.11 then raise the pin).