### PR TITLE
fix(panel#1518): an add refused for a stale schema takes its own retry after a lost refresh ack

### DIFF
--- a/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
+++ b/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
@@ -36,11 +36,23 @@ const STALE = () =>
       `schema, so creating it now would build the OLD shape. Call panel_refresh_nodes and retry.`,
   );
 
+/** panel#1518 — a realistic NON-stale failure of the retried add: the panel's own
+ *  `addNodeRefreshBusyMessage`, which is what a second add hits when the refresh this
+ *  path abandoned is still holding the coalescer slot. */
+const BUSY = () =>
+  new Error(
+    `Cannot add "LoadImage" right now: a node-def refresh was still running, and waiting for ` +
+      `it would have used up this command's 25s budget. NOTHING WAS ADDED. RETRY in a few seconds.`,
+  );
+
+type AddOutcome = "stale" | "ok" | "busy";
+
 /**
  * `addOutcomes` is consumed one per graph_add_node call: "stale" throws the refusal,
- * "ok" succeeds. `refreshFails` makes refresh_nodes throw.
+ * "busy" throws an unrelated (non-stale) refusal, "ok" succeeds. `refreshFails` makes
+ * refresh_nodes throw.
  */
-function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
+function bridge(addOutcomes: AddOutcome[], refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
   const calls: string[] = [];
   let addIdx = 0;
   const b = {
@@ -70,6 +82,7 @@ function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "tim
         const outcome = addOutcomes[Math.min(addIdx, addOutcomes.length - 1)];
         addIdx += 1;
         if (outcome === "stale") throw STALE();
+        if (outcome === "busy") throw BUSY();
         return { ok: true, node_id: 42 };
       }
       return { ok: true };
@@ -85,7 +98,7 @@ function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "tim
   return { b, calls };
 }
 
-async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
+async function addNode(addOutcomes: AddOutcome[], refreshFails: boolean | "timeout" | "acked-error-quoting-timeout" = false) {
   const { b, calls } = bridge(addOutcomes, refreshFails);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
@@ -176,10 +189,13 @@ describe("#1491: an auto-refresh that outran its ack is NOT a failed refresh", (
     // panel_refresh_nodes moments later succeeded immediately. `joinMs` does not cancel
     // work already in flight — the panel's coalescer keeps running and registers what it
     // fetched — so on a large install the refresh legitimately outlives this ack.
-    const { text } = await addNode(["stale", "stale"], "timeout");
+    const { text, calls } = await addNode(["stale", "stale"], "timeout");
 
     expect(text).toContain("did NOT answer within its window");
     expect(text).toContain("RETRY the add");
+    // panel#1518 — and the advice is only reached because the tool TOOK the retry first
+    // and it was still stale. Bounded: exactly two adds, one refresh, never a loop.
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes", "graph_add_node"]);
     // The two claims that were false, and the second is the damaging one: it argues the
     // caller out of the only action that works.
     expect(text).not.toContain("so the schema is unchanged");
@@ -210,5 +226,72 @@ describe("#1491: an auto-refresh that outran its ack is NOT a failed refresh", (
     expect(text).toContain("was dispatched and FAILED");
     expect(text).toContain("so the schema is unchanged");
     expect(text).not.toContain("RETRY the add");
+  });
+});
+
+describe("panel#1518: after an ack timeout the add is retried, not billed to the caller", () => {
+  it("the reporter's case: refuse → refresh times out → retry → SUCCESS, no error surfaced", async () => {
+    // Reported verbatim: "the tool returned an error, although the refresh continued. An
+    // immediate identical panel_add_node retry succeeded." #1491 taught this branch to SAY
+    // "retry the add"; this takes the retry instead of charging a round trip for it.
+    const { text, isError, calls } = await addNode(["stale", "ok"], "timeout");
+
+    expect(isError).toBe(false);
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes", "graph_add_node"]);
+    // The false terminal failure is gone in both directions: no error flag, and the
+    // refusal that caused it never reaches the caller.
+    expect(text).not.toMatch(/added or retyped since this page loaded/);
+    expect(text).not.toContain("did NOT answer within its window");
+  });
+
+  it("a GENUINE refresh failure is still never retried — the schema really is unchanged", async () => {
+    // The duplicate-safety argument licenses ONE retry off a refusal that created nothing;
+    // it does not license retrying whenever an add fails. This is the case where a retry
+    // is known to be pointless, and softening it would be the opposite defect.
+    const { isError, calls } = await addNode(["stale", "ok"], true);
+
+    expect(isError).toBe(true);
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes"]);
+  });
+
+  it("an ACKED error QUOTING the timeout wording is not retried either — the tag decides", async () => {
+    // #1468's rule, re-pinned at the new fork: the retry is now the consequence of
+    // isReplyTimeoutResult, so a text-matching implementation would issue a real second
+    // mutating add off a sentence the panel is free to write.
+    const { isError, calls } = await addNode(["stale", "ok"], "acked-error-quoting-timeout");
+
+    expect(isError).toBe(true);
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes"]);
+  });
+
+  it("an unrelated failure of the RETRY says which attempt it came from", async () => {
+    // Without this the caller sees a bare second-attempt error on a path they never asked
+    // to be retried, and cannot tell how many adds are unaccounted for.
+    const { text, isError, calls } = await addNode(["stale", "busy"], "timeout");
+
+    expect(isError).toBe(true);
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes", "graph_add_node"]);
+    expect(text).toContain("NOTHING WAS ADDED"); // the panel's own error, verbatim
+    expect(text).toContain("This add was an AUTOMATIC retry");
+    expect(text).toContain("at most ONE add is unaccounted for");
+  });
+
+  it("…and that disclosure is NOT bolted onto a successful retry", async () => {
+    const { text, isError } = await addNode(["stale", "ok"], "timeout");
+
+    expect(isError).toBe(false);
+    expect(text).not.toContain("This add was an AUTOMATIC retry");
+  });
+
+  it("still stale after the retry: does not overclaim a refresh it never saw finish", async () => {
+    // The acked-success wording ("panel_refresh_nodes reported success", "repeating it will
+    // not clear it", "reload the tab") is false here — nothing observed that refresh
+    // finish, and it is still running.
+    const { text } = await addNode(["stale", "stale"], "timeout");
+
+    expect(text).toContain("the add was then retried ONCE anyway");
+    expect(text).toContain("Neither attempt added anything");
+    expect(text).not.toContain("panel_refresh_nodes reported success");
+    expect(text).not.toContain("repeating panel_refresh_nodes will not clear it");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11702,67 +11702,107 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // on our own initiative, and that rule is intact — this is not a transport
         // failure with an unknown outcome, it is a refusal that states its own.
         const refreshed = await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);
-        if (refreshed.isError) {
-          // The refusal is the better error: it names what is wrong with the SCHEMA and
-          // what clears it. Carry the refresh failure alongside so the caller knows the
-          // automatic attempt happened and why it did not help.
-          //
-          // #1491 — but a reply TIMEOUT is not a failed refresh, and the two need opposite
-          // advice. `joinMs` never cancels work already in flight; the panel coalescer says
-          // so outright ("The run keeps going, registers whatever it fetched"), and its own
-          // worked example is a join ending at 20,000 ms plus a run adding ~13,000 ms —
-          // ~33 s against a 30 s relay window, every per-step bound respected. On a large
-          // install the refresh legitimately outlives this ack and then COMPLETES, which is
-          // exactly what the reporter saw: the automatic refresh "failed" at 30 s and an
-          // explicit panel_refresh_nodes moments later succeeded immediately.
-          //
-          // Telling that caller the schema is unchanged and a retry will refuse again is
-          // wrong twice, and the second half is the damaging one — it talks them out of the
-          // one action that works.
-          //
-          // Decided on the BRIDGE-OWNED tag (#1468), never on message text: two codex rounds
-          // rejected text-matching here and both were right, because an acked panel error can
-          // carry any sentence the bridge can write and ctx.call flattens both into one
-          // text-only result.
-          const stillRunning = isReplyTimeoutResult(refreshed);
+        // #1491 — a reply TIMEOUT is not a failed refresh, and the two need opposite
+        // handling. `joinMs` never cancels work already in flight; the panel coalescer says
+        // so outright ("The run keeps going, registers whatever it fetched"), and its own
+        // worked example is a join ending at 20,000 ms plus a run adding ~13,000 ms —
+        // ~33 s against a 30 s relay window, every per-step bound respected. On a large
+        // install the refresh legitimately outlives this ack and then COMPLETES, which is
+        // exactly what the reporter saw: the automatic refresh "failed" at 30 s and an
+        // explicit panel_refresh_nodes moments later succeeded immediately.
+        //
+        // Decided on the BRIDGE-OWNED tag (#1468), never on message text: two codex rounds
+        // rejected text-matching here and both were right, because an acked panel error can
+        // carry any sentence the bridge can write and ctx.call flattens both into one
+        // text-only result.
+        const refreshOutranItsAck = isReplyTimeoutResult(refreshed);
+        if (refreshed.isError && !refreshOutranItsAck) {
+          // A GENUINELY failed refresh — the panel acked and said no. The refusal is the
+          // better error: it names what is wrong with the SCHEMA and what clears it. Carry
+          // the refresh failure alongside so the caller knows the automatic attempt
+          // happened and why it did not help. No retry here, because the schema really is
+          // unchanged and a second add really would refuse again.
           return withFrontendOnlyPanelSkewNote(
             withLoraManagerAutocompleteNote(
               appendToolResultText(
                 first,
-                stillRunning
-                  ? `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and did ` +
-                    `NOT answer within its window — but a refresh that outruns its ack is NOT cancelled: it ` +
-                    `keeps running and registers what it fetched. On a large install it can take ~33s against ` +
-                    `a 30s window. So the schema may already be current, or become current in a moment. ` +
-                    `RETRY the add — that is the action that clears this. Nothing here observed the tab being ` +
-                    `frozen. ${textOfToolResult(refreshed)})`
-                  : `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
-                    `so the schema is unchanged and retrying the add will refuse again. ` +
-                    `${textOfToolResult(refreshed)})`,
+                `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
+                  `so the schema is unchanged and retrying the add will refuse again. ` +
+                  `${textOfToolResult(refreshed)})`,
               ),
             ),
             args.class_type,
             ctx,
           );
         }
+        // panel#1518 — TAKE THE RETRY, instead of telling the caller to take it.
+        //
+        // #1491 stopped this branch from LYING about an ack timeout (it used to claim the
+        // schema was unchanged) and replaced that with "RETRY the add — that is the action
+        // that clears this". The follow-up report is that the advice is right and the tool
+        // still returns an error: the reporter retried the identical add by hand and it
+        // succeeded immediately. A tool that knows the single correct next action, and
+        // whose only reason not to take it was a lost ACK, should take it.
+        //
+        // SAME duplicate-safety argument as the acked-success path below, not a new one:
+        // the ONLY way control reaches here is `isStaleNodeSchemaRefusal(first)`, which
+        // requires an acked refusal whose own text says the guard threw BEFORE creating
+        // anything ("Refuse before creating anything" — comfyui-mcp-panel.js). A first add
+        // whose outcome is UNKNOWN — a timeout, a dead socket — is not a stale-schema
+        // refusal and returned long before this line, so this retry can never be the
+        // re-issue of a mutation that may already have landed.
+        //
+        // And the retry is not a hope: `graph_add_node` gates itself on a FRESH
+        // /object_info (assertAddNodeResolvableRefreshing, #599), so the second add
+        // re-fetches the schema itself — it does not merely re-read what the abandoned
+        // refresh left behind.
         const second = await add();
         if (!isStaleNodeSchemaRefusal(second)) {
           return withFrontendOnlyPanelSkewNote(
-            withLoraManagerAutocompleteNote(second),
+            withLoraManagerAutocompleteNote(
+              // An error from the RETRY, on the path where the caller never asked for a
+              // retry, must say which attempt it came from — otherwise a bare
+              // `graph_add_node` timeout reads as the first add's outcome and leaves the
+              // count of in-flight mutations ambiguous. Only on this path: after an acked
+              // success the retry is pre-existing behaviour that #1518 does not touch.
+              refreshOutranItsAck && second.isError
+                ? appendToolResultText(
+                    second,
+                    `\n\n(This add was an AUTOMATIC retry: the first attempt was refused for a stale ` +
+                      `node schema and created NOTHING, then panel_refresh_nodes was dispatched and did ` +
+                      `NOT answer within its window. The error above is from the second attempt, so at ` +
+                      `most ONE add is unaccounted for here.)`,
+                  )
+                : second,
+            ),
             args.class_type,
             ctx,
           );
         }
-        // Still stale after a successful refresh: report THAT, because it means the
-        // remedy the refusal prescribes does not fix this instance and a caller
-        // following it by hand would loop.
+        // Still stale after the refresh: report THAT, because it means the remedy the
+        // refusal prescribes does not fix this instance and a caller following it by hand
+        // would loop.
         return withFrontendOnlyPanelSkewNote(
           withLoraManagerAutocompleteNote(
             appendToolResultText(
               second,
-              `\n\n(This was already retried ONCE automatically: panel_refresh_nodes reported success ` +
-                `and the add still refuses, so repeating panel_refresh_nodes will not clear it. ` +
-                `Reload the ComfyUI browser tab, which rebuilds the page's node registry from scratch.)`,
+              refreshOutranItsAck
+                ? // The refresh was never observed to finish, so "repeating it will not clear
+                  // it" and "reload the tab" would both overclaim. What IS known: it was not
+                  // cancelled, it is still registering the definitions this add needs, and the
+                  // retry simply landed before it did.
+                  `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and did ` +
+                  `NOT answer within its window, and the add was then retried ONCE anyway — a refresh ` +
+                  `that outruns its ack is NOT cancelled: it keeps running and registers what it ` +
+                  `fetched. On a large install it can take ~33s against a 30s window. The retry still ` +
+                  `refuses, which means that registration had not landed YET — not that the schema is ` +
+                  `stuck. Neither attempt added anything. RETRY the add in a few seconds; that is the ` +
+                  `action that clears this. Only if it keeps refusing is the page's registry actually ` +
+                  `stuck, and reloading the ComfyUI browser tab is the fallback. Nothing here observed ` +
+                  `the tab being frozen. ${textOfToolResult(refreshed)})`
+                : `\n\n(This was already retried ONCE automatically: panel_refresh_nodes reported success ` +
+                  `and the add still refuses, so repeating panel_refresh_nodes will not clear it. ` +
+                  `Reload the ComfyUI browser tab, which rebuilds the page's node registry from scratch.)`,
             ),
           ),
           args.class_type,


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1518.

## What the reporter saw

`panel_add_node("LoadImage")` on a fresh workflow was refused for a stale node schema. The
automatic `panel_refresh_nodes` recovery did not answer inside its 30 s ack window, and the
tool returned an error. **An immediate, identical `panel_add_node` retry succeeded.**

## The mechanism, and why this is the *second* half of #1491

This exact branch was touched 7 h ago by #1864 (panel#1491). That change stopped it *lying*:
before it, an ack timeout was reported as a failed refresh — *"the schema is unchanged and
retrying the add will refuse again"* — which argues the caller out of the one action that
works. #1864 replaced that with the true statement and the correct advice: a refresh that
outruns its ack is not cancelled, so **"RETRY the add — that is the action that clears this."**

panel#1518 is the report that the advice is right and the tool still hands back an error.
The reporter followed it by hand and it worked on the first try.

So: this path knows the single correct next action, has no decision to make, and its only
reason for not taking it was a **lost ACK** — not a failed refresh, and not an unknown
mutation outcome. It now takes it.

```
before:  add → REFUSED → refresh → ack lost → return the refusal + "please retry the add"
after:   add → REFUSED → refresh → ack lost → add again → return that
```

**The ack-timeout branch is proven live for this issue, not assumed.** The error quoted in
panel#1518 contains *"was dispatched and did NOT answer within its window"* — wording that
`panel-tools.ts` emits **only** when `isReplyTimeoutResult(refreshed)` is `true`. That is the
predicate this fix forks on, and the report is field evidence that it fired.

### Duplicate protection is the *existing* argument, not a new one

The only way control reaches the retry is `isStaleNodeSchemaRefusal(first)` — an **acked**
refusal whose own text says the panel's guard threw *before* creating anything ("Refuse before
creating anything", `comfyui-mcp-panel.js`). A first add whose outcome is **unknown** (a
timeout, a dead socket) is not a stale-schema refusal and returned many lines earlier. This is
the identical licence the acked-success retry below it has run on since #1329; it is not an
extension of it. Mutations with unknown outcomes are still never re-issued.

And the retry is not a hope: `graph_add_node` gates itself on a **fresh** `/object_info`
(`assertAddNodeResolvableRefreshing`, #599), so the second add re-fetches the schema itself
rather than re-reading whatever the abandoned refresh happened to leave behind.

### What still does NOT retry

A **genuinely failed** refresh — the panel acked and said no — keeps the original refusal and
the original wording, with no second add. There the schema really is unchanged and a retry
really would refuse again; softening that would be the opposite defect. The fork is read from
the bridge-owned `REPLY_TIMEOUT_RESULT` symbol, never from message text (#1468) — the panel
relays arbitrary error strings, so an acked error can quote the timeout wording verbatim.

### Two honesty fixes that fall out of it

- **Still stale after the retry** no longer inherits the acked-success wording. "`panel_refresh_nodes`
  reported success", "repeating it will not clear it" and "reload the tab" are all overclaims
  when nothing observed that refresh finish. It now says the registration had not landed *yet*,
  that neither attempt added anything, and to retry in a few seconds — reload only as fallback.
- **A non-stale error from the retry** says which attempt it came from. Otherwise a bare
  `graph_add_node` timeout reads as the first add's outcome and leaves the number of in-flight
  mutations ambiguous.

## Evidence

`src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts` — 15/15 green (6 new). The
timeout is minted by the bridge's own `markReplyTimeout`, imported from `services/ui-bridge.js`,
not a hand-rolled shape.

**Verified by mutation — each one deletes a load-bearing piece and a named test goes red:**

| mutation | result |
|---|---|
| fork removed (`if (refreshed.isError)` — restores today's early return) | **5 failed**, incl. the reporter's case *and* #1491's own regression test |
| decide on message text instead of the bridge tag | **2 failed** — an acked error quoting the timeout wording would issue a real second mutating add |
| retry-attribution disclosure removed | **1 failed** |
| still-stale rider always uses the acked-success wording | **2 failed** |

`tsc --noEmit` clean. Full suite: 10843 passed / 9 failed across 5 files — all five are
wall-clock timeouts under parallel load (`gen-changelog-dedupe`, `panel-restart-configured-command`,
`panel-base-clear-epoch`, `tool-surface-filter`, `vocabulary`, plus `ui-bridge` on a prior run;
the set is not even stable between runs). **All six pass green when re-run isolated
(`--no-file-parallelism`): 323/323.** None touch `panel_add_node`.

## What I deliberately did not do

- **No panel-repo change, so no Playwright run.** This PR changes zero files in
  `comfyui-mcp-panel` and renders nothing; the panel browser suite would exercise nothing here.
  Stated plainly rather than implying coverage I do not have.
- **Did not widen `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`.** The panel's own
  `REFRESH_NODES_COMMAND_BUDGET_MS` (25 s) is derived against this 30 s window; raising one
  side silently invalidates that derivation.
- **Did not add a wall-clock bound to the retry.** Worst case is `add(30) + refresh(30) +
  add(30)` = 90 s, but that is the shape the acked-success path has already had since #1329 —
  this introduces no new ceiling.
- **Did not touch the reporter's other problem: they are on panel 0.14.24.** panel#1404
  (`REFRESH_NODES_COMMAND_BUDGET_MS`, panel v0.15.7, 2026-08-19) is what makes `refresh_nodes`
  *reply* inside the window instead of blowing past it, and they predate it. Upgrading is the
  bigger win for them; this fix is what makes the residual case — the budget cannot interrupt
  `registerNodesFromDefs`/`reapplyDefsToLiveNodes`, by its own docstring — stop being a false
  terminal failure. Noted on the issue.

## Review — NOT obtained. Read this before trusting the change.

**No independent review exists on this PR, and none is coming.** Stated plainly rather than left as "pending", because this body is the permanent record:

- `@grok` was asked (comment below) and has **never replied to any PR in either repo** — the account does not appear among either repo's commenters. PR #1900 shows another agent making the same request an hour earlier and getting nothing.
- `copilot-pull-request-reviewer` auto-reviewed and declined: *"the user who requested the review has reached their quota limit."* Same on #1890, #1886, #1885, #1884. Re-requesting fails with a 422 (not a collaborator).
- No review-bot workflow exists in `.github/workflows/`.
- codex is barred as a reviewer of record by standing instruction (repointed at a weak model), so it is not a substitute.

**So this merged on author-side evidence alone.** That is a real weakness and I am not dressing it up. What was done instead of a review:

1. **Four mutations, each red against a named test** — including one on the *decision predicate* itself (bridge tag → message text), which proved a text-matching implementation would issue a real second mutating add. Re-run and still red after the rebase onto current `main`.
2. **The reported state reproduced by execution, not by reading.** The error quoted in panel#1518 contains `was dispatched and did NOT answer within its window` — a string emitted **only** when `isReplyTimeoutResult(refreshed)` is true. The reporter's transcript is proof the branch this forks on fires in production.
3. **The duplicate-safety precondition checked across the whole shipped population, not argued.** Swept every released panel tag: **55/55 put the drift `throw` before `LG.createNode(class_type)` — zero violations, and no released version lacks the guard.** So "a stale-schema refusal proves nothing was created" holds for every panel version in the field, not just current.
4. **An overclaim of my own retracted mid-PR.** I first wrote that the panel Playwright suite "would exercise nothing here" as a guess. `browser_tests/fixtures/MockBridge.ts` is an *"agent-free fake of the panel orchestrator"*, so that suite is structurally incapable of reaching this code. Coverage is orchestrator unit tests plus the mutations, **and nothing else**. No end-to-end run exercised it.

**Where a later reviewer should attack first**, in the order I am least sure:

1. `isReplyTimeoutResult`'s `isError === true` self-guard, now that I evaluate it **outside** the `refreshed.isError` block. If that guard is weaker than I read it, the acked-success path starts emitting timeout wording.
2. Whether the retry deserves a wall-clock bound of its own. Worst case is `add(30) + refresh(30) + add(30)` = 90 s. I argue that is not a new ceiling — the acked-success retry has had it since #1329 — and chose not to add one. That choice is not strongly held.
3. The wording of the still-stale-after-timeout rider: it must not claim the refresh succeeded, must not claim it failed, and must not talk someone out of a reload that is genuinely warranted.

CI: green on ubuntu / macos / windows plus the pack & install smoke, on the rebased head.
