### PR TITLE
release: v0.52.22 — blog pipeline + npm-minor-patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.22] - 2026-08-19
+
+### MCP
+
+#### Changed
+- bump the npm-minor-patch group across 1 directory with 10 updates (#1837)
+- from bug report to published release, autonomously (#1831)
+
+
 ## [0.52.21] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.21",
+  "version": "0.52.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.21",
+      "version": "0.52.22",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.21",
+  "version": "0.52.22",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.22 from `main`.

Carries:

- #1831 — docs blog: from bug report to published release, autonomously (landed on main after 0.52.21)
- #1837 — npm-minor-patch group (`@comfyorg/sdk` 0.1.5→0.1.7, `@modelcontextprotocol/sdk` 1.29→1.30, `ws`, `vitest`, optional SDK bumps)

Held out: #1839 `@ai-sdk/anthropic` 4 (CI red). #1697 P1 still in drain (`wt-1697`).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.22` tag on the version commit). Tag is local; push `v0.52.22` after merge.