### PR TITLE
fix(1870): panel_update_node reports the Manager update-git error, not a stale generation traceback

### DIFF
--- a/src/__tests__/orchestrator/update-node-stale-traceback.test.ts
+++ b/src/__tests__/orchestrator/update-node-stale-traceback.test.ts
@@ -1,0 +1,259 @@
+// #1870 — panel_update_node reported a stale generation traceback as the
+// Manager update failure.
+//
+// The reporter called panel_update_node(id:"fal-api", version:"nightly") after
+// a ByteDance generation died with FalApiError HTTP 500. The pack is a Comfy
+// Registry zip (no nested .git). Manager's do_update stored the generic
+// sentence and logged `res.result=False, res.action=update-git`. The panel
+// (#1320) then attached /internal/logs/raw as "Manager traceback:" — and the
+// last traceback that named `fal-api` was the previous generation, not the
+// update.
+//
+// These tests drive the SHIPPED panel_update_node handler. A helper-only suite
+// would stay green if the handler never called it.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const disk = vi.hoisted(() => ({ root: undefined as string | undefined }));
+const mode = vi.hoisted(() => ({ remote: false }));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, isRemoteMode: () => mode.remote };
+});
+
+vi.mock("../../services/workspace-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/workspace-env.js")>();
+  return {
+    ...actual,
+    resolveEffectiveComfyUIBase: () => disk.root ?? actual.resolveEffectiveComfyUIBase(),
+  };
+});
+
+const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const PACK = "fal-api";
+const TAB = "11111111-2222-3333-4444-555555555555";
+
+const FAL_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\${PACK}\\nodes.py", line 88, in execute`,
+  '    raise FalApiError("Downstream service error (HTTP 500)")',
+  "FalApiError: Downstream service error (HTTP 500)",
+].join("\n");
+
+const UPDATE_GIT_LINE =
+  `ERROR: An error occurred while updating '${PACK}'. (res.result=False, res.action=update-git)`;
+
+const GENERIC = `An error occurred while updating '${PACK}'.`;
+
+/** The reporter's exact panel failure, as ctx.call surfaces it (fail() prefix). */
+function reportedFailure(traceback: string): string {
+  return (
+    `Error: Update of "${PACK}" FAILED: the ComfyUI-Manager task terminated with an ` +
+    `error (dialect v2): ${GENERIC}. The pack was NOT updated. Manager traceback:\n` +
+    traceback
+  );
+}
+
+const REAL_MANAGER_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\ComfyUI-Manager\\glob\\manager_core.py", line 2100, in repo_update`,
+  "    remote.fetch()",
+  "git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)",
+  "  cmdline: git fetch",
+  UPDATE_GIT_LINE,
+].join("\n");
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+function makeCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => "yes" as const,
+    tabId: TAB,
+  };
+  return { ctx, calls };
+}
+
+function zipPackRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "cmcp-1870-"));
+  mkdirSync(join(root, "custom_nodes", PACK), { recursive: true });
+  writeFileSync(join(root, "custom_nodes", PACK, "__init__.py"), "# zip install\n");
+  return root;
+}
+
+afterEach(() => {
+  if (disk.root) {
+    rmSync(disk.root, { recursive: true, force: true });
+    disk.root = undefined;
+  }
+  mode.remote = false;
+});
+
+describe("#1870 panel_update_node does not attach a stale generation traceback", () => {
+  it("THE REPORT: FalApiError is omitted; update-git is the Manager error", async () => {
+    disk.root = zipPackRoot();
+    const { ctx, calls } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(`${FAL_TB}\n${UPDATE_GIT_LINE}`) }],
+      isError: true,
+    });
+
+    const res = await defByName("panel_update_node").handler(
+      { id: PACK, version: "nightly" },
+      ctx,
+    );
+
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_update_node",
+      id: PACK,
+      version: "nightly",
+    });
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toMatch(/Update of "fal-api" FAILED/);
+    expect(text).toMatch(/res\.action=update-git/);
+    expect(text).toMatch(/res\.result=False/);
+    expect(text).not.toMatch(/FalApiError/);
+    expect(text).not.toMatch(/Downstream service error \(HTTP 500\)/);
+    expect(text).toMatch(/execution history, not this Manager update/);
+    expect(text).toMatch(/Comfy Registry zip/);
+    expect(text).toMatch(/install_custom_node \(action:"reinstall"/);
+    expect(text).toMatch(/panel_install_node/);
+  });
+
+  it("a generation traceback with no Manager evidence is dropped even without res.action", async () => {
+    // The panel's fallback extractor attaches the last traceback that NAMES the
+    // pack when it cannot find the generic ERROR line. That path still must not
+    // label FalApiError as the Manager update.
+    disk.root = zipPackRoot();
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(FAL_TB) }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler(
+      { id: PACK, version: "nightly" },
+      ctx,
+    );
+    const text = textOf(res);
+    expect(text).not.toMatch(/FalApiError/);
+    expect(text).toMatch(/execution history, not this Manager update/);
+    expect(text).toMatch(/Comfy Registry zip/);
+    expect(text).not.toMatch(/Manager traceback:/);
+  });
+
+  it("a real Manager update traceback is kept (GitCommandError in repo_update)", async () => {
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(REAL_MANAGER_TB) }],
+      isError: true,
+    });
+
+    const res = await defByName("panel_update_node").handler({ id: PACK, version: "nightly" }, ctx);
+    const text = textOf(res);
+    expect(text).toMatch(/GitCommandError/);
+    expect(text).toMatch(/repo_update/);
+    expect(text).toMatch(/res\.action=update-git/);
+    expect(text).not.toMatch(/execution history, not this Manager update/);
+  });
+
+  it("a successful update is not rewritten", async () => {
+    const ok = {
+      queued: true,
+      updated: true,
+      verified: true,
+      id: PACK,
+      note: "Update applied and VERIFIED by the ComfyUI-Manager task.",
+    };
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: JSON.stringify(ok) }],
+    });
+    const res = await defByName("panel_update_node").handler({ id: PACK }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toBe(JSON.stringify(ok));
+  });
+
+  it("an unrelated bridge failure is left alone", async () => {
+    const raw = 'Error: no connected tab with id "dead". Connected: none';
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: raw }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler({ id: PACK }, ctx);
+    expect(textOf(res)).toBe(raw);
+  });
+
+  it("does not claim a zip install when the disk could not be observed (remote)", async () => {
+    mode.remote = true;
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(`${FAL_TB}\n${UPDATE_GIT_LINE}`) }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler(
+      { id: PACK, version: "nightly" },
+      ctx,
+    );
+    const text = textOf(res);
+    expect(text).not.toMatch(/FalApiError/);
+    expect(text).toMatch(/res\.action=update-git/);
+    expect(text).not.toMatch(/Comfy Registry zip/);
+    expect(text).not.toMatch(/no nested \.git/);
+  });
+
+  it("does not re-route a git checkout as a zip", async () => {
+    const root = zipPackRoot();
+    mkdirSync(join(root, "custom_nodes", PACK, ".git"));
+    disk.root = root;
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(REAL_MANAGER_TB) }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler({ id: PACK, version: "nightly" }, ctx);
+    expect(textOf(res)).not.toMatch(/Comfy Registry zip/);
+    expect(textOf(res)).toMatch(/GitCommandError/);
+  });
+});
+
+describe("#1870 WIRING: the handler actually sanitizes", () => {
+  it("panel_update_node calls sanitizePanelUpdateNodeResult on the panel reply", () => {
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(
+      /import \{ sanitizePanelUpdateNodeResult \} from "\.\.\/services\/manager-update-error\.js";/,
+    );
+    const start = src.search(/def\(\r?\n\s*"panel_update_node"/);
+    expect(start).toBeGreaterThan(-1);
+    const end = src.search(/def\(\r?\n\s*"panel_node_queue_status"/);
+    expect(end).toBeGreaterThan(start);
+    const handler = src.slice(start, end);
+    expect(handler).toMatch(/sanitizePanelUpdateNodeResult\(res/);
+    expect(handler).toMatch(/cmd: "graph_update_node"/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -51,6 +51,7 @@ import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import { nodesInstallCommandArgs } from "../services/node-management.js";
+import { sanitizePanelUpdateNodeResult } from "../services/manager-update-error.js";
 import {
   formatQueueStatusPartialNote,
   getManifestPartialLeftover,
@@ -14729,10 +14730,19 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       },
       async (args: A, ctx) => {
         assertPanelNotTargetedUnverifiable("panel_update_node", args.id);
-        return ctx.call(
+        const res = await ctx.call(
           { cmd: "graph_update_node", id: args.id, version: args.version, channel: args.channel, mode: args.mode },
           30000,
         );
+        // #1870 — the panel attaches /internal/logs/raw as "Manager traceback"
+        // when do_update stores only the generic sentence. That log also holds
+        // the previous generation error, which names the same pack, so a zip
+        // update-git miss was reported as FalApiError. Keep Manager evidence
+        // (res.action=update-git) and drop execution history.
+        return sanitizePanelUpdateNodeResult(res, {
+          id: typeof args.id === "string" ? args.id : "",
+          version: typeof args.version === "string" ? args.version : undefined,
+        });
       },
     ),
     def(

--- a/src/services/manager-update-error.ts
+++ b/src/services/manager-update-error.ts
@@ -1,0 +1,219 @@
+/**
+ * #1870 — `panel_update_node` labeled a previous generation traceback as the
+ * Manager update traceback.
+ *
+ * The panel (#1320) fetches `/internal/logs/raw` when Manager stores only
+ * "An error occurred while updating 'X'." and attaches the last traceback that
+ * NAMES the pack. After a failed generation the log still holds that node's
+ * execution stack (`FalApiError: Downstream service error (HTTP 500)` in the
+ * report). For pack `fal-api` that stack names the pack, so it is attached as
+ * `Manager traceback:` while the Manager log only says
+ * `res.result=False, res.action=update-git`.
+ *
+ * The orchestrator keeps Manager task evidence (the generic update ERROR line,
+ * `res.action`/`res.result`, `do_update` / `repo_update` frames) and drops
+ * ComfyUI execution history. When `update-git` failed and the pack is a
+ * registry zip (no nested `.git`), it names that and re-routes to reinstall
+ * rather than leaving the reader debugging a stale generation error.
+ *
+ * Never throws: this runs on an error path, and a guard that becomes the error
+ * is strictly worse than the message it was improving.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  capturePackPresenceContext,
+  findPackOnDisk,
+} from "./node-management.js";
+
+const MANAGER_TRACEBACK_MARKER = /Manager traceback:\s*/i;
+
+/** Frames / log lines that belong to a Manager UPDATE, not a generation. */
+const MANAGER_UPDATE_EVIDENCE =
+  /\bdo_update\b|\bunified_update\b|\brepo_update\b|manager_server\.py|manager_core\.py|\bres\.action\s*=|\bres\.result\s*=/i;
+
+const GENERIC_UPDATE_LINE = /An error occurred while updating\s+'([^']+)'/i;
+
+const UPDATE_GIT = /res\.action\s*=\s*update-git/i;
+
+const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+
+export interface PanelUpdateFailureOpts {
+  id: string;
+  version?: string;
+}
+
+/**
+ * A ToolResult-shaped reply. Kept structural so this module does not import
+ * the orchestrator's type (panel-tools is the caller).
+ */
+export interface UpdateErrorToolResult {
+  content: Array<{ type: string; text?: string; [k: string]: unknown }>;
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+}
+
+function stripAnsi(line: string): string {
+  return line.replace(ANSI, "");
+}
+
+function isTracebackStart(line: string): boolean {
+  return /Traceback \(most recent call last\):/.test(line);
+}
+
+function isTracebackContinuation(line: string): boolean {
+  const s = stripAnsi(line);
+  if (!s.trim()) return true;
+  if (/^\s/.test(s)) return true;
+  if (isTracebackStart(s)) return true;
+  if (/During handling of the above exception/.test(s)) return true;
+  if (/The above exception was the direct cause/.test(s)) return true;
+  return /^[A-Za-z_][\w.]*(Error|Exception|Exit|Warning|Interrupt):/.test(s.trim());
+}
+
+/**
+ * True when `text` is evidence of the Manager UPDATE itself — not a node's
+ * generation failure that happens to name the same pack.
+ */
+export function isManagerUpdateEvidence(text: string): boolean {
+  return typeof text === "string" && MANAGER_UPDATE_EVIDENCE.test(text);
+}
+
+/**
+ * Observe whether the installed pack has a nested `.git`.
+ *
+ * `true`  — a git checkout (file or directory `.git`).
+ * `false` — the pack is on disk here and has no `.git` (registry zip / copy).
+ * `undefined` — we could not look (remote session, no root, pack not found,
+ *               unreadable). Absence of an observation is not "no git".
+ */
+export function observePackNestedGit(id: string): boolean | undefined {
+  try {
+    const ctx = capturePackPresenceContext();
+    if (ctx.remote || !ctx.diskRoot) return undefined;
+    const disk = findPackOnDisk(id, ctx.diskRoot);
+    if (disk.state !== "found") return undefined;
+    return existsSync(join(disk.dir, ".git"));
+  } catch {
+    return undefined;
+  }
+}
+
+function nonGitRegistryNote(id: string): string {
+  return (
+    `NOTE: "${id}" is installed as a Comfy Registry zip (no nested .git), so ` +
+    `Manager's update-git cannot pull a nightly/git HEAD. The pack was NOT ` +
+    `git-updated. Reinstall it from the registry instead: install_custom_node ` +
+    `(action:"reinstall", id:"${id}") — or panel_install_node with the same id. ` +
+    `Nightly needs a git checkout; a zip-installed pack cannot be git-updated.`
+  );
+}
+
+function collectTracebackAt(lines: string[], start: number): string[] | null {
+  if (start < 0 || start >= lines.length || !isTracebackStart(lines[start])) return null;
+  const out = [lines[start]];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (!isTracebackContinuation(lines[i])) break;
+    out.push(lines[i]);
+  }
+  while (out.length && !out[out.length - 1].trim()) out.pop();
+  return out.length ? out : null;
+}
+
+/**
+ * Keep Manager-task lines from an attached traceback; drop execution-history
+ * frames. Returns `{ kept, droppedExecution }` so the caller can disclose the
+ * omission rather than silently shrinking the message.
+ */
+export function keepManagerUpdateEvidence(traceback: string): {
+  kept: string;
+  droppedExecution: boolean;
+} {
+  const lines = traceback.split(/\r?\n/).map(stripAnsi);
+  const kept: string[] = [];
+  let droppedExecution = false;
+  let i = 0;
+  while (i < lines.length) {
+    if (isTracebackStart(lines[i])) {
+      const block = collectTracebackAt(lines, i);
+      if (!block) {
+        i += 1;
+        continue;
+      }
+      i += block.length;
+      if (isManagerUpdateEvidence(block.join("\n"))) {
+        kept.push(block.join("\n").trimEnd());
+      } else {
+        droppedExecution = true;
+      }
+      continue;
+    }
+    const line = lines[i].trimEnd();
+    if (GENERIC_UPDATE_LINE.test(line) || /\bres\.(action|result)\s*=/.test(line)) {
+      kept.push(line.trim());
+    }
+    i += 1;
+  }
+  return { kept: kept.join("\n").trim(), droppedExecution };
+}
+
+function wantsNonGitReroute(message: string, version: string | undefined): boolean {
+  if (UPDATE_GIT.test(message)) return true;
+  return typeof version === "string" && version.trim().toLowerCase() === "nightly";
+}
+
+/**
+ * Rewrite a `panel_update_node` failure so Manager task evidence is not mixed
+ * with ComfyUI execution history. Identity when there is nothing to change.
+ */
+export function sanitizePanelUpdateFailure(
+  message: string,
+  opts: PanelUpdateFailureOpts,
+): string {
+  if (typeof message !== "string" || !message) return message;
+
+  let out = message;
+  const marker = MANAGER_TRACEBACK_MARKER.exec(message);
+  if (marker && marker.index !== undefined) {
+    const head = message.slice(0, marker.index).trimEnd();
+    const tb = message.slice(marker.index + marker[0].length);
+    const { kept, droppedExecution } = keepManagerUpdateEvidence(tb);
+    if (droppedExecution) {
+      const omitted =
+        " (The previous ComfyUI generation traceback is execution history, not this Manager update, and was omitted.)";
+      out = kept
+        ? `${head}${omitted} Manager traceback:\n${kept}`
+        : `${head}${omitted}`;
+    }
+  }
+
+  if (wantsNonGitReroute(out, opts.version) && observePackNestedGit(opts.id) === false) {
+    const note = nonGitRegistryNote(opts.id);
+    if (!out.includes(note)) out = `${out.trimEnd()}\n\n${note}`;
+  }
+  return out;
+}
+
+/**
+ * Post-process the ToolResult `panel_update_node` got from the panel. Success
+ * and unrelated failures pass through. Never throws.
+ */
+export function sanitizePanelUpdateNodeResult<T extends UpdateErrorToolResult>(
+  res: T,
+  opts: PanelUpdateFailureOpts,
+): T {
+  try {
+    if (!res?.isError || !Array.isArray(res.content)) return res;
+    const idx = res.content.findIndex((c) => c.type === "text" && typeof c.text === "string");
+    if (idx < 0) return res;
+    const text = res.content[idx].text ?? "";
+    const cleaned = sanitizePanelUpdateFailure(text, opts);
+    if (cleaned === text) return res;
+    const content = res.content.slice();
+    content[idx] = { ...content[idx], text: cleaned };
+    return { ...res, content };
+  } catch {
+    return res;
+  }
+}


### PR DESCRIPTION
Fixes #1870

## What was reported

`panel_update_node(id:"fal-api", version:"nightly")` failed because the installed registry pack has no nested `.git`, but the tool labeled the previous ByteDance generation traceback as the Manager update traceback:

```
Error: Update of "fal-api" FAILED ... Manager traceback:
FalApiError: Downstream service error (HTTP 500)
```

while the Manager log only said `res.result=False, res.action=update-git`.

## Why

The panel (#1320) fetches `/internal/logs/raw` when Manager stores only `An error occurred while updating 'X'.` and attaches the last traceback that **names the pack**. After a failed generation that log still holds the node's execution stack. For pack `fal-api` that stack names the pack, so it is attached as `Manager traceback:` even though it is ComfyUI execution history, not this update.

## The fix

`panel_update_node` still dispatches `graph_update_node`. On a failure the orchestrator now:

1. Keeps Manager task evidence (`res.action=update-git`, `do_update` / `repo_update` frames, the generic update ERROR line).
2. Drops generation/execution frames (the reporter's `FalApiError`) instead of labeling them as the Manager traceback.
3. When `update-git` failed (or `version:"nightly"` was requested) **and** the pack is observably a registry zip (on disk here, no nested `.git`), names that and re-routes to `install_custom_node (action:"reinstall")` / `panel_install_node`. A remote session that cannot look at disk does not invent a zip install.

A real Manager traceback (`GitCommandError` in `repo_update`) is unchanged. Successes and unrelated bridge failures pass through.

## Verification

`src/__tests__/orchestrator/update-node-stale-traceback.test.ts` drives the shipped `panel_update_node` handler:

- the reporter's FalApiError + `update-git` zip install
- a generation traceback with no Manager evidence
- a real `repo_update` GitCommandError (kept)
- success / unrelated error pass-through
- remote session does not claim a zip install
- a git checkout is not re-routed as a zip
- source wiring: the handler calls `sanitizePanelUpdateNodeResult`

`npx tsc --noEmit` clean.
`npx vitest run --maxWorkers=4 src/__tests__/orchestrator/update-node-stale-traceback.test.ts src/__tests__/services/panel-pin-guard.test.ts src/__tests__/services/manager-error-body.test.ts` — 132 passed.
