### PR TITLE
release: v0.52.27 — panel_run node id, stale tab, get_errors wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.27] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- panel_run takes the node id its own tools printed (#1874)
+- a stale tab advertisement stops being reported as a restored graph binding (#1868)
+- panel_get_errors waits as long as the panel is allowed to take (#1867)
+
+
 ## [0.52.26] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.26",
+  "version": "0.52.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.26",
+      "version": "0.52.27",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.26",
+  "version": "0.52.27",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.27 from `main`.

Carries:

- #1874 / panel#1497 — `panel_run` takes the node id its own tools printed
- #1868 / panel#1494 — a stale tab advertisement stops being reported as a restored graph binding
- #1867 / #1493 — `panel_get_errors` waits as long as the panel is allowed to take

Held out: #1851/#1847 CONFLICTING; #1839 anthropic 4 CI red; #1697 P1 reengaged this cycle; #1866/#1869/#1870 claimed this cycle.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.27` tag on the version commit). Tag is local; push `v0.52.27` after merge.