### PR TITLE
fix(1841): a departed Blind tab stops blinding the whole conversation, and the strip says it happened

### DIFF
--- a/src/__tests__/orchestrator/blind-tab-gate.test.ts
+++ b/src/__tests__/orchestrator/blind-tab-gate.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveBlindTabGate,
+  BLIND_TAB_GRACE_MS,
+} from "../../orchestrator/blind-tab-gate.js";
+
+// #1841 — the reported failure: one blind tab that WENT AWAY pinned the whole
+// conversation blind for the life of the orchestrator process. Every assertion
+// below is about one of the two directions this gate must never get wrong:
+//   fail CLOSED while a blind tab might still be watching, and
+//   RETIRE an entry once it provably is not.
+
+const T0 = 1_700_000_000_000;
+
+function gate(
+  over: Partial<Parameters<typeof resolveBlindTabGate>[0]> & {
+    blindTabs: Set<string>;
+  },
+) {
+  return resolveBlindTabGate({
+    unreachableSince: new Map(),
+    canReach: () => true,
+    now: T0,
+    ...over,
+  });
+}
+
+describe("resolveBlindTabGate (#1841)", () => {
+  it("no blind tabs → not blind", () => {
+    const r = gate({ blindTabs: new Set() });
+    expect(r.blind).toBe(false);
+    expect(r.pruned).toEqual([]);
+  });
+
+  it("a reachable blind tab → blind, and never pruned", () => {
+    const blindTabs = new Set(["live"]);
+    const r = gate({ blindTabs, canReach: () => true });
+    expect(r.blind).toBe(true);
+    expect(r.pruned).toEqual([]);
+    expect(blindTabs.has("live")).toBe(true);
+  });
+
+  // THE fail-closed case. A websocket drop is routine and brief; counting only
+  // reachable tabs would hand pixels to the agent inside that window for a user
+  // who never turned Blind off.
+  it("an unreachable blind tab stays BLIND on first sight and is not pruned", () => {
+    const blindTabs = new Set(["gone"]);
+    const unreachableSince = new Map<string, number>();
+    const r = gate({ blindTabs, unreachableSince, canReach: () => false });
+    expect(r.blind).toBe(true);
+    expect(r.pruned).toEqual([]);
+    expect(r.pendingGone).toEqual(["gone"]);
+    expect(blindTabs.has("gone")).toBe(true);
+    expect(unreachableSince.get("gone")).toBe(T0);
+  });
+
+  it("stays blind for the whole grace window, then retires the tab", () => {
+    const blindTabs = new Set(["gone"]);
+    const unreachableSince = new Map([["gone", T0]]);
+    const canReach = () => false;
+
+    const justInside = gate({
+      blindTabs,
+      unreachableSince,
+      canReach,
+      now: T0 + BLIND_TAB_GRACE_MS - 1,
+    });
+    expect(justInside.blind).toBe(true);
+    expect(blindTabs.has("gone")).toBe(true);
+
+    const atBoundary = gate({
+      blindTabs,
+      unreachableSince,
+      canReach,
+      now: T0 + BLIND_TAB_GRACE_MS,
+    });
+    expect(atBoundary.blind).toBe(false);
+    expect(atBoundary.pruned).toEqual(["gone"]);
+    expect(blindTabs.has("gone")).toBe(false);
+    expect(unreachableSince.has("gone")).toBe(false);
+  });
+
+  it("a reconnect inside the window clears the clock, so the tab is not retired later", () => {
+    const blindTabs = new Set(["flappy"]);
+    const unreachableSince = new Map<string, number>();
+
+    gate({ blindTabs, unreachableSince, canReach: () => false, now: T0 });
+    expect(unreachableSince.get("flappy")).toBe(T0);
+
+    // Back online well inside the grace window.
+    gate({ blindTabs, unreachableSince, canReach: () => true, now: T0 + 1_000 });
+    expect(unreachableSince.has("flappy")).toBe(false);
+
+    // Drops again later — the clock restarts from NOW, not from the first drop,
+    // so the original absence cannot retire it retroactively.
+    const later = T0 + BLIND_TAB_GRACE_MS + 2_000;
+    const r = gate({ blindTabs, unreachableSince, canReach: () => false, now: later });
+    expect(r.blind).toBe(true);
+    expect(r.pruned).toEqual([]);
+    expect(blindTabs.has("flappy")).toBe(true);
+  });
+
+  // A live blind tab must not mask the pruning of a dead one: the dead entry is
+  // exactly what pins the session once the live tab finally goes.
+  it("sweeps EVERY entry — a live blind tab does not shield a long-departed one", () => {
+    const blindTabs = new Set(["live", "gone"]);
+    const unreachableSince = new Map([["gone", T0]]);
+    const r = gate({
+      blindTabs,
+      unreachableSince,
+      canReach: (t) => t === "live",
+      now: T0 + BLIND_TAB_GRACE_MS + 1,
+    });
+    expect(r.blind).toBe(true); // "live" is still blind
+    expect(r.pruned).toEqual(["gone"]); // ...and "gone" was still retired
+    expect(blindTabs.has("live")).toBe(true);
+    expect(blindTabs.has("gone")).toBe(false);
+  });
+
+  it("a THROWING reachability probe is treated as unreachable, never as proof of departure", () => {
+    const blindTabs = new Set(["boom"]);
+    const unreachableSince = new Map<string, number>();
+    const canReach = () => {
+      throw new Error("bridge exploded");
+    };
+    const first = gate({ blindTabs, unreachableSince, canReach, now: T0 });
+    expect(first.blind).toBe(true);
+    expect(blindTabs.has("boom")).toBe(true);
+
+    // ...but a permanently-throwing probe must not pin the session forever either.
+    const later = gate({
+      blindTabs,
+      unreachableSince,
+      canReach,
+      now: T0 + BLIND_TAB_GRACE_MS,
+    });
+    expect(later.blind).toBe(false);
+    expect(later.pruned).toEqual(["boom"]);
+  });
+
+  it("a clock that moves BACKWARDS re-stamps instead of retiring early", () => {
+    const blindTabs = new Set(["gone"]);
+    const unreachableSince = new Map([["gone", T0]]);
+    const r = gate({
+      blindTabs,
+      unreachableSince,
+      canReach: () => false,
+      now: T0 - 60_000,
+    });
+    expect(r.blind).toBe(true);
+    expect(r.pruned).toEqual([]);
+    expect(unreachableSince.get("gone")).toBe(T0 - 60_000);
+  });
+
+  it("drops a stale clock for a tab that left the set via an explicit blind-off", () => {
+    const blindTabs = new Set<string>();
+    const unreachableSince = new Map([["turned-off", T0]]);
+    const r = gate({ blindTabs, unreachableSince, canReach: () => false, now: T0 });
+    expect(r.blind).toBe(false);
+    expect(unreachableSince.has("turned-off")).toBe(false);
+  });
+});

--- a/src/orchestrator/blind-tab-gate.ts
+++ b/src/orchestrator/blind-tab-gate.ts
@@ -1,0 +1,141 @@
+/**
+ * The conversation-wide Blind-mode gate, as a pure decision over the blind-tab
+ * set — extracted from the orchestrator so the one predicate that decides
+ * whether the shared agent ever receives pixels is unit-testable without a
+ * websocket (the same reason `panel-sync.ts` is a pure module).
+ *
+ * WHY THIS EXISTS AT ALL (#1841). Blind (#90) is a per-tab UI setting; #884 made
+ * the GATE conversation-wide, because the agent is shared and a per-tab gate
+ * would leak pixels to it through some other tab. The set that backs it was only
+ * ever written by an explicit blind-off FROM THAT SAME TAB ID, or by the hello
+ * migration path — so nothing removed a tab that simply WENT AWAY (browser
+ * closed, a reconnect that minted a new id outside the migration path, a ComfyUI
+ * restart). One departed blind tab therefore pinned `anyTabBlind()` true for the
+ * life of the orchestrator process: every later agent and tool spawn got
+ * `COMFYUI_MCP_BLIND=1` and every run completion was stripped, while the user's
+ * current tab reported Blind as OFF and the panel composed its SIGHTED note.
+ *
+ * WHY NOT JUST `canReach()`. The obvious repair — count only tabs the bridge can
+ * reach right now — inverts the failure direction of a privacy promise. A
+ * websocket drop is routine and brief; during it every blind tab reads as
+ * unreachable, so a completion landing in that window would hand pixels to the
+ * agent for a user who never turned Blind off. Blind must fail CLOSED.
+ *
+ * WHAT THIS DOES INSTEAD. Unreachability starts a clock; it does not decide
+ * anything. A blind tab that cannot be reached KEEPS blinding the conversation
+ * for `graceMs`, and is dropped only once it has been continuously unreachable
+ * past that grace. A reconnect inside the window clears the clock, and the tab's
+ * own hello re-asserts its setting either way — so the reconnect path needs no
+ * cooperation from this module. The exposure window a bare `canReach()` opened is
+ * closed, and the permanent pin is bounded.
+ *
+ * The sweep is LEVEL-TRIGGERED — it needs no disconnect hook, no tab-lifecycle
+ * callback, and no cooperation from the bridge beyond a reachability probe.
+ */
+
+/** How long a blind tab keeps blinding the conversation after it stops being
+ *  reachable. Comfortably longer than a websocket reconnect (seconds), short
+ *  enough that a closed tab cannot pin a long session. */
+export const BLIND_TAB_GRACE_MS = 5 * 60_000;
+
+export interface BlindTabGateInput {
+  /** Tab ids currently known to have Blind ON. MUTATED: provably-gone ids are removed. */
+  blindTabs: Set<string>;
+  /** Tab id → epoch ms when it was first observed unreachable. MUTATED. */
+  unreachableSince: Map<string, number>;
+  /** Can a command bound to this exact tab id reach a live tab right now? */
+  canReach: (tabId: string) => boolean;
+  /** Injected clock (epoch ms). */
+  now: number;
+  /** Override the grace window; defaults to {@link BLIND_TAB_GRACE_MS}. */
+  graceMs?: number;
+}
+
+export interface BlindTabGateResult {
+  /** Whether pixels must be withheld from the shared agent. */
+  blind: boolean;
+  /** Tab ids dropped by THIS sweep because they outlived the grace window. */
+  pruned: string[];
+  /** Blind tabs currently unreachable but still inside their grace window. */
+  pendingGone: string[];
+}
+
+/**
+ * Sweep the blind-tab set and answer whether the conversation is blind.
+ *
+ * Every entry is visited on every call — no early return — so a live blind tab
+ * can never mask the pruning of a stale one. That matters because the live tab
+ * is usually the one that comes and goes, and an early return would leave the
+ * permanently-dead entry unswept for exactly as long as anything else was blind.
+ *
+ * `blindTabs` and `unreachableSince` are mutated in place: this is the only
+ * writer that retires an entry on evidence rather than on an explicit user
+ * action, and keeping the bookkeeping beside the decision is what stops the two
+ * from drifting apart.
+ */
+export function resolveBlindTabGate({
+  blindTabs,
+  unreachableSince,
+  canReach,
+  now,
+  graceMs = BLIND_TAB_GRACE_MS,
+}: BlindTabGateInput): BlindTabGateResult {
+  const pruned: string[] = [];
+  const pendingGone: string[] = [];
+  let blind = false;
+
+  for (const tabId of [...blindTabs]) {
+    let reachable = false;
+    try {
+      reachable = canReach(tabId) === true;
+    } catch {
+      // A probe that THREW told us nothing. Treat it as unreachable so the grace
+      // clock still runs (a permanently-throwing probe must not pin the session
+      // forever either), but never as proof the tab is gone.
+      reachable = false;
+    }
+    if (reachable) {
+      // Present and blind: the clock is irrelevant, so clear it. Without this a
+      // tab that flapped once would carry a stale stamp and could be pruned mid-
+      // session while its user is still watching.
+      unreachableSince.delete(tabId);
+      blind = true;
+      continue;
+    }
+    const since = unreachableSince.get(tabId);
+    if (since == null) {
+      // FIRST observation of absence is not evidence of departure — start the
+      // clock and stay blind. This is the branch that makes the gate fail closed.
+      unreachableSince.set(tabId, now);
+      pendingGone.push(tabId);
+      blind = true;
+      continue;
+    }
+    // A clock running backwards (system time moved) must not retire an entry
+    // early — re-stamp and keep blinding rather than trust the difference.
+    if (now < since) {
+      unreachableSince.set(tabId, now);
+      pendingGone.push(tabId);
+      blind = true;
+      continue;
+    }
+    if (now - since < graceMs) {
+      pendingGone.push(tabId);
+      blind = true;
+      continue;
+    }
+    // Continuously unreachable past the grace window: retire it. If that user
+    // returns, their hello re-asserts Blind and re-adds the id.
+    blindTabs.delete(tabId);
+    unreachableSince.delete(tabId);
+    pruned.push(tabId);
+  }
+
+  // Stamps for ids no longer in the set (an explicit blind-off arrived while a
+  // clock was running) would otherwise accumulate for the process's lifetime.
+  for (const tabId of [...unreachableSince.keys()]) {
+    if (!blindTabs.has(tabId)) unreachableSince.delete(tabId);
+  }
+
+  return { blind, pruned, pendingGone };
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -44,6 +44,7 @@ import { judgeHelloRetarget, canonComfyuiTargetUrl } from "../services/hello-ret
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { performPanelSync, reassessPanelAfterSyncFailure } from "../services/panel-sync.js";
+import { resolveBlindTabGate } from "./blind-tab-gate.js";
 import { clearPanelDiskObservation } from "../services/panel-workspace.js";
 import { panelRecoveryContext } from "../services/panel-recovery.js";
 import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
@@ -1950,7 +1951,30 @@ export async function runPanelOrchestrator(): Promise<void> {
   // pixels. The agent is now shared, so the promise is conversation-wide: pixels
   // are withheld while ANY tab has Blind on (a per-tab gate would leak pixels to
   // the shared agent through the other tabs).
-  const anyTabBlind = (): boolean => blindTabs.size > 0;
+  // #1841 — `blindTabs.size > 0` never retired a tab that WENT AWAY: every
+  // delete site needs an explicit blind-off from that same id (or the hello
+  // migration path), so one departed blind tab pinned the whole conversation
+  // blind for the life of this process while the user's live tab reported Blind
+  // OFF. The sweep retires an id only after it has been continuously unreachable
+  // past a grace window — unreachability starts a clock, it does not decide —
+  // so a routine websocket drop still fails CLOSED. See blind-tab-gate.ts.
+  const blindUnreachableSince = new Map<string, number>();
+  const anyTabBlind = (): boolean => {
+    const { blind, pruned } = resolveBlindTabGate({
+      blindTabs,
+      unreachableSince: blindUnreachableSince,
+      canReach: (tabId) => bridge.canReach(tabId),
+      now: Date.now(),
+    });
+    if (pruned.length) {
+      logger.info(
+        `[panel-orchestrator] Blind gate: retired ${pruned.length} departed blind tab(s) ` +
+          `(${pruned.map((t) => t.slice(0, 8)).join(", ")}) — unreachable past the grace window; ` +
+          `conversation blind = ${blind}`,
+      );
+    }
+    return blind;
+  };
 
   // ---- live ENVIRONMENT-CAPABILITIES block ----
   // Gather the machine's facts ONCE at startup (CACHED) — OS/CPU/RAM from node,
@@ -5203,7 +5227,38 @@ export async function runPanelOrchestrator(): Promise<void> {
       // agent_event frames with images onto a blinded desktop tab.
       // #884 — the receiving agent is shared, so the pixel gate is conversation-
       // wide: any tab with Blind on withholds pixels from the shared agent.
-      const evForTab = anyTabBlind() ? { ...ev, images: [] } : ev;
+      // #884 followup — emptying `images` is INVISIBLE downstream. Every
+      // "withheld / attached below" sentence the completion composer can emit is
+      // gated on `imgs.length`, so a blind-stripped completion produced NO
+      // disclosure at all: the agent received the panel's SIGHTED storyboard note
+      // ("Review motion, sharpness, and temporal consistency") with zero pixels
+      // and no reason, which is precisely the confabulation the blind note exists
+      // to prevent. The panel picks its blind/sighted note from ITS OWN tab
+      // (`agentReceivesImages()`), while this gate is conversation-wide
+      // (`anyTabBlind()`), so the two disagree whenever any OTHER tab is blind —
+      // and the disagreement was unobservable.
+      //
+      // Fail-closed is unchanged: pixels are still removed, and the journal still
+      // stores the stripped copy. Only the SILENCE is fixed, by appending the
+      // disclosure to the note the composer already renders verbatim, which also
+      // overrides a sighted "review this" instruction that must not be obeyed.
+      const blindWithheldCount = anyTabBlind() && Array.isArray(ev.images) ? ev.images.length : 0;
+      const evForTab = anyTabBlind()
+        ? {
+            ...ev,
+            images: [],
+            ...(blindWithheldCount > 0
+              ? {
+                  note:
+                    `${typeof ev.note === "string" && ev.note.trim() ? `${ev.note.trim()} ` : ""}` +
+                    `⚠️ Blind mode is ON: ${blindWithheldCount} image(s) from this run were withheld ` +
+                    `from you and are NOT attached — they ARE shown to the user in the panel. Do NOT ` +
+                    `comment on motion, sharpness, composition or any other visual quality, and do not ` +
+                    `claim you reviewed them; ask the user to describe what they see, or to turn Blind off.`,
+                }
+              : {}),
+          }
+        : ev;
       // #468 — a RUN COMPLETION is a promise `panel_run` made ("end your turn,
       // you WILL be notified"), so it goes through the journal: correlated by
       // exact prompt id ONCE, here, and replayed until the turn that carries it


### PR DESCRIPTION
Fixes #1841

## The report

A user watched a video storyboard render in the panel. The agent was told, in the same event, to *"Review motion, sharpness, and temporal consistency"* — and received no pixels and no explanation. Confirmed live in-session by calling an unrelated image tool:

```
get_image action:"get" filename:"blog_header_krea2_00001_.png"
→ [Blind mode: image withheld (278 KB, image/png). The user's Blind setting
   means you NEVER receive image pixels …]
```

`COMFYUI_MCP_BLIND=1` was active in the tool process while the panel believed the agent was sighted, and the user's own Blind toggle was off.

## Two defects, and why both had to be fixed

**Blind never let go of a tab that went away.** `anyTabBlind()` was `blindTabs.size > 0`, and all three `blindTabs.delete` sites need an explicit blind-off *from that same tab id* (or the hello migration path). Nothing prunes a tab that closes, or reconnects with a new id outside the migration path, or is lost to a ComfyUI restart. One such tab pins the conversation blind for the life of the orchestrator process.

**The strip was silent.** Every disclosure sentence in the completion composer — `"The image(s) are attached below"`, `"NONE of these outputs are attached … fetch one with get_image"`, both budget branches — is gated on `imgs.length`. `{ ...ev, images: [] }` sets that to `0`, so a blind-stripped completion took the note-only path, whose own comment describes it as *"a video that produced no storyboard"*. The two states were byte-identical.

They compound: defect 1 is why the panel picks the wrong note (it reads Blind from **its own tab** via `agentReceivesImages()`, while the gate is conversation-wide), and defect 2 is why nobody can tell.

## Why not just `canReach()`

That was the first thing I tried and it is wrong. Counting only reachable tabs inverts the failure direction of a privacy promise: a websocket drop is routine and brief, and a completion landing in that window would hand pixels to the agent for a user who never turned Blind off. **Blind must fail closed.**

Instead, unreachability starts a clock and decides nothing. A blind tab that cannot be reached keeps blinding for `BLIND_TAB_GRACE_MS` (5 min — comfortably longer than a reconnect, short enough that a closed tab can't pin a long session) and is retired only once continuously unreachable past it. A reconnect inside the window clears the clock, and the tab's hello re-asserts the setting anyway. The sweep is level-triggered: no disconnect hook, no lifecycle callback.

## Proof

`resolveBlindTabGate` is a pure module precisely so the one predicate deciding whether the shared agent ever sees pixels is testable without a websocket. 9 tests, then each guarantee mutation-checked independently:

| mutation | result |
|---|---|
| revert to `blindTabs.size > 0` (**the shipped bug**) | **7 of 9 fail** |
| unreachable ⇒ immediately not blind (**the tempting wrong fix**) | **5 of 9 fail** |
| early-return on first blind tab (stale entry masked by a live one) | 1 fails |
| drop the backwards-clock guard | 1 fails |
| throwing probe treated as reachable | 1 fails |

Gate: `npm run build` exit 0 · `tsc --noEmit` clean · `check:vocabulary` and `check:unknown-collapse` pass · **167 test files / 2893 tests green** across `src/__tests__/orchestrator/`, `blind-image-gate`, `panel-sync`.

## Not fixed here

The panel side still picks its storyboard note from its own tab while the server gates conversation-wide. With this merged the two can no longer disagree *in the reported way* (the stale pin is gone) and a disagreement is now self-disclosing rather than silent, but the underlying asymmetry is real and belongs in comfyui-mcp-panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
