### PR TITLE
chore(deps): AI SDK 6 -> 7 (ai + all three providers, together)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@modelcontextprotocol/sdk": "~1.30.0",
         "@stable-canvas/comfyui-client": "^1.5.9",
         "better-sqlite3": "^12.6.2",
-        "cloudflared": "0.7.3",
         "dotenv": "^16.4.7",
         "sharp": "^0.35.3",
         "ws": "^8.21.3",
@@ -36,112 +35,114 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@ai-sdk/anthropic": "^3.0.79",
-        "@ai-sdk/google": "^3.0.79",
-        "@ai-sdk/openai": "^3.0.65",
+        "@ai-sdk/anthropic": "^4.0.40",
+        "@ai-sdk/google": "^4.0.48",
+        "@ai-sdk/openai": "^4.0.45",
         "@anthropic-ai/claude-agent-sdk": "^0.3.233",
         "@aws-sdk/client-s3": "^3.1111.0",
         "@azure/storage-blob": "^12.33.0",
         "@openai/codex": "0.147.0",
-        "ai": "^6.0.191",
+        "ai": "^7.0.71",
         "cloudflared": "^0.7.3"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.79.tgz",
-      "integrity": "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==",
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.40.tgz",
+      "integrity": "sha512-cFlCZspCUC1LGDipARsKx3+4A8c9qI+vFuG0/04Phs0deKwifNsl8wDmcU2HO31aiNR9AJgEBcvg5S00zUS70g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.28"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.120",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
-      "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
+      "version": "4.0.57",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.57.tgz",
+      "integrity": "sha512-RmDBcAZW4RKQYOuZzU4x1sxIodP1a9JzRdMpoRr1f+5RPkFjHgafP5t4h3Fyp7s1NC7XPQ3FrAH3MJxjJAwJ7A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.28",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.79.tgz",
-      "integrity": "sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==",
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.48.tgz",
+      "integrity": "sha512-7QYyXCUgl29DQD2ogBlPap92X6vxdP+NEQum2VfLUv8TKx1YJyNSRrdlUgYRAcUNMehGDLF6xdm7+lddNHBFHw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.28"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.65",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.65.tgz",
-      "integrity": "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==",
+      "version": "4.0.45",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.45.tgz",
+      "integrity": "sha512-F/zHXTfCaHO0Q5egf8HRdc645Mp/ofLE9NSjl5RwaXfqrqLfiLROE9xScgKf4iziElsjuQYbesPEcW37mmZy3w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.28"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
-      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "version": "5.0.28",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.28.tgz",
+      "integrity": "sha512-TnHUyd/rCYQqHg5RuiOaz/hUql6U+kbUaBW0Rp+0N5UhnAInA9CzzV0HXvuAAPwppDsK6fAx9Rd+tRawpJ/3pg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.7",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -2079,16 +2080,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.144.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
@@ -3003,6 +2994,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3027,19 +3025,18 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.191",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
-      "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
+      "version": "7.0.71",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.71.tgz",
+      "integrity": "sha512-e3PhIepVn9zErrsOjvM2ed3rvB2bTLzJYKPIqDSJles9sKx45ZCUSDSWavhh+WGQ9BQo2RMsjtf+venEmGFHlg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.120",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.57",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.28"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -5394,6 +5391,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -76,14 +76,14 @@
     "zod": "^4.0.0"
   },
   "optionalDependencies": {
-    "@ai-sdk/anthropic": "^3.0.79",
-    "@ai-sdk/google": "^3.0.79",
-    "@ai-sdk/openai": "^3.0.65",
+    "@ai-sdk/anthropic": "^4.0.40",
+    "@ai-sdk/google": "^4.0.48",
+    "@ai-sdk/openai": "^4.0.45",
     "@anthropic-ai/claude-agent-sdk": "^0.3.233",
     "@aws-sdk/client-s3": "^3.1111.0",
     "@azure/storage-blob": "^12.33.0",
     "@openai/codex": "0.147.0",
-    "ai": "^6.0.191",
+    "ai": "^7.0.71",
     "cloudflared": "^0.7.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Supersedes #1839. Moves the whole AI SDK family to current, which is what #1839 could not do alone.

## Why #1839 could not merge

The AI SDK pins core and providers to a shared **provider-spec major**. Read straight off npm:

| package | `@ai-sdk/provider` | `provider-utils` |
|---|---|---|
| `ai@6.0.191` (was) | 3.0.10 | 4.0.27 |
| `@ai-sdk/anthropic@3.0.79` (was) | 3.0.10 | 4.0.27 |
| `@ai-sdk/anthropic@4.0.39` (#1839) | **4.0.7** | 5.0.27 |
| `ai@7.0.0` | **4.0.0** | — |

So #1839 moved one provider onto spec v4 while `ai` stayed on v3, and CI said exactly that:

```
src/experimental/provider-registry.ts(46,9): error TS2322:
  Type 'AnthropicProvider' is not assignable to type 'ProviderV3'.
```

`npm ci` runs `prepare` → `tsc`, so this failed before a single test ran. It is the same lockstep the SDK documents for 5.x — *"all provider packages must adhere to specification version v2"* — one major on. Nothing was wrong with CI: it correctly reported a real breakage.

## What this does

All four to current, which agree on `@ai-sdk/provider` 4.0.7 and `provider-utils` 5.0.28:

```
ai                 ^6.0.191 -> ^7.0.71
@ai-sdk/anthropic  ^3.0.79  -> ^4.0.40
@ai-sdk/google     ^3.0.79  -> ^4.0.48
@ai-sdk/openai     ^3.0.65  -> ^4.0.45
```

`package.json` + `package-lock.json` only — **no source changes were needed**, which is worth stating rather than leaving implied. The consumed surface is five symbols across two files (`src/experimental/provider-registry.ts`, `src/experimental/chat-handler.ts`): `createProviderRegistry`, `streamText`, `tool`, `convertToModelMessages`, `stepCountIs`. Of the 7.0 breaking changes, only two could have applied here:

- `convertToModelMessages` became async — already awaited at `chat-handler.ts:165` (the 6.0 change had been taken).
- `stepCountIs` → `isStepCount` — `stepCountIs` is **still exported** in 7.x beside its replacement, verified by calling both at runtime. I left the call site alone: renaming it is unrelated to this bump and would put a source edit in a lockfile PR. Worth doing separately before the alias goes.

Nothing here touches a removed API.

## Verification

- **`tsc --noEmit` clean**, and I checked the check — with a deliberate `TS2322` injected it exits 1 and names the file, so the clean run means something. `npm run lint` and `npm run build` also clean.
- **The exact CI error is gone**: zero `provider-registry.ts` diagnostics.
- **Runtime, not just types.** Types passing does not prove the registry constructs, so I built it for real against the installed v7 + v4 packages:

  ```
  registry built OK
  resolved model id: claude-sonnet-4-5
  provider: anthropic.messages
  specificationVersion: v4
  ```

  That is the thing #1839 broke, working — and `v4` confirms the family is coherent rather than merely type-compatible.
- **Full suite: 596 files / 11004 passed / 0 failed.** A first run showed 4 failures in 2 files; it was running concurrently with three gates, and a clean re-run is fully green. Flagging that rather than quietly reporting only the green number.
- Gates CI runs: `check:vocabulary` (1732 files), `check:unknown-collapse` (0 sites), `asset-counts --check` — all pass.
- No security advisory against the 3.x line, so this is hygiene rather than a fix: keeping current with what users install.

## Scope

`ai` and the three providers are **optionalDependencies**, reached through `requireOptionalDep` and only behind `COMFYUI_MCP_AGENT_POC`. A slim install without them still parses. So the blast radius is the experimental embedded-agent POC, not the default MCP server.

## Review

**Review pending — not gated, and I am claiming no verdict.** @grok please review, aimed at these three:

1. **The runtime probe covers construction, not a request.** It builds the registry and resolves a model; it never calls the provider. If 7.x changed anything about how `streamText` drives a provider, my evidence does not reach it — `chat-handler.ts:162` is the site.
2. **`stepCountIs` deliberately left as-is.** It is a deprecated alias in 7.x. I judged renaming out of scope for a dependency PR; if you think a lockfile PR should carry it so the deprecation does not rot, say so.
3. **`@ai-sdk/google` and `@ai-sdk/openai` are moved but never exercised** by any test or by my probe beyond registry construction — the POC's default is Anthropic. They are the least-verified part of this change.

Per `.github/dependabot.yml`, dependency bumps here are reviewed by a human rather than driven to merge by an agent, so I am not merging this.
