### PR TITLE
release: v0.52.42 — multi-connection downloads, self-restart lock reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.42] - 2026-08-20
+
+### MCP
+
+#### Added
+- multi-connection model downloads, with the single-connection path proven as fallback (#1956)
+
+#### Fixed
+- self-restart no longer leaves an unreclaimable panel-op.lock (#1955)
+
+
 ## [0.52.41] - 2026-08-20
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.41",
+  "version": "0.52.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.41",
+      "version": "0.52.42",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.41",
+  "version": "0.52.42",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.42** from `main` (after v0.52.41).

Carries:

- #1956 / #1697 — multi-connection model downloads, with the single-connection path proven as fallback
- #1955 / #1953 — self-restart no longer leaves an unreclaimable panel-op.lock

Held out: mcp#1421 and panel#1555/#1556/#1557 claimed this cycle; panel#1554 inflight (`wt-p1554-cc`); panel#1472 typescript 5→7 (blocked).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.42` tag on the version commit). Tag is local; push `v0.52.42` after merge.
