### PR TITLE
fix(panel#1515): the ENV line reports the panel ComfyUI will run, and the refusal names the cause that applied

### DIFF
--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -603,6 +603,53 @@ describe("readInstalledPanelVersion (disk fallback)", () => {
     expect(readInstalledPanelVersion(dir)).toBe("0.12.0");
   });
 
+  // panel #1515 — TWO copies installed, the documented #1269/#641 two-panels state
+  // (a git clone at comfyui-mcp-panel beside a Registry install at
+  // comfyui-agent-panel). Both carry the same authoritative [project].name, so the
+  // name screen passes for both and the scan used to return whichever dir the
+  // hardcoded list named first. On the reporter's rig that stamped an abandoned
+  // 0.7.3 clone onto the agent's ENVIRONMENT line while the live pack was 0.15.24.
+  it("prefers the NEWEST copy when the pack is installed twice (stale clone first in the list)", async () => {
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.7.3"\n`,
+    );
+    await writePanel(
+      "comfyui-agent-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.15.24"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.15.24");
+  });
+
+  // The SAME rule with the directories swapped. Without this, reordering
+  // PANEL_DIR_NAMES alone would satisfy the test above while leaving the defect —
+  // a list's order still deciding the answer — fully intact.
+  it("prefers the NEWEST copy irrespective of which dir name holds it", async () => {
+    await writePanel(
+      "comfyui-agent-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.7.3"\n`,
+    );
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.15.24"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.15.24");
+  });
+
+  it("ignores a squatted copy and still reports the real panel's version", async () => {
+    // The name screen and the newest-wins scan compose: 9.9.9 is the highest
+    // version present but is not the panel, so it must not win.
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\nname = "some-other-node"\nversion = "9.9.9"\n`,
+    );
+    await writePanel(
+      "comfyui-agent-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.15.24"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.15.24");
+  });
+
   it("returns undefined for a non-panel pyproject squatting a known dir (wrong project name)", async () => {
     // Authoritative guard: only [project].name == comfyui-agent-panel is trusted,
     // so a different node at the same dir name never yields a WRONG version.

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -493,13 +493,15 @@ describe("recovery guidance depends on the session, not on a hardcoded string", 
 describe("disk-current but handshake-old is diagnosed as a stale tab, not a stale install", () => {
   const SKEW = { diskVersion: "0.11.38", requiredVersion: "0.11.35" };
 
-  it("tells the user to hard-refresh, and NOT to update anything", () => {
+  it("tells the user to reload the tab, and NOT to update anything", () => {
     const text = describePanelUpdateRecovery(undefined, {
       ...SKEW,
       handshakeVersion: "0.11.34",
     });
     expect(text).toMatch(/Do NOT update the panel/);
-    expect(text).toMatch(/HARD-REFRESH/);
+    expect(text).toMatch(/RELOAD THIS COMFYUI TAB/);
+    // The cache-bypassing reload survives as the ESCALATION (panel #1515), so
+    // the keystroke a user needs when a plain reload does not take is still here.
     expect(text).toMatch(/Ctrl\+Shift\+R/);
     expect(text).toMatch(/0\.11\.38/); // what is really on disk
     expect(text).toMatch(/0\.11\.34/); // what the tab announced
@@ -540,12 +542,49 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     const text = describePanelUpdateRecovery(undefined, SKEW);
     expect(text).toMatch(/advertised no version/);
     expect(text).toMatch(/Updating the panel will not fix this/); // the proven part
-    expect(text).not.toMatch(/This BROWSER TAB is running an older cached copy/); // the unproven part
+    expect(text).not.toMatch(/This BROWSER TAB is running an OLDER copy/); // the unproven part
     expect(text).toMatch(/does not by itself say why/);
-    expect(text).toMatch(/\(1\) It is a ComfyUI browser tab/);
-    expect(text).toMatch(/HARD-REFRESH/); // still leads with the actionable fix
-    expect(text).toMatch(/\(2\) It is NOT a panel tab/);
-    expect(text).toMatch(/nothing to refresh/);
+    expect(text).toMatch(/\(1\) THE PACK WAS UPDATED IN PLACE WHILE THIS TAB WAS OPEN/);
+    expect(text).toMatch(/RELOAD THIS COMFYUI TAB/); // still leads with the actionable fix
+    expect(text).toMatch(/\(3\) It is NOT a panel tab/);
+    expect(text).toMatch(/nothing to reload/);
+  });
+
+  // panel #1515 — the reporter's session had an in-place ComfyUI-Manager update
+  // at 11:37 on a tab opened at 11:11, with no restart and no reload. The text
+  // led with the HTTP cache and sent them to Cmd+Shift+R, naming a cause that
+  // did not apply; ComfyUI-Manager's own post-update line already tells users to
+  // refresh the browser.
+  it("leads with the in-place pack update, and does not assert the HTTP cache as the cause", () => {
+    const text = describePanelUpdateRecovery(undefined, SKEW);
+    const updatedInPlace = text.indexOf("THE PACK WAS UPDATED IN PLACE");
+    const notAPanelTab = text.indexOf("It is NOT a panel tab");
+    expect(updatedInPlace).toBeGreaterThan(-1);
+    // ORDER is the ask, not mere presence: the leading cause must be the one
+    // that actually applied.
+    expect(updatedInPlace).toBeLessThan(notAPanelTab);
+    // ComfyUI-Manager's own wording, so the user recognises the line they saw.
+    expect(text).toMatch(/After restarting ComfyUI, please refresh the browser/);
+    // The stale mechanism claim is GONE. The panel repo measured the opposite
+    // (ComfyUI 0.31.1+ answers Cache-Control: no-store on /extensions/), so this
+    // sentence asserted a cause that cannot apply on a current host.
+    expect(text).not.toMatch(/carry no cache-busting key/);
+    expect(text).not.toMatch(/an ordinary reload can serve the stale file again/);
+    // And it says the plain reload is normally enough rather than opening on the
+    // cache-bypassing one.
+    expect(text).toMatch(/An ordinary reload is normally enough/);
+  });
+
+  // The one possibility in this list that a reload provably CANNOT fix. Leaving
+  // it unnamed means the user reloads, stays broken, and has no next step —
+  // exactly the dead end this module exists to remove.
+  it("names the two-panels install, and says a reload cannot fix it", () => {
+    const text = describePanelUpdateRecovery(undefined, SKEW);
+    expect(text).toMatch(/\(2\) The pack is INSTALLED TWICE/);
+    expect(text).toContain("custom_nodes/comfyui-mcp-panel");
+    expect(text).toContain("custom_nodes/comfyui-agent-panel");
+    expect(text).toMatch(/reloading cannot fix that/);
+    expect(text).toMatch(/remove the one you do not use/);
   });
 
   it("an ADVERTISED old version is still a definite diagnosis", () => {
@@ -554,8 +593,11 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     // the same served file), so hedging there would be its own failure.
     const text = describePanelUpdateRecovery(undefined, { ...SKEW, handshakeVersion: "0.11.34" });
     expect(text).toMatch(/Do NOT update the panel/);
-    expect(text).toMatch(/This BROWSER TAB is running an older cached copy/);
+    expect(text).toMatch(/This BROWSER TAB is running an OLDER copy/);
     expect(text).not.toMatch(/does not by itself say why/);
+    // panel #1515 — the skew is proven, but WHY the tab is old is not, so the
+    // definite branch names the ordinary reason without asserting a mechanism.
+    expect(text).toMatch(/updated in place while this tab\s+stayed open/);
   });
 
   it("the skew branch outranks remote mode — and still never names an uncallable tool", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2540,7 +2540,11 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "stale-bundle" })
         .catch((e: Error) => e);
       expect((err as Error).message).toMatch(/Do NOT update the panel/);
-      expect((err as Error).message).toMatch(/HARD-REFRESH/);
+      // panel #1515 — the remedy now leads with a plain reload (ComfyUI answers
+      // no-store on /extensions/, so one is normally enough) and keeps the
+      // cache-bypassing reload as the escalation.
+      expect((err as Error).message).toMatch(/RELOAD THIS COMFYUI TAB/);
+      expect((err as Error).message).toMatch(/Ctrl\+Shift\+R/);
       expect((err as Error).message).toMatch(/0\.11\.38/);
       // It must NOT send them back to the tool that will report nothing to do.
       expect((err as Error).message).not.toMatch(/Run install_comfyui\(action:'panel', panel_action:'update'\)/);
@@ -2711,12 +2715,17 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       expect(msg).toMatch(/Updating the panel will not fix this/);
       expect(msg).toMatch(/already 0\.11\.38/);
       expect(msg).not.toMatch(/Run install_comfyui\(action:'panel', panel_action:'update'\)/);
-      // The UNPROVEN part is not asserted...
-      expect(msg).not.toMatch(/This BROWSER TAB is running an older cached copy/);
-      // ...it is ranked, actionable case first, the other named rather than hidden.
-      expect(msg).toMatch(/\(1\) It is a ComfyUI browser tab/);
-      expect(msg).toMatch(/HARD-REFRESH/);
-      expect(msg).toMatch(/\(2\) It is NOT a panel tab/);
+      // The UNPROVEN part is not asserted... (re-anchored for panel #1515: the
+      // definite branch now says "an OLDER copy", so the pre-#1515 wording would
+      // have made this negative assertion pass vacuously.)
+      expect(msg).not.toMatch(/This BROWSER TAB is running an OLDER copy/);
+      // ...it is ranked, actionable case first, the others named rather than
+      // hidden. #1515 puts the in-place pack update at the top, because that is
+      // the one that actually applied in the session that reported it.
+      expect(msg).toMatch(/\(1\) THE PACK WAS UPDATED IN PLACE WHILE THIS TAB WAS OPEN/);
+      expect(msg).toMatch(/RELOAD THIS COMFYUI TAB/);
+      expect(msg).toMatch(/\(2\) The pack is INSTALLED TWICE/);
+      expect(msg).toMatch(/\(3\) It is NOT a panel tab/);
       expect(msg).not.toMatch(/[A-Za-z)"']\.\./);
       sock.close();
     } finally {
@@ -3199,8 +3208,9 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       expect(msg).toMatch(/already 0\.11\.38/);
       expect(msg).not.toMatch(/Run install_comfyui\(action:'panel', panel_action:'update'\)/);
       // Still no fabricated cause — the causes are ranked, as for no version.
-      expect(msg).not.toMatch(/This BROWSER TAB is running an older cached copy/);
-      expect(msg).toMatch(/\(1\) It is a ComfyUI browser tab/);
+      // (Re-anchored for panel #1515, same reason as the no-version case above.)
+      expect(msg).not.toMatch(/This BROWSER TAB is running an OLDER copy/);
+      expect(msg).toMatch(/\(1\) THE PACK WAS UPDATED IN PLACE WHILE THIS TAB WAS OPEN/);
       sock.close();
     } finally {
       clearPanelDiskObservation();

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -24,7 +24,7 @@ import { isForceRemoteFlagSet } from "../config.js";
 import { resolveComfyuiPython, pythonVersionsAgree, torchVersionsAgree } from "./workspace-env.js";
 import { resolveLiveInterpreter } from "./live-interpreter.js";
 import { parsePyproject } from "./node-authoring.js";
-import { detectInstallMode } from "./self-update.js";
+import { compareSemver, detectInstallMode } from "./self-update.js";
 import { logger } from "../utils/logger.js";
 
 // The interpreter resolver lives in workspace-env (which owns ComfyUI-base
@@ -740,7 +740,13 @@ export interface GatherOptions {
 
 // The panel's known custom_nodes dir names (registry unpack vs repo name), kept
 // in sync with panel-installer's FAST_PATH_DIRS.
-const PANEL_DIR_NAMES = ["comfyui-mcp-panel", "comfyui-agent-panel"] as const;
+//
+// Canonical Registry name FIRST (panel #1515). The order is no longer the thing
+// that decides the answer — `readInstalledPanelVersion` now picks the NEWEST of
+// the copies it finds — but it is still the tie-break when two copies carry
+// versions that cannot be compared, and the Registry install is the one the
+// installer manages.
+const PANEL_DIR_NAMES = ["comfyui-agent-panel", "comfyui-mcp-panel"] as const;
 // pyproject `[project].name` — the AUTHORITATIVE panel identity (a dir may be
 // squatted; the project name is not). Mirrors panel-installer's PANEL_REGISTRY_ID.
 const PANEL_PROJECT_NAME = "comfyui-agent-panel";
@@ -758,9 +764,35 @@ const PANEL_PROJECT_NAME = "comfyui-agent-panel";
  * panel's — a non-panel pyproject squatting a known dir name yields undefined,
  * never a wrong version. Best-effort: returns undefined on any failure, never
  * throws.
+ *
+ * NEWEST WINS, NOT FIRST-LISTED (panel #1515).
+ *
+ * The pack can be installed TWICE — a git clone at `custom_nodes/comfyui-mcp-panel`
+ * alongside a Manager/Registry install at `custom_nodes/comfyui-agent-panel`. That
+ * is not hypothetical: it is the documented #1269 / #641 two-panels state, and
+ * panel-recovery's own PANEL_DIR_NAMES comment exists to stop this module's advice
+ * from manufacturing it. Both dirs carry the same authoritative `[project].name`,
+ * so the name screen passes for BOTH and the loop returned whichever the hardcoded
+ * list happened to name first.
+ *
+ * In panel #1515 that read `0.7.3` off an abandoned clone while the live pack was
+ * `0.15.24`, and stamped 0.7.3 onto the agent's ENVIRONMENT line — the surface bug
+ * reports version-match against. A list's order is not evidence about which copy
+ * ComfyUI serves, so it may not decide the answer.
+ *
+ * The tie-break is NEWEST, and it is the panel's own rule rather than a guess: the
+ * bundle guard added for #1269 arbitrates the page so the newer copy runs and the
+ * older stands down ("A stale copy must never win just because its directory sorts
+ * first" — web/js/lib/duplicate-panel-guard.js). Reporting the newest install
+ * therefore names the bundle the browser will actually run.
+ *
+ * Two versions that cannot be compared (compareSemver answers 0 for anything that
+ * is not `major.minor.patch`) keep the first-found copy, which is the pre-existing
+ * behaviour and PANEL_DIR_NAMES' remaining job.
  */
 export function readInstalledPanelVersion(comfyuiPath?: string): string | undefined {
   if (!comfyuiPath) return undefined;
+  let best: string | undefined;
   for (const name of PANEL_DIR_NAMES) {
     try {
       const toml = readFileSync(
@@ -768,12 +800,15 @@ export function readInstalledPanelVersion(comfyuiPath?: string): string | undefi
         "utf8",
       );
       const parsed = parsePyproject(toml);
-      if (parsed.projectName === PANEL_PROJECT_NAME && parsed.version) return parsed.version;
+      if (parsed.projectName !== PANEL_PROJECT_NAME || !parsed.version) continue;
+      // Keep scanning after a hit: the FIRST readable copy is not evidence that
+      // it is the live one.
+      if (best === undefined || compareSemver(parsed.version, best) > 0) best = parsed.version;
     } catch {
       /* try the next known dir name */
     }
   }
-  return undefined;
+  return best;
 }
 
 /**

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -243,9 +243,18 @@ export function manualPanelUpdateCommands(comfyuiPath?: string): string {
  *
  * Told to "run install_comfyui(action:'panel', panel_action:'update')", such a user gets "nothing to
  * update" — true, and completely useless, because nothing is wrong with their
- * install. The fix is a cache-bypassing reload of the tab, and saying so is the
- * whole remedy. (The cache-busting itself is #584 / panel #596 and is not
- * addressed here; this only makes the diagnosis and the guidance correct.)
+ * install. The fix is a reload of the tab, and saying so is the whole remedy.
+ * (The cache-busting itself is #584 / panel #596 and is not addressed here; this
+ * only makes the diagnosis and the guidance correct.)
+ *
+ * WHY THE TAB IS OLD is a separate question from the fact that it is, and panel
+ * #1515 is the correction: this text used to answer it "the HTTP cache", which
+ * the panel repo has since measured to be untrue on any current host (ComfyUI
+ * 0.31.1+ answers `Cache-Control: no-store` on /extensions/, and the pack adds
+ * the same backstop where a host sets none). The ordinary reason is duller and
+ * needs no cache at all — the pack was updated in place and the tab has been
+ * open since before it moved. A cache-bypassing reload stays in the text as the
+ * escalation, not the opening diagnosis.
  */
 export interface PanelBundleSkew {
   /** Version READ FROM DISK, already proven to satisfy the requirement. */
@@ -323,34 +332,68 @@ export function describePanelUpdateRecovery(
     //  - the client advertised a version BELOW the floor → the served pack and
     //    the announced build genuinely disagree. Both the version and the
     //    capability are built by the same served file, so a client running the
-    //    installed bundle would have announced the installed version. A stale
-    //    cached bundle is then a conclusion, not a guess.
+    //    installed bundle would have announced the installed version. An OLDER
+    //    bundle in the tab is then a conclusion, not a guess — though WHY it is
+    //    older stays open, so the text names the ordinary reason (the pack moved
+    //    under an open tab) without asserting a mechanism it did not observe.
     //  - the client advertised NO version → nothing was observed. A browser tab
-    //    on a cached bundle looks exactly like a relay or other non-panel client
-    //    that never implemented the fence at all, and "hard-refresh your tab" is
-    //    unactionable for the latter. Asserting the cache is the fabrication
-    //    this cluster exists to remove, so that variant RANKS the possibilities
-    //    instead — the actionable one first, the other named rather than hidden.
-    const HARD_REFRESH =
-      `The panel's module URLs carry no cache-busting key, so an ordinary reload can ` +
-      `serve the stale file again: HARD-REFRESH this ComfyUI tab with a cache-bypassing ` +
-      `reload (Ctrl+Shift+R, or Cmd+Shift+R on macOS; if that does not take, open ` +
-      `DevTools and use right-click reload → "Empty Cache and Hard Reload"). `;
+    //    on an old bundle looks exactly like a relay or other non-panel client
+    //    that never implemented the fence at all, and "reload your tab" is
+    //    unactionable for the latter. Asserting a cause is the fabrication this
+    //    cluster exists to remove, so that variant RANKS the possibilities
+    //    instead — the actionable ones first, the others named rather than
+    //    hidden. The second rank (panel #1515) is the two-panels install, which
+    //    is the one possibility here that a reload provably CANNOT fix, so it
+    //    must be named rather than left to be discovered after the reload fails.
+    // RELOAD FIRST, HARD-REFRESH AS THE ESCALATION (panel #1515).
+    //
+    // This used to open by asserting the HTTP cache as the mechanism ("the module
+    // URLs carry no cache-busting key, so an ordinary reload can serve the stale
+    // file again") and send the user straight to Ctrl+Shift+R. The panel repo has
+    // since MEASURED that claim and recorded the opposite in its own __init__.py:
+    // "ComfyUI 0.31.1 already answers `Cache-Control: no-store` on every
+    // /extensions/ path — ours and other packs' alike — so the HTTP cache is not
+    // the mechanism there", and the pack installs a no-store backstop for hosts
+    // that set none. On any current host an ordinary reload DOES pick up new JS.
+    //
+    // Leading with the cache therefore named a cause that no longer applies and
+    // buried the one that does — a tab that has simply been open since before the
+    // pack changed. #1515's reporter had an in-place ComfyUI-Manager update at
+    // 11:37 on a tab opened at 11:11, with no restart and no reload; they were
+    // sent to diagnose a cache they did not have. The remedy survives (a reload
+    // fixes both), so this is a change of CAUSE and of ORDER, not of action.
+    const RELOAD_TAB =
+      `RELOAD THIS COMFYUI TAB. An ordinary reload is normally enough — ComfyUI ` +
+      `answers Cache-Control: no-store on /extensions/ assets (and the pack sets it ` +
+      `as a backstop where the host does not), so the tab picks up the new JS. If the ` +
+      `refusal survives a reload, escalate to a cache-bypassing one (Ctrl+Shift+R, or ` +
+      `Cmd+Shift+R on macOS; if that does not take, open DevTools and use right-click ` +
+      `reload → "Empty Cache and Hard Reload"). `;
     return (
       (skew.handshakeVersion
         ? `Do NOT update the panel — the pack ON DISK is already ${skew.diskVersion}, which ` +
           `meets the ${skew.requiredVersion}+ a graph write needs. This BROWSER TAB is running ` +
-          `an older cached copy of the panel's JavaScript (it advertised ` +
+          `an OLDER copy of the panel's JavaScript (it advertised ` +
           `${skew.handshakeVersion}), and the capability check reads what the TAB ` +
-          `announced. ${HARD_REFRESH}`
+          `announced — most often because the pack was updated in place while this tab ` +
+          `stayed open. ${RELOAD_TAB}`
         : `Updating the panel will not fix this — the pack ON DISK is already ` +
           `${skew.diskVersion}, which meets the ${skew.requiredVersion}+ a graph write needs, ` +
           `so the SERVED panel is already capable. What connected advertised no version and ` +
-          `no workflow fence, which does not by itself say why, so here are both ` +
-          `possibilities. (1) It is a ComfyUI browser tab — much the more common case — ` +
-          `running a cached older copy of the panel's JavaScript. ${HARD_REFRESH}` +
-          `(2) It is NOT a panel tab (a relay or other client): then it does not implement ` +
-          `the fence at all and there is nothing to refresh — issue graph WRITES from a ` +
+          `no workflow fence, which does not by itself say why, so here are the ` +
+          `possibilities, likeliest first. (1) THE PACK WAS UPDATED IN PLACE WHILE THIS TAB ` +
+          `WAS OPEN, and the tab is still running the JavaScript it loaded before the ` +
+          `update — ComfyUI-Manager says as much after every update ("After restarting ` +
+          `ComfyUI, please refresh the browser"), and a tab opened before the update never ` +
+          `did. ${RELOAD_TAB}` +
+          `(2) The pack is INSTALLED TWICE — a git clone at custom_nodes/comfyui-mcp-panel ` +
+          `beside a Registry install at custom_nodes/comfyui-agent-panel. ComfyUI loads ` +
+          `both bundles into the page, and an old enough copy hellos without a version at ` +
+          `all; reloading cannot fix that, because the stale copy is served from its own ` +
+          `directory and re-registers on every load. Check custom_nodes for both names and ` +
+          `remove the one you do not use. ` +
+          `(3) It is NOT a panel tab (a relay or other client): then it does not implement ` +
+          `the fence at all and there is nothing to reload — issue graph WRITES from a ` +
           `ComfyUI tab running the panel. `) +
       // Only name the tool where naming it is useful. In a remote/cloud session
       // it is not callable at all, so mentioning it is a pointless mention of an


### PR DESCRIPTION
Fixes the two changes requested in artokun/comfyui-mcp-panel#1515. Both live **here**, not in the panel repo — the write-fence text is built in `src/services/panel-recovery.ts` and the ENVIRONMENT line's panel version in `src/services/env-capabilities.ts`. (Zero hits for the reported error text anywhere in the panel pack's own source.)

**Review is PENDING — not gated, not reviewed.** See "What I want a reviewer to attack" below.

## The reporter saw three answers; there is one cause

| surface | said |
|---|---|
| agent ENVIRONMENT line | `panel 0.7.3` |
| `pyproject.toml` / `PANEL_VERSION` | `0.15.24` |
| write fence | tab advertised **no version** |

`readInstalledPanelVersion` scanned two known `custom_nodes` dir names and returned the **first readable one**:

```ts
const PANEL_DIR_NAMES = ["comfyui-mcp-panel", "comfyui-agent-panel"] as const;
for (const name of PANEL_DIR_NAMES) { ... if (name matches && version) return parsed.version; }
```

Both dirs carry the same authoritative `[project].name`, so the name screen passes for **both** and a leftover git clone at `custom_nodes/comfyui-mcp-panel` outranks the live Registry install at `custom_nodes/comfyui-agent-panel` purely because it is listed first. That is the documented two-panels state (#1269 / #641) — `panel-recovery.ts`'s own `PANEL_DIR_NAMES` comment exists to stop this module's advice from manufacturing it.

Verified against the panel repo rather than assumed:

- **0.7.3 is a real released panel version** (`43b46698`), and its `pyproject.toml` declares `name = "comfyui-agent-panel"` — so it passes the screen and is returned as "the installed panel".
- `panel_version` entered the hello at panel **0.11.3** (`27878273`/`d7930f41`, whose pyproject reads `0.11.3`). A 0.7.3 bundle predates it and therefore hellos with **no version** — exactly what the fence reported.

So the same stale copy explains the ENV line *and* the missing advertisement. One cause, three symptoms.

> Correcting my own first pass: I initially read this as 0.11.83 from `git tag --contains`. That was wrong — v0.11.83 is the panel repo's **earliest tag**, so `--contains` reports it for any older commit. Reading the pyproject at the commit gives 0.11.3.

## Change 1 — newest wins, not first-listed

The scan keeps going after a hit and reports the **newest** copy. The tie-break is the panel's own rule, not a guess: the #1269 bundle guard arbitrates the page so the newer copy runs and the older stands down ("A stale copy must never win just because its directory sorts first" — `web/js/lib/duplicate-panel-guard.js`). The newest install therefore names the bundle the browser will actually run. Two incomparable versions keep the first-found copy, which is today's behaviour.

## Change 2 — the refusal names the cause that applied

The text opened by asserting the HTTP cache and sent the user to `Cmd+Shift+R`. The panel repo has since **measured** the opposite and recorded it in `__init__.py`:

> "ComfyUI 0.31.1 already answers `Cache-Control: no-store` on every `/extensions/` path — ours and other packs' alike — **so the HTTP cache is not the mechanism there.**"

The reporter had no cache to clear; their tab had simply been open since before an in-place ComfyUI-Manager update (tab 11:11, update 11:37, no restart, no reload). Causes are now ranked:

1. **the pack was updated in place while this tab was open** — quoting Manager's own "After restarting ComfyUI, please refresh the browser"
2. **the pack is installed twice** — named second because it is the one possibility a reload provably *cannot* fix, so leaving it out means the user reloads, stays broken, and has no next step
3. not a panel tab

A plain reload leads; the cache-bypassing reload stays as the escalation. Same action, corrected cause and order.

## Evidence — by mutation, not by a green suite

| mutation | result |
|---|---|
| `readInstalledPanelVersion` reverted to first-match-wins | ✗ `prefers the NEWEST copy irrespective of which dir name holds it` — **exactly 1 failure** |
| `panel-recovery.ts` restored to `origin/main` | ✗ 5 failures, incl. both new #1515 tests |

Worth stating plainly: the *other* new test — "stale clone first in the list" — **still passes** under the first mutation, because reordering `PANEL_DIR_NAMES` alone satisfies it. The order-independence test is the one carrying the fix, and that is why it exists.

The bridge-level assertions in `ui-bridge.test.ts` go through the real bridge, so they pin that production reaches this text and not just the helper.

**Two negative assertions were re-anchored, deliberately.** They pinned `"This BROWSER TAB is running an older cached copy"`, which this PR renames to `"an OLDER copy"`. Left alone they would still have passed — against a string that no longer exists anywhere — a weakened assertion wearing a green tick.

## What I deliberately did NOT do

- **The persistent reload banner / server-side push** suggested in the issue. That is a feature, and the freeze is active.
- **The sticky `latestPanelVersion` cache** (`orchestrator/index.ts:2026`). It is never cleared, so once any hello carries a version the `??` in `gatherEnvCapabilities` makes the disk fallback unreachable for the process's life. It is **not** what produced 0.7.3 here (a 0.7.3 bundle cannot advertise 0.7.3), and changing which version the ENV line prefers is a semantics call that could regress bug-report version-matching. Flagging rather than folding it in.
- **Adjacent bug, not fixed here:** the panel's cache backstop is scoped to `_ASSET_PREFIX = "/extensions/comfyui-mcp-panel/"`, so a Registry install (`comfyui-agent-panel`) gets no backstop on hosts that set no policy. Only matters pre-0.31.1, and it is the panel repo's to fix.

## Browser verification

Not applicable and not claimed: this changes orchestrator-side text and a disk read. No panel JS, no sidebar rendering path is touched.

## What I want a reviewer to attack

1. **Is "newest wins" the right tie-break?** It rests on the #1269 guard being present in the copy that wins the page. If both copies predate that guard, the page arbitration doesn't happen and the newest-on-disk is not necessarily the one running. I claim that's still strictly better than list order — but it is the load-bearing judgement call here.
2. **The 0.7.3 provenance is inferred, not observed on the reporter's machine.** I proved 0.7.3 *can* produce all three symptoms; I could not prove it *did*. If you can construct another path to `panel 0.7.3` on the ENV line, the disk read may not be the whole story.
3. **Cause ordering is a judgement.** I ranked in-place-update first on the reporter's evidence; if the two-panels state is actually more common in the wild, ranks 1 and 2 should swap.

Refs artokun/comfyui-mcp-panel#1515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
