### PR TITLE
test(1904): restart tests no longer depend on a live ComfyUI port

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -26,6 +26,14 @@ vi.mock("../../services/process-control.js", async (importOriginal) => {
   return { ...actual, restartComfyUI: hoisted.restart };
 });
 
+// #1904 live-probe gate: nothing here may open a REAL WebSocket. The branch
+// under test stubs restartComfyUI itself, so the witness is never reached —
+// pin that by stubbing the acquisition outright.
+vi.mock("../../services/instance-witness.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../services/instance-witness.js")>()),
+  acquireInstanceWitness: async () => undefined,
+}));
+
 import {
   buildPanelToolDefs,
   rebootNoEndpoint,

--- a/src/__tests__/services/live-probe-gate.test.ts
+++ b/src/__tests__/services/live-probe-gate.test.ts
@@ -248,23 +248,11 @@ const KNOWN_UNSTUBBED: Record<string, string[]> = {
   "live process table (uncollapsed observation)": [
     "__tests__/services/env-capabilities.test.ts",
   ],
-  // The witness channel as it stands today. Ratcheted rather than fixed wholesale, for
-  // the same reason as the list above: five passing files is a large diff with no
-  // observable failure behind it, and each needs its own judgement about what the
-  // witness should return for the case it drives.
-  //
-  // `restart-live-first.test.ts` is the one that already cost three red CI runners
-  // (#1315). Note what its fix was: keeping the `startedAt` stamp so the #914 branch is
-  // not taken — a PER-TEST avoidance, not a stub. That is why it still appears here and
-  // should: the file can reach the channel again the moment a case omits the stamp, and
-  // nothing but this list would notice.
-  "instance witness (real WebSocket)": [
-    "__tests__/orchestrator/panel-restart-legacy-fallback.test.ts",
-    "__tests__/services/restart-launcher-env.test.ts",
-    "__tests__/services/restart-live-first.test.ts",
-    "__tests__/services/restart-posix-port-release.test.ts",
-    "__tests__/services/restart-relaunch-lifecycle.test.ts",
-  ],
+  // Empty on purpose (#1904): the five restart/stop files that used to live here
+  // now stub `acquireInstanceWitness`, so a future test that reaches the real
+  // WebSocket without stubbing fails the "NO NEW" assertion instead of joining
+  // a ratchet that had already named the known offenders.
+  "instance witness (real WebSocket)": [],
 };
 
 describe.each(PROBES)("host-reaching probe: $id (#1290/#1263)", (probe) => {

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -132,6 +132,14 @@ vi.mock("../../services/workspace-env.js", () => ({
   resetLocalComfyUILaunchState: vi.fn(),
 }));
 
+// #1904: acquireInstanceWitness opens a REAL WebSocket to COMFYUI_URL. Stub
+// it so this file takes the no-witness branch whether or not something is
+// listening on the configured ComfyUI port.
+vi.mock("../../services/instance-witness.js", async () => ({
+  ...(await vi.importActual("../../services/instance-witness.js")),
+  acquireInstanceWitness: async () => undefined,
+}));
+
 import { detectStabilityMatrix } from "../../services/launcher-env.js";
 import {
   __processControlTestHooks,

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -149,6 +149,14 @@ vi.mock("../../services/workspace-env.js", () => ({
   resetLocalComfyUILaunchState: vi.fn(),
 }));
 
+// #1904: acquireInstanceWitness opens a REAL WebSocket to COMFYUI_URL. Stub
+// it so this file takes the no-witness branch whether or not something is
+// listening on the configured ComfyUI port.
+vi.mock("../../services/instance-witness.js", async () => ({
+  ...(await vi.importActual("../../services/instance-witness.js")),
+  acquireInstanceWitness: async () => undefined,
+}));
+
 import {
   __processControlTestHooks,
   restartComfyUI,

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -94,6 +94,14 @@ vi.mock("../../services/workspace-env.js", () => ({
   resetLocalComfyUILaunchState: vi.fn(),
 }));
 
+// #1904: acquireInstanceWitness opens a REAL WebSocket to COMFYUI_URL. Stub
+// it so this file takes the no-witness branch whether or not something is
+// listening on the configured ComfyUI port.
+vi.mock("../../services/instance-witness.js", async () => ({
+  ...(await vi.importActual("../../services/instance-witness.js")),
+  acquireInstanceWitness: async () => undefined,
+}));
+
 import {
   __processControlTestHooks,
   restartComfyUI,

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -124,6 +124,14 @@ vi.mock("../../services/workspace-env.js", () => ({
   resetLocalComfyUILaunchState: vi.fn(),
 }));
 
+// #1904: acquireInstanceWitness opens a REAL WebSocket to COMFYUI_URL. Stub
+// it so this file takes the no-witness branch whether or not something is
+// listening on the configured ComfyUI port.
+vi.mock("../../services/instance-witness.js", async () => ({
+  ...(await vi.importActual("../../services/instance-witness.js")),
+  acquireInstanceWitness: async () => undefined,
+}));
+
 import {
   __processControlTestHooks,
   preflightLocalRestart,


### PR DESCRIPTION
Fixes #1904

`acquireInstanceWitness` opens a real WebSocket to the configured ComfyUI URL. Five restart/stop tests reached it unstubbed, so they took the live-socket branch when something was listening on the port and the no-witness branch in CI. Green locally and green in CI were not the same path.

## What changed

- Stub `acquireInstanceWitness` (returns `undefined`) in:
  - `src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts`
  - `src/__tests__/services/restart-launcher-env.test.ts`
  - `src/__tests__/services/restart-live-first.test.ts`
  - `src/__tests__/services/restart-posix-port-release.test.ts`
  - `src/__tests__/services/restart-relaunch-lifecycle.test.ts`
- Empty the `live-probe-gate` known-unstubbed list for this channel so a future test that forgets the stub fails the gate instead of joining an allowlist.

The mock path matches what those files already import (`../../services/instance-witness.js`). Relative importActual / importOriginal style matches the sibling restart/orchestrator stubs already in the tree.

## Verification

```
npx vitest run --maxWorkers=4 \
  src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts \
  src/__tests__/services/restart-launcher-env.test.ts \
  src/__tests__/services/restart-live-first.test.ts \
  src/__tests__/services/restart-posix-port-release.test.ts \
  src/__tests__/services/restart-relaunch-lifecycle.test.ts \
  src/__tests__/services/live-probe-gate.test.ts
```

205 passed (6 files), including the gate.
