### PR TITLE
release: v0.52.26 — Blind fails closed at every completion door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.26] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- a Blind conversation no longer receives run-completion pixels through the synthesised (watchdog) door — the strip now applies wherever a completion enters, and video refs are named rather than attached as `image/png` (#1863)
+- `panel_add_node`'s automatic refresh no longer reports a reply TIMEOUT as a failed refresh: a refresh that outruns its ack keeps running, so the reply now says the schema may already be current and to retry, instead of telling the caller a retry will refuse again (#1864)
+- `panel_load_workflow` loads a saved workflow after a confirmed restart instead of failing with ECONNREFUSED (#1850)
+
 ## [0.52.25] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.25",
+  "version": "0.52.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.25",
+      "version": "0.52.26",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.25",
+  "version": "0.52.26",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.26**. Three unreleased fixes on `main`, all in the same family: a reply asserting something it could not know.

| issue | fix |
|---|---|
| #1863 | Blind is stripped at **both** completion doors, and video refs are named rather than attached as `image/png` |
| #1864 | an auto-refresh that outran its ack is reported as still-running, not as a failed refresh |
| #1850 | `panel_load_workflow` loads a saved workflow after a confirmed restart instead of failing with ECONNREFUSED |

**#1863 is the one worth reading.** A run completion arrives through two doors — the panel's own `executed` frame, and the #1789 watchdog that synthesises one when that frame never comes. Only the first stripped images under Blind. That was inert while the watchdog's `images` was always empty; #1853 filled it from `/history` and the bypass went live: Blind ON plus a dropped frame attached the render's pixels to the agent turn about 45 s later. The strip is now a pure module both doors call, so a third arrival point cannot inherit a near-copy that drifts.

Version bumped in `package.json` + `package-lock.json`; CHANGELOG entry added under a single `## [0.52.26]` heading. Diff shape matches the previous release exactly (2 / 4 / 9 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)