### PR TITLE
fix(1421): panel_strip_workflow strips a pack against the connected panel, not localhost

### DIFF
--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -1,28 +1,25 @@
-// #1359 — the graph and its node definitions come from different authorities, and the
-// failure never said so.
+// #1359 / #1421 — the graph and its node definitions come from different authorities.
 //
-// `panel_strip_workflow` captures the live canvas through the connected panel, then
-// fetches /object_info through the GLOBAL headless client, which resolves COMFYUI_URL.
-// One machine for a local session; two for a connected REMOTE panel. When they differ
-// the reporter got:
+// `panel_strip_workflow` used to fetch /object_info through the GLOBAL headless client,
+// which resolves COMFYUI_URL. One machine for a local session; two for a connected
+// REMOTE panel. When they differ the reporter got:
 //
 //   fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting
 //   http://127.0.0.1:8188/object_info
 //
-// Nothing there mentions that the workflow itself came from a ComfyUI on a different
-// host. They had to read dist/orchestrator/panel-tools.js to work it out.
+// #1359 routed the LIVE CANVAS through `graph_get_object_info` and left pack/path/inline
+// on COMFYUI_URL. That is the original #1421 case: `panel_strip_workflow({pack:
+// 'krea2-txt2img-manual'})` with a live remote panel still requested localhost. Recurrence
+// on 0.52.41, same session, `panel_run` working.
 //
-// THE SPLIT IS NOW FIXED, so most of this file changed meaning. The live canvas takes its
-// definitions from the panel that supplied the graph (`graph_get_object_info`, panel
-// 0.13.0 / #1006), so the message these tests were written for — "THE GRAPH AND ITS NODE
-// DEFINITIONS CAME FROM DIFFERENT PLACES", with a WORKAROUND to repoint COMFYUI_URL — is
-// unreachable and has been deleted rather than left as a confident explanation of a
-// situation the code can no longer produce.
-//
-// What remains here is the pack/path/inline case, where COMFYUI_URL genuinely IS the right
-// authority, plus a test that the live canvas no longer touches it at all.
+// Every source now takes definitions from the connected panel. The mocked global client
+// throws ECONNREFUSED for every call — if any strip path still consults it, that string
+// appears here.
 
 import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { collectNodeTypes } from "../../services/workflow-converter.js";
+import type { UiWorkflow } from "../../comfyui/types.js";
 
 const hoisted = vi.hoisted(() => ({ objectInfoFails: { value: true } }));
 vi.mock("../../comfyui/client.js", () => ({
@@ -62,6 +59,9 @@ let objectInfoReply: unknown = {
   object_info: { KSampler: { input: { required: { seed: ["INT"] } }, output: [], name: "KSampler" } },
 };
 
+/** Commands the fake panel was asked, in order. Reset per `stripResult`. */
+const cmds: string[] = [];
+
 async function stripWithPanelObjectInfo(reply: unknown): Promise<string> {
   const prev = objectInfoReply;
   objectInfoReply = reply;
@@ -76,6 +76,7 @@ async function stripWithPanelObjectInfo(reply: unknown): Promise<string> {
 function bridge(serverOrigin: string | null) {
   return {
     send: async (cmd: Record<string, unknown>) => {
+      cmds.push(String(cmd.cmd));
       if (cmd.cmd === "graph_serialize" || cmd.cmd === "graph_get_state") {
         // A NON-EMPTY graph. It was empty, which made `object_info: {}` look like a
         // perfectly good conversion — the fixture blessed the exact shape the fail-closed
@@ -96,12 +97,27 @@ function bridge(serverOrigin: string | null) {
   } as unknown as PanelToolCtx["bridge"];
 }
 
-async function strip(args: object, serverOrigin: string | null = REMOTE): Promise<string> {
+async function stripResult(args: object, serverOrigin: string | null = REMOTE): Promise<ToolResult> {
+  cmds.length = 0;
   const ctx = makePanelToolCtx(bridge(serverOrigin), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_strip_workflow");
   if (!def) throw new Error("panel_strip_workflow is not registered");
-  const res: ToolResult = await def.handler(args as never, ctx);
+  return await def.handler(args as never, ctx);
+}
+
+async function strip(args: object, serverOrigin: string | null = REMOTE): Promise<string> {
+  const res = await stripResult(args, serverOrigin);
   return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+const REPORTER_PACK = "krea2-txt2img-manual";
+
+function defsCovering(types: readonly string[]): Record<string, unknown> {
+  const object_info: Record<string, unknown> = {};
+  for (const t of types) {
+    object_info[t] = { input: { required: {} }, output: [], name: t };
+  }
+  return object_info;
 }
 
 describe("an /object_info failure names which host it asked (#1359)", () => {
@@ -151,7 +167,7 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
       object_info: { KSampler: { input: { required: { seed: ["INT"] } }, output: [], name: "KSampler" } },
     });
     expect(text).not.toMatch(/EMPTY node-definition map/i);
-    expect(text).not.toMatch(/do not describe this canvas/i);
+    expect(text).not.toMatch(/do not describe this graph/i);
     expect(text).not.toMatch(/nothing was converted/i);
     // ASSERT THE POSITIVE, not just the absence of two error phrases (codex P2). The
     // earlier version passed with the guard removed entirely, because "no error appeared"
@@ -173,7 +189,7 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
         AlsoUnrelated: { input: { required: {} }, output: [], name: "AlsoUnrelated" },
       },
     });
-    expect(text).toMatch(/do not describe this canvas/i);
+    expect(text).toMatch(/do not describe this graph/i);
     expect(text).toMatch(/KSampler/); // names what it was looking for
     expect(text).toMatch(/nothing was converted/i);
   });
@@ -216,14 +232,46 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
   });
 
 
-  it("a PACK/PATH/INLINE source is not told about the panel at all", async () => {
-    // Those sources are deliberately tied to COMFYUI_URL, so the bare failure is
-    // already about the host the caller asked for. Blaming a host mismatch there
-    // would send them to change a setting that is correct.
-    const text = await strip({ graph: { nodes: [], links: [] } });
+  it("PACK: the reporter's pack strip asks the panel, never localhost (#1421)", async () => {
+    // The original report: panel_strip_workflow({pack:'krea2-txt2img-manual'}) with a
+    // live remote panel, COMFYUI_URL still at 127.0.0.1:8188. The live-canvas path
+    // was already panel-sourced; this source was not.
+    const packUi = JSON.parse(
+      readFileSync(new URL("../../../packs/krea2-txt2img-manual/workflow.json", import.meta.url), "utf8"),
+    ) as UiWorkflow;
+    const types = collectNodeTypes(packUi);
+    expect(types.length, "the reporter's pack must still have nodes to convert").toBeGreaterThan(0);
 
-    expect(text).toMatch(/Node definitions are read from COMFYUI_URL/);
-    expect(text).not.toMatch(/DIFFERENT PLACES/);
-    expect(text).not.toContain(REMOTE);
+    const prev = objectInfoReply;
+    objectInfoReply = { ok: true, served_by: REMOTE, object_info: defsCovering(types) };
+    let res: ToolResult;
+    try {
+      res = await stripResult({ pack: REPORTER_PACK });
+    } finally {
+      objectInfoReply = prev;
+    }
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(text).not.toMatch(/ECONNREFUSED 127\.0\.0\.1:8188/);
+    expect(text).not.toMatch(/Node definitions are read from COMFYUI_URL/);
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/Stripped to \d+ nodes/);
+    expect(cmds).toContain("graph_get_object_info");
+    // Pack is read from disk; a canvas capture would mean we took the live path.
+    expect(cmds).not.toContain("graph_serialize");
+    expect(cmds).not.toContain("graph_get_state");
+    const structured = res.structuredContent as { node_count?: number } | undefined;
+    expect(structured?.node_count).toBeGreaterThan(0);
+  });
+
+  it("an INLINE graph also asks the panel, never localhost (#1421)", async () => {
+    const text = await strip({
+      graph: { nodes: liveNodes, links: [] },
+    });
+    expect(text).not.toMatch(/ECONNREFUSED 127\.0\.0\.1:8188/);
+    expect(text).not.toMatch(/Node definitions are read from COMFYUI_URL/);
+    expect(text).toMatch(/Stripped to \d+ nodes/);
+    expect(cmds).toContain("graph_get_object_info");
+    expect(cmds).not.toContain("graph_serialize");
   });
 });

--- a/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
+++ b/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
@@ -1,19 +1,14 @@
-// #1359 — `panel_strip_workflow` captured the graph from the connected panel and then
-// fetched node definitions through the global client, which resolves COMFYUI_URL. One
-// machine locally; two whenever the panel is remote. The reporter's canvas was on a
-// runpod proxy URL and the definitions request went to 127.0.0.1:8188, so a remote panel
-// could not strip its own canvas at all.
+// #1359 / #1421 — `panel_strip_workflow` fetched node definitions through the global
+// client, which resolves COMFYUI_URL. One machine locally; two whenever the panel is
+// remote. #1359 wired the live canvas through the panel; pack/path/inline still hit
+// localhost, which is the original #1421 report (`{pack:'krea2-txt2img-manual'}`).
 //
-// A partial fix already shipped (5eeca00): the failure names which host was asked and why.
-// Its own comment says it "does NOT fix the split authority — that needs the panel to
-// serve its own /object_info, a protocol change tracked separately."
-//
-// That panel change had ALREADY SHIPPED, in panel 0.13.0 (#1006). Nothing called it. This
-// is the wiring, and the tests below are mostly about the direction that must NOT happen:
-// falling back to COMFYUI_URL when the panel cannot answer. Both hosts can respond, and if
-// they disagree a fallback returns a confidently wrong workflow — converted against a
-// different ComfyUI's schema, with wrong widget order and input names, silently. That is
-// worse than the ECONNREFUSED this issue was filed about, which at least failed loudly.
+// Every source now asks the panel. The tests below are mostly about the direction that
+// must NOT happen: falling back to COMFYUI_URL when the panel cannot answer. Both hosts
+// can respond, and if they disagree a fallback returns a confidently wrong workflow —
+// converted against a different ComfyUI's schema, with wrong widget order and input names,
+// silently. That is worse than the ECONNREFUSED this issue was filed about, which at least
+// failed loudly.
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -31,18 +26,43 @@ function panelToolsCode(): string {
     .replace(/\/\/.*/g, "");
 }
 
-describe("the live canvas is converted with ITS OWN ComfyUI's definitions (#1359)", () => {
-  it("WIRING: a live-canvas strip asks the PANEL, not the global client", () => {
-    const src = panelToolsCode();
-    const at = src.indexOf("const liveCanvasSource =");
-    expect(at, "the live-canvas discriminator must still exist").toBeGreaterThan(-1);
-    const block = src.slice(at, at + 1200);
-    expect(block).toMatch(/if \(liveCanvasSource\)/);
-    // Passes the graph's node types now, so the reply can be judged against the canvas it
-    // is meant to describe rather than against its own shape (codex round 3).
-    expect(block).toMatch(/panelObjectInfo\(ctx, collectNodeTypes\(ui\)\)/);
-    // …and the global client is still used for the sources that genuinely belong to it.
-    expect(block).toMatch(/getObjectInfo\(\)/);
+/** The `def("panel_strip_workflow", …)` body, comments already stripped. */
+function stripHandlerSource(): string {
+  const src = panelToolsCode();
+  const nameAt = src.indexOf('"panel_strip_workflow",');
+  expect(nameAt, "panel_strip_workflow is not registered by name any more").toBeGreaterThan(0);
+  const start = src.lastIndexOf("def(", nameAt);
+  expect(start, "no def( opens the panel_strip_workflow registration").toBeGreaterThan(0);
+  const open = src.indexOf("(", start + 3);
+  let depth = 0;
+  let end = open;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  const body = src.slice(start, end);
+  expect(body, "the def( walk overran into the next tool").not.toContain('"panel_flatten_workflow",');
+  return body;
+}
+
+describe("every strip source is converted with the PANEL's ComfyUI definitions (#1359/#1421)", () => {
+  it("WIRING: a strip asks the PANEL, not the global client — pack included", () => {
+    const body = stripHandlerSource();
+    expect(body).toMatch(/panelObjectInfo\(ctx, collectNodeTypes\(ui\)\)/);
+    // #1421: pack/path/inline used to branch to getObjectInfo() here. That is the
+    // reporter's localhost /object_info. There is no remaining source that belongs
+    // to COMFYUI_URL on this tool.
+    expect(body.includes("getObjectInfo("), "pack/path/inline must not consult COMFYUI_URL").toBe(
+      false,
+    );
+    expect(body).not.toMatch(/liveCanvasSource/);
   });
 
   it("the panel helper sends the command the panel actually implements", () => {
@@ -58,35 +78,32 @@ describe("the live canvas is converted with ITS OWN ComfyUI's definitions (#1359
 
   it("NO FALLBACK: the BACKFILL is skipped too, or the guarantee leaks one line later", () => {
     // `backfillObjectInfo` fetches each type it lacks from
-    // `${getComfyUIBaseUrl()}/object_info/<Type>` — COMFYUI_URL, the host the live path
+    // `${getComfyUIBaseUrl()}/object_info/<Type>` — COMFYUI_URL, the host this path
     // just refused. Refusing the bulk fetch and then backfilling from that server merges a
     // DIFFERENT ComfyUI's definitions into the panel's map, which is exactly the silent
     // wrong-schema outcome the refusal exists to prevent. It fails soft, so it degrades to
     // "type absent" when that host is unreachable and to a quietly wrong schema when it is
     // not.
-    const src = panelToolsCode();
-    const at = src.indexOf("const objectInfo =");
-    expect(at).toBeGreaterThan(-1);
-    const line = src.slice(at, at + 200);
-    expect(line).toMatch(/liveCanvasSource\s*\?\s*bulk/);
-    expect(line).toMatch(/backfillObjectInfo\(bulk, collectNodeTypes\(ui\)\)/);
+    const body = stripHandlerSource();
+    expect(
+      body.includes("backfillObjectInfo("),
+      "a pack strip must not backfill from COMFYUI_URL after a panel schema",
+    ).toBe(false);
   });
 
-  it("NO FALLBACK: the live-canvas path never reaches getObjectInfo() on a panel failure", () => {
+  it("NO FALLBACK: no strip source reaches getObjectInfo() on a panel failure", () => {
     // THE TEST THIS FILE EXISTS FOR. A fallback is the tempting shape and the dangerous
     // one, and it would pass every other assertion here.
     const src = panelToolsCode();
     const at = src.indexOf("async function panelObjectInfo");
-    const body = src.slice(at, src.indexOf("function objectInfoHostMismatchMessage"));
+    const helper = src.slice(at, src.indexOf("export type RestartIdentityBlocker"));
     expect(
-      body.includes("getObjectInfo("),
+      helper.includes("getObjectInfo("),
       "the panel-sourced path must not call the global client, on any branch",
     ).toBe(false);
 
     // …and the caller returns on a failure rather than continuing.
-    const call = src.indexOf("const liveCanvasSource =");
-    const callBlock = src.slice(call, call + 1200);
-    expect(callBlock).toMatch(/if \(!reply\.ok\) return fail\(reply\.message\)/);
+    expect(stripHandlerSource()).toMatch(/if \(!reply\.ok\) return fail\(reply\.message\)/);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -264,8 +264,6 @@ import {
 } from "./ask-answer-journal.js";
 import {
   getClient,
-  getObjectInfo,
-  backfillObjectInfo,
   getQueueVerified,
   resetClient,
   resetObjectInfoCache,
@@ -2231,13 +2229,13 @@ function unboundLocalRestartRefusalNote(
 }
 
 /**
- * Node definitions from the ComfyUI the PANEL is connected to (#1359 / #1006).
+ * Node definitions from the ComfyUI the PANEL is connected to (#1359 / #1421 / #1006).
  *
- * The panel has served these since 0.13.0 and the orchestrator never asked. Everything
- * that pairs a panel-captured graph with definitions was reading the graph from the tab
- * and the schema from COMFYUI_URL — one machine locally, two for a remote panel, and no
- * way at all to convert a live canvas in a tunnel or loopback-only topology, where the
- * browser is the only thing that can reach that ComfyUI.
+ * The panel has served these since 0.13.0. Everything that converts a graph — the live
+ * canvas AND a pack/path/inline source — used to read the schema from COMFYUI_URL. That
+ * is one machine locally and two whenever the panel is remote, so a pack strip with a
+ * live RunPod tab still requested unreachable 127.0.0.1:8188. In a tunnel or
+ * loopback-only topology the browser is the only thing that can reach that ComfyUI.
  *
  * FAIL CLOSED, DELIBERATELY, AND ALL THE WAY THROUGH. Every failure here returns a
  * message instead of falling back to `getObjectInfo()`. A fallback is the tempting move
@@ -2293,14 +2291,13 @@ async function panelObjectInfo(
         `Could not read node definitions from the panel's own ComfyUI: ${raw}
 
 ` +
-        `The live canvas is converted using definitions from the ComfyUI the PANEL is ` +
+        `panel_strip_workflow converts using definitions from the ComfyUI the PANEL is ` +
         `connected to, not from COMFYUI_URL — those are different machines whenever the ` +
-        `panel is remote, and only the browser can reach a tunnelled or loopback-only host. ` +
-        `Or pass an explicit \`pack\`/\`path\`/\`graph\` source, which is read from ` +
-        `COMFYUI_URL by design.
+        `panel is remote, and only the browser can reach a tunnelled or loopback-only host.
 
-No fallback to COMFYUI_URL is attempted on purpose ` +
-        `(#1359): both hosts can answer, and converting this canvas against a different ` +
+` +
+        `No fallback to COMFYUI_URL is attempted on purpose ` +
+        `(#1359/#1421): both hosts can answer, and converting this graph against a different ` +
         `ComfyUI's schema would return a confidently wrong workflow instead of an error.`,
     };
   }
@@ -2424,7 +2421,7 @@ The conversion is refused rather than retried against ` +
       return {
         ok: false,
         message:
-          `The panel returned node definitions that do not describe this canvas` +
+          `The panel returned node definitions that do not describe this graph` +
           (r.served_by ? ` (served from ${r.served_by})` : "") +
           `: none of its ${neededTypes.length} node type(s) — e.g. ${neededTypes.slice(0, 3).join(", ")} — ` +
           `appear among the ${Object.keys(r.object_info).length} definition(s) returned. ` +
@@ -2436,26 +2433,6 @@ The conversion is refused rather than retried against ` +
   return { ok: true, objectInfo: r.object_info };
 }
 
-/**
- * #1359 — an /object_info failure that names WHICH host it asked.
- *
- * ONLY pack/path/inline sources reach this now. The live-canvas branch it used to carry —
- * "THE GRAPH AND ITS NODE DEFINITIONS CAME FROM DIFFERENT PLACES", with a WORKAROUND
- * telling the user to repoint COMFYUI_URL — described a split that no longer exists: the
- * live canvas takes its definitions from the panel that supplied the graph. That message
- * was the best available answer while the split stood, and keeping it would now be a
- * confident explanation of a situation the code cannot produce.
- *
- * For a pack/path/inline source COMFYUI_URL genuinely IS the right authority, so the bare
- * failure is already about the host the caller asked for. Say only what is true.
- */
-function objectInfoHostMismatchMessage(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  const configured = getComfyUIBaseUrl();
-  return `${raw}
-
-Node definitions are read from COMFYUI_URL (${configured}) for a pack/path/inline source. That host did not answer /object_info.`;
-}
 /**
  * panel#1546 — WHY the binding proof failed, when it failed.
  *
@@ -12439,63 +12416,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const captureNotes: string[] = [];
         const raw = await resolveWorkflowInput(args, ctx, true, captureNotes);
         const ui = raw as unknown as UiWorkflow;
-        // #1359 — the graph came from the PANEL; the node definitions come from
-        // COMFYUI_URL. Those are the same machine for a local session and different
-        // ones for a connected REMOTE panel, and when they differ this fails with a
-        // bare `ECONNREFUSED 127.0.0.1:8188` that never mentions the canvas host. The
-        // reporter had to read dist/ to discover that the two halves have different
-        // authorities.
+        // #1421 / #1359 — EVERY source takes definitions from the connected panel.
         //
-        // Only the live-canvas source is affected: a pack/path/inline graph is
-        // deliberately tied to COMFYUI_URL, so its definitions belong there.
-        const liveCanvasSource = args.pack == null && args.path == null && args.graph == null;
-        let bulk: Awaited<ReturnType<typeof getObjectInfo>>;
-        if (liveCanvasSource) {
-          // THE DEFINITIONS NOW COME FROM THE SAME PLACE AS THE GRAPH (#1359).
-          //
-          // The panel has served its own /object_info since 0.13.0 (#1006) and nothing
-          // here called it. Asking the browser is not a workaround for the remote case —
-          // it is the only correct source for ANY case, because the tab that drew this
-          // canvas is by definition able to reach the ComfyUI that defines its nodes. In a
-          // tunnel or loopback-only topology the browser is the sole thing that can.
-          //
-          // FAIL CLOSED. If the panel cannot serve definitions we surface that; we do NOT
-          // fall back to COMFYUI_URL. A fallback would convert the live canvas against a
-          // DIFFERENT ComfyUI's schema and return a confident, wrong workflow — silently,
-          // since the two hosts can both answer and disagree. That is strictly worse than
-          // the ECONNREFUSED this issue was filed about, which at least failed loudly.
-          const reply = await panelObjectInfo(ctx, collectNodeTypes(ui));
-          if (!reply.ok) return fail(reply.message);
-          bulk = reply.objectInfo;
-        } else {
-          try {
-            bulk = await getObjectInfo();
-          } catch (err) {
-            // Returned as a tool ERROR rather than thrown: a throw here escapes the
-            // handler and reaches the caller as a transport-shaped failure, which is how
-            // the bare ECONNREFUSED got to the reporter in the first place.
-            return fail(objectInfoHostMismatchMessage(err));
-          }
-        }
-        // THE FAIL-CLOSED GUARANTEE LEAKED ONE LINE LATER, so this branches too.
+        // #1359 wired the live canvas through `graph_get_object_info` and left
+        // pack/path/inline on COMFYUI_URL "by design". That is the reporter's
+        // case: `panel_strip_workflow({pack:'krea2-txt2img-manual'})` with a live
+        // remote panel still requested /object_info from unreachable
+        // 127.0.0.1:8188. A pack is converted so it can run on the ComfyUI the
+        // panel is on; that schema is what the browser can reach, not localhost.
         //
-        // `backfillObjectInfo` fetches each type it is missing from
-        // `${getComfyUIBaseUrl()}/object_info/<Type>` — COMFYUI_URL, the exact authority
-        // the live-canvas path just refused to consult. Refusing the bulk fetch and then
-        // backfilling from that host would merge a DIFFERENT ComfyUI's definitions into
-        // the panel's map, silently, which is the outcome the branch above exists to
-        // prevent. It fails soft (each miss is swallowed), so on an unreachable
-        // COMFYUI_URL it degrades to "type absent" — but when that host IS reachable and
-        // is a different server, the schema is quietly wrong.
-        //
-        // For a panel-sourced map a miss is not something to repair from elsewhere: the
-        // panel returned that ComfyUI's WHOLE /object_info, so a type absent from it is
-        // absent from the server that will run the workflow. convertUiToApi already
-        // reports unknown types as warnings, which is the honest outcome.
-        const objectInfo = liveCanvasSource
-          ? bulk
-          : await backfillObjectInfo(bulk, collectNodeTypes(ui));
-        const converted = convertUiToApi(ui, objectInfo);
+        // FAIL CLOSED, same as the live canvas. No getObjectInfo(), no
+        // backfillObjectInfo() — both hit `${COMFYUI_URL}/object_info` and would
+        // convert against a different server's schema when that host answers.
+        const reply = await panelObjectInfo(ctx, collectNodeTypes(ui));
+        if (!reply.ok) return fail(reply.message);
+        const converted = convertUiToApi(ui, reply.objectInfo);
         const workflow = converted.workflow;
         const warnings = [...captureNotes, ...converted.warnings];
 
@@ -12546,7 +12481,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // `structuredContent` deleted from ToolResult, `tsc --noEmit` still exited 0).
         // A typed local restores it, so the field is a contract the compiler enforces
         // rather than a comment.
-        const reply: ToolResult = {
+        const result: ToolResult = {
           content: [
             { type: "text", text: proseSummary },
             { type: "text", text: JSON.stringify(workflow, null, 2) },
@@ -12558,7 +12493,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             warnings,
           },
         };
-        return reply;
+        return result;
       },
     ),
     def(


### PR DESCRIPTION
Fixes #1421

## What the user now observes

With a live remote panel and `COMFYUI_URL` still at `127.0.0.1:8188`, `panel_strip_workflow({pack:'krea2-txt2img-manual'})` converts against the panel's ComfyUI. It no longer requests `/object_info` from unreachable localhost.

## Cause

#1359 / PR #1390 routed the *live canvas* through `graph_get_object_info` and left pack/path/inline on `COMFYUI_URL` "by design". That is the original report: a pack strip with a connected RunPod panel still hit `ECONNREFUSED 127.0.0.1:8188`. Recurrence on 0.52.41; `panel_run` and `panel_graph_outline` worked because they already go through the panel.

A pack is converted so it can run on the ComfyUI the panel is on. In a tunnel or loopback-only topology the browser is the only thing that can reach that schema.

## Fix

Every `panel_strip_workflow` source — live canvas, pack, path, inline — takes node definitions from the connected panel. No `getObjectInfo()`, no `backfillObjectInfo()`: both hit `${COMFYUI_URL}/object_info` and would convert against a different server's schema when that host answers.

Fail closed, same as #1359. A panel that cannot serve definitions is refused rather than retried on localhost.

Headless `get_workflow(action:"strip")` is unchanged and still uses `COMFYUI_URL`.

## Tests

- Drives `panel_strip_workflow({pack:'krea2-txt2img-manual'})` with a remote panel while the global client throws `ECONNREFUSED 127.0.0.1:8188`. The panel is asked for `graph_get_object_info`; the canvas is not captured; the strip succeeds.
- Inline graph takes the same panel path.
- Structural wiring: the strip handler calls `panelObjectInfo` and does not contain `getObjectInfo(` / `backfillObjectInfo(` / `liveCanvasSource`.
