### PR TITLE
fix(panel#1524): panel_run returns queued:true after a mid-command drop if the prompt is already in the queue

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -25,7 +25,11 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
-import { markReplyTimeout } from "../../services/ui-bridge.js";
+import {
+  markDispatched,
+  markMidCommandDisconnect,
+  markReplyTimeout,
+} from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "11111111-2222-4333-8444-555555555555";
@@ -316,5 +320,80 @@ describe("a graph_* timeout while a prompt is running is named QUEUE BUSY (#1639
     expect(res.isError).toBe(true);
     expect(text).toMatch(/did not reply to "graph_run"/);
     expect(text).not.toMatch(/QUEUE BUSY/);
+  });
+});
+
+describe("panel_run treats a post-queue disconnect as queued when the prompt is new (panel#1524)", () => {
+  function makeDisconnectBridge(afterDispatch?: () => void) {
+    const sent: string[] = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, o?: { onDispatchedRid?: (rid: string) => void }) => {
+        sent.push(String(cmd.cmd));
+        o?.onDispatchedRid?.("rid-disco-1");
+        afterDispatch?.();
+        throw markMidCommandDisconnect(
+          markDispatched(
+            new Error(
+              `panel tab ${TAB.slice(0, 8)} disconnected mid-command ("${cmd.cmd}") — OUTCOME UNKNOWN: ` +
+                `the command was already sent, so the panel may have applied it (for a run, ComfyUI may already be rendering).`,
+            ),
+            true,
+          ),
+        );
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: true, uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    return { bridge, sent };
+  }
+
+  it("a NEW running prompt after graph_run disconnects is returned as queued:true", async () => {
+    const { bridge, sent } = makeDisconnectBridge(() => {
+      qm.state.runningPromptId = "p-poyo-queued";
+      qm.state.queueRemaining = 1;
+    });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_run").handler({ to_node_id: 3 } as never, ctx);
+    const text = textOf(res);
+
+    expect(sent).toEqual(["graph_run"]);
+    expect(res.isError, `expected queued success, got: ${text}`).toBeFalsy();
+    expect(text).toContain("p-poyo-queued");
+    expect(text).toContain("[RECOVERED]");
+    expect(text).toMatch(/queued:true|"queued":\s*true/);
+    expect(text).toContain("notified automatically");
+    expect(text).toMatch(/Do NOT re-run/i);
+  });
+
+  it("the SAME prompt that was already running is NOT claimed as this run", async () => {
+    startRender("p-already");
+    QueueMonitor.markSelfQueued("p-already");
+    const { bridge } = makeDisconnectBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_run").handler({ allow_duplicate: true } as never, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/OUTCOME UNKNOWN/);
+    expect(text).not.toContain("[RECOVERED]");
+  });
+
+  it("an idle queue after disconnect stays unknown — does not invent a prompt id", async () => {
+    const { bridge } = makeDisconnectBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_run").handler({} as never, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/OUTCOME UNKNOWN/);
+    expect(text).not.toContain("[RECOVERED]");
+    expect(text).not.toMatch(/"queued":\s*true/);
   });
 });

--- a/src/__tests__/orchestrator/run-late-ack-reconcile.test.ts
+++ b/src/__tests__/orchestrator/run-late-ack-reconcile.test.ts
@@ -295,6 +295,60 @@ describe("panel_run reconciles a late graph_run acknowledgement (#1175)", () => 
   });
 });
 
+describe("panel_run reconciles a graph_run whose tab dropped after queueing (panel#1524)", () => {
+  it("THE REPORT: a paid run that queued then lost the tab is queued:true, not UNKNOWN", async () => {
+    const sock = await connectPanel("tab-disco-run");
+    const rids: string[] = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+      if (typeof msg.rid !== "string" || msg.cmd !== "graph_run") return;
+      rids.push(msg.rid);
+      sock.close();
+    });
+    const ctx = fastCtx("tab-disco-run", 5_000);
+    const runP = panelRun().handler({ to_node_id: 3 }, ctx);
+
+    for (let i = 0; i < 100 && rids.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(rids, "graph_run must have been written before the drop").toHaveLength(1);
+    await settle();
+
+    const sock2 = await connectPanel("tab-disco-run");
+    sock2.send(
+      JSON.stringify({
+        rid: rids[0],
+        ok: true,
+        result: { queued: true, prompt_id: "p-poyo-1", ran_to_node: 3 },
+      }),
+    );
+
+    const res = await runP;
+    const text = textOf(res);
+    expect(res.isError, `expected a recovered success, got: ${text}`).toBeFalsy();
+    expect(text).toContain("p-poyo-1");
+    expect(text).toContain("[RECOVERED]");
+    expect(text).toContain("notified automatically");
+    expect(rids).toHaveLength(1);
+  });
+
+  it("a disconnect that never acknowledges and whose queue did not change stays unknown", async () => {
+    const sock = await connectPanel("tab-disco-silent");
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+      if (typeof msg.rid === "string" && msg.cmd === "graph_run") sock.close();
+    });
+    __panelToolsTestHooks.setRunLateAckGraceMs(200);
+    const ctx = fastCtx("tab-disco-silent", 5_000);
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+    expect(res.isError).toBe(true);
+    expect(text).not.toContain("[RECOVERED]");
+    expect(text).toMatch(/disconnected mid-command \("graph_run"\)/);
+    expect(text).toMatch(/OUTCOME UNKNOWN/);
+  });
+});
+
 describe("UiBridge late-mutation retention keeps the reply body (#1175)", () => {
   it("peek does not drain, take does", async () => {
     const sock = await connectPanel("tab-peek");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5068,6 +5068,46 @@ describe("UiBridge (late MUTATION outcome — #694)", () => {
     expect(bridge.takeLateMutation(rid)).toBeUndefined();
     sock.close();
   });
+
+  it("retains a mutation that completed after a mid-command disconnect (panel#1524)", async () => {
+    // The timeout path already retains. A disconnect used to reject immediately
+    // WITHOUT stashing the rid, so the panel's lost-reply replay of a write that
+    // already applied (graph_run that queued) was an unknown rid and was dropped.
+    const sock = await connectPanel("tab-disco-mut", "wf");
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-disco-mut")).toBe(true),
+    );
+    let rid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_set_node_mode") {
+        rid = msg.rid;
+        sock.close();
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "graph_set_node_mode", node_id: 1, mode: "active" },
+        { tabId: "tab-disco-mut", timeoutMs: 5000 },
+      ),
+    ).rejects.toThrow(/disconnected mid-command/);
+    expect(rid, "the command must have been written before the drop").toBeTruthy();
+
+    const sock2 = await connectPanel("tab-disco-mut", "wf");
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-disco-mut")).toBe(true),
+    );
+    sock2.send(JSON.stringify({ rid, ok: true, result: { mode: "active" } }));
+    const late = await waitFor(() => {
+      const got = bridge.peekLateMutation(rid);
+      expect(got, "disconnect must retain the late receipt, not drop it").toBeTruthy();
+      return got;
+    });
+    expect(late?.ok).toBe(true);
+    expect(late?.cmd).toBe("graph_set_node_mode");
+    expect(late?.result).toEqual({ mode: "active" });
+    sock2.close();
+  });
 });
 
 // #952 — the headless tools failed with `fetch failed` while every panel tool

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -137,6 +137,7 @@ import {
   GRAPH_CMD_EFFECT,
   isCapabilityRefusal,
   isPanelCmdUnsupportedError,
+  isMidCommandDisconnectTagged,
   isReplyTimeoutTagged,
   isRoutingAmbiguity,
   requiresWorkflowStampEnforcement,
@@ -2681,6 +2682,32 @@ function carryReplyTimeoutMark(err: unknown, res: ToolResult): ToolResult {
  *  error can never carry this, whatever its text says. */
 function isReplyTimeoutResult(res: ToolResult): boolean {
   return res?.isError === true && (res as Record<symbol, unknown>)[REPLY_TIMEOUT_RESULT] === true;
+}
+
+/** panel#1524 — carry the bridge's typed mid-command-disconnect marker onto the
+ *  ToolResult the same way reply-timeout is carried: an acked panel error can
+ *  quote "OUTCOME UNKNOWN", so the reconcile must not key on message text. */
+const MID_COMMAND_DISCONNECT_RESULT = Symbol("panel.midCommandDisconnectResult");
+
+function carryMidCommandDisconnectMark(err: unknown, res: ToolResult): ToolResult {
+  if (!isMidCommandDisconnectTagged(err)) return res;
+  Object.defineProperty(res, MID_COMMAND_DISCONNECT_RESULT, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return res;
+}
+
+function isMidCommandDisconnectResult(res: ToolResult): boolean {
+  return (
+    res?.isError === true && (res as Record<symbol, unknown>)[MID_COMMAND_DISCONNECT_RESULT] === true
+  );
+}
+
+/** A `graph_run` we wrote and then lost the reply for — timeout or disconnect. */
+function isUnackedGraphRunResult(res: ToolResult): boolean {
+  return isReplyTimeoutResult(res) || isMidCommandDisconnectResult(res);
 }
 
 /**
@@ -9489,7 +9516,7 @@ export function makePanelToolCtx(
     const res = await callOnce(cmd, timeoutMs, onDispatchedRid, (err) => {
       failure = err;
     });
-    return carryPanelAnsweredMark(failure, res);
+    return carryMidCommandDisconnectMark(failure, carryPanelAnsweredMark(failure, res));
   };
   // Human-in-the-loop confirmation for a DESTRUCTIVE op: render a yes/no card in
   // the panel and block on the user's pick. Returns false on decline, timeout, or
@@ -10291,44 +10318,84 @@ function runLateAckGraceMs(): number {
 }
 
 /**
- * Wait, bounded, for the panel to acknowledge a `graph_run` we stopped waiting
- * for — and hand back the reply it would have produced on time (#1175).
+ * Wait, bounded, for evidence that a `graph_run` we stopped waiting for still
+ * queued — and hand back the reply it would have produced on time (#1175,
+ * panel#1524).
  *
- * Returns null when there is nothing to reconcile, which is every case except a
- * retained `graph_run` success WITH its body. The negatives are deliberate:
+ * Two receipts, in this order:
  *
- *  - NOT a reply timeout ⇒ nothing to wait for. Gated on the bridge's own typed
- *    mark, never on message text: an acked panel error can quote our timeout
- *    sentence verbatim (#1468 round 2), and the difference between the two is
- *    whether the tab answered, which only the bridge knows.
- *  - NO retained body ⇒ leave the entry ALONE. The retry-token layer drains this
- *    same rid to tell the caller their earlier attempt landed; consuming it here
- *    to answer a question we then could not act on would delete the recovery the
- *    caller still had. Hence peek-then-take.
- *  - A DIFFERENT command's entry ⇒ leave it alone for the same reason. The rid is
- *    ours, so this should not happen; if it ever does, the safe reading of a
- *    surprise is not to spend someone else's notice on it.
+ *  1. The panel's own late `graph_run` body, retained by the bridge after a
+ *     reply-timeout (#1175) or a mid-command disconnect (panel#1524). Stronger:
+ *     it is the executor's answer, rid-correlated.
+ *  2. A prompt id that appeared in ComfyUI's queue AFTER this dispatch, which
+ *     was not the in-flight prompt when we sent `graph_run`. Weaker: inferred
+ *     from the watchdog, not the panel. Used when the tab dropped before
+ *     acknowledging a paid render that is observably running.
+ *
+ * Returns null when there is nothing to reconcile. The negatives are deliberate:
+ *
+ *  - NOT an unacked post-write (timeout or disconnect) ⇒ nothing to wait for.
+ *    Gated on the bridge's own typed marks, never on message text: an acked
+ *    panel error can quote our timeout/OUTCOME UNKNOWN sentence verbatim
+ *    (#1468 round 2), and the difference is whether the tab answered, which
+ *    only the bridge knows.
+ *  - NO retained body AND no new queue prompt ⇒ leave any unusable late-mutation
+ *    entry ALONE. The retry-token layer drains this same rid to tell the caller
+ *    their earlier attempt landed; consuming it here to answer a question we
+ *    then could not act on would delete the recovery the caller still had.
+ *    Hence peek-then-take.
+ *  - A DIFFERENT command's entry ⇒ leave it alone for the same reason.
+ *  - The SAME prompt that was already running at dispatch ⇒ not this command's
+ *    receipt. Claiming it would launder a prior render as this run.
  */
+function promptAppearedAfterDispatch(preRunningPromptId: string | null | undefined): string | null {
+  const id = QueueMonitor.snapshot().runningPromptId;
+  if (typeof id !== "string") return null;
+  const now = id.trim();
+  if (now === "") return null;
+  const pre =
+    typeof preRunningPromptId === "string" && preRunningPromptId.trim() !== ""
+      ? preRunningPromptId.trim()
+      : null;
+  if (pre !== null && now === pre) return null;
+  return now;
+}
+
 async function reconcileLateRunAck(
   ctx: PanelToolCtx,
   res: ToolResult,
   rid: string | undefined,
-): Promise<{ result: unknown; lateByMs: number } | null> {
-  if (!rid || !isReplyTimeoutResult(res)) return null;
+  preRunningPromptId?: string | null,
+): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" } | null> {
+  if (!isUnackedGraphRunResult(res)) return null;
+  const fromQueue = (): { result: unknown; lateByMs: number; via: "queue" } | null => {
+    const promptId = promptAppearedAfterDispatch(preRunningPromptId);
+    if (!promptId) return null;
+    return { result: { queued: true, prompt_id: promptId }, lateByMs: 0, via: "queue" };
+  };
   const bridge = ctx.bridge;
-  if (typeof bridge?.peekLateMutation !== "function") return null;
-  if (typeof bridge?.takeLateMutation !== "function") return null;
-  const deadline = Date.now() + runLateAckGraceMs();
+  const canPeek =
+    Boolean(rid) &&
+    typeof bridge?.peekLateMutation === "function" &&
+    typeof bridge?.takeLateMutation === "function";
+  // Stubbed bridges in unit tests have no late-mutation map. One-shot the queue
+  // (no grace wait) so a timeout whose prompt did not change still returns in
+  // the same tick it always has.
+  if (!canPeek) return fromQueue();
+  const startedAt = Date.now();
+  const deadline = startedAt + runLateAckGraceMs();
   for (;;) {
-    const seen = bridge.peekLateMutation(rid);
+    const seen = bridge.peekLateMutation(rid!);
     if (seen) {
-      if (seen.cmd !== "graph_run" || !("result" in seen)) return null;
+      if (seen.cmd !== "graph_run" || !("result" in seen)) return fromQueue();
       // Only now is it certain this entry will be USED, so draining it costs the
       // caller nothing: they are about to be handed its contents.
-      const taken = bridge.takeLateMutation(rid);
-      if (!taken || !("result" in taken)) return null;
-      return { result: taken.result, lateByMs: taken.lateByMs };
+      const taken = bridge.takeLateMutation(rid!);
+      if (!taken || !("result" in taken)) return fromQueue();
+      return { result: taken.result, lateByMs: taken.lateByMs, via: "ack" };
     }
+    const queued = fromQueue();
+    if (queued) return { ...queued, lateByMs: Date.now() - startedAt };
     const left = deadline - Date.now();
     if (left <= 0) return null;
     await sleep(Math.max(1, Math.min(RUN_LATE_ACK_POLL_MS, left)));
@@ -10347,6 +10414,18 @@ function lateRunAckNote(lateByMs: number): string {
     `duplicate render. You may see the earlier attempt described as outcome-unknown in a log; ` +
     `this is its outcome. (A queue listing taken in the moments after a run is accepted can still ` +
     `be empty, so an empty queue would not have settled this either way.)`
+  );
+}
+
+/** panel#1524 — the panel never acknowledged, but the queue holds a prompt this
+ *  dispatch created. Names the id and says we did not re-issue. */
+function queueRunReceiptNote(promptId: string): string {
+  return (
+    `\n\n[RECOVERED] The panel tab disconnected (or missed its ack) before acknowledging this ` +
+    `graph_run, but ComfyUI's queue now contains prompt ${promptId} — which was not the in-flight ` +
+    `prompt when this command was dispatched. Treating that as this run's receipt (queued:true). ` +
+    `Nothing was dispatched a second time. Do NOT re-run: a second panel_run would bill/queue ` +
+    `another render behind the one already running.`
   );
 }
 
@@ -12541,10 +12620,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // guidance. Rebuilding the reply here (rather than describing it) is what
         // makes that possible — `ok()` is exactly what ctx.call would have produced.
         const reconcileRun = async (): Promise<void> => {
-          const recovered = await reconcileLateRunAck(ctx, res, runRid);
+          const recovered = await reconcileLateRunAck(ctx, res, runRid, pre.runningPromptId);
           if (!recovered) return;
           res = ok(recovered.result);
-          lateAckNote = lateRunAckNote(recovered.lateByMs);
+          lateAckNote =
+            recovered.via === "queue"
+              ? queueRunReceiptNote(
+                  typeof (recovered.result as { prompt_id?: unknown }).prompt_id === "string"
+                    ? (recovered.result as { prompt_id: string }).prompt_id
+                    : "?",
+                )
+              : lateRunAckNote(recovered.lateByMs);
         };
         await reconcileRun();
         // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1508,6 +1508,33 @@ export function isReplyTimeoutTagged(err: unknown): boolean {
 }
 
 /**
+ * panel#1524 — a POST-write mid-command disconnect: the request was written to a
+ * socket that then died before a reply. Distinct from a reply-timeout (the tab
+ * stayed connected and simply never answered) and from a pre-write send failure
+ * (`dispatched:false`). Callers that wait for a late mutation receipt — panel_run
+ * reconciling a `graph_run` that already queued — key on THIS marker rather than
+ * parsing "OUTCOME UNKNOWN" out of the message, for the same reason reply-timeout
+ * has a typed mark: an acked panel error can quote that sentence verbatim.
+ */
+const MID_COMMAND_DISCONNECT = Symbol.for("comfyui-mcp.bridge.mid-command-disconnect");
+
+/** Tag an error as a mid-command disconnect and return it (for throw/reject). */
+export function markMidCommandDisconnect<E extends Error>(err: E): E {
+  Object.defineProperty(err, MID_COMMAND_DISCONNECT, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return err;
+}
+
+/** True when `err` carries the typed mid-command-disconnect marker. */
+export function isMidCommandDisconnectTagged(err: unknown): boolean {
+  if (err == null || (typeof err !== "object" && typeof err !== "function")) return false;
+  return (err as Record<symbol, unknown>)[MID_COMMAND_DISCONNECT] === true;
+}
+
+/**
  * Frame `type`s that are safe to MIRROR to a tab's viewers — genuine shared-session
  * activity a remote-control phone should see. This is an ALLOWLIST (default-deny):
  * a `cid`-based denylist leaked cid-less correlated replies (pair_url, secret_saved,
@@ -1790,8 +1817,12 @@ export class UiBridge {
    *  - MUTATIONS only. A read that is abandoned costs nothing because you just
    *    retry it (#1154's asymmetry); retaining reads would make this unbounded
    *    noise for no recoverable information.
-   *  - populated only when the TIMER fires. A mutation that replies in time
-   *    resolves its caller directly and has nothing to report later.
+   *  - populated when we STOP WAITING for a reply we already wrote — the reply
+   *    timer firing (#694), OR a mid-command disconnect of a filtered mutation
+   *    (panel#1524). A mutation that replies in time resolves its caller directly
+   *    and has nothing to report later. Without the disconnect arm, the panel's
+   *    lost-reply replay of a `graph_run` that already queued is an unknown rid
+   *    and is dropped — the caller is stuck with OUTCOME UNKNOWN for a paid render.
    */
   private timedOutMutations = new Map<string, { cmd: string; tabId: string; ts: number }>();
   /** Installed by the retry-token layer; see setLateMutationFilter. Null means
@@ -3008,7 +3039,7 @@ export class UiBridge {
         if (p.sock === sock) {
           clearTimeout(p.timer);
           this.pending.delete(rid);
-          this.handleMidCommandDisconnect(p);
+          this.handleMidCommandDisconnect(p, rid);
         }
       }
     });
@@ -4950,10 +4981,7 @@ export class UiBridge {
       // panel may still reply; without this the reply is an unknown rid and the
       // message loop drops it, which is precisely how a write that landed stays
       // invisible to the caller who was told "outcome unknown".
-      if (this.lateMutationFilter?.(cmd.cmd)) {
-        this.pruneLateMutations();
-        this.timedOutMutations.set(rid, { cmd: cmd.cmd, tabId: ctx.tabId, ts: Date.now() });
-      }
+      this.retainAbandonedMutation(rid, cmd.cmd, ctx.tabId);
       // This timer only fires AFTER sock.send() below returned successfully — the command
       // WAS WRITTEN to the socket; the tab (possibly backgrounded/frozen) merely didn't
       // reply in time and may still apply it. So this is a POST-write outcome: tag it
@@ -5051,10 +5079,21 @@ export class UiBridge {
     }
   }
 
+  /**
+   * Remember that we stopped waiting for `rid` so a later reply — a frozen tab
+   * catching up, or a lost-reply replay after reconnect — is retained instead of
+   * dropped as an unknown rid (#694, panel#1524).
+   */
+  private retainAbandonedMutation(rid: string, cmd: string, tabId: string): void {
+    if (!rid || !this.lateMutationFilter?.(cmd)) return;
+    this.pruneLateMutations();
+    this.timedOutMutations.set(rid, { cmd, tabId, ts: Date.now() });
+  }
+
   /** A pending command's socket died before its reply arrived. Decide, WITHOUT
    *  ever risking double execution, whether to wait for the tab to reconnect and
    *  resume (idempotent reads) or surface an honest outcome-unknown/gone error. */
-  private handleMidCommandDisconnect(pend: Pending): void {
+  private handleMidCommandDisconnect(pend: Pending, rid: string): void {
     const { ctx, cmd } = pend;
     const short = ctx.tabId.slice(0, 8);
     // Idempotent read, still within its deadline → park it for a bounded grace and
@@ -5098,15 +5137,21 @@ export class UiBridge {
     // bare failure invites a blind retry that double-applies the action (e.g. a
     // second render). Say the outcome is UNKNOWN so the caller verifies first.
     if (ctx.mutating) {
+      // panel#1524 — keep the rid so a lost-reply replay of a write that already
+      // applied (a `graph_run` that queued a paid render) is retained, not dropped.
+      // NEVER re-dispatch: resumeAwaitingReconnect is for idempotent reads only.
+      this.retainAbandonedMutation(rid, cmd, ctx.tabId);
       ctx.reject(
-        markDispatched(
-          new Error(
-            // #952 — the remedy depends on WHAT was interrupted. An interactive
-            // card cannot be checked with queue/get_image, and a retry after a
-            // reconnect duplicates it in front of a human.
-            midCommandDisconnectMessage({ short, cmd }),
+        markMidCommandDisconnect(
+          markDispatched(
+            new Error(
+              // #952 — the remedy depends on WHAT was interrupted. An interactive
+              // card cannot be checked with queue/get_image, and a retry after a
+              // reconnect duplicates it in front of a human.
+              midCommandDisconnectMessage({ short, cmd }),
+            ),
+            true,
           ),
-          true,
         ),
       );
     } else {


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1524

The shipped function is `panel_run` in this repo (`src/orchestrator/panel-tools.ts`), not a panel-side receipt. `graph_run` already returns `queued:true` with a `prompt_id` when it queues; the orchestrator was throwing that away on a mid-command disconnect.

## The bug

After a restart + open/pin, `panel_run(to_node_id:3)` sent `graph_run`, queued a paid PoYo render, then the panel tab dropped before acknowledging. The tool returned:

```
panel tab wf:… disconnected mid-command ("graph_run") — OUTCOME UNKNOWN.
QUEUE BUSY: running prompt …
```

The render was already in flight. UNKNOWN invites a blind retry; a second `panel_run` on a paid API node is duplicate billing.

Two independent holes produced that:

1. **The receipt was not preserved across reconnects.** Reply-timeout already stashes the rid in the late-mutation map so a late panel body can be retained (#694 / #1175). A mutating *disconnect* rejected immediately without stashing, so the panel's lost-reply replay of the already-queued `graph_run` arrived as an unknown rid and was dropped.
2. **`panel_run` only reconciled reply-timeouts**, not disconnects. `queueBusyTimeoutNote` named the running prompt on the same error instead of treating it as this command's receipt.

## The fix

- On a filtered mutating disconnect, stash the rid the same way a reply-timeout does. Never re-dispatch `graph_run`.
- Carry a *typed* mid-command-disconnect mark onto the ToolResult (not `/OUTCOME UNKNOWN/` text — an acked panel error can quote that sentence).
- `panel_run` waits the existing late-ack grace for the panel's own `graph_run` body.
- If that body never arrives, a prompt id that appeared in ComfyUI's queue **after this dispatch** — and was not the in-flight prompt when `graph_run` was sent — is returned as `queued:true` with that `prompt_id`. The same prompt that was already running is not claimed.

Tests drive `panel_run` end-to-end over a real bridge (disconnect + lost-reply replay) and the queue-receipt path through the shipped handler.
