### PR TITLE
release: v0.52.34 — mode current does not steal another pins routing target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.34] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- mode:"current" may not claim a routing target the turn pin holds elsewhere (#1919)
+
+
 ## [0.52.33] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.33",
+  "version": "0.52.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.33",
+      "version": "0.52.34",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.33",
+  "version": "0.52.34",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.34 from main.

Carries:

- #1919 / #1917 — mode:current may not claim a routing target the turn pin holds elsewhere

Held out: #1839 anthropic 4 CI red; #1697 P1 inflight; panel#654 inflight.

Do not squash-merge. Merge-commit (keeps the v0.52.34 tag on the version commit). Tag is local; push v0.52.34 after merge.