### PR TITLE
fix(1933): the QUEUE BUSY refusal names TOOLS, not bridge commands

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -21,9 +21,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildPanelToolDefs,
   makePanelToolCtx,
+  panelToolForGraphCmd,
+  QUEUE_BUSY_READ_TOOLS,
+  RETRY_TOKEN_CMD_BY_TOOL,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
+import { GRAPH_CMD_EFFECT } from "../../services/ui-bridge.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 import {
   markDispatched,
@@ -195,6 +199,12 @@ describe("graph MUTATIONS still fail fast while a prompt is running (#1639)", ()
     expect(text).toMatch(/QUEUE BUSY/);
     expect(text).toMatch(/was NOT sent — nothing was applied/);
     expect(text).toMatch(/running prompt p-in-flight/);
+    // #1933 — it must name the TOOL the caller called, not the bridge command
+    // that tool dispatches. The reporter quoted the old wording back verbatim:
+    // "graph_set_widget was NOT sent", naming something they never called.
+    expect(text).toMatch(/panel_set_widget was NOT sent/);
+    expect(text).toMatch(/panel_set_widget MUTATES the workflow/);
+    expect(text).not.toMatch(/(?<![a-z_])graph_set_widget(?![a-z_])/);
     // A mutation that never left must not invite retry_of / unknown-outcome.
     expect(text).not.toMatch(/may have been applied/);
     expect(text).not.toMatch(/retry_of/);
@@ -212,10 +222,99 @@ describe("graph MUTATIONS still fail fast while a prompt is running (#1639)", ()
     const text = textOf(res);
 
     expect(text).toMatch(/currently at node 42/);
-    expect(text).toMatch(/graph_outline/);
     expect(text).toMatch(/NOT fenced/);
+    // #1933 — the reads are named by their REGISTERED tool names. The previous
+    // assertion was `toMatch(/graph_outline/)`, which `panel_graph_outline` and
+    // the wrong bare `graph_outline` both satisfy — so it stayed green for the
+    // whole life of the defect. Anchored on both sides, it cannot.
+    expect(text).toMatch(/panel_graph_outline \/ panel_query_graph \/ panel_get_errors/);
+    expect(text).not.toMatch(/\(graph_outline/);
     // The old text told every caller reads were unavailable too. Nothing may say so.
     expect(text).not.toMatch(/including read-only/);
+  });
+
+  // #1933 — the load-bearing property, and the one no assertion held before:
+  // every tool name this refusal utters must be a tool the caller can actually
+  // call. A recovery instruction naming a non-tool is worse than none — the
+  // agent following it gets "unknown tool" during an already-degraded state.
+  it("every tool name in the refusal is a REGISTERED tool", async () => {
+    startRender();
+
+    const { bridge } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+
+    const registered = new Set(buildPanelToolDefs().map((d) => d.name));
+    // Read from the MESSAGE, not from the constant — a test that re-reads the
+    // list the code built the string from would pass on a string built from a
+    // different list.
+    const mentioned = textOf(res).match(/panel_[a-z0-9_]+/g) ?? [];
+    expect(mentioned.length).toBeGreaterThan(0);
+    for (const name of new Set(mentioned)) expect([name, registered.has(name)]).toEqual([name, true]);
+
+    // And the inverse: no bare bridge command survives anywhere in the text.
+    // `graph_` never appears except as the tail of a `panel_graph_*` tool name.
+    expect(textOf(res)).not.toMatch(/(?<![a-z_])graph_[a-z_]+/);
+  });
+
+  it("the three advertised reads are registered AND are the ones the fence lets past", () => {
+    const registered = new Set(buildPanelToolDefs().map((d) => d.name));
+    for (const name of QUEUE_BUSY_READ_TOOLS) {
+      expect([name, registered.has(name)]).toEqual([name, true]);
+    }
+    // The claim "are NOT fenced" has to be true of the commands behind them, or
+    // the message is accurate about names and wrong about behaviour.
+    for (const cmd of ["graph_outline", "graph_query", "graph_get_errors"]) {
+      expect([cmd, GRAPH_CMD_EFFECT[cmd]]).toEqual([cmd, "inert"]);
+    }
+  });
+
+  // #1933 — the reverse index must resolve every command this fence can refuse,
+  // or a real refusal silently falls back to the anonymous subject.
+  it("every command the fence can refuse resolves to a tool, except ambiguous graph_load", () => {
+    const refusable = Object.entries(GRAPH_CMD_EFFECT)
+      .filter(([cmd, effect]) => cmd.startsWith("graph_") && cmd !== "graph_run" && effect === "targeted")
+      .map(([cmd]) => cmd);
+    expect(refusable.length).toBeGreaterThan(20);
+
+    const unresolved = refusable.filter((cmd) => panelToolForGraphCmd(cmd) === undefined);
+    // graph_load is dispatched by TWO tools (panel_load_workflow and
+    // panel_flatten_workflow), so the index declines to pick one. That is the
+    // designed behaviour, not a coverage hole — pinned here so a future
+    // "cleanup" that makes it guess fails.
+    expect(unresolved).toEqual(["graph_load"]);
+    expect(
+      Object.entries(RETRY_TOKEN_CMD_BY_TOOL).filter(([, cmd]) => cmd === "graph_load").length,
+    ).toBe(2);
+
+    // And a resolved one resolves to the RIGHT tool, not merely to some tool.
+    expect(panelToolForGraphCmd("graph_set_widget")).toBe("panel_set_widget");
+    expect(panelToolForGraphCmd("graph_auto_layout")).toBe("panel_auto_layout");
+  });
+
+  it("an ambiguous command falls back to a subject that names no tool", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    // Dispatch graph_load through ctx.call directly: both tools that reach it
+    // read the live canvas first, so this is the only way to exercise the
+    // fallback branch at the point the fence actually runs.
+    const res = await ctx.call({ cmd: "graph_load", workflow: { nodes: [], links: [] } });
+    const text = textOf(res);
+
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/This edit was NOT sent — nothing was applied/);
+    // It must not invent a tool: naming one of two possible callers would be a
+    // confidently wrong answer, which is the defect class, not a smaller one.
+    expect(text).not.toMatch(/panel_load_workflow/);
+    expect(text).not.toMatch(/panel_flatten_workflow/);
+    expect(text).not.toMatch(/(?<![a-z_])graph_load(?![a-z_])/);
   });
 
   it("a targeted command that is not a node edit is fenced as well", async () => {

--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -274,6 +274,13 @@ describe("graph MUTATIONS still fail fast while a prompt is running (#1639)", ()
 
   // #1933 — the reverse index must resolve every command this fence can refuse,
   // or a real refusal silently falls back to the anonymous subject.
+  //
+  // Enumerating from GRAPH_CMD_EFFECT is complete, not merely convenient: the
+  // ledger FAILS CLOSED, so an unlisted graph_* command is fenced too and would
+  // be invisible here — except that graph-command-effect.test.ts holds the
+  // COMPLETENESS half, scanning every "graph_..." literal in the orchestrator
+  // sources and requiring an entry. That test is what makes this enumeration
+  // exhaustive; without it this assertion would be narrower than it reads.
   it("every command the fence can refuse resolves to a tool, except ambiguous graph_load", () => {
     const refusable = Object.entries(GRAPH_CMD_EFFECT)
       .filter(([cmd, effect]) => cmd.startsWith("graph_") && cmd !== "graph_run" && effect === "targeted")

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1113,6 +1113,34 @@ function graphCmdIsInertUnderQueueBusy(name: string): boolean {
   return GRAPH_CMD_EFFECT[name] === "inert";
 }
 
+/**
+ * #1933 — the READ TOOLS this refusal advertises, by their REGISTERED tool name.
+ *
+ * They must be tool names, not the `graph_outline` / `graph_query` /
+ * `graph_get_errors` bridge commands they dispatch: this string is the whole
+ * recovery contract for a fenced write, and an agent that follows it calls what
+ * it is told to call. A bridge command is not callable, so the advice returned
+ * "unknown tool" — a hard failure mid-degraded-state that the agent cannot
+ * diagnose, and from which it can only conclude that reads are unavailable
+ * during a render, which is precisely the state panel#1489 fixed and this
+ * sentence exists to advertise (reported from the field in
+ * artokun/comfyui-mcp-panel#1549).
+ *
+ * The mapping is NOT the `panel_` prefix mechanically applied — `graph_query`'s
+ * tool is `panel_query_graph`, not `panel_graph_query`. So these are written
+ * out, and `graph-read-during-render.test.ts` asserts every one of them is in
+ * `buildPanelToolDefs()` — the registry the caller actually dispatches against.
+ * That test is what stops this list from drifting again: the old literal was
+ * green for the whole of its life with all three names wrong, because the
+ * assertion matched `/graph_outline/`, which a wrong name and a right one both
+ * satisfy.
+ */
+export const QUEUE_BUSY_READ_TOOLS: readonly string[] = [
+  "panel_graph_outline",
+  "panel_query_graph",
+  "panel_get_errors",
+];
+
 function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   if (!name.startsWith("graph_") || name === "graph_run") return null;
@@ -1121,13 +1149,23 @@ function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | 
   if (graphCmdIsInertUnderQueueBusy(name)) return null;
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return null;
+  // #1933 — name what the CALLER called. `cmd.cmd` is the BRIDGE command
+  // (observed: a `panel_set_widget` call arrives here as `graph_set_widget`),
+  // and PanelToolCtx.call carries no tool identity, so the tool name is
+  // recovered from the retry map's reverse index. That index REFUSES to answer
+  // when two tools share one command (graph_load ← panel_load_workflow /
+  // panel_flatten_workflow), so an unresolvable command falls back to a subject
+  // naming no tool at all rather than picking the wrong one: the caller already
+  // knows which tool it called, and a confidently wrong name is the defect being
+  // fixed here, not a smaller version of it.
+  const subject = panelToolForGraphCmd(name) ?? "This edit";
   return (
-    `${name} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
-    `${queueBusySnapshotNote()}. ${name} MUTATES the workflow, and the panel tab often ` +
+    `${subject} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
+    `${queueBusySnapshotNote()}. ${subject} MUTATES the workflow, and the panel tab often ` +
     `cannot service a graph edit while a prompt is executing — delivering it would only ` +
     `surface a generic "tab may be backgrounded or frozen" timeout with an unknown ` +
     `outcome, leaving you unable to say whether the edit applied. Read-only graph calls ` +
-    `(graph_outline / graph_query / graph_get_errors) are NOT fenced and can be used right ` +
+    `(${QUEUE_BUSY_READ_TOOLS.join(" / ")}) are NOT fenced and can be used right ` +
     `now to inspect the graph. Retry this edit after queue (action:"list") shows running: 0.`
   );
 }
@@ -11540,6 +11578,47 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
 export const RETRY_TOKEN_CMDS: ReadonlySet<string> = new Set(
   Object.values(RETRY_TOKEN_CMD_BY_TOOL).concat(["workflow_save_as"]),
 );
+
+/**
+ * #1933 — the reverse of RETRY_TOKEN_CMD_BY_TOOL: which TOOL does a caller reach
+ * this bridge command through?
+ *
+ * An agent-facing message written below the tool layer can only see `cmd.cmd`;
+ * `PanelToolCtx.call` takes a command object and no tool identity, so by the
+ * time a pre-dispatch refusal is worded the tool name is genuinely gone. This
+ * recovers it from the map that already maintains the correspondence, rather
+ * than adding a second hand-written list that can drift out of step with the
+ * first.
+ *
+ * IT REFUSES TO GUESS. The forward map is not injective — `graph_load` is
+ * dispatched by both `panel_load_workflow` and `panel_flatten_workflow` — and
+ * naming one of two possible tools is a confidently wrong answer, which is worse
+ * than declining to name one. Ambiguous commands are therefore OMITTED, and
+ * callers must handle `undefined`.
+ *
+ * Coverage is not assumed either: every `targeted` GRAPH_CMD_EFFECT command
+ * except `graph_run` is a value of the forward map, so the queue-busy fence
+ * resolves a tool for everything it can refuse except `graph_load`.
+ * `graph-read-during-render.test.ts` pins both halves — the resolution and the
+ * refusal to guess.
+ */
+export const PANEL_TOOL_BY_GRAPH_CMD: ReadonlyMap<string, string> = (() => {
+  const claims = new Map<string, string[]>();
+  for (const [tool, cmd] of Object.entries(RETRY_TOKEN_CMD_BY_TOOL)) {
+    const prior = claims.get(cmd);
+    if (prior) prior.push(tool);
+    else claims.set(cmd, [tool]);
+  }
+  const unique = new Map<string, string>();
+  for (const [cmd, tools] of claims) if (tools.length === 1) unique.set(cmd, tools[0]!);
+  return unique;
+})();
+
+/** #1933 — the registered tool a bridge command is reached through, or
+ *  `undefined` when no tool, or more than one tool, claims it. */
+export function panelToolForGraphCmd(cmd: string): string | undefined {
+  return PANEL_TOOL_BY_GRAPH_CMD.get(cmd);
+}
 
 /** #694 — augment one MUTATING tool def: accept retry_of and attach it, UNTOUCHED,
  *  to every mutating command the handler dispatches (per-command gated so a read


### PR DESCRIPTION
Fixes #1933.

## What was wrong

`graphCmdBlockedByRunningPrompt` (`src/orchestrator/panel-tools.ts`) is the entire
recovery contract an agent gets when a graph edit is fenced behind a running render.
Every tool name in it was uncallable.

**Observed by execution on `origin/main` @ 0.52.36**, not read off the source — a real
`panel_set_widget` call driven through `buildPanelToolDefs()` with a prompt in flight
returned:

```
graph_set_widget was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is
running (running prompt p-in-flight, currently at node 42). graph_set_widget MUTATES
the workflow, ... Read-only graph calls (graph_outline / graph_query /
graph_get_errors) are NOT fenced and can be used right now to inspect the graph.
```

Two defects, one cause — the function sits *below* the tool layer, and `PanelToolCtx.call`
takes a command object with no tool identity, so all it can see is `cmd.cmd`:

1. **The three advertised reads are bridge commands.** `buildPanelToolDefs()` registers
   `panel_graph_outline`, `panel_query_graph`, `panel_get_errors`; it registers no
   `graph_outline`. An agent that follows the advice gets a hard "unknown tool" during an
   already-degraded state and can reasonably conclude reads are unavailable mid-render —
   which is precisely the state panel#1489 fixed and this sentence exists to advertise.
   The mapping is **not** the `panel_` prefix mechanically applied: `graph_query`'s tool is
   `panel_query_graph`, and `panel_graph_query` does not exist (verified against the
   registry, printed: `HAS panel_query_graph: true`, `HAS panel_graph_query: false`).

2. **`${name}` interpolated the bridge command.** The caller of `panel_set_widget` was told
   "graph_set_widget was NOT sent … Retry this edit", naming a tool they never called. The
   field report quoted exactly this back (artokun/comfyui-mcp-panel#1549).

## The fix

- `QUEUE_BUSY_READ_TOOLS` — the three reads as registered tool names, in one place, pinned
  by a test against `buildPanelToolDefs()`.
- `panelToolForGraphCmd` / `PANEL_TOOL_BY_GRAPH_CMD` — the **reverse index of
  `RETRY_TOKEN_CMD_BY_TOOL`**, the map that already maintains the tool/command
  correspondence. No second hand-written list.
- **It refuses to guess.** The forward map is not injective: `graph_load` is dispatched by
  both `panel_load_workflow` and `panel_flatten_workflow`. Ambiguous commands resolve to
  `undefined` and the message falls back to a subject naming no tool at all
  ("This edit was NOT sent…"). Naming one of two possible callers would be the same defect
  class in a smaller size. Coverage is otherwise complete: every `targeted`
  `GRAPH_CMD_EFFECT` command except `graph_run` is a value of the forward map, asserted.

Emitted now (observed, same harness):

```
panel_set_widget was NOT sent — nothing was applied. QUEUE BUSY: ... panel_set_widget
MUTATES the workflow, ... Read-only graph calls (panel_graph_outline /
panel_query_graph / panel_get_errors) are NOT fenced ...
```

## Why no test caught this

The one consumer of the text asserted `toMatch(/graph_outline/)` — which the wrong name
and the right name **both** satisfy. It was green for the whole life of the defect. That
assertion is now anchored on the full triple, and a new test reads the tool names back
**out of the emitted message** (`/panel_[a-z0-9_]+/g`) and requires each to be in the
registry — deliberately not re-reading the constant the code built the string from, since
that would pass against a string built from a different list.

## Mutation evidence (fix deleted, named tests fail)

| # | mutation | result |
|---|---|---|
| M1 | reads sentence back to `graph_outline / graph_query / graph_get_errors` | **RED** — 2 failed: "the refusal names the reads that ARE available", "every tool name in the refusal is a REGISTERED tool" |
| M2 | `subject` back to `name` (the bridge command) | **RED** — 3 failed, incl. `expected 'graph_set_widget was NOT sent…' to match /panel_set_widget was NOT sent/` |
| M3 | reverse index guesses instead of refusing on ambiguity | **RED** — 2 failed: `expected [] to deeply equal [ 'graph_load' ]`, and the fallback emitted `panel_flatten_workflow was NOT sent` |
| M4 | `panel_query_graph` → `panel_graph_query` (the uniform-prefix mistake) | **RED** — 2 failed |
| M5 | invent a 4th read tool `panel_graph_state` (isolates the registry check) | **RED** — `expected [ 'panel_graph_state', false ] to deeply equal [ 'panel_graph_state', true ]` |

Each mutation asserted its anchor applied before running (a CRLF-eaten replacement reads as
"survived"), and restored the file afterwards.

## Gates

- `npm run check:vocabulary` — **OK**, 1734 files, 160 dead names in the ledger, no live
  references. (Baseline on clean `origin/main`: OK, same ledger.) The three new names are
  live tools, so nothing was added to the ledger.
- `npx tsc --noEmit` — clean.
- `graph-read-during-render.test.ts` — 20/20 pass (was 15).
- Full suite vs a clean `origin/main` baseline worktree — see the review-request comment.
- Prettier reports both touched files unformatted **on clean `origin/main` too** (CRLF), so
  it is not run here; `--write` would produce a several-thousand-line unrelated diff.

## Review

**Review pending — grok requested in a comment below. Not gated, not reviewed, no verdict
claimed.**

## Deliberately not done

- **`src/services/ui-bridge.ts:4749/4756` has the same defect class** — the workflow-instance
  mismatch refusal also names `graph_outline / graph_query` to the agent, and
  `fence-lookalike-refusals.test.ts` asserts that exact prose. It is a *different* message
  with a different fence and its own test contract; folding it in here would widen the blast
  radius past the reported defect under the freeze. Flagged for a follow-up issue rather than
  silently bundled.
- No browser/Playwright run: this changes an orchestrator-side string only. Nothing the panel
  renders is touched.
- `codex-gate.mjs` not run, per the brief.
