### PR TITLE
fix(panel#1546): the restart refusal names WHICH identity proof was missing

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
@@ -25,9 +25,12 @@ vi.mock("../../comfyui/client.js", () => ({
   resetObjectInfoCache: () => resetObjectInfoCache(),
 }));
 
-const { buildPanelToolDefs, restartIdentityBlockerNote, __panelToolsTestHooks } = await import(
-  "../../orchestrator/panel-tools.js"
-);
+const {
+  buildPanelToolDefs,
+  restartIdentityBlockerNote,
+  classifyOriginBlocker,
+  __panelToolsTestHooks,
+} = await import("../../orchestrator/panel-tools.js");
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import { __processControlTestHooks } from "../../services/process-control.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
@@ -43,16 +46,28 @@ function makeCtx(opts: {
   isLocal?: boolean;
   /** The SERVER-OBSERVED handshake Origin (undefined = the handshake carried none). */
   serverOrigin?: string;
-}): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
+  /** The origin the tab reports AFTER the confirmation card is answered — a binding
+   *  lost during the confirm wait. This is the ONLY way to reach the SECOND refusal
+   *  site: the first gate runs before the card and would refuse there otherwise. */
+  originAfterConfirm?: string;
+}): {
+  ctx: PanelToolCtx;
+  sends: Array<Record<string, unknown>>;
+  /** How many times the confirmation card was put to the user. Non-zero proves the
+   *  FIRST identity gate (which runs before the card) let the call through. */
+  confirms: { count: number };
+} {
   const sends: Array<Record<string, unknown>> = [];
+  const confirms = { count: 0 };
+  const origin = { current: opts.serverOrigin };
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       sends.push(cmd);
       if (cmd.cmd === "comfy_reboot") return { rebooting: true };
       return {};
     },
-    tabOrigin: () => opts.serverOrigin,
-    tabServerOrigin: () => opts.serverOrigin,
+    tabOrigin: () => origin.current,
+    tabServerOrigin: () => origin.current,
     tabIsLocal: () => opts.isLocal !== false,
     canReach: () => true,
   } as unknown as PanelToolCtx["bridge"];
@@ -60,7 +75,11 @@ function makeCtx(opts: {
     call: async () => {
       throw new Error("ctx.call must not be used by the restart handler");
     },
-    confirm: async () => "yes",
+    confirm: async () => {
+      confirms.count++;
+      if (opts.originAfterConfirm !== undefined) origin.current = opts.originAfterConfirm;
+      return "yes";
+    },
     ensureReachable: () => {},
     bridge,
     tabId: "bound-tab",
@@ -68,7 +87,7 @@ function makeCtx(opts: {
     awaitPostRestartReachable: async () => true,
     tabCanMutateGraph: () => true,
   } as unknown as PanelToolCtx;
-  return { ctx, sends };
+  return { ctx, sends, confirms };
 }
 
 function restartTool() {
@@ -130,12 +149,14 @@ describe("panel#1546 — the identity refusal names the missing proof", () => {
     const note = await refusalNote({ serverOrigin: "http://localhost:8188" });
 
     expect(note).toMatch(/WHY I could not confirm it:/);
-    expect(note).toMatch(/http:\/\/localhost:8188/);
+    expect(note).toMatch(/this panel is open at http:\/\/localhost:8188/);
     // It must say WHY localhost is not proof — not merely that it differs.
     expect(note).toMatch(/127\.0\.0\.1 or ::1/);
     // And the remedy must name the concrete literal to open the panel at.
     expect(note).toMatch(/FIX: open the panel at http:\/\/127\.0\.0\.1:8188/);
-    expect(note).toMatch(/COMFYUI_URL/);
+    // NOT the reverse remedy: this user's browser is the ambiguous side, so
+    // telling them to repoint COMFYUI_URL at `localhost` would re-create it.
+    expect(note).not.toMatch(/set COMFYUI_URL to http:\/\/localhost/);
   });
 
   it("an ABSENT handshake Origin gets its own reason and its own remedy", async () => {
@@ -175,6 +196,42 @@ describe("panel#1546 — the identity refusal names the missing proof", () => {
     expect(new Set(notes).size).toBe(3);
   });
 
+  // THE SECOND REFUSAL SITE. #1593 shipped a fix that only reached the first one
+  // and needed a follow-up commit to cover this branch; a mutation run confirmed
+  // the same gap here — dropping the blocker at THIS call site left every test
+  // green. Wiring is asserted at both sites, not at the helper.
+  it("a binding lost during the confirm wait explains itself too", async () => {
+    const { ctx, sends, confirms } = makeCtx({
+      serverOrigin: BOOT_BASE, // proven before the card...
+      originAfterConfirm: "http://localhost:8188", // ...gone by the preflight
+    });
+    const body = parse(await restartTool().handler({}, ctx));
+
+    // The card WAS put to the user, so the pre-card identity gate passed and this
+    // refusal is the LATER one. Without this the test would silently re-cover the
+    // first site and the second would stay unpinned (the surviving mutation).
+    expect(confirms.count).toBe(1);
+    expect(body.refused).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(String(body.note)).toMatch(/WHY I could not confirm it:/);
+    expect(String(body.note)).toMatch(/127\.0\.0\.1 or ::1/);
+    expect(String(body.note)).toMatch(/FIX: open the panel at http:\/\/127\.0\.0\.1:8188/);
+  });
+
+  it("the second refusal distinguishes its causes as well as the first", async () => {
+    const lost = async (after: string) => {
+      const { ctx, confirms } = makeCtx({ serverOrigin: BOOT_BASE, originAfterConfirm: after });
+      const note = String(parse(await restartTool().handler({}, ctx)).note);
+      expect(confirms.count).toBe(1); // again: the SECOND site, not the first
+      return note;
+    };
+    const ambiguous = await lost("http://localhost:8188");
+    const different = await lost("http://127.0.0.1:8189");
+    expect(ambiguous).not.toBe(different);
+    expect(different).toMatch(/http:\/\/127\.0\.0\.1:8189/);
+    expect(different).not.toMatch(/127\.0\.0\.1 or ::1/);
+  });
+
   it("a PROVEN binding still dispatches — the refactor did not move the gate", async () => {
     const { ctx, sends } = makeCtx({ serverOrigin: BOOT_BASE });
     const body = parse(await restartTool().handler({}, ctx));
@@ -190,13 +247,56 @@ describe("panel#1546 — the identity refusal names the missing proof", () => {
 // this process was not started with. Pinned at the helper so the switch stays
 // TOTAL — a new blocker kind that falls through would return "" and silently
 // restore the undiagnosable refusal this issue is about.
+// The DNS ambiguity must only be blamed for what it actually causes. These are
+// pure-function tests because the boot base is fixed at process start, so the
+// boot-side-ambiguous direction has no handler fixture at all.
+describe("panel#1546 — `localhost` is blamed only when resolving it would settle it", () => {
+  it("same port, no mount, panel side ambiguous → the DNS verdict, panel remedy", () => {
+    const b = classifyOriginBlocker("http://localhost:8188", "http://127.0.0.1:8188");
+    expect(b.kind).toBe("origin-dns-ambiguous");
+    expect(b).toMatchObject({ ambiguousSide: "panel", concrete: "http://127.0.0.1:8188" });
+    expect(restartIdentityBlockerNote(b)).toMatch(/FIX: open the panel at http:\/\/127\.0\.0\.1:8188/);
+  });
+
+  it("BOOT side ambiguous → the remedy is COMFYUI_URL, not 'open the panel at localhost'", () => {
+    const b = classifyOriginBlocker("http://127.0.0.1:8188", "http://localhost:8188");
+    expect(b.kind).toBe("origin-dns-ambiguous");
+    expect(b).toMatchObject({ ambiguousSide: "boot", concrete: "http://127.0.0.1:8188" });
+    const note = restartIdentityBlockerNote(b);
+    expect(note).toMatch(/this server booted against http:\/\/localhost:8188/);
+    expect(note).toMatch(/FIX: set COMFYUI_URL to http:\/\/127\.0\.0\.1:8188/);
+    expect(note).not.toMatch(/FIX: open the panel at/);
+  });
+
+  it("a DIFFERENT PORT is a different server even when one side says localhost", () => {
+    // Resolving the hostname never reconciles :8188 with :8189, so calling this
+    // a DNS ambiguity would send the reader to fix the wrong thing.
+    expect(classifyOriginBlocker("http://localhost:8189", "http://127.0.0.1:8188").kind).toBe(
+      "origin-different",
+    );
+  });
+
+  it("a basePath mount stays the PATH verdict — the pathless Origin cannot prove it", () => {
+    expect(classifyOriginBlocker("http://localhost:8188", "http://127.0.0.1:8188/comfy").kind).toBe(
+      "origin-different",
+    );
+    expect(classifyOriginBlocker("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfy").kind).toBe(
+      "origin-path-ambiguous",
+    );
+  });
+
+  it("localhost on BOTH sides is not this branch — those canonicalize equal", () => {
+    expect(classifyOriginBlocker("http://localhost:8189", "http://localhost:8188").kind).toBe(
+      "origin-different",
+    );
+  });
+});
+
 describe("panel#1546 — blocker branches with no handler-reachable fixture", () => {
   it("a basePath mount says the Origin cannot prove the mount", () => {
-    const note = restartIdentityBlockerNote({
-      kind: "origin-path-ambiguous",
-      bootBase: "http://127.0.0.1:8188/comfy",
-      origin: "http://127.0.0.1:8188",
-    });
+    const note = restartIdentityBlockerNote(
+      classifyOriginBlocker("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfy"),
+    );
     expect(note).toMatch(/mounted under a path/);
     expect(note).toMatch(/http:\/\/127\.0\.0\.1:8188\/comfy/);
     expect(note).toMatch(/same host and port/);

--- a/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
@@ -285,6 +285,15 @@ describe("panel#1546 — `localhost` is blamed only when resolving it would sett
     );
   });
 
+  it("a DEFAULT port on one side only is still the same spot", () => {
+    // normalizeHandshakeOrigin fills 80/443 in explicitly, so the Origin says
+    // ":80" while a default-port boot base has port "". Comparing raw ports read
+    // that as a port mismatch and misfiled it as a different server.
+    const b = classifyOriginBlocker("http://localhost:80", "http://127.0.0.1");
+    expect(b.kind).toBe("origin-dns-ambiguous");
+    expect(b).toMatchObject({ ambiguousSide: "panel" });
+  });
+
   it("localhost on BOTH sides is not this branch — those canonicalize equal", () => {
     expect(classifyOriginBlocker("http://localhost:8189", "http://localhost:8188").kind).toBe(
       "origin-different",

--- a/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
@@ -1,0 +1,221 @@
+// panel#1546 — WHEN panel_restart_comfyui REFUSES, IT MUST SAY WHY.
+//
+// The reporter's panel was attached, server-trusted-local and graph-tool ready,
+// and the restart refused with "I could not confirm that this panel's ComfyUI is
+// the local instance I can account for". Every precondition in the binding
+// capture fails into that ONE sentence, so the reader cannot tell which proof was
+// missing. Measured before the fix: a `localhost` browser origin, an absent
+// handshake Origin, and a tab that never arrived on the loopback listener
+// produced a BYTE-IDENTICAL note — yet the first is cured in one step (open the
+// panel at the literal), the second by updating the panel, and the third not from
+// this machine at all.
+//
+// These tests pin the DISCLOSURE. The gate is unchanged and is asserted
+// unchanged: every refusal still refuses, still dispatches nothing, and still
+// leaves the tab bound.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, restartIdentityBlockerNote, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { __processControlTestHooks } from "../../services/process-control.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const text = (res: ToolResult): string =>
+  res.content.find((c) => c.type === "text")!.text as string;
+const parse = (res: ToolResult): Record<string, unknown> => JSON.parse(text(res));
+
+function makeCtx(opts: {
+  /** SERVER-TRUSTED locality — the tab arrived on the token-less loopback listener. */
+  isLocal?: boolean;
+  /** The SERVER-OBSERVED handshake Origin (undefined = the handshake carried none). */
+  serverOrigin?: string;
+}): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
+  const sends: Array<Record<string, unknown>> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sends.push(cmd);
+      if (cmd.cmd === "comfy_reboot") return { rebooting: true };
+      return {};
+    },
+    tabOrigin: () => opts.serverOrigin,
+    tabServerOrigin: () => opts.serverOrigin,
+    tabIsLocal: () => opts.isLocal !== false,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = {
+    call: async () => {
+      throw new Error("ctx.call must not be used by the restart handler");
+    },
+    confirm: async () => "yes",
+    ensureReachable: () => {},
+    bridge,
+    tabId: "bound-tab",
+    panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
+    awaitPostRestartReachable: async () => true,
+    tabCanMutateGraph: () => true,
+  } as unknown as PanelToolCtx;
+  return { ctx, sends };
+}
+
+function restartTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def;
+}
+
+/** Run the handler and return the refusal note, asserting the gate still held. */
+async function refusalNote(opts: Parameters<typeof makeCtx>[0]): Promise<string> {
+  const { ctx, sends } = makeCtx(opts);
+  const res = await restartTool().handler({}, ctx);
+  const body = parse(res);
+  // THE GATE IS NOT WEAKENED — asserted on every scenario, not once.
+  expect(body.refused).toBe(true);
+  expect(body.rebooting).toBe(false);
+  expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  return body.note as string;
+}
+
+beforeEach(() => {
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 60,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+  __panelToolsTestHooks.setDeclineProbeTiming({ windowMs: 20, intervalMs: 5, probeTimeoutMs: 5 });
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  __processControlTestHooks.reset();
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setDeclineProbeTiming(null);
+  __processControlTestHooks.reset();
+});
+
+describe("panel#1546 — the identity refusal names the missing proof", () => {
+  it("REPRO: the reported state — attached, local, ready, and refused", async () => {
+    // The exact shape the issue was filed from: a browser at localhost:8188
+    // against a 127.0.0.1:8188 boot base. Graph tools stay ready and the tab
+    // stays bound, which is why the report reads as "refuses on an attached,
+    // ready local panel".
+    const { ctx, sends } = makeCtx({ serverOrigin: "http://localhost:8188" });
+    const body = parse(await restartTool().handler({}, ctx));
+
+    expect(body.refused).toBe(true);
+    expect(body.rebooting).toBe(false);
+    expect(body.graph_tools_ready).toBe(true);
+    expect(body.panel_tab_reconnected).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    expect(body.note).toMatch(/could not confirm that this panel's ComfyUI is/);
+  });
+
+  it("a `localhost` origin names the ambiguity AND the one-step fix", async () => {
+    const note = await refusalNote({ serverOrigin: "http://localhost:8188" });
+
+    expect(note).toMatch(/WHY I could not confirm it:/);
+    expect(note).toMatch(/http:\/\/localhost:8188/);
+    // It must say WHY localhost is not proof — not merely that it differs.
+    expect(note).toMatch(/127\.0\.0\.1 or ::1/);
+    // And the remedy must name the concrete literal to open the panel at.
+    expect(note).toMatch(/FIX: open the panel at http:\/\/127\.0\.0\.1:8188/);
+    expect(note).toMatch(/COMFYUI_URL/);
+  });
+
+  it("an ABSENT handshake Origin gets its own reason and its own remedy", async () => {
+    const note = await refusalNote({ serverOrigin: undefined });
+
+    expect(note).toMatch(/carried no Origin/);
+    expect(note).toMatch(/updating the panel/);
+    // Must NOT borrow the localhost story — this tab never named an address.
+    expect(note).not.toMatch(/127\.0\.0\.1 or ::1/);
+    expect(note).not.toMatch(/FIX: open the panel at/);
+  });
+
+  it("a tab that is not loopback-local is told it cannot be fixed from here", async () => {
+    const note = await refusalNote({ isLocal: false, serverOrigin: BOOT_BASE });
+
+    expect(note).toMatch(/did not arrive on the local loopback listener/);
+    expect(note).toMatch(/relay, tunnel, LAN address or pairing link/);
+    expect(note).toMatch(/Restart it from the machine it actually runs on/);
+    expect(note).not.toMatch(/FIX: open the panel at/);
+  });
+
+  it("a DIFFERENT host:port is named as a different server", async () => {
+    const note = await refusalNote({ serverOrigin: "http://127.0.0.1:8189" });
+
+    expect(note).toMatch(/http:\/\/127\.0\.0\.1:8189/);
+    expect(note).toMatch(/a different server/);
+    expect(note).not.toMatch(/127\.0\.0\.1 or ::1/);
+  });
+
+  // THE REGRESSION THIS ISSUE IS: three different failures, one message.
+  it("the three ordinary local failures no longer read the same", async () => {
+    const notes = [
+      await refusalNote({ serverOrigin: "http://localhost:8188" }),
+      await refusalNote({ serverOrigin: undefined }),
+      await refusalNote({ isLocal: false, serverOrigin: BOOT_BASE }),
+    ];
+    expect(new Set(notes).size).toBe(3);
+  });
+
+  it("a PROVEN binding still dispatches — the refactor did not move the gate", async () => {
+    const { ctx, sends } = makeCtx({ serverOrigin: BOOT_BASE });
+    const body = parse(await restartTool().handler({}, ctx));
+
+    expect(body.refused).toBeUndefined();
+    expect(body.rebooting).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    expect(String(body.note)).not.toMatch(/WHY I could not confirm it:/);
+  });
+});
+
+// The two branches a handler-driven fixture cannot reach: they need a boot base
+// this process was not started with. Pinned at the helper so the switch stays
+// TOTAL — a new blocker kind that falls through would return "" and silently
+// restore the undiagnosable refusal this issue is about.
+describe("panel#1546 — blocker branches with no handler-reachable fixture", () => {
+  it("a basePath mount says the Origin cannot prove the mount", () => {
+    const note = restartIdentityBlockerNote({
+      kind: "origin-path-ambiguous",
+      bootBase: "http://127.0.0.1:8188/comfy",
+      origin: "http://127.0.0.1:8188",
+    });
+    expect(note).toMatch(/mounted under a path/);
+    expect(note).toMatch(/http:\/\/127\.0\.0\.1:8188\/comfy/);
+    expect(note).toMatch(/same host and port/);
+  });
+
+  it("an off-box configured ComfyUI says it is not a process on this machine", () => {
+    const note = restartIdentityBlockerNote({
+      kind: "boot-base-not-loopback",
+      bootBase: "http://192.168.1.50:8188",
+    });
+    expect(note).toMatch(/not a loopback address/);
+    expect(note).toMatch(/http:\/\/192\.168\.1\.50:8188/);
+  });
+
+  it("remote/cloud and no-boot-base each say something, and nothing says nothing", () => {
+    for (const kind of ["not-local-mode", "no-boot-base"] as const) {
+      expect(restartIdentityBlockerNote({ kind })).toMatch(/WHY I could not confirm it:/);
+    }
+    // Only a PROVEN binding contributes no reason — the note stays as it was.
+    expect(restartIdentityBlockerNote(null)).toBe("");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2427,8 +2427,16 @@ export type RestartIdentityBlocker =
   | { kind: "tab-not-local" }
   /** The WS handshake carried no usable Origin (an older panel / non-browser client). */
   | { kind: "origin-absent"; bootBase: string }
-  /** `localhost` on either side: no concrete loopback family, so no match is possible. */
-  | { kind: "origin-dns-ambiguous"; bootBase: string; origin: string }
+  /** `localhost` on ONE side: no concrete loopback family, so no match is possible.
+   *  `concrete` is the OTHER side's literal — the address that resolves the ambiguity,
+   *  and which side it belongs to decides which remedy is the right one to name. */
+  | {
+      kind: "origin-dns-ambiguous";
+      bootBase: string;
+      origin: string;
+      concrete: string;
+      ambiguousSide: "panel" | "boot";
+    }
   /** The boot base is mounted under a basePath the pathless Origin cannot prove. */
   | { kind: "origin-path-ambiguous"; bootBase: string; origin: string }
   /** Proven a different scheme/host/port — the #851 wrong-server case. */
@@ -2470,14 +2478,7 @@ function resolveRebootHealthBinding(ctx: PanelToolCtx): {
     // kind names the FIRST thing that made a match impossible, because that is the
     // one the reader can act on.
     if (!origin) return no({ kind: "origin-absent", bootBase: base });
-    if (isDnsAmbiguousLoopback(origin) || isDnsAmbiguousLoopback(base))
-      return no({ kind: "origin-dns-ambiguous", bootBase: base, origin });
-    // The Origin is pathless by construction, so a boot base under a basePath mount
-    // can be same-ORIGIN yet unprovable as the same INSTANCE. Distinguish that from a
-    // genuinely different host:port, which is the #851 wrong-server case.
-    if (sameHttpOrigin(origin, base))
-      return no({ kind: "origin-path-ambiguous", bootBase: base, origin });
-    return no({ kind: "origin-different", bootBase: base, origin });
+    return no(classifyOriginBlocker(origin, base));
   }
   // Return a CONNECTABLE probe URL bound to the SAME concrete family identity matched
   // above: a wildcard-bound (0.0.0.0/::) local ComfyUI is reachable on loopback, so probe
@@ -2488,6 +2489,58 @@ function resolveRebootHealthBinding(ctx: PanelToolCtx): {
 
 function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   return resolveRebootHealthBinding(ctx).base;
+}
+
+/**
+ * panel#1546 — WHY a present Origin failed to match the boot base.
+ *
+ * Ordered so each verdict names the FIRST thing that made a match impossible, and
+ * NEVER blames the DNS ambiguity for something the ambiguity did not cause. A
+ * `localhost` origin on a DIFFERENT PORT is a different server and is reported as
+ * one; a `localhost` origin against a basePath mount is unprovable even with the
+ * host resolved, so it stays the path verdict. Only the case where resolving
+ * `localhost` would ACTUALLY settle it — same port, no mount, exactly one
+ * ambiguous side — gets the DNS answer and its one-step remedy.
+ *
+ * Exported for test: the boot base is fixed at process start, so the
+ * boot-side-ambiguous direction has no handler-driven fixture.
+ */
+export function classifyOriginBlocker(
+  origin: string,
+  bootBase: string,
+): Extract<
+  RestartIdentityBlocker,
+  { kind: "origin-dns-ambiguous" | "origin-path-ambiguous" | "origin-different" }
+> {
+  const originAmbiguous = isDnsAmbiguousLoopback(origin);
+  const bootAmbiguous = isDnsAmbiguousLoopback(bootBase);
+  if (originAmbiguous !== bootAmbiguous) {
+    let sameSpot = false;
+    try {
+      const o = new URL(origin);
+      const b = new URL(bootBase);
+      // A handshake Origin is pathless, so the DNS answer can only settle a boot
+      // base that is not under a mount. Ports must already agree — resolving a
+      // hostname never reconciles :8188 with :8189.
+      sameSpot = o.port === b.port && o.protocol === b.protocol && b.pathname.replace(/\/+$/, "") === "";
+    } catch {
+      sameSpot = false;
+    }
+    if (sameSpot) {
+      return {
+        kind: "origin-dns-ambiguous",
+        bootBase,
+        origin,
+        concrete: originAmbiguous ? bootBase : origin,
+        ambiguousSide: originAmbiguous ? "panel" : "boot",
+      };
+    }
+  }
+  // The Origin is pathless by construction, so a boot base under a basePath mount
+  // can be same-ORIGIN yet unprovable as the same INSTANCE. Distinguish that from a
+  // genuinely different host:port, which is the #851 wrong-server case.
+  if (sameHttpOrigin(origin, bootBase)) return { kind: "origin-path-ambiguous", bootBase, origin };
+  return { kind: "origin-different", bootBase, origin };
 }
 
 /** True when a URL's host is the DNS-ambiguous `localhost` — it names a loopback
@@ -2543,15 +2596,22 @@ export function restartIdentityBlockerNote(blocker: RestartIdentityBlocker | nul
         `${why}this tab's WebSocket handshake carried no Origin, so there is nothing to check against ` +
         `the boot instance (${blocker.bootBase}). An older panel build does this; updating the panel restores the proof.`
       );
-    case "origin-dns-ambiguous":
+    case "origin-dns-ambiguous": {
+      // Name the remedy for the side that is ACTUALLY ambiguous. Telling a user
+      // whose browser is already on 127.0.0.1 to "open the panel at localhost"
+      // would be advice that re-creates the problem.
+      const ambiguous = blocker.ambiguousSide === "panel" ? blocker.origin : blocker.bootBase;
+      const fix =
+        blocker.ambiguousSide === "panel"
+          ? `FIX: open the panel at ${loopbackProbeUrl(blocker.concrete)} — the same ComfyUI, addressed by its literal.`
+          : `FIX: set COMFYUI_URL to ${loopbackProbeUrl(blocker.concrete)} — the same ComfyUI, addressed by the literal your browser is already on.`;
       return (
-        `${why}this panel is open at ${blocker.origin}, and "localhost" does not say which loopback ` +
-        `address the browser actually reached — it can be 127.0.0.1 or ::1, and those can be DIFFERENT ` +
-        `ComfyUI instances on the same port. The boot instance I account for is ${blocker.bootBase}. ` +
-        `FIX: open the panel at ${loopbackProbeUrl(blocker.bootBase)} (the same ComfyUI, addressed by ` +
-        `its literal), or set COMFYUI_URL to the address your browser uses; either one makes the two ` +
-        `sides comparable and this restart works.`
+        `${why}${blocker.ambiguousSide === "panel" ? "this panel is open at" : "this server booted against"} ` +
+        `${ambiguous}, and "localhost" does not say which loopback address was actually reached — it can ` +
+        `be 127.0.0.1 or ::1, and those can be DIFFERENT ComfyUI instances on the same port. The other ` +
+        `side is ${blocker.concrete}, so I cannot show the two are one server. ${fix}`
       );
+    }
     case "origin-path-ambiguous":
       return (
         `${why}the boot instance is mounted under a path (${blocker.bootBase}) and a handshake Origin ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1951,14 +1951,7 @@ export function classifyRestartFallbackTarget({
   observedOrigin?: string | null;
 }): { kind: "same" } | { kind: "different"; proven: string } | { kind: "unproven" } {
   if (panelBase != null && sameHttpBase(headlessBase, panelBase)) return { kind: "same" };
-  const dnsAmbiguous = (u: string | null) => {
-    if (!u) return false;
-    try {
-      return new URL(u).hostname.toLowerCase().replace(/^\[|\]$/g, "") === "localhost";
-    } catch {
-      return false;
-    }
-  };
+  const dnsAmbiguous = isDnsAmbiguousLoopback;
   const originMismatch =
     observedOrigin != null &&
     !dnsAmbiguous(observedOrigin) &&
@@ -2126,7 +2119,14 @@ function restartRefusedPreservingBinding(ctx: PanelToolCtx, note: string): ToolR
   });
 }
 
-function unboundLocalRestartRefusalNote(ctx: PanelToolCtx, panelBase: string | null): string {
+function unboundLocalRestartRefusalNote(
+  ctx: PanelToolCtx,
+  panelBase: string | null,
+  // panel#1546 — the blocker from the SAME capture that produced `panelBase`.
+  // Passed in rather than re-derived: a second call to the classifier could read
+  // a binding that changed in between and explain a refusal that did not happen.
+  blocker: RestartIdentityBlocker | null = null,
+): string {
   return (
     "Refusing to restart ComfyUI: I could not confirm that this panel's ComfyUI is " +
     "the local instance I can account for, so I cannot tell which server the restart " +
@@ -2153,6 +2153,10 @@ function unboundLocalRestartRefusalNote(ctx: PanelToolCtx, panelBase: string | n
       panelBase,
       observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
     }) +
+    // panel#1546 — and say WHICH proof was missing. Without this, a `localhost`
+    // origin (curable in one step), an absent Origin (cured by updating the
+    // panel) and a relayed tab (not curable here at all) were the same sentence.
+    restartIdentityBlockerNote(blocker) +
     // artokun/comfyui-mcp-panel#769 — a REMOTE ComfyUI reached over a
     // tunnel or port-forward has a LOOPBACK host, and remoteUrlActive is
     // derived from exactly that (`forceRemote || !isLoopbackHost(host)`).
@@ -2398,13 +2402,53 @@ function objectInfoHostMismatchMessage(err: unknown): string {
 
 Node definitions are read from COMFYUI_URL (${configured}) for a pack/path/inline source. That host did not answer /object_info.`;
 }
-function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
-  if (isCloudMode() || isRemoteMode()) return null;
+/**
+ * panel#1546 — WHY the binding proof failed, when it failed.
+ *
+ * `captureRebootHealthBase` answers null for SEVEN structurally different
+ * reasons and the refusal built on it said only "I could not confirm". Three of
+ * them were verified to produce a BYTE-IDENTICAL note (a `localhost` origin, an
+ * absent Origin, a tab that is not server-trusted-local), so the reader could
+ * not tell which proof was missing — and they do not have the same answer:
+ * `origin-dns-ambiguous` is cured by opening the panel at the concrete literal,
+ * while `tab-not-local` cannot be cured from this machine at all.
+ *
+ * This is a DISCLOSURE, not a loosened gate. Every branch below still returns
+ * null from the capture; the blocker only names what was already decided.
+ */
+export type RestartIdentityBlocker =
+  /** Remote/cloud target: there is no local process to account for by design. */
+  | { kind: "not-local-mode" }
+  /** No boot-time local ComfyUI URL was resolvable at all. */
+  | { kind: "no-boot-base" }
+  /** The configured ComfyUI is off-box, so this host cannot account for it. */
+  | { kind: "boot-base-not-loopback"; bootBase: string }
+  /** The tab's socket did not arrive on the token-less loopback listener. */
+  | { kind: "tab-not-local" }
+  /** The WS handshake carried no usable Origin (an older panel / non-browser client). */
+  | { kind: "origin-absent"; bootBase: string }
+  /** `localhost` on either side: no concrete loopback family, so no match is possible. */
+  | { kind: "origin-dns-ambiguous"; bootBase: string; origin: string }
+  /** The boot base is mounted under a basePath the pathless Origin cannot prove. */
+  | { kind: "origin-path-ambiguous"; bootBase: string; origin: string }
+  /** Proven a different scheme/host/port — the #851 wrong-server case. */
+  | { kind: "origin-different"; bootBase: string; origin: string };
+
+/** The SINGLE decision. `captureRebootHealthBase` returns `.base`; the refusal
+ *  note reads `.blocker`. Two readers of one evidence set that cannot disagree —
+ *  the same reason `classifyRestartFallbackTarget` was extracted for #1593. */
+function resolveRebootHealthBinding(ctx: PanelToolCtx): {
+  base: string | null;
+  blocker: RestartIdentityBlocker | null;
+} {
+  const no = (blocker: RestartIdentityBlocker) => ({ base: null, blocker });
+  if (isCloudMode() || isRemoteMode()) return no({ kind: "not-local-mode" });
   const bootBase = getBootLocalComfyUIBaseUrl(); // server-authorized, hello-immutable
-  if (!bootBase || !isLoopbackOrigin(bootBase)) return null;
+  if (!bootBase) return no({ kind: "no-boot-base" });
+  if (!isLoopbackOrigin(bootBase)) return no({ kind: "boot-base-not-loopback", bootBase });
   const base = bootBase.replace(/\/+$/, "");
   // Server-trusted provenance: the tab arrived on the token-less loopback listener.
-  if (ctx.bridge?.tabIsLocal?.(ctx.tabId) !== true) return null;
+  if (ctx.bridge?.tabIsLocal?.(ctx.tabId) !== true) return no({ kind: "tab-not-local" });
   // And the rebooted tab must provably front THAT SAME boot instance. Use the SERVER-
   // OBSERVED handshake Origin (tabServerOrigin) — the browser sets it on the WS upgrade
   // and blocks page JS from forging it — NOT the spoofable client hello.comfyui_url
@@ -2421,12 +2465,105 @@ function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   // (loopbackFamily → null), so it never matches a concrete literal and this returns null
   // (coordinator P0). A different instance / family / path / absent Origin → null too.
   const origin = ctx.bridge?.tabServerOrigin?.(ctx.tabId);
-  if (!sameHttpBase(origin, base)) return null;
+  if (!sameHttpBase(origin, base)) {
+    // SAME verdict as before — only the reason is now carried out. Ordered so each
+    // kind names the FIRST thing that made a match impossible, because that is the
+    // one the reader can act on.
+    if (!origin) return no({ kind: "origin-absent", bootBase: base });
+    if (isDnsAmbiguousLoopback(origin) || isDnsAmbiguousLoopback(base))
+      return no({ kind: "origin-dns-ambiguous", bootBase: base, origin });
+    // The Origin is pathless by construction, so a boot base under a basePath mount
+    // can be same-ORIGIN yet unprovable as the same INSTANCE. Distinguish that from a
+    // genuinely different host:port, which is the #851 wrong-server case.
+    if (sameHttpOrigin(origin, base))
+      return no({ kind: "origin-path-ambiguous", bootBase: base, origin });
+    return no({ kind: "origin-different", bootBase: base, origin });
+  }
   // Return a CONNECTABLE probe URL bound to the SAME concrete family identity matched
   // above: a wildcard-bound (0.0.0.0/::) local ComfyUI is reachable on loopback, so probe
   // the family literal at that port (127.0.0.1 / [::1]). The probe (and the auth headers
   // it carries) can therefore never cross to a different-family instance.
-  return loopbackProbeUrl(base);
+  return { base: loopbackProbeUrl(base), blocker: null };
+}
+
+function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
+  return resolveRebootHealthBinding(ctx).base;
+}
+
+/** True when a URL's host is the DNS-ambiguous `localhost` — it names a loopback
+ *  service without revealing which family the browser actually reached, which is
+ *  exactly why `loopbackFamily` refuses it (coordinator P0, #1233). Shared by the
+ *  blocker classifier and `classifyRestartFallbackTarget` so "ambiguous" means one
+ *  thing in this file. */
+function isDnsAmbiguousLoopback(rawUrl: string | null | undefined): boolean {
+  if (!rawUrl) return false;
+  try {
+    return new URL(rawUrl).hostname.toLowerCase().replace(/^\[|\]$/g, "") === "localhost";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * panel#1546 — the one sentence that turns the refusal from a dead end into a step.
+ *
+ * The reporter's panel was attached, local and graph-tool ready; the refusal named
+ * neither what was missing nor how to supply it, so the filed diagnosis was
+ * "target identity cannot be confirmed" with no next action. Each blocker has a
+ * DIFFERENT next action, and `origin-dns-ambiguous` — a browser at
+ * `localhost:8188` against a `127.0.0.1:8188` boot base, the ordinary local setup
+ * this file's own comments already flag as returning null — has a one-step one.
+ *
+ * Deliberately NOT a fix for the underlying ambiguity. Proving that a `localhost`
+ * tab reached the boot family would mean trusting a resolution this process did
+ * not observe, and #1233 recorded why that is a P0. Naming the cause costs no
+ * soundness; guessing it would.
+ */
+export function restartIdentityBlockerNote(blocker: RestartIdentityBlocker | null): string {
+  if (!blocker) return "";
+  const why = " WHY I could not confirm it: ";
+  switch (blocker.kind) {
+    case "not-local-mode":
+      return `${why}this target is configured as remote/cloud, so there is no local process here to account for.`;
+    case "no-boot-base":
+      return `${why}no local ComfyUI address was resolvable when this server started, so there is no boot instance to compare against.`;
+    case "boot-base-not-loopback":
+      return (
+        `${why}the ComfyUI this server booted against (${blocker.bootBase}) is not a loopback address, ` +
+        "so it is not a process on this machine that I can account for."
+      );
+    case "tab-not-local":
+      return (
+        `${why}this panel tab did not arrive on the local loopback listener — it reached me over a relay, ` +
+        "tunnel, LAN address or pairing link, so I cannot treat the ComfyUI behind it as one of mine. " +
+        "Restart it from the machine it actually runs on."
+      );
+    case "origin-absent":
+      return (
+        `${why}this tab's WebSocket handshake carried no Origin, so there is nothing to check against ` +
+        `the boot instance (${blocker.bootBase}). An older panel build does this; updating the panel restores the proof.`
+      );
+    case "origin-dns-ambiguous":
+      return (
+        `${why}this panel is open at ${blocker.origin}, and "localhost" does not say which loopback ` +
+        `address the browser actually reached — it can be 127.0.0.1 or ::1, and those can be DIFFERENT ` +
+        `ComfyUI instances on the same port. The boot instance I account for is ${blocker.bootBase}. ` +
+        `FIX: open the panel at ${loopbackProbeUrl(blocker.bootBase)} (the same ComfyUI, addressed by ` +
+        `its literal), or set COMFYUI_URL to the address your browser uses; either one makes the two ` +
+        `sides comparable and this restart works.`
+      );
+    case "origin-path-ambiguous":
+      return (
+        `${why}the boot instance is mounted under a path (${blocker.bootBase}) and a handshake Origin ` +
+        `carries no path (${blocker.origin}), so this tab could be fronting a different ComfyUI at the ` +
+        "same host and port. I will not stop a server on that."
+      );
+    case "origin-different":
+      return (
+        `${why}this panel is open at ${blocker.origin}, which is not the ComfyUI this server booted ` +
+        `against (${blocker.bootBase}) — a different server, so stopping mine would not restart yours.`
+      );
+  }
 }
 
 /**
@@ -15583,7 +15720,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // of the current binding: a silent rebind here would confirm a restart of
         // a tab the user was not working in. Healing belongs on the refusal path.
         if (!isRemoteMode() && !isCloudMode()) {
-          const identityHealthBase = captureRebootHealthBase(ctx);
+          const identityBinding = resolveRebootHealthBinding(ctx);
+          const identityHealthBase = identityBinding.base;
           const identityBound =
             identityHealthBase != null &&
             sameHttpBase(getComfyUIBaseUrl(), identityHealthBase);
@@ -15595,7 +15733,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             if (tabStillHere) {
               return restartRefusedPreservingBinding(
                 ctx,
-                unboundLocalRestartRefusalNote(ctx, identityHealthBase),
+                unboundLocalRestartRefusalNote(ctx, identityHealthBase, identityBinding.blocker),
               );
             }
             // Tab is gone: confirm will be unreachable and #1671 crash-recovery
@@ -16285,7 +16423,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // can be proven. They keep restart_comfyui, and the note says so. Weighed
         // against #814 — where exactly such a user's server was stopped and never came
         // back — declining is the recoverable side.
-        const preflightHealthBase = captureRebootHealthBase(ctx);
+        const preflightBinding = resolveRebootHealthBinding(ctx);
+        const preflightHealthBase = preflightBinding.base;
         const preflightBound =
           preflightHealthBase != null &&
           sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase);
@@ -16315,7 +16454,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // still here must stay usable (#1819).
           return restartRefusedPreservingBinding(
             ctx,
-            unboundLocalRestartRefusalNote(ctx, preflightHealthBase),
+            unboundLocalRestartRefusalNote(ctx, preflightHealthBase, preflightBinding.blocker),
           );
         }
         if (preflightBound) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2519,10 +2519,18 @@ export function classifyOriginBlocker(
     try {
       const o = new URL(origin);
       const b = new URL(bootBase);
-      // A handshake Origin is pathless, so the DNS answer can only settle a boot
-      // base that is not under a mount. Ports must already agree — resolving a
-      // hostname never reconciles :8188 with :8189.
-      sameSpot = o.port === b.port && o.protocol === b.protocol && b.pathname.replace(/\/+$/, "") === "";
+      // A handshake Origin is pathless BY CONSTRUCTION — normalizeHandshakeOrigin
+      // rebuilds it from protocol/hostname/port and relayIdentityOrigin uses
+      // URL.origin — so only the BOOT base can carry a mount, and the DNS answer
+      // can never settle one. Ports must already agree; resolving a hostname never
+      // reconciles :8188 with :8189. Compare EFFECTIVE ports: the same normalizer
+      // fills in 80/443 explicitly, so a default-port boot base ("") would
+      // otherwise read as a port mismatch against an origin that says "80".
+      const port = (u: URL) => u.port || (u.protocol === "https:" ? "443" : "80");
+      sameSpot =
+        o.protocol === b.protocol &&
+        port(o) === port(b) &&
+        b.pathname.replace(/\/+$/, "") === "";
     } catch {
       sameSpot = false;
     }


### PR DESCRIPTION
Fixes the underlying cause reported in artokun/comfyui-mcp-panel#1546 (P2, via-panel, filed by codex against panel 0.15.25 / mcp 0.52.34).

## ⚠️ NO INDEPENDENT REVIEW WAS OBTAINED. This is NOT gated.

Stating this plainly because the body becomes the permanent record and PRs here can be merged from outside the authoring session:

- **grok** was asked (comment above, with the risky parts named and ranked). Asynchronous, no reply. No grok account appears among either repo's commenters on any PR.
- **Copilot** auto-reviewed this PR and declined: *"unable to review … the user who requested the review has reached their quota limit."* That is a quota message, not a verdict, and must not be counted as one.
- **codex** is barred as reviewer-of-record (repointed at a weak model), so running it would return a weak opinion wearing a gate's authority.
- I did **not** substitute a self-review. An author reads their own guard as obviously right; that is exactly the defect class this would miss.

So what stands behind this change is author-side evidence, disclosed as such: the reported state reproduced by execution, 9/9 mutations red with both refusal call sites pinned independently, and a full green suite. **That is not a review.**

### Where a reviewer should attack, ranked

1. **The claim that the gate is unchanged.** The refactor turned a chain of `return null` into `return no({...})` inside `resolveRebootHealthBinding`. If the order or conditions shifted anywhere, this is a #814/#851-class defect (stopping a server we cannot identify) wearing a message fix. Check especially that `isLoopbackOrigin(bootBase)` still gates before `tabIsLocal`, and that splitting `if (!bootBase || !isLoopbackOrigin(bootBase))` into two branches is behaviour-identical for an empty-string `bootBase` (`!bootBase` catches `""` in both, but confirm it).
2. **Is the remedy safe advice?** For the panel-side case the note says "open the panel at `http://127.0.0.1:8188`" — advice to change which instance the user is attached to. If their `localhost` was resolving to a different ComfyUI on `[::1]:8188`, that silently moves them. I argue it is acceptable because the switch is explicit and visible in the address bar, unlike the silent wrong-target restart #851 was about. This is a judgement call about user-facing safety, not something a test settles, and it is the single item I most want a second opinion on.
3. **`classifyOriginBlocker`'s port/mount conditions.** It blames the DNS ambiguity only for same-scheme, same-effective-port, unmounted comparisons. If any real boot base shape falls outside that and lands in `origin-different`, the user is sent hunting for a second ComfyUI that does not exist. (The gate verdict is unaffected either way — it still refuses.)
4. **Message accuracy under a mid-flight retarget.** The blocker is captured with the base and passed down rather than re-derived, so it should describe the binding that actually caused *this* refusal. Worth confirming at the post-card preflight site, where the binding changed during the confirm wait.

Two questions I raised for review I have since answered myself and closed out in a follow-up comment (the pathless-Origin assumption — which turned up a real default-port bug, now fixed — and switch totality, which the compiler does enforce: `TS2366`). They are recorded there rather than here so they do not read as unexamined.

## Where the bug actually is

The reported string is not in the panel pack. `grep "could not confirm that this panel"` across `comfyui-mcp-panel` returns zero hits; it lives here, in `src/orchestrator/panel-tools.ts`. So the issue is filed on the panel and fixed in the orchestrator, as with `fix(panel#1262)` (#1737).

## The reported state, reproduced by execution

Not by reading. Driving the real `panel_restart_comfyui` handler with a server-observed handshake Origin of `http://localhost:8188` against a `127.0.0.1:8188` boot base returns:

```
refused: true, rebooting: false, graph_tools_ready: true, panel_tab_reconnected: true
```

with no `comfy_reboot` dispatched — an **attached, ready, local panel that refuses**, which is exactly what #1546 describes.

## The defect: one sentence for seven different problems

`captureRebootHealthBase` answers `null` for seven structurally distinct reasons, and every one of them produced the same refusal. Measured on `origin/main` before this change, these three produced a **byte-identical** note:

| state | what the user must do |
|---|---|
| browser at `localhost:8188`, boot base `127.0.0.1:8188` | open the panel at the literal — one step |
| handshake carried no `Origin` | update the panel |
| tab arrived over a relay/tunnel/LAN/pairing link | cannot be fixed from this machine at all |

The reader could not tell which one they were in. That is why the report's own diagnosis is "target identity cannot be confirmed" with no next action, and why it asks for the server identity to be *exposed* to the guard. This file's own comments already concede the case — "returns null for ordinary local setups (an ambiguous `localhost` origin, a basePath mount, an older panel)" — but nothing said so to the user.

## The change

`captureRebootHealthBase` becomes a thin wrapper over `resolveRebootHealthBinding`, which returns `{ base, blocker }`. The capture reads `.base`; the refusal reads `.blocker`. **One decision, two readers that cannot disagree** — the same reason `classifyRestartFallbackTarget` was extracted for #1593. The blocker travels from the *same* capture that produced the base rather than being re-derived, so a binding that changes in between can never explain a refusal that did not happen.

What the reporter now sees instead of a dead end:

> WHY I could not confirm it: this panel is open at http://localhost:8188, and "localhost" does not say which loopback address was actually reached — it can be 127.0.0.1 or ::1, and those can be DIFFERENT ComfyUI instances on the same port. The other side is http://127.0.0.1:8188, so I cannot show the two are one server. **FIX: open the panel at http://127.0.0.1:8188** — the same ComfyUI, addressed by its literal.

## THE GATE IS NOT LOOSENED, and that is deliberate

Every branch still returns `null` from the capture. Every refusal still refuses, dispatches nothing, and leaves the tab bound — asserted on **every** scenario, plus a mutation (M6) that certifies all origins and must turn the refusal tests red.

I deliberately did **not** make the `localhost` case succeed. Proving that a `localhost` tab reached the boot family would mean trusting a resolution this process never observed; #1233 recorded that as a coordinator P0, and #851/#814 are the record of what stopping the wrong server costs. Naming the cause costs no soundness — guessing it would. The remedy is handed to the user instead.

## Round 2 on my own work (second commit)

The first cut had two real defects I found and fixed before asking for review:

1. **The remedy was backwards in one direction.** It always said "open the panel at `loopbackProbeUrl(bootBase)`". When the *boot base* is the ambiguous side, that returns the localhost URL unchanged — so the advice was "open the panel at `http://localhost:8188`", the exact address causing the refusal. The blocker now carries `ambiguousSide` and the other side's concrete literal; the boot-side case prescribes `COMFYUI_URL`.
2. **It over-claimed.** A `localhost` origin on a *different port* was being reported as a DNS ambiguity, sending the reader to fix a hostname that was never the problem. `classifyOriginBlocker` now blames the ambiguity only when resolving the host would actually settle it: same scheme and port, and no basePath mount (a handshake Origin is pathless, so a mount is unprovable however the host resolves).

## Evidence

- **Mutation verified, 9/9 red.** Each mutation applied to the working tree and reverted in place — never `git checkout`, which would take the fix with it.
  - Both refusal call sites pinned **independently**. This mattered: in round 1, dropping the blocker at the *post-card preflight* site left every test green. That is precisely the gap #1593 shipped and had to close in a follow-up commit (`test(1593): cover the second refusal, and stop calling an unreachable branch a fix`). The test now proves it reached the second site by asserting the confirmation card was answered first.
  - `M6` (certify every origin) and `M3` (helper explains nothing — restores the pre-fix message exactly) both red, so the gate assertions and the disclosure assertions each bite.
  - `M7`/`M8` cover the round-2 defects: ignoring `ambiguousSide`, and dropping the port/mount guard.
- **Full suite green:** 597 files, 11021 passed, 4 skipped, 0 failed. `npm run lint`, `npm run build`, `i18n:check`, `check:docs-*`, `check:vocabulary`, `check:unknown-collapse` all clean; `docs:gen` is a content no-op.

## What I did NOT do

- **Did not loosen the `localhost` gate** (reasoning above). If a reviewer wants that, the sound version is a listener-exclusion probe on the other loopback family, and it deserves its own issue and its own adversarial pass — not a rider on a message fix.
- **Did not run the panel Playwright suite.** This branch changes zero files in `comfyui-mcp-panel`; the panel would be running unchanged code, and its e2e harness fakes the orchestrator (MockBridge), so it cannot exercise this path either way. Claiming browser coverage here would be claiming coverage I do not have.
- **Could not confirm from artifacts which blocker the reporter actually hit** — which is the bug. The refusal disclosed nothing, and no orchestrator log records it. `localhost` is the hypothesis the evidence supports (this machine has `~/.comfyui-mcp/instances/localhost_8188` and a prior `local-target` recording `http://localhost:8188`; ComfyUI listens only on `127.0.0.1:8188`, with nothing on `[::1]:8188`). After this change the answer is in the message, whichever one it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

