### PR TITLE
fix(1493): panel_get_errors waits as long as the panel is allowed to take

### DIFF
--- a/src/__tests__/orchestrator/get-errors-ack-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-ack-budget.test.ts
@@ -1,0 +1,137 @@
+// #1493 — `panel_get_errors` timed out at 20 000 ms on a tab that was alive.
+//
+// Reported sequence: `panel_refresh_nodes`, three `panel_set_widget` writes on promoted
+// COMBO widgets of a model-loader subgraph, `panel_save_workflow` — every one acked — and
+// then `panel_get_errors` came back as
+//
+//   Panel tab workflows/… did not reply to "graph_get_errors" within 20000 ms —
+//   the ComfyUI tab may be backgrounded or frozen
+//
+// The tab was neither backgrounded nor frozen. It had just answered four commands, and
+// `graph_get_errors` is the panel command that deliberately spends the LONGEST wall clock:
+// its handler awaits a FORCED /object_info re-register before it will trust a combo to
+// clear a resolved missing-model candidate (#610, measured at ~14.5 s on a real Windows
+// install), and it spends a shared 18 000 ms elective budget across that refresh race, the
+// /system_stats probe and the /view media probes (GET_ERRORS_TOTAL_BUDGET_MS in the panel's
+// web/js/lib/get-errors-budget.js).
+//
+// That 18 000 ms was sized against the orchestrator's generic 20 000 ms read default, which
+// leaves 2 000 ms for everything the call still does AFTER its waits — collectMissingAssets
+// over the whole graph, the per-node live combo scan, the subgraph walk, and serializing a
+// reply large enough that the tool ships two truncation riders for it. On the reporter's
+// workflow that margin was not enough, so the panel replied LATE and the orchestrator had
+// already given up — leaving the agent with no error surface at all for a workflow whose
+// nodes are visibly red, which is exactly what the shared budget exists to prevent (#589).
+//
+// The margin has to come from the ORCHESTRATOR. The panel's 18 s bound must stay where it
+// is: it is what keeps a current panel safe in front of an older orchestrator still using
+// the 20 s default. So `graph_get_errors` joins the #599 refresh-ack cohort — the same
+// bounded 30 s budget `graph_set_widget`, `graph_add_node`, `graph_remove_widget`,
+// `graph_get_object_info` and `refresh_nodes` already forward for the same reason.
+//
+// The property under test is the CALL SITE. A shared constant that nothing passes still
+// greps, and a one-argument wiring change is invisible to any test that only exercises the
+// bridge — so these run the real tool def and read the bound it actually forwarded.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { buildPanelToolDefs, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { BRIDGE_READ_DEFAULT_TIMEOUT_MS } from "../../services/ui-bridge.js";
+
+const PANEL_TOOLS_TS = fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url));
+
+/** The #599 bounded refresh-ack budget (OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS). Duplicated as
+ *  a literal on purpose: if the constant moves, these tests force the relationship to the
+ *  panel's own budget to be re-examined rather than silently re-broken. */
+const REFRESH_ACK_MS = 30_000;
+
+/** GET_ERRORS_TOTAL_BUDGET_MS in the PANEL repo (web/js/lib/get-errors-budget.js) — the
+ *  wall clock one graph_get_errors call may spend on elective server waits alone, before
+ *  any of its own graph work. The orchestrator's wait must clear this with real margin.
+ *  Duplicated across repos deliberately, exactly as the panel duplicates the 20 000 ms
+ *  read default in its own budget test. */
+const PANEL_GET_ERRORS_ELECTIVE_BUDGET_MS = 18_000;
+
+/** Run a real panel tool def against a stub ctx and hand back the per-call ack bound it
+ *  forwarded as `ctx.call`'s second argument. `undefined` means the tool passed none and
+ *  the bridge would fall back to its own default — which is the bug. */
+async function forwardedAckMs(
+  tool: string,
+  args: Record<string, unknown> = {},
+): Promise<{ cmd: Record<string, unknown> | undefined; timeoutMs: number | undefined }> {
+  const def = buildPanelToolDefs().find((d) => d.name === tool);
+  if (!def) throw new Error(`tool ${tool} not found in buildPanelToolDefs()`);
+  let seenCmd: Record<string, unknown> | undefined;
+  let seenTimeout: number | undefined;
+  const ctx = {
+    call: async (cmd: Record<string, unknown>, timeoutMs?: number) => {
+      seenCmd = cmd;
+      seenTimeout = timeoutMs;
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] };
+    },
+    tabId: "test-tab",
+  } as unknown as PanelToolCtx;
+  await def.handler(args, ctx);
+  return { cmd: seenCmd, timeoutMs: seenTimeout };
+}
+
+describe("panel_get_errors ack budget (#1493)", () => {
+  it("forwards graph_get_errors with the bounded refresh-ack budget, not the 20 s read default", async () => {
+    const { cmd, timeoutMs } = await forwardedAckMs("panel_get_errors");
+    expect(cmd).toMatchObject({ cmd: "graph_get_errors" });
+    expect(timeoutMs).toBe(REFRESH_ACK_MS);
+    // The regression this closes: no bound at all, so the bridge applied its generic
+    // read default. Named separately so a revert reads as the reported bug, not as an
+    // off-by-one in the constant.
+    expect(timeoutMs).not.toBeUndefined();
+    expect(timeoutMs).toBeGreaterThan(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+  });
+
+  it("clears the panel's own elective budget with real margin, not the 2 s that failed", async () => {
+    const { timeoutMs } = await forwardedAckMs("panel_get_errors");
+    // The panel can legitimately spend its whole 18 000 ms budget waiting on the server
+    // before it starts the graph work whose reply this bound is waiting for. The old
+    // default left 2 000 ms for that work plus delivery; the reporter's workflow needed
+    // more. Require the orchestrator to leave at least half the panel's budget again.
+    expect(timeoutMs!).toBeGreaterThanOrEqual(
+      PANEL_GET_ERRORS_ELECTIVE_BUDGET_MS + PANEL_GET_ERRORS_ELECTIVE_BUDGET_MS / 2,
+    );
+  });
+
+  it("stays BOUNDED, so a genuinely frozen tab still fails", async () => {
+    const { timeoutMs } = await forwardedAckMs("panel_get_errors");
+    expect(Number.isFinite(timeoutMs!)).toBe(true);
+    expect(timeoutMs!).toBeLessThanOrEqual(60_000);
+  });
+
+  it("uses the SAME bound as the #599 siblings, so the cohort cannot drift apart", async () => {
+    // Read from the real defs rather than from the literal: if the shared constant is
+    // ever re-tuned, every member moves together or this fails.
+    const errors = await forwardedAckMs("panel_get_errors");
+    const refresh = await forwardedAckMs("panel_refresh_nodes");
+    const setWidget = await forwardedAckMs("panel_set_widget", {
+      node_id: 39,
+      widget: "ckpt_name",
+      value: "sd_xl_base_1.0.safetensors",
+    });
+    expect(refresh.cmd).toMatchObject({ cmd: "refresh_nodes" });
+    expect(setWidget.cmd).toMatchObject({ cmd: "graph_set_widget" });
+    expect(errors.timeoutMs).toBe(refresh.timeoutMs);
+    expect(errors.timeoutMs).toBe(setWidget.timeoutMs);
+  });
+
+  it("leaves no OTHER graph_get_errors dispatch on the default (a second call site is a third path)", () => {
+    // A behavioural test can only see the call site it exercises. Counting occurrences
+    // cannot see a call site added later on a different branch, so pin the SOURCE: every
+    // graph_get_errors dispatch in the file must carry the refresh-ack constant.
+    const src = readFileSync(PANEL_TOOLS_TS, "utf8");
+    const dispatches = [...src.matchAll(/cmd:\s*"graph_get_errors"[^\n]*/g)].map((m) => m[0]);
+    expect(dispatches.length).toBeGreaterThan(0);
+    for (const line of dispatches) {
+      expect(
+        line,
+        `a graph_get_errors dispatch is missing OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS: ${line}`,
+      ).toContain("OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS");
+    }
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12477,8 +12477,32 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_get_errors",
       "WHY IS THAT NODE RED / WHY DID THE RUN FAIL? The single error surface for the user's open tab: every errored node JOINED TO ITS CAUSE, which ComfyUI itself does not show — LiteGraph only paints a red outline and stores no reason, which is why users report \"red node, no error message\". Call this whenever the user mentions a red/highlighted/erroring node, a failed run, or \"required models are missing\" — instead of guessing from widget values. Each entry in `nodes[]` is the node's full detail summary plus `red_outline` and `reasons[]`, drawn from every source: `missing_model` (exact file, its models directory, the widget holding it, and a download URL when known), `missing_media` (a referenced input image/video that isn't on disk — the usual cause of a red LoadImage), `validation` (per-input errors from the last queue attempt: message, details, offending input), and `execution` (runtime failure with `exception_type`, e.g. PIL.UnidentifiedImageError). TWO THINGS THAT MAKE THIS ESSENTIAL: (1) missing model/media assets paint nodes red AS SOON AS THE WORKFLOW LOADS, long before any queue attempt — so the raw validation map is still EMPTY while the user is staring at red nodes; (2) a node that throws AT RUNTIME is never painted red at all, so it can't be spotted on the canvas — it appears here with red_outline:false. Also returns graph-level `missing_models`, `missing_media`, `missing_node_types` (or `missing_node_count`), plus the raw `node_errors` map and `last_execution_error` for reference. A ⚠️ GRAPH VALIDATION block is auto-injected at your turn start when this state changes; call this to re-check on demand (e.g. after you edit widgets/links). Read-only.",
       {},
+      // #1493 — graph_get_errors belongs to the #599 refresh-ack cohort above, and was the
+      // one member of it left on the generic read default.
+      //
+      // Its frontend handler deliberately awaits a FORCED /object_info re-register before it
+      // will trust a combo to clear a resolved missing-model candidate (#610), and it spends a
+      // shared 18 000 ms elective budget across that refresh race, the /system_stats probe and the
+      // /view media probes (GET_ERRORS_TOTAL_BUDGET_MS, panel web/js/lib/get-errors-budget.js).
+      // That budget was sized to sit under BRIDGE_READ_DEFAULT_TIMEOUT_MS — which leaves 2 000 ms
+      // for everything the call still has to do AFTER the waits: collectMissingAssets over the
+      // whole graph, the per-node live combo scan, the subgraph walk, and serializing a reply big
+      // enough that this tool ships two truncation riders for it.
+      //
+      // The reported sequence spends that budget exactly as designed — panel_refresh_nodes, three
+      // promoted-widget writes on a model-loader subgraph, a save — and panel_get_errors was then
+      // declared "backgrounded or frozen" at 20 000 ms by a tab that had just answered four
+      // commands and did reply, late. That is the precise failure the shared budget exists to
+      // prevent (#589): an agent left with NO error surface for a workflow whose nodes are red.
+      //
+      // The margin has to come from THIS side. The panel's 18 s bound must stay where it is — it
+      // is what keeps a current panel safe in front of an OLDER orchestrator still using the 20 s
+      // default — so the orchestrator widens its own wait to the same bounded budget its
+      // refresh-before-validate siblings already use. This read is idempotent, so waiting longer
+      // costs a slow reply and never a double-applied write; it stays BOUNDED (never Infinity), so
+      // a genuinely frozen tab still fails, just at 30 s instead of 20 s.
       async (_args, ctx) =>
-        withTruncationHints(await ctx.call({ cmd: "graph_get_errors" }), [
+        withTruncationHints(await ctx.call({ cmd: "graph_get_errors" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS), [
           {
             flag: "truncated",
             key: "truncation_hint",


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1493 (cross-repo — the report is filed against the panel, the defect is on the orchestrator side of the same invariant; the issue is closed by hand after merge).

## What was reported

`panel_refresh_nodes` → three `panel_set_widget` writes on promoted COMBO widgets of a model-loader subgraph → `panel_save_workflow` — every one acked — then:

```
Panel tab workflows/LTX2.5_Character_ReferenceVideo_Pose_Control.json did not reply to
graph_get_errors within 20000 ms — the ComfyUI tab may be backgrounded or frozen
```

The tab was neither backgrounded nor frozen. It had just answered four commands.

## Mechanism

`graph_get_errors` is the panel command that deliberately spends the longest wall clock:

- its handler awaits a **forced** `/object_info` re-register before it will trust a combo to clear a resolved missing-model candidate (#610 measured that at ~14.5 s on a real Windows install);
- and it spends a **shared 18 000 ms elective budget** across that refresh race, the `/system_stats` probe and the `/view` media probes — `GET_ERRORS_TOTAL_BUDGET_MS` in the panel's `web/js/lib/get-errors-budget.js`.

That 18 000 ms was sized against the orchestrator's generic **20 000 ms** read default (`BRIDGE_READ_DEFAULT_TIMEOUT_MS`). Which leaves **2 000 ms** for everything the call still has to do *after* its waits: `collectMissingAssets` over the whole graph, the per-node live combo scan, the subgraph walk, and serializing a reply large enough that this very tool ships two truncation riders for it.

The reported sequence spends the budget exactly as designed. `panel_refresh_nodes` leaves an `/object_info` run in flight; `graph_get_errors` sees raw missing-model candidates (the reason the user was re-setting those widgets), so it takes its full 15 s refresh cap, then up to 3 s of media probes — 18 s gone before the graph work starts. The panel replied; the orchestrator had already given up. The agent is then left with **no error surface at all** for a workflow whose nodes are visibly red, which is precisely the outcome the shared budget exists to prevent (#589).

So the reporter is right about the symptom and their prescribed fix is already in the product: the asset scan **is** budgeted separately and **does** return partial state. What is wrong is the headroom the budget was sized against.

## The fix

`graph_get_errors` joins the **#599 refresh-ack cohort** and forwards the same bounded `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` (30 s) that `graph_set_widget`, `graph_add_node`, `graph_remove_widget`, `graph_get_object_info` and `refresh_nodes` already use — all for the same reason, all waiting on the same `/object_info` fetch. It was the one member of that cohort left on the generic read default, and it is the member that spends the most of it.

**Why this side, not the panel.** The panel's 18 s bound must stay where it is: it is what keeps a current panel safe in front of an *older* orchestrator still using the 20 s default. Lowering it would buy margin by cutting verification (a skipped refresh means a resolved model keeps reporting missing). Widening the orchestrator's own wait costs nothing but patience on a read that is idempotent — waiting longer can never double-apply anything — and the bound stays finite, so a genuinely frozen tab still fails, at 30 s instead of 20 s.

One line changed. The rest of the diff is the comment recording why, and the tests.

## Proof

`src/__tests__/orchestrator/get-errors-ack-budget.test.ts` — the property under test is the **call site**, not the constant. A shared constant that nothing passes still greps, and a one-argument wiring change is invisible to any test that only exercises the bridge, so every case runs the real tool def and reads the bound it actually forwarded:

1. `panel_get_errors` forwards 30 000 ms, and specifically *something*, and specifically more than `BRIDGE_READ_DEFAULT_TIMEOUT_MS`.
2. It clears the panel's own 18 s elective budget with real margin — not the 2 s that failed.
3. It stays bounded (finite, ≤ 60 s), so a dead tab still fails.
4. It matches its #599 siblings, read from their real defs, so the cohort cannot drift apart if the shared constant is re-tuned.
5. Source guard: **every** `graph_get_errors` dispatch in `panel-tools.ts` carries the constant, so a second call site added later on another branch cannot quietly ship on the default (counting occurrences cannot see a third path).

**Mutation-tested after committing the fix:**

- delete the argument → **5 of 5 fail**;
- shrink it to `21_000` (still above the read default, so the naive "is it bigger than 20 s" check would pass) → **4 of 5 fail**.

**Suite:** `npx vitest run` → 584 files / 10 800 tests pass. Two failures, both pre-existing and unrelated: `scripts/package-hooks` (`files` allowlist wants a built `dist/`, absent in a fresh worktree) and `orchestrator/late-mutation-e2e` (the known wall-clock load flake — **passes 5/5 when re-run alone**, confirmed). `npx tsc --noEmit` clean. `npm run check:vocabulary` clean.

**Browser gate:** deliberately not run, and it does not apply. This change is orchestrator-side only — one argument to `ctx.call`. Nothing the panel renders, and no panel file, is touched.

## Gate

codex was unavailable (account exhausted); gated by an independent adversarial review instead — `node .claude/autopilot/claude-gate.mjs`. Verdict recorded in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
