### PR TITLE
fix(panel#1517): a read-only graph command is sent while a prompt runs

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -6,11 +6,19 @@
 //
 // The frontend main thread is what cannot answer. The orchestrator CAN see the
 // running prompt via QueueMonitor (HTTP /queue, independent of the panel tab).
-// Fail closed BEFORE dispatch for canvas-touching graph commands so the agent
-// gets an explicit QUEUE BUSY instead of a 20/30s unknown-outcome timeout.
-// `graph_run` is excluded: queuing behind an in-flight job is the documented
-// sweep path. A timeout that still happens (graph_run, or a lagging snapshot)
-// is annotated with the same QUEUE BUSY rather than "backgrounded or frozen".
+// Fail closed BEFORE dispatch for graph EDITS so the agent gets an explicit
+// QUEUE BUSY instead of a 20/30s unknown-outcome timeout. `graph_run` is
+// excluded: queuing behind an in-flight job is the documented sweep path. A
+// timeout that still happens is annotated with the same QUEUE BUSY rather than
+// "backgrounded or frozen".
+//
+// panel#1517 — #1745 applied that refusal to READS too, which cost read-only
+// inspection for the whole duration of a render: an agent could not read the
+// prompt warning it was trying to correct for the next run. A read has no
+// mutation outcome to be unknown about, so an `inert` command (GRAPH_CMD_EFFECT)
+// is DISPATCHED while a prompt runs; if the tab genuinely cannot answer it, the
+// bounded read budget produces the same QUEUE BUSY text on the timeout path.
+// The edit refusal is unchanged — that is what the unknown outcome is about.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -21,7 +29,7 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
-import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { isMutatingGraphCommand, markReplyTimeout } from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "11111111-2222-4333-8444-555555555555";
@@ -106,43 +114,10 @@ afterEach(() => {
   qm.url = null;
 });
 
-describe("graph_* fail fast while a prompt is running (#1639)", () => {
-  it("a read-only graph_query is NOT sent — QUEUE BUSY names the running prompt", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.currentNode = "42";
-    qm.state.queueRemaining = 1;
-
-    const { bridge, sent } = makeBridge();
-    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
-    const text = textOf(res);
-
-    expect(sent).toEqual([]);
-    expect(res.isError).toBe(true);
-    expect(text).toMatch(/QUEUE BUSY/);
-    expect(text).toMatch(/running prompt p-in-flight/);
-    expect(text).toMatch(/currently at node 42/);
-    expect(text).toMatch(/was NOT sent — nothing was applied/);
-    expect(text).toMatch(/running: 0/);
-    // Mentions the generic frozen-tab wording only as the diagnosis it refuses to
-    // surface — the actual headline is QUEUE BUSY, not a backgrounded tab.
-  });
-
-  it("panel_graph_outline is the same — reads are not exempt", async () => {
-    qm.state.runningPromptId = "p-in-flight";
-    qm.state.queueRemaining = 1;
-
-    const { bridge, sent } = makeBridge();
-    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const res = await defByName("panel_graph_outline").handler({} as never, ctx);
-
-    expect(sent).toEqual([]);
-    expect(res.isError).toBe(true);
-    expect(textOf(res)).toMatch(/QUEUE BUSY/);
-  });
-
+describe("graph EDITS fail fast while a prompt is running (#1639)", () => {
   it("panel_set_widget is NOT delivered — outcome is known (nothing applied)", async () => {
     qm.state.runningPromptId = "p-in-flight";
+    qm.state.currentNode = "42";
     qm.state.queueRemaining = 1;
 
     const { bridge, sent } = makeBridge();
@@ -156,10 +131,32 @@ describe("graph_* fail fast while a prompt is running (#1639)", () => {
     expect(sent).toEqual([]);
     expect(res.isError).toBe(true);
     expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/running prompt p-in-flight/);
+    expect(text).toMatch(/currently at node 42/);
     expect(text).toMatch(/was NOT sent — nothing was applied/);
+    expect(text).toMatch(/running: 0/);
     // A mutation that never left must not invite retry_of / unknown-outcome.
     expect(text).not.toMatch(/may have been applied/);
     expect(text).not.toMatch(/retry_of/);
+  });
+
+  it("the edit refusal points at the reads that ARE still available (panel#1517)", async () => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.queueRemaining = 1;
+
+    const { bridge } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+    const text = textOf(res);
+
+    expect(text).toMatch(/panel_graph_outline/);
+    expect(text).toMatch(/panel_query_graph/);
+    // The pre-#1517 wording told the agent reads were refused too. If that ever
+    // comes back the message is lying about the behaviour this file pins below.
+    expect(text).not.toMatch(/including read-only graph_query \/ graph_outline/);
   });
 
   it("idle queue: the same read is dispatched", async () => {
@@ -183,6 +180,72 @@ describe("graph_* fail fast while a prompt is running (#1639)", () => {
 
     expect(sent).toContain("graph_run");
     expect(textOf(res)).not.toMatch(/was NOT sent/);
+  });
+});
+
+// panel#1517 — the reported defect: a live-canvas READ is refused while a prompt
+// runs, so an agent cannot inspect or correct a prompt warning for the next run.
+// These pin that reads are DISPATCHED. Delete the `isMutatingGraphCommand` line
+// in graphCmdBlockedByRunningPrompt and every one of them fails on `sent`.
+describe("read-only graph commands are dispatched while a prompt runs (panel#1517)", () => {
+  beforeEach(() => {
+    qm.state.runningPromptId = "p-in-flight";
+    qm.state.currentNode = "42";
+    qm.state.queueRemaining = 1;
+  });
+
+  it("panel_graph_outline is sent and answers — the reported call", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_graph_outline").handler({} as never, ctx);
+
+    expect(sent).toEqual(["graph_outline"]);
+    expect(res.isError).not.toBe(true);
+    expect(textOf(res)).not.toMatch(/was NOT sent/);
+  });
+
+  it("panel_query_graph is sent — the other call named in the report", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx);
+
+    expect(sent).toEqual(["graph_query"]);
+    expect(res.isError).not.toBe(true);
+  });
+
+  it("panel_get_errors is sent — the prompt-warning surface the reporter wanted", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_get_errors").handler({} as never, ctx);
+
+    expect(sent).toContain("graph_get_errors");
+    expect(textOf(res)).not.toMatch(/was NOT sent/);
+  });
+
+  it("a read that DOES time out still gets the QUEUE BUSY explanation, not a frozen tab", async () => {
+    const { bridge, sent } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_graph_outline").handler({} as never, ctx);
+    const text = textOf(res);
+
+    // It was ATTEMPTED — that is the whole change. The outcome when the tab
+    // really cannot answer is no worse than the old refusal, only later.
+    expect(sent).toContain("graph_outline");
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/running prompt p-in-flight/);
+    expect(text).toMatch(/not a backgrounded or frozen tab/i);
+  });
+
+  it("an UNCLASSIFIED graph_* command still fails closed as an edit", async () => {
+    // The ledger fails closed, so a command nobody classified is refused here —
+    // the same rule GRAPH_CMD_EFFECT applies at the workflow fence. Asserted
+    // through the predicate the guard actually consults.
+    expect(isMutatingGraphCommand("graph_some_future_mutator")).toBe(true);
+    expect(isMutatingGraphCommand("graph_outline")).toBe(false);
+    expect(isMutatingGraphCommand("graph_query")).toBe(false);
+    expect(isMutatingGraphCommand("graph_get_errors")).toBe(false);
+    expect(isMutatingGraphCommand("graph_set_widget")).toBe(true);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -136,6 +136,7 @@ import {
   dispatchOutcomeOf,
   GRAPH_CMD_EFFECT,
   isCapabilityRefusal,
+  isMutatingGraphCommand,
   isPanelCmdUnsupportedError,
   isReplyTimeoutTagged,
   isRoutingAmbiguity,
@@ -956,13 +957,35 @@ function sleep(ms: number): Promise<void> {
 // frozen/backgrounded tab fails in bounded time instead of hanging forever.
 const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
 
-// #1639 — while a ComfyUI prompt is running the frontend main thread often
-// cannot service graph_* at all (reads included). Waiting out the 20/30 s ack
-// bound only surfaces "tab may be backgrounded or frozen" with an unknown
-// mutation outcome. Fail closed BEFORE dispatch for canvas-touching graph
-// commands so the agent gets an explicit QUEUE BUSY instead. `graph_run` is
-// excluded: queuing behind an in-flight job is the documented sweep path, and
-// panel_run already has its own duplicate fence.
+// #1639 — while a ComfyUI prompt is running the frontend main thread may not
+// service a graph_* command. Waiting out the 20/30 s ack bound then surfaces
+// "tab may be backgrounded or frozen" with an UNKNOWN mutation outcome: the
+// edit may or may not have landed, and the agent has to round-trip a verifying
+// read to find out. Fail closed BEFORE dispatch so that outcome is KNOWN
+// instead. `graph_run` is excluded: queuing behind an in-flight job is the
+// documented sweep path, and panel_run already has its own duplicate fence.
+//
+// panel#1517 — the refusal is scoped to commands that HAVE a mutation outcome.
+// #1745 applied it to every graph_* except graph_run, which took read-only
+// inspection away for the whole duration of a render: panel_graph_outline,
+// panel_query_graph and panel_get_errors were refused without being sent, so an
+// agent could not read the prompt warning it was trying to correct for the NEXT
+// run — and ctx.call routes every INTERNAL read through here too, so
+// workflow_open's own live-graph fence probe could not clear either.
+//
+// A read has no outcome to be unknown about. The worst case for dispatching one
+// is the bounded read ack budget followed by the SAME QUEUE BUSY text the
+// refusal would have produced immediately (queueBusyTimeoutNote, appended on the
+// timeout path) — i.e. never a worse OUTCOME than refusing, only later. The
+// upside is the answer itself, which is what a tab that IS servicing its main
+// thread returns in milliseconds. That trade is worth taking for a read and is
+// not worth taking for an edit, so the classification is by EFFECT.
+//
+// The discriminator is GRAPH_CMD_EFFECT via isMutatingGraphCommand — the #778
+// ledger that already answers "can this change the user's workflow", rather than
+// a fourth hand-maintained list that would drift from it. It fails closed: a
+// graph_* command nobody classified is `targeted`, so it stays refused here and
+// is RECORDED as a ledger gap rather than being waved through by omission.
 function queueBusySnapshotNote(): string {
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return "";
@@ -975,14 +998,21 @@ function queueBusySnapshotNote(): string {
 function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   if (!name.startsWith("graph_") || name === "graph_run") return null;
+  // panel#1517 — `inert` commands (pure reads, plus viewport/selection/scope
+  // changes) cannot change workflow content, so there is no unknown outcome to
+  // protect the agent from. Send them and let the bounded read budget decide.
+  if (!isMutatingGraphCommand(name)) return null;
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return null;
   return (
     `${name} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
-    `${queueBusySnapshotNote()}. The panel tab typically cannot answer graph_* commands ` +
-    `(including read-only graph_query / graph_outline) while a prompt is executing — ` +
-    `waiting out the ack timeout would only surface a generic "tab may be backgrounded ` +
-    `or frozen" with an unknown outcome. Retry after queue (action:"list") shows running: 0.`
+    `${queueBusySnapshotNote()}. A graph EDIT is held back while a prompt executes: the tab's ` +
+    `main thread may not service it, and waiting out the ack timeout would surface a generic ` +
+    `"tab may be backgrounded or frozen" with an UNKNOWN outcome — the edit may or may not ` +
+    `have landed. Read-only graph commands are NOT held back: panel_graph_outline, ` +
+    `panel_query_graph and panel_get_errors are still sent while a prompt runs, so you can ` +
+    `inspect the graph now and stage the edit for when it drains. Retry this edit after ` +
+    `queue (action:"list") shows running: 0.`
   );
 }
 
@@ -990,7 +1020,7 @@ function queueBusyTimeoutNote(): string {
   if (!QueueMonitor.snapshot().running) return "";
   return (
     `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}. ` +
-    `The panel tab typically cannot answer graph_* (including read-only queries) while a ` +
+    `The panel tab sometimes cannot answer graph_* (including read-only queries) while a ` +
     `prompt is executing — this is not a backgrounded or frozen tab. Retry after queue ` +
     `(action:"list") shows running: 0.`
   );


### PR DESCRIPTION
Reported as artokun/comfyui-mcp-panel#1517 (`via-panel`, P2). The code is here, not
in the panel: the panel has no execution gate on `graph_*` at all
(`git grep` over `web/js` finds no running-prompt refusal), so the refusal was
entirely the orchestrator's pre-dispatch fence.

## What the reporter hit

Queue a workflow, then call `panel_graph_outline` while it runs:

```
graph_outline was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is
running (...). The panel tab typically cannot answer graph_* commands (including
read-only graph_query / graph_outline) while a prompt is executing.
```

They wanted to inspect and correct a prompt warning **for the next run** — a pure
read, refused for the whole duration of a render.

## Mechanism

`graphCmdBlockedByRunningPrompt` (`src/orchestrator/panel-tools.ts`) refused every
`graph_*` except `graph_run` while `QueueMonitor` saw a running prompt. That fence
was added by #1745 for #1639.

Reading #1639 closely, its reporter asked for two things, in order:

> Either (a) keep the panel's command channel responsive during execution (**the
> reads at minimum should never be blocked by a running prompt**), or (b) if the
> frontend genuinely cannot answer mid-execution, have the orchestrator … say so
> explicitly instead of surfacing a generic 20/30s timeout.

#1745 shipped (b) — and applied it to reads as well as edits. #1517 is the cost of
that: (a) was never done, and (b) took reads away.

**The refusal's own justification is about an unknown MUTATION outcome.** A read has
no outcome to be unknown about. So the fence is now scoped by EFFECT:

```ts
if (!name.startsWith("graph_") || name === "graph_run") return null;
if (!isMutatingGraphCommand(name)) return null;   // ← panel#1517
```

`isMutatingGraphCommand` is the existing #778 `GRAPH_CMD_EFFECT` ledger, not a new
list — deliberately, since #778 exists because that knowledge had been duplicated
into a third list the gate could not see. It **fails closed**: an unclassified
`graph_*` is `targeted`, stays refused here, and is *recorded* as a ledger gap.

Edits are unchanged. The refusal text now also names the reads that remain
available instead of claiming they are blocked.

## Blast radius was wider than the two tools in the title

`ctx.call` routes **every internal read** through this same guard, so while a prompt
ran:

- `panel_get_errors` (`graph_get_errors`) — the prompt-warning surface the reporter
  was actually reaching for — was refused without being sent.
- `probeLiveGraphUnderCurrentFence` — `workflow_open`'s own live-graph probe, added
  by the *other half of #1745* — could not run, so an open could not clear its fence
  during a render either.

Both are fixed by the same one-line scope change; `panel_get_errors` is pinned below.

## Evidence

**Mutation-verified.** Deleted the fix line and re-ran — 4 named tests go red with
exactly the production symptom (`sent` is empty, i.e. never dispatched):

```
× panel_graph_outline is sent and answers — the reported call
    AssertionError: expected [] to deeply equal [ 'graph_outline' ]
× panel_query_graph is sent — the other call named in the report
    AssertionError: expected [] to deeply equal [ 'graph_query' ]
× panel_get_errors is sent — the prompt-warning surface the reporter wanted
    AssertionError: expected [] to include 'graph_get_errors'
× a read that DOES time out still gets the QUEUE BUSY explanation, not a frozen tab
    AssertionError: expected [] to include 'graph_outline'
 Tests  4 failed | 7 passed (11)
```

Restored → 11/11 pass. The tests drive the **real tool surface**
(`buildPanelToolDefs().find(...).handler`), not a helper, so this is the call site.

**Suites:** `src/__tests__/orchestrator` + `src/__tests__/services` — 420 files,
8422 passed, 0 failed. `tsc --noEmit` clean.

**Full `npm test`** (590 files) showed 4 and then 10 failures across two runs, but a
*different, disjoint* set each time — all hook/test timeouts under parallel load.
Re-ran all 6 implicated files with `--maxWorkers=1`: **6 files / 323 tests passed**.
None of them import the changed code.

**Not run: Playwright.** This change is entirely orchestrator-side; the panel repo
is untouched and nothing it renders changes. I am not claiming browser coverage.

## The trade, stated plainly

When the tab genuinely cannot service its main thread, a read now costs up to the
bounded read ack budget (20 s) and then returns `queueBusyTimeoutNote()` — the *same*
QUEUE BUSY text the refusal produced instantly. So the **outcome** is never worse
than today, only later; the upside is the answer itself, which a tab that IS
servicing its main thread returns in milliseconds.

I deliberately did **not** shorten the read budget for this case. 20 s is the
`BRIDGE_READ_DEFAULT_TIMEOUT_MS` set by #357 precisely because a healthy-but-loaded
tab is slow, and a running prompt is definitionally that condition — capping it lower
would cut off exactly the reads that need the tolerance.

## Review pending

Not gated, not reviewed yet — requesting review in a comment.
