### PR TITLE
fix(1889): a rejected node id says what it wanted and what it got

### DIFF
--- a/src/__tests__/orchestrator/node-id-union-message.test.ts
+++ b/src/__tests__/orchestrator/node-id-union-message.test.ts
@@ -234,6 +234,45 @@ describe("#1889 describeReceived is TOTAL — it runs inside zod's error path", 
     arr.push(arr);
     expect(describeReceived(arr)).toBe("an array");
   });
+
+  // The list below is the probe that found the last hole rather than a
+  // decoration on a fix already believed complete. The REVOKED PROXY case threw:
+  // `Array.isArray` is itself a proxy trap, so the recovery path inside the
+  // catch was another way out of this function. Nine of ten hostile inputs were
+  // already handled; enumerating them is what surfaced the tenth.
+  //
+  // None of these can arrive over the MCP wire, where input is parsed JSON. They
+  // are here because the CONTRACT is "cannot throw", and a contract that holds
+  // only for the inputs one happened to imagine is not one worth stating.
+  const hostile: Array<[string, () => unknown]> = [
+    ["a proxy whose get trap throws", () => new Proxy({}, { get: () => { throw new Error("boom"); } })],
+    ["a proxy whose ownKeys trap throws", () => new Proxy({}, { ownKeys: () => { throw new Error("boom"); } })],
+    ["a REVOKED proxy", () => { const p = Proxy.revocable({}, {}); p.revoke(); return p.proxy; }],
+    ["an object whose toJSON throws", () => ({ toJSON: () => { throw new Error("boom"); } })],
+    ["an object with a throwing getter", () =>
+      Object.defineProperty({}, "x", { get: () => { throw new Error("boom"); }, enumerable: true })],
+    ["a null-prototype object", () => Object.create(null)],
+    ["a Map", () => new Map([[1, 2]])],
+    ["an object whose Symbol.toPrimitive throws", () =>
+      ({ [Symbol.toPrimitive]: () => { throw new Error("boom"); } })],
+  ];
+
+  it.each(hostile)("survives %s", (_label, make) => {
+    let out: string | undefined;
+    expect(() => {
+      out = describeReceived(make());
+    }).not.toThrow();
+    expect(typeof out).toBe("string");
+  });
+
+  it("a revoked proxy specifically — the one that got past the outer catch", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    // Both the stringify AND the naive `Array.isArray` fallback throw on this.
+    expect(() => JSON.stringify(proxy)).toThrow();
+    expect(() => Array.isArray(proxy)).toThrow(); // the trap, stated outright
+    expect(describeReceived(proxy)).toBe("an object");
+  });
 });
 
 describe("#1889 unionErrorFor composes the two halves", () => {

--- a/src/__tests__/orchestrator/node-id-union-message.test.ts
+++ b/src/__tests__/orchestrator/node-id-union-message.test.ts
@@ -1,0 +1,245 @@
+// #1889 — a node-id rejection said only `Invalid input`, while the field beside it
+// said `expected string, received undefined`. Read left-to-right the two lines look
+// like ONE sentence about node_id that then blames title, which is what confused the
+// reporter:
+//
+//     Invalid input at node_id
+//     Invalid input: expected string, received undefined at title
+//
+// Cause: zod 4 reports a failed `z.union` as one `invalid_union` issue whose own
+// `message` is the constant `"Invalid input"`, with the per-member messages —
+// NODE_ID_MESSAGE among them — in a nested `errors` array. The MCP SDK's
+// `getParseErrorMessage` (1.30) renders `${issue.message} at ${dotPath}` and never
+// descends into the nest, so the useful half was dropped on the way out.
+//
+// The first suite deliberately goes through a REAL McpServer + Client rather than
+// calling `z.object(def.schema).safeParse` directly: the string the reporter quoted
+// is produced by the SDK's renderer, not by zod, so a schema-level assertion would
+// be testing a different sentence than the one that reached them.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { buildPanelToolDefs, registerPanelTools, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { NODE_ID_MESSAGE, describeReceived, unionErrorFor } from "../../orchestrator/node-id.js";
+
+function makeFakeCtx(): PanelToolCtx {
+  return {
+    call: async (cmd) => ({ content: [{ type: "text", text: JSON.stringify(cmd) }] }),
+    confirm: async () => "yes" as const,
+    bridge: { send: async () => ({}) } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+}
+
+describe("#1889 the message an agent actually receives over MCP", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "node-id-union-message-test", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "node-id-union-message-test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const errorText = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const r = await client.callTool({ name, arguments: args });
+    expect(r.isError, `${name} was expected to reject ${JSON.stringify(args)}`).toBe(true);
+    return (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+  };
+
+  it("REPRODUCTION: the reporter's exact call now explains node_id instead of saying `Invalid input`", async () => {
+    const text = await errorText("panel_set_node_title", {});
+
+    // What they got.
+    expect(text).not.toMatch(/^Invalid input at node_id$/m);
+    // What they get now — both halves the sibling field had.
+    expect(text).toContain(NODE_ID_MESSAGE);
+    expect(text).toMatch(/received undefined at node_id/);
+
+    // The sibling line is untouched. Its wording is zod's, not ours, and the fix
+    // must not have quietly reworded the field that was already correct.
+    expect(text).toContain("Invalid input: expected string, received undefined at title");
+  });
+
+  it("the two lines can no longer be misread as one sentence about node_id", async () => {
+    const lines = (await errorText("panel_set_node_title", {})).split("\n").filter(Boolean);
+    const nodeIdLine = lines.find((l) => l.endsWith("at node_id"));
+    const titleLine = lines.find((l) => l.endsWith("at title"));
+    expect(nodeIdLine, "no node_id line").toBeDefined();
+    expect(titleLine, "no title line").toBeDefined();
+    // Each line now stands on its own: names its field's expectation AND its input.
+    for (const line of [nodeIdLine!, titleLine!]) {
+      expect(line).toMatch(/received/);
+      expect(line).not.toBe("Invalid input at node_id");
+    }
+  });
+
+  it("names what it got, for every shape that fails BOTH union members", async () => {
+    const cases: Array<[unknown, string]> = [
+      [null, "received null"],
+      [4.5, "received 4.5"],
+      [true, "received true"],
+      [{ id: 3 }, 'received {"id":3}'],
+      [[1, 2], "received [1,2]"],
+    ];
+    for (const [value, expected] of cases) {
+      const text = await errorText("panel_set_node_title", { node_id: value, title: "t" });
+      expect(text, JSON.stringify(value)).toContain(NODE_ID_MESSAGE);
+      expect(text, JSON.stringify(value)).toContain(expected);
+    }
+  });
+
+  it("a BAD STRING was never affected — that path always printed the message", async () => {
+    // `"42px"` fails only the string member, so zod collapses it to a plain
+    // `invalid_format` issue and NODE_ID_MESSAGE was already reaching the caller.
+    // Stated outright so the fix is not credited with more than it did.
+    const text = await errorText("panel_set_node_title", { node_id: "42px", title: "t" });
+    expect(text).toContain(NODE_ID_MESSAGE);
+  });
+
+  it("panel_run's to_node_id gets the same treatment — #1497's reason was buried the same way", async () => {
+    const text = await errorText("panel_run", { to_node_id: 4.5 });
+    expect(text).not.toMatch(/^Invalid input at to_node_id$/m);
+    expect(text).toContain("a run-to-node target must be a plain integer node id");
+    expect(text).toContain("received 4.5");
+  });
+
+  it("ACCEPTANCE IS UNCHANGED — this is a wording fix and nothing else", async () => {
+    // Every spelling #845/#1425/#1497 fought for still validates. A union-level
+    // `error` that accidentally narrowed the union would be a far worse bug than
+    // the one being fixed, and it would not show up in any message assertion.
+    for (const id of [42, "42", "120:104", "120:113:78", -20, "-20", "-20:3"]) {
+      const r = await client.callTool({
+        name: "panel_set_node_title",
+        arguments: { node_id: id, title: "t" },
+      });
+      const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+      expect(text, `${JSON.stringify(id)} should reach the handler`).not.toMatch(
+        /Input validation error/,
+      );
+    }
+    // …and what was refused is still refused.
+    for (const id of ["4.5", "", "abc", "1:", ":1", "1::2", "1:-2"]) {
+      const text = await errorText("panel_set_node_title", { node_id: id, title: "t" });
+      expect(text, JSON.stringify(id)).toContain(NODE_ID_MESSAGE);
+    }
+  });
+});
+
+describe("#1889 coverage across every node-id argument, not just the reported one", () => {
+  // A green test on panel_set_node_title proves the helper works; it says nothing
+  // about whether the other node-id arguments route through that helper. This
+  // sweeps every registered tool and fails if ANY node-id-shaped field still
+  // renders the bare union message.
+  const defs = buildPanelToolDefs();
+
+  const nodeIdFields = defs.flatMap((d) =>
+    Object.keys(d.schema)
+      .filter((k) => k === "node_id" || k === "to_node_id")
+      .map((k) => [d.name, k] as const),
+  );
+
+  it("the sweep is non-vacuous — it found node-id arguments to check", () => {
+    expect(nodeIdFields.length).toBeGreaterThan(5);
+  });
+
+  it.each(nodeIdFields)("%s.%s explains itself when it fails every union member", (name, field) => {
+    const def = defs.find((d) => d.name === name)!;
+    const shape = def.schema as z.ZodRawShape;
+    const issue = z
+      .object(shape)
+      .safeParse({ [field]: null })
+      .error?.issues.find((i) => i.path[0] === field);
+    expect(issue, `${name}.${field} accepted null?`).toBeDefined();
+    expect(issue!.message).not.toBe("Invalid input");
+    expect(issue!.message).toMatch(/received null/);
+  });
+});
+
+describe("#1889 the advertised input schema is untouched", () => {
+  // node-id.ts chose `.regex()` over `.refine()` specifically so the MCP input
+  // schema carries a `pattern` — a client reading the schema learns the shape
+  // without failing a call first. A union-level `error` must not disturb that.
+  it("a node_id still advertises anyOf[integer, string with the node-id pattern]", () => {
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_node_title")!;
+    const json = z.toJSONSchema(z.object(def.schema as z.ZodRawShape), { io: "input" }) as {
+      properties: Record<string, unknown>;
+    };
+    expect(json.properties.node_id).toEqual({
+      anyOf: [
+        { type: "integer", minimum: -9007199254740991, maximum: 9007199254740991 },
+        { type: "string", pattern: "^-?\\d+(?::\\d+)*$" },
+      ],
+    });
+  });
+});
+
+describe("#1889 describeReceived is TOTAL — it runs inside zod's error path", () => {
+  // A formatter that throws here turns a clean validation refusal into a crash,
+  // so the hostile inputs are enumerated rather than assumed. `JSON.stringify`
+  // alone fails four of these: it THROWS on a BigInt and on a circular object,
+  // and returns the bare `undefined` value for a symbol and a function.
+  const circular: Record<string, unknown> = { a: 1 };
+  circular.self = circular;
+
+  const cases: Array<[string, unknown, string]> = [
+    ["undefined", undefined, "undefined"],
+    ["null", null, "null"],
+    ["a bigint", 10n, "10n"],
+    ["a symbol", Symbol("nope"), "Symbol(nope)"],
+    ["a function", () => 1, "a function"],
+    ["NaN", Number.NaN, "NaN"],
+    ["Infinity", Number.POSITIVE_INFINITY, "Infinity"],
+    ["-Infinity", Number.NEGATIVE_INFINITY, "-Infinity"],
+    ["a circular object", circular, "an object"],
+    ["a plain object", { a: 1 }, '{"a":1}'],
+    ["an array", [1, "2"], '[1,"2"]'],
+    ["a string", "42px", '"42px"'],
+    ["true", true, "true"],
+    ["a float", 4.5, "4.5"],
+  ];
+
+  it.each(cases)("renders %s without throwing", (_label, input, expected) => {
+    expect(describeReceived(input)).toBe(expected);
+  });
+
+  it("NaN and Infinity are NOT reported as null", () => {
+    // JSON.stringify renders both as `null`, which would tell a caller who passed
+    // NaN that they passed null — a different mistake than the one they made.
+    expect(JSON.stringify(Number.NaN)).toBe("null"); // the trap, stated outright
+    expect(describeReceived(Number.NaN)).toBe("NaN");
+    expect(describeReceived(Number.POSITIVE_INFINITY)).toBe("Infinity");
+  });
+
+  it("truncates a large value instead of pasting it into the message", () => {
+    const huge = { blob: "x".repeat(5000) };
+    const rendered = describeReceived(huge);
+    expect(rendered.length).toBeLessThanOrEqual(61);
+    expect(rendered.endsWith("…")).toBe(true);
+  });
+
+  it("a circular ARRAY says array, not object", () => {
+    const arr: unknown[] = [1];
+    arr.push(arr);
+    expect(describeReceived(arr)).toBe("an array");
+  });
+});
+
+describe("#1889 unionErrorFor composes the two halves", () => {
+  it("keeps the caller's expectation and appends what arrived", () => {
+    const fn = unionErrorFor(NODE_ID_MESSAGE);
+    expect(fn({ input: undefined })).toBe(`${NODE_ID_MESSAGE}; received undefined`);
+    expect(fn({ input: 4.5 })).toBe(`${NODE_ID_MESSAGE}; received 4.5`);
+  });
+});

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -147,7 +147,16 @@ export function describeReceived(input: unknown): string {
   try {
     rendered = JSON.stringify(input) ?? String(input);
   } catch {
-    return Array.isArray(input) ? "an array" : "an object";
+    // The fallback needs its own guard: `Array.isArray` THROWS on a revoked
+    // proxy ("Cannot perform 'IsArray' on a proxy that has been revoked"), so
+    // the naive recovery path was itself a way for this function to throw.
+    // Measured, not assumed — it is the one hostile input of ten that got past
+    // the outer catch.
+    try {
+      return Array.isArray(input) ? "an array" : "an object";
+    } catch {
+      return "an object";
+    }
   }
   return rendered.length > RECEIVED_MAX ? `${rendered.slice(0, RECEIVED_MAX)}…` : rendered;
 }

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -82,3 +82,72 @@ export function normalizeNodeId(v: number | string): number | string {
  *  caller holding `263:78` needs to know whether it is unsupported or malformed. */
 export const NODE_ID_MESSAGE =
   "a node id must be an integer (e.g. 42) or a subgraph-qualified id (e.g. 120:104)";
+
+/**
+ * #1889 — a bare `z.union` renders as the word `Invalid input` and nothing else.
+ *
+ * Zod 4 reports a failed union as ONE `invalid_union` issue whose own `message`
+ * is the constant `"Invalid input"`; the per-member messages (NODE_ID_MESSAGE
+ * among them) live in a nested `errors` array. Every renderer that reaches an
+ * agent flattens `issue.message` and drops that nest — the MCP SDK's
+ * `getParseErrorMessage` (1.30) joins `` `${i.message} at ${path}` ``, zod's own
+ * `prettifyError` prints `✖ ${i.message}`, and 1.29 JSON-stringifies the issues.
+ * So a node-id rejection read:
+ *
+ *     Invalid input at node_id
+ *     Invalid input: expected string, received undefined at title
+ *
+ * NODE_ID_MESSAGE was never dead prose — a BAD STRING (`"42px"`) fails only the
+ * string member, zod collapses that to a plain `invalid_format` issue, and the
+ * message prints. It is unreachable only for inputs that fail EVERY member
+ * (undefined, null, 4.5, an object), which is the common case and the reported
+ * one. This is what makes the union say the same thing there.
+ *
+ * `received` is carried too, because the complaint was the asymmetry with the
+ * sibling `title`, and half of what `title` said was what it actually got.
+ */
+export function unionErrorFor(expected: string): (iss: { input: unknown }) => string {
+  return (iss) => `${expected}; received ${describeReceived(iss.input)}`;
+}
+
+/** How long a rendered value may get before it is cut. A node id is a handful of
+ *  characters; anything near this is a caller error worth showing, not quoting. */
+const RECEIVED_MAX = 60;
+
+/**
+ * Render an arbitrary rejected input for a message, TOTALLY.
+ *
+ * This runs inside zod's error path, so it must never throw: a formatter that
+ * throws converts a clean validation refusal into a 500. `JSON.stringify` alone
+ * is not safe here — it throws on a BigInt and on a circular object, returns the
+ * bare `undefined` value for a symbol or a function, and renders NaN/Infinity as
+ * `null`, which would tell a caller who passed NaN that they passed null. Each
+ * of those is handled before the stringify, and the stringify itself is caught.
+ */
+export function describeReceived(input: unknown): string {
+  if (input === null) return "null";
+  switch (typeof input) {
+    case "undefined":
+      return "undefined";
+    case "bigint":
+      return `${input}n`;
+    case "symbol":
+      return input.toString();
+    case "function":
+      return "a function";
+    case "number":
+    case "boolean":
+      // `String` and not `JSON.stringify`: the latter renders NaN and ±Infinity
+      // as `null`, which would tell a caller who passed NaN that they passed null.
+      return String(input);
+    default:
+      break;
+  }
+  let rendered: string;
+  try {
+    rendered = JSON.stringify(input) ?? String(input);
+  } catch {
+    return Array.isArray(input) ? "an array" : "an object";
+  }
+  return rendered.length > RECEIVED_MAX ? `${rendered.slice(0, RECEIVED_MAX)}…` : rendered;
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -79,6 +79,7 @@ import {
   NODE_ID_PATTERN,
   normalizeNodeId,
   PLAIN_NODE_ID_PATTERN,
+  unionErrorFor,
 } from "./node-id.js";
 import {
   parseContradictoryPromotedWidgetRefusal,
@@ -10720,10 +10721,12 @@ function validatePanelEditNodeArgs(args: Record<string, unknown>): string | null
  */
 const nodeId = () =>
   z
-    .union([
-      z.number().int(),
-      z.string().regex(NODE_ID_PATTERN, NODE_ID_MESSAGE),
-    ])
+    // #1889 — the union-level `error` is what a caller actually reads. Without it
+    // zod names the failed union `"Invalid input"` and buries NODE_ID_MESSAGE in a
+    // nested `errors` array that no renderer prints. See unionErrorFor.
+    .union([z.number().int(), z.string().regex(NODE_ID_PATTERN, NODE_ID_MESSAGE)], {
+      error: unionErrorFor(NODE_ID_MESSAGE),
+    })
     .transform(normalizeNodeId);
 
 /**
@@ -10756,10 +10759,13 @@ const RUN_TO_NODE_ID_MESSAGE =
 
 const runToNodeId = () =>
   z
-    .union([
-      z.number().int(),
-      z.string().regex(PLAIN_NODE_ID_PATTERN, RUN_TO_NODE_ID_MESSAGE),
-    ])
+    // #1889, same as nodeId(): #1497 wrote RUN_TO_NODE_ID_MESSAGE so a qualified id
+    // would be "refused now by name, with a reason" — and for the shapes that fail
+    // BOTH members the name and the reason were dropped on the floor.
+    .union(
+      [z.number().int(), z.string().regex(PLAIN_NODE_ID_PATTERN, RUN_TO_NODE_ID_MESSAGE)],
+      { error: unionErrorFor(RUN_TO_NODE_ID_MESSAGE) },
+    )
     .transform((v) => (typeof v === "number" ? v : Number.parseInt(v, 10)));
 
 /**


### PR DESCRIPTION
Fixes #1889.

## What was wrong

A panel write tool called with a missing or malformed `node_id` answered with the single word `Invalid input`, while the field beside it explained itself in full:

```
MCP error -32602: Input validation error: Invalid arguments for tool panel_set_node_title: Invalid input at node_id
Invalid input: expected string, received undefined at title
```

Read left-to-right the two lines look like one sentence about `node_id` that then blames `title`, which is what confused the reporter.

## Mechanism, and the part the report did not have

`nodeId()` is a `z.union`. Zod 4 reports a failed union as **one** `invalid_union` issue whose own `message` is the constant `"Invalid input"`; the per-member messages — `NODE_ID_MESSAGE` among them — sit in a nested `errors` array. Every renderer that reaches an agent flattens `issue.message` and never descends into that nest.

I pinned down which renderer produced the reporter's exact string, because the answer was not obvious. `@modelcontextprotocol/sdk` **1.29** (the version in the stale local checkout) JSON-stringifies the issues, which is not what they quoted. **1.30**, the version on `main`, does this:

```js
// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
return error.issues.map((i) => i.path?.length ? `${i.message} at ${getDotPath(i.path)}` : i.message).join('\n')
```

That is the reporter's string verbatim, so the reproduction below runs through a real `McpServer` + `Client` rather than asserting on a `safeParse` result — a schema-level assertion would be checking a different sentence than the one that reached them.

**A correction to the report's framing:** `NODE_ID_MESSAGE` is not unreachable. A *bad string* (`"42px"`) fails only the string member, zod collapses that to a plain `invalid_format` issue, and the message printed correctly all along — I measured this, and there is a test asserting it so the fix is not credited with more than it did. The message was dropped only for inputs that fail **every** member: `undefined`, `null`, `4.5`, an object. That is the common case and the reported one.

## The fix

A union-level `error` on both node-id unions. It carries `received` as well as `expected`, because the complaint was the asymmetry with the sibling field, and half of what the sibling said was what it actually got:

```
a node id must be an integer (e.g. 42) or a subgraph-qualified id (e.g. 120:104); received undefined at node_id
Invalid input: expected string, received undefined at title
```

The existing `NODE_ID_MESSAGE` is reused rather than a new string invented, so the two rejection paths (regex failure and union failure) now say the same thing.

**`runToNodeId()` is fixed too.** It is the identical shape with the identical hole, and #1497 wrote `RUN_TO_NODE_ID_MESSAGE` specifically so a subgraph-qualified execution root would be "refused now by name, with a reason" — which was true for a qualified string and false for every shape that failed both members.

`describeReceived()` is deliberately total. It runs **inside zod's error path**, where a formatter that throws converts a clean validation refusal into a crash. `JSON.stringify` alone fails four ways there: it throws on a BigInt and on a circular object, returns the bare `undefined` value for a symbol or a function, and renders `NaN`/`Infinity` as `null` — which would tell a caller who passed NaN that they passed null. Output is capped at 60 chars.

**Second commit: that totality claim was false when I first wrote it.** I probed the function against ten hostile inputs instead of re-reading it, and the tenth got through — in the least visible place, *inside the catch*. `JSON.stringify` throws on a revoked proxy, so control reached the recovery path, and the recovery path called `Array.isArray` to pick between `"an array"` and `"an object"`. `Array.isArray` is itself a proxy operation and throws on a revoked proxy, so the fallback was another way out of a function that must not have one. Nine of the ten were already handled; enumerating them is the only reason the tenth surfaced. No revoked proxy can arrive over the MCP wire — input there is parsed JSON — but the contract is "cannot throw", and one that holds only for the inputs I happened to imagine is not worth stating in a comment.

## Evidence

**Behaviour is unchanged — asserted, not assumed.** A union-level `error` that accidentally narrowed the union would be a far worse bug than this one and would not show up in any message assertion, so acceptance is tested directly: `42`, `"42"`, `"120:104"`, `"120:113:78"`, `-20`, `"-20"`, `"-20:3"` all still validate; `"4.5"`, `""`, `"abc"`, `"1:"`, `":1"`, `"1::2"`, `"1:-2"` are all still refused. The advertised MCP input schema is also asserted byte-for-byte — it still carries the regex `pattern` that `node-id.ts` chose `.regex()` over `.refine()` to preserve.

**Coverage is swept, not spot-checked.** A green test on `panel_set_node_title` proves the helper works; it says nothing about whether the other node-id arguments route through it. The suite enumerates every registered tool and fails if any node-id field still renders the bare union message — **21 arguments across 20 tools**.

**Verified by deleting the fix.** Four mutations, each killing named tests:

| mutation | tests killed |
|---|---|
| remove `error:` from `nodeId()` | **23** (3 message + 20 swept tools) |
| remove `error:` from `runToNodeId()` | **2** (`panel_run` message + `panel_run.to_node_id` sweep) |
| `unionErrorFor` drops the `received` half | **24** |
| `describeReceived` → raw `JSON.stringify` | **11** (bigint and circular *throw*) |
| remove the nested revoked-proxy guard | **2** |

56 tests in the new file, all green unmutated. `tsc --noEmit` clean. `check:vocabulary` OK (1727 files). `check:unknown-collapse` OK.

**Not a regression.** `git log -L` over the `nodeId` definition returns exactly two commits — #845 created it, #1425 widened it. No union-level message ever existed and was removed.

## What I deliberately did not do

- **No browser gate.** This is orchestrator-side zod wording; no panel file is touched, and panel#1490 was closed as upstream on the grounds that the panel registers no MCP tools and does not own this validation. Playwright would not exercise the change, so I did not run it and am not implying coverage I do not have.
- **`slotRef` and the other bare unions in this file are the same defect class and are left alone.** `slotRef = z.union([z.string(), z.number().int().min(0)])` renders the same bare `Invalid input`. Fixing it means inventing new caller-facing vocabulary for a surface nobody has reported, which is a wider change than a P3 wording bug under the freeze. Named here so it is a decision, not an oversight.
- **The regex-failure path still prints no `received`.** `"42px"` gets `NODE_ID_MESSAGE` with no value echo, matching zod's own `invalid_format` idiom. The value is in the caller's own call and the shape is named; adding it there was scope I did not need.

## Review

**Review is pending — this has not been reviewed by anyone but me, and I am not treating my own reading as a review.**

@grok — the load-bearing claims, in the order I'd attack them:

1. **The one I am least sure of: does a union-level `error` change what the union ACCEPTS?** My whole "wording only" claim rests on no. I asserted the accept/reject sets directly and `z.toJSONSchema` is unchanged, but if zod 4.4.3 has any path where a supplied `error` alters member evaluation or short-circuiting, this is where it bites and my tests would not catch a subtle case (e.g. a value where the union previously picked a *different* member's result before the transform).
2. **`describeReceived` totality — this one already failed once, so treat my confidence as low.** It sits inside an error path, so a throw is a crash, not a bad message. I now enumerate bigint / symbol / function / circular object / circular array / NaN / ±Infinity / throwing `get` trap / throwing `ownKeys` trap / revoked proxy / throwing `toJSON` / throwing getter / null-prototype object / `Map` / throwing `Symbol.toPrimitive`. The revoked proxy is the one that got through my first version. **What is the eleventh?** I am specifically unsure whether `String(input)` in the `?? String(input)` branch can throw — it is reachable only when `JSON.stringify` returns `undefined`, and I did not construct that case.
3. **Is the sweep actually load-bearing, or does it pass vacuously?** It keys on top-level schema keys named `node_id`/`to_node_id`. A node-id argument under any other name, or nested inside an object/array field, is invisible to it — `panel_select_nodes.node_ids` (an array) is one I know it does not cover. Mutation 1 killed 20 of its cases, so it is not vacuous, but its *scope* may be narrower than the PR implies.
4. **The renderer claim.** I assert the SDK 1.30 path produces the reporter's string. If the orchestrator ever serves these tools through a different transport whose renderer descends into `issue.errors`, the union-level message would be a second, redundant sentence rather than the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
