### PR TITLE
fix(1873): Save-As 409 names the rename path instead of a third filename

### DIFF
--- a/src/__tests__/orchestrator/save-as-name-conflict.test.ts
+++ b/src/__tests__/orchestrator/save-as-name-conflict.test.ts
@@ -1,0 +1,165 @@
+// #1873 — after a Save-As copy, saving the edited graph back under the original
+// name 409s, and the panel's "choose a different name" is what forced a third
+// workflow file. There is no overwrite switch (ComfyUI's saveWorkflowAs would
+// DELETE the occupant on confirm; the panel refuses that path). The supported
+// way is panel_rename_workflow on the closed original, then on the active copy.
+//
+// Tests drive panel_save_workflow. The 409 text is the panel's conflictError.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/A_backup.json";
+
+/** The reporter's exact 409 (issue #1873, from the panel's conflictError). */
+const REPORTER_CONFLICT =
+  `a workflow named "MiniMax_H3_Modular_Ref2VA_Long" already exists (409 Conflict) — ` +
+  `choose a different name. The active tab was left unchanged (issue #309).`;
+
+function bridge(message: string) {
+  const calls: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      throw new Error(message);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+function saveDef() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_save_workflow");
+  if (!def) throw new Error("panel_save_workflow is not registered");
+  return def;
+}
+
+async function saveAs(name: string | undefined, message: string) {
+  const { b, calls } = bridge(message);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const res: ToolResult = await saveDef().handler(
+    (name === undefined ? {} : { name }) as never,
+    ctx,
+  );
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("#1873 panel_save_workflow names the rename path on a Save-As 409", () => {
+  it("the reporter's case: keeps the 409 and does not tell the agent to pick a third name as the fix", async () => {
+    const { text, isError, calls } = await saveAs(
+      "MiniMax_H3_Modular_Ref2VA_Long",
+      REPORTER_CONFLICT,
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_CONFLICT);
+    expect(text).toMatch(/Do NOT pick a third name/i);
+    expect(text).toContain("panel_rename_workflow");
+    expect(text).toMatch(/CLOSED listed/i);
+    expect(text).toMatch(/panel_save_workflow\(\)/);
+    expect(calls).toEqual(["workflow_save_as"]);
+  });
+
+  it("does not dispatch a rename or a second save — the 409 wrote nothing", async () => {
+    const { calls } = await saveAs("A", REPORTER_CONFLICT);
+    expect(calls).toEqual(["workflow_save_as"]);
+    expect(calls).not.toContain("workflow_rename");
+    expect(calls).not.toContain("workflow_save");
+  });
+
+  it("an in-place 409 over the workflow's OWN file is left alone (#442)", async () => {
+    const inplace =
+      `Error storing user data file 'workflows/MiniMax_H3_Modular_Ref2VA_Long.json': 409 Conflict`;
+    const { text, isError } = await saveAs(undefined, inplace);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(inplace);
+    expect(text).not.toMatch(/Do NOT pick a third name/i);
+    expect(text).not.toContain("panel_rename_workflow");
+  });
+
+  it("a different named-save failure is left alone", async () => {
+    const other = "name must not be blank — pass a non-whitespace workflow name";
+    const { text, isError } = await saveAs("  ", other);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(other);
+    expect(text).not.toMatch(/Do NOT pick a third name/i);
+  });
+
+  it("a successful Save-As is untouched", async () => {
+    const calls: string[] = [];
+    const b = {
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push(String(cmd.cmd));
+        if (cmd.cmd === "workflow_save_as") {
+          return {
+            saved: true,
+            workflow: "A_backup",
+            saved_as: true,
+            copied_from: "A",
+            original_on_disk: true,
+            workflow_uuid: "11111111-2222-4333-8444-555555555555",
+          };
+        }
+        if (cmd.cmd === "workflow_list") {
+          return {
+            active: {
+              path: "workflows/A_backup.json",
+              filename: "A_backup.json",
+              workflow_uuid: "11111111-2222-4333-8444-555555555555",
+            },
+            active_confirmed: true,
+            workflows: [],
+          };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      workflowUuidFor: () => ({ known: true, uuid: "11111111-2222-4333-8444-555555555555" }),
+      refreshWorkflowUuid: () => true,
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const res = await saveDef().handler({ name: "A_backup" } as never, ctx);
+
+    expect(res.isError).toBeFalsy();
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+    expect(text).not.toMatch(/Do NOT pick a third name/i);
+    expect(calls[0]).toBe("workflow_save_as");
+  });
+
+  it("the tool description names the rename path so the 409 is not the first time the agent hears it", () => {
+    const desc = saveDef().description;
+    expect(desc).toMatch(/409 Conflict/);
+    expect(desc).toMatch(/do NOT pick a third name/i);
+    expect(desc).toContain("panel_rename_workflow");
+
+    const rename = buildPanelToolDefs().find((d) => d.name === "panel_rename_workflow");
+    if (!rename) throw new Error("panel_rename_workflow is not registered");
+    expect(rename.description).toMatch(/CLOSED listed/i);
+    expect(rename.description).toContain("panel_save_workflow()");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3931,6 +3931,37 @@ function appendToolResultText(res: ToolResult, extra: string): ToolResult {
   return { ...res, content };
 }
 
+/**
+ * #1873 — Save-As onto an EXISTING name 409s on purpose. ComfyUI's userdata POST
+ * returns 409 when overwrite=false; the frontend's saveWorkflowAs then prompts
+ * and, on confirm, DELETES the occupant. The panel refuses that delete path and
+ * surfaces "choose a different name", which is what forced a third workflow file.
+ *
+ * Matched on the panel's relocating-save collision (`conflictError` in
+ * workflow-save.js), not a generic "409 Conflict" — an in-place save can 409
+ * over its OWN file (#442) and that remedy is not this one.
+ */
+function isSaveAsNameConflict(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  const text = textOfToolResult(res);
+  return /already exists \(409 Conflict\)/i.test(text) && /choose a different name/i.test(text);
+}
+
+const SAVE_AS_NAME_CONFLICT_NOTE =
+  `\n\nDo NOT pick a third name. Save-As never overwrites an existing file — that 409 is ` +
+  `the copy contract, not a missing overwrite switch. To land the edited copy under the ` +
+  `intended original name while keeping a backup of the pre-edit original:\n` +
+  `1. panel_rename_workflow({path: "<original>", name: "<original>_pre_edit"}) — path can ` +
+  `target a CLOSED listed workflow, so this does not disturb the active tab.\n` +
+  `2. panel_rename_workflow({name: "<original>"}) — no path, so this renames the ACTIVE ` +
+  `copy onto the freed name; the tab follows the file.\n` +
+  `3. panel_save_workflow() — in-place save from then on.`;
+
+function withSaveAsNameConflictNote(res: ToolResult): ToolResult {
+  if (!isSaveAsNameConflict(res)) return res;
+  return appendToolResultText(res, SAVE_AS_NAME_CONFLICT_NOTE);
+}
+
 // ---- #1695: bound the panel_set_widget previous/new echo --------------------
 //
 // Code-mode clients (Codex `functions.exec`) batch several panel_set_widget
@@ -14398,8 +14429,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_save_workflow",
-      "Save the user's open workflow PROGRAMMATICALLY — no Save/Rename dialog ever pops. With no `name`: saves in place (or auto-names + persists a never-saved workflow). With `name`: if the workflow is ALREADY saved under a different name this is a SAVE-AS — it writes a NEW file and leaves the original untouched on disk (it NEVER renames/moves/destroys the original); for a never-saved workflow it is simply the first save. The result reports what happened: `saved_as`+`copied_from`+`original_on_disk` (a disk-verified check that the original file still exists) for a Save-As copy, or `first_save` for a brand-new workflow. Use this freely (e.g. after building a graph) — it won't interrupt the user.",
-      { name: z.string().optional().describe("Name for the workflow (no .json needed). If the workflow is already saved under a different name, this writes a NEW file (Save-As COPY) and leaves the original in place — it never renames/moves/destroys it. Omit to save in place / auto-name an unsaved workflow.") },
+      "Save the user's open workflow PROGRAMMATICALLY — no Save/Rename dialog ever pops. With no `name`: saves in place (or auto-names + persists a never-saved workflow). With `name`: if the workflow is ALREADY saved under a different name this is a SAVE-AS — it writes a NEW file and leaves the original untouched on disk (it NEVER renames/moves/destroys the original); for a never-saved workflow it is simply the first save. The result reports what happened: `saved_as`+`copied_from`+`original_on_disk` (a disk-verified check that the original file still exists) for a Save-As copy, or `first_save` for a brand-new workflow. A Save-As onto an EXISTING name is a 409 Conflict (the copy never overwrites) — do NOT pick a third name; panel_rename_workflow can target a closed listed original to free the name, then rename the active copy onto it, then panel_save_workflow() in place. Use this freely (e.g. after building a graph) — it won't interrupt the user.",
+      { name: z.string().optional().describe("Name for the workflow (no .json needed). If the workflow is already saved under a different name, this writes a NEW file (Save-As COPY) and leaves the original in place — it never renames/moves/destroys it. An existing target name 409s; do not invent a third name — use panel_rename_workflow to free the original then rename the active copy onto it. Omit to save in place / auto-name an unsaved workflow.") },
       async (args: A, ctx) => {
         // #402: await a stable tab binding before dispatching the (mutating) save, so
         // a save issued in the post-restart "Connected: none" window reaches a live
@@ -14427,7 +14458,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             }
           }
         }
-        if (res.isError) return res;
+        if (res.isError) {
+          // #1873 — named Save-As 409s by contract; the panel's "choose a different
+          // name" is what forced a third file. Keep the 409 and name the rename path.
+          return args.name ? withSaveAsNameConflictNote(res) : res;
+        }
         // #1045 — a SAVE-AS replaces the active workflow instance: the canvas is
         // now the NEW file, with its own identity, while this session's command
         // fence still names the pre-save one. Every graph call afterwards fails
@@ -15203,10 +15238,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_rename_workflow",
-      "Rename a workflow (the active one, or the one matching `path`).",
+      "Rename a workflow (the active one, or the one matching `path`). `path` can name a CLOSED listed workflow — renaming it does not disturb the active tab. After a Save-As copy, this is how to land the edited graph under the original name without a third file: rename the closed original aside (`path` + new name), then rename the active copy onto the freed name (no `path`), then panel_save_workflow().",
       {
         name: z.string().describe("New name (no .json needed)."),
-        path: z.string().optional().describe("Which workflow to rename; omit for the active one."),
+        path: z.string().optional().describe("Which workflow to rename; omit for the active one. Can name a CLOSED listed workflow (does not disturb the active tab)."),
       },
       async (args: A, ctx) => ctx.call({ cmd: "workflow_rename", name: args.name, path: args.path }, 15000),
     ),


### PR DESCRIPTION
Fixes #1873

## What the reporter hit
After `panel_save_workflow` Save-As created a backup and made it active, calling `panel_save_workflow` with the original name returned 409 Conflict. The error said "choose a different name", which forced a third workflow file.

## ComfyUI frontend / backend (the unpark question)
This is **not** an upstream bug, and there is no pending ComfyUI PR that adds a safer overwrite API.

- **Backend** (`POST /userdata/{file}`): `overwrite=false` returns 409 when the file exists. Working as designed. Default is actually `overwrite=true`.
- **Frontend** (`saveWorkflowAs` in `workflowService.ts`): if the target exists, it **prompts to confirm overwrite**, then **deletes the occupant** and writes the current graph under that name. Temporary sources are renamed/moved (the #226 hazard). There is no "update that named file, keep the Save-As backup" primitive.
- **Panel**: deliberately uses `overwrite:false` and refuses `saveWorkflowAs` / `renameWorkflow` because those helpers can delete, overwrite, or strand a file. The 409 is the copy contract.

An agent-callable overwrite flag would be the frontend's delete-then-save-as path without a confirm dialog. That is still the identity-proof product call from the park comment, not this PR.

## What this PR changes
The 409 stays. The tool no longer tells the agent to invent a third name.

On the panel's relocating-save collision (`already exists (409 Conflict)` + `choose a different name`), `panel_save_workflow` keeps the 409 and names the already-supported path:

1. `panel_rename_workflow({path: original, name: original_pre_edit})` — can target a **closed listed** workflow, so the active tab is untouched
2. `panel_rename_workflow({name: original})` — no `path`, so the **active** copy takes the freed name
3. `panel_save_workflow()` — in-place from then on

In-place 409s over the workflow's own file (#442) are left alone. The tool descriptions for `panel_save_workflow` and `panel_rename_workflow` now say the same thing up front.

## Tests
`src/__tests__/orchestrator/save-as-name-conflict.test.ts` drives `panel_save_workflow` with the reporter's exact 409.
