### PR TITLE
release: v0.52.30 — occupied GPU named, queued run after drop, Desktop relaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.30] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- panel_run returns queued:true after a mid-command drop if the prompt is already in the queue (#1901)
+- a rejected node id says what it wanted and what it got (#1897)
+- an occupied GPU after free is named instead of a silent freed:true (#1898)
+- the ENV line reports the panel ComfyUI will run, and the refusal names the cause that applied
+
+
 ## [0.52.29] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.29",
+  "version": "0.52.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.29",
+      "version": "0.52.30",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.29",
+  "version": "0.52.30",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.30** from `main` (after v0.52.29).

Carries:

- #1898 / #1895 — occupied GPU after `/free` is named instead of a silent `freed:true`
- #1901 / panel#1524 — `panel_run` returns `queued:true` after a mid-command drop if the prompt is already in the queue
- #1897 / #1889 — a rejected `node_id` says what it wanted and what it got
- #1899 / panel#1515 — ENV line reports the panel ComfyUI will run
- #1851 / #1847 — Desktop relaunch from proven launch files when the parent cmdline is unreadable
- #1894 / #1888 — `panel_update_node` no longer recommends reinstall without Manager evidence
- #1891 / #1567 — a queued respawn sees downloads started after the save

Held out: #1880/#1869 ubuntu red; #1839 anthropic 4; #1697 P1 inflight.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.30` tag on the version commit). Push `v0.52.30` after merge if the workflow did not.