### PR TITLE
chore(security): track dependency advisories, weekly and grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependency and CVE tracking.
+#
+# WHY THIS EXISTS: the publish path here is fast and wide — releases are tagged
+# by automation and every install runs a self-updater that polls npm hourly, so a
+# dependency problem reaches the whole fleet about as quickly as a fix does. The
+# repo's existing security gates all look INWARD (the panel's bandit and
+# YARA-parity passes scan our own shipped files for malicious patterns); nothing
+# was watching for a published advisory against something we already depend on.
+#
+# WEEKLY AND GROUPED, deliberately. A daily per-package firehose trains everyone
+# to rubber-stamp bumps, which is worse than not having them: the point is that
+# each PR gets read. One grouped PR a week for minor/patch is a thing a human
+# actually reviews. Majors are left ungrouped on purpose — they break things and
+# deserve to arrive alone.
+#
+# OUT OF SCOPE FOR THE AUTOPILOT, by decision. The swarm's finisher only adopts
+# PRs whose issue it dispatched, and it now also skips bot-authored PRs outright
+# — necessary, because its issue-number extraction reads the PR body and falls
+# back to digits in the branch name, and a bump quoting an upstream "#1524" in
+# its changelog resolves to a real issue number in this repo. Dependency bumps
+# are reviewed by a human, not driven to merge by an agent.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - "dependencies"
+    groups:
+      # One PR for the routine stuff. Majors deliberately excluded so they land
+      # on their own and get read on their own.
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # The workflows are part of the supply chain too: a compromised action runs
+  # with the release job's credentials, which is the one place in this repo that
+  # can publish.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - "dependencies"
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes the gap that drafting the pipeline blog post surfaced: **nothing was watching our dependencies for published advisories.** Every security gate this project has looks *inward* — the panel's bandit and YARA-parity passes scan our own shipped files for malicious patterns — and an inward-looking scan cannot see a CVE filed against a package we already trust.

That gap matters more here than in a slower project: releases are tagged by automation and every install runs a self-updater polling npm hourly, so a dependency problem reaches the fleet about as fast as a fix does.

## Config

| ecosystem | why |
|---|---|
| npm | the shipped package |
| github-actions | a compromised action runs with the release job's credentials — the one place here that can publish |

**Weekly, grouped, limit 3.** A daily per-package firehose trains everyone to rubber-stamp bumps, which is worse than not having them. One grouped PR a week for minor/patch is a thing a human actually reads; majors stay ungrouped so they arrive alone.

## Out of scope for the autopilot — enforced, not assumed

The swarm's finisher only adopts PRs whose issue it dispatched, so bot PRs were *mostly* out of scope already. Checking properly showed "mostly" wasn't good enough:

```
dependabot/npm_and_yarn/zod-3.24.1  ->  issueRef: 1524
```

Its issue-number extraction reads the PR body and falls back to digits in the branch name — so a bump whose changelog quotes an upstream `#1524` resolves to a **real issue number in this repo**. Had that issue been dispatched, the finisher would have adopted a Dependabot PR and driven it toward merge.

`finish.mjs` now skips bot-authored PRs outright (`author.is_bot` or a dependabot/renovate/github-actions login). Author is the one field a crafted body cannot spoof. That file is local tooling and untracked, so it is not in this diff — noted here so it is on the record.

## Also landed alongside (local gate tooling, untracked)

- **A SHIP verdict is no longer unconditional.** Both gates hold a diff touching `package.json`, any lockfile, `pyproject.toml`, anything under `.github/`, or the publish scripts, unless `AUTOPILOT_HUMAN_ACK=1` records that a human looked.
- **A truncated diff no longer counts as reviewed.** Both gates cap the embedded diff; a pass over a diff we know was clipped downgrades to the hold state.

Guard verified against 11 cases including the one that matters — a lockfile buried among 40 innocuous files still holds the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)