### PR TITLE
release: v0.52.37 — code-mode sharing-violation retry, QUEUE BUSY names tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.37] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- the QUEUE BUSY refusal names TOOLS, not bridge commands (#1934)
+- first Windows code-mode call survives a sharing-violation host spawn (#1932)
+
+
 ## [0.52.36] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.36",
+  "version": "0.52.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.36",
+      "version": "0.52.37",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.36",
+  "version": "0.52.37",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.37 from main.

Carries:

- #1932 / #1929 — first Windows code-mode call survives a sharing-violation host spawn
- #1934 / #1933 — the QUEUE BUSY refusal names TOOLS, not bridge commands

Held out: #1697 P1 inflight; #1765 P2 inflight; #1935 P2 inflight this cycle; panel#1472 typescript 5 to 7 (CI red).

Do not squash-merge. Merge-commit (keeps the v0.52.37 tag on the version commit). Tag is local; push v0.52.37 after merge.