### PR TITLE
fix(panel#1497): panel_run takes the node id its own tools printed

### DIFF
--- a/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
+++ b/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
@@ -186,3 +186,68 @@ describe("#845(3): which args each action consumes", () => {
     expect(ignoredCanvasArgs("teleport", { node_id: 42, scale: 1 })).toEqual([]);
   });
 });
+
+// #1497 — the ONE argument #845 never reached.
+//
+// The reporter did exactly what the tool descriptions tell an agent to do: read
+// the id back out of panel_add_node (`"11"`, because summarizeNode returns
+// `id: node.id` and LiteGraph ids are strings on the modern frontend) and hand it
+// to panel_run as `to_node_id`. That call died in zod with
+// `expected number, received string` — the identical failure #845 fixed for the
+// other 27 node-id arguments and #427 hit on panel_create_group. A canonical
+// validator is adopted per CALL SITE; this call site was missed.
+//
+// The wire is unchanged: what the panel receives is still the NUMBER it has
+// always received. That matters beyond tidiness — two branches in panel_run gate
+// on `typeof args.to_node_id === "number"` (#772's stamp-race re-issue and #468's
+// run ticket), so a to_node_id that stayed a string would silently skip both.
+describe("#1497: panel_run accepts the node id its own tools printed", () => {
+  it("takes the string spelling panel_add_node returns", async () => {
+    const res = await callTool("panel_run", { to_node_id: "11" });
+    expect(res.isError).toBeFalsy();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].cmd).toBe("graph_run");
+    // Normalized to the number the panel has always been sent…
+    expect(sent[0].to_node_id).toBe(11);
+    // …and it really is a number, not the string that merely prints as one:
+    // #772/#468 both branch on typeof === "number".
+    expect(typeof sent[0].to_node_id).toBe("number");
+  });
+
+  it("still takes the numeric spelling", async () => {
+    const res = await callTool("panel_run", { to_node_id: 11 });
+    expect(res.isError).toBeFalsy();
+    expect(sent[0].to_node_id).toBe(11);
+  });
+
+  it("leaves a full run alone — an omitted to_node_id stays undefined", async () => {
+    const res = await callTool("panel_run", { batch_count: 2 });
+    expect(res.isError).toBeFalsy();
+    expect(sent[0].to_node_id).toBeUndefined();
+    expect(sent[0].batch_count).toBe(2);
+  });
+
+  // The half that must NOT widen. A run-to-node target is an EXECUTION ROOT, and
+  // the panel resolves it numerically the whole way down (findNodeInScopes matches
+  // on Number(id); the reply reports ran_to_node: Number(to_node_id)). Accepting
+  // "120:104" here would swap a clear schema refusal for a panel-side
+  // "node 120:104 was not found" about a node that plainly exists — and drop the
+  // #468 run ticket on the way. So it is still refused, but now BY NAME.
+  it("refuses a subgraph-qualified id, and says why", async () => {
+    const res = await callTool("panel_run", { to_node_id: "120:104" });
+    expect(res.isError).toBe(true);
+    expect(sent).toHaveLength(0); // nothing was dispatched
+    const msg = textOf(res);
+    expect(msg).toContain("plain integer node id");
+    expect(msg).toContain("execution root");
+  });
+
+  it("refuses ids that are not ids at all", async () => {
+    for (const bad of ["11px", "1.5", "", "abc", "1:", " 11"]) {
+      sent = [];
+      const res = await callTool("panel_run", { to_node_id: bad });
+      expect(res.isError, JSON.stringify(bad)).toBe(true);
+      expect(sent, JSON.stringify(bad)).toHaveLength(0);
+    }
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -919,12 +919,14 @@ describe("panel-tools: panel_run (run-to-node partial execution)", () => {
       "retry_of",
       "to_node_id",
     ]);
-    // to_node_id is an optional int — accepts a node id, rejects non-numbers,
-    // and (being optional) accepts undefined for a normal full run.
+    // to_node_id takes a node id in EITHER spelling the readers print (#1497 —
+    // 27 and "27" both mean node 27), rejects a non-id, and (being optional)
+    // accepts undefined for a normal full run.
     const toNode = def.schema.to_node_id as {
       safeParse: (v: unknown) => { success: boolean };
     };
     expect(toNode.safeParse(27).success).toBe(true);
+    expect(toNode.safeParse("27").success).toBe(true);
     expect(toNode.safeParse("x").success).toBe(false);
     expect(toNode.safeParse(undefined).success).toBe(true);
     // allow_duplicate is an optional boolean — defaults to the fenced behavior.

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -22,8 +22,18 @@
  * reader printed, all the way to the panel.
  */
 
-/** A plain integer id, the form the wire has always carried. */
-const PLAIN = /^-?\d+$/;
+/**
+ * A plain integer id, the form the wire has always carried.
+ *
+ * Exported because one argument needs this shape ON ITS OWN: panel_run's
+ * `to_node_id` (#1497). Everything else takes NODE_ID_PATTERN, which admits the
+ * qualified form too — but a run-to-node target is resolved by NUMBER all the way
+ * down (the panel's findNodeInScopes does `Number(id)`, and its reply reports
+ * `ran_to_node: Number(to_node_id)`), so admitting `"120:104"` there would trade a
+ * clear schema refusal for a panel-side "node not found" about a node that exists.
+ * The shape lives here so the two patterns cannot drift apart.
+ */
+export const PLAIN_NODE_ID_PATTERN = /^-?\d+$/;
 
 /**
  * A subgraph-qualified id: integer segments joined by colons (`120:104`,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -73,7 +73,12 @@ import {
 } from "../services/panel-workspace.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 import type { ScopeRepinOutcome } from "./turn-origins.js";
-import { NODE_ID_MESSAGE, NODE_ID_PATTERN, normalizeNodeId } from "./node-id.js";
+import {
+  NODE_ID_MESSAGE,
+  NODE_ID_PATTERN,
+  normalizeNodeId,
+  PLAIN_NODE_ID_PATTERN,
+} from "./node-id.js";
 import {
   parseContradictoryPromotedWidgetRefusal,
   resolveInnerPromotedTarget,
@@ -10545,6 +10550,42 @@ const nodeId = () =>
     .transform(normalizeNodeId);
 
 /**
+ * #1497 — the ONE node-id argument #845 never reached: panel_run's `to_node_id`.
+ *
+ * #845 made every panel tool accept back an id it had PRINTED, because the graph
+ * readers hand out ids as strings (`summarizeNode` returns `id: node.id`, and on
+ * the modern ComfyUI frontend that is `"11"`, not `11`). Twenty-seven node-id
+ * arguments adopted `nodeId()`; this one kept `z.number().int()` and was missed,
+ * so the documented round trip — take the id `panel_add_node` just returned, hand
+ * it to panel_run — failed with a raw `expected number, received string`, exactly
+ * as #845 described and #427 hit for panel_create_group. A canonical validator is
+ * adopted per CALL SITE, and this call site never adopted it.
+ *
+ * NOT `nodeId()`, deliberately. That helper also admits the subgraph-QUALIFIED
+ * shape (`"120:104"`, #1425) and passes it through as a string, which is right for
+ * a write that addresses a node by key. A run-to-node target is not addressed by
+ * key — it is an EXECUTION ROOT, resolved numerically the whole way down:
+ * the panel's `findNodeInScopes` matches on `Number(id)`, its reply reports
+ * `ran_to_node: Number(to_node_id)`, and two branches here (#772's stamp-race
+ * re-issue and #468's run ticket) gate on `typeof args.to_node_id === "number"`.
+ * Widening this argument to the qualified form would therefore turn a clear schema
+ * refusal into a panel-side "node 120:104 was not found" about a node that plainly
+ * exists, and silently drop the run ticket that correlates the completion. So the
+ * spelling widens and the SHAPE does not: `11` and `"11"` both mean node 11, and
+ * a qualified id is still refused — now by name, with a reason.
+ */
+const RUN_TO_NODE_ID_MESSAGE =
+  'a run-to-node target must be a plain integer node id — 42 or "42" both work. A subgraph-qualified id (e.g. "120:104") is not an execution root: pass the output node\'s own plain id, which is what panel_query_graph prints for it even when it is nested inside a subgraph';
+
+const runToNodeId = () =>
+  z
+    .union([
+      z.number().int(),
+      z.string().regex(PLAIN_NODE_ID_PATTERN, RUN_TO_NODE_ID_MESSAGE),
+    ])
+    .transform((v) => (typeof v === "number" ? v : Number.parseInt(v, 10)));
+
+/**
  * #845 — which `panel_canvas` arguments the chosen action actually consumes.
  *
  * The tool accepted node_id/dx/dy/scale for every action and forwarded them all,
@@ -12134,12 +12175,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .max(100)
           .optional()
           .describe("Times to queue (default 1)."),
-        to_node_id: z
-          .number()
-          .int()
+        to_node_id: runToNodeId()
           .optional()
           .describe(
-            "Output node id to render UP TO (partial execution). Omit to run the whole graph. Must be an OUTPUT node — one with is_output:true in panel_query_graph's detail rows. May be nested inside a subgraph (pass the node's own id).",
+            "Output node id to render UP TO (partial execution). Omit to run the whole graph. Must be an OUTPUT node — one with is_output:true in panel_query_graph's detail rows. May be nested inside a subgraph (pass the node's own id). Takes the id EXACTLY as the readers print it: 11 and \"11\" both mean node 11 (#1497). A subgraph-qualified id (\"120:104\") is not an execution root and is refused.",
           ),
         allow_duplicate: z
           .boolean()


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1497

## The report, and what it actually is

`panel_run({to_node_id:"11"})` came back with
`MCP error -32602: Input validation error: Invalid input: expected number, received string at to_node_id`.
The reporter had just taken `"11"` out of `panel_add_node`'s own reply — the round trip
the tool descriptions tell an agent to make.

That is not a new class of bug. It is **#845**, unfinished. The graph readers hand out ids
as strings (`summarizeNode` returns `id: node.id`, and LiteGraph ids are strings on the
modern ComfyUI frontend), so #845 made every panel tool accept back an id it had printed.
Twenty-seven node-id arguments adopted the `nodeId()` helper. `panel_run`'s `to_node_id`
kept `z.number().int()` and was missed — on `origin/main` it is the **only** node-id
argument in `panel-tools.ts` still spelled that way:

```
$ grep -c 'nodeId()' src/orchestrator/panel-tools.ts     # 27
$ grep -n  'node_id: z\.number' src/orchestrator/panel-tools.ts
12137:        to_node_id: z                                # ← the one
```

The linked #427 (`panel_create_group` string-vs-number set arithmetic) is the same root
cause, already closed by #845's sweep. A canonical validator is adopted **per call site**;
this call site never adopted it.

## The fix

`to_node_id` now takes either spelling and normalizes to the number the wire has always
carried: `11` and `"11"` both mean node 11.

Keeping the wire numeric is load-bearing, not cosmetic. Two branches inside `panel_run`
gate on `typeof args.to_node_id === "number"` — #772's certified stamp-race re-issue and
#468's run ticket (`toNodeId`) — so a `to_node_id` that stayed a string would have queued
fine and silently skipped both. There is a test asserting the forwarded value is a
`number`, not merely something that prints as one.

## What deliberately did NOT widen

The obvious move is to reuse `nodeId()`. That is the wrong helper here, and the reason is
the whole point of this PR.

`nodeId()` also admits the **subgraph-qualified** shape (`"120:104"`, #1425) and forwards
it *verbatim as a string*, which is correct for a write that addresses a node by key.
A run-to-node target is not addressed by key — it is an **execution root**, and it is
resolved numerically the whole way down:

- panel `web/js/lib/subgraph-scope.js` → `findNodeInScopes()` does `const num = Number(id)`
  and matches on it. `Number("120:104")` is `NaN`, which matches nothing.
- panel `comfyui-mcp-panel.js` reports `ran_to_node: Number(to_node_id)` and
  `ranToNode: Number(to_node_id)` in its reply.
- the two `typeof === "number"` branches named above.

There is a second reason, visible once you read the panel's resolver: a colon path is the
**output** of run-to-node resolution, not an input. `resolveRunToNodeTarget` returns
`execId` — `"10:15:359"` for a nested target, `String(id)` at root — and *that* is what
becomes ComfyUI's `partial_execution_targets`. It is computed from the live graph.
A caller-supplied `"120:104"` is lexically the same shape but a different thing entirely,
and letting one in through the front door invites it to be mistaken for the other.

So accepting a qualified id would have traded a clear schema refusal for a panel-side
*"node 120:104 was not found on the root graph or in any subgraph"* — about a node that
plainly exists — plus a dropped run ticket. It is still refused, but now **by name and
with a reason** (`RUN_TO_NODE_ID_MESSAGE`) instead of a raw zod type error.

The shape lives in `node-id.ts` as an exported `PLAIN_NODE_ID_PATTERN` (it was already
there as a dead `const PLAIN`) so the plain and qualified patterns cannot drift apart.

**Not done here, on purpose:** making run-to-node work *for* a qualified root id. That is
a real gap — `findNodeInScopes` never adopted the panel's own `canonicalNodeId()` from
#1425 — but it is a panel-side change to the execution-root resolver plus the two
`Number(to_node_id)` reply fields, in a different repo, and nothing in this report asks
for it. Widening the validator without it is exactly the trade this PR refuses.

## Verification

- **Mutation 1** — restore `z.number().int()`: 3 tests fail across 2 files
  (`takes the string spelling panel_add_node returns`,
  `refuses a subgraph-qualified id, and says why`,
  `exposes a batch_count + optional to_node_id schema`).
- **Mutation 2** — drop the numeric normalization (`.transform((v) => v)`): the
  `typeof … === "number"` assertion fails. Both restored, tree clean, fix committed
  *before* mutating.
- **Reachability** — the schema is the production path: both registration sites
  (`registerPanelTools` for the MCP SDK, `createPanelMcpServer` for the in-process
  Anthropic SDK) wrap `d.schema` in `strictPanelSchema()` = `z.object(shape).strict()`
  and hand the handler the parsed value. That is the same mechanism the other 27
  arguments already rely on, and the same one that produced the reporter's -32602.
- `npx tsc --noEmit` — clean.
- `npm run check:vocabulary` — OK (1721 files, no live dead names).
- `npx vitest run` — 10814 passed, 1 failed: `package-hooks.test.ts > every entry in
  \`files\` exists on disk`, `expected [ 'dist' ] to deeply equal []`. Pre-existing on any
  unbuilt worktree; this PR touches no packaging.
- **Browser suite not run.** This change is entirely orchestrator-side (MCP input schema);
  no panel file is touched and nothing the sidebar renders changes. Claiming Playwright
  coverage for it would be claiming coverage I did not take.

## Gate

codex was unavailable and this run was dispatched with the substitute gate named in the
autopilot brief, so the review was done by `.claude/autopilot/claude-gate.mjs` — a fresh
adversarial reviewer that has never seen the reasoning above. I did not re-probe codex
myself; the unavailability is the brief's standing note, not something I measured. This is
disclosed because disclosure is the condition the substitution was accepted under, and
because no self-review ever gates a merge here. Verdict recorded in a comment below.
