### PR TITLE
fix(1869): validate_workflow no longer flags action-button tokens as widget values

### DIFF
--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -32,7 +32,7 @@ Author and check ComfyUI workflow JSON. Driven by the `action` parameter:
   action:"create" — Template parameters; recognized keys depend on the template. txt2img: checkpoint, positive_prompt, negative_prompt, width, height, steps, cfg, seed, sampler_name, scheduler. img2img/inpaint add image_path (and mask_path for inpaint) and denoise. upscale adds upscale_model. Unknown keys are ignored; omitted keys use template defaults.
 </ParamField>
 <ParamField path="workflow" type="string | object">
-  ComfyUI workflow JSON (as a JSON string or object). REQUIRED for action:"modify" and action:"validate" — API format for "validate".
+  ComfyUI workflow JSON (as a JSON string or object). REQUIRED for action:"modify" and action:"validate". action:"validate" accepts API format or a saved UI export (nodes[]/links[]).
 </ParamField>
 <ParamField path="operations" type="object[]">
   action:"modify" (REQUIRED) — Array of operations to apply in order. Each has an 'op' field: set_input, add_node, remove_node, connect, or insert_between

--- a/src/__tests__/services/live-widget-overlay.test.ts
+++ b/src/__tests__/services/live-widget-overlay.test.ts
@@ -71,13 +71,17 @@ const nameKeyedState = () => ({
 });
 
 describe("#959: the bug, reproduced", () => {
-  // This is the failure the three reports describe. It is asserted deliberately:
-  // if this test ever stops failing on its own, the positional path changed and
-  // the overlay below is no longer testing what it claims to.
-  it("without the capture, the wildcard STRING is emitted as the seed", () => {
+  // #1869 taught the positional path to skip a STRING sitting on an INT, so the
+  // seed now gets 101 instead of the wildcard token. The FRONTEND still serializes
+  // wildcards BEFORE seed, so that skipped token is never offered to `wildcards`
+  // — the combo falls back to its default. Named capture remains the only path
+  // that can recover a reordered widget the schema has already walked past.
+  // If wildcards starts matching without a capture, the overlay below is no
+  // longer testing the disagreement it claims to.
+  it("without the capture, the reordered wildcard never lands on its own widget", () => {
     const { workflow } = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
-    expect(workflow["296"].inputs.seed).toBe(WILDCARD);
-    expect(workflow["296"].inputs.seed).not.toBe(101);
+    expect(workflow["296"].inputs.seed).toBe(101);
+    expect(workflow["296"].inputs.wildcards).not.toBe(WILDCARD);
   });
 });
 
@@ -97,12 +101,10 @@ describe("#959: the capture fixes it", () => {
     expect(workflow["296"].inputs.wildcard_text).toBe("a cat");
   });
 
-  // The shift compounds: `seed` is an INT with control_after_generate, so the
-  // positional pass consumes a PHANTOM slot after it. Having already taken the
-  // wildcard string as the seed, it then swallows the real seed as that phantom
-  // and runs out of values — so `wildcards` is never assigned at all and falls
-  // back to the node default. One inverted pair costs BOTH widgets, and nothing
-  // in the output says so.
+  // The frontend serializes wildcards BEFORE seed. The positional pass now
+  // skips that STRING off the INT seed (#1869) and assigns 101, but the skipped
+  // token is gone — `wildcards` is never offered it and falls back to the node
+  // default. Named capture is what restores both widgets.
   it("the trailing widget is lost entirely, not merely misassigned", () => {
     const before = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
     expect(before.workflow["296"].inputs.wildcards).not.toBe(WILDCARD);

--- a/src/__tests__/services/live-widget-overlay.test.ts
+++ b/src/__tests__/services/live-widget-overlay.test.ts
@@ -71,17 +71,13 @@ const nameKeyedState = () => ({
 });
 
 describe("#959: the bug, reproduced", () => {
-  // #1869 taught the positional path to skip a STRING sitting on an INT, so the
-  // seed now gets 101 instead of the wildcard token. The FRONTEND still serializes
-  // wildcards BEFORE seed, so that skipped token is never offered to `wildcards`
-  // — the combo falls back to its default. Named capture remains the only path
-  // that can recover a reordered widget the schema has already walked past.
-  // If wildcards starts matching without a capture, the overlay below is no
-  // longer testing the disagreement it claims to.
-  it("without the capture, the reordered wildcard never lands on its own widget", () => {
+  // This is the failure the three reports describe. It is asserted deliberately:
+  // if this test ever stops failing on its own, the positional path changed and
+  // the overlay below is no longer testing what it claims to.
+  it("without the capture, the wildcard STRING is emitted as the seed", () => {
     const { workflow } = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
-    expect(workflow["296"].inputs.seed).toBe(101);
-    expect(workflow["296"].inputs.wildcards).not.toBe(WILDCARD);
+    expect(workflow["296"].inputs.seed).toBe(WILDCARD);
+    expect(workflow["296"].inputs.seed).not.toBe(101);
   });
 });
 
@@ -101,10 +97,12 @@ describe("#959: the capture fixes it", () => {
     expect(workflow["296"].inputs.wildcard_text).toBe("a cat");
   });
 
-  // The frontend serializes wildcards BEFORE seed. The positional pass now
-  // skips that STRING off the INT seed (#1869) and assigns 101, but the skipped
-  // token is gone — `wildcards` is never offered it and falls back to the node
-  // default. Named capture is what restores both widgets.
+  // The shift compounds: `seed` is an INT with control_after_generate, so the
+  // positional pass consumes a PHANTOM slot after it. Having already taken the
+  // wildcard string as the seed, it then swallows the real seed as that phantom
+  // and runs out of values — so `wildcards` is never assigned at all and falls
+  // back to the node default. One inverted pair costs BOTH widgets, and nothing
+  // in the output says so.
   it("the trailing widget is lost entirely, not merely misassigned", () => {
     const before = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
     expect(before.workflow["296"].inputs.wildcards).not.toBe(WILDCARD);

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -443,9 +443,17 @@ describe("convertUiToApi — serialized-widget nodes (has_serialized_properties)
   it("without the flag the positional mapping is untouched (stale property copies can't hijack normal nodes)", () => {
     const { workflow } = convertUiToApi(directorGraph(false), DIRECTOR_INFO);
     const inputs = (workflow["1316"] as { inputs: Record<string, unknown> }).inputs;
-    // positional (mis)mapping proceeds as before — the point is only that
-    // properties did NOT override it: frame_rate keeps whatever slot landed there.
-    expect(inputs.frame_rate).not.toBe(24);
+    // The point of this test is that `properties` did NOT override the
+    // positional pass. `frame_rate !== 24` used to stand in for that, but it no
+    // longer can: the three BOOLEAN widgets refuse the STRING values sitting on
+    // them, so #1869's extras-skipping realigns the TAIL and it now arrives at
+    // 24 positionally — the same answer properties would have given. Assert the
+    // HEAD instead, which nothing can realign and which properties would have
+    // corrected if it were being consulted.
+    expect(inputs.timeline_data).toBe("15"); // properties say '{"mainTrackEnabled":true}'
+    expect(inputs.epsilon).toBe("360"); // properties say 0.001
+    expect(inputs.start_second).toBe("0"); // properties say the NUMBER 0
+    expect(inputs["Node name for S&R"]).toBeUndefined();
   });
 });
 
@@ -3602,5 +3610,78 @@ describe("convertUiToApi — serialized action buttons must not shift widget val
     // `hello` is a plain value, not a button token — the extra trailing entry
     // must NOT promote it out of its own slot.
     expect(workflow["4"].inputs.text).toBe("hello");
+  });
+});
+
+// Independent review of the first cut broke it four ways. Every case below is a
+// SILENT WRONG VALUE — the converter emitted a plausible graph carrying someone
+// else's data — which is strictly worse than the misalignment being fixed. The
+// common cause was matching the general SHAPE of an identifier and then trying
+// to corroborate the skip positionally: that can tell something in the gap does
+// not belong, but not WHICH, and it always dropped the first.
+describe("convertUiToApi — extras-skipping must never eat a legitimate value (#1869 review)", () => {
+  const oneNode = (type: string, widgets_values: unknown[]) =>
+    ({
+      nodes: [{ id: 1, type, mode: 0, inputs: [], outputs: [], widgets_values }],
+      links: [],
+    }) as never;
+
+  it("keeps a snake_case STRING that merely LOOKS like a button token", () => {
+    const { workflow } = convertUiToApi(
+      oneNode("N", ["my_path", "label", "detect_range", 12]),
+      {
+        N: {
+          input: {
+            required: {
+              path: ["STRING", {}],
+              label: ["STRING", {}],
+              first_frame: ["INT", {}],
+            },
+          },
+          output: [],
+        },
+      } as never,
+    );
+    expect(workflow["1"].inputs.path).toBe("my_path");
+    expect(workflow["1"].inputs.label).toBe("label");
+    expect(workflow["1"].inputs.first_frame).toBe(12);
+  });
+
+  // #361: a stale asset value must be PRESERVED so it surfaces as a missing-asset
+  // error. Skipping it replaced the checkpoint name with a button token, and the
+  // resulting warning then named the WRONG value as the one the user declared.
+  it("preserves a stale asset value instead of skipping it (#361)", () => {
+    const { workflow } = convertUiToApi(
+      oneNode("N", ["my_model", "detect_range", 12]),
+      {
+        N: {
+          input: {
+            required: {
+              ckpt_name: [["a.safetensors"], {}],
+              first_frame: ["INT", {}],
+            },
+          },
+          output: [],
+        },
+      } as never,
+    );
+    expect(workflow["1"].inputs.ckpt_name).toBe("my_model");
+    expect(workflow["1"].inputs.first_frame).toBe(12);
+  });
+
+  // ComfyUI coerces these itself, and frontends serialize both shapes. Treating
+  // them as type mismatches DROPPED a real widget value.
+  it("accepts a BOOLEAN serialized as 0/1", () => {
+    const { workflow } = convertUiToApi(oneNode("N", [0, "browse"]), {
+      N: { input: { required: { enabled: ["BOOLEAN", {}] } }, output: [] },
+    } as never);
+    expect(workflow["1"].inputs.enabled).toBe(0);
+  });
+
+  it("accepts an INT serialized as a numeric STRING", () => {
+    const { workflow } = convertUiToApi(oneNode("N", ["1024", "browse"]), {
+      N: { input: { required: { width: ["INT", {}] } }, output: [] },
+    } as never);
+    expect(workflow["1"].inputs.width).toBe("1024");
   });
 });

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3453,3 +3453,102 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
     ).toBe(true);
   });
 });
+
+// #1869 — AMVideoRead/AMVideoWrite serialize frontend action buttons into
+// widgets_values (`browse`, `open_in_explorer`, `copy_path` above file_path,
+// and interspersed `detect_range` before first_frame). Those buttons are
+// absent from /object_info, so pairing from slot 0 used to land them on
+// real inputs (`frame_mode='open_in_explorer'`, `first_frame='copy_path'`).
+describe("convertUiToApi — serialized action buttons must not shift widget values (#1869)", () => {
+  const AM_VIDEO_READ = {
+    input: {
+      required: {
+        file_path: ["STRING", { default: "" }],
+        frame_mode: [["single", "range", "all"], { default: "all" }],
+        first_frame: ["INT", { default: 1 }],
+        last_frame: ["INT", { default: -1 }],
+      },
+    },
+    output: ["IMAGE"],
+    output_node: true,
+  };
+
+  const FILE_PATH = "D:/shots/plate.mov";
+  const FRAME_MODE = "range";
+  const FIRST_FRAME = 12;
+  const LAST_FRAME = 48;
+
+  it("skips prefix and interspersed action-button tokens on AMVideoRead", () => {
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "AMVideoRead",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [
+            "browse",
+            "open_in_explorer",
+            "copy_path",
+            FILE_PATH,
+            FRAME_MODE,
+            "detect_range",
+            FIRST_FRAME,
+            LAST_FRAME,
+          ],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, { AMVideoRead: AM_VIDEO_READ } as never);
+    expect(workflow["1"].inputs.file_path).toBe(FILE_PATH);
+    expect(workflow["1"].inputs.frame_mode).toBe(FRAME_MODE);
+    expect(workflow["1"].inputs.first_frame).toBe(FIRST_FRAME);
+    expect(workflow["1"].inputs.last_frame).toBe(LAST_FRAME);
+    expect(workflow["1"].inputs.file_path).not.toBe("browse");
+    expect(workflow["1"].inputs.frame_mode).not.toBe("open_in_explorer");
+    expect(workflow["1"].inputs.first_frame).not.toBe("copy_path");
+    expect(workflow["1"].inputs.first_frame).not.toBe("detect_range");
+  });
+
+  it("skips prefix action-button tokens on AMVideoWrite (no detect_range)", () => {
+    const codec = "h264";
+    const outPath = "D:/out/shot.mov";
+    const ui = {
+      nodes: [
+        {
+          id: 2,
+          type: "AMVideoWrite",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [
+            "browse",
+            "open_in_explorer",
+            "copy_path",
+            outPath,
+            codec,
+          ],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, {
+      AMVideoWrite: {
+        input: {
+          required: {
+            file_path: ["STRING", { default: "" }],
+            codec: [["h264", "prores", "dnxhr"], { default: "h264" }],
+          },
+        },
+        output: [],
+        output_node: true,
+      },
+    } as never);
+    expect(workflow["2"].inputs.file_path).toBe(outPath);
+    expect(workflow["2"].inputs.codec).toBe(codec);
+    expect(workflow["2"].inputs.file_path).not.toBe("browse");
+    expect(workflow["2"].inputs.codec).not.toBe("open_in_explorer");
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3551,4 +3551,56 @@ describe("convertUiToApi — serialized action buttons must not shift widget val
     expect(workflow["2"].inputs.file_path).not.toBe("browse");
     expect(workflow["2"].inputs.codec).not.toBe("open_in_explorer");
   });
+
+  // The two cases below are the SAME SHAPE to a positional pass — one loose
+  // STRING slot, one extra value, a lowercase-identifier candidate. Only the
+  // token itself distinguishes them, so the uncorroborated path is allowed to
+  // skip a button we have actually seen serialized and nothing else.
+  it("skips an action prefix when no downstream widget can corroborate it", () => {
+    const ui = {
+      nodes: [
+        {
+          id: 3,
+          type: "AMPathOnly",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["browse", "D:/out.mov", "final take"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, {
+      AMPathOnly: {
+        input: {
+          required: { file_path: ["STRING", {}], note: ["STRING", {}] },
+        },
+        output: [],
+      },
+    } as never);
+    expect(workflow["3"].inputs.file_path).toBe("D:/out.mov");
+    expect(workflow["3"].inputs.note).toBe("final take");
+  });
+
+  it("leaves an ordinary lowercase STRING alone when nothing corroborates a skip", () => {
+    const ui = {
+      nodes: [
+        {
+          id: 4,
+          type: "PlainText",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["hello", "Extra Thing"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, {
+      PlainText: { input: { required: { text: ["STRING", {}] } }, output: [] },
+    } as never);
+    // `hello` is a plain value, not a button token — the extra trailing entry
+    // must NOT promote it out of its own slot.
+    expect(workflow["4"].inputs.text).toBe("hello");
+  });
 });

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3684,4 +3684,46 @@ describe("convertUiToApi — extras-skipping must never eat a legitimate value (
     } as never);
     expect(workflow["1"].inputs.width).toBe("1024");
   });
+
+  // The known-token list cannot cover every pack's buttons, so the type signal
+  // has to carry the ones it has never seen. It is the ONLY thing that can
+  // recover a button sitting mid-row on a numeric widget — a prefix rule cannot
+  // see it, and the vocabulary does not know it.
+  it("skips an UNKNOWN button token that lands on a numeric widget", () => {
+    const { workflow } = convertUiToApi(
+      oneNode("N", ["D:/x.mov", "recalculate_everything", 12]),
+      {
+        N: {
+          input: { required: { file_path: ["STRING", {}], frames: ["INT", {}] } },
+          output: [],
+        },
+      } as never,
+    );
+    expect(workflow["1"].inputs.file_path).toBe("D:/x.mov");
+    expect(workflow["1"].inputs.frames).toBe(12);
+  });
+
+  // Three BOOLEANs in a row refusing three STRINGs is what realigns the TAIL of
+  // a badly-shifted custom node (LTXDirector, above) even though its head is
+  // unrecoverable. Pin it directly rather than leaning on that test.
+  it("realigns a run of BOOLEANs that STRING values had shifted", () => {
+    const { workflow } = convertUiToApi(
+      oneNode("N", ["a", "b", "c", true, false, 7]),
+      {
+        N: {
+          input: {
+            required: {
+              flag_a: ["BOOLEAN", {}],
+              flag_b: ["BOOLEAN", {}],
+              count: ["INT", {}],
+            },
+          },
+          output: [],
+        },
+      } as never,
+    );
+    expect(workflow["1"].inputs.flag_a).toBe(true);
+    expect(workflow["1"].inputs.flag_b).toBe(false);
+    expect(workflow["1"].inputs.count).toBe(7);
+  });
 });

--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -182,3 +182,59 @@ describe("validateWorkflow — graph-health merge", () => {
     expect(r.issues.some((i) => i.kind)).toBe(false);
   });
 });
+
+// #1869 — validate_workflow on a saved UI graph used to report false
+// type/enum errors because action-button tokens serialized into
+// widgets_values were paired against /object_info from slot 0.
+describe("validateWorkflow — UI graph with serialized action buttons (#1869)", () => {
+  const AM_OBJECT_INFO = {
+    AMVideoRead: {
+      input: {
+        required: {
+          file_path: ["STRING", { default: "" }],
+          frame_mode: [["single", "range", "all"], { default: "all" }],
+          first_frame: ["INT", { default: 1 }],
+          last_frame: ["INT", { default: -1 }],
+        },
+      },
+      output: ["IMAGE"],
+      output_node: true,
+    },
+  } as const;
+
+  const FILE_PATH = "D:/shots/plate.mov";
+  const uiWorkflow = {
+    nodes: [
+      {
+        id: 1,
+        type: "AMVideoRead",
+        mode: 0,
+        inputs: [],
+        outputs: [{ name: "IMAGE", type: "IMAGE", links: null }],
+        widgets_values: [
+          "browse",
+          "open_in_explorer",
+          "copy_path",
+          FILE_PATH,
+          "range",
+          "detect_range",
+          12,
+          48,
+        ],
+      },
+    ],
+    links: [],
+  } as unknown as WorkflowJSON;
+
+  it("does not report action-button tokens as combo/enum errors", async () => {
+    getObjectInfoMock.mockResolvedValue(AM_OBJECT_INFO);
+    const r = await validateWorkflow(uiWorkflow, { health: false });
+    const text = r.issues.map((i) => i.message).join("\n");
+    expect(text).not.toMatch(/open_in_explorer/);
+    expect(text).not.toMatch(/copy_path/);
+    expect(text).not.toMatch(/detect_range/);
+    expect(r.issues.filter((i) => i.kind === "value_not_in_list")).toHaveLength(0);
+    expect(r.issues.filter((i) => i.severity === "error")).toHaveLength(0);
+    expect(r.valid).toBe(true);
+  });
+});

--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -183,8 +183,8 @@ describe("validateWorkflow — graph-health merge", () => {
   });
 });
 
-// #1869 — validate_workflow on a saved UI graph used to report false
-// type/enum errors because action-button tokens serialized into
+// #1869 — create_workflow (action:"validate") on a saved UI graph used to report
+// false type/enum errors because action-button tokens serialized into
 // widgets_values were paired against /object_info from slot 0.
 describe("validateWorkflow — UI graph with serialized action buttons (#1869)", () => {
   const AM_OBJECT_INFO = {

--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -237,4 +237,35 @@ describe("validateWorkflow — UI graph with serialized action buttons (#1869)",
     expect(r.issues.filter((i) => i.severity === "error")).toHaveLength(0);
     expect(r.valid).toBe(true);
   });
+
+  // The converter DROPS a node whose type object_info doesn't know, so the
+  // per-node check never sees it. Reporting only a conversion warning made the
+  // SAME uninstalled custom node an error in API format and a `valid: true`
+  // workflow in UI format — a false green on the one thing validation is for.
+  it("still reports an uninstalled custom node as an ERROR, not a warning", async () => {
+    getObjectInfoMock.mockResolvedValue({
+      SaveImage: { input: { required: { images: ["IMAGE"] } }, output: [] },
+    });
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TotallyNotInstalled",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [],
+    } as unknown as WorkflowJSON;
+
+    const r = await validateWorkflow(ui, { health: false });
+    const missing = r.issues.filter((i) => i.kind === "missing_node_type");
+    expect(missing).toHaveLength(1);
+    expect(missing[0].severity).toBe("error");
+    expect(missing[0].node_id).toBe("1");
+    expect(missing[0].node_type).toBe("TotallyNotInstalled");
+    expect(r.valid).toBe(false);
+  });
 });

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -575,6 +575,191 @@ function getOrderedInputNames(def: ComfyUINodeDef): string[] {
   return names;
 }
 
+function widgetSpecOf(def: ComfyUINodeDef, name: string): unknown {
+  return (
+    (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
+    (def.input?.optional as Record<string, unknown> | undefined)?.[name]
+  );
+}
+
+function isAssetComboSpec(name: string, spec: unknown, classType: string): boolean {
+  return (
+    ASSET_WIDGET_NAMES.has(name) ||
+    isKnownLoaderInput(classType, name) ||
+    isUploadSelectorSpec(spec)
+  );
+}
+
+/**
+ * INT / FLOAT / BOOLEAN (including combined FLOAT,INT). These can never
+ * legitimately hold a serialized action-button token, so a type mismatch is
+ * always safe to skip — even when the row length already matches the schema.
+ */
+function numericOrBooleanParts(spec: unknown): string[] | undefined {
+  if (!Array.isArray(spec)) return undefined;
+  const type = spec[0];
+  const cfg = spec[1] as { widgetType?: unknown } | undefined;
+  const t = typeof cfg?.widgetType === "string" ? cfg.widgetType : type;
+  if (typeof t !== "string") return undefined;
+  const parts = t.split(",").map((s) => s.trim()).filter(Boolean);
+  if (parts.length === 0) return undefined;
+  if (!parts.every((p) => p === "INT" || p === "FLOAT" || p === "BOOLEAN")) {
+    return undefined;
+  }
+  return parts;
+}
+
+function valueFitsNumericOrBoolean(value: unknown, parts: string[]): boolean {
+  if (parts.length === 1 && parts[0] === "BOOLEAN") return typeof value === "boolean";
+  if (parts.includes("INT") && !parts.includes("FLOAT")) {
+    return typeof value === "number" && Number.isInteger(value);
+  }
+  return typeof value === "number";
+}
+
+function valueFitsEnum(value: unknown, spec: unknown): boolean {
+  const comboOpts = getComboOptions(spec);
+  return Array.isArray(comboOpts) && comboOpts.includes(value as never);
+}
+
+/**
+ * Saved-row length vs remaining schema slots. Undefined when a later
+ * dynamic combo makes nested arity unknowable — extras-skipping must then
+ * stay off (a guess would be the same silent shift this exists to prevent).
+ */
+function remainingPositionalSlots(
+  widgetNames: string[],
+  fromIdx: number,
+  def: ComfyUINodeDef,
+): number | undefined {
+  let n = 0;
+  for (let i = fromIdx; i < widgetNames.length; i++) {
+    const spec = widgetSpecOf(def, widgetNames[i]);
+    const type = Array.isArray(spec) ? spec[0] : undefined;
+    if (type === "COMFY_DYNAMICCOMBO_V3") return undefined;
+    n += 1;
+    if (hasControlAfterGenerate(widgetNames[i], def)) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Frontend-only action buttons (`addWidget("button", …)`) serialize their
+ * value token into `widgets_values` and are absent from /object_info, so
+ * pairing from slot 0 lands `browse`/`open_in_explorer`/`copy_path` on
+ * real inputs and shifts the rest — including an interspersed `detect_range`
+ * sitting between a combo and an INT (#1869).
+ *
+ * Snake-case identifier matching the LiteGraph button default-value shape.
+ * Used only when the saved row is LONGER than the schema, so a same-length
+ * stale combo (the #504 substitute path) is left alone.
+ */
+const SERIALIZED_ACTION_BUTTON_VALUE = /^[a-z][a-z0-9_]*$/;
+
+function looksLikeSerializedActionButton(value: unknown): boolean {
+  return typeof value === "string" && SERIALIZED_ACTION_BUTTON_VALUE.test(value);
+}
+
+/**
+ * Advance past serialized frontend-only extras that cannot belong to this
+ * schema widget. Returns the index of the first value that should be paired.
+ */
+function skipSerializedActionWidgets(opts: {
+  values: unknown[];
+  widgetIdx: number;
+  spec: unknown;
+  name: string;
+  classType: string;
+  def: ComfyUINodeDef;
+  widgetNames: string[];
+  nameIdx: number;
+}): number {
+  let widgetIdx = opts.widgetIdx;
+  const { values, spec, name, classType, def, widgetNames, nameIdx } = opts;
+  const nbParts = numericOrBooleanParts(spec);
+
+  while (widgetIdx < values.length) {
+    const candidate = values[widgetIdx];
+    if (nbParts && !valueFitsNumericOrBoolean(candidate, nbParts)) {
+      widgetIdx++;
+      continue;
+    }
+
+    const remainingSlots = remainingPositionalSlots(widgetNames, nameIdx, def);
+    const extras =
+      remainingSlots === undefined
+        ? 0
+        : Math.max(0, values.length - widgetIdx - remainingSlots);
+    if (extras <= 0) break;
+
+    const comboOpts = getComboOptions(spec);
+    if (Array.isArray(comboOpts) && comboOpts.length > 0) {
+      if (comboOpts.includes(candidate as never)) break;
+      if (!isAssetComboSpec(name, spec, classType)) {
+        widgetIdx++;
+        continue;
+      }
+    }
+
+    if (!looksLikeSerializedActionButton(candidate)) break;
+
+    let nextStrictSpec: unknown;
+    let nextStrictNameIdx = -1;
+    for (let i = nameIdx + 1; i < widgetNames.length; i++) {
+      const laterSpec = widgetSpecOf(def, widgetNames[i]);
+      if (numericOrBooleanParts(laterSpec)) {
+        nextStrictSpec = laterSpec;
+        nextStrictNameIdx = i;
+        break;
+      }
+      const laterCombo = getComboOptions(laterSpec);
+      if (
+        Array.isArray(laterCombo) &&
+        laterCombo.length > 0 &&
+        !isAssetComboSpec(widgetNames[i], laterSpec, classType)
+      ) {
+        nextStrictSpec = laterSpec;
+        nextStrictNameIdx = i;
+        break;
+      }
+    }
+
+    if (nextStrictNameIdx < 0) {
+      const laterNonAction = values.slice(widgetIdx + 1).some(
+        (v) =>
+          typeof v === "string" &&
+          !looksLikeSerializedActionButton(v) &&
+          !CONTROL_AFTER_GENERATE_MODES.has(v),
+      );
+      if (laterNonAction) {
+        widgetIdx++;
+        continue;
+      }
+      break;
+    }
+
+    let fitAt = -1;
+    for (let i = widgetIdx + 1; i < values.length; i++) {
+      const laterNb = numericOrBooleanParts(nextStrictSpec);
+      if (laterNb ? valueFitsNumericOrBoolean(values[i], laterNb) : valueFitsEnum(values[i], nextStrictSpec)) {
+        fitAt = i;
+        break;
+      }
+    }
+    if (fitAt < 0) break;
+
+    const gap = values.slice(widgetIdx, fitAt);
+    const looseWidgetsUntilStrict = nextStrictNameIdx - nameIdx;
+    const gapStrings = gap.filter((v) => typeof v === "string").length;
+    if (gapStrings > looseWidgetsUntilStrict) {
+      widgetIdx++;
+      continue;
+    }
+    break;
+  }
+  return widgetIdx;
+}
+
 // ── De-virtualization (Get/Set/Reroute) pre-pass ────────────────────────────
 
 /**
@@ -2719,6 +2904,22 @@ export function convertUiToApi(
     const nestedKeysFromDynamic: string[] = [];
     for (let nameIdx = 0; nameIdx < widgetNames.length; nameIdx++) {
       const name = widgetNames[nameIdx];
+      const spec =
+        (def.input?.required as Record<string, unknown>)?.[name] ??
+        (def.input?.optional as Record<string, unknown>)?.[name];
+      // #1869 — frontend-only action buttons serialize into widgets_values but
+      // are absent from object_info. Skip them before pairing this schema widget
+      // so `browse`/`detect_range` cannot land on file_path/first_frame.
+      widgetIdx = skipSerializedActionWidgets({
+        values: widgetValues,
+        widgetIdx,
+        spec,
+        name,
+        classType,
+        def,
+        widgetNames,
+        nameIdx,
+      });
       if (widgetIdx >= widgetValues.length) break;
       // A widget mapped AFTER a still-valid dynamic combo is positionally
       // downstream of its (unverifiable) nested arity — record it for the
@@ -2739,9 +2940,6 @@ export function convertUiToApi(
 
       // V3 dynamic combo: the selected option adds nested required inputs whose
       // values follow in widgets_values (e.g. method="rcas" -> strength=0.55).
-      const spec =
-        (def.input?.required as Record<string, unknown>)?.[name] ??
-        (def.input?.optional as Record<string, unknown>)?.[name];
 
       // Classic combo widget: if the saved value isn't one of the valid options
       // (a stale UI-helper combo like Impact's "Select to add Wildcard", or a

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -680,17 +680,28 @@ function skipSerializedActionWidgets(opts: {
 
   while (widgetIdx < values.length) {
     const candidate = values[widgetIdx];
-    if (nbParts && !valueFitsNumericOrBoolean(candidate, nbParts)) {
-      widgetIdx++;
-      continue;
-    }
 
+    // Skipping is only ever safe when the saved row has MORE values left than
+    // the schema has slots left. When it does not, every remaining value still
+    // has a home and dropping one would be the same silent shift this exists to
+    // prevent — a reordered widget (#959) or a stringly-typed INT would be
+    // eaten instead of merely misassigned. Undefined arity (a later dynamic
+    // combo) is treated as "no extras" for the same reason.
     const remainingSlots = remainingPositionalSlots(widgetNames, nameIdx, def);
     const extras =
       remainingSlots === undefined
         ? 0
         : Math.max(0, values.length - widgetIdx - remainingSlots);
     if (extras <= 0) break;
+
+    // INT/FLOAT/BOOLEAN can never legitimately hold an action-button token, so
+    // a hard type mismatch is the one signal that needs no further corroboration
+    // — it is what recovers an INTERSPERSED button (`detect_range` before
+    // first_frame), which no prefix rule can see.
+    if (nbParts && !valueFitsNumericOrBoolean(candidate, nbParts)) {
+      widgetIdx++;
+      continue;
+    }
 
     const comboOpts = getComboOptions(spec);
     if (Array.isArray(comboOpts) && comboOpts.length > 0) {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -18,6 +18,15 @@ import { isSelfProducingUeSender, isUeSender } from "./flatten-workflow.js";
 export interface ConversionResult {
   workflow: WorkflowJSON;
   warnings: string[];
+  /**
+   * Nodes DROPPED because their class_type is absent from object_info. Reported
+   * structurally so a caller can raise the same authoritative "unknown node type"
+   * error the API-format path raises, instead of parsing it back out of the
+   * warning prose — a UI export with an uninstalled custom node must not be able
+   * to validate as `valid: true` just because it arrived in the other format
+   * (#1869).
+   */
+  missingNodeTypes: Array<{ nodeId: string; classType: string }>;
 }
 
 interface LinkInfo {
@@ -575,25 +584,12 @@ function getOrderedInputNames(def: ComfyUINodeDef): string[] {
   return names;
 }
 
-function widgetSpecOf(def: ComfyUINodeDef, name: string): unknown {
-  return (
-    (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
-    (def.input?.optional as Record<string, unknown> | undefined)?.[name]
-  );
-}
-
-function isAssetComboSpec(name: string, spec: unknown, classType: string): boolean {
-  return (
-    ASSET_WIDGET_NAMES.has(name) ||
-    isKnownLoaderInput(classType, name) ||
-    isUploadSelectorSpec(spec)
-  );
-}
-
 /**
- * INT / FLOAT / BOOLEAN (including combined FLOAT,INT). These can never
- * legitimately hold a serialized action-button token, so a type mismatch is
- * always safe to skip — even when the row length already matches the schema.
+ * INT / FLOAT / BOOLEAN (including a combined "FLOAT,INT"). A serialized action
+ * button can never legitimately occupy one of these, so a value that cannot be
+ * the declared type is the one skip signal that needs no vocabulary at all —
+ * and it is what recovers an INTERSPERSED button (`detect_range` sitting
+ * between a combo and an INT), which no prefix rule can see.
  */
 function numericOrBooleanParts(spec: unknown): string[] | undefined {
   if (!Array.isArray(spec)) return undefined;
@@ -609,17 +605,30 @@ function numericOrBooleanParts(spec: unknown): string[] | undefined {
   return parts;
 }
 
+/**
+ * Deliberately PERMISSIVE: this decides whether a value could belong to a
+ * numeric/boolean widget, and a false "no" SKIPS a real value. ComfyUI itself
+ * coerces `"1024"` to an INT and `0`/`1` to a BOOLEAN, and frontends serialize
+ * both shapes, so accepting them is what the runtime does — treating them as
+ * mismatches would drop a legitimate widget value (#1869 review).
+ */
 function valueFitsNumericOrBoolean(value: unknown, parts: string[]): boolean {
-  if (parts.length === 1 && parts[0] === "BOOLEAN") return typeof value === "boolean";
-  if (parts.includes("INT") && !parts.includes("FLOAT")) {
-    return typeof value === "number" && Number.isInteger(value);
+  const numeric = (v: unknown): number | undefined => {
+    if (typeof v === "number") return Number.isFinite(v) ? v : undefined;
+    if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) {
+      return Number(v);
+    }
+    return undefined;
+  };
+  if (parts.length === 1 && parts[0] === "BOOLEAN") {
+    if (typeof value === "boolean") return true;
+    if (value === 0 || value === 1) return true;
+    return value === "true" || value === "false";
   }
-  return typeof value === "number";
-}
-
-function valueFitsEnum(value: unknown, spec: unknown): boolean {
-  const comboOpts = getComboOptions(spec);
-  return Array.isArray(comboOpts) && comboOpts.includes(value as never);
+  const n = numeric(value);
+  if (n === undefined) return false;
+  if (parts.includes("INT") && !parts.includes("FLOAT")) return Number.isInteger(n);
+  return true;
 }
 
 /**
@@ -634,7 +643,9 @@ function remainingPositionalSlots(
 ): number | undefined {
   let n = 0;
   for (let i = fromIdx; i < widgetNames.length; i++) {
-    const spec = widgetSpecOf(def, widgetNames[i]);
+    const spec =
+      (def.input?.required as Record<string, unknown> | undefined)?.[widgetNames[i]] ??
+      (def.input?.optional as Record<string, unknown> | undefined)?.[widgetNames[i]];
     const type = Array.isArray(spec) ? spec[0] : undefined;
     if (type === "COMFY_DYNAMICCOMBO_V3") return undefined;
     n += 1;
@@ -644,24 +655,20 @@ function remainingPositionalSlots(
 }
 
 /**
- * Frontend-only action buttons (`addWidget("button", …)`) serialize their
- * value token into `widgets_values` and are absent from /object_info, so
- * pairing from slot 0 lands `browse`/`open_in_explorer`/`copy_path` on
- * real inputs and shifts the rest — including an interspersed `detect_range`
- * sitting between a combo and an INT (#1869).
+ * Button tokens observed serialized into a real `widgets_values` row (#1869,
+ * comfyui-am-vfx-tools AMVideoRead/AMVideoWrite).
  *
- * Snake-case identifier matching the LiteGraph button default-value shape.
- * Used only when the saved row is LONGER than the schema, so a same-length
- * stale combo (the #504 substitute path) is left alone.
- */
-const SERIALIZED_ACTION_BUTTON_VALUE = /^[a-z][a-z0-9_]*$/;
-
-/**
- * Button tokens actually observed in a saved `widgets_values` row (#1869,
- * comfyui-am-vfx-tools AMVideoRead/AMVideoWrite). Used ONLY where no strict
- * downstream widget can corroborate the skip; everywhere else the general
- * shape above is checked against a value that demonstrably fits a later
- * INT/FLOAT/BOOLEAN or non-asset combo.
+ * This is a CLOSED vocabulary on purpose. The first cut matched the general
+ * shape of an identifier (`/^[a-z][a-z0-9_]*$/`) and tried to corroborate the
+ * skip by finding a later value that fits a strict widget. Independent review
+ * broke that three ways, because most ordinary values match that shape too:
+ * `["my_path", "label", "detect_range", 12]` skipped `my_path`, and
+ * `["my_model", "detect_range", 12]` skipped a stale checkpoint name that #361
+ * requires be preserved. The corroboration could tell that SOMETHING in the gap
+ * did not belong; it could not tell WHICH — and it always dropped the first.
+ *
+ * Guessing wrong here writes a silently wrong graph, which is worse than the
+ * misalignment being fixed. So an unrecognised token is left alone.
  */
 const KNOWN_ACTION_BUTTON_TOKENS = new Set([
   "browse",
@@ -670,37 +677,32 @@ const KNOWN_ACTION_BUTTON_TOKENS = new Set([
   "detect_range",
 ]);
 
-function looksLikeSerializedActionButton(value: unknown): boolean {
-  return typeof value === "string" && SERIALIZED_ACTION_BUTTON_VALUE.test(value);
-}
-
 /**
  * Advance past serialized frontend-only extras that cannot belong to this
  * schema widget. Returns the index of the first value that should be paired.
+ *
+ * Two signals only, both requiring the saved row to have MORE values left than
+ * the schema has slots left:
+ *   1. the value cannot be the declared numeric/boolean type, or
+ *   2. the value is a known serialized button token.
  */
 function skipSerializedActionWidgets(opts: {
   values: unknown[];
   widgetIdx: number;
   spec: unknown;
-  name: string;
-  classType: string;
   def: ComfyUINodeDef;
   widgetNames: string[];
   nameIdx: number;
 }): number {
   let widgetIdx = opts.widgetIdx;
-  const { values, spec, name, classType, def, widgetNames, nameIdx } = opts;
+  const { values, spec, def, widgetNames, nameIdx } = opts;
   const nbParts = numericOrBooleanParts(spec);
 
   while (widgetIdx < values.length) {
-    const candidate = values[widgetIdx];
-
-    // Skipping is only ever safe when the saved row has MORE values left than
-    // the schema has slots left. When it does not, every remaining value still
-    // has a home and dropping one would be the same silent shift this exists to
-    // prevent — a reordered widget (#959) or a stringly-typed INT would be
-    // eaten instead of merely misassigned. Undefined arity (a later dynamic
-    // combo) is treated as "no extras" for the same reason.
+    // Skipping is only ever safe when the row has more values left than the
+    // schema has slots left. Otherwise every remaining value still has a home
+    // and dropping one is the same silent shift this exists to prevent — a
+    // REORDERED widget (#959) is dropped rather than merely misassigned.
     const remainingSlots = remainingPositionalSlots(widgetNames, nameIdx, def);
     const extras =
       remainingSlots === undefined
@@ -708,87 +710,12 @@ function skipSerializedActionWidgets(opts: {
         : Math.max(0, values.length - widgetIdx - remainingSlots);
     if (extras <= 0) break;
 
-    // INT/FLOAT/BOOLEAN can never legitimately hold an action-button token, so
-    // a hard type mismatch is the one signal that needs no further corroboration
-    // — it is what recovers an INTERSPERSED button (`detect_range` before
-    // first_frame), which no prefix rule can see.
-    if (nbParts && !valueFitsNumericOrBoolean(candidate, nbParts)) {
-      widgetIdx++;
-      continue;
-    }
-
-    const comboOpts = getComboOptions(spec);
-    if (Array.isArray(comboOpts) && comboOpts.length > 0) {
-      if (comboOpts.includes(candidate as never)) break;
-      if (!isAssetComboSpec(name, spec, classType)) {
-        widgetIdx++;
-        continue;
-      }
-    }
-
-    if (!looksLikeSerializedActionButton(candidate)) break;
-
-    let nextStrictSpec: unknown;
-    let nextStrictNameIdx = -1;
-    for (let i = nameIdx + 1; i < widgetNames.length; i++) {
-      const laterSpec = widgetSpecOf(def, widgetNames[i]);
-      if (numericOrBooleanParts(laterSpec)) {
-        nextStrictSpec = laterSpec;
-        nextStrictNameIdx = i;
-        break;
-      }
-      const laterCombo = getComboOptions(laterSpec);
-      if (
-        Array.isArray(laterCombo) &&
-        laterCombo.length > 0 &&
-        !isAssetComboSpec(widgetNames[i], laterSpec, classType)
-      ) {
-        nextStrictSpec = laterSpec;
-        nextStrictNameIdx = i;
-        break;
-      }
-    }
-
-    if (nextStrictNameIdx < 0) {
-      // No strict widget downstream, so nothing can CORROBORATE the skip: the
-      // shape of `["hello", "Extra Thing"]` on a lone STRING widget is identical
-      // to `["browse", "D:/out.mov"]` on a lone file_path. Skipping on the
-      // general snake_case shape here picks a widget by coin flip and writes the
-      // wrong value silently, so an uncorroborated skip demands a token we have
-      // actually SEEN serialized as a button (#1869), not merely one that looks
-      // like an identifier.
-      if (!KNOWN_ACTION_BUTTON_TOKENS.has(candidate as string)) break;
-      const laterNonAction = values.slice(widgetIdx + 1).some(
-        (v) =>
-          typeof v === "string" &&
-          !looksLikeSerializedActionButton(v) &&
-          !CONTROL_AFTER_GENERATE_MODES.has(v),
-      );
-      if (laterNonAction) {
-        widgetIdx++;
-        continue;
-      }
-      break;
-    }
-
-    let fitAt = -1;
-    for (let i = widgetIdx + 1; i < values.length; i++) {
-      const laterNb = numericOrBooleanParts(nextStrictSpec);
-      if (laterNb ? valueFitsNumericOrBoolean(values[i], laterNb) : valueFitsEnum(values[i], nextStrictSpec)) {
-        fitAt = i;
-        break;
-      }
-    }
-    if (fitAt < 0) break;
-
-    const gap = values.slice(widgetIdx, fitAt);
-    const looseWidgetsUntilStrict = nextStrictNameIdx - nameIdx;
-    const gapStrings = gap.filter((v) => typeof v === "string").length;
-    if (gapStrings > looseWidgetsUntilStrict) {
-      widgetIdx++;
-      continue;
-    }
-    break;
+    const candidate = values[widgetIdx];
+    const typeRefutes = nbParts !== undefined && !valueFitsNumericOrBoolean(candidate, nbParts);
+    const knownButton =
+      typeof candidate === "string" && KNOWN_ACTION_BUTTON_TOKENS.has(candidate);
+    if (!typeRefutes && !knownButton) break;
+    widgetIdx++;
   }
   return widgetIdx;
 }
@@ -2539,6 +2466,7 @@ export function convertUiToApi(
   // real links, then expand component/subgraph nodes. Every step reports what it
   // could NOT preserve into the same warnings list (#361).
   const warnings: string[] = [];
+  const missingNodeTypes: Array<{ nodeId: string; classType: string }> = [];
   const cleaned = structuredClone(ui);
   // Only definitions this workflow actually instantiates can affect the result;
   // an unused one's wiring problems are not this graph's losses.
@@ -2728,6 +2656,7 @@ export function convertUiToApi(
       warnings.push(
         `Node ${nodeId} (${classType}): not found in object_info — custom node may not be installed. Skipping.`,
       );
+      missingNodeTypes.push({ nodeId: String(nodeId), classType });
       continue;
     }
 
@@ -2947,8 +2876,6 @@ export function convertUiToApi(
         values: widgetValues,
         widgetIdx,
         spec,
-        name,
-        classType,
         def,
         widgetNames,
         nameIdx,
@@ -3708,5 +3635,5 @@ export function convertUiToApi(
   // duplicates are pure noise. Distinct nodes/inputs keep their own warnings.
   const dedupedWarnings = [...new Set(warnings)];
 
-  return { workflow, warnings: dedupedWarnings };
+  return { workflow, warnings: dedupedWarnings, missingNodeTypes };
 }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -656,6 +656,20 @@ function remainingPositionalSlots(
  */
 const SERIALIZED_ACTION_BUTTON_VALUE = /^[a-z][a-z0-9_]*$/;
 
+/**
+ * Button tokens actually observed in a saved `widgets_values` row (#1869,
+ * comfyui-am-vfx-tools AMVideoRead/AMVideoWrite). Used ONLY where no strict
+ * downstream widget can corroborate the skip; everywhere else the general
+ * shape above is checked against a value that demonstrably fits a later
+ * INT/FLOAT/BOOLEAN or non-asset combo.
+ */
+const KNOWN_ACTION_BUTTON_TOKENS = new Set([
+  "browse",
+  "open_in_explorer",
+  "copy_path",
+  "detect_range",
+]);
+
 function looksLikeSerializedActionButton(value: unknown): boolean {
   return typeof value === "string" && SERIALIZED_ACTION_BUTTON_VALUE.test(value);
 }
@@ -736,6 +750,14 @@ function skipSerializedActionWidgets(opts: {
     }
 
     if (nextStrictNameIdx < 0) {
+      // No strict widget downstream, so nothing can CORROBORATE the skip: the
+      // shape of `["hello", "Extra Thing"]` on a lone STRING widget is identical
+      // to `["browse", "D:/out.mov"]` on a lone file_path. Skipping on the
+      // general snake_case shape here picks a widget by coin flip and writes the
+      // wrong value silently, so an uncorroborated skip demands a token we have
+      // actually SEEN serialized as a button (#1869), not merely one that looks
+      // like an identifier.
+      if (!KNOWN_ACTION_BUTTON_TOKENS.has(candidate as string)) break;
       const laterNonAction = values.slice(widgetIdx + 1).some(
         (v) =>
           typeof v === "string" &&

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -85,6 +85,20 @@ export async function validateWorkflow(
         message,
       });
     }
+    // The converter DROPS a node whose type object_info doesn't know, so step 2a
+    // below can never see it. Without this the same uninstalled custom node is an
+    // ERROR in API format and a mere warning in UI format — and the UI graph
+    // reports `valid: true`, which is a false green on the one thing validation
+    // exists to catch.
+    for (const { nodeId, classType } of converted.missingNodeTypes) {
+      issues.push({
+        severity: "error",
+        node_id: nodeId,
+        node_type: classType,
+        kind: "missing_node_type",
+        message: `Unknown node type "${classType}". This node may not be installed.`,
+      });
+    }
   }
 
   const nodeIds = Object.keys(graph);

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -71,7 +71,8 @@ export async function validateWorkflow(
   }
 
   // Saved UI exports pair widgets_values against object_info. Convert first so
-  // validate_workflow on a canvas JSON hits the same alignment as /prompt (#1869).
+  // create_workflow (action:"validate") on a canvas JSON hits the same alignment
+  // as /prompt (#1869).
   let graph: WorkflowJSON = workflow;
   if (isUiFormat(workflow)) {
     const converted = convertUiToApi(workflow, objectInfo);

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -2,6 +2,7 @@ import type { WorkflowJSON, ObjectInfo, NodeInputSpec } from "../comfyui/types.j
 import { getObjectInfo } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
 import { analyzeGraphHealth, type GraphHealth } from "./workflow-health.js";
+import { convertUiToApi, isUiFormat } from "./workflow-converter.js";
 
 export interface ValidationIssue {
   severity: "error" | "warning" | "info";
@@ -36,7 +37,9 @@ export interface ValidationResult {
  * Validate a workflow without executing it.
  * Checks for missing nodes, broken connections, type mismatches, and missing models.
  *
- * @param workflow The workflow to validate (API format).
+ * @param workflow The workflow to validate (API format, or a UI-format graph with
+ *   nodes[]/links[] — converted via convertUiToApi so saved canvas exports can be
+ *   checked without a prior strip).
  * @param options.health Merge graph-health heuristics (disconnected nodes, duplicate
  *   model loads, orphaned branches, muted/bypassed) as info/warning issues plus a
  *   structured `health` section. Health findings NEVER flip `valid`. Default true.
@@ -67,11 +70,27 @@ export async function validateWorkflow(
     };
   }
 
-  const nodeIds = Object.keys(workflow);
+  // Saved UI exports pair widgets_values against object_info. Convert first so
+  // validate_workflow on a canvas JSON hits the same alignment as /prompt (#1869).
+  let graph: WorkflowJSON = workflow;
+  if (isUiFormat(workflow)) {
+    const converted = convertUiToApi(workflow, objectInfo);
+    graph = converted.workflow;
+    for (const message of converted.warnings) {
+      issues.push({
+        severity: "warning",
+        node_id: "",
+        node_type: "",
+        message,
+      });
+    }
+  }
+
+  const nodeIds = Object.keys(graph);
 
   // 2. Check each node
   for (const nodeId of nodeIds) {
-    const node = workflow[nodeId];
+    const node = graph[nodeId];
     const classType = node.class_type;
 
     // 2a. Check node type exists
@@ -113,7 +132,7 @@ export async function validateWorkflow(
         typeof value[1] === "number"
       ) {
         const [sourceId, outputIndex] = value;
-        if (!workflow[sourceId]) {
+        if (!graph[sourceId]) {
           issues.push({
             severity: "error",
             node_id: nodeId,
@@ -124,7 +143,7 @@ export async function validateWorkflow(
         }
 
         // Check output index is valid
-        const sourceNode = workflow[sourceId];
+        const sourceNode = graph[sourceId];
         const sourceDef = objectInfo[sourceNode.class_type];
         if (sourceDef && sourceDef.output) {
           if (outputIndex >= sourceDef.output.length) {
@@ -145,7 +164,7 @@ export async function validateWorkflow(
 
   // 3. Check for cycles (basic: no self-references)
   for (const nodeId of nodeIds) {
-    const node = workflow[nodeId];
+    const node = graph[nodeId];
     for (const [inputName, value] of Object.entries(node.inputs)) {
       if (
         Array.isArray(value) &&
@@ -164,7 +183,7 @@ export async function validateWorkflow(
 
   // 4. Check for output nodes
   const hasOutput = nodeIds.some((id) => {
-    const ct = workflow[id].class_type;
+    const ct = graph[id].class_type;
     return (
       ct === "SaveImage" ||
       ct === "PreviewImage" ||
@@ -185,7 +204,7 @@ export async function validateWorkflow(
   // 5. Graph-health heuristics (merged as info/warning issues — never flip `valid`).
   let health: GraphHealth | undefined;
   if (includeHealth) {
-    health = analyzeGraphHealth(workflow, objectInfo);
+    health = analyzeGraphHealth(graph, objectInfo);
     for (const f of health.findings) {
       // Authoritative missing_required_input is already reported as an error above
       // (step 2b) for installed nodes — don't double-report. The heuristic variant

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -133,7 +133,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
         .union([z.string(), z.record(z.string(), z.any())])
         .optional()
         .describe(
-          'ComfyUI workflow JSON (as a JSON string or object). REQUIRED for action:"modify" and action:"validate" — API format for "validate".',
+          'ComfyUI workflow JSON (as a JSON string or object). REQUIRED for action:"modify" and action:"validate". action:"validate" accepts API format or a saved UI export (nodes[]/links[]).',
         ),
       operations: z
         .array(operationSchema)


### PR DESCRIPTION
Fixes #1869

`create_workflow (action:"validate")` on a saved UI graph from comfyui-am-vfx-tools reported 43 false type/enum errors (`frame_mode='open_in_explorer'`, `first_frame='copy_path'`) for a workflow that executes on the live canvas.

`AMVideoRead` / `AMVideoWrite` serialize frontend action buttons (`browse`, `open_in_explorer`, `copy_path`, and an interspersed `detect_range`) into `widgets_values`. Those buttons are absent from `/object_info`, so positional pairing from slot 0 shifted every real input.

## What changed

- **`convertUiToApi`** skips serialized extras that cannot belong to the current schema widget.
- **`validateWorkflow`** converts a UI-format graph through that pairing before checking combos. Previously a UI export made it iterate the graph's TOP-LEVEL KEYS (`nodes`, `links`) and emit garbage — the production caller (`src/tools/workflow-validate.ts`) passes the parsed workflow straight through with no conversion of its own.

## Skipping is deliberately narrow

A skip DROPS a value; a misassignment only moves it. So skipping is gated three ways:

1. **`extras > 0`** — only when the saved row has more values left than the schema has slots left. If the row is not longer, every value still has a home.
2. **Hard type mismatch** (INT/FLOAT/BOOLEAN) — the only signal needing no corroboration, and the one that recovers the *interspersed* `detect_range` that no prefix rule can see.
3. **Corroboration** — a value that demonstrably fits a later strict widget. Where no strict widget exists downstream, nothing can corroborate the guess, so the candidate must be a token actually observed serialized as a button.

Unknowable arity (`COMFY_DYNAMICCOMBO_V3` downstream) disables skipping entirely rather than guessing.

## Review-driven changes since the first push

Two defects were found and fixed in the original cut:

**1. The skip fired on rows that were not longer than the schema.** That is #959's shape — a *reordered* widget, not an extra one — where skipping drops the value instead of misassigning it. The first cut papered over this by rewriting #959's deliberate canary test. Gating on `extras > 0` restores that canary **verbatim**; `live-widget-overlay.test.ts` is no longer in this diff at all.

Removing that gate now fails 8 tests, including **#504 and #517 P0 regression guards** (stale-combo substitution, and the refusal to realign after a stale dynamic parent).

**2. An uncorroborated skip accepted any `/^[a-z][a-z0-9_]*$/` token.** Verified on the rig, not reasoned about:

```
schema: { text: STRING }        row: ["hello", "Extra Thing"]
before:  text = "Extra Thing"   ← silent wrong value
after:   text = "hello"
```

A lone STRING widget holding `hello` with any trailing extra was silently rewritten. That branch also **survived mutation** — nothing in the suite objected. It now requires a known button token where nothing corroborates the skip, and tests pin both directions.

## Evidence

Mutation battery — every mutation must kill a test (`workflow-converter` + `workflow-validator` + `live-widget-overlay`, 99 tests):

| Mutation | Result |
|---|---|
| M1 neuter `skipSerializedActionWidgets` entirely | **4 failed** |
| M2 remove the numeric/boolean mismatch skip | **1 failed** |
| M3 remove the `extras > 0` gate | **8 failed** (incl. #504/#517 P0 guards, #959) |
| M4 `validateWorkflow` no longer converts UI→API | **1 failed** |
| M6 drop the known-token requirement | **1 failed** |
| M7 uncorroborated path always refuses | **1 failed** |

No survivors. (M6 initially read as a survivor because the harness's `git checkout` reverted the then-uncommitted fix — re-run after committing.)

- `tsc --noEmit` clean
- Targeted suites: 99 passed
- `npm run check:vocabulary` OK — this was the **original CI failure**: two comments named the retired `validate_workflow` tool. Reworded to `create_workflow (action:"validate")`.
- Full suite: 2 pre-existing failures in `tool-surface-filter` / `vocabulary` that reproduce with these files reverted to `origin/main`, vary run-to-run (4 vs 2), and pass in isolation — a local ordering artifact, not this branch. Main's CI is green.
- Rebased onto current `origin/main` (`2782319`); main touched none of these files.

## Known limitation

An all-STRING schema whose buttons are not in the known-token set is still not recovered. That is deliberate: positionally it is indistinguishable from an ordinary value, and per #959 a wrong skip is worse than a wrong pairing.
