### PR TITLE
fix(panel#1292): an origin-less download turn after a workflow switch inherits the routed tab, not the retired id

### DIFF
--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -309,6 +309,151 @@ describe("TurnOriginTracker — inherited origins for tab-less turns (gate 3, P1
     expect(warnings.join("\n")).toMatch(/no origin and no established prior origin/);
   });
 
+  // panel#1292 RECURRENCE — the reported sequence end to end: a workflow switch
+  // (a same-socket re-hello that re-keys the tab id), then an async model
+  // download settles and injects an origin-less turn. Inheritance judged
+  // ownership on the RECORDED id while every other ownership check in the class
+  // judged it on the ROUTED one, so the retired id — deleted from `tabBackends`
+  // by the migration — answered with the DEFAULT backend and a conversation on
+  // any other backend read its own healthy tab as foreign.
+  //
+  // Default backend is claude and this conversation is codex, exactly as in the
+  // requeue-after-migration test above: that is what makes a default-backend
+  // fallback observable at all. The original coverage for this branch used the
+  // DEFAULT backend and no migration, where the raw lookup happens to agree —
+  // which is why the hole survived.
+  it("a download_done turn AFTER a workflow switch still inherits — ownership is judged on the live id, not the retired one (panel#1292)", async () => {
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends, tabAliases, warnings } = makeTracker({ defaultBackend: "claude" });
+    tabBackends.set("tmp:abc", "codex");
+    tracker.recordForMid("m-user", "uuid-a", "tmp:abc");
+    tracker.onSeen(KEY_CODEX, "m-user");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBe("tmp:abc");
+    tracker.turnEnded(KEY_CODEX);
+
+    // The user switches workflow. The panel re-hellos the SAME socket under a
+    // new id; the orchestrator carries the backend mapping onto it and deletes
+    // the predecessor's, and the bridge keeps the migration alias.
+    tabAliases.set("tmp:abc", "wf:r1:foo.json");
+    tabBackends.delete("tmp:abc");
+    tabBackends.set("wf:r1:foo.json", "codex");
+
+    // A model download settles and injects its tab-less turn.
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY_CODEX, mid);
+    await flushMicrotasks();
+
+    // Inherits, at the recorded identity the bridge resolves onward. Before the
+    // fix this was a null pin, and every scope-addressed call in that turn
+    // (panel_refresh_nodes / panel_graph_outline / panel_list_workflows) hit
+    // "no connected tab can be chosen … issued from multiple workflows at once".
+    expect(tracker.pinOf(KEY_CODEX)).toBe("tmp:abc");
+    expect(tracker.stampOf(KEY_CODEX)).toBe("uuid-a");
+    // And the pin survives resolution-time re-verification, which is what the
+    // bridge actually consults — a pin that only passes at batch close and is
+    // nulled on first use would reproduce the same refusal one step later.
+    expect(tracker.resolvedPinOf(KEY_CODEX)).toBe("tmp:abc");
+    expect(warnings.join("\n")).not.toMatch(/FAILS CLOSED/);
+  });
+
+  it("inheritance after a migration still refuses when the tab genuinely changed hands (panel#1292 keeps gate 3 closed)", async () => {
+    // Same shape as above, but the migrated surface is now on ANOTHER backend.
+    // Routing through the alias must not become a way to adopt it.
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends, tabAliases, warnings } = makeTracker({ defaultBackend: "claude" });
+    tabBackends.set("tmp:abc", "codex");
+    tracker.recordForMid("m-user", "uuid-a", "tmp:abc");
+    tracker.onSeen(KEY_CODEX, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY_CODEX);
+
+    tabAliases.set("tmp:abc", "wf:r1:foo.json");
+    tabBackends.delete("tmp:abc");
+    tabBackends.set("wf:r1:foo.json", "gemini");
+
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY_CODEX, mid);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBeNull();
+    expect(tracker.stampOf(KEY_CODEX)).toBeUndefined();
+    // The refusal names the tab the verdict was reached on, not only the id the
+    // origin was recorded under.
+    expect(warnings.join("\n")).toMatch(/last established origin tab tmp:abc \(routing to wf:r1:fo\)/);
+  });
+
+  it("a RECORDED origin id that a LIVE tab of another backend now holds is refused — exact identity beats the alias (panel#1292)", async () => {
+    // wf:<tabRouteId>:<path> ids are deterministic and RECUR. If the id the
+    // origin names is currently held by another backend's live tab, that tab is
+    // what it routes to, and inheritance must refuse — the revived-id hazard
+    // resolvedPinOf() already guards, now guarded at the inherit step too.
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends } = makeTracker({ defaultBackend: "claude" });
+    tabBackends.set("wf:r1:foo.json", "codex");
+    tracker.recordForMid("m-user", "uuid-a", "wf:r1:foo.json");
+    tracker.onSeen(KEY_CODEX, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY_CODEX);
+    // The surface goes away and a NEW socket helloes under the same id, on
+    // claude. No alias is involved: the id resolves to ITSELF, at a foreign tab.
+    tabBackends.set("wf:r1:foo.json", "claude");
+
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY_CODEX, mid);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBeNull();
+    expect(tracker.stampOf(KEY_CODEX)).toBeUndefined();
+  });
+
+  it("an inherited origin whose surface resolves NOWHERE still fails closed — unprovable ownership is not ownership (panel#1292)", async () => {
+    // The raw-id fallback is deliberate: routing through liveTabOf must not
+    // become a laundering path for an origin whose tab is simply gone.
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends, tabAliases, warnings } = makeTracker({ defaultBackend: "claude" });
+    tabBackends.set("tmp:abc", "codex");
+    tracker.recordForMid("m-user", "uuid-a", "tmp:abc");
+    tracker.onSeen(KEY_CODEX, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY_CODEX);
+    tabAliases.set("tmp:abc", null);
+    tabBackends.delete("tmp:abc");
+
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY_CODEX, mid);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBeNull();
+    expect(tracker.stampOf(KEY_CODEX)).toBeUndefined();
+    // No alias to report, so the refusal names the recorded id alone.
+    expect(warnings.join("\n")).toMatch(/last established origin tab tmp:abc now belongs to another backend/);
+  });
+
+  it("a MULTI-WORKFLOW event replay after a workflow switch inherits too (#1001 path, panel#1292 fix)", async () => {
+    // routes.size > 1, all injected — the other shape that reaches the inherit
+    // branch. It was refused for the same raw-id reason.
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends, tabAliases, warnings } = makeTracker({ defaultBackend: "claude" });
+    tabBackends.set("tmp:abc", "codex");
+    tracker.recordForMid("m-user", "uuid-a", "tmp:abc");
+    tracker.onSeen(KEY_CODEX, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY_CODEX);
+
+    tabAliases.set("tmp:abc", "wf:r1:foo.json");
+    tabBackends.delete("tmp:abc");
+    tabBackends.set("wf:r1:foo.json", "codex");
+    tabBackends.set("wf:r1:bar.json", "codex");
+
+    // Two journaled completions from two workflows replay into ONE turn.
+    tracker.recordForMid("e1", "uuid-a", "wf:r1:foo.json", true);
+    tracker.recordForMid("e2", "uuid-b", "wf:r1:bar.json", true);
+    tracker.onSeen(KEY_CODEX, "e1");
+    tracker.onSeen(KEY_CODEX, "e2");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBe("tmp:abc");
+    expect(tracker.stampOf(KEY_CODEX)).toBe("uuid-a");
+    expect(warnings.join("\n")).toMatch(/inherits the conversation's last established origin/);
+  });
+
   it("a REWIND kills the last established origin — a download landing before the edited message REFUSES, never resurrects the dropped branch (gate-3 confirm P1)", async () => {
     const { tracker } = makeTracker();
     // The dropped branch established an origin…

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -145,6 +145,27 @@ export class TurnOriginTracker {
 
   constructor(private readonly deps: TurnOriginDeps) {}
 
+  /**
+   * The tab a recorded origin ROUTES to today — the one view every ownership
+   * check in this class judges backends on.
+   *
+   * A same-socket migration (a workflow switch, a save, tmp:→wf:) re-keys the
+   * orchestrator's backend map onto the NEW id and DELETES the old one, so
+   * `backendForTab(<retired id>)` answers with the DEFAULT backend rather than
+   * the tab's real one. Judged on the raw id, a conversation whose backend is
+   * not the default therefore reads its own healthy migrated tab as foreign.
+   *
+   * An id that resolves NOWHERE falls back to itself, deliberately: unprovable
+   * ownership must stay unprovable, not become a way to launder an origin whose
+   * tab is gone (see the "resolves NOWHERE" case in the requeue path).
+   *
+   * `liveTabOf` is optional only for lightweight test trackers; production
+   * always wires it to the bridge's own resolution.
+   */
+  private routedTabOf(tab: string): string {
+    return this.deps.liveTabOf ? (this.deps.liveTabOf(tab) ?? tab) : tab;
+  }
+
   /** Record a message's issue-time origin, keyed by its mid, to be applied at
    *  dequeue. Captures the tab's backend NOW so the application can verify the
    *  tab still belongs to the same conversation then. `injected` marks an
@@ -250,7 +271,7 @@ export class TurnOriginTracker {
       // (independent gate on gate 4, P1 — a false refusal, not a leak). When the
       // origin resolves nowhere at all we keep the strict reading: unprovable
       // ownership still fails closed.
-      const liveOrigin = this.deps.liveTabOf ? (this.deps.liveTabOf(rec.tab) ?? rec.tab) : rec.tab;
+      const liveOrigin = this.routedTabOf(rec.tab);
       if (rec.backend !== backend || this.deps.backendForTab(liveOrigin) !== backend) {
         // Dropped from BOTH maps: a re-queue of this item must fail closed
         // again (unknown), not silently inherit the last established origin.
@@ -359,8 +380,28 @@ export class TurnOriginTracker {
           // issue-time uuid, so the panel fence (and the dispatch-time
           // stamp-target agreement gate, #1656) refuse it loudly if the routed
           // canvas is not the one the stamp names.
+          //
+          // Ownership is judged on the tab the inherited origin ROUTES to
+          // today (routedTabOf), NOT on the id it was recorded under — the
+          // same view the message-origin check above and resolvedPinOf() have
+          // always used, and the one place that was still left on the raw id
+          // (panel#1292 recurrence). The last established origin is written at
+          // batch close and keeps its issue-time identity, so a same-socket
+          // migration after it — a WORKFLOW SWITCH, the exact thing the report
+          // starts with — leaves it naming a retired id that `tabBackends` no
+          // longer knows. `backendForTab` then answers with the DEFAULT
+          // backend, so every conversation NOT on the default backend read its
+          // own healthy tab as another backend's and failed the turn closed:
+          // an async download completing after a workflow switch nulled the
+          // pin, and panel_refresh_nodes / panel_graph_outline /
+          // panel_list_workflows all hit "no connected tab can be chosen …
+          // issued from multiple workflows at once" until an explicit
+          // mode:"current" rebind. Cross-backend safety is untouched: the
+          // bridge resolves an id a live foreign tab currently holds to THAT
+          // tab (exact match beats the migration alias), and an origin that
+          // resolves nowhere still falls back to its raw id and fails closed.
           const last = this.lastOriginByKey.get(key);
-          if (last && this.deps.backendForTab(last.tab) === this.deps.backendOfKey(key)) {
+          if (last && this.deps.backendForTab(this.routedTabOf(last.tab)) === this.deps.backendOfKey(key)) {
             this.lastTurnUuidByKey.set(key, last.uuid);
             this.turnTargetTabByKey.set(key, last.tab);
             if (closed.routes.size > 1) {
@@ -373,7 +414,12 @@ export class TurnOriginTracker {
             this.turnTargetTabByKey.set(key, null);
             this.deps.warn(
               last
-                ? `[panel-orchestrator] ${key} dispatched ${closed.routes.size > 1 ? "a multi-workflow event replay (#1001)" : "an origin-less turn"} whose last established origin tab ${last.tab.slice(0, 8)} now belongs to another backend's conversation — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884 confirming gate 3)`
+                ? `[panel-orchestrator] ${key} dispatched ${closed.routes.size > 1 ? "a multi-workflow event replay (#1001)" : "an origin-less turn"} whose last established origin tab ${last.tab.slice(0, 8)}${
+                    // Name the tab the verdict was actually reached on. Judging
+                    // moved to the ROUTED id (panel#1292), so reporting only the
+                    // recorded one would blame an id this branch never looked at.
+                    this.routedTabOf(last.tab) !== last.tab ? ` (routing to ${this.routedTabOf(last.tab).slice(0, 8)})` : ""
+                  } now belongs to another backend's conversation — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884 confirming gate 3)`
                 : `[panel-orchestrator] ${key} dispatched a turn with no ${closed.routes.size > 1 ? "user origin (a multi-workflow event replay, #1001) and no" : "origin and no"} established prior origin — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884)`,
             );
           }


### PR DESCRIPTION
Panel issue: https://github.com/Artokun/comfyui-mcp-panel/issues/1292 (recurrence — the prior fix, #1750, did not cover this shape)

## The report

> after an async model-download completion following a workflow switch, `panel_refresh_nodes`, `panel_graph_outline` and `panel_list_workflows` all fail with `no connected tab can be chosen ... current turn was issued from multiple workflows at once`. `panel_set_workflow_target({mode:"current"})` recovers the session.

Reporter: comfyui-mcp 0.52.24 / panel 0.15.11 — above the 0.52.4 cut that shipped #1750.

#1750 was **bind-time** work: it made `mode:"current"` recover the null pin before `awaitReachable` yields, and stopped `graph_binding:"bound"` being emitted while the pin was still ambiguous. That recovery still works — which is exactly what the reporter observed when the later `mode:"current"` fixed the session. This recurrence is a **later** pin, re-nulled *after* the bind by the download turn's own batch close, so nothing #1750 added is on the path.

## Mechanism (verified against `origin/main`, not inherited from the prior diagnosis)

`TurnOriginTracker`'s batch-close **inheritance** was the one ownership check in the class still judged on the tab id **as recorded**:

- `src/orchestrator/turn-origins.ts:363` (origin/main) — `backendForTab(last.tab) === backendOfKey(key)`

Every other ownership check in the same file already judges on the tab the origin **routes to** today:

- `onSeen`, message origins — `turn-origins.ts:253` — `liveTabOf(rec.tab) ?? rec.tab` (the gate-4 P1 fix)
- `resolvedPinOf`, pins at use — `turn-origins.ts:484`
- `tabChangedBackend`, pin invalidation — `turn-origins.ts:414`

The two facts that turn that inconsistency into the reported refusal:

1. `backendForTab` falls back to the **default** backend for an id it does not know — `index.ts:1831`, `tabBackends.get(panelTabId) ?? defaultBackend`.
2. A same-socket workflow switch **deletes the predecessor's entry** — `index.ts:4063`, `tabBackends.delete(migratedFrom)` — after carrying the mapping onto the new id.

`lastOriginByKey` is written at batch close and keeps its issue-time identity, so after a workflow switch it names a retired id. `backendForTab(<retired id>)` therefore answers `defaultBackend`, and **any conversation whose backend is not the default backend** read its own healthy migrated tab as another backend's. The origin-less `download_done` turn (`index.ts:6160`, `mid: turnOrigins.mintInheritedOrigin()`) then took the refuse branch: `turnTargetTabByKey = null`, `lastTurnUuidByKey = undefined`. A `null` scope pin is what mints the reported sentence at `ui-bridge.ts:4206` — for *every* scope-addressed call in that turn, which is why three unrelated-looking tools failed together, `panel_list_workflows` among them (it is a pre-dispatch refusal, so the panel never sees the call).

### Measured, before the fix

Driving the real `TurnOriginTracker` with `index.ts`'s own wiring (`backendForTab = tabBackends.get(t) ?? default`, `liveTabOf = bridge.liveTabIdFor`), replaying: user message from `tmp:abc` → same-socket switch to `wf:r1:foo.json` → `mintInheritedOrigin()` → `onSeen` → batch close.

| case | conversation | result on `origin/main` |
| --- | --- | --- |
| A | `codex` (default `claude`) | `pin = null`, `stamp = undefined` — **the reported refusal** |
| B | `claude` (default `claude`) | `pin = "tmp:abc"`, `stamp = "uuid-a"` — inherits |
| C | `claude`, surface gone entirely | `pin = "tmp:abc"`, unroutable → downstream "no connected tab" (a *different*, already-documented message) |

Case A's warn, verbatim from the run:

```
orchestrator::codex dispatched an origin-less turn whose last established origin tab tmp:abc
now belongs to another backend's conversation — scope routing FAILS CLOSED until an explicit
target or an origin-bearing message (#884 confirming gate 3)
```

After the fix, A inherits (`pin = "tmp:abc"`, `stamp = "uuid-a"`, no warn); B and C are byte-identical to before.

**Scope, stated honestly:** this reproduces the reported symptom exactly, for the reported sequence, on a conversation whose backend is not the configured default (`backendId`). The report does not name the reporter's backend, so I cannot claim the default-backend case was ever affected — case B shows it was not, because the fallback happens to agree there. That asymmetry is also why the existing coverage for this branch missed it: it used the default backend and no migration.

## The fix

Judge inheritance on the routed tab, via the same rule the other two checks already use, factored into one private `routedTabOf()` so they cannot diverge a third time. One decision line changes.

Behaviour at the edges, deliberately:

- **stale alias that resolves** → judged on the live tab; inherits. The pin keeps the *recorded* identity (`last.tab`) and the bridge resolves it onward, matching the existing pin contract.
- **id that resolves nowhere** (unknown / disconnected) → falls back to itself, exactly as `onSeen` does. Unprovable ownership stays unprovable and still fails closed; case C above shows this path is unchanged.
- **id a live foreign tab currently holds** → `resolveTarget` matches the exact id before any migration alias, so it routes to that foreign tab and is still refused. The revived-`wf:` -id hazard `resolvedPinOf` guards is now guarded at the inherit step too.
- `liveTabOf` stays optional for lightweight test trackers.

The refusal warn now also names the routed tab when it differs, so the fail-closed branch cannot blame an id it never looked at.

## Tests

Five cases added to `turn-origins.test.ts` (46 pass, was 41):

- the reported sequence end to end — switch, then `download_done` — inherits, **and survives `resolvedPinOf`** (a pin that only passes at batch close would reproduce the same refusal one step later)
- the `#1001` multi-workflow event replay after a switch, the other shape reaching this branch
- three cross-backend safety cases: the migrated surface genuinely changed hands; the recorded id revived by a live foreign tab (no alias — exact identity beats the alias); the surface resolving nowhere

### Mutation-tested in both directions

- **Revert the fix** (`routedTabOf(last.tab)` → `last.tab`): the 2 behaviour tests fail, 44 pass. The fix is pinned.
- **Open the guard** (`if (last && …)` → `if (last)`): all 3 new safety tests fail, plus the pre-existing `an INHERITED origin whose tab has since switched provider refuses instead of inheriting`. None of them are vacuous.

## Verification

- `npx tsc --noEmit` — clean
- `src/__tests__/orchestrator/**` + `ui-bridge.test.ts` — **3457 passed**, 3 failed
- The 3 failures are `node-id-union-message.test.ts` (#1889) and are **pre-existing on `origin/main`**: confirmed by reverting both of my files to `origin/main` and re-running that file alone — same 3 failures, 53 pass. Unrelated to this change.

Codex gate result is posted as a follow-up comment. **Leaving this open for independent review — do not merge before fresh required CI and an independent Codex gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
