### PR TITLE
release: v0.52.41 — bound after settling read, connected-panel timeout, revoke/requeue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.41] - 2026-08-20
+
+### MCP
+
+#### Fixed
+- panel_set_workflow_target reports bound after a settling read that proves writes (#1951)
+- a timed-out ComfyUI call makes the same connected-panel comparison a refused one does (#1952)
+- correct what a successful revoke actually proves, and pin the requeue window (#1949)
+
+
 ## [0.52.40] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.40",
+  "version": "0.52.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.40",
+      "version": "0.52.41",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.40",
+  "version": "0.52.41",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.41** from `main` (after v0.52.40).

Carries:

- #1951 / #1696 — `panel_set_workflow_target` reports bound after a settling read that proves writes
- #1952 / #1896 — a timed-out ComfyUI call makes the same connected-panel comparison a refused one does
- #1949 / #1948 — correct what a successful revoke actually proves, and pin the requeue window

Held out: #1697 P1 inflight; #1953 claimed this cycle; panel#1472 typescript 5→7 (blocked).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.41` tag on the version commit). Tag is local; push `v0.52.41` after merge.
