### PR TITLE
fix(1704): restart_comfyui relaunches the venv python, not the trampoline's base child

### DIFF
--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -862,6 +862,145 @@ describe("restart_comfyui — Stability Matrix package venv, not Assets CPython 
   });
 });
 
+describe("restart_comfyui — Windows venv trampoline parent, not the base child (#1704)", () => {
+  // Recurrence 2026-08-20: the port owner was a base CPython CHILD while its
+  // parent was `<install>/venv/Scripts/python.exe`; both had matching
+  // `main.py --port 8190 --use-sage-attention`. Restart stopped the tree and
+  // relaunched the child's image — a home interpreter with no sqlalchemy.
+  // #1761 only remaps Stability Matrix Assets CPython; this is the generic
+  // trampoline shape, including when the home happens to be Assets.
+  const TRAMPOLINE_ROOT = resolve("VenvTrampolineComfy");
+  const TRAMPOLINE_MAIN = join(TRAMPOLINE_ROOT, "main.py");
+  const TRAMPOLINE_VENV_PY = join(
+    TRAMPOLINE_ROOT,
+    "venv",
+    "Scripts",
+    "python.exe",
+  );
+  const TRAMPOLINE_BASE_PY = join(resolve("CPythonHome"), "python.exe");
+  const TRAMPOLINE_ARGV = [
+    TRAMPOLINE_MAIN,
+    "--port",
+    "8190",
+    "--use-sage-attention",
+  ];
+  const PARENT_PID = 1001;
+
+  function useTrampolineTree(opts?: {
+    childCommandLine?: string;
+    parentCommandLine?: string;
+    parentPid?: number;
+  }): void {
+    mockFindComfyuiPython.mockReturnValue(TRAMPOLINE_BASE_PY);
+    mockLiveRootFromArgv.mockReturnValue(TRAMPOLINE_ROOT);
+    mockGetSystemStats.mockResolvedValue({ system: { argv: TRAMPOLINE_ARGV } });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return (
+        s === TRAMPOLINE_MAIN ||
+        s === TRAMPOLINE_VENV_PY ||
+        s === TRAMPOLINE_BASE_PY
+      );
+    });
+    const childCL =
+      opts?.childCommandLine ??
+      `"${TRAMPOLINE_BASE_PY}" "${TRAMPOLINE_MAIN}" --port 8190 --use-sage-attention`;
+    const parentCL =
+      opts?.parentCommandLine ??
+      `"${TRAMPOLINE_VENV_PY}" "${TRAMPOLINE_MAIN}" --port 8190 --use-sage-attention`;
+    const parentPid = opts?.parentPid ?? PARENT_PID;
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) {
+        return {
+          startedAt: "child-stamp",
+          commandLine: childCL,
+          parentPid,
+        };
+      }
+      if (pid === parentPid) {
+        return { startedAt: "parent-stamp", commandLine: parentCL };
+      }
+      return undefined;
+    });
+  }
+
+  async function restartAndReturnSpawn(): Promise<{
+    exe: string;
+    args: string[];
+  }> {
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const result = await restartComfyUI();
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args] = mockSpawn.mock.calls[0];
+    killSpy.mockRestore();
+    return { exe: String(exe), args: args as string[] };
+  }
+
+  it("relaunches the venv parent when the port owner is the trampoline's base CPython child", async () => {
+    useTrampolineTree();
+
+    const { exe, args } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(TRAMPOLINE_VENV_PY);
+    expect(exe).not.toBe(TRAMPOLINE_BASE_PY);
+    expect(args).toEqual(TRAMPOLINE_ARGV);
+  });
+
+  it("relaunches the package venv when the trampoline child is Stability Matrix Assets CPython", async () => {
+    // Same tree shape, home = SM Assets. #1761 remapping also covers Assets
+    // when a Packages path is already in argv; the parent walk is what remains
+    // when the observation is this child/parent pair.
+    mockFindComfyuiPython.mockReturnValue(SM_ASSETS_PY);
+    mockLiveRootFromArgv.mockReturnValue(SM_PKG);
+    const argv = [SM_MAIN, "--port", "8190", "--use-sage-attention"];
+    mockGetSystemStats.mockResolvedValue({ system: { argv } });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === SM_MAIN || s === SM_PY || s === SM_ASSETS_PY;
+    });
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) {
+        return {
+          startedAt: "child-stamp",
+          commandLine: `"${SM_ASSETS_PY}" "${SM_MAIN}" --port 8190 --use-sage-attention`,
+          parentPid: PARENT_PID,
+        };
+      }
+      if (pid === PARENT_PID) {
+        return {
+          startedAt: "parent-stamp",
+          commandLine: `"${SM_PY}" "${SM_MAIN}" --port 8190 --use-sage-attention`,
+        };
+      }
+      return undefined;
+    });
+
+    const { exe } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(SM_PY);
+    expect(exe).not.toBe(SM_ASSETS_PY);
+  });
+
+  it("does not adopt a venv parent whose command line is a different ComfyUI", async () => {
+    useTrampolineTree({
+      parentCommandLine: `"${TRAMPOLINE_VENV_PY}" "${join(resolve("OtherComfy"), "main.py")}" --port 8190 --use-sage-attention`,
+    });
+
+    const { exe } = await restartAndReturnSpawn();
+
+    expect(exe).toBe(TRAMPOLINE_BASE_PY);
+    expect(exe).not.toBe(TRAMPOLINE_VENV_PY);
+  });
+});
+
 describe("launcher layout detection — path-root handling (#776)", () => {
   // The paths come from the running ComfyUI's sys.argv, which is WINDOWS-flavored
   // whenever ComfyUI runs on Windows regardless of this host. These are pure

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1485,6 +1485,61 @@ function observedInterpreterFromIdentity(
 }
 
 /**
+ * A package venv interpreter: `<root>/venv/Scripts/python.exe` or
+ * `<root>/.venv/bin/python`. The Windows trampoline that actually owns the
+ * environment; its child is the BASE CPython `pyvenv.cfg` named, which has no
+ * ComfyUI site-packages.
+ */
+function isVenvInterpreterPath(exe: string): boolean {
+  const segs = exe.replace(/\\/g, "/").split("/").filter(Boolean);
+  if (segs.length < 3) return false;
+  const file = segs[segs.length - 1]!.toLowerCase();
+  if (!/^python(w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(file)) return false;
+  const dir = segs[segs.length - 2]!.toLowerCase();
+  const env = segs[segs.length - 3]!.toLowerCase();
+  return (dir === "scripts" || dir === "bin") && (env === "venv" || env === ".venv");
+}
+
+/**
+ * Windows venv trampoline (#1704 recurrence): the port owner is the BASE
+ * CPython child; its parent is `<install>/venv/Scripts/python.exe`; both carry
+ * the same `main.py …` arguments. Spawning the child image relaunches an
+ * interpreter with no sqlalchemy/torch (Assets CPython or any other `home`).
+ *
+ * The parent is an OS observation of THIS tree, not a layout guess — an
+ * observed *venv* interpreter on the port owner is left alone (#1654).
+ */
+function observedInterpreterFromTrampolineParent(
+  child: ProcessIdentity,
+  serverArgv: string[],
+): string | undefined {
+  const childExe = observedInterpreterFromIdentity(child);
+  if (childExe && isVenvInterpreterPath(childExe)) return undefined;
+  const parentPid = child.parentPid;
+  if (!parentPid || parentPid <= 0) return undefined;
+  const parent = resolveProcessIdentity(parentPid);
+  if (!parent) return undefined;
+  const parentExe = observedInterpreterFromIdentity(parent);
+  if (!parentExe || !isVenvInterpreterPath(parentExe)) return undefined;
+  if (childExe && sameInterpreterPath(childExe, parentExe)) return undefined;
+  const matchArgv =
+    serverArgv.length > 0
+      ? serverArgv
+      : child.argv && child.argv.length > 1
+        ? child.argv.slice(1)
+        : [];
+  if (matchArgv.length === 0) return undefined;
+  if (!commandLineMatchesArgv(parent.commandLine, matchArgv)) return undefined;
+  return parentExe;
+}
+
+function sameInterpreterPath(a: string, b: string): boolean {
+  const norm = (s: string): string =>
+    s.replace(/[\\/]+$/, "").replace(/[\\/]/g, "/").toLowerCase();
+  return norm(a) === norm(b);
+}
+
+/**
  * The live environment of a pid we can still PROVE is the process we identified.
  *
  * Reading `/proc/<pid>/environ` from a bare number is not enough: between the port
@@ -2755,14 +2810,18 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // unreadable — the same observation `install_comfyui(action:"environment")`
   // already reports — so a server started outside this session is not relaunched
   // with Stability Matrix's unused Assets CPython.
+  //
+  // #1704 recurrence: the port owner can be the trampoline's BASE child. argv[0]
+  // of that child is the home CPython (Assets or otherwise); the parent is the
+  // package venv that actually has site-packages. Prefer that parent.
   const interpreterIdentity =
     corroboration.kind === "confirmed"
       ? corroboration.identity
       : (osIdentity ?? resolveProcessIdentity(pid));
-  const observedInterpreter =
-    !desktop && interpreterIdentity
-      ? observedInterpreterFromIdentity(interpreterIdentity)
-      : undefined;
+  const observedInterpreter = !desktop && interpreterIdentity
+    ? (observedInterpreterFromTrampolineParent(interpreterIdentity, argv) ??
+      observedInterpreterFromIdentity(interpreterIdentity))
+    : undefined;
   const startedAt = desktop
     ? undefined
     : corroboration.kind === "confirmed"


### PR DESCRIPTION
## What the user now observes

`restart_comfyui(action:"restart")` relaunches the **venv** interpreter (`<install>/venv/Scripts/python.exe`), not the Windows venv trampoline's **base CPython child**. The relaunch can import sqlalchemy/torch and comes back up.

## Root cause

#1761 remaps Stability Matrix **Assets** CPython onto the package venv when a Packages path is already in hand. The 2026-08-20 recurrence on 0.52.26 is a different observation of the same tree:

- The **port owner** is the trampoline's base CPython child (Assets, or any other `pyvenv.cfg` home).
- Its **parent** is `<install>/venv/Scripts/python.exe`.
- Both have matching `main.py --port 8190 --use-sage-attention` arguments.

`observedInterpreter` took argv[0] of the child. Spawning that image is a python with no ComfyUI site-packages (`ModuleNotFoundError: sqlalchemy`, exit 1). #1761 does not fire when the home is not classified as Assets, or when remapping cannot see a Packages path.

## Fix

When the port owner's interpreter is **not** a venv python, walk one parent: if that parent is `venv`/`.venv` `Scripts`/`bin` python **and** its command line matches this server's argv, use the parent. An observed venv interpreter on the port owner is left alone (#1654). #1761 Assets remapping stays as the fallback when there is no parent to read.

## Verification

Targeted vitest (`--maxWorkers=4`):

- `restart-launcher-env.test.ts` — 72 passed (incl. 3 new #1704 trampoline cases: generic base child; SM Assets child whose layout cannot be corroborated; venv parent of a *different* ComfyUI is not adopted)
- `process-control.test.ts`, `restart-live-first.test.ts`, `restart-relaunch-lifecycle.test.ts`, `desktop-restart.test.ts` — 132 passed

Fixes #1704
