### PR TITLE
release: comfyui-mcp 0.52.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,10 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.33] - 2026-08-20
+
 ### MCP
 
 #### Fixed
-- a PINNED session's graph reads recover their missing instance stamp after reconnect without releasing the pin (#1913)
+- pinned graph reads recover their instance stamp after reconnect without releasing the pin (#1916 / #1913)
+- panel_restart_comfyui accounts for a loopback instance on a non-default port (#1914)
+
 
 ## [0.52.32] - 2026-08-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.32",
+  "version": "0.52.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.32",
+      "version": "0.52.33",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.32",
+  "version": "0.52.33",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary
- bump comfyui-mcp to 0.52.33
- include the post-0.52.32 fixes for loopback restart detection and pinned graph-read instance recovery

## Validation
- `npm run build`
- release CI must pass before merge