### PR TITLE
fix(1881): a post-restart graph READ waits out the reconnect instead of losing the race

### DIFF
--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -908,3 +908,84 @@ describe("#436 a MUTATING graph edit awaits the reconnect before dispatch", () =
     expect(Date.now() - t0).toBeLessThan(1000);
   });
 });
+
+// #1881 — the other half of #436's flap, on the READ side.
+//
+// After a full ComfyUI Desktop restart the panel's chat frame is delivered while its
+// `hello` (the only writer of the connected-tab registry) has not landed yet: the turn
+// is live, `Connected: none` is literally true, and panel_graph_outline failed both
+// immediately and on a 3s retry. #436 gated MUTATIONS behind awaitReachable() and left
+// reads on the flat ~400ms settle, on the reasoning that a read "survives that window
+// (it is parked mid-command and is retry-safe)" — but a resolveTarget refusal happens
+// BEFORE any socket write, so nothing is parked and the single re-issue simply loses
+// the same race reconnectWaitTiming's docstring describes.
+describe("#1881 a retry-safe READ waits out the post-restart 0-tab window", () => {
+  // The reconnect must land AFTER the settle, or the pre-fix single re-issue would
+  // catch it and the test would pass without the fix.
+  const settleBeatsReconnect = (): void => {
+    __panelToolsTestHooks.setRetrySettleMs(5);
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 2000, intervalMs: 5 });
+  };
+
+  it("graph_outline recovers: waits for the re-hello, rebinds, and answers", async () => {
+    settleBeatsReconnect();
+    const { bridge, live, sent } = reconnectingBridge([]); // Connected: none
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    setTimeout(() => live.add("reconnected-tab"), 120); // the browser re-hellos, post-settle
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    // Dispatched to the RECONNECTED tab — not into the dead binding, and not refused.
+    expect(sent.at(-1)?.cmd).toMatchObject({ cmd: "graph_outline" });
+    expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+    expect(ctx.tabId).toBe("reconnected-tab");
+  });
+
+  it("workflow_list recovers too — the wait lives in ctx.call, not in one tool", async () => {
+    settleBeatsReconnect();
+    const { bridge, live, sent } = reconnectingBridge([]);
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    setTimeout(() => live.add("reconnected-tab"), 120);
+    const res = await defByName("panel_list_workflows").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+  });
+
+  it("still FAILS — bounded — when nothing ever reconnects", async () => {
+    settleBeatsReconnect();
+    const { bridge, sent } = reconnectingBridge([]); // stays Connected: none
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(sent.length).toBe(0); // never dispatched into the dead binding
+    // Bounded by the reconnect budget — it must not hang, and must not silently
+    // succeed. (Budget 2000ms + settle; a generous ceiling keeps this off the
+    // wall-clock-flake list while still catching an unbounded wait.)
+    expect(Date.now() - t0).toBeLessThan(15_000);
+  });
+
+  it("a HEALTHY read is untouched — no wait, no extra round trip", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 5000, intervalMs: 50 });
+    const { bridge, sent } = reconnectingBridge(["live-tab"]);
+    const ctx = makePanelToolCtx(bridge, "live-tab", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(Date.now() - t0).toBeLessThan(1000); // did NOT wait the 5s budget
+    expect(sent.filter((s) => s.cmd.cmd === "graph_outline").length).toBe(1); // first try
+  });
+
+  it("a read whose tab is live but which is NOT retry-safe keeps failing fast", async () => {
+    // The wait is inside the retry-safe branch, so a read absent from RETRY_SAFE_CMDS
+    // must never reach it — pinned here as well as in the #436 block above, because
+    // this is the exact regression the new await could introduce.
+    settleBeatsReconnect();
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 5000, intervalMs: 5 });
+    const { bridge } = reconnectingBridge([]);
+    const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_list_subgraphs").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(Date.now() - t0).toBeLessThan(1000);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8546,6 +8546,38 @@ export function makePanelToolCtx(
         let holdTab = ctx.tabId;
         try {
           await sleep(retrySettleMs());
+          // #1881 — a retry-safe READ that failed on an EMPTY tab registry gets the
+          // same bounded reconnect wait a mutating edit already gets, instead of
+          // spending its one re-issue ~400ms in.
+          //
+          // #436 gated mutations here and deliberately left the read path alone, on
+          // the reasoning that "a read survives that window (it is parked mid-command
+          // and is retry-safe)". Parking is what happens to a command the bridge
+          // ACCEPTED and cannot answer yet. This failure happens strictly earlier:
+          // resolveTarget throws before any socket write (dispatched:false), so there
+          // is no parked command — the read just gets one re-issue after the settle,
+          // and reconnectWaitTiming's own docstring says why that loses: "the browser
+          // reconnects its own socket seconds-to-tens-of-seconds after ComfyUI comes
+          // back, so the existing single ~400ms retry always loses the race."
+          //
+          // Reported shape: after a full ComfyUI Desktop restart the panel's chat
+          // frame is delivered (deliverPanelEvent runs whether or not the socket has
+          // re-registered) while its `hello` — the ONLY writer of the connected-tab
+          // registry — has not landed yet. So the turn is live, `Connected: none` is
+          // true, and panel_graph_outline failed both immediately and 3s later; only
+          // a manual browser refresh cleared it.
+          //
+          // awaitReachable() is SELF-GATING, which is the whole safety argument: it
+          // returns at once when the bound tab is reachable, and it loops ONLY while
+          // zero interactive tabs are connected. So this adds latency in exactly one
+          // state — the genuine post-restart empty registry — and changes nothing for
+          // a healthy session, a multi-tab session, or a panel that answered (a
+          // pre-executor / workflow-switch refusal reaches here with its tab still
+          // connected, so the wait is a no-op for those). The command is idempotent
+          // and NOTHING was dispatched, so waiting cannot double-apply. Reads outside
+          // RETRY_SAFE_CMDS never enter this branch at all, so graph_list_subgraphs
+          // and training_get_state keep failing fast.
+          await awaitReachable();
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
           const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));


### PR DESCRIPTION
Fixes #1881

## What was reported

After a full ComfyUI Desktop restart, the user sent a new sidebar chat message from the reopened workflow. The chat turn ran — but `panel_graph_outline` answered `Connected: none`, both immediately and again 3 seconds later. Only a manual browser refresh cleared it.

## Why the chat can be live while the registry is empty

They are the same WebSocket, but they are gated differently. `UiBridge.conns` — the connected-tab registry every `panel_*` routing decision reads — is written in exactly one place: the `hello` branch (`src/services/ui-bridge.ts:2321`, `conns.set` at `:2483`). A `user_message` frame takes a different exit: `deliverPanelEvent` is called *outside* the `if (effectiveTab)` guard (`ui-bridge.ts:2847`), so the turn is delivered whether or not the socket has re-registered.

So "the chat came back but the graph socket did not" is not a contradiction — it is the documented shape of the post-restart window, and `Connected: none` was literally true.

## Why the read never recovered

`#436` gated **mutating** graph edits behind the bounded `awaitReachable()` and deliberately left the read path alone, on this reasoning:

> A read survives that window (it is parked mid-command and is retry-safe)

Parking is what happens to a command the bridge **accepted** and cannot answer yet. This failure happens strictly earlier: `resolveTarget` throws *before any socket write* (`dispatched:false`), so nothing is parked. The read just gets one re-issue after a flat `retrySettleMs()` — ~400 ms — and `reconnectWaitTiming`'s own docstring, three hundred lines up, already says why that loses:

> the browser reconnects its own socket seconds-to-tens-of-seconds after ComfyUI comes back, so the existing single ~400ms retry always loses the race

A mutation gets 20 s of patience for this exact window. A read got 0.4 s. That asymmetry is the bug.

## The change

One line in `ctx.call`'s retry-safe branch: await the same reconnect window before spending the single re-issue.

`awaitReachable()` is **self-gating**, and that is the whole safety argument — it returns at once when the bound tab is reachable, and it loops *only* while zero interactive tabs are connected. So latency moves in exactly one state, the genuine post-restart empty registry:

| state | before | after |
| --- | --- | --- |
| healthy session | first try succeeds | unchanged (never enters the branch) |
| multi-tab / stale pin, tabs live | ~400 ms then fail | unchanged (`awaitReachable` returns at once) |
| pre-executor / workflow-switch refusal | ~400 ms then retry | unchanged (the panel answered → its tab is connected) |
| **zero tabs, post-restart** | **fails after ~400 ms** | **waits for the re-hello, rebinds, answers** |
| zero tabs, nothing ever reconnects | fails ~400 ms | fails, bounded by the reconnect budget |

Nothing was dispatched and the command is idempotent, so waiting cannot double-apply. Reads outside `RETRY_SAFE_CMDS` never enter this branch at all, so `graph_list_subgraphs` / `training_get_state` keep failing fast — pinned by both the existing #436 tests and a new one.

## Verification

- **The fix was deleted and the tests watched to fail.** With `await awaitReachable()` removed, the two recovery cases fail (`expected true to be falsy` — the read errors out); restored, they pass. The other three new cases are *guards* — they pass either way by design, because their job is to catch the regression this await could introduce.
- `src/__tests__/orchestrator/` — **195 files, 3151 tests, all green**.
- `tsc --noEmit` clean.
- Not run: the panel repo's Playwright suite. This change is orchestrator-side retry timing in `comfyui-mcp` with no panel-rendered surface, so that suite would be exercising unchanged code in a different repo. Stating it rather than implying coverage I do not have.

## Deliberately not done

While tracing the transport I found that `msg.tab_id` is only overwritten server-side inside the `if (effectiveTab)` branch (`ui-bridge.ts:2843`), so a socket that has never `hello`'d can supply its own `tab_id` and pass the orchestrator's `!event.tab_id` guard. That is a separate concern from #1881, it is out of this PR's scope, and on a single-machine local trust domain it is not the reported failure — flagging it here rather than expanding the diff.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead — `claude-gate.mjs`, which spawns a fresh reviewer that has not seen this reasoning.
