### PR TITLE
fix(panel#1529): a workflow pin may not claim a graph target it did not establish

### DIFF
--- a/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
+++ b/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
@@ -380,7 +380,11 @@ describe("panel#1529 — a pin may not claim a graph target it did not establish
     const outline = await tool("panel_graph_outline").handler({}, ctx);
     expect(outline.isError).toBeFalsy();
     expect(textOf(outline)).toContain("Wan2VideoEditApi");
-    expect(page.seen.filter((f) => f.cmd === "graph_outline")[0]?.workflow_path).toBeUndefined();
+    // Assert the frame EXISTS before asserting what it lacks — `[0]?.workflow_path`
+    // on an empty array is undefined too, and would pass this vacuously.
+    const outlineFrames = page.seen.filter((f) => f.cmd === "graph_outline");
+    expect(outlineFrames).toHaveLength(1);
+    expect(outlineFrames[0].workflow_path).toBeUndefined();
   });
 
   it("does NOT claim the graph target for a pin it could not verify", async () => {

--- a/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
+++ b/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
@@ -1,0 +1,433 @@
+// panel#1529 — "Workflow pin reports success but graph tools stay on previous tab".
+//
+// WHAT WAS REPORTED. `panel_set_workflow_target({mode:"pinned"})` answered
+// «Pinned to X. Graph tools will target that workflow» and, in the same reply,
+// «this session's turn routing was NOT re-pinned … the existing pin (tmp:2fb3)
+// still reaches a live tab». The very next `panel_graph_outline` came back with
+// the OTHER workflow's nodes. Two selectors — the workflow-target store and the
+// turn-routing pin — disagreed, and the reply read as a success either way.
+//
+// WHAT THIS FILE PROVES, and why it is an e2e over a REAL bridge rather than a
+// unit test on the helper. The claim lives in the TOOL's reply, the verdict is
+// computed in `resolvePinTarget`, and the two are joined by one assignment at the
+// call site. A helper-level test survives that assignment being deleted — it was
+// deleted here, deliberately, and only the reply-level assertions below went red.
+// So every assertion reads the string/field an agent actually receives, produced
+// by the real tool def, the real workflow-target store, the real UiBridge and the
+// real turn-origin pin, against scripted panel sockets.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import {
+  TurnOriginTracker,
+  makeScopeRepinHandler,
+  makeScopeTargetResolver,
+} from "../../orchestrator/turn-origins.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { SHARED_SESSION_SCOPE, isScopeAddress } from "../../services/session-scope.js";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c as { text: string }).text : "")).join("\n");
+
+const jsonOf = (res: ToolResult): Record<string, unknown> => {
+  try {
+    return JSON.parse(textOf(res)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+/** The exact sentence that asserts the graph target moved. */
+const GRAPH_TARGET_CLAIM = "Graph tools will target that workflow";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** Same shape as ui-bridge.test.ts's harness: retry past the close/rebind race so
+ *  a bind flake is never reported as a feature failure. */
+async function startBridgeOnFreePort(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close/rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+const SCOPE = `${SHARED_SESSION_SCOPE}::claude`;
+
+interface Wf {
+  path: string;
+  filename: string;
+  key: string;
+  routing_key: string;
+  uuid: string;
+  outline: string;
+}
+
+/** The workflow the turn was issued from — an UNSAVED tab, as in the report. */
+const A: Wf = {
+  path: "workflows/wan_video_edit.json",
+  filename: "wan_video_edit",
+  key: "wan_video_edit.json",
+  routing_key: "wf:workflows/wan_video_edit.json",
+  uuid: "aaaaaaaa-1111-4111-8111-111111111111",
+  outline: '1 Wan2VideoEditApi "edit"',
+};
+/** The workflow the agent asks to pin. */
+const B: Wf = {
+  path: "workflows/api_seedance2_5_video_extend.json",
+  filename: "api_seedance2_5_video_extend",
+  key: "api_seedance2_5_video_extend.json",
+  routing_key: "wf:workflows/api_seedance2_5_video_extend.json",
+  uuid: "bbbbbbbb-2222-4222-8222-222222222222",
+  outline: '1 SeedanceVideoExtendApi "extend"',
+};
+
+/** How this panel answers `workflow_list`. */
+type ListShape =
+  | "full" // current panel: enumerable tabs + a top-level active record
+  | "active-only" // no `workflows` array, but the active canvas IS reported
+  | "opaque"; // neither — nothing about the live canvas can be established
+
+let bridge: UiBridge;
+let port: number;
+const sockets: WebSocket[] = [];
+
+/** A scripted panel page. Records every command frame it receives so the test can
+ *  assert on what was ROUTED, not only on what the tool said. */
+class FakePanel {
+  sock!: WebSocket;
+  readonly seen: Array<{ cmd: string; workflow_path?: string }> = [];
+
+  constructor(
+    public tabId: string,
+    public open: Wf[],
+    public activeIdx: number,
+    public listShape: ListShape = "full",
+  ) {}
+
+  get active(): Wf {
+    return this.open[this.activeIdx];
+  }
+
+  async connect(): Promise<void> {
+    this.sock = await new Promise<WebSocket>((resolve, reject) => {
+      const s = new WebSocket(`ws://127.0.0.1:${port}`);
+      sockets.push(s);
+      s.on("open", () => resolve(s));
+      s.on("error", reject);
+    });
+    this.hello(this.tabId);
+    this.sock.on("message", (buf) => this.onMessage(buf.toString()));
+    await settle();
+  }
+
+  hello(tabId: string): void {
+    this.tabId = tabId;
+    this.sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: tabId,
+        title: this.active.filename,
+        backend: "claude",
+        workflow_uuid: this.active.uuid,
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+  }
+
+  private record(w: Wf, i: number): Record<string, unknown> {
+    return {
+      path: w.path,
+      filename: w.filename,
+      title: w.filename,
+      key: w.key,
+      routing_key: w.routing_key,
+      active: i === this.activeIdx,
+      modified: false,
+      persisted: true,
+    };
+  }
+
+  private onMessage(raw: string): void {
+    const msg = JSON.parse(raw) as Record<string, unknown>;
+    const cmd = msg.cmd as string | undefined;
+    const rid = msg.rid as string | undefined;
+    if (!cmd || !rid) return;
+    this.seen.push({
+      cmd,
+      workflow_path: typeof msg.workflow_path === "string" ? msg.workflow_path : undefined,
+    });
+    const reply = (result: unknown): void =>
+      this.sock.send(JSON.stringify({ rid, ok: true, result, workflow_uuid: this.active.uuid }));
+    const refuse = (error: string): void =>
+      this.sock.send(JSON.stringify({ rid, ok: false, error }));
+
+    // The panel's shipped PINNED-TARGET GUARD (#349/#186): a `workflow_path` that
+    // is not the active canvas is refused rather than executed. Modelled here so
+    // the cost of a wrong pin shows up in the test the way it shows up for a user.
+    const pinned = msg.workflow_path;
+    const targetless = cmd === "workflow_list" || cmd === "workflow_open" || cmd === "workflow_new";
+    if (typeof pinned === "string" && pinned.trim() && !targetless) {
+      const forms = [this.active.path, this.active.key, this.active.filename, this.active.routing_key];
+      if (!forms.includes(pinned)) {
+        refuse(
+          `workflow mismatch: your session is pinned to "${pinned}", but that is not the active ` +
+            `canvas ("${this.active.path}").`,
+        );
+        return;
+      }
+    }
+
+    switch (cmd) {
+      case "workflow_list": {
+        if (this.listShape === "opaque") {
+          reply({});
+          return;
+        }
+        const activeObj = {
+          path: this.active.path,
+          filename: this.active.filename,
+          title: this.active.filename,
+          key: this.active.key,
+          routing_key: this.active.routing_key,
+          workflow_uuid: this.active.uuid,
+        };
+        if (this.listShape === "active-only") {
+          reply({ active: activeObj });
+          return;
+        }
+        reply({
+          active: activeObj,
+          open: this.open.map((w, i) => this.record(w, i)),
+          workflows: this.open.map((w, i) => this.record(w, i)),
+          active_confirmed: true,
+          backend_socket: "up",
+          mutations_ready: true,
+          canvas_binding: "bound",
+          graph_binding: "bound",
+        });
+        return;
+      }
+      case "workflow_open": {
+        const want = String(msg.path ?? "");
+        const idx = this.open.findIndex(
+          (w) => w.path === want || w.key === want || w.filename === want,
+        );
+        if (idx < 0) {
+          refuse(`not open: ${want}`);
+          return;
+        }
+        this.activeIdx = idx;
+        reply({
+          ok: true,
+          path: this.active.path,
+          filename: this.active.filename,
+          key: this.active.key,
+          routing_key: this.active.routing_key,
+          active_routing_key: this.active.routing_key,
+          active_matches_target: true,
+          workflow_uuid: this.active.uuid,
+          active: true,
+        });
+        // A real panel re-helloes under the NEW workflow's route id on the SAME
+        // socket when the active workflow changes (per-workflow routes, #640).
+        setTimeout(() => this.hello(`wf:r1:${this.active.path}`), 5);
+        return;
+      }
+      case "graph_outline":
+        reply({ outline: this.active.outline, node_count: 1, detail_level: "full" });
+        return;
+      default:
+        reply({ ok: true });
+    }
+  }
+}
+
+async function settle(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 12));
+}
+
+let tracker: TurnOriginTracker;
+let workflowTargets: WorkflowTargetStore;
+const tabStamp = new Map<string, string>();
+
+beforeEach(async () => {
+  ({ bridge, port } = await startBridgeOnFreePort());
+  tabStamp.clear();
+  workflowTargets = new WorkflowTargetStore();
+  // EXACTLY what orchestrator/index.ts installs, so the scope address resolves
+  // through the production turn-origin pin rather than a test stand-in.
+  const scopeAgentKeyOf = (scopeId: string): string =>
+    scopeId === SHARED_SESSION_SCOPE ? `${SHARED_SESSION_SCOPE}::claude` : scopeId;
+  const backendForTab = (): string => "claude";
+  const backendOfKey = (key: string): string => key.split("::")[1] ?? "claude";
+  tracker = new TurnOriginTracker({
+    backendForTab,
+    backendOfKey,
+    uuidOfTab: (t) => tabStamp.get(t),
+    liveTabOf: (t) => {
+      try {
+        return bridge.canReach(t) ? t : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    warn: () => {},
+  });
+  bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker, scopeAgentKeyOf }));
+  bridge.setScopeRepinHandler(
+    makeScopeRepinHandler({
+      bridge,
+      tracker,
+      scopeAgentKeyOf,
+      backendForTab,
+      backendOfKey,
+      info: () => {},
+    }),
+  );
+  bridge.setHelloBackendNormalizer(() => "claude");
+  bridge.setTabWorkflowUuidResolver(
+    (tabId) =>
+      isScopeAddress(tabId) ? tracker.stampOf(scopeAgentKeyOf(tabId)) : tabStamp.get(tabId),
+    (tabId, workflowUuid) => {
+      if (typeof workflowUuid !== "string" || !workflowUuid)
+        return { ok: false, reason: "no uuid" };
+      const real = isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : tabId;
+      if (!real) return { ok: false, reason: "no panel tab" };
+      tabStamp.set(real, workflowUuid);
+      if (isScopeAddress(tabId)) tracker.setStamp(scopeAgentKeyOf(tabId), workflowUuid);
+      return true;
+    },
+  );
+});
+
+afterEach(async () => {
+  for (const s of sockets.splice(0)) s.close();
+  await bridge.stop();
+});
+
+const tool = (name: string) => buildPanelToolDefs().find((d) => d.name === name)!;
+
+/** The real ctx, with only the default command deadline shortened. */
+function ctxFor(tabId: string): PanelToolCtx {
+  const real = makePanelToolCtx(bridge, tabId, workflowTargets);
+  const c = Object.create(real) as PanelToolCtx;
+  c.call = (cmd, t, onRid) => real.call(cmd, t ?? 800, onRid);
+  return c;
+}
+
+const pin = (ctx: PanelToolCtx, w: Wf): Promise<ToolResult> =>
+  tool("panel_set_workflow_target").handler(
+    { mode: "pinned", path: w.path, filename: w.filename },
+    ctx,
+  );
+
+describe("panel#1529 — a pin may not claim a graph target it did not establish", () => {
+  it("REFUSES a pin the panel reports is not the live canvas, even with no enumerable tab list", async () => {
+    // The reporter's shape: the turn is routed to the tab showing A, and the panel
+    // answers workflow_list WITHOUT an enumerable `workflows` array — which used to
+    // discard its perfectly readable top-level `active` record and make the pin
+    // "indeterminate", i.e. accepted unverified.
+    const page = new FakePanel("tmp:2fb3aaaa-1111-4111-8111-111111111111", [A], 0, "active-only");
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const res = await pin(ctx, B);
+
+    expect(res.isError, `pin should have been refused, got: ${textOf(res)}`).toBe(true);
+    // It says what it OBSERVED — the live canvas — and never that the target "is
+    // open", which this evidence cannot support.
+    expect(textOf(res)).toContain(A.filename);
+    expect(textOf(res)).not.toContain(GRAPH_TARGET_CLAIM);
+    // And nothing was written: a refused pin must not leave the store aimed at a
+    // workflow the next graph command cannot reach.
+    expect(workflowTargets.get(SCOPE)).toEqual({ mode: "current" });
+
+    // The consequence the reporter actually felt: with the bad pin written, the
+    // next graph read carried it and was refused by the panel's own guard. Now the
+    // read carries no pin at all and returns the canvas that is genuinely live.
+    await settle();
+    const outline = await tool("panel_graph_outline").handler({}, ctx);
+    expect(outline.isError).toBeFalsy();
+    expect(textOf(outline)).toContain("Wan2VideoEditApi");
+    expect(page.seen.filter((f) => f.cmd === "graph_outline")[0]?.workflow_path).toBeUndefined();
+  });
+
+  it("does NOT claim the graph target for a pin it could not verify", async () => {
+    // A panel that establishes nothing about its live canvas. The pin is still
+    // WRITTEN — older/partial panels must keep working, and that leniency is
+    // deliberate — but the reply may not turn it into a routing promise.
+    const page = new FakePanel("tmp:2fb3aaaa-1111-4111-8111-111111111111", [A], 0, "opaque");
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const res = await pin(ctx, B);
+
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.mode).toBe("pinned");
+    // The machine-readable verdict, so a caller never has to parse the prose.
+    expect(body.pin_verified_active).toBe(false);
+    const note = String(body.note ?? "");
+    expect(note).not.toContain(GRAPH_TARGET_CLAIM);
+    expect(note).toContain("NOT CONFIRMED");
+    // …and it hands back the cheap read that settles it, rather than leaving the
+    // caller to believe the routing question was answered.
+    expect(note).toContain("panel_graph_outline");
+  });
+
+  it("still makes the claim — and delivers it — when the pin IS verified active", async () => {
+    // The healthy path this must not over-refuse: the agent opens B, the panel
+    // re-helloes under B's route on the same socket, the turn pin follows through
+    // the migration alias, and graph commands really do reach B. The turn routing
+    // is deliberately NOT re-pinned here (a live pin is never displaced), so this
+    // is the same two-selector state as the report — with the selectors agreeing.
+    const page = new FakePanel("tmp:2fb3aaaa-1111-4111-8111-111111111111", [A, B], 0, "full");
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const opened = await tool("panel_open_workflow").handler({ path: B.path }, ctx);
+    expect(opened.isError).toBeFalsy();
+    await settle();
+
+    const res = await pin(ctx, B);
+    expect(res.isError, textOf(res)).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.pin_verified_active).toBe(true);
+    expect(String(body.note ?? "")).toContain(GRAPH_TARGET_CLAIM);
+
+    await settle();
+    const outline = await tool("panel_graph_outline").handler({}, ctx);
+    expect(outline.isError, textOf(outline)).toBeFalsy();
+    expect(textOf(outline)).toContain("SeedanceVideoExtendApi");
+  });
+});

--- a/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
+++ b/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
@@ -403,6 +403,32 @@ describe("panel#1529 — a pin may not claim a graph target it did not establish
     expect(note).toContain("panel_graph_outline");
   });
 
+  it("a BARE KEY token is not refused on this evidence — the boundary, on purpose", async () => {
+    // Where the refusal above STOPS, measured rather than assumed. The oracle needs a
+    // canonical saved identity on our side, and a bare basename/key is deliberately not
+    // one: it is an alias selector that can name two files in different directories.
+    // Widening it is not free — a `tmp:` routing token would then read as "different"
+    // from any named active tab and start refusing valid pins to unsaved workflows.
+    //
+    // So on a key-shaped token the pin is still accepted leniently — and the SECOND
+    // half of the fix is what protects the caller there: no routing claim is made.
+    const page = new FakePanel("tmp:2fb3aaaa-1111-4111-8111-111111111111", [A], 0, "active-only");
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const res = await tool("panel_set_workflow_target").handler(
+      { mode: "pinned", path: B.key, filename: B.filename },
+      ctx,
+    );
+
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.pin_verified_active).toBe(false);
+    expect(String(body.note ?? "")).not.toContain(GRAPH_TARGET_CLAIM);
+  });
+
   it("still makes the claim — and delivers it — when the pin IS verified active", async () => {
     // The healthy path this must not over-refuse: the agent opens B, the panel
     // re-helloes under B's route on the same socket, the turn pin follows through

--- a/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
+++ b/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
@@ -108,7 +108,8 @@ const B: Wf = {
 type ListShape =
   | "full" // current panel: enumerable tabs + a top-level active record
   | "active-only" // no `workflows` array, but the active canvas IS reported
-  | "opaque"; // neither — nothing about the live canvas can be established
+  | "opaque" // neither — nothing about the live canvas can be established
+  | "errors"; // the probe itself fails: no evidence of any kind comes back
 
 let bridge: UiBridge;
 let port: number;
@@ -203,6 +204,10 @@ class FakePanel {
 
     switch (cmd) {
       case "workflow_list": {
+        if (this.listShape === "errors") {
+          refuse("workflow_list failed on this tab");
+          return;
+        }
         if (this.listShape === "opaque") {
           reply({});
           return;
@@ -401,6 +406,28 @@ describe("panel#1529 — a pin may not claim a graph target it did not establish
     // …and it hands back the cheap read that settles it, rather than leaving the
     // caller to believe the routing question was answered.
     expect(note).toContain("panel_graph_outline");
+  });
+
+  it("makes no claim when the verifying probe itself FAILED", async () => {
+    // The route that reaches a CURRENT panel. `workflows` has been emitted since
+    // panel 0.11.20, so a modern build is never the "no enumerable list" shape — but
+    // `resolveOpenWorkflow` also returns indeterminate whenever the `workflow_list`
+    // probe does not come back at all (a transient reconnect, a busy canvas past the
+    // 6 s budget). There is no evidence to refuse on there, and inventing one would
+    // fail healthy pins — so the pin is written and the REPORT is what changes.
+    const page = new FakePanel("tmp:2fb3aaaa-1111-4111-8111-111111111111", [A], 0, "errors");
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const res = await pin(ctx, B);
+
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.pin_verified_active).toBe(false);
+    expect(String(body.note ?? "")).not.toContain(GRAPH_TARGET_CLAIM);
+    expect(String(body.note ?? "")).toContain("NOT CONFIRMED");
   });
 
   it("a BARE KEY token is not refused on this evidence — the boundary, on purpose", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14506,7 +14506,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           target.mode === "pinned"
             ? pinVerifiedActive
               ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
-              : `Pinned to "${target.filename ?? target.path}" — but NOT CONFIRMED: this panel did not report which workflow is the active canvas, so the pin could not be checked against it, and this call does NOT establish that graph tools will reach that workflow. The pin travels on graph commands as a GUARD: if the active canvas is a different workflow, the next graph call FAILS with a workflow mismatch rather than editing it. Settle it with one cheap read — panel_graph_outline — before relying on this.`
+              // The CAUSE is deliberately not named. `verifiedActive:false` covers a
+              // workflow_list that never answered, one that answered without an
+              // enumerable tab list, and one whose records share no comparable
+              // identity with the active canvas. Picking one of those to print would
+              // be a confident wrong diagnosis; what is true in all three is that the
+              // check did not happen.
+              : `Pinned to "${target.filename ?? target.path}" — but NOT CONFIRMED: the live canvas could not be read back to check this pin against it, so this call does NOT establish that graph tools will reach that workflow. The pin travels on graph commands as a GUARD: if the active canvas is a different workflow, the next graph call FAILS with a workflow mismatch rather than editing it. Settle it with one cheap read — panel_graph_outline — before relying on this.`
             : "Following the user's current workflow tab.";
         // #803 — this used to END here for every mode:"current" call, with the
         // unconditional "Following the user's current workflow tab." Reporters followed

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7186,13 +7186,24 @@ interface ResolvedOpenWorkflow {
  *    array (indeterminate — caller should fall back to the raw path, NOT fail);
  *  - the sentinel `NOT_OPEN` when the list IS known but the target is absent, so
  *    the caller can FAIL CLOSED instead of letting the panel silently route the
- *    pin to some other open tab.
+ *    pin to some other open tab;
+ *  - `{targetNotActive}` (panel#1529) when the tab list is NOT enumerable but the
+ *    panel's own top-level `active` record POSITIVELY names a different workflow.
+ *    "Which tabs exist" is unknown there, but "the target is not the live canvas"
+ *    is known — and that alone is enough to refuse, because a pin that is not the
+ *    active canvas can never be what graph tools reach.
  */
 const NOT_OPEN = Symbol("workflow-not-open");
+/** panel#1529 — the target is positively NOT the active canvas, established from
+ *  the top-level `active` record alone (no enumerable tab list to say more). */
+interface TargetNotActive {
+  targetNotActive: true;
+  activeLabel?: string;
+}
 async function resolveOpenWorkflow(
   ctx: PanelToolCtx,
   path: string,
-): Promise<ResolvedOpenWorkflow | null | typeof NOT_OPEN> {
+): Promise<ResolvedOpenWorkflow | TargetNotActive | null | typeof NOT_OPEN> {
   let parsed: Record<string, unknown> | null = null;
   try {
     parsed = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
@@ -7202,7 +7213,36 @@ async function resolveOpenWorkflow(
   if (!parsed) return null;
   const rawList = (parsed as { workflows?: unknown }).workflows;
   if (!Array.isArray(rawList) || rawList.length === 0) {
-    // No enumerable tab list (older panel / stub) — can't verify, don't fail closed.
+    // No enumerable tab list (older panel / stub) — can't verify WHICH tabs exist.
+    //
+    // panel#1529 — but the reply's TOP-LEVEL `active` record is a separate,
+    // direct report of the live canvas, and "is the target the active canvas?"
+    // is the ONE question a pin has to answer (the panel edits the in-view
+    // workflow and nothing else — #349/#186). Discarding it because a DIFFERENT
+    // field was missing turned a readable POSITIVE mismatch into "indeterminate",
+    // and indeterminate is LENIENT: the pin was accepted unverified against a tab
+    // showing another workflow, panel_set_workflow_target then reported "Graph
+    // tools will target that workflow", and the very next graph command was
+    // refused by the panel's pin guard (or, on a build whose guard does not fire
+    // for that pin form, silently read the OTHER canvas) — the reported
+    // "pin reports success but graph tools stay on the previous tab".
+    //
+    // Only a POSITIVE identification refuses. `readOpenActiveAgainstTarget` is the
+    // #887 oracle already used for the post-open drift notice, and it is generous
+    // in exactly the direction that matters here: an active record it cannot read,
+    // or one that plausibly IS the requested workflow, stays "indeterminate" and
+    // keeps today's lenient behaviour. An older panel that reports no usable
+    // active identity is therefore untouched.
+    const activeOnly = (parsed as { active?: unknown }).active;
+    if (
+      readOpenActiveAgainstTarget(
+        activeOnly,
+        path,
+        (parsed as { active_confirmed?: unknown }).active_confirmed,
+      ) === "different"
+    ) {
+      return { targetNotActive: true, activeLabel: workflowRecordLabel(activeOnly) };
+    }
     return null;
   }
   const activeObj = (parsed as { active?: unknown }).active;
@@ -7502,9 +7542,22 @@ function workflowRecordLabel(rec: unknown): string | undefined {
   return undefined;
 }
 
-/** Outcome of validating + canonicalizing a pin target. */
+/** Outcome of validating + canonicalizing a pin target.
+ *
+ *  `verifiedActive` (panel#1529) says whether the panel POSITIVELY confirmed the
+ *  target is the live canvas. It is false on every LENIENT acceptance — an
+ *  unreachable/unparseable `workflow_list`, a panel that enumerates no tabs, a
+ *  record with no comparable active identity. Those pins are still written (older
+ *  panels must keep working), but the caller must not report them as a settled
+ *  graph target: that unearned claim is the whole of #1529. */
 export type PinTargetResolution =
-  | { ok: true; pinPath: string; pinFilename?: string; workflowUuid?: string }
+  | {
+      ok: true;
+      pinPath: string;
+      pinFilename?: string;
+      workflowUuid?: string;
+      verifiedActive: boolean;
+    }
   | { ok: false; error: string };
 
 /**
@@ -7535,7 +7588,26 @@ export async function resolvePinTarget(
         `never land on the wrong tab.)`,
     };
   }
-  if (resolved && resolved.isActive === false) {
+  // panel#1529 — the tab list was not enumerable, so we cannot say whether the
+  // target is OPEN; the panel's own active record says it is not the LIVE CANVAS,
+  // and that is the fact a pin turns on. Refuse with exactly what was observed —
+  // never "it is open but not active", which this branch has no evidence for.
+  if (resolved && "targetNotActive" in resolved) {
+    const activeName = resolved.activeLabel ? ` — "${resolved.activeLabel}" is` : " — a different workflow is";
+    return {
+      ok: false,
+      error:
+        `Cannot pin to "${filename ?? path}"${activeName} the active canvas right now. ` +
+        `Graph tools run against the ACTIVE canvas (the panel cannot read or edit a background ` +
+        `tab), so this pin could not make graph tools target that workflow — it would report ` +
+        `success and then fail, or read the other canvas, on your next panel_* graph call. ` +
+        `Switch to it first with panel_open_workflow (that makes it the active canvas), then ` +
+        `pin — or pin the workflow already in view. (This panel build did not enumerate its ` +
+        `open tabs, so whether your target is open at all could not be checked; ` +
+        `panel_list_workflows shows what it does report.)`,
+    };
+  }
+  if (resolved && "isActive" in resolved && resolved.isActive === false) {
     const activeName = resolved.activeLabel ? ` (currently "${resolved.activeLabel}")` : "";
     return {
       ok: false,
@@ -7566,10 +7638,15 @@ export async function resolvePinTarget(
       pinPath: rec.key ?? rec.path ?? path,
       pinFilename: filename ?? rec.filename ?? rec.path,
       workflowUuid,
+      // panel#1529 — VERIFIED only on a positive `true`. `undefined` is the
+      // indeterminate rung (no per-record flag AND nothing comparable), which is
+      // accepted leniently and must not be reported as a confirmed graph target.
+      verifiedActive: resolved.isActive === true,
     };
   }
-  // Indeterminate list — stay lenient (older/partial panel).
-  return { ok: true, pinPath: path, pinFilename: filename };
+  // Indeterminate list — stay lenient (older/partial panel), but say so: nothing
+  // here established that the target is the canvas graph tools will reach.
+  return { ok: true, pinPath: path, pinFilename: filename, verifiedActive: false };
 }
 
 export const __openWorkflowTestHooks = {
@@ -14277,12 +14354,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         let pinPath = path;
         let pinFilename = filename;
         let pinnedWorkflowUuid: string | undefined;
+        // panel#1529 — did the panel POSITIVELY confirm the target is the live
+        // canvas? A lenient (indeterminate) acceptance still writes the pin, but
+        // it establishes nothing about where graph tools land, so it may not be
+        // narrated as one. Defaults to false: an unpinned/`current` call makes no
+        // graph-target claim either.
+        let pinVerifiedActive = false;
         if (mode === "pinned" && path) {
           const res = await resolvePinTarget(ctx, path, filename);
           if (!res.ok) return fail(res.error);
           pinPath = res.pinPath;
           pinFilename = res.pinFilename;
           pinnedWorkflowUuid = res.workflowUuid;
+          pinVerifiedActive = res.verifiedActive;
         }
         const target = ctx.workflowTarget.set(ctx.tabId, {
           mode,
@@ -14407,9 +14491,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             rebindNote += ` The panel dropped mid-call: this session moved from tab ${tabBeforeProbe} onto tab ${ctx.tabId}, and mode:"current" was applied there too.`;
           }
         }
+        // panel#1529 — "Graph tools will target that workflow" is a CLAIM ABOUT
+        // ROUTING, and this call only ever wrote the workflow-target store. It is
+        // true when the panel confirmed the target IS the live canvas, because a
+        // graph command then reaches it. It was being said unconditionally — including
+        // on the lenient rung, where nothing about the active canvas was established —
+        // and the reporter's session was pinned to one workflow while every graph call
+        // kept landing on the tab the turn-routing pin still names. Two selectors, one
+        // sentence, no way for the caller to tell they disagreed. So the claim is now
+        // made only on the evidence that supports it; without that evidence the reply
+        // says what IS true (the pin is set and acts as a GUARD) and hands back the
+        // cheap read that settles it.
         const hint =
           target.mode === "pinned"
-            ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
+            ? pinVerifiedActive
+              ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
+              : `Pinned to "${target.filename ?? target.path}" — but NOT CONFIRMED: this panel did not report which workflow is the active canvas, so the pin could not be checked against it, and this call does NOT establish that graph tools will reach that workflow. The pin travels on graph commands as a GUARD: if the active canvas is a different workflow, the next graph call FAILS with a workflow mismatch rather than editing it. Settle it with one cheap read — panel_graph_outline — before relying on this.`
             : "Following the user's current workflow tab.";
         // #803 — this used to END here for every mode:"current" call, with the
         // unconditional "Following the user's current workflow tab." Reporters followed
@@ -14658,6 +14755,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         return ok({
           ...target,
           ...(deferredBind ? { deferred: true } : {}),
+          // panel#1529 — the same verdict the note carries, MACHINE-READABLE, so a
+          // caller never has to parse prose to learn whether the graph target was
+          // actually established. Only for a pin: `current` makes no such claim.
+          ...(target.mode === "pinned" ? { pin_verified_active: pinVerifiedActive } : {}),
           ...(fence ? { graph_binding: fence.binding } : {}),
           ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
           ...(typeof scopeRepin === "string" || currentModeTurnRepinned


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1529 — "Workflow pin reports success but graph tools stay on previous tab" (severity:P2, via-panel).

> **Corrected below.** The "no enumerable `workflows` array" rung described here reproduces the reported reply on clean `origin/main`, but it is a **pre-0.11.20 panel shape** and therefore NOT the reporter’s 0.13.6 build. The rung that reaches a current panel is a `workflow_list` probe that does not come back, which the report-honesty half of this fix covers and the hard-refusal half does not. See the correction comment for the full accounting — read it before this body.

**Review is PENDING.** This has NOT been through an independent review; a request for grok naming the risky parts is posted below. Do not read the evidence here as a verdict.

## The report

`panel_open_workflow` said workflow B was active (`active_matches_target:true`). `panel_set_workflow_target({mode:"pinned"})` then answered

> Pinned to "api_seedance2_5_video_extend". **Graph tools will target that workflow** without switching the user's view. NOTE — the workflow target was set, but this session's turn routing was NOT re-pinned: the existing pin (tmp:2fb3) still reaches a live tab of this conversation…

and the very next `panel_graph_outline` returned the *other* workflow's nodes. Two selectors — the workflow-target store and the turn-routing pin — disagreed, and the reply read as a success either way.

## Mechanism, established by execution (not by reading)

I stood up a harness with the **real** `UiBridge` on a real socket, the **real** `TurnOriginTracker` + `makeScopeTargetResolver` / `makeScopeRepinHandler` (wired exactly as `orchestrator/index.ts` wires them), the **real** `WorkflowTargetStore` and the **real** panel tool defs, driven against scripted panel sockets, and ran the reporter's three calls against **clean `origin/main`**. Recorded off the wire:

- **Healthy control** — one page, A active, `panel_open_workflow(B)` switches it and the panel re-helloes under B's route on the same socket. The turn pin follows through the migration alias, `graph_outline` is dispatched to that tab carrying `workflow_path=B`, and B's outline comes back. Correct, and it stays correct.
- **The reported state** — the turn pin routes to the tab showing A, and the panel answers `workflow_list` **without** an enumerable `workflows` array. On `origin/main` this printed, verbatim:

  ```
  "note": "Pinned to \"api_seedance2_5_video_extend\". Graph tools will target that workflow
   without switching the user's view. NOTE — … this session's turn routing was NOT re-pinned:
   the existing pin (tmp:2fb3) still reaches a live tab of this conversation …"
  ```

  …and the next `graph_outline` went to the tab showing A carrying `workflow_path=<B>`, which the panel's shipped pin guard (#349/#186) refuses — or, on a build whose guard does not fire for that pin form, silently answers with A's canvas. That is the reporter's sentence.

The enabling defect is in `resolveOpenWorkflow`. It returns `null` — *indeterminate*, which `resolvePinTarget` treats as **lenient, pin anyway** — the moment the reply carries no `workflows` array:

```ts
const rawList = (parsed as { workflows?: unknown }).workflows;
if (!Array.isArray(rawList) || rawList.length === 0) {
  return null;                       // ← the top-level `active` record, never read
}
const activeObj = (parsed as { active?: unknown }).active;
```

"Which tabs are open" really is unknown there. But the reply's **top-level `active` record was sitting right behind that early return**, and it answers the only question a pin turns on: the panel reads and edits the in-view workflow and nothing else, so if the target is not the live canvas the pin cannot make graph tools reach it. Discarding a readable *positive mismatch* because a *different* field was missing is what turned a refusable pin into a silent unverified one. (A well-formed list refuses correctly today — that control is in the suite.)

Then, one layer up, the routing claim was unconditional:

```ts
const hint = target.mode === "pinned"
  ? `Pinned to "…". Graph tools will target that workflow without switching the user's view.`
  : "Following the user's current workflow tab.";
```

so a pin that established nothing about the active canvas still announced that graph tools would reach it, in the same breath as saying the routing pin had been left alone.

## The change (2 files)

1. **`resolveOpenWorkflow`** — when the tab list is not enumerable, read the top-level `active` record through `readOpenActiveAgainstTarget` (the #887 oracle already used for the post-open drift notice) and refuse on `"different"` only. It is generous in the direction that matters: an unreadable active record, or one that plausibly *is* the requested workflow, stays `"indeterminate"` and keeps today's lenient behaviour, so an older panel that reports no usable active identity is untouched. The refusal is a new `{targetNotActive}` outcome with its own message, because this branch has no evidence the target is *open* and must not say "it is open but not active".
2. **`resolvePinTarget` → the tool** — the resolution now carries `verifiedActive`, and `panel_set_workflow_target` makes the routing claim only when the panel positively confirmed the target is the live canvas. Unverified pins are still **written** (leniency is deliberate) but the reply says so, says the pin travels as a GUARD, and names the one cheap read that settles it — plus a machine-readable `pin_verified_active`, so nobody has to parse prose to learn whether the graph target was established.

## Evidence

Three named tests in `src/__tests__/orchestrator/pin-vs-graph-target.test.ts`, all end-to-end over a real bridge and all asserting on the reply an agent actually receives. Each mutation below was applied and measured; each killed **exactly one** test:

| mutation | test that went red |
| --- | --- |
| restore the pre-fix `return null` (drop the active-record branch) | `REFUSES a pin the panel reports is not the live canvas, even with no enumerable tab list` — *expected undefined to be true* |
| **delete the CALL SITE line** `pinVerifiedActive = res.verifiedActive;` | `still makes the claim — and delivers it — when the pin IS verified active` |
| force the verdict to always-verified in `resolvePinTarget` | `does NOT claim the graph target for a pin it could not verify` |

The middle row is the point of running this end-to-end: the join between the verdict and the claim is a single assignment, and a helper-level test survives its deletion. These assert on the tool's own reply text and fields, so they do not.

Suite: `10961 passed`, `4 failed | 2 files` — `scripts/package-hooks.test.ts` (`files` allowlist, needs a built `dist/`) and `orchestrator/node-id-union-message.test.ts` (#1889). Both were measured **failing identically on a clean `origin/main` worktree** before blaming this branch. Typecheck clean (probe-verified: a deliberate type error was injected and caught, so the check is real).

## What I deliberately did NOT do

- **No panel-repo change.** The panel behaved correctly throughout: it refuses a `workflow_path` that is not the active canvas. The false claim was entirely orchestrator-side, so `comfyui-mcp-panel` is untouched and its Playwright suite cannot exercise this path (its specs run against a MockBridge, which replaces the orchestrator). The suite was run anyway for the record; result reported in a comment.
- **Did not make sessions workflow- or tab-scoped.** Sessions are orchestrator-scoped by design; the disagreement is fixed by refusing to claim what was not established, never by re-scoping the session.
- **Did not displace the live turn-routing pin.** The #884 P0 stands: a pin that still reaches a live tab of this conversation is never taken away by a `mode:"pinned"` call, however explicit. This PR does not touch `makeScopeRepinHandler`.
- **Did not make every unverified pin an error.** Refusing on absence of evidence would newly fail legitimate pins on panels that report no active identity at all. The refusal fires only on a *positive* mismatch; the no-evidence case is disclosed, not failed. That line is the judgement call most worth a reviewer's attention.
- **Did not run `codex-gate.mjs`** and did not spawn codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
