### PR TITLE
fix(1948): correct what a successful revoke actually proves, and pin the requeue window

### DIFF
--- a/src/__tests__/orchestrator/run-completion-requeued-in-flight.test.ts
+++ b/src/__tests__/orchestrator/run-completion-requeued-in-flight.test.ts
@@ -1,0 +1,220 @@
+// #1948 — "a requeued in-flight turn can put an already-dequeued completion back
+// where revokeEvent can splice it".
+//
+// Filed as a maintainer-side residual of #1946 (the fix for #1327's second
+// recurrence). #1946 replaced the old `handoffs > 0` guard with "can the #468
+// revoker still pull this item back", and documented a successful revoke as PROOF
+// that the model has not been shown the text. This file MEASURES that claim
+// against the real PanelAgent instead of restating it, because a premise stated
+// and never measured is exactly how #1618 shipped dormant and how #1327 came back
+// thirteen releases later.
+//
+// WHAT THE MEASUREMENT SAYS.
+//
+//   1. The residual is REAL. `revokeEvent` returns false while the carrying turn is
+//      live, and TRUE again once `interrupt({ requeueInFlight: true })` has restored
+//      that turn's items to the queue — for text the backend was already sent.
+//
+//   2. The second failure mode in the report is NOT real. It claimed a requeued item
+//      carries the drain's batched `eventTokens`, so revoking one token would splice
+//      several completions. It does not: `carriedTokens` is assigned to `inFlight` /
+//      `turnEventTokens`, `inFlight.items` keeps each item's own single-token array,
+//      and the requeue restores those items. Pinned below anyway — a future change
+//      that DID put a multi-token array on a queue item would turn that splice into a
+//      silent loss of the sibling tokens, which nothing else would catch.
+//
+//   3. The residual is DELIBERATELY NOT SPECIAL-CASED, and the last two tests are why.
+//      The suggested direction — mark carried items and have `revokeEvent` refuse them
+//      so "revocable" keeps meaning "never shown" — makes the agent read the WRONG
+//      verdict about its own render, in full, with no correction. Allowing the claim
+//      costs a partially-seen line in a turn that was ABORTED anyway, and the
+//      correction that follows is flagged `replayed` so it reads as a late
+//      re-delivery rather than a second render. Duplicate over loss, which is this
+//      journal's standing rule.
+//
+// If you are here because you are about to implement the refusal: the last test is
+// the one that will go red, and it is the reason not to.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { PanelAgent } from "../../orchestrator/panel-agent.js";
+import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
+import { makeCaptureBackend } from "./helpers/capture-backend.js";
+
+const TAB = "wf:workflows/a.json";
+const CONV = "conv-1";
+const PID = "ba60be81-a4a3-4406-b1d7-56cf571cd72b";
+
+const FRAME = {
+  kind: "executed",
+  prompt_id: PID,
+  duration_s: 0.1,
+  images: [{ filename: "ComfyUI_00149_.png" }],
+};
+
+const MATCHED = "This is the run YOU queued with panel_run";
+const UNDETERMINED = "does NOT match any run you queued";
+const REDELIVERED = "RE-DELIVERED — this completion could not be handed to you when it arrived";
+
+function startAgent(tabId: string) {
+  const backend = makeCaptureBackend();
+  const agent = new PanelAgent(
+    tabId,
+    { mcpServers: {}, systemAppend: "", model: "m" } as never,
+    backend,
+  );
+  void agent.start();
+  return { agent, backend };
+}
+
+/** The orchestrator's own wiring (index.ts): inject to flush, revoke + reflush. */
+function wire(
+  journal: RunCompletionJournalImpl,
+  agent: PanelAgent,
+  revoke: (token: string) => boolean = (t) => agent.revokeEvent(t),
+) {
+  const flush = (key: string) =>
+    journal.deliverPending(key, (payload, token) =>
+      agent.injectEvent(payload as never, { eventToken: token }),
+    );
+  journal.setRevoker(
+    (_key, token) => revoke(token),
+    (key) => void flush(key),
+  );
+  return flush;
+}
+
+describe("the requeue window, MEASURED against the real agent (#1948)", () => {
+  it("a completion is unrevocable IN a live turn and revocable again once re-queued", async () => {
+    const { agent, backend } = startAgent(TAB);
+    expect(agent.injectEvent({ ...FRAME } as never, { eventToken: "tok-A" })).toBe(true);
+
+    // The agent DRAINS it: the text has gone to the backend.
+    await vi.waitFor(() => expect(backend.turns.length).toBe(1));
+    expect(backend.allText()).toContain("A run on the user's canvas just finished");
+
+    // The proof #1946 rests on, and it holds while the turn is live.
+    expect(agent.revokeEvent("tok-A")).toBe(false);
+
+    // …and here is the window. "Send now" (and the run-error burst) re-queue the
+    // interrupted turn's ORIGINAL items, so the already-read completion is back on
+    // the queue with nothing recording that it was ever carried.
+    await agent.interrupt({ requeueInFlight: true });
+
+    // THE RESIDUAL, measured rather than argued: revocable again.
+    expect(agent.revokeEvent("tok-A")).toBe(true);
+    await agent.stop?.();
+  });
+
+  it("a re-queued item carries only its OWN token — never the drain's batch", async () => {
+    // The report's second failure mode ("revoking one token can remove an item
+    // carrying several other completions' tokens") has no producer: the batched
+    // `carriedTokens` never go back onto a queue item. Pinned so a change that
+    // introduced one would fail HERE rather than silently strand sibling tokens on a
+    // spliced item — nothing releases those, so they would not even be replayed.
+    const { agent, backend } = startAgent(TAB);
+    agent.injectEvent({ ...FRAME } as never, { eventToken: "tok-A" });
+    agent.injectEvent({ ...FRAME, prompt_id: "second-pid" } as never, { eventToken: "tok-B" });
+    agent.send("and while you're there, upscale it");
+
+    // One turn, three items — the drain merges them, and `inFlight.eventTokens` is the
+    // batch ["tok-A", "tok-B"].
+    await vi.waitFor(() => expect(backend.turns.length).toBe(1));
+    await agent.interrupt({ requeueInFlight: true });
+
+    // THE FACT THE REPORT GOT WRONG: the re-queue restores the ORIGINAL items, each
+    // still holding only its own token. The batch stayed on the (now discarded)
+    // in-flight turn.
+    const requeued = (agent as unknown as { queue: Array<{ eventTokens?: string[] }> }).queue;
+    expect(requeued.map((i) => i.eventTokens ?? [])).toEqual([["tok-A"], ["tok-B"], []]);
+
+    // So a splice takes exactly one completion…
+    expect(agent.revokeEvent("tok-A")).toBe(true);
+    // …the sibling is still there and still separately revocable (it would not be if
+    // tok-A's splice had taken its item with it)…
+    expect(agent.revokeEvent("tok-B")).toBe(true);
+    // …and the user's own message is untouched by either.
+    const left = agent.takePending();
+    expect(left.map((i) => i.text)).toEqual(["and while you're there, upscale it"]);
+    await agent.stop?.();
+  });
+});
+
+describe("what the claim does in that window, end to end (#1948)", () => {
+  /** The reporter's #1327 sequence, with a send-now interrupt landing inside it. */
+  async function runWindow(revoke?: (agent: PanelAgent, token: string) => boolean) {
+    const journal = new RunCompletionJournalImpl();
+    const { agent, backend } = startAgent(TAB);
+    const flush = wire(journal, agent, revoke ? (t) => revoke(agent, t) : undefined);
+
+    const dispatchedAt = Date.now();
+    // The cached render beats its own /prompt reply back; the live agent takes it.
+    journal.record(TAB, FRAME as never, { conversation: CONV });
+    expect(flush(TAB).delivered).toBe(1);
+
+    // It drains, so the UNDETERMINED wording really did reach the backend…
+    await vi.waitFor(() => expect(backend.turns.length).toBe(1));
+    expect(backend.allText()).toContain(UNDETERMINED);
+
+    // …and THEN the panel's "send now" interrupts and re-queues that turn. The
+    // `panel_run` call is still awaiting /prompt — it is served by the panel MCP
+    // server, not by the turn — so `openRun` still runs after this.
+    await agent.interrupt({ requeueInFlight: true });
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 149, dispatchedAt });
+
+    const entry = journal.allOutstanding()[0];
+    const reused = (journal.ticketFor(PID) as { reused?: boolean } | undefined)?.reused ?? false;
+    // What the agent will actually hand the model next.
+    const next = agent.takePending().map((i) => i.text).join("\n");
+    await agent.stop?.();
+    return { status: entry?.correlation.status, reused, next };
+  }
+
+  it("ALLOWING it corrects the verdict, and the correction is disclosed as a replay", async () => {
+    const { status, reused, next } = await runWindow();
+
+    // The completion is re-attributed to the run that produced it…
+    expect(status).toBe("matched");
+    // …the ticket stays clean, so LATER completions for the same run are still
+    // attributable (the second-order harm #1618 claimed to fix)…
+    expect(reused).toBe(false);
+    // …the stale copy is gone from the queue, and what replaces it says the honest
+    // thing AND flags itself as a late re-delivery, so the agent does not count the
+    // partially-seen copy and this one as two renders.
+    expect(next).toContain(MATCHED);
+    expect(next).toContain(REDELIVERED);
+    expect(next).not.toContain(UNDETERMINED);
+  });
+
+  it("REFUSING it (the suggested fix) re-introduces #1327's reported harm", async () => {
+    // The suggested direction, simulated exactly: mark items the drain has carried and
+    // have the revoker refuse those, so "still revocable" keeps meaning "never shown".
+    const carried = new WeakSet<object>();
+    const { status, reused, next } = await runWindow((agent, token) => {
+      const queue = (agent as unknown as { queue: object[] }).queue;
+      // Everything on the queue at revoke time got there via the re-queue, i.e. it was
+      // carried — which is the whole state the suggested `dequeuedAt` flag would record.
+      for (const item of queue) carried.add(item);
+      const hit = (queue as Array<{ eventTokens?: string[] }>).find((i) =>
+        i.eventTokens?.includes(token),
+      );
+      if (hit && carried.has(hit)) return false; // "partially read — refuse"
+      return agent.revokeEvent(token);
+    });
+
+    // The proof is now strictly correct — and the agent is strictly worse off. Its own
+    // successful render is still reported as UNDETERMINED, and this time it reads that
+    // verdict in FULL, with no correction behind it. That is the exact sentence #1327
+    // was filed about: it does not merely mislabel a result, it tells the agent to
+    // disbelieve a correct one.
+    expect(status).toBe("foreign");
+    expect(next).toContain(UNDETERMINED);
+    expect(next).not.toContain(MATCHED);
+    // …and it does not stop at this one completion. With the claim refused, the entry
+    // is still journaled under an id the fresh ticket has no history for, so the ticket
+    // is marked REUSED — which turns EVERY later completion for that run undetermined
+    // too. That is the second-order harm #1618/#1946 exist to prevent, and refusing the
+    // requeued item hands it straight back.
+    expect(reused).toBe(true);
+  });
+});

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -707,16 +707,34 @@ export class PanelAgent {
 
   /**
    * Pull a still-queued INJECTED COMPLETION back off the queue by its journal
-   * token (#468). Returns true only if it was found and removed — false once the
-   * turn carrying it has started, where the text is already in the model's
-   * context and cannot be recalled.
+   * token (#468). Returns true only if it was found and removed.
+   *
+   * WHAT A `true` ACTUALLY PROVES (#1948). It proves the item is ON THE QUEUE —
+   * i.e. not inside a LIVE turn. That is very nearly "the model has never been
+   * shown it", and it used to be documented as exactly that, but the two come
+   * apart in one measured window: `interrupt({ requeueInFlight: true })` restores
+   * the aborted turn with `queue.unshift(...interrupted.items)`, so a
+   * `completionOnly` item that HAD been dequeued is back on `queue` and revocable
+   * again even though its text already went to the backend. Nothing on the item
+   * records that it was carried, and `findIndex` cannot tell the two apart.
+   *
+   * That is left alone DELIBERATELY — see `stillUnread` in run-completion-journal.ts
+   * for the measurement and the reasoning, and
+   * `run-completion-requeued-in-flight.test.ts` for the tests that pin it. Short
+   * version: in that window every revoker moves the entry toward the HONEST
+   * wording and the re-delivery is flagged `replayed` ("RE-DELIVERED …"), so the
+   * agent reads it as a late re-delivery rather than a second render. Refusing
+   * instead would leave the stale verdict as the only thing the model ever reads.
    *
    * Needed because the event's wording is materialized when it is queued: if the
    * journal later has to WEAKEN that completion's correlation (a prompt id
    * reused, a conversation replaced), the already-queued copy would still claim
    * "this is the run YOU queued". Revoking lets the journal re-deliver the
    * downgraded, honest version instead. Only `completionOnly` items are eligible,
-   * so no user message is ever removed.
+   * so no user message is ever removed — and each queued item carries only its
+   * OWN token (the drain's batched `carriedTokens` go onto `inFlight`/
+   * `turnEventTokens`, never back onto an item), so a splice can never take a
+   * sibling completion's token with it.
    */
   revokeEvent(token: string): boolean {
     const i = this.queue.findIndex((item) => item.completionOnly && item.eventTokens?.includes(token));

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -388,7 +388,14 @@ export class RunCompletionJournalImpl {
 
   /** Re-arm an entry whose correlation just weakened, if its already-queued copy
    *  can still be pulled back. Once the carrying turn has started the text is in
-   *  the model's context and cannot be recalled — nothing to do but leave it. */
+   *  the model's context and cannot be recalled — nothing to do but leave it.
+   *
+   *  (#1948 — with one measured exception, an interrupted turn re-queued by
+   *  "send now": that copy becomes revocable again. Harmless here, and in the right
+   *  direction — this path only ever replaces a claim we can no longer prove with the
+   *  weaker honest one, so pulling the requeued copy back stops the agent re-reading
+   *  "this is the run YOU queued" about a run we can no longer attribute. See
+   *  `stillUnread` for the full reasoning.) */
   private reissueAfterDowngrade(entry: JournalEntry): void {
     if (entry.state !== "handed_off") return;
     if (!this.revoke?.(entry.key, entry.token)) return;
@@ -537,9 +544,42 @@ export class RunCompletionJournalImpl {
    * The honest question was never "was it handed over" but "has the agent READ it",
    * and this journal already owns the only thing that can answer it: the revoker
    * (#468). `revokeEvent` splices the injected item out of the agent's queue and
-   * returns false the moment that item has been dequeued into a running turn — i.e.
-   * once the text is in the model's context and can no longer be recalled. A
-   * successful revoke IS the proof that nobody has been told.
+   * returns false once that item has been dequeued into a running turn — i.e. once
+   * the text is in the model's context and can no longer be recalled.
+   *
+   * EXACTLY WHAT A SUCCESSFUL REVOKE PROVES (#1948), because the previous sentence
+   * used to overclaim and that overclaiming is this file's whole failure history. It
+   * proves the item is NOT INSIDE A LIVE TURN. That is "nobody has been told" in every
+   * case but one, and the exception is measured rather than assumed:
+   * `PanelAgent.interrupt({ requeueInFlight: true })` — the panel's "send now", and the
+   * run-error burst in `injectRunError` — restores the aborted turn with
+   * `queue.unshift(...interrupted.items)`. A `completionOnly` item that HAD been
+   * dequeued is therefore back on the queue and revocable again, so `stillUnread` can
+   * answer "unread" for text the backend has already been sent.
+   *
+   * THAT IS DELIBERATELY NOT SPECIAL-CASED, and refusing it would be the worse bug.
+   * Measured end to end (run-completion-requeued-in-flight.test.ts):
+   *   - refusing a requeued item leaves the entry `foreign`, so the requeued turn
+   *     re-reads "does NOT match any run you queued — its origin is UNDETERMINED"
+   *     about the agent's OWN render, in full, with no correction. That is precisely
+   *     the harm #1327 reports;
+   *   - allowing it re-attributes the entry to the run that produced it and re-queues
+   *     the corrected wording, and because the re-delivery has `attempts > 0` it is
+   *     flagged `replayed` — the agent is handed "(RE-DELIVERED — this completion could
+   *     not be handed to you when it arrived.)", i.e. told to read it as a late
+   *     re-delivery, not as a second render.
+   * So the window costs at most a partially-seen line in a turn that was ABORTED
+   * anyway, followed by a disclosed, correctly-attributed re-delivery — the duplicate
+   * side of this journal's standing duplicate-over-loss rule. It also cannot widen the
+   * claim: `claimRaced` only ever moves an entry foreign → matched, never the reverse,
+   * and every ownership and timing proof still has to pass first.
+   *
+   * The revoke also cannot take a bystander with it. Each queued item carries only its
+   * own token — the drain's batched `carriedTokens` are assigned to `inFlight`/
+   * `turnEventTokens`, and the requeue restores `interrupted.items`, not one merged
+   * item — so splicing the named token's item leaves every sibling completion and every
+   * user message on the queue. (Pinned by test, because a future change that DID put a
+   * multi-token array on a queue item would turn this splice into a silent loss.)
    *
    * Fail-closed in every direction that matters:
    *   - no revoker installed (a bare journal, a unit test) => a handed-off entry is
@@ -1485,8 +1525,11 @@ export class RunCompletionJournalImpl {
         // loop would then grow that queue without limit while the journal stayed
         // at 32 — and the whole backlog drains into ONE turn, which is how the
         // genuine completion gets starved. Revoking keeps the two bounded
-        // together. (No-op once the carrying turn has started; that copy is
-        // already committed and is bounded by the turn instead.)
+        // together. (No-op while the carrying turn is live; that copy is already
+        // committed and is bounded by the turn instead. It stops being a no-op if
+        // that turn is interrupted and re-queued — #1948 — which is the direction
+        // this cap wants anyway: the copy is back on the queue it exists to bound,
+        // and the drop is already counted and disclosed via `dropped_completions`.)
         this.revoke?.(victim.key, victim.token);
         // Its own loss PLUS any disclosure it was carrying for the tab — moved to
         // whatever survives, so an eviction can never drop the disclosure itself.


### PR DESCRIPTION
Closes #1948.

**Zero executable change.** The production diff is comments only — verified mechanically:

```
$ git diff origin/main -- src/orchestrator/ | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -vE '^[+-]\s*(\*|//|/\*\*)'
(no output)
```

What changes is a **claim the code makes about itself** that turns out to be false, plus the tests that pin the decision not to "fix" it.

## The claim, and the measurement

#1946 replaced #1327's `handoffs > 0` guard with the #468 revoker, and documented the new proof like this:

> `revokeEvent` … returns false the moment that item has been dequeued into a running turn — i.e. once the text is in the model's context and can no longer be recalled. **A successful revoke IS the proof that nobody has been told.**

Measured against the real `PanelAgent` (not read — executed):

| state | `revokeEvent("tok-A")` |
|---|---|
| queued, never dequeued | `true` |
| dequeued into a live turn | `false` |
| that turn interrupted with `requeueInFlight: true` | **`true`** |

`interrupt({requeueInFlight:true})` restores the aborted turn with `queue.unshift(...interrupted.items)`. Nothing on a `QueueItem` records that it was ever carried, so `findIndex` cannot tell a requeued item from one that was never dequeued. **The residual in #1948 is real.** A successful revoke proves the item is not inside a *live* turn — which is "never shown" everywhere except this window.

Reachable, if narrow: the "send now" interrupt arrives over the bridge (`index.ts:5319`, `event.requeue === true`), completely independent of the agent's turn, and `panel_run` is served by the panel MCP server rather than by the turn — so `openRun` still runs after the interrupt aborts the turn that called it.

## The second reported failure mode is NOT real

The issue also claims a requeued item carries the drain's **batched** `eventTokens`, so revoking one token would splice several completions. Measured, that has no producer:

- `carriedTokens` is assigned to `inFlight.eventTokens` / `turnEventTokens`;
- `inFlight.items = batch` keeps each item's own single-token array;
- the requeue restores `interrupted.items`, not the merged turn.

Observed on a three-item batch `[completion A, completion B, user message]`: after the requeue the queue is `[["tok-A"], ["tok-B"], []]`, and `revokeEvent("tok-A")` removes exactly A's item, leaving B individually revocable and the user's message untouched. Pinned anyway — a future change that *did* put a multi-token array on a queue item would make that splice a silent **loss** (the sibling tokens go nowhere: nothing releases them, so they are not even replayed).

## Why the behaviour is deliberately unchanged

The suggested direction — mark carried items, have `revokeEvent` refuse them so "revocable" keeps meaning "never shown" — makes the proof strictly correct and the **agent strictly worse off**. Both sides measured end to end through the real agent and the real journal:

| | correlation | ticket `reused` | what the agent reads next |
|---|---|---|---|
| **current (allow)** | `matched` | `false` | `(RE-DELIVERED — …)` + *"This is the run YOU queued with panel_run"* |
| **refuse requeued** | `foreign` | **`true`** | *"does NOT match any run you queued — its origin is UNDETERMINED"*, in full, no correction |

Two things the refusal costs, the second of which I did not expect:

1. The agent reads the wrong verdict about its **own successful render** — the exact sentence #1327 was filed about, which does not merely mislabel a result, it tells the agent to disbelieve a correct one. And unlike the current path there is no correction behind it.
2. With the claim refused, the entry stays journaled under an id the fresh ticket has no history for, so the ticket is marked **`reused`** — turning *every later completion for that run* undetermined too. That is the second-order harm #1618/#1946 exist to prevent, handed straight back.

What the current path actually costs is a partially-seen line in a turn that **was aborted anyway**, followed by a correctly-attributed re-delivery that is flagged `replayed` — so the agent is handed `(RE-DELIVERED — this completion could not be handed to you when it arrived.)` and reads it as a late re-delivery rather than a second render. Duplicate over loss, which is this journal's standing rule. The claim also cannot widen: `claimRaced` only ever moves an entry `foreign → matched`, never the reverse, and every ownership and timing proof still has to pass first.

So the defect was the **sentence**, not the behaviour. Three sites stated the false invariant (`revokeEvent`, `stillUnread`, `trimEntries`), plus `reissueAfterDowngrade`; all four now state what is actually true and why the window is left alone. This matters because a premise stated and never measured is this exact file's failure history — it is how #1618 shipped dormant and how #1327 came back thirteen releases later, and the next agent to read #1948 would have built on it.

## Evidence

**Mutation — I implemented the suggested fix in production and watched the new tests die.** Marked requeued items in `interrupt()` and made `revokeEvent` refuse them:

```
 ❯ run-completion-requeued-in-flight.test.ts (4 tests | 3 failed)
   × a completion is unrevocable IN a live turn and revocable again once re-queued
   × a re-queued item carries only its OWN token — never the drain's batch
   × ALLOWING it corrects the verdict, and the correction is disclosed as a replay
```

**The load-bearing part: `run-completion-queued-not-read.test.ts` — #1327's own regression suite — stayed 9/9 GREEN under that mutation.** The suggested fix would have shipped with the suite that exists to protect this exact behaviour showing no objection at all. That is the gap this file closes, and it is the single strongest reason the tests are worth having even though nothing executable changed.

Mutation reverted; `git diff origin/main` confirms no `__carried` residue.

- `npx tsc --noEmit` — clean
- `npm run check:vocabulary` — OK, 1740 files
- `npm run check:unknown-collapse` — OK
- **Full suite: 602 files / 11078 passed, 4 skipped, 0 failed.**

## What I deliberately did not do

- **No `dequeuedAt` / `wasCarried` flag.** That is the issue's suggested direction and the table above is why not. grok's instruction on #1946 ("do not special-case requeued in-flight items") turns out to be right for reasons stronger than "the window is tiny".
- **Did not touch the `RE-DELIVERED` wording.** In this one window "could not be handed to you when it arrived" is imprecise — it *was* handed, into a turn that was then aborted. The operative instruction ("read this as landed late, not as a second render") is correct and is what makes the duplicate benign, so changing user-facing text under the freeze to fix an adverb is not worth the regression surface. Flagging rather than fixing.
- **No Playwright run.** Nothing here is panel-visible — the diff contains no executable statement. Saying so explicitly rather than implying coverage I do not have.

## Review

**Returned clean** (2026-08-21T04:07Z, head `50d0ced` — same tree, since rebased onto `c45bf09`). Verdict was `COMMENT INTENDED: APPROVE` — posted as a comment rather than an Approve event because the reviewer runs under the same GitHub user.

All three things I asked to have attacked were checked against shipped code rather than against my description:

- **`claimRaced` only ever assigns `matched`** — confirmed by walking the continues and the single write; a failed `stillUnread` never mutates. "A false `stillUnread` in the send-now window cannot produce a *worse* correlation than the frozen foreign wording."
- **`reused: true` under refusal is real journal behaviour, not a WeakSet artefact** — `openRun` mints it from `hasHistoryFor(..., claimed)`, and refusing leaves `claimed` empty. Correctly noted that my WeakSet is an *over-approximation* of a `dequeuedAt` flag (it would also refuse a never-dequeued item sitting on the queue), but that in `runWindow` the queue at revoke time holds only the requeued in-flight items, so the stand-in matches a real flag for this sequence.
- **Not manufacturing work** — "an issue comment would not have failed CI when the next agent implemented `dequeuedAt`."

Explicit instructions carried into this PR: *do not add `dequeuedAt`; do not restore `handoffs > 0`;* leaving the `RE-DELIVERED` adverb imprecise is the right freeze call. No revisions were requested.

Corrections I published against my own body before merging: the "`node-id-union-message.test.ts` is red on `origin/main`" claim was **wrong** (stale junctioned `node_modules` serving MCP SDK 1.29.0 against a `~1.30.0` pin — 56/56 green after `npm ci`), and #1327's suite is **9** tests, not 10. Details in the comment thread.
