### PR TITLE
release: v0.52.25 — launch-server tests collect on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.25] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- launch-server tests collect on a Windows checkout (#1860)
+
+
 ## [0.52.24] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.24",
+  "version": "0.52.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.24",
+      "version": "0.52.25",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.24",
+  "version": "0.52.25",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.25 from `main`.

Carries:

- #1860 / #1857 — launch-server tests collect on a Windows checkout (CRLF shebang)

Held out: #1861 P1 Blind-gate leak on synthesised completions (claimed this cycle, not yet PR); #1850/#1845 windows red; #1851/#1847 CONFLICTING; #1839 anthropic 4 CI red; #1697 P1 Windows no-repro.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.25` tag on the version commit). Tag is local; push `v0.52.25` after merge.