### PR TITLE
fix(1953): self-restart no longer leaves an unreclaimable panel-op.lock

### DIFF
--- a/src/__tests__/services/panel-lock-dead-owner.test.ts
+++ b/src/__tests__/services/panel-lock-dead-owner.test.ts
@@ -167,12 +167,13 @@ describe("#1489 a provably dead lock owner is reported at once", () => {
   });
 
   it("a FRESH lock with a dead owner is NOT fast-failed, however long we wait", async () => {
-    // The age gate. `reclaimAbandonedPanelLock` refuses on AGE before it ever
-    // consults a pid, and this module must not hold a second opinion about what
-    // freshness means. The budget is long enough for several probes, so a
-    // missing age gate would fire here rather than hide behind a short timeout —
-    // which is exactly how mutation M3 slipped through a first version of these
-    // tests once the two-observation rule slowed the fast path down.
+    // Acquire still age-gates the fast-fail: this loop must not delete, and a
+    // young dead-owner lock is reclaimable via unlock / hello auto-sync (#1953)
+    // rather than by this wait. The budget is long enough for several probes,
+    // so a missing age gate would fire here rather than hide behind a short
+    // timeout — which is exactly how mutation M3 slipped through a first
+    // version of these tests once the two-observation rule slowed the fast
+    // path down.
     writeLock(DEAD_PID, 60_000); // a minute old: dead owner, but FRESH
     const { withPanelMutationLock } = await lockModule();
 

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -135,6 +135,7 @@ import {
   panelPendingOpsPath,
   reclaimAbandonedPanelLock,
   recordPanelPendingOp,
+  releaseOwnedPanelLock,
   targetsPanelPack,
   targetsPanelPackExactly,
   withPanelMutationLock,
@@ -369,9 +370,10 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     expect(order).toEqual(["holder:start", "nested", "holder:end", "outsider"]);
   });
 
-  it("does NOT reclaim a fresh lock even when its recorded pid is dead", async () => {
-    // Age is a mandatory part of the proof. A just-created lock can still be
-    // in the small window before its writer has committed its pid record.
+  it("does NOT auto-reclaim a fresh lock even when its recorded pid is dead", async () => {
+    // #779: the acquire loop never deletes. A young dead-owner lock is
+    // reclaimable via unlock / hello auto-sync (#1953); this path times out
+    // and leaves the file, naming that recovery.
     writeFileSync(panelLockPath(), JSON.stringify({ pid: 999999 }));
     await expect(
       withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
@@ -576,14 +578,17 @@ describe("reclaimAbandonedPanelLock — the explicit recovery for a wedged lock 
     expect(existsSync(path)).toBe(true);
   });
 
-  it("REFUSES a recent lock even when its recorded pid is dead", async () => {
-    // A just-taken lock can be in the window before its writer committed the
-    // pid record; youth means "cannot call it abandoned", not "abandoned".
+  it("RECLAIMS a recent lock when its recorded pid is dead (#1953)", async () => {
+    // The 10-minute window protects a slow live ComfyUI-Manager op, not a
+    // lock whose owner has already exited. Self-restart leaves exactly this
+    // shape: seconds old, owner pid gone, unlock used to refuse it.
     const path = await plantLock(JSON.stringify({ pid: DEAD_PID }));
     const res = reclaimAbandonedPanelLock();
-    expect(res.outcome).toBe("refused");
-    expect(res.detail).toMatch(/window/);
-    expect(existsSync(path)).toBe(true);
+    expect(res.outcome).toBe("reclaimed");
+    expect(existsSync(path)).toBe(false);
+    await expect(
+      withPanelMutationLock(async () => "recovered", { timeoutMs: 500 }),
+    ).resolves.toBe("recovered");
   });
 
   it("REFUSES an old lock whose content is not valid JSON", async () => {
@@ -672,7 +677,10 @@ describe("reclaimAbandonedPanelLock — the explicit recovery for a wedged lock 
     // pid, and a young lock gets reclaimed. The observation is descriptor-
     // pinned, so the age and the owner bytes always come from one instance.
     const path = await plantLock(JSON.stringify({ pid: DEAD_PID }), 60 * 60_000);
-    const fresh = JSON.stringify({ pid: DEAD_PID - 1, startedAt: "fresh" });
+    // A LIVE young replacement: a dead-owner fresh lock is now reclaimable
+    // (#1953), so this test would no longer prove the age was read from the
+    // replacement instance if the replacement's pid were also dead.
+    const fresh = JSON.stringify({ pid: process.pid, startedAt: "fresh" });
     fsyncTracker.onBeforeOpen = (p, flags) => {
       if (p === path && flags === "r") {
         // Replace the stale lock with a fresh one just before observation.
@@ -1282,5 +1290,103 @@ describe("#836 — a reclaimable lock needs ownership proofs everywhere", () => 
     expect(res.detail).toMatch(/inside the/i);
     expect(res.detail).not.toMatch(/STILL RUNNING/);
     expect(res.detail).not.toMatch(/cannot be determined/i);
+  });
+
+  it("reclaims a lock whose pid is ours but whose owner start predates this process (#1953)", async () => {
+    // pid reuse onto US: the number matches, kill(0) says alive, but the
+    // recorded process start is from a previous life. That is the identity
+    // `ownerStartedMs` exists to answer without treating existence as identity.
+    const path = await plantLock(
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: "long ago",
+        ownerStartedMs: Date.now() - process.uptime() * 1000 - 60_000,
+      }),
+      60 * 60_000,
+    );
+    const res = reclaimAbandonedPanelLock();
+    expect(res.outcome).toBe("reclaimed");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("refuses an old lock that still names THIS process's start time as live", async () => {
+    // With a matching start time the pid IS us, even 50 hours later. Refusing
+    // as "may have been reused" would be the lie identity was added to stop.
+    const path = await plantLock(
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: "long ago",
+        ownerStartedMs: Date.now() - process.uptime() * 1000,
+      }),
+      7 * 24 * 60 * 60_000,
+    );
+    const res = reclaimAbandonedPanelLock();
+    expect(res.outcome).toBe("refused");
+    expect(res.detail).toMatch(/still running/i);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("reclaims when kill(0) claims the pid exists but the OS process table does not (#1953)", async () => {
+    // The 50-hour wedge: unlock said pid 26864 existed; Get-Process did not
+    // find it. kill(0) is not the process table.
+    const fakePid = 424242;
+    const path = await plantLock(
+      JSON.stringify({ pid: fakePid, startedAt: "long ago" }),
+      50 * 60 * 60_000,
+    );
+    const realKill = process.kill.bind(process);
+    const spy = vi.spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      sig?: Parameters<typeof process.kill>[1],
+    ) => {
+      if (pid === fakePid) return true as unknown as void;
+      return realKill(pid, sig);
+    }) as typeof process.kill);
+    try {
+      const res = reclaimAbandonedPanelLock();
+      expect(res.outcome).toBe("reclaimed");
+      expect(existsSync(path)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("releaseOwnedPanelLock — drop a lock this process owns on the way out (#1953)", () => {
+  it("releases a lock naming this pid so the next acquire proceeds", async () => {
+    const path = panelLockPath();
+    writeFileSync(
+      path,
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        token: "self-restart",
+      }),
+    );
+    const res = releaseOwnedPanelLock();
+    expect(res.outcome).toBe("released");
+    expect(existsSync(path)).toBe(false);
+    await expect(
+      withPanelMutationLock(async () => "next-op", { timeoutMs: 500 }),
+    ).resolves.toBe("next-op");
+  });
+
+  it("leaves a lock owned by another pid in place", async () => {
+    const path = panelLockPath();
+    const payload = JSON.stringify({
+      pid: 0x7fffffff,
+      startedAt: new Date().toISOString(),
+      token: "someone-else",
+    });
+    writeFileSync(path, payload);
+    const res = releaseOwnedPanelLock();
+    expect(res.outcome).toBe("not-ours");
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(payload);
+  });
+
+  it("reports no-lock when the path is empty", () => {
+    const res = releaseOwnedPanelLock();
+    expect(res.outcome).toBe("no-lock");
   });
 });

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -1309,6 +1309,29 @@ describe("#836 — a reclaimable lock needs ownership proofs everywhere", () => 
     expect(existsSync(path)).toBe(false);
   });
 
+  it("refuses a FRESH lock naming our pid with a mismatched start — a clock step is not a death (#1955 review)", async () => {
+    // `ownerStartedMs` is derived from `Date.now() - uptime*1000`. The recorded
+    // value is written at lock take; this reading is recomputed now. Only
+    // Date.now() follows a wall-clock step, so a resume from sleep or an NTP
+    // correction shifts them apart with no process having died — here modelled
+    // as a recorded start an hour "earlier" than the live one.
+    //
+    // Without the stale-window floor this reclaims: a live orchestrator deletes
+    // the lock guarding its own in-flight panel op. Inside the window a
+    // mismatch has to be read as clock drift, not as a recycled pid.
+    const path = await plantLock(
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: "just now",
+        ownerStartedMs: Date.now() - process.uptime() * 1000 - 60 * 60_000,
+      }),
+      2 * 60_000,
+    );
+    const res = reclaimAbandonedPanelLock();
+    expect(res.outcome).toBe("refused");
+    expect(existsSync(path)).toBe(true);
+  });
+
   it("refuses an old lock that still names THIS process's start time as live", async () => {
     // With a matching start time the pid IS us, even 50 hours later. Refusing
     // as "may have been reused" would be the lie identity was added to stop.

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -782,6 +782,35 @@ describe("performPanelSync", () => {
     expect(h.updates).toBe(1);
     expect(existsSync(lockPath)).toBe(false);
   });
+
+  it("reclaims a FRESH lock whose owner is already dead and proceeds (#1953)", async () => {
+    // Self-restart leaves a seconds-old lock owned by the now-dead pre-restart
+    // pid. The 10-minute grace used to protect it; hello auto-sync then timed
+    // out every turn. performPanelSync is that unattended path.
+    const lockPath = process.env.COMFYUI_MCP_PANEL_LOCK!;
+    const deadPid = 0x7ffffffe;
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: deadPid,
+        startedAt: new Date().toISOString(),
+        token: "fresh-dead-self-restart",
+      }),
+    );
+    expect(existsSync(lockPath)).toBe(true);
+
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+
+    expect(r.synced).toBe(true);
+    expect(h.updates).toBe(1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/services/self-restart.test.ts
+++ b/src/__tests__/services/self-restart.test.ts
@@ -3,7 +3,11 @@
 // timers, registry, or process spawns).
 
 import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SelfRestarter, type SelfRestartDeps } from "../../services/self-restart.js";
+import { releaseOwnedPanelLock } from "../../services/panel-pin-guard.js";
 import type { InstallInfo, SelfUpdateResult } from "../../services/self-update.js";
 
 interface Harness {
@@ -24,6 +28,7 @@ function makeHarness(opts: {
   uptimeMs?: number;
   spawnOk?: boolean;
   mtime?: number;
+  releasePanelLock?: () => void;
 }): Harness {
   const calls: string[] = [];
   const spawns: Array<{ npxVersion?: string }> = [];
@@ -57,6 +62,10 @@ function makeHarness(opts: {
       spawns.push(o);
       return opts.spawnOk ?? true;
     },
+    releasePanelLock: () => {
+      calls.push("releasePanelLock");
+      opts.releasePanelLock?.();
+    },
     exit: () => {
       calls.push("exit");
     },
@@ -88,7 +97,7 @@ describe("SelfRestarter — dev rebuild watch", () => {
     expect(h.calls).toEqual([]);
     h.restarter.devTick(); // stable → arm + fire (idle)
     await Promise.resolve();
-    expect(h.calls).toEqual(["spawn", "teardown", "exit"]);
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
     expect(h.spawns[0]?.npxVersion).toBeUndefined(); // same argv respawn
   });
 
@@ -116,7 +125,7 @@ describe("SelfRestarter — dev rebuild watch", () => {
     h.setIdle(true);
     h.restarter.tryRestart();
     await Promise.resolve();
-    expect(h.calls).toEqual(["spawn", "teardown", "exit"]);
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
   });
 
   it("respects the minimum-uptime guard", () => {
@@ -136,7 +145,7 @@ describe("SelfRestarter — dev rebuild watch", () => {
     h.restarter.devTick();
     h.restarter.devTick();
     await Promise.resolve();
-    expect(h.calls).toEqual(["spawn"]); // no teardown, no exit
+    expect(h.calls).toEqual(["spawn"]); // no release, no teardown, no exit
     expect(h.announces.some((a) => a.includes("Restart failed"))).toBe(true);
   });
 });
@@ -150,7 +159,7 @@ describe("SelfRestarter — published installs", () => {
     h.restarter.start();
     await h.restarter.updateTick();
     await Promise.resolve();
-    expect(h.calls).toEqual(["check", "spawn", "teardown", "exit"]);
+    expect(h.calls).toEqual(["check", "spawn", "releasePanelLock", "teardown", "exit"]);
     expect(h.spawns[0]?.npxVersion).toBeUndefined(); // disk already updated — same argv
   });
 
@@ -166,7 +175,7 @@ describe("SelfRestarter — published installs", () => {
     h.restarter.start();
     await h.restarter.updateTick();
     await Promise.resolve();
-    expect(h.calls).toEqual(["spawn", "teardown", "exit"]);
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
     expect(h.spawns[0]?.npxVersion).toBe("1.2.0");
   });
 
@@ -208,5 +217,76 @@ describe("SelfRestarter — opt-outs", () => {
     expect(h.calls).toEqual([]); // never spawned/tore down/exited
     const nags = h.announces.filter((a) => a.includes("auto-restart is off"));
     expect(nags).toHaveLength(1);
+  });
+});
+
+describe("SelfRestarter — releases panel-op.lock this process owns (#1953)", () => {
+  it("a successful restart drops the lock so the successor can acquire it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-self-restart-lock-"));
+    const prev = process.env.COMFYUI_MCP_PANEL_LOCK;
+    const lock = join(dir, "panel-op.lock");
+    process.env.COMFYUI_MCP_PANEL_LOCK = lock;
+    writeFileSync(
+      lock,
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        token: "pre-restart",
+      }),
+    );
+    try {
+      const h = makeHarness({
+        mode: "linked",
+        mtime: 1000,
+        releasePanelLock: () => {
+          releaseOwnedPanelLock();
+        },
+      });
+      h.restarter.start();
+      h.setMtime(2000);
+      h.restarter.devTick();
+      h.restarter.devTick();
+      await Promise.resolve();
+      expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
+      expect(existsSync(lock)).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_MCP_PANEL_LOCK;
+      else process.env.COMFYUI_MCP_PANEL_LOCK = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a failed spawn leaves the lock in place — we are staying alive", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-self-restart-lock-fail-"));
+    const prev = process.env.COMFYUI_MCP_PANEL_LOCK;
+    const lock = join(dir, "panel-op.lock");
+    process.env.COMFYUI_MCP_PANEL_LOCK = lock;
+    const payload = JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      token: "still-held",
+    });
+    writeFileSync(lock, payload);
+    try {
+      const h = makeHarness({
+        mode: "linked",
+        mtime: 1000,
+        spawnOk: false,
+        releasePanelLock: () => {
+          releaseOwnedPanelLock();
+        },
+      });
+      h.restarter.start();
+      h.setMtime(2000);
+      h.restarter.devTick();
+      h.restarter.devTick();
+      await Promise.resolve();
+      expect(h.calls).toEqual(["spawn"]);
+      expect(existsSync(lock)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_MCP_PANEL_LOCK;
+      else process.env.COMFYUI_MCP_PANEL_LOCK = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -49,6 +49,7 @@ import { resolveBlindTabGate } from "./blind-tab-gate.js";
 import { clearPanelDiskObservation } from "../services/panel-workspace.js";
 import { panelRecoveryContext } from "../services/panel-recovery.js";
 import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
+import { releaseOwnedPanelLock } from "../services/panel-pin-guard.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
 import { pairUrlDurability } from "./pair-durability.js";
 import { loadOrCreatePairToken } from "./pair-token-store.js";
@@ -6731,6 +6732,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (cur?.pid === process.pid) unlinkSync(lockPath);
     } catch {
       // No lockfile / unreadable — nothing to clean up.
+    }
+    // Same for panel-op.lock: a clean exit (SIGINT or self-restart) must not
+    // leave a lock whose owner is about to die (#1953). Idempotent if the
+    // restarter already released it; a lock naming any other pid is left.
+    try {
+      releaseOwnedPanelLock();
+    } catch {
+      /* best-effort — unlock/reclaim remains the recovery if this fails */
     }
   };
   /** The single in-flight teardown, so repeated signals queue behind it. */

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -24,6 +24,7 @@
 // depends only on the pin store (and panel-recovery, which is itself a leaf over
 // config + panel-workspace and reaches back into neither).
 
+import { execFileSync } from "node:child_process";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import {
@@ -328,10 +329,11 @@ function sleep(ms: number): Promise<void> {
  *   - `"unsure"` — a process exists, but the lock is old enough that the number
  *                 may since have been reused. Liveness is UNDETERMINED.
  *
- * The `startedAt` on the record is the LOCK's creation time, not the process's,
- * so it cannot establish identity either; closing that properly needs a
- * per-process start time this module does not have. What it CAN do is stop
- * asserting the strong claim.
+ * The `startedAt` on the record is the LOCK's creation time. Identity of the
+ * owner is `ownerStartedMs` (the process start time recorded at lock take).
+ * This probe stays a cheap existence check for the acquire poll; reclaim
+ * consults `ownerStartedMs` and the OS process table to resolve reuse / the
+ * Windows kill(0) false-positive (#1953).
  */
 function pidLiveness(pid: unknown, ageMs: number): boolean | "unsure" {
   if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
@@ -361,13 +363,66 @@ function pidLiveness(pid: unknown, ageMs: number): boolean | "unsure" {
 }
 
 /**
- * A lock is PROVABLY abandoned only when it is BOTH older than this AND owned
- * by a dead process. Panel operations are ComfyUI-Manager queue cycles
- * measured in seconds to minutes; ten minutes is far beyond a legitimate one,
- * so a lock older than that with a dead owner cannot be a live op — while a
- * younger lock, even with a dead-looking owner, stays untouched.
+ * Age beyond which a live-looking pid is equally well explained by reuse.
+ * The grace window applies ONLY when the recorded owner is NOT proven dead
+ * (#1953): a self-restart leaves a fresh lock whose owner is already gone,
+ * and protecting that for ten minutes is how panel sync wedged indefinitely.
  */
 const STALE_LOCK_MS = 10 * 60_000;
+
+/** Clock skew / tick rounding when comparing recorded vs live process start. */
+const OWNER_START_TOLERANCE_MS = 2_000;
+
+/** This process's start time (uptime-derived). */
+function processStartMs(): number {
+  return Date.now() - process.uptime() * 1000;
+}
+
+/**
+ * Does the OS process table list this pid? Independent of `process.kill(pid, 0)`,
+ * which on Windows has claimed a pid Get-Process could not find (#1953).
+ *
+ * `true` / `false` are answers; `undefined` means the probe could not tell
+ * (missing tool, permission, timeout) and must not be spent as either.
+ */
+function processTableHasPid(pid: number): boolean | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (process.platform === "linux") {
+    try {
+      return existsSync(`/proc/${pid}`);
+    } catch {
+      return undefined;
+    }
+  }
+  if (process.platform === "win32") {
+    try {
+      const out = execFileSync("tasklist.exe", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], {
+        encoding: "utf8",
+        timeout: 3000,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      // CSV row is `"image","pid","session",...`. The "no match" INFO line does
+      // not quote the pid as a field.
+      return out.includes(`","${pid}",`);
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "pid="], {
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return new RegExp(`(?:^|\\s)${pid}(?:\\s|$)`).test(out);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { status?: number };
+    if (e.code === "ENOENT") return undefined;
+    if (e.status === 1) return false;
+    return undefined;
+  }
+}
 
 /** What observing the lock file could establish about its holder. */
 interface PanelLockObservation {
@@ -379,11 +434,46 @@ interface PanelLockObservation {
   pid?: number;
   /** When the lock was taken (the record's startedAt), for messages. */
   startedAt?: string;
+  /** Process start time recorded at lock take — identity, not lock age. */
+  ownerStartedMs?: number;
   /** Pid liveness — only set when a valid pid was recorded. */
   /** Tri-state: see `pidLiveness`. "unsure" must NOT be read as either boolean. */
   alive?: boolean | "unsure";
   /** Why the content proved nothing about the owner (unreadable/corrupt/pid). */
   contentProblem?: string;
+}
+
+function startTimesMatch(obs: PanelLockObservation): boolean {
+  if (obs.ownerStartedMs === undefined) return false;
+  return Math.abs(obs.ownerStartedMs - processStartMs()) <= OWNER_START_TOLERANCE_MS;
+}
+
+/**
+ * Is the recorded owner gone, without pid-reuse ambiguity?
+ *
+ *   - kill(0) says no such process.
+ *   - kill(0) says yes, but the OS process table does not list it (Windows
+ *     kill(0) false-positive, #1953).
+ *   - the pid is ours, but the recorded process start predates this life
+ *     (the number was recycled onto us).
+ */
+function ownerProvablyDead(obs: PanelLockObservation): boolean {
+  if (obs.pid === undefined) return false;
+  if (obs.pid === process.pid) {
+    if (obs.ownerStartedMs !== undefined) {
+      if (obs.ownerStartedMs < processStartMs() - OWNER_START_TOLERANCE_MS) return true;
+      if (startTimesMatch(obs)) return false;
+    }
+    // The number is ours. Without a recorded start we cannot tell this life
+    // from a previous one, and we already know we exist — do not spawn a
+    // process-table probe to re-learn that.
+    return false;
+  }
+  if (obs.alive === false) return true;
+  if (obs.alive === true || obs.alive === "unsure") {
+    return processTableHasPid(obs.pid) === false;
+  }
+  return false;
 }
 
 /**
@@ -431,18 +521,26 @@ function observePanelLock(path: string): PanelLockObservation | undefined {
     if (before.mtimeMs !== after.mtimeMs || before.size !== after.size) {
       return { ageMs, contentProblem: "changed while being read" };
     }
-    let record: { pid?: unknown; startedAt?: unknown };
+    let record: { pid?: unknown; startedAt?: unknown; ownerStartedMs?: unknown };
     try {
-      record = JSON.parse(raw) as { pid?: unknown; startedAt?: unknown };
+      record = JSON.parse(raw) as {
+        pid?: unknown;
+        startedAt?: unknown;
+        ownerStartedMs?: unknown;
+      };
     } catch {
       return { ageMs, raw, contentProblem: "is not valid JSON" };
     }
     const startedAt = typeof record?.startedAt === "string" ? record.startedAt : undefined;
+    const ownerStartedMs =
+      typeof record?.ownerStartedMs === "number" && Number.isFinite(record.ownerStartedMs)
+        ? record.ownerStartedMs
+        : undefined;
     const pid = record?.pid;
     if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
       return { ageMs, raw, startedAt, contentProblem: "records no valid owner pid" };
     }
-    return { ageMs, raw, pid, startedAt, alive: pidLiveness(pid, ageMs) };
+    return { ageMs, raw, pid, startedAt, ownerStartedMs, alive: pidLiveness(pid, ageMs) };
   } catch (err) {
     // A mid-read failure (e.g. the fd turned out to be a directory). The age
     // here is display-only — the contentProblem is what the decision reads.
@@ -502,10 +600,11 @@ export interface PanelLockReclaimResult {
 }
 
 /**
- * Reclaim the panel operation lock — ONLY when it is provably abandoned
- * (#760): older than STALE_LOCK_MS AND owned by a recorded pid that is dead.
- * Every other state refuses, because deleting a lock whose holder might be
- * alive is how two panel mutations run at once.
+ * Reclaim the panel operation lock — ONLY when its recorded owner is
+ * provably dead (#760, #1953). Age alone is not abandonment, and a live
+ * (or reuse-ambiguous) pid is never deleted. A FRESH lock whose owner is
+ * already gone is abandoned: the 10-minute window protects a slow
+ * ComfyUI-Manager op, not a process that has already exited.
  *
  * This is the explicit, operator/agent-invoked recovery that the acquire
  * path's timeout message names. The acquire loop itself NEVER reclaims
@@ -549,34 +648,40 @@ export function reclaimAbandonedPanelLock(): PanelLockReclaimResult {
         `so there is no owner whose death could prove it abandoned.`,
     );
   }
-  if (obs.ageMs <= STALE_LOCK_MS) {
+  // Owner-aware: a dead owner is abandoned even inside the grace window. A
+  // self-restart (#1953) leaves a lock seconds old whose holder is already gone.
+  if (!ownerProvablyDead(obs)) {
+    if (obs.pid === process.pid && startTimesMatch(obs)) {
+      return refuse(
+        `it is held by this process (pid ${obs.pid}), which is still running, ` +
+          `so it cannot be called abandoned.`,
+      );
+    }
+    if (obs.ageMs <= STALE_LOCK_MS) {
+      return refuse(
+        `it was taken only ${describeLockAge(obs.ageMs)} ago — inside the ` +
+          `${STALE_LOCK_MS / 60_000}-minute window in which a slow ComfyUI-Manager ` +
+          `operation is still legitimate, so it cannot be called abandoned.`,
+      );
+    }
+    if (obs.alive === "unsure" || obs.alive === true) {
+      // NOT "STILL RUNNING" unless identity matched above. A recycled PID used
+      // to refuse this reclaim indefinitely — #760's wedge surviving its own
+      // fix. Still refusing is right when identity cannot be proven, but the
+      // reason has to be true.
+      return refuse(
+        `it is ${describeLockAge(obs.ageMs)} old and a process with pid ${obs.pid} exists, ` +
+          `but at that age the pid may have been REUSED by an unrelated program — so whether ` +
+          `the original owner is still running cannot be determined, and abandonment cannot ` +
+          `be proven. Nothing was deleted. If you are certain no panel operation is running ` +
+          `(check that pid: if it is not a comfyui-mcp orchestrator, it is not the owner), ` +
+          `delete ${path} by hand.`,
+      );
+    }
     return refuse(
-      `it was taken only ${describeLockAge(obs.ageMs)} ago — inside the ` +
-        `${STALE_LOCK_MS / 60_000}-minute window in which a slow ComfyUI-Manager ` +
-        `operation is still legitimate, so it cannot be called abandoned.`,
+      `its owner could not be proven dead (${describeObservedLock(path, obs)}).`,
     );
   }
-  if (obs.alive === "unsure") {
-    // NOT "STILL RUNNING" (codex gate P1). The old code asserted that from a bare
-    // existence check, so a recycled PID refused this reclaim indefinitely — #760's
-    // wedge surviving its own fix. Still refusing is right (deleting a live lock is
-    // worse than leaving a stuck one), but the reason has to be true, and the user
-    // needs the manual path that the false certainty used to hide.
-    return refuse(
-      `it is ${describeLockAge(obs.ageMs)} old and a process with pid ${obs.pid} exists, ` +
-        `but at that age the pid may have been REUSED by an unrelated program — so whether ` +
-        `the original owner is still running cannot be determined, and abandonment cannot ` +
-        `be proven. Nothing was deleted. If you are certain no panel operation is running ` +
-        `(check that pid: if it is not a comfyui-mcp orchestrator, it is not the owner), ` +
-        `delete ${path} by hand.`,
-    );
-  }
-  // NOTE: there is deliberately no `obs.alive === true` branch here. With the
-  // reuse doubt bounded by STALE_LOCK_MS — the same line the age check above
-  // draws — any lock that reaches this point is already past it, so liveness is
-  // "unsure" or a proven dead pid. A `STILL RUNNING` branch would be unreachable
-  // code that reads like a live guarantee. `describeLock` still reports a running
-  // owner for YOUNGER locks, where an existing pid really is evidence.
 
   // Provably abandoned. Rename aside, verify the moved file is the EXACT bytes
   // that were judged abandoned, and only then delete.
@@ -679,6 +784,103 @@ export function reclaimAbandonedPanelLock(): PanelLockReclaimResult {
   }
 }
 
+export interface PanelLockReleaseResult {
+  outcome: "no-lock" | "released" | "not-ours";
+  detail: string;
+}
+
+/**
+ * Drop a panel-op.lock THIS process owns. The self-restart path (and any other
+ * clean exit) knows it is about to die; leaving the file behind is how a
+ * successor then waits forever behind a pid that is gone (#1953).
+ *
+ * Same rename-aside + byte check as reclaim: we only delete the instance we
+ * observed as ours. A lock naming any other pid is left untouched so a
+ * replacement that already took the path is not stolen.
+ */
+export function releaseOwnedPanelLock(): PanelLockReleaseResult {
+  const path = panelLockPath();
+  assertNotWritingRealHomeInTests(path, "the panel operation lock");
+  const obs = observePanelLock(path);
+  if (!obs) {
+    return {
+      outcome: "no-lock",
+      detail: `No panel operation lock is present at ${path}.`,
+    };
+  }
+  if (obs.pid !== process.pid) {
+    return {
+      outcome: "not-ours",
+      detail:
+        obs.pid === undefined
+          ? `The lock at ${path} records no valid owner pid; not deleting it on the way out.`
+          : `The lock at ${path} is owned by pid ${obs.pid}, not this process (${process.pid}); left in place.`,
+    };
+  }
+  const claim = `${path}.release-${randomUUID()}`;
+  try {
+    renameSync(path, claim);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return {
+        outcome: "no-lock",
+        detail: `The lock at ${path} disappeared before it could be released.`,
+      };
+    }
+    logger.warn(
+      `[panel] could not take the panel op lock at ${path} aside to release it (${
+        err instanceof Error ? err.message : String(err)
+      }); it may still be held.`,
+    );
+    return {
+      outcome: "not-ours",
+      detail: `Could not move the lock aside to release it; left in place.`,
+    };
+  }
+  let moved: string | undefined;
+  try {
+    moved = readFileSync(claim, "utf-8");
+  } catch {
+    moved = undefined;
+  }
+  let movedPid: unknown;
+  if (moved !== undefined) {
+    try {
+      movedPid = (JSON.parse(moved) as { pid?: unknown }).pid;
+    } catch {
+      movedPid = undefined;
+    }
+  }
+  if (movedPid === process.pid) {
+    try {
+      rmSync(claim, { force: true });
+    } catch (err) {
+      logger.warn(
+        `[panel] released the panel op lock but could not delete ${claim}: ${
+          err instanceof Error ? err.message : String(err)
+        }. It is no longer at ${path}, so it blocks nothing.`,
+      );
+    }
+    return {
+      outcome: "released",
+      detail: `Released the panel operation lock at ${path} (owned by this process, pid ${process.pid}).`,
+    };
+  }
+  try {
+    linkSync(claim, path);
+    rmSync(claim, { force: true });
+  } catch {
+    logger.warn(
+      `[panel] the panel op lock at ${path} was no longer this process's at release; ` +
+        `the file taken aside is preserved at ${claim}.`,
+    );
+  }
+  return {
+    outcome: "not-ours",
+    detail: `The lock at ${path} was no longer this process's when released; it was restored rather than deleted.`,
+  };
+}
+
 /** The `token` from a lock record, or undefined when it cannot be read. Used to
  *  identify a lock across observations (#1489); pid+startedAt alone cannot. */
 function lockRecordToken(obs: { raw?: string }): string | undefined {
@@ -721,16 +923,18 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
         // record would be truncated (an unreadable owner pid that reclaim can
         // never prove abandoned — the #760 wedge again), so fail the init and
         // let the cleanup below remove the husk (codex gate). The payload is
-        // ASCII (pid + ISO timestamp), so string offsets track byte offsets.
-        // `token` is what makes this lock IDENTIFIABLE, not merely attributable
-        // (codex gate P0). pid+startedAt cannot distinguish two locks taken by the
-        // same process, and more importantly they cannot tell the release closure
-        // whether the file still at the path is the one it created — which is the
-        // question that matters once a lock can be RECLAIMED out from under a
-        // holder.
+        // ASCII (pid + ISO timestamp + ownerStartedMs + uuid), so string offsets
+        // track byte offsets. `token` is what makes this lock IDENTIFIABLE, not
+        // merely attributable (codex gate P0). pid+startedAt cannot distinguish
+        // two locks taken by the same process, and more importantly they cannot
+        // tell the release closure whether the file still at the path is the one
+        // it created — which is the question that matters once a lock can be
+        // RECLAIMED out from under a holder. `ownerStartedMs` is the PROCESS
+        // start time, so reclaim can tell our life from a recycled pid (#1953).
         const payload = JSON.stringify({
           pid: process.pid,
           startedAt: new Date().toISOString(),
+          ownerStartedMs: Math.round(processStartMs()),
           token,
         });
         let written = 0;
@@ -899,7 +1103,7 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
             `concurrent pre-upgrade orchestrator could replace an observed stale path ` +
             `with a fresh lock. To recover a proven abandoned lock, run ` +
             `install_comfyui(action:'panel', panel_action:'unlock') — it re-verifies that the recorded owner is ` +
-            `dead and the lock is old before deleting anything, and refuses otherwise. ` +
+            `dead before deleting anything, and refuses otherwise. ` +
             `Or do it by hand: stop or restart every comfyui-mcp orchestrator, verify ` +
             `none remain, delete this exact lock file, then retry.`,
         );
@@ -920,14 +1124,12 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
       // maybe and MUST keep waiting — treating it as dead is the exact
       // existence-for-identity fold `pidLiveness` was written to stop. `true`
       // means a real operation may still be running.
-      // AGE GATES BEFORE LIVENESS, matching `reclaimAbandonedPanelLock`, which
-      // refuses on age before it ever consults a pid. A FRESH lock is protected
-      // even when its recorded owner is dead — that is a deliberate rule with
-      // its own test ("does NOT reclaim a fresh lock even when its recorded pid
-      // is dead"), and an early report that ignored it would be this module
-      // holding two different opinions about what freshness means. Short-cutting
-      // only the STALE case still covers the report, whose lock had been
-      // blocking long enough to need a manual unlock.
+      // Acquire still age-gates the fast-fail: this loop must NOT delete, and a
+      // young lock whose owner is dead is now reclaimable via unlock / hello
+      // auto-sync (`reclaimAbandonedPanelLock` is owner-aware as of #1953).
+      // Short-cutting only the STALE case keeps the acquire path from holding
+      // a second opinion about freshness while still covering a lock that has
+      // been blocking long enough to need a manual unlock.
       if (Date.now() >= nextLivenessProbe) {
         nextLivenessProbe = Date.now() + LIVENESS_PROBE_MS;
         const early = observePanelLock(path);
@@ -974,7 +1176,7 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
               `timeout, and not deleting it either: a concurrent orchestrator could have ` +
               `replaced it since it was observed. To clear a proven abandoned lock, run ` +
               `install_comfyui(action:'panel', panel_action:'unlock') — it re-verifies that the recorded ` +
-              `owner is dead and the lock is old before deleting anything, and refuses ` +
+              `owner is dead before deleting anything, and refuses ` +
               `otherwise. Or do it by hand: stop or restart every comfyui-mcp orchestrator, ` +
               `verify none remain, delete this exact lock file, then retry.`,
           );

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -455,13 +455,33 @@ function startTimesMatch(obs: PanelLockObservation): boolean {
  *   - kill(0) says yes, but the OS process table does not list it (Windows
  *     kill(0) false-positive, #1953).
  *   - the pid is ours, but the recorded process start predates this life
- *     (the number was recycled onto us).
+ *     (the number was recycled onto us) AND the lock is past the stale window.
  */
 function ownerProvablyDead(obs: PanelLockObservation): boolean {
   if (obs.pid === undefined) return false;
   if (obs.pid === process.pid) {
     if (obs.ownerStartedMs !== undefined) {
-      if (obs.ownerStartedMs < processStartMs() - OWNER_START_TOLERANCE_MS) return true;
+      // The age floor is load-bearing, not belt-and-braces (review of #1955).
+      // `processStartMs()` is `Date.now() - uptime*1000`: the recorded value is
+      // written once at lock take, the live one is recomputed here, and only
+      // Date.now() absorbs a wall-clock step. A forward step of more than the
+      // tolerance (a resume from sleep, an NTP correction) therefore makes THIS
+      // process read its OWN live lock as a recycled pid and delete the lock
+      // guarding its own in-flight op — the concurrent-mutation case this
+      // module exists to prevent, reachable because hello auto-sync calls
+      // reclaim outside `lockHolderContext`.
+      //
+      // Requiring the stale window puts the floor exactly where the identity
+      // signal is weakest. It costs nothing real: for this to matter our pid
+      // must have been recycled onto us AND the dead predecessor's lock be
+      // under ten minutes old. Past that window the branch still fires, which
+      // is the wedge it was added for.
+      if (
+        obs.ageMs > STALE_LOCK_MS &&
+        obs.ownerStartedMs < processStartMs() - OWNER_START_TOLERANCE_MS
+      ) {
+        return true;
+      }
       if (startTimesMatch(obs)) return false;
     }
     // The number is ours. Without a recorded start we cannot tell this life

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -635,13 +635,14 @@ export async function performPanelSync(
   opts: PerformSyncOptions = {},
 ): Promise<PanelSyncResult> {
   const deps = opts.deps ?? defaultDeps;
-  // #1828 — hello auto-sync is unattended. An abandoned panel-op.lock (dead
-  // owner AND past the stale threshold) used to fail it every session for
-  // days, while the timeout named panel_action:'unlock' as the recovery
-  // nobody was there to run. Reclaim uses that same verified path (owner
-  // re-checked dead + age, rename-aside + byte compare); a live or fresh
-  // lock still refuses and acquire waits/times out as before. Explicit
-  // panel_action:'sync' shares this function, so it unblocks the same way.
+  // #1828 / #1953 — hello auto-sync is unattended. An abandoned panel-op.lock
+  // (recorded owner provably dead — including a fresh one left by a
+  // self-restart) used to fail it every session for days, while the timeout
+  // named panel_action:'unlock' as the recovery nobody was there to run.
+  // Reclaim uses that same verified path (owner re-checked dead, rename-aside
+  // + byte compare); a live or reuse-ambiguous lock still refuses and acquire
+  // waits/times out as before. Explicit panel_action:'sync' shares this
+  // function, so it unblocks the same way.
   reclaimAbandonedPanelLock();
   // The status read, the DECISION, and the mutation all run inside the op
   // lock: a decision made outside could go stale before the lock is acquired,

--- a/src/services/self-restart.ts
+++ b/src/services/self-restart.ts
@@ -17,10 +17,11 @@
 // Restart discipline: a restart may NEVER eat a reply. We wait until every
 // agent is idle with nothing queued (plus any extra caller gate — held
 // messages, a render in flight), announce to the panel, spawn a DETACHED
-// replacement with the same command line, then run the caller's clean teardown
-// and exit. The replacement rides the bridge's existing bind-retry while our
-// port frees; agent sessions resume from the durable session store; the panel
-// reconnects on its own.
+// replacement with the same command line, drop any panel-op.lock we still
+// hold (#1953 — the successor otherwise waits forever behind a dead pid),
+// then run the caller's clean teardown and exit. The replacement rides the
+// bridge's existing bind-retry while our port frees; agent sessions resume
+// from the durable session store; the panel reconnects on its own.
 //
 // Loop safety: restarts are strictly CHANGE-driven (a version newer than the
 // one running, or an entry mtime newer than the one we booted with), so a
@@ -45,6 +46,7 @@ import {
   isNewer,
   type InstallInfo,
 } from "./self-update.js";
+import { releaseOwnedPanelLock } from "./panel-pin-guard.js";
 import { logger } from "../utils/logger.js";
 
 /** Registry re-check period. An hour keeps update latency low at ~24 tiny
@@ -77,6 +79,12 @@ export interface SelfRestartDeps {
   teardown: () => Promise<void>;
   /** Spawn the detached replacement process. Returns false on failure. */
   spawnReplacement: (opts: { npxVersion?: string }) => boolean;
+  /**
+   * Drop a panel-op.lock this process owns. Called after a successful spawn
+   * and before teardown so the successor is not blocked by a lock whose
+   * owner is about to exit (#1953).
+   */
+  releasePanelLock: () => void;
   exit: (code: number) => void;
   uptimeMs: () => number;
 }
@@ -134,6 +142,9 @@ export const defaultSelfRestartDeps: SelfRestartDeps = {
   announce: () => {},
   teardown: async () => {},
   spawnReplacement: defaultSpawnReplacement,
+  releasePanelLock: () => {
+    releaseOwnedPanelLock();
+  },
   exit: (code) => process.exit(code),
   uptimeMs: () => process.uptime() * 1000,
 };
@@ -301,6 +312,17 @@ export class SelfRestarter {
       this.deps.announce("⚠️ Restart failed to launch a replacement — still running the current version.");
       this.restarting = false;
       return;
+    }
+    // The successor is already running. Drop any panel-op.lock we still hold
+    // so it is not stuck behind a pid that is about to exit (#1953). Spawn
+    // failure must NOT release: we are staying alive and may still own a
+    // legitimate in-flight op.
+    try {
+      this.deps.releasePanelLock();
+    } catch (err) {
+      logger.debug(
+        `[self-restart] release panel lock: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     this.stop();
     try {

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -239,10 +239,11 @@ export async function panelAction(
     // Recovery for the wedge from #760: a crashed/killed orchestrator
     // leaves panel-op.lock behind and the acquire path deliberately never
     // auto-reclaims it (#779). This is the explicit recovery the timeout
-    // message names — it re-verifies the lock is provably abandoned (old
-    // AND its recorded owner is dead) before deleting anything, and says
-    // exactly what it observed when it refuses. It does NOT take the lock
-    // itself: a wedged lock is the very case this exists for.
+    // message names — it re-verifies the recorded owner is provably dead
+    // before deleting anything (#1953: a fresh lock whose owner already
+    // exited is abandoned; the 10-minute window does not protect it), and
+    // says exactly what it observed when it refuses. It does NOT take the
+    // lock itself: a wedged lock is the very case this exists for.
     return json({ action: "unlock", ...reclaimAbandonedPanelLock() });
   }
 


### PR DESCRIPTION
Fixes #1953

## What the user now observes

A self-restart no longer leaves `~/.comfyui-mcp/panel-op.lock` behind. Hello auto-sync and `panel_action:'unlock'` reclaim a lock whose recorded owner is already dead, including a seconds-old one. Panel version sync is not blocked for hours behind a pid that exited.

## Cause

The hourly self-restart spawned a replacement and exited while still owning the panel operation lock. Two refusal paths then combined into a dead end:

- A **fresh** lock (inside the 10-minute grace window) was refused even though the owner was already gone.
- An **old** lock whose `process.kill(pid, 0)` probe claimed the pid existed — on Windows that probe has matched a pid `Get-Process` could not find — was refused as possible pid-reuse forever.

Both times the only recovery was deleting the file by hand. The panel stayed on an old version and showed "no agent waiting on the bridge".

## Fix

1. **Release on the way out.** After a successful replacement spawn, self-restart drops any `panel-op.lock` this process owns. SIGINT/SIGTERM teardown does the same. A failed spawn does not release: we are staying alive.
2. **Owner-aware grace window.** `reclaimAbandonedPanelLock` (unlock and hello auto-sync) reclaims when the recorded owner is provably dead, at any age. The 10-minute window still protects a lock whose owner is live or reuse-ambiguous.
3. **More than a pid.** The lock record now stores process start time. A recycled pid onto us is distinguishable from this life. When `kill(0)` claims a *foreign* pid exists, reclaim consults the OS process table (`tasklist` / `/proc` / `ps`) so a Windows false-positive is treated as dead.

Acquire still never auto-deletes (#779).

## Tests

- Self-restart drives `releaseOwnedPanelLock` on the real lock file: spawn success drops it; spawn failure leaves it.
- Unlock/hello auto-sync reclaim a seconds-old lock with a dead pid, then the next mutation proceeds.
- A lock whose pid is ours but whose start predates this process is reclaimed (pid reuse).
- `kill(0)` claiming a pid the process table does not list is reclaimed.
- A live owner, a reuse-ambiguous old pid, and acquire's no-delete rule are unchanged.
