### PR TITLE
fix(1921): panel_create_group auto-bounds survive SaveImage rehydration

### DIFF
--- a/src/__tests__/orchestrator/create-group-collapsed.test.ts
+++ b/src/__tests__/orchestrator/create-group-collapsed.test.ts
@@ -190,21 +190,33 @@ describe("#1877 collapsed node membership (panel_create_group)", () => {
     expect(group.node_ids).toEqual([]);
   });
 
-  it("passes a successful create through without extra round trips", async () => {
+  it("does not edit when requested members already fit their live size", async () => {
     const calls: Forwarded[] = [];
     const ctx: PanelToolCtx = {
       call: async (cmd) => {
         calls.push(cmd);
-        return jsonResult({
-          group: { id: 1, bounding: [0, 0, 400, 300], node_count: 2, node_ids: [1, 2] },
-        });
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: { id: 1, bounding: [0, 0, 400, 300], node_count: 2, node_ids: [1, 2] },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            text:
+              `2 match(es)\n` +
+              JSON.stringify({ id: 1, type: "KSampler", pos: [20, 20], size: [210, 80] }) +
+              "\n" +
+              JSON.stringify({ id: 2, type: "CLIPTextEncode", pos: [20, 140], size: [210, 80] }),
+          });
+        }
+        return jsonResult({ ok: true });
       },
       confirm: async () => "yes" as const,
       bridge: {} as PanelToolCtx["bridge"],
       tabId: "test-tab",
     };
     const res = await defByName("panel_create_group").handler({ node_ids: [1, 2] }, ctx);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group", "graph_query"]);
     expect((parseResult(res).group as Record<string, unknown>).node_ids).toEqual([1, 2]);
   });
 

--- a/src/__tests__/orchestrator/create-group-rehydrate.test.ts
+++ b/src/__tests__/orchestrator/create-group-rehydrate.test.ts
@@ -1,0 +1,227 @@
+// #1921 — panel_create_group auto-bounds from compact SaveImage size do not
+// survive widget rehydration. The shipped path is panel_create_group →
+// graph_create_group; the handler now expands the box (graph_edit_group) so a
+// requested SaveImage whose origin is already inside stays a member after its
+// body grows from [270,58] to [270,326].
+//
+// The mock panel here applies LiteGraph's containsCentre rule independently
+// against the REHYDRATED size (boundingRect = pos with a 30px title above).
+// It does not import the expander under test.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  expandGroupBoundsForMembership,
+  nodePosInsideGroupBounds,
+  type QueriedNodeGeom,
+} from "../../orchestrator/create-group-membership.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+
+const TITLE = 30;
+
+/** Reporter's auto-fit box around nodes 5, 6, 7 before SaveImage rehydrate. */
+const CREATED_BOUNDS: [number, number, number, number] = [1090, -30, 580, 404];
+const COMPACT: [number, number] = [270, 58];
+const REHYDRATED: [number, number] = [270, 326];
+
+const NODE_5: QueriedNodeGeom = {
+  id: 5,
+  type: "SaveImage",
+  pos: [1120, 40],
+  size: COMPACT,
+};
+const NODE_6: QueriedNodeGeom = {
+  id: 6,
+  type: "SaveImage",
+  pos: [1370, 40],
+  size: COMPACT,
+};
+const NODE_7: QueriedNodeGeom = {
+  id: 7,
+  type: "SaveImage",
+  pos: [1370, 250],
+  size: COMPACT,
+};
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found in buildPanelToolDefs()`);
+  return def;
+}
+
+function jsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function parseResult(res: ToolResult): Record<string, unknown> {
+  const text = res.content.find((c) => c.type === "text")?.text;
+  return JSON.parse(text ?? "{}") as Record<string, unknown>;
+}
+
+function asQuad(v: unknown): [number, number, number, number] | null {
+  if (!Array.isArray(v) || v.length !== 4) return null;
+  const q: [number, number, number, number] = [Number(v[0]), Number(v[1]), Number(v[2]), Number(v[3])];
+  return q.every(Number.isFinite) ? q : null;
+}
+
+/**
+ * LiteGraph containsCentre of boundingRect (title bar above pos, max edge exclusive).
+ * `size` is the body used for membership — compact at create, rehydrated after reopen.
+ */
+function panelContainsCentre(
+  bounds: [number, number, number, number],
+  node: QueriedNodeGeom,
+  size: [number, number],
+): boolean {
+  const w = size[0] > 0 ? size[0] : 200;
+  const h = size[1] > 0 ? size[1] : 100;
+  const cx = node.pos[0] + w / 2;
+  const cy = node.pos[1] - TITLE + (h + TITLE) / 2;
+  const [gx, gy, gw, gh] = bounds;
+  return cx >= gx && cx < gx + gw && cy >= gy && cy < gy + gh;
+}
+
+function detailLine(node: QueriedNodeGeom): string {
+  return JSON.stringify({
+    id: node.id,
+    type: node.type,
+    pos: node.pos,
+    size: node.size,
+  });
+}
+
+describe("#1921 SaveImage auto-bounds survive rehydration (panel_create_group)", () => {
+  it("the reporter's compact box contains node 7 now and excludes it after rehydrate", () => {
+    expect(nodePosInsideGroupBounds(NODE_7.pos, CREATED_BOUNDS)).toBe(true);
+    expect(panelContainsCentre(CREATED_BOUNDS, NODE_7, COMPACT)).toBe(true);
+    expect(panelContainsCentre(CREATED_BOUNDS, NODE_7, REHYDRATED)).toBe(false);
+    expect(panelContainsCentre(CREATED_BOUNDS, NODE_5, REHYDRATED)).toBe(true);
+    expect(panelContainsCentre(CREATED_BOUNDS, NODE_6, REHYDRATED)).toBe(true);
+  });
+
+  it("expanding those bounds keeps the rehydrated centre a member", () => {
+    const expanded = expandGroupBoundsForMembership(CREATED_BOUNDS, [NODE_5, NODE_6, NODE_7]);
+    expect(panelContainsCentre(expanded, NODE_7, REHYDRATED)).toBe(true);
+    expect(panelContainsCentre(expanded, NODE_5, REHYDRATED)).toBe(true);
+    expect(panelContainsCentre(expanded, NODE_6, REHYDRATED)).toBe(true);
+    expect(nodePosInsideGroupBounds(NODE_7.pos, expanded)).toBe(true);
+  });
+
+  it("panel_create_group persists bounds that still contain node 7 after SaveImage rehydrate", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: {
+              id: 3,
+              title: "Group",
+              bounding: CREATED_BOUNDS,
+              node_count: 3,
+              node_ids: [5, 6, 7],
+              requested_node_ids: [5, 6, 7],
+            },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            total: 3,
+            matched: 3,
+            shown: 3,
+            text:
+              `3 match(es) of 3 in scope (viewing: 3 nodes)\n` +
+              `${detailLine(NODE_5)}\n${detailLine(NODE_6)}\n${detailLine(NODE_7)}`,
+          });
+        }
+        if (cmd.cmd === "graph_edit_group") {
+          const bounds = asQuad(cmd.bounds);
+          const members = [NODE_5, NODE_6, NODE_7].filter((n) =>
+            bounds ? panelContainsCentre(bounds, n, REHYDRATED) : false,
+          );
+          return jsonResult({
+            group: {
+              id: 3,
+              title: "Group",
+              bounding: bounds ?? CREATED_BOUNDS,
+              node_count: members.length,
+              node_ids: members.map((n) => n.id),
+            },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_create_group").handler({ node_ids: [5, 6, 7] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group", "graph_query", "graph_edit_group"]);
+
+    const payload = parseResult(res);
+    const group = payload.group as Record<string, unknown>;
+    expect(group.node_ids).toEqual([5, 6, 7]);
+    expect(group.node_count).toBe(3);
+    expect(group.missing_node_ids).toBeUndefined();
+    const persisted = asQuad(group.bounding);
+    expect(persisted).not.toEqual(CREATED_BOUNDS);
+    expect(persisted && panelContainsCentre(persisted, NODE_7, REHYDRATED)).toBe(true);
+  });
+
+  it("does not grow a collapsed SaveImage to preview height", async () => {
+    const collapsed: QueriedNodeGeom = {
+      id: 7,
+      type: "SaveImage",
+      pos: NODE_7.pos,
+      size: [270, 0],
+      collapsed: true,
+      full_height: 30,
+    };
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_create_group") {
+          return jsonResult({
+            group: {
+              id: 3,
+              bounding: CREATED_BOUNDS,
+              node_count: 1,
+              node_ids: [7],
+            },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            text:
+              `1 match(es)\n` +
+              JSON.stringify({
+                id: 7,
+                type: "SaveImage",
+                pos: collapsed.pos,
+                size: collapsed.size,
+                collapsed: true,
+                full_height: 30,
+              }),
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_create_group").handler({ node_ids: [7] }, ctx);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_create_group", "graph_query"]);
+    expect(asQuad((parseResult(res).group as Record<string, unknown>).bounding)).toEqual(CREATED_BOUNDS);
+  });
+});

--- a/src/orchestrator/create-group-membership.ts
+++ b/src/orchestrator/create-group-membership.ts
@@ -1,17 +1,23 @@
 /**
- * #1877 — panel_create_group can wrap a collapsed node and still report it
- * missing.
+ * #1877 / #1921 — panel_create_group auto-bounds from live `pos`/`size` can
+ * miss a requested node whose origin is already inside the box.
  *
- * The panel sizes the box from live `pos`/`size`. A collapsed node often has
- * `size[1] === 0` (title-chip only), so the box is ~100px tall around the
- * node's origin. Membership then tests the CENTRE of a boundingRect rebuilt
- * with the panel's `finiteExtent` fallback (0 is not a usable height, so the
- * body becomes 100px plus a 30px title). That centre sits a few pixels below
- * the box, so the group is empty even though the node's coordinates are inside.
+ * #1877: a collapsed node often has `size[1] === 0` (title-chip only), so the
+ * box is ~100px tall around the origin. Membership then tests the CENTRE of a
+ * boundingRect rebuilt with the panel's `finiteExtent` fallback (0 is not a
+ * usable height, so the body becomes 100px plus a 30px title). That centre
+ * sits a few pixels below the box, so the group is empty even though the
+ * node's coordinates are inside.
+ *
+ * #1921: SaveImage / other DOM-preview nodes start compact (`size[1] === 58`)
+ * and rehydrate to ~326px after the image widget mounts (save/reopen). The
+ * compact auto-box still reports them as members; after rehydrate their centre
+ * drops below the persisted bottom and they fall out.
  *
  * These helpers expand a created group's bounds just enough to contain every
  * membership-plausible centre of a requested node whose origin is already in
- * the box — then the caller writes those bounds with graph_edit_group.
+ * the box — including the stable full-height centre of a DOM-preview node —
+ * then the caller writes those bounds with graph_edit_group.
  *
  * Constants match comfyui-mcp-panel `web/js/lib/group-geometry.js`
  * (`COLLAPSED_TITLE_HEIGHT`, `COLLAPSED_PILL_WIDTH`, `finiteExtent` fallbacks)
@@ -28,6 +34,18 @@ export const NODE_TITLE_HEIGHT = 30;
 export const COLLAPSED_PILL_WIDTH = 80;
 export const DEFAULT_NODE_WIDTH = 200;
 export const DEFAULT_NODE_BODY_HEIGHT = 100;
+/** Compact SaveImage body is ~58px; after the image-preview DOM widget mounts it is 326px (#1921). */
+export const DOM_PREVIEW_NODE_MIN_BODY_HEIGHT = 326;
+/** Node types whose LiteGraph size grows when a DOM/preview widget rehydrates. */
+export const DOM_PREVIEW_NODE_TYPES = new Set([
+  "SaveImage",
+  "PreviewImage",
+  "LoadImage",
+  "LoadImageMask",
+  "SaveVideo",
+  "VHS_LoadVideo",
+  "VHS_VideoCombine",
+]);
 
 export type GroupQuad = [number, number, number, number];
 
@@ -35,6 +53,7 @@ export type QueriedNodeGeom = {
   id: string | number;
   pos: [number, number];
   size: [number, number];
+  type?: string;
   collapsed?: boolean;
   full_height?: number;
 };
@@ -58,9 +77,13 @@ export function nodePosInsideGroupBounds(pos: [number, number], bounds: GroupQua
   return x >= gx && x <= gx + gw && y >= gy && y <= gy + gh;
 }
 
+export function isDomPreviewNodeType(type: unknown): boolean {
+  return typeof type === "string" && DOM_PREVIEW_NODE_TYPES.has(type);
+}
+
 /**
  * Centres LiteGraph / the panel might use for containsCentre, given only the
- * geometry panel_query_graph actually returns (pos, size, collapsed, full_height).
+ * geometry panel_query_graph actually returns (pos, size, type, collapsed, full_height).
  */
 export function membershipCandidateCenters(node: QueriedNodeGeom): Array<{ x: number; y: number }> {
   const x = node.pos[0];
@@ -69,7 +92,7 @@ export function membershipCandidateCenters(node: QueriedNodeGeom): Array<{ x: nu
   const fullW = finiteExtent(node.size[0], DEFAULT_NODE_WIDTH);
   const fullH = finiteExtent(node.size[1], DEFAULT_NODE_BODY_HEIGHT);
   const chipH = finiteExtent(node.full_height, NODE_TITLE_HEIGHT);
-  return [
+  const points: Array<{ x: number; y: number }> = [
     // Collapsed title-chip (syncNodeArea without forceCollapsed).
     { x: x + pillW / 2, y: y - NODE_TITLE_HEIGHT + chipH / 2 },
     // forceCollapsed wantedNodeArea: size[1]===0 falls back to DEFAULT_NODE_BODY_HEIGHT.
@@ -77,6 +100,15 @@ export function membershipCandidateCenters(node: QueriedNodeGeom): Array<{ x: nu
     // Raw pos + stored size (degenerate when size[1] is 0 — origin itself).
     { x: x + fullW / 2, y: y + (node.size[1] > 0 ? node.size[1] : 0) / 2 },
   ];
+  // #1921 — expanded DOM-preview body after widget rehydrate. Collapsed chips stay chips.
+  if (!node.collapsed && isDomPreviewNodeType(node.type)) {
+    const previewH = Math.max(fullH, DOM_PREVIEW_NODE_MIN_BODY_HEIGHT);
+    if (previewH > fullH) {
+      points.push({ x: x + fullW / 2, y: y + previewH / 2 });
+      points.push({ x: x + fullW / 2, y: y - NODE_TITLE_HEIGHT + (previewH + NODE_TITLE_HEIGHT) / 2 });
+    }
+  }
+  return points;
 }
 
 /** Grow `bounds` so every point is a containsCentre member (max edge exclusive). */
@@ -173,6 +205,7 @@ export function parseDetailNodesFromQueryText(text: unknown): QueriedNodeGeom[] 
       const h = Number(size[1]);
       if (![x, y, w, h].every(Number.isFinite)) continue;
       const geom: QueriedNodeGeom = { id, pos: [x, y], size: [w, h] };
+      if (typeof row.type === "string" && row.type) geom.type = row.type;
       if (row.collapsed === true) geom.collapsed = true;
       if (typeof row.full_height === "number" && Number.isFinite(row.full_height)) {
         geom.full_height = row.full_height;
@@ -223,9 +256,10 @@ type Call = (
 ) => Promise<ToolResultLike>;
 
 /**
- * After graph_create_group, if requested ids are missing AND their origin sits
- * inside the new box, expand the box so those centres are members and rewrite
- * the reply. Never throws: a failed repair returns the original create result.
+ * After graph_create_group, query the requested nodes and expand the box so
+ * every origin-inside node stays a containsCentre member — including collapsed
+ * fallback centres (#1877) and DOM-preview full height after rehydrate (#1921).
+ * Never throws: a failed repair returns the original create result.
  */
 export async function includeRequestedCreateGroupMembers<T extends ToolResultLike>(
   created: T,
@@ -242,26 +276,20 @@ export async function includeRequestedCreateGroupMembers<T extends ToolResultLik
     if (!group) return created;
     const bounds = finiteQuad(group.bounding);
     if (!bounds) return created;
-    const live = asIdList(group.node_ids);
-    const reportedMissing = asIdList(group.missing_node_ids);
-    const missing = reportedMissing.length
-      ? reportedMissing.filter((id) => requested.some((r) => idKey(r) === idKey(id)))
-      : classifyRequestedMembership(requested, live).missing;
-    if (!missing.length) return created;
 
     const query = await call(
       {
         cmd: "graph_query",
-        ids: missing,
+        ids: requested,
         fields: "detail",
-        limit: Math.min(Math.max(missing.length, 1), 200),
+        limit: Math.min(Math.max(requested.length, 1), 200),
       },
       8000,
     );
     if (query.isError) return created;
     const qPayload = parseToolJson(query);
     const nodes = parseDetailNodesFromQueryText(qPayload?.text).filter((n) =>
-      missing.some((id) => idKey(id) === idKey(n.id)),
+      requested.some((id) => idKey(id) === idKey(n.id)),
     );
     const repairable = nodes.filter((n) => nodePosInsideGroupBounds(n.pos, bounds));
     if (!repairable.length) return created;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -15091,6 +15091,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       },
       // #1877 — a collapsed node can sit inside the auto-fit box and still be
       // reported missing (size[1]===0 vs membership's 100px body fallback).
+      // #1921 — SaveImage/preview nodes grow after DOM rehydration; expand
+      // auto-bounds to the stable full height before persisting.
       async (args: A, ctx) =>
         includeRequestedCreateGroupMembers(
           await ctx.call(


### PR DESCRIPTION
Fixes #1921

## What was reported

`panel_create_group({node_ids:[5,6,7]})` reported all three nodes inside group 3 with bounds `[1090,-30,580,404]`. After saving, reconnecting and reopening, `panel_query_graph` reported only nodes 5 and 6 inside the group. Node 7 was unchanged at `[1370,250]`, but both SaveImage nodes had rehydrated from initial size `[270,58]` to `[270,326]`. Its centre moved below the original auto-sized group bottom.

## Why

The panel auto-fits the box from live `pos`/`size`. A freshly added SaveImage is still compact (`size[1] === 58`) until the image-preview DOM widget mounts. After save/reopen that body is 326px, so LiteGraph containsCentre of the lower SaveImage sits below the persisted bottom and it drops out of the group.

#1877 already expanded bounds when a requested node was missing at create time (collapsed size[1]===0). This case is different: all three nodes ARE members at create time, and fall out later.

## The fix

`panel_create_group` still dispatches `graph_create_group`. After create it queries every requested node. When a requested origin-inside DOM/preview node (SaveImage, PreviewImage, LoadImage, …) is still compact, it expands the box just enough to contain the stable full-height centre (326px body, the rehydrated SaveImage size from the report), writes those bounds with `graph_edit_group`, and returns the repaired membership.

A requested node whose origin is genuinely outside the box is left missing. A collapsed preview node is not grown to preview height. A failed query or edit leaves the original create reply unchanged.

## Verification

`src/__tests__/orchestrator/create-group-rehydrate.test.ts` drives the shipped `panel_create_group` handler against a mock panel that applies LiteGraph containsCentre independently against the rehydrated size:

- the reporter's compact create of nodes 5/6/7 is expanded so node 7 remains a member at `[270,326]`
- a collapsed SaveImage is not grown to preview height
- a successful create of non-preview nodes queries but does not edit

`npx tsc --noEmit` clean.
`npx vitest run --maxWorkers=4 src/__tests__/orchestrator/create-group-collapsed.test.ts src/__tests__/orchestrator/create-group-rehydrate.test.ts src/__tests__/orchestrator/rgthree-authoring-awareness.test.ts src/__tests__/services/graph-command-effect.test.ts` — 69 passed.
