### PR TITLE
fix(1765): install_custom_node refuses a local write aimed at an install this session is not connected to

### DIFF
--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -161,19 +161,28 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-// The OS process-table probe. `resolveLiveServerRoot`'s `observed-process` tier
-// anchors on where the interpreter BINARY lives, which workspace-env.ts itself
-// documents as "KNOWN GAP … not proof of where the SCRIPT was resolved from".
-// A resolution with a documented soundness gap may FIND a root; it may not be
-// what REFUSES a user's write, so this must never be consulted here.
-const probe = vi.hoisted(() => ({ calls: 0 }));
+// The OS process-table probe — `resolveLiveServerRoot`'s `observed-process` tier.
+//
+// MEASURED against the ComfyUI running on the development machine (0.33.2,
+// ComfyUI Desktop): argv[0] is the RELATIVE "ComfyUI\main.py" and the
+// /system_stats payload carries no `cwd` field at all. `liveRootFromArgv`
+// resolves a relative script only against an absolute server cwd, so on that
+// layout — and on the Windows portable bundle, and on `comfy launch`, which runs
+// `python main.py` from the workspace — the argv tier answers NOTHING. An
+// argv-only guard is green in every test here and INERT on the machines where
+// several installs coexist. Hence this tier, and hence these tests.
+const probe = vi.hoisted(() => ({
+  calls: 0,
+  /** What the OS says is running on the port; undefined = nothing observable. */
+  result: undefined as { python: string; pid: number } | undefined,
+}));
 vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
   return {
     ...actual,
-    observeLiveServerProcess: (...args: unknown[]) => {
+    observeLiveServerProcess: () => {
       probe.calls += 1;
-      return (actual.observeLiveServerProcess as (...a: unknown[]) => unknown)(...args);
+      return probe.result;
     },
   };
 });
@@ -211,6 +220,7 @@ let priorEnvPath: string | undefined;
 beforeEach(() => {
   git.calls = [];
   probe.calls = 0;
+  probe.result = undefined;
   http.mode = "refuse-enqueue";
   live.reachable = true;
   live.statsCalls = 0;
@@ -364,19 +374,49 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("fails OPEN on the Desktop/portable shape, without probing the process table", async () => {
-    // ComfyUI Desktop and the Windows portable bundle both report a RELATIVE
-    // main.py and no cwd. The server's SELF-REPORT cannot resolve a root there,
-    // and the interpreter-anchored tier that can is not sound enough to refuse
-    // on — so nothing is refused, and the OS probe is never even taken.
+  it("REFUSES the relative-main.py shape too, via the OS process observation", async () => {
+    // The shape the live rig actually reports, and the one `comfy launch`
+    // produces: a relative launch script and no server cwd. Nothing in argv
+    // names a root; the interpreter the OS says is on the port does.
+    live.argv = ["main.py", "--port", "8189"];
+    probe.result = { python: join(CONNECTED, ".venv", "Scripts", "python.exe"), pid: 4242 };
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+    expect(error).toContain(CONNECTED);
+    expect(error).toContain("OS process listening on that port");
+    expect(probe.calls).toBeGreaterThan(0);
+  });
+
+  it("fails OPEN when the relative main.py can be anchored on NOTHING", async () => {
+    // Relative script, and the OS observation yields no interpreter (a remote
+    // proxy, a permissions failure, an unreadable process table). Unprovable is
+    // not the same as wrong, so nothing is refused.
     live.argv = ["ComfyUI/main.py", "--port", "8189"];
+    probe.result = undefined;
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
     expect(error).toBeUndefined();
     expect(ok).toMatchObject({ mechanism: "git-clone" });
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
-    expect(probe.calls).toBe(0);
+  });
+
+  it("fails OPEN when the observed interpreter belongs to no install we can anchor", async () => {
+    // A SYSTEM python: walking up from it reaches directories that are not the
+    // install at all, which is the unsoundness `interpreterBelongsToInstall`
+    // exists to reject. It must not produce a root, and so must not refuse.
+    live.argv = ["ComfyUI/main.py", "--port", "8189"];
+    probe.result = { python: join(SANDBOX, "python", "python.exe"), pid: 4243 };
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
   it("refuses the comfy-cli branch too — --workspace has the identical hazard", async () => {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -161,6 +161,23 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+// The OS process-table probe. `resolveLiveServerRoot`'s `observed-process` tier
+// anchors on where the interpreter BINARY lives, which workspace-env.ts itself
+// documents as "KNOWN GAP … not proof of where the SCRIPT was resolved from".
+// A resolution with a documented soundness gap may FIND a root; it may not be
+// what REFUSES a user's write, so this must never be consulted here.
+const probe = vi.hoisted(() => ({ calls: 0 }));
+vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
+  return {
+    ...actual,
+    observeLiveServerProcess: (...args: unknown[]) => {
+      probe.calls += 1;
+      return (actual.observeLiveServerProcess as (...a: unknown[]) => unknown)(...args);
+    },
+  };
+});
+
 const { installCustomNode } = await import("../../services/node-management.js");
 const { configureWorkspace, resetWorkspaceConfig } = await import(
   "../../services/workspace-env.js"
@@ -193,6 +210,7 @@ let priorEnvPath: string | undefined;
 
 beforeEach(() => {
   git.calls = [];
+  probe.calls = 0;
   http.mode = "refuse-enqueue";
   live.reachable = true;
   live.statsCalls = 0;
@@ -329,9 +347,11 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("fails OPEN when the server's main.py root cannot be resolved", async () => {
-    // ComfyUI Desktop reports a RELATIVE main.py and no cwd. Nothing here is
-    // provable, so nothing is refused.
+  it("fails OPEN on the Desktop/portable shape, without probing the process table", async () => {
+    // ComfyUI Desktop and the Windows portable bundle both report a RELATIVE
+    // main.py and no cwd. The server's SELF-REPORT cannot resolve a root there,
+    // and the interpreter-anchored tier that can is not sound enough to refuse
+    // on — so nothing is refused, and the OS probe is never even taken.
     live.argv = ["ComfyUI/main.py", "--port", "8189"];
 
     const { ok, error } = await install({ id: REPO, source: "git" });
@@ -339,6 +359,7 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(error).toBeUndefined();
     expect(ok).toMatchObject({ mechanism: "git-clone" });
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+    expect(probe.calls).toBe(0);
   });
 
   it("refuses the comfy-cli branch too — --workspace has the identical hazard", async () => {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -321,6 +321,21 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(error).toContain("--base-directory");
   });
 
+  it("fails OPEN when --base-directory is relative and unresolvable", async () => {
+    // The server WAS given a base directory, but a relative one with no server
+    // cwd to resolve it against. It scans custom_nodes/ from a directory we
+    // cannot name — and the main.py root, which argv does give us, is then
+    // confidently NOT that directory. Judging the write against it would be
+    // comparing the base to the wrong tree, so nothing is refused.
+    live.argv = [join(CONNECTED, "main.py"), "--base-directory", "data"];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
   it("clones normally when the server's --base-directory IS the configured root", async () => {
     // The #1715/#1770 split shape: main.py in one tree, custom_nodes scanned from
     // the data root — which is exactly the root we were about to write into.

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -254,6 +254,7 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(error).toContain(CONNECTED);
     expect(error).toContain("http://127.0.0.1:8189");
     expect(error).toContain("SAVED DEFAULT WORKSPACE");
+    expect(error).toContain("--base-directory");
     expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
     expect(error).toContain(`COMFYUI_PATH=${CONNECTED}`);
   });
@@ -322,13 +323,29 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("leaves an EXPLICIT COMFYUI_PATH in charge — that is #1766's shipped contract", async () => {
-    // A named COMFYUI_PATH is the user stating which install this session acts on
-    // (and, on a split deployment, which DATA root packs belong in). Only a
-    // machine-wide GUESS — the saved default workspace, or auto-detection across
-    // six installs — may be overruled by the running server.
+  it("refuses a COMFYUI_PATH that disagrees too — the env var is not proof of intent", async () => {
+    // The panel orchestrator resolves `COMFYUI_PATH || detectLocalComfyUIPath()`
+    // and forwards the RESULT to every child MCP as COMFYUI_PATH, so "the env var
+    // is set" cannot distinguish a deliberate setting from an auto-detected guess.
+    // A carve-out keyed on it would have switched this check off in exactly the
+    // panel sessions it exists for.
     process.env.COMFYUI_PATH = SAVED_DEFAULT;
     cfg.comfyuiPath = SAVED_DEFAULT;
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toContain("COMFYUI_PATH");
+    expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
+    // …and it names the supported way to make that data root authoritative.
+    expect(error).toContain(`--base-directory ${SAVED_DEFAULT}`);
+  });
+
+  it("clones normally when COMFYUI_PATH names the connected install", async () => {
+    process.env.COMFYUI_PATH = SAVED_DEFAULT;
+    cfg.comfyuiPath = SAVED_DEFAULT;
+    live.argv = [join(SAVED_DEFAULT, "main.py"), "--port", "8189"];
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -86,13 +86,45 @@ vi.mock("../../comfyui/client.js", () => ({
   resetObjectInfoCache: vi.fn(),
 }));
 
-// ── ComfyUI-Manager REFUSES the git-URL enqueue (HTTP 403 — a 3.x
-//    security_level / allow_git_url_install gate), which is the #1129 divert
-//    into the direct-clone fallback the reporter landed on. ──────────────────
-vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: async () =>
-    new Response("gated by security_level", { status: 403, statusText: "Forbidden" }),
+// ── ComfyUI-Manager. BOTH roads to the direct-clone fallback are exercised:
+//
+//   "refuse-enqueue"  HTTP 403 on the enqueue — a 3.x security_level /
+//                     allow_git_url_install gate; the #1129 divert.
+//   "accept-enqueue"  the queue ACCEPTS and drains, but the pack is not in the
+//                     installed list afterwards, because it is unregistered —
+//                     the reporter's own shape ("reported git-clone success").
+//
+// They reach `cloneCustomNodeFallback` from two different call sites, and a
+// guard on only one of them is a guard that is not there. ────────────────────
+const http = vi.hoisted(() => ({
+  mode: "refuse-enqueue" as "refuse-enqueue" | "accept-enqueue",
 }));
+vi.mock("../../comfyui/fetch.js", () => {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  return {
+    comfyuiFetch: async (url: string) => {
+      if (http.mode === "refuse-enqueue") {
+        return new Response("gated by security_level", {
+          status: 403,
+          statusText: "Forbidden",
+        });
+      }
+      const { pathname } = new URL(url);
+      if (pathname === "/manager/queue/install") return json({ ui_id: "queued" });
+      if (pathname === "/manager/queue/start") return json({});
+      if (pathname === "/manager/queue/status") {
+        return json({ is_processing: false, done_count: 1, total_count: 1 });
+      }
+      // Unregistered: the Manager drained the task without installing anything.
+      if (pathname === "/customnode/installed") return json([]);
+      return new Response("no such route", { status: 404, statusText: "Not Found" });
+    },
+  };
+});
 
 // ── `git clone` stands in as a directory creation, so nothing hits the network
 //    and the destination it was handed is observable. ────────────────────────
@@ -134,6 +166,8 @@ const { configureWorkspace, resetWorkspaceConfig } = await import(
   "../../services/workspace-env.js"
 );
 const { setManagerApiCacheForTests } = await import("../../services/manager-api-cache.js");
+const { setQueueTimingForTests } = await import("../../services/node-management.js");
+setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5_000 });
 
 /** The reporter's shape: an unregistered repository, installed by git URL. */
 const REPO = "https://github.com/someone/unregistered-pack";
@@ -159,6 +193,7 @@ let priorEnvPath: string | undefined;
 
 beforeEach(() => {
   git.calls = [];
+  http.mode = "refuse-enqueue";
   live.reachable = true;
   live.statsCalls = 0;
   live.argv = [join(CONNECTED, "main.py"), "--port", "8189"];
@@ -211,6 +246,32 @@ describe("#1765 — install_custom_node must not write into an install this sess
   });
 
   it("clones normally when the configured root IS the connected install", async () => {
+    live.argv = [join(SAVED_DEFAULT, "main.py"), "--port", "8189"];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("REFUSES on the other road to the same clone — the Manager accepted, then had nothing", async () => {
+    // The reporter's own shape: the queue takes the task, drains, and the pack is
+    // still not installed because it is unregistered. That reaches
+    // cloneCustomNodeFallback from a DIFFERENT call site than the 403 divert.
+    http.mode = "accept-enqueue";
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+    expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
+    expect(error).toContain(CONNECTED);
+  });
+
+  it("still clones on that road when the configured root IS the connected install", async () => {
+    http.mode = "accept-enqueue";
     live.argv = [join(SAVED_DEFAULT, "main.py"), "--port", "8189"];
 
     const { ok, error } = await install({ id: REPO, source: "git" });

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -1,0 +1,312 @@
+// #1765, the recurrence reported against 0.52.35.
+//
+// The original issue asked for split code/data roots and got them: `COMFYUI_CODE_PATH`
+// shipped in 0.52.11 via #1766. What came back is a different failure wearing the same
+// title. On macOS with SIX local installs, the session targeted
+// `http://127.0.0.1:8189` (the reporter's "krea-2"), and `install_custom_node` with
+// `source:"git"` cloned an unregistered repository into a DIFFERENT install — the saved
+// default workspace, serving :8188. The call reported `git-clone` SUCCESS; only the
+// returned `nodeDir` named the wrong tree, and the configured :8189 install never
+// received the pack.
+//
+// MEASURED, not reasoned (the first revision of this file was the reproduction, and it
+// reproduced the reporter's outcome exactly): the destination came from
+// `resolveEffectiveComfyUIBase()` — `COMFYUI_PATH` env, then auto-detection, then the
+// saved default workspace — i.e. from CONFIGURATION ALONE. `resolveLiveServerRoot`, which
+// workspace-env.ts documents as "the single notion every write-side caller (download
+// destination, package install) must resolve through, so they can never disagree about
+// which install is 'the live one'", was never consulted on this path: `/system_stats` was
+// not called even once during the install.
+//
+// These tests drive the REAL `installCustomNode` — the call site, not a helper — through
+// the REAL resolvers against two REAL directories on disk.
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ── Two REAL installs on one machine ───────────────────────────────────────────
+const SANDBOX = mkdtempSync(join(tmpdir(), "wrong-install-1765-"));
+/** The install the session is CONNECTED to (the reporter's krea-2 on :8189). */
+const CONNECTED = join(SANDBOX, "krea-2");
+/** The install the saved default workspace names (the reporter's qwen-image-edit). */
+const SAVED_DEFAULT = join(SANDBOX, "qwen-image-edit");
+/** A third tree, used as a `--base-directory` data root. */
+const DATA_ROOT = join(SANDBOX, "comfy-data");
+for (const root of [CONNECTED, SAVED_DEFAULT, DATA_ROOT]) {
+  mkdirSync(join(root, "custom_nodes"), { recursive: true });
+  mkdirSync(join(root, "models"), { recursive: true });
+  writeFileSync(join(root, "main.py"), "# ComfyUI\n");
+}
+const WORKSPACE_JSON = join(SANDBOX, "workspace.json");
+writeFileSync(WORKSPACE_JSON, JSON.stringify({ defaultWorkspace: SAVED_DEFAULT }));
+/** A stand-in comfy-cli executable, so the `useCmCli` branch is reachable. */
+const FAKE_COMFY_CLI = join(SANDBOX, "comfy");
+writeFileSync(FAKE_COMFY_CLI, "#!/bin/sh");
+
+// ── config: a LOOPBACK target on :8189 (that is LOCAL mode, which is why the
+//    filesystem fallback runs at all), with COMFYUI_PATH unset. ───────────────
+const cfg = vi.hoisted(() => ({
+  comfyuiPath: undefined as string | undefined,
+  comfyuiCodePath: undefined as string | undefined,
+  resolvedPort: 8189,
+  comfyuiHost: "127.0.0.1",
+  comfyuiSsl: false,
+  githubToken: undefined as string | undefined,
+}));
+vi.mock("../../config.js", () => ({
+  config: cfg,
+  getComfyUIBaseUrl: () => `http://${cfg.comfyuiHost}:${cfg.resolvedPort}`,
+  getComfyUIAuthHeaders: () => ({}),
+  isLoopbackHost: (host: string | undefined) =>
+    !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host),
+  isForceRemoteFlagSet: () => false,
+  isRemoteMode: () => false,
+  isLocalMode: () => true,
+  isCloudMode: () => false,
+}));
+
+// ── the LIVE server's self-report ─────────────────────────────────────────────
+const live = vi.hoisted(() => ({
+  argv: [] as string[],
+  reachable: true,
+  /** How many times the running server was asked to describe itself. Zero is the
+   *  measurement that proves the shipped code never consulted it. */
+  statsCalls: 0,
+}));
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: async () => {
+    live.statsCalls += 1;
+    if (!live.reachable) throw new Error("connect ECONNREFUSED 127.0.0.1:8189");
+    return { system: { argv: live.argv } };
+  },
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+// ── ComfyUI-Manager REFUSES the git-URL enqueue (HTTP 403 — a 3.x
+//    security_level / allow_git_url_install gate), which is the #1129 divert
+//    into the direct-clone fallback the reporter landed on. ──────────────────
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: async () =>
+    new Response("gated by security_level", { status: 403, statusText: "Forbidden" }),
+}));
+
+// ── `git clone` stands in as a directory creation, so nothing hits the network
+//    and the destination it was handed is observable. ────────────────────────
+const git = vi.hoisted(() => ({ calls: [] as string[][] }));
+vi.mock("node:child_process", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  return {
+    execFile: vi.fn(),
+    // `comfy --json --version`, so comfy-cli reads as installed and supported.
+    spawnSync: vi.fn(() => ({
+      status: 0,
+      stdout: JSON.stringify({
+        schema: "envelope/1",
+        type: "envelope",
+        ok: true,
+        command: "version",
+        version: "1.11.1",
+        where: null,
+        data: {},
+        error: null,
+      }),
+      stderr: "",
+    })),
+    execFileSync: vi.fn((file: string, args: string[]) => {
+      git.calls.push([file, ...args]);
+      if (file === "git" && args[0] === "clone") {
+        const dest = args[args.length - 1];
+        fs.mkdirSync(dest, { recursive: true });
+        fs.writeFileSync(path.join(dest, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      }
+      return "";
+    }),
+  };
+});
+
+const { installCustomNode } = await import("../../services/node-management.js");
+const { configureWorkspace, resetWorkspaceConfig } = await import(
+  "../../services/workspace-env.js"
+);
+const { setManagerApiCacheForTests } = await import("../../services/manager-api-cache.js");
+
+/** The reporter's shape: an unregistered repository, installed by git URL. */
+const REPO = "https://github.com/someone/unregistered-pack";
+const PACK_DIR = join("custom_nodes", "unregistered-pack");
+
+/** Where did the clone actually land? `undefined` when no clone ran at all. */
+function clonedInto(): string | undefined {
+  const clone = git.calls.find((c) => c[0] === "git" && c[1] === "clone");
+  return clone?.[clone.length - 1];
+}
+
+async function install(
+  opts: Parameters<typeof installCustomNode>[0],
+): Promise<{ ok?: unknown; error?: string }> {
+  try {
+    return { ok: await installCustomNode(opts) };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+let priorEnvPath: string | undefined;
+
+beforeEach(() => {
+  git.calls = [];
+  live.reachable = true;
+  live.statsCalls = 0;
+  live.argv = [join(CONNECTED, "main.py"), "--port", "8189"];
+  cfg.comfyuiPath = undefined;
+  priorEnvPath = process.env.COMFYUI_PATH;
+  delete process.env.COMFYUI_PATH;
+  configureWorkspace({ configPath: WORKSPACE_JSON });
+  // The 403 below is the ENQUEUE refusal, not a dialect probe — pin the dialect
+  // so detection does not consume it.
+  setManagerApiCacheForTests("http://127.0.0.1:8189", "legacy");
+});
+
+afterEach(() => {
+  resetWorkspaceConfig();
+  if (priorEnvPath === undefined) delete process.env.COMFYUI_PATH;
+  else process.env.COMFYUI_PATH = priorEnvPath;
+  for (const root of [CONNECTED, SAVED_DEFAULT, DATA_ROOT]) {
+    rmSync(join(root, "custom_nodes"), { recursive: true, force: true });
+    mkdirSync(join(root, "custom_nodes"), { recursive: true });
+  }
+});
+
+afterAll(() => rmSync(SANDBOX, { recursive: true, force: true }));
+
+describe("#1765 — install_custom_node must not write into an install this session is not connected to", () => {
+  it("REFUSES the reporter's case instead of reporting a success in the wrong tree", async () => {
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    // NOTHING ran. Before this change the same inputs returned
+    // { mechanism: "git-clone", details: { nodeDir: "<SAVED_DEFAULT>/custom_nodes/..." } }.
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+    expect(existsSync(join(CONNECTED, PACK_DIR))).toBe(false);
+
+    // And the refusal NAMES both installs, which selector produced each, and the
+    // remedy — the reporter could only tell the write had gone astray by reading
+    // `nodeDir` out of a success payload.
+    expect(error).toContain(SAVED_DEFAULT);
+    expect(error).toContain(CONNECTED);
+    expect(error).toContain("http://127.0.0.1:8189");
+    expect(error).toContain("SAVED DEFAULT WORKSPACE");
+    expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
+    expect(error).toContain(`COMFYUI_PATH=${CONNECTED}`);
+  });
+
+  it("asks the running server which install it is — the shipped path never did", async () => {
+    await install({ id: REPO, source: "git" });
+    expect(live.statsCalls).toBeGreaterThan(0);
+  });
+
+  it("clones normally when the configured root IS the connected install", async () => {
+    live.argv = [join(SAVED_DEFAULT, "main.py"), "--port", "8189"];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("refuses when the server's --base-directory names a different tree", async () => {
+    live.argv = [join(CONNECTED, "main.py"), "--base-directory", DATA_ROOT];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toContain(DATA_ROOT);
+    expect(error).toContain("--base-directory");
+  });
+
+  it("clones normally when the server's --base-directory IS the configured root", async () => {
+    // The #1715/#1770 split shape: main.py in one tree, custom_nodes scanned from
+    // the data root — which is exactly the root we were about to write into.
+    live.argv = [join(CONNECTED, "main.py"), "--base-directory", SAVED_DEFAULT];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("leaves an EXPLICIT COMFYUI_PATH in charge — that is #1766's shipped contract", async () => {
+    // A named COMFYUI_PATH is the user stating which install this session acts on
+    // (and, on a split deployment, which DATA root packs belong in). Only a
+    // machine-wide GUESS — the saved default workspace, or auto-detection across
+    // six installs — may be overruled by the running server.
+    process.env.COMFYUI_PATH = SAVED_DEFAULT;
+    cfg.comfyuiPath = SAVED_DEFAULT;
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("fails OPEN when the server cannot be reached — an outage is not evidence", async () => {
+    live.reachable = false;
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("fails OPEN when the server's main.py root cannot be resolved", async () => {
+    // ComfyUI Desktop reports a RELATIVE main.py and no cwd. Nothing here is
+    // provable, so nothing is refused.
+    live.argv = ["ComfyUI/main.py", "--port", "8189"];
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+  });
+
+  it("refuses the comfy-cli branch too — --workspace has the identical hazard", async () => {
+    const priorCli = process.env.COMFY_CLI_PATH;
+    process.env.COMFY_CLI_PATH = FAKE_COMFY_CLI;
+    try {
+      const { ok, error } = await install({ id: REPO, source: "git", useCmCli: true });
+
+      expect(ok).toBeUndefined();
+      expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
+      expect(error).toContain("comfy-cli");
+      // The subprocess never ran: no `comfy ... install` and no `git clone`.
+      expect(git.calls.filter((c) => c[0] === FAKE_COMFY_CLI)).toHaveLength(0);
+      expect(clonedInto()).toBeUndefined();
+      expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+    } finally {
+      if (priorCli === undefined) delete process.env.COMFY_CLI_PATH;
+      else process.env.COMFY_CLI_PATH = priorCli;
+    }
+  });
+
+  it("does not touch the registry path, which the Manager routes to the connected server", async () => {
+    // A plain CNR id is installed BY the connected ComfyUI-Manager: there is no
+    // local destination to misdirect, so the guard must not fire (and must not
+    // spend a /system_stats probe).
+    const { error } = await install({ id: "comfyui-kjnodes" });
+
+    expect(error).toBeDefined();
+    expect(error).not.toMatch(/two DIFFERENT ComfyUI installs/);
+    expect(live.statsCalls).toBe(0);
+  });
+});

--- a/src/__tests__/services/node-install-invalidates-object-info.test.ts
+++ b/src/__tests__/services/node-install-invalidates-object-info.test.ts
@@ -45,6 +45,25 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
   },
 }));
 
+// #1765 — the LAST unstubbed network boundary in this file. installCustomNode now
+// asks the CONNECTED server where it lives before any local write, so on a machine
+// that really is running ComfyUI on 127.0.0.1:8188 this test reached the developer's
+// own install, correctly observed that it is not `/fake/comfy`, and refused. The
+// test is about the object_info cache and says nothing about install targeting, so
+// the honest fixture is a server that is not there: the mismatch check then has no
+// evidence and fails open, exactly as it does offline and on CI.
+vi.mock("../../comfyui/client.js", async () => {
+  const actual = await vi.importActual<typeof import("../../comfyui/client.js")>(
+    "../../comfyui/client.js",
+  );
+  return {
+    ...actual,
+    getSystemStats: async () => {
+      throw new Error("no ComfyUI in this fixture");
+    },
+  };
+});
+
 // Stub the comfy-cli subprocess so the useCmCli install path returns cleanly
 // without spawning anything. The probe exports are stubbed too: installCustomNode
 // checks CLI usability before choosing the subprocess path (#808), and this test

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2523,7 +2523,9 @@ function wrongInstallRefusal(
   const provenBy =
     m.liveSource === "base-directory"
       ? "its own --base-directory"
-      : "its own /system_stats launch argv";
+      : m.liveSource === "argv"
+        ? "its own /system_stats launch argv"
+        : "the OS process listening on that port, anchored on the interpreter it runs";
   return (
     `${what} would write into ${m.base}, but this session is connected to ` +
     `${target}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2507,7 +2507,13 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
  * `detectLocalWriteTargetMismatch` only ever reports a mismatch for a base
  * nobody named for this session.
  */
-function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string {
+function wrongInstallRefusal(
+  m: LocalWriteTargetMismatch,
+  what: string,
+  /** The target CAPTURED for this operation — not `getComfyUIBaseUrl()` read at
+   *  throw time, which a panel retarget mid-call would have already moved. */
+  target: string,
+): string {
   const chosenBy =
     m.baseSource === "comfyui-path"
       ? "COMFYUI_PATH"
@@ -2520,7 +2526,7 @@ function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string 
       : "its own /system_stats launch argv";
   return (
     `${what} would write into ${m.base}, but this session is connected to ` +
-    `${getComfyUIBaseUrl()}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +
+    `${target}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +
     `Those are two DIFFERENT ComfyUI installs, so NOTHING was written: the pack would have ` +
     `landed in a custom_nodes/ the connected server never scans, and this call would have ` +
     `reported success. ${m.base} was chosen by ${chosenBy} — configuration, which describes ` +
@@ -2908,9 +2914,16 @@ async function installCustomNodeImpl(
   // checkout for want of a path (codex gate rounds 5-6).
   const managerBase = managerBaseUrl();
   const cliWorkspace = opts.comfyuiPath ?? resolveEffectiveComfyUIBase();
+  const presenceCtx = capturePackPresenceContext(cliWorkspace);
   // #1765 — and is that root the install this session is actually CONNECTED to?
-  // Observed HERE, pinned to the very cliWorkspace the write will use, so a panel
-  // retarget mid-call cannot judge one install's root against another's server.
+  // Pinned to the very cliWorkspace the write will use, so a panel retarget
+  // mid-call cannot judge one install's root against another's server.
+  //
+  // AFTER presenceCtx, deliberately: this is the first await in the function, and
+  // capturePackPresenceContext must be taken at operation ENTRY from the mode and
+  // config as they are NOW (codex gate round 11 — computing it after an await lets
+  // a mid-op retarget pair Manager A's answer with disk B).
+  //
   // Taken only when a LOCAL write is reachable for this call: a registry install
   // goes through ComfyUI-Manager, which targets the connected server by
   // construction and has no local destination to misdirect.
@@ -2918,7 +2931,6 @@ async function installCustomNodeImpl(
     source === "git" || opts.useCmCli === true
       ? await detectLocalWriteTargetMismatch(cliWorkspace)
       : undefined;
-  const presenceCtx = capturePackPresenceContext(cliWorkspace);
   // THE PRE-STATE, OBSERVED BEFORE THE OPERATION (codex gate P0). The "already
   // installed" verdict below used to be inferred from POST-op disk state alone:
   // a pack that was absent before the call and installed as a registry ZIP —
@@ -2944,7 +2956,7 @@ async function installCustomNodeImpl(
       // is identical here to the direct clone below.
       if (localWriteMismatch) {
         throw new ProcessControlError(
-          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", comfy-cli)'),
+          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", comfy-cli)', managerBase),
         );
       }
       // cm-cli install accepts registry ids and git urls alike.
@@ -3044,7 +3056,7 @@ async function installCustomNodeImpl(
       });
       if (localWriteMismatch) {
         throw new ProcessControlError(
-          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)'),
+          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
       return withCliNote(
@@ -3073,7 +3085,7 @@ async function installCustomNodeImpl(
     }
     if (localWriteMismatch) {
       throw new ProcessControlError(
-        wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)'),
+        wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
       );
     }
     return withCliNote(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2515,9 +2515,7 @@ function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string 
   const provenBy =
     m.liveSource === "base-directory"
       ? "its own --base-directory"
-      : m.liveSource === "argv"
-        ? "its own /system_stats launch argv"
-        : "the OS process listening on that port";
+      : "its own /system_stats launch argv";
   return (
     `${what} would write into ${m.base}, but this session is connected to ` +
     `${getComfyUIBaseUrl()}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2509,9 +2509,11 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
  */
 function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string {
   const chosenBy =
-    m.baseSource === "saved-default-workspace"
-      ? 'the SAVED DEFAULT WORKSPACE (workspace action:"set_default")'
-      : "AUTO-DETECTION of ComfyUI installs on this machine";
+    m.baseSource === "comfyui-path"
+      ? "COMFYUI_PATH"
+      : m.baseSource === "saved-default-workspace"
+        ? 'the SAVED DEFAULT WORKSPACE (workspace action:"set_default")'
+        : "AUTO-DETECTION of ComfyUI installs on this machine";
   const provenBy =
     m.liveSource === "base-directory"
       ? "its own --base-directory"
@@ -2521,10 +2523,11 @@ function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string 
     `${getComfyUIBaseUrl()}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +
     `Those are two DIFFERENT ComfyUI installs, so NOTHING was written: the pack would have ` +
     `landed in a custom_nodes/ the connected server never scans, and this call would have ` +
-    `reported success. ${m.base} was chosen by ${chosenBy} — a guess about this MACHINE, ` +
-    `not a statement about which install this session targets. Set ` +
-    `COMFYUI_PATH=${m.liveRoot} (or to whichever install you actually mean) and retry, or ` +
-    `point the session at the install you want to modify.`
+    `reported success. ${m.base} was chosen by ${chosenBy} — configuration, which describes ` +
+    `this MACHINE; the root above is what the running server says about ITSELF. To install ` +
+    `into the connected server, set COMFYUI_PATH=${m.liveRoot} and retry. If ${m.base} really ` +
+    `is where you want packs for this server, launch it with --base-directory ${m.base} — ` +
+    `that is the flag that makes a data root authoritative, and it is honored here.`
   );
 }
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3057,15 +3057,17 @@ async function installCustomNodeImpl(
       // LOCAL tree that is not the server we are connected to, so "the Manager
       // refused" is the honest and complete answer there.
       if (refusedBy === undefined || isRemoteMode()) throw err;
-      logger.info("Manager refused the git install enqueue — cloning directly", {
-        status: refusedBy,
-        gitId,
-      });
+      // BEFORE the log line, which says "cloning directly" and would otherwise be
+      // recording an action that then does not happen.
       if (localWriteMismatch) {
         throw new ProcessControlError(
           wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
+      logger.info("Manager refused the git install enqueue — cloning directly", {
+        status: refusedBy,
+        gitId,
+      });
       return withCliNote(
         await cloneCustomNodeFallback(gitId, repoName, gitRef, { manager_refused: refusedBy }, cliWorkspace, {
           refFromVersion,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -21,6 +21,8 @@ import {
 } from "./manager-api-cache.js";
 export type { ManagerApi } from "./manager-api-cache.js";
 import {
+  type LocalWriteTargetMismatch,
+  detectLocalWriteTargetMismatch,
   resolveEffectiveComfyUIBase,
   resolveEffectiveComfyUICodeBase,
   resolveInstallInterpreter,
@@ -2488,6 +2490,46 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
   return status === 403 || status === 404 ? status : undefined;
 }
 
+/**
+ * #1765 (recurrence on 0.52.35) — the write was aimed at the wrong ComfyUI.
+ *
+ * The reporter ran six installs on one machine, pointed the MCP at
+ * `http://127.0.0.1:8189`, and got a `git-clone` SUCCESS whose `nodeDir` named a
+ * different install entirely; the connected server never received the pack. The
+ * refusal below is what replaces that success. It names both roots, says which
+ * selector produced each, and gives the one-step remedy — because the failure
+ * this class produces is not an error the user can see, it is a report of work
+ * that was done somewhere else.
+ *
+ * Deliberately a REFUSAL and not a retarget: on a `--base-directory` split
+ * install an explicit `COMFYUI_PATH` IS the pack root (#1715/#1770/#1766), so
+ * silently preferring the live `main.py` root would trade this bug for that one.
+ * `detectLocalWriteTargetMismatch` only ever reports a mismatch for a base
+ * nobody named for this session.
+ */
+function wrongInstallRefusal(m: LocalWriteTargetMismatch, what: string): string {
+  const chosenBy =
+    m.baseSource === "saved-default-workspace"
+      ? 'the SAVED DEFAULT WORKSPACE (workspace action:"set_default")'
+      : "AUTO-DETECTION of ComfyUI installs on this machine";
+  const provenBy =
+    m.liveSource === "base-directory"
+      ? "its own --base-directory"
+      : m.liveSource === "argv"
+        ? "its own /system_stats launch argv"
+        : "the OS process listening on that port";
+  return (
+    `${what} would write into ${m.base}, but this session is connected to ` +
+    `${getComfyUIBaseUrl()}, which runs from ${m.liveRoot} (established from ${provenBy}). ` +
+    `Those are two DIFFERENT ComfyUI installs, so NOTHING was written: the pack would have ` +
+    `landed in a custom_nodes/ the connected server never scans, and this call would have ` +
+    `reported success. ${m.base} was chosen by ${chosenBy} — a guess about this MACHINE, ` +
+    `not a statement about which install this session targets. Set ` +
+    `COMFYUI_PATH=${m.liveRoot} (or to whichever install you actually mean) and retry, or ` +
+    `point the session at the install you want to modify.`
+  );
+}
+
 async function cloneCustomNodeFallback(
   gitId: string,
   repoName: string,
@@ -2865,6 +2907,16 @@ async function installCustomNodeImpl(
   // checkout for want of a path (codex gate rounds 5-6).
   const managerBase = managerBaseUrl();
   const cliWorkspace = opts.comfyuiPath ?? resolveEffectiveComfyUIBase();
+  // #1765 — and is that root the install this session is actually CONNECTED to?
+  // Observed HERE, pinned to the very cliWorkspace the write will use, so a panel
+  // retarget mid-call cannot judge one install's root against another's server.
+  // Taken only when a LOCAL write is reachable for this call: a registry install
+  // goes through ComfyUI-Manager, which targets the connected server by
+  // construction and has no local destination to misdirect.
+  const localWriteMismatch =
+    source === "git" || opts.useCmCli === true
+      ? await detectLocalWriteTargetMismatch(cliWorkspace)
+      : undefined;
   const presenceCtx = capturePackPresenceContext(cliWorkspace);
   // THE PRE-STATE, OBSERVED BEFORE THE OPERATION (codex gate P0). The "already
   // installed" verdict below used to be inferred from POST-op disk state alone:
@@ -2887,6 +2939,13 @@ async function installCustomNodeImpl(
   if (opts.useCmCli) {
     const cliProblem = comfyCliUnavailableReason(cliWorkspace);
     if (cliProblem === undefined) {
+      // #1765 — comfy-cli writes into `--workspace`, so the wrong-install hazard
+      // is identical here to the direct clone below.
+      if (localWriteMismatch) {
+        throw new ProcessControlError(
+          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", comfy-cli)'),
+        );
+      }
       // cm-cli install accepts registry ids and git urls alike.
       const installId = source === "git" ? gitId : id;
       const out = runCmCli(["install", installId, "--mode", mode, "--channel", channel], cliWorkspace);
@@ -2982,6 +3041,11 @@ async function installCustomNodeImpl(
         status: refusedBy,
         gitId,
       });
+      if (localWriteMismatch) {
+        throw new ProcessControlError(
+          wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)'),
+        );
+      }
       return withCliNote(
         await cloneCustomNodeFallback(gitId, repoName, gitRef, { manager_refused: refusedBy }, cliWorkspace, {
           refFromVersion,
@@ -3005,6 +3069,11 @@ async function installCustomNodeImpl(
         message: `Installed "${repoName}" via ComfyUI-Manager. Restart may be required to load new nodes.`,
         details: status,
       });
+    }
+    if (localWriteMismatch) {
+      throw new ProcessControlError(
+        wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)'),
+      );
     }
     return withCliNote(
       await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, { refFromVersion }),

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2502,10 +2502,15 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
  * that was done somewhere else.
  *
  * Deliberately a REFUSAL and not a retarget: on a `--base-directory` split
- * install an explicit `COMFYUI_PATH` IS the pack root (#1715/#1770/#1766), so
- * silently preferring the live `main.py` root would trade this bug for that one.
- * `detectLocalWriteTargetMismatch` only ever reports a mismatch for a base
- * nobody named for this session.
+ * install the configured root IS the pack root (#1715/#1770/#1766), so silently
+ * preferring the live `main.py` root would trade this bug for that one. A
+ * `--base-directory` the server actually reports is honored FIRST, so that
+ * deployment never reaches this refusal in the first place.
+ *
+ * A `COMFYUI_PATH` that disagrees with the running server IS refused, and that
+ * is deliberate — see `detectLocalWriteTargetMismatch` for why the env var
+ * cannot be read as the user naming this install (the panel orchestrator
+ * forwards an auto-detected path under exactly that name).
  */
 function wrongInstallRefusal(
   m: LocalWriteTargetMismatch,

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -279,18 +279,20 @@ export async function resolveEffectiveComfyUIBaseLive(): Promise<string | undefi
 // ---------------------------------------------------------------------------
 
 /**
- * How the base a local write is about to land in was chosen — but ONLY for the
- * two answers that are a guess about THE MACHINE rather than a statement about
- * THIS SESSION's target. An explicit `COMFYUI_PATH` is neither, and is never
- * described here (see `detectLocalWriteTargetMismatch`).
+ * Which selector produced the base a local write was about to land in. Every one
+ * of them answers from CONFIGURATION — none is a statement by the running server
+ * about itself, which is the whole point of comparing them against one.
  */
-export type GuessedBaseSource = "saved-default-workspace" | "auto-detected";
+export type ConfiguredBaseSource =
+  | "comfyui-path"
+  | "saved-default-workspace"
+  | "auto-detected";
 
 export interface LocalWriteTargetMismatch {
   /** The root the write was about to land in. */
   base: string;
-  /** Which machine-wide guess produced `base`. */
-  baseSource: GuessedBaseSource;
+  /** Which configuration selector produced `base`. */
+  baseSource: ConfiguredBaseSource;
   /** The root the CONNECTED server actually scans `custom_nodes/` from. */
   liveRoot: string;
   /** What established `liveRoot`. Both are the server's OWN self-report. */
@@ -316,18 +318,6 @@ function canonicalRoot(p: string): string {
 /** Do these two paths name the SAME install? */
 export function sameInstallRoot(a: string, b: string): boolean {
   return canonicalRoot(a) === canonicalRoot(b);
-}
-
-/**
- * Was `COMFYUI_PATH` set explicitly for this process?
- *
- * `config.comfyuiPath` conflates two very different things: the user NAMING an
- * install for this session, and `detectComfyUIPaths()` picking the first of
- * however many installs happen to sit on the machine. Only the env var is the
- * former, so only the env var may outrank the running server's self-report.
- */
-function comfyuiPathWasNamedExplicitly(): boolean {
-  return Boolean(normalizeInstallPathEnv(process.env.COMFYUI_PATH).path);
 }
 
 /**
@@ -357,30 +347,47 @@ function comfyuiPathWasNamedExplicitly(): boolean {
  *
  *   1. the session is LOCAL (a remote target has no local write to misdirect —
  *      the callers refuse that separately, and earlier);
- *   2. `base` came from a machine-wide GUESS. An explicit `COMFYUI_PATH` is the
- *      user naming this install, and keeps winning exactly as documented;
- *   3. the connected server PROVES a pack root — its resolved `--base-directory`,
+ *   2. the connected server PROVES a pack root — its resolved `--base-directory`,
  *      else its own `main.py` root — and that root exists on disk and looks like
  *      an install;
- *   4. the two are not the same tree after canonicalization.
+ *   3. the two are not the same tree after canonicalization.
  *
  * FAILS OPEN everywhere else, deliberately: an unreachable server, a Desktop
  * launch whose relative `main.py` cannot be anchored, or a `--base-directory` we
  * cannot resolve all mean we do not KNOW the write is misdirected — and a refusal
  * on a root we merely failed to prove would break every install that works today.
  * Never throws.
+ *
+ * THERE IS NO "BUT THE USER SET COMFYUI_PATH" CARVE-OUT, and the first revision
+ * of this function had one. It was wrong: the panel orchestrator resolves
+ * `envComfyuiPath || detectLocalComfyUIPath()` and forwards the RESULT to every
+ * child MCP as `COMFYUI_PATH` (orchestrator/index.ts), so in a panel-spawned
+ * child an auto-detected guess is byte-identical to a user's deliberate setting.
+ * A carve-out keyed on "the env var is set" would therefore have disabled this
+ * check in exactly the sessions it exists for, while reading as careful scoping.
+ *
+ * KNOWN FALSE POSITIVE, stated rather than implied: a deployment that adds
+ * `custom_nodes` to the live server's `extra_model_paths` config pointing at the
+ * configured base IS read by that server, and this cannot see that — it would be
+ * refused. The refusal names both roots and NOTHING is written, and the Manager
+ * install route (which targets the connected server directly) is untouched, so
+ * the cost is a refusal on an exotic layout rather than a wrong write on a
+ * common one. Corroborating against the server's own extra paths is the fix if
+ * that shape shows up; it is a different seam and is not claimed here.
  */
 export async function detectLocalWriteTargetMismatch(
   base: string | undefined,
 ): Promise<LocalWriteTargetMismatch | undefined> {
   if (!base || isRemoteMode()) return undefined;
-  if (comfyuiPathWasNamedExplicitly()) return undefined;
 
+  const envPath = normalizeInstallPathEnv(process.env.COMFYUI_PATH).path;
   const savedDefault = getSavedDefaultWorkspaceSync();
-  const baseSource: GuessedBaseSource =
-    savedDefault && sameInstallRoot(savedDefault, base)
-      ? "saved-default-workspace"
-      : "auto-detected";
+  const baseSource: ConfiguredBaseSource =
+    envPath && sameInstallRoot(envPath, base)
+      ? "comfyui-path"
+      : savedDefault && sameInstallRoot(savedDefault, base)
+        ? "saved-default-workspace"
+        : "auto-detected";
 
   const snapshot = await getLiveServerSnapshot();
   if (!snapshot.reachable) return undefined;

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve as pathResolve, sep } from "node:path";
@@ -271,6 +271,144 @@ export async function resolveEffectiveComfyUIBaseLive(): Promise<string | undefi
     return undefined;
   }
   return configured;
+}
+
+// ---------------------------------------------------------------------------
+// #1765 (recurrence on 0.52.35) — a local WRITE aimed at an install the session
+// is not connected to.
+// ---------------------------------------------------------------------------
+
+/**
+ * How the base a local write is about to land in was chosen — but ONLY for the
+ * two answers that are a guess about THE MACHINE rather than a statement about
+ * THIS SESSION's target. An explicit `COMFYUI_PATH` is neither, and is never
+ * described here (see `detectLocalWriteTargetMismatch`).
+ */
+export type GuessedBaseSource = "saved-default-workspace" | "auto-detected";
+
+export interface LocalWriteTargetMismatch {
+  /** The root the write was about to land in. */
+  base: string;
+  /** Which machine-wide guess produced `base`. */
+  baseSource: GuessedBaseSource;
+  /** The root the CONNECTED server actually scans `custom_nodes/` from. */
+  liveRoot: string;
+  /** What established `liveRoot` — all three are observations of the running server. */
+  liveSource: "base-directory" | "argv" | "observed-process";
+}
+
+/** Canonical spelling for comparing two install roots. realpath resolves the
+ *  symlink/`/private/var` spellings of one tree; a failure keeps the lexical
+ *  form (a path that cannot be canonicalized is compared as written). Case is
+ *  folded only where the platform's filesystem is case-insensitive by default —
+ *  folding can only ever make two roots look EQUAL, i.e. suppress a refusal,
+ *  which is the safe direction for a check that fails open. */
+function canonicalRoot(p: string): string {
+  let out = pathResolve(p);
+  try {
+    out = realpathSync(out);
+  } catch {
+    /* unresolvable — compare the lexical form */
+  }
+  return platform() === "win32" || platform() === "darwin" ? out.toLowerCase() : out;
+}
+
+/** Do these two paths name the SAME install? */
+export function sameInstallRoot(a: string, b: string): boolean {
+  return canonicalRoot(a) === canonicalRoot(b);
+}
+
+/**
+ * Was `COMFYUI_PATH` set explicitly for this process?
+ *
+ * `config.comfyuiPath` conflates two very different things: the user NAMING an
+ * install for this session, and `detectComfyUIPaths()` picking the first of
+ * however many installs happen to sit on the machine. Only the env var is the
+ * former, so only the env var may outrank the running server's self-report.
+ */
+function comfyuiPathWasNamedExplicitly(): boolean {
+  return Boolean(normalizeInstallPathEnv(process.env.COMFYUI_PATH).path);
+}
+
+/**
+ * Is `base` — the root a LOCAL filesystem write is about to land in — a
+ * different install from the one this session is connected to?
+ *
+ * #1765 recurrence. On a machine with six ComfyUI installs, `install_custom_node`
+ * (`source:"git"`) cloned an unregistered pack into the SAVED DEFAULT WORKSPACE
+ * while the session was connected to `http://127.0.0.1:8189`. The call reported
+ * `git-clone` success; only the returned `nodeDir` named the wrong tree, and the
+ * connected server never received the pack. The cause is that the write resolved
+ * its target through `resolveEffectiveComfyUIBase()` — which answers from
+ * CONFIGURATION alone (`COMFYUI_PATH` env, then auto-detection, then the saved
+ * default workspace) — and never asked `resolveLiveServerRoot`, the resolver this
+ * file documents as "the single notion every write-side caller must resolve
+ * through, so they can never disagree about which install is the live one".
+ *
+ * This does NOT pick a winner. It answers only "are these provably two different
+ * installs?", so the caller can REFUSE and name both, instead of silently writing
+ * into whichever one configuration happened to name. Preferring the live root
+ * silently would be a different bug: on a `--base-directory` split install an
+ * explicit `COMFYUI_PATH` IS the pack root (#1715/#1770), and #1766 shipped that
+ * design for this very issue.
+ *
+ * Hence the scope, stated precisely because an overclaiming comment is how the
+ * original survived: a mismatch is reported ONLY when
+ *
+ *   1. the session is LOCAL (a remote target has no local write to misdirect —
+ *      the callers refuse that separately, and earlier);
+ *   2. `base` came from a machine-wide GUESS. An explicit `COMFYUI_PATH` is the
+ *      user naming this install, and keeps winning exactly as documented;
+ *   3. the connected server PROVES a pack root — its resolved `--base-directory`,
+ *      else its own `main.py` root — and that root exists on disk and looks like
+ *      an install;
+ *   4. the two are not the same tree after canonicalization.
+ *
+ * FAILS OPEN everywhere else, deliberately: an unreachable server, a Desktop
+ * launch whose relative `main.py` cannot be anchored, or a `--base-directory` we
+ * cannot resolve all mean we do not KNOW the write is misdirected — and a refusal
+ * on a root we merely failed to prove would break every install that works today.
+ * Never throws.
+ */
+export async function detectLocalWriteTargetMismatch(
+  base: string | undefined,
+): Promise<LocalWriteTargetMismatch | undefined> {
+  if (!base || isRemoteMode()) return undefined;
+  if (comfyuiPathWasNamedExplicitly()) return undefined;
+
+  const baseSource: GuessedBaseSource =
+    getSavedDefaultWorkspaceSync() && sameInstallRoot(getSavedDefaultWorkspaceSync()!, base)
+      ? "saved-default-workspace"
+      : "auto-detected";
+
+  const snapshot = await getLiveServerSnapshot();
+  if (!snapshot.reachable) return undefined;
+
+  // 1. The runtime's OWN base directory. When it is set, ComfyUI scans
+  //    custom_nodes/ from there and nowhere else (#1715).
+  const baseDir = parseBaseDirFromArgv(snapshot.argv, snapshot.cwd);
+  if (baseDir) {
+    if (!safeExists(baseDir)) return undefined;
+    return sameInstallRoot(baseDir, base)
+      ? undefined
+      : { base, baseSource, liveRoot: baseDir, liveSource: "base-directory" };
+  }
+  // A --base-directory that cannot be resolved makes EVERY root we could derive
+  // name a different tree than the one being served — including the main.py root
+  // below. Nothing is provable here.
+  if (hasUnresolvableRelativeBaseDirFlag(snapshot.argv, snapshot.cwd)) return undefined;
+
+  // 2. The server's own install root. Without --base-directory this is where it
+  //    scans custom_nodes/ from.
+  const live = resolveLiveServerRoot(snapshot.argv, snapshot.cwd, { remote: false });
+  if (!live.root || live.source === "unresolved") return undefined;
+  if (!safeExists(live.root)) return undefined;
+  if (!safeExists(join(live.root, "models")) && !safeExists(join(live.root, "custom_nodes"))) {
+    return undefined;
+  }
+  return sameInstallRoot(live.root, base)
+    ? undefined
+    : { base, baseSource, liveRoot: live.root, liveSource: live.source };
 }
 
 /**

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -293,8 +293,8 @@ export interface LocalWriteTargetMismatch {
   baseSource: GuessedBaseSource;
   /** The root the CONNECTED server actually scans `custom_nodes/` from. */
   liveRoot: string;
-  /** What established `liveRoot` — all three are observations of the running server. */
-  liveSource: "base-directory" | "argv" | "observed-process";
+  /** What established `liveRoot`. Both are the server's OWN self-report. */
+  liveSource: "base-directory" | "argv";
 }
 
 /** Canonical spelling for comparing two install roots. realpath resolves the
@@ -376,8 +376,9 @@ export async function detectLocalWriteTargetMismatch(
   if (!base || isRemoteMode()) return undefined;
   if (comfyuiPathWasNamedExplicitly()) return undefined;
 
+  const savedDefault = getSavedDefaultWorkspaceSync();
   const baseSource: GuessedBaseSource =
-    getSavedDefaultWorkspaceSync() && sameInstallRoot(getSavedDefaultWorkspaceSync()!, base)
+    savedDefault && sameInstallRoot(savedDefault, base)
       ? "saved-default-workspace"
       : "auto-detected";
 
@@ -398,17 +399,28 @@ export async function detectLocalWriteTargetMismatch(
   // below. Nothing is provable here.
   if (hasUnresolvableRelativeBaseDirFlag(snapshot.argv, snapshot.cwd)) return undefined;
 
-  // 2. The server's own install root. Without --base-directory this is where it
-  //    scans custom_nodes/ from.
-  const live = resolveLiveServerRoot(snapshot.argv, snapshot.cwd, { remote: false });
-  if (!live.root || live.source === "unresolved") return undefined;
-  if (!safeExists(live.root)) return undefined;
-  if (!safeExists(join(live.root, "models")) && !safeExists(join(live.root, "custom_nodes"))) {
+  // 2. The server's own main.py root, from its argv. Without --base-directory
+  //    this is where it scans custom_nodes/ from. Same two observations, same
+  //    on-disk checks, and in the same order as `resolveEffectiveComfyUIBaseLive`
+  //    — so what this reports is precisely "configuration shadowed a live answer
+  //    that disagrees with it".
+  //
+  //    Deliberately `liveRootFromArgv` and NOT `resolveLiveServerRoot`: that
+  //    resolver's `observed-process` tier anchors on where the interpreter
+  //    BINARY lives, which its own docstring documents as not being proof of
+  //    where the SCRIPT was resolved from ("KNOWN GAP, measured and filed").
+  //    That is a fine basis for finding a root when there is otherwise none; it
+  //    is not a fine basis for REFUSING a user's write. It also keeps this off
+  //    the process-table probe entirely, so no install pays for a netstat/WMI
+  //    scan it cannot act on.
+  const liveRoot = liveRootFromArgv(snapshot.argv, snapshot.cwd);
+  if (!liveRoot || !safeExists(liveRoot)) return undefined;
+  if (!safeExists(join(liveRoot, "models")) && !safeExists(join(liveRoot, "custom_nodes"))) {
     return undefined;
   }
-  return sameInstallRoot(live.root, base)
+  return sameInstallRoot(liveRoot, base)
     ? undefined
-    : { base, baseSource, liveRoot: live.root, liveSource: live.source };
+    : { base, baseSource, liveRoot, liveSource: "argv" };
 }
 
 /**

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -295,8 +295,8 @@ export interface LocalWriteTargetMismatch {
   baseSource: ConfiguredBaseSource;
   /** The root the CONNECTED server actually scans `custom_nodes/` from. */
   liveRoot: string;
-  /** What established `liveRoot`. Both are the server's OWN self-report. */
-  liveSource: "base-directory" | "argv";
+  /** What established `liveRoot` — see `resolveLiveServerRoot` for the tiers. */
+  liveSource: "base-directory" | "argv" | "observed-process";
 }
 
 /** Canonical spelling for comparing two install roots. realpath resolves the
@@ -352,8 +352,8 @@ export function sameInstallRoot(a: string, b: string): boolean {
  *      an install;
  *   3. the two are not the same tree after canonicalization.
  *
- * FAILS OPEN everywhere else, deliberately: an unreachable server, a Desktop
- * launch whose relative `main.py` cannot be anchored, or a `--base-directory` we
+ * FAILS OPEN everywhere else, deliberately: an unreachable server, a relative
+ * `main.py` that no process observation can anchor, or a `--base-directory` we
  * cannot resolve all mean we do not KNOW the write is misdirected — and a refusal
  * on a root we merely failed to prove would break every install that works today.
  * Never throws.
@@ -406,28 +406,43 @@ export async function detectLocalWriteTargetMismatch(
   // below. Nothing is provable here.
   if (hasUnresolvableRelativeBaseDirFlag(snapshot.argv, snapshot.cwd)) return undefined;
 
-  // 2. The server's own main.py root, from its argv. Without --base-directory
-  //    this is where it scans custom_nodes/ from. Same two observations, same
-  //    on-disk checks, and in the same order as `resolveEffectiveComfyUIBaseLive`
-  //    — so what this reports is precisely "configuration shadowed a live answer
-  //    that disagrees with it".
+  // 2. The server's own install root — WITHOUT --base-directory, the directory
+  //    it scans custom_nodes/ from. `resolveLiveServerRoot` is the module's one
+  //    notion of that, and BOTH its tiers are used here.
   //
-  //    Deliberately `liveRootFromArgv` and NOT `resolveLiveServerRoot`: that
-  //    resolver's `observed-process` tier anchors on where the interpreter
-  //    BINARY lives, which its own docstring documents as not being proof of
-  //    where the SCRIPT was resolved from ("KNOWN GAP, measured and filed").
-  //    That is a fine basis for finding a root when there is otherwise none; it
-  //    is not a fine basis for REFUSING a user's write. It also keeps this off
-  //    the process-table probe entirely, so no install pays for a netstat/WMI
-  //    scan it cannot act on.
-  const liveRoot = liveRootFromArgv(snapshot.argv, snapshot.cwd);
-  if (!liveRoot || !safeExists(liveRoot)) return undefined;
-  if (!safeExists(join(liveRoot, "models")) && !safeExists(join(liveRoot, "custom_nodes"))) {
+  //    An earlier revision used `liveRootFromArgv` alone, on the reasoning that
+  //    the `observed-process` tier anchors on where the interpreter BINARY lives
+  //    and its own docstring calls that a "KNOWN GAP … not proof of where the
+  //    SCRIPT was resolved from" — too weak a basis for refusing a user's write.
+  //    That reasoning was refuted by measurement against the ComfyUI running on
+  //    the development machine (0.33.2, ComfyUI Desktop):
+  //
+  //      argv[0] : "ComfyUI\main.py"      (RELATIVE)
+  //      cwd     : the /system_stats payload has no `cwd` FIELD AT ALL
+  //
+  //    `liveRootFromArgv` resolves a relative script only against an absolute
+  //    server cwd, and ComfyUI does not report one — so the argv tier answers
+  //    only for launches whose argv[0] is absolute. ComfyUI Desktop, the Windows
+  //    portable bundle, and `comfy launch` (which runs `python main.py` from the
+  //    workspace) are all relative. Argv-only made this check permanently INERT
+  //    on the layouts where several installs on one machine is most likely —
+  //    green tests, zero reachability.
+  //
+  //    The `observed-process` tier is also what the DOWNLOAD path already
+  //    resolves its write DESTINATION through (#369/#1374), so trusting it to
+  //    detect a mismatch is strictly weaker than what already ships. Its gap is
+  //    real and bounded: with a stale bundle's python on PATH it can name a
+  //    stale root, which here costs a refusal that writes nothing — never a
+  //    wrong write.
+  const live = resolveLiveServerRoot(snapshot.argv, snapshot.cwd, { remote: false });
+  if (!live.root || live.source === "unresolved") return undefined;
+  if (!safeExists(live.root)) return undefined;
+  if (!safeExists(join(live.root, "models")) && !safeExists(join(live.root, "custom_nodes"))) {
     return undefined;
   }
-  return sameInstallRoot(liveRoot, base)
+  return sameInstallRoot(live.root, base)
     ? undefined
-    : { base, baseSource, liveRoot, liveSource: "argv" };
+    : { base, baseSource, liveRoot: live.root, liveSource: live.source };
 }
 
 /**


### PR DESCRIPTION
## What this is

The recurrence reported on **0.52.35** against #1765 — not the original feature. `COMFYUI_CODE_PATH` shipped in **0.52.11** via #1766 and is not what failed. The report is:

> On macOS with six local installs, the MCP target was `http://127.0.0.1:8189` (the krea-2 install), but `install_custom_node` with `source:"git"` cloned an unregistered repository into comfy-cli's saved default workspace for a different running install (qwen-image-edit on :8188). The call reported `git-clone` success and only the returned `nodeDir` exposed the wrong target.

That is a **wrong-target write**: a pack installed into a ComfyUI the user did not name, reported as a success.

## Which selector chose the install — established by execution, not by reading

The first revision of `src/__tests__/services/install-node-target-1765.test.ts` was a reproduction, and it reproduced the report verbatim. Two real install trees on disk, a live server self-reporting `<krea-2>/main.py` on :8189, a saved default workspace naming `<qwen-image-edit>`, the real `installCustomNode`:

```
RESULT: { "mechanism": "git-clone",
          "details": { "nodeDir": ".../qwen-image-edit/custom_nodes/unregistered-pack" } }
GIT CALLS: [["git","clone","--depth","1","--end-of-options",
             "https://github.com/someone/unregistered-pack",
             ".../qwen-image-edit/custom_nodes/unregistered-pack"]]
```

The destination came from **`resolveEffectiveComfyUIBase()`** — `COMFYUI_PATH` env, then auto-detection, then the saved default workspace, i.e. **configuration alone**. In the reporter's shape (six installs in non-standard directories, so auto-detection finds nothing) that resolves to the saved default workspace, which is a statement about the *machine* and not about the *session's target*.

`/system_stats` was **not called once** during the install. `resolveLiveServerRoot` — which `workspace-env.ts` documents as *"the single notion every write-side caller (download destination, package install) must resolve through, so they can never disagree about which install is 'the live one'"* — was never consulted on this path. This is the canonical-resolver-adopted-per-call-site shape: the resolver is right, the call site never adopted it.

Both roads into `cloneCustomNodeFallback` have it (a Manager 403 refusal — #1129's divert — and a Manager enqueue that drains without installing an unregistered pack), and so does the `useCmCli` branch, which passes the same root as `comfy-cli --workspace`.

## The change

`detectLocalWriteTargetMismatch()` (workspace-env.ts) answers exactly one question: **are these provably two different installs?** It asks the running server where it lives — its resolved `--base-directory` first, else `resolveLiveServerRoot`, this module's single notion of the live install root — and reports a mismatch only when that root is proven, exists on disk, looks like an install, and is a different tree than the base the write was about to land in.

That order is ComfyUI's own, verified against `folder_paths.py` in the install running on this machine: `base_path` is `abspath(args.base_directory)` when the flag is present and `dirname(realpath(__file__))` otherwise, and `custom_nodes` is seeded with exactly one entry under it. Note the `realpath` — symlinked spellings collapse there, which is why the comparison canonicalizes rather than comparing strings.

`installCustomNodeImpl` takes that observation once, pinned to the same `cliWorkspace` the write will use, and **refuses** at each local-write site. The refusal names both roots, which selector produced each, and two remedies.

**It refuses; it does not retarget.** Silently preferring the live `main.py` root would trade this bug for its mirror image: on a `--base-directory` split install the configured data root *is* the pack root (#1715/#1770), which is the design #1766 shipped for this very issue. A refusal that names the ambiguity cannot write into the wrong tree; a silent pick can.

**Scope, and where it fails open** (deliberately, and stated rather than implied):
- remote sessions — no local write to misdirect, and refused earlier anyway;
- the server unreachable — an outage is not evidence;
- a relative `main.py` that no process observation can anchor — unprovable is not wrong;
- an observed interpreter belonging to no install we can anchor (a system python) — the containment test rejects it, so no root, so no refusal;
- a `--base-directory` that cannot be resolved — every root derivable is then the wrong one;
- the registry install path — it goes through ComfyUI-Manager against the connected server, so there is no local destination to misdirect, and it does not even pay for the `/system_stats` probe.

## Three things earlier revisions got wrong, and how each was caught

1. **An argv-only live root made the whole guard INERT on the layouts that matter — caught by running it against the real server, not by reading it.** One revision used `liveRootFromArgv` alone, reasoning that `resolveLiveServerRoot`'s `observed-process` tier anchors on where the interpreter *binary* lives and its own docstring calls that a *"KNOWN GAP ... not proof of where the SCRIPT was resolved from"* — too weak a basis for refusing a user's write. Principled, and wrong. Measured against the ComfyUI running on this machine (0.33.2, ComfyUI Desktop):

   ```
   argv[0] : "ComfyUI\main.py"      <- RELATIVE
   cwd     : the /system_stats payload has no `cwd` FIELD AT ALL
   ```

   `liveRootFromArgv` resolves a relative script only against an absolute server cwd, and **ComfyUI does not report one**. So the argv tier answers only when argv[0] is absolute — and ComfyUI Desktop, the Windows portable bundle, and `comfy launch` (which runs `python main.py` from the workspace) are all relative. Every test in this file was green while the guard did nothing on the real rig. Both tiers are used now.

   The `observed-process` tier is also what the **download** path already resolves its write *destination* through (#369/#1374), so trusting it to *detect* a mismatch is strictly weaker than what already ships — and its documented gap costs a refusal that writes nothing, never a wrong write.

   Live-verified on the same rig after the change: a different tree reports a mismatch, the live root itself does not, and neither does an uppercased backslash spelling of it.

2. **It carved out an explicit `COMFYUI_PATH`** on the theory that the env var means the user named the install. That is false here: the panel orchestrator resolves `envComfyuiPath || detectLocalComfyUIPath()` and forwards the **result** to every child MCP as `COMFYUI_PATH` (`orchestrator/index.ts`), so in a panel-spawned child an auto-detected guess is byte-identical to a deliberate setting. The carve-out would have switched the check off in exactly the sessions it exists for while reading as careful scoping. It is gone; the refusal instead names `--base-directory` as the supported way to make a data root authoritative.

3. **Two ordering defects found by re-reading my own diff**, both committed: the mismatch probe is the function's first `await` and had been placed *before* `capturePackPresenceContext`, which codex gate round 11 requires be taken at operation entry (otherwise a mid-op retarget pairs Manager A's answer with disk B); and the refusal read `getComfyUIBaseUrl()` at throw time rather than the `managerBase` already pinned for the operation.

## Evidence

**Mutation-tested — every one of these was applied, run, and killed a named test** (the fix was committed first, so `git checkout` could not silently revert it, and the mutation script fails loudly when the pattern does not match):

| mutation | tests killed (of 16) |
|---|---|
| helper always returns "no mismatch" | 7 |
| guard deleted at the 403-divert clone site | 4 |
| guard deleted at the unregistered-pack clone site | 1 |
| guard deleted at the `comfy-cli` site | 1 |
| probe taken unconditionally instead of only where a local write is reachable | 1 |
| `--base-directory` branch removed | 2 |
| `sameInstallRoot` always false | 5 |
| `observed-process` tier dropped (back to argv-only) | 1 |
| unresolvable-`--base-directory` fail-open gate removed | 1 |

**Two of these survived on first run** — the unregistered-pack call site and the unresolvable-`--base-directory` gate. Neither had a test. Both got one, rather than the mutation being explained away.

**Suite:** baselined on a clean `origin/main` worktree first — `2 failed files / 4 failed tests` (`node-id-union-message.test.ts`, `package-hooks.test.ts`), pre-existing and unrelated. This branch: the same two files, the same four tests, plus the 16 added here.

**Live-verified against the real ComfyUI on this machine** (0.33.2, Desktop, port 8188). That is what exposed the inertness in point 1 above, and what confirmed the fix. No Manager traffic and no writes — the check only asks the running server where it lives and compares.

And then the suite verified it a second way, without being asked. `node-install-invalidates-object-info.test.ts` (#444) stubs every network boundary except `/system_stats`, so on this machine it reached the developer's **own running install**, observed that it is not the fixture's `/fake/comfy`, and refused — with nothing about the live path mocked: real `/system_stats`, real process-table probe, real install root. That is the guard working end to end. The fixture now has no server, so it fails open exactly as it does on CI, where nothing is listening.

**Review is PENDING.** Nothing here has been reviewed by anyone but its author. Not gated: `codex-gate.mjs` was not run and codex was not spawned.

## What I deliberately did not do

- **Did not extend the guard to `uninstall`/`enable`/`disable`.** They resolve the same root through `resolveEffectiveComfyUIBase()` and carry the same hazard — worse, in fact, since `comfy-cli uninstall` deletes — but only behind an explicit `useCmCli`, and they are not what was reported. Worth a follow-up; not smuggled into a P2 bug fix.
- **Did not change `resolveEffectiveComfyUIBase`/`…Live`.** Every filesystem-backed tool reads them; narrowing a shared resolver to fix one caller is how the next three break.
- **Did not touch any tool description**, so the tool-vocabulary ledger is unchanged (`check:vocabulary` green regardless).
- **No panel change**, so no Playwright run — nothing here renders.
- **Known false positive, named rather than hidden:** a deployment that lists `custom_nodes` in the live server's `extra_model_paths` config pointing at the configured base *is* read by that server, and this cannot see that — it would be refused. Nothing is written, the Manager route still works, and the message names both roots. Corroborating against the server's own extra paths is a different seam and is not claimed here.

## Review

A review of head `826c5fd` came back **COMMENT INTENDED: APPROVE**, and its nit is fixed here (a comment still claimed the helper "only ever reports a mismatch for a base nobody named for this session", which stopped being true when the carve-out was removed).

**That approval does not carry to this head, and I am not treating it as one.** It was written against the argv-only revision, and two of its findings explicitly bless what I have since changed: it recorded "Desktop/portable relative `main.py` fail open (tested)" and "Deliberately skips `observed-process`" as correct fail-open behaviour. The live measurement above shows that combination made the check inert on the layouts that matter, so the newer commits do the opposite. A verdict on a superseded diff is not a verdict on this one — re-review requested.

Fixes the recurrence reported on #1765.
