### PR TITLE
fix(1929): first Windows code-mode call survives a sharing-violation host spawn

### DIFF
--- a/src/__tests__/orchestrator/codex-code-mode-host-retry.test.ts
+++ b/src/__tests__/orchestrator/codex-code-mode-host-retry.test.ts
@@ -1,0 +1,272 @@
+// #1929 — Windows can refuse the bundled `codex-code-mode-host.exe` spawn with
+// ERROR_SHARING_VIOLATION (os error 32). The first code-mode call failed before
+// JS ran; repeating the identical call succeeded. Codex does not retry that
+// spawn; CodexBackend.runTurn() must, once, with a short backoff.
+//
+// These tests drive the live notificationHandler (the same seam as the
+// interrupt-recovery suite) so the retry is proven on the shipped turn path.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+type Backend = InstanceType<BackendModule["CodexBackend"]>;
+
+let CodexBackend: BackendModule["CodexBackend"];
+let isWindowsCodeModeHostSharingViolation: BackendModule["isWindowsCodeModeHostSharingViolation"];
+
+beforeAll(async () => {
+  vi.stubEnv("COMFYUI_MCP_CODEX_HOST_SPAWN_RETRY_MS", "15");
+  vi.resetModules();
+  ({ CodexBackend, isWindowsCodeModeHostSharingViolation } = await import(
+    "../../orchestrator/codex-backend.js"
+  ));
+});
+
+afterAll(() => vi.unstubAllEnvs());
+
+/** The reporter's exact (scrubbed) Windows error — French FormatMessage + os error 32. */
+const REPORTER_ERROR =
+  "failed to spawn code-mode host ~/AppData/Roaming/nvm/v22.22.3/node_modules/comfyui-mcp/node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex-code-mode-host.exe: Le processus ne peut pas acceder au fichier car ce fichier est utilise par un autre processus. (os error 32)";
+
+const MISSING_HOST_ERROR =
+  "failed to spawn code-mode host /opt/homebrew/bin/codex-code-mode-host: No such file or directory (os error 2)";
+
+type Handler = ((message: unknown) => void) | null;
+
+async function waitUntil(pred: () => boolean, timeoutMs = 500): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitUntil timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function turnStartsOf(request: ReturnType<typeof vi.fn>): number {
+  return request.mock.calls.filter((c) => c[0] === "turn/start").length;
+}
+
+/** Open a live turn on a fake app-server client and return the notify seam. */
+async function liveTurn() {
+  let starts = 0;
+  const client = {
+    notificationHandler: null as Handler,
+    exitError: null,
+    exitPromise: new Promise(() => {}),
+    request: vi.fn(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
+      if (method === "turn/start") {
+        starts += 1;
+        return { turn: { id: `turn-${starts}` } };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const backend: Backend = new CodexBackend({ model: "gpt-5.6-sol" });
+  Object.assign(backend, { client });
+
+  async function* channel() {
+    yield { text: "read ALL_TOOLS" };
+  }
+
+  const iterator = backend.run({ channel: channel() });
+  await iterator.next(); // session
+  const pending = iterator.next();
+  await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-1");
+
+  const notify = (msg: Record<string, unknown>) => client.notificationHandler?.(msg);
+  return { backend, client, iterator, pending, notify };
+}
+
+describe("isWindowsCodeModeHostSharingViolation (#1929)", () => {
+  it("matches the reporter's French os-error-32 host spawn", () => {
+    expect(isWindowsCodeModeHostSharingViolation(REPORTER_ERROR)).toBe(true);
+  });
+
+  it("matches the English sharing-violation wording", () => {
+    expect(
+      isWindowsCodeModeHostSharingViolation(
+        "failed to spawn code-mode host C:\\codex-code-mode-host.exe: The process cannot access the file because it is being used by another process. (os error 32)",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a missing host (os error 2) — that is not transient", () => {
+    expect(isWindowsCodeModeHostSharingViolation(MISSING_HOST_ERROR)).toBe(false);
+  });
+
+  it("does not match an unrelated os-error-32", () => {
+    expect(
+      isWindowsCodeModeHostSharingViolation(
+        "The process cannot access the file because it is being used by another process. (os error 32)",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("CodexBackend code-mode host spawn retry (#1929)", () => {
+  it("retries the turn once after the reporter's sharing-violation, then succeeds", async () => {
+    const { backend, client, iterator, pending, notify } = await liveTurn();
+    expect(turnStartsOf(client.request)).toBe(1);
+
+    notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: false,
+        error: { message: REPORTER_ERROR },
+      },
+    });
+
+    await waitUntil(() => turnStartsOf(client.request) >= 2);
+    await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-2");
+
+    notify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-2", status: "completed" } },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: { type: "result", ok: true, subtype: "completed" },
+    });
+    expect(turnStartsOf(client.request)).toBe(2);
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("a racing turn/completed for the failed turn does not prevent the retry", async () => {
+    const { backend, client, iterator, pending, notify } = await liveTurn();
+
+    notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: false,
+        error: { message: REPORTER_ERROR },
+      },
+    });
+    notify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "failed" } },
+    });
+
+    await waitUntil(() => turnStartsOf(client.request) >= 2);
+    await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-2");
+
+    notify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-2", status: "completed" } },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: { type: "result", ok: true, subtype: "completed" },
+    });
+    expect(turnStartsOf(client.request)).toBe(2);
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("a second sharing-violation after the retry is terminal", async () => {
+    const { backend, client, iterator, pending, notify } = await liveTurn();
+
+    notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: false,
+        error: { message: REPORTER_ERROR },
+      },
+    });
+    await waitUntil(() => turnStartsOf(client.request) >= 2);
+    await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-2");
+
+    notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-2",
+        willRetry: false,
+        error: { message: REPORTER_ERROR },
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: { type: "error", message: REPORTER_ERROR },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: "result", ok: false, subtype: "error" },
+    });
+    expect(turnStartsOf(client.request)).toBe(2);
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("does not retry a missing-host spawn (os error 2)", async () => {
+    const { client, iterator, pending, notify } = await liveTurn();
+
+    notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: false,
+        error: { message: MISSING_HOST_ERROR },
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: { type: "error", message: MISSING_HOST_ERROR },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: "result", ok: false, subtype: "error" },
+    });
+    expect(turnStartsOf(client.request)).toBe(1);
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("retries when turn/start itself rejects with the sharing-violation", async () => {
+    let startCalls = 0;
+    const client = {
+      notificationHandler: null as Handler,
+      exitError: null,
+      exitPromise: new Promise(() => {}),
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
+        if (method === "turn/start") {
+          startCalls += 1;
+          if (startCalls === 1) throw new Error(REPORTER_ERROR);
+          return { turn: { id: "turn-2" } };
+        }
+        throw new Error(`unexpected request: ${method}`);
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend: Backend = new CodexBackend({ model: "gpt-5.6-sol" });
+    Object.assign(backend, { client });
+
+    async function* channel() {
+      yield { text: "read ALL_TOOLS" };
+    }
+    const iterator = backend.run({ channel: channel() });
+    await iterator.next();
+    const pending = iterator.next();
+
+    await waitUntil(() => startCalls >= 2);
+    await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-2");
+
+    client.notificationHandler?.({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-2", status: "completed" } },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: { type: "result", ok: true, subtype: "completed" },
+    });
+    expect(startCalls).toBe(2);
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+});

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -84,6 +84,12 @@ const CODEX_FORCE_KILL_GRACE_MS =
     : 500;
 const CODEX_CLIENT_CLOSE_BUDGET_MS =
   CODEX_CLOSE_TIMEOUT_MS * 2 + CODEX_FORCE_KILL_GRACE_MS + 100;
+const configuredHostSpawnRetryMs = Number(process.env.COMFYUI_MCP_CODEX_HOST_SPAWN_RETRY_MS);
+const CODEX_HOST_SPAWN_RETRY_MS =
+  Number.isFinite(configuredHostSpawnRetryMs) && configuredHostSpawnRetryMs >= 0
+    ? configuredHostSpawnRetryMs
+    : 150;
+const CODEX_HOST_SPAWN_RETRIES = 1;
 
 async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
   let timer: NodeJS.Timeout | undefined;
@@ -628,6 +634,28 @@ export function resolveCodexSandbox(): string {
 }
 
 /**
+ * #1929 — Windows can refuse CreateProcess on the bundled
+ * `codex-code-mode-host.exe` with ERROR_SHARING_VIOLATION (os error 32) while
+ * Defender / a previous host still holds the image. Codex does not retry that
+ * spawn; the next identical call succeeds. Match the host-spawn failure, not
+ * every os-error-32, so a missing binary (os error 2) stays terminal.
+ */
+export function isWindowsCodeModeHostSharingViolation(message: string): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  const isHost = m.includes("code-mode host") || m.includes("codex-code-mode-host");
+  if (!isHost) return false;
+  return (
+    /\bos error 32\b/.test(m) ||
+    m.includes("error_sharing_violation") ||
+    m.includes("sharing violation") ||
+    m.includes("being used by another process") ||
+    m.includes("utilise par un autre processus") ||
+    m.includes("utilizado por otro proceso")
+  );
+}
+
+/**
  * The Codex app-server adapter. One instance per PanelAgent; it holds the live
  * app-server client + current thread/turn ids and re-opens on each `run()`.
  */
@@ -1063,6 +1091,12 @@ export class CodexBackend implements AgentBackend {
     let activeTurnId: string | null = null;
     let turnIdKnown = false;
     const buffered: RpcMessage[] = [];
+    // #1929 — one bounded retry of turn/start after a Windows sharing-violation
+    // on the bundled code-mode host. While the retry is armed, drop notifications
+    // for the dead turn so a racing turn/completed cannot finish us first.
+    let hostSpawnRetries = 0;
+    let retryPending = false;
+    let retryTimer: NodeJS.Timeout | undefined;
     const belongsToTurn = (msg: RpcMessage): boolean => {
       const params = (msg.params ?? {}) as Record<string, unknown>;
       const msgThreadId = params.threadId as string | undefined;
@@ -1150,6 +1184,38 @@ export class CodexBackend implements AgentBackend {
     };
     this.abortActiveTurn = abortActiveTurn;
 
+    // Assigned after turn input is built — the retry timer only fires after a
+    // turn/start has already run, so this is never invoked while still a no-op.
+    let issueTurnStart: () => void = () => {};
+
+    const tryRetryCodeModeHostSpawn = (message: string): boolean => {
+      if (interrupted || finishedResult || retryPending) return false;
+      if (hostSpawnRetries >= CODEX_HOST_SPAWN_RETRIES) return false;
+      if (!isWindowsCodeModeHostSharingViolation(message)) return false;
+      hostSpawnRetries += 1;
+      retryPending = true;
+      logger.warn(
+        `[codex-backend] code-mode host spawn hit a Windows sharing violation; retrying once after ${CODEX_HOST_SPAWN_RETRY_MS}ms (#1929)`,
+      );
+      try {
+        onActivity?.();
+      } catch {
+        // a watchdog bump must never break the protocol reader
+      }
+      retryTimer = setTimeout(() => {
+        retryTimer = undefined;
+        if (interrupted || finishedResult || this.disposed) {
+          retryPending = false;
+          return;
+        }
+        turnIdKnown = false;
+        buffered.length = 0;
+        issueTurnStart();
+      }, CODEX_HOST_SPAWN_RETRY_MS);
+      retryTimer.unref?.();
+      return true;
+    };
+
     // Normalize ONE notification (already confirmed to belong to this turn) into
     // canonical AgentEvents. Pulled out so it can be applied to both live and
     // buffered (replayed) notifications.
@@ -1160,6 +1226,9 @@ export class CodexBackend implements AgentBackend {
       // (double-completing PanelAgent's gate) or enqueue deltas into a closing
       // iterator. This is the "exactly one result" invariant (P0-B).
       if (finishedResult) return;
+      // The previous turn died on a retryable host-spawn; wait for the replacement
+      // turn/start rather than treating its turn/completed as ours (#1929).
+      if (retryPending) return;
       const params = (msg.params ?? {}) as Record<string, unknown>;
       switch (msg.method) {
         case "turn/started": {
@@ -1247,10 +1316,14 @@ export class CodexBackend implements AgentBackend {
           // for either a later terminal error or turn/completed.
           const e = (params.error ?? {}) as { message?: string };
           if (params.willRetry === true) break;
+          const message = e.message ?? "Codex error";
+          // #1929 — a Windows sharing-violation on the bundled code-mode host is
+          // the same transient the user already proved by retrying the call.
+          if (tryRetryCodeModeHostSpawn(message)) break;
           // A non-retrying `error` ends the turn: emit it AND finish, so a turn that
           // errors out (no following turn/completed) doesn't hang (P0-2). Route it
           // through the idempotent helper to avoid racing another terminal path.
-          emitTerminalError(e.message ?? "Codex error");
+          emitTerminalError(message);
           break;
         }
         case "turn/completed": {
@@ -1363,7 +1436,7 @@ export class CodexBackend implements AgentBackend {
       );
     }
 
-    try {
+    issueTurnStart = () => {
       // turn/start delivers the user text plus any resolved image input items.
       const turnModel = this.resolveTurnModel();
       client
@@ -1384,6 +1457,7 @@ export class CodexBackend implements AgentBackend {
           outputSchema: null,
         })
         .then((res) => {
+          retryPending = false;
           // Set the active turn id, flush the buffer (replaying only this turn's
           // notifications), then switch the handler to live filtering.
           if (res.turn?.id) {
@@ -1411,13 +1485,21 @@ export class CodexBackend implements AgentBackend {
           // returns without one, hanging PanelAgent's gate forever. Route through
           // the idempotent helper so it always emits exactly one result.
           if (interrupted) {
+            retryPending = false;
             // Deliberate teardown (interrupt restored/closed the turn): still end
             // with a result so the gate advances, but no user-facing error.
             abortActiveTurn();
+          } else if (tryRetryCodeModeHostSpawn(msgOf(err))) {
+            // retryPending is now true; the dead turn's result is deferred.
           } else {
+            retryPending = false;
             emitTerminalError(msgOf(err));
           }
         });
+    };
+
+    try {
+      issueTurnStart();
 
       // Drain the bridged queue until the turn completes.
       while (true) {
@@ -1432,6 +1514,11 @@ export class CodexBackend implements AgentBackend {
       // Flush any trailing events queued between the last drain and done.
       while (queue.length) yield queue.shift()!;
     } finally {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+      retryPending = false;
       // Mark interrupted so a late turn/start rejection / exit doesn't surface as
       // a spurious error after we've already torn the turn down.
       interrupted = true;


### PR DESCRIPTION
Fixes #1929

The first Codex code-mode call on Windows could fail before any JavaScript ran: Windows refused CreateProcess on the bundled `codex-code-mode-host.exe` with ERROR_SHARING_VIOLATION (os error 32). Repeating the identical call succeeded. Codex does not retry that spawn (the failing binary is the bundled runtime), so the panel treated a transient file-lock race as a terminal turn error.

`CodexBackend.runTurn()` now recognizes that host-spawn sharing violation (English or the reporter's French FormatMessage, both carrying `os error 32`) and re-issues `turn/start` once after a short backoff. A racing `turn/completed` for the dead turn cannot finish the iterator first. A missing host (`os error 2`) stays terminal. The retry delay is `COMFYUI_MCP_CODEX_HOST_SPAWN_RETRY_MS` (default 150ms).

## Tests

Drive the shipped `runTurn()` path through a fake app-server client (same seam as the interrupt-recovery suite), using the reporter's exact error string:

- first sharing-violation → one retry → completed
- racing `turn/completed` on the failed turn does not eat the retry
- a second sharing-violation after the retry is terminal
- missing host (os error 2) is not retried
- `turn/start` itself rejecting with the same error also retries once

Targeted: `npx vitest run --maxWorkers=4 src/__tests__/orchestrator/codex-code-mode-host-retry.test.ts src/__tests__/orchestrator/codex-interrupt-recovery.test.ts src/__tests__/orchestrator/codex-watchdog-liveness.test.ts` — 25/25 passed.

Did not run the full suite; CI is authority for that.
