### PR TITLE
fix(1828): auto-sync reclaims abandoned panel locks; frontend-only add-node errors name version skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,13 +759,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- Panel auto-sync reclaims a provably-abandoned operation lock instead of failing for days; panel_add_node names version skew (pack update + hard tab refresh) when an allowlisted frontend-only type is refused as a missing backend node (#1828)
+
 ## [0.52.18] - 2026-08-19
 
 ### MCP
 
 #### Added
 - panel_unexpose_subgraph_input/output — remove a subgraph boundary slot by name (#1812)
-
 
 ## [0.52.17] - 2026-08-19
 

--- a/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
+++ b/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
@@ -1,0 +1,141 @@
+// #1828 — panel_add_node for an allowlisted frontend-only type failed with
+// "the ComfyUI backend does not provide it" and pointed at unrelated
+// failed-import packs. The actual cause was panel version skew: the connected
+// tab was running a pre-allowlist guard. After a pack update the same error
+// persisted until a hard tab refresh (cached JS).
+//
+// The orchestrator must keep the panel's refusal and name the floor + the
+// pack-update + Ctrl+Shift+R path, instead of leaving the backend-missing
+// diagnosis as the last word.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { requiredPanelVersion } from "../../services/ui-bridge.js";
+import { compareSemver } from "../../services/self-update.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const REPORTER_TYPE = "Fast Groups Muter (rgthree)";
+const REPORTER_PANEL = "0.14.37";
+
+/** The reporter's exact panel refusal (issue #1828). */
+const REPORTER_REFUSAL =
+  `Unknown node type "Fast Groups Muter (rgthree)" — the ComfyUI backend does not provide it ` +
+  `(not installed, its pack was removed, or its pack failed to import). ` +
+  `Check the exact class_type via create_workflow (action:"node_info") ` +
+  `ComfyUI reported that these packs FAILED TO IMPORT at startup — .claude, teacache, foreach, ` +
+  `comfyui-ltxvideo-registry-mattabyte.`;
+
+function bridge(opts: {
+  message: string;
+  advertised?: string;
+}) {
+  const calls: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      throw new Error(opts.message);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    advertisedPanelVersion: () =>
+      opts.advertised ? { version: opts.advertised, raw: opts.advertised } : {},
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function addNode(classType: string, message: string, advertised?: string) {
+  const { b, calls } = bridge({ message, advertised });
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+  if (!def) throw new Error("panel_add_node is not registered");
+  const res: ToolResult = await def.handler({ class_type: classType } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("panel_add_node names panel version skew for allowlisted frontend-only types (#1828)", () => {
+  it("the reporter's case: keeps the refusal and names pack update + hard refresh", async () => {
+    const required = requiredPanelVersion();
+    expect(compareSemver(REPORTER_PANEL, required)).toBeLessThan(0);
+
+    const { text, isError, calls } = await addNode(
+      REPORTER_TYPE,
+      REPORTER_REFUSAL,
+      REPORTER_PANEL,
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_REFUSAL);
+    expect(text).toContain(REPORTER_TYPE);
+    expect(text).toContain(REPORTER_PANEL);
+    expect(text).toContain(required);
+    expect(text).toMatch(/NOT a missing backend pack/i);
+    expect(text).toMatch(/frontend-only/i);
+    expect(text).toMatch(/Ctrl\+Shift\+R/);
+    expect(text).toMatch(/install_comfyui\(action:'panel', panel_action:'update'\)|update the panel pack on the ComfyUI host/);
+    expect(text).toMatch(/cached old JS|hard-refresh/i);
+    expect(calls).toEqual(["graph_add_node"]);
+  });
+
+  it("does not invent skew when the tab already announces the required floor", async () => {
+    const required = requiredPanelVersion();
+    const { text, isError } = await addNode(REPORTER_TYPE, REPORTER_REFUSAL, required);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_REFUSAL);
+    expect(text).not.toMatch(/NOT a missing backend pack/i);
+    expect(text).not.toMatch(/Ctrl\+Shift\+R/);
+  });
+
+  it("does not invent skew when the tab announced no version", async () => {
+    const { text, isError } = await addNode(REPORTER_TYPE, REPORTER_REFUSAL);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_REFUSAL);
+    expect(text).not.toMatch(/NOT a missing backend pack/i);
+    expect(text).not.toMatch(/Ctrl\+Shift\+R/);
+  });
+
+  it("a type the current panel still refuses is left as a backend-missing error", async () => {
+    // Bookmark is frontend-only but NOT on the add-node allowlist. Wrapping it
+    // as version skew would send the caller to update a panel that would still
+    // refuse the add.
+    const { text, isError } = await addNode(
+      "Bookmark (rgthree)",
+      `Unknown node type "Bookmark (rgthree)" — the ComfyUI backend does not provide it ` +
+        `(not installed, its pack was removed, or its pack failed to import).`,
+      REPORTER_PANEL,
+    );
+
+    expect(isError).toBe(true);
+    expect(text).not.toMatch(/NOT a missing backend pack/i);
+    expect(text).not.toMatch(/Ctrl\+Shift\+R/);
+  });
+
+  it("a genuine missing backend type is left alone even on an old panel", async () => {
+    const missing =
+      `Unknown node type "KSampler" — the ComfyUI backend does not provide it ` +
+      `(not installed, its pack was removed, or its pack failed to import).`;
+    const { text, isError } = await addNode("KSampler", missing, REPORTER_PANEL);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(missing);
+    expect(text).not.toMatch(/NOT a missing backend pack/i);
+    expect(text).not.toMatch(/Ctrl\+Shift\+R/);
+  });
+});

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -6,6 +6,7 @@
 // Everything else here is supporting detail.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -472,7 +473,17 @@ function makeDeps(opts: {
 const RUN = { requiredVersion: REQUIRED, orchestratorVersion: ORCH } as const;
 
 describe("performPanelSync", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    const lockPath = process.env.COMFYUI_MCP_PANEL_LOCK;
+    if (lockPath && existsSync(lockPath)) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // leftover lock must not fail the next test's setup
+      }
+    }
+  });
 
   it("syncs a behind, unpinned panel and reports the version RE-READ from disk", async () => {
     const h = makeDeps({
@@ -688,6 +699,39 @@ describe("performPanelSync", () => {
     expect(r.synced).toBe(false);
     expect(r.decision).toBe("dev-install");
     expect(h.updates).toBe(0);
+  });
+
+  it("reclaims a provably-abandoned lock and proceeds instead of failing for days (#1828)", async () => {
+    // The reporter's auto-sync sat behind panel-op.lock for 54h: owner pid dead,
+    // lock well past the stale threshold, acquire fast-failed and named
+    // panel_action:'unlock' as the recovery nobody was there to run. Hello
+    // auto-sync IS performPanelSync, so this is the unattended path.
+    const lockPath = process.env.COMFYUI_MCP_PANEL_LOCK!;
+    const deadPid = 0x7ffffffe;
+    const ageMs = 20 * 60_000;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: deadPid,
+        startedAt: new Date(Date.now() - ageMs).toISOString(),
+        token: "abandoned-test",
+      }),
+    );
+    const when = (Date.now() - ageMs) / 1000;
+    utimesSync(lockPath, when, when);
+    expect(existsSync(lockPath)).toBe(true);
+
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+
+    expect(r.synced).toBe(true);
+    expect(h.updates).toBe(1);
+    expect(existsSync(lockPath)).toBe(false);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -62,9 +62,10 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { UiBridge } from "../services/ui-bridge.js";
-import { SEMVER_RE } from "../services/ui-bridge.js";
+import type { UiBridge, PanelVersionReading } from "../services/ui-bridge.js";
+import { requiredPanelVersion, SEMVER_RE } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
+import { describeInstallPanelAction } from "../services/panel-recovery.js";
 import {
   primePanelBase,
   verifiedPanelDiskVersion,
@@ -3188,6 +3189,88 @@ const LORA_MANAGER_AUTOCOMPLETE_NOTE =
 function withLoraManagerAutocompleteNote(res: ToolResult): ToolResult {
   if (!isLoraManagerAutocompleteRefusal(res)) return res;
   return appendToolResultText(res, LORA_MANAGER_AUTOCOMPLETE_NOTE);
+}
+
+/**
+ * Types the CURRENT panel's add-node guard allowlists (comfyui-mcp-panel
+ * `web/js/lib/node-resolve.js` `FRONTEND_ONLY_NODE_TYPES`). An older panel
+ * without that allowlist refuses them as "the ComfyUI backend does not provide
+ * it" and points at unrelated failed-import packs (#1828).
+ *
+ * Kept as a copy of the panel's list rather than the orchestrator's
+ * `FRONTEND_ONLY_NODE_TYPES` (workflow-converter): that set is the runtime
+ * classifier's skip list and deliberately omits third-party names. Adding
+ * rgthree types there would change check_runtime, which is not this bug.
+ */
+const PANEL_ADD_NODE_FRONTEND_ONLY_TYPES: ReadonlySet<string> = new Set([
+  "Note",
+  "MarkdownNote",
+  "Reroute",
+  "PrimitiveNode",
+  "Fast Bypasser (rgthree)",
+  "Fast Muter (rgthree)",
+  "Fast Groups Bypasser (rgthree)",
+  "Fast Groups Muter (rgthree)",
+  "Label (rgthree)",
+  "Reroute (rgthree)",
+  "Node Collector (rgthree)",
+  "SetNode",
+  "GetNode",
+]);
+
+function isUnknownBackendNodeRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return /Unknown node type .+ — the ComfyUI backend does not provide it/i.test(
+    textOfToolResult(res),
+  );
+}
+
+function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
+  const fn = ctx.bridge.advertisedPanelVersion;
+  if (typeof fn !== "function") return undefined;
+  let reading: PanelVersionReading;
+  try {
+    reading = fn.call(ctx.bridge, ctx.tabId);
+  } catch {
+    return undefined;
+  }
+  const v = reading?.version;
+  return typeof v === "string" && SEMVER_RE.test(v.trim()) ? v.trim() : undefined;
+}
+
+/**
+ * #1828 — an allowlisted frontend-only type refused as "backend does not
+ * provide it" is version skew when the tab's advertised panel is below this
+ * orchestrator's floor, not a missing pack. Keep the panel's refusal and name
+ * the pack update + hard-refresh; a restart alone leaves cached JS running the
+ * old guard.
+ */
+function withFrontendOnlyPanelSkewNote(
+  res: ToolResult,
+  classType: unknown,
+  ctx: PanelToolCtx,
+): ToolResult {
+  if (typeof classType !== "string") return res;
+  if (!isUnknownBackendNodeRefusal(res)) return res;
+  if (!PANEL_ADD_NODE_FRONTEND_ONLY_TYPES.has(classType)) return res;
+  const advertised = tabAdvertisedPanelVersion(ctx);
+  if (!advertised) return res;
+  const required = requiredPanelVersion();
+  if (compareSemver(advertised, required) >= 0) return res;
+  const update = describeInstallPanelAction(
+    "update",
+    "update the panel pack on the ComfyUI host",
+  );
+  return appendToolResultText(
+    res,
+    `\n\nThis is NOT a missing backend pack. "${classType}" is a frontend-only type ` +
+      `that current panels (${required}+) allowlist, so its absence from /object_info is ` +
+      `expected. This tab announced panel ${advertised}, which is below that floor — ` +
+      `the add-node guard in this tab's JavaScript does not have the allowlist. ` +
+      `${update}, restart ComfyUI, then HARD-REFRESH the ComfyUI browser tab ` +
+      `(Ctrl+Shift+R, or Cmd+Shift+R on macOS). A restart alone leaves the tab running ` +
+      `cached old JS, which is why this error can persist after an update.`,
+  );
 }
 
 function appendToolResultText(res: ToolResult, extra: string): ToolResult {
@@ -10987,7 +11070,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
           );
         const first = await add();
-        if (!isStaleNodeSchemaRefusal(first)) return withLoraManagerAutocompleteNote(first);
+        if (!isStaleNodeSchemaRefusal(first)) {
+          return withFrontendOnlyPanelSkewNote(
+            withLoraManagerAutocompleteNote(first),
+            args.class_type,
+            ctx,
+          );
+        }
 
         // #1329 — DO THE REFRESH THE REFUSAL ASKS FOR, instead of billing the caller.
         //
@@ -11006,27 +11095,41 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // The refusal is the better error: it names what is wrong with the SCHEMA and
           // what clears it. Carry the refresh failure alongside so the caller knows the
           // automatic attempt happened and why it did not help.
-          return withLoraManagerAutocompleteNote(
-            appendToolResultText(
-              first,
-              `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
-                `so the schema is unchanged and retrying the add will refuse again. ` +
-                `${textOfToolResult(refreshed)})`,
+          return withFrontendOnlyPanelSkewNote(
+            withLoraManagerAutocompleteNote(
+              appendToolResultText(
+                first,
+                `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
+                  `so the schema is unchanged and retrying the add will refuse again. ` +
+                  `${textOfToolResult(refreshed)})`,
+              ),
             ),
+            args.class_type,
+            ctx,
           );
         }
         const second = await add();
-        if (!isStaleNodeSchemaRefusal(second)) return withLoraManagerAutocompleteNote(second);
+        if (!isStaleNodeSchemaRefusal(second)) {
+          return withFrontendOnlyPanelSkewNote(
+            withLoraManagerAutocompleteNote(second),
+            args.class_type,
+            ctx,
+          );
+        }
         // Still stale after a successful refresh: report THAT, because it means the
         // remedy the refusal prescribes does not fix this instance and a caller
         // following it by hand would loop.
-        return withLoraManagerAutocompleteNote(
-          appendToolResultText(
-            second,
-            `\n\n(This was already retried ONCE automatically: panel_refresh_nodes reported success ` +
-              `and the add still refuses, so repeating panel_refresh_nodes will not clear it. ` +
-              `Reload the ComfyUI browser tab, which rebuilds the page's node registry from scratch.)`,
+        return withFrontendOnlyPanelSkewNote(
+          withLoraManagerAutocompleteNote(
+            appendToolResultText(
+              second,
+              `\n\n(This was already retried ONCE automatically: panel_refresh_nodes reported success ` +
+                `and the add still refuses, so repeating panel_refresh_nodes will not clear it. ` +
+                `Reload the ComfyUI browser tab, which rebuilds the page's node registry from scratch.)`,
+            ),
           ),
+          args.class_type,
+          ctx,
         );
       },
     ),

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -34,6 +34,7 @@ import {
   type PanelInstallerDeps,
   type PanelStatus,
 } from "./panel-installer.js";
+import { reclaimAbandonedPanelLock } from "./panel-pin-guard.js";
 import {
   describePanelPin,
   PANEL_PIN_ENV_VAR,
@@ -617,6 +618,14 @@ export async function performPanelSync(
   opts: PerformSyncOptions = {},
 ): Promise<PanelSyncResult> {
   const deps = opts.deps ?? defaultDeps;
+  // #1828 — hello auto-sync is unattended. An abandoned panel-op.lock (dead
+  // owner AND past the stale threshold) used to fail it every session for
+  // days, while the timeout named panel_action:'unlock' as the recovery
+  // nobody was there to run. Reclaim uses that same verified path (owner
+  // re-checked dead + age, rename-aside + byte compare); a live or fresh
+  // lock still refuses and acquire waits/times out as before. Explicit
+  // panel_action:'sync' shares this function, so it unblocks the same way.
+  reclaimAbandonedPanelLock();
   // The status read, the DECISION, and the mutation all run inside the op
   // lock: a decision made outside could go stale before the lock is acquired,
   // and a newer panel installed in that gap would be blindly overwritten by

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3126,6 +3126,22 @@ export class UiBridge {
   }
 
   /**
+   * The version THIS connection advertised in its own hello (#1828).
+   *
+   * Routed through `connPanelVersionReading` so an inherited reconnect value is
+   * `.inherited` and never `.version` — a caller comparing against
+   * `requiredPanelVersion()` must not treat a stale inherited reading as this
+   * tab's current build. Unroutable tabs and omitted-version hellos yield `{}`.
+   */
+  advertisedPanelVersion(tabId: string): PanelVersionReading {
+    try {
+      return connPanelVersionReading(this.resolveTarget(tabId));
+    } catch {
+      return {};
+    }
+  }
+
+  /**
    * Is the connected panel PROVABLY too old to publish a workflow_uuid on the
    * replies the fence recovery trusts? (#1043)
    *


### PR DESCRIPTION
Fixes #1828

Hello auto-sync sat behind a dead `panel-op.lock` for days: acquire fast-failed and named `panel_action:'unlock'` as the recovery nobody was there to run. `performPanelSync` now runs the same verified reclaim unlock already implements (owner dead AND past the stale threshold, rename-aside + byte compare) before taking the lock. A live or fresh lock still refuses.

`panel_add_node` for an allowlisted frontend-only type (`Fast Groups Muter (rgthree)` and the rest of the panel's `FRONTEND_ONLY_NODE_TYPES`) used to surface the old guard's "backend does not provide it" error, including unrelated failed-import packs. When the connected tab announces a panel below `requiredPanelVersion()`, the refusal now also names the floor and the pack-update + hard-refresh (`Ctrl+Shift+R`) path — a restart alone leaves cached JS running the old guard.
