### PR TITLE
release: v0.52.21 — Blind-tab prune, symlink behind:true, TypeScript 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.21] - 2026-08-19
+
+### MCP
+
+#### Fixed
+- a departed Blind tab stops blinding the whole conversation, and the strip says it happened (#1842)
+- a dev-symlink panel below the floor reports behind:true (#1840)
+
+#### Changed
+- bump the actions-all group with 6 updates (#1836)
+- bump typescript from 5.9.3 to 7.0.2 (#1838)
+
+
 ## [0.52.20] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.20",
+  "version": "0.52.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.20",
+      "version": "0.52.21",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.20",
+  "version": "0.52.21",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.21 from `main` (3b78e16).

Carries:

- #1842 / #1841 — a departed Blind tab stops blinding the whole conversation
- #1840 / #1834 — a dev-symlink panel below the floor reports `behind:true`
- #1836 — GitHub Actions group bump
- #1838 — TypeScript 5.9 → 7.0 (already on main)

Held out: #1831 docs blog (author asked for review); #1837/#1839 Dependabot CI red.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.21` tag on the version commit). Tag is local; push `v0.52.21` after merge.