### PR TITLE
release: v0.52.24 — synth completion filenames + PoYo paid-service class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.24] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- check_runtime knows PoYo's pack is a paid service, not a local node (#1858)
+- a dropped panel completion still arrives with the history output filenames (#1856)
+
+
 ## [0.52.23] - 2026-08-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.23",
+  "version": "0.52.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.23",
+      "version": "0.52.24",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.23",
+  "version": "0.52.24",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.24 from `main`.

Carries:

- #1856 / #1853 — a dropped panel completion still arrives with the history output filenames
- #1858 / #1855 — check_runtime knows PoYo's pack is a paid service, not a local node

Held out: #1850/#1845 windows CI red; #1851/#1847 CONFLICTING; #1839 anthropic 4 CI red; #1697 P1 Windows no-repro.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.24` tag on the version commit). Tag is local; push `v0.52.24` after merge.