### PR TITLE
release: v0.52.35 — reconnect wait, routing disclosure, group rehydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,11 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.35] - 2026-08-20
+
 ### MCP
 
 #### Fixed
 - **`panel_graph_outline` after `panel_restart_comfyui` waits out a 26–28s Desktop recover (panel#654).**
   The post-restart tab wait defaulted to 20s (`COMFYUI_PANEL_RECONNECT_WAIT_S`). ComfyUI Desktop recoveries of 26–28s after the server was already healthy expired that budget, so `panel_graph_outline` reported still reconnecting / `Connected: none` and only a hard browser refresh restored the tab. The default is now 35s (still capped at 60s).
+- **`panel_get_workflow_target` discloses when a live turn pin routes graph commands elsewhere (#1924).** The read and set tools now share the same machine-readable routing verdict so an agent is not told that `mode:"current"` governs graph commands when the live turn pin still holds another tab.
+- **`panel_create_group` preserves requested preview-node membership after SaveImage rehydration (#1925).** Auto-bounds now account for the stable full-height center of requested DOM-preview nodes before persisting the group, while preserving collapsed-node and failed-repair behavior.
 
 ## [0.52.34] - 2026-08-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.34",
+  "version": "0.52.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.34",
+      "version": "0.52.35",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.34",
+  "version": "0.52.35",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release v0.52.35

Includes the merged swarm work:

- panel#654 / #1922: `panel_graph_outline` waits through 26–28s Desktop recovery (35s default, 60s cap)
- #1924: `panel_get_workflow_target` discloses the same live turn-pin routing split as the set tool
- #1925: `panel_create_group` preserves requested DOM-preview membership after SaveImage rehydration
- #1923: test-only coverage for the second routing-split success site

## Verification

- `npm run build`
- `npm test -- --reporter=dot`
- 596 test files; 11,004 passed, 4 skipped
- i18n, docs, blog, and structure checks green
- native `better-sqlite3` rebuilt before validation