### PR TITLE
fix(panel#1494): a stale tab advertisement stops being reported as a restored graph binding

### DIFF
--- a/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
+++ b/src/__tests__/orchestrator/carried-stamp-wiring.test.ts
@@ -105,10 +105,16 @@ describe("#1656 — carried-stamp provenance is WIRED, not merely available", ()
   it("SOURCE: the gate consults the predicate, and the recovery probe stays exempt", () => {
     const src = bridgeSrc();
     // The gate reads provenance for the CONNECTION's canonical id — the tab the
-    // frame would actually land on — not for the caller's address.
-    expect(src).toContain("this.isCarriedTabStamp?.(conn.tabId) === true");
+    // frame would actually land on — not for the caller's address. #1494 moved the
+    // comparison into one shared helper, so the property is pinned in BOTH halves:
+    // the helper reads provenance from its ROUTED-tab parameter…
+    expect(src).toContain("this.isCarriedTabStamp?.(routedTabId) === true");
+    // …and send() passes the caller's address and the connection's canonical id in
+    // that order. Swapping them would read provenance for the wrong tab and is
+    // invisible to a behavioural test that installs its own predicate.
+    expect(src).toContain("this.stampTargetVerdict(opts.tabId, conn.tabId)");
     // The refusal is pre-dispatch and typed, like #1682's.
-    const idx = src.indexOf("if (issuedFor && landedOn && carried) {");
+    const idx = src.indexOf('if (verdict.refuses && verdict.kind === "carried") {');
     expect(idx, "carried refusal branch not found").toBeGreaterThan(-1);
     const branch = src.slice(idx, idx + 1200);
     expect(branch).toContain("markDispatched(");

--- a/src/__tests__/services/stamp-target-disagreement-recovery.test.ts
+++ b/src/__tests__/services/stamp-target-disagreement-recovery.test.ts
@@ -178,6 +178,26 @@ describe("a stale tab advertisement is REPORTED, not papered over (#1494)", () =
     sock.close();
   });
 
+  it("a CANONICAL-ID caller is exempt here because `send` exempts it — the same short-circuit", async () => {
+    // The one state that separates the two: `send()` never runs the gate for a caller
+    // addressing the connection by its canonical id, so the capability probe must not
+    // either — both answers would come from ONE lookup, which cannot be a
+    // disagreement. Carried is set precisely because it is the arm that would
+    // otherwise fire on a pair that IS equal, making this the input that catches a
+    // missing short-circuit rather than one that merely happens to agree.
+    advertised.set(TAB, LIVE);
+    sessionStamp = LIVE;
+    carried = true;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    expect(bridge.tabGraphMutationCapability(TAB)).toEqual({ known: true, canMutate: true });
+    // …and that IS what send does: addressed canonically, the command dispatches.
+    received.length = 0;
+    await expect(bridge.send({ cmd: "graph_add_node" }, { tabId: TAB })).resolves.toBeTruthy();
+    expect(received.map((f) => f.cmd)).toEqual(["graph_add_node"]);
+    sock.close();
+  });
+
   it("does NOT fire when the two agree — the settled session is untouched", async () => {
     advertised.set(TAB, LIVE);
     sessionStamp = LIVE;

--- a/src/__tests__/services/stamp-target-disagreement-recovery.test.ts
+++ b/src/__tests__/services/stamp-target-disagreement-recovery.test.ts
@@ -1,0 +1,256 @@
+// #1494 — a transient workflow-instance mismatch whose own recovery reported success.
+//
+// Reported shape, verbatim: `panel_add_node` succeeded, seconds later the next one was
+// refused with "workflow instance mismatch: … issued for workflow instance <A>, but the
+// routed tab reported <B>", and `panel_set_workflow_target({mode:"current"})` called
+// immediately afterwards answered `graph_binding:"bound"`,
+// `graph_binding_status:"already_current"` — naming <A>, the very uuid the refusal was
+// being measured against. Two answers about one session, contradicting each other.
+//
+// They contradicted because they compared DIFFERENT facts:
+//
+//   the dispatch-time agreement gate (#1656, ui-bridge send)
+//        session stamp  vs  the identity the ROUTED TAB last advertised in a hello
+//   the rebind recovery (rebindWorkflowFence)
+//        session stamp  vs  the LIVE canvas read back with workflow_list
+//
+// When the ADVERTISEMENT is the stale side those two disagree by construction: the live
+// canvas equals the stamp (so the rebind short-circuits to `already_current` and repairs
+// nothing — `corroborateTabStamp` refuses outright when the values differ), while the
+// gate keeps refusing every fenced command against the advertisement nothing has
+// touched. The recovery the refusal itself prescribes could not clear the refusal, and
+// said it had.
+//
+// The fix does not move the gate: the refusals below are byte-identical. It gives the
+// gate ONE implementation (`stampTargetVerdict`) and lets the capability probe the
+// recovery reports from ask it, so "can this session run graph commands" stops being
+// answered by a check that cannot see what is refusing them.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import { isScopeAddress } from "../../services/session-scope.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/** What the session was issued for, and what the live canvas keeps reporting. */
+const LIVE = "4808c797-417c-4c33-8ab0-99cf2f6ba648";
+/** The stale value the routed tab's last handshake left behind. */
+const STALE = "caf45251-53ad-431b-afdd-02239fdb7119";
+const TAB = "wf:route1:workflows/a.json";
+const SCOPE = "orchestrator::claude";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** A self-corroborating workflow_list reply — the active record also appears in the
+ *  open-workflow list flagged active, which is what corroboration requires. */
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+describe("a stale tab advertisement is REPORTED, not papered over (#1494)", () => {
+  let bridge: UiBridge;
+  let port: number;
+
+  /** The orchestrator's two answers, modelled separately BECAUSE they diverge in the
+   *  bug: the per-tab advertised identity (tabCommandWorkflowUuid, refreshed by every
+   *  hello) and the conversation's issue-time stamp (turnOrigins.stampOf). */
+  const advertised = new Map<string, string>();
+  let sessionStamp: string | undefined;
+  let carried: boolean;
+  /** What the fake panel says the LIVE canvas is when workflow_list is read. */
+  let liveCanvas: string;
+  let received: Array<Record<string, unknown>>;
+
+  beforeEach(async () => {
+    advertised.clear();
+    sessionStamp = undefined;
+    carried = false;
+    liveCanvas = LIVE;
+    received = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver((id) =>
+      isScopeAddress(id) ? sessionStamp : advertised.get(id),
+    );
+    bridge.setCarriedTabStampPredicate((id) => !isScopeAddress(id) && carried);
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  function connectPanel(tabId: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: tabId,
+            title: tabId,
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+          }),
+        );
+        resolve(sock);
+      });
+      sock.on("error", reject);
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString());
+        if (!msg.rid || !msg.cmd) return;
+        received.push(msg);
+        const result = msg.cmd === "workflow_list" ? settled(liveCanvas) : { cmd: msg.cmd };
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result }));
+      });
+    });
+  }
+
+  /** The reported state: the session stamp names the live canvas, the routed tab's
+   *  last advertisement does not. */
+  async function inTheReportedState(): Promise<WebSocket> {
+    advertised.set(TAB, STALE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    received.length = 0;
+    return sock;
+  }
+
+  it("the gate still refuses, in exactly the words that were reported", async () => {
+    const sock = await inTheReportedState();
+    const err = await bridge.send({ cmd: "graph_add_node" }, { tabId: SCOPE }).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(`issued for workflow instance ${LIVE}`);
+    expect(err!.message).toContain(`different active workflow (${STALE})`);
+    // Pre-dispatch: nothing reached the panel.
+    expect(received).toEqual([]);
+    sock.close();
+  });
+
+  it("and the capability probe the recovery reports now SEES that refusal", async () => {
+    const sock = await inTheReportedState();
+    const cap = bridge.tabGraphMutationCapability(SCOPE);
+    expect(cap).toEqual({ known: true, canMutate: false, because: "target_disagreement" });
+    // The boolean gate agrees — graph tools really are unusable in this state.
+    expect(bridge.tabCanMutateGraph(SCOPE)).toBe(false);
+    sock.close();
+  });
+
+  it("a CARRIED (inherited) stamp is the same verdict — the other arm of the same gate", async () => {
+    advertised.set(TAB, LIVE);
+    sessionStamp = LIVE;
+    carried = true;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({
+      known: true,
+      canMutate: false,
+      because: "target_disagreement",
+    });
+    sock.close();
+  });
+
+  it("does NOT fire when the two agree — the settled session is untouched", async () => {
+    advertised.set(TAB, LIVE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({ known: true, canMutate: true });
+    // …and a caller addressing the connection by its canonical id reads both answers
+    // from one lookup, so it can never be a disagreement.
+    expect(bridge.tabGraphMutationCapability(TAB)).toEqual({ known: true, canMutate: true });
+    sock.close();
+  });
+
+  it("an ABSENT session stamp is still no_identity — the new check is LAST", async () => {
+    // A missing value is not divergence. This is the state that would be misreported
+    // if the disagreement check ran before the ones it presupposes.
+    advertised.set(TAB, LIVE);
+    sessionStamp = undefined;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({
+      known: true,
+      canMutate: false,
+      because: "no_identity",
+    });
+    sock.close();
+  });
+
+  it("END TO END: the rebind stops answering `bound` while the gate is refusing", async () => {
+    const sock = await inTheReportedState();
+    const ctx = makePanelToolCtx(bridge, SCOPE, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+    if (!def) throw new Error("panel_set_workflow_target is not registered");
+    const res: ToolResult = await def.handler({ mode: "current" } as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    // The recovery really did read the live canvas — without this the assertions
+    // below could be satisfied by a reply that never consulted the panel.
+    expect(received.map((f) => f.cmd)).toContain("workflow_list");
+    // THE REPORTED CONTRADICTION, gone: this is the reply that used to say
+    // graph_binding:"bound" / already_current on the very uuid being refused against.
+    expect(res.isError).toBe(true);
+    expect(text).not.toContain('"graph_binding": "bound"');
+    expect(text).toContain("did NOT restore this session's graph binding");
+    // It names WHICH comparison is refusing, and a remedy that can actually clear it.
+    expect(text).toContain("last advertised");
+    expect(text).toContain("panel_open_workflow");
+    // And it does not sell the state as reads-only: this gate refuses graph reads too.
+    expect(text).not.toContain("Reads work");
+    sock.close();
+  });
+
+  it("END TO END: the mismatch diagnosis stops prescribing a bare retry it cannot honour", async () => {
+    const sock = await inTheReportedState();
+    const ctx = makePanelToolCtx(bridge, SCOPE, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+    if (!def) throw new Error("panel_add_node is not registered");
+    const res: ToolResult = await def.handler({ node_type: "KSampler" } as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(res.isError).toBe(true);
+    // The check ran against the live canvas, and found it agrees with the stamp…
+    expect(received.map((f) => f.cmd)).toContain("workflow_list");
+    expect(text).toMatch(/CHECKED/);
+    // …so #1330's TRANSIENT wording would have fired here and told the caller to
+    // re-issue a call the gate compares against the same unchanged advertisement.
+    expect(text).not.toContain("RETRY THIS EXACT CALL ONCE");
+    expect(text).toContain("last advertised");
+    expect(text).toContain("panel_open_workflow");
+    // The refusal itself is preserved verbatim — the comparison is the evidence.
+    expect(text).toContain(`issued for workflow instance ${LIVE}`);
+    expect(text).toContain(STALE);
+    // Nothing was dispatched by the refused call; only the diagnosis read the panel.
+    expect(received.map((f) => f.cmd)).not.toContain("graph_add_node");
+    sock.close();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5984,10 +5984,12 @@ function describeFenceRebind(
   const mutationsUnknown = canMutate === undefined;
   // #1494 — `reads_only` would be a FALSE consolation for this one cause. The
   // dispatch-time agreement gate covers `graph_*` READS as well as mutations
-  // (requiresStampTargetAgreement), so a session in that state has no working graph
-  // tools at all — and the whole report is that this call answered "bound" while
-  // every one of them was being refused. It is `not_recovered`: the caller must not
-  // read success out of it.
+  // (requiresStampTargetAgreement), so a session in that state has neither working
+  // graph reads NOR writes — only the canvas-INDEPENDENT ops that predicate exempts
+  // (graph_update_node, the virtual-type reads) still dispatch, which is not what a
+  // caller reads "reads_only" as. And the whole report is that this call answered
+  // "bound" while everything the gate covers was being refused. It is
+  // `not_recovered`: the caller must not read success out of it.
   const okBinding: "bound" | "reads_only" | "unverified" | "not_recovered" = mutationsRefused
     ? refusalCause === "target_disagreement"
       ? "not_recovered"

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5962,7 +5962,7 @@ function describeFenceRebind(
    * both yield `canMutate:false` but need opposite advice, and narrating the
    * first as the second is a bucket standing in for a cause (codex gate P1).
    */
-  refusalCause?: "unroutable" | "disconnected" | "no_identity" | "capability",
+  refusalCause?: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement",
   /**
    * #1043 — the version-gap sentence, when the connected panel is PROVABLY too
    * old to publish the reply uuid this rebind exists to avoid needing. Passed in
@@ -5982,8 +5982,16 @@ function describeFenceRebind(
   // A panel that cannot fence a WRITE gives reads only, however good the stamp is.
   const mutationsRefused = canMutate === false;
   const mutationsUnknown = canMutate === undefined;
-  const okBinding: "bound" | "reads_only" | "unverified" = mutationsRefused
-    ? "reads_only"
+  // #1494 — `reads_only` would be a FALSE consolation for this one cause. The
+  // dispatch-time agreement gate covers `graph_*` READS as well as mutations
+  // (requiresStampTargetAgreement), so a session in that state has no working graph
+  // tools at all — and the whole report is that this call answered "bound" while
+  // every one of them was being refused. It is `not_recovered`: the caller must not
+  // read success out of it.
+  const okBinding: "bound" | "reads_only" | "unverified" | "not_recovered" = mutationsRefused
+    ? refusalCause === "target_disagreement"
+      ? "not_recovered"
+      : "reads_only"
     : mutationsUnknown
       ? "unverified"
       : "bound";
@@ -6009,6 +6017,20 @@ function describeFenceRebind(
       `\n\nWHAT TO DO: call this tool again to bind an identity. If it keeps coming back ` +
       `without one, have the user click into the workflow tab so the panel reports an active ` +
       `canvas, then call this again.`
+    : mutationsRefused && refusalCause === "target_disagreement"
+    ? `\n\nBUT THIS DID NOT CLEAR THE REFUSAL, and saying otherwise is the bug this ` +
+      `wording exists to stop (#1494). Graph commands are refused BEFORE they are ` +
+      `dispatched, by a comparison this call does not perform: the session's stamp against ` +
+      `the identity the ROUTED TAB last advertised in its handshake. This call compared the ` +
+      `stamp against the LIVE canvas instead, and those are different facts — the live ` +
+      `canvas agreeing is exactly why nothing above says "rebound". Graph READS are refused ` +
+      `by the same gate, so this is not a reads-only session.` +
+      `\n\nWHAT TO DO: re-open the workflow you mean with panel_open_workflow(<path>) — an ` +
+      `open proves an identity for the tab under its current id, which is what the gate is ` +
+      `missing; for a never-saved canvas use its routing_key from panel_list_workflows. The ` +
+      `panel also re-advertises on its own when it notices the drift, so a command that ` +
+      `keeps failing here may start working without you doing anything — do NOT read that as ` +
+      `this call having repaired it.`
     : mutationsRefused && refusalCause === "unroutable"
     ? `\n\nBUT this tab is NOT REACHABLE from the orchestrator right now, so graph mutations ` +
       `are refused — and reads are not working either, whatever this note says about them. ` +
@@ -8105,7 +8127,7 @@ export interface PanelToolCtx {
     | {
         known: true;
         canMutate: false;
-        because: "unroutable" | "disconnected" | "no_identity" | "capability";
+        because: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement";
       }
     | { known: false; reason: string };
 }
@@ -8777,14 +8799,52 @@ export function makePanelToolCtx(
         let verdict: string;
         try {
           const probe = await rebindWorkflowFence(ctx, { adopt: false });
+          // #1494 — WHICH COMPARISON IS REFUSING, asked of the gate itself rather than
+          // inferred from the probe.
+          //
+          // The probe reads the LIVE canvas. The dispatch-time agreement gate refuses on
+          // the identity the ROUTED TAB last advertised. When the advertisement is the
+          // stale side, those two disagree — the probe reports `already_current` on the
+          // very uuid the command carried, which reads as "transient, retry" while every
+          // retry is compared against the same unchanged advertisement and refused
+          // identically. That is the reported contradiction: an immediate rebind
+          // confirming the original instance, next to a refusal naming another one.
+          //
+          // Typed, from `tabGraphMutationCapability` (the bridge's own verdict, sharing
+          // one predicate with `send()`), never a second reading of the refusal's prose.
+          let gateStillRefuses = false;
+          try {
+            const cap = ctx.tabGraphMutationCapability?.();
+            gateStillRefuses =
+              cap?.known === true &&
+              cap.canMutate === false &&
+              cap.because === "target_disagreement";
+          } catch {
+            gateStillRefuses = false; // a diagnostic must never replace the outcome
+          }
           verdict =
             probe.status === "already_current" && stamped && probe.uuid === stamped
-              ? `\n\nCHECKED: the live canvas now reports the SAME workflow instance this ` +
-                `command carried (${stamped}), so the mismatch was TRANSIENT: the identity ` +
-                `flipped and settled back, which happens while a new unsaved workflow is still ` +
-                `materialising. RETRY THIS EXACT CALL ONCE. Nothing was applied, so a retry ` +
-                `cannot double-apply, and re-issuing the whole build would duplicate the work ` +
-                `that already succeeded.`
+              ? gateStillRefuses
+                ? `\n\nCHECKED, and the two claims are BOTH true of different things: the live ` +
+                  `canvas does report the SAME workflow instance this command carried ` +
+                  `(${stamped}), and the refusal above is not about the live canvas — it is ` +
+                  `the pre-dispatch check on the identity the ROUTED TAB last advertised, ` +
+                  `which is the stale side here. So a bare retry is compared against that ` +
+                  `same unchanged value and is refused the same way; ` +
+                  `panel_set_workflow_target({mode:"current"}) reports "already current" for ` +
+                  `the same reason and does not clear it either. Nothing was applied. WHAT TO ` +
+                  `DO: re-open the workflow you mean with panel_open_workflow(<path>) — that ` +
+                  `proves an identity for the tab under its CURRENT id, which is what is ` +
+                  `missing; for a never-saved canvas use its routing_key from ` +
+                  `panel_list_workflows. The panel also re-advertises on its own once it ` +
+                  `notices the drift, so a retry may start working shortly — that is the ` +
+                  `panel repairing it, not this call.`
+                : `\n\nCHECKED: the live canvas now reports the SAME workflow instance this ` +
+                  `command carried (${stamped}), so the mismatch was TRANSIENT: the identity ` +
+                  `flipped and settled back, which happens while a new unsaved workflow is still ` +
+                  `materialising. RETRY THIS EXACT CALL ONCE. Nothing was applied, so a retry ` +
+                  `cannot double-apply, and re-issuing the whole build would duplicate the work ` +
+                  `that already succeeded.`
               : probe.status === "already_current"
                 ? `\n\nCHECKED: the session's fence already names the live canvas ` +
                   `(${probe.uuid}), so it was not the stale side. Retry once — if it refuses ` +
@@ -13511,7 +13571,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // which can be refused by the exact fence this repairs.
         const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
+        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;
         try {
           if (ctx.tabGraphMutationCapability) {
             const cap = ctx.tabGraphMutationCapability();
@@ -13838,7 +13898,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // fence" — a claim about the panel built from our own failure to look
         // (codex gate). Only an OBSERVED negative may say that.
         let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
+        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;
         try {
           if (ctx.tabGraphMutationCapability) {
             const cap = ctx.tabGraphMutationCapability();
@@ -14107,7 +14167,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // it one confusing mismatch at a time.
         const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
+        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;
         try {
           if (ctx.tabGraphMutationCapability) {
             const cap = ctx.tabGraphMutationCapability();

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1118,6 +1118,25 @@ const STAMP_TARGET_CANVAS_INDEPENDENT = new Set<string>([
   "free_vram",
 ]);
 
+/**
+ * #1656/#1494 — the dispatch-time agreement gate's verdict, as a value.
+ *
+ * FOUR outcomes, not two, because the three non-refusing ones have to stay
+ * distinguishable: `agrees` is an observation that the two identities match,
+ * `unreadable` is an observation NOT MADE (a missing value is not divergence — the
+ * panel's own fence judges those), and `same_address` means both answers came from
+ * one lookup and could only ever agree. Collapsing them into a bare boolean is how a
+ * "no refusal" would come to be reported as "the target was confirmed".
+ */
+export type StampTargetVerdict =
+  | {
+      refuses: false;
+      kind: "agrees" | "unreadable" | "same_address";
+      issuedFor?: string;
+      landedOn?: string;
+    }
+  | { refuses: true; kind: "disagrees" | "carried"; issuedFor: string; landedOn: string };
+
 /** #1656 — commands that read or mutate whichever canvas the routed tab has ACTIVE,
  *  and therefore may only be dispatched when the session's workflow stamp and the
  *  tab's reported active workflow AGREE (see the dispatch gate in send()).
@@ -3229,6 +3248,40 @@ export class UiBridge {
   }
 
   /**
+   * #1656/#1494 — the dispatch-time agreement question, with ONE implementation.
+   *
+   * `send()` asks it to decide whether a fenced command may be written, and
+   * `tabGraphMutationCapability` asks it so the fence-rebind recovery can report the
+   * same answer. They used to be unable to: the gate compares the session's stamp
+   * against the routed tab's LAST ADVERTISED identity, while the recovery compares
+   * the session's stamp against the LIVE canvas it reads with `workflow_list`. Those
+   * are different facts, and when only the advertisement is stale they disagree —
+   * the recovery reported `already_current` / `graph_binding:"bound"` on the very
+   * uuid the gate was refusing against, so it announced success and cleared nothing
+   * (#1494's report, verbatim). Sharing the predicate is what keeps them honest.
+   *
+   * `refuses:false` is returned for every state the gate itself lets through,
+   * including an UNREADABLE side — a missing value is not evidence of divergence,
+   * and the panel's own fence is the judge there (unchanged from #1656).
+   */
+  private stampTargetVerdict(
+    callerTabId: string,
+    routedTabId: string,
+  ): StampTargetVerdict {
+    // A caller addressing the connection by its canonical id reads BOTH answers from
+    // the same lookup, so they can only agree — never a disagreement to report.
+    if (callerTabId === routedTabId) return { refuses: false, kind: "same_address" };
+    const issuedFor = this.resolveTabWorkflowUuid?.(callerTabId);
+    const landedOn = this.resolveTabWorkflowUuid?.(routedTabId);
+    if (!issuedFor || !landedOn) return { refuses: false, kind: "unreadable" };
+    if (issuedFor !== landedOn) return { refuses: true, kind: "disagrees", issuedFor, landedOn };
+    if (this.isCarriedTabStamp?.(routedTabId) === true) {
+      return { refuses: true, kind: "carried", issuedFor, landedOn };
+    }
+    return { refuses: false, kind: "agrees", issuedFor, landedOn };
+  }
+
+  /**
    * #770/#803 — the same question, TRI-STATE, for anyone who has to REPORT the
    * answer rather than act on it.
    *
@@ -3253,7 +3306,12 @@ export class UiBridge {
     | {
         known: true;
         canMutate: false;
-        because: "unroutable" | "disconnected" | "no_identity" | "capability";
+        because:
+          | "unroutable"
+          | "disconnected"
+          | "no_identity"
+          | "capability"
+          | "target_disagreement";
       }
     | { known: false; reason: string } {
     let conn: Conn;
@@ -3286,6 +3344,18 @@ export class UiBridge {
       }
       if (typeof stamp !== "string" || stamp.length === 0) {
         return { known: true, canMutate: false, because: "no_identity" };
+      }
+      // #1494 — LAST, because it presupposes everything above it: a routable, open,
+      // fence-advertising tab that DOES have a stamp, whose stamp nevertheless
+      // disagrees with what the routed tab last advertised. `send()` refuses every
+      // fenced command in that state, so answering `canMutate:true` here made the
+      // rebind recovery report a working binding while nothing could be dispatched.
+      // Reported as its own cause, never folded into `no_identity`: there IS an
+      // identity, and the remedy is the opposite one (prove an identity for the
+      // ROUTED tab, rather than acquire one for the session).
+      const verdict = this.stampTargetVerdict(tabId, conn.tabId);
+      if (verdict.refuses) {
+        return { known: true, canMutate: false, because: "target_disagreement" };
       }
       return { known: true, canMutate: true };
     } catch (err) {
@@ -4717,15 +4787,20 @@ export class UiBridge {
     // instant any hello or validated reply establishes an identity for this tab id, the
     // provenance flips to proven and nothing about the pre-#1656 behaviour changes.
     if (opts.tabId && opts.tabId !== conn.tabId && requiresStampTargetAgreement(cmd)) {
-      const issuedFor = this.resolveTabWorkflowUuid?.(opts.tabId);
-      const landedOn = this.resolveTabWorkflowUuid?.(conn.tabId);
-      const carried = this.isCarriedTabStamp?.(conn.tabId) === true;
-      if (issuedFor && landedOn && issuedFor !== landedOn) {
+      // #1494 — ONE implementation of the question, asked here and by
+      // `tabGraphMutationCapability`. The recovery this refusal names used to answer
+      // "bound / already_current" while this gate went on refusing every fenced
+      // command, because the two sides read DIFFERENT facts: the gate compares the
+      // session stamp against the routed tab's advertisement, the recovery compares
+      // the session stamp against the LIVE canvas. Sharing the predicate is what
+      // stops them contradicting each other again.
+      const verdict = this.stampTargetVerdict(opts.tabId, conn.tabId);
+      if (verdict.refuses && verdict.kind === "disagrees") {
         return Promise.reject(
           markDispatched(
             new Error(
-              `workflow instance mismatch: this command was issued for workflow instance ${issuedFor}, ` +
-                `but the tab it routed to has since reported a different active workflow (${landedOn}). ` +
+              `workflow instance mismatch: this command was issued for workflow instance ${verdict.issuedFor}, ` +
+                `but the tab it routed to has since reported a different active workflow (${verdict.landedOn}). ` +
                 `Nothing was dispatched. Re-target with panel_set_workflow_target({mode:"current"}), ` +
                 `then retry.`,
             ),
@@ -4733,13 +4808,13 @@ export class UiBridge {
           ),
         );
       }
-      if (issuedFor && landedOn && carried) {
+      if (verdict.refuses && verdict.kind === "carried") {
         return Promise.reject(
           markDispatched(
             new Error(
-              `workflow instance mismatch: this command was issued for workflow instance ${issuedFor}, ` +
+              `workflow instance mismatch: this command was issued for workflow instance ${verdict.issuedFor}, ` +
                 `and the tab it routed to has not re-established its workflow identity since it ` +
-                `re-registered under a new id — the uuid it currently carries (${landedOn}) was ` +
+                `re-registered under a new id — the uuid it currently carries (${verdict.landedOn}) was ` +
                 `inherited from the tab id it replaced, so it is not evidence about the canvas now ` +
                 `mounted there. Nothing was dispatched. Re-target with ` +
                 `panel_set_workflow_target({mode:"current"}), then retry.`,


### PR DESCRIPTION
Fixes the underlying cause reported in artokun/comfyui-mcp-panel#1494.

## What was reported

A live-canvas `panel_add_node` was refused with

```
workflow instance mismatch: this command was issued for workflow instance 4808c797…,
but the tab it routed to has since reported a different active workflow (caf45251…).
```

and `panel_set_workflow_target({mode:"current"})`, called immediately afterwards —
the recovery that refusal itself prescribes — answered `graph_binding:"bound"`,
`graph_binding_status:"already_current"`, naming `4808c797…`. Two answers about one
session, contradicting each other, with no user-visible tab switch between them.

## Why (measured, not inferred)

The reporter was right about the symptom and the mechanism is one step behind the one
they proposed. This is **not** the panel's fence — that refusal reads *"and the active
canvas reports X"*. This is the orchestrator's **dispatch-time agreement gate**
(#1656, `UiBridge.send`), which is where *"the tab it routed to has since reported"*
comes from and which refuses **before** anything is written.

The gate and its own recovery compare **different facts**:

| | compares |
|---|---|
| the gate (`send`) | the session's stamp vs. the identity the **routed tab last advertised** in a hello (`tabCommandWorkflowUuid`) |
| the recovery (`rebindWorkflowFence`) | the session's stamp vs. the **live canvas** it reads back with `workflow_list` |

When the **advertisement** is the stale side those two disagree by construction. The
live canvas equals the stamp, so the rebind takes the `already_current`
short-circuit — which returns *before* `refreshWorkflowUuid`, and whose
`corroborateTabStamp` refuses outright when the values differ (by design, #1646) — so
it repairs nothing and reports success. Meanwhile the gate keeps refusing every fenced
command against an advertisement nothing has touched. Only the panel's own drift
re-hello clears it, and the recovery said it had. The tab-advertisement side is also
invisible to `tabGraphMutationCapability`, which is the probe every fence-rebind reply
renders its verdict from — so a routable, open, fence-advertising, correctly-stamped
session answered `canMutate: true` while nothing could be dispatched. That is the
`graph_binding:"bound"` in the report.

## What changed

**The gate does not move.** Both refusals are byte-identical, no fence is adopted,
re-pointed or widened, and the read-only probe stays read-only. What changes is that
the gate now has **one implementation** (`stampTargetVerdict`), and the capability
probe the recovery reports from asks it:

- `panel_set_workflow_target({mode:"current"})` reports `not_recovered` instead of
  `bound` while the gate is refusing, and names a remedy that can clear it
  (`panel_open_workflow`, which proves an identity for the tab under its **current**
  id). Deliberately **not** `reads_only`: this gate covers `graph_*` reads too
  (`requiresStampTargetAgreement`), so that would be a false consolation.
- #1330's mismatch diagnosis stops prescribing `RETRY THIS EXACT CALL ONCE` in the one
  state where the retry is compared against the same unchanged value. It says which
  comparison is refusing instead.
- the new cause is its own value (`target_disagreement`), never folded into
  `no_identity`: there **is** an identity, and the remedy is the opposite one.

The new check is **last** in `tabGraphMutationCapability` because it presupposes every
condition above it, and an unreadable side stays a non-refusal — a missing value is not
divergence, unchanged from #1656.

### Considered and rejected

Auto-adopting the live-canvas uuid onto the routed tab (the reporter's "transparently
refresh the fence") would clear the refusal in one call — and would re-open #1656 in
the mirror case. There, the hello advertising `B` is the panel's *positive assertion of
a switch* while the frontend identity `workflow_list` reads back can still lag on `A`;
preferring the read over the hello would drag the advertisement back to `A` and let a
command land on the previous canvas, which is the corruption the gate exists to
prevent. The two states are structurally identical at that instant and only a timeout
separates them, so nothing here writes.

## Verification

- `src/__tests__/services/stamp-target-disagreement-recovery.test.ts` — new; drives the
  **real** `UiBridge` over a real socket and the **real** tool handlers end to end: the
  refusal in the reported words, the capability verdict, the `panel_set_workflow_target`
  reply, and the `panel_add_node` mismatch diagnosis. Also pins the three states that
  must **not** fire it (agreeing session, canonical-id caller, absent stamp).
- Mutation-tested after committing: removing the capability check kills 4 tests,
  reverting `okBinding` kills the rebind-reply test, breaking the `gateStillRefuses`
  discriminator kills the diagnosis test, and swapping the verdict's argument order
  kills the source-level wiring test.
- `carried-stamp-wiring.test.ts` updated, not loosened: its old anchors named the
  inlined gate. It now pins both halves of the same property — the helper reads
  provenance from its **routed-tab** parameter, and `send()` passes
  `(opts.tabId, conn.tabId)` in that order.
- Full suite: **586 files, 10804 passed, 4 skipped, 0 failed**. `npm run lint` and
  `npm run check:vocabulary` clean.
- **No Playwright run**: this change touches no panel file (`comfyui-mcp-panel` is
  untouched), so there is nothing the sidebar renders differently. Stating that rather
  than implying coverage I do not have.

## Gate

codex was unavailable (account exhausted until 2026-08-19 per the standing note; still
exhausted at time of writing); gated by an independent adversarial review instead
(`.claude/autopilot/claude-gate.mjs`), which spawns a fresh reviewer that has not seen
this reasoning. Verdict recorded in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
