### PR TITLE
fix(1491): an auto-refresh that outran its ack is not a failed refresh

### DIFF
--- a/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
+++ b/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
@@ -18,6 +18,7 @@
 // unknown, which is exactly why those are never re-issued on our own initiative.
 
 import { describe, expect, it } from "vitest";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
 
 import {
   buildPanelToolDefs,
@@ -39,13 +40,21 @@ const STALE = () =>
  * `addOutcomes` is consumed one per graph_add_node call: "stale" throws the refusal,
  * "ok" succeeds. `refreshFails` makes refresh_nodes throw.
  */
-function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails = false) {
+function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" = false) {
   const calls: string[] = [];
   let addIdx = 0;
   const b = {
     send: async (cmd: Record<string, unknown>) => {
       calls.push(String(cmd.cmd));
       if (cmd.cmd === "refresh_nodes") {
+        // #1491 — THREE outcomes, not two. A reply TIMEOUT is tagged by the bridge
+        // itself (markReplyTimeout); an acked executor error is a plain throw. The
+        // orchestrator must tell them apart, because the correct advice is opposite.
+        if (refreshFails === "timeout") {
+          throw markReplyTimeout(
+            new Error(`Panel tab ${TAB} did not reply to "refresh_nodes" within 30000 ms`),
+          );
+        }
         if (refreshFails) throw new Error("panel did not answer the refresh");
         return { refreshed: true };
       }
@@ -68,7 +77,7 @@ function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails = false) {
   return { b, calls };
 }
 
-async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails = false) {
+async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" = false) {
   const { b, calls } = bridge(addOutcomes, refreshFails);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
@@ -150,5 +159,34 @@ describe("a stale node schema is refreshed and retried once (#1329)", () => {
     expect(res.isError).toBe(true);
     expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(1);
     expect(calls).not.toContain("refresh_nodes");
+  });
+});
+
+describe("#1491: an auto-refresh that outran its ack is NOT a failed refresh", () => {
+  it("a reply TIMEOUT tells the caller to retry, and never says the schema is unchanged", async () => {
+    // The reported case: the automatic refresh "failed" at 30s and an explicit
+    // panel_refresh_nodes moments later succeeded immediately. `joinMs` does not cancel
+    // work already in flight — the panel's coalescer keeps running and registers what it
+    // fetched — so on a large install the refresh legitimately outlives this ack.
+    const { text } = await addNode(["stale", "stale"], "timeout");
+
+    expect(text).toContain("did NOT answer within its window");
+    expect(text).toContain("RETRY the add");
+    // The two claims that were false, and the second is the damaging one: it argues the
+    // caller out of the only action that works.
+    expect(text).not.toContain("so the schema is unchanged");
+    expect(text).not.toContain("retrying the add will refuse again");
+    // And it must not assert a frozen tab it never observed.
+    expect(text).toContain("Nothing here observed the tab being frozen");
+  });
+
+  it("a GENUINE refresh failure keeps the original advice", async () => {
+    // An acked executor error is not a timeout: the refresh really did not happen, so a
+    // retry really will refuse again. Softening this case would be the opposite defect.
+    const { text } = await addNode(["stale", "stale"], true);
+
+    expect(text).toContain("was dispatched and FAILED");
+    expect(text).toContain("so the schema is unchanged");
+    expect(text).not.toContain("RETRY the add");
   });
 });

--- a/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
+++ b/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
@@ -40,7 +40,7 @@ const STALE = () =>
  * `addOutcomes` is consumed one per graph_add_node call: "stale" throws the refusal,
  * "ok" succeeds. `refreshFails` makes refresh_nodes throw.
  */
-function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" = false) {
+function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
   const calls: string[] = [];
   let addIdx = 0;
   const b = {
@@ -50,6 +50,14 @@ function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "tim
         // #1491 — THREE outcomes, not two. A reply TIMEOUT is tagged by the bridge
         // itself (markReplyTimeout); an acked executor error is a plain throw. The
         // orchestrator must tell them apart, because the correct advice is opposite.
+        // An ACKED executor error that merely QUOTES the bridge's timeout wording. The
+        // panel relays arbitrary error text, so this shape is reachable — and it is the
+        // only input that separates "read the bridge's tag" from "match the message".
+        if (refreshFails === "acked-error-quoting-timeout") {
+          throw new Error(
+            `refresh aborted: last attempt reported Panel tab ${TAB} did not reply to "refresh_nodes" within 30000 ms`,
+          );
+        }
         if (refreshFails === "timeout") {
           throw markReplyTimeout(
             new Error(`Panel tab ${TAB} did not reply to "refresh_nodes" within 30000 ms`),
@@ -77,7 +85,7 @@ function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "tim
   return { b, calls };
 }
 
-async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" = false) {
+async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
   const { b, calls } = bridge(addOutcomes, refreshFails);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
@@ -178,6 +186,20 @@ describe("#1491: an auto-refresh that outran its ack is NOT a failed refresh", (
     expect(text).not.toContain("retrying the add will refuse again");
     // And it must not assert a frozen tab it never observed.
     expect(text).toContain("Nothing here observed the tab being frozen");
+  });
+
+  it("an ACKED error that QUOTES the timeout wording is still a failure", async () => {
+    // #1468's point, and the reason this decision may not be made from message text: the
+    // panel relays arbitrary error text, and ctx.call flattens a tagged timeout and an
+    // acked error into the same text-only result. Only the bridge-owned tag separates
+    // them. Without this fixture a text-matching implementation passes every other test
+    // here — verified: it did.
+    const { text } = await addNode(["stale", "stale"], "acked-error-quoting-timeout");
+
+    expect(text).toContain("was dispatched and FAILED");
+    expect(text).toContain("so the schema is unchanged");
+    expect(text).not.toContain("RETRY the add");
+    expect(text).not.toContain("did NOT answer within its window");
   });
 
   it("a GENUINE refresh failure keeps the original advice", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11153,13 +11153,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // The refusal is the better error: it names what is wrong with the SCHEMA and
           // what clears it. Carry the refresh failure alongside so the caller knows the
           // automatic attempt happened and why it did not help.
+          //
+          // #1491 — but a reply TIMEOUT is not a failed refresh, and the two need opposite
+          // advice. `joinMs` never cancels work already in flight; the panel coalescer says
+          // so outright ("The run keeps going, registers whatever it fetched"), and its own
+          // worked example is a join ending at 20,000 ms plus a run adding ~13,000 ms —
+          // ~33 s against a 30 s relay window, every per-step bound respected. On a large
+          // install the refresh legitimately outlives this ack and then COMPLETES, which is
+          // exactly what the reporter saw: the automatic refresh "failed" at 30 s and an
+          // explicit panel_refresh_nodes moments later succeeded immediately.
+          //
+          // Telling that caller the schema is unchanged and a retry will refuse again is
+          // wrong twice, and the second half is the damaging one — it talks them out of the
+          // one action that works.
+          //
+          // Decided on the BRIDGE-OWNED tag (#1468), never on message text: two codex rounds
+          // rejected text-matching here and both were right, because an acked panel error can
+          // carry any sentence the bridge can write and ctx.call flattens both into one
+          // text-only result.
+          const stillRunning = isReplyTimeoutResult(refreshed);
           return withFrontendOnlyPanelSkewNote(
             withLoraManagerAutocompleteNote(
               appendToolResultText(
                 first,
-                `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
-                  `so the schema is unchanged and retrying the add will refuse again. ` +
-                  `${textOfToolResult(refreshed)})`,
+                stillRunning
+                  ? `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and did ` +
+                    `NOT answer within its window — but a refresh that outruns its ack is NOT cancelled: it ` +
+                    `keeps running and registers what it fetched. On a large install it can take ~33s against ` +
+                    `a 30s window. So the schema may already be current, or become current in a moment. ` +
+                    `RETRY the add — that is the action that clears this. Nothing here observed the tab being ` +
+                    `frozen. ${textOfToolResult(refreshed)})`
+                  : `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
+                    `so the schema is unchanged and retrying the add will refuse again. ` +
+                    `${textOfToolResult(refreshed)})`,
               ),
             ),
             args.class_type,


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1491. Filed on the panel; the dispatch and the message are orchestrator-side, so the fix lands here.

## The reporter's diagnosis is wrong, and the correct one is the fix

They concluded the auto-recovery inside `panel_add_node` "should use the same reliable dispatch path as explicit `panel_refresh_nodes`". It already does — byte for byte:

```ts
// panel_add_node auto-recovery (:11151)
const refreshed = await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);

// panel_refresh_nodes tool (:12463)
ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS)
```

Same command, same constant, same call. What differs is what happens **after the ack window closes**: `joinMs` never cancels work already in flight. The panel's coalescer says so outright —

> "`opts.joinMs` never cancels work already in flight. The run keeps going, registers whatever it fetched, and clears the slot exactly as before."

— and its own worked example is a join ending at 20,000 ms plus a run adding ~13,000 ms: **~33 s against a 30 s relay window**, with every per-step bound respected.

So on a large install the refresh legitimately outlives the ack and then **completes**. The explicit `panel_refresh_nodes` that "succeeded immediately afterward" was not a more reliable path — it was the same work, already done.

## What was actually broken: the reply

On that timeout the caller was told:

> *"panel_refresh_nodes was dispatched and FAILED, so the schema is unchanged and retrying the add will refuse again."*

Both halves are false in the timeout case, and the second is the damaging one — **it argues the caller out of the one action that works**, which is precisely what the reporter did next, twice, successfully.

A reply timeout and an acked executor failure now get opposite advice. The genuine-failure branch is untouched; softening it would be the same defect mirrored.

## Decided on the bridge-owned tag, not the message text

`isReplyTimeoutResult()` reads the `REPLY_TIMEOUT_RESULT` symbol that `ctx.call` carries from the bridge (#1468). The comment there records that two codex rounds rejected deciding this from text and both were right: the panel relays arbitrary error text, and `ctx.call` flattens a tagged timeout and an acked error into the same text-only result.

## My own tests did not pin that at first

Mutation testing caught it: replacing the tag check with a `/did not reply to/` text match **passed all 8 tests**. The suite agreed with both implementations, because the timeout fixture's text contained the phrase and the failure fixture's did not.

The separating input is the one #1468 describes — an **acked** executor error whose text *quotes* the bridge's timeout wording. That fixture is now in the suite, and text-matching fails against it.

## Verification

- 9/9 in `add-node-stale-schema-retry.test.ts`; full suite **10793 passed**, `tsc --noEmit` clean.
- **Two mutations, both killed**: text-matching instead of the tag (1 red), and treating every error as still-running (2 red).
- The single remaining suite failure is `package-hooks.test.ts` wanting a built `dist/` in a fresh worktree — pre-existing, reproduces on clean `main`.

Worth noting: `launch-server.test.ts` now **passes** in this fresh worktree, which confirms #1860's `.gitattributes` fix works for new checkouts (existing clones still need `git add --renormalize .`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
