### PR TITLE
release: v0.52.40 — live sibling socket producers, queued completion is unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.40] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- panel_add_node names live sibling socket producers instead of a missing-output dead end (#1947)
+- a completion QUEUED onto an agent is not one the agent has READ (#1946)
+
+
 ## [0.52.39] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.39",
+  "version": "0.52.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.39",
+      "version": "0.52.40",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.39",
+  "version": "0.52.40",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.52.40 from main.

Carries:

- #1947 / #1944 — panel_add_node names live sibling socket producers instead of a missing-output dead end
- #1946 / #1327 — a completion QUEUED onto an agent is not one the agent has READ

Held out: #1697 P1 inflight; #1696 reengaged this cycle; #1948 inflight; panel#1472 typescript 5 to 7 (CI red).

Do not squash-merge. Merge-commit (keeps the v0.52.40 tag on the version commit). Tag is local; push v0.52.40 after merge.