### PR TITLE
fix(panel#1554): a restart confirmation the user gave late is claimed by the next attempt, not discarded

### DIFF
--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1029,7 +1029,18 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // A different browser tab taking over a recurring key is a conversation
     // boundary too — the ENTRIES are tab-keyed, so the newcomer must be shut out
     // of them at the hello, not merely kept from the debt.
-    expect(src).toMatch(/setTabTakenOverListener\(\(tabId\) => AskAnswers\.closeAsks\(tabId\)\)/);
+    // Asserted on the listener's BODY, not on a one-expression shape. panel#1554 gave
+    // this same boundary a second retirement (an abandoned confirmation card must not
+    // be claimable by the newcomer either) and the listener became a block. The
+    // guarantee under test is "the takeover retires ask state", and a regex that only
+    // matches one statement would fail the moment anything legitimately joins it —
+    // pressure to install a SECOND setTabTakenOverListener instead, which (it is a
+    // setter, not an adder) would silently replace this one and un-ship #486.
+    const takeoverAt = src.indexOf("bridge.setTabTakenOverListener(");
+    expect(takeoverAt, "takeover listener not found").toBeGreaterThan(-1);
+    expect(src.slice(takeoverAt, takeoverAt + 300)).toContain("AskAnswers.closeAsks(tabId)");
+    // …and exactly one is installed, which is what makes the body the whole story.
+    expect(src.split("bridge.setTabTakenOverListener(").length - 1).toBe(1);
     expect(src).toContain("AskAnswers.setIncarnationResolver(");
     // The ack must carry WHO is acking, or a switched provider can certify the
     // previous conversation's answer.

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -35,6 +35,7 @@ import {
   forgetAbandonedConfirmCards,
   makePanelToolCtx,
   resetAbandonedConfirmCards,
+  __panelToolsTestHooks,
   type ConfirmOptions,
   type PanelToolCtx,
   type ToolResult,
@@ -338,6 +339,48 @@ describe("panel#1554 the recovered decision is disclosed, not slipped in", () =>
 
     expect(out).toContain("That card is still live");
     expect(out).not.toContain("and I'll re-ask");
+  });
+
+  it("END TO END: two real tool calls, real confirm, and the second one claims the click", async () => {
+    // Everything above either drives `confirm` directly or stubs it. This drives NEITHER:
+    // the REAL handler, twice, through the REAL confirm, with the recovery reached the
+    // way production reaches it. Without it the chain call site → opts → confirm →
+    // recovery is only proven by composition.
+    //
+    // The recovered answer is the DECLINE, because it is the one post-confirm branch
+    // that settles deterministically without dispatching a reboot or waiting out a
+    // readiness budget — the probe is stubbed healthy and its recheck window shrunk.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    __panelToolsTestHooks.setDeclineProbeTiming({
+      windowMs: 20,
+      intervalMs: 5,
+      probeTimeoutMs: 5,
+    });
+    try {
+      const h = harness();
+
+      // Call 1: the card is dispatched and nobody answers inside the 90s budget.
+      const first = textOf(await restartDef().handler({} as never, h.ctx));
+      expect(first).toContain("No confirmation received within");
+      expect(h.cards).toHaveLength(1);
+
+      // The user answers it afterwards. The bridge buffers it under the card's own id.
+      h.late.set(String(h.cards[0].ask_id), "No, cancel");
+
+      // Call 2: no second card, and the reply carries the disclosure.
+      const second = textOf(await restartDef().handler({} as never, h.ctx));
+
+      expect(h.cards).toHaveLength(1);
+      expect(second).toContain("NO NEW CONFIRMATION CARD WAS SHOWN");
+      expect(second).toContain("No, cancel");
+      // …and it is the DECLINE branch's own reply, not the timeout's.
+      expect(second).not.toContain("No confirmation received within");
+      // Nothing was restarted on a decline — the safe path is untouched.
+      expect(h.cards.every((c) => c.cmd === "ask_user")).toBe(true);
+    } finally {
+      __panelToolsTestHooks.setHealthProbe(null);
+      __panelToolsTestHooks.setDeclineProbeTiming(null);
+    }
   });
 
   it("the note is its OWN block: a structured reply stays parseable at index 0", () => {

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -24,12 +24,15 @@
 // nothing: every stub returns whatever it was told to, so the one line that decides
 // whether a buffered answer is claimed was never executed.
 
+import { readFileSync } from "node:fs";
+
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   appendReplyNote,
   buildPanelToolDefs,
   confirmAnswerRecoveryWindowMs,
+  forgetAbandonedConfirmCards,
   makePanelToolCtx,
   resetAbandonedConfirmCards,
   type ConfirmOptions,
@@ -215,6 +218,50 @@ describe("panel#1554 a late confirmation is claimed, not discarded", () => {
     const h = harness(TAB, { answerCards: true });
     expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("yes");
     expect(h.drained).toHaveLength(0);
+  });
+
+  it("a TAKEOVER of the route key drops it — the newcomer never answered that card", async () => {
+    // `wf:` keys recur: close the browser tab, open the same workflow elsewhere, and the
+    // newcomer inherits the address. #486 calls that a conversation boundary and retires
+    // the departing occupant's asks on it; a confirmation card is no different.
+    const h = harness();
+    const askId = await abandonOnce(h);
+    h.late.set(askId, "Yes, go ahead");
+
+    forgetAbandonedConfirmCards(TAB);
+
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+    // The departed occupant's answer is left where it was — not served to the newcomer.
+    // (Asserted on the BUFFER, not on `drained`: confirm's own zero-width grace poll
+    // looks that id up once on the way to reporting the timeout, so a "never looked"
+    // assertion would be false for a reason that has nothing to do with this rule.)
+    expect(h.late.get(askId)).toBe("Yes, go ahead");
+  });
+
+  it("a takeover of ANOTHER key leaves this one alone", async () => {
+    const h = harness();
+    const askId = await abandonOnce(h);
+    h.late.set(askId, "Yes, go ahead");
+
+    forgetAbandonedConfirmCards(OTHER_TAB);
+
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("yes");
+  });
+
+  it("WIRING: the takeover listener retires confirmations as well as asks", () => {
+    // The bridge takes ONE takeover listener (a setter, not an adder), so this fix had
+    // to join the existing call rather than add a second one — a second
+    // setTabTakenOverListener would have silently replaced #486's and un-shipped it.
+    // Behavioural tests above cannot see that; this is the shape of the call site.
+    const src = readFileSync("src/orchestrator/index.ts", "utf8");
+    const at = src.indexOf("bridge.setTabTakenOverListener(");
+    expect(at).toBeGreaterThan(-1);
+    const call = src.slice(at, at + 200);
+    expect(call).toContain("AskAnswers.closeAsks(tabId)");
+    expect(call).toContain("forgetAbandonedConfirmCards(tabId)");
+    // Exactly one listener is installed — the whole hazard.
+    expect(src.split("bridge.setTabTakenOverListener(").length - 1).toBe(1);
   });
 
   it("the staleness bound IS the bridge's buffer TTL, not a second copy of it", () => {

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -1,0 +1,310 @@
+// panel#1554 — the reporter's restart confirmation was ACCEPTED by the panel and
+// DISCARDED by the orchestrator.
+//
+// `panel_restart_comfyui` bounds its confirmation card at 90s (#404) so an undelivered
+// card fails fast instead of reading as a 4-minute hang. What #404 did not account for
+// is the ANSWER. The panel retires a card only when the connection that painted it is
+// REPLACED (#952) — never on a caller's timeout — so the card stays painted and stays
+// clickable. A click after the deadline still reaches the bridge, which buffers the
+// validated answer under its `ask_id` for LATE_ASK_TTL_MS.
+//
+// Nothing ever read it back. #486's durable journal accepts only `pa-`-prefixed
+// panel_ask ids, and confirm's own grace poll is ZERO-WIDTH here: `timeoutMs` 90s is
+// spent entirely on the card deadline, so `graceMs` computes to 0 and #360's
+// late-honour poll takes one look and gives up. The answer was TTL-pruned unread while
+// the tool reported "No confirmation received within 90s, so I did NOT restart
+// ComfyUI" — to a user who had clicked "Yes, go ahead" and watched the card collapse to
+// "✓ Yes, go ahead". They went and found the headless `restart_comfyui` instead.
+//
+// THE FIX READS IT rather than waiting longer, so #404's 90s is untouched: the
+// abandoned card's id is remembered, and the NEXT attempt at the same confirmation
+// drains it before dispatching a second card.
+//
+// These tests drive the REAL `ctx.confirm`. An earlier draft stubbed it and proved
+// nothing: every stub returns whatever it was told to, so the one line that decides
+// whether a buffered answer is claimed was never executed.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  appendReplyNote,
+  buildPanelToolDefs,
+  confirmAnswerRecoveryWindowMs,
+  makePanelToolCtx,
+  resetAbandonedConfirmCards,
+  type ConfirmOptions,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { LATE_ASK_TTL_MS } from "../../services/ui-bridge.js";
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const OTHER_TAB = "wf:workflows/b.json";
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const QUESTION =
+  "Restart ComfyUI now? It (and this agent) will go down briefly, then reconnect and resume automatically.";
+const HEADER = "Restart ComfyUI";
+
+/** The bridge's canonical no-reply text — the ONLY shape isReplyTimeoutError accepts
+ *  from an untagged error, so a fixture that gets it wrong would be surfaced as a real
+ *  error ("unreachable") and would silently stop testing the timeout branch. */
+const replyTimeout = (tabId: string) =>
+  new Error(
+    `Panel tab ${tabId.slice(0, 8)} did not reply to "ask_user" within 500 ms — ` +
+      "the ComfyUI tab may be backgrounded or frozen",
+  );
+
+interface Harness {
+  ctx: PanelToolCtx;
+  /** ask_user frames the orchestrator actually put on the wire. */
+  cards: Array<Record<string, unknown>>;
+  /** The bridge's late-answer buffer (ask_id → what the user clicked). */
+  late: Map<string, unknown>;
+  /** Every takeLateAskReply(id) this run made — proves WHICH id was claimed. */
+  drained: string[];
+}
+
+function harness(tabId = TAB, opts: { answerCards?: boolean } = {}): Harness {
+  const cards: Array<Record<string, unknown>> = [];
+  const late = new Map<string, unknown>();
+  const drained: string[] = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "ask_user") {
+        cards.push(cmd);
+        // The reporter's case: the card is dispatched and painted, and no answer comes
+        // back inside the caller's budget.
+        if (!opts.answerCards) throw replyTimeout(tabId);
+        // bridge.send resolves with the REPLY'S RESULT — for a card, the label the
+        // user picked — which is what isAffirmative is handed.
+        return "Yes, go ahead";
+      }
+      return { ok: true };
+    },
+    takeLateAskReply: (askId: string) => {
+      drained.push(askId);
+      if (!late.has(askId)) return undefined;
+      const v = late.get(askId);
+      late.delete(askId); // the real buffer is one-shot too
+      return v;
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: tabId, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => tabId,
+    tabIsLocal: () => true,
+    tabServerOrigin: () => BOOT_BASE,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return {
+    ctx: makePanelToolCtx(bridge, tabId, new WorkflowTargetStore()),
+    cards,
+    late,
+    drained,
+  };
+}
+
+const RECOVER: ConfirmOptions = { recoverAbandonedAnswer: true };
+
+/** One abandoned attempt: dispatch a card, get no answer inside the budget. */
+async function abandonOnce(h: Harness, question = QUESTION, header = HEADER): Promise<string> {
+  const outcome = await h.ctx.confirm(question, header, 500, RECOVER);
+  expect(outcome).toBe("timeout");
+  return String(h.cards[h.cards.length - 1].ask_id);
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join("\n");
+
+describe("panel#1554 a late confirmation is claimed, not discarded", () => {
+  beforeEach(() => resetAbandonedConfirmCards());
+
+  it("the abandoned card's YES is honoured by the next attempt, with no second card", async () => {
+    const h = harness();
+    const askId = await abandonOnce(h);
+    expect(h.cards).toHaveLength(1);
+
+    // The user clicks "Yes, go ahead" after the tool gave up. The panel delivers it;
+    // the bridge buffers it under the card's own id (this is real bridge behaviour —
+    // see UiBridge's late-reply branch — not something this fix introduces).
+    h.late.set(askId, "Yes, go ahead");
+
+    const outcome = await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER);
+
+    expect(outcome).toBe("yes");
+    // …and nothing was painted over the card the user already answered.
+    expect(h.cards).toHaveLength(1);
+    // Claimed by EXACT id — not "the most recent answer".
+    expect(h.drained).toContain(askId);
+  });
+
+  it("a late DECLINE is honoured too — it is lost the same way today", async () => {
+    const h = harness();
+    const askId = await abandonOnce(h);
+    h.late.set(askId, "No, cancel");
+
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("no");
+    expect(h.cards).toHaveLength(1);
+  });
+
+  it("an unanswered card is not an answer: the next attempt asks again", async () => {
+    const h = harness();
+    await abandonOnce(h);
+    // Nothing buffered — the user genuinely never answered.
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+  });
+
+  it("ONE-SHOT: a recovered answer satisfies exactly one call", async () => {
+    const h = harness();
+    const askId = await abandonOnce(h);
+    h.late.set(askId, "Yes, go ahead");
+
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("yes");
+    // A third call must not re-serve the same click as a fresh confirmation.
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+  });
+
+  it("a DIFFERENT question on the same tab cannot claim it", async () => {
+    const h = harness();
+    const askId = await abandonOnce(h);
+    h.late.set(askId, "Yes, go ahead");
+
+    // Same tab, same header, different words: not the question that was answered.
+    const outcome = await h.ctx.confirm("Clear the canvas?", HEADER, 500, RECOVER);
+
+    expect(outcome).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+    // The yes is still sitting in the buffer — untouched, not mis-served.
+    expect(h.late.get(askId)).toBe("Yes, go ahead");
+  });
+
+  it("a DIFFERENT tab cannot claim it — an answer given on one tab is not another's", async () => {
+    const a = harness(TAB);
+    const askId = await abandonOnce(a);
+    a.late.set(askId, "Yes, go ahead");
+
+    const b = harness(OTHER_TAB);
+    // Same words, same header, other tab. (b's own buffer is empty by construction;
+    // the point is that b does not even LOOK at the card a left behind.)
+    expect(await b.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("timeout");
+    expect(b.drained).not.toContain(askId);
+    expect(a.late.get(askId)).toBe("Yes, go ahead");
+  });
+
+  it("opting OUT keeps the old behaviour: nothing is remembered and nothing is claimed", async () => {
+    // The mutation that matters most — if `recoverAbandonedAnswer` stopped gating this,
+    // panel_clear would inherit a mechanism nobody reviewed for a canvas wipe.
+    const h = harness();
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500)).toBe("timeout");
+    const askId = String(h.cards[0].ask_id);
+    h.late.set(askId, "Yes, go ahead");
+
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500)).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+    expect(h.late.get(askId)).toBe("Yes, go ahead");
+  });
+
+  it("an ANSWERED card is not remembered — only an abandoned one is", async () => {
+    const h = harness(TAB, { answerCards: true });
+    expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("yes");
+    expect(h.drained).toHaveLength(0);
+  });
+
+  it("the staleness bound IS the bridge's buffer TTL, not a second copy of it", () => {
+    // A private "5 minutes" over in panel-tools would be a bound deciding a correctness
+    // question in two places, free to drift. Pin that it is the same value.
+    expect(confirmAnswerRecoveryWindowMs()).toBe(LATE_ASK_TTL_MS);
+  });
+});
+
+describe("panel#1554 the recovered decision is disclosed, not slipped in", () => {
+  beforeEach(() => resetAbandonedConfirmCards());
+
+  const restartDef = () => {
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+    if (!def) throw new Error("panel_restart_comfyui is not registered");
+    return def;
+  };
+
+  it("THE CALL SITE opts in — the helper alone proves nothing about production", async () => {
+    // Verified by mutation: dropping the options object from the ctx.confirm(...) call
+    // in panel_restart_comfyui leaves every test above green, because they call confirm
+    // directly. This is the assertion that goes red.
+    const h = harness();
+    let seen: ConfirmOptions | undefined;
+    h.ctx.confirm = async (_q, _hd, _t, opts) => {
+      seen = opts;
+      return "timeout";
+    };
+
+    await restartDef().handler({} as never, h.ctx);
+
+    expect(seen?.recoverAbandonedAnswer).toBe(true);
+    expect(typeof seen?.onRecoveredAnswer).toBe("function");
+  });
+
+  it("a note raised anywhere in the handler rides the reply it returns", async () => {
+    // The handler has ~25 return points after its confirmation card, and the disclosure
+    // has to ride all of them — one that only survives the happy path reads as a FRESH
+    // confirmation on every other branch. withReplyNote is what makes that true for all
+    // of them at once; the timeout branch is simply the cheapest reply to reach
+    // deterministically (the decline branch probes ComfyUI's health for seconds, and
+    // the accept branch dispatches a real reboot).
+    const h = harness();
+    h.ctx.confirm = async (_q, _hd, _t, opts) => {
+      opts?.onRecoveredAnswer?.({ outcome: "yes", ageMs: 132_000 });
+      return "timeout";
+    };
+
+    const out = textOf(await restartDef().handler({} as never, h.ctx));
+
+    expect(out).toContain("This is NOT a fresh confirmation");
+    expect(out).toContain("Yes, go ahead");
+    expect(out).toContain("132s ago");
+  });
+
+  it("no recovery, no note — an ordinary reply is left exactly as the handler built it", async () => {
+    const h = harness();
+    h.ctx.confirm = async () => "timeout";
+
+    const res = await restartDef().handler({} as never, h.ctx);
+
+    expect(res.content).toHaveLength(1);
+    expect(textOf(res)).not.toContain("This is NOT a fresh confirmation");
+  });
+
+  it("the timeout wording stops calling the live card dead", async () => {
+    // "Tell me to restart it and I'll re-ask" described a card that was finished and a
+    // decision that had to be made again. It was neither — and believing it is what
+    // sent the reporter looking for the headless tool.
+    const h = harness();
+    h.ctx.confirm = async () => "timeout";
+
+    const out = textOf(await restartDef().handler({} as never, h.ctx));
+
+    expect(out).toContain("That card is still live");
+    expect(out).not.toContain("and I'll re-ask");
+  });
+
+  it("the note is its OWN block: a structured reply stays parseable at index 0", () => {
+    // Splicing it into the first block would corrupt the JSON document the agent (and
+    // this repo's tests) parse from there; pushing it in FRONT would move that document
+    // to index 1 and break every reader that takes index 0.
+    const doc = { restarted: true, confirmed_cycle: false };
+    const res: ToolResult = { content: [{ type: "text", text: JSON.stringify(doc) }] };
+
+    const noted = appendReplyNote(res, "[NOTE] recovered");
+
+    expect(JSON.parse((noted.content[0] as { text: string }).text)).toEqual(doc);
+    expect((noted.content[1] as { text: string }).text).toBe("[NOTE] recovered");
+    // An empty note adds nothing at all.
+    expect(appendReplyNote(res, "")).toBe(res);
+  });
+});

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -312,7 +312,7 @@ describe("panel#1554 the recovered decision is disclosed, not slipped in", () =>
 
     const out = textOf(await restartDef().handler({} as never, h.ctx));
 
-    expect(out).toContain("This is NOT a fresh confirmation");
+    expect(out).toContain("NO NEW CONFIRMATION CARD WAS SHOWN");
     expect(out).toContain("Yes, go ahead");
     expect(out).toContain("132s ago");
   });
@@ -324,7 +324,7 @@ describe("panel#1554 the recovered decision is disclosed, not slipped in", () =>
     const res = await restartDef().handler({} as never, h.ctx);
 
     expect(res.content).toHaveLength(1);
-    expect(textOf(res)).not.toContain("This is NOT a fresh confirmation");
+    expect(textOf(res)).not.toContain("NO NEW CONFIRMATION CARD WAS SHOWN");
   });
 
   it("the timeout wording stops calling the live card dead", async () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -138,6 +138,7 @@ import {
   resolvePinTarget,
   secretSavedReply,
   setApplyMcpReload,
+  forgetAbandonedConfirmCards,
   RETRY_TOKEN_CMDS,
 } from "./panel-tools.js";
 import {
@@ -2863,7 +2864,14 @@ export async function runPanelOrchestrator(): Promise<void> {
   // newcomer never asked the previous occupant's questions, so its answers must
   // stop being recoverable and stop being pushed. closeAsks downgrades and
   // unsends; it never deletes, so those answers are still reported.
-  bridge.setTabTakenOverListener((tabId) => AskAnswers.closeAsks(tabId));
+  // panel#1554 — same boundary, same reason: a confirmation card the previous
+  // occupant abandoned must not be claimable by the newcomer. Both retirements ride
+  // THIS one listener because the bridge takes a single takeover listener, so a
+  // second setTabTakenOverListener call would silently replace the first.
+  bridge.setTabTakenOverListener((tabId) => {
+    AskAnswers.closeAsks(tabId);
+    forgetAbandonedConfirmCards(tabId);
+  });
   bridge.setTabGoneListener((tabId, incarnation) => AskAnswers.retireDebt(tabId, incarnation));
   // #694 — the bridge retains a late mutation only for commands that can come
   // back as a retry token, which is the retry-token layer's own set. Installed

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9354,6 +9354,24 @@ export function takeRecoveredConfirmAnswer(
   };
 }
 
+/**
+ * A DIFFERENT browser tab has taken this recurring route key over (#486’s takeover
+ * event) — drop anything this key was holding.
+ *
+ * The key is the route key, not the browser tab, and `wf:` keys recur: close the tab,
+ * open the same workflow somewhere else, and the newcomer inherits the address. It did
+ * not answer the previous occupant’s card, so it must not inherit that answer either.
+ * A RECONNECT is deliberately not this event — the same browser tab returns under the
+ * same incarnation and no takeover fires — which is what keeps the reporter’s case
+ * (“do not lose it across agent/panel reconnect”) working.
+ */
+export function forgetAbandonedConfirmCards(tabId: string): void {
+  const prefix = `${tabId}\u0000`;
+  for (const key of abandonedConfirmCards.keys()) {
+    if (key.startsWith(prefix)) abandonedConfirmCards.delete(key);
+  }
+}
+
 /** Test seam: forget every remembered abandoned card. */
 export function resetAbandonedConfirmCards(): void {
   abandonedConfirmCards.clear();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -31,7 +31,7 @@ import {
   toolActionPolicyError,
   toolAllowed,
 } from "../tools/tool-surface-filter.js";
-import { logger, logger as toolPolicyLogger } from "../utils/logger.js";
+import { logger as toolPolicyLogger } from "../utils/logger.js";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
 import {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -31,7 +31,7 @@ import {
   toolActionPolicyError,
   toolAllowed,
 } from "../tools/tool-surface-filter.js";
-import { logger as toolPolicyLogger } from "../utils/logger.js";
+import { logger, logger as toolPolicyLogger } from "../utils/logger.js";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
 import {
@@ -64,7 +64,7 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge, PanelVersionReading } from "../services/ui-bridge.js";
-import { requiredPanelVersion, SEMVER_RE } from "../services/ui-bridge.js";
+import { requiredPanelVersion, SEMVER_RE, LATE_ASK_TTL_MS } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
 import {
@@ -406,6 +406,52 @@ function ok(value: unknown): ToolResult {
 function fail(err: unknown): ToolResult {
   const msg = err instanceof Error ? err.message : String(err);
   return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
+}
+
+/**
+ * Add a note to a reply the handler has already built — as its OWN content block,
+ * never spliced into the first one.
+ *
+ * The first block of a structured reply is a JSON document (`ok(object)`), and both
+ * the agent and this repo's tests read it as one. A note pasted into that string
+ * would corrupt it; a note pushed in FRONT of it would move the document to index 1
+ * and break every reader that takes index 0. So it goes last, additively.
+ */
+export function appendReplyNote(res: ToolResult, note: string): ToolResult {
+  if (!note) return res;
+  return { ...res, content: [...res.content, { type: "text", text: note }] };
+}
+
+/**
+ * panel#1554 — let a handler attach a note to WHICHEVER of its many replies it ends
+ * up returning.
+ *
+ * `panel_restart_comfyui` has ~25 return points after its confirmation card, and the
+ * disclosure that a decision was recovered from an EARLIER card (see
+ * AbandonedConfirmCard) has to ride all of them — a disclosure that only survives the
+ * happy path is the kind of half-honesty that reads as a fresh confirmation on every
+ * other branch. Threading a note through 25 returns is how one gets missed; a single
+ * wrapper around the handler cannot.
+ *
+ * Per CALL, not per ctx: the note lives in a local array created on entry. `ctx` is
+ * built once per panel MCP server and shared by every tool call it serves, so parking
+ * the note there would make mis-attribution possible for exactly the class of
+ * statement that must never be mis-attributed.
+ */
+function withReplyNote(
+  handler: (
+    args: Record<string, unknown>,
+    ctx: PanelToolCtx,
+    note: (text: string) => void,
+  ) => Promise<ToolResult>,
+): (args: Record<string, unknown>, ctx: PanelToolCtx) => Promise<ToolResult> {
+  return async (args, ctx) => {
+    const notes: string[] = [];
+    const res = await handler(args, ctx, (text) => {
+      if (text) notes.push(text);
+    });
+    return notes.length ? appendReplyNote(res, notes.join(" ")) : res;
+  };
 }
 
 /**
@@ -9193,6 +9239,142 @@ const nodeSize = () =>
 export type ConfirmOutcome = "yes" | "no" | "timeout" | "unreachable";
 
 /**
+ * panel#1554 — A CONFIRMATION THE USER GAVE, THROWN AWAY BY THE TOOL THAT ASKED FOR IT.
+ *
+ * `panel_restart_comfyui` bounds its confirmation-card wait at 90s (#404, so an
+ * undelivered card fails fast instead of reading as a 4-minute hang). What #404 did not
+ * account for is what happens to the ANSWER afterwards, and the answer is not gone:
+ *
+ *   • the card stays painted and stays clickable — the panel retires a card only when
+ *     the connection that painted it is REPLACED (#952), never on a caller's timeout;
+ *   • a click after the deadline still reaches the bridge, which buffers the validated
+ *     answer under its `ask_id` for LATE_ASK_TTL_MS (takeLateAskReply);
+ *   • but a CONFIRM card is not a `panel_ask` card. #486's durable journal accepts only
+ *     `pa-`-prefixed ids (PANEL_ASK_ID_PREFIX), and confirm's own grace poll is
+ *     ZERO-WIDTH here — with timeoutMs === 90s the whole budget is spent on the card
+ *     deadline, so `graceMs` computes to 0 and #360's late-honour poll takes one
+ *     immediate look and gives up.
+ *
+ * So nothing ever reads that buffered answer back. It is TTL-pruned unread while the
+ * tool reports "No confirmation received within 90s, so I did NOT restart ComfyUI" —
+ * to a user who clicked "Yes, go ahead" and watched the card collapse to "✓ Yes, go
+ * ahead". That is panel#1554: the reporter's confirmation was accepted by the panel,
+ * discarded by the orchestrator, and they had to go find the headless `restart_comfyui`
+ * to get the restart they had already authorised.
+ *
+ * THE FIX IS TO READ IT, NOT TO WAIT LONGER. #404's 90s stands exactly as it is: the
+ * abandoned card's `ask_id` is remembered, and the NEXT attempt at the SAME confirmation
+ * drains it BEFORE dispatching a second card. Costs no wall-clock, works across an agent
+ * respawn or a panel reconnect (this store is process-scoped, not session-scoped), and
+ * honours a late "No, cancel" exactly as it honours a late yes — a decline the user
+ * already gave is lost the same way today.
+ *
+ * WHAT MAKES IT ATTRIBUTABLE, and why each part is load-bearing:
+ *
+ *   • EXACT ASK-ID EQUALITY. The recovered value is whatever the bridge buffered for the
+ *     one card id we dispatched. Never "the most recent answer", never a fuzzy match.
+ *   • SAME TAB + IDENTICAL QUESTION AND HEADER as the key, so an answer given to the
+ *     restart card can only ever satisfy the restart card, on the tab it was shown on.
+ *   • ONE-SHOT. The entry is removed on the first look, answered or not, so a recovered
+ *     answer can satisfy exactly one call and a stale key cannot linger.
+ *   • THE BRIDGE'S OWN TTL IS THE ONLY STALENESS BOUND. Past LATE_ASK_TTL_MS
+ *     takeLateAskReply has already dropped the answer, so a fresh card is dispatched.
+ *     The prune below uses the SAME imported constant rather than a second copy of it.
+ *   • OPT-IN PER CALL SITE. Only `panel_restart_comfyui` asks for this. `panel_clear`
+ *     wipes the canvas and gets the full 285s card wait, so its loss window is far
+ *     narrower and the cost of resurrecting a stale yes is far higher — it stays out
+ *     until someone has a reported failure to point at.
+ *   • DISCLOSED, NEVER SILENT. A recovered decision rides its own line in the tool's
+ *     reply (see withReplyNote): acting on an answer from an earlier card is exactly
+ *     the kind of thing the agent must not present as a fresh confirmation.
+ */
+interface AbandonedConfirmCard {
+  askId: string;
+  at: number;
+}
+const abandonedConfirmCards = new Map<string, AbandonedConfirmCard>();
+
+/** The recovery window — the bridge's buffer TTL, imported so it cannot drift. */
+export function confirmAnswerRecoveryWindowMs(): number {
+  return LATE_ASK_TTL_MS;
+}
+
+/** Identity of a confirmation: the tab it is shown on plus the exact words asked.
+ *  A NUL separator cannot appear in either half, so no pair of inputs can collide. */
+function confirmRecoveryKey(tabId: string, header: string, question: string): string {
+  return `${tabId}\u0000${header}\u0000${question}`;
+}
+
+function pruneAbandonedConfirmCards(now: number): void {
+  for (const [key, entry] of abandonedConfirmCards) {
+    if (now - entry.at > LATE_ASK_TTL_MS) abandonedConfirmCards.delete(key);
+  }
+}
+
+/** Remember a card whose wait expired unanswered, so the next attempt can drain it. */
+export function rememberAbandonedConfirmCard(
+  tabId: string,
+  header: string,
+  question: string,
+  askId: string,
+  now: number = Date.now(),
+): void {
+  pruneAbandonedConfirmCards(now);
+  abandonedConfirmCards.set(confirmRecoveryKey(tabId, header, question), { askId, at: now });
+}
+
+/**
+ * Claim the answer left on a previous, abandoned card for this exact confirmation —
+ * or null when there was no such card, or nobody ever answered it.
+ *
+ * ONE-SHOT by construction: the remembered card is dropped on the way past whether or
+ * not it had an answer waiting, so a second call always dispatches a fresh card.
+ */
+export function takeRecoveredConfirmAnswer(
+  bridge: Pick<UiBridge, "takeLateAskReply"> | undefined,
+  tabId: string,
+  header: string,
+  question: string,
+  now: number = Date.now(),
+): { outcome: "yes" | "no"; ageMs: number; askId: string } | null {
+  pruneAbandonedConfirmCards(now);
+  const key = confirmRecoveryKey(tabId, header, question);
+  const entry = abandonedConfirmCards.get(key);
+  if (!entry) return null;
+  abandonedConfirmCards.delete(key);
+  const take = (bridge as { takeLateAskReply?: (id: string) => unknown } | undefined)
+    ?.takeLateAskReply;
+  if (typeof take !== "function") return null;
+  const late = take.call(bridge, entry.askId);
+  if (late === undefined) return null;
+  return {
+    outcome: isAffirmative(late) ? "yes" : "no",
+    ageMs: Math.max(0, now - entry.at),
+    askId: entry.askId,
+  };
+}
+
+/** Test seam: forget every remembered abandoned card. */
+export function resetAbandonedConfirmCards(): void {
+  abandonedConfirmCards.clear();
+}
+
+/** Per-call options for ctx.confirm — see AbandonedConfirmCard for the whole argument. */
+export interface ConfirmOptions {
+  /**
+   * Before dispatching a card, claim the answer to a PREVIOUS card for this exact
+   * confirmation whose wait expired unanswered (panel#1554), and remember this card
+   * the same way if its own wait expires. Opt-in: a caller that turns this on is
+   * saying an answer the user already gave for this question, on this tab, inside the
+   * bridge's late-answer window, is a decision it will act on.
+   */
+  recoverAbandonedAnswer?: boolean;
+  /** Called INSTEAD of dispatching a card, when the outcome came from a previous one.
+   *  The caller must disclose this — it is not a fresh confirmation. */
+  onRecoveredAnswer?: (info: { outcome: "yes" | "no"; ageMs: number }) => void;
+}
+
+/**
  * The execution context every tool handler receives. Both transports (Anthropic
  * SDK in-process, MCP-SDK over HTTP) build the SAME context bound to a tab, so a
  * handler is transport-agnostic — it only ever talks to the bridge via `call` /
@@ -9212,7 +9394,12 @@ export interface PanelToolCtx {
    *  user never answered in time. `timeoutMs` (optional, #536) caps the WHOLE confirm
    *  wait (card deadline + late-answer grace) for a caller with a tighter
    *  whole-handler budget (e.g. panel_restart) — always clamped under the ask ceiling. */
-  confirm: (question: string, header: string, timeoutMs?: number) => Promise<ConfirmOutcome>;
+  confirm: (
+    question: string,
+    header: string,
+    timeoutMs?: number,
+    opts?: ConfirmOptions,
+  ) => Promise<ConfirmOutcome>;
   /** The raw bridge + tab id, for the handful of tools that need bespoke wiring
    *  (image screenshots, secret collection). */
   bridge: UiBridge;
@@ -10487,7 +10674,23 @@ export function makePanelToolCtx(
     question: string,
     header: string,
     timeoutMs?: number,
+    opts?: ConfirmOptions,
   ): Promise<ConfirmOutcome> => {
+    // panel#1554 — FIRST, claim any answer left on this confirmation's PREVIOUS card.
+    // Before dispatching, because a second card painted over an answered one is the
+    // state the orchestrator's own #952 wording has to apologise for ("the user may
+    // see two — tell them which one to answer"). See AbandonedConfirmCard.
+    if (opts?.recoverAbandonedAnswer) {
+      const recovered = takeRecoveredConfirmAnswer(bridge, ctx.tabId, header, question);
+      if (recovered) {
+        toolPolicyLogger.info(
+          `[panel-tools] confirm "${header}" answered on an earlier card ` +
+            `(${Math.round(recovered.ageMs / 1000)}s ago) — honouring it instead of re-asking`,
+        );
+        opts.onRecoveredAnswer?.({ outcome: recovered.outcome, ageMs: recovered.ageMs });
+        return recovered.outcome;
+      }
+    }
     // #360: the enclosing MCP `tools/call` is killed at ~300s. A hardcoded 300s
     // card wait had ZERO margin below that budget — so an unanswered confirm blew
     // the whole tool call (a transport timeout) instead of returning cleanly, and
@@ -10540,6 +10743,13 @@ export function makePanelToolCtx(
       if (isReplyTimeoutError(err)) {
         const late = await pollLateAskReply(bridge, askId, timing, budgetEnd);
         if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
+        // panel#1554 — the card is STILL on screen and still answerable (the panel
+        // retires a card on a replaced connection, never on our timeout), and the
+        // bridge will buffer whatever the user clicks. Remember the id so the next
+        // attempt at this same confirmation drains it instead of asking again.
+        if (opts?.recoverAbandonedAnswer) {
+          rememberAbandonedConfirmCard(ctx.tabId, header, question, askId);
+        }
         return "timeout";
       }
       return "unreachable";
@@ -16114,7 +16324,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       "panel_restart_comfyui",
       "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. If a crash takes the panel bridge offline so the confirmation card cannot be shown, this tool falls back to a headless restart of the configured local process (or COMFYUI_RESTART_COMMAND) instead of depending on the dead bridge — it still refuses a readable busy queue without force:true, and still refuses when a relaunch cannot be proven. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead, or set COMFYUI_RESTART_COMMAND to the exact command that restarts the instance (e.g. `docker restart <container>`): the restart then runs through that command (the busy guard above still applies) instead of needing the launch path.",
       { force: z.boolean().optional() },
-      async ({ force }, ctx) => {
+      // panel#1554 — `note` rides WHICHEVER reply this handler returns, so a decision
+      // recovered from an earlier confirmation card is disclosed on every branch, not
+      // just the one that restarts. See withReplyNote / AbandonedConfirmCard.
+      withReplyNote(async ({ force }, ctx, note) => {
         // Whole-handler budget (#536): confirm + dispatch + readiness — INCLUDING
         // the legacy path's UNPREEMPTIBLE synchronous execSync blocks — must ALL finish
         // under the outer ~300s tools/call limit. 255s + the legacy admission rule below
@@ -16175,10 +16388,25 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           1,
           Math.min(RESTART_CONFIRM_TIMEOUT_MS, overallDeadline - Date.now()),
         );
+        // panel#1554 — recovery is opted into HERE, and only here. The card this
+        // dispatches is the one whose answer #404's 90s cap leaves behind; the next
+        // attempt at this same question, on this same tab, claims it rather than
+        // painting a second card over an answer the user already gave.
         const decision = await ctx.confirm(
           "Restart ComfyUI now? It (and this agent) will go down briefly, then reconnect and resume automatically.",
           "Restart ComfyUI",
           confirmBudget,
+          {
+            recoverAbandonedAnswer: true,
+            onRecoveredAnswer: ({ outcome, ageMs }) =>
+              note(
+                `[NOTE] This is NOT a fresh confirmation. You (the user) answered ` +
+                  `"${outcome === "yes" ? "Yes, go ahead" : "No, cancel"}" on the restart card ` +
+                  `from an earlier attempt — that answer arrived after I had stopped waiting for ` +
+                  `it, about ${Math.round(ageMs / 1000)}s ago, so no new card was shown and I ` +
+                  `acted on it now. If it no longer reflects what you want, say so.`,
+              ),
+          },
         );
         if (decision === "timeout") {
           // #851 — the fallback used to be recommended unconditionally, and
@@ -16203,8 +16431,16 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           return ok(
             `No confirmation received within ${Math.round(confirmBudget / 1000)}s, so I did NOT ` +
               "restart ComfyUI. The panel tab may be backgrounded or still reconnecting after a " +
-              "previous restart, so the confirmation card wasn't answered. Tell me to restart it " +
-              `and I'll re-ask. ${fallback}`,
+              "previous restart, so the confirmation card wasn't answered. " +
+              // panel#1554 — the card is still on screen and still answerable, and this
+              // now MATTERS rather than being trivia: its answer is held for the next
+              // attempt (see AbandonedConfirmCard). The old wording ("tell me to restart
+              // it and I'll re-ask") described a card that was dead and a decision that
+              // had to be made again, which is what sent the reporter off to find the
+              // headless tool for a restart they had already authorised.
+              "That card is still live: if the user answers it now and then asks again, " +
+              "this tool takes that answer instead of showing a second card — so just call " +
+              `panel_restart_comfyui again when they say to. ${fallback}`,
           );
         }
         // #1671 — set when the confirmation card was UNREACHABLE and ComfyUI is
@@ -17492,7 +17728,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                   "before issuing graph tools.") +
             ".") + argvNote + (preflightNote ? ` ${preflightNote}` : ""),
         });
-      },
+      }),
     ),
     def(
       "panel_free_vram",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16418,11 +16418,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             recoverAbandonedAnswer: true,
             onRecoveredAnswer: ({ outcome, ageMs }) =>
               note(
-                `[NOTE] This is NOT a fresh confirmation. You (the user) answered ` +
-                  `"${outcome === "yes" ? "Yes, go ahead" : "No, cancel"}" on the restart card ` +
-                  `from an earlier attempt — that answer arrived after I had stopped waiting for ` +
-                  `it, about ${Math.round(ageMs / 1000)}s ago, so no new card was shown and I ` +
-                  `acted on it now. If it no longer reflects what you want, say so.`,
+                `[NOTE] NO NEW CONFIRMATION CARD WAS SHOWN for this call. The user picked ` +
+                  `"${outcome === "yes" ? "Yes, go ahead" : "No, cancel"}" on the restart card from ` +
+                  `an EARLIER attempt, about ${Math.round(ageMs / 1000)}s ago; that answer landed ` +
+                  `after this tool had stopped waiting for it, so it was claimed now instead of ` +
+                  `being discarded. Tell the user that is what you acted on, and check with them ` +
+                  `if anything has changed since.`,
               ),
           },
         );

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9329,6 +9329,11 @@ export function rememberAbandonedConfirmCard(
  *
  * ONE-SHOT by construction: the remembered card is dropped on the way past whether or
  * not it had an answer waiting, so a second call always dispatches a fresh card.
+ *
+ * `ageMs` is the age of the CARD (how long ago its wait expired), NOT of the click. The
+ * bridge buffers the answer without handing back when it arrived, so the click time is
+ * genuinely unknown here — anything reported from this number has to say so, or the
+ * number gets quoted back as "the user answered N seconds ago", which nothing establishes.
  */
 export function takeRecoveredConfirmAnswer(
   bridge: Pick<UiBridge, "takeLateAskReply"> | undefined,
@@ -16420,7 +16425,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               note(
                 `[NOTE] NO NEW CONFIRMATION CARD WAS SHOWN for this call. The user picked ` +
                   `"${outcome === "yes" ? "Yes, go ahead" : "No, cancel"}" on the restart card from ` +
-                  `an EARLIER attempt, about ${Math.round(ageMs / 1000)}s ago; that answer landed ` +
+                  `an EARLIER attempt — the one this tool put up about ${Math.round(ageMs / 1000)}s ` +
+                  `ago (WHEN they clicked is not known here, only that it was after that). Their ` +
+                  `answer landed ` +
                   `after this tool had stopped waiting for it, so it was claimed now instead of ` +
                   `being discarded. Tell the user that is what you acted on, and check with them ` +
                   `if anything has changed since.`,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -38,6 +38,20 @@ import {
 export const DEFAULT_BRIDGE_PORT = 9101;
 
 /**
+ * How long a BUFFERED late `ask_user` answer stays claimable via
+ * takeLateAskReply(). An answer given after its command's reply timer fired has
+ * nowhere else to go, so it is held here until something drains it or this
+ * elapses.
+ *
+ * EXPORTED because it is the real bound on how long a late answer can be
+ * recovered, and panel#1554 added a second reader that has to respect exactly
+ * that window (see confirmAnswerRecoveryWindowMs in panel-tools.ts). A private
+ * copy of "5 minutes" over there would be a bound deciding a correctness
+ * question in two places, free to drift apart.
+ */
+export const LATE_ASK_TTL_MS = 5 * 60 * 1000;
+
+/**
  * The subset of the `ws` WebSocket surface `handleConnection` actually needs.
  * A real `ws.WebSocket` satisfies this structurally. It also lets a non-network
  * pseudo-socket plug in — the relay client (see relay-client.ts) wraps each
@@ -1808,10 +1822,8 @@ export class UiBridge {
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
   private lateAskReplies = new Map<string, { result: unknown; ts: number }>();
-  /** TTL for a BUFFERED late ask answer. Only an in-flight caller drains this
-   *  (its grace poll lives well under 5 minutes), and the durable copy is the
-   *  journal the sink feeds — so this stays short. */
-  private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
+  /** TTL for a BUFFERED late ask answer — see the exported LATE_ASK_TTL_MS. */
+  private static readonly LATE_ASK_TTL_MS = LATE_ASK_TTL_MS;
   /**
    * Mutations whose reply timer fired (rid -> what it was), so a reply arriving
    * afterwards can be RECOGNISED as the late completion of a known write rather


### PR DESCRIPTION
Fixes the underlying cause reported in artokun/comfyui-mcp-panel#1554 (P2, `via-panel`).
**Review is PENDING** — see "What I want reviewed" at the bottom. Nothing here has been gated.

## The report

> `panel_restart_comfyui` displayed a restart-confirmation flow but the tool waited 90 seconds and returned "No confirmation received within 90s, so I did NOT restart ComfyUI." … Call the catalog `restart_comfyui` action directly; restart succeeds in about 16 seconds.

The reporter's own guess — "the confirmation-card response was not correlated back to the pending panel tool call" — is **wrong in its literal form**: the card carries a `randomUUID()` `ask_id`, the bridge correlates on exact id equality, and the whole #486 journal is built on that. Nothing is mis-correlated.

The second half of their ask is the real defect: *"If the confirmation was already accepted, do not lose it."*

## Mechanism

`panel_restart_comfyui` bounds its confirmation card at 90s (#404) so an undelivered card fails fast instead of reading as a four-minute hang. What #404 did not account for is what happens to the **answer**:

1. **The card stays live.** The panel retires an interactive card only when the connection that painted it is REPLACED (#952) — it does nothing with the command's own `timeout_ms` (verified: `web/js/comfyui-mcp-panel.js` reads `msg.timeout_ms` in exactly one place, the #517 duplicate-reply await). So the card is still painted and still clickable after the orchestrator has given up.
2. **A late click still reaches the bridge**, which buffers the validated answer under its `ask_id` for `LATE_ASK_TTL_MS`. This is not speculation — `src/__tests__/services/ui-bridge.test.ts:4425` already drives the real `UiBridge` over a real socket and proves a timed-out `ask_user` card's late answer is retrievable via `takeLateAskReply`.
3. **Nothing ever reads it back for a CONFIRM card.** #486's durable journal accepts only `pa-`-prefixed ids (`PANEL_ASK_ID_PREFIX`) — a confirm card is deliberately excluded. And `confirm()`'s own grace poll is **zero-width** here: `timeoutMs` (90s) is the hard ceiling on *deadline + grace*, so `deadlineMs = 90s` and `graceMs = 90s − 90s = 0`. #360's late-honour poll takes one look and gives up.

So the answer is TTL-pruned unread while the tool reports *"No confirmation received within 90s, so I did NOT restart ComfyUI"* — to a user who clicked **"Yes, go ahead"** and watched the card collapse to **"✓ Yes, go ahead"**. They then went and found the headless tool for a restart they had already authorised. That is the whole of #1554.

This is a **regression by omission**: #404 (bound the wait) silently disabled the mechanism #360 installed (honour a late answer), for the one caller that passes a tighter budget.

## The fix — read the answer, don't wait longer

**#404's 90s is untouched.** No path waits any longer than it does today.

- On timeout, the abandoned card's `ask_id` is remembered against `(tabId, header, question)`.
- The **next** attempt at that same confirmation drains it **before** dispatching a second card — because painting a second card over an answered one is the state the orchestrator's own #952 wording has to apologise for ("the user may see two — tell them which one to answer").
- A late **"No, cancel"** is honoured identically. That decline is lost today too, and re-asking a question the user already answered "no" to is its own defect.

Attribution rules, each load-bearing:

| Rule | Why |
|---|---|
| Exact `ask_id` equality | never "the most recent answer" |
| Same tab **and** identical question **and** header | an answer to the restart card can only satisfy the restart card |
| One-shot (entry dropped on the first look, answered or not) | a recovered answer satisfies exactly one call; no stale key lingers |
| Staleness bound = the bridge's own `LATE_ASK_TTL_MS` | past it `takeLateAskReply` has already dropped the answer. `LATE_ASK_TTL_MS` is now **exported** rather than copied, so the second reader cannot drift from it |
| Route-key **takeover** retires it | `wf:` keys recur; the newcomer never answered that card. Rides #486's existing takeover listener (a *setter*, so a second `setTabTakenOverListener` would have silently replaced #486's). A **reconnect** is deliberately not this event — same browser tab, same incarnation — which is what makes the reporter's "across agent/panel reconnect" case work |
| Opt-in per call site | only `panel_restart_comfyui`. `panel_clear` wipes the canvas and gets the full 285s wait, so its loss window is far narrower and the cost of resurrecting a stale yes far higher. It stays out until someone has a reported failure to point at |
| Disclosed, never silent | acting on an earlier card's answer must not read as a fresh confirmation |

`withReplyNote` exists because the disclosure has to ride **all ~25** of the handler's return points. A disclosure that only survives the happy path reads as a fresh confirmation on every other branch, and threading a note through 25 returns is how one gets missed. It holds the note in a **per-call local**, not on `ctx` — `ctx` is built once per panel MCP server and shared by every tool call it serves, so parking it there would make mis-attribution possible for exactly the class of statement that must never be mis-attributed.

The timeout wording also changes. "Tell me to restart it and I'll re-ask" described a card that was finished and a decision that had to be made again. It was neither — and believing it is what sent the reporter looking for the headless tool.

## Evidence

**17 new tests**, driving the **real** `ctx.confirm` (an earlier draft stubbed it and proved nothing — every stub returns what it was told to, so the line that decides whether a buffered answer is claimed never ran).

**Mutation-verified — each mutation applied to the live tree, run, then reverted:**

| # | Mutation | Result |
|---|---|---|
| M1 | recovery lookup made unreachable | RED: YES-honoured, late-DECLINE, ONE-SHOT |
| M2 | timeout stops remembering the card | RED: same three |
| M3 | **call site** opts out (`recoverAbandonedAnswer: false`) | RED: **only** the call-site test — the other 13 stay green, which is the point |
| M4 | `withReplyNote` drops the note | RED: the disclosure test |
| M5 | `appendReplyNote` prepends instead of appends | RED: the structured-reply test |
| M6 | recovery key forgets the tab | RED: the cross-tab test |
| M7 | takeover forgets nothing | RED: the takeover test |
| M8 | the listener drops `forgetAbandonedConfirmCards` | RED: the wiring test |
| M9 | the listener drops `AskAnswers.closeAsks` | RED: **#486's own** boundary test — proving the assertion I relaxed there still bites |

**Full suite:** 606 files / 11129 tests green. One earlier run reported a single failure whose name I did not capture; it did not reproduce across three subsequent full runs. I am flagging that rather than claiming a clean sweep I only observed three times out of four.

**A false green I caught and am reporting:** my first attempt at M4–M6 ran the mutation through `child_process.execSync`, where MSYS does not translate `/tmp`, so the mutations silently never applied and vitest printed "14 passed". Re-run directly from the shell they all went red as tabled. Separately, a `git checkout --` revert between mutations ate an **uncommitted** part of the fix and produced a red that had nothing to do with the mutation; everything above was re-run against a committed tree.

## Browser verification

**No panel/web code changed** — this is entirely orchestrator-side (`src/orchestrator/`, `src/services/ui-bridge.ts`). The panel's Playwright suite fakes the orchestrator (MockBridge), so it cannot exercise any of this; I did not run it and am not implying coverage I do not have.

The **panel-side half of the story is unchanged by design**: the card staying live past the orchestrator's timeout is precisely what this fix depends on, and it is what makes the answer available to claim.

## What I deliberately did NOT do

- **Did not extend any wait.** #404's 90s stands. A grace carved out of the 90s would have been near-worthless (an answer inside the window already resolves `bridge.send`), and a grace added on top would have re-created the hang #404 was filed about.
- **Did not auto-fall-back to the headless restart**, which the report asks for ("deterministic fallback instead of forcing discovery of a separate headless catalog tool"). That would restart ComfyUI with no confirmation at all, and #851 is the record of why an unconditional `restart_comfyui` recommendation is itself a defect. The conditional advice from #851 is unchanged.
- **Did not journal confirm answers into `AskAnswers`.** That store is `panel_ask`-only for stated reasons and its recovery matches on question *fingerprint*; a confirm needs the stricter card-id identity, which is what this uses.
- **Did not enable recovery for `panel_clear`.**
- **Did not "fix" the zero-width grace** in `confirm()`. It is now not load-bearing, and changing it moves wall-clock behaviour #404 deliberately bounded.

## What I want reviewed (the load-bearing claims, and where I am least sure)

1. **Is resurrecting a ≤5-minute-old "Yes" acceptable for a RESTART?** This is the judgement call of the whole PR. My argument: same tab, byte-identical question, exact card id, one-shot, disclosed in the reply, bounded by an existing TTL, and the alternative is discarding a decision the user explicitly made and watched the panel accept. But a restart aborts in-flight renders, and if you think a destructive gate must never accept an answer from an earlier card, this design is wrong and I would restrict it to *reporting* the recovered answer instead of acting on it.
2. **Is the takeover boundary the right one, and is it sufficient?** I chose it because a reconnect must *not* retire (that is the reporter's case) while a different browser tab on a recurring `wf:` key must. If there is a third state — same browser tab, genuinely new conversation (New chat) — that should also retire, I have missed it. `AskAnswers.closeAsks` is called from four other places in `index.ts` that I did **not** join.
3. **Relaxing #486's assertion.** I changed an exact-source-shape regex on the takeover listener to an anchored body check plus an "exactly one listener installed" assertion. M9 shows it still fails when `closeAsks` leaves the body — but this is someone else's guard and I loosened it, so it deserves an independent look.
4. **`withReplyNote` changes the handler's signature at the `def()` call site.** It is the only tool wrapped this way. Is a per-call note channel the right shape, or should the disclosure be threaded explicitly?
5. **Is the reporter's actual failure the one I fixed?** I could not reproduce their session. The chain — the card outlives the timeout, the bridge buffers the answer, nobody reads it — is established by code and by an existing real-socket bridge test, but whether *their* click landed after 90s or they simply never clicked is not something the report settles. If they never clicked, this PR fixes a real adjacent defect and their session would still have timed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
