### PR TITLE
fix(1895): an occupied GPU after free is named instead of a silent freed:true

### DIFF
--- a/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
+++ b/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
@@ -18,6 +18,10 @@
 // These tests pass `base` into the injected reader and assert it. Discarding
 // the argument is what made a `const base = "http://wrong.example:1"` mutation
 // of annotateFreeVramAck leave every test green.
+//
+// #1895 — an occupied card whose torch pool is empty must still NAME the
+// device (isError stays false). An unproven tab must not look like a
+// measured GPU. Tests drive annotateFreeVramAck / deviceStillPinned directly.
 
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
@@ -123,6 +127,14 @@ function expectQueriedProven(ctx: PanelToolCtx): void {
   const proven = __panelToolsTestHooks.captureRebootHealthBase(ctx);
   expect(proven).toBeTruthy();
   expect(queriedBases).toEqual([proven]);
+}
+
+const FREED_ACK_BODY = { freed: true, unload_models: true, free_memory: true };
+
+function ackFreed(): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(FREED_ACK_BODY, null, 2) }],
+  };
 }
 
 /** Reporter: 4× RTX 2080 Ti, 21 GB. GPU 2 at vram_free=187552724 and
@@ -264,6 +276,9 @@ describe("panel_free_vram reads occupancy from this tab's server, not the global
     // Tab fronts a DIFFERENT local instance than boot. Global is the boot
     // server. Returning pinned devices if that host is queried makes a
     // wrong-target read fail this test — the #1878 tests were blind to it.
+    // #1895 — the ack is no longer byte-identical to a measured GPU: it must
+    // say occupancy was never re-read. Swapping the gate to getComfyUIBaseUrl()
+    // still fails: queriedBases would be non-empty and GPU 2 would be named.
     setDevices(reporterDevices);
     expect(setComfyuiTarget(BOOT_BASE)).toBe(true);
     const out = await run("ok", { origin: OTHER_BASE });
@@ -276,6 +291,8 @@ describe("panel_free_vram reads occupancy from this tab's server, not the global
     expect(out.text).not.toMatch(/STILL PINNED/);
     expect(out.text).not.toMatch(/panel_restart_comfyui/);
     expect(out.text).not.toMatch(/"index": 2/);
+    expect(out.text).toMatch(/"occupancy_reread": false/);
+    expect(out.text).toMatch(/never re-read/);
   });
 });
 
@@ -289,7 +306,15 @@ describe("panel_free_vram attributes a pin to this ComfyUI's torch pool, not the
     expect(out.text).toMatch(/"freed": true/);
     expect(out.text).not.toMatch(/"freed": false/);
     expect(out.text).not.toMatch(/STILL PINNED/);
-    expect(out.text).not.toMatch(/panel_restart_comfyui/);
+    // #1895 — silence was the bug. Keep isError false but name the device,
+    // the live counter, and that /system_stats cannot say which process.
+    expect(out.text).toContain("795579336");
+    expect(out.text).toMatch(/device 0/);
+    expect(out.text).toMatch(/device globally/);
+    expect(out.text).toMatch(/cannot name which process/);
+    expect(out.text).toMatch(/Ray/);
+    expect(out.text).toMatch(/second ComfyUI/);
+    expect(out.text).toMatch(/will not/);
   });
 
   it("does not treat device-global vram_free as a pin when torch counters are absent", async () => {
@@ -299,7 +324,11 @@ describe("panel_free_vram attributes a pin to this ComfyUI's torch pool, not the
     expectQueriedProven(out.ctx);
     expect(out.isError).toBe(false);
     expect(out.text).toMatch(/"freed": true/);
-    expect(out.text).not.toMatch(/panel_restart_comfyui/);
+    expect(out.text).not.toMatch(/"freed": false/);
+    expect(out.text).not.toMatch(/STILL PINNED/);
+    expect(out.text).toContain("795579336");
+    expect(out.text).toMatch(/device 0/);
+    expect(out.text).toMatch(/cannot name which process/);
   });
 
   it("still names a pin when THIS instance's torch pool is occupied even if the card looks free", async () => {
@@ -320,5 +349,116 @@ describe("panel_free_vram attributes a pin to this ComfyUI's torch pool, not the
     expect(out.text).toMatch(/device 2/);
     expect(out.text).toMatch(/panel_restart_comfyui/);
     expect(out.text).not.toMatch(/device 0/);
+  });
+});
+
+describe("annotateFreeVramAck discloses occupied-but-not-torch-pinned (#1895)", () => {
+  it("keeps isError false, names device 0, and prints the live 795579336 counter", async () => {
+    setDevices(otherProcessHoldsCard);
+    const ctx = makePanelToolCtx(bridge({ reply: "ok" }), TAB, new WorkflowTargetStore());
+    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed());
+
+    expectQueriedProven(ctx);
+    expect(out.isError === true).toBe(false);
+    const text = textOf(out);
+    expect(text).toMatch(/"freed": true/);
+    expect(text).not.toMatch(/"freed": false/);
+    expect(text).toContain("795579336");
+    expect(text).toMatch(/device 0/);
+    expect(text).toMatch(/"occupied_devices"/);
+    expect(text).toMatch(/device globally/);
+    expect(text).toMatch(/cannot name which process/);
+    expect(text).toMatch(/Ray/);
+    expect(text).toMatch(/second ComfyUI/);
+    expect(text).toMatch(/will not/);
+    expect(text).not.toMatch(/STILL PINNED/);
+    expect(text).not.toMatch(/Next: panel_restart_comfyui/);
+  });
+
+  it("reads occupancy from captureRebootHealthBase, not getComfyUIBaseUrl", async () => {
+    setDevices(otherProcessHoldsCard);
+    expect(setComfyuiTarget(OTHER_BASE)).toBe(true);
+    const ctx = makePanelToolCtx(bridge({ reply: "ok" }), TAB, new WorkflowTargetStore());
+    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed());
+
+    const proven = __panelToolsTestHooks.captureRebootHealthBase(ctx);
+    expect(proven).toBeTruthy();
+    expect(__panelToolsTestHooks.sameHttpBase(proven, getComfyUIBaseUrl())).toBe(false);
+    expect(queriedBases).toEqual([proven]);
+    expect(out.isError === true).toBe(false);
+    expect(textOf(out)).toContain("795579336");
+  });
+
+  it("does not return a byte-identical freed:true when the tab's server is unproven", async () => {
+    setDevices(reporterDevices);
+    const ctx = makePanelToolCtx(
+      bridge({ reply: "ok", origin: OTHER_BASE }),
+      TAB,
+      new WorkflowTargetStore(),
+    );
+    const ack = ackFreed();
+    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ack);
+
+    expect(__panelToolsTestHooks.captureRebootHealthBase(ctx)).toBeNull();
+    expect(queriedBases).toEqual([]);
+    expect(out.isError === true).toBe(false);
+    const text = textOf(out);
+    expect(text).toMatch(/"freed": true/);
+    expect(text).not.toBe(textOf(ack));
+    expect(text).toMatch(/"occupancy_reread": false/);
+    expect(text).toMatch(/never re-read/);
+    expect(text).toMatch(/receipt/);
+    expect(text).not.toMatch(/"index": 2/);
+    expect(text).not.toMatch(/STILL PINNED/);
+    expect(text).not.toMatch(/panel_restart_comfyui/);
+  });
+
+  it("discloses an occupied card after a server-side settle without blaming the torch pool", async () => {
+    __panelToolsTestHooks.setFreeVramDirect(async (base: string) => {
+      queriedBases.push(base);
+      return { ok: true, before: otherProcessHoldsCard, after: otherProcessHoldsCard };
+    });
+    const out = await run("timeout");
+
+    expectQueriedProven(out.ctx);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/"freed": false/);
+    expect(out.text).toContain("795579336");
+    expect(out.text).toMatch(/device 0/);
+    expect(out.text).toMatch(/"verified": "server-side"/);
+    expect(out.text).not.toMatch(/STILL PINNED/);
+    expect(out.text).not.toMatch(/Next: panel_restart_comfyui/);
+  });
+});
+
+describe("deviceStillPinned (#1887 / #1895)", () => {
+  const pin = (d: Parameters<typeof __panelToolsTestHooks.deviceStillPinned>[0]) =>
+    __panelToolsTestHooks.deviceStillPinned(d);
+
+  it("is false for the live 32 MiB torch pool next to a 97% occupied card", () => {
+    expect(pin(otherProcessHoldsCard[0])).toBe(false);
+  });
+
+  it("is true for the reporter's GPU 2 torch pool (~0.24% free)", () => {
+    expect(pin(reporterDevices[2])).toBe(true);
+  });
+
+  it("is false when torch counters are absent", () => {
+    expect(pin(deviceGlobalOccupiedTorchAbsent[0])).toBe(false);
+  });
+
+  it("measures pool fullness, not reserved share of the card (predicate-shape note)", () => {
+    // #1895 item 3: 24 GiB card at 3% device-free, this ComfyUI still reserves
+    // 5 GiB of which 4 GiB is unused inside the pool. NOT observed live after
+    // /free — documents the current predicate, does not invent a measurement.
+    expect(
+      pin({
+        vram_total: 24 * GIB,
+        vram_free: Math.round(0.03 * 24 * GIB),
+        torch_vram_total: 5 * GIB,
+        torch_vram_free: 4 * GIB,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -863,6 +863,10 @@ export const __panelToolsTestHooks = {
   ): void {
     readVramDevicesOverride = fn;
   },
+  /** #1895 tests drive these, not a copy. A mutation of either that the
+   *  tool-handler suite never reaches must still fail. */
+  annotateFreeVramAck,
+  deviceStillPinned,
   /** Direct access to the #742 decline recheck loop so its hard-deadline
    *  guarantee (codex gate r2) can be unit-tested with a custom deadline. */
   probeDeclineRecovery,
@@ -2918,6 +2922,11 @@ function sampleVramDevice(d: unknown): VramDeviceSample {
  *  H3 case was device 2 with the torch pool at ~0.24% free — that occupancy
  *  is what this threshold names.
  *
+ *  The ratio is pool FULLNESS, not the reserved share of the card
+ *  (`torch_vram_total / vram_total`). A 5 GiB reservation with 4 GiB unused
+ *  inside the pool is not pinned here — that shape was not observed live
+ *  after /free (#1895 item 3).
+ *
  *  Unknown/unreadable torch counters are NOT pinned: an unknown answer
  *  claims nothing in either direction (#1473). Device-global counters
  *  alone also claim nothing — they cannot tell ComfyUI from another process. */
@@ -2938,25 +2947,83 @@ function pinnedVramDevices(devices: VramDeviceSample[]): VramDeviceSample[] {
   return devices.filter(deviceStillPinned);
 }
 
-/** /free only unloads ComfyUI's model manager. Ray workers, parallel CLIP
- *  loaders, and other custom-node allocations survive it and keep the GPU
- *  occupied — which is why a 2xx from /free is not evidence VRAM is free. */
-function pinnedVramAfterFreeNote(pinned: VramDeviceSample[]): string {
-  const named = pinned
+/** Device-global occupancy (`vram_free` / `vram_total`). Same 1 GiB / 20%
+ *  thresholds as the torch pin, applied to the WHOLE card. Used to disclose
+ *  an occupied card that is not this ComfyUI's torch pin (#1895) — never to
+ *  flip freed:true to a /free failure. */
+function deviceOccupiedGlobally(d: VramDeviceSample): boolean {
+  const total = d.vram_total;
+  const free = d.vram_free;
+  if (typeof total !== "number" || typeof free !== "number") return false;
+  if (!Number.isFinite(total) || !Number.isFinite(free)) return false;
+  if (total < PINNED_VRAM_MIN_TOTAL_BYTES) return false;
+  if (free < 0) return true;
+  return free / total <= PINNED_VRAM_FREE_RATIO;
+}
+
+function occupiedVramDevices(devices: VramDeviceSample[]): VramDeviceSample[] {
+  return devices.filter(deviceOccupiedGlobally);
+}
+
+function nameVramDevices(devices: VramDeviceSample[]): string {
+  return devices
     .map((d) => {
       if (typeof d.index === "number") return `device ${d.index}`;
       if (typeof d.name === "string" && d.name) return d.name;
       return "an unnamed device";
     })
     .join(", ");
+}
+
+/** /free only unloads ComfyUI's model manager. Ray workers, parallel CLIP
+ *  loaders, and other custom-node allocations survive it and keep the GPU
+ *  occupied — which is why a 2xx from /free is not evidence VRAM is free. */
+function pinnedVramAfterFreeNote(pinned: VramDeviceSample[]): string {
   return (
     `ComfyUI /free accepted (unload_models + free_memory) but VRAM is STILL PINNED on ` +
-    `${named}. /free only unloads ComfyUI's model manager — it does not terminate Ray ` +
+    `${nameVramDevices(pinned)}. /free only unloads ComfyUI's model manager — it does not terminate Ray ` +
     `workers or custom-node allocations (Raylight sequence-parallel, parallel CLIP loaders). ` +
     `This is not a successful VRAM recovery. Next: panel_restart_comfyui (last resort; ` +
     `refuses mid-render) after confirming with get_system_stats (action:"stats").`
   );
 }
+
+/** #1895 — the free DID succeed (torch pool not pinned) but the card is still
+ *  occupied. /system_stats is device-global and cannot name the holder, so
+ *  the wording asserts neither (a) this ComfyUI outside torch nor (b) another
+ *  process. */
+function occupiedCardAfterFreeNote(occupied: VramDeviceSample[]): string {
+  const named = nameVramDevices(occupied);
+  const verb = occupied.length === 1 ? "is" : "are";
+  return (
+    `ComfyUI /free accepted and THIS instance's torch pool is not pinned, so the free DID succeed. ` +
+    `${named} ${verb} still occupied. /system_stats reports the device globally and cannot name ` +
+    `which process holds it. Two shapes this reading cannot distinguish: (a) allocations this ` +
+    `ComfyUI made outside torch's allocator (Ray workers, sequence-parallel / parallel CLIP ` +
+    `loaders) — panel_restart_comfyui of THIS instance can clear those; (b) a different process ` +
+    `on the host (a second ComfyUI, a trainer, the browser) — restarting THIS instance will not ` +
+    `free that VRAM.`
+  );
+}
+
+function occupiedCardAfterFreeResult(
+  occupied: VramDeviceSample[],
+  extra: Record<string, unknown>,
+): ToolResult {
+  return ok({
+    freed: true,
+    unload_models: true,
+    free_memory: true,
+    model_manager_freed: true,
+    occupied_devices: occupied,
+    ...extra,
+    note: occupiedCardAfterFreeNote(occupied),
+  });
+}
+
+const UNOBSERVED_OCCUPANCY_NOTE =
+  `freed:true is the panel's /free receipt, not a measured device — this tab's server could ` +
+  `not be proven as the local boot instance, so /system_stats was never re-read.`;
 
 function pinnedVramAfterFreeResult(
   pinned: VramDeviceSample[],
@@ -3091,10 +3158,16 @@ async function settleFreeVramAfterAckTimeout(
   };
   // #1866 — a 2xx from /free is not a free GPU. Ray/CLIP workers can keep a
   // device pinned. When we have occupancy numbers, they are the verdict.
+  // #1895 — a card that is occupied while THIS instance's torch pool is empty
+  // is not a /free failure; disclose the device instead of a bare freed:true.
   if (direct.after != null) {
     const pinned = pinnedVramDevices(direct.after);
     if (pinned.length > 0) {
       return pinnedVramAfterFreeResult(pinned, extra);
+    }
+    const occupied = occupiedVramDevices(direct.after);
+    if (occupied.length > 0) {
+      return occupiedCardAfterFreeResult(occupied, extra);
     }
   }
   const statsNote =
@@ -3125,22 +3198,42 @@ async function settleFreeVramAfterAckTimeout(
  * settle uses (`captureRebootHealthBase(ctx)`), never `getComfyUIBaseUrl()`.
  * A hello from another tab can retarget the global base asynchronously;
  * reporting that GPU as this command's failure is the wrong-target failure
- * the gate exists to prevent. No proven local server → leave the ack.
+ * the gate exists to prevent.
+ *
+ * #1895 — no proven local server must not look like a measured GPU: disclose
+ * that occupancy was never re-read. An occupied card whose torch pool is
+ * empty is not a /free failure (isError stays false, freed stays true) but
+ * MUST name the device and that /system_stats is device-global.
  */
 async function annotateFreeVramAck(ctx: PanelToolCtx, res: ToolResult): Promise<ToolResult> {
   if (res.isError) return res;
   const parsed = parseToolResultJson(res);
   if (!parsed || parsed.freed !== true) return res;
   const base = captureRebootHealthBase(ctx);
-  if (!base) return res;
+  if (!base) {
+    return ok({
+      ...parsed,
+      occupancy_reread: false,
+      note: UNOBSERVED_OCCUPANCY_NOTE,
+    });
+  }
   const devices = await readVramDevicesMaybe(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
   if (devices == null) return res;
   const pinned = pinnedVramDevices(devices);
-  if (pinned.length === 0) return res;
-  return pinnedVramAfterFreeResult(pinned, {
-    acknowledged: true,
-    devices,
-  });
+  if (pinned.length > 0) {
+    return pinnedVramAfterFreeResult(pinned, {
+      acknowledged: true,
+      devices,
+    });
+  }
+  const occupied = occupiedVramDevices(devices);
+  if (occupied.length > 0) {
+    return occupiedCardAfterFreeResult(occupied, {
+      acknowledged: true,
+      devices,
+    });
+  }
+  return res;
 }
 
 // ---- panel_install_node: accepted-but-never-enqueued (#1129) ---------------
@@ -16392,7 +16485,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_free_vram",
-      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory. After /free, THIS instance's torch-pool occupancy is re-read from /system_stats on the server this tab provably fronts: if a device remains pinned (Ray workers, parallel CLIP, custom-node allocations /free cannot terminate), the reply names those devices and does NOT claim VRAM was freed — next step is panel_restart_comfyui. Device-global occupancy held by another process is not this free failing. If the panel tab is frozen and cannot acknowledge, the free is instead issued DIRECTLY to the ComfyUI server and verified there (same /free, idempotent) whenever the tab provably fronts the local server — otherwise the outcome is reported unknown rather than claimed.",
+      "Unload all loaded models and free VRAM (ComfyUI /free). Use to unwedge a stuck/OOM ComfyUI when a cancel didn't free memory — before retrying or, last resort, restarting (panel_restart_comfyui). Does NOT restart ComfyUI; it just drops resident models and frees cached memory. After /free, THIS instance's torch-pool occupancy is re-read from /system_stats on the server this tab provably fronts: if a device remains pinned (Ray workers, parallel CLIP, custom-node allocations /free cannot terminate), the reply names those devices and does NOT claim VRAM was freed — next step is panel_restart_comfyui. Device-global occupancy with an empty torch pool is not this free failing (freed:true) but the reply still names the device and that /system_stats cannot say which process holds the card. If this tab's server cannot be proven, freed:true is the panel's /free receipt — occupancy was not re-read. If the panel tab is frozen and cannot acknowledge, the free is instead issued DIRECTLY to the ComfyUI server and verified there (same /free, idempotent) whenever the tab provably fronts the local server — otherwise the outcome is reported unknown rather than claimed.",
       {},
       async (_args, ctx) => {
         const res = await ctx.call({ cmd: "free_vram" }, 15000);


### PR DESCRIPTION
Fixes #1895

Follow-up to #1887 / #1890. The wrong-target read is still gated on `captureRebootHealthBase`. This is about the silent `freed:true` that replaced the misattributed warning.

## Occupied card, empty torch pool

Live `/system_stats` from the filing machine: `vram_free 795579336` of `25756696576` (3.09% free) with a 32 MiB torch pool. That is (correctly) not a `/free` failure — `isError` stays false, `freed` stays true — but the reply now names the device, prints the counters, and says `/system_stats` is device-global. The wording asserts neither holder: (a) this ComfyUI outside torch (Ray/CLIP loaders — `panel_restart_comfyui` of THIS instance can clear those); (b) another process (a second ComfyUI — restarting THIS instance will not).

## Unproven tab

When `captureRebootHealthBase(ctx)` is null, occupancy is still not read. The ack is no longer byte-identical to a measured GPU: `occupancy_reread: false` and a one-sentence note that `freed:true` is the panel's `/free` receipt.

## Pin ratio

Left as pool fullness (`torch_vram_free / torch_vram_total`). Reserved share of the card was a predicate-shape note, not a live observation after `/free`.

## Tests

Drive `annotateFreeVramAck` and `deviceStillPinned` via `__panelToolsTestHooks`. The #1887 URL-pin tests still fail if occupancy is swapped to `getComfyUIBaseUrl()`.
