### PR TITLE
fix(1887): a successful free is no longer reported as failure from another server's GPU

### DIFF
--- a/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
+++ b/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
@@ -5,6 +5,19 @@
 // loader on GPUs 2/3. /free unloads ComfyUI's model manager only; Ray workers
 // and custom-node allocations stay resident. The tool must not claim VRAM was
 // freed when a device remains pinned — it must name the pinned device(s).
+//
+// #1887 — two states #1866 did not distinguish:
+//   1. Occupancy is read from the tab's proven local server
+//      (captureRebootHealthBase), never getComfyUIBaseUrl(). A hello from
+//      another tab can retarget the global base; reporting that GPU as this
+//      command's failure is a wrong-target failure.
+//   2. Pin detection keys on torch_vram_* (this process's allocator), not
+//      device-global vram_free. Another process holding the card is not a
+//      ComfyUI /free failure and must not prescribe panel_restart_comfyui.
+//
+// These tests pass `base` into the injected reader and assert it. Discarding
+// the argument is what made a `const base = "http://wrong.example:1"` mutation
+// of annotateFreeVramAck leave every test green.
 
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
@@ -18,13 +31,22 @@ vi.mock("../../comfyui/client.js", () => ({
 const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
-import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { getBootLocalComfyUIBaseUrl, getComfyUIBaseUrl, setComfyuiTarget } from "../../config.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 const TAB = "11111111-2222-3333-4444-555555555555";
 const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+/** A distinct loopback instance — not the boot server, still classified local. */
+function otherLoopback(base: string): string {
+  const u = new URL(base);
+  u.port = u.port === "18188" ? "18189" : "18188";
+  return u.toString().replace(/\/+$/, "");
+}
+
+const OTHER_BASE = otherLoopback(BOOT_BASE);
 
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
@@ -38,13 +60,17 @@ const ackTimeout = (cmd: string, ms: number): Error =>
   );
 
 let sent: string[] = [];
+let queriedBases: string[] = [];
+let originalTarget: string;
 
-function bridge(opts: { reply: "timeout" | "ok" }): PanelToolCtx["bridge"] {
+function bridge(opts: {
+  reply: "timeout" | "ok";
+  origin?: string | null;
+}): PanelToolCtx["bridge"] {
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
       if (cmd.cmd !== "free_vram") return { ok: true };
-      // The reporter's exact success payload from the panel.
       if (opts.reply === "ok") return { freed: true, unload_models: true, free_memory: true };
       throw markReplyTimeout(ackTimeout("free_vram", 15000));
     },
@@ -58,16 +84,45 @@ function bridge(opts: { reply: "timeout" | "ok" }): PanelToolCtx["bridge"] {
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     tabIsLocal: () => true,
-    tabServerOrigin: () => BOOT_BASE,
+    tabServerOrigin: () =>
+      opts.origin === undefined ? BOOT_BASE : (opts.origin ?? undefined),
   } as unknown as PanelToolCtx["bridge"];
 }
 
-async function run(reply: "timeout" | "ok"): Promise<{ text: string; isError: boolean }> {
-  const ctx = makePanelToolCtx(bridge({ reply }), TAB, new WorkflowTargetStore());
+async function run(
+  reply: "timeout" | "ok",
+  opts?: { origin?: string | null },
+): Promise<{ text: string; isError: boolean; ctx: PanelToolCtx }> {
+  const ctx = makePanelToolCtx(bridge({ reply, origin: opts?.origin }), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
   if (!def) throw new Error("panel_free_vram is not registered");
   const res: ToolResult = await def.handler({} as never, ctx);
-  return { text: textOf(res), isError: res.isError === true };
+  return { text: textOf(res), isError: res.isError === true, ctx };
+}
+
+/** Inject occupancy. The reader MUST consume `base` — that is the #1887
+ *  assertion. Returning devices for any host is what hid the wrong-target
+ *  read; tests below check which host was actually asked. */
+function setDevices(
+  devices: Array<{
+    name?: string;
+    index?: number;
+    vram_total?: number;
+    vram_free?: number;
+    torch_vram_total?: number;
+    torch_vram_free?: number;
+  }> | null,
+): void {
+  __panelToolsTestHooks.setReadVramDevices(async (base: string) => {
+    queriedBases.push(base);
+    return devices;
+  });
+}
+
+function expectQueriedProven(ctx: PanelToolCtx): void {
+  const proven = __panelToolsTestHooks.captureRebootHealthBase(ctx);
+  expect(proven).toBeTruthy();
+  expect(queriedBases).toEqual([proven]);
 }
 
 /** Reporter: 4× RTX 2080 Ti, 21 GB. GPU 2 at vram_free=187552724 and
@@ -91,21 +146,47 @@ const allMostlyFree = reporterDevices.map((d) => ({
   torch_vram_free: MOSTLY_FREE,
 }));
 
+/** Live /system_stats from #1887: device-global 3.09% free (old logic: PINNED)
+ *  while this ComfyUI's torch pool is 32 MiB — it holds ~nothing. */
+const otherProcessHoldsCard = [
+  {
+    name: "cuda:0",
+    index: 0,
+    vram_total: 25756696576,
+    vram_free: 795579336,
+    torch_vram_total: 33554432,
+    torch_vram_free: 0,
+  },
+];
+
+const deviceGlobalOccupiedTorchAbsent = [
+  {
+    name: "cuda:0",
+    index: 0,
+    vram_total: 25756696576,
+    vram_free: 795579336,
+  },
+];
+
 beforeEach(() => {
   sent = [];
+  queriedBases = [];
+  originalTarget = getComfyUIBaseUrl();
 });
 
 afterEach(() => {
+  setComfyuiTarget(originalTarget);
   __panelToolsTestHooks.setFreeVramDirect(null);
   __panelToolsTestHooks.setReadVramDevices(null);
 });
 
 describe("panel_free_vram does not claim VRAM freed when a device stays pinned (#1866)", () => {
   it("names GPU 2 as still pinned after the panel's freed:true ack", async () => {
-    __panelToolsTestHooks.setReadVramDevices(async () => reporterDevices);
+    setDevices(reporterDevices);
     const out = await run("ok");
 
     expect(sent).toEqual(["free_vram"]);
+    expectQueriedProven(out.ctx);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"freed": false/);
     expect(out.text).not.toMatch(/"freed": true/);
@@ -121,36 +202,123 @@ describe("panel_free_vram does not claim VRAM freed when a device stays pinned (
   });
 
   it("still reports freed when occupancy matches the siblings that were mostly free", async () => {
-    __panelToolsTestHooks.setReadVramDevices(async () => allMostlyFree);
+    setDevices(allMostlyFree);
     const out = await run("ok");
 
+    expectQueriedProven(out.ctx);
     expect(out.isError).toBe(false);
     expect(out.text).toMatch(/"freed": true/);
     expect(out.text).not.toMatch(/STILL PINNED/);
   });
 
   it("leaves the panel ack untouched when occupancy cannot be read", async () => {
-    __panelToolsTestHooks.setReadVramDevices(async () => null);
+    setDevices(null);
     const out = await run("ok");
 
+    expectQueriedProven(out.ctx);
     expect(out.isError).toBe(false);
     expect(out.text).toMatch(/"freed": true/);
     expect(out.text).not.toMatch(/pinned_devices/);
   });
 
   it("does not claim freed on the frozen-tab settle when /system_stats still shows GPU 2 pinned", async () => {
-    __panelToolsTestHooks.setFreeVramDirect(async () => ({
-      ok: true,
-      before: reporterDevices,
-      after: reporterDevices,
-    }));
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      queriedBases.push(base);
+      return {
+        ok: true,
+        before: reporterDevices,
+        after: reporterDevices,
+      };
+    });
     const out = await run("timeout");
 
+    expectQueriedProven(out.ctx);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"freed": false/);
     expect(out.text).not.toMatch(/"freed": true/);
     expect(out.text).toContain(String(GPU2_FREE));
     expect(out.text).toMatch(/device 2/);
     expect(out.text).toMatch(/"verified": "server-side"/);
+  });
+});
+
+describe("panel_free_vram reads occupancy from this tab's server, not the global base (#1887)", () => {
+  it("queries the proven local base after getComfyUIBaseUrl is retargeted to another host", async () => {
+    setDevices(reporterDevices);
+    expect(setComfyuiTarget(OTHER_BASE)).toBe(true);
+    // Premise: the global configured base is no longer this tab's server.
+    expect(__panelToolsTestHooks.sameHttpBase(getComfyUIBaseUrl(), BOOT_BASE)).toBe(false);
+
+    const out = await run("ok");
+    const proven = __panelToolsTestHooks.captureRebootHealthBase(out.ctx);
+    expect(proven).toBeTruthy();
+    expect(__panelToolsTestHooks.sameHttpBase(proven, getComfyUIBaseUrl())).toBe(false);
+    expect(queriedBases).toEqual([proven]);
+    // Occupancy is THIS tab's GPU 2, not whatever the retargeted host would show.
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"index": 2/);
+    expect(out.text).toMatch(/panel_restart_comfyui/);
+  });
+
+  it("does not name another server's GPU as this tab's failed free", async () => {
+    // Tab fronts a DIFFERENT local instance than boot. Global is the boot
+    // server. Returning pinned devices if that host is queried makes a
+    // wrong-target read fail this test — the #1878 tests were blind to it.
+    setDevices(reporterDevices);
+    expect(setComfyuiTarget(BOOT_BASE)).toBe(true);
+    const out = await run("ok", { origin: OTHER_BASE });
+
+    expect(__panelToolsTestHooks.captureRebootHealthBase(out.ctx)).toBeNull();
+    expect(queriedBases).toEqual([]);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/"freed": false/);
+    expect(out.text).not.toMatch(/STILL PINNED/);
+    expect(out.text).not.toMatch(/panel_restart_comfyui/);
+    expect(out.text).not.toMatch(/"index": 2/);
+  });
+});
+
+describe("panel_free_vram attributes a pin to this ComfyUI's torch pool, not the whole card (#1887)", () => {
+  it("does not blame ComfyUI when the torch pool is empty and another process holds the card", async () => {
+    setDevices(otherProcessHoldsCard);
+    const out = await run("ok");
+
+    expectQueriedProven(out.ctx);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/"freed": false/);
+    expect(out.text).not.toMatch(/STILL PINNED/);
+    expect(out.text).not.toMatch(/panel_restart_comfyui/);
+  });
+
+  it("does not treat device-global vram_free as a pin when torch counters are absent", async () => {
+    setDevices(deviceGlobalOccupiedTorchAbsent);
+    const out = await run("ok");
+
+    expectQueriedProven(out.ctx);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/panel_restart_comfyui/);
+  });
+
+  it("still names a pin when THIS instance's torch pool is occupied even if the card looks free", async () => {
+    // Inverse discriminator: device-global mostly free (old vram_free rule
+    // would report success) while GPU 2's torch pool matches the reporter's
+    // 0.24% leftover — that is ComfyUI's doing.
+    const torchPinnedDeviceGlobalFree = reporterDevices.map((d) =>
+      d.index === 2
+        ? { ...d, vram_free: MOSTLY_FREE, torch_vram_free: GPU2_TORCH_FREE }
+        : { ...d, vram_free: MOSTLY_FREE, torch_vram_free: MOSTLY_FREE },
+    );
+    setDevices(torchPinnedDeviceGlobalFree);
+    const out = await run("ok");
+
+    expectQueriedProven(out.ctx);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"freed": false/);
+    expect(out.text).toMatch(/device 2/);
+    expect(out.text).toMatch(/panel_restart_comfyui/);
+    expect(out.text).not.toMatch(/device 0/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2843,20 +2843,25 @@ function sampleVramDevice(d: unknown): VramDeviceSample {
   return sample;
 }
 
-/** A device with at least 1 GiB of VRAM is still PINNED when less than 20% is
- *  free after /free. CUDA context leftover on an unloaded GPU is a few hundred
- *  MB to a couple of GiB, not 80%+ of a 21 GiB card. The reporter's Raylight
- *  MiniMax H3 case was device 2 at ~0.8% free (~179 MiB of 21 GiB) next to
- *  siblings at ~44% free — that occupancy is what this threshold names.
+/** A device whose ComfyUI torch pool is at least 1 GiB is still PINNED when
+ *  less than 20% of that pool is free after /free. `vram_free` is
+ *  torch.cuda.mem_get_info — the whole device, every process — so it cannot
+ *  attribute a pin to THIS ComfyUI. `torch_vram_total` / `torch_vram_free`
+ *  are this process's allocator: a 32 MiB leftover pool next to a card
+ *  occupied by another instance is not a /free failure and must not
+ *  prescribe panel_restart_comfyui (#1887). The reporter's Raylight MiniMax
+ *  H3 case was device 2 with the torch pool at ~0.24% free — that occupancy
+ *  is what this threshold names.
  *
- *  Unknown/unreadable counters are NOT pinned: an unknown answer claims
- *  nothing in either direction (#1473). */
+ *  Unknown/unreadable torch counters are NOT pinned: an unknown answer
+ *  claims nothing in either direction (#1473). Device-global counters
+ *  alone also claim nothing — they cannot tell ComfyUI from another process. */
 const PINNED_VRAM_MIN_TOTAL_BYTES = 1024 * 1024 * 1024;
 const PINNED_VRAM_FREE_RATIO = 0.2;
 
 function deviceStillPinned(d: VramDeviceSample): boolean {
-  const total = d.vram_total;
-  const free = d.vram_free;
+  const total = d.torch_vram_total;
+  const free = d.torch_vram_free;
   if (typeof total !== "number" || typeof free !== "number") return false;
   if (!Number.isFinite(total) || !Number.isFinite(free)) return false;
   if (total < PINNED_VRAM_MIN_TOTAL_BYTES) return false;
@@ -3050,12 +3055,18 @@ async function settleFreeVramAfterAckTimeout(
  * GPU. After the tab says it posted /free, re-read /system_stats and refuse to
  * claim VRAM was freed when a device is still occupied. Unreadable stats leave
  * the original ack UNTOUCHED: an unknown answer claims nothing extra.
+ *
+ * #1887 — occupancy is read from the same proven local base the frozen-tab
+ * settle uses (`captureRebootHealthBase(ctx)`), never `getComfyUIBaseUrl()`.
+ * A hello from another tab can retarget the global base asynchronously;
+ * reporting that GPU as this command's failure is the wrong-target failure
+ * the gate exists to prevent. No proven local server → leave the ack.
  */
-async function annotateFreeVramAck(res: ToolResult): Promise<ToolResult> {
+async function annotateFreeVramAck(ctx: PanelToolCtx, res: ToolResult): Promise<ToolResult> {
   if (res.isError) return res;
   const parsed = parseToolResultJson(res);
   if (!parsed || parsed.freed !== true) return res;
-  const base = (getComfyUIBaseUrl() || "").replace(/\/+$/, "");
+  const base = captureRebootHealthBase(ctx);
   if (!base) return res;
   const devices = await readVramDevicesMaybe(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
   if (devices == null) return res;
@@ -16259,7 +16270,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_free_vram",
-      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory. After /free, occupancy is re-read from /system_stats: if a device remains pinned (Ray workers, parallel CLIP, custom-node allocations /free cannot terminate), the reply names those devices and does NOT claim VRAM was freed — next step is panel_restart_comfyui. If the panel tab is frozen and cannot acknowledge, the free is instead issued DIRECTLY to the ComfyUI server and verified there (same /free, idempotent) whenever the tab provably fronts the local server — otherwise the outcome is reported unknown rather than claimed.",
+      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory. After /free, THIS instance's torch-pool occupancy is re-read from /system_stats on the server this tab provably fronts: if a device remains pinned (Ray workers, parallel CLIP, custom-node allocations /free cannot terminate), the reply names those devices and does NOT claim VRAM was freed — next step is panel_restart_comfyui. Device-global occupancy held by another process is not this free failing. If the panel tab is frozen and cannot acknowledge, the free is instead issued DIRECTLY to the ComfyUI server and verified there (same /free, idempotent) whenever the tab provably fronts the local server — otherwise the outcome is reported unknown rather than claimed.",
       {},
       async (_args, ctx) => {
         const res = await ctx.call({ cmd: "free_vram" }, 15000);
@@ -16271,7 +16282,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         if (isReplyTimeoutResult(res)) return settleFreeVramAfterAckTimeout(ctx, res);
         // #1866 — a successful /free ack is not a free GPU. Re-read occupancy
         // and refuse to report freed:true when a device is still pinned.
-        return annotateFreeVramAck(res);
+        return annotateFreeVramAck(ctx, res);
       },
     ),
     def(


### PR DESCRIPTION
Fixes #1887

`panel_free_vram` had two remaining honesty bugs after #1878.

## P0 — a correct free on this tab's server was reported as a failure from another GPU

`annotateFreeVramAck` took no `ctx` and read `getComfyUIBaseUrl()` — the orchestrator's global configured base, which any tab's hello can retarget. Its sibling `settleFreeVramAfterAckTimeout` already gates on `captureRebootHealthBase(ctx)` so a direct `/free` cannot aim at a different server than the tab was asked to free.

Executed: tab `tabServerOrigin = http://127.0.0.1:8189`, `setComfyuiTarget("http://127.0.0.1:8188")`, panel replies `{freed:true}` — occupancy was read from :8188 and named as this command's failure, prescribing `panel_restart_comfyui`. The free on :8189 had succeeded.

Occupancy now uses the same `ctx` gate. No proven local server → the original ack is left untouched.

## P1 — device-global `vram_free` cannot attribute the pin

`deviceStillPinned` keyed on `vram_free` (`torch.cuda.mem_get_info` — whole device, all processes). Live `/system_stats` from the filing machine:

```
vram_total 25756696576  vram_free 795579336  -> 3.09% free  => PINNED
torch_vram_total 33554432 (32 MiB)           -> ComfyUI holds ~nothing
```

The torch-pool figures were already fetched and discarded. A pin is now this process's `torch_vram_total` / `torch_vram_free`. A 32 MiB leftover pool next to a card occupied by another instance is not a `/free` failure and does not prescribe `panel_restart_comfyui`. The reporter's Raylight GPU 2 (torch pool ~0.24% free) is still named.

## Tests

`free-vram-pinned-device.test.ts` now passes `base` into the injected reader and asserts it against `captureRebootHealthBase(ctx)`. Retargeting `getComfyUIBaseUrl` to another loopback host, or pointing the tab at a different instance than boot, fails until the P0 gate is in place. The live 32 MiB torch-pool numbers fail until pin detection reads torch, not device-global `vram_free`.
