### PR TITLE
fix(1940): subgraph promoted COMBO refusals name the inner option list

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -22,9 +22,14 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import {
+  comboOptionsFromObjectInfo,
+  comboValueIsListed,
   isContradictoryPromotedWidgetRefusal,
+  isSubgraphUuidType,
   matchListedName,
   parseContradictoryPromotedWidgetRefusal,
+  parseEmptyPromotedComboRefusal,
+  resolveInnerComboOptions,
   resolveInnerPromotedTarget,
 } from "../../orchestrator/promoted-widget.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
@@ -338,5 +343,313 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(calls[0]).toMatchObject({ widget: "Width" });
     expect(calls[1]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
     expect(text).not.toMatch(/is not a promoted widget/);
+  });
+});
+
+// #1940 — promoted COMBO on a subgraph UUID: empty option list is not stale.
+const SUBGRAPH_UUID = "6c697765-ebd7-4e1e-8af0-d84d620be471";
+const EMPTY_COMBO =
+  `panel_set_widget refused "choice" on node 816 (${SUBGRAPH_UUID}) after refreshing combo options: ` +
+  `Combo widget "choice" has an EMPTY option list; the server's option list may simply be stale — ` +
+  `refreshing it before deciding.`;
+
+const COMBO_SUBGRAPH = {
+  subgraph_of: { node_id: 816, title: "Ideogram 4" },
+  node_count: 3,
+  nodes: [
+    {
+      id: 795,
+      type: "KSampler",
+      widgets: { seed: 1, noise_seed: 1, steps: 20 },
+    },
+    {
+      id: 801,
+      type: "CustomCombo",
+      widgets: { choice: "Quality" },
+      widget_options: { choice: ["Quality", "Default", "Turbo"] },
+    },
+    {
+      id: 810,
+      type: "UNETLoader",
+      widgets: { unet_name: "model.fp8.safetensors", weight_dtype: "fp8" },
+    },
+  ],
+};
+
+const OBJECT_INFO = {
+  UNETLoader: {
+    input: {
+      required: {
+        unet_name: [["model.fp8.safetensors", "model.nvfp4.safetensors"], {}],
+        weight_dtype: ["COMBO", { options: ["default", "fp8", "fp16"] }],
+      },
+    },
+  },
+  KSampler: {
+    input: {
+      required: {
+        seed: ["INT", {}],
+        steps: ["INT", {}],
+      },
+    },
+  },
+};
+
+function emptyComboBridge(opts: {
+  subgraph?: Record<string, unknown> | Error;
+  objectInfo?: Record<string, unknown> | Error;
+  firstWrite?: "empty" | "ok" | "other";
+}) {
+  const calls: Array<Record<string, unknown>> = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_set_widget") {
+        const which = opts.firstWrite ?? "empty";
+        if (which === "ok") {
+          return { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
+        }
+        if (which === "other") throw new Error("No node with id 816 in the current graph");
+        throw new Error(EMPTY_COMBO);
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (opts.subgraph instanceof Error) throw opts.subgraph;
+        return opts.subgraph ?? COMBO_SUBGRAPH;
+      }
+      if (cmd.cmd === "graph_get_object_info") {
+        if (opts.objectInfo instanceof Error) throw opts.objectInfo;
+        return { ok: true, object_info: opts.objectInfo ?? OBJECT_INFO };
+      }
+      if (cmd.cmd === "graph_enter_subgraph" || cmd.cmd === "graph_exit_subgraph") {
+        throw new Error("must not enter the subgraph for a link-driven promoted combo");
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function setEmptyComboWidget(
+  args: { node_id: number | string; widget: string; value: number | string },
+  opts: Parameters<typeof emptyComboBridge>[0] = {},
+) {
+  const { b, calls } = emptyComboBridge(opts);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("parseEmptyPromotedComboRefusal", () => {
+  it("the reporter's error is an empty combo on a subgraph UUID", () => {
+    expect(parseEmptyPromotedComboRefusal(EMPTY_COMBO, "choice")).toEqual({
+      nodeId: "816",
+      widget: "choice",
+      type: SUBGRAPH_UUID,
+    });
+    expect(isSubgraphUuidType(SUBGRAPH_UUID)).toBe(true);
+  });
+
+  it("a genuine empty list on a backend type is not this bug", () => {
+    const text =
+      `panel_set_widget refused "unet_name" on node 12 (UNETLoader) after refreshing combo options: ` +
+      `Combo widget "unet_name" has an EMPTY option list; the server's option list may simply be stale — ` +
+      `refreshing it before deciding.`;
+    expect(parseEmptyPromotedComboRefusal(text, "unet_name")).toBeNull();
+  });
+
+  it("an unrelated failure is never this bug", () => {
+    expect(parseEmptyPromotedComboRefusal("No node with id 816 in the current graph", "choice")).toBeNull();
+    expect(parseEmptyPromotedComboRefusal(CONTRADICTORY, "width")).toBeNull();
+  });
+});
+
+describe("resolveInnerComboOptions", () => {
+  it("takes UNETLoader options from /object_info, not the subgraph UUID", () => {
+    const resolved = resolveInnerComboOptions(COMBO_SUBGRAPH, "unet_name", OBJECT_INFO);
+    expect(resolved).toMatchObject({
+      innerNodeId: 810,
+      widget: "unet_name",
+      innerType: "UNETLoader",
+      source: "object_info",
+    });
+    expect(resolved?.options).toEqual(["model.fp8.safetensors", "model.nvfp4.safetensors"]);
+    expect(comboValueIsListed("model.nvfp4.safetensors", resolved?.options ?? [])).toBe(true);
+    expect(comboValueIsListed("missing.safetensors", resolved?.options ?? [])).toBe(false);
+  });
+
+  it("falls back to the serialized options when the inner type is absent from /object_info", () => {
+    const resolved = resolveInnerComboOptions(COMBO_SUBGRAPH, "choice", OBJECT_INFO);
+    expect(resolved).toMatchObject({
+      innerNodeId: 801,
+      widget: "choice",
+      innerType: "CustomCombo",
+      source: "serialized",
+      options: ["Quality", "Default", "Turbo"],
+    });
+  });
+
+  it("does not guess when two inners share the widget name", () => {
+    expect(
+      resolveInnerComboOptions(
+        {
+          nodes: [
+            { id: 1, type: "UNETLoader", widgets: { unet_name: "a" } },
+            { id: 2, type: "UNETLoader", widgets: { unet_name: "b" } },
+          ],
+        },
+        "unet_name",
+        OBJECT_INFO,
+      ),
+    ).toBeNull();
+  });
+
+  it("V2 COMBO {options} specs are readable", () => {
+    expect(comboOptionsFromObjectInfo(OBJECT_INFO, "UNETLoader", "weight_dtype")).toEqual([
+      "default",
+      "fp8",
+      "fp16",
+    ]);
+  });
+});
+
+describe("panel_set_widget empty promoted combo (#1940)", () => {
+  it("the reporter's case: Default is a valid CustomCombo option, and the refusal is not 'stale'", async () => {
+    const { text, isError, calls } = await setEmptyComboWidget({
+      node_id: 816,
+      widget: "choice",
+      value: "Default",
+    });
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/subgraph UUID/i);
+    expect(text).toMatch(/CustomCombo node 801 "choice"/);
+    expect(text).toMatch(/IS a valid option/);
+    expect(text).not.toMatch(/may simply be stale/i);
+    expect(text).toMatch(/panel_refresh_nodes cannot fill it/);
+    expect(text).toMatch(/Do not panel_enter_subgraph/);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_get_object_info",
+    ]);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("a promoted unet_name swap is validated against the inner UNETLoader list", async () => {
+    const unetEmpty =
+      `panel_set_widget refused "unet_name" on node 816 (${SUBGRAPH_UUID}) after refreshing combo options: ` +
+      `Combo widget "unet_name" has an EMPTY option list; the server's option list may simply be stale — ` +
+      `refreshing it before deciding.`;
+    const { b, calls } = emptyComboBridge({});
+    const failing = {
+      ...(b as object),
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push({ ...cmd });
+        if (cmd.cmd === "graph_set_widget") throw new Error(unetEmpty);
+        if (cmd.cmd === "graph_get_subgraph") return COMBO_SUBGRAPH;
+        if (cmd.cmd === "graph_get_object_info") return { ok: true, object_info: OBJECT_INFO };
+        throw new Error("must not enter the subgraph for a link-driven promoted combo");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(failing, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!def) throw new Error("panel_set_widget is not registered");
+    const res = await def.handler(
+      { node_id: 816, widget: "unet_name", value: "model.nvfp4.safetensors" } as never,
+      ctx,
+    );
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/UNETLoader node 810 "unet_name"/);
+    expect(text).toMatch(/IS a valid option/);
+    expect(text).not.toMatch(/may simply be stale/i);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("an off-list value is refused against the inner options, not as a stale list", async () => {
+    const { text, isError, calls } = await setEmptyComboWidget({
+      node_id: 816,
+      widget: "choice",
+      value: "NotAMode",
+    });
+    expect(isError).toBe(true);
+    expect(text).toMatch(/not a valid option for the inner CustomCombo/);
+    expect(text).toMatch(/"Quality"/);
+    expect(text).toMatch(/"Default"/);
+    expect(text).toMatch(/"Turbo"/);
+    expect(text).not.toMatch(/may simply be stale/i);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("a healthy write is untouched", async () => {
+    const { isError, calls } = await setEmptyComboWidget(
+      { node_id: 3, widget: "steps", value: 20 },
+      { firstWrite: "ok" },
+    );
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+  });
+
+  it("a non-UUID empty combo is never recovered as this bug", async () => {
+    const backendEmpty =
+      `panel_set_widget refused "unet_name" on node 12 (UNETLoader) after refreshing combo options: ` +
+      `Combo widget "unet_name" has an EMPTY option list; the server's option list may simply be stale — ` +
+      `refreshing it before deciding.`;
+    const calls: Array<Record<string, unknown>> = [];
+    const failing = {
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push({ ...cmd });
+        throw new Error(backendEmpty);
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(failing, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!def) throw new Error("panel_set_widget is not registered");
+    const res = await def.handler(
+      { node_id: 12, widget: "unet_name", value: "model.nvfp4.safetensors" } as never,
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+  });
+
+  it("an unrelated failure is never recovered", async () => {
+    const { isError, calls } = await setEmptyComboWidget(
+      { node_id: 816, widget: "choice", value: "Default" },
+      { firstWrite: "other" },
+    );
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+  });
+
+  it("a truncated subgraph read is not treated as unique", async () => {
+    const { text, isError, calls } = await setEmptyComboWidget(
+      { node_id: 816, widget: "choice", value: "Default" },
+      { subgraph: { ...COMBO_SUBGRAPH, truncated: true } },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(/did not uniquely identify/);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -82,7 +82,11 @@ import {
   unionErrorFor,
 } from "./node-id.js";
 import {
+  comboValueIsListed,
+  formatComboOptionsPreview,
   parseContradictoryPromotedWidgetRefusal,
+  parseEmptyPromotedComboRefusal,
+  resolveInnerComboOptions,
   resolveInnerPromotedTarget,
 } from "./promoted-widget.js";
 import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
@@ -4093,6 +4097,124 @@ async function refuseAnimaRegionalPromptWrite(
   const type = parseQueriedNodeType(parseToolResultJson(probe));
   if (!type || !ANIMA_REGIONAL_CANVAS_TYPES.has(type)) return null;
   return animaRegionalPromptRefusal(type, widget);
+}
+
+function objectInfoFromToolResult(res: ToolResult): unknown {
+  const payload = parseToolResultJson(res);
+  if (!payload) return null;
+  return payload.object_info ?? payload;
+}
+
+/**
+ * #1940 — a promoted COMBO on a subgraph UUID is refused with an EMPTY option
+ * list "that may simply be stale". The legal values live on the inner node.
+ * Resolve that list from /object_info (or the serialized inner widget) and
+ * either refuse the VALUE against it, or replace the stale-list wording.
+ * Never enter the subgraph to write the inner widget: it is link-driven from
+ * the parent rail, so an inner write would report success over a value that
+ * does not serialize.
+ */
+async function recoverEmptyPromotedComboWrite(
+  first: ToolResult,
+  args: { node_id: unknown; widget: string; value: unknown },
+  ctx: PanelToolCtx,
+): Promise<ToolResult | null> {
+  const parsed = parseEmptyPromotedComboRefusal(textOfToolResult(first), args.widget);
+  if (!parsed || String(parsed.nodeId) !== String(args.node_id)) return null;
+
+  const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id });
+  if (sub.isError) {
+    return appendToolResultText(
+      first,
+      `\n\n(This node type ${parsed.type} is a subgraph UUID, which is absent from ` +
+        `/object_info by design — the empty combo list is not a stale cache, so ` +
+        `panel_refresh_nodes cannot fill it. Tried to resolve "${parsed.widget}" to the ` +
+        `inner node that owns it and graph_get_subgraph FAILED: ${textOfToolResult(sub)})`,
+    );
+  }
+
+  const infoRes = await ctx.call(
+    { cmd: "graph_get_object_info" },
+    OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+  );
+  const objectInfo = infoRes.isError ? null : objectInfoFromToolResult(infoRes);
+  const inner = resolveInnerComboOptions(
+    parseToolResultJson(sub),
+    parsed.widget,
+    objectInfo,
+  );
+  if (!inner) {
+    return appendToolResultText(
+      first,
+      `\n\n(This node type ${parsed.type} is a subgraph UUID, which is absent from ` +
+        `/object_info by design — the empty combo list is not a stale cache, so ` +
+        `panel_refresh_nodes cannot fill it. graph_get_subgraph did not uniquely ` +
+        `identify an inner node that owns "${parsed.widget}", so the value was not ` +
+        `checked against an inner option list — guessing among several inners, or ` +
+        `acting on a truncated inner list, would target the wrong node.)`,
+    );
+  }
+
+  const innerLabel =
+    inner.innerType != null
+      ? `${inner.innerType} node ${inner.innerNodeId} "${inner.widget}"`
+      : `inner node ${inner.innerNodeId} "${inner.widget}"`;
+  const listSource =
+    inner.source === "object_info"
+      ? "that node's /object_info"
+      : "the serialized inner widget";
+
+  if (Array.isArray(inner.options)) {
+    if (inner.options.length === 0) {
+      return fail(
+        `panel_set_widget refused "${parsed.widget}" on subgraph node ${parsed.nodeId}: ` +
+          `the inner ${innerLabel} has an EMPTY option list (${listSource}) — nothing is ` +
+          `installed for that combo, so ${JSON.stringify(args.value)} is not writable. ` +
+          `The subgraph type ${parsed.type} is absent from /object_info by design; this is ` +
+          `not a stale cache, and panel_refresh_nodes cannot help.`,
+      );
+    }
+    if (!comboValueIsListed(args.value, inner.options)) {
+      return fail(
+        `panel_set_widget refused "${parsed.widget}" on subgraph node ${parsed.nodeId}: ` +
+          `value ${JSON.stringify(args.value)} is not a valid option for the inner ${innerLabel} ` +
+          `(${inner.options.length} option${inner.options.length === 1 ? "" : "s"} from ` +
+          `${listSource}). The subgraph type ${parsed.type} is absent from /object_info by ` +
+          `design — this is not a stale list, and panel_refresh_nodes cannot help. Valid ` +
+          `options: ${formatComboOptionsPreview(inner.options)}.`,
+      );
+    }
+    return fail(
+      `panel_set_widget refused "${parsed.widget}" on subgraph node ${parsed.nodeId} ` +
+        `(${parsed.type}): Combo widget "${parsed.widget}" has an EMPTY option list because ` +
+        `this node's type is a subgraph UUID, which is absent from /object_info — not ` +
+        `because the server's list is stale. panel_refresh_nodes cannot fill it. ` +
+        `${JSON.stringify(args.value)} IS a valid option for the inner ${innerLabel} ` +
+        `(${inner.options.length} option${inner.options.length === 1 ? "" : "s"} from ` +
+        `${inner.source === "object_info" ? "/object_info" : "the serialized inner widget"}). ` +
+        `The write did not land. Do not panel_enter_subgraph to set the inner widget: it is ` +
+        `link-driven from this parent rail, so the parent value still wins at queue time.`,
+    );
+  }
+
+  const whyNone =
+    inner.innerType != null && (infoRes.isError || objectInfo == null)
+      ? `inner type ${inner.innerType} could not be looked up` +
+        (infoRes.isError ? ` (graph_get_object_info FAILED: ${textOfToolResult(infoRes)})` : "")
+      : inner.innerType != null
+        ? `inner type ${inner.innerType} is itself absent from /object_info (a frontend-only node) ` +
+          `and the serialized inner widget carried no options array`
+        : `the inner node has no type string and the serialized widget carried no options array`;
+
+  return fail(
+    `panel_set_widget refused "${parsed.widget}" on subgraph node ${parsed.nodeId} ` +
+      `(${parsed.type}): Combo widget "${parsed.widget}" has an EMPTY option list because ` +
+      `this node's type is a subgraph UUID, which is absent from /object_info — not ` +
+      `because the server's list is stale. panel_refresh_nodes cannot fill it. ` +
+      `Resolved "${parsed.widget}" to ${innerLabel}, but ${whyNone}, so the value ` +
+      `${JSON.stringify(args.value)} could not be checked against an inner option list. ` +
+      `The write did not land.`,
+  );
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -12680,7 +12802,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           textOfToolResult(first),
           args.widget as string,
         );
-        if (!refusal || String(refusal.nodeId) !== String(args.node_id)) return first;
+        if (!refusal || String(refusal.nodeId) !== String(args.node_id)) {
+          // #1940 — a promoted COMBO on a subgraph UUID is refused with an empty
+          // option list "that may simply be stale". Resolve the inner node's list
+          // instead; do not enter the subgraph (the inner widget is link-driven).
+          return (await recoverEmptyPromotedComboWrite(
+            first,
+            { node_id: args.node_id, widget: args.widget as string, value },
+            ctx,
+          )) ?? first;
+        }
 
         if (refusal.widget !== args.widget) {
           const remapped = await write(args.node_id, refusal.widget);

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -116,3 +116,261 @@ export function isContradictoryPromotedWidgetRefusal(
 ): boolean {
   return parseContradictoryPromotedWidgetRefusal(text, requestedWidget) != null;
 }
+
+// ---- #1940: empty combo on a subgraph UUID --------------------------------
+//
+// panel_set_widget on a subgraph instance's promoted COMBO is refused:
+//
+//   panel_set_widget refused "choice" on node 816 (<uuid>) after refreshing
+//   combo options: Combo widget "choice" has an EMPTY option list; the
+//   server's option list may simply be stale — refreshing it before deciding.
+//
+// The subgraph node's type is a UUID, which is never in /object_info. Combo
+// validation keys that UUID and gets []. The legal values live on the INNER
+// node (CustomCombo / UNETLoader / CLIPLoader). Refreshing cannot help.
+// Entering the subgraph and writing the inner widget is NOT equivalent: the
+// inner widget is link-driven from the parent rail, so the parent value still
+// wins at queue time.
+
+export type EmptyPromotedComboRefusal = {
+  nodeId: string;
+  widget: string;
+  type: string;
+};
+
+export type InnerComboOptionSource = "object_info" | "serialized" | "none";
+
+export type InnerComboOptions = {
+  innerNodeId: number | string;
+  widget: string;
+  innerType: string | null;
+  options: unknown[] | null;
+  source: InnerComboOptionSource;
+};
+
+const EMPTY_COMBO_RE =
+  /panel_set_widget refused "([^"]+)" on node (\S+) \(([^)]+)\)(?: after refreshing combo options)?: Combo widget "([^"]+)" has an EMPTY option list/i;
+
+const SUBGRAPH_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isSubgraphUuidType(type: string): boolean {
+  return SUBGRAPH_UUID_RE.test(type.trim());
+}
+
+/**
+ * Parse the empty-combo refusal that names a subgraph UUID type. Returns null
+ * unless the refused widget matches (when supplied) and the type is a UUID —
+ * a genuine empty list on a backend type (nothing installed) is left alone.
+ */
+export function parseEmptyPromotedComboRefusal(
+  text: string,
+  requestedWidget?: string,
+): EmptyPromotedComboRefusal | null {
+  const m = EMPTY_COMBO_RE.exec(text);
+  if (!m) return null;
+  const widget = m[1];
+  const comboWidget = m[4];
+  if (widget !== comboWidget) return null;
+  if (requestedWidget != null && requestedWidget !== widget && requestedWidget.toLowerCase() !== widget.toLowerCase()) {
+    return null;
+  }
+  const type = m[3].trim();
+  if (!isSubgraphUuidType(type)) return null;
+  return { nodeId: m[2].replace(/[,:]$/, ""), widget, type };
+}
+
+/** Combo option list from an /object_info input spec, or null when it is not a combo. */
+export function comboOptionsFromInputSpec(spec: unknown): unknown[] | null {
+  if (!Array.isArray(spec) || spec.length === 0) return null;
+  const type = spec[0];
+  if (Array.isArray(type)) return type;
+  if (typeof type !== "string") return null;
+  const cfg = spec[1];
+  if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) return null;
+  const opts = (cfg as { options?: unknown }).options;
+  if (!Array.isArray(opts)) return null;
+  return opts.map((o) =>
+    o && typeof o === "object" && !Array.isArray(o) && "key" in (o as Record<string, unknown>)
+      ? (o as { key: unknown }).key
+      : o,
+  );
+}
+
+function inputSpecsOf(def: unknown): Record<string, unknown> | null {
+  if (!def || typeof def !== "object" || Array.isArray(def)) return null;
+  const input = (def as { input?: unknown }).input;
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  const rec = input as { required?: unknown; optional?: unknown };
+  const required =
+    rec.required && typeof rec.required === "object" && !Array.isArray(rec.required)
+      ? (rec.required as Record<string, unknown>)
+      : {};
+  const optional =
+    rec.optional && typeof rec.optional === "object" && !Array.isArray(rec.optional)
+      ? (rec.optional as Record<string, unknown>)
+      : {};
+  return { ...required, ...optional };
+}
+
+export function comboOptionsFromObjectInfo(
+  objectInfo: unknown,
+  classType: string,
+  widgetName: string,
+): unknown[] | null {
+  if (!objectInfo || typeof objectInfo !== "object" || Array.isArray(objectInfo)) return null;
+  const def = (objectInfo as Record<string, unknown>)[classType];
+  const specs = inputSpecsOf(def);
+  if (!specs) return null;
+  const matched = matchListedName(widgetName, Object.keys(specs));
+  if (!matched) return null;
+  return comboOptionsFromInputSpec(specs[matched]);
+}
+
+function asOptionList(raw: unknown): unknown[] | null {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const values = (raw as { values?: unknown }).values;
+    if (Array.isArray(values)) return values;
+    const options = (raw as { options?: unknown }).options;
+    if (Array.isArray(options)) return options;
+  }
+  return null;
+}
+
+/**
+ * Combo options carried on a serialized inner node. graph_get_subgraph's usual
+ * summary is name→value only; when a payload DOES include an options array
+ * (widget_options, a widget object, or a widgets[] row) that is the fallback
+ * for a frontend-only inner type with no /object_info entry.
+ */
+export function comboOptionsFromSerializedNode(
+  node: Record<string, unknown>,
+  widgetName: string,
+): unknown[] | null {
+  const named = (bag: unknown): unknown[] | null => {
+    if (!bag || typeof bag !== "object" || Array.isArray(bag)) return null;
+    const rec = bag as Record<string, unknown>;
+    const matched = matchListedName(widgetName, Object.keys(rec));
+    return matched ? asOptionList(rec[matched]) : null;
+  };
+
+  const fromNamed = named(node.widget_options) ?? named(node.widgets);
+  if (fromNamed) return fromNamed;
+
+  const widgets = node.widgets;
+  if (Array.isArray(widgets)) {
+    for (const raw of widgets) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+      const row = raw as Record<string, unknown>;
+      if (typeof row.name !== "string" || matchListedName(widgetName, [row.name]) == null) continue;
+      return asOptionList(row.options) ?? asOptionList(row);
+    }
+  }
+  return null;
+}
+
+export function comboValueIsListed(value: unknown, options: readonly unknown[]): boolean {
+  if (options.includes(value as never)) return true;
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+    return false;
+  }
+  const label = String(value);
+  return options.some(
+    (o) =>
+      (typeof o === "string" || typeof o === "number" || typeof o === "boolean") &&
+      String(o) === label,
+  );
+}
+
+function innerTypeOf(node: Record<string, unknown>): string | null {
+  const t = node.type ?? node.class_type;
+  return typeof t === "string" && t.trim() !== "" ? t : null;
+}
+
+function uniqueInnerNode(
+  subgraph: Record<string, unknown> | null | undefined,
+  displayedWidget: string,
+): { innerNodeId: number | string; widget: string; node: Record<string, unknown> } | null {
+  if (!subgraph || typeof subgraph !== "object") return null;
+  if (subgraph.truncated === true) return null;
+  const nodes = subgraph.nodes;
+  if (!Array.isArray(nodes)) return null;
+
+  const hits: { innerNodeId: number | string; widget: string; node: Record<string, unknown> }[] =
+    [];
+  for (const raw of nodes) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const node = raw as Record<string, unknown>;
+    const id = innerNodeId(node);
+    if (id == null) continue;
+    const names = [
+      ...widgetNamesOnInner(node),
+      ...(node.widget_options && typeof node.widget_options === "object" && !Array.isArray(node.widget_options)
+        ? Object.keys(node.widget_options as Record<string, unknown>).filter((n) => n.length > 0)
+        : []),
+      ...(Array.isArray(node.widgets)
+        ? (node.widgets as unknown[])
+            .map((w) =>
+              w && typeof w === "object" && !Array.isArray(w) && typeof (w as { name?: unknown }).name === "string"
+                ? (w as { name: string }).name
+                : "",
+            )
+            .filter((n) => n.length > 0)
+        : []),
+    ];
+    const matched = matchListedName(displayedWidget, names);
+    if (matched) hits.push({ innerNodeId: id, widget: matched, node });
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+/**
+ * Resolve a promoted combo's option list from the unique inner node.
+ * Prefer /object_info of that inner type; if the type is absent (frontend-only),
+ * fall back to the serialized node's own options array.
+ */
+export function resolveInnerComboOptions(
+  subgraph: Record<string, unknown> | null | undefined,
+  displayedWidget: string,
+  objectInfo: unknown,
+): InnerComboOptions | null {
+  const hit = uniqueInnerNode(subgraph, displayedWidget);
+  if (!hit) return null;
+  const innerType = innerTypeOf(hit.node);
+  const fromInfo =
+    innerType != null ? comboOptionsFromObjectInfo(objectInfo, innerType, hit.widget) : null;
+  // A returned array — including [] — is the server's list for this input. []
+  // means nothing is installed, not "we could not look it up".
+  if (fromInfo != null) {
+    return {
+      innerNodeId: hit.innerNodeId,
+      widget: hit.widget,
+      innerType,
+      options: fromInfo,
+      source: "object_info",
+    };
+  }
+  const serialized = comboOptionsFromSerializedNode(hit.node, hit.widget);
+  if (serialized != null) {
+    return {
+      innerNodeId: hit.innerNodeId,
+      widget: hit.widget,
+      innerType,
+      options: serialized,
+      source: "serialized",
+    };
+  }
+  return {
+    innerNodeId: hit.innerNodeId,
+    widget: hit.widget,
+    innerType,
+    options: null,
+    source: "none",
+  };
+}
+
+export function formatComboOptionsPreview(options: readonly unknown[], limit = 40): string {
+  const preview = options.slice(0, limit).map((o) => JSON.stringify(o)).join(", ");
+  return options.length > limit ? `${preview}, …` : preview;
+}


### PR DESCRIPTION
Fixes #1940

`panel_set_widget` on a subgraph instance's promoted COMBO was refused with an empty option list "that may simply be stale". The subgraph node's type is a UUID, which is never in `/object_info`, so a refresh cannot fill the list. The legal values live on the inner node (`CustomCombo` / `UNETLoader` / `CLIPLoader`).

After the panel's empty-list refusal, `panel_set_widget` now:

- resolves the unique inner node that owns the widget (`graph_get_subgraph`)
- reads that inner type's combo options from `/object_info`, or falls back to the serialized inner widget's own `options` array when the type is frontend-only
- refuses an off-list value against that inner list
- names the inner type and that this is not a stale cache when the value *is* listed — `panel_refresh_nodes` cannot help, and `panel_enter_subgraph` to set the inner widget is not equivalent (the inner widget is link-driven from the parent rail)

The parent-rail write is still refused by the live combo validator (empty `options.values` on the promoted widget). This change stops the stale-refresh loop and fail-closes against the inner node's real list instead of treating a structurally absent type as a cache miss.

Tests drive the shipped `panel_set_widget` handler.
