### PR TITLE
fix(1909): panel_restart_comfyui accounts for a loopback instance on a non-default port

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -438,5 +438,78 @@ describe("getLocalComfyuiUrl (#269 LAN fallback)", () => {
     expect(seen[0].url).toBe("http://192.168.1.50:8188");
     expect(seen[0].generation).toBe(g0 + 1);
     expect(seen[0].generation).toBe(mod.getComfyuiTargetGeneration());
+  });
+});
+
+describe("rescopeLocalTargetFile (#1909 non-default loopback port)", () => {
+  let fakeHome: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    fakeHome = mkdtempSync(join(tmpdir(), "config-home-"));
+    process.env.COMFYUI_MCP_LOCAL_TARGET_FILE = join(fakeHome, "local-target.json");
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_CODE_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_PORT = "8188";
+    process.env.COMFYUI_MCP_FORCE_REMOTE = "";
+    process.env.COMFYUI_URL = "";
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+  });
+
+  function writtenUrl(path: string): unknown {
+    return (JSON.parse(readFileSync(path, "utf-8")) as { url?: unknown }).url;
+  }
+
+  it("records a loopback COMFYUI_URL assigned after config init, not the :8188 default", async () => {
+    // Production order: config.ts is imported first (boot.ts static import),
+    // then boot.ts assigns COMFYUI_URL from `connect` / --comfyui-url, then
+    // the orchestrator calls rescopeLocalTargetFile. The default-seeded
+    // lastNonPodTarget must not win over the live configured origin.
+    const mod = await import("../config.js");
+    const configured = "http://127.0.0.1:18188";
+    process.env.COMFYUI_URL = configured;
+    const scoped = join(fakeHome, "local-target-9180.json");
+    mod.rescopeLocalTargetFile(scoped);
+    expect(writtenUrl(scoped)).toBe(configured);
+    expect(mod.getLocalComfyuiUrl()).toBe(configured);
+    // Restart identity reads these — they must name the configured instance
+    // or panel_restart_comfyui still refuses a panel that is on that port.
+    expect(mod.getBootLocalComfyUIBaseUrl()).toBe(configured);
+    expect(mod.getComfyUIBaseUrl()).toBe(configured);
+  });
+
+  it("overwrites a stale scoped file that still says :8188", async () => {
+    const configured = "http://127.0.0.1:18188";
+    const scoped = join(fakeHome, "local-target-9180.json");
+    writeFileSync(scoped, JSON.stringify({ url: "http://127.0.0.1:8188" }));
+    const mod = await import("../config.js");
+    process.env.COMFYUI_URL = configured;
+    mod.rescopeLocalTargetFile(scoped);
+    expect(writtenUrl(scoped)).toBe(configured);
+  });
+
+  it("records the configured URL when it is already set at import", async () => {
+    const configured = "http://127.0.0.1:18188";
+    process.env.COMFYUI_URL = configured;
+    const mod = await import("../config.js");
+    const scoped = join(fakeHome, "local-target-9180.json");
+    mod.rescopeLocalTargetFile(scoped);
+    expect(writtenUrl(scoped)).toBe(configured);
+    expect(mod.getBootLocalComfyUIBaseUrl()).toBe(configured);
+  });
+
+  it("keeps :8188 when that is the configured loopback URL", async () => {
+    const configured = "http://127.0.0.1:8188";
+    process.env.COMFYUI_URL = configured;
+    const mod = await import("../config.js");
+    const scoped = join(fakeHome, "local-target-9180.json");
+    mod.rescopeLocalTargetFile(scoped);
+    expect(writtenUrl(scoped)).toBe(configured);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -775,6 +775,29 @@ export function getBootLocalComfyUIBaseUrl(): string | null {
   return `${bootComfyui.ssl ? "https" : "http"}://${bootComfyui.host}:${bootComfyui.port}${bootComfyui.basePath}`;
 }
 
+/** #1909: COMFYUI_URL / --comfyui-url may be assigned after this module's init
+ *  (boot.ts `connect` writes it after the static import). Re-read so a loopback
+ *  host on a non-default port is persisted as that origin, not :8188. This is
+ *  still process-start — rescope runs once before hellos, and setComfyuiTarget
+ *  still cannot mutate bootComfyui. */
+function adoptLiveConfiguredLocalTarget(): void {
+  const live = resolveUrlOverride();
+  if (!live || !isLocalOrLanHost(live.host) || !(live.port > 0)) return;
+  const liveUrl = `${live.ssl ? "https" : "http"}://${live.host}:${live.port}${live.basePath}`;
+  lastNonPodTarget = liveUrl;
+  if (!isLoopbackHost(live.host)) return;
+  // The configured loopback origin IS the process-start local instance.
+  bootComfyui.host = live.host;
+  bootComfyui.port = live.port;
+  bootComfyui.ssl = live.ssl;
+  bootComfyui.basePath = live.basePath;
+  config.comfyuiHost = live.host;
+  config.comfyuiPort = live.port;
+  config.resolvedPort = live.port;
+  config.comfyuiSsl = live.ssl;
+  config.comfyuiBasePath = live.basePath;
+}
+
 /** Orchestrator startup hook: re-point the saved-target file (port-scoped, so
  *  parallel orchestrators for different rigs never restore each other's rig)
  *  and re-restore when booted on a pod — the module-init restore ran before
@@ -799,6 +822,9 @@ export function rescopeLocalTargetFile(path: string): void {
     // finding: a headless session's global save defeated the port isolation).
     lastNonPodTarget = readSavedLocalTarget();
   }
+  // A live loopback/LAN COMFYUI_URL is not a pod URL, so this will not clobber
+  // a pod boot's scoped LAN restore above.
+  adoptLiveConfiguredLocalTarget();
   if (lastNonPodTarget !== null) {
     // Persist into the scoped file so the next restart restores it — a direct
     // LAN boot otherwise lives in memory only and the pod-inherited restart


### PR DESCRIPTION
With `COMFYUI_URL=http://127.0.0.1:18188`, the scoped `local-target-*.json` file was still written as `{"url":"http://127.0.0.1:8188"}`. `panel_restart_comfyui` then correctly refused a mismatch against the panel on `:18188`, which permanently disabled restart for a second local ComfyUI on a non-default loopback port.

`rescopeLocalTargetFile` now re-reads the live `COMFYUI_URL` / `--comfyui-url` (boot.ts assigns it after config's static import) and persists that host+port. The process-start boot snapshot is aligned to the same origin so the restart identity check can confirm the configured instance. The account-for-this-instance guard is unchanged: a panel on a different server still refuses.

Fixes #1909
