### PR TITLE
fix(1905): upload_image names a 413 as too large, not a bad ComfyUI URL

### DIFF
--- a/src/__tests__/comfyui/json-guard.test.ts
+++ b/src/__tests__/comfyui/json-guard.test.ts
@@ -350,6 +350,22 @@ describe("classifyNonJson names what answered instead of ComfyUI (#828)", () => 
     expect(d.message).not.toContain("really is a ComfyUI API root");
   });
 
+  it("does not prescribe a base-URL check for HTTP 413 (#1905)", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/upload/image",
+      status: 413,
+      statusText: "Content Too Large",
+      contentType: "text/plain",
+      body: "Maximum request body size 104857600 exceeded, actual body size 104923136",
+    });
+    expect(d.message).toContain("413");
+    expect(d.message).toMatch(/request-size limit/i);
+    expect(d.message).toMatch(/trim or compress/i);
+    expect(d.message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(d.message).not.toContain("the same catch-all that produced this page");
+    expect(d.message).not.toContain("really is a ComfyUI API root");
+  });
+
   it("names a previously-validated root as an outage, not a misconfiguration", () => {
     noteComfyApiRootValidated(getComfyUIBaseUrl());
     const d = classifyNonJson({

--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -137,14 +137,16 @@ describe("status branches after a ComfyUI API call are reachable (#385)", () => 
     // Making this branch reachable must not cost the #1160 diagnosis, and must
     // not print a raw body — a gateway that reflects the request can put our own
     // credential in it. So it classifies instead of interpolating.
+    // #1905: 413 is a size limit, not a non-JSON stranger / bad base URL.
     answer(413, "too large", "text/plain");
     const err = await uploadImageHttp("big.png", Buffer.from("x")).then(
       () => null,
       (e: unknown) => e,
     );
-    expect((err as { code?: string }).code).toBe("NON_JSON_RESPONSE");
+    expect((err as { code?: string }).code).toBe("UPLOAD_TOO_LARGE");
     expect((err as Error).message).toContain("/upload/image");
     expect((err as Error).message).toContain("413");
+    expect((err as Error).message).not.toContain("Confirm the configured ComfyUI base URL");
   });
 
   it("uploadImageHttp still names a sign-in gate on a 401 (#1160 must not regress)", async () => {

--- a/src/__tests__/comfyui/upload-too-large.test.ts
+++ b/src/__tests__/comfyui/upload-too-large.test.ts
@@ -1,0 +1,123 @@
+// #1905 — upload_image (action:"video") received HTTP 413 with ComfyUI/aiohttp's
+// plain-text size-limit sentence and classified it as NON_JSON_RESPONSE, then
+// recommended checking the configured ComfyUI base URL. Connectivity was fine
+// (/system_stats JSON). The cause was request size.
+//
+// These tests drive the SHIPPED upload helper (`uploadImageHttp`) through the
+// real client wiring. Mocking classifyNonJson would let a 413 still become
+// NON_JSON_RESPONSE plus the SPA-catch-all remedy.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { resetClient, uploadImageHttp } from "../../comfyui/client.js";
+import { isNonJsonResponseError, resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
+
+/** The exact sentence ComfyUI/aiohttp wrote in the reported 413. */
+const COMFY_SIZE_LIMIT_BODY =
+  "Maximum request body size 104857600 exceeded, actual body size 104923136";
+
+function answer(status: number, body: string, contentType: string, statusText?: string): void {
+  global.fetch = vi.fn(async () => {
+    return new Response(body, {
+      status,
+      statusText: statusText ?? "",
+      headers: { "content-type": contentType },
+    });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+  resetComfyApiRootValidated();
+});
+
+describe("uploadImageHttp names HTTP 413 as a size limit, not a bad base URL (#1905)", () => {
+  it("returns UPLOAD_TOO_LARGE for ComfyUI's plain-text size-limit sentence", async () => {
+    answer(413, COMFY_SIZE_LIMIT_BODY, "text/plain", "Content Too Large");
+
+    const err = await uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4").then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(isNonJsonResponseError(err)).toBe(false);
+    expect((err as { code?: string }).code).toBe("UPLOAD_TOO_LARGE");
+
+    const message = (err as Error).message;
+    expect(message).toContain("/upload/image");
+    expect(message).toContain("413");
+    // Names the configured/observed limits from the body, not a guessed ceiling.
+    expect(message).toContain("104857600");
+    expect(message).toContain("104923136");
+    expect(message).toMatch(/trim or compress/i);
+    expect(message).toMatch(/FFmpeg/);
+    // The misdiagnosis the reporter got.
+    expect(message).not.toContain("NON_JSON_RESPONSE");
+    expect(message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(message).not.toContain("really is a ComfyUI API root");
+    expect(message).not.toContain("the same catch-all that produced this page");
+    expect((err as { details?: { limitBytes?: number; actualBytes?: number } }).details).toMatchObject({
+      status: 413,
+      limitBytes: 104857600,
+      actualBytes: 104923136,
+    });
+  });
+
+  it("still treats a 413 without the aiohttp sentence as a size limit", async () => {
+    answer(413, "too large", "text/plain");
+
+    const err = await uploadImageHttp("big.png", Buffer.from("x")).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect((err as { code?: string }).code).toBe("UPLOAD_TOO_LARGE");
+    const message = (err as Error).message;
+    expect(message).toMatch(/trim or compress/i);
+    expect(message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(message).not.toContain("really is a ComfyUI API root");
+  });
+
+  it("does not recast a 401 sign-in gate as a size limit (#1160 must not regress)", async () => {
+    answer(
+      401,
+      '<!DOCTYPE html><html><head><title>Sign in</title></head><body><form action="/login"><input type="password" name="p"></form></body></html>',
+      "text/html",
+      "Unauthorized",
+    );
+
+    const err = await uploadImageHttp("cat.png", Buffer.from("x")).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(isNonJsonResponseError(err)).toBe(true);
+    expect((err as { code?: string }).code).toBe("NON_JSON_RESPONSE");
+    expect((err as Error).message).toMatch(/SIGN-IN PAGE/);
+  });
+
+  it("still succeeds on a normal 2xx JSON response", async () => {
+    answer(
+      200,
+      JSON.stringify({ name: "clip.mp4", subfolder: "", type: "input" }),
+      "application/json",
+    );
+    await expect(uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4")).resolves.toEqual({
+      name: "clip.mp4",
+      subfolder: "",
+      type: "input",
+    });
+  });
+});

--- a/src/__tests__/tools/upload-image-too-large.test.ts
+++ b/src/__tests__/tools/upload-image-too-large.test.ts
@@ -1,0 +1,95 @@
+// #1905 — upload_image (action:"video") on a healthy ComfyUI answered HTTP 413
+// with aiohttp's plain-text size-limit sentence, and the tool classified it as
+// NON_JSON_RESPONSE then recommended checking the base URL. Drive the SHIPPED
+// tool through the real upload helper; mocking the service would let the
+// misdiagnosis survive.
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { resetClient } from "../../comfyui/client.js";
+import { resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+const COMFY_SIZE_LIMIT_BODY =
+  "Maximum request body size 104857600 exceeded, actual body size 104923136";
+
+function serve413(): void {
+  global.fetch = vi.fn(async () => {
+    return new Response(COMFY_SIZE_LIMIT_BODY, {
+      status: 413,
+      statusText: "Content Too Large",
+      headers: { "content-type": "text/plain" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+let scratch: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+  resetComfyApiRootValidated();
+  scratch = undefined;
+});
+
+afterEach(async () => {
+  if (scratch) await rm(scratch, { recursive: true, force: true });
+});
+
+describe('upload_image action:"video" names HTTP 413 as UPLOAD_TOO_LARGE (#1905)', () => {
+  it("does not recommend a wrong ComfyUI base URL when the body is the size-limit sentence", async () => {
+    serve413();
+    scratch = await mkdtemp(join(tmpdir(), "upload-413-"));
+    const sourcePath = join(scratch, "clip.mp4");
+    await writeFile(sourcePath, Buffer.from("not-a-real-mp4-but-the-server-never-sees-it"));
+
+    const out = await getHandler("upload_image")({
+      action: "video",
+      source_path: sourcePath,
+    });
+
+    expect(out.isError).toBe(true);
+    const text = out.content[0]?.text ?? "";
+    const parsed = JSON.parse(text) as { error?: string; message?: string; details?: { limitBytes?: number; actualBytes?: number } };
+    expect(parsed.error).toBe("UPLOAD_TOO_LARGE");
+    expect(parsed.message).toContain("/upload/image");
+    expect(parsed.message).toContain("104857600");
+    expect(parsed.message).toContain("104923136");
+    expect(parsed.message).toMatch(/trim or compress/i);
+    expect(parsed.message).not.toContain("Confirm the configured ComfyUI base URL");
+    expect(parsed.message).not.toContain("really is a ComfyUI API root");
+    expect(parsed.message).not.toContain("NON_JSON_RESPONSE");
+    expect(parsed.details).toMatchObject({
+      limitBytes: 104857600,
+      actualBytes: 104923136,
+    });
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -30,6 +30,7 @@ import {
   rethrowWithJsonDiagnosis,
   scrubLogLines,
   scrubSecretShapedText,
+  uploadTooLargeError,
 } from "./json-guard.js";
 import * as cloudClient from "./cloud-client.js";
 import type { ObjectInfo, SystemStats, QueueStatus } from "./types.js";
@@ -1221,6 +1222,16 @@ export async function uploadImageHttp(
     // unknown-ok: "" only means an unreadable body, which classifyNonJson reports
     // as an empty one — a loss of detail, never a wrong conclusion.
     const text = await res.text().catch(() => "");
+    // #1905 — HTTP 413 is a size limit. Classifying it as NON_JSON_RESPONSE
+    // (plain-text aiohttp body) then recommended checking the ComfyUI base URL,
+    // even when /system_stats was healthy JSON. Name the limit before any parse.
+    const tooLarge = uploadTooLargeError({
+      url: "/upload/image",
+      status: res.status,
+      statusText: res.statusText,
+      body: text,
+    });
+    if (tooLarge) throw tooLarge;
     throw new NonJsonResponseError(
       classifyNonJson({
         url: "/upload/image",

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -913,6 +913,75 @@ const STANDARD_REASON_PHRASES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * aiohttp / ComfyUI: "Maximum request body size 104857600 exceeded, actual body size 104923136"
+ * (#1905). Capture the configured ceiling and, when present, the observed body.
+ */
+const MAX_BODY_SIZE_RE =
+  /Maximum request body size (\d+) exceeded(?:,\s*actual body size (\d+))?/i;
+
+function parseRequestBodySizeLimit(body: string): {
+  limitBytes: number;
+  actualBytes?: number;
+} | null {
+  const m = body.match(MAX_BODY_SIZE_RE);
+  if (!m) return null;
+  const limitBytes = Number(m[1]);
+  if (!Number.isFinite(limitBytes) || limitBytes < 0) return null;
+  const actualBytes = m[2] !== undefined ? Number(m[2]) : undefined;
+  return {
+    limitBytes,
+    actualBytes:
+      actualBytes !== undefined && Number.isFinite(actualBytes) && actualBytes >= 0
+        ? actualBytes
+        : undefined,
+  };
+}
+
+function formatByteCount(n: number): string {
+  const mib = n / (1024 * 1024);
+  const pretty = Number.isInteger(mib) ? String(mib) : mib.toFixed(1);
+  return `${n} bytes (${pretty} MiB)`;
+}
+
+/**
+ * HTTP 413 on an upload is a size limit, not a wrong ComfyUI API root (#1905).
+ *
+ * Classify this BEFORE JSON parsing: ComfyUI/aiohttp answers 413 as plain text,
+ * and feeding that body to the non-JSON catch-all produced NON_JSON_RESPONSE
+ * plus "confirm the configured ComfyUI base URL" — even when /system_stats was
+ * healthy JSON. Return null for any other status so callers keep their own path.
+ */
+export function uploadTooLargeError(args: {
+  url: string;
+  status: number;
+  statusText?: string;
+  body: string;
+}): ComfyUIError | null {
+  if (args.status !== 413) return null;
+  const url = redactUrlForDiagnosis(args.url);
+  const reason = describeStatus(args.status, args.statusText);
+  const parsed = parseRequestBodySizeLimit(args.body);
+  const sizes = parsed
+    ? parsed.actualBytes !== undefined
+      ? ` The configured request-body limit is ${formatByteCount(parsed.limitBytes)}; this request was ${formatByteCount(parsed.actualBytes)}.`
+      : ` The configured request-body limit is ${formatByteCount(parsed.limitBytes)}.`
+    : "";
+  let evidence = "";
+  if (!parsed) {
+    const prefix = bodyPrefixOf(args.body);
+    if (prefix && prefix !== "(empty)") evidence = ` Body starts: ${prefix}.`;
+  }
+  const message =
+    `${url} answered ${reason}: the upload was rejected because the request body exceeded the server's size limit.${sizes}${evidence} ` +
+    `This is a file-size limit, not a sign that the configured ComfyUI base URL is pointing at the wrong place. ` +
+    `Trim or compress the media (for video, FFmpeg) and retry.`;
+  return new ComfyUIError(message, "UPLOAD_TOO_LARGE", {
+    status: 413,
+    ...(parsed ?? {}),
+  });
+}
+
+/**
  * Classify a non-JSON response body. Pure (no I/O) so the classification rules
  * are unit-testable without a server.
  */
@@ -1038,14 +1107,22 @@ export function classifyNonJson(args: {
   // ComfyUI API root" — sent operators to reconfigure a working COMFYUI_URL
   // after a CUDA crash took the server down (#1670). Name the outage; only
   // HTML/wrong-responder answers still get the base-URL check.
+  //
+  // HTTP 413 is the same class of wrong next-step (#1905): ComfyUI/aiohttp
+  // answers "Maximum request body size … exceeded" as plain text, which this
+  // classifier used to treat as a non-JSON stranger and then recommend checking
+  // the base URL. Connectivity was fine; the file was too big.
   const statsCheck = `${redactUrlForDiagnosis(getComfyUIBaseUrl())}/system_stats`;
   const gatewayOutage = kind === "proxy-error";
+  const requestTooLarge = status === 413;
   const nextStep = gatewayOutage
     ? wasComfyApiRootValidated()
       ? `This same ComfyUI API root already served ${statsCheck} JSON this session, so the base URL is not newly misconfigured. Treat this as a temporary server outage (crash, restart, or a proxy that cannot reach ComfyUI) and retry after the server is back`
       : `This is a temporary server outage — ComfyUI crashed, is restarting, or a proxy in front of it could not reach it — not evidence that the configured ComfyUI base URL is pointing at the wrong place. Retry after the server is back; if ${statsCheck} then returns JSON, the base URL was fine`
-    : `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
-      `The check is that ${statsCheck} returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong`;
+    : requestTooLarge
+      ? `This is a request-size limit (HTTP 413), not evidence that the configured ComfyUI base URL is pointing at the wrong place. Trim or compress the media and retry`
+      : `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
+        `The check is that ${statsCheck} returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong`;
   const message =
     `${url} answered ${reason} with ${what} where JSON was expected. This means ${cause}. ` +
     `Content-Type: ${contentType || "(none)"}. Body starts: ${bodyPrefix || "(empty)"}. ` +


### PR DESCRIPTION
HTTP 413 from ComfyUI `/upload/image` is a request-size limit. `upload_image` used to classify the plain-text aiohttp body as `NON_JSON_RESPONSE` and then recommend checking the configured ComfyUI base URL — even when `/system_stats` returned JSON.

The upload path now classifies 413 before JSON parsing and returns `UPLOAD_TOO_LARGE`, naming the configured/observed byte limit and recommending trim/compress. It no longer suggests a wrong API root for that status.

Fixes #1905
