### PR TITLE
release: v0.52.19 — auto-sync reclaims abandoned panel locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,10 +759,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.19] - 2026-08-19
+
 ### MCP
 
 #### Fixed
 - Panel auto-sync reclaims a provably-abandoned operation lock instead of failing for days; panel_add_node names version skew (pack update + hard tab refresh) when an allowlisted frontend-only type is refused as a missing backend node (#1828)
+
+### MCP
+
+#### Fixed
+- auto-sync reclaims abandoned panel locks; frontend-only add-node errors name version skew (#1830)
+
 
 ## [0.52.18] - 2026-08-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.18",
+  "version": "0.52.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.18",
+      "version": "0.52.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.18",
+  "version": "0.52.19",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.19 from `main` (e862f93).

Carries:

- #1830 / #1828 — auto-sync reclaims a provably-abandoned panel lock; frontend-only add-node errors name version skew

Held out of this cut: #1831 docs blog (author asked for review before merge).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.19` tag on the version commit). Tag is local; push `v0.52.19` after merge.