### PR TITLE
fix(1696): panel_set_workflow_target reports bound after a settling read that proves writes

### DIFF
--- a/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
+++ b/src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts
@@ -46,8 +46,13 @@ function bridge(opts: {
   activeUuid: string;
   /** "ok" passes; "mismatch" is a real fence refusal; "timeout" is an inconclusive failure. */
   graphRead: "ok" | "mismatch" | "timeout";
-  /** true/false answer the write-capability probe; "unknown" leaves it unanswerable. */
-  canMutate?: boolean | "unknown";
+  /**
+   * true/false answer the write-capability probe.
+   * "unknown" stays unanswerable even after the settling read.
+   * "unknown-until-read" is the post-restart race (#1696): unknown until
+   * graph_query has round-tripped, then observed can-mutate.
+   */
+  canMutate?: boolean | "unknown" | "unknown-until-read";
 }) {
   return {
     send: async (cmd: Record<string, unknown>) => {
@@ -91,22 +96,31 @@ function bridge(opts: {
     resolveActiveTabId: () => TAB,
     refreshWorkflowUuid: () => true,
     workflowUuidFor: () => ({ known: true, uuid: SAME_UUID }),
-    tabCanMutateGraph: () => (opts.canMutate === "unknown" ? undefined : opts.canMutate !== false),
-    tabGraphMutationCapability: () =>
-      opts.canMutate === "unknown"
-        ? { known: false }
-        : {
-            known: true,
-            canMutate: opts.canMutate !== false,
-            ...(opts.canMutate === false ? { because: "capability" as const } : {}),
-          },
+    tabCanMutateGraph: () =>
+      opts.canMutate === "unknown" ||
+      (opts.canMutate === "unknown-until-read" && !sent.includes("graph_query"))
+        ? undefined
+        : opts.canMutate !== false,
+    tabGraphMutationCapability: () => {
+      if (opts.canMutate === "unknown") return { known: false };
+      if (opts.canMutate === "unknown-until-read") {
+        return sent.includes("graph_query")
+          ? { known: true, canMutate: true }
+          : { known: false };
+      }
+      return {
+        known: true,
+        canMutate: opts.canMutate !== false,
+        ...(opts.canMutate === false ? { because: "capability" as const } : {}),
+      };
+    },
   } as unknown as PanelToolCtx["bridge"];
 }
 
 async function setTargetCurrent(opts: {
   activeUuid: string;
   graphRead: "ok" | "mismatch" | "timeout";
-  canMutate?: boolean | "unknown";
+  canMutate?: boolean | "unknown" | "unknown-until-read";
 }) {
   const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
@@ -157,6 +171,24 @@ describe("an UNCONFIRMED record whose uuid matches the fence gets its answer up 
     expect(out.text).toMatch(/did NOT restore/);
     expect(out.text).toMatch(/CHECKED FOR YOU/);
     expect(out.text).toMatch(/it SUCCEEDED/);
+  });
+
+  it("reports BOUND when write capability is unknown only until the settling read answers (#1696)", async () => {
+    // The pre-probe snapshot is taken while the tab may still be reconnecting, so
+    // canMutateNow is undefined. The settling graph_query then round-trips; the
+    // write-capability probe must be asked AGAIN of the tab that answered, not
+    // left as the stale unknown (and not rounded up to true without looking).
+    const out = await setTargetCurrent({
+      activeUuid: SAME_UUID,
+      graphRead: "ok",
+      canMutate: "unknown-until-read",
+    });
+
+    expect(sent).toContain("graph_query");
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"graph_binding":\s*"bound"/);
+    expect(out.text).toMatch(/ACCEPTED by the panel/);
+    expect(out.text).not.toMatch(/did NOT restore/);
   });
 
   it("keeps the failure when the graph read is REFUSED", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1370,6 +1370,38 @@ function sessionRouteIsLive(ctx: PanelToolCtx): boolean {
   }
 }
 
+type MutationRefusalCause =
+  | "unroutable"
+  | "disconnected"
+  | "no_identity"
+  | "capability"
+  | "target_disagreement";
+
+/**
+ * Snapshot of whether this tab can fence a graph WRITE right now.
+ *
+ * `known:false` (resolver threw, ctx threw) is `undefined`, not `false`: the
+ * boolean probe fails closed, and rendering that as "your panel lacks the write
+ * fence" is a claim built from our own failure to look.
+ */
+function readTabMutationCapability(ctx: PanelToolCtx): {
+  canMutateNow: boolean | undefined;
+  refusalCause: MutationRefusalCause | undefined;
+} {
+  try {
+    if (ctx.tabGraphMutationCapability) {
+      const cap = ctx.tabGraphMutationCapability();
+      return {
+        canMutateNow: cap.known ? cap.canMutate : undefined,
+        refusalCause: cap.known && !cap.canMutate ? cap.because : undefined,
+      };
+    }
+    return { canMutateNow: ctx.tabCanMutateGraph?.(), refusalCause: undefined };
+  } catch {
+    return { canMutateNow: undefined, refusalCause: undefined };
+  }
+}
+
 /**
  * #1331 — the bridge refused a mutation because the active workflow has no identity to
  * fence against (ui-bridge's `no trusted identity` branch).
@@ -15070,23 +15102,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // unreadable capability would be RENDERED as "your panel lacks the write
         // fence" — a claim about the panel built from our own failure to look
         // (codex gate). Only an OBSERVED negative may say that.
-        let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;
-        try {
-          if (ctx.tabGraphMutationCapability) {
-            const cap = ctx.tabGraphMutationCapability();
-            canMutateNow = cap.known ? cap.canMutate : undefined;
-            if (cap.known && !cap.canMutate) refusalCause = cap.because;
-          } else {
-            // The legacy boolean probe cannot say WHY, and guessing would put us
-            // back where the tri-state started. Leave the cause undefined so the
-            // narration falls back to the generic wording rather than inventing one.
-            canMutateNow = ctx.tabCanMutateGraph?.();
-          }
-        } catch {
-          canMutateNow = undefined; // a guard that can throw is not a guard
-          refusalCause = undefined;
-        }
+        //
+        // This snapshot is taken BEFORE the settling read. After a restart the
+        // tab can still be reconnecting, so the honest answer here is often
+        // unknown (`undefined`) even though a moment later `graph_query` will
+        // round-trip. #1696 re-reads after that probe, on the tab that answered.
+        let { canMutateNow, refusalCause } = readTabMutationCapability(ctx);
         // #1043 (codex review) — NO version note on THIS path, deliberately.
         //
         // The note claims that on 0.11.45+ "the command that re-pointed the canvas
@@ -15201,6 +15222,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
           if (probeOk) {
             probePassed = true;
+            // #1696 — the snapshot above is taken BEFORE this read, while the tab
+            // may still be reconnecting. `canMutateNow` is then undefined (the
+            // probe could not inspect the tab) even though this command just
+            // proved the socket and fence are live. Re-read on the tab that
+            // answered; a still-unknown or still-refused write capability keeps
+            // the failure below. Treating unknown as true is not this fix.
+            ({ canMutateNow, refusalCause } = readTabMutationCapability(ctx));
             settledNote =
               // ONE OBSERVATION, STATED AS ONE (codex r2). A passing graph_query proves that
               // read passed this fence just now — not that every command will, and not that


### PR DESCRIPTION
Fixes #1696

After a ComfyUI restart, `panel_set_workflow_target({mode:"current"})` applied the target, matched the existing fence, and its own verification `graph_query` succeeded — then still returned `isError` because `canMutateNow` was snapshotted **before** that read, while the tab could still be reconnecting. The honest value at that instant is `undefined` (could not inspect), so the #1688 BOUND flip never fired.

This does not treat unknown as true. After the settling read is accepted, the write-capability probe is asked again of the tab that answered. A still-unknown or still-refused write capability keeps the failure; an inspectable tab that accepts edits reports `graph_binding: "bound"`.

## Test
- `npx vitest run src/__tests__/orchestrator/unconfirmed-matching-fence.test.ts src/__tests__/orchestrator/fence-matching-uuid.test.ts src/__tests__/orchestrator/target-verify-no-tab.test.ts --maxWorkers=4` — 16/16
