### PR TITLE
fix(1913): pinned graph reads recover their instance stamp after reconnect without releasing the pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,13 +759,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- a PINNED session's graph reads recover their missing instance stamp after reconnect without releasing the pin (#1913)
+
 ## [0.52.32] - 2026-08-20
 
 ### MCP
 
 #### Fixed
 - a workflow pin may not claim a graph target it did not establish (#1912)
-
 
 ## [0.52.31] - 2026-08-20
 

--- a/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
+++ b/src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts
@@ -38,6 +38,13 @@ let fence: { known: boolean; uuid?: string };
  *  a green assertion cannot come from the diagnosis text. */
 const OUTLINE = { node_count: 3, outline: "1 CheckpointLoaderSimple \"ckpt\"" };
 
+/** Distinctive `graph_get_errors` payload so a green assertion cannot come from
+ *  the diagnosis text either. The reporter's other refused read (#1913). */
+const ERRORS = {
+  nodes: [{ id: 7, type: "LoadImage", reasons: ["missing_media: input.png"] }],
+  errored_count: 1,
+};
+
 /** A self-corroborating workflow_list reply: the active record also appears in the
  *  open-workflow list flagged active, which is what corroboration requires. */
 function settled(uuid: string | null): Record<string, unknown> {
@@ -84,13 +91,13 @@ function bridge(opts: BridgeOpts) {
         return settled(opts.liveUuid);
       }
       const outlineSends = sent.filter((c) => c === "graph_outline").length;
-      if (
-        name === "graph_outline" &&
-        ((opts.serveOutlineWhen === "adopted" && adopted.length > 0) ||
-          (opts.serveOutlineWhen === "retry" && outlineSends > 1))
-      ) {
-        return OUTLINE;
-      }
+      const errorSends = sent.filter((c) => c === "graph_get_errors").length;
+      const admitted =
+        (opts.serveOutlineWhen === "adopted" && adopted.length > 0) ||
+        (opts.serveOutlineWhen === "retry" &&
+          (name === "graph_outline" ? outlineSends > 1 : errorSends > 1));
+      if (admitted && name === "graph_outline") return OUTLINE;
+      if (admitted && name === "graph_get_errors") return ERRORS;
       throw new Error(refusal);
     },
     push: () => 1,
@@ -110,19 +117,28 @@ function bridge(opts: BridgeOpts) {
   } as unknown as PanelToolCtx["bridge"];
 }
 
-/** Drive a real READ tool (panel_graph_outline) through the real ctx.call path. */
-async function outline(
+/** Drive a real READ tool through the real ctx.call path. */
+async function callRead(
+  name: "panel_graph_outline" | "panel_get_errors",
   opts: BridgeOpts,
   store = new WorkflowTargetStore(),
 ): Promise<{ text: string; isError: boolean }> {
   const ctx = makePanelToolCtx(bridge(opts), TAB, store);
-  const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
-  if (!def) throw new Error("panel_graph_outline is not registered");
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
   const res: ToolResult = await def.handler({} as never, ctx);
   return {
     text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
     isError: res.isError === true,
   };
+}
+
+/** Drive a real READ tool (panel_graph_outline) through the real ctx.call path. */
+async function outline(
+  opts: BridgeOpts,
+  store = new WorkflowTargetStore(),
+): Promise<{ text: string; isError: boolean }> {
+  return callRead("panel_graph_outline", opts, store);
 }
 
 /** The remedy that is right ONLY for an absent stamp. */
@@ -224,10 +240,12 @@ describe("a fenced graph READ is diagnosed, and a missing stamp is not a wrong o
     expect(adopted).toEqual([]);
   });
 
-  it("PINNED: naming mode:\"current\" also discloses that it releases the pin", async () => {
+  it("PINNED to a DIFFERENT workflow: naming mode:\"current\" also discloses that it releases the pin", async () => {
     // mode:"current" is the right remedy for a missing stamp AND it silently drops a
     // pin. A caller who followed it to fix a read would lose their target and find
-    // out by editing the wrong workflow later.
+    // out by editing the wrong workflow later. This is NOT the reconnect case
+    // (#1913) where the pin still names the live canvas — minting from live
+    // here would abandon b.json.
     const store = new WorkflowTargetStore();
     store.set(TAB, { mode: "pinned", path: "workflows/b.json", filename: "b.json" });
     const { text } = await outline({ issuedFor: null, liveUuid: LIVE }, store);
@@ -237,6 +255,11 @@ describe("a fenced graph READ is diagnosed, and a missing stamp is not a wrong o
     expect(text).toMatch(/RELEASES that pin/);
     expect(text).toMatch(/panel_open_workflow\("workflows\/b\.json"\)/);
     expect(adopted).toEqual([]);
+    expect(store.get(TAB)).toEqual({
+      mode: "pinned",
+      path: "workflows/b.json",
+      filename: "b.json",
+    });
   });
 
   it("UNSTATED SHAPE: a refusal that names neither state gets NO remedy invented for it", async () => {
@@ -474,5 +497,81 @@ describe("an unstamped inert read is admitted (#1519 remaining)", () => {
     expect(text).not.toMatch(/no graph data was read/);
     expect(text).not.toMatch(/this is a read/);
     expect(adopted).toEqual([]);
+  });
+});
+
+describe("a PIN to the live canvas does not block minting a missing stamp (#1913)", () => {
+  // After ComfyUI restarted and the panel reconnected, the session was still
+  // pinned to the active workflow, the live canvas had a valid instance identity,
+  // and both panel_graph_outline and panel_get_errors were refused for carrying
+  // no stamp. The documented recovery (mode:"current") restored the fence AND
+  // released the pin. Minting from the live canvas while the pin still names
+  // that canvas keeps the pin.
+
+  function pinToLive(): WorkflowTargetStore {
+    const store = new WorkflowTargetStore();
+    store.set(TAB, { mode: "pinned", path: "workflows/a.json", filename: "a.json" });
+    return store;
+  }
+
+  function pinStillHeld(store: WorkflowTargetStore): void {
+    expect(store.get(TAB)).toEqual({
+      mode: "pinned",
+      path: "workflows/a.json",
+      filename: "a.json",
+    });
+  }
+
+  it("panel_graph_outline runs, the stamp is minted from the live canvas, and the pin is kept", async () => {
+    const store = pinToLive();
+    const { text, isError } = await outline(
+      { issuedFor: null, liveUuid: LIVE, serveOutlineWhen: "adopted" },
+      store,
+    );
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(adopted).toEqual([LIVE]);
+    expect(isError).toBe(false);
+    expect(text).toContain("CheckpointLoaderSimple");
+    expect(text).not.toMatch(/Error:/);
+    expect(text).not.toMatch(REBIND);
+    expect(text).not.toMatch(/RELEASES that pin/);
+    expect(sent.filter((c) => c === "graph_outline").length).toBeGreaterThan(1);
+    pinStillHeld(store);
+  });
+
+  it("panel_get_errors runs the same way — the other refused read", async () => {
+    const store = pinToLive();
+    const { text, isError } = await callRead(
+      "panel_get_errors",
+      { issuedFor: null, liveUuid: LIVE, serveOutlineWhen: "adopted" },
+      store,
+    );
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(adopted).toEqual([LIVE]);
+    expect(isError).toBe(false);
+    expect(text).toContain("missing_media: input.png");
+    expect(text).not.toMatch(/Error:/);
+    expect(text).not.toMatch(REBIND);
+    expect(sent.filter((c) => c === "graph_get_errors").length).toBeGreaterThan(1);
+    pinStillHeld(store);
+  });
+
+  it("already_current: retries without minting and without releasing the pin", async () => {
+    // The fence appeared between dispatch and the probe. Retrying now carries it;
+    // minting again would claim a repair this call did not make, and mode:"current"
+    // would drop the pin for nothing.
+    fence = { known: true, uuid: LIVE };
+    const store = pinToLive();
+    const { text, isError } = await outline(
+      { issuedFor: null, liveUuid: LIVE, serveOutlineWhen: "retry" },
+      store,
+    );
+    expect(isError).toBe(false);
+    expect(text).toContain("CheckpointLoaderSimple");
+    expect(adopted).toEqual([]);
+    expect(sent.filter((c) => c === "graph_outline").length).toBeGreaterThan(1);
+    pinStillHeld(store);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5655,13 +5655,13 @@ function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
  */
 export type WorkflowFenceRebind =
   /** Read the live identity; it differed from the stamp and has REPLACED it. */
-  | { status: "refreshed"; uuid: string; before: FenceRead }
+  | { status: "refreshed"; uuid: string; before: FenceRead; active?: Record<string, unknown> }
   /** #1646 — a READ-ONLY probe (`adopt:false`) found the live identity differs
    *  from the fence and deliberately did NOT adopt it: a mismatch diagnosis
    *  must never re-point mutation routing on its own authority. */
-  | { status: "diverged"; uuid: string; before: FenceRead }
+  | { status: "diverged"; uuid: string; before: FenceRead; active?: Record<string, unknown> }
   /** Read the live identity; the stamp already named it. Nothing to repair. */
-  | { status: "already_current"; uuid: string; before: FenceRead }
+  | { status: "already_current"; uuid: string; before: FenceRead; active?: Record<string, unknown> }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
   | { status: "unreadable"; before: FenceRead; detail: string }
   /** The panel answered, but no usable identity could be adopted from it. TWO
@@ -6201,14 +6201,14 @@ async function rebindWorkflowFence(
     // off parsed prose, and the result is ignored: this is corroboration, and a diagnostic
     // must never replace the outcome it is describing.
     corroborateTabStamp(ctx, uuid);
-    return { status: "already_current", uuid, before };
+    return { status: "already_current", uuid, before, active };
   }
   // #1646 — a READ-ONLY probe never moves the fence: the live canvas naming a
   // DIFFERENT workflow is reported, not adopted. Only a deliberate rebind
   // (panel_set_workflow_target, open/new) may replace the fence — a mismatch
   // diagnosis that re-pointed the session on its own authority routed the
   // caller's NEXT edits onto the very canvas the refusal named as the wrong one.
-  if (opts?.adopt === false) return { status: "diverged", uuid, before };
+  if (opts?.adopt === false) return { status: "diverged", uuid, before, active };
   // refreshWorkflowUuid routes through the orchestrator's validator, which
   // re-checks reachability and the uuid's shape/origin binding. A `false` here is
   // a REFUSAL, not a no-op, so it gets its own status rather than being reported
@@ -6222,7 +6222,7 @@ async function rebindWorkflowFence(
   // write, so `rejected`'s "the previous fence is unchanged" would be a state
   // nobody observed.
   try {
-    if (refreshWorkflowUuid(ctx, active)) return { status: "refreshed", uuid, before };
+    if (refreshWorkflowUuid(ctx, active)) return { status: "refreshed", uuid, before, active };
     // #1077 — carry WHY. The validator has three independent gates and all of
     // them used to surface as the same bare "REFUSED", which left a wedged
     // session with nothing to act on. One of them (no server-observed Origin on
@@ -6247,6 +6247,36 @@ async function rebindWorkflowFence(
       detail: err instanceof Error ? err.message : String(err ?? "unknown error"),
     };
   }
+}
+
+/** Corroborated live-canvas record from a fence probe, when the probe published one. */
+function liveActiveFromProbe(probe: WorkflowFenceRebind): Record<string, unknown> | undefined {
+  if (
+    probe.status === "diverged" ||
+    probe.status === "already_current" ||
+    probe.status === "refreshed"
+  ) {
+    return probe.active;
+  }
+  return undefined;
+}
+
+/**
+ * #1913 — a pin is a PATH, not an instance stamp. After a ComfyUI reconnect the
+ * canvas can still be that path while this session has no workflow-instance uuid
+ * to stamp commands with. Honoring the pin means the live canvas IS the pinned
+ * workflow, so minting a first stamp from it does not abandon the named target
+ * and does not require `mode:"current"` (which would release the pin). A pin to
+ * any other canvas, or a pin we cannot positively match, is left alone (#1519).
+ */
+function pinHonorsLiveCanvas(
+  pin: { mode?: string; path?: string } | undefined,
+  liveActive: Record<string, unknown> | undefined,
+): boolean {
+  if (pin?.mode !== "pinned") return true;
+  if (typeof pin.path !== "string" || pin.path.length === 0) return false;
+  if (!liveActive) return false;
+  return readOpenActiveAgainstTarget(liveActive, pin.path) === "same";
 }
 
 /**
@@ -9377,9 +9407,12 @@ export function makePanelToolCtx(
       //
       // AN UNSTAMPED INERT READ IS ADMITTED by minting a first fence from the
       // live canvas and retrying once. That is not the retarget #1646 removed:
-      // there is no named workflow to abandon, and a pinned session is left
-      // alone. The panel fence is unchanged (#718). A WRONG stamp still fails.
-      // The probe stays read-only until this branch decides to mint.
+      // there is no named workflow to abandon. A PIN to a DIFFERENT workflow
+      // is still left alone (#1519). #1913: a PIN whose workflow is still the
+      // live canvas is not an abandonment — reconnect dropped the instance
+      // stamp, not the pin — so the stamp is minted and the pin is kept. A
+      // WRONG stamp still fails. The probe stays read-only until this branch
+      // decides to mint.
       if (isWorkflowInstanceMismatch(err) && isFencedGraphRead(cmd)) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
         const raw = err instanceof Error ? err.message : String(err);
@@ -9422,7 +9455,9 @@ export function makePanelToolCtx(
           const priorAbsent =
             "before" in probe && probe.before.known === true && !probe.before.uuid;
           const admitUnstampedRead =
-            inertRead && shape === "unstamped" && pin?.mode !== "pinned";
+            inertRead &&
+            shape === "unstamped" &&
+            pinHonorsLiveCanvas(pin, liveActiveFromProbe(probe));
           // Mint a first stamp only when this session has none. A fence naming
           // some other workflow is the retarget #1646 removed; we do not move it.
           if (


### PR DESCRIPTION
Fixes #1913

After ComfyUI restarted and the panel reconnected, `panel_graph_outline` and `panel_get_errors` were refused because the commands carried no workflow-instance stamp even though the session was already pinned to the active workflow. The live canvas had a valid instance identity. `panel_set_workflow_target({mode:"current"})` restored the fence — and released the pin.

Unstamped inert graph reads already mint a first stamp from the live canvas and retry once (#1519 / #1787), but a pinned session was excluded so minting could not abandon a named target. That left the reporter needing `mode:"current"` solely to reacquire a stamp.

This admits the unstamped read when the live canvas **is** the pinned workflow: mint the stamp, retry once, keep the pin. A pin to a different workflow is still left alone, and a wrong stamp still fails.

Tests drive the shipped `panel_graph_outline` and `panel_get_errors` handlers on the real `ctx.call` path.
