### PR TITLE
fix(panel#1546): a localhost COMFYUI_URL is loopback, and now says so

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
@@ -25,6 +25,21 @@ vi.mock("../../comfyui/client.js", () => ({
   resetObjectInfoCache: () => resetObjectInfoCache(),
 }));
 
+// The boot base is captured at PROCESS START and immutable, so a `localhost`
+// COMFYUI_URL has no fixture unless it is overridable. It needs one: grok's review
+// of #1927 found that branch reachable in production and unreachable in my tests,
+// which is how a wrong message ("not a loopback address", about a loopback address)
+// survived a green suite. Overriding here drives the REAL resolveRebootHealthBinding
+// through the REAL handler.
+const hoistedBoot = vi.hoisted(() => ({ base: { value: null as string | null } }));
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    getBootLocalComfyUIBaseUrl: () => hoistedBoot.base.value ?? actual.getBootLocalComfyUIBaseUrl(),
+  };
+});
+
 const {
   buildPanelToolDefs,
   restartIdentityBlockerNote,
@@ -118,9 +133,11 @@ beforeEach(() => {
   __panelToolsTestHooks.setDeclineProbeTiming({ windowMs: 20, intervalMs: 5, probeTimeoutMs: 5 });
   __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
   __processControlTestHooks.reset();
+  hoistedBoot.base.value = null;
 });
 
 afterEach(() => {
+  hoistedBoot.base.value = null;
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
   __panelToolsTestHooks.setLocalRestartPreflight(null);
@@ -254,18 +271,46 @@ describe("panel#1546 — `localhost` is blamed only when resolving it would sett
   it("same port, no mount, panel side ambiguous → the DNS verdict, panel remedy", () => {
     const b = classifyOriginBlocker("http://localhost:8188", "http://127.0.0.1:8188");
     expect(b.kind).toBe("origin-dns-ambiguous");
-    expect(b).toMatchObject({ ambiguousSide: "panel", concrete: "http://127.0.0.1:8188" });
     expect(restartIdentityBlockerNote(b)).toMatch(/FIX: open the panel at http:\/\/127\.0\.0\.1:8188/);
   });
 
-  it("BOOT side ambiguous → the remedy is COMFYUI_URL, not 'open the panel at localhost'", () => {
+  // grok's review of #1927. `isLoopbackOrigin` is `loopbackFamily(host) !== null`
+  // and loopbackFamily rejects `localhost` BY DESIGN, so a localhost COMFYUI_URL
+  // never reaches the origin comparison at all — it is caught two branches earlier.
+  // Driven through the real handler, because the previous version of this test
+  // called the classifier directly and therefore "covered" a branch production
+  // could not reach, while the branch production DID reach said the wrong thing.
+  it("a `localhost` COMFYUI_URL is caught before the origin compare, with a config remedy", async () => {
+    hoistedBoot.base.value = "http://localhost:8188";
+    const note = await refusalNote({ serverOrigin: "http://localhost:8188" });
+
+    // NOT the off-box verdict: localhost IS loopback, and saying otherwise sent
+    // the reader looking for a remote install they do not have.
+    expect(note).not.toMatch(/is not a loopback address/);
+    expect(note).toMatch(/COMFYUI_URL=http:\/\/localhost:8188/);
+    expect(note).toMatch(/That IS loopback/);
+    expect(note).toMatch(/FIX: set COMFYUI_URL to the literal/);
+    // And it must say the scope: this disables the panel restart for EVERY tab.
+    expect(note).toMatch(/every tab/);
+  });
+
+  it("the localhost COMFYUI_URL reason is distinct from the genuinely off-box one", async () => {
+    hoistedBoot.base.value = "http://localhost:8188";
+    const ambiguous = await refusalNote({ serverOrigin: "http://localhost:8188" });
+    hoistedBoot.base.value = "http://192.168.1.50:8188";
+    const offBox = await refusalNote({ serverOrigin: "http://192.168.1.50:8188" });
+
+    expect(ambiguous).not.toBe(offBox);
+    expect(offBox).toMatch(/is not a loopback address/);
+    expect(offBox).not.toMatch(/That IS loopback/);
+  });
+
+  it("classifyOriginBlocker never sees an ambiguous boot base, so it has no boot direction", () => {
+    // Documents the invariant the removed branch was pretending to handle: past
+    // isLoopbackOrigin, the boot base is always a concrete literal.
     const b = classifyOriginBlocker("http://127.0.0.1:8188", "http://localhost:8188");
-    expect(b.kind).toBe("origin-dns-ambiguous");
-    expect(b).toMatchObject({ ambiguousSide: "boot", concrete: "http://127.0.0.1:8188" });
-    const note = restartIdentityBlockerNote(b);
-    expect(note).toMatch(/this server booted against http:\/\/localhost:8188/);
-    expect(note).toMatch(/FIX: set COMFYUI_URL to http:\/\/127\.0\.0\.1:8188/);
-    expect(note).not.toMatch(/FIX: open the panel at/);
+    expect(b.kind).toBe("origin-different");
+    expect(b).not.toHaveProperty("ambiguousSide");
   });
 
   it("a DIFFERENT PORT is a different server even when one side says localhost", () => {
@@ -291,7 +336,6 @@ describe("panel#1546 — `localhost` is blamed only when resolving it would sett
     // that as a port mismatch and misfiled it as a different server.
     const b = classifyOriginBlocker("http://localhost:80", "http://127.0.0.1");
     expect(b.kind).toBe("origin-dns-ambiguous");
-    expect(b).toMatchObject({ ambiguousSide: "panel" });
   });
 
   it("localhost on BOTH sides is not this branch — those canonicalize equal", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2423,20 +2423,21 @@ export type RestartIdentityBlocker =
   | { kind: "no-boot-base" }
   /** The configured ComfyUI is off-box, so this host cannot account for it. */
   | { kind: "boot-base-not-loopback"; bootBase: string }
+  /** COMFYUI_URL is `localhost`: loopback, but with no concrete family, so
+   *  `isLoopbackOrigin` rejects it and no tab can ever bind to it. Split out from
+   *  `boot-base-not-loopback` because that verdict's prose — "not a loopback
+   *  address" — is FALSE about localhost and sends the reader looking for a remote
+   *  install they do not have. Found in review of this change (grok on #1927). */
+  | { kind: "boot-base-dns-ambiguous"; bootBase: string }
   /** The tab's socket did not arrive on the token-less loopback listener. */
   | { kind: "tab-not-local" }
   /** The WS handshake carried no usable Origin (an older panel / non-browser client). */
   | { kind: "origin-absent"; bootBase: string }
-  /** `localhost` on ONE side: no concrete loopback family, so no match is possible.
-   *  `concrete` is the OTHER side's literal — the address that resolves the ambiguity,
-   *  and which side it belongs to decides which remedy is the right one to name. */
-  | {
-      kind: "origin-dns-ambiguous";
-      bootBase: string;
-      origin: string;
-      concrete: string;
-      ambiguousSide: "panel" | "boot";
-    }
+  /** The PANEL is at `localhost`: no concrete loopback family, so it cannot be matched
+   *  against the boot base. Only the panel side can be ambiguous here — an ambiguous
+   *  boot base never reaches the origin comparison (it is caught by
+   *  `boot-base-dns-ambiguous` above), so there is no second direction to carry. */
+  | { kind: "origin-dns-ambiguous"; bootBase: string; origin: string }
   /** The boot base is mounted under a basePath the pathless Origin cannot prove. */
   | { kind: "origin-path-ambiguous"; bootBase: string; origin: string }
   /** Proven a different scheme/host/port — the #851 wrong-server case. */
@@ -2453,6 +2454,12 @@ function resolveRebootHealthBinding(ctx: PanelToolCtx): {
   if (isCloudMode() || isRemoteMode()) return no({ kind: "not-local-mode" });
   const bootBase = getBootLocalComfyUIBaseUrl(); // server-authorized, hello-immutable
   if (!bootBase) return no({ kind: "no-boot-base" });
+  // `localhost` fails isLoopbackOrigin (loopbackFamily returns null for it by
+  // design), so it lands here — NOT in the origin comparison below, which never
+  // sees an ambiguous boot base. Naming it separately is the difference between
+  // "your ComfyUI is not on this machine" (false) and a config line to change.
+  if (isDnsAmbiguousLoopback(bootBase))
+    return no({ kind: "boot-base-dns-ambiguous", bootBase });
   if (!isLoopbackOrigin(bootBase)) return no({ kind: "boot-base-not-loopback", bootBase });
   const base = bootBase.replace(/\/+$/, "");
   // Server-trusted provenance: the tab arrived on the token-less loopback listener.
@@ -2512,9 +2519,11 @@ export function classifyOriginBlocker(
   RestartIdentityBlocker,
   { kind: "origin-dns-ambiguous" | "origin-path-ambiguous" | "origin-different" }
 > {
-  const originAmbiguous = isDnsAmbiguousLoopback(origin);
-  const bootAmbiguous = isDnsAmbiguousLoopback(bootBase);
-  if (originAmbiguous !== bootAmbiguous) {
+  // Callers reach here only past `isLoopbackOrigin(bootBase)`, which rejects
+  // `localhost` — so the boot base is always a concrete literal and the panel is
+  // the only side that can be ambiguous. Asserted, not assumed: an ambiguous boot
+  // base would make the comparison below meaningless rather than merely wrong.
+  if (isDnsAmbiguousLoopback(origin) && !isDnsAmbiguousLoopback(bootBase)) {
     let sameSpot = false;
     try {
       const o = new URL(origin);
@@ -2534,15 +2543,7 @@ export function classifyOriginBlocker(
     } catch {
       sameSpot = false;
     }
-    if (sameSpot) {
-      return {
-        kind: "origin-dns-ambiguous",
-        bootBase,
-        origin,
-        concrete: originAmbiguous ? bootBase : origin,
-        ambiguousSide: originAmbiguous ? "panel" : "boot",
-      };
-    }
+    if (sameSpot) return { kind: "origin-dns-ambiguous", bootBase, origin };
   }
   // The Origin is pathless by construction, so a boot base under a basePath mount
   // can be same-ORIGIN yet unprovable as the same INSTANCE. Distinguish that from a
@@ -2593,6 +2594,15 @@ export function restartIdentityBlockerNote(blocker: RestartIdentityBlocker | nul
         `${why}the ComfyUI this server booted against (${blocker.bootBase}) is not a loopback address, ` +
         "so it is not a process on this machine that I can account for."
       );
+    case "boot-base-dns-ambiguous":
+      return (
+        `${why}this server is configured with COMFYUI_URL=${blocker.bootBase}. That IS loopback, but ` +
+        `"localhost" does not say which address it resolves to — 127.0.0.1 and ::1 can be DIFFERENT ` +
+        "ComfyUI instances on the same port — so I cannot tie it to a specific local process, and no " +
+        "panel tab can be matched against it. This disables the panel restart for every tab, not just " +
+        "this one. FIX: set COMFYUI_URL to the literal your ComfyUI actually listens on " +
+        "(http://127.0.0.1:<port>, or http://[::1]:<port> for an IPv6-only bind) and restart this server."
+      );
     case "tab-not-local":
       return (
         `${why}this panel tab did not arrive on the local loopback listener — it reached me over a relay, ` +
@@ -2604,22 +2614,14 @@ export function restartIdentityBlockerNote(blocker: RestartIdentityBlocker | nul
         `${why}this tab's WebSocket handshake carried no Origin, so there is nothing to check against ` +
         `the boot instance (${blocker.bootBase}). An older panel build does this; updating the panel restores the proof.`
       );
-    case "origin-dns-ambiguous": {
-      // Name the remedy for the side that is ACTUALLY ambiguous. Telling a user
-      // whose browser is already on 127.0.0.1 to "open the panel at localhost"
-      // would be advice that re-creates the problem.
-      const ambiguous = blocker.ambiguousSide === "panel" ? blocker.origin : blocker.bootBase;
-      const fix =
-        blocker.ambiguousSide === "panel"
-          ? `FIX: open the panel at ${loopbackProbeUrl(blocker.concrete)} — the same ComfyUI, addressed by its literal.`
-          : `FIX: set COMFYUI_URL to ${loopbackProbeUrl(blocker.concrete)} — the same ComfyUI, addressed by the literal your browser is already on.`;
+    case "origin-dns-ambiguous":
       return (
-        `${why}${blocker.ambiguousSide === "panel" ? "this panel is open at" : "this server booted against"} ` +
-        `${ambiguous}, and "localhost" does not say which loopback address was actually reached — it can ` +
-        `be 127.0.0.1 or ::1, and those can be DIFFERENT ComfyUI instances on the same port. The other ` +
-        `side is ${blocker.concrete}, so I cannot show the two are one server. ${fix}`
+        `${why}this panel is open at ${blocker.origin}, and "localhost" does not say which loopback ` +
+        `address the browser actually reached — it can be 127.0.0.1 or ::1, and those can be DIFFERENT ` +
+        `ComfyUI instances on the same port. The boot instance I account for is ${blocker.bootBase}, so ` +
+        `I cannot show the two are one server. FIX: open the panel at ${loopbackProbeUrl(blocker.bootBase)} ` +
+        `— the same ComfyUI, addressed by its literal.`
       );
-    }
     case "origin-path-ambiguous":
       return (
         `${why}the boot instance is mounted under a path (${blocker.bootBase}) and a handshake Origin ` +


### PR DESCRIPTION
Follow-up to #1927 (merged as `f5be0a2`). Carries the one review finding that did not make it in.

**Why this is a separate PR:** #1927 was squash-merged from outside my session while I was still applying grok's review. The merge deleted the branch, so the fourth commit could not land on it. This is that commit, cherry-picked onto current main. The defect below is live on main right now.

## The finding (grok, on #1927) — confirmed by execution, and correct

`isLoopbackOrigin` is `loopbackFamily(host) !== null` (panel-tools.ts:1559), and `loopbackFamily` returns **null for `localhost` by design** (#1233 — a DNS-ambiguous host has no concrete family). So a user configured with `COMFYUI_URL=http://localhost:8188`:

- never reaches the origin comparison at all — they are caught two branches earlier, at `!isLoopbackOrigin(bootBase)`;
- and were therefore told, by the message #1927 just added: *"the ComfyUI this server booted against (http://localhost:8188) **is not a loopback address**, so it is not a process on this machine that I can account for."*

That is false about `localhost`, and it is worse than the vague message it replaced: it sends the reader looking for a remote install they do not have. #1927 set out to stop the refusal being a dead end and, for this one configuration, made it a confidently wrong one.

## The same fact made my own branch dead code

Past `isLoopbackOrigin`, the boot base is **always** a concrete literal — so `classifyOriginBlocker` can only ever see an ambiguous *panel*. The `ambiguousSide: "boot"` direction #1927 added could not be reached in production.

Its test passed because it called the classifier **directly**. A branch production cannot reach: covered. The branch production *does* reach: wrong. That is my brief's own rule — green tests prove a mechanism works, never that production reaches it — and I broke it in the same PR where I quoted it.

## The change

- A `boot-base-dns-ambiguous` blocker **at the point it actually occurs**, which says `localhost` *is* loopback, says the ambiguity disables the panel restart for **every tab** rather than just this one, and names the config line to change.
- The dead boot direction is **deleted**, not left with a test pretending to cover it, and the invariant that permits deleting it is now asserted.
- The new branch is driven through the **real handler** by overriding the boot base (`getBootLocalComfyUIBaseUrl`), not by calling the classifier — which is the entire point of the finding.

Before → after for `COMFYUI_URL=http://localhost:8188`:

> ~~the ComfyUI this server booted against (http://localhost:8188) is not a loopback address, so it is not a process on this machine that I can account for.~~
>
> this server is configured with COMFYUI_URL=http://localhost:8188. That IS loopback, but "localhost" does not say which address it resolves to — 127.0.0.1 and ::1 can be DIFFERENT ComfyUI instances on the same port — so I cannot tie it to a specific local process, and no panel tab can be matched against it. This disables the panel restart for every tab, not just this one. FIX: set COMFYUI_URL to the literal your ComfyUI actually listens on (http://127.0.0.1:&lt;port&gt;, or http://[::1]:&lt;port&gt; for an IPv6-only bind) and restart this server.

**The gate is still unchanged.** Every branch still returns `base: null`; every refusal still refuses and dispatches nothing. Asserted on every scenario, plus a mutation that certifies all origins and must turn those assertions red.

## Evidence

- **Mutation verified, 10/10 red**, including `M7`: delete the new branch and the localhost user falls back to the false "not a loopback address" message.
- The harness now **LF-normalises before matching**. This tree is CRLF, and two multi-line anchors had silently missed — which prints identically to a surviving mutation. It now reports `ANCHOR-MISS` as a hard failure, because "did not apply" and "survived" must never look the same. Re-running with that fixed is what turned `M7`/`M8` from apparent passes into real reds.
- Full suite green: 597 files, 11023 passed, 4 skipped. `tsc`, `lint`, `build` clean.

## Review status

**grok's finding on #1927 is addressed here; this follow-up has not itself been reviewed.** Copilot is quota-exhausted (it auto-declined on #1927 with a quota message, not a verdict) and codex is barred as reviewer-of-record. Where to attack: (1) that `boot-base-dns-ambiguous` is ordered correctly relative to `no-boot-base` and `boot-base-not-loopback`; (2) that deleting the boot direction is genuinely safe — i.e. that no caller of `classifyOriginBlocker` can pass an ambiguous boot base now or later.

Also worth noting for the record: I lost this work once mid-run — the worktree was reaped by the background cleaner while the fix was uncommitted, and only the three pushed commits survived. Reconstructed from the pushed tip and re-verified from scratch, not from memory of a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
