### PR TITLE
release: v0.52.36 — restart identity proof, AI SDK 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.36] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- a localhost COMFYUI_URL is loopback, and now says so (#1931)
+- the restart refusal names WHICH identity proof was missing (#1927)
+
+#### Changed
+- AI SDK 6 -> 7 (ai + all three providers, together) (#1928)
+
+
 ## [0.52.35] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.35",
+  "version": "0.52.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.35",
+      "version": "0.52.36",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.35",
+  "version": "0.52.36",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.36** from `main` (after v0.52.35).

Carries:

- #1931 / panel#1546 — a `COMFYUI_URL=http://localhost:…` boot is loopback, and the restart refusal now says so (follow-up to #1927)
- #1927 / panel#1546 — the restart refusal names WHICH identity proof was missing
- #1928 — AI SDK 6→7 (`ai` + all three providers, together)

Held out: #1697 P1; #1929 P2 inflight; panel#1472 typescript 5→7.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.36` tag on the version commit).