### PR TITLE
release: v0.52.17 — call_tool accepts parameters as well as args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.17] - 2026-08-19
+
+### MCP
+
+#### Fixed
+- call_tool runs when the payload is under parameters instead of args (#1825)
+
+
 ## [0.52.16] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.16",
+  "version": "0.52.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.16",
+      "version": "0.52.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.16",
+  "version": "0.52.17",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.17 from `main` (2d303ce).

Carries:

- #1825 / #1824 — `call_tool` runs when the payload is under `parameters` instead of `args` (`multi_tool_use.parallel`)

Do **not** squash-merge. Merge-commit (keeps the `v0.52.17` tag on the version commit). Tag is local; push `v0.52.17` after merge.