### PR TITLE
fix(1327): a completion QUEUED onto an agent is not one the agent has READ

### DIFF
--- a/src/__tests__/orchestrator/run-completion-queued-not-read.test.ts
+++ b/src/__tests__/orchestrator/run-completion-queued-not-read.test.ts
@@ -135,6 +135,37 @@ describe("a completion that beat its ticket is claimed even once QUEUED (#1327)"
     expect(text.split("A run on the user's canvas just finished").length - 1).toBe(1);
     await agent.stop?.();
   });
+
+  it("a REOPENED ticket re-delivers the completion it pulled back, never swallows it", async () => {
+    // openRun has two branches and the claim runs on BOTH. This is the reopen one: a
+    // prompt id whose ticket still exists — ComfyUI reuses ids, and a `retry_of`
+    // dispatch that the panel dedupes returns the SAME id — hit by the same fast
+    // cached render, so the completion is queued to the agent before the reply comes
+    // back and opens the ticket again.
+    //
+    // The entry is already `matched` here, so nothing about the VERDICT changes. What
+    // changes is that the claim pulls the queued copy off the agent to rebind it to
+    // the new generation — and if the reopen branch forgets to re-deliver it, the
+    // agent is left with no completion at all. That is a silent LOSS, strictly worse
+    // than the wrong wording this whole file is about, and it is invisible to any
+    // assertion that only reads the journal.
+    const journal = new RunCompletionJournalImpl();
+    const { agent, backend } = startAgent(TAB);
+    const flush = wire(journal, agent);
+
+    // An earlier dispatch already ticketed this id.
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt: Date.now() - 60_000 });
+
+    // The re-dispatch, and its render beating the reply back.
+    const dispatchedAt = Date.now();
+    journal.record(TAB, FRAME as never, { conversation: CONV });
+    expect(flush(TAB).delivered).toBe(1);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 149, dispatchedAt });
+
+    await vi.waitFor(() => expect(backend.allText()).toContain("ComfyUI_00149_.png"));
+    expect(backend.allText()).toContain("A run on the user's canvas just finished");
+    await agent.stop?.();
+  });
 });
 
 describe("…and UNDETERMINED still fires when it should (#1327)", () => {

--- a/src/__tests__/orchestrator/run-completion-queued-not-read.test.ts
+++ b/src/__tests__/orchestrator/run-completion-queued-not-read.test.ts
@@ -1,0 +1,251 @@
+// #1327, SECOND RECURRENCE — reported 2026-08-21 on comfyui-mcp 0.52.25 / panel
+// 0.15.22, thirteen releases after the previous fix (#1618, v0.51.57) shipped.
+//
+//   panel_run(to_node_id: 149) returned prompt ba60be81-…; its delayed re-delivery
+//   carried the identical id but said it did not match a queued run and marked the
+//   origin UNDETERMINED. get_history confirmed success and output node 149.
+//
+// #1618 IS A FIX PRODUCTION NEVER REACHED, and its own tests are why nobody saw it.
+// It moved the claim guard from `attempts` to `handoffs` on the stated premise that
+// the arrival flush is REFUSED — "the agent is busy inside the very panel_run call
+// whose reply has not come back yet" — and it PINNED that premise by hard-coding the
+// refusal in the test: `journal.deliverPending(TAB, () => false)`.
+//
+// The real `PanelAgent.injectEvent` has no busy check. It refuses only for an agent
+// that is missing, stopped, or handed a payload it cannot compose text for. For the
+// ordinary via-panel session the agent exists and is mid-turn, so the flush TAKES the
+// completion and returns true — `handoffs` is 1 before `openRun` ever runs, and the
+// claim is skipped on precisely the race it exists to repair. Both counters are 1 at
+// that instant, so swapping one for the other changed nothing on the live path.
+//
+// These tests drive the REAL PanelAgent and the REAL revoker wiring, so the premise
+// cannot be assumed again — it is measured here (see the BASELINE test), and every
+// verdict below is the one an agent would actually be shown.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { PanelAgent } from "../../orchestrator/panel-agent.js";
+import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
+import { makeCaptureBackend } from "./helpers/capture-backend.js";
+
+const TAB = "wf:workflows/a.json";
+const CONV = "conv-1";
+const PID = "ba60be81-a4a3-4406-b1d7-56cf571cd72b";
+
+/** The panel's real `executed` frame for the reporter's run. */
+const FRAME = {
+  kind: "executed",
+  prompt_id: PID,
+  duration_s: 0.1,
+  images: [{ filename: "ComfyUI_00149_.png" }],
+};
+
+function startAgent(tabId: string) {
+  const backend = makeCaptureBackend();
+  const agent = new PanelAgent(
+    tabId,
+    { mcpServers: {}, systemAppend: "", model: "m" } as never,
+    backend,
+  );
+  void agent.start();
+  return { agent, backend };
+}
+
+/**
+ * The orchestrator's own wiring, verbatim in shape: `flushRunCompletions` injects
+ * into the tab's agent, and `setRevoker` is given BOTH the revoke and the reflush
+ * (index.ts). Tests that skip the revoker are testing a journal production does not
+ * run — which is exactly how the previous fix passed while dormant.
+ */
+function wire(journal: RunCompletionJournalImpl, agent: PanelAgent) {
+  const flush = (key: string) =>
+    journal.deliverPending(key, (payload, token) =>
+      agent.injectEvent(payload as never, { eventToken: token }),
+    );
+  journal.setRevoker(
+    (_key, token) => agent.revokeEvent(token),
+    (key) => void flush(key),
+  );
+  return flush;
+}
+
+describe("the premise the previous fix rested on, MEASURED (#1327)", () => {
+  it("the arrival flush is TAKEN by a live agent — idle AND mid-turn", async () => {
+    const { agent } = startAgent(TAB);
+
+    const idle = agent.injectEvent({ ...FRAME } as never, { eventToken: "tok-idle" });
+    // …and now with a turn genuinely in flight, which is the state #1618 assumed
+    // would refuse.
+    agent.send("render it" as never);
+    expect(agent.isBusy).toBe(true);
+    const midTurn = agent.injectEvent({ ...FRAME } as never, { eventToken: "tok-busy" });
+
+    // THE DEFECT'S ROOT: both are hand-offs, so `handoffs > 0` was true before
+    // `openRun` ran. Neither of these is a refusal.
+    expect(idle).toBe(true);
+    expect(midTurn).toBe(true);
+    await agent.stop?.();
+  });
+});
+
+describe("a completion that beat its ticket is claimed even once QUEUED (#1327)", () => {
+  it("the reporter's sequence, end to end, through the real agent", async () => {
+    const journal = new RunCompletionJournalImpl();
+    const { agent, backend } = startAgent(TAB);
+    const flush = wire(journal, agent);
+    agent.send("render it" as never); // the turn sitting inside panel_run
+
+    const dispatchedAt = Date.now();
+    // The 0.1s cached render beats its own /prompt reply: index.ts records, then
+    // flushes immediately — and the live agent TAKES it.
+    journal.record(TAB, FRAME as never, { conversation: CONV });
+    const arrival = flush(TAB);
+    expect(arrival.delivered).toBe(1); // taken, not refused — the production ordering
+    expect(arrival.blockedOn).toBeNull();
+
+    // …and only now does the /prompt reply come back and open the ticket.
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 149, dispatchedAt });
+
+    const entry = journal.allOutstanding()[0];
+    // THE RECURRENCE: this was `foreign` — the reporter's "origin is UNDETERMINED".
+    expect(entry?.correlation.status).toBe("matched");
+    // …and the second-order harm #1618 also claimed to fix was back with it: the
+    // already-journaled entry made the fresh ticket `reused`, so EVERY later
+    // completion for the run read UNDETERMINED too.
+    expect((journal.ticketFor(PID) as { reused?: boolean } | undefined)?.reused ?? false).toBe(
+      false,
+    );
+
+    // AND THE AGENT MUST ACTUALLY HAVE IT. Revoking without re-delivering would
+    // replace a wrong verdict with no verdict at all — strictly worse. This is the
+    // assertion that fails if `reissueClaimed` is deleted from the call site.
+    // Asserted on CONTENT, not on a turn count: the agent batches everything queued
+    // into one turn, so the completion may ride the same turn as the user message.
+    // (Also NOT backend.waitForTurns() — that helper re-queues its own waiter from
+    // inside the backend's drain loop and spins the event loop forever when it is
+    // asked for a count the backend has not reached yet.)
+    await vi.waitFor(() =>
+      expect(backend.allText()).toContain("This is the run YOU queued with panel_run"),
+    );
+    const text = backend.allText();
+    expect(text).toContain("This is the run YOU queued with panel_run");
+    expect(text).toContain("ComfyUI_00149_.png");
+    expect(text).not.toContain("does NOT match any run you queued");
+    // Exactly one completion reached it — the revoked copy never did.
+    expect(text.split("A run on the user's canvas just finished").length - 1).toBe(1);
+    await agent.stop?.();
+  });
+});
+
+describe("…and UNDETERMINED still fires when it should (#1327)", () => {
+  it("a verdict the carrying turn ALREADY READ is never rewritten under it", async () => {
+    // The guard's whole reason for existing. Once the injected item has been dequeued
+    // into a running turn the text is in the model's context and cannot be recalled —
+    // `revokeEvent` says so by returning false, and the claim must respect it.
+    const journal = new RunCompletionJournalImpl();
+    const { agent, backend } = startAgent(TAB);
+    const flush = wire(journal, agent);
+
+    const dispatchedAt = Date.now();
+    journal.record(TAB, FRAME as never, { conversation: CONV });
+    expect(flush(TAB).delivered).toBe(1);
+    // The agent DRAINS it — the turn carrying the foreign wording has now started.
+    await vi.waitFor(() => expect(backend.turns.length).toBe(1));
+    expect(backend.allText()).toContain("does NOT match any run you queued");
+
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 149, dispatchedAt });
+
+    const entry = journal.allOutstanding()[0];
+    expect(entry?.correlation.status).toBe("foreign");
+    await agent.stop?.();
+  });
+
+  it("a completion from BEFORE the dispatch is not claimed — and not even pulled back", async () => {
+    // The over-broad direction, and the one that matters most: an id genuinely reused
+    // by ComfyUI carries a completion that predates this dispatch. Claiming it would
+    // attribute an older run's result to a new one, which is worse than the bug.
+    //
+    // The entry here IS revocable (queued, unread), so only the timing proof refuses
+    // it — and the revoke must never have been attempted, or a completion would be
+    // yanked off an agent's queue for a claim that is then rejected.
+    const journal = new RunCompletionJournalImpl();
+    const { agent } = startAgent(TAB);
+    const flush = wire(journal, agent);
+
+    journal.record(TAB, { ...FRAME, duration_s: 9 } as never, { conversation: CONV });
+    expect(flush(TAB).delivered).toBe(1);
+    const token = journal.allOutstanding()[0]?.token as string;
+
+    // The dispatch happens AFTER that arrival.
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt: Date.now() + 5_000 });
+
+    expect(journal.allOutstanding()[0]?.correlation.status).toBe("foreign");
+    // Still sitting on the agent's queue, untouched: a successful revoke here proves
+    // the claim never reached for it.
+    expect(agent.revokeEvent(token)).toBe(true);
+    await agent.stop?.();
+  });
+
+  it("another party's completion is not claimed, however revocable it is", async () => {
+    const journal = new RunCompletionJournalImpl();
+    const { agent } = startAgent("wf:other.json");
+    const flush = wire(journal, agent);
+
+    const dispatchedAt = Date.now();
+    journal.record("wf:other.json", FRAME as never, { conversation: "conv-2" });
+    expect(flush("wf:other.json").delivered).toBe(1);
+
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    expect(journal.allOutstanding()[0]?.correlation.status).toBe("foreign");
+    await agent.stop?.();
+  });
+
+  it("an ID-LESS completion is never claimed, queued or not", async () => {
+    const journal = new RunCompletionJournalImpl();
+    const { agent } = startAgent(TAB);
+    const flush = wire(journal, agent);
+
+    const dispatchedAt = Date.now();
+    journal.record(TAB, { kind: "executed", images: [{ filename: "x.png" }] } as never, {
+      conversation: CONV,
+    });
+    expect(flush(TAB).delivered).toBe(1);
+
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    expect(journal.allOutstanding()[0]?.correlation.status).toBe("unidentified");
+    await agent.stop?.();
+  });
+
+  it("with NO revoker installed a handed-off entry is left exactly as before", () => {
+    // Fail-closed: a journal that cannot ask the agent anything must not assume the
+    // answer. (This is also every bare-journal caller in the rest of the suite.)
+    const journal = new RunCompletionJournalImpl();
+    const dispatchedAt = Date.now();
+    journal.record(TAB, FRAME as never, { conversation: CONV });
+    journal.deliverPending(TAB, () => true); // taken, and unrevocable
+    journal.release(journal.allOutstanding()[0]?.token as string, { carried: true });
+
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    expect(journal.allOutstanding()[0]?.correlation.status).toBe("foreign");
+  });
+});
+
+describe("WIRING: the claim depends on a revoker the orchestrator actually installs", () => {
+  it("index.ts gives setRevoker BOTH a revoke and a reflush", async () => {
+    // `stillUnread` can only pull an entry back if production installed the revoker,
+    // and `reissueClaimed` can only re-deliver it if production installed the REFLUSH.
+    // Drop either argument and the fix goes dormant with every unit test still green —
+    // which is the exact failure mode #1618 shipped with.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+
+    const at = src.indexOf("RunCompletions.setRevoker(");
+    expect(at).toBeGreaterThan(-1);
+    const call = src.slice(at, src.indexOf(");", at));
+    expect(call).toContain("manager.revokeEvent(");
+    expect(call).toContain("flushRunCompletions(");
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -165,21 +165,34 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
 //
 // The fix above was real but only reachable in the ordering ITS OWN TESTS used. The
 // orchestrator flushes the journal the instant a completion arrives (index.ts:
-// `record(...)` then `flushRunCompletions(...)`), and at that instant the agent is
-// still inside the `panel_run` tool call that queued the render — so the offer is
-// REFUSED. Refused or not, it counted an `attempts`, and `claimRaced` skipped any
-// entry with attempts > 0. The guard therefore fired on precisely the race it was
+// `record(...)` then `flushRunCompletions(...)`), so the offer is made before the
+// ticket exists. Refused or not, it counted an `attempts`, and `claimRaced` skipped
+// any entry with attempts > 0. The guard therefore fired on precisely the race it was
 // written to repair:
 //
-//   record → flush REFUSED (attempts=1, nobody told) → openRun → claim SKIPPED
+//   record -> flush (attempts=1) -> openRun -> claim SKIPPED
 //
 // `attempts` counts OFFERS; only a taken hand-off tells an agent anything.
+//
+// READ THIS BEFORE TRUSTING THE `() => false` BELOW (#1327, third occurrence).
+// This block used to assert that the arrival offer is REFUSED because "the agent is
+// busy inside the very panel_run call whose reply has not come back yet", and the
+// tests in this describe hard-code that refusal. MEASURED against the real
+// PanelAgent, it is not true: `injectEvent` has no busy check, and refuses only for
+// an agent that is missing, stopped, or handed a payload it cannot compose text for.
+// For an ordinary via-panel session the offer is TAKEN, so `handoffs` was 1 before
+// openRun ran and this fix was dormant on the live path for thirteen releases.
+// The refusal below is still a REAL case (no agent, or a stopped one) and these tests
+// keep covering it -- it is simply not the common one. The taken-offer path, driven
+// against the real agent rather than a stub, lives in
+// run-completion-queued-not-read.test.ts.
 describe("the recurrence: a refused offer is not a verdict anyone was told (#1327)", () => {
   it("the production ordering — arrival flush cannot hand off, THEN openRun", () => {
     const dispatchedAt = Date.now();
     journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, { conversation: CONV });
-    // flushRunCompletions fires here, and injectEvent refuses: the agent is busy
-    // inside the very panel_run call whose reply has not come back yet.
+    // flushRunCompletions fires here and finds nobody able to take it -- an agent
+    // that is missing or stopped, which is what injectEvent actually refuses on. (The
+    // BUSY case does NOT refuse; see the note above this describe.)
     const refused = journal.deliverPending(TAB, () => false);
     expect(refused.delivered).toBe(0);
     expect(refused.blockedOn).not.toBeNull(); // it really was offered and refused

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -402,6 +402,22 @@ export class RunCompletionJournalImpl {
   }
 
   /**
+   * Re-deliver the entries `stillUnread` pulled back off an agent's queue (#1327).
+   *
+   * Called only from `openRun`, and only AFTER `bindClaimed` — the entry is not fully
+   * this run's until it carries the ticket's generation, and re-queueing it at
+   * generation 0 would leave `ack()` unable to prove it, so a later resend of the same
+   * frame would arrive looking like a second render.
+   *
+   * A revoked entry left merely `pending` would sit there until some unrelated later
+   * flush, which for a run whose turn is ending right now means the agent simply never
+   * sees its own render — strictly worse than the wrong verdict this is correcting.
+   */
+  private reissueClaimed(keys: Set<string>): void {
+    for (const key of keys) this.reflush?.(key);
+  }
+
+  /**
    * A NEW run has taken over `promptId`, so every completion already journaled
    * under it belongs to an OLDER run. Retire them: superseded (so they can never
    * be merged into, settle a ticket, or memoize a delivery), downgraded from
@@ -466,31 +482,13 @@ export class RunCompletionJournalImpl {
   private claimRaced(
     promptId: string,
     meta: { tabId: string; conversation?: string; dispatchedAt?: number },
-  ): Set<JournalEntry> {
+  ): { claimed: Set<JournalEntry>; reissue: Set<string> } {
     const claimed = new Set<JournalEntry>();
+    /** Keys whose queued copy was pulled back and must now be re-delivered. */
+    const reissue = new Set<string>();
     // No dispatch time means no proof — do nothing rather than guess.
-    if (typeof meta.dispatchedAt !== "number") return claimed;
+    if (typeof meta.dispatchedAt !== "number") return { claimed, reissue };
     for (const entry of this.entries.values()) {
-      // NOBODY HAS BEEN TOLD YET is the real condition, and only `handoffs` says so.
-      //
-      // Not `state`: a released entry (handed to an agent whose turn ended without an
-      // ack) goes back to `pending`, so a state check would silently re-stamp a verdict
-      // an agent had already been given.
-      //
-      // And NOT `attempts`, which is what this guard used to read — the recurrence of
-      // #1327. The orchestrator flushes the journal the moment a completion arrives, so
-      // a render that beats its own /prompt reply is offered to an agent still sitting
-      // inside the `panel_run` call that queued it. That offer is REFUSED, which tells
-      // the agent nothing at all, but it still counted an attempt — so this guard fired
-      // on the exact race it exists to repair, and the reporter got their own render
-      // back as "RE-DELIVERED … origin is UNDETERMINED" a second time.
-      //
-      // A refused offer reached nobody; only a TAKEN one commits a verdict to an agent.
-      if (entry.handoffs > 0) continue;
-      // Subsumed by the line above today (every non-pending state is reached through a
-      // taken hand-off), and kept because it can only ever REFUSE a claim: a future
-      // state that arrives without one would otherwise be claimed by default.
-      if (entry.state !== "pending") continue;
       // An ID-LESS completion carries no run identity at all, so nothing can prove it
       // belongs here — it stays unidentified rather than being claimed on timing alone.
       if (entry.correlation.status === "unidentified") continue;
@@ -502,6 +500,11 @@ export class RunCompletionJournalImpl {
         entry.key === meta.tabId ||
         (meta.conversation !== undefined && entry.conversation === meta.conversation);
       if (!sameParty) continue;
+      // NOBODY HAS BEEN TOLD YET — see stillUnread. Asked LAST, deliberately: it is
+      // the only guard with a side effect (it un-queues the entry), and every check
+      // above is a cheap pure refusal. Nothing is ever pulled back off an agent for a
+      // claim that is then rejected on other grounds.
+      if (!this.stillUnread(entry, reissue)) continue;
       claimed.add(entry);
       if (entry.correlation.status === "matched") continue;
       entry.correlation = { status: "matched", promptId };
@@ -510,7 +513,60 @@ export class RunCompletionJournalImpl {
         `[run-completions] prompt ${promptId} completed before its ticket existed (a fast/cached run) — the journaled completion is re-attributed to the run that produced it instead of being reported as foreign`,
       );
     }
-    return claimed;
+    return { claimed, reissue };
+  }
+
+  /**
+   * Has this entry's verdict actually REACHED an agent yet? (#1327, second recurrence.)
+   *
+   * QUEUED IS NOT READ, and conflating the two is what let this defect come back.
+   * The guard here used to be `handoffs > 0` — "an agent TOOK this onto its queue" —
+   * resting on the stated premise that the arrival flush is REFUSED while the agent
+   * sits inside the `panel_run` call that queued the render. MEASURED against the
+   * real `PanelAgent`, that premise is false: `injectEvent` has no busy check at all.
+   * It refuses only for an agent that is missing, stopped, or handed a payload it
+   * cannot compose text for — so for the ordinary via-panel session (an agent that
+   * exists and is mid-turn) the flush TAKES the completion and returns true.
+   * `handoffs` was therefore already 1 when `openRun` ran, the claim was skipped on
+   * precisely the race it exists to repair, and the reporter got their own render
+   * back as "does NOT match any run you queued". The previous fix swapped `attempts`
+   * for `handoffs`, but on the real path BOTH are 1 at that instant, so the swap
+   * changed nothing production reaches — its tests passed by hard-coding a refusal
+   * (`deliverPending(TAB, () => false)`) that the live agent does not perform.
+   *
+   * The honest question was never "was it handed over" but "has the agent READ it",
+   * and this journal already owns the only thing that can answer it: the revoker
+   * (#468). `revokeEvent` splices the injected item out of the agent's queue and
+   * returns false the moment that item has been dequeued into a running turn — i.e.
+   * once the text is in the model's context and can no longer be recalled. A
+   * successful revoke IS the proof that nobody has been told.
+   *
+   * Fail-closed in every direction that matters:
+   *   - no revoker installed (a bare journal, a unit test) => a handed-off entry is
+   *     left exactly as it is today;
+   *   - the carrying turn already started, or the agent is gone => revoke returns
+   *     false, and a verdict an agent was actually given is never rewritten under it;
+   *   - nothing here widens WHICH completions may be claimed. Every ownership and
+   *     timing proof above is untouched, so a completion that is genuinely
+   *     unattributable is still reported UNDETERMINED.
+   *
+   * A revoked entry is off the agent's queue, so its key is recorded for the caller
+   * to re-deliver. That re-delivery is deliberately NOT done here: the claim is only
+   * half-applied until `bindClaimed` has given the entry the ticket's generation, and
+   * re-queueing at generation 0 would resurrect the ack/settle defect that made a
+   * later resend look like a second render.
+   */
+  private stillUnread(entry: JournalEntry, reissue: Set<string>): boolean {
+    // Never offered, or offered and refused: no agent ever took the text.
+    if (entry.handoffs === 0 && entry.state === "pending") return true;
+    // Taken onto a queue. Only the agent can say whether it has since been read.
+    if (!this.revoke?.(entry.key, entry.token)) return false;
+    entry.state = "pending";
+    reissue.add(entry.key);
+    logger.info(
+      `[run-completions] pulled a queued completion back off its agent before the carrying turn read it — it can be re-delivered as the run that produced it`,
+    );
+    return true;
   }
 
   /**
@@ -592,7 +648,7 @@ export class RunCompletionJournalImpl {
     // dispatch created it, so a completion carrying it that arrived at/after that
     // moment is necessarily this run's. Entries older than the dispatch are a genuinely
     // reused id and keep the existing ambiguity handling.
-    const claimed = this.claimRaced(promptId, meta);
+    const { claimed, reissue } = this.claimRaced(promptId, meta);
     // NOTE: no memo clearing is needed here. The delivered memo is keyed by
     // ticket GENERATION, and every path below either bumps the generation (a
     // reopen) or mints a fresh one (a new ticket), so a newly queued run's memo
@@ -619,6 +675,7 @@ export class RunCompletionJournalImpl {
       existing.reused = true;
       this.bindClaimed(claimed, existing.seq);
       this.retireOlderEntriesFor(promptId, claimed);
+      this.reissueClaimed(reissue);
       return true;
     }
     // A FRESH ticket is only a fresh IDENTITY if this tab has no history for the
@@ -656,6 +713,7 @@ export class RunCompletionJournalImpl {
     // this, an older `matched` entry survives untouched and goes on telling the
     // agent "this is the run YOU queued" for the id now outstanding.
     this.retireOlderEntriesFor(promptId, claimed);
+    this.reissueClaimed(reissue);
     this.trimTickets();
     return true;
   }


### PR DESCRIPTION
Fixes #1327

**Review is PENDING** — grok requested in a comment below. Not gated, not reviewed, no verdict claimed.

## The report, and why the version answer did not close it

The recurrence (2026-08-21T02:23Z) is on comfyui-mcp **0.52.25** / panel **0.15.22**:

> `panel_run(to_node_id=149)` returned prompt `ba60be81-a4a3-4406-b1d7-56cf571cd72b`; its delayed re-delivery carried the identical id but said it did not match a queued run and marked the origin UNDETERMINED. `get_history` confirmed success and output node 149.

First question was whether they simply lacked the fix. They did not:

- #1618 (`55272af`) shipped in **v0.51.57** — `git tag --contains 55272af --sort=v:refname | head -1`.
- #1791 (`ef8ed62`), the only other commit to `run-completion-journal.ts` since, shipped in **v0.52.11**.
- Nothing since v0.52.25 touches the journal at all.

So the reporter had both fixes. This is a genuine third occurrence, not a stale client.

## The mechanism — established by execution, not by reading

**#1618 is a real fix that production never reaches, and its own tests are why nobody saw it.**

It moved `claimRaced`'s guard from `attempts` to `handoffs` on a stated premise:

> the orchestrator flushes the journal the instant a completion arrives, and at that instant the agent is still sitting inside the `panel_run` call whose `/prompt` reply has not come back yet. So the completion is offered to an agent that cannot take it, and the offer is **refused**.

and it pinned that premise in the test by hard-coding the refusal:

```js
const refused = journal.deliverPending(TAB, () => false);
```

Measured against the real `PanelAgent`, the premise is false. `injectEvent` has **no busy check**. It refuses only when the agent is missing, stopped, or handed a payload it cannot compose text for:

```js
if (this.closed) return false;
...
if (!text) return false;
this.busy = true;
this.queue.push({ ... });
return true;
```

So for an ordinary via-panel session — an agent that exists and is mid-turn, which is exactly the reporter's configuration — the arrival flush **TAKES** the completion and returns `true`.

Driving the real agent through the real journal on current `main`:

```
isBusy=true   injectEvent(idle)=true   injectEvent(mid-turn)=true
arrival flush: delivered=1 blockedOn=no          <- taken, not refused
re-delivery:   {"c":"foreign","prior":false,"replayed":true}   <- the reporter's exact verdict
ticket.reused = true                              <- and the second-order harm is back too
```

`handoffs` was already 1 when `openRun` ran, so `if (entry.handoffs > 0) continue;` skipped the claim on precisely the race it exists to repair. Both counters are 1 at that instant, so swapping one for the other changed nothing on the live path. And because the entry then still counted as prior history, the fresh ticket was born `reused` — so **every later completion for that run read UNDETERMINED too**, which is the compounding harm #1618 also claimed to have fixed.

For the record, the first sweep I ran found three sequences that reproduce the reported shape on `main`; only this one is reachable from a production call site (`openRun` always receives `dispatchedAt`, and `arrivedAt`/`dispatchedAt` share one clock).

## The fix

The honest question was never "was it handed over" but "has the agent **READ** it", and the journal already owns the only thing that can answer that: the #468 revoker. `PanelAgent.revokeEvent` splices the injected item out of the agent's queue and returns `false` the moment it has been dequeued into a running turn — i.e. once the text is in the model's context and cannot be recalled. **A successful revoke IS the proof that nobody has been told.**

`claimRaced`'s blunt `handoffs > 0` becomes `stillUnread(entry, reissue)`, asked **last** because it is the only guard with a side effect — nothing is ever pulled off an agent for a claim that is then rejected on other grounds. A revoked entry is off the queue, so `openRun` re-delivers it via `reissueClaimed`, deliberately **after** `bindClaimed`: re-queueing at generation 0 would resurrect the ack/settle defect that made a later resend look like a second render.

### Proof the UNDETERMINED path still fires

A guard that accepts everything would be worse than the bug. Nothing here widens *which* completions may be claimed — every ownership and timing proof is untouched — and it is fail-closed in each direction, with a test for each:

| state | claim | test |
|---|---|---|
| carrying turn already READ it | refused (`revokeEvent` false) | `a verdict the carrying turn ALREADY READ is never rewritten under it` |
| arrived BEFORE the dispatch (a genuinely reused id) | refused, **and never even pulled back** | `a completion from BEFORE the dispatch is not claimed — and not even pulled back` |
| another party's completion | refused | `another party's completion is not claimed, however revocable it is` |
| no `prompt_id` at all | stays `unidentified` | `an ID-LESS completion is never claimed, queued or not` |
| no revoker installed | left exactly as today | `with NO revoker installed a handed-off entry is left exactly as before` |

## Mutation evidence

Six mutations, each run against the new file **and** `run-completion-race.test.ts`; every one killed a **named** test. The fix was committed first so `git checkout` reverted the mutation and not the fix.

| # | mutation | killed |
|---|---|---|
| M1 | restore `if (entry.handoffs > 0) continue;` (delete the fix) | `the reporter's sequence, end to end, through the real agent` |
| M2a | delete `this.reissueClaimed(reissue)` from the **fresh-ticket** branch | same |
| M2b | delete `this.reissueClaimed(reissue)` from the **reopen** branch | `a REOPENED ticket re-delivers the completion it pulled back, never swallows it` |
| M3 | make `stillUnread` accept everything | 3 tests, incl. #1618's own `but a verdict an agent ACTUALLY took is still never rewritten` |
| M4 | remove the `arrivedAt < dispatchedAt` timing proof | 2 tests, incl. #1618's `a completion from BEFORE the dispatch is not claimed` |
| M5 | drop the reflush argument from `setRevoker` in `index.ts` | `index.ts gives setRevoker BOTH a revoke and a reflush` |

**M2b survived the first round** and that mattered. Deleting the call site on `openRun`'s *reopen* branch killed nothing, so I wrote the missing test. The failure there is not a wrong verdict but a silent **loss**: the claim pulls the queued copy off the agent to rebind its generation, and with nothing to put it back the agent ends up with no completion at all. Invisible to any assertion that only reads the journal — which is why the reproduction test asserts on the text the agent actually received.

## Deliberately not done

- **No change to the `replayed` / "RE-DELIVERED" wording.** A revoked-and-reissued entry still carries `replayed: true`, so the agent sees "(RE-DELIVERED — this completion could not be handed to you when it arrived.)" before a correctly-attributed render. That matches the documented meaning of `attempts` and is what #1618 shipped as correct for the refused case; the completion genuinely did fail to reach the agent when it arrived. Cosmetic, and widening `attempts`' semantics is a bigger change than this bug warrants.
- **No panel Playwright run.** This is orchestrator-side only; no panel-rendered surface changes. Stated rather than implied.
- **The interrupt-requeue residual is filed, not fixed here.** Raised in review: `interrupt({ requeueInFlight: true })` does `queue.unshift(...interrupted.items)`, which can put a `completionOnly` item the turn had already dequeued back where `revokeEvent` can splice it — so `stillUnread` could report "unread" for something partially seen. A requeued item also carries the *batched* `eventTokens`, so revoking one token splices an item holding several. Both land on the duplicate side of this journal's duplicate-over-loss rule, and the window is an interrupt arriving between the `/prompt` reply and `openRun` inside one tool call. Reviewer's explicit instruction was not to special-case it here, so it is **#1948** (P3) rather than a line in this diff — a residual that lives only in a review body dies with the PR.
- **`capture-backend.ts` left alone.** Its `waitForTurns(n)` re-queues its own waiter from inside the backend's drain loop, so asking for a count the backend has not reached yet spins the event loop forever (it hung this suite until I switched to `vi.waitFor`). Real latent trap, unrelated to this bug, not widened into this PR.

Local: `tsc --noEmit` clean, `check:vocabulary` OK, `check:unknown-collapse` OK.

