### PR TITLE
fix(1846): panel_open_workflow succeeds after placeholder definition rehydration

### DIFF
--- a/src/__tests__/orchestrator/open-definitions-rehydrate.test.ts
+++ b/src/__tests__/orchestrator/open-definitions-rehydrate.test.ts
@@ -1,0 +1,310 @@
+// #1846 — panel_open_workflow reported unknown because the canvas differed from
+// the loaded state on `definitions` after unknown placeholders rehydrated.
+//
+// The open bound the requested workflow; a later outline/query showed the right
+// nodes with real schemas. Verification was treating node-definition / widget-
+// schema normalization as a failed open.
+//
+// Tests drive panel_open_workflow. Dest file comes through the same userdata
+// read that handler uses; live canvas comes from graph_serialize.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const destByKey = new Map<string, Record<string, unknown>>();
+
+vi.mock("../../services/userdata-library.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/userdata-library.js")>();
+  return {
+    ...actual,
+    userdataFetch: async (route: string) => {
+      for (const [key, graph] of destByKey) {
+        if (route.includes(encodeURIComponent(key)) || route.includes(key)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(graph),
+          } as Response;
+        }
+      }
+      throw new Error(`no dest fixture for ${route}`);
+    },
+  };
+});
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+
+const TAB = "wf:workflows/rehydrate.json";
+const PATH = "workflows/rehydrate.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+const PRIOR = "11111111-1111-4111-8111-111111111111";
+const SG_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const DEFINITIONS_ONLY =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `does not match the state that was loaded. Specifically: definitions.`;
+
+function destGraph(opts?: {
+  innerType?: string;
+  innerWidgets?: unknown[];
+  links?: unknown[];
+  extraNode?: Record<string, unknown>;
+}) {
+  const innerType = opts?.innerType ?? "CustomPackNode";
+  const innerWidgets = opts?.innerWidgets ?? ["ckpt.safetensors"];
+  const links = opts?.links ?? [
+    [1, 1, 0, 2, 0, "IMAGE"],
+    [2, 2, 0, 3, 0, "IMAGE"],
+  ];
+  const nodes: Array<Record<string, unknown>> = [
+    {
+      id: 1,
+      type: "LoadImage",
+      widgets_values: ["photo.png"],
+      widgets_values_named: { image: "photo.png" },
+    },
+    { id: 2, type: SG_ID, widgets_values: [] },
+    {
+      id: 3,
+      type: "SaveImage",
+      widgets_values: ["out"],
+      widgets_values_named: { filename_prefix: "out" },
+    },
+  ];
+  if (opts?.extraNode) nodes.push(opts.extraNode);
+  return {
+    nodes,
+    links,
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+    definitions: {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Inner",
+          nodes: [
+            {
+              id: 10,
+              type: innerType,
+              widgets_values: innerWidgets,
+              inputs: [],
+              outputs: [],
+            },
+          ],
+          links: [],
+        },
+      ],
+    },
+  };
+}
+
+function liveGraph(opts?: { innerType?: string; innerWidgets?: unknown[]; links?: unknown[] }) {
+  const innerType = opts?.innerType ?? "CustomPackNode";
+  const innerWidgets = opts?.innerWidgets ?? ["ckpt.safetensors"];
+  const links = opts?.links ?? [
+    [1, 1, 0, 2, 0, "IMAGE"],
+    [2, 2, 0, 3, 0, "IMAGE"],
+  ];
+  return {
+    nodes: [
+      {
+        id: 1,
+        type: "LoadImage",
+        widgets_values: ["photo.png"],
+        widgets_values_named: { image: "photo.png" },
+      },
+      { id: 2, type: SG_ID, widgets_values: [] },
+      {
+        id: 3,
+        type: "SaveImage",
+        widgets_values: ["out"],
+        widgets_values_named: { filename_prefix: "out" },
+      },
+    ],
+    links,
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+    definitions: {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Inner",
+          nodes: [
+            {
+              id: 10,
+              type: innerType,
+              size: [280, 140],
+              order: 2,
+              properties: { "Node name for S&R": innerType },
+              widgets_values: innerWidgets,
+              widgets_values_named: { ckpt_name: innerWidgets[0] },
+              inputs: [{ name: "image", type: "IMAGE", link: null }],
+              outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+            },
+          ],
+          links: [],
+          state: { lastNodeId: 14, lastLinkId: 3 },
+        },
+      ],
+    },
+  };
+}
+
+type GraphQuery = "answers" | "mismatch";
+
+function bridge(opts: { live: Record<string, unknown>; graphQuery: GraphQuery }) {
+  const calls: string[] = [];
+  let stamp: string | undefined = PRIOR;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        const active = { path: PATH, routing_key: `wf:${PATH}`, workflow_uuid: LIVE };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(DEFINITIONS_ONLY);
+      if (cmd.cmd === "graph_query") {
+        if (opts.graphQuery === "mismatch") {
+          throw new Error(
+            `workflow instance mismatch: issued for workflow instance ${PRIOR} but canvas is ${LIVE}`,
+          );
+        }
+        return { ids: [1, 2, 3], node_count: 3 };
+      }
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: opts.live, node_count: 3 };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "rehydrate", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls, stampOf: () => stamp };
+}
+
+beforeEach(() => {
+  destByKey.clear();
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+afterEach(() => {
+  destByKey.clear();
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+async function openWorkflow(opts: {
+  dest: Record<string, unknown>;
+  live: Record<string, unknown>;
+  graphQuery: GraphQuery;
+}) {
+  destByKey.set(PATH, opts.dest);
+  const { b, calls, stampOf } = bridge({ live: opts.live, graphQuery: opts.graphQuery });
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+    stamp: stampOf(),
+  };
+}
+
+describe("panel_open_workflow ignores definition/schema normalization after rehydrate (#1846)", () => {
+  it("the reporter's case: definitions-only mismatch after placeholder rehydration succeeds", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph(),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(false);
+    expect(calls).toContain("graph_serialize");
+    expect(stamp).toBe(LIVE);
+    expect(text).toMatch(/content_normalized/);
+    expect(text).toMatch(/Opened/);
+    expect(text).not.toMatch(/Treat the canvas as UNKNOWN/);
+    expect(text).not.toMatch(/PREVIOUS workflow/);
+  });
+
+  it("the same dest is accepted when the prior fence still answers", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph(),
+      graphQuery: "answers",
+    });
+
+    expect(isError).toBe(false);
+    expect(text).toMatch(/content_normalized/);
+  });
+
+  it("an unknown placeholder type rehydrated to the real class is still dest", async () => {
+    const { isError } = await openWorkflow({
+      dest: destGraph({ innerType: "Unknown" }),
+      live: liveGraph({ innerType: "CustomPackNode" }),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(false);
+  });
+
+  it("a dest widget value the live graph does not hold stays unknown", async () => {
+    const { isError, text, calls } = await openWorkflow({
+      dest: destGraph({ innerWidgets: ["ckpt.safetensors"] }),
+      live: liveGraph({ innerWidgets: ["other.safetensors"] }),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c)).toContain("graph_serialize");
+    expect(text).not.toMatch(/content_normalized/);
+    expect(text).toMatch(/definitions/);
+  });
+
+  it("a rewired dest link stays unknown", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph({
+        links: [
+          [1, 1, 0, 2, 0, "IMAGE"],
+          [2, 2, 0, 3, 0, "IMAGE"],
+        ],
+      }),
+      live: liveGraph({
+        links: [
+          [1, 1, 0, 3, 0, "IMAGE"],
+          [2, 2, 0, 3, 0, "IMAGE"],
+        ],
+      }),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(true);
+    expect(text).not.toMatch(/content_normalized/);
+  });
+
+  it("a dest node missing from the live canvas stays unknown", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph({ extraNode: { id: 99, type: "Note", widgets_values: ["keep"] } }),
+      live: liveGraph(),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(true);
+    expect(text).not.toMatch(/content_normalized/);
+  });
+});

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -258,3 +258,160 @@ export function patchOpenIdentity(
 export function isStampMismatchSaveRefusal(text: string): boolean {
   return /stamped as belonging to/i.test(text) && /extra\.comfyui_mcp\.workflow_path/i.test(text);
 }
+
+/**
+ * #1846 — dest vs live after a load that only rewrote node definitions / widget
+ * schema (unknown placeholders rehydrated after a custom-node install).
+ *
+ * The panel compares the just-loaded state to the live serialize and treats an
+ * unexplained `definitions` difference as unknown. This asks a narrower question:
+ * does the live canvas still hold dest's nodes, connections, and non-empty widget
+ * values? Schema fields (inputs/outputs/properties/size/order) and the
+ * definitions store's widget-schema filling are ignored. Fail closed on anything
+ * else — a rewired link, a missing node, a dest widget value live does not hold.
+ */
+function isUnknownPlaceholderType(type: string): boolean {
+  const t = type.trim().toLowerCase();
+  return t === "unknown" || t === "unknownnode";
+}
+
+function typesCompatibleForRehydration(destType: string, liveType: string): boolean {
+  return destType === liveType || isUnknownPlaceholderType(destType);
+}
+
+function nodesById(graph: unknown): Map<string, Record<string, unknown>> | null {
+  if (!isPlainObject(graph) || !Array.isArray(graph.nodes)) return null;
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const raw of graph.nodes) {
+    if (!isPlainObject(raw) || raw.id == null) return null;
+    const id = String(raw.id);
+    if (byId.has(id)) return null;
+    byId.set(id, raw);
+  }
+  return byId;
+}
+
+function nodeIdentitiesMatchAllowingRehydration(dest: unknown, live: unknown): boolean {
+  const destById = nodesById(dest);
+  const liveById = nodesById(live);
+  if (!destById || !liveById || destById.size !== liveById.size) return false;
+  for (const [id, destNode] of destById) {
+    const liveNode = liveById.get(id);
+    if (!liveNode) return false;
+    if (typeof destNode.type !== "string" || typeof liveNode.type !== "string") return false;
+    if (!typesCompatibleForRehydration(destNode.type, liveNode.type)) return false;
+  }
+  return true;
+}
+
+function linkEndpointKey(link: unknown): string | null {
+  if (Array.isArray(link) && link.length >= 5) {
+    const origin = link[1];
+    const target = link[3];
+    if (origin == null || target == null) return null;
+    return `${String(origin)}\0${String(link[2])}\0${String(target)}\0${String(link[4])}`;
+  }
+  if (!isPlainObject(link)) return null;
+  const origin = link.origin_id ?? link.from;
+  const target = link.target_id ?? link.to;
+  if (origin == null || target == null) return null;
+  const originSlot = link.origin_slot ?? link.from_slot ?? 0;
+  const targetSlot = link.target_slot ?? link.to_slot ?? 0;
+  return `${String(origin)}\0${String(originSlot)}\0${String(target)}\0${String(targetSlot)}`;
+}
+
+function linkTopologySet(graph: unknown): Set<string> | null {
+  if (!isPlainObject(graph)) return null;
+  if (graph.links == null) return new Set();
+  if (!Array.isArray(graph.links)) return null;
+  const keys = new Set<string>();
+  for (const link of graph.links) {
+    const key = linkEndpointKey(link);
+    if (key == null) return null;
+    keys.add(key);
+  }
+  return keys;
+}
+
+function linkTopologiesMatch(dest: unknown, live: unknown): boolean {
+  const destLinks = linkTopologySet(dest);
+  const liveLinks = linkTopologySet(live);
+  if (!destLinks || !liveLinks || destLinks.size !== liveLinks.size) return false;
+  for (const key of destLinks) if (!liveLinks.has(key)) return false;
+  return true;
+}
+
+function stableWidgetsDisagree(destNode: Record<string, unknown>, liveNode: Record<string, unknown>): boolean {
+  const destNamed = namedWidgets(destNode);
+  if (destNamed) {
+    const liveMap = namedWidgets(liveNode) ?? {};
+    for (const [key, destVal] of Object.entries(destNamed)) {
+      if (isEmptyWidgetValue(destVal)) continue;
+      const liveVal = liveMap[key];
+      if (isEmptyWidgetValue(liveVal) || valuesDiffer(liveVal, destVal)) return true;
+    }
+    return false;
+  }
+  if (!Array.isArray(destNode.widgets_values)) return false;
+  const destWv = destNode.widgets_values;
+  const liveWv = Array.isArray(liveNode.widgets_values) ? liveNode.widgets_values : [];
+  for (let i = 0; i < destWv.length; i++) {
+    if (isEmptyWidgetValue(destWv[i])) continue;
+    if (isEmptyWidgetValue(liveWv[i]) || valuesDiffer(liveWv[i], destWv[i])) return true;
+  }
+  return false;
+}
+
+function graphStableWidgetsDisagree(dest: unknown, live: unknown): boolean {
+  const destById = nodesById(dest);
+  const liveById = nodesById(live);
+  if (!destById || !liveById) return true;
+  for (const [id, destNode] of destById) {
+    const liveNode = liveById.get(id);
+    if (!liveNode || stableWidgetsDisagree(destNode, liveNode)) return true;
+  }
+  return false;
+}
+
+function subgraphEntries(graph: unknown): unknown[] | null {
+  if (!isPlainObject(graph)) return null;
+  if (!Object.prototype.hasOwnProperty.call(graph, "definitions")) return [];
+  const defs = graph.definitions;
+  if (defs == null) return [];
+  if (!isPlainObject(defs)) return null;
+  if (!Object.prototype.hasOwnProperty.call(defs, "subgraphs")) return [];
+  const subgraphs = defs.subgraphs;
+  if (subgraphs == null) return [];
+  if (Array.isArray(subgraphs)) return subgraphs;
+  if (isPlainObject(subgraphs)) return Object.values(subgraphs);
+  return null;
+}
+
+function subgraphsById(graph: unknown): Map<string, Record<string, unknown>> | null {
+  const entries = subgraphEntries(graph);
+  if (!entries) return null;
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const raw of entries) {
+    if (!isPlainObject(raw)) return null;
+    if (typeof raw.id !== "string" && typeof raw.id !== "number") return null;
+    const id = String(raw.id);
+    if (byId.has(id)) return null;
+    byId.set(id, raw);
+  }
+  return byId;
+}
+
+export function openLiveMatchesDestContent(live: unknown, dest: unknown): boolean {
+  if (!nodeIdentitiesMatchAllowingRehydration(dest, live)) return false;
+  if (!linkTopologiesMatch(dest, live)) return false;
+  if (graphStableWidgetsDisagree(dest, live)) return false;
+  const destSgs = subgraphsById(dest);
+  const liveSgs = subgraphsById(live);
+  if (!destSgs || !liveSgs) return false;
+  for (const [id, destSg] of destSgs) {
+    const liveSg = liveSgs.get(id);
+    if (!liveSg) return false;
+    if (!openLiveMatchesDestContent(liveSg, destSg)) return false;
+  }
+  return true;
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -84,6 +84,7 @@ import {
 import {
   isPlainObject,
   isStampMismatchSaveRefusal,
+  openLiveMatchesDestContent,
   patchOpenIdentity,
   shouldRebindOpenIdentity,
   workflowFromSerializeReply,
@@ -4848,6 +4849,50 @@ function openedIdentityReboundResult(
   });
 }
 
+function openedNormalizedContentResult(destPath: string): ToolResult {
+  return ok({
+    opened: { path: destPath },
+    content_normalized: true,
+    note:
+      `Opened ${destPath}. The live canvas matches the saved workflow's nodes, connections, ` +
+      `and widget values. Node-definition and widget-schema fields differed after load ` +
+      `(placeholder rehydration / frontend normalization) and are not treated as an unknown open.`,
+  });
+}
+
+/**
+ * #1846 — the panel's identity-proven CONTENT_UNVERIFIED reply is not unknown
+ * when dest's structural content is already on the canvas.
+ *
+ * Fail closed: dest unreadable, a missing/extra node, a rewired link, or a dest
+ * widget value the live graph does not hold leaves the panel error in place.
+ */
+async function tryAcceptNormalizedOpenContent(
+  ctx: PanelToolCtx,
+  destPath: string,
+): Promise<{ status: "accepted" } | { status: "skipped" }> {
+  let live: Record<string, unknown> | null = null;
+  try {
+    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+    live = workflowFromSerializeReply(parseToolResultJson(serialized));
+  } catch {
+    return { status: "skipped" };
+  }
+  if (!live) return { status: "skipped" };
+
+  let dest: Record<string, unknown>;
+  try {
+    dest = await readWorkflowFromPath(destPath);
+  } catch {
+    return { status: "skipped" };
+  }
+  if (!openLiveMatchesDestContent(live, dest)) return { status: "skipped" };
+
+  const destUuid = await activeWorkflowUuidForPath(ctx, destPath);
+  if (destUuid) refreshWorkflowUuid(ctx, { workflow_uuid: destUuid });
+  return { status: "accepted" };
+}
+
 function identityClaimedButLiveGraphUnchangedNote(ctx: PanelToolCtx): string {
   const fence = currentWorkflowFence(ctx);
   const fenceTxt =
@@ -4887,6 +4932,11 @@ async function clearFenceOnIdentityProvenOpen(
       if (rebound.status === "rebound") {
         return { res: openedIdentityReboundResult(requestedPath, rebound), repaired: true };
       }
+      // #1846 — dest already on the canvas; only definitions/schema normalized.
+      const accepted = await tryAcceptNormalizedOpenContent(ctx, requestedPath);
+      if (accepted.status === "accepted") {
+        return { res: openedNormalizedContentResult(requestedPath), repaired: true };
+      }
     }
     return { res: appendToolResultText(res, identityClaimedButLiveGraphUnchangedNote(ctx)), repaired: false };
   }
@@ -4919,6 +4969,14 @@ async function clearFenceOnIdentityProvenOpen(
     note =
       `\n\nFENCE: NOT cleared — the re-derivation threw, so the fence state is UNKNOWN and graph ` +
       `commands may still be refused. (${err instanceof Error ? err.message : String(err)})`;
+  }
+  // #1846 — after the fence is live again, dest-vs-live can still prove this was
+  // definition/schema normalization rather than a lost graph.
+  if (repaired && requestedPath) {
+    const accepted = await tryAcceptNormalizedOpenContent(ctx, requestedPath);
+    if (accepted.status === "accepted") {
+      return { res: openedNormalizedContentResult(requestedPath), repaired: true };
+    }
   }
   return { res: appendToolResultText(res, note), repaired };
 }


### PR DESCRIPTION
Fixes #1846

## What
`panel_open_workflow` treated a successful reopen as unknown when the live canvas differed from the loaded state on `definitions` after unknown placeholders rehydrated (custom nodes installed, workflow saved, closed, reopened). Follow-up `panel_graph_outline` / `panel_query_graph` already showed the right graph.

## Why
The panel compares loaded-state vs live serialize and still has no account for node-definition / widget-schema filling. MCP was forwarding that CONTENT_UNVERIFIED error even when dest's nodes, connections, and widget values were already on the canvas.

## How
On the identity-proven open path, serialize the live graph and read dest (same userdata path as other open handlers). If dest matches live on node identities (including Unknown to real type), link topology, and non-empty widget values — recursively through `definitions.subgraphs` — report the open applied (`content_normalized`) instead of unknown. Schema fields (inputs/outputs/properties/size/order) are ignored. A missing/extra node, rewired link, or dest widget value the live graph does not hold still fails closed.

## Tests
`src/__tests__/orchestrator/open-definitions-rehydrate.test.ts` drives `panel_open_workflow` with the reporter's definitions-only verdict, dest via userdata, live via `graph_serialize`. Also pins widget-value, rewired-link, and missing-node refusals, and the existing #1337/#1639/#1710 open tests.
