### PR TITLE
fix(panel#1489): read-only graph calls are no longer refused while a render runs

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -1,16 +1,20 @@
-// #1639 — while a ComfyUI prompt is running, graph_* (including read-only
-// graph_query / graph_outline) time out with "tab may be backgrounded or frozen"
-// and mutating commands report an unknown outcome. 100% correlated with
-// queue action:"list" showing running:1; the same calls succeed the moment
-// the queue drains.
+// #1639 — while a ComfyUI prompt is running, a graph_* MUTATION can time out with
+// "tab may be backgrounded or frozen" and an unknown outcome. The orchestrator CAN
+// see the running prompt via QueueMonitor (HTTP /queue, independent of the panel
+// tab), so it fails a write closed BEFORE dispatch and the agent gets an explicit
+// QUEUE BUSY instead of a 20/30s unknown-outcome timeout. `graph_run` is excluded:
+// queuing behind an in-flight job is the documented sweep path.
 //
-// The frontend main thread is what cannot answer. The orchestrator CAN see the
-// running prompt via QueueMonitor (HTTP /queue, independent of the panel tab).
-// Fail closed BEFORE dispatch for canvas-touching graph commands so the agent
-// gets an explicit QUEUE BUSY instead of a 20/30s unknown-outcome timeout.
-// `graph_run` is excluded: queuing behind an in-flight job is the documented
-// sweep path. A timeout that still happens (graph_run, or a lagging snapshot)
-// is annotated with the same QUEUE BUSY rather than "backgrounded or frozen".
+// panel#1489 — that fence was applied to READS too, and this file used to pin
+// exactly that (`expect(sent).toEqual([])` for panel_query_graph and
+// panel_graph_outline). It should not have: a read that fails carries no unknown
+// outcome, so refusing it unsent bought no safety and cost the agent its only way
+// to LOOK at the graph mid-render.
+//
+// The property under test is therefore the SPLIT: `targeted` graph commands are
+// refused unsent, `inert` ones are dispatched, and a dispatched read that does
+// time out still comes back named QUEUE BUSY rather than "backgrounded or frozen".
+// The classification is read from GRAPH_CMD_EFFECT, not from a second list.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -82,6 +86,13 @@ function makeBridge(opts?: { timeoutCmds?: Set<string> }) {
   return { bridge, sent };
 }
 
+/** Put a foreign prompt in flight, exactly as the reporter's repro does. */
+function startRender(promptId = "p-in-flight", node: string | null = null): void {
+  qm.state.runningPromptId = promptId;
+  qm.state.currentNode = node;
+  qm.state.queueRemaining = 1;
+}
+
 beforeEach(() => {
   qm.url = "http://127.0.0.1:9999";
   qm.stopped = false;
@@ -106,44 +117,66 @@ afterEach(() => {
   qm.url = null;
 });
 
-describe("graph_* fail fast while a prompt is running (#1639)", () => {
-  it("a read-only graph_query is NOT sent — QUEUE BUSY names the running prompt", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.currentNode = "42";
-    qm.state.queueRemaining = 1;
-
-    const { bridge, sent } = makeBridge();
-    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
-    const text = textOf(res);
-
-    expect(sent).toEqual([]);
-    expect(res.isError).toBe(true);
-    expect(text).toMatch(/QUEUE BUSY/);
-    expect(text).toMatch(/running prompt p-in-flight/);
-    expect(text).toMatch(/currently at node 42/);
-    expect(text).toMatch(/was NOT sent — nothing was applied/);
-    expect(text).toMatch(/running: 0/);
-    // Mentions the generic frozen-tab wording only as the diagnosis it refuses to
-    // surface — the actual headline is QUEUE BUSY, not a backgrounded tab.
-  });
-
-  it("panel_graph_outline is the same — reads are not exempt", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.queueRemaining = 1;
+describe("read-only graph inspection is allowed while a prompt runs (panel#1489)", () => {
+  it("panel_graph_outline IS dispatched mid-render and returns the graph", async () => {
+    startRender();
 
     const { bridge, sent } = makeBridge();
     const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
     const res = await defByName("panel_graph_outline").handler({} as never, ctx);
 
-    expect(sent).toEqual([]);
-    expect(res.isError).toBe(true);
-    expect(textOf(res)).toMatch(/QUEUE BUSY/);
+    // The reported failure: rejected before dispatch, so the agent never saw the graph.
+    expect(sent).toEqual(["graph_outline"]);
+    expect(res.isError).not.toBe(true);
+    expect(textOf(res)).not.toMatch(/QUEUE BUSY/);
+    expect(textOf(res)).not.toMatch(/was NOT sent/);
   });
 
+  it("panel_query_graph IS dispatched mid-render", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_query_graph").handler(
+      { ids: [1], fields: "ids" } as never,
+      ctx,
+    );
+
+    expect(sent).toEqual(["graph_query"]);
+    expect(res.isError).not.toBe(true);
+  });
+
+  it("panel_get_errors IS dispatched mid-render — the recurrence report's second command", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_get_errors").handler({} as never, ctx);
+
+    // Diagnosing a stalled render is the moment this read matters most, and it was
+    // refused for being spelled graph_*.
+    expect(sent).toEqual(["graph_get_errors"]);
+    expect(res.isError).not.toBe(true);
+  });
+
+  it("an inert non-read (a selection change) is dispatched too — the gate keys on EFFECT", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    // graph_select_nodes is GRAPH_CMD_EFFECT "inert" but is NOT in
+    // BRIDGE_READONLY_CMDS — so this fails if the split is ever re-derived from
+    // the re-dispatch-safety list instead of the effect ledger (#778's defect).
+    const res = await defByName("panel_select_nodes").handler({ node_ids: [1] } as never, ctx);
+
+    expect(sent).toEqual(["graph_select_nodes"]);
+    expect(res.isError).not.toBe(true);
+  });
+});
+
+describe("graph MUTATIONS still fail fast while a prompt is running (#1639)", () => {
   it("panel_set_widget is NOT delivered — outcome is known (nothing applied)", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.queueRemaining = 1;
+    startRender();
 
     const { bridge, sent } = makeBridge();
     const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
@@ -157,17 +190,53 @@ describe("graph_* fail fast while a prompt is running (#1639)", () => {
     expect(res.isError).toBe(true);
     expect(text).toMatch(/QUEUE BUSY/);
     expect(text).toMatch(/was NOT sent — nothing was applied/);
+    expect(text).toMatch(/running prompt p-in-flight/);
     // A mutation that never left must not invite retry_of / unknown-outcome.
     expect(text).not.toMatch(/may have been applied/);
     expect(text).not.toMatch(/retry_of/);
   });
 
-  it("idle queue: the same read is dispatched", async () => {
+  it("the refusal names the reads that ARE available instead of sending the agent to poll", async () => {
+    startRender("p-in-flight", "42");
+
+    const { bridge } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+    const text = textOf(res);
+
+    expect(text).toMatch(/currently at node 42/);
+    expect(text).toMatch(/graph_outline/);
+    expect(text).toMatch(/NOT fenced/);
+    // The old text told every caller reads were unavailable too. Nothing may say so.
+    expect(text).not.toMatch(/including read-only/);
+  });
+
+  it("a targeted command that is not a node edit is fenced as well", async () => {
+    startRender();
+
     const { bridge, sent } = makeBridge();
     const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
+    // graph_auto_layout moves every node; "targeted" in the ledger, and absent from
+    // the MUTATING_GRAPH_EDIT_CMDS allowlist used by the reconnect gate.
+    const res = await defByName("panel_auto_layout").handler({} as never, ctx);
 
-    expect(sent).toEqual(["graph_query"]);
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/QUEUE BUSY/);
+  });
+
+  it("idle queue: the same mutation is dispatched", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+
+    expect(sent).toEqual(["graph_set_widget"]);
     expect(res.isError).not.toBe(true);
   });
 
@@ -187,9 +256,43 @@ describe("graph_* fail fast while a prompt is running (#1639)", () => {
 });
 
 describe("a graph_* timeout while a prompt is running is named QUEUE BUSY (#1639)", () => {
+  it("a READ that times out mid-render still names the running prompt", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_graph_outline").handler({} as never, ctx);
+    const text = textOf(res);
+
+    // This is the half of #1639 that survives: the read is attempted, and when the
+    // tab genuinely cannot answer, the diagnosis is still explicit rather than a
+    // bare "backgrounded or frozen".
+    expect(sent).toContain("graph_outline");
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/did not reply to "graph_outline"/);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/running prompt p-in-flight/);
+    expect(text).toMatch(/running: 0/);
+  });
+
+  it("that diagnosis does not over-claim: a backgrounded tab is ruled out only once idle", async () => {
+    startRender();
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    // Reads reach this path now, and a read that goes unanswered mid-render is
+    // genuinely ambiguous — the render is the LIKELY cause, not a proven one. The
+    // note used to flatly assert "this is not a backgrounded or frozen tab", which
+    // is a claim the orchestrator cannot make about a tab that just went silent.
+    expect(text).toMatch(/most likely reason/);
+    expect(text).not.toMatch(/this is not a backgrounded or frozen tab/i);
+    expect(text).toMatch(/if it still does not answer once the queue is idle/i);
+  });
+
   it("graph_run's missing ack names the running prompt instead of a frozen tab", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.queueRemaining = 1;
+    startRender();
     QueueMonitor.markSelfQueued("p-in-flight");
 
     const { bridge, sent } = makeBridge({ timeoutCmds: new Set(["graph_run"]) });
@@ -202,7 +305,6 @@ describe("a graph_* timeout while a prompt is running is named QUEUE BUSY (#1639
     expect(text).toMatch(/did not reply to "graph_run"/);
     expect(text).toMatch(/QUEUE BUSY/);
     expect(text).toMatch(/running prompt p-in-flight/);
-    expect(text).toMatch(/not a backgrounded or frozen tab/i);
   });
 
   it("an idle queue does not append QUEUE BUSY onto a genuine timeout", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -976,10 +976,13 @@ const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
 // running render was rejected unsent, forcing queue-polling and a later retry
 // just to LOOK at the graph.
 //
-// It also asserted more than we know. Execution is server-side Python; a
-// foregrounded tab's main thread is usually free to answer a read while the GPU
-// works, and in practice it does. "The tab typically cannot answer" was a
-// prediction, and the refusal made it unfalsifiable by never letting a read try.
+// It also asserted more than we know, in BOTH directions. "The tab typically
+// cannot answer" is a prediction, not a measurement — and refusing the call made
+// it unfalsifiable, because no read ever got to try. The architectural reason to
+// doubt it is that ComfyUI executes in server-side Python, so the browser main
+// thread is not the thing doing the work; how often a real tab answers mid-render
+// is NOT measured here, and nothing below depends on a number for it. Attempting
+// the read is what turns the question back into something observable.
 //
 // Note what #1639 actually asked for: "(a) keep the panel's command channel
 // responsive during execution (the reads at minimum should never be blocked by a

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -957,12 +957,44 @@ function sleep(ms: number): Promise<void> {
 const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
 
 // #1639 — while a ComfyUI prompt is running the frontend main thread often
-// cannot service graph_* at all (reads included). Waiting out the 20/30 s ack
-// bound only surfaces "tab may be backgrounded or frozen" with an unknown
-// mutation outcome. Fail closed BEFORE dispatch for canvas-touching graph
-// commands so the agent gets an explicit QUEUE BUSY instead. `graph_run` is
-// excluded: queuing behind an in-flight job is the documented sweep path, and
-// panel_run already has its own duplicate fence.
+// cannot service graph_* at all. Waiting out the 20/30 s ack bound only
+// surfaces "tab may be backgrounded or frozen" with an unknown mutation
+// outcome. Fail closed BEFORE dispatch for canvas-touching graph commands so
+// the agent gets an explicit QUEUE BUSY instead. `graph_run` is excluded:
+// queuing behind an in-flight job is the documented sweep path, and panel_run
+// already has its own duplicate fence.
+//
+// panel#1489 — that fence was applied to READS too, and it should not have been.
+//
+// The harm #1639 names is specific to a WRITE: a delivered frame cannot be
+// retracted, so a write that times out mid-render leaves the caller unable to say
+// whether it applied. A read carries no such outcome. Abandoning one costs a
+// retry and nothing else — the asymmetry BRIDGE_DEFAULT_TIMEOUT_MS's own doc
+// spells out ("a read abandoned too early costs a retry; a write abandoned too
+// early is UNRECOVERABLE ambiguity"). So fencing reads bought no safety at all,
+// and it cost the reporter the thing they needed: panel_graph_outline on a
+// running render was rejected unsent, forcing queue-polling and a later retry
+// just to LOOK at the graph.
+//
+// It also asserted more than we know. Execution is server-side Python; a
+// foregrounded tab's main thread is usually free to answer a read while the GPU
+// works, and in practice it does. "The tab typically cannot answer" was a
+// prediction, and the refusal made it unfalsifiable by never letting a read try.
+//
+// Note what #1639 actually asked for: "(a) keep the panel's command channel
+// responsive during execution (the reads at minimum should never be blocked by a
+// running prompt), or (b) ... say so explicitly instead of a generic timeout."
+// It shipped (b) and applied it to reads as well, which is the one combination
+// the reporter did not ask for. Reads now get BOTH halves: the call is attempted,
+// and if the tab really cannot answer, queueBusyTimeoutNote still names the
+// running prompt instead of surfacing a bare "backgrounded or frozen".
+//
+// Reads keep their normal tolerant ack budget on purpose. Shortening it mid-render
+// is tempting — a frozen tab costs the caller 20 s instead of 0 — but that is the
+// trade #357 and #589 were both regressions of, in a file whose read-timeout policy
+// is "reads get MORE patience, not less, because a false timeout costs an agent its
+// only look at a broken graph". #589 is precisely this: panel_get_errors was given a
+// 30 s budget because the panel's own bound is 18 s. A cap here would re-break it.
 function queueBusySnapshotNote(): string {
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return "";
@@ -972,27 +1004,55 @@ function queueBusySnapshotNote(): string {
   return `${prompt}${node}${close}`;
 }
 
+/**
+ * panel#1489 — is this `graph_*` command one the queue-busy fence must let past?
+ *
+ * Answered from GRAPH_CMD_EFFECT, which is the ledger that classifies a graph
+ * command by exactly the property this gate turns on: `targeted` means "changes
+ * workflow content, publishes from it, or queues a render of it — a delivered
+ * frame cannot be retracted", which IS the unknown-outcome hazard #1639 fenced.
+ * `inert` means it cannot change workflow content and cannot act on it, so a
+ * frame delivered into a busy tab has nothing to leave half-done.
+ *
+ * NOT `BRIDGE_READONLY_CMDS`: that set answers re-dispatch safety (which default
+ * timeout, may a mid-command socket drop be parked), and #778 is the standing
+ * record of what reading one list for the other question costs — `graph_canvas`
+ * is inert but not idempotent, `refresh_nodes` is idempotent but not a read.
+ *
+ * Fail-closed by construction: an unlisted command has no entry, `undefined` is
+ * not `"inert"`, and it stays fenced. A new mutator is never waved past this gate
+ * by omission.
+ */
+function graphCmdIsInertUnderQueueBusy(name: string): boolean {
+  return GRAPH_CMD_EFFECT[name] === "inert";
+}
+
 function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   if (!name.startsWith("graph_") || name === "graph_run") return null;
+  // panel#1489 — reads and view/selection changes go through. Only a command
+  // that could leave the workflow half-changed is worth refusing unsent.
+  if (graphCmdIsInertUnderQueueBusy(name)) return null;
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return null;
   return (
     `${name} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
-    `${queueBusySnapshotNote()}. The panel tab typically cannot answer graph_* commands ` +
-    `(including read-only graph_query / graph_outline) while a prompt is executing — ` +
-    `waiting out the ack timeout would only surface a generic "tab may be backgrounded ` +
-    `or frozen" with an unknown outcome. Retry after queue (action:"list") shows running: 0.`
+    `${queueBusySnapshotNote()}. ${name} MUTATES the workflow, and the panel tab often ` +
+    `cannot service a graph edit while a prompt is executing — delivering it would only ` +
+    `surface a generic "tab may be backgrounded or frozen" timeout with an unknown ` +
+    `outcome, leaving you unable to say whether the edit applied. Read-only graph calls ` +
+    `(graph_outline / graph_query / graph_get_errors) are NOT fenced and can be used right ` +
+    `now to inspect the graph. Retry this edit after queue (action:"list") shows running: 0.`
   );
 }
 
 function queueBusyTimeoutNote(): string {
   if (!QueueMonitor.snapshot().running) return "";
   return (
-    `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}. ` +
-    `The panel tab typically cannot answer graph_* (including read-only queries) while a ` +
-    `prompt is executing — this is not a backgrounded or frozen tab. Retry after queue ` +
-    `(action:"list") shows running: 0.`
+    `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}, which is the ` +
+    `most likely reason the tab did not answer in time — a render can occupy the panel's main ` +
+    `thread. Retry after queue (action:"list") shows running: 0; if it still does not answer ` +
+    `once the queue is idle, THEN treat the tab as backgrounded or frozen.`
   );
 }
 
@@ -8508,9 +8568,11 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
-      // #1639 — a running prompt freezes the tab's graph_* channel. Refuse
-      // BEFORE dispatch so a mutation is known-not-applied rather than
+      // #1639 — a running prompt can freeze the tab's graph_* channel. Refuse a
+      // MUTATION before dispatch so it is known-not-applied rather than
       // delivered-into-a-frozen-tab with a 20/30s unknown-outcome timeout.
+      // panel#1489 — reads are NOT refused here: they carry no unknown outcome,
+      // so they are dispatched on the bounded budget above instead.
       const blocked = graphCmdBlockedByRunningPrompt(cmd);
       if (blocked) return fail(blocked);
       const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid));


### PR DESCRIPTION
Reported as artokun/comfyui-mcp-panel#1489 (a `via-panel` report that was twice
triaged in the panel repo and routed here, but never actually filed or fixed here —
it recurred on 2026-08-20).

## The bug

The QUEUE BUSY preflight added for #1639 (PR #1745) fences every `graph_*` command
except `graph_run` whenever `QueueMonitor` sees a running prompt. It was applied to
**reads** as well:

```
Error: graph_outline was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI
prompt is running (…). The panel tab typically cannot answer graph_* commands
(including read-only graph_query / graph_outline) while a prompt is executing …
```

So `panel_graph_outline`, `panel_query_graph` and `panel_get_errors` are rejected
before dispatch during any render. An agent that only wants to **look** at the graph
has to poll `queue action:"list"` and come back later — and the recurrence report
notes this is exactly what blocks diagnosing a *stalled* render, which is the moment
`panel_get_errors` matters most.

## Why fencing reads bought nothing

The harm #1639 names is specific to a WRITE: a delivered frame cannot be retracted,
so a write that times out mid-render leaves the caller unable to say whether it
applied. A read has no such outcome — abandoning one costs a retry. That asymmetry is
already written down in this repo, in `BRIDGE_DEFAULT_TIMEOUT_MS`'s own doc:

> A read abandoned too early costs a retry. Nothing is ambiguous.
> A write abandoned too early is UNRECOVERABLE ambiguity.

The refusal also asserted more than we know. "The tab typically cannot answer" is a
prediction, not a measurement — and refusing the call made it unfalsifiable, because
no read ever got to try. The architectural reason to doubt it is that ComfyUI executes
in server-side Python, so the browser main thread is not the thing doing the work.
**How often a real tab answers mid-render is not measured here, and nothing in this
change depends on a number for it** — attempting the read is what turns the question
back into something observable.

Worth noting what #1639 actually asked for:

> Either (a) keep the panel's command channel responsive during execution (**the reads
> at minimum should never be blocked by a running prompt**), or (b) … say so explicitly
> instead of surfacing a generic 20/30s timeout.

It shipped (b) and applied it to reads too — the one combination the reporter did not
ask for. Reads now get **both** halves.

## The change

`graphCmdBlockedByRunningPrompt` now keys on `GRAPH_CMD_EFFECT`: `targeted` is refused
unsent, `inert` is dispatched.

- That is the ledger built for exactly this question — `targeted` is defined as
  "changes workflow content, publishes from it, or queues a render of it. A delivered
  frame cannot be retracted", which IS the unknown-outcome hazard being fenced.
- **Fails closed by construction.** An unclassified command has no entry, `undefined`
  is not `"inert"`, so it stays fenced. A new mutator is never waved past by omission.
- Deliberately **not** `BRIDGE_READONLY_CMDS`, which answers re-dispatch safety.
  #778 is the standing record of what conflating the two costs (`graph_canvas` is inert
  but not idempotent; `refresh_nodes` is idempotent but not a read). A test drives
  `graph_select_nodes` — inert, absent from `BRIDGE_READONLY_CMDS` — so re-deriving the
  split from the wrong list fails.

Two things deliberately kept:

- **Reads keep their full tolerant ack budget.** Capping it mid-render is tempting (a
  frozen tab now costs the caller 20 s instead of 0) but #357 and #589 were both
  regressions of precisely that trade, and #589 gave `panel_get_errors` a 30 s budget
  *because the panel's own bound is 18 s*. A cap here would re-break it.
- **The explicit diagnosis survives for reads.** A dispatched read that does time out is
  still annotated by `queueBusyTimeoutNote`, naming the running prompt — so the #1639
  benefit ("actionable, not a generic frozen-tab timeout") is preserved without the cost.

`queueBusyTimeoutNote` no longer flatly asserts *"this is not a backgrounded or frozen
tab"*. Reads reach that path now, and a tab that goes silent mid-render is genuinely
ambiguous; it now says the render is the most likely cause and how to tell the two
apart once the queue drains.

The mutation refusal also stops telling callers reads are unavailable, and instead
names the reads they can use right now.

## Verification

`src/__tests__/orchestrator/graph-read-during-render.test.ts` rewritten to pin the
split (it previously pinned `expect(sent).toEqual([])` for the two reads). 13 tests,
driving the real tool surface via `buildPanelToolDefs()`.

**Verified by mutation, not by a green suite:**

- Delete the one-line inert exemption → **6 tests fail** (`panel_graph_outline`,
  `panel_query_graph`, `panel_get_errors`, `panel_select_nodes` dispatch; both
  read-timeout-diagnosis tests). The 7 that stay green are the mutation-fence and
  `graph_run` tests, which that line does not touch.
- Restore the old over-claiming timeout note → **1 test fails**, confirming that
  assertion is load-bearing on its own and not just riding on the first mutation.

Full suite green (589/589 files pre-rebase; rebased onto current `main`, which picked
up #1886 touching the same `callOnce`); `tsc --noEmit` clean. One local full run after
the rebase flaked on `tool-surface-filter` / `vocabulary` with 30 s timeouts under
machine load — unrelated code paths, and both files pass 94/94 in isolation.

**Interaction with #1886 (merged into this same function while this was open):** a
mid-render read timeout does not enter the retry-safe reconnect branch that PR
widened — that branch requires `isTransientReconnectError` or a workflow-switch
refusal, and a reply timeout is neither. No double wait.

**Browser suite not run, and not applicable:** this diff is entirely orchestrator-side
in `src/orchestrator/panel-tools.ts`. There is no change in the panel pack and nothing
the panel renders is affected — the panel already treats `graph_outline` / `graph_query`
/ `graph_get_errors` as read-only (`READ_ONLY_GRAPH_COMMANDS` in
`web/js/lib/graph-binding.js`) and never saw these commands, because they were refused
before dispatch.

---

Gated by `codex-gate.mjs` (codex quota has recovered — the account was exhausted only
until 2026-08-19 20:43): **SHIP**, exit 0.
