### PR TITLE
fix(1567): a queued respawn sees downloads started after the save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- a queued tool-session respawn sees the downloads started after the save, instead of killing them with no warning (#1567)
+- it waits on those transfers' live byte counts rather than treating every one as already stalled (#1567)
+
 ## [0.52.28] - 2026-08-20
 
 ### MCP

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -26,6 +26,41 @@ function pendingFiles(): string[] {
   return readdirSync(dir).filter((f) => f.startsWith(mod.CONTROL_PREFIX));
 }
 
+describe("readDownloadProgress uses the late-bound dir (#1567)", () => {
+  // The orchestrator has no COMFYUI_MCP_PROGRESS_DIR; it late-binds via
+  // setProgressDir. A respawn-time snapshot runs in that process, so a reader
+  // that only looked at the import-time env capture returned null for every
+  // live transfer and the hold treated them as already stalled.
+  it("finds a row written into the dir the orchestrator actually uses", async () => {
+    vi.resetModules();
+    const lateDir = mkdtempSync(join(tmpdir(), "dl-late-"));
+    const saved = process.env.COMFYUI_MCP_PROGRESS_DIR;
+    delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+    try {
+      const late = await import("../../services/download-progress.js");
+      late.setProgressDir(lateDir);
+      writeFileSync(
+        join(lateDir, "abc-deadbeef.json"),
+        JSON.stringify({
+          id: "abc",
+          name: "m.safetensors",
+          downloaded: 42,
+          total: 100,
+          bytes_per_sec: 1,
+          status: "downloading",
+          updated: Date.now(),
+        }),
+      );
+      expect(late.readDownloadProgress("abc")?.downloaded).toBe(42);
+      expect(late.listInFlightDownloadProgress().map((r) => r.id)).toEqual(["abc"]);
+    } finally {
+      if (saved === undefined) delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+      else process.env.COMFYUI_MCP_PROGRESS_DIR = saved;
+      rmSync(lateDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("download target stamping (#269)", () => {
   it("stamps the row with the writer's COMFYUI_URL at write time", () => {
     process.env.COMFYUI_URL = "https://podabc-3000.proxy.runpod.net";

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -17,7 +17,10 @@
 // not its internal binding — my first version of this file mocked it and got an empty list
 // back from working code.
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   progress: {} as Record<string, { downloaded: number }>,
@@ -29,6 +32,7 @@ vi.mock("../../services/download-progress.js", async (orig) => ({
 }));
 
 const { downloadsAtRiskOfRespawn } = await import("../../services/download-jobs.js");
+const { setProgressDir, CONTROL_PREFIX } = await import("../../services/download-progress.js");
 
 type Job = Parameters<typeof downloadsAtRiskOfRespawn>[0];
 const jobs = (...list: Record<string, unknown>[]): Job => list as unknown as Job;
@@ -341,5 +345,103 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     expect(src).toMatch(/atRiskNote\(receipt\.atRiskDownloads/);
     const receiptRenderer = code("../../orchestrator/panel-tools.ts");
     expect(receiptRenderer).not.toMatch(/downloadsAtRiskOfRespawn\(\)/);
+  });
+});
+
+describe("downloadsAtRiskOfRespawn sees live tray rows (#1567)", () => {
+  // The save-time job list cannot see a transfer that starts after the save:
+  // downloads run in the MCP child, persist can lag a heartbeat, and the
+  // orchestrator's in-memory registry is empty. The tray files are the child's
+  // live writes. Re-calling this function at respawn on the job list alone still
+  // reported nothing for the nine downloads started in that window.
+  let dir = "";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "at-risk-tray-"));
+    setProgressDir(dir);
+  });
+
+  afterEach(() => {
+    setProgressDir("");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeTray = (row: {
+    id: string;
+    name: string;
+    downloaded: number;
+    status: "downloading" | "done" | "error";
+  }) => {
+    writeFileSync(
+      join(dir, `${row.id}-deadbeef.json`),
+      JSON.stringify({
+        id: row.id,
+        name: row.name,
+        downloaded: row.downloaded,
+        total: row.downloaded + 1,
+        bytes_per_sec: 1,
+        status: row.status,
+        updated: Date.now(),
+      }),
+    );
+  };
+
+  it("names a transfer that exists only as a live tray row — the ones started AFTER save", () => {
+    writeTray({
+      id: "d5819adcd02a4257",
+      name: "flux-dev.safetensors",
+      downloaded: 4_000_000_000,
+      status: "downloading",
+    });
+    // Empty job list: the save-time snapshot, and the orchestrator's registry.
+    const at = downloadsAtRiskOfRespawn(jobs());
+    expect(at).toEqual([
+      { id: "d5819adcd02a4257", filename: "flux-dev.safetensors", bytes: 4_000_000_000 },
+    ]);
+  });
+
+  it("does not double a transfer already in the job list", () => {
+    writeTray({
+      id: "a",
+      name: "flux-dev.safetensors",
+      downloaded: 9_000_000_000,
+      status: "downloading",
+    });
+    hoisted.progress = { a: { downloaded: 4_000_000_000 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs({ filename: "flux-dev.safetensors", status: "downloading", trayId: "a" }),
+    );
+    expect(at).toHaveLength(1);
+    // Live tray bytes win when they are further along than the (possibly stale) job read.
+    expect(at[0]).toEqual({ id: "a", filename: "flux-dev.safetensors", bytes: 9_000_000_000 });
+  });
+
+  it("ignores a settled tray row and a control-channel file", () => {
+    writeTray({
+      id: "done-id",
+      name: "finished.safetensors",
+      downloaded: 1,
+      status: "done",
+    });
+    writeFileSync(
+      join(dir, `${CONTROL_PREFIX}job-not-a-tray-owner.json`),
+      JSON.stringify({
+        id: "not-a-tray",
+        name: "secret.safetensors",
+        downloaded: 99,
+        status: "downloading",
+        updated: Date.now(),
+      }),
+    );
+    expect(downloadsAtRiskOfRespawn(jobs())).toEqual([]);
+  });
+
+  it("WIRING: the respawn-time enumerator unions the live tray", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("../../services/download-jobs.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    const fn = src.slice(src.indexOf("export function downloadsAtRiskOfRespawn"));
+    expect(fn).toMatch(/listInFlightDownloadProgress\(\)/);
   });
 });

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -33,6 +33,7 @@ import type { ResumeDiagnostic } from "./download-resume-diag.js";
 import { ModelError } from "../utils/errors.js";
 import {
   readDownloadProgress,
+  listInFlightDownloadProgress,
   persistDownloadJob,
   readPersistedDownloadJob,
   listPersistedDownloadJobs,
@@ -2162,18 +2163,44 @@ export function downloadsAtRiskOfRespawn(
   jobs: readonly DownloadJob[] = listDownloadJobs(),
 ): { id: string; filename: string; bytes: number }[] {
   const at: { id: string; filename: string; bytes: number }[] = [];
+  const byId = new Map<string, number>();
   for (const job of jobs) {
     if (job.status !== "downloading") continue;
     const progress = readDownloadProgress(job.progressId ?? job.trayId);
-    at.push({
+    const id = job.progressId ?? job.trayId ?? job.filename ?? "";
+    const entry = {
       // AN IDENTITY THAT IS NOT THE DISPLAY NAME (codex P2). Two different downloads
       // whose names are both credential-shaped redact to the SAME string, so a consumer
       // deduplicating on the filename collapsed them into one entry and reported the
       // larger byte count instead of both files and their total — under-reporting the
       // loss precisely when the names are least informative.
-      id: job.progressId ?? job.trayId ?? job.filename ?? "",
+      id,
       filename: redactSecretishFilename(job.filename),
       bytes: progress?.downloaded ?? 0,
+    };
+    byId.set(id, at.length);
+    at.push(entry);
+  }
+  // #1567 — UNION the live tray. The job list is what a SAVE-TIME snapshot can
+  // see, and for a queued respawn that list is taken in the orchestrator, which
+  // does not run the downloads: persist can lag a heartbeat, and a transfer
+  // started AFTER the save is not in the in-memory registry at all. The tray
+  // files are written by the child as it streams, so they are what exists at
+  // respawn-execution time. A first version that only re-called this function
+  // on the job list still reported nothing for the reporter's nine downloads.
+  for (const row of listInFlightDownloadProgress()) {
+    const id = row.id;
+    const bytes = typeof row.downloaded === "number" ? row.downloaded : 0;
+    const existing = byId.get(id);
+    if (existing !== undefined) {
+      if (bytes > at[existing].bytes) at[existing] = { ...at[existing], bytes };
+      continue;
+    }
+    byId.set(id, at.length);
+    at.push({
+      id,
+      filename: redactSecretishFilename(row.name),
+      bytes,
     });
   }
   return at;

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -397,20 +397,26 @@ export function reportDownloadProgress(
  * bytes/throughput instead of a bare "still going". Progress files are
  * TARGET-SCOPED ({id}-{disc}.json — the same URL can download for local AND a
  * pod at once), so scan every variant for this id and return the most recently
- * updated snapshot. Returns null when progress reporting is off (no
- * COMFYUI_MCP_PROGRESS_DIR) or nothing has been written yet — callers must
- * treat byte counts as decoration, never as the source of truth for whether a
- * download finished.
+ * updated snapshot. Returns null when progress reporting is off (no channel
+ * dir — neither COMFYUI_MCP_PROGRESS_DIR nor the orchestrator's late-bound
+ * dir) or nothing has been written yet — callers must treat byte counts as
+ * decoration, never as the source of truth for whether a download finished.
  */
 export function readDownloadProgress(id: string): DownloadProgress | null {
-  if (!PROGRESS_DIR) return null;
+  // `channelDir()`, not the import-time env capture: the orchestrator has no
+  // COMFYUI_MCP_PROGRESS_DIR and late-binds via setProgressDir. A respawn-time
+  // at-risk snapshot runs in THAT process (#1567); reading only PROGRESS_DIR
+  // made every transfer look like 0 bytes, so the hold treated live downloads
+  // as already stalled.
+  const dir = channelDir();
+  if (!dir) return null;
   try {
     const prefix = `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-`;
     let best: DownloadProgress | null = null;
-    for (const f of readdirSync(PROGRESS_DIR)) {
+    for (const f of readdirSync(dir)) {
       if (!f.startsWith(prefix) || !f.endsWith(".json")) continue;
       try {
-        const parsed = JSON.parse(readFileSync(join(PROGRESS_DIR, f), "utf8")) as DownloadProgress;
+        const parsed = JSON.parse(readFileSync(join(dir, f), "utf8")) as DownloadProgress;
         if (parsed && typeof parsed === "object" && typeof parsed.updated === "number") {
           if (!best || parsed.updated > best.updated) best = parsed;
         }
@@ -527,12 +533,13 @@ export function isSupersededAttempt(row: AttemptRowLike, newest: Map<string, num
 /** Remove a download's progress file(s) (e.g. on cancel). Target-scoped files
  *  share the id prefix, so clear every variant for the logical download. */
 export function clearDownloadProgress(id: string): void {
-  if (!PROGRESS_DIR) return;
+  const dir = channelDir();
+  if (!dir) return;
   lastWriteAt.delete(id);
   try {
     const prefix = `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-`;
-    for (const f of readdirSync(PROGRESS_DIR)) {
-      if (f.startsWith(prefix) && f.endsWith(".json")) rmSync(join(PROGRESS_DIR, f), { force: true });
+    for (const f of readdirSync(dir)) {
+      if (f.startsWith(prefix) && f.endsWith(".json")) rmSync(join(dir, f), { force: true });
     }
   } catch {
     // ignore
@@ -599,6 +606,52 @@ export const CONTROL_PREFIX = "control-";
 const REQUEST_PREFIX = `${CONTROL_PREFIX}target-`;
 const APPLIED_PREFIX = `${CONTROL_PREFIX}applied-`;
 let controlSeq = 0;
+
+/**
+ * Live tray rows that a tool-session respawn would kill, enumerated NOW.
+ *
+ * `downloadsAtRiskOfRespawn` used to read only the job registry. That list is
+ * what existed at save time in the orchestrator (usually nothing — downloads
+ * run in the MCP child, and persist can lag a heartbeat). The tray files are
+ * the child's live writes, so they are the ones that exist for a transfer
+ * started AFTER the save and BEFORE the queued respawn fires (#1567).
+ *
+ * Control-channel files are skipped: those are not downloads. Terminal rows
+ * are skipped: they have already settled and a respawn does not orphan them.
+ */
+export function listInFlightDownloadProgress(): DownloadProgress[] {
+  const dir = channelDir();
+  if (!dir) return [];
+  const best = new Map<string, DownloadProgress>();
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json") || f.startsWith(CONTROL_PREFIX)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, f), "utf8")) as DownloadProgress;
+      if (!parsed || typeof parsed !== "object") continue;
+      if (typeof parsed.id !== "string" || !parsed.id) continue;
+      if (parsed.status !== "downloading") continue;
+      const downloaded = typeof parsed.downloaded === "number" ? parsed.downloaded : 0;
+      const updated = typeof parsed.updated === "number" ? parsed.updated : 0;
+      const prev = best.get(parsed.id);
+      if (
+        !prev ||
+        downloaded > (typeof prev.downloaded === "number" ? prev.downloaded : 0) ||
+        (downloaded === prev.downloaded && updated > (prev.updated ?? 0))
+      ) {
+        best.set(parsed.id, parsed);
+      }
+    } catch {
+      // mid-write or corrupt — not a download we can name
+    }
+  }
+  return [...best.values()];
+}
 
 function controlDirPath(dir: string = channelDir()): string | null {
   return dir || null;


### PR DESCRIPTION
Fixes #1567.

A queued tool-session respawn still killed downloads started *after* the credential save, because the at-risk snapshot was the job list the orchestrator could see at save time — usually nothing. Downloads run in the MCP child; persist can lag a heartbeat; the child's live tray files are what actually exist when the respawn fires.

`downloadsAtRiskOfRespawn` now unions those live tray rows at the moment of teardown. Byte counts are read from the orchestrator's late-bound progress dir (it has no `COMFYUI_MCP_PROGRESS_DIR`), so the hold can wait on real progress instead of treating every transfer as already stalled.

The receipt warning and the stall-hold from #1576 / #1613 stay; this is the remaining ordering gap: snapshot at respawn, not only at save.
