### PR TITLE
fix(1917): panel_get_workflow_target discloses the same routing split

### DIFF
--- a/src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts
+++ b/src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts
@@ -498,3 +498,77 @@ describe("mcp#1917 — mode:'current' may not claim a routing target the turn pi
     expect(body.turn_routing).toBeUndefined();
   });
 });
+
+// The SAME false claim, on the tool an unsure agent actually reaches for.
+// panel_get_workflow_target exists to answer "which workflow will my panel_* edits
+// affect?", and its own description answers `current` with "graph tools follow
+// whatever tab the user is viewing". In the split state that is untrue for exactly
+// the reason panel_set_workflow_target's sentence was: the in-flight turn pin is
+// holding every graph command on another tab. Fixing only the SET tool would leave
+// the READ tool quietly restating the belief that wedged the reporter.
+describe("mcp#1917 — panel_get_workflow_target discloses the same split", () => {
+  const getTarget = (ctx: PanelToolCtx): Promise<ToolResult> =>
+    tool("panel_get_workflow_target").handler({}, ctx);
+
+  it("names BOTH tabs instead of answering a bare mode:'current'", async () => {
+    const { tabA, tabB, ctx } = await twoTabsPinnedElsewhere();
+
+    const res = await getTarget(ctx);
+
+    expect(res.isError, textOf(res)).toBeFalsy();
+    const body = jsonOf(res);
+    // Still reports the target it was asked for — the disclosure is added, not swapped.
+    expect(body.mode).toBe("current");
+    const note = String(body.note ?? "");
+    expect(note).toContain("Basic_V37");
+    expect(note).toContain("PHOTO");
+    expect(note).toContain("READS AND MUTATIONS ALIKE");
+    // The call-site half: a helper that computes the split but is never spread into
+    // THIS reply passes every prose assertion above.
+    expect(body.turn_routing).toBe("pinned_elsewhere");
+    expect(body.turn_routing_tab).toBe(tabA.tabId);
+    expect(body.current_would_route_to).toBe(tabB.tabId);
+  });
+
+  it("does not move the pin — it is a READ (#884)", async () => {
+    const { tabA, ctx } = await twoTabsPinnedElsewhere();
+    const pinBefore = tracker.pinOf(SCOPE);
+
+    await getTarget(ctx);
+
+    expect(tracker.pinOf(SCOPE)).toBe(pinBefore);
+    expect(tracker.pinOf(SCOPE)).toBe(tabA.tabId);
+  });
+
+  it("says nothing when the two selectors AGREE — the boundary, on purpose", async () => {
+    const page = new FakePanel("wf:r1:workflows/PHOTO.json", "r1", [PHOTO], 0);
+    await page.connect();
+    tabStamp.set(page.tabId, PHOTO.uuid);
+    tracker.repinTo(SCOPE, page.tabId);
+
+    const body = jsonOf(await getTarget(ctxFor(SCOPE)));
+
+    expect(body.mode).toBe("current");
+    expect(body.note).toBeUndefined();
+    expect(body.turn_routing).toBeUndefined();
+    expect(body.turn_routing_tab).toBeUndefined();
+  });
+
+  it("leaves a PINNED target alone — its guard reply is a different claim (#1912)", async () => {
+    // A pin makes no "follows the tab you are viewing" claim for a split to
+    // contradict: it travels on graph commands as a GUARD and a mismatch fails
+    // loudly. Reporting a routing split on top of that would attach #1917's remedy
+    // to a state whose remedy is panel#1529's.
+    const { tabA, ctx } = await twoTabsPinnedElsewhere();
+    workflowTargets.set(SCOPE, { mode: "pinned", path: BASIC.path, filename: BASIC.filename });
+    // The precondition holds: the two selectors still name different tabs.
+    expect(bridge.resolveSharedTabId(SCOPE)).toBe(tabA.tabId);
+    expect(bridge.resolveSharedTabId(SCOPE)).not.toBe(bridge.resolveActiveScopeTab());
+
+    const body = jsonOf(await getTarget(ctx));
+
+    expect(body.mode).toBe("pinned");
+    expect(body.turn_routing).toBeUndefined();
+    expect(body.note).toBeUndefined();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14660,9 +14660,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // addressed. What changes is the CLAIM: when two selectors name different
         // tabs, say so and name both, rather than silently reporting one of them.
         // Compared as CANONICAL connection ids on both sides — see
-        // turnPinRoutesElsewhereFor. `turn_routing:"repinned"` and
-        // `"pinned_elsewhere"` are mutually exclusive by construction: this arm
-        // requires `!currentModeTurnRepinned`.
+        // turnPinRoutesElsewhereFor.
+        //
+        // `!currentModeTurnRepinned` is REDUNDANT on every ordinary path and is kept
+        // deliberately: a repin moves the pin ONTO the active tab, so the equality
+        // check inside the helper already returns undefined. It earns its place only
+        // in the race where the active tab changes between the repin and this line —
+        // there the helper WOULD report a split, and the note attached to it says
+        // "that pin was NOT displaced", which had just stopped being true. Suppressing
+        // it there keeps `turn_routing:"repinned"` and `"pinned_elsewhere"` mutually
+        // exclusive and keeps the reply from contradicting itself. Staging that race
+        // deterministically is not worth a test, so a mutation dropping this condition
+        // survives the suite; that is a known and accepted gap, not an oversight.
         const turnPinRoutesElsewhere =
           mode === "current" && !currentModeTurnRepinned
             ? turnPinRoutesElsewhereFor(ctx)

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -113,6 +113,14 @@ import { NO_ORIGIN_REMEDY } from "./fence-refusal.js";
  *  labeled "foreign" and boundary sweeps could never close the ticket (codex
  *  round 3, P1). Resolves the scope to the active tab; a real-tab ctx is
  *  returned unchanged. */
+function journalTabFor(ctx: PanelToolCtx): string {
+  if (!isScopeAddress(ctx.tabId)) return ctx.tabId;
+  // Pass the ctx's own (backend-qualified) scope address so the RIGHT
+  // conversation's in-flight-turn pin is consulted (#884 P0).
+  const b = ctx.bridge as { resolveSharedTabId?: (scopeId?: string) => string | undefined };
+  return b.resolveSharedTabId?.(ctx.tabId) ?? ctx.tabId;
+}
+
 /**
  * #1917 — the CANONICAL tab id a SCOPE-addressed session's commands are dispatched
  * to right now: the in-flight turn's routing pin, resolved onward through any
@@ -140,12 +148,49 @@ function scopeRoutedTabId(ctx: PanelToolCtx): string | undefined {
   }
 }
 
-function journalTabFor(ctx: PanelToolCtx): string {
-  if (!isScopeAddress(ctx.tabId)) return ctx.tabId;
-  // Pass the ctx's own (backend-qualified) scope address so the RIGHT
-  // conversation's in-flight-turn pin is consulted (#884 P0).
-  const b = ctx.bridge as { resolveSharedTabId?: (scopeId?: string) => string | undefined };
-  return b.resolveSharedTabId?.(ctx.tabId) ?? ctx.tabId;
+/**
+ * #1917 — the two selectors a `mode:"current"` session routes by, WHEN THEY
+ * DISAGREE: the tab this conversation's in-flight turn pin is holding every graph
+ * command on, and the tab "current" would otherwise resolve to. Undefined when
+ * they agree, when either cannot be resolved, or for a real-tab ctx — i.e. the
+ * disclosure is made only on the evidence that supports it.
+ *
+ * Both sides are CANONICAL connection ids (`resolveSharedTabId` and
+ * `resolveActiveScopeTab` both answer with `conn.tabId`), so a pin that merely
+ * names a RETIRED per-workflow route id but still reaches the same live socket is
+ * NOT a split — otherwise this would fire on every healthy single-tab session that
+ * has run a `panel_open_workflow` (#640).
+ *
+ * An AMBIGUOUS pin (`null` from the resolver, a mixed-origin batch) resolves to
+ * undefined here and is deliberately not reported as a split: routing is refused
+ * outright on that shape, which is a different reply with a different remedy.
+ */
+function turnPinRoutesElsewhereFor(
+  ctx: PanelToolCtx,
+): { routedTab: string; activeScopeTab: string } | undefined {
+  if (!isScopeAddress(ctx.tabId)) return undefined;
+  const routedTab = scopeRoutedTabId(ctx);
+  const activeScopeTab =
+    typeof ctx.bridge.resolveActiveScopeTab === "function"
+      ? ctx.bridge.resolveActiveScopeTab()
+      : undefined;
+  if (typeof routedTab !== "string" || typeof activeScopeTab !== "string") return undefined;
+  return routedTab === activeScopeTab ? undefined : { routedTab, activeScopeTab };
+}
+
+/** #1917 — the split verdict, MACHINE-READABLE, so an agent never has to read
+ *  "the two selectors disagree" out of prose. Shared by the tool that SETS the
+ *  target and the tool that REPORTS it, so the two can never drift apart. */
+function turnRoutingSplitFieldsFor(
+  split: { routedTab: string; activeScopeTab: string } | undefined,
+): Record<string, unknown> {
+  return split
+    ? {
+        turn_routing: "pinned_elsewhere" as const,
+        turn_routing_tab: split.routedTab,
+        current_would_route_to: split.activeScopeTab,
+      }
+    : {};
 }
 
 /** #704 — the CONVERSATION a ticket belongs to: the backend-qualified agent key
@@ -14274,7 +14319,38 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       {},
       async (_args, ctx) => {
         const target = ctx.workflowTarget?.get(ctx.tabId) ?? { mode: "current" as const };
-        return ok(target);
+        // #1917 — this tool's whole job is to answer "which workflow will my
+        // panel_* edits affect?", and its own description answers `current` with
+        // "graph tools follow whatever tab the user is viewing". That is the SAME
+        // routing claim panel_set_workflow_target was making, so it is false in the
+        // same state: when this conversation's in-flight turn pin is holding every
+        // graph command on a different tab, the tab the user is viewing is NOT where
+        // the edits land. An agent that is unsure enough to call this is exactly the
+        // caller that must not be told the reassuring half.
+        //
+        // Only for `current`. A PIN makes no claim this could contradict — it travels
+        // on graph commands as a GUARD and a mismatch fails loudly (#1912), so a
+        // pinned session is left to that reply.
+        const split = target.mode === "pinned" ? undefined : turnPinRoutesElsewhereFor(ctx);
+        if (!split) return ok(target);
+        return ok({
+          ...target,
+          ...turnRoutingSplitFieldsFor(split),
+          note:
+            `mode:"current" is the workflow TARGET, but it is NOT where graph commands ` +
+            `are going right now. This conversation's IN-FLIGHT TURN is pinned to tab ` +
+            `${shortTabId(split.routedTab)}, so every graph command — READS AND ` +
+            `MUTATIONS ALIKE — is dispatched there, not to ` +
+            `${shortTabId(split.activeScopeTab)}, which is the tab "current" would ` +
+            `resolve to. TWO SELECTORS NAME DIFFERENT TABS. A pin that still reaches a ` +
+            `live tab of this conversation is never displaced, however explicit the ` +
+            `request (#884), so calling panel_set_workflow_target({mode:"current"}) ` +
+            `will NOT move it. Work on tab ${shortTabId(split.routedTab)} (read it ` +
+            `first with panel_graph_outline) if that is the workflow you mean; ` +
+            `otherwise ask the user to send a message from the tab they want — the ` +
+            `turn pin is released at the end of this turn and the next message's ` +
+            `origin establishes routing.`,
+        });
       },
     ),
     def(
@@ -14583,36 +14659,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // would re-aim an in-flight conversation's mutations at a tab it never
         // addressed. What changes is the CLAIM: when two selectors name different
         // tabs, say so and name both, rather than silently reporting one of them.
-        const routedTab = scopeRoutedTabId(ctx);
-        const activeScopeTab =
-          typeof ctx.bridge.resolveActiveScopeTab === "function"
-            ? ctx.bridge.resolveActiveScopeTab()
-            : undefined;
-        // Compared as CANONICAL connection ids on both sides (resolveSharedTabId and
-        // resolveActiveScopeTab both answer with `conn.tabId`), so a pin that merely
-        // names a RETIRED per-workflow route id but still resolves onto the same live
-        // socket does not read as a split — only a genuinely different tab does.
+        // Compared as CANONICAL connection ids on both sides — see
+        // turnPinRoutesElsewhereFor. `turn_routing:"repinned"` and
+        // `"pinned_elsewhere"` are mutually exclusive by construction: this arm
+        // requires `!currentModeTurnRepinned`.
         const turnPinRoutesElsewhere =
-          mode === "current" &&
-          !currentModeTurnRepinned &&
-          isScopeAddress(ctx.tabId) &&
-          typeof routedTab === "string" &&
-          typeof activeScopeTab === "string" &&
-          routedTab !== activeScopeTab
-            ? { routedTab, activeScopeTab }
+          mode === "current" && !currentModeTurnRepinned
+            ? turnPinRoutesElsewhereFor(ctx)
             : undefined;
         // panel#1529's `pin_verified_active` rule, applied to the routing half: the
         // same verdict the note carries, MACHINE-READABLE, so an agent never has to
-        // read "the two selectors disagree" out of prose. `turn_routing:"repinned"`
-        // and `"pinned_elsewhere"` are mutually exclusive by construction — the
-        // predicate above requires `!currentModeTurnRepinned`.
-        const turnRoutingSplitFields = turnPinRoutesElsewhere
-          ? {
-              turn_routing: "pinned_elsewhere" as const,
-              turn_routing_tab: turnPinRoutesElsewhere.routedTab,
-              current_would_route_to: turnPinRoutesElsewhere.activeScopeTab,
-            }
-          : {};
+        // read "the two selectors disagree" out of prose.
+        const turnRoutingSplitFields = turnRoutingSplitFieldsFor(turnPinRoutesElsewhere);
         const hint =
           target.mode === "pinned"
             ? pinVerifiedActive


### PR DESCRIPTION
**Review: PENDING** — requested from grok in a comment below. Nothing here is gated and no verdict is claimed.
Not panel-rendered: this changes an orchestrator tool's reply payload, so the panel Playwright gate does not apply.

Follow-up to #1917 / #1919. The issue is already closed and this does not reopen it — #1919 fixed the tool that **sets** the workflow target; this fixes the identical false claim on the tool that **reports** it.

### The gap #1919 left

`panel_get_workflow_target` exists to answer *"which workflow will my `panel_*` edits affect?"* — its own description answers `current` with **"graph tools follow whatever tab the user is viewing"**. That is the same routing claim `panel_set_workflow_target` was making, so it is false in the same state, and the reply carried nothing to correct it:

```
panel_get_workflow_target()  ->  { "mode": "current" }
```

No note, no fields — while every graph command was being dispatched to the tab this conversation's in-flight turn pin names. An agent unsure enough to call this is precisely the caller that must not be handed the reassuring half. Fixing only the SET tool left the READ tool quietly restating the belief that wedged the reporter.

### What changes

`panel_get_workflow_target` now carries the same disclosure and the same machine-readable verdict `#1919` established:

```
{ "mode": "current",
  "turn_routing": "pinned_elsewhere",
  "turn_routing_tab": "wf:rA:Basic_V37.json",
  "current_would_route_to": "wf:rB:PHOTO.json",
  "note": "mode:\"current\" is the workflow TARGET, but it is NOT where graph commands
           are going right now. … every graph command — READS AND MUTATIONS ALIKE — is
           dispatched there … A pin that still reaches a live tab of this conversation
           is never displaced, however explicit the request (#884), so calling
           panel_set_workflow_target({mode:\"current\"}) will NOT move it. …" }
```

Both tools now build the verdict from **one shared predicate** (`turnPinRoutesElsewhereFor` / `turnRoutingSplitFieldsFor`), so the two replies cannot drift apart. The set-site keeps its behaviour exactly — the refactor is extraction, and the original mutations still kill the original tests.

Only for `current`. A **pin** makes no claim a split could contradict: it travels on graph commands as a GUARD and a mismatch fails loudly (panel#1529 / #1912). A named test holds that boundary, so #1917's remedy is never attached to a state whose remedy is #1529's.

### #884 is untouched here too

`panel_get_workflow_target` is a **READ**. It resolves the two selectors and reports them; `turn-origins.ts` and `makeScopeRepinHandler` are not modified, no pin is displaced to make a sentence true, and a named test asserts the pin is exactly where it was after the call.

### Also in here

- `scopeRoutedTabId` is moved **below** `journalTabFor`. Inserted where #1919 put it, it separated `journalTabFor` from its own #884 JSDoc, which then read as documentation for the new function.
- A comment recording why `!currentModeTurnRepinned` is kept in the set-site predicate even though it is redundant — see *Known gap* below.

### Verification

Four new e2e tests over a real `UiBridge` on a real socket, with the real `TurnOriginTracker` + `makeScopeTargetResolver`/`makeScopeRepinHandler` wired as `orchestrator/index.ts` wires them and the real `WorkflowTargetStore` — the same harness #1919 added. Every assertion reads the field or string an agent actually receives. 10/10 in the file.

Mutation-verified, each mutation's application **counted before the run** so a mutation that silently fails to apply cannot read as survived:

| mutation | result |
|---|---|
| drop the split spread from the GET reply | 1 test red (the machine-readable one) |
| GET never computes the split | 1 test red |
| GET drops the pinned-target guard (reports a split on a PIN too) | 1 test red — the boundary test |
| GET returns early, never reaching the disclosure | 1 test red |
| helper drops the same-tab equality guard (over-reports) | 3 tests red, across BOTH tools |
| drop both set-site spreads (#1919's own wiring, after the extraction) | still red |

The helper mutation and the call-site mutations turn *different* tests red, so the wiring is pinned and not only the helper.

`tsc --noEmit`, `tsc`, `i18n:check`, all four docs/blog checks, `asset-counts --check`, `check:vocabulary`, `check:unknown-collapse` and `vocab:export --check` are green locally. A full-suite run on this change's content passed **595 files / 10994 tests** before main moved; a later local re-run collided with another agent's concurrent suite on this machine (501 failed *files*, 41 failed *tests* — the load-contention signature, none of them in this file), so CI on a clean runner is the authority for the full suite here and I am not claiming a green I could not isolate.

### Known gap, stated rather than hidden

A mutation that drops `!currentModeTurnRepinned` from the set-site predicate **survives** the suite. It is redundant on every ordinary path — a repin moves the pin onto the active tab, so the helper's own equality check already returns `undefined`. It earns its place only in the race where the active tab changes between the repin and that line, where the reply would otherwise carry `pinned_elsewhere` beside a note claiming the pin was not displaced, which had just stopped being true. Staging that race deterministically is not worth a test; the condition and the gap are both documented in the code.

Separately, and pre-existing rather than introduced here: the disclosure (like the `rebindNote` beside it) is captured before the fence-probe block, which can itself call `rebindToActiveTab`. That call is gated on `!sessionRouteIsLive(ctx)`, which is false in the split state by construction — the split requires a pin that resolves — so it is reachable only if the pinned tab dies mid-call. Left alone deliberately: restructuring the capture order of a delicate handler is a larger change than the window justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


