### PR TITLE
fix(1834): a dev-symlink panel below the floor reports behind:true

### DIFF
--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -363,6 +363,49 @@ describe("evaluatePanelSync — cases where we must not guess", () => {
     expect(decide({ isDevSymlink: true, installedVersion: "0.1.0" })).toBe("dev-install");
   });
 
+  // #1834 — `behind` is a version fact, not a permission to act. A 0.15.3
+  // checkout under a 0.15.11 floor is proven older than the floor even though
+  // we will never touch a dev symlink. Hardcoding `behind: false` on this
+  // branch made that gap indistinguishable from an up-to-date checkout.
+  it("a dev symlink BELOW the floor is behind:true and names the gap, without telling them to unpin (#1834)", () => {
+    const a = evaluatePanelSync(
+      status({ isDevSymlink: true, installedVersion: "0.15.3" }),
+      { requiredVersion: "0.15.11", orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("dev-install");
+    expect(a.behind).toBe(true);
+    expect(a.installedVersion).toBe("0.15.3");
+    expect(a.requiredPanelVersion).toBe("0.15.11");
+    expect(a.summary).toMatch(/BEHIND/);
+    expect(a.summary).toContain("0.15.3");
+    expect(a.summary).toContain("0.15.11");
+    expect(a.summary).toMatch(/pull its checkout/i);
+    // Unpin is the pinned-install remedy. A developer owns this checkout;
+    // telling them to unpin would be the wrong advice.
+    expect(a.summary).not.toMatch(/unpin/i);
+  });
+
+  it("a dev symlink AT the floor is behind:false and does not invent a gap (#1834)", () => {
+    const a = evaluatePanelSync(
+      status({ isDevSymlink: true, installedVersion: "0.15.11" }),
+      { requiredVersion: "0.15.11", orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("dev-install");
+    expect(a.behind).toBe(false);
+    expect(a.summary).not.toMatch(/BEHIND/);
+    expect(a.summary).not.toMatch(/unpin/i);
+  });
+
+  it("a dev symlink with an uncomparable version is never claimed behind (#1834)", () => {
+    const a = evaluatePanelSync(
+      status({ isDevSymlink: true, installedVersion: "nightly" }),
+      { requiredVersion: "0.15.11", orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("dev-install");
+    expect(a.behind).toBe(false);
+    expect(a.summary).not.toMatch(/BEHIND/);
+  });
+
   it("remote/cloud → not-applicable", () => {
     expect(decide({ applicable: false, installed: false })).toBe("not-applicable");
   });
@@ -699,6 +742,12 @@ describe("performPanelSync", () => {
     expect(r.synced).toBe(false);
     expect(r.decision).toBe("dev-install");
     expect(h.updates).toBe(0);
+    // #1834 — declining to TOUCH it is not the same as reporting it current.
+    // The refusal message must still name the proven version gap.
+    expect(r.message).toMatch(/BEHIND/);
+    expect(r.message).toContain("0.11.3");
+    expect(r.message).toContain(REQUIRED);
+    expect(r.message).not.toMatch(/unpin/i);
   });
 
   it("reclaims a provably-abandoned lock and proceeds instead of failing for days (#1828)", async () => {

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -261,6 +261,13 @@ export function evaluatePanelSync(
   // The skill PROMISES visible drift when a user sits on a pinned version —
   // that warning is owed in every state, including the early-return ones
   // (remote / dev install), not only on paths that could act.
+  // Proven-behind is a VERSION fact, independent of whether we are allowed to
+  // act on it. Kept separate from `driftNote` (which is about a PIN) so a branch
+  // that declines to touch the install still reports the drift honestly.
+  const provenBehind =
+    !!status.installedVersion &&
+    isComparableVersion(status.installedVersion) &&
+    compareSemver(status.installedVersion, required) < 0;
   const driftNote = (() => {
     if (!pin.pinned || pin.indeterminate) return "";
     if (!status.installedVersion || !isComparableVersion(status.installedVersion)) return "";
@@ -291,10 +298,20 @@ export function evaluatePanelSync(
     return {
       ...base,
       decision: "dev-install",
-      behind: false,
+      // A dev checkout is one we never TOUCH — that is not a reason to report it
+      // as current. `behind` is documented as "we PROVED the panel is older than
+      // requiredPanelVersion", and a comparable dev version below the floor is
+      // exactly that proof. Hardcoding false here made a 0.15.3 checkout under a
+      // 0.15.11 floor indistinguishable from an up-to-date one, so a panel
+      // carrying already-fixed bugs read as healthy in every status call.
+      behind: provenBehind,
       summary:
         `The panel at ${status.dir ?? "custom_nodes"} is a dev symlink — update it ` +
         `through its own git checkout. Nothing here will modify it.` +
+        (provenBehind
+          ? ` NOTE: it is BEHIND what ${orch} expects ` +
+            `(${status.installedVersion} < ${required}) — pull its checkout to close the gap.`
+          : "") +
         driftNote,
     };
   }


### PR DESCRIPTION
Fixes #1834

`install_comfyui(action:"panel", panel_action:"status")` hardcoded `behind: false` on the `dev-install` branch, so a comparable checkout 13 patches below `requiredPanelVersion` (0.15.3 vs 0.15.11) still read as current. `behind` is a version fact, not a permission to act: a proven-old dev symlink now reports `behind: true` and the summary names the gap (`pull its checkout`), while the decision stays `dev-install` and nothing is modified. Unreadable versions (`nightly`) are still never claimed behind; a checkout at the floor stays `behind: false`. Unpin is not the remedy on this path.
