### PR TITLE
fix(1853): a dropped panel completion still arrives with the history output filenames

### DIFF
--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -33,13 +33,17 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     const src = indexSrc();
     expect(src).toContain("createRunCompletionWatchdog({");
     const start = src.indexOf("createRunCompletionWatchdog({");
-    const block = src.slice(start, start + 1600);
+    const block = src.slice(start, start + 1800);
     // It asks the journal whether the run is still owed a completion…
     expect(block).toContain("RunCompletions.awaitingCompletion(");
     // …and delivers through the SAME arrival path the panel's frame uses, so the
     // completion is correlated, journaled and replayable rather than pushed raw.
     expect(block).toContain("RunCompletions.record(");
     expect(block).toContain("flushRunCompletions(");
+    // #1853 — outputs come from the shipped /history parse, not a status-only
+    // pointer. A second path that invented filenames would be the over-claim.
+    expect(block).toContain("resolveOutputs:");
+    expect(block).toContain("resolveHistoryCompletionImages(");
   });
 
   it("SOURCE: QueueMonitor's completions are TEED to the watchdog from the broadcaster's single drain", () => {

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -17,9 +17,12 @@
 // on) fails here rather than shipping.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { HistoryEntry } from "../../comfyui/client.js";
 import {
   createRunCompletionWatchdog,
   synthesizeCompletionPayload,
+  resolveHistoryCompletionImages,
+  historyOutputRefsFromEntry,
   DEFAULT_SYNTHESIS_GRACE_MS,
 } from "../../orchestrator/run-completion-watchdog.js";
 import { RunCompletions, type CompletionPayload, type RunTicket } from "../../orchestrator/run-completion-journal.js";
@@ -32,7 +35,12 @@ beforeEach(() => RunCompletions.reset());
 afterEach(() => RunCompletions.reset());
 
 /** A watchdog wired to the real journal, with a controllable clock. */
-function makeWatchdog(clock: { t: number }) {
+function makeWatchdog(
+  clock: { t: number },
+  extras: {
+    resolveOutputs?: (promptId: string) => Promise<CompletionPayload["images"]>;
+  } = {},
+) {
   const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
   const wd = createRunCompletionWatchdog({
     awaiting: (id) => RunCompletions.awaitingCompletion(id),
@@ -43,8 +51,31 @@ function makeWatchdog(clock: { t: number }) {
       });
     },
     now: () => clock.t,
+    ...(extras.resolveOutputs ? { resolveOutputs: extras.resolveOutputs } : {}),
   });
   return { wd, delivered };
+}
+
+const VIDEO_FILENAME = "perfume_citrus_spring_00001_.mp4";
+const VIDEO_SUBFOLDER = "video";
+
+function saveVideoHistoryEntry(promptId: string): HistoryEntry {
+  return {
+    prompt: {},
+    outputs: {
+      "12": {
+        videos: [{ filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" }],
+      },
+    },
+    status: {
+      status_str: "success",
+      completed: true,
+      messages: [
+        ["execution_start", { prompt_id: promptId, timestamp: 1_000 }],
+        ["execution_success", { prompt_id: promptId, timestamp: 503_060 }],
+      ],
+    },
+  } as HistoryEntry;
 }
 
 describe("#1789: a completion the panel never reported is filled in from ComfyUI's history", () => {
@@ -242,5 +273,145 @@ describe("#1789: the synthesised note claims only what was observed", () => {
     );
     expect(note).toContain("INTERRUPTED");
     expect(note).toContain("Nothing crashed");
+  });
+
+  it("#1853: history output refs ride the synthesised payload, and the note stops claiming they are missing", () => {
+    const refs = historyOutputRefsFromEntry(PID, saveVideoHistoryEntry(PID));
+    const payload = synthesizeCompletionPayload(
+      { promptId: PID, status: "success", observedAt: 1000 },
+      { deliveredAt: 1000 + 46_000, images: refs },
+    );
+    expect(payload.images).toEqual(refs);
+    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
+    expect(String(payload.note)).toContain(VIDEO_FILENAME);
+    expect(String(payload.note)).not.toContain("NOT attached");
+    expect(String(payload.note)).not.toContain('get_image (action:"list_outputs")');
+  });
+
+  it("empty or malformed image refs are dropped, never forwarded as outputs", () => {
+    const payload = synthesizeCompletionPayload(
+      { promptId: PID, status: "success", observedAt: 0 },
+      {
+        deliveredAt: 45_000,
+        images: [
+          { filename: "" },
+          { filename: "   " },
+          { filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" },
+          { filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" },
+        ],
+      },
+    );
+    expect(payload.images).toHaveLength(1);
+    expect(payload.images[0].filename).toBe(VIDEO_FILENAME);
+  });
+});
+
+describe("#1853: a dropped panel frame still yields the completed prompt's history outputs", () => {
+  it("the synthesised completion attaches SaveVideo outputs resolved from /history", async () => {
+    const clock = { t: 9_000_000 };
+    const entry = saveVideoHistoryEntry(PID);
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
+    });
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+
+    expect(delivered).toHaveLength(1);
+    const payload = delivered[0].payload;
+    expect(payload.prompt_id).toBe(PID);
+    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
+    expect(payload.images.some((img) => img.subfolder === VIDEO_SUBFOLDER)).toBe(true);
+    expect(String(payload.note)).toContain(VIDEO_FILENAME);
+    expect(String(payload.note)).not.toContain("NOT attached");
+
+    const seen: CompletionPayload[] = [];
+    RunCompletions.deliverPending(TAB, (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
+  });
+
+  it("history with no media stays status-only — nothing is invented", async () => {
+    const clock = { t: 10_000_000 };
+    const empty: HistoryEntry = {
+      prompt: {},
+      outputs: {},
+      status: { status_str: "success", completed: true, messages: [] },
+    };
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: empty })),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.images).toEqual([]);
+    expect(String(delivered[0].payload.note)).toContain("NOT attached");
+  });
+
+  it("a history fetch failure still delivers the status-only notice", async () => {
+    const clock = { t: 11_000_000 };
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.images).toEqual([]);
+    expect(String(delivered[0].payload.note)).toContain("NOT attached");
+  });
+
+  it("a panel frame that lands during the history fetch still wins", async () => {
+    const clock = { t: 12_000_000 };
+    let release!: (refs: NonNullable<CompletionPayload["images"]>) => void;
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    const pending = wd.tick();
+    RunCompletions.record(
+      TAB,
+      { kind: "executed", prompt_id: PID, images: [{ filename: "storyboard.png" }] },
+      { conversation: CONV },
+    );
+    release([{ filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" }]);
+    await pending;
+    expect(delivered).toHaveLength(0);
+    expect(RunCompletions.outstanding(TAB)[0].payload.images).toEqual([{ filename: "storyboard.png" }]);
+  });
+
+  it("resolveHistoryCompletionImages returns [] when /history has no entry for the prompt", async () => {
+    const refs = await resolveHistoryCompletionImages(PID, async () => ({}));
+    expect(refs).toEqual([]);
+  });
+
+  it("historyOutputRefsFromEntry reads images AND videos through the shipped parser", () => {
+    const entry = {
+      prompt: {},
+      outputs: {
+        "9": { images: [{ filename: "still.png", subfolder: "", type: "output" }] },
+        "12": { videos: [{ filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" }] },
+      },
+      status: { status_str: "success", completed: true, messages: [] },
+    } as HistoryEntry;
+    const refs = historyOutputRefsFromEntry(PID, entry);
+    expect(refs.some((img) => img.filename === "still.png")).toBe(true);
+    expect(refs.some((img) => img.filename === VIDEO_FILENAME && img.subfolder === VIDEO_SUBFOLDER)).toBe(true);
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -215,7 +215,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
-import { createRunCompletionWatchdog } from "./run-completion-watchdog.js";
+import { createRunCompletionWatchdog, resolveHistoryCompletionImages } from "./run-completion-watchdog.js";
 import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
@@ -6373,6 +6373,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // still wins whenever it is coming.
   const runCompletionWatchdog = createRunCompletionWatchdog({
     awaiting: (promptId) => RunCompletions.awaitingCompletion(promptId),
+    resolveOutputs: (promptId) => resolveHistoryCompletionImages(promptId),
     deliver: (payload, ticket) => {
       // The SAME arrival path the panel's frame takes: correlated once, here,
       // against the ticket that is still open — so the agent is told this is the

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -37,13 +37,16 @@
 //                real frame would have used.
 //
 // WHY A GRACE RATHER THAN IMMEDIATELY. The panel's frame is the better one — it
-// carries the output images, the duration and the metadata; ours carries a
-// terminal status and a pointer. The normal path lands within a second or two,
-// and the panel's OWN recovery sweep re-reconciles every 20 s, so a grace
-// comfortably past both lets the real frame win every time it is coming. Past
-// the grace there are exactly two shapes, and NEITHER loses anything — stated
-// precisely, because the coalescing one is the narrower case, not the general
-// one (gate finding):
+// carries the output images, the duration and the metadata. Ours used to carry
+// only a terminal status and a pointer (#1789); #1853 fills the images from
+// the same completed /history record JobWatcher already parses, so a dropped
+// panel frame still yields the output filenames. Never fabricated: no history
+// entry, no usable media refs, or a fetch failure ⇒ images stay []. The normal
+// path lands within a second or two, and the panel's OWN recovery sweep
+// re-reconciles every 20 s, so a grace comfortably past both lets the real
+// frame win every time it is coming. Past the grace there are exactly two
+// shapes, and NEITHER loses anything — stated precisely, because the coalescing
+// one is the narrower case, not the general one (gate finding):
 //   • nothing took the synthesised entry (no live agent at that instant), so it
 //     is still `pending` — the journal COALESCES the real payload onto it
 //     (record()), and the agent sees ONE turn, with the images. This is the only
@@ -60,9 +63,13 @@
 // nothing — the same silence as before, which is why the rider also stopped
 // promising more than this can keep.
 
+import { getHistory, type HistoryEntry } from "../comfyui/client.js";
+import { buildCompletionNotification } from "../services/job-watcher.js";
 import { logger } from "../utils/logger.js";
 import type { CompletionStatus } from "../services/queue-monitor.js";
 import type { CompletionPayload, RunTicket } from "./run-completion-journal.js";
+
+type CompletionImage = NonNullable<CompletionPayload["images"]>[number];
 
 /** One completion QueueMonitor observed, held until its grace expires. */
 interface ArmedCompletion {
@@ -79,6 +86,12 @@ export interface RunCompletionWatchdogDeps {
   awaiting: (promptId: string) => RunTicket | undefined;
   /** Journal + flush a synthesised completion for `ticket`. */
   deliver: (payload: CompletionPayload, ticket: RunTicket) => void;
+  /**
+   * Resolve output refs from the completed prompt's ComfyUI history. Wired to
+   * `resolveHistoryCompletionImages` in production. Missing / throwing / empty
+   * is the #1789 status-only notice, never a fabricated image.
+   */
+  resolveOutputs?: (promptId: string) => Promise<CompletionPayload["images"]>;
   /** How long to let the panel's own frame (and its 20 s reconcile sweep) win
    *  before filling in. */
   graceMs?: number;
@@ -100,22 +113,91 @@ export interface RunCompletionWatchdog {
   /** Feed QueueMonitor's drained completions in. Never throws. */
   observe(events: ReadonlyArray<{ promptId: string; status: CompletionStatus }>): void;
   /** Expire armed observations; synthesise for the ones still unanswered. */
-  tick(): void;
+  tick(): Promise<void>;
   /** Diagnostics/tests: how many completions are currently armed. */
   armedCount(): number;
+}
+
+function usableHistoryImages(images: CompletionPayload["images"]): CompletionImage[] {
+  if (!Array.isArray(images)) return [];
+  const out: CompletionImage[] = [];
+  const seen = new Set<string>();
+  for (const img of images) {
+    const filename = typeof img?.filename === "string" ? img.filename.trim() : "";
+    if (!filename) continue;
+    const subfolder = typeof img.subfolder === "string" ? img.subfolder : "";
+    const type = typeof img.type === "string" && img.type ? img.type : "output";
+    const key = `${subfolder}\0${type}\0${filename}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      filename,
+      ...(subfolder ? { subfolder } : {}),
+      type,
+    });
+  }
+  return out;
+}
+
+/**
+ * Flatten a history entry's media into the completion-payload `images` shape.
+ * Extraction is `buildCompletionNotification` — the same parse JobWatcher and
+ * asset reconcile already ship — so a SaveVideo `videos` ref and a SaveImage
+ * `images` ref take the same path a watched completion would.
+ */
+export function historyOutputRefsFromEntry(
+  promptId: string,
+  entry: HistoryEntry,
+): CompletionImage[] {
+  const notification = buildCompletionNotification(promptId, entry, 0);
+  const refs: CompletionImage[] = [];
+  for (const node of notification.outputs) {
+    for (const img of node.images) {
+      refs.push({ filename: img.filename, subfolder: img.subfolder, type: img.type });
+    }
+  }
+  for (const node of notification.video_outputs) {
+    for (const vid of node.videos) {
+      refs.push({ filename: vid.filename, subfolder: vid.subfolder, type: vid.type });
+    }
+  }
+  return usableHistoryImages(refs);
+}
+
+/**
+ * Fetch `/history/<promptId>` and return the real output refs, or [] when the
+ * record is missing, unreadable, or lists no usable media. Never fabricates.
+ */
+export async function resolveHistoryCompletionImages(
+  promptId: string,
+  fetchHistory: (id: string) => Promise<Record<string, HistoryEntry>> = getHistory,
+): Promise<CompletionImage[]> {
+  const id = typeof promptId === "string" ? promptId.trim() : "";
+  if (!id) return [];
+  try {
+    const history = await fetchHistory(id);
+    const entry = history?.[id];
+    if (!entry) return [];
+    return historyOutputRefsFromEntry(id, entry);
+  } catch (err) {
+    logger.debug(
+      `[run-completion-watchdog] history fetch for ${id} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
 }
 
 /**
  * Compose the synthesised completion payload.
  *
- * Every claim in it is one the orchestrator actually observed. It does NOT say
- * "here is your image" — a CompletionEvent carries a prompt id, a terminal
- * status and a timestamp, never outputs — and it does not name WHICH channel
- * saw the finish, because recordCompletion is fed by both the WS execution
- * events and the /history diff and does not record which one won. It does not
- * say the panel is broken, only that its completion
- * never arrived here. Naming the delay is what lets the agent tell this apart
- * from a fresh render finishing now.
+ * Every claim in it is one the orchestrator actually observed. Output refs are
+ * only those resolved from the completed prompt's /history record (#1853);
+ * without them the notice stays status-only (#1789) and points at get_image /
+ * get_history. It does not name WHICH channel saw the finish, because
+ * recordCompletion is fed by both the WS execution events and the /history
+ * diff and does not record which one won. It does not say the panel is broken,
+ * only that its completion never arrived here. Naming the delay is what lets
+ * the agent tell this apart from a fresh render finishing now.
  *
  * A FAILED run is reported through this same non-urgent `executed` shape rather
  * than `run_error`: run_error INTERRUPTS the live turn and front-queues "your
@@ -126,20 +208,26 @@ export interface RunCompletionWatchdog {
  */
 export function synthesizeCompletionPayload(
   armed: ArmedCompletion,
-  opts: { deliveredAt: number },
+  opts: { deliveredAt: number; images?: CompletionPayload["images"] },
 ): CompletionPayload {
   const waitedS = Math.max(0, Math.round((opts.deliveredAt - armed.observedAt) / 1000));
+  const images = usableHistoryImages(opts.images);
   const outcome =
     armed.status === "success"
       ? "finished SUCCESSFULLY"
       : armed.status === "interrupted"
         ? "was INTERRUPTED (cancelled before it finished)"
         : "FAILED";
+  const names = images
+    .map((img) => (img.subfolder ? `${img.subfolder}/${img.filename}` : img.filename))
+    .join(", ");
   const next =
     armed.status === "success"
-      ? `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
-        `status, not its images. Fetch them with get_image (action:"list_outputs") ` +
-        `or get_history for this prompt id before describing or using the result.`
+      ? images.length > 0
+        ? `The output file(s) from ComfyUI history are attached: ${names}.`
+        : `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
+          `status, not its images. Fetch them with get_image (action:"list_outputs") ` +
+          `or get_history for this prompt id before describing or using the result.`
       : armed.status === "interrupted"
         ? `Nothing crashed; it did not run to completion. Re-queue it if the cancellation was unintended.`
         : `Read the failure with panel_get_errors, or get_history for this prompt id. Do NOT report the ` +
@@ -147,7 +235,7 @@ export function synthesizeCompletionPayload(
   return {
     kind: "executed",
     prompt_id: armed.promptId,
-    images: [],
+    images,
     // Machine-readable provenance: this completion was NOT reported by the panel.
     completion_source: "orchestrator-history-watchdog",
     run_status: armed.status,
@@ -161,6 +249,7 @@ export function synthesizeCompletionPayload(
 export function createRunCompletionWatchdog({
   awaiting,
   deliver,
+  resolveOutputs,
   graceMs = DEFAULT_SYNTHESIS_GRACE_MS,
   now = () => Date.now(),
 }: RunCompletionWatchdogDeps): RunCompletionWatchdog {
@@ -194,7 +283,7 @@ export function createRunCompletionWatchdog({
       }
     },
 
-    tick() {
+    async tick() {
       if (armed.size === 0) return;
       const at = now();
       for (const entry of [...armed.values()]) {
@@ -215,16 +304,36 @@ export function createRunCompletionWatchdog({
         // The panel's own frame landed inside the grace — the normal case, and
         // the one this must stay quiet for.
         if (!ticket) continue;
-        // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
-        // only detector of a lost completion was a human noticing the agent had
-        // gone quiet.
-        logger.warn(
-          `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
-            (at - entry.observedAt) / 1000,
-          )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
-        );
         try {
-          deliver(synthesizeCompletionPayload(entry, { deliveredAt: at }), ticket);
+          let images: CompletionImage[] = [];
+          if (resolveOutputs) {
+            try {
+              images = usableHistoryImages(await resolveOutputs(entry.promptId));
+            } catch (err) {
+              logger.debug(
+                `[run-completion-watchdog] history outputs for ${entry.promptId} unavailable: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+            // A panel frame that landed DURING the fetch still wins.
+            try {
+              ticket = awaiting(entry.promptId);
+            } catch (err) {
+              logger.debug(
+                `[run-completion-watchdog] could not re-check prompt ${entry.promptId} after history fetch: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              continue;
+            }
+            if (!ticket) continue;
+          }
+          // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
+          // only detector of a lost completion was a human noticing the agent had
+          // gone quiet.
+          logger.warn(
+            `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
+              (at - entry.observedAt) / 1000,
+            )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
+          );
+          deliver(synthesizeCompletionPayload(entry, { deliveredAt: at, images }), ticket);
         } catch (err) {
           logger.warn(
             `[run-completion-watchdog] could not deliver the synthesised completion for prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
Fixes #1853

The #1789 watchdog kept `panel_run`'s completion promise when the panel never sent its `executed` frame, but `synthesizeCompletionPayload()` was status-only (`images: []`) by design. After a MiniMax H3 SaveVideo finished SUCCESSFULLY (~502s) ComfyUI history already had `video/perfume_citrus_spring_00001_.mp4`, and the synthesised notice ~45s later still told the agent the outputs were NOT attached.

## What the agent now sees

When the grace elapses and the panel still has not reported, the watchdog fetches `/history/<prompt_id>` and attaches the real output refs (SaveImage `images` and SaveVideo `videos`/`video`/`gifs`) that `buildCompletionNotification` already parses for JobWatcher. A dropped frontend event therefore yields the same `{filename, subfolder, type}` payload a normal completion would.

Nothing is fabricated: missing history, no usable media refs, or a fetch failure still produce the #1789 status-only notice. A panel frame that lands during the fetch still wins.

## Wiring

`createRunCompletionWatchdog` now takes `resolveOutputs`, wired in `index.ts` to `resolveHistoryCompletionImages` — the shipped `/history` parse, not a second extractor.

## Tests

- Reporter case: SaveVideo history → synthesised payload carries `perfume_citrus_spring_00001_.mp4`
- Empty history / fetch failure → status-only, `images: []`
- Panel frame during the fetch → watchdog stays silent
- Source wiring: `resolveHistoryCompletionImages` is actually passed in `index.ts`
