### PR TITLE
fix(1935): the instance-mismatch refusal names TOOLS, not bridge commands

### DIFF
--- a/src/__tests__/orchestrator/fence-lookalike-refusals.test.ts
+++ b/src/__tests__/orchestrator/fence-lookalike-refusals.test.ts
@@ -58,7 +58,7 @@ const capabilityRefusal = (): Error =>
   markCapabilityRefusal(
     markDispatched(
       new Error(
-        `"workflow_save" cannot be safely targeted to the active workflow: panel tab ` +
+        `"panel_save_workflow" cannot be safely targeted to the active workflow: panel tab ` +
           `${TAB} does not recheck workflow targeting at the graph write boundary after ` +
           `asynchronous work (detected panel 0.11.40; a graph WRITE needs panel 0.11.62+, ` +
           `the first build that rechecks the fence after an await). Update the panel and ` +
@@ -66,7 +66,8 @@ const capabilityRefusal = (): Error =>
           `HERE, and is not claimed: a read carries this session's stamp (${STAMP}), and ` +
           `this tab's panel runs it only while that stamp still names the ACTIVE canvas — ` +
           `a comparison only the panel can make. If the workflow was switched or replaced ` +
-          `after this session bound to it, graph_outline / graph_query are refused with ` +
+          `after this session bound to it, panel_graph_outline / panel_query_graph / ` +
+          `panel_get_errors are refused with ` +
           `"workflow instance mismatch" as well; if it was not, they work. Try ` +
           `panel_list_workflows — the panel exempts that read from this fence (it is the ` +
           `recovery probe), though a build predating the exemption fences it too. ` +
@@ -82,11 +83,11 @@ const capabilityRefusal = (): Error =>
 const noTrustedIdentityRefusal = (): Error =>
   markDispatched(
     new Error(
-      `"workflow_save" cannot be safely targeted to the active workflow: this workflow has ` +
+      `"panel_save_workflow" cannot be safely targeted to the active workflow: this workflow has ` +
         `no trusted identity for the panel to fence the command against. GRAPH READS ARE ` +
         `REFUSED TOO, for this same missing stamp: this tab's panel enforces the ` +
         `per-command fence and refuses an UNSTAMPED command rather than fail open, so ` +
-        `graph_outline / graph_query answer "workflow instance mismatch: this command ` +
+        `panel_graph_outline / panel_query_graph / panel_get_errors answer "workflow instance mismatch: this command ` +
         `carries no workflow-instance stamp" as well. Try panel_list_workflows — the panel ` +
         `exempts that read from this fence (it is the recovery probe), though a build ` +
         `predating the exemption fences it too. Non-graph tools are unaffected.`,

--- a/src/__tests__/services/unstamped-reads-claim.test.ts
+++ b/src/__tests__/services/unstamped-reads-claim.test.ts
@@ -40,7 +40,9 @@
 import { createServer } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
 import { UiBridge } from "../../services/ui-bridge.js";
+import { panelToolForGraphCmd } from "../../services/panel-graph-cmd-tools.js";
 
 let bridge: UiBridge;
 const sockets: WebSocket[] = [];
@@ -326,5 +328,81 @@ describe("the #1519 correction moves no fence", () => {
     const frames = panel.received.filter((f) => f.cmd === "graph_outline");
     expect(frames.length).toBe(1);
     expect(frames[0]).not.toHaveProperty("workflow_uuid");
+  });
+});
+
+/** Bare `graph_*` bridge commands — `panel_graph_outline` must not trip this. */
+const BARE_GRAPH_CMD = /(?<![a-z_])graph_[a-z_]+/;
+
+function assertEveryPanelNameIsRegistered(msg: string): void {
+  const registered = new Set(buildPanelToolDefs().map((d) => d.name));
+  // Read from the MESSAGE, not from the constant the string was built from.
+  const mentioned = msg.match(/panel_[a-z0-9_]+/g) ?? [];
+  expect(mentioned.length).toBeGreaterThan(0);
+  for (const name of new Set(mentioned)) {
+    // `panel_action` is a parameter key of install_comfyui, not a tool.
+    if (name === "panel_action") continue;
+    expect([name, registered.has(name)]).toEqual([name, true]);
+  }
+  expect(msg).not.toMatch(BARE_GRAPH_CMD);
+}
+
+describe("#1935 — the instance-mismatch write refusal names TOOLS, not bridge commands", () => {
+  it("NO STAMP (refused): names registered reads, and the TOOL that was called", async () => {
+    await connectPanel("tmp:stampless-names", FENCING, LIVE);
+    const msg = await failureOf("graph_add_node");
+
+    expect(msg).toMatch(REFUSED_CLAIM);
+    expect(msg).toMatch(/"panel_add_node" cannot be safely targeted/);
+    expect(msg).not.toMatch(/"graph_add_node"/);
+    // Anchored on both sides so `graph_outline` and `panel_graph_outline` cannot
+    // both satisfy it — the #1933 lesson.
+    expect(msg).toMatch(/panel_graph_outline \/ panel_query_graph \/ panel_get_errors/);
+    expect(msg).not.toMatch(/\(graph_outline/);
+    assertEveryPanelNameIsRegistered(msg);
+  });
+
+  it("STALE STAMP (unknown): names registered reads, not graph_outline / graph_query", async () => {
+    await connectPanel("tmp:stale-names", FENCING_NO_AT_WRITE, LIVE);
+    bridge.setTabWorkflowUuidResolver(() => STALE);
+    const msg = await failureOf("graph_add_node");
+
+    expect(msg).toMatch(UNKNOWN_CLAIM);
+    expect(msg).toMatch(/"panel_add_node" cannot be safely targeted/);
+    expect(msg).toMatch(/panel_graph_outline \/ panel_query_graph \/ panel_get_errors/);
+    expect(msg).not.toMatch(/\(graph_outline/);
+    assertEveryPanelNameIsRegistered(msg);
+  });
+
+  it("NO FENCE (execute): names registered view tools and omits graph_get_state", async () => {
+    await connectPanel("tmp:oldpanel-names", {});
+    bridge.setTabWorkflowUuidResolver(() => STALE);
+    const msg = await failureOf("graph_add_node");
+
+    expect(msg).toMatch(OLD_CLAIM);
+    expect(msg).toMatch(/"panel_add_node" cannot be safely targeted/);
+    expect(msg).toMatch(/panel_graph_outline/);
+    expect(msg).toMatch(/panel_query_graph/);
+    expect(msg).toMatch(/panel_find_nodes/);
+    expect(msg).toMatch(/panel_list_subgraphs/);
+    expect(msg).toMatch(/panel_screenshot/);
+    expect(msg).toMatch(/panel_canvas/);
+    // Internal pre-0.8.2 fallback — no callable tool. Advertising it is the
+    // same defect as advertising graph_outline.
+    expect(msg).not.toMatch(/graph_get_state/);
+    expect(msg).not.toMatch(/panel_graph_query/);
+    assertEveryPanelNameIsRegistered(msg);
+  });
+
+  it("the reverse index resolves the advertised reads and declines graph_get_state", () => {
+    expect(panelToolForGraphCmd("graph_outline")).toBe("panel_graph_outline");
+    expect(panelToolForGraphCmd("graph_query")).toBe("panel_query_graph");
+    expect(panelToolForGraphCmd("graph_get_errors")).toBe("panel_get_errors");
+    expect(panelToolForGraphCmd("graph_find_nodes")).toBe("panel_find_nodes");
+    expect(panelToolForGraphCmd("graph_list_subgraphs")).toBe("panel_list_subgraphs");
+    expect(panelToolForGraphCmd("graph_screenshot")).toBe("panel_screenshot");
+    expect(panelToolForGraphCmd("graph_canvas")).toBe("panel_canvas");
+    expect(panelToolForGraphCmd("graph_get_state")).toBeUndefined();
+    expect(panelToolForGraphCmd("graph_add_node")).toBe("panel_add_node");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -216,6 +216,18 @@ import {
   requiresWorkflowStampEnforcement,
 } from "../services/ui-bridge.js";
 import {
+  PANEL_TOOL_BY_GRAPH_CMD,
+  QUEUE_BUSY_READ_TOOLS,
+  RETRY_TOKEN_CMD_BY_TOOL,
+  panelToolForGraphCmd,
+} from "../services/panel-graph-cmd-tools.js";
+export {
+  PANEL_TOOL_BY_GRAPH_CMD,
+  QUEUE_BUSY_READ_TOOLS,
+  RETRY_TOKEN_CMD_BY_TOOL,
+  panelToolForGraphCmd,
+};
+import {
   type WorkflowTargetStore,
   withWorkflowTarget,
 } from "../services/workflow-target-store.js";
@@ -1112,34 +1124,6 @@ function queueBusySnapshotNote(): string {
 function graphCmdIsInertUnderQueueBusy(name: string): boolean {
   return GRAPH_CMD_EFFECT[name] === "inert";
 }
-
-/**
- * #1933 — the READ TOOLS this refusal advertises, by their REGISTERED tool name.
- *
- * They must be tool names, not the `graph_outline` / `graph_query` /
- * `graph_get_errors` bridge commands they dispatch: this string is the whole
- * recovery contract for a fenced write, and an agent that follows it calls what
- * it is told to call. A bridge command is not callable, so the advice returned
- * "unknown tool" — a hard failure mid-degraded-state that the agent cannot
- * diagnose, and from which it can only conclude that reads are unavailable
- * during a render, which is precisely the state panel#1489 fixed and this
- * sentence exists to advertise (reported from the field in
- * artokun/comfyui-mcp-panel#1549).
- *
- * The mapping is NOT the `panel_` prefix mechanically applied — `graph_query`'s
- * tool is `panel_query_graph`, not `panel_graph_query`. So these are written
- * out, and `graph-read-during-render.test.ts` asserts every one of them is in
- * `buildPanelToolDefs()` — the registry the caller actually dispatches against.
- * That test is what stops this list from drifting again: the old literal was
- * green for the whole of its life with all three names wrong, because the
- * assertion matched `/graph_outline/`, which a wrong name and a right one both
- * satisfy.
- */
-export const QUEUE_BUSY_READ_TOOLS: readonly string[] = [
-  "panel_graph_outline",
-  "panel_query_graph",
-  "panel_get_errors",
-];
 
 function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
@@ -11498,79 +11482,6 @@ const RETRY_OF_ARG = {
     ),
 } satisfies z.ZodRawShape;
 
-/**
- * #694 — the MUTATING panel tools that accept retry_of, keyed to the bridge
- * command each dispatches. Covers every command the bridge fences to a workflow
- * (GRAPH_CMD_EFFECT "targeted" — see requiresWorkflowStampEnforcement) plus the
- * four workflow mutators (workflow_save / workflow_save_as / workflow_rename /
- * workflow_close). Navigation/creation (workflow_open / workflow_new) and the
- * tools whose descriptions declare them view/read-only (panel_find_nodes,
- * panel_canvas, panel_screenshot, panel_list_subgraphs) are excluded: a read must
- * never mint or carry a retry token — its retry could be answered from the ledger
- * with a STALE outcome (codex gate).
- *
- * Four UI-STATE commands are admitted on purpose (graph_select_nodes,
- * graph_enter/exit_subgraph, graph_copy_nodes): they change selection, subgraph
- * scope or clipboard idempotently, so a deduped retry is a no-op. THIS MAP — not
- * the workflow fence — is what decides whether a token is minted and whether a
- * caller-supplied one reaches the wire, so those four keep behaving exactly as
- * they did before #778 reclassified them as `inert` for the fence. The two
- * questions are related but not the same, and answering one with the other is
- * the defect #778 is about.
- *
- * EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
- * maintenance model — keep in sync when mutating tools are added. Exported for
- * the #694 surface-integrity test.
- */
-export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
-  panel_add_node: "graph_add_node",
-  panel_edit_node: "graph_edit_node",
-  panel_remove_node: "graph_remove_node",
-  panel_clear: "graph_clear",
-  panel_flatten_workflow: "graph_load",
-  panel_load_workflow: "graph_load",
-  panel_connect: "graph_connect",
-  panel_disconnect: "graph_disconnect",
-  // Idempotent: inputs/outputs/default_mode are absolute values, so a deduped
-  // retry writes the same metadata again rather than doubling anything.
-  panel_configure_app_mode: "graph_configure_app_mode",
-  panel_set_widget: "graph_set_widget",
-  panel_remove_widget: "graph_remove_widget",
-  panel_set_property: "graph_set_node_property",
-  panel_move_node: "graph_move_node",
-  panel_resize_node: "graph_resize_node",
-  panel_auto_layout: "graph_auto_layout",
-  panel_run: "graph_run",
-  panel_save_workflow: "workflow_save", // workflow_save_as when `name` is given
-  panel_rename_workflow: "workflow_rename",
-  panel_close_workflow: "workflow_close",
-  panel_select_nodes: "graph_select_nodes",
-  panel_create_subgraph: "graph_create_subgraph",
-  panel_subgraph_group: "graph_subgraph_group",
-  panel_copy_nodes: "graph_copy_nodes",
-  panel_paste_nodes: "graph_paste_nodes",
-  panel_save_subgraph: "graph_save_subgraph",
-  panel_add_subgraph: "graph_add_subgraph",
-  panel_create_group: "graph_create_group",
-  panel_move_group: "graph_move_group",
-  panel_edit_group: "graph_edit_group",
-  panel_remove_group: "graph_remove_group",
-  panel_set_node_title: "graph_set_title",
-  panel_set_node_collapsed: "graph_set_node_collapsed",
-  panel_set_node_mode: "graph_set_node_mode",
-  panel_set_node_color: "graph_set_node_color",
-  panel_enter_subgraph: "graph_enter_subgraph",
-  panel_exit_subgraph: "graph_exit_subgraph",
-  panel_move_rail: "graph_move_rail",
-  panel_promote_widget: "graph_promote_widget",
-  panel_expose_subgraph_output: "graph_expose_subgraph_output",
-  panel_expose_subgraph_input: "graph_expose_subgraph_input",
-  panel_unexpose_subgraph_output: "graph_unexpose_subgraph_output",
-  panel_unexpose_subgraph_input: "graph_unexpose_subgraph_input",
-  panel_unpack_subgraph: "graph_unpack_subgraph",
-  panel_update_node: "graph_update_node",
-};
-
 /** #694 — the bridge commands the retry map admits, for the mint gate: a
  *  dispatched timeout/drop only mints a retry token when the command is in
  *  this set (bridge classification alone would include read/view-only
@@ -11578,47 +11489,6 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
 export const RETRY_TOKEN_CMDS: ReadonlySet<string> = new Set(
   Object.values(RETRY_TOKEN_CMD_BY_TOOL).concat(["workflow_save_as"]),
 );
-
-/**
- * #1933 — the reverse of RETRY_TOKEN_CMD_BY_TOOL: which TOOL does a caller reach
- * this bridge command through?
- *
- * An agent-facing message written below the tool layer can only see `cmd.cmd`;
- * `PanelToolCtx.call` takes a command object and no tool identity, so by the
- * time a pre-dispatch refusal is worded the tool name is genuinely gone. This
- * recovers it from the map that already maintains the correspondence, rather
- * than adding a second hand-written list that can drift out of step with the
- * first.
- *
- * IT REFUSES TO GUESS. The forward map is not injective — `graph_load` is
- * dispatched by both `panel_load_workflow` and `panel_flatten_workflow` — and
- * naming one of two possible tools is a confidently wrong answer, which is worse
- * than declining to name one. Ambiguous commands are therefore OMITTED, and
- * callers must handle `undefined`.
- *
- * Coverage is not assumed either: every `targeted` GRAPH_CMD_EFFECT command
- * except `graph_run` is a value of the forward map, so the queue-busy fence
- * resolves a tool for everything it can refuse except `graph_load`.
- * `graph-read-during-render.test.ts` pins both halves — the resolution and the
- * refusal to guess.
- */
-export const PANEL_TOOL_BY_GRAPH_CMD: ReadonlyMap<string, string> = (() => {
-  const claims = new Map<string, string[]>();
-  for (const [tool, cmd] of Object.entries(RETRY_TOKEN_CMD_BY_TOOL)) {
-    const prior = claims.get(cmd);
-    if (prior) prior.push(tool);
-    else claims.set(cmd, [tool]);
-  }
-  const unique = new Map<string, string>();
-  for (const [cmd, tools] of claims) if (tools.length === 1) unique.set(cmd, tools[0]!);
-  return unique;
-})();
-
-/** #1933 — the registered tool a bridge command is reached through, or
- *  `undefined` when no tool, or more than one tool, claims it. */
-export function panelToolForGraphCmd(cmd: string): string | undefined {
-  return PANEL_TOOL_BY_GRAPH_CMD.get(cmd);
-}
 
 /** #694 — augment one MUTATING tool def: accept retry_of and attach it, UNTOUCHED,
  *  to every mutating command the handler dispatches (per-command gated so a read

--- a/src/services/panel-graph-cmd-tools.ts
+++ b/src/services/panel-graph-cmd-tools.ts
@@ -1,0 +1,183 @@
+/**
+ * Tool ↔ bridge-command correspondence used by agent-facing refusals.
+ *
+ * Two maps, one reverse index. The forward maps are NOT injective (graph_load
+ * is dispatched by two tools), so the reverse index omits ambiguous commands
+ * rather than guessing — a confidently wrong tool name is the defect this
+ * module exists to prevent (#1933, #1935).
+ *
+ * Lives here, not in panel-tools.ts, so ui-bridge can name tools in its own
+ * refusals without a circular import (panel-tools already imports ui-bridge).
+ */
+
+/**
+ * #694 — the MUTATING panel tools that accept retry_of, keyed to the bridge
+ * command each dispatches. Covers every command the bridge fences to a workflow
+ * (GRAPH_CMD_EFFECT "targeted" — see requiresWorkflowStampEnforcement) plus the
+ * four workflow mutators (workflow_save / workflow_save_as / workflow_rename /
+ * workflow_close). Navigation/creation (workflow_open / workflow_new) and the
+ * tools whose descriptions declare them view/read-only (panel_find_nodes,
+ * panel_canvas, panel_screenshot, panel_list_subgraphs) are excluded: a read must
+ * never mint or carry a retry token — its retry could be answered from the ledger
+ * with a STALE outcome (codex gate).
+ *
+ * Four UI-STATE commands are admitted on purpose (graph_select_nodes,
+ * graph_enter/exit_subgraph, graph_copy_nodes): they change selection, subgraph
+ * scope or clipboard idempotently, so a deduped retry is a no-op. THIS MAP — not
+ * the workflow fence — is what decides whether a token is minted and whether a
+ * caller-supplied one reaches the wire, so those four keep behaving exactly as
+ * they did before #778 reclassified them as `inert` for the fence. The two
+ * questions are related but not the same, and answering one with the other is
+ * the defect #778 is about.
+ *
+ * EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
+ * maintenance model — keep in sync when mutating tools are added. Exported for
+ * the #694 surface-integrity test.
+ */
+export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
+  panel_add_node: "graph_add_node",
+  panel_edit_node: "graph_edit_node",
+  panel_remove_node: "graph_remove_node",
+  panel_clear: "graph_clear",
+  panel_flatten_workflow: "graph_load",
+  panel_load_workflow: "graph_load",
+  panel_connect: "graph_connect",
+  panel_disconnect: "graph_disconnect",
+  // Idempotent: inputs/outputs/default_mode are absolute values, so a deduped
+  // retry writes the same metadata again rather than doubling anything.
+  panel_configure_app_mode: "graph_configure_app_mode",
+  panel_set_widget: "graph_set_widget",
+  panel_remove_widget: "graph_remove_widget",
+  panel_set_property: "graph_set_node_property",
+  panel_move_node: "graph_move_node",
+  panel_resize_node: "graph_resize_node",
+  panel_auto_layout: "graph_auto_layout",
+  panel_run: "graph_run",
+  panel_save_workflow: "workflow_save", // workflow_save_as when `name` is given
+  panel_rename_workflow: "workflow_rename",
+  panel_close_workflow: "workflow_close",
+  panel_select_nodes: "graph_select_nodes",
+  panel_create_subgraph: "graph_create_subgraph",
+  panel_subgraph_group: "graph_subgraph_group",
+  panel_copy_nodes: "graph_copy_nodes",
+  panel_paste_nodes: "graph_paste_nodes",
+  panel_save_subgraph: "graph_save_subgraph",
+  panel_add_subgraph: "graph_add_subgraph",
+  panel_create_group: "graph_create_group",
+  panel_move_group: "graph_move_group",
+  panel_edit_group: "graph_edit_group",
+  panel_remove_group: "graph_remove_group",
+  panel_set_node_title: "graph_set_title",
+  panel_set_node_collapsed: "graph_set_node_collapsed",
+  panel_set_node_mode: "graph_set_node_mode",
+  panel_set_node_color: "graph_set_node_color",
+  panel_enter_subgraph: "graph_enter_subgraph",
+  panel_exit_subgraph: "graph_exit_subgraph",
+  panel_move_rail: "graph_move_rail",
+  panel_promote_widget: "graph_promote_widget",
+  panel_expose_subgraph_output: "graph_expose_subgraph_output",
+  panel_expose_subgraph_input: "graph_expose_subgraph_input",
+  panel_unexpose_subgraph_output: "graph_unexpose_subgraph_output",
+  panel_unexpose_subgraph_input: "graph_unexpose_subgraph_input",
+  panel_unpack_subgraph: "graph_unpack_subgraph",
+  panel_update_node: "graph_update_node",
+};
+
+/**
+ * #1935 — the READ / view-only tools that agent-facing refusals may advertise,
+ * keyed to the bridge command each dispatches.
+ *
+ * Separate from RETRY_TOKEN_CMD_BY_TOOL on purpose: a read must never mint a
+ * retry token (that map's own doc). The instance-mismatch refusal in ui-bridge
+ * still has to NAME these, and the mapping is NOT the `panel_` prefix
+ * mechanically applied — `graph_query`'s tool is `panel_query_graph`, not
+ * `panel_graph_query`.
+ *
+ * `graph_get_state` is omitted: it is an internal pre-0.8.2 fallback
+ * (panel_strip_workflow reconstruction), not a registered tool. Naming it would
+ * send the agent to an "unknown tool" the same way the bare bridge commands did.
+ */
+export const GRAPH_READ_CMD_BY_TOOL: Readonly<Record<string, string>> = {
+  panel_graph_outline: "graph_outline",
+  panel_query_graph: "graph_query",
+  panel_get_errors: "graph_get_errors",
+  panel_find_nodes: "graph_find_nodes",
+  panel_list_subgraphs: "graph_list_subgraphs",
+  panel_screenshot: "graph_screenshot",
+  panel_canvas: "graph_canvas",
+};
+
+/**
+ * #1933 — the READ TOOLS the QUEUE BUSY refusal advertises, by their REGISTERED
+ * tool name.
+ *
+ * They must be tool names, not the `graph_outline` / `graph_query` /
+ * `graph_get_errors` bridge commands they dispatch: this string is the whole
+ * recovery contract for a fenced write, and an agent that follows it calls what
+ * it is told to call. A bridge command is not callable, so the advice returned
+ * "unknown tool" — a hard failure mid-degraded-state that the agent cannot
+ * diagnose, and from which it can only conclude that reads are unavailable
+ * during a render, which is precisely the state panel#1489 fixed and this
+ * sentence exists to advertise (reported from the field in
+ * artokun/comfyui-mcp-panel#1549).
+ *
+ * Written out (not derived by prefixing `panel_`) because `graph_query`'s tool
+ * is `panel_query_graph`. `graph-read-during-render.test.ts` asserts every one
+ * of them is in `buildPanelToolDefs()` — the registry the caller actually
+ * dispatches against. That test is what stops this list from drifting again:
+ * the old literal was green for the whole of its life with all three names
+ * wrong, because the assertion matched `/graph_outline/`, which a wrong name
+ * and a right one both satisfy.
+ *
+ * #1935 reuses this same list in the workflow-instance-stamp refusal's
+ * refused/unknown branches, rather than a third hand-written name list.
+ */
+export const QUEUE_BUSY_READ_TOOLS: readonly string[] = [
+  "panel_graph_outline",
+  "panel_query_graph",
+  "panel_get_errors",
+];
+
+/**
+ * #1933/#1935 — the reverse of RETRY_TOKEN_CMD_BY_TOOL ∪ GRAPH_READ_CMD_BY_TOOL:
+ * which TOOL does a caller reach this bridge command through?
+ *
+ * An agent-facing message written below the tool layer can only see `cmd.cmd`;
+ * `PanelToolCtx.call` takes a command object and no tool identity, so by the
+ * time a pre-dispatch refusal is worded the tool name is genuinely gone. This
+ * recovers it from the maps that already maintain the correspondence, rather
+ * than adding another hand-written list that can drift out of step with the
+ * first.
+ *
+ * IT REFUSES TO GUESS. The forward maps are not injective — `graph_load` is
+ * dispatched by both `panel_load_workflow` and `panel_flatten_workflow` — and
+ * naming one of two possible tools is a confidently wrong answer, which is worse
+ * than declining to name one. Ambiguous commands are therefore OMITTED, and
+ * callers must handle `undefined`.
+ *
+ * Coverage of mutations is not assumed either: every `targeted` GRAPH_CMD_EFFECT
+ * command except `graph_run` is a value of the retry map, so the queue-busy
+ * fence resolves a tool for everything it can refuse except `graph_load`.
+ * `graph-read-during-render.test.ts` pins both halves — the resolution and the
+ * refusal to guess. Reads resolve through GRAPH_READ_CMD_BY_TOOL; `graph_get_state`
+ * is intentionally absent (no callable tool).
+ */
+export const PANEL_TOOL_BY_GRAPH_CMD: ReadonlyMap<string, string> = (() => {
+  const claims = new Map<string, string[]>();
+  for (const map of [RETRY_TOKEN_CMD_BY_TOOL, GRAPH_READ_CMD_BY_TOOL]) {
+    for (const [tool, cmd] of Object.entries(map)) {
+      const prior = claims.get(cmd);
+      if (prior) prior.push(tool);
+      else claims.set(cmd, [tool]);
+    }
+  }
+  const unique = new Map<string, string>();
+  for (const [cmd, tools] of claims) if (tools.length === 1) unique.set(cmd, tools[0]!);
+  return unique;
+})();
+
+/** #1933/#1935 — the registered tool a bridge command is reached through, or
+ *  `undefined` when no tool, or more than one tool, claims it. */
+export function panelToolForGraphCmd(cmd: string): string | undefined {
+  return PANEL_TOOL_BY_GRAPH_CMD.get(cmd);
+}

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -30,6 +30,10 @@ import { primePanelBase, verifiedPanelDiskVersion } from "./panel-workspace.js";
 import { compareSemver, detectInstallMode } from "./self-update.js";
 import { SHARED_SESSION_SCOPE, isScopeAddress } from "./session-scope.js";
 import type { ScopeRepinOutcome } from "../orchestrator/turn-origins.js";
+import {
+  QUEUE_BUSY_READ_TOOLS,
+  panelToolForGraphCmd,
+} from "./panel-graph-cmd-tools.js";
 
 export const DEFAULT_BRIDGE_PORT = 9101;
 
@@ -4742,25 +4746,52 @@ export class UiBridge {
           `Try panel_list_workflows — the panel exempts that read from this fence (it is the ` +
           `recovery probe), though a build predating the exemption fences it too. Non-graph ` +
           `tools are unaffected.`;
+        // #1935 — name TOOLS, not the bridge commands they dispatch. An agent
+        // that follows this recovery advice calls what it is told to call, and
+        // none of graph_outline / graph_query / graph_get_state is registered.
+        // The mapping is not a mechanical `panel_` prefix (graph_query →
+        // panel_query_graph), so names come from panelToolForGraphCmd /
+        // QUEUE_BUSY_READ_TOOLS rather than a third hand-written list.
+        // graph_get_state is an internal pre-0.8.2 fallback with no callable
+        // tool — the reverse index omits it, so it drops out of the execute
+        // list rather than being advertised.
+        const readTools = QUEUE_BUSY_READ_TOOLS.join(" / ");
+        const viewTools = (
+          [
+            "graph_outline",
+            "graph_query",
+            "graph_get_state",
+            "graph_find_nodes",
+            "graph_list_subgraphs",
+            "graph_screenshot",
+            "graph_canvas",
+          ] as const
+        )
+          .map((c) => panelToolForGraphCmd(c))
+          .filter((n): n is string => n !== undefined)
+          .join(", ");
         const readsNote =
           readsVerdict === "refused"
             ? `GRAPH READS ARE REFUSED TOO, for this same missing stamp: this tab's panel ` +
               `enforces the per-command fence and refuses an UNSTAMPED command rather than ` +
-              `fail open, so graph_outline / graph_query answer "workflow instance mismatch: ` +
+              `fail open, so ${readTools} answer "workflow instance mismatch: ` +
               `this command carries no workflow-instance stamp" as well. ${PROBE}`
             : readsVerdict === "unknown"
               ? `WHETHER GRAPH READS STILL WORK IS NOT KNOWN FROM HERE, and is not claimed: a ` +
                 `read carries this session's stamp (${trustedStamp}), and this tab's panel runs ` +
                 `it only while that stamp still names the ACTIVE canvas — a comparison only the ` +
                 `panel can make. If the workflow was switched or replaced after this session ` +
-                `bound to it, graph_outline / graph_query are refused with "workflow instance ` +
+                `bound to it, ${readTools} are refused with "workflow instance ` +
                 `mismatch" as well; if it was not, they work. ${PROBE}`
-              : `Reads and view-only commands still work (graph_outline, graph_query, ` +
-                `graph_get_state, graph_find_nodes, graph_list_subgraphs, graph_screenshot, ` +
-                `graph_canvas).`;
+              : `Reads and view-only commands still work (${viewTools}).`;
+        // Same defect on the SUBJECT: `cmd.cmd` is the bridge command the tool
+        // dispatched (observed: panel_add_node arrives here as graph_add_node).
+        // Ambiguous commands fall back to a subject naming no tool at all.
+        const subject =
+          panelToolForGraphCmd(typeof cmd.cmd === "string" ? cmd.cmd : "") ?? "This command";
         const refusal = markDispatched(
           new Error(
-            `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. ${readsNote}`,
+            `"${subject}" cannot be safely targeted to the active workflow: ${why}. ${readsNote}`,
           ),
           false,
         );


### PR DESCRIPTION
Fixes #1935.

## What was wrong

`src/services/ui-bridge.ts` builds the workflow-instance-stamp write refusal. Every tool name in its `readsNote` was uncallable, and the quoted subject was the raw `cmd.cmd` bridge command.

Observed by driving `UiBridge.send({ cmd: "graph_add_node" })` through the real pre-dispatch gate (`unstamped-reads-claim.test.ts` — a live WebSocket panel, not a string fixture):

**NO STAMP (refused):**

```
"graph_add_node" cannot be safely targeted to the active workflow: this workflow has
no trusted identity … GRAPH READS ARE REFUSED TOO … so graph_outline / graph_query
answer "workflow instance mismatch: this command carries no workflow-instance stamp"
as well.
```

**NO FENCE (execute)** — the worst of the three: a seven-name list of things that "still work", none of them callable:

```
Reads and view-only commands still work (graph_outline, graph_query, graph_get_state,
graph_find_nodes, graph_list_subgraphs, graph_screenshot, graph_canvas).
```

Same defect class as #1933, different fence — split on purpose (PR #1934 flagged this and did not bundle it). `buildPanelToolDefs()` registers `panel_graph_outline`, `panel_query_graph`, `panel_find_nodes`, …; it registers no `graph_outline`. The mapping is **not** the `panel_` prefix mechanically applied (`graph_query` → `panel_query_graph`). `graph_get_state` is an internal pre-0.8.2 fallback with no callable tool at all.

An agent that follows this recovery advice during a degraded state gets a hard "unknown tool" and can reasonably conclude reads are unavailable — while the refusal was specifically telling it that reads still work (or naming *which* reads are refused too).

The same message already got this right one line above, in `PROBE`: `Try panel_list_workflows`.

## The fix

- `panelToolForGraphCmd` / `QUEUE_BUSY_READ_TOOLS` moved to `src/services/panel-graph-cmd-tools.ts` so ui-bridge can reuse them without a circular import (panel-tools already imports ui-bridge). panel-tools re-exports the same names.
- `GRAPH_READ_CMD_BY_TOOL` feeds the reverse index so read commands resolve (the retry map excludes them on purpose — a read must never mint a token).
- **refused / unknown** `readsNote` uses `QUEUE_BUSY_READ_TOOLS` (`panel_graph_outline / panel_query_graph / panel_get_errors`).
- **execute** maps the original seven-name list through `panelToolForGraphCmd`; `graph_get_state` is omitted because the index declines to name a non-tool.
- The quoted subject uses `panelToolForGraphCmd(cmd.cmd) ?? "This command"` — same "refuse to guess" rule as #1933 (`graph_load` stays anonymous).

Emitted now (same harness):

```
"panel_add_node" cannot be safely targeted … so panel_graph_outline / panel_query_graph /
panel_get_errors answer "workflow instance mismatch: …"
```

```
Reads and view-only commands still work (panel_graph_outline, panel_query_graph,
panel_find_nodes, panel_list_subgraphs, panel_screenshot, panel_canvas).
```

## Why no test caught this

`fence-lookalike-refusals.test.ts` quoted the affected prose **verbatim** as a fixture for a different property (lookalike mismatch handling). It pinned the wrong names. Those fixtures moved with the fix.

The load-bearing tests drive `UiBridge.send` on a real socket (`unstamped-reads-claim.test.ts`) and read tool names **out of the emitted message** (`/panel_[a-z0-9_]+/g`), requiring each to be in `buildPanelToolDefs()` — not re-reading the constant the string was built from. Bare `graph_*` commands are rejected with a lookbehind so `panel_graph_outline` cannot satisfy `/graph_outline/`.

## Gates

- `unstamped-reads-claim.test.ts` — 11/11 (was 7)
- `fence-lookalike-refusals.test.ts` — 2/2
- `graph-read-during-render.test.ts` — 20/20 (#1933 still green)
- `panel-retry-identity.test.ts` — 36/36
- `graph-command-effect.test.ts` — 41/41
- `ui-bridge.test.ts` — 208/208
- `npx tsc --noEmit` — clean
- `npm run check:vocabulary` — OK, 1735 files, 160 dead names in the ledger, no live references
