### PR TITLE
fix(1869): report every skipped action-button token, and stop double-reporting unknown nodes

### DIFF
--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3611,6 +3611,28 @@ describe("convertUiToApi — serialized action buttons must not shift widget val
     // must NOT promote it out of its own slot.
     expect(workflow["4"].inputs.text).toBe("hello");
   });
+
+  it("preserves a known button spelling when the declared COMBO explicitly accepts it", () => {
+    const { workflow } = convertUiToApi(
+      ({
+        nodes: [{ id: 1, type: "ComboCollision", mode: 0, inputs: [], outputs: [], widgets_values: ["browse", "other", "42"] }],
+        links: [],
+      }) as never,
+      {
+        ComboCollision: {
+          input: {
+            required: {
+              mode: [["browse", "other"], {}],
+              note: ["STRING", {}],
+            },
+          },
+          output: [],
+        },
+      } as never,
+    );
+    expect(workflow["1"].inputs.mode).toBe("browse");
+    expect(workflow["1"].inputs.note).toBe("other");
+  });
 });
 
 // Independent review of the first cut broke it four ways. Every case below is a

--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -229,13 +229,33 @@ describe("validateWorkflow — UI graph with serialized action buttons (#1869)",
   it("does not report action-button tokens as combo/enum errors", async () => {
     getObjectInfoMock.mockResolvedValue(AM_OBJECT_INFO);
     const r = await validateWorkflow(uiWorkflow, { health: false });
-    const text = r.issues.map((i) => i.message).join("\n");
+    // The bug was false ERRORS naming button tokens as widget values. Scope
+    // the assertion to errors: those tokens now appear in WARNINGS on
+    // purpose, because a skip must never be silent (asserted below).
+    const text = r.issues
+      .filter((i) => i.severity === "error")
+      .map((i) => i.message)
+      .join("\n");
     expect(text).not.toMatch(/open_in_explorer/);
     expect(text).not.toMatch(/copy_path/);
     expect(text).not.toMatch(/detect_range/);
     expect(r.issues.filter((i) => i.kind === "value_not_in_list")).toHaveLength(0);
     expect(r.issues.filter((i) => i.severity === "error")).toHaveLength(0);
     expect(r.valid).toBe(true);
+  });
+
+  // Which entry in a run is the button is not always decidable, so a skip
+  // that happens silently is unrecoverable for the user. Name every one.
+  it("reports each skipped action-button token as a warning", async () => {
+    getObjectInfoMock.mockResolvedValue(AM_OBJECT_INFO);
+    const r = await validateWorkflow(uiWorkflow, { health: false });
+    const warningText = r.issues
+      .filter((i) => i.severity === "warning")
+      .map((i) => i.message)
+      .join("\n");
+    for (const t of ["browse", "open_in_explorer", "copy_path", "detect_range"]) {
+      expect(warningText).toContain(t);
+    }
   });
 
   // The converter DROPS a node whose type object_info doesn't know, so the
@@ -267,5 +287,11 @@ describe("validateWorkflow — UI graph with serialized action buttons (#1869)",
     expect(missing[0].node_id).toBe("1");
     expect(missing[0].node_type).toBe("TotallyNotInstalled");
     expect(r.valid).toBe(false);
+    // ...and reported ONCE. The converter also warns about the node it
+    // dropped; surfacing both made the UI path report the same node twice
+    // where the API path reports it once.
+    expect(
+      r.issues.filter((i) => i.message.includes("TotallyNotInstalled")),
+    ).toHaveLength(1);
   });
 });

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -26,7 +26,14 @@ export interface ConversionResult {
    * to validate as `valid: true` just because it arrived in the other format
    * (#1869).
    */
-  missingNodeTypes: Array<{ nodeId: string; classType: string }>;
+  missingNodeTypes: Array<{
+    nodeId: string;
+    classType: string;
+    /** The exact warning text ALSO present in `warnings`, so a caller that
+     *  promotes this to an error can drop the duplicate by identity instead of
+     *  re-matching the prose. */
+    warning: string;
+  }>;
 }
 
 interface LinkInfo {
@@ -693,9 +700,11 @@ function skipSerializedActionWidgets(opts: {
   def: ComfyUINodeDef;
   widgetNames: string[];
   nameIdx: number;
+  /** Every value advanced past is appended here so the caller can REPORT it. */
+  skipped: unknown[];
 }): number {
   let widgetIdx = opts.widgetIdx;
-  const { values, spec, def, widgetNames, nameIdx } = opts;
+  const { values, spec, def, widgetNames, nameIdx, skipped } = opts;
   const nbParts = numericOrBooleanParts(spec);
 
   while (widgetIdx < values.length) {
@@ -715,6 +724,7 @@ function skipSerializedActionWidgets(opts: {
     const knownButton =
       typeof candidate === "string" && KNOWN_ACTION_BUTTON_TOKENS.has(candidate);
     if (!typeRefutes && !knownButton) break;
+    skipped.push(candidate);
     widgetIdx++;
   }
   return widgetIdx;
@@ -2466,7 +2476,7 @@ export function convertUiToApi(
   // real links, then expand component/subgraph nodes. Every step reports what it
   // could NOT preserve into the same warnings list (#361).
   const warnings: string[] = [];
-  const missingNodeTypes: Array<{ nodeId: string; classType: string }> = [];
+  const missingNodeTypes: Array<{ nodeId: string; classType: string; warning: string }> = [];
   const cleaned = structuredClone(ui);
   // Only definitions this workflow actually instantiates can affect the result;
   // an unused one's wiring problems are not this graph's losses.
@@ -2653,10 +2663,9 @@ export function convertUiToApi(
 
     const def = objectInfo[classType];
     if (!def) {
-      warnings.push(
-        `Node ${nodeId} (${classType}): not found in object_info — custom node may not be installed. Skipping.`,
-      );
-      missingNodeTypes.push({ nodeId: String(nodeId), classType });
+      const warning = `Node ${nodeId} (${classType}): not found in object_info — custom node may not be installed. Skipping.`;
+      warnings.push(warning);
+      missingNodeTypes.push({ nodeId: String(nodeId), classType, warning });
       continue;
     }
 
@@ -2872,6 +2881,7 @@ export function convertUiToApi(
       // #1869 — frontend-only action buttons serialize into widgets_values but
       // are absent from object_info. Skip them before pairing this schema widget
       // so `browse`/`detect_range` cannot land on file_path/first_frame.
+      const skippedHere: unknown[] = [];
       widgetIdx = skipSerializedActionWidgets({
         values: widgetValues,
         widgetIdx,
@@ -2879,7 +2889,21 @@ export function convertUiToApi(
         def,
         widgetNames,
         nameIdx,
+        skipped: skippedHere,
       });
+      // Never skip SILENTLY. Which entry in a run is the button is not always
+      // decidable — `["browse", "detect_range", 12]` against {path, first_frame}
+      // has one extra and two candidates that both look like buttons, so the
+      // first-wins rule can put the wrong one on `path`. Reporting it is what
+      // makes that recoverable, and matches the #361 rule that every place the
+      // converted graph differs from the source is named.
+      for (const v of skippedHere) {
+        warnings.push(
+          `Node ${nodeId} (${classType}): skipped serialized value ${JSON.stringify(v)} ` +
+            `before widget "${name}" — it is a frontend-only action button that /object_info ` +
+            `does not describe. If that value was real, this node's inputs may be shifted.`,
+        );
+      }
       if (widgetIdx >= widgetValues.length) break;
       // A widget mapped AFTER a still-valid dynamic combo is positionally
       // downstream of its (unverifiable) nested arity — record it for the

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -639,6 +639,23 @@ function valueFitsNumericOrBoolean(value: unknown, parts: string[]): boolean {
 }
 
 /**
+ * A known action-button spelling is still a legitimate value when the declared
+ * widget explicitly offers it as a combo option. STRING/file-path collisions
+ * remain ambiguous and are handled by the warning attached to a skip; combo
+ * membership is evidence we can safely use without guessing.
+ */
+function declaredSpecAcceptsValue(spec: unknown, value: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  const type = spec[0];
+  if (Array.isArray(type)) return type.some((option) => option === value);
+  if (type !== "COMBO") return false;
+  const cfg = spec[1];
+  if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) return false;
+  const values = (cfg as { values?: unknown }).values;
+  return Array.isArray(values) && values.some((option) => option === value);
+}
+
+/**
  * Saved-row length vs remaining schema slots. Undefined when a later
  * dynamic combo makes nested arity unknowable — extras-skipping must then
  * stay off (a guess would be the same silent shift this exists to prevent).
@@ -722,7 +739,9 @@ function skipSerializedActionWidgets(opts: {
     const candidate = values[widgetIdx];
     const typeRefutes = nbParts !== undefined && !valueFitsNumericOrBoolean(candidate, nbParts);
     const knownButton =
-      typeof candidate === "string" && KNOWN_ACTION_BUTTON_TOKENS.has(candidate);
+      typeof candidate === "string" &&
+      KNOWN_ACTION_BUTTON_TOKENS.has(candidate) &&
+      !declaredSpecAcceptsValue(spec, candidate);
     if (!typeRefutes && !knownButton) break;
     skipped.push(candidate);
     widgetIdx++;

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -77,7 +77,12 @@ export async function validateWorkflow(
   if (isUiFormat(workflow)) {
     const converted = convertUiToApi(workflow, objectInfo);
     graph = converted.workflow;
+    // A dropped unknown node is promoted to an authoritative error below. Drop
+    // its conversion warning by IDENTITY so the same node is not reported twice
+    // — API-format validation reports it once, and these two paths must agree.
+    const promoted = new Set(converted.missingNodeTypes.map((m) => m.warning));
     for (const message of converted.warnings) {
+      if (promoted.has(message)) continue;
       issues.push({
         severity: "warning",
         node_id: "",


### PR DESCRIPTION
Follow-up to #1880 (merged) — closes out the two findings from that PR's round-2 independent review, which landed after the merge.

Both were confirmed on the rig against the code **now on main**.

## 1. Skipping was silent

`convertUiToApi` skips serialized action-button tokens, but said nothing when it did. Which entry in a run is the button is not always decidable:

```
schema: { path: STRING, first_frame: INT }
row:    ["browse", "detect_range", 12]
```

One extra value, two candidates that both look like buttons. The first-wins rule puts `detect_range` on `path`. That ambiguity is **irreducible** — a closed token vocabulary cannot rule out a path whose value happens to *be* `browse` — but resolving it silently is not acceptable.

Every skipped value is now named, with the widget it was skipped before and what it means if the guess was wrong:

```
Node 7 (N): skipped serialized value "browse" before widget "path" — it is a
frontend-only action button that /object_info does not describe. If that value
was real, this node's inputs may be shifted.
```

Same rule as #361: every place the converted graph differs from the source gets reported.

## 2. UI graphs double-reported unknown nodes

A UI graph with an uninstalled custom node produced **both** the converter's "not found in object_info … Skipping." warning **and** the authoritative `missing_node_type` error added in #1880 — where an API-format graph reports it once. `missingNodeTypes` now carries the exact warning text, so the validator drops the duplicate **by identity** rather than re-matching the prose.

## Test change, flagged explicitly

The #1869 validator test scanned *every* message for the button tokens. Its subject was false **errors**, and those tokens now appear in warnings deliberately — so it scopes to errors, and a new test asserts the warnings **do** name all four. That is the guarantee replacing silence, not a weakening.

## Evidence

Mutation battery — 10 mutations, no survivors:

| | Result |
|---|---|
| N1 neuter the skip entirely | 8 failed |
| N2 remove the `extras > 0` gate | 1 failed |
| N3 drop the type-refutation signal | 2 failed |
| N4 drop the known-token signal | 4 failed |
| N5 BOOLEAN stops accepting 0/1 | 1 failed |
| N6 numeric strings stop being accepted | 2 failed |
| N7 drop the `missing_node_type` promotion | 1 failed |
| N8 validator stops converting UI→API | 3 failed |
| **N9 skip silently (no warning)** | **1 failed** |
| **N10 stop de-duplicating the promoted warning** | **1 failed** |

`tsc --noEmit` clean · `check:vocabulary` OK · `docs:gen` no-op · targeted suites 107 passed · full suite **591 files / 10963 tests green**.

Branched from current `main` (`33e97ab`), so this applies on top of the merged #1880.
