### PR TITLE
fix(1845): panel_load_workflow loads a saved workflow after a confirmed restart

### DIFF
--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -50,11 +50,14 @@ vi.mock("../../comfyui/client.js", async (importOriginal) => {
 const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
 // #810: the listing route is now shared with get_workflow (action:"list"), so pinning the literal
 // here would let the two drift apart again — which is how one recursed and one did not.
-const { WORKFLOW_LIBRARY_LISTING_ROUTE } = await import("../../services/userdata-library.js");
+const { WORKFLOW_LIBRARY_LISTING_ROUTE, __userdataLibraryTestHooks } = await import(
+  "../../services/userdata-library.js"
+);
 import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { config } from "../../config.js";
 
 type Forwarded = Record<string, unknown>;
-function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+function makeCtx(opts?: { panelOrigin?: string }): { ctx: PanelToolCtx; calls: Forwarded[] } {
   const calls: Forwarded[] = [];
   const ctx = {
     call: async (cmd: Forwarded) => {
@@ -62,7 +65,12 @@ function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
       return { content: [{ type: "text", text: "ok" }] };
     },
     confirm: async () => "yes" as const,
-    bridge: { send: async (cmd: Forwarded) => { calls.push(cmd); return {}; } },
+    bridge: {
+      send: async (cmd: Forwarded) => { calls.push(cmd); return {}; },
+      ...(opts?.panelOrigin
+        ? { tabServerOrigin: () => opts.panelOrigin }
+        : {}),
+    },
     tabId: "test-tab",
   } as unknown as PanelToolCtx;
   return { ctx, calls };
@@ -75,17 +83,26 @@ function loadWorkflow() {
 }
 
 let savedComfyPath: string | undefined;
+let savedConfigPath: string | undefined;
 beforeEach(() => {
   fetchApi.mockReset();
   fetchInit.mockReset();
   savedComfyPath = process.env.COMFYUI_PATH;
+  savedConfigPath = config.comfyuiPath;
   // No local COMFYUI_PATH → the guessed workflows dirs are empty, so a relative
   // name misses on disk and MUST fall through to the userdata API.
   delete process.env.COMFYUI_PATH;
+  config.comfyuiPath = undefined;
+  // Existing tests assert a single fetch; #1845 retries are exercised separately.
+  __userdataLibraryTestHooks.setRetryDelays([]);
+  __userdataLibraryTestHooks.setSleep(async () => {});
 });
 afterEach(() => {
   if (savedComfyPath === undefined) delete process.env.COMFYUI_PATH;
   else process.env.COMFYUI_PATH = savedComfyPath;
+  config.comfyuiPath = savedConfigPath;
+  __userdataLibraryTestHooks.setRetryDelays(null);
+  __userdataLibraryTestHooks.setSleep(null);
 });
 
 describe("panel_load_workflow: userdata fallback for a custom --user-directory (#202)", () => {
@@ -1185,6 +1202,85 @@ describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening
     } finally {
       rmSync(root, { recursive: true, force: true });
       rmSync(external, { recursive: true, force: true });
+    }
+  });
+});
+
+// #1845 — immediately after panel_restart_comfyui reports server_ready, a
+// relative panel_load_workflow can ECONNREFUSED the headless userdata GET and
+// then claim COMFYUI_PATH is unset even though the trusted workspace is known.
+describe("panel_load_workflow after a confirmed restart (#1845)", () => {
+  it("retries a refused userdata GET and loads the graph once the listener is back", async () => {
+    __userdataLibraryTestHooks.setRetryDelays([0]);
+    const graph = { nodes: [{ id: 1, type: "AfterRestartKSampler" }], links: [] };
+    fetchApi
+      .mockRejectedValueOnce(Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" }))
+      .mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(graph) });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler(
+      { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+  });
+
+  it("reads the library through the connected panel origin when the headless target is refused", async () => {
+    const graph = { nodes: [{ id: 2, type: "PanelOriginLoad" }], links: [] };
+    fetchApi.mockImplementation(async (url: string) => {
+      if (String(url).startsWith("http://localhost:8188/")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify(graph) };
+      }
+      throw Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" });
+    });
+
+    const { ctx, calls } = makeCtx({ panelOrigin: "http://localhost:8188" });
+    const res = await loadWorkflow().handler(
+      { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      `http://localhost:8188/api/userdata/${encodeURIComponent("workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json")}`,
+    );
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+  });
+
+  it("loads from the trusted workspace when COMFYUI_PATH env is unset", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-trusted-ws-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const staged = { nodes: [{ id: 9, type: "TrustedWorkspaceNode" }], links: [] };
+      writeFileSync(
+        join(defaultDir, "minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json"),
+        JSON.stringify(staged),
+        "utf8",
+      );
+      // Reporter shape: env unset, but the workspace install_comfyui environment
+      // reports is already on config.comfyuiPath.
+      config.comfyuiPath = root;
+      fetchApi.mockRejectedValue(
+        Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" }),
+      );
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler(
+        { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+        ctx,
+      );
+
+      expect(res.isError).toBeUndefined();
+      expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+      expect(calls[0].graph).toMatchObject(staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -149,7 +149,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
 import { tryInstallRetiredNameRedirect } from "../tools/retired-redirect.js";
-import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
+import { config, isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import {
   AGENT_IDENTITY_ENV,
@@ -1463,6 +1463,12 @@ export async function runPanelOrchestrator(): Promise<void> {
         `base_path from the panel status route: ${comfyuiPath} (#296).`,
     );
   }
+  // #1845 — panel_load_workflow runs IN this process and reconstructs the
+  // workflow library from config.comfyuiPath, not from the spawn env handed to
+  // child MCP servers. A recovered path that never reached config left the
+  // local fallback claiming "COMFYUI_PATH not set" while install_comfyui
+  // environment (the child) reported the same trusted workspace.
+  if (comfyuiPath && !config.comfyuiPath) config.comfyuiPath = comfyuiPath;
   // Force the child remote only when opted in (--force-remote) or the target is
   // non-loopback; a default loopback panel user with no COMFYUI_PATH is left to
   // auto-detect its local install (keeps download_model/apply_manifest/scans).
@@ -3416,6 +3422,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         if (canonTargetUrl(comfyuiUrl) !== canonTargetUrl(next)) return;
         if (comfyuiPath === recovered) return;
         comfyuiPath = recovered;
+        if (!config.comfyuiPath) config.comfyuiPath = recovered;
         logger.info(
           `[panel-orchestrator] recovered ComfyUI base_path from panel status route ` +
             `after retarget: ${recovered} (#296).`,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7318,7 +7318,13 @@ function comfyWorkflowsDirs(): string[] {
     const p = normalizeInstallPathEnv(raw).path;
     if (p && !bases.includes(p)) bases.push(p);
   };
-  add(process.env.COMFYUI_PATH);
+  // Wrapped AT THE READ even though `add` normalizes: #1512's guard is line-level by
+  // design, because a proximity rule passes when the normalized result is discarded
+  // and the raw value forwarded anyway. It cannot see into `add`, and making it try
+  // would be the weakening that lets the next raw read through. normalizeInstallPathEnv
+  // is idempotent (trim + unquote), so the second pass inside `add` is a no-op and
+  // reports changed:false, emitting no duplicate ingestion warning.
+  add(normalizeInstallPathEnv(process.env.COMFYUI_PATH).path);
   add(resolveEffectiveComfyUIBase());
   add(peekResolvedPanelBase());
   const dirs: string[] = [];

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -67,6 +67,7 @@ import { requiredPanelVersion, SEMVER_RE } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
 import {
+  peekResolvedPanelBase,
   primePanelBase,
   verifiedPanelDiskVersion,
 } from "../services/panel-workspace.js";
@@ -156,6 +157,7 @@ import { describeUnappliedFilters } from "./civitai-filter-guard.js";
 import { recordTodo, normalizeTodoItems, TODO_STATUS_INPUTS } from "./todo-state.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
+import { resolveEffectiveComfyUIBase } from "../services/workspace-env.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { RunCompletions } from "./run-completion-journal.js";
@@ -4793,7 +4795,7 @@ async function tryRebindConfirmedOpenIdentity(
 
   let dest: Record<string, unknown>;
   try {
-    dest = await readWorkflowFromPath(destPath);
+    dest = await readWorkflowFromPath(destPath, ctx);
   } catch {
     return { status: "skipped" };
   }
@@ -7304,12 +7306,27 @@ function comfyWorkflowsDirs(): string[] {
   // #1512 — a trailing space here does not fail loudly: it silently builds
   // `<path> /user/default/workflows`, a directory that does not exist, so the
   // workflow library simply appears empty and every lookup misses.
-  const base = normalizeInstallPathEnv(process.env.COMFYUI_PATH).path;
-  if (!base) return [];
-  return [
-    join(base, "user", "default", "workflows"),
-    join(base, "user", "workflows"),
-  ];
+  //
+  // #1845 — process.env.COMFYUI_PATH is not the only trusted root. The
+  // orchestrator often knows the workspace via auto-detect, a saved default, or
+  // the already-primed panel base, while the env var itself stays unset in this
+  // process (it is forwarded to spawned MCP children). Claiming "COMFYUI_PATH
+  // not set" then hid a tree install_comfyui(action:"environment") had just
+  // reported.
+  const bases: string[] = [];
+  const add = (raw: string | undefined): void => {
+    const p = normalizeInstallPathEnv(raw).path;
+    if (p && !bases.includes(p)) bases.push(p);
+  };
+  add(process.env.COMFYUI_PATH);
+  add(resolveEffectiveComfyUIBase());
+  add(peekResolvedPanelBase());
+  const dirs: string[] = [];
+  for (const base of bases) {
+    dirs.push(join(base, "user", "default", "workflows"));
+    dirs.push(join(base, "user", "workflows"));
+  }
+  return dirs;
 }
 
 // The raw-Response userdata GET (why it bypasses `fetchApi`, and what a thrown error
@@ -7445,7 +7462,10 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
  * Guards: must be .json and must parse to a UI workflow (a top-level `nodes`
  * array). Every failure names exactly what was tried.
  */
-async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unknown>> {
+async function readWorkflowFromPath(
+  rawPath: string,
+  ctx?: PanelToolCtx,
+): Promise<Record<string, unknown>> {
   const p = (rawPath ?? "").trim();
   if (!p) throw new Error("Provide a non-empty `path` to a workflow .json file.");
   if (!/\.json$/i.test(p)) {
@@ -7523,7 +7543,9 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   const fetchUserdataKey = async (key: string): Promise<Outcome> => {
     let res: Response;
     try {
-      res = await userdataFetch(`/api/userdata/${encodeURIComponent(key)}`);
+      res = await userdataFetch(`/api/userdata/${encodeURIComponent(key)}`, {
+        panelOrigin: ctx?.bridge?.tabServerOrigin?.(ctx.tabId) ?? undefined,
+      });
     } catch (err) {
       // No Response object exists — the request never received an answer
       // (connection refused, DNS, TLS, timeout), or no client could be built at
@@ -7860,7 +7882,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
 
   throw new Error(
     `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's ` +
-      `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}).` +
+      `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set and no trusted workspace/user-directory was known"}).` +
       (misspelled.length
         ? ` A file exists on disk as ${misspelled.map((f) => `"${f}"`).join(", ")}, which is` +
           ` not how you spelled it (letter case, repeated separator, or Unicode` +
@@ -9458,7 +9480,7 @@ async function resolveWorkflowInput(
   }
   if (args.path) {
     return assertUiWorkflow(
-      await readWorkflowFromPath(args.path as string),
+      await readWorkflowFromPath(args.path as string, ctx),
       `Workflow file "${String(args.path)}"`,
     );
   }
@@ -11488,7 +11510,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Read an arbitrary workflow JSON server-side — a local disk path, or
             // (for a relative name under a custom --user-directory) the connected
             // ComfyUI's userdata API — keeping the big JSON out of chat (#202).
-            data = await readWorkflowFromPath(args.path as string);
+            data = await readWorkflowFromPath(args.path as string, ctx);
           } else if (args.graph != null) {
             data = typeof args.graph === "string" ? JSON.parse(args.graph as string) : args.graph;
           } else {

--- a/src/services/panel-workspace.ts
+++ b/src/services/panel-workspace.ts
@@ -400,6 +400,15 @@ function targetGeneration(): number {
   }
 }
 
+/**
+ * The already-resolved panel ComfyUI base, or undefined when nothing is cached.
+ * Sync on purpose: panel_load_workflow's local fallback must not issue HTTP
+ * after the userdata library has just been unreachable (#1845).
+ */
+export function peekResolvedPanelBase(): string | undefined {
+  return cachedResolution()?.base;
+}
+
 function cachedResolution(): PanelBaseResolution | undefined {
   if (!cached) return undefined;
   if (cached.target !== targetKey()) return undefined;

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -13,6 +13,8 @@
 // for #202) while get_workflow (action:"list") did not, which is exactly the drift a shared helper
 // removes.
 import { getClient } from "../comfyui/client.js";
+import { getComfyUIBasePath } from "../config.js";
+import { describeFetchFailure } from "../utils/errors.js";
 
 /**
  * The listing route for the workflow library.
@@ -60,11 +62,77 @@ export const WORKFLOW_LIBRARY_LISTING_ROUTE =
  *   - a thrown error       = no Response exists, so the request never got one
  * Nothing here reads a body, so a body that cannot be decoded can never be mistaken
  * for a transport failure.
+ *
+ * #1845 — a confirmed ComfyUI restart can still leave the next userdata GET
+ * racing the listener (ECONNREFUSED on 127.0.0.1:8188 while the panel tab is
+ * already talking to the same server). Transient connection failures retry a
+ * bounded number of times. When a connected panel origin is supplied AND its
+ * spelling differs from the headless client URL (localhost vs 127.0.0.1, a
+ * different port), that origin is tried after the headless URL is exhausted —
+ * the browser's origin is the one that just proved reachable.
  */
-export async function userdataFetch(route: string): Promise<Response> {
+export async function userdataFetch(
+  route: string,
+  opts?: { panelOrigin?: string },
+): Promise<Response> {
   const client = getClient();
-  return await client.fetch(client.apiURL(route), { headers: client.apiHeaders() });
+  const headers = client.apiHeaders();
+  const primary = client.apiURL(route);
+  const urls = [primary];
+  const origin = opts?.panelOrigin?.trim();
+  if (origin) {
+    const alt = userdataUrlAtOrigin(origin, route);
+    if (alt && alt !== primary) urls.push(alt);
+  }
+
+  let lastErr: unknown;
+  for (const url of urls) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await client.fetch(url, { headers });
+      } catch (err) {
+        lastErr = err;
+        if (!isTransientUnreachable(err)) throw err;
+        if (attempt >= retryDelaysMs.length) break;
+        await sleepImpl(retryDelaysMs[attempt]!);
+      }
+    }
+  }
+  throw lastErr;
 }
+
+/** Connection-level failures that a just-restarted listener commonly produces. */
+function isTransientUnreachable(err: unknown): boolean {
+  const { code, message } = describeFetchFailure(err);
+  return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|EPIPE/i.test(
+    `${code ?? ""} ${message}`,
+  );
+}
+
+function userdataUrlAtOrigin(origin: string, route: string): string {
+  let basePath = "";
+  try {
+    basePath = getComfyUIBasePath().replace(/\/$/, "");
+  } catch {
+    basePath = "";
+  }
+  const path = route.startsWith("/") ? route : `/${route}`;
+  return `${origin.replace(/\/$/, "")}${basePath}${path}`;
+}
+
+const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [200, 600, 1500];
+let retryDelaysMs: readonly number[] = DEFAULT_RETRY_DELAYS_MS;
+let sleepImpl = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const __userdataLibraryTestHooks = {
+  setRetryDelays(delays: readonly number[] | null): void {
+    retryDelaysMs = delays ?? DEFAULT_RETRY_DELAYS_MS;
+  },
+  setSleep(fn: ((ms: number) => Promise<void>) | null): void {
+    sleepImpl = fn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  },
+};
 
 /**
  * The outcome of one library listing, with "the library is empty" kept DISTINCT from


### PR DESCRIPTION
Fixes #1845

After panel_restart_comfyui reports server_ready / graph_tools_ready / panel_tab_reconnected, panel_load_workflow with a saved-library path no longer fails on a transient headless ECONNREFUSED or by claiming COMFYUI_PATH is unset.

- Retry the userdata library GET on connection-refused/reset/timeout so a just-restarted listener can come back.
- If the headless target stays refused, retry the same GET against the connected panel origin (localhost vs 127.0.0.1, a different port).
- Local fallback now uses the trusted workspace already known by install_comfyui environment (config.comfyuiPath, saved default, primed panel base), not only process.env.COMFYUI_PATH.