### PR TITLE
fix(1917): mode:"current" may not claim a routing target the turn pin holds elsewhere

### DIFF
--- a/src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts
+++ b/src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts
@@ -1,0 +1,500 @@
+// mcp#1917 — "A live turn-routing pin is never displaced by a workflow target, so
+// graph reads and graph MUTATIONS split across two tabs".
+//
+// WHAT WAS REPORTED (panel#1529 comment 2, split out as #1917): after
+// `panel_open_workflow` bound a saved PHOTO copy, `panel_set_workflow_target({mode:
+// "current"})` answered as a success, `panel_graph_outline` read that copy, and
+// `panel_remove_node({node_id:99})` came back refused against the older Basic_V37
+// workflow — "the prior reply explicitly retained the healthy older turn-routing pin".
+//
+// WHAT WAS MEASURED, and what it changes. Driven over a real UiBridge on a real
+// socket with the real turn-origin pin and scope resolver, reads and mutations are
+// NOT two selectors: `graph_outline` and `graph_remove_node` are both dispatched by
+// `UiBridge.resolveTarget(<scope>)` through the same pin, both carry the same
+// `workflow_uuid` from the same `commandStampAddress` resolution, and the panel
+// fences them identically (`activeWorkflowFenceApplies` covers every `graph_*`, and
+// a missing stamp counts as a mismatch, #718). No state was found in which the two
+// route to different tabs — the last test here pins that, by asserting BOTH land on
+// the same tab in the very state the report describes.
+//
+// What IS true, and is the whole of this fix: `mode:"current"` claimed
+// «Following the user's current workflow tab.» while a live turn pin was holding
+// every graph command on a DIFFERENT tab, and said nothing about it. For a
+// scope-bound ctx whose pin still reaches a live tab, `rebindToActiveTab`
+// short-circuits (#884 — a live pin is never displaced) and returns
+// `{rebound:false}` with no `repinRefusal`, so not one word of the reply mentioned
+// the pin. Measured on clean main: pin on the tab showing Basic_V37, active-scope
+// resolution naming the tab showing PHOTO, reply «Following the user's current
+// workflow tab.» with `graph_binding:"bound"`, and both the following
+// `panel_graph_outline` and `panel_remove_node` dispatched to Basic_V37.
+//
+// The pin is NOT moved to make that sentence true. #884 is a P0 invariant and
+// `makeScopeRepinHandler` is untouched by this change; the third test asserts the
+// pin is exactly where it was after the call. What changes is the CLAIM.
+//
+// This is an e2e over a real bridge for the same reason the panel#1529 file is: the
+// claim lives in the TOOL's reply and the verdict is joined to it by assignments at
+// the call site, which a helper-level test survives. Every assertion below reads the
+// string or field an agent actually receives.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import {
+  TurnOriginTracker,
+  makeScopeRepinHandler,
+  makeScopeTargetResolver,
+} from "../../orchestrator/turn-origins.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { SHARED_SESSION_SCOPE, isScopeAddress } from "../../services/session-scope.js";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c as { text: string }).text : "")).join("\n");
+
+const jsonOf = (res: ToolResult): Record<string, unknown> => {
+  try {
+    return JSON.parse(textOf(res)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+/** The unconditional sentence this fix stops printing when it is not true. */
+const CURRENT_CLAIM = "Following the user's current workflow tab.";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** Same shape as the other bridge e2e harnesses: retry past the close/rebind race
+ *  so a bind flake is never reported as a feature failure. */
+async function startBridgeOnFreePort(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close/rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+const SCOPE = `${SHARED_SESSION_SCOPE}::claude`;
+
+interface Wf {
+  path: string;
+  filename: string;
+  key: string;
+  routing_key: string;
+  uuid: string;
+  outline: string;
+}
+
+/** The workflow the turn was issued from — the report's Basic_V37. */
+const BASIC: Wf = {
+  path: "workflows/Basic_V37.json",
+  filename: "Basic_V37",
+  key: "Basic_V37.json",
+  routing_key: "wf:workflows/Basic_V37.json",
+  uuid: "aaaaaaaa-1111-4111-8111-111111111111",
+  outline: '1 BasicNode "basic"',
+};
+/** The workflow the agent believes it moved to — the report's saved PHOTO copy. */
+const PHOTO: Wf = {
+  path: "workflows/PHOTO.json",
+  filename: "PHOTO",
+  key: "PHOTO.json",
+  routing_key: "wf:workflows/PHOTO.json",
+  uuid: "bbbbbbbb-2222-4222-8222-222222222222",
+  outline: '99 PhotoNode "photo"',
+};
+
+let bridge: UiBridge;
+let port: number;
+const sockets: WebSocket[] = [];
+
+/** A scripted panel page. Records every command frame it receives so the tests can
+ *  assert on what was ROUTED, not only on what the tool said. */
+class FakePanel {
+  sock!: WebSocket;
+  readonly seen: Array<{ cmd: string; workflow_uuid?: string }> = [];
+
+  constructor(
+    public tabId: string,
+    /** The per-browser-tab route id (#640) this page re-helloes under on a switch. */
+    public route: string,
+    public open: Wf[],
+    public activeIdx: number,
+  ) {}
+
+  get active(): Wf {
+    return this.open[this.activeIdx];
+  }
+
+  async connect(): Promise<void> {
+    this.sock = await new Promise<WebSocket>((resolve, reject) => {
+      const s = new WebSocket(`ws://127.0.0.1:${port}`);
+      sockets.push(s);
+      s.on("open", () => resolve(s));
+      s.on("error", reject);
+    });
+    this.hello(this.tabId);
+    this.sock.on("message", (buf) => this.onMessage(buf.toString()));
+    await settle();
+  }
+
+  hello(tabId: string): void {
+    this.tabId = tabId;
+    this.sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: tabId,
+        title: this.active.filename,
+        backend: "claude",
+        workflow_uuid: this.active.uuid,
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+  }
+
+  private record(w: Wf, i: number): Record<string, unknown> {
+    return {
+      path: w.path,
+      filename: w.filename,
+      title: w.filename,
+      key: w.key,
+      routing_key: w.routing_key,
+      active: i === this.activeIdx,
+      modified: false,
+      persisted: true,
+    };
+  }
+
+  private onMessage(raw: string): void {
+    const msg = JSON.parse(raw) as Record<string, unknown>;
+    const cmd = msg.cmd as string | undefined;
+    const rid = msg.rid as string | undefined;
+    if (!cmd || !rid) return;
+    const stamp = typeof msg.workflow_uuid === "string" ? msg.workflow_uuid : undefined;
+    this.seen.push({ cmd, workflow_uuid: stamp });
+    const reply = (result: unknown): void =>
+      this.sock.send(JSON.stringify({ rid, ok: true, result, workflow_uuid: this.active.uuid }));
+    const refuse = (error: string): void =>
+      this.sock.send(JSON.stringify({ rid, ok: false, error }));
+
+    // The panel's shipped WORKFLOW-INSTANCE FENCE (#570/#718), modelled the way the
+    // panel actually applies it: `activeWorkflowFenceApplies` covers EVERY `graph_*`
+    // command — reads included — and `commandWorkflowMismatch` counts a MISSING stamp
+    // as a mismatch. Reads and mutations are deliberately treated alike here, because
+    // that is what the panel does; a harness that fenced only writes would manufacture
+    // the very read/mutation split these tests exist to measure.
+    if (cmd.startsWith("graph_")) {
+      if (!stamp) {
+        refuse(
+          `workflow instance mismatch: this command carries no workflow-instance stamp, and ` +
+            `the active canvas reports ${this.active.uuid}. Nothing was applied.`,
+        );
+        return;
+      }
+      if (stamp !== this.active.uuid) {
+        refuse(
+          `workflow instance mismatch: this command was issued for workflow instance ${stamp}, ` +
+            `and the active canvas reports ${this.active.uuid}. Nothing was applied.`,
+        );
+        return;
+      }
+    }
+
+    switch (cmd) {
+      case "workflow_list": {
+        reply({
+          active: {
+            path: this.active.path,
+            filename: this.active.filename,
+            title: this.active.filename,
+            key: this.active.key,
+            routing_key: this.active.routing_key,
+            workflow_uuid: this.active.uuid,
+          },
+          open: this.open.map((w, i) => this.record(w, i)),
+          workflows: this.open.map((w, i) => this.record(w, i)),
+          active_confirmed: true,
+          backend_socket: "up",
+          mutations_ready: true,
+          canvas_binding: "bound",
+          graph_binding: "bound",
+        });
+        return;
+      }
+      case "workflow_open": {
+        const want = String(msg.path ?? "");
+        const idx = this.open.findIndex(
+          (w) => w.path === want || w.key === want || w.filename === want,
+        );
+        if (idx < 0) {
+          refuse(`not open: ${want}`);
+          return;
+        }
+        this.activeIdx = idx;
+        reply({
+          ok: true,
+          path: this.active.path,
+          filename: this.active.filename,
+          key: this.active.key,
+          routing_key: this.active.routing_key,
+          active_routing_key: this.active.routing_key,
+          active_matches_target: true,
+          workflow_uuid: this.active.uuid,
+          active: true,
+        });
+        // A real panel re-helloes under the NEW workflow's route id on the SAME
+        // socket when the active workflow changes (per-workflow routes, #640).
+        setTimeout(() => this.hello(`wf:${this.route}:${this.active.path}`), 5);
+        return;
+      }
+      case "graph_outline":
+        reply({ outline: this.active.outline, node_count: 1, detail_level: "full" });
+        return;
+      case "graph_remove_node":
+        reply({ ok: true, removed: [msg.node_id], on: this.active.filename });
+        return;
+      default:
+        reply({ ok: true });
+    }
+  }
+}
+
+async function settle(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise((r) => setTimeout(r, 12));
+}
+
+let tracker: TurnOriginTracker;
+let workflowTargets: WorkflowTargetStore;
+const tabStamp = new Map<string, string>();
+
+beforeEach(async () => {
+  ({ bridge, port } = await startBridgeOnFreePort());
+  tabStamp.clear();
+  workflowTargets = new WorkflowTargetStore();
+  // EXACTLY what orchestrator/index.ts installs, so the scope address resolves
+  // through the production turn-origin pin rather than a test stand-in.
+  const scopeAgentKeyOf = (scopeId: string): string =>
+    scopeId === SHARED_SESSION_SCOPE ? `${SHARED_SESSION_SCOPE}::claude` : scopeId;
+  const backendForTab = (): string => "claude";
+  const backendOfKey = (key: string): string => key.split("::")[1] ?? "claude";
+  tracker = new TurnOriginTracker({
+    backendForTab,
+    backendOfKey,
+    uuidOfTab: (t) => tabStamp.get(t),
+    liveTabOf: (t) => {
+      try {
+        return bridge.canReach(t) ? t : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    warn: () => {},
+  });
+  bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker, scopeAgentKeyOf }));
+  bridge.setScopeRepinHandler(
+    makeScopeRepinHandler({
+      bridge,
+      tracker,
+      scopeAgentKeyOf,
+      backendForTab,
+      backendOfKey,
+      info: () => {},
+    }),
+  );
+  bridge.setHelloBackendNormalizer(() => "claude");
+  bridge.setTabWorkflowUuidResolver(
+    (tabId) =>
+      isScopeAddress(tabId) ? tracker.stampOf(scopeAgentKeyOf(tabId)) : tabStamp.get(tabId),
+    (tabId, workflowUuid) => {
+      if (typeof workflowUuid !== "string" || !workflowUuid)
+        return { ok: false, reason: "no uuid" };
+      const real = isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : tabId;
+      if (!real) return { ok: false, reason: "no panel tab" };
+      tabStamp.set(real, workflowUuid);
+      if (isScopeAddress(tabId)) tracker.setStamp(scopeAgentKeyOf(tabId), workflowUuid);
+      return true;
+    },
+  );
+});
+
+afterEach(async () => {
+  for (const s of sockets.splice(0)) s.close();
+  await bridge.stop();
+});
+
+const tool = (name: string) => buildPanelToolDefs().find((d) => d.name === name)!;
+
+/** The real ctx, with only the default command deadline shortened. */
+function ctxFor(tabId: string): PanelToolCtx {
+  const real = makePanelToolCtx(bridge, tabId, workflowTargets);
+  const c = Object.create(real) as PanelToolCtx;
+  c.call = (cmd, t, onRid) => real.call(cmd, t ?? 800, onRid);
+  return c;
+}
+
+const setCurrent = (ctx: PanelToolCtx): Promise<ToolResult> =>
+  tool("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+
+/** The reported two-tab state: the turn was issued from the tab showing Basic_V37,
+ *  and a second browser tab showing the saved PHOTO copy connected after it — so the
+ *  active-scope (pin-bypassing) resolution names PHOTO's tab while the in-flight
+ *  turn's pin still names Basic_V37's. */
+async function twoTabsPinnedElsewhere(): Promise<{
+  tabA: FakePanel;
+  tabB: FakePanel;
+  ctx: PanelToolCtx;
+}> {
+  const tabA = new FakePanel("wf:rA:workflows/Basic_V37.json", "rA", [BASIC], 0);
+  await tabA.connect();
+  tabStamp.set(tabA.tabId, BASIC.uuid);
+  const tabB = new FakePanel("wf:rB:workflows/PHOTO.json", "rB", [PHOTO], 0);
+  await tabB.connect();
+  tabStamp.set(tabB.tabId, PHOTO.uuid);
+  tracker.repinTo(SCOPE, tabA.tabId);
+  await settle();
+  // The precondition, asserted rather than assumed: the two selectors really do
+  // name different tabs before the tool is called.
+  expect(bridge.resolveSharedTabId(SCOPE)).toBe(tabA.tabId);
+  expect(bridge.resolveActiveScopeTab()).toBe(tabB.tabId);
+  return { tabA, tabB, ctx: ctxFor(SCOPE) };
+}
+
+describe("mcp#1917 — mode:'current' may not claim a routing target the turn pin holds elsewhere", () => {
+  it("names BOTH tabs instead of claiming it follows the current one", async () => {
+    const { tabA, tabB, ctx } = await twoTabsPinnedElsewhere();
+
+    const res = await setCurrent(ctx);
+
+    expect(res.isError, textOf(res)).toBeFalsy();
+    const note = String(jsonOf(res).note ?? "");
+    // The claim that was made unconditionally, and is false in this state.
+    expect(note).not.toContain(CURRENT_CLAIM);
+    // Both tabs are NAMED, so the caller can tell which canvas it is actually on.
+    expect(note).toContain("Basic_V37");
+    expect(note).toContain("PHOTO");
+    // And it says the thing the report needed said: this covers MUTATIONS too.
+    expect(note).toContain("READS AND MUTATIONS ALIKE");
+  });
+
+  it("carries the split MACHINE-READABLY, so no caller has to parse the prose", async () => {
+    // The call-site half. A helper that computes the split but is never spread into
+    // the reply passes every prose assertion above; this field only exists if the
+    // wiring at the `ok(...)` return is present.
+    const { tabA, tabB, ctx } = await twoTabsPinnedElsewhere();
+
+    const body = jsonOf(await setCurrent(ctx));
+
+    expect(body.turn_routing).toBe("pinned_elsewhere");
+    expect(body.turn_routing_tab).toBe(tabA.tabId);
+    expect(body.current_would_route_to).toBe(tabB.tabId);
+    // `repinned` and `pinned_elsewhere` are mutually exclusive: this call moved nothing.
+    expect(body.turn_routing).not.toBe("repinned");
+  });
+
+  it("does NOT displace the live pin to make its own sentence true (#884)", async () => {
+    const { tabA, ctx } = await twoTabsPinnedElsewhere();
+    const pinBefore = tracker.pinOf(SCOPE);
+
+    await setCurrent(ctx);
+
+    // The P0 invariant this issue must not trade away: a pin that still reaches a
+    // live tab of this conversation is never displaced, however explicit the request.
+    expect(tracker.pinOf(SCOPE)).toBe(pinBefore);
+    expect(tracker.pinOf(SCOPE)).toBe(tabA.tabId);
+  });
+
+  it("the disclosure is TRUE: the next read AND the next mutation both land on the pinned tab", async () => {
+    // The reported shape, executed. #1917 states that reads follow the workflow
+    // target while mutations follow the turn pin; over a real bridge they do not
+    // split — `graph_outline` and `graph_remove_node` are resolved by the same
+    // `resolveTarget(<scope>)` through the same pin. Asserting BOTH frames arrive at
+    // the PINNED tab is what makes the new "READS AND MUTATIONS ALIKE" sentence a
+    // measured statement rather than a plausible one.
+    const { tabA, tabB, ctx } = await twoTabsPinnedElsewhere();
+    await setCurrent(ctx);
+    await settle();
+
+    const outline = await tool("panel_graph_outline").handler({}, ctx);
+    expect(outline.isError, textOf(outline)).toBeFalsy();
+    expect(textOf(outline)).toContain("BasicNode");
+
+    const removed = await tool("panel_remove_node").handler({ node_id: 99 }, ctx);
+    expect(removed.isError, textOf(removed)).toBeFalsy();
+
+    // Assert the frames EXIST before asserting where they did not go — an empty
+    // array would satisfy a bare "tabB saw nothing" vacuously.
+    expect(tabA.seen.map((f) => f.cmd)).toEqual(
+      expect.arrayContaining(["graph_outline", "graph_remove_node"]),
+    );
+    expect(tabB.seen.filter((f) => f.cmd.startsWith("graph_"))).toHaveLength(0);
+  });
+
+  it("says nothing when the two selectors AGREE — the boundary, on purpose", async () => {
+    // One connected tab: the pin and the active-scope resolution are the same tab, so
+    // there is no split to report and the ordinary reply must be unchanged. Over-
+    // reporting here would put a scary two-tab warning on every healthy recovery.
+    const page = new FakePanel("wf:r1:workflows/PHOTO.json", "r1", [PHOTO], 0);
+    await page.connect();
+    tabStamp.set(page.tabId, PHOTO.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const body = jsonOf(await setCurrent(ctx));
+
+    expect(String(body.note ?? "")).toContain(CURRENT_CLAIM);
+    expect(body.turn_routing).toBeUndefined();
+    expect(body.turn_routing_tab).toBeUndefined();
+  });
+
+  it("a RETIRED route id that still reaches the same socket is not a split", async () => {
+    // The comparison is between CANONICAL connection ids, not raw id strings. A
+    // per-workflow route id (#640) is retired on every workflow switch, so the pin
+    // routinely names an id that is no longer any connection's canonical id while
+    // still resolving — through the same-socket migration alias — onto the very tab
+    // "current" would pick. Comparing the raw pin string against the active tab id
+    // would call that a disagreement and print the warning on a perfectly healthy
+    // single-tab session after any `panel_open_workflow`.
+    const page = new FakePanel("wf:r1:workflows/Basic_V37.json", "r1", [BASIC, PHOTO], 0);
+    await page.connect();
+    tabStamp.set(page.tabId, BASIC.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+    const retiredPin = page.tabId;
+    const ctx = ctxFor(SCOPE);
+
+    const opened = await tool("panel_open_workflow").handler({ path: PHOTO.path }, ctx);
+    expect(opened.isError, textOf(opened)).toBeFalsy();
+    await settle();
+
+    // The pin still names the RETIRED id, and that id is no longer the canonical one.
+    expect(tracker.pinOf(SCOPE)).toBe(retiredPin);
+    expect(bridge.resolveSharedTabId(SCOPE)).not.toBe(retiredPin);
+    // …but it resolves onto the same live tab the active resolution picks.
+    expect(bridge.resolveSharedTabId(SCOPE)).toBe(bridge.resolveActiveScopeTab());
+
+    const body = jsonOf(await setCurrent(ctx));
+    expect(String(body.note ?? "")).toContain(CURRENT_CLAIM);
+    expect(body.turn_routing).toBeUndefined();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -113,6 +113,33 @@ import { NO_ORIGIN_REMEDY } from "./fence-refusal.js";
  *  labeled "foreign" and boundary sweeps could never close the ticket (codex
  *  round 3, P1). Resolves the scope to the active tab; a real-tab ctx is
  *  returned unchanged. */
+/**
+ * #1917 — the CANONICAL tab id a SCOPE-addressed session's commands are dispatched
+ * to right now: the in-flight turn's routing pin, resolved onward through any
+ * same-socket migration alias, else the active-tab fallback when no turn is
+ * pinned. Undefined when nothing resolves — and, deliberately, for a REAL-TAB ctx,
+ * which routes by its own id and has no second selector to disagree with.
+ *
+ * Canonical on purpose: `resolveSharedTabId` answers with `conn.tabId`, the same
+ * value `resolveActiveScopeTab` answers with, so the two can be compared for
+ * "different TAB" rather than "different id string". A pin naming a retired
+ * `wf:<route>:<path>` id that still reaches the same live socket resolves to that
+ * socket's current canonical id and is therefore NOT a disagreement.
+ *
+ * Never throws: an unresolvable pin is the bridge's own loud failure at dispatch
+ * time, and a reporting helper must not turn it into a different one here.
+ */
+function scopeRoutedTabId(ctx: PanelToolCtx): string | undefined {
+  if (!isScopeAddress(ctx.tabId)) return undefined;
+  const b = ctx.bridge as { resolveSharedTabId?: (scopeId?: string) => string | undefined };
+  if (typeof b.resolveSharedTabId !== "function") return undefined;
+  try {
+    return b.resolveSharedTabId(ctx.tabId);
+  } catch {
+    return undefined;
+  }
+}
+
 function journalTabFor(ctx: PanelToolCtx): string {
   if (!isScopeAddress(ctx.tabId)) return ctx.tabId;
   // Pass the ctx's own (backend-qualified) scope address so the RIGHT
@@ -14537,6 +14564,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // made only on the evidence that supports it; without that evidence the reply
         // says what IS true (the pin is set and acts as a GUARD) and hands back the
         // cheap read that settles it.
+        //
+        // #1917 — the SAME rule for the `mode:"current"` arm, which panel#1529's fix
+        // deliberately did not take. "Following the user's current workflow tab." is
+        // also a claim about ROUTING, and it was likewise unconditional. It is FALSE
+        // whenever this conversation's in-flight turn pin is holding routing on a
+        // different tab: `rebindToActiveTab` short-circuits for a scope ctx whose pin
+        // still reaches a live tab (#884 — a live pin is never displaced) and returns
+        // `{rebound:false}` with no `repinRefusal` at all, so nothing in the reply
+        // mentioned the pin. Measured on clean main over a real bridge: with the pin
+        // on the tab showing Basic_V37 and the active-scope resolution naming the tab
+        // showing PHOTO, this call answered «Following the user's current workflow
+        // tab.» with `graph_binding:"bound"`, and the next `panel_graph_outline` AND
+        // the next `panel_remove_node` were both dispatched to Basic_V37.
+        //
+        // The pin is NOT moved to make the sentence true — that is #884's P0, and
+        // widening "displace" from dead-or-ambiguous to dead-or-ambiguous-or-different
+        // would re-aim an in-flight conversation's mutations at a tab it never
+        // addressed. What changes is the CLAIM: when two selectors name different
+        // tabs, say so and name both, rather than silently reporting one of them.
+        const routedTab = scopeRoutedTabId(ctx);
+        const activeScopeTab =
+          typeof ctx.bridge.resolveActiveScopeTab === "function"
+            ? ctx.bridge.resolveActiveScopeTab()
+            : undefined;
+        // Compared as CANONICAL connection ids on both sides (resolveSharedTabId and
+        // resolveActiveScopeTab both answer with `conn.tabId`), so a pin that merely
+        // names a RETIRED per-workflow route id but still resolves onto the same live
+        // socket does not read as a split — only a genuinely different tab does.
+        const turnPinRoutesElsewhere =
+          mode === "current" &&
+          !currentModeTurnRepinned &&
+          isScopeAddress(ctx.tabId) &&
+          typeof routedTab === "string" &&
+          typeof activeScopeTab === "string" &&
+          routedTab !== activeScopeTab
+            ? { routedTab, activeScopeTab }
+            : undefined;
+        // panel#1529's `pin_verified_active` rule, applied to the routing half: the
+        // same verdict the note carries, MACHINE-READABLE, so an agent never has to
+        // read "the two selectors disagree" out of prose. `turn_routing:"repinned"`
+        // and `"pinned_elsewhere"` are mutually exclusive by construction — the
+        // predicate above requires `!currentModeTurnRepinned`.
+        const turnRoutingSplitFields = turnPinRoutesElsewhere
+          ? {
+              turn_routing: "pinned_elsewhere" as const,
+              turn_routing_tab: turnPinRoutesElsewhere.routedTab,
+              current_would_route_to: turnPinRoutesElsewhere.activeScopeTab,
+            }
+          : {};
         const hint =
           target.mode === "pinned"
             ? pinVerifiedActive
@@ -14548,7 +14624,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               // be a confident wrong diagnosis; what is true in all three is that the
               // check did not happen.
               : `Pinned to "${target.filename ?? target.path}" — but NOT CONFIRMED: the live canvas could not be read back to check this pin against it, so this call does NOT establish that graph tools will reach that workflow. The pin travels on graph commands as a GUARD: if the active canvas is a different workflow, the next graph call FAILS with a workflow mismatch rather than editing it. Settle it with one cheap read — panel_graph_outline — before relying on this.`
-            : "Following the user's current workflow tab.";
+            : turnPinRoutesElsewhere
+              ? `The workflow target is now mode:"current" — but graph tools will NOT ` +
+                `follow the tab this session would otherwise resolve to. This ` +
+                `conversation's IN-FLIGHT TURN is pinned to tab ` +
+                `${shortTabId(turnPinRoutesElsewhere.routedTab)}, and that pin was NOT ` +
+                `displaced: a pin that still reaches a live tab of this conversation is ` +
+                `never displaced, however explicit the request (#884). So every graph ` +
+                `command — READS AND MUTATIONS ALIKE — is dispatched to ` +
+                `${shortTabId(turnPinRoutesElsewhere.routedTab)}, not to ` +
+                `${shortTabId(turnPinRoutesElsewhere.activeScopeTab)}, which is where ` +
+                `"current" would resolve. TWO SELECTORS NAME DIFFERENT TABS and this ` +
+                `call moved neither, so do not read it as "graph tools now follow the ` +
+                `user's current tab". WHAT TO DO: read the pinned tab first ` +
+                `(panel_graph_outline) and work there if that is the workflow you mean; ` +
+                `otherwise ask the user to send a message from the tab they want — the ` +
+                `turn pin is released at the end of this turn and the next message's ` +
+                `origin establishes routing. Retrying this tool will not move it.`
+              : "Following the user's current workflow tab.";
         // #803 — this used to END here for every mode:"current" call, with the
         // unconditional "Following the user's current workflow tab." Reporters followed
         // that as the documented recovery, read it as success, and stayed wedged. The
@@ -14756,6 +14849,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               graph_binding: "bound",
               ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
               ...(currentModeTurnRepinned ? { turn_routing: "repinned" } : {}),
+              ...turnRoutingSplitFields,
               note:
                 hint +
                 rebindNote +
@@ -14805,6 +14899,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           ...(typeof scopeRepin === "string" || currentModeTurnRepinned
             ? { turn_routing: "repinned" }
             : {}),
+          ...turnRoutingSplitFields,
           note: hint + rebindNote + (fence?.note ?? "") + scopeRepinNote,
         });
       },


### PR DESCRIPTION
Closes #1917.

**Review is PENDING.** grok's review is requested in a comment below; no verdict exists yet and nothing here is described as gated.

## What the report claimed, and what execution found

#1917 states there are two selectors, and that *reads* follow the workflow-target store while *mutations* follow the turn-routing pin. **That is not true, and I could not reproduce a read/mutation routing split.** Measured over a real `UiBridge` on a real socket, with the real `TurnOriginTracker` + `makeScopeTargetResolver`/`makeScopeRepinHandler` wired exactly as `orchestrator/index.ts` wires them, the real `WorkflowTargetStore`, the real panel tool defs and scripted panel sockets:

- `graph_outline` and `graph_remove_node` are both resolved by `UiBridge.resolveTarget(<scope>)` through the **same** pin;
- both carry the **same** `workflow_uuid`, from the same `commandStampAddress` resolution (`requiresStampTargetAgreement` is true for every `graph_*`, so both take the caller address);
- the panel fences them **identically** — `activeWorkflowFenceApplies` covers every `graph_*` (reads included), and `commandWorkflowMismatch` counts a *missing* stamp as a mismatch (#718);
- `withWorkflowTarget` injects `workflow_path` into reads and writes alike.

I swept the states that could plausibly split them: a retired-route-id pin resolving through the migration alias; a stale conversation stamp; an absent conversation stamp; a `wf:<route>:<path>` id taken over by another connection; the workflow-target store in `pinned` mode. In every one, the read and the mutation landed on the same tab and got the same verdict. The only read/mutation asymmetry that exists on our side is the mutation-only `requiresWorkflowStampEnforcement` gate, and it fires on panel *capability*, not on the turn pin, so it cannot produce a refusal naming the older workflow.

## What IS wrong, reproduced verbatim on clean main

`panel_set_workflow_target({mode:"current"})` answered **"Following the user's current workflow tab."** unconditionally. That is a claim about ROUTING, and it is false whenever this conversation's in-flight turn pin is holding every graph command on a different tab. It is the exact arm panel#1529's fix (#1912) left open: that change made only the `mode:"pinned"` claim conditional.

Worse, nothing in the reply mentioned the pin at all. For a scope-bound ctx whose pin still reaches a live tab, `rebindToActiveTab` short-circuits **before** consulting the repin handler (#884 — a live pin is never displaced) and returns `{rebound:false}` with no `repinRefusal`, so even #1077's "the session pin was NOT moved" note never fires on this path.

Measured on clean `origin/main`, two connected tabs, pin on the tab showing `Basic_V37`, active-scope resolution naming the tab showing `PHOTO`:

```
resolveActiveScopeTab = wf:rB:workflows/PHOTO.json
scope resolves to     = wf:rA:workflows/Basic_V37.json

panel_set_workflow_target({mode:"current"}) ->
  { "mode":"current", "graph_binding":"bound", "graph_binding_status":"already_current",
    "note":"Following the user's current workflow tab. ..." }

panel_graph_outline  -> BasicNode        (dispatched to wf:rA, Basic_V37)
panel_remove_node    -> ok, on Basic_V37 (dispatched to wf:rA, Basic_V37)
```

The agent is told it is following the user's current tab, and every graph command — read and mutation — goes somewhere else, unannounced. That is the same "reports success, the effect never happened" shape as #1529, and it is the honest explanation available for the reporter's second reproduction.

## The change

**#884 is untouched.** `turn-origins.ts` is not modified at all, `makeScopeRepinHandler` is not modified at all, and no pin is displaced to make any sentence true. A named test asserts the pin is exactly where it was after the call.

Instead, when the turn pin and the active-scope resolution name **different tabs**, `mode:"current"` now:

1. stops printing "Following the user's current workflow tab.";
2. names **both** tabs, states that the pin was not displaced and why (#884), says explicitly that this covers **reads and mutations alike**, and says what does and does not move the pin (retrying the tool does not; the pin is released at turn end and the next message's origin establishes routing);
3. carries it machine-readably — `turn_routing:"pinned_elsewhere"`, `turn_routing_tab`, `current_would_route_to` — the same rule #1912's `pin_verified_active` established, so no agent has to read a routing verdict out of prose.

This is option 3 of the reporter's own list (a refusal/disclosure instead of a false claim), and the "cheaper first step" #1917's own body names. It deliberately does **not** take options 1 or 2 (synchronize the route, or let a workflow target displace a live pin) — see below.

The comparison is between **canonical connection ids** on both sides (`resolveSharedTabId` and `resolveActiveScopeTab` both answer with `conn.tabId`). A pin naming a retired per-workflow route id (#640) that still resolves onto the same live socket is therefore **not** a disagreement — otherwise this warning would fire on every healthy single-tab session after any `panel_open_workflow`.

## Verification

`src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts` — 6 tests, e2e over a real bridge on a real socket, every assertion reading the string or field an agent actually receives from the real tool def.

**Mutation-verified — four independent deletions, each turning exactly the named tests red:**

| mutation | red |
|---|---|
| revert the `hint` branch to the unconditional claim | `names BOTH tabs instead of claiming it follows the current one` |
| delete the `...turnRoutingSplitFields` spread at **both** `ok()` call sites | `carries the split MACHINE-READABLY, so no caller has to parse the prose` |
| neuter the canonical-id comparison (`routedTab !== activeScopeTab` to `true`) | `says nothing when the two selectors AGREE`, `a RETIRED route id that still reaches the same socket is not a split` |
| make the `scopeRoutedTabId` helper always return `undefined` | the first two tests |

Restore gives 6/6. The helper mutation and the call-site mutation turn *different* tests red, so the one-line wiring is pinned rather than only the helper.

**Suite:** full `vitest run` on this branch, run alone — **595 files / 10990 passed / 4 skipped / 0 failed**. A baseline on a clean `origin/main` worktree reported 3 files / 5 tests failing, all 30-second timeouts, and all of them pass here: they were machine-load artifacts from two suites running concurrently, not pre-existing breakage. `tsc --noEmit` clean. `npm run check:vocabulary` OK.

**Browser suite: not run, and not implied.** This change is orchestrator-side only — one tool reply string and three reply fields. Nothing in `comfyui-mcp-panel` is touched and nothing the panel renders changes.

## Deliberately not done

- **The pin is not displaced.** Widening `makeScopeRepinHandler` from *dead-or-ambiguous* to *dead-or-ambiguous-or-different* would re-aim an in-flight conversation's mutations at a tab it never addressed — #884's P0, and the reason the #1529 work left that handler alone.
- **Sessions are not made workflow- or tab-scoped.** They are orchestrator-scoped by design.
- **The `mode:"pinned"` arm is unchanged.** #888's `scopeRepinNote` already discloses a refused repin there, and #1912 already conditioned its claim.
- **No `fail()` on this path.** The result stays `ok`: the target write and the fence rebind did happen, and failing here would break the documented recovery for ordinary two-tab users on a predicate that can legitimately differ. The claim is corrected; the outcome is not manufactured.
- **`panel_open_workflow` not refreshing the conversation stamp.** The sweep showed the scope stamp still naming the previous workflow immediately after a successful `panel_open_workflow` plus same-socket re-hello (the following `mode:"current"` is what refreshes it). That is a separate question, and it is left out rather than folded in silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
