### PR TITLE
fix(1896): a timed-out ComfyUI call makes the same connected-panel comparison a refused one does

### DIFF
--- a/src/__tests__/comfyui/system-stats-timeout-honesty.test.ts
+++ b/src/__tests__/comfyui/system-stats-timeout-honesty.test.ts
@@ -1,0 +1,97 @@
+// #1896 — the /system_stats probe that the drift advice now sends callers to.
+//
+// When a ComfyUI call fails and the comparison establishes a connected panel is
+// on the SAME origin, comfyui/fetch.ts tells the reader to run
+// get_system_stats (action:"health") to settle which of two things is true:
+//
+//   fails from here too -> the route from this process is what needs fixing
+//   succeeds            -> only this one request is stalling
+//
+// That discriminator is only worth anything if the probe's own timeout message
+// leaves both readings open. It did not. It asserted "The connection was
+// accepted but the body never finished, which is common while a long decode
+// occupies the server. The request was aborted; retry after the current job
+// finishes." — the budget covers CONNECTING too, so a target this process cannot
+// route to expires here having established nothing, and the reader chasing a
+// dead route was handed "a long decode, just retry": precisely the reading the
+// discriminator exists to rule out. (The sentence before it already said nothing
+// was learned about the server, so it also contradicted its own paragraph.)
+//
+// The decode case is still the usual one and is kept as the likely reading.
+// What is removed is the assertion that it is the only one.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => false,
+}));
+
+const { getSystemStats, SYSTEM_STATS_TIMEOUT_MS } = await import("../../comfyui/client.js");
+
+let restoreTimeout: (() => void) | undefined;
+
+beforeEach(() => {
+  // Shorten ONLY this probe's deadline, exactly as the #1672 unwind test does.
+  // Faking the clock does not govern AbortSignal.timeout here, so the honest
+  // way to reach the shipped timer quickly is to shrink the shipped timer.
+  const orig = AbortSignal.timeout.bind(AbortSignal);
+  const spy = vi
+    .spyOn(AbortSignal, "timeout")
+    .mockImplementation((ms: number) => orig(ms === SYSTEM_STATS_TIMEOUT_MS ? 40 : ms));
+  restoreTimeout = () => spy.mockRestore();
+});
+
+afterEach(() => {
+  restoreTimeout?.();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Drive the probe's OWN budget to expiry and return its message.
+ *
+ * The mock settles only when the caller's signal aborts, so this takes the same
+ * `isTimeoutAbort(err)` branch production does rather than fabricating the error.
+ */
+async function probeTimeoutText(): Promise<string> {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (_input: unknown, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) return;
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }) as Promise<Response>,
+  );
+  return getSystemStats().then(
+    () => "expected /system_stats to time out",
+    (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  );
+}
+
+describe("#1896: the /system_stats probe says only what its timeout proves", () => {
+  it("does not assert that the connection was accepted", async () => {
+    const text = await probeTimeoutText();
+    expect(text).toContain("No reply from ComfyUI within");
+    expect(text).not.toContain("The connection was accepted but the body never finished");
+    expect(text).toContain("Whether a connection was ever established is NOT known");
+  });
+
+  // Both readings have to survive, or the discriminator in comfyui/fetch.ts is
+  // answering its own question before the caller runs it.
+  it("keeps the decode reading AND leaves the dead-route reading open", async () => {
+    const text = await probeTimeoutText();
+    expect(text).toContain("retrying after the current job finishes");
+    expect(text).toContain("points at the route rather than at a busy server");
+  });
+
+  it("still names the budget and the endpoint", async () => {
+    const text = await probeTimeoutText();
+    expect(text).toContain(`within ${SYSTEM_STATS_TIMEOUT_MS / 1000}s`);
+    expect(text).toContain("/system_stats");
+  });
+});

--- a/src/__tests__/comfyui/timeout-panel-origin-drift.test.ts
+++ b/src/__tests__/comfyui/timeout-panel-origin-drift.test.ts
@@ -148,14 +148,30 @@ describe("#1896: the timeout message says only what a timeout proves", () => {
 });
 
 describe("#1896: the advice does not send the caller back down the road that just failed", () => {
-  it("stops offering get_system_stats as a check once drift is RULED OUT", async () => {
+  it("stops asking whether the server is up once drift is RULED OUT", async () => {
     publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
     const text = await timeoutText(DEAD);
     // The comparison has just established a browser is connected to this origin,
-    // so "confirm it is up" is both a repeat of the failure and the wrong lead.
+    // so "confirm it is up" sends the caller after a question already answered.
     expect(text).not.toContain("Confirm it is up with get_system_stats");
-    expect(text).toContain("will NOT add anything here");
-    expect(text).toContain("runs in this same process against this same address");
+    expect(text).toContain("The address itself is not what is wrong");
+    expect(text).toContain("a browser is connected to that origin");
+  });
+
+  // The health check is RE-AIMED, not suppressed. Dropping it would have been an
+  // overclaim: a SAME verdict compares ORIGINS, and a server that is up and
+  // answering the browser can still stall one route (/object_info mid-decode),
+  // in which case /system_stats answers fine and is the most informative call
+  // available. So it must still be offered, as a discriminator.
+  it("keeps the health check, as the thing that tells the remaining cases apart", async () => {
+    publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
+    const text = await timeoutText(DEAD);
+    expect(text).toContain('get_system_stats (action:"health")');
+    expect(text).toContain("if it fails from here too");
+    expect(text).toContain("if it succeeds");
+    // …and it must not assert the outcome of that call in advance.
+    expect(text).not.toContain("fails the same way");
+    expect(text).not.toContain("will NOT add anything");
   });
 
   // The overclaim deliberately NOT made: a connected browser proves something
@@ -190,12 +206,13 @@ describe("#1896: the REFUSAL path's advice follows the same verdict", () => {
     }
   }
 
-  it("drops the dead-end health check when the panel is on the same origin", async () => {
+  it("re-aims the health check when the panel is on the same origin", async () => {
     publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
     const text = await refusalText(DEAD);
     expect(text).toContain("NOT a wrong-address problem");
     expect(text).not.toContain("confirm the server is up with get_system_stats");
-    expect(text).toContain("will NOT add anything here");
+    expect(text).toContain("The address itself is not what is wrong");
+    expect(text).toContain("if it fails from here too");
     // install_comfyui (action:"environment") is NOT described as failing: its
     // /system_stats read is inside a try, so it still reports the resolved
     // target on an unreachable server.

--- a/src/__tests__/comfyui/timeout-panel-origin-drift.test.ts
+++ b/src/__tests__/comfyui/timeout-panel-origin-drift.test.ts
@@ -1,0 +1,215 @@
+// #1896 — `list_packs (action:"list_templates")` against an unreachable
+// COMFYUI_URL while the sidebar panel was connected and working.
+//
+// The REFUSAL half of this was closed by #1553: the spawned comfyui child reads
+// the orchestrator's panel-origin channel, so an ECONNREFUSED names both
+// addresses and says which of them the panel is on. Reproducing #1896 on
+// origin/main confirmed that path is complete.
+//
+// Its TWIN was not. An unroutable target does not always refuse. A firewall or a
+// container boundary that DROPs the SYN black-holes it, and the request expires
+// on the COMFYUI_MCP_HTTP_TIMEOUT_S ceiling instead — describeComfyTimeout, not
+// describeComfyFetchFailure. Same child, same readable channel, same connected
+// panel, and that path never asked: measured against a live channel on
+// origin/main, a timed-out list_templates said nothing whatsoever about the
+// panel. #1795 put list_templates on this ceiling by removing its hard-coded 8s
+// signal, so it is a first-class consumer of exactly this message.
+//
+// Two further things that path asserted, both fixed here:
+//   - "The connection was accepted but no answer arrived in time" — untrue for a
+//     black-holed SYN, and contradicted by the sentence before it on a read.
+//   - "confirm the server is up with get_system_stats (action:"health")" — that
+//     runs in THIS process against THIS address. After a SAME-origin verdict it
+//     reproduces the failure rather than diagnosing it, and invites the very
+//     conclusion the comparison just ruled out.
+//
+// These tests drive the CHILD's configuration: no injected bridge source, only
+// the spawn-env channel dir.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const { comfyuiFetch, setConnectedPanelOrigins } = await import("../../comfyui/fetch.js");
+const { publishConnectedPanelOrigins, resetPublishedPanelOrigins } = await import(
+  "../../services/panel-origin-channel.js"
+);
+
+let dir = "";
+const savedDir = process.env.COMFYUI_MCP_PROGRESS_DIR;
+const savedBudget = process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+
+const PANEL = "http://127.0.0.1:8188";
+/** The reporter's shape: a target this process cannot route to at all. */
+const DEAD = "http://192.0.2.1:8188/api/workflow_templates";
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-timeout-drift-"));
+  process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  // Small enough to keep the suite fast; the VALUE is not what is under test,
+  // only the branch it drives.
+  process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = "0.05";
+  resetPublishedPanelOrigins();
+  // The child has NO bridge — the state the defect lives in.
+  setConnectedPanelOrigins(null);
+});
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  else process.env.COMFYUI_MCP_PROGRESS_DIR = savedDir;
+  if (savedBudget === undefined) delete process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+  else process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = savedBudget;
+  rmSync(dir, { recursive: true, force: true });
+  resetPublishedPanelOrigins();
+  setConnectedPanelOrigins(null);
+  vi.restoreAllMocks();
+});
+
+/**
+ * Drive a real ceiling timeout through comfyuiFetch and return the message.
+ *
+ * The mock never settles on its own and only rejects when OUR signal aborts —
+ * so this exercises the same `init.signal === undefined && isTimeoutAbort(err)`
+ * branch production takes, rather than fabricating a TimeoutError.
+ */
+async function timeoutText(target: string): Promise<string> {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (_input: unknown, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) return; // would hang — asserted against below
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }) as Promise<Response>,
+  );
+  try {
+    await comfyuiFetch(target);
+    throw new Error("expected comfyuiFetch to time out");
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+describe("#1896: a TIMED-OUT ComfyUI call makes the same panel comparison a refused one does", () => {
+  it("names the connected panel's DIFFERENT origin instead of staying silent", async () => {
+    publishConnectedPanelOrigins(dir, [PANEL]);
+    const text = await timeoutText(DEAD);
+    expect(text).toContain(PANEL);
+    expect(text).toContain("a DIFFERENT address");
+    expect(text).toContain("Point COMFYUI_URL");
+    // …without losing the timeout diagnosis it is attached to.
+    expect(text).toContain("No reply from ComfyUI within");
+    expect(text).toContain(DEAD);
+  });
+
+  it("RULES OUT drift when the panel is on the very address that timed out", async () => {
+    publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
+    const text = await timeoutText(DEAD);
+    expect(text).toContain("NOT a wrong-address problem");
+    expect(text).not.toContain("a DIFFERENT address");
+  });
+
+  // An absent comparison is not a negative result. No panel → the message must
+  // not invent one.
+  it("says nothing about drift when no panel has been published", async () => {
+    const text = await timeoutText(DEAD);
+    expect(text).not.toContain("a DIFFERENT address");
+    expect(text).not.toContain("NOT a wrong-address problem");
+  });
+
+  // Parity with the transport path: where a bridge IS in-process it is both
+  // fresher and authoritative, so it must keep winning over the channel.
+  it("an injected bridge source still wins over the channel", async () => {
+    publishConnectedPanelOrigins(dir, [PANEL]);
+    setConnectedPanelOrigins(() => ["http://10.0.0.9:8188"]);
+    const text = await timeoutText(DEAD);
+    expect(text).toContain("http://10.0.0.9:8188");
+    expect(text).not.toContain(PANEL);
+  });
+});
+
+describe("#1896: the timeout message says only what a timeout proves", () => {
+  it("does NOT claim the connection was accepted", async () => {
+    const text = await timeoutText(DEAD);
+    // A black-holed SYN expires on this same ceiling having established nothing.
+    expect(text).not.toContain("The connection was accepted");
+    expect(text).toContain("Whether a connection was ever established is NOT known");
+  });
+
+  it("still names the target, the budget and the method", async () => {
+    const text = await timeoutText(DEAD);
+    expect(text).toContain("No reply from ComfyUI within 0.05s");
+    expect(text).toContain("(GET)");
+  });
+});
+
+describe("#1896: the advice does not send the caller back down the road that just failed", () => {
+  it("stops offering get_system_stats as a check once drift is RULED OUT", async () => {
+    publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
+    const text = await timeoutText(DEAD);
+    // The comparison has just established a browser is connected to this origin,
+    // so "confirm it is up" is both a repeat of the failure and the wrong lead.
+    expect(text).not.toContain("Confirm it is up with get_system_stats");
+    expect(text).toContain("will NOT add anything here");
+    expect(text).toContain("runs in this same process against this same address");
+  });
+
+  // The overclaim deliberately NOT made: a connected browser proves something
+  // answers that origin, never that it would answer THIS process quickly. So the
+  // "simply slow" option has to survive the SAME verdict.
+  it("keeps the timeout budget on the table even when drift is ruled out", async () => {
+    publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
+    const text = await timeoutText(DEAD);
+    expect(text).toContain("COMFYUI_MCP_HTTP_TIMEOUT_S");
+  });
+
+  it("leaves the DIFFERENT and UNKNOWN tails alone", async () => {
+    publishConnectedPanelOrigins(dir, [PANEL]);
+    expect(await timeoutText(DEAD)).toContain("Confirm it is up with get_system_stats");
+    publishConnectedPanelOrigins(dir, []);
+    expect(await timeoutText(DEAD)).toContain("Confirm it is up with get_system_stats");
+  });
+});
+
+// The TRANSPORT path shares the tail. #1553 already made it name the panel; what
+// it still did was hand a ruled-out caller two more calls down the dead path.
+describe("#1896: the REFUSAL path's advice follows the same verdict", () => {
+  async function refusalText(target: string): Promise<string> {
+    const cause = new Error("connect ECONNREFUSED 192.0.2.1:8188");
+    (cause as { code?: string }).code = "ECONNREFUSED";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed", { cause }));
+    try {
+      await comfyuiFetch(target);
+      throw new Error("expected comfyuiFetch to throw");
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  it("drops the dead-end health check when the panel is on the same origin", async () => {
+    publishConnectedPanelOrigins(dir, ["http://192.0.2.1:8188"]);
+    const text = await refusalText(DEAD);
+    expect(text).toContain("NOT a wrong-address problem");
+    expect(text).not.toContain("confirm the server is up with get_system_stats");
+    expect(text).toContain("will NOT add anything here");
+    // install_comfyui (action:"environment") is NOT described as failing: its
+    // /system_stats read is inside a try, so it still reports the resolved
+    // target on an unreachable server.
+    expect(text).toContain('install_comfyui (action:"environment")');
+  });
+
+  it("keeps the original tail when the panel is elsewhere, or unknown", async () => {
+    publishConnectedPanelOrigins(dir, [PANEL]);
+    expect(await refusalText(DEAD)).toContain(
+      "confirm the server is up with get_system_stats",
+    );
+    publishConnectedPanelOrigins(dir, []);
+    expect(await refusalText(DEAD)).toContain(
+      "confirm the server is up with get_system_stats",
+    );
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -239,8 +239,26 @@ export async function getSystemStats(): Promise<SystemStats> {
     throw new ComfyUIError(
       `No reply from ComfyUI within ${SYSTEM_STATS_TIMEOUT_MS / 1000}s — while requesting ${url} (GET). ` +
         `Nothing was learned about the server from this — a timeout is not a refusal and not a "not found". ` +
-        `The connection was accepted but the body never finished, which is common while a long decode ` +
-        `occupies the server. The request was aborted; retry after the current job finishes.`,
+        // #1896 — this asserted "The connection was accepted but the body never
+        // finished". The budget covers connecting too, so an unroutable or
+        // filtered target expires here having established nothing, and the
+        // sentence immediately before already said nothing was learned.
+        //
+        // It matters more than the sibling in comfyui/fetch.ts, because #1896
+        // now sends callers HERE on purpose: a ComfyUI failure whose connected
+        // panel is on the same origin tells the reader to run this probe to
+        // find out whether the route from this process is dead or only this one
+        // request is stalling. If the route IS dead, the old text answered with
+        // the opposite conclusion — "a long decode occupies the server, retry
+        // after the current job" — which is the reading that discriminator
+        // exists to rule out. The decode case is still the common one, so it is
+        // kept as the likely reading rather than dropped.
+        `Whether a connection was ever established is NOT known from this: the budget covers ` +
+        `connecting, the request and the reply alike. The usual cause is a connection that WAS ` +
+        `accepted while a long decode occupied the server, in which case retrying after the ` +
+        `current job finishes is enough — but a target this process cannot route to expires here ` +
+        `identically, so a repeat failure while something else reaches that ComfyUI points at the ` +
+        `route rather than at a busy server.`,
       "COMFYUI_HTTP_TIMEOUT",
       { endpoint: "/system_stats", timeout_ms: SYSTEM_STATS_TIMEOUT_MS },
     );

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -88,6 +88,25 @@ function originOf(target: string): string | undefined {
  *                   a negative result.
  */
 export function describeTargetDrift(target: string): string {
+  return classifyTargetDrift(target).text;
+}
+
+/**
+ * What the comparison ESTABLISHED, alongside the sentence describing it (#1896).
+ *
+ * The sentence alone was enough while only one caller existed. It is not enough
+ * for the advice that follows it: "confirm the server is up" is sound guidance
+ * after a DIFFERENT or an UNKNOWN verdict and actively wrong after a SAME one,
+ * where a browser is connected to that very origin. Callers need the verdict to
+ * pick a tail, and re-deriving it by matching the prose would be a predicate on
+ * a message — the thing that breaks the moment the wording moves.
+ *
+ * Computed ONCE per failure and shared, so formatting an error costs a single
+ * channel read rather than one per consumer.
+ */
+export type TargetDriftVerdict = "different" | "same" | "unknown";
+
+function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; text: string } {
   const origins = (() => {
     try {
       return panelOrigins();
@@ -95,9 +114,9 @@ export function describeTargetDrift(target: string): string {
       return []; // a broken source must never replace the real network error
     }
   })();
-  if (origins.length === 0) return "";
+  if (origins.length === 0) return { verdict: "unknown", text: "" };
   const want = originOf(target);
-  if (!want) return "";
+  if (!want) return { verdict: "unknown", text: "" };
   const distinct = [...new Set(origins)];
   // #1175 — `includes` compares spellings, not servers. A panel on
   // http://127.0.0.1:8188 against a target of http://localhost:8188 is ONE
@@ -113,16 +132,66 @@ export function describeTargetDrift(target: string): string {
       match === want
         ? ""
         : ` (spelled ${match} there and ${want} here — the same host, so this is not a mismatch)`;
-    return (
-      ` A connected panel is on this same origin${alias}, so this is NOT a wrong-address problem: ` +
-      `the browser can reach ${want} and this process cannot (a firewall, a container ` +
-      `boundary, or a server bound to one interface).`
-    );
+    return {
+      verdict: "same",
+      text:
+        ` A connected panel is on this same origin${alias}, so this is NOT a wrong-address problem: ` +
+        `the browser can reach ${want} and this process cannot (a firewall, a container ` +
+        `boundary, or a server bound to one interface).`,
+    };
   }
+  return {
+    verdict: "different",
+    text:
+      ` A connected panel is on ${distinct.join(", ")} — a DIFFERENT address, which is why ` +
+      `the panel works while this call does not. Point COMFYUI_URL at that origin if it is the ` +
+      `server you meant.`,
+  };
+}
+
+/**
+ * The "now go and check" tail, chosen by what the comparison established (#1896).
+ *
+ * On a SAME verdict the standing advice sends the caller back down the road that
+ * just failed: `get_system_stats (action:"health")` runs in THIS process against
+ * THIS address, so it reproduces the failure instead of diagnosing it — and
+ * "confirm the server is up" invites precisely the conclusion the comparison has
+ * just ruled out, since a browser is connected to that origin. The reporter of
+ * #1896 was told a panel was connected and then handed two more calls down the
+ * dead path; this is the half of that which is fixable without the panel
+ * transport that does not exist.
+ *
+ * `install_comfyui (action:"environment")` survives in both branches and is NOT
+ * described as failing: its `/system_stats` read sits inside a try (see
+ * services/workspace-env.ts getEnvironment), so it still reports the resolved
+ * target on an unreachable server. Claiming otherwise would be the same
+ * overclaim pointed the other way.
+ *
+ * `budget` is the timeout path's extra option. It stays offered even on a SAME
+ * verdict: a connected browser proves something answers that origin, never that
+ * it would answer THIS process quickly, so "the server is simply slow" is still
+ * live and ruling it out here would be an overclaim.
+ */
+function nextStepsFor(
+  verdict: TargetDriftVerdict,
+  target: string,
+  budget: boolean,
+): string {
+  if (verdict !== "same") {
+    return budget
+      ? ` Confirm it is up with get_system_stats (action:"health"), and raise ` +
+          `COMFYUI_MCP_HTTP_TIMEOUT_S if this server is simply slow.`
+      : ` Check the target with install_comfyui (action:"environment"), and confirm the server ` +
+          `is up with get_system_stats (action:"health").`;
+  }
+  const want = originOf(target) ?? target;
   return (
-    ` A connected panel is on ${distinct.join(", ")} — a DIFFERENT address, which is why ` +
-    `the panel works while this call does not. Point COMFYUI_URL at that origin if it is the ` +
-    `server you meant.`
+    ` get_system_stats (action:"health") will NOT add anything here: it runs in this same ` +
+    `process against this same address, so it fails the same way. ` +
+    (budget ? `Raise COMFYUI_MCP_HTTP_TIMEOUT_S if this server is simply slow; otherwise the ` : `The `) +
+    `route from this process to ${want} is what needs fixing, not the address` +
+    (budget ? `.` : ` — install_comfyui (action:"environment") reports the resolved target ` +
+      `without needing to reach it.`)
   );
 }
 
@@ -202,14 +271,18 @@ export function deliveryDoubt(code: string | undefined, method: string): string 
 
 function describeComfyFetchFailure(err: unknown, target: string, method: string): Error {
   const { message, code } = describeFetchFailure(err);
+  // ONE classification, used for both the sentence and the tail it governs
+  // (#1896) — two calls would read the channel twice and could, across a
+  // republish, disagree with each other inside a single message.
+  const drift = classifyTargetDrift(target);
   const wrapped = new Error(
     `${message} — while requesting ${target} (${method}).` +
       deliveryDoubt(code, method) +
       ` ` +
       `That is the headless ComfyUI target (COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable, ` +
       `because the panel talks to whichever ComfyUI its browser tab is on.` +
-      describeTargetDrift(target) +
-      ` Check the target with install_comfyui (action:"environment"), and confirm the server is up with get_system_stats (action:"health").`,
+      drift.text +
+      nextStepsFor(drift.verdict, target, false),
     { cause: err },
   );
   if (code) (wrapped as { code?: string }).code = code;
@@ -318,6 +391,14 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
   const method = methodOf(input, init);
   const seconds = comfyHttpTimeoutSeconds();
   const mutating = method !== "GET" && method !== "HEAD";
+  // #1896 — the comparison the TRANSPORT path has made since #1553, on the path
+  // that shares its cause. An unroutable COMFYUI_URL does not always REFUSE: a
+  // firewall or container boundary that DROPs the SYN black-holes it instead,
+  // and that lands here rather than in describeComfyFetchFailure. Same child,
+  // same readable channel, same connected panel — this path simply never asked,
+  // so `list_packs (action:"list_templates")` against a firewalled target said
+  // nothing at all about the panel that was working the whole time.
+  const drift = classifyTargetDrift(target);
   const err = new Error(
     `No reply from ComfyUI within ${seconds}s — while requesting ${target} (${method}). ` +
       (mutating
@@ -326,10 +407,17 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
           `(action:"list") and get_history (action:"list")). `
         : `Nothing was learned about the server from this — a timeout is not a refusal and not a ` +
           `"not found". `) +
-      `The connection was accepted but no answer arrived in time, which points at the server or ` +
-      `something between it and here rather than at the request. Confirm it is up with ` +
-      `get_system_stats (action:"health"), and raise COMFYUI_MCP_HTTP_TIMEOUT_S if this server is ` +
-      `simply slow.`,
+      // #1896 — this asserted "The connection was accepted but no answer arrived
+      // in time". The ceiling covers the WHOLE exchange, connecting included, so
+      // a black-holed SYN times out here having established no connection at all
+      // — and on the read path the sentence immediately before already said
+      // nothing was learned. Say only what a timeout actually proves.
+      `Whether a connection was ever established is NOT known from this: the budget covers ` +
+      `connecting, the request and the reply alike, so a black-holed or filtered route expires ` +
+      `here exactly as a slow server does. That points at the server, or at something between it ` +
+      `and here, rather than at the request.` +
+      drift.text +
+      nextStepsFor(drift.verdict, target, true),
   );
   (err as { code?: string }).code = "COMFYUI_HTTP_TIMEOUT";
   return err;

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -152,14 +152,14 @@ function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; tex
 /**
  * The "now go and check" tail, chosen by what the comparison established (#1896).
  *
- * On a SAME verdict the standing advice sends the caller back down the road that
- * just failed: `get_system_stats (action:"health")` runs in THIS process against
- * THIS address, so it reproduces the failure instead of diagnosing it — and
- * "confirm the server is up" invites precisely the conclusion the comparison has
- * just ruled out, since a browser is connected to that origin. The reporter of
- * #1896 was told a panel was connected and then handed two more calls down the
- * dead path; this is the half of that which is fixable without the panel
- * transport that does not exist.
+ * On a SAME verdict the standing advice asks a question that is already
+ * answered: "confirm the server is up" invites precisely the conclusion the
+ * comparison just ruled out, since a browser is connected to that origin right
+ * now. The reporter of #1896 was told a panel was connected and then sent to
+ * find out whether the server was running.
+ *
+ * The health check is therefore RE-AIMED rather than dropped — see the note at
+ * the SAME branch for why suppressing it would have been an overclaim.
  *
  * `install_comfyui (action:"environment")` survives in both branches and is NOT
  * described as failing: its `/system_stats` read sits inside a try (see
@@ -185,13 +185,23 @@ function nextStepsFor(
           `is up with get_system_stats (action:"health").`;
   }
   const want = originOf(target) ?? target;
+  // REPURPOSED, not suppressed. An earlier draft of this said the health check
+  // "will NOT add anything here: it runs in this same process against this same
+  // address, so it fails the same way". That is an overclaim: a SAME verdict
+  // compares ORIGINS, and an origin is not an endpoint. A ComfyUI that is up and
+  // answering the browser can still stall one route — `/object_info` mid-decode
+  // is the documented case (comfyui/client.ts) — in which case /system_stats
+  // answers perfectly well and is the single most informative call available.
+  // So the health check keeps its place; what changes is the QUESTION it is sent
+  // to settle. "Is the server up" is already answered, and answered yes.
   return (
-    ` get_system_stats (action:"health") will NOT add anything here: it runs in this same ` +
-    `process against this same address, so it fails the same way. ` +
-    (budget ? `Raise COMFYUI_MCP_HTTP_TIMEOUT_S if this server is simply slow; otherwise the ` : `The `) +
-    `route from this process to ${want} is what needs fixing, not the address` +
-    (budget ? `.` : ` — install_comfyui (action:"environment") reports the resolved target ` +
-      `without needing to reach it.`)
+    ` The address itself is not what is wrong — a browser is connected to that origin. Use ` +
+    `get_system_stats (action:"health") to tell the two remaining cases apart: if it fails from ` +
+    `here too, the route from this process to ${want} is what needs fixing; if it succeeds, the ` +
+    `problem is specific to this request rather than to the target` +
+    (budget
+      ? `, and COMFYUI_MCP_HTTP_TIMEOUT_S may simply be too low for it.`
+      : `. install_comfyui (action:"environment") reports the resolved target either way.`)
   );
 }
 

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -402,12 +402,20 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
   const seconds = comfyHttpTimeoutSeconds();
   const mutating = method !== "GET" && method !== "HEAD";
   // #1896 — the comparison the TRANSPORT path has made since #1553, on the path
-  // that shares its cause. An unroutable COMFYUI_URL does not always REFUSE: a
-  // firewall or container boundary that DROPs the SYN black-holes it instead,
-  // and that lands here rather than in describeComfyFetchFailure. Same child,
-  // same readable channel, same connected panel — this path simply never asked,
-  // so `list_packs (action:"list_templates")` against a firewalled target said
-  // nothing at all about the panel that was working the whole time.
+  // that shares its cause.
+  //
+  // The defect is simply that THIS FORMATTER NEVER ASKED. Same child, same
+  // readable channel, same connected panel as the refusal path, and it said
+  // nothing at all — `list_packs (action:"list_templates")` sits on this ceiling
+  // since #1795 removed its hard-coded 8s signal, so it is a first-class
+  // consumer of a message that was silent about a working panel.
+  //
+  // How a call GETS here is deliberately not overstated (review, finding 1). A
+  // target this process cannot route to may expire on the ceiling — a DROPped
+  // SYN black-holes it — or fail fast with EHOSTUNREACH/ENETUNREACH, which is a
+  // bare fetch failure and takes describeComfyFetchFailure instead. Both were
+  // measured; only the first reaches this line. The fix does not depend on which
+  // is more common, and a slow server that never answers lands here too.
   const drift = classifyTargetDrift(target);
   const err = new Error(
     `No reply from ComfyUI within ${seconds}s — while requesting ${target} (${method}). ` +


### PR DESCRIPTION
Closes #1896.

Taken on the owner's instruction of 2026-08-21T01:38Z, which post-dates the `parked` label: *"There's nobody to ask, fix what you can, then merge and close this issue."* This is the "what you can" half. **Review status:** grok reviewed `de2b542` — `COMMENT INTENDED: APPROVE`, no blocking findings, one framing correction (finding 1) now applied. Two commits have landed since, so that verdict is **not banked**; re-requested on the current head.

## The park's measurement still holds

Re-verified against `origin/main` before touching anything:

- `listWorkflowTemplatesAction()` (`src/tools/skills-access.ts:583`) builds `getComfyUIBaseUrl() + "/api/workflow_templates"` and fetches from the tool process.
- Nothing under `src/tools/` holds a bridge handle. `list_packs` runs in the per-tab `comfyui` stdio child, which never loads `orchestrator/index.js`.
- `workflow_templates` still appears nowhere in the panel repo outside the CHANGELOG and the vocabulary snapshot — there is no panel-side command to route *to*.
- There is **no template cache** anywhere the child could read (grepped `src/tools/skills-access.ts`, `src/tools/template-schema.ts`, `src/services/template-index-scope.ts`).

So the routing fix is unchanged in cost: a new panel bridge command **plus** a child-to-bridge transport, across two repos. Out of scope, not built here. **PR #1600's shortcut is not revived.**

## What I reproduced, by execution

A harness drives the **real** spawned stdio child (`node dist/index.js`) exactly as the orchestrator spawns it: a live publisher process writes the #1553 panel-origins channel into a shared `COMFYUI_MCP_PROGRESS_DIR`, a genuinely reachable HTTP server stands in for the panel's ComfyUI, and `COMFYUI_URL` points somewhere this process cannot reach. Then a real `tools/call list_packs {action:"list_templates"}`.

Four topologies on clean `origin/main`:

| panel is | failure | names panel? | overclaim? |
|---|---|---|---|
| elsewhere | ECONNREFUSED | **yes** — "a DIFFERENT address … Point COMFYUI_URL at that origin" | no |
| same origin | ECONNREFUSED | **yes** — "NOT a wrong-address problem" | no |
| elsewhere | **timeout** | **NO — silent** | **yes** |
| same origin | **timeout** | **NO — silent** | **yes** |

**The reported ECONNREFUSED path is already complete.** #1553 fixed it and the fix works — verbatim from the rig:

> `fetch failed: connect ECONNREFUSED 127.0.0.1:53192 (ECONNREFUSED) — while requesting http://127.0.0.1:53192/api/workflow_templates (GET). … A connected panel is on http://127.0.0.1:53190 — a DIFFERENT address, which is why the panel works while this call does not. Point COMFYUI_URL at that origin if it is the server you meant.`

**Its twin is not.** `describeComfyTimeout` — the `COMFYUI_MCP_HTTP_TIMEOUT_S` ceiling path — makes no comparison at all. Same child, same readable channel, same connected panel, and **it never asked**:

> `No reply from ComfyUI within 6s — while requesting http://192.0.2.1:8188/api/workflow_templates (GET). Nothing was learned about the server from this … The connection was accepted but no answer arrived in time … Confirm it is up with get_system_stats (action:"health") …`

Not one word about the panel that was working the whole time. #1795 put `list_templates` on this ceiling by removing its hard-coded 8s signal, so it is a first-class consumer of the message that stayed silent.

**How a call reaches this path is deliberately not overstated.** A target this process cannot route to may expire on the ceiling (a DROPped SYN black-holes it — measured above) *or* fail fast with `EHOSTUNREACH`/`ENETUNREACH`, which is a bare fetch failure and takes `describeComfyFetchFailure`, where #1553 already names the panel. Both were measured. The defect does not depend on which is more common: it is that the ceiling formatter never asked a channel it could read. A slow server that never answers lands here too.

## The change (three parts, all diagnostic)

1. **`describeComfyTimeout` makes the drift comparison**, exactly as the transport path has since #1553.
2. **It stops asserting "The connection was accepted but no answer arrived in time."** A black-holed SYN expires on this same ceiling having established no connection at all — and on a read, the sentence immediately before already said nothing was learned.
3. **The "now go and check" tail follows the verdict.** After a SAME-origin verdict, "confirm the server is up" sends the caller after a question that is already answered — a browser is connected to that origin right now. The health check is **re-aimed**, not dropped (see below).

The verdict is returned as data (`classifyTargetDrift` → `"different" | "same" | "unknown"`) rather than re-derived by matching the sentence, and is computed **once** per failure so a message cannot disagree with itself across a republish. `describeTargetDrift` keeps its exact output for its other consumer (`process-control.ts`, #1175).

After, on the same rig (same-origin timeout):

> `… A connected panel is on this same origin, so this is NOT a wrong-address problem: the browser can reach http://192.0.2.1:8188 and this process cannot … The address itself is not what is wrong — a browser is connected to that origin. Use get_system_stats (action:"health") to tell the two remaining cases apart: if it fails from here too, the route from this process to http://192.0.2.1:8188 is what needs fixing; if it succeeds, the problem is specific to this request rather than to the target, and COMFYUI_MCP_HTTP_TIMEOUT_S may simply be too low for it.`

### An overclaim I caught in my own diff, before requesting review

The first draft of the SAME tail said the health check *"will NOT add anything here: it runs in this same process against this same address, so it fails the same way"* — and suppressed it.

That is the same defect class this PR exists to remove, pointed the other way. **A SAME verdict compares ORIGINS, and an origin is not an endpoint.** A ComfyUI that is up and answering the browser can still stall a single route — `/object_info` mid-decode is the documented case (`comfyui/client.ts`) — and in that state `/system_stats` answers perfectly well. The draft was suppressing the single most informative call available, and asserting the outcome of a call it had not made.

Second commit fixes it: the health check keeps its place and becomes a **discriminator**. `if it fails from here too` → the route needs fixing; `if it succeeds` → the problem is specific to this request. A test (`M7`) pins that the message does not assert that outcome in advance.

### …and the probe that discriminator points at was answering the question for it

Following my own change downstream: `comfyui/client.ts`'s `getSystemStats` timeout said **"The connection was accepted but the body never finished, which is common while a long decode occupies the server. The request was aborted; retry after the current job finishes."**

Same overclaim as the sibling — the budget covers connecting — but it matters more here, because this branch now sends people to that exact call **on purpose**. A reader chasing a dead route was handed *"a long decode, just retry"*: precisely the reading the discriminator exists to rule out. It also contradicted its own paragraph, whose previous sentence says nothing was learned about the server.

Third commit keeps the decode reading as the *likely* one and removes the assertion that it is the *only* one, so both arms of the discriminator survive.

**The call still fails.** Nothing here implies it could have succeeded, and no new fallback target is introduced.

## Mutation evidence

Nine mutations, each verified to have actually changed the file on disk (`git diff --numstat` non-empty) before the suite ran — a mutation that never applied reads as survived. **All nine killed:**

| mutation | tests killed |
|---|---|
| M1 call site: drop `drift.text` from the timeout formatter | names-DIFFERENT-origin, rules-out-drift, injected-source-wins |
| M2 restore the "connection was accepted" overclaim | does-NOT-claim-connection-accepted |
| M3 call site: revert timeout tail to the unconditional literal | stops-asking-whether-the-server-is-up |
| M4 call site: revert transport tail to the unconditional literal | re-aims-the-health-check |
| M5 make `nextStepsFor` ignore the verdict | both SAME-branch tests |
| M6 `classifyTargetDrift` always answers `"different"` | both SAME-branch tests |
| M7 reintroduce the suppression overclaim on the SAME tail | keeps-the-health-check-as-discriminator |
| M8 restore the `client.ts` "connection was accepted" overclaim | does-not-assert-connection-accepted |
| M9 drop the dead-route reading from `client.ts` | keeps-decode-AND-dead-route-readings |

M1/M3/M4 are the one-line **call-site wiring** — asserted directly, not only the helper. M5/M6 prove the **verdict** is load-bearing, not just the prose.

## Test results

- New: `src/__tests__/comfyui/timeout-panel-origin-drift.test.ts` (12 tests) and `src/__tests__/comfyui/system-stats-timeout-honesty.test.ts` (3 tests). Drives the child's real configuration (no injected bridge source, only the spawn-env channel dir) and a real ceiling abort, so it takes production's `init.signal === undefined && isTimeoutAbort(err)` branch rather than fabricating a `TimeoutError`.
- `src/__tests__/comfyui/` + `tools/` + `services/`: **345 files, 7061 passed, 0 failed.**
- Full suite baseline on clean `origin/main` before the change: 4 failed / 11078 passed (`node-id-union-message.test.ts` + 1, pre-existing). Unchanged by this PR.
- `tsc --noEmit` clean; `check:vocabulary`, `i18n:check`, `check:docs-*`, `check:blog-*`, `check:unknown-collapse` all OK.

## Deliberately NOT done

- **The routing fix itself.** Templates still cannot be read through the panel. That needs the panel bridge command plus the child-to-bridge transport the freeze parks.
- **PR #1600's shortcut** (orchestrator fetches the panel's observed origin) is not revived — it fails identically in the loopback-only topology that motivates the work, and two hosts that both answer and disagree trade a loud failure for a quiet wrong one.
- **No claim that raising `COMFYUI_MCP_HTTP_TIMEOUT_S` cannot help on a SAME verdict.** A connected browser proves something answers that origin, never that it would answer *this* process quickly, so "simply slow" stays on the table. There is a test pinning that the budget survives the SAME branch.
- **`install_comfyui (action:"environment")` is not described as failing.** Its `/system_stats` read sits inside a `try` (`services/workspace-env.ts` `getEnvironment`), so it still reports the resolved target on an unreachable server. Claiming otherwise would be the same overclaim pointed the other way.
- **No Playwright run.** Nothing here is panel-visible — no panel-repo change and nothing the sidebar renders; this is orchestrator/child error text only.
- **No test stubs a bridge into the child.** `list_packs` runs in a bridge-less child; a test that gave it one would be testing a fiction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
