### PR TITLE
fix(1819): panel_restart_comfyui refuses an unidentifiable local instance before asking, leaving the tab connected

### DIFF
--- a/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
+++ b/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
@@ -29,9 +29,11 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "wf:workflows/a.json";
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
 
 function bridge() {
   return {
@@ -41,7 +43,10 @@ function bridge() {
     isHeadless: () => false,
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => TAB,
-    tabServerOrigin: () => null,
+    // Bound to the local boot instance so panel_restart_comfyui reaches its
+    // confirmation card (#1819 refuses unbindable targets before asking).
+    tabIsLocal: () => true,
+    tabServerOrigin: () => BOOT_BASE,
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -39,7 +39,7 @@ vi.mock("../../config.js", async (importOriginal) => {
   };
 });
 
-const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
@@ -49,6 +49,7 @@ import {
   PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
 } from "../../services/process-control.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 // The orchestrator's immutable boot endpoint — what the decline-probe and the
 // refuse-safe preflight bind to when the tab provably fronts our boot instance.
@@ -425,46 +426,56 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("an UNBOUND probe target gets a generic unreachable report — never a causation claim (codex gate)", async () => {
-    // The bound tab does NOT provably front our boot instance, so the only probe
-    // is the configured endpoint — no proven relationship to the restart. The
-    // report may say the server is unreachable, but must NEVER claim a restart
-    // (ours or an earlier one) stopped it.
+  it("an UNBOUND probe target is refused BEFORE the card, so a decline never claims causation (#1819)", async () => {
+    // Used to show the card, take a "no", then probe the configured endpoint
+    // and talk about whether it was down. That is the reporter's sequence:
+    // ask first, then refuse identity. A live unbindable tab is now refused
+    // without asking, so the decline probe — and any causation it could mint —
+    // never runs.
     let probes = 0;
     __panelToolsTestHooks.setHealthProbe(async () => {
       probes++;
       return "down";
     });
+    let confirmCalled = false;
     const { ctx, sends } = makeCtx({ confirm: "no", frontsBoot: false });
+    ctx.confirm = async () => {
+      confirmCalled = true;
+      return "no";
+    };
 
     const res = await restartTool().handler({}, ctx);
-    const t = text(res);
+    const out = parse(res);
 
     expect(res.isError).toBeFalsy();
-    expect(t).not.toMatch(/^Cancelled/);
-    expect(t).toMatch(/appears to be DOWN|unreachable/i);
-    // NO causation: not "stopped by a restart", not "did not come back".
-    expect(t).not.toMatch(/restart initiated earlier/i);
-    expect(t).not.toMatch(/STOPPED and did not come back/i);
-    expect(t).not.toMatch(/was NOT what stopped it/i);
-    expect(t).toMatch(/can't tell|can't confirm|isn't provably/i);
-    expect(probes).toBeGreaterThan(1);
+    expect(confirmCalled).toBe(false);
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    expect(String(out.note)).not.toMatch(/restart initiated earlier/i);
+    expect(String(out.note)).not.toMatch(/STOPPED and did not come back/i);
+    expect(String(out.note)).not.toMatch(/was NOT what stopped it/i);
+    expect(probes).toBe(0);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("an UNBOUND probe target that recovers keeps the plain cancel line", async () => {
-    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+  it("an UNBOUND probe target that would have recovered is still refused without asking (#1819)", async () => {
     let probes = 0;
     __panelToolsTestHooks.setHealthProbe(async () => {
-      const s = seq[Math.min(probes, seq.length - 1)];
       probes++;
-      return s;
+      return "healthy";
     });
+    let confirmCalled = false;
     const { ctx, sends } = makeCtx({ confirm: "no", frontsBoot: false });
+    ctx.confirm = async () => {
+      confirmCalled = true;
+      return "no";
+    };
 
-    const res = await restartTool().handler({}, ctx);
+    const out = parse(await restartTool().handler({}, ctx));
 
-    expect(text(res)).toBe("Cancelled — ComfyUI was not restarted.");
+    expect(confirmCalled).toBe(false);
+    expect(out.refused).toBe(true);
+    expect(probes).toBe(0);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
@@ -912,6 +923,97 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     // r4/r5: the dispatch was recorded on acceptance AND cleared when the
     // restart was observed back — a completed restart explains no later down.
     expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+  });
+});
+
+describe("panel_restart_comfyui — identity is resolved BEFORE the confirmation card (#1819)", () => {
+  // The reporter: first call timed out at 90s ("did NOT restart"), second call was
+  // confirmed then refused ("could not confirm that this panel's ComfyUI is the
+  // local instance"), then every graph call failed with Connected: none. The card
+  // was shown before identity was known, so the same unbindable target produced
+  // two outcomes, and the wait left graph tools looking like a reconnect.
+
+  it("an unbindable local target refuses WITHOUT showing a confirmation card", async () => {
+    let confirmCalled = false;
+    const preflight = vi.fn(async () => ({ ok: true }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+    ctx.confirm = async () => {
+      confirmCalled = true;
+      return "yes";
+    };
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(confirmCalled).toBe(false);
+    expect(sends).toEqual([]);
+    expect(preflight).not.toHaveBeenCalled();
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(String(out.note)).toMatch(/cannot tell which server the restart would stop/i);
+  });
+
+  it("a refused restart keeps the live tab and reports one terminal state, not a reconnect", async () => {
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+    const identityBefore = ctx.panelConnectionIdentity();
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    // Nothing was restarted, so graph tools stay usable on the same tab.
+    expect(out.ready).toBe(true);
+    expect(out.graph_tools_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(ctx.tabId).toBe("bound-tab");
+    expect(ctx.bridge.canReach(ctx.tabId)).toBe(true);
+    expect(ctx.panelConnectionIdentity()).toEqual(identityBefore);
+    expect(resetClient).not.toHaveBeenCalled();
+    expect(resetObjectInfoCache).not.toHaveBeenCalled();
+    await ctx.bridge.send({ cmd: "graph_get_errors" } as { cmd: string }, {
+      tabId: ctx.tabId,
+    } as never);
+    expect(sends).toEqual([{ cmd: "graph_get_errors" }]);
+  });
+
+  it("panel_get_errors still reaches the live tab after an identity refusal (real ctx)", async () => {
+    // Drive the shipped handler AND the next graph tool the reporter hit, on the
+    // real makePanelToolCtx path — not a stub that skips confirm/call wiring.
+    const TAB = "bound-tab";
+    const sends: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sends.push(cmd);
+        if (cmd.cmd === "graph_get_errors") return { nodes: [], missing_models: [] };
+        return { ok: true };
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      tabIsLocal: () => true,
+      tabServerOrigin: () => "http://127.0.0.1:8189",
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+
+    const restart = parse(await restartTool().handler({}, ctx));
+    expect(restart.refused).toBe(true);
+    expect(restart.rebooting).toBe(false);
+    expect(restart.ready).toBe(true);
+    expect(restart.panel_tab_reconnected).toBe(true);
+    expect(sends.some((c) => c.cmd === "ask_user")).toBe(false);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+
+    const getErrors = buildPanelToolDefs().find((d) => d.name === "panel_get_errors");
+    if (!getErrors) throw new Error("panel_get_errors not found");
+    const errors = await getErrors.handler({}, ctx);
+    expect(errors.isError).toBeFalsy();
+    expect(sends.some((c) => c.cmd === "graph_get_errors")).toBe(true);
+    expect(ctx.tabId).toBe(TAB);
+    expect(ctx.bridge.canReach(TAB)).toBe(true);
   });
 });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4474,6 +4474,15 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
     return (res.content[0] as { text: string }).text;
   }
 
+  // #1819 refuses an unbindable local target before the confirmation card, so
+  // tests that exercise the card itself must model the ordinary bound panel.
+  const boundLocalTab = {
+    tabIsLocal: () => true as const,
+    tabServerOrigin: () =>
+      (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/[/]+$/, ""),
+    canReach: () => true,
+  };
+
   // #814 widened the refuse-safe preflight to EVERY local target, not only a
   // tab-bound one, so panel_restart_comfyui now consults it on this path too.
   // These tests are about the confirm card, and the real preflight would do live
@@ -4503,6 +4512,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
         dispatched.push(cmd);
         return { rebooting: true };
       },
+      ...boundLocalTab,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "abcd1234");
 
@@ -4531,6 +4541,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
         }
         return { rebooting: true };
       },
+      ...boundLocalTab,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "abcd1234");
 
@@ -4557,6 +4568,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
         }
         return { rebooting: true };
       },
+      ...boundLocalTab,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "abcd1234");
 
@@ -4583,6 +4595,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
         dispatched.push(cmd);
         return { rebooting: true };
       },
+      ...boundLocalTab,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "abcd1234");
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1928,6 +1928,80 @@ export function restartRefusalHandoffAdvice(args: {
 }
 
 /**
+ * #1819 — a restart that was NOT dispatched must not look like a reconnect.
+ *
+ * Showing the confirmation card before instance identity was resolved produced two
+ * contradictory outcomes for the same unbindable target (a 90s timeout, then a
+ * yes that refused). The card wait is also what left graph tools reporting
+ * "still reconnecting after a restart/reload" about a panel that never restarted.
+ * Re-heal the current tab, then report one terminal state: refused, not rebooting,
+ * and the live tab's actual graph-tool readiness — including `panel_tab_reconnected`
+ * so a caller can tell this apart from a real reload.
+ */
+function restartRefusedPreservingBinding(ctx: PanelToolCtx, note: string): ToolResult {
+  ctx.ensureReachable?.();
+  const tabReady =
+    typeof ctx.bridge?.canReach === "function" ? ctx.bridge.canReach(ctx.tabId) === true : true;
+  const graphToolsReady =
+    tabReady && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
+  return ok({
+    rebooting: false,
+    ready: graphToolsReady,
+    graph_tools_ready: graphToolsReady,
+    confirmed_cycle: false,
+    refused: true,
+    panel_tab_reconnected: tabReady ? true : ("unknown" as const),
+    note,
+  });
+}
+
+function unboundLocalRestartRefusalNote(ctx: PanelToolCtx, panelBase: string | null): string {
+  return (
+    "Refusing to restart ComfyUI: I could not confirm that this panel's ComfyUI is " +
+    "the local instance I can account for, so I cannot tell which server the restart " +
+    "would stop — and it STOPS it, relying on whatever supervises it to start it " +
+    // A claim about what I DID, not about a server I have just said I cannot
+    // identify: "it is still running" would be exactly the unvalidated
+    // assertion the stale-target rule forbids (r8).
+    "again. Nothing was dispatched, so nothing was stopped. " +
+    // The alternative is NAMED and the difference EXPLAINED (coordinator
+    // ruling): this tool restarts whatever the calling TAB fronts, which is
+    // exactly the thing that could not be identified here. restart_comfyui is
+    // not tab-scoped — it acts on the ComfyUI this server is configured for,
+    // which it can identify and assess — so it remains available. A user who
+    // loses one entry point must be told the other one works, and why.
+    //
+    // #1593 — but only when it is actually the other one. This line used to
+    // recommend restart_comfyui unconditionally, which is #851's defect
+    // exactly: it targets COMFYUI_URL, not the ComfyUI the panel is inside,
+    // and this branch fires precisely when those are most likely to differ.
+    // The discriminator #851 built has been next door ever since and was
+    // never consulted here; now it is, and both addresses are named.
+    restartRefusalHandoffAdvice({
+      headlessBase: getComfyUIBaseUrl(),
+      panelBase,
+      observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
+    }) +
+    // artokun/comfyui-mcp-panel#769 — a REMOTE ComfyUI reached over a
+    // tunnel or port-forward has a LOOPBACK host, and remoteUrlActive is
+    // derived from exactly that (`forceRemote || !isLoopbackHost(host)`).
+    // So a cloud pod fronted at 127.0.0.1:<port> classifies as LOCAL, this
+    // branch runs, and it correctly reports it cannot find a local process
+    // to account for — because there isn't one. The refusal is right about
+    // what it observed and useless about what to do, since the reader is
+    // looking for a local install that does not exist. Name the one setting
+    // that re-classifies it; it is a config fix, not a workaround.
+    " NOTE: if this ComfyUI is actually REMOTE but reached through a tunnel " +
+    "or port-forward (a 127.0.0.1 address that is not this machine), it is " +
+    "being classified as local because that classification reads the HOST — " +
+    "which proves the route is local, not the instance. Set " +
+    "COMFYUI_MCP_FORCE_REMOTE=1 (or pass --force-remote) and this tool takes " +
+    "the remote path, which restarts through ComfyUI-Manager and does not " +
+    "need a local process to account for."
+  );
+}
+
+/**
  * Node definitions from the ComfyUI the PANEL is connected to (#1359 / #1006).
  *
  * The panel has served these since 0.13.0 and the orchestrator never asked. Everything
@@ -14329,6 +14403,34 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               " To restart the server without a panel confirmation card, use restart_comfyui.",
           );
         }
+        // #1819: resolve instance identity BEFORE the confirmation card. Asking the
+        // user to confirm a restart, then refusing because we cannot tell which
+        // ComfyUI this tab fronts, is two contradictory outcomes (timeout vs refuse)
+        // for the same unbindable target — and the card wait is what left graph
+        // tools reporting a reconnect/reload that never happened. Remote/cloud skip
+        // this gate (the Manager reboot is their only restart path). This is a READ
+        // of the current binding: a silent rebind here would confirm a restart of
+        // a tab the user was not working in. Healing belongs on the refusal path.
+        if (!isRemoteMode() && !isCloudMode()) {
+          const identityHealthBase = captureRebootHealthBase(ctx);
+          const identityBound =
+            identityHealthBase != null &&
+            sameHttpBase(getComfyUIBaseUrl(), identityHealthBase);
+          if (!identityBound) {
+            const tabStillHere =
+              typeof ctx.bridge?.canReach === "function"
+                ? ctx.bridge.canReach(ctx.tabId) === true
+                : true;
+            if (tabStillHere) {
+              return restartRefusedPreservingBinding(
+                ctx,
+                unboundLocalRestartRefusalNote(ctx, identityHealthBase),
+              );
+            }
+            // Tab is gone: confirm will be unreachable and #1671 crash-recovery
+            // decides whether a headless restart can still be accounted for.
+          }
+        }
         // #404: BOUND the confirmation wait. It previously inherited the full remaining
         // ~255s budget, so an unanswered/undelivered card (the panel tab backgrounded or
         // still reconnecting after a PRIOR restart — the second-restart-in-one-turn repro)
@@ -15033,54 +15135,13 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // a supervised remote (the tunnelled Desktop app) restarts through it by
         // design, so refusing there would remove a path that works.
         if (!preflightBound && !isRemoteMode() && !isCloudMode()) {
-          return ok({
-            rebooting: false,
-            ready: false,
-            confirmed_cycle: false,
-            refused: true,
-            note:
-              "Refusing to restart ComfyUI: I could not confirm that this panel's ComfyUI is " +
-              "the local instance I can account for, so I cannot tell which server the restart " +
-              "would stop — and it STOPS it, relying on whatever supervises it to start it " +
-              // A claim about what I DID, not about a server I have just said I cannot
-              // identify: "it is still running" would be exactly the unvalidated
-              // assertion the stale-target rule forbids (r8).
-              "again. Nothing was dispatched, so nothing was stopped. " +
-              // The alternative is NAMED and the difference EXPLAINED (coordinator
-              // ruling): this tool restarts whatever the calling TAB fronts, which is
-              // exactly the thing that could not be identified here. restart_comfyui is
-              // not tab-scoped — it acts on the ComfyUI this server is configured for,
-              // which it can identify and assess — so it remains available. A user who
-              // loses one entry point must be told the other one works, and why.
-              //
-              // #1593 — but only when it is actually the other one. This line used to
-              // recommend restart_comfyui unconditionally, which is #851's defect
-              // exactly: it targets COMFYUI_URL, not the ComfyUI the panel is inside,
-              // and this branch fires precisely when those are most likely to differ.
-              // The discriminator #851 built has been next door ever since and was
-              // never consulted here; now it is, and both addresses are named.
-              restartRefusalHandoffAdvice({
-                headlessBase: getComfyUIBaseUrl(),
-                panelBase: preflightHealthBase,
-                observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
-              }) +
-              // artokun/comfyui-mcp-panel#769 — a REMOTE ComfyUI reached over a
-              // tunnel or port-forward has a LOOPBACK host, and remoteUrlActive is
-              // derived from exactly that (`forceRemote || !isLoopbackHost(host)`).
-              // So a cloud pod fronted at 127.0.0.1:<port> classifies as LOCAL, this
-              // branch runs, and it correctly reports it cannot find a local process
-              // to account for — because there isn't one. The refusal is right about
-              // what it observed and useless about what to do, since the reader is
-              // looking for a local install that does not exist. Name the one setting
-              // that re-classifies it; it is a config fix, not a workaround.
-              " NOTE: if this ComfyUI is actually REMOTE but reached through a tunnel " +
-              "or port-forward (a 127.0.0.1 address that is not this machine), it is " +
-              "being classified as local because that classification reads the HOST — " +
-              "which proves the route is local, not the instance. Set " +
-              "COMFYUI_MCP_FORCE_REMOTE=1 (or pass --force-remote) and this tool takes " +
-              "the remote path, which restarts through ComfyUI-Manager and does not " +
-              "need a local process to account for.",
-          });
+          // Identity was proven before the card; landing here means the binding
+          // was lost during the confirm wait. Same refusal, and the tab that is
+          // still here must stay usable (#1819).
+          return restartRefusedPreservingBinding(
+            ctx,
+            unboundLocalRestartRefusalNote(ctx, preflightHealthBase),
+          );
         }
         if (preflightBound) {
           // Snapshot the target GENERATION at the decision (r11): a final-state
@@ -15208,13 +15269,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const dispatchBound =
           healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase);
         if (!dispatchBound && !isRemoteMode() && !isCloudMode()) {
-          return ok({
-            rebooting: false,
-            ready: false,
-            confirmed_cycle: false,
-            refused: true,
-            note:
-              "Refusing to restart ComfyUI: the panel connection changed while the restart " +
+          return restartRefusedPreservingBinding(
+            ctx,
+            "Refusing to restart ComfyUI: the panel connection changed while the restart " +
               "was being prepared, and I can no longer confirm which ComfyUI this tab " +
               "fronts — a restart STOPS a server, so it is never sent to one I cannot " +
               // Again: what I did, not what an unidentified instance is doing.
@@ -15229,7 +15286,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 panelBase: healthBase,
                 observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
               }),
-          });
+          );
         }
         const timing = getPanelRebootTiming();
         const dispatchTimeout = Math.max(1, Math.min(15000, overallDeadline - Date.now()));


### PR DESCRIPTION
Fixes #1819

`panel_restart_comfyui` showed its confirmation card before instance identity was resolved. An unbindable local target therefore produced two contradictory outcomes — a 90s timeout ("I did NOT restart"), then a yes that refused ("I could not confirm which server") — and the wait left graph tools reporting `Connected: none` / "still reconnecting after a restart/reload" about a panel that never restarted.

This resolves identity first. A live unbindable local tab is refused without asking, returns one terminal state (`refused:true`, `rebooting:false`, `panel_tab_reconnected` from the live tab), and `panel_get_errors` still reaches that tab. A missing tab still falls through to confirmation so the #1671 crash-recovery path is unchanged.
