### PR TITLE
release: v0.52.31 — workflow validation, routed download turns, stale-schema retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,12 +759,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.31] - 2026-08-20
+
 ### MCP
 
 #### Fixed
-- `validate_workflow` reports serialized action-button skips and preserves declared COMBO values that use button spellings (#1869)
-- origin-less download completion turns inherit the routed tab after a workflow switch (#1292)
-- a stale-schema node add takes its own retry after a lost refresh acknowledgement (#1518)
+- report every skipped action-button token, and stop double-reporting unknown nodes (#1908)
+- an origin-less download turn after a workflow switch inherits the routed tab, not the retired id (#1906)
+- validate_workflow no longer flags action-button tokens as widget values (#1880)
+- an add refused for a stale schema takes its own retry after a lost refresh ack (#1902)
+
+#### Changed
+- restart tests no longer depend on a live ComfyUI port (#1907)
+
 
 ## [0.52.30] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- `validate_workflow` reports serialized action-button skips and preserves declared COMBO values that use button spellings (#1869)
+- origin-less download completion turns inherit the routed tab after a workflow switch (#1292)
+- a stale-schema node add takes its own retry after a lost refresh acknowledgement (#1518)
+
 ## [0.52.30] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.30",
+  "version": "0.52.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.30",
+      "version": "0.52.31",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.30",
+  "version": "0.52.31",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.31** from current main after v0.52.30.\n\nCarries:\n\n- #1908 / #1869 — serialized action-button skips are disclosed, unknown-node validation is not duplicated, and declared COMBO values that resemble buttons are preserved\n- #1906 / panel#1292 — origin-less download completion turns inherit the routed tab after a workflow switch\n- #1902 / panel#1518 — stale-schema node adds take their own retry after a lost refresh acknowledgement\n- #1907 / #1904 — restart tests no longer depend on a live ComfyUI port (test-only)\n\nDo not squash-merge; preserve the release commit and tag **v0.52.31** on it. Push the tag after merge if needed.