### PR TITLE
fix(panel#654): panel_graph_outline waits out a 26-28s Desktop recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,13 +759,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_graph_outline` after `panel_restart_comfyui` waits out a 26–28s Desktop recover (panel#654).**
+  The post-restart tab wait defaulted to 20s (`COMFYUI_PANEL_RECONNECT_WAIT_S`). ComfyUI Desktop recoveries of 26–28s after the server was already healthy expired that budget, so `panel_graph_outline` reported still reconnecting / `Connected: none` and only a hard browser refresh restored the tab. The default is now 35s (still capped at 60s).
+
 ## [0.52.34] - 2026-08-20
 
 ### MCP
 
 #### Fixed
 - mode:"current" may not claim a routing target the turn pin holds elsewhere (#1919)
-
 
 ## [0.52.33] - 2026-08-20
 

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -94,7 +94,7 @@ beforeEach(() => {
   // panel-recovery-cluster.test.ts, which does this correctly and is not
   // one of the flaky files.
   __resetPanelBaseCache();
-  // Keep the reconnect wait fast so tests don't sit through the real ~20s budget.
+  // Keep the reconnect wait fast so tests don't sit through the real ~35s budget.
   __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 500, intervalMs: 5 });
   // The #742 refuse-safe preflight passes by default here (the live one would
   // probe real processes/ports); these tests exercise the post-dispatch paths.
@@ -987,5 +987,63 @@ describe("#1881 a retry-safe READ waits out the post-restart 0-tab window", () =
     const res = await defByName("panel_list_subgraphs").handler({}, ctx);
     expect(res.isError).toBe(true);
     expect(Date.now() - t0).toBeLessThan(1000);
+  });
+});
+
+// panel#654 — ComfyUI Desktop recoveries of 26–28s after the server was already
+// healthy expired the 20s reconnectWaitTiming default. panel_graph_outline then
+// reported still reconnecting / Connected: none, and only a hard refresh restored
+// the tab. The default is 35s; this pins that number AND drives the shipped
+// panel_graph_outline path through reconnectWaitTiming() (env, not the test
+// override) so a hello landing after a 20s-scaled budget still answers.
+describe("#654 reconnect wait covers a 26-28s Desktop recover", () => {
+  const prevWait = (): string | undefined => process.env.COMFYUI_PANEL_RECONNECT_WAIT_S;
+  const prevPoll = (): string | undefined => process.env.COMFYUI_PANEL_RECONNECT_POLL_S;
+  const restoreEnv = (wait: string | undefined, poll: string | undefined): void => {
+    if (wait === undefined) delete process.env.COMFYUI_PANEL_RECONNECT_WAIT_S;
+    else process.env.COMFYUI_PANEL_RECONNECT_WAIT_S = wait;
+    if (poll === undefined) delete process.env.COMFYUI_PANEL_RECONNECT_POLL_S;
+    else process.env.COMFYUI_PANEL_RECONNECT_POLL_S = poll;
+  };
+
+  it("default budget is 35s — past the 26-28s Desktop recover, under the 60s ceiling", () => {
+    const wait = prevWait();
+    const poll = prevPoll();
+    delete process.env.COMFYUI_PANEL_RECONNECT_WAIT_S;
+    delete process.env.COMFYUI_PANEL_RECONNECT_POLL_S;
+    __panelToolsTestHooks.setReconnectWaitTiming(null);
+    try {
+      const t = __panelToolsTestHooks.getReconnectWaitTiming();
+      expect(t.budgetMs).toBe(35_000);
+      expect(t.budgetMs).toBeGreaterThan(28_000);
+      expect(t.budgetMs).toBeLessThanOrEqual(60_000);
+    } finally {
+      restoreEnv(wait, poll);
+    }
+  });
+
+  it("panel_graph_outline recovers when the re-hello lands after a 20s wait would have given up", async () => {
+    // Scale: 35s default → 350ms here; a 22s Desktop hello → 220ms, which is past
+    // the old 200ms (20s) budget and inside the new one. No override hook — the
+    // shipped reconnectWaitTiming() reads the env the production path reads.
+    const wait = prevWait();
+    const poll = prevPoll();
+    process.env.COMFYUI_PANEL_RECONNECT_WAIT_S = "0.35";
+    process.env.COMFYUI_PANEL_RECONNECT_POLL_S = "0.02";
+    __panelToolsTestHooks.setReconnectWaitTiming(null);
+    __panelToolsTestHooks.setRetrySettleMs(5);
+    try {
+      expect(__panelToolsTestHooks.getReconnectWaitTiming().budgetMs).toBe(350);
+      const { bridge, live, sent } = reconnectingBridge([]);
+      const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+      setTimeout(() => live.add("reconnected-tab"), 220);
+      const res = await defByName("panel_graph_outline").handler({}, ctx);
+      expect(res.isError).toBeFalsy();
+      expect(sent.at(-1)?.cmd).toMatchObject({ cmd: "graph_outline" });
+      expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+    } finally {
+      restoreEnv(wait, poll);
+      __panelToolsTestHooks.setRetrySettleMs(null);
+    }
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -5998,7 +5998,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
   it("does NOT read the live canvas at all when the rebind DEFERRED (zero tabs connected)", async () => {
     // There is nothing to read from yet, and the deferred note already says so.
     // Probing anyway would turn a truthful deferral into a spurious failure.
-    // Collapse the real ~20s reconnect wait — this asserts a branch, not a clock.
+    // Collapse the real ~35s reconnect wait — this asserts a branch, not a clock.
     __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 1, intervalMs: 1 });
     const sent: Array<Record<string, unknown>> = [];
     const refresh = vi.fn(() => true);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -931,9 +931,13 @@ export const __panelToolsTestHooks = {
   setRetrySettleMs(ms: number | null): void {
     retrySettleMsOverride = ms;
   },
-  /** Inject fast reconnect-wait timing so #400/#402 tests don't wait the real ~20s. */
+  /** Inject fast reconnect-wait timing so #400/#402 tests don't wait the real ~35s. */
   setReconnectWaitTiming(timing: { budgetMs: number; intervalMs: number } | null): void {
     reconnectWaitTimingOverride = timing;
+  },
+  /** The reconnect wait the tools actually use (env/default, or the test override). */
+  getReconnectWaitTiming(): { budgetMs: number; intervalMs: number } {
+    return reconnectWaitTiming();
   },
   /** Shrink the #1175 late-acknowledgement grace so a reconcile test doesn't wait 10s. */
   setRunLateAckGraceMs(ms: number | null): void {
@@ -1434,12 +1438,17 @@ let reconnectWaitTimingOverride: ReconnectWaitTiming | null = null;
 /** Hard ceiling on the reconnect wait so an oversized env value can never make a
  *  tool block near/over the outer MCP tools/call deadline (~300s). */
 const RECONNECT_WAIT_MAX_MS = 60_000;
+/** Default seconds to wait for a tab re-hello after restart/reload.
+ *  20s lost to ComfyUI Desktop recoveries of 26–28s after the server was already
+ *  healthy (panel#654): `panel_graph_outline` reported Connected: none and only a
+ *  hard refresh restored the tab. 35s covers those recoveries; the 60s ceiling stays. */
+const RECONNECT_WAIT_DEFAULT_S = 35;
 function reconnectWaitTiming(): ReconnectWaitTiming {
   if (reconnectWaitTimingOverride) return reconnectWaitTimingOverride;
   return {
     budgetMs: Math.min(
       RECONNECT_WAIT_MAX_MS,
-      Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_RECONNECT_WAIT_S", 20) * 1000),
+      Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_RECONNECT_WAIT_S", RECONNECT_WAIT_DEFAULT_S) * 1000),
     ),
     intervalMs: Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_RECONNECT_POLL_S", 0.5) * 1000),
   };


### PR DESCRIPTION
After a confirmed `panel_restart_comfyui`, ComfyUI Desktop was healthy but `panel_graph_outline` still reported the panel reconnecting / `Connected: none`, and `panel_set_workflow_target({mode:\"current\"})` could not restore the graph binding. A hard browser refresh was required.

The post-restart tab wait (`COMFYUI_PANEL_RECONNECT_WAIT_S`) defaulted to 20s. Desktop recoveries of 26–28s after the server was already healthy expired that budget. The default is now 35s (still capped at 60s).

This is the remaining MCP-owned residual after panel #1347 (re-hello when the bridge survives the restart). Turn-pin / `mode:\"current\"` follow-ups (#1916 / #1919) stay on main as they were.

Tests drive `panel_graph_outline` on the shipped `reconnectWaitTiming()` path (env, not the test override): a re-hello landing after a 20s-scaled budget now answers.

Fixes artokun/comfyui-mcp-panel#654