### PR TITLE
release: v0.52.38 — instance-mismatch names tools, split-root install refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.38] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- the instance-mismatch refusal names TOOLS, not bridge commands (#1939)
+- install_custom_node refuses a local write aimed at an install this session is not connected to (#1938)
+
+#### Changed
+- prove the tool/command PAIRING end-to-end across the fenced surface (#1937)
+
+
 ## [0.52.37] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.37",
+  "version": "0.52.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.37",
+      "version": "0.52.38",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.37",
+  "version": "0.52.38",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.38 from main.

Carries:

- #1939 / #1935 — the instance-mismatch refusal names TOOLS, not bridge commands
- #1937 / #1933 — prove the tool/command pairing end-to-end across the fenced surface
- #1938 / #1765 — install_custom_node refuses a local write aimed at an install this session is not connected to

Held out: #1697 P1 inflight; #1130/#1873/#1940/#1549 inflight this cycle; #1696 claimed; #1896 parked; panel#1472 typescript 5 to 7 (CI red).

Do not squash-merge. Merge-commit (keeps the v0.52.38 tag on the version commit). Tag is local; push v0.52.38 after merge.