### PR TITLE
release: v0.52.16 — virtual-types classifier, fence recovery, empty-zip install honesty, restart identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.16] - 2026-08-19
+
+### MCP
+
+#### Added
+- check_runtime consults the panel-proven frontend virtual registry (#1817)
+
+#### Fixed
+- panel_restart_comfyui refuses an unidentifiable local instance before asking, leaving the tab connected (#1822)
+- a stale graph fence no longer blocks Manager search/install/reboot or mode:current recovery (#1821)
+- empty registry zip installs fail instead of reporting success (#1820)
+
+
 ## [0.52.15] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.15",
+  "version": "0.52.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.15",
+      "version": "0.52.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.15",
+  "version": "0.52.16",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.16 from `main` (10b98b3).

Carries:

- #1817 / #1400 — `check_runtime` consults the panel-proven frontend virtual registry (min panel 0.15.11)
- #1822 / #1819 — `panel_restart_comfyui` refuses an unidentifiable local instance before asking
- #1821 / #1815 — a stale graph fence no longer blocks Manager search/install/reboot or `mode:current` recovery
- #1820 / #1816 — empty registry zip installs fail instead of reporting success

Do **not** squash-merge. Merge-commit (keeps the `v0.52.16` tag on the version commit). Tag is local; push `v0.52.16` after merge.