### PR TITLE
fix(1824): call_tool runs when the payload is under parameters instead of args

### DIFF
--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -330,6 +330,35 @@ describe("compact mode over a real MCP client/server pair", () => {
     expect(textOf(res as never)).toBe("generated:a dog:default");
   });
 
+  // #1824 — ChatGPT multi_tool_use.parallel names each recipient payload
+  // `parameters`. After the first functions.call_tool in a batch the model
+  // copies that key inward instead of `args`. The SDK Zod shape used to
+  // strip the unknown field, so download_model (and anything with a required
+  // action) saw an empty object and failed with "action: Invalid option".
+  it("call_tool accepts parameters as an alias for args (#1824)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "gen_image", parameters: { prompt: "a cat", steps: 4 } },
+    })) as { isError?: boolean };
+    expect(res.isError).not.toBe(true);
+    expect(textOf(res as never)).toBe("generated:a cat:4");
+  });
+
+  it("call_tool prefers args over a colliding parameters wrapper (#1824)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: {
+        name: "gen_image",
+        args: { prompt: "from-args", steps: 2 },
+        parameters: { prompt: "from-parameters", steps: 9 },
+      },
+    })) as { isError?: boolean };
+    expect(res.isError).not.toBe(true);
+    expect(textOf(res as never)).toBe("generated:from-args:2");
+  });
+
   it("call_tool works with omitted args for zero-arg tools", async () => {
     const client = await compactPair(fakeCatalog());
     const res = await client.callTool({ name: "call_tool", arguments: { name: "ping" } });

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -281,6 +281,11 @@ export function registerCompactTools(
           "The tool's parameters as an object matching its describe_tool schema. A JSON-encoded string is also accepted. Omit for tools without parameters.",
         ),
       arguments: z.unknown().optional().describe("Alias for args."),
+      // #1824 — ChatGPT's multi_tool_use.parallel wrapper names its payload
+      // `parameters`. After the first call_tool in a batch the model often
+      // copies that key inward instead of `args`, and Zod would strip the
+      // unknown field so the inner tool saw an empty object (`action` missing).
+      parameters: z.unknown().optional().describe("Alias for args."),
     },
     async (params) => {
       const name = params.name ?? params.tool_name;
@@ -297,7 +302,7 @@ export function registerCompactTools(
       const facadeMeta = !tool && (name === "list_tools" || name === "describe_tool") ? name : null;
       if (!tool && !facadeMeta) return errorText(unknownToolMessage(catalog, name));
 
-      const args = params.args ?? params.arguments;
+      const args = params.args ?? params.arguments ?? params.parameters;
       let rawArgs: Record<string, unknown> = {};
       if (typeof args === "string") {
         if (args.trim()) {


### PR DESCRIPTION
Fixes #1824

ChatGPT `multi_tool_use.parallel` names each recipient payload `parameters`. After the first `functions.call_tool` in a batch the model often copies that key inward instead of `args`. The compact `call_tool` schema did not declare `parameters`, so Zod stripped it and the inner tool (`download_model` here) saw an empty object and failed with `action: Invalid option`.

`call_tool` now accepts `parameters` as an alias for `args` (same as the existing `arguments` alias). `args` still wins when both are present.
