### PR TITLE
fix(1861): Blind fails closed at both completion doors, and videos are never attached as PNG

### DIFF
--- a/src/__tests__/orchestrator/blind-completion.test.ts
+++ b/src/__tests__/orchestrator/blind-completion.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #1861 — Blind must fail CLOSED at EVERY door a run completion enters.
+ *
+ * The panel's own `executed` frame arrives at the orchestrator's agent-event ingress; the
+ * #1789 watchdog SYNTHESISES a completion when that frame never comes. The strip lived
+ * inline at the first door only, so the second recorded the raw payload. That was inert
+ * while its `images` was always empty — and #1853 filled it from `/history`, making the
+ * bypass live: Blind ON plus a dropped `executed` frame attached the render's pixels to
+ * the agent turn about 45 s later.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { stripBlindCompletion } from "../../orchestrator/blind-completion.js";
+
+const INDEX_TS = fileURLToPath(new URL("../../orchestrator/index.ts", import.meta.url));
+
+const completion = () => ({
+  kind: "executed",
+  prompt_id: "p1",
+  images: [
+    { filename: "secret_render_00001_.png", type: "output" },
+    { filename: "secret_render_00002_.png", type: "output" },
+  ],
+  note: "The render finished.",
+});
+
+describe("stripBlindCompletion (#1861)", () => {
+  it("removes the pixels and says so when blind", () => {
+    const out = stripBlindCompletion(completion(), true);
+    expect(out.images).toEqual([]);
+    expect(String(out.note)).toContain("Blind mode is ON: 2 image(s)");
+    // The original note is kept — the disclosure is appended, not substituted.
+    expect(String(out.note)).toContain("The render finished.");
+    // It must also override a sighted instruction the agent would otherwise follow.
+    expect(String(out.note)).toContain("Do NOT comment on motion, sharpness, composition");
+  });
+
+  it("passes the completion through untouched when not blind", () => {
+    const ev = completion();
+    const out = stripBlindCompletion(ev, false);
+    expect(out).toBe(ev);
+    expect(out.images).toHaveLength(2);
+  });
+
+  it("discloses nothing when there was nothing to withhold", () => {
+    // A status-only completion has no pixels; claiming images were withheld would report
+    // a withholding that never happened.
+    const out = stripBlindCompletion({ kind: "executed", note: "It failed." }, true);
+    expect(out.images).toEqual([]);
+    expect(String(out.note)).toBe("It failed.");
+    expect(String(out.note)).not.toContain("Blind mode is ON");
+  });
+
+  it("treats a malformed images field as nothing to withhold, and still empties it", () => {
+    // Fail closed on shape too: whatever `images` was, it is [] afterwards.
+    for (const bad of [undefined, null, "two", 7, {}]) {
+      const out = stripBlindCompletion({ kind: "executed", images: bad } as never, true);
+      expect(out.images).toEqual([]);
+      expect(String(out.note ?? "")).not.toContain("Blind mode is ON");
+    }
+  });
+});
+
+describe("#1861 WIRING: both completion doors go through the strip", () => {
+  // A strip that is correct and applied at one door is the bug this fixes. Assert on the
+  // source, because the second door's payload reaches `RunCompletions.record` inside the
+  // orchestrator's construction and no unit test stands that up.
+  const src = readFileSync(INDEX_TS, "utf8");
+
+  it("the pure strip is the only implementation", () => {
+    expect(src).toMatch(/import \{ stripBlindCompletion \} from "\.\/blind-completion\.js";/);
+    // The disclosure text must not have been copied back inline anywhere.
+    expect(src).not.toMatch(/Blind mode is ON: \$\{/);
+  });
+
+  it("EVERY RunCompletions.record call strips first", () => {
+    const calls = src.match(/RunCompletions\.record\([^)]*/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of calls) {
+      expect(
+        /blindStrippedCompletion\(|evForTab/.test(call),
+        `a completion is recorded without the blind strip: ${call}`,
+      ).toBe(true);
+    }
+  });
+
+  it("the ingress and the watchdog both name the strip", () => {
+    expect(src).toMatch(/const evForTab = blindStrippedCompletion\(ev\);/);
+    expect(src).toMatch(/RunCompletions\.record\(ticket\.tabId, blindStrippedCompletion\(payload\)/);
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -291,6 +291,30 @@ describe("#1789: the synthesised note claims only what was observed", () => {
     expect(String(payload.note)).toContain("get_image");
   });
 
+  it("#1861: the allowlist tracks what the ATTACH PATH can label, not what is an image", () => {
+    // claude-backend.ts keeps only image/{png,jpeg,gif,webp} and rewrites everything else
+    // to image/png. .bmp IS an image, and ComfyUI serves it image/bmp — so attaching it
+    // would declare PNG over BMP bytes. A smaller lie than an .mp4, the same lie.
+    const payload = synthesizeCompletionPayload(
+      { promptId: PID, status: "success", observedAt: 0 },
+      {
+        deliveredAt: 45_000,
+        images: [
+          { filename: "keep_00001_.png", type: "output" },
+          { filename: "keep_00002_.WEBP", type: "output" },
+          { filename: "name_only_00001_.bmp", type: "output" },
+          { filename: "name_only_00002_.avif", type: "output" },
+          { filename: "no_extension_at_all", type: "output" },
+        ],
+      },
+    );
+    expect(payload.images.map((i) => i.filename)).toEqual(["keep_00001_.png", "keep_00002_.WEBP"]);
+    for (const named of ["name_only_00001_.bmp", "name_only_00002_.avif", "no_extension_at_all"]) {
+      expect(String(payload.note)).toContain(named);
+    }
+    expect(String(payload.note)).toContain("NOT attached (not an inline-attachable image)");
+  });
+
   it("empty or malformed image refs are dropped, never forwarded as outputs", () => {
     const payload = synthesizeCompletionPayload(
       { promptId: PID, status: "success", observedAt: 0 },

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -281,11 +281,14 @@ describe("#1789: the synthesised note claims only what was observed", () => {
       { promptId: PID, status: "success", observedAt: 1000 },
       { deliveredAt: 1000 + 46_000, images: refs },
     );
-    expect(payload.images).toEqual(refs);
-    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
+    // #1861 — the refs still ride, but a VIDEO is NAMED, never attached. `images` is
+    // consumed by attaching inline with the media type forced to image/png, so an .mp4
+    // in it becomes ftyp bytes sent as a PNG. This test previously asserted exactly that.
+    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(false);
     expect(String(payload.note)).toContain(VIDEO_FILENAME);
-    expect(String(payload.note)).not.toContain("NOT attached");
-    expect(String(payload.note)).not.toContain('get_image (action:"list_outputs")');
+    expect(String(payload.note)).toContain("NOT attached (not an inline-attachable image)");
+    // The agent still learns the run produced output and how to get it.
+    expect(String(payload.note)).toContain("get_image");
   });
 
   it("empty or malformed image refs are dropped, never forwarded as outputs", () => {
@@ -296,18 +299,20 @@ describe("#1789: the synthesised note claims only what was observed", () => {
         images: [
           { filename: "" },
           { filename: "   " },
-          { filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" },
-          { filename: VIDEO_FILENAME, subfolder: VIDEO_SUBFOLDER, type: "output" },
+          // An IMAGE here: this test is about blanks and dedup, and a video fixture would
+          // now be filtered for an unrelated reason and prove nothing about either.
+          { filename: "render_00001_.png", subfolder: "out", type: "output" },
+          { filename: "render_00001_.png", subfolder: "out", type: "output" },
         ],
       },
     );
     expect(payload.images).toHaveLength(1);
-    expect(payload.images[0].filename).toBe(VIDEO_FILENAME);
+    expect(payload.images[0].filename).toBe("render_00001_.png");
   });
 });
 
 describe("#1853: a dropped panel frame still yields the completed prompt's history outputs", () => {
-  it("the synthesised completion attaches SaveVideo outputs resolved from /history", async () => {
+  it("the synthesised completion NAMES SaveVideo outputs from /history, and never attaches them", async () => {
     const clock = { t: 9_000_000 };
     const entry = saveVideoHistoryEntry(PID);
     const { wd, delivered } = makeWatchdog(clock, {
@@ -323,17 +328,19 @@ describe("#1853: a dropped panel frame still yields the completed prompt's histo
     expect(delivered).toHaveLength(1);
     const payload = delivered[0].payload;
     expect(payload.prompt_id).toBe(PID);
-    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
-    expect(payload.images.some((img) => img.subfolder === VIDEO_SUBFOLDER)).toBe(true);
+    // #1861 — a video must never reach `images`: its only consumer attaches inline with
+    // the type forced to image/png.
+    expect(payload.images.some((img) => img.filename === VIDEO_FILENAME)).toBe(false);
     expect(String(payload.note)).toContain(VIDEO_FILENAME);
-    expect(String(payload.note)).not.toContain("NOT attached");
+    expect(String(payload.note)).toContain("NOT attached (not an inline-attachable image)");
 
     const seen: CompletionPayload[] = [];
     RunCompletions.deliverPending(TAB, (p) => {
       seen.push(p);
       return true;
     });
-    expect(seen[0].images.some((img) => img.filename === VIDEO_FILENAME)).toBe(true);
+    expect(seen[0].images.some((img) => img.filename === VIDEO_FILENAME)).toBe(false);
+    expect(String(seen[0].note)).toContain(VIDEO_FILENAME);
   });
 
   it("history with no media stays status-only — nothing is invented", async () => {

--- a/src/orchestrator/blind-completion.ts
+++ b/src/orchestrator/blind-completion.ts
@@ -1,0 +1,48 @@
+/**
+ * Blind, applied to a run completion.
+ *
+ * Blind is conversation-wide (#884) and must fail CLOSED (`blind-tab-gate.ts`). A run
+ * completion reaches the agent through more than one door: the panel's own `executed`
+ * frame arrives at the orchestrator's agent-event ingress, and the #1789 watchdog
+ * SYNTHESISES one when that frame never comes.
+ *
+ * #1861 — the watchdog door recorded the raw payload. That was inert only while its
+ * `images` was always empty; #1853 filled it from `/history` and the bypass became live:
+ * Blind ON plus a dropped `executed` frame attached the render's pixels to the agent turn
+ * ~45 s later. The strip lived inline at one door, so nothing carried it to the next one.
+ *
+ * It is a pure function here so both doors call the SAME implementation and it can be
+ * tested without standing up the orchestrator.
+ */
+
+/** The note appended when pixels are withheld. Also overrides a sighted "review this"
+ *  instruction that must not be obeyed — the composer renders it verbatim. */
+function blindDisclosure(existing: unknown, withheld: number): string {
+  const prefix = typeof existing === "string" && existing.trim() ? `${existing.trim()} ` : "";
+  return (
+    `${prefix}⚠️ Blind mode is ON: ${withheld} image(s) from this run were withheld ` +
+    `from you and are NOT attached — they ARE shown to the user in the panel. Do NOT ` +
+    `comment on motion, sharpness, composition or any other visual quality, and do not ` +
+    `claim you reviewed them; ask the user to describe what they see, or to turn Blind off.`
+  );
+}
+
+/**
+ * Return `ev` with its pixels removed when `blind`, otherwise unchanged.
+ *
+ * The disclosure is only added when something was actually withheld: a completion that
+ * carried no images has nothing to disclose, and saying otherwise would report a
+ * withholding that did not happen.
+ */
+export function stripBlindCompletion<T extends { images?: unknown; note?: unknown }>(
+  ev: T,
+  blind: boolean,
+): T {
+  if (!blind) return ev;
+  const withheld = Array.isArray(ev.images) ? ev.images.length : 0;
+  return {
+    ...ev,
+    images: [],
+    ...(withheld > 0 ? { note: blindDisclosure(ev.note, withheld) } : {}),
+  };
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -19,6 +19,7 @@ import {
   rmSync,
   appendFileSync,
 } from "node:fs";
+import { stripBlindCompletion } from "./blind-completion.js";
 import { execFileSync } from "node:child_process";
 import { tmpdir, homedir, networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
@@ -1975,6 +1976,18 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     return blind;
   };
+
+  /**
+   * Blind, applied to a run completion — the SAME implementation at every door.
+   *
+   * #1861: the panel's `executed` frame arrives at the ingress below; the #1789 watchdog
+   * SYNTHESISES one when that frame never comes, and that door recorded the raw payload.
+   * Inert while its `images` was always empty, live once #1853 filled it from /history.
+   * The logic lives in blind-completion.ts so a new arrival point cannot get a
+   * near-copy that drifts, and so it is testable without the orchestrator.
+   */
+  const blindStrippedCompletion = <T extends { images?: unknown; note?: unknown }>(ev: T): T =>
+    stripBlindCompletion(ev, anyTabBlind());
 
   // ---- live ENVIRONMENT-CAPABILITIES block ----
   // Gather the machine's facts ONCE at startup (CACHED) — OS/CPU/RAM from node,
@@ -5242,23 +5255,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // stores the stripped copy. Only the SILENCE is fixed, by appending the
       // disclosure to the note the composer already renders verbatim, which also
       // overrides a sighted "review this" instruction that must not be obeyed.
-      const blindWithheldCount = anyTabBlind() && Array.isArray(ev.images) ? ev.images.length : 0;
-      const evForTab = anyTabBlind()
-        ? {
-            ...ev,
-            images: [],
-            ...(blindWithheldCount > 0
-              ? {
-                  note:
-                    `${typeof ev.note === "string" && ev.note.trim() ? `${ev.note.trim()} ` : ""}` +
-                    `⚠️ Blind mode is ON: ${blindWithheldCount} image(s) from this run were withheld ` +
-                    `from you and are NOT attached — they ARE shown to the user in the panel. Do NOT ` +
-                    `comment on motion, sharpness, composition or any other visual quality, and do not ` +
-                    `claim you reviewed them; ask the user to describe what they see, or to turn Blind off.`,
-                }
-              : {}),
-          }
-        : ev;
+      const evForTab = blindStrippedCompletion(ev);
       // #468 — a RUN COMPLETION is a promise `panel_run` made ("end your turn,
       // you WILL be notified"), so it goes through the journal: correlated by
       // exact prompt id ONCE, here, and replayed until the turn that carries it
@@ -6378,7 +6375,8 @@ export async function runPanelOrchestrator(): Promise<void> {
       // The SAME arrival path the panel's frame takes: correlated once, here,
       // against the ticket that is still open — so the agent is told this is the
       // run IT queued, and the journal's replay/ack durability covers it too.
-      const entry = RunCompletions.record(ticket.tabId, payload, {
+      // #1861 — the SAME strip the panel ingress applies. Blind is conversation-wide.
+      const entry = RunCompletions.record(ticket.tabId, blindStrippedCompletion(payload), {
         ...(ticket.conversation !== undefined ? { conversation: ticket.conversation } : {}),
       });
       logger.info(

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -118,6 +118,33 @@ export interface RunCompletionWatchdog {
   armedCount(): number;
 }
 
+/**
+ * Extensions the completion `images` array may carry.
+ *
+ * #1861 — an ALLOWLIST, not a video denylist. The only consumer of `images` attaches
+ * them inline with the media type forced to `image/png` ("ComfyUI outputs are PNG by
+ * default"), so anything that is not actually an image is sent to the model as PNG bytes
+ * that are not PNG. A SaveVideo `.mp4` from /history took that path: the panel never
+ * produced this shape — its video ref is an uploaded `storyboard_<base>.png` or
+ * note-only — which is why the coercion was safe until the watchdog began reading
+ * /history directly. An unknown extension therefore fails CLOSED: named in the note,
+ * never attached.
+ */
+const ATTACHABLE_IMAGE_EXT_RE = /\.(?:png|jpe?g|webp|gif|bmp)$/i;
+
+/** Split media refs into what may be attached inline and what may only be named. */
+export function partitionAttachableMedia(refs: CompletionImage[]): {
+  images: CompletionImage[];
+  other: CompletionImage[];
+} {
+  const images: CompletionImage[] = [];
+  const other: CompletionImage[] = [];
+  for (const ref of refs) {
+    (ATTACHABLE_IMAGE_EXT_RE.test(ref.filename) ? images : other).push(ref);
+  }
+  return { images, other };
+}
+
 function usableHistoryImages(images: CompletionPayload["images"]): CompletionImage[] {
   if (!Array.isArray(images)) return [];
   const out: CompletionImage[] = [];
@@ -211,21 +238,28 @@ export function synthesizeCompletionPayload(
   opts: { deliveredAt: number; images?: CompletionPayload["images"] },
 ): CompletionPayload {
   const waitedS = Math.max(0, Math.round((opts.deliveredAt - armed.observedAt) / 1000));
-  const images = usableHistoryImages(opts.images);
+  const { images, other: otherMedia } = partitionAttachableMedia(usableHistoryImages(opts.images));
   const outcome =
     armed.status === "success"
       ? "finished SUCCESSFULLY"
       : armed.status === "interrupted"
         ? "was INTERRUPTED (cancelled before it finished)"
         : "FAILED";
-  const names = images
-    .map((img) => (img.subfolder ? `${img.subfolder}/${img.filename}` : img.filename))
-    .join(", ");
+  const refName = (m: CompletionImage) => (m.subfolder ? `${m.subfolder}/${m.filename}` : m.filename);
+  const names = images.map(refName).join(", ");
+  // Named, never attached — the agent still learns the render produced them.
+  const otherNote =
+    otherMedia.length > 0
+      ? ` NOT attached (not an inline-attachable image): ${otherMedia.map(refName).join(", ")}.`
+      : "";
   const next =
     armed.status === "success"
       ? images.length > 0
-        ? `The output file(s) from ComfyUI history are attached: ${names}.`
-        : `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
+        ? `The output file(s) from ComfyUI history are attached: ${names}.${otherNote}`
+        : otherMedia.length > 0
+          ? `The output(s) are NOT attached — this run produced media that cannot be sent inline.${otherNote} ` +
+            `Fetch with get_image (action:"list_outputs") or get_history for this prompt id.`
+          : `The output file(s) are NOT attached to this notice — the orchestrator read the run's terminal ` +
           `status, not its images. Fetch them with get_image (action:"list_outputs") ` +
           `or get_history for this prompt id before describing or using the result.`
       : armed.status === "interrupted"

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -129,8 +129,15 @@ export interface RunCompletionWatchdog {
  * note-only — which is why the coercion was safe until the watchdog began reading
  * /history directly. An unknown extension therefore fails CLOSED: named in the note,
  * never attached.
+ *
+ * The question this asks is NOT "is it an image" — it is "can the attach path label
+ * these bytes honestly?" `claude-backend.ts:390` keeps only `image/{png,jpeg,gif,webp}`
+ * and rewrites everything else to `image/png`. So `.bmp` is excluded even though it IS
+ * an image: ComfyUI serves it `image/bmp` (WAS-Suite `Image Save` writes them), and it
+ * would ship as PNG-declared BMP — a smaller lie than an .mp4, but the same one.
+ * Widening this set is only safe alongside the backend's.
  */
-const ATTACHABLE_IMAGE_EXT_RE = /\.(?:png|jpe?g|webp|gif|bmp)$/i;
+const ATTACHABLE_IMAGE_EXT_RE = /\.(?:png|jpe?g|webp|gif)$/i;
 
 /** Split media refs into what may be attached inline and what may only be named. */
 export function partitionAttachableMedia(refs: CompletionImage[]): {


### PR DESCRIPTION
Fixes #1861. Both defects were raised on #1856 before it merged; this is the follow-through.

## Blind was bypassed at the second door

A run completion reaches the agent through **two** doors: the panel's own `executed` frame at the agent-event ingress, and the #1789 watchdog, which *synthesises* one when that frame never comes.

The strip lived inline at the first door. The second called `RunCompletions.record` with the **raw payload**. That was inert only while its `images` was always `[]` — #1853 filled it from `/history`, and the bypass went live: **Blind ON plus a dropped `executed` frame attached the render's pixels to the agent turn ~45 s later**, which is exactly the case #1789 exists to cover. `blind-tab-gate.ts` states the invariant it broke: *Blind must fail CLOSED.*

The strip is now a pure module (`blind-completion.ts`) that both doors call. Not for tidiness — a strip that has to be *remembered* at each new arrival point is one that gets missed at the next one, which is precisely what happened here. It is also now testable without standing up the orchestrator.

A wiring test asserts **every** `RunCompletions.record` call strips first, and that the disclosure text has not been copied back inline anywhere.

## Videos were attached as `image/png`

`run-completion-watchdog` pushed SaveVideo refs into `images`, whose only consumer attaches them inline with the media type forced to `image/png` ("ComfyUI outputs are PNG by default"), with no strip-and-retry in that backend. A `/history` `.mp4` therefore reached the Messages API as `ftyp` bytes inside an image block — verified against a live ComfyUI, `Content-Type: video/mp4`, under the size cap.

The panel never produced this shape — its video ref is an uploaded `storyboard_<base>.png` or note-only — which is why the coercion was safe until the watchdog began reading `/history` directly.

Media is now partitioned by an **allowlist** of attachable image extensions, so an unknown type fails closed: named in the note, never attached. The agent still learns the run produced it and how to fetch it.

## Three existing tests asserted the defect

They pinned the video-as-attachment behaviour rather than catching it. Two are corrected to assert it is named and not attached. The third — "empty or malformed image refs are dropped" — was about **blanks and dedup**, and its video fixture was incidental; it keeps its intent with an image fixture, because a video there would now be filtered for an unrelated reason and prove nothing about either.

## Verification

- **Two mutations, both killed**: reverting the watchdog door to the raw payload (2 tests red), and attaching every ref again (2 tests red).
- New suite 7/7; watchdog suites 141/141; full suite **10776 passed**, `tsc --noEmit` clean.
- The 2 failing files are pre-existing environment noise on an unbuilt worktree — `package-hooks` wants `dist/`, and `launch-server.test.ts` fails to collect (#1857). Both reproduce identically on clean `origin/main`.

Nothing here reverts #1856 — its correlation and journal work is good, and this is about what its newly-real `images` array reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
