### PR TITLE
release: v0.52.32 — truthful workflow pin routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.32] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- a workflow pin may not claim a graph target it did not establish (#1912)
+
+
 ## [0.52.31] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.31",
+  "version": "0.52.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.31",
+      "version": "0.52.32",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.31",
+  "version": "0.52.32",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.32** from current main after v0.52.31.\n\nCarries:\n\n- #1912 / panel#1529 — a workflow pin no longer claims graph tools target an unverified workflow; proven active mismatches refuse at pin time and indeterminate checks are disclosed\n\nLocal build passes. Do not squash-merge; preserve the release commit and tag **v0.52.32** on it. Push the tag after merge if needed.