### PR TITLE
fix(1877): panel_create_group includes requested collapsed nodes

### DIFF
--- a/src/__tests__/orchestrator/create-group-collapsed.test.ts
+++ b/src/__tests__/orchestrator/create-group-collapsed.test.ts
@@ -1,0 +1,235 @@
+// #1877 — panel_create_group with a collapsed node created an empty group and
+// listed that node as missing, even though the returned bounds wrapped its
+// origin. The shipped path is panel_create_group → graph_create_group; the
+// handler now expands the box (graph_edit_group) when a requested node whose
+// origin is already inside is still missing.
+//
+// The mock panel here applies LiteGraph's containsCentre rule independently
+// (forceCollapsed wantedNodeArea: size[1]===0 falls back to a 100px body plus
+// a 30px title). It does not import the expander under test.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  expandGroupBoundsForMembership,
+  nodePosInsideGroupBounds,
+  type QueriedNodeGeom,
+} from "../../orchestrator/create-group-membership.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+
+const TITLE = 30;
+const DEFAULT_BODY = 100;
+
+/** Reporter's collapsed VAEDecode: origin inside a 100px-tall auto-fit box. */
+const NODE_81: QueriedNodeGeom = {
+  id: 81,
+  pos: [9750, 5410],
+  size: [225, 0],
+  collapsed: true,
+  full_height: 30,
+};
+const CREATED_BOUNDS: [number, number, number, number] = [9720, 5340, 285, 100];
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found in buildPanelToolDefs()`);
+  return def;
+}
+
+function jsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function parseResult(res: ToolResult): Record<string, unknown> {
+  const text = res.content.find((c) => c.type === "text")?.text;
+  return JSON.parse(text ?? "{}") as Record<string, unknown>;
+}
+
+/**
+ * LiteGraph containsCentre of the panel's forceCollapsed footprint
+ * (`wantedNodeArea(node, true)` in group-geometry.js): zero-height size falls
+ * back to 100, title band sits above pos. Max edge exclusive.
+ */
+function panelContainsCentre(
+  bounds: [number, number, number, number],
+  node: QueriedNodeGeom,
+): boolean {
+  const w = node.size[0] > 0 ? node.size[0] : 200;
+  const h = node.size[1] > 0 ? node.size[1] : DEFAULT_BODY;
+  const cx = node.pos[0] + w / 2;
+  const cy = node.pos[1] - TITLE + (h + TITLE) / 2;
+  const [gx, gy, gw, gh] = bounds;
+  return cx >= gx && cx < gx + gw && cy >= gy && cy < gy + gh;
+}
+
+function asQuad(v: unknown): [number, number, number, number] | null {
+  if (!Array.isArray(v) || v.length !== 4) return null;
+  const q: [number, number, number, number] = [Number(v[0]), Number(v[1]), Number(v[2]), Number(v[3])];
+  return q.every(Number.isFinite) ? q : null;
+}
+
+describe("#1877 collapsed node membership (panel_create_group)", () => {
+  it("the reporter's auto-fit box covers the origin and excludes the membership centre", () => {
+    expect(nodePosInsideGroupBounds(NODE_81.pos, CREATED_BOUNDS)).toBe(true);
+    expect(panelContainsCentre(CREATED_BOUNDS, NODE_81)).toBe(false);
+  });
+
+  it("expanding those bounds makes the same centre a member", () => {
+    const expanded = expandGroupBoundsForMembership(CREATED_BOUNDS, [NODE_81]);
+    expect(panelContainsCentre(expanded, NODE_81)).toBe(true);
+    expect(nodePosInsideGroupBounds(NODE_81.pos, expanded)).toBe(true);
+  });
+
+  it("panel_create_group includes the requested collapsed node after the empty create", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: {
+              id: 13,
+              title: "Group",
+              bounding: CREATED_BOUNDS,
+              node_count: 0,
+              node_ids: [],
+              requested_node_ids: [81],
+              missing_node_ids: [81],
+              warning: "group membership is geometric: misses 1 requested node(s)",
+            },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            total: 1,
+            matched: 1,
+            shown: 1,
+            text:
+              `1 match(es) of 1 in scope (viewing: 1 nodes)\n` +
+              JSON.stringify({
+                id: 81,
+                type: "VAEDecode",
+                pos: NODE_81.pos,
+                size: NODE_81.size,
+                full_height: NODE_81.full_height,
+                collapsed: true,
+              }),
+          });
+        }
+        if (cmd.cmd === "graph_edit_group") {
+          const bounds = asQuad(cmd.bounds);
+          const included = bounds ? panelContainsCentre(bounds, NODE_81) : false;
+          return jsonResult({
+            group: {
+              id: 13,
+              title: "Group",
+              bounding: bounds ?? CREATED_BOUNDS,
+              node_count: included ? 1 : 0,
+              node_ids: included ? [81] : [],
+            },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_create_group").handler({ node_ids: [81] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group", "graph_query", "graph_edit_group"]);
+
+    const payload = parseResult(res);
+    const group = payload.group as Record<string, unknown>;
+    expect(group.node_ids).toEqual([81]);
+    expect(group.node_count).toBe(1);
+    expect(group.missing_node_ids).toBeUndefined();
+    expect(asQuad(group.bounding)).not.toEqual(CREATED_BOUNDS);
+  });
+
+  it("does not drag the box to a requested node whose origin is outside it", async () => {
+    const far: QueriedNodeGeom = { id: 9, pos: [0, 0], size: [210, 80] };
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: {
+              id: 2,
+              bounding: CREATED_BOUNDS,
+              node_count: 0,
+              node_ids: [],
+              missing_node_ids: [9],
+            },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            text: `1 match(es)\n${JSON.stringify({ id: 9, pos: far.pos, size: far.size })}`,
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_create_group").handler({ node_ids: [9] }, ctx);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group", "graph_query"]);
+    const group = (parseResult(res).group as Record<string, unknown>) ?? {};
+    expect(group.missing_node_ids).toEqual([9]);
+    expect(group.node_ids).toEqual([]);
+  });
+
+  it("passes a successful create through without extra round trips", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({
+          group: { id: 1, bounding: [0, 0, 400, 300], node_count: 2, node_ids: [1, 2] },
+        });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+    const res = await defByName("panel_create_group").handler({ node_ids: [1, 2] }, ctx);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group"]);
+    expect((parseResult(res).group as Record<string, unknown>).node_ids).toEqual([1, 2]);
+  });
+
+  it("leaves the original missing report if the query fails", async () => {
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: {
+              id: 13,
+              bounding: CREATED_BOUNDS,
+              node_count: 0,
+              node_ids: [],
+              missing_node_ids: [81],
+            },
+          });
+        }
+        return { isError: true, content: [{ type: "text", text: "Error: panel went away" }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+    const res = await defByName("panel_create_group").handler({ node_ids: [81] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect((parseResult(res).group as Record<string, unknown>).missing_node_ids).toEqual([81]);
+  });
+});

--- a/src/orchestrator/create-group-membership.ts
+++ b/src/orchestrator/create-group-membership.ts
@@ -1,0 +1,284 @@
+/**
+ * #1877 — panel_create_group can wrap a collapsed node and still report it
+ * missing.
+ *
+ * The panel sizes the box from live `pos`/`size`. A collapsed node often has
+ * `size[1] === 0` (title-chip only), so the box is ~100px tall around the
+ * node's origin. Membership then tests the CENTRE of a boundingRect rebuilt
+ * with the panel's `finiteExtent` fallback (0 is not a usable height, so the
+ * body becomes 100px plus a 30px title). That centre sits a few pixels below
+ * the box, so the group is empty even though the node's coordinates are inside.
+ *
+ * These helpers expand a created group's bounds just enough to contain every
+ * membership-plausible centre of a requested node whose origin is already in
+ * the box — then the caller writes those bounds with graph_edit_group.
+ *
+ * Constants match comfyui-mcp-panel `web/js/lib/group-geometry.js`
+ * (`COLLAPSED_TITLE_HEIGHT`, `COLLAPSED_PILL_WIDTH`, `finiteExtent` fallbacks)
+ * and LiteGraph's containsCentre rule (min edge inclusive, max edge exclusive).
+ */
+
+/** The slice of a panel tool result this module reads and rewrites. */
+type ToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+export const NODE_TITLE_HEIGHT = 30;
+export const COLLAPSED_PILL_WIDTH = 80;
+export const DEFAULT_NODE_WIDTH = 200;
+export const DEFAULT_NODE_BODY_HEIGHT = 100;
+
+export type GroupQuad = [number, number, number, number];
+
+export type QueriedNodeGeom = {
+  id: string | number;
+  pos: [number, number];
+  size: [number, number];
+  collapsed?: boolean;
+  full_height?: number;
+};
+
+function finiteExtent(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function finiteQuad(v: unknown): GroupQuad | null {
+  if (!Array.isArray(v) || v.length !== 4) return null;
+  const q: GroupQuad = [Number(v[0]), Number(v[1]), Number(v[2]), Number(v[3])];
+  return q.every(Number.isFinite) ? q : null;
+}
+
+export function nodePosInsideGroupBounds(pos: [number, number], bounds: GroupQuad): boolean {
+  const [gx, gy, gw, gh] = bounds;
+  const [x, y] = pos;
+  // Inclusive on every edge: the reporter's "bounds cover the node" is a
+  // top-left origin sitting on or inside the box, not a centre test.
+  return x >= gx && x <= gx + gw && y >= gy && y <= gy + gh;
+}
+
+/**
+ * Centres LiteGraph / the panel might use for containsCentre, given only the
+ * geometry panel_query_graph actually returns (pos, size, collapsed, full_height).
+ */
+export function membershipCandidateCenters(node: QueriedNodeGeom): Array<{ x: number; y: number }> {
+  const x = node.pos[0];
+  const y = node.pos[1];
+  const pillW = finiteExtent(node.size[0], COLLAPSED_PILL_WIDTH);
+  const fullW = finiteExtent(node.size[0], DEFAULT_NODE_WIDTH);
+  const fullH = finiteExtent(node.size[1], DEFAULT_NODE_BODY_HEIGHT);
+  const chipH = finiteExtent(node.full_height, NODE_TITLE_HEIGHT);
+  return [
+    // Collapsed title-chip (syncNodeArea without forceCollapsed).
+    { x: x + pillW / 2, y: y - NODE_TITLE_HEIGHT + chipH / 2 },
+    // forceCollapsed wantedNodeArea: size[1]===0 falls back to DEFAULT_NODE_BODY_HEIGHT.
+    { x: x + fullW / 2, y: y - NODE_TITLE_HEIGHT + (fullH + NODE_TITLE_HEIGHT) / 2 },
+    // Raw pos + stored size (degenerate when size[1] is 0 — origin itself).
+    { x: x + fullW / 2, y: y + (node.size[1] > 0 ? node.size[1] : 0) / 2 },
+  ];
+}
+
+/** Grow `bounds` so every point is a containsCentre member (max edge exclusive). */
+export function expandBoundsToContainCenters(bounds: GroupQuad, points: Array<{ x: number; y: number }>): GroupQuad {
+  let [x, y, w, h] = bounds;
+  let x2 = x + w;
+  let y2 = y + h;
+  for (const p of points) {
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    if (p.x < x) x = p.x;
+    if (p.y < y) y = p.y;
+    if (p.x >= x2) x2 = p.x + 1;
+    if (p.y >= y2) y2 = p.y + 1;
+  }
+  return [x, y, x2 - x, y2 - y];
+}
+
+export function expandGroupBoundsForMembership(bounds: GroupQuad, nodes: QueriedNodeGeom[]): GroupQuad {
+  const points: Array<{ x: number; y: number }> = [];
+  for (const n of nodes) {
+    if (!nodePosInsideGroupBounds(n.pos, bounds)) continue;
+    points.push(...membershipCandidateCenters(n));
+  }
+  return points.length ? expandBoundsToContainCenters(bounds, points) : bounds;
+}
+
+function idKey(id: unknown): string {
+  return String(id);
+}
+
+export function classifyRequestedMembership(
+  requested: Array<string | number>,
+  members: Array<string | number>,
+): { extra: Array<string | number>; missing: Array<string | number> } {
+  const reqKeys = new Set(requested.map(idKey));
+  const memberKeys = new Set(members.map(idKey));
+  return {
+    extra: members.filter((id) => !reqKeys.has(idKey(id))),
+    missing: requested.filter((id) => !memberKeys.has(idKey(id))),
+  };
+}
+
+function asIdList(v: unknown): Array<string | number> {
+  if (!Array.isArray(v)) return [];
+  return v.filter((id) => typeof id === "number" || typeof id === "string");
+}
+
+function parseToolJson(res: ToolResultLike): Record<string, unknown> | null {
+  if (!res || res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function withPayload<T extends ToolResultLike>(res: T, payload: unknown): T {
+  const first = res.content[0];
+  if (!first || first.type !== "text") return res;
+  return {
+    ...res,
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }, ...res.content.slice(1)],
+  };
+}
+
+function groupFromCreateReply(payload: Record<string, unknown>): Record<string, unknown> | null {
+  const inner = payload.group;
+  if (inner && typeof inner === "object" && !Array.isArray(inner)) return inner as Record<string, unknown>;
+  if ("bounding" in payload || "node_ids" in payload) return payload;
+  return null;
+}
+
+export function parseDetailNodesFromQueryText(text: unknown): QueriedNodeGeom[] {
+  if (typeof text !== "string") return [];
+  const out: QueriedNodeGeom[] = [];
+  for (const line of text.split("\n")) {
+    const s = line.trim();
+    if (!s.startsWith("{")) continue;
+    try {
+      const row = JSON.parse(s) as Record<string, unknown>;
+      const id = row.id;
+      if (typeof id !== "number" && typeof id !== "string") continue;
+      const pos = row.pos;
+      const size = row.size;
+      if (!Array.isArray(pos) || pos.length < 2 || !Array.isArray(size) || size.length < 2) continue;
+      const x = Number(pos[0]);
+      const y = Number(pos[1]);
+      const w = Number(size[0]);
+      const h = Number(size[1]);
+      if (![x, y, w, h].every(Number.isFinite)) continue;
+      const geom: QueriedNodeGeom = { id, pos: [x, y], size: [w, h] };
+      if (row.collapsed === true) geom.collapsed = true;
+      if (typeof row.full_height === "number" && Number.isFinite(row.full_height)) {
+        geom.full_height = row.full_height;
+      }
+      out.push(geom);
+    } catch {
+      /* skip a non-JSON detail line */
+    }
+  }
+  return out;
+}
+
+function honestyWarning(extra: number, missing: number): string {
+  return (
+    "group membership is geometric: the box that wraps the requested nodes " +
+    `also captures ${extra} unrelated node(s) (their centre falls inside)` +
+    (missing ? ` and misses ${missing} requested node(s)` : "") +
+    ". Move the intended nodes into a contiguous region (panel_edit_node / " +
+    "panel_auto_layout) before grouping, or edit the group bounds, to get an exact set."
+  );
+}
+
+function attachHonesty(
+  group: Record<string, unknown>,
+  requested: Array<string | number>,
+): Record<string, unknown> {
+  const live = asIdList(group.node_ids);
+  const { extra, missing } = classifyRequestedMembership(requested, live);
+  const out: Record<string, unknown> = { ...group, requested_node_ids: requested };
+  delete out.extra_node_ids;
+  delete out.missing_node_ids;
+  delete out.warning;
+  if (extra.length || missing.length) {
+    if (extra.length) out.extra_node_ids = extra;
+    if (missing.length) out.missing_node_ids = missing;
+    out.warning = honestyWarning(extra.length, missing.length);
+  }
+  return out;
+}
+
+function quadsEqual(a: GroupQuad, b: GroupQuad): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+}
+
+type Call = (
+  cmd: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<ToolResultLike>;
+
+/**
+ * After graph_create_group, if requested ids are missing AND their origin sits
+ * inside the new box, expand the box so those centres are members and rewrite
+ * the reply. Never throws: a failed repair returns the original create result.
+ */
+export async function includeRequestedCreateGroupMembers<T extends ToolResultLike>(
+  created: T,
+  requestedIds: unknown,
+  call: Call,
+): Promise<T> {
+  try {
+    if (created.isError) return created;
+    const requested = asIdList(requestedIds);
+    if (!requested.length) return created;
+    const payload = parseToolJson(created);
+    if (!payload) return created;
+    const group = groupFromCreateReply(payload);
+    if (!group) return created;
+    const bounds = finiteQuad(group.bounding);
+    if (!bounds) return created;
+    const live = asIdList(group.node_ids);
+    const reportedMissing = asIdList(group.missing_node_ids);
+    const missing = reportedMissing.length
+      ? reportedMissing.filter((id) => requested.some((r) => idKey(r) === idKey(id)))
+      : classifyRequestedMembership(requested, live).missing;
+    if (!missing.length) return created;
+
+    const query = await call(
+      {
+        cmd: "graph_query",
+        ids: missing,
+        fields: "detail",
+        limit: Math.min(Math.max(missing.length, 1), 200),
+      },
+      8000,
+    );
+    if (query.isError) return created;
+    const qPayload = parseToolJson(query);
+    const nodes = parseDetailNodesFromQueryText(qPayload?.text).filter((n) =>
+      missing.some((id) => idKey(id) === idKey(n.id)),
+    );
+    const repairable = nodes.filter((n) => nodePosInsideGroupBounds(n.pos, bounds));
+    if (!repairable.length) return created;
+
+    const expanded = expandGroupBoundsForMembership(bounds, repairable);
+    if (quadsEqual(expanded, bounds)) return created;
+
+    const groupId = group.id;
+    if (typeof groupId !== "number" && typeof groupId !== "string") return created;
+    const edited = await call({ cmd: "graph_edit_group", group_id: groupId, bounds: expanded }, 15000);
+    if (edited.isError) return created;
+    const ePayload = parseToolJson(edited);
+    if (!ePayload) return created;
+    const editedGroup = groupFromCreateReply(ePayload);
+    if (!editedGroup) return created;
+    return withPayload(created, { ...ePayload, group: attachHonesty(editedGroup, requested) });
+  } catch {
+    return created;
+  }
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -84,6 +84,7 @@ import {
   parseContradictoryPromotedWidgetRefusal,
   resolveInnerPromotedTarget,
 } from "./promoted-widget.js";
+import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
 import {
   fastGroupsFilterPropertyNote,
   isFastGroupsFilterProperty,
@@ -14516,17 +14517,23 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         color: z.string().optional().describe("Box/header color, e.g. '#3f789e'."),
         font_size: z.number().optional().describe("Title font size (default 24)."),
       },
+      // #1877 — a collapsed node can sit inside the auto-fit box and still be
+      // reported missing (size[1]===0 vs membership's 100px body fallback).
       async (args: A, ctx) =>
-        ctx.call(
-          {
-            cmd: "graph_create_group",
-            title: args.title,
-            node_ids: args.node_ids,
-            bounds: args.bounds,
-            color: args.color,
-            font_size: args.font_size,
-          },
-          15000,
+        includeRequestedCreateGroupMembers(
+          await ctx.call(
+            {
+              cmd: "graph_create_group",
+              title: args.title,
+              node_ids: args.node_ids,
+              bounds: args.bounds,
+              color: args.color,
+              font_size: args.font_size,
+            },
+            15000,
+          ),
+          args.node_ids,
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
         ),
     ),
     def(


### PR DESCRIPTION
Fixes #1877

## What was reported

`panel_create_group` with `node_ids` containing a collapsed node created an empty group and listed that node as missing, even though the returned bounds wrapped its coordinates.

Reporter: collapsed VAEDecode node 81 at `[9750, 5410]` → group 13 with bounds `[9720, 5340, 285, 100]`, `node_count: 0`, `missing_node_ids: [81]`.

## Why

The panel auto-fits the box from live `pos`/`size`. A collapsed node often has `size[1] === 0` (title-chip only), so that box is ~100px tall around the origin. Membership then tests the centre of a boundingRect rebuilt with the panel's `finiteExtent` fallback (0 is not a usable height, so the body becomes 100px plus a 30px title). That centre sits a few pixels below the box, so the group is empty even though the node's origin is inside it.

## The fix

`panel_create_group` still dispatches `graph_create_group`. When a requested id is missing **and** its origin already sits inside the new box, the handler:

1. Reads that node's `pos`/`size`/`collapsed` via `graph_query`.
2. Expands the box just enough to contain every membership-plausible centre (collapsed chip, force-uncollapsed fallback, raw pos/size).
3. Writes those bounds with `graph_edit_group` and returns the repaired membership.

A requested node whose origin is genuinely outside the box is left missing. A failed query or edit leaves the original create reply unchanged.

## Verification

`src/__tests__/orchestrator/create-group-collapsed.test.ts` drives the shipped `panel_create_group` handler against a mock panel that applies LiteGraph containsCentre independently:

- the reporter's empty create of collapsed node 81 is repaired to `node_ids: [81]`
- a requested node whose origin is outside is not pulled in
- a successful create is passed through with no extra round trips
- a failed query leaves the original missing report

`npx tsc --noEmit` clean.
`npx vitest run --maxWorkers=4 src/__tests__/orchestrator/create-group-collapsed.test.ts src/__tests__/services/graph-command-effect.test.ts src/__tests__/orchestrator/rgthree-authoring-awareness.test.ts` — 65 passed.
