### PR TITLE
fix(1815): a stale graph fence no longer blocks Manager search/install/reboot or mode:current recovery

### DIFF
--- a/src/__tests__/orchestrator/open-workflow-fence-unreadable.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-fence-unreadable.test.ts
@@ -290,6 +290,9 @@ describe("the remedy branches on the cause, not on the symptom", () => {
     expect(text).toMatch(/WHAT TO DO: retry in a moment/);
     // Reopening needs a tab too, so it must NOT be advertised as the fix here.
     expect(text).not.toMatch(/reopen the workflow you want/);
+    // Silence is still silence — #1815 only rewords a fence refusal.
+    expect(text).toMatch(/the panel did not answer/);
+    expect(text).not.toMatch(/the panel ANSWERED, but it refused/);
   });
 
   it("switches to the reopen lead when the FENCE is what refused", async () => {
@@ -306,6 +309,10 @@ describe("the remedy branches on the cause, not on the symptom", () => {
 
     expect(text).toMatch(/reopen the workflow you want/);
     expect(text).not.toMatch(/WHAT TO DO: retry in a moment/);
+    // #1815 — a fence refusal is an answer. Saying "the panel did not answer"
+    // here sent the reporter hunting a dead bridge while panel_ask still worked.
+    expect(text).toMatch(/the panel ANSWERED, but it refused/);
+    expect(text).not.toMatch(/the panel did not answer/);
   });
 });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -5847,6 +5847,27 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/Do NOT use panel_reload/);
   });
 
+  it("a fence-refused identity read is NOT narrated as a dead panel (#1815)", async () => {
+    // The reporter's mode:"current" hit this exact throw: workflow_list came
+    // back as a mismatch, and the lead said "the panel did not answer" while
+    // panel_ask was still working.
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      listThrows:
+        "workflow instance mismatch: this command targets a different workflow than the active canvas",
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/did NOT restore this session's graph binding/);
+    expect(text).toMatch(/the panel ANSWERED, but it refused/);
+    expect(text).not.toMatch(/the panel did not answer/);
+    expect(text).toMatch(/reopen the workflow you want/);
+    expect(text).toContain(STALE);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE);
+  });
+
   it("an UNREADABLE read is an unknown even with NO prior fence — it never claims reads work", async () => {
     // The read that would have told us whether this session is usable is the one
     // that failed. Reporting "graph READS work" from a failed observation is the

--- a/src/__tests__/services/stamp-target-agreement.test.ts
+++ b/src/__tests__/services/stamp-target-agreement.test.ts
@@ -19,6 +19,7 @@ import { createServer } from "node:net";
 import WebSocket from "ws";
 import {
   UiBridge,
+  commandStampAddress,
   dispatchOutcomeOf,
   requiresStampTargetAgreement,
 } from "../../services/ui-bridge.js";
@@ -84,6 +85,25 @@ describe("requiresStampTargetAgreement (#1656)", () => {
     ).toBe(false);
     expect(requiresStampTargetAgreement({ cmd: "show_media" })).toBe(false);
     expect(requiresStampTargetAgreement({})).toBe(false);
+  });
+
+  it("stamps graph ops from the caller address and exempt ops from the routed tab (#1815)", () => {
+    const caller = "orchestrator::claude";
+    const routed = "wf:route1:workflows/live.json";
+    expect(commandStampAddress({ cmd: "graph_outline" }, caller, routed)).toBe(caller);
+    expect(commandStampAddress({ cmd: "graph_add_node" }, caller, routed)).toBe(caller);
+    expect(commandStampAddress({ cmd: "workflow_save" }, caller, routed)).toBe(caller);
+    // The reporter's blocked tools, plus the recovery probe that made
+    // mode:"current" a dead end: a stale conversation stamp on these is what
+    // the panel compared and refused.
+    expect(commandStampAddress({ cmd: "nodes_search" }, caller, routed)).toBe(routed);
+    expect(commandStampAddress({ cmd: "nodes_install" }, caller, routed)).toBe(routed);
+    expect(commandStampAddress({ cmd: "comfy_reboot" }, caller, routed)).toBe(routed);
+    expect(commandStampAddress({ cmd: "workflow_list" }, caller, routed)).toBe(routed);
+    expect(commandStampAddress({ cmd: "workflow_open", path: "x" }, caller, routed)).toBe(routed);
+    // No caller address (a real-tab send) still resolves.
+    expect(commandStampAddress({ cmd: "graph_outline" }, undefined, routed)).toBe(routed);
+    expect(commandStampAddress({ cmd: "nodes_search" }, undefined, routed)).toBe(routed);
   });
 });
 
@@ -210,6 +230,10 @@ describe("dispatch-time stamp/target agreement gate (#1656)", () => {
     const probe = await bridge.send({ cmd: "workflow_list" }, { tabId: SCOPE });
     expect(probe).toEqual({ cmd: "workflow_list" });
     expect(received.map((f) => f.cmd)).toEqual(["workflow_list"]);
+    // #1815 — and it is stamped with the LIVE tab, not the stale conversation
+    // stamp. The reporter's mode:"current" asked this probe under UUID_A and
+    // the panel refused it as a mismatch, so recovery never ran.
+    expect(received[0].workflow_uuid).toBe(UUID_B);
 
     // After the documented rebind adopts the live identity, the same calls dispatch.
     sessionStamp = UUID_B;
@@ -230,6 +254,41 @@ describe("dispatch-time stamp/target agreement gate (#1656)", () => {
     const res = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE });
     expect(res).toEqual({ cmd: "graph_outline" });
     expect(received[0].workflow_uuid).toBeUndefined();
+    sock.close();
+  });
+
+  it("stamps Manager/reboot/list from the live tab so a stale session fence cannot refuse them (#1815)", async () => {
+    advertised.set(TAB_A, UUID_A);
+    sessionStamp = UUID_A;
+    const sock = await connectPanel(TAB_A);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_A));
+
+    hello(sock, TAB_B);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB_B));
+    advertised.delete(TAB_A);
+    advertised.set(TAB_B, UUID_B);
+    received.length = 0;
+
+    // The reporter's first call of the turn — a read-only Manager search — and
+    // the install / reboot that the same fence also blocked. None of them
+    // reads or writes the graph; they must still reach the panel, stamped as
+    // the canvas that is actually mounted.
+    for (const cmd of ["nodes_search", "nodes_install", "comfy_reboot"] as const) {
+      received.length = 0;
+      const res = await bridge.send({ cmd }, { tabId: SCOPE });
+      expect(res).toEqual({ cmd });
+      expect(received).toHaveLength(1);
+      expect(received[0].cmd).toBe(cmd);
+      expect(received[0].workflow_uuid).toBe(UUID_B);
+    }
+
+    // A graph read is still refused: that is the fence doing its job.
+    const readErr = await bridge.send({ cmd: "graph_outline" }, { tabId: SCOPE }).then(
+      () => null,
+      (err) => err as Error,
+    );
+    expect(readErr).not.toBeNull();
+    expect(readErr!.message).toMatch(/^workflow instance mismatch:/);
     sock.close();
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5932,8 +5932,18 @@ function describeFenceRebind(
       return {
         binding: "not_recovered",
         note:
-          ` Could NOT read the live canvas identity — the panel did not answer, so NOTHING ` +
-          `about this session's graph binding was observed.` +
+          // #1815 — a fence refusal is an ANSWER, not a silence. The lead used
+          // to say "the panel did not answer" for every unreadable, and the
+          // reporter (whose panel_ask / panel_set_todo / panel_show_media were
+          // all working) treated that as a dead bridge and never found the
+          // reopen exit. The WHAT TO DO already split on this; the lead must.
+          (/workflow instance mismatch/i.test(r.detail)
+            ? ` Could NOT read the live canvas identity — the panel ANSWERED, but it refused ` +
+              `the identity read because of the workflow-instance fence this call exists to ` +
+              `clear. That is not a dead bridge: non-graph tools (panel_search_nodes, ` +
+              `panel_ask, panel_set_todo) can still round-trip.`
+            : ` Could NOT read the live canvas identity — the panel did not answer, so NOTHING ` +
+              `about this session's graph binding was observed.`) +
           // #1043 — NAME THE VERSION GAP when that is what this is.
           //
           // The repair that would have avoided this read entirely

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1127,6 +1127,27 @@ export function requiresStampTargetAgreement(cmd: { cmd?: unknown }): boolean {
 }
 
 /**
+ * #1815 — which resolver address a command's `workflow_uuid` is taken from.
+ *
+ * Graph reads/writes and the four active-workflow mutators are issued FOR a
+ * workflow: they keep the caller's address so a switch fails closed (#570/#1656).
+ * Everything else (Manager search/install/reboot, the workflow_list recovery
+ * probe, open/new) does not act on that workflow. Stamping those with the
+ * conversation's issue-time identity is what wedged the reporter: the panel
+ * compared the stale stamp and refused even `nodes_search`, and the documented
+ * rebind then asked `workflow_list` under the same stamp and reported "the
+ * panel did not answer". Those commands take the routed tab's last-advertised
+ * identity instead — the live canvas, not the turn they were conceived in.
+ */
+export function commandStampAddress(
+  cmd: { cmd?: unknown },
+  callerTabId: string | undefined,
+  routedTabId: string,
+): string {
+  return requiresStampTargetAgreement(cmd) ? (callerTabId ?? routedTabId) : routedTabId;
+}
+
+/**
  * Default reply timeout for a MUTATING command with no explicit timeout.
  *
  * This was 6000 ms — the flat pre-#574 default, kept when reads were raised to
@@ -4713,13 +4734,21 @@ export class UiBridge {
         tabId: conn.tabId,
         mutating: !UiBridge.READONLY_CMDS.has(cmd.cmd),
         deadline: Date.now() + timeoutMs,
-        // #570 — resolve from the CALLER'S intended tab (opts.tabId), NOT the canonical
-        // conn.tabId: after a same-socket switch the two differ, and we must stamp the
-        // workflow the command was ISSUED FOR (so the panel, now showing a different one,
-        // declines it) — never the workflow it happens to have landed on. #884: for the
-        // SHARED SCOPE the orchestrator's resolver answers with the current TURN's
-        // issue-time workflow — same rule, conversation-level.
-        workflowUuid: this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId) ?? undefined,
+        // #570 — graph ops resolve from the CALLER'S intended tab (opts.tabId), NOT
+        // the canonical conn.tabId: after a same-socket switch the two differ, and
+        // we must stamp the workflow the command was ISSUED FOR (so the panel, now
+        // showing a different one, declines it) — never the workflow it happens to
+        // have landed on. #884: for the SHARED SCOPE the orchestrator's resolver
+        // answers with the current TURN's issue-time workflow — same rule,
+        // conversation-level.
+        //
+        // #1815 — Manager / recovery / navigation commands do not act on that
+        // workflow. They take the routed tab's advertised identity so a stale
+        // conversation stamp cannot refuse a search, an install, a reboot, or the
+        // workflow_list the documented rebind needs.
+        workflowUuid:
+          this.resolveTabWorkflowUuid?.(commandStampAddress(cmd, opts.tabId, conn.tabId)) ??
+          undefined,
         onDispatchedRid: opts.onDispatchedRid,
       };
       this.dispatch(conn, ctx);


### PR DESCRIPTION
Fixes #1815.

A stale workflow-instance stamp was attached to every panel command, including tools that never read or write the graph. After a canvas remint (or two ComfyUI restarts) the panel compared that stamp and refused `panel_search_nodes`, `panel_install_node`, and `panel_restart_comfyui`. The documented recovery, `panel_set_workflow_target({mode:"current"})`, asked `workflow_list` under the same stale stamp, so it reported "the panel did not answer" while `panel_ask` was still working.

Graph reads and writes still stamp from the conversation's issue-time identity, so a tab switch keeps failing closed. Manager / recovery / navigation commands now stamp from the routed tab's last-advertised identity — the live canvas. A fence-refused identity read is narrated as an answer, not a dead bridge.
