### PR TITLE
fix(1857): launch-server tests collect on a Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,11 @@ docs/design/tool-vocabulary.json text eol=lf
 # suggest. The translations are pinned alongside it so every catalog in the
 # directory is the same shape on every platform.
 locales/**/*.json text eol=lf
+
+# Shebang .mjs files imported by vitest fail to COLLECT on Windows when
+# core.autocrlf checks them out as CRLF (#1857). The transform treats
+# `#!/usr/bin/env node\r` as a syntax error; the file reports "1 failed /
+# Tests no tests" and the tests that exist never run. `node --check` is
+# fine either way — it strips shebangs itself. CI is Linux, so the hole
+# is invisible there. Force LF the same way we do for the ratchet files.
+*.mjs text eol=lf

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -7,13 +7,18 @@
 //
 // The decisions are exercised against the REAL exports — the launcher is
 // import-safe by design, so importing it here is also the proof that importing
-// it spawns nothing.
+// it spawns nothing. The import is inside beforeAll, not at collection: a
+// top-level `await import` of a CRLF shebang is a SyntaxError during
+// transform, which vitest reports as "1 failed / Tests no tests" (#1857).
 
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-const launcher = await import("../../../plugin/scripts/launch-server.mjs");
-const { globalEntry, serverSpec } = launcher as {
+const LAUNCHER_REL = "plugin/scripts/launch-server.mjs";
+const LAUNCHER_URL = new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url);
+
+type Launcher = {
   globalEntry: (stdout: unknown, opts?: { exists?: (p: string) => boolean }) => string | null;
   serverSpec: (
     entry: string | null,
@@ -22,10 +27,40 @@ const { globalEntry, serverSpec } = launcher as {
   ) => { command: string; args: string[]; shell: boolean };
 };
 
+let globalEntry!: Launcher["globalEntry"];
+let serverSpec!: Launcher["serverSpec"];
+
+async function loadLauncher(): Promise<void> {
+  const launcher = (await import("../../../plugin/scripts/launch-server.mjs")) as Launcher;
+  globalEntry = launcher.globalEntry;
+  serverSpec = launcher.serverSpec;
+}
+
 const mcpJson = (): { comfyui: { command: string; args: string[] } } =>
   JSON.parse(readFileSync(new URL("../../../plugin/.mcp.json", import.meta.url), "utf8"));
 
+describe("launch-server shebang checkout (#1857)", () => {
+  it("the shebang has no CR — vitest's transform treats `#!...\\r` as a syntax error", () => {
+    const bytes = readFileSync(LAUNCHER_URL);
+    const nl = bytes.indexOf(0x0a);
+    expect(nl).toBeGreaterThan(0);
+    expect(bytes[nl - 1], "CR before LF on the shebang").not.toBe(0x0d);
+    expect(bytes.subarray(0, nl).toString("utf8")).toBe("#!/usr/bin/env node");
+  });
+
+  it("gitattributes pins the launcher to LF so a Windows clone cannot reintroduce the CR", () => {
+    // git check-attr is the real matcher — reading .gitattributes and guessing
+    // which pattern applies would reimplement the thing under test.
+    const out = execFileSync("git", ["check-attr", "eol", "--", LAUNCHER_REL], {
+      encoding: "utf8",
+    });
+    expect(out.trim()).toMatch(/eol: lf$/);
+  });
+});
+
 describe("launch-server global resolution (#1447)", () => {
+  beforeAll(loadLauncher);
+
   it("resolves the global entry point when the install is present", () => {
     const entry = globalEntry("/usr/local/lib/node_modules\n", { exists: () => true });
     expect(entry).toMatch(/node_modules[\\/]comfyui-mcp[\\/]dist[\\/]index\.js$/);
@@ -54,6 +89,8 @@ describe("launch-server global resolution (#1447)", () => {
 });
 
 describe("launch-server spawn spec (#1447)", () => {
+  beforeAll(loadLauncher);
+
   it("warm path: spawns node on the resolved entry, no shell", () => {
     const spec = serverSpec("/global/node_modules/comfyui-mcp/dist/index.js", ["--full"], {
       platform: "linux",
@@ -108,22 +145,16 @@ describe("plugin/.mcp.json (#1447)", () => {
   });
 
   it("the wrapper is import-safe — side effects sit behind the main guard", () => {
-    // The dynamic import at the top of this file is the behavioural half: had
-    // main() run, the test process would have spawned an npx install. This
-    // pins the source shape that makes the import safe.
-    const src = readFileSync(
-      new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url),
-      "utf8",
-    );
+    // loadLauncher() is the behavioural half: had main() run, the test process
+    // would have spawned an npx install. This pins the source shape that makes
+    // the import safe.
+    const src = readFileSync(LAUNCHER_URL, "utf8");
     expect(src).toMatch(/import\.meta\.url === pathToFileURL\(process\.argv\[1\]\)\.href/);
     expect(src).toMatch(/if \(isMain\) \{/);
   });
 
   it("the wrapper never writes to stdout — stdio is the MCP transport", () => {
-    const src = readFileSync(
-      new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url),
-      "utf8",
-    );
+    const src = readFileSync(LAUNCHER_URL, "utf8");
     expect(src).not.toMatch(/console\.log\(/);
     expect(src).not.toMatch(/process\.stdout\.write\(/);
     // stdio must be inherited verbatim, or the handshake frames never reach the client.


### PR DESCRIPTION
Fixes #1857.

`src/__tests__/scripts/launch-server.test.ts` contributed **0 tests** on any Windows checkout. It was not skipped — the suite failed to *collect*: `SyntaxError: Invalid or unexpected token`, reported as one failed file with no tests.

`plugin/scripts/launch-server.mjs` checked out as `#!/usr/bin/env node\r\n`. `node --check` exits 0 either way (it strips shebangs itself). Vitest's transform does not, and the suite reached the file through `await import("../../../plugin/scripts/launch-server.mjs")`. That import *is* the proof that importing the launcher is safe (#1447), so the assertion the suite exists to make never ran.

Measured on this worktree, only the shebang line's `\r` differing:

| first line | result |
|---|---|
| `#!/usr/bin/env node\r\n` | Test Files 1 failed, Tests no tests |
| `#!/usr/bin/env node\n` | Test Files 1 passed, Tests 11 passed |

CI is Linux, so `.mjs` checks out LF there. The hole was invisible to CI by construction.

## Fix

`.gitattributes` already forces LF on the tool-surface ratchet and locale catalogs for the same reason. This adds `*.mjs text eol=lf` so a Windows clone cannot reintroduce the CR.

The suite also moves the import from collection into `beforeAll`, so a regression is a failed hook (and a failed shebang-byte test) rather than an empty file. A `git check-attr eol` assertion pins the attribute on the real launcher path — reading `.gitattributes` and guessing which pattern applies would reimplement the matcher.

## Verification

- `npx vitest run src/__tests__/scripts/launch-server.test.ts --maxWorkers=4` — **13 passed** on this Windows worktree (the original 11 plus the shebang-byte and `git check-attr` pins).
- Mutation: restore the CRLF shebang → collection still reports 13 tests; the shebang-byte test fails with `CR before LF on the shebang`; the import describes fail with `SyntaxError` instead of contributing 0 tests. Restore LF → 13 passed again.
