### PR TITLE
fix(1888): panel_update_node no longer recommends reinstall on errors that never reached Manager

### DIFF
--- a/src/__tests__/orchestrator/update-node-stale-traceback.test.ts
+++ b/src/__tests__/orchestrator/update-node-stale-traceback.test.ts
@@ -239,6 +239,79 @@ describe("#1870 panel_update_node does not attach a stale generation traceback",
   });
 });
 
+describe("#1888 reinstall note requires observed Manager evidence, not version", () => {
+  // The sanitizer is sound; the defect is the gate. wantsNonGitReroute fired
+  // on version==="nightly" alone, so a zip-installed pack got a reinstall NOTE
+  // on every isError — including failures that never reached Manager.
+  const DISCONNECTED = 'Error: no connected tab with id "dead". Connected: none';
+  const REPLY_TIMEOUT =
+    'Error: Panel tab tab-1 did not reply to "graph_update_node" within 30000 ms — the ComfyUI tab may be backgrounded or frozen\n\n' +
+    'To retry this exact mutation, re-issue identical args plus retry_of:"11111111-2222-3333-4444-555555555555"; otherwise call normally.';
+
+  it("THE REPORT: a disconnected-tab error with version nightly does not get the reinstall note", async () => {
+    disk.root = zipPackRoot();
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: DISCONNECTED }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler(
+      { id: PACK, version: "nightly" },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toBe(DISCONNECTED);
+    expect(text).not.toMatch(/Comfy Registry zip/);
+    expect(text).not.toMatch(/The pack was NOT git-updated/);
+    expect(text).not.toMatch(/install_custom_node \(action:"reinstall"/);
+  });
+
+  it("a reply-timeout (outcome unknown) with version nightly does not get the reinstall note", async () => {
+    disk.root = zipPackRoot();
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: REPLY_TIMEOUT }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler(
+      { id: PACK, version: "nightly" },
+      ctx,
+    );
+    const text = textOf(res);
+    expect(text).toBe(REPLY_TIMEOUT);
+    expect(text).toMatch(/retry_of:"11111111-2222-3333-4444-555555555555"/);
+    expect(text).not.toMatch(/Comfy Registry zip/);
+    expect(text).not.toMatch(/The pack was NOT git-updated/);
+  });
+
+  it("update-git evidence still re-routes a zip pack when version is not nightly", async () => {
+    disk.root = zipPackRoot();
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(`${FAL_TB}\n${UPDATE_GIT_LINE}`) }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler({ id: PACK }, ctx);
+    const text = textOf(res);
+    expect(text).toMatch(/res\.action=update-git/);
+    expect(text).toMatch(/Comfy Registry zip/);
+    expect(text).toMatch(/install_custom_node \(action:"reinstall"/);
+    expect(text).not.toMatch(/FalApiError/);
+  });
+
+  it("the generic Manager update line still re-routes a zip pack without nightly or update-git", async () => {
+    disk.root = zipPackRoot();
+    const { ctx } = makeCtx({
+      content: [{ type: "text", text: reportedFailure(FAL_TB) }],
+      isError: true,
+    });
+    const res = await defByName("panel_update_node").handler({ id: PACK, version: "latest" }, ctx);
+    const text = textOf(res);
+    expect(text).toMatch(/An error occurred while updating 'fal-api'/);
+    expect(text).toMatch(/Comfy Registry zip/);
+    expect(text).not.toMatch(/FalApiError/);
+    expect(text).not.toMatch(/res\.action=update-git/);
+  });
+});
+
 describe("#1870 WIRING: the handler actually sanitizes", () => {
   it("panel_update_node calls sanitizePanelUpdateNodeResult on the panel reply", () => {
     const src = readFileSync(

--- a/src/services/manager-update-error.ts
+++ b/src/services/manager-update-error.ts
@@ -12,9 +12,11 @@
  *
  * The orchestrator keeps Manager task evidence (the generic update ERROR line,
  * `res.action`/`res.result`, `do_update` / `repo_update` frames) and drops
- * ComfyUI execution history. When `update-git` failed and the pack is a
- * registry zip (no nested `.git`), it names that and re-routes to reinstall
- * rather than leaving the reader debugging a stale generation error.
+ * ComfyUI execution history. When that evidence shows an update-git (or
+ * generic update) failure and the pack is a registry zip (no nested `.git`),
+ * it names that and re-routes to reinstall rather than leaving the reader
+ * debugging a stale generation error. The reinstall note is gated on that
+ * observed Manager evidence, not on the caller's `version` argument (#1888).
  *
  * Never throws: this runs on an error path, and a guard that becomes the error
  * is strictly worse than the message it was improving.
@@ -158,9 +160,15 @@ export function keepManagerUpdateEvidence(traceback: string): {
   return { kept: kept.join("\n").trim(), droppedExecution };
 }
 
-function wantsNonGitReroute(message: string, version: string | undefined): boolean {
-  if (UPDATE_GIT.test(message)) return true;
-  return typeof version === "string" && version.trim().toLowerCase() === "nightly";
+/**
+ * #1888 — the reinstall note is a claim about Manager's update, so it fires
+ * only when the message itself carries that evidence. `version === "nightly"`
+ * is the caller's argument, not an observation: on a zip-installed pack it
+ * bolted the note onto every `isError`, including a disconnected tab and a
+ * reply-timeout whose own text says the mutation's outcome is unknown.
+ */
+function wantsNonGitReroute(message: string): boolean {
+  return UPDATE_GIT.test(message) || GENERIC_UPDATE_LINE.test(message);
 }
 
 /**
@@ -188,7 +196,7 @@ export function sanitizePanelUpdateFailure(
     }
   }
 
-  if (wantsNonGitReroute(out, opts.version) && observePackNestedGit(opts.id) === false) {
+  if (wantsNonGitReroute(out) && observePackNestedGit(opts.id) === false) {
     const note = nonGitRegistryNote(opts.id);
     if (!out.includes(note)) out = `${out.trimEnd()}\n\n${note}`;
   }


### PR DESCRIPTION
Fixes #1888

## What was reported

`panel_update_node(id:"fal-api", version:"nightly")` on a zip-installed pack bolted a reinstall NOTE onto **every** `isError` result. A disconnected tab came back as:

```
Error: no connected tab with id "dead". Connected: none

NOTE: "fal-api" is installed as a Comfy Registry zip (no nested .git) …
The pack was NOT git-updated. Reinstall it from the registry instead:
install_custom_node (action:"reinstall", id:"fal-api") …
```

The same NOTE appeared on a reply-timeout whose own text says the mutation's outcome is unknown (`retry_of:…`). The sanitizer from #1879 is sound; the gate was not.

## Why

`wantsNonGitReroute` fired on `version === "nightly"` alone. That is the caller's argument, not Manager evidence, so it was equal to "Manager reported update-git" on the happy path and different on every transport failure.

## The fix

Gate the reinstall NOTE on observed Manager-update evidence (`res.action=update-git` or the generic `An error occurred while updating 'X'.` line), still only when the pack is observably a registry zip (on disk here, no nested `.git`). A disconnected tab, a reply-timeout, and any other error that never reached Manager stay identity. A zip pack whose Manager failure is `update-git` or the generic update line still re-routes, including when `version` is not nightly.

## Verification

`src/__tests__/orchestrator/update-node-stale-traceback.test.ts` drives the shipped `panel_update_node` handler:

- reporter: nightly + zip + disconnected tab is identity (no reinstall NOTE)
- nightly + zip + reply-timeout is identity (retry_of kept, no NOTE)
- `update-git` evidence still re-routes a zip pack without nightly
- the generic Manager update line still re-routes a zip pack without nightly or `update-git`
- existing #1870 cases (FalApiError drop, real `repo_update` traceback, success pass-through, remote does not invent a zip, git checkout is not re-routed)

`npx tsc --noEmit` clean.
`npx vitest run --maxWorkers=4 src/__tests__/orchestrator/update-node-stale-traceback.test.ts src/__tests__/services/panel-pin-guard.test.ts src/__tests__/services/manager-error-body.test.ts` — 136 passed.
