### PR TITLE
fix(panel#1556): a successful panel_run completion is no longer left silent for 45s

### DIFF
--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -44,6 +44,10 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     // pointer. A second path that invented filenames would be the over-claim.
     expect(block).toContain("resolveOutputs:");
     expect(block).toContain("resolveHistoryCompletionImages(");
+    // #1556 — reconnect looks the still-owed ids up in /history, not only in
+    // the QueueMonitor drain that may have already missed them.
+    expect(block).toContain("lookupStatus:");
+    expect(block).toContain("resolveHistoryCompletionStatus(");
   });
 
   it("SOURCE: QueueMonitor's completions are TEED to the watchdog from the broadcaster's single drain", () => {
@@ -55,7 +59,7 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     expect(start).toBeGreaterThan(-1);
     const block = src.slice(start, start + 900);
     expect(block).toContain("QueueMonitor.drainCompletions()");
-    expect(block).toContain("runCompletionWatchdog.observe(");
+    expect(block).toContain(".observe(completions)");
   });
 
   it("SOURCE: the watchdog is ticked on the poll timer, AFTER the drain that feeds it", () => {
@@ -63,12 +67,25 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     const start = src.indexOf("const queueStatusTimer = setInterval(");
     expect(start).toBeGreaterThan(-1);
     const block = src.slice(start, start + 700);
-    expect(block).toContain("runCompletionWatchdog.tick()");
+    expect(block).toContain("wd.tick()");
     // Ordering matters: the broadcaster tick is what arms the watchdog, so
     // expiring first would delay every arm by a whole poll interval.
     expect(block.indexOf("queueStatusBroadcaster.tick()")).toBeLessThan(
-      block.indexOf("runCompletionWatchdog.tick()"),
+      block.indexOf("wd.tick()"),
     );
+  });
+
+  it("SOURCE: a panel hello reconciles owed panel_run ids against ComfyUI history immediately", () => {
+    const src = indexSrc();
+    const helloAt = src.indexOf('if (event.type === "hello" && event.tab_id)');
+    expect(helloAt).toBeGreaterThan(-1);
+    // The hello handler is large; pin the reconcile next to the queue_status
+    // seed that already runs on connect, not some unrelated later hello.
+    const seedAt = src.indexOf("buildQueueStatusFrame(QueueMonitor.snapshot())", helloAt);
+    expect(seedAt).toBeGreaterThan(helloAt);
+    const block = src.slice(seedAt, seedAt + 900);
+    expect(block).toContain("runCompletionWatchdog?.reconcile(");
+    expect(block).toContain("RunCompletions.owedCompletions()");
   });
 });
 

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -22,9 +22,12 @@ import {
   createRunCompletionWatchdog,
   synthesizeCompletionPayload,
   resolveHistoryCompletionImages,
+  resolveHistoryCompletionStatus,
+  completionStatusFromHistoryEntry,
   historyOutputRefsFromEntry,
   DEFAULT_SYNTHESIS_GRACE_MS,
 } from "../../orchestrator/run-completion-watchdog.js";
+import type { CompletionStatus } from "../../services/queue-monitor.js";
 import { RunCompletions, type CompletionPayload, type RunTicket } from "../../orchestrator/run-completion-journal.js";
 
 const TAB = "tab-1789";
@@ -39,6 +42,7 @@ function makeWatchdog(
   clock: { t: number },
   extras: {
     resolveOutputs?: (promptId: string) => Promise<CompletionPayload["images"]>;
+    lookupStatus?: (promptId: string) => Promise<CompletionStatus | null>;
   } = {},
 ) {
   const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
@@ -52,6 +56,7 @@ function makeWatchdog(
     },
     now: () => clock.t,
     ...(extras.resolveOutputs ? { resolveOutputs: extras.resolveOutputs } : {}),
+    ...(extras.lookupStatus ? { lookupStatus: extras.lookupStatus } : {}),
   });
   return { wd, delivered };
 }
@@ -220,11 +225,21 @@ describe("#1789: a completion the panel never reported is filled in from ComfyUI
 });
 
 describe("#1789: awaitingCompletion answers 'is this run still owed its notification?'", () => {
+  it("#1556: the grace no longer waits for a panel sweep that may never come", () => {
+    // The panel's own recovery sweep is 20 s. Waiting past it is what left the
+    // reporter's successful SaveImage silent for 45 s. 5 s is past the normal
+    // 1–2 s frame; reconnect skips even that.
+    expect(DEFAULT_SYNTHESIS_GRACE_MS).toBeLessThan(20_000);
+    expect(DEFAULT_SYNTHESIS_GRACE_MS).toBeGreaterThan(1_000);
+  });
+
   it("true for a fresh ticket, false once ANY completion for it is journaled", () => {
     RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
     expect(RunCompletions.awaitingCompletion(PID)?.promptId).toBe(PID);
+    expect(RunCompletions.owedCompletions().map((t) => t.promptId)).toEqual([PID]);
     RunCompletions.record(TAB, { kind: "executed", prompt_id: PID }, { conversation: CONV });
     expect(RunCompletions.awaitingCompletion(PID)).toBeUndefined();
+    expect(RunCompletions.owedCompletions()).toEqual([]);
   });
 
   it("false while the completion is merely HANDED OFF (the journal owns the replay from there)", () => {
@@ -444,5 +459,212 @@ describe("#1853: a dropped panel frame still yields the completed prompt's histo
     const refs = historyOutputRefsFromEntry(PID, entry);
     expect(refs.some((img) => img.filename === "still.png")).toBe(true);
     expect(refs.some((img) => img.filename === VIDEO_FILENAME && img.subfolder === VIDEO_SUBFOLDER)).toBe(true);
+  });
+});
+
+describe("#1556: reconnect reconciles owed panel_run ids against ComfyUI history immediately", () => {
+  it("an already-armed observation is delivered without waiting the grace", async () => {
+    const clock = { t: 20_000_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+    expect(wd.armedCount()).toBe(1);
+
+    await wd.reconcile([]);
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+    expect(wd.armedCount()).toBe(0);
+    expect(RunCompletions.awaitingCompletion(PID)).toBeUndefined();
+  });
+
+  it("an unarmed owed ticket is synthesised from /history on reconcile, not after the grace", async () => {
+    const clock = { t: 21_000_000 };
+    const lookedUp: string[] = [];
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: async (id) => {
+        lookedUp.push(id);
+        return resolveHistoryCompletionStatus(id, async (promptId) => ({
+          [promptId]: {
+            prompt: {},
+            outputs: {
+              "9": { images: [{ filename: "ComfyUI_00001_.png", type: "output" }] },
+            },
+            status: { status_str: "success", completed: true, messages: [] },
+          },
+        }));
+      },
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({
+          [promptId]: {
+            prompt: {},
+            outputs: {
+              "9": { images: [{ filename: "ComfyUI_00001_.png", type: "output" }] },
+            },
+            status: { status_str: "success", completed: true, messages: [] },
+          },
+        })),
+    });
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+    expect(wd.armedCount()).toBe(0);
+
+    await wd.reconcile(RunCompletions.owedCompletions().map((t) => t.promptId));
+
+    expect(lookedUp).toEqual([PID]);
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+    expect(delivered[0].payload.completion_source).toBe("orchestrator-history-watchdog");
+    expect(delivered[0].payload.images).toEqual([{ filename: "ComfyUI_00001_.png", type: "output" }]);
+    expect(RunCompletions.outstanding(TAB)[0].correlation).toEqual({ status: "matched", promptId: PID });
+  });
+
+  it("a still-running history record is NOT synthesised", async () => {
+    const clock = { t: 22_000_000 };
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: (id) =>
+        resolveHistoryCompletionStatus(id, async (promptId) => ({
+          [promptId]: {
+            prompt: {},
+            outputs: {},
+            status: { status_str: "running", completed: false, messages: [] },
+          },
+        })),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    await wd.reconcile([PID]);
+    expect(delivered).toHaveLength(0);
+    expect(RunCompletions.awaitingCompletion(PID)?.promptId).toBe(PID);
+  });
+
+  it("a missing history record is NOT synthesised", async () => {
+    const clock = { t: 23_000_000 };
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: (id) => resolveHistoryCompletionStatus(id, async () => ({})),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    await wd.reconcile([PID]);
+    expect(delivered).toHaveLength(0);
+  });
+
+  it("a ticket the panel already journaled is skipped — exactly one completion", async () => {
+    const clock = { t: 24_000_000 };
+    let lookups = 0;
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: async () => {
+        lookups += 1;
+        return "success";
+      },
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    RunCompletions.record(
+      TAB,
+      { kind: "executed", prompt_id: PID, images: [{ filename: "panel.png" }] },
+      { conversation: CONV },
+    );
+
+    await wd.reconcile([PID]);
+    expect(lookups).toBe(0);
+    expect(delivered).toHaveLength(0);
+    expect(RunCompletions.outstanding(TAB)).toHaveLength(1);
+    expect(RunCompletions.outstanding(TAB)[0].payload.images).toEqual([{ filename: "panel.png" }]);
+  });
+
+  it("reconcile is idempotent — a second call does not produce a second delivery", async () => {
+    const clock = { t: 25_000_000 };
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: async () => "success",
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    await wd.reconcile([PID]);
+    await wd.reconcile([PID]);
+    expect(delivered).toHaveLength(1);
+  });
+
+  it("a foreign prompt this session never queued is not looked up", async () => {
+    const clock = { t: 26_000_000 };
+    const lookedUp: string[] = [];
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: async (id) => {
+        lookedUp.push(id);
+        return "success";
+      },
+    });
+    await wd.reconcile(["p-foreign"]);
+    expect(lookedUp).toEqual([]);
+    expect(delivered).toHaveLength(0);
+  });
+
+  it("a panel frame that lands during the history-status lookup still wins", async () => {
+    const clock = { t: 27_000_000 };
+    let release!: (status: CompletionStatus | null) => void;
+    const { wd, delivered } = makeWatchdog(clock, {
+      lookupStatus: () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    const pending = wd.reconcile([PID]);
+    RunCompletions.record(
+      TAB,
+      { kind: "executed", prompt_id: PID, images: [{ filename: "storyboard.png" }] },
+      { conversation: CONV },
+    );
+    release("success");
+    await pending;
+    expect(delivered).toHaveLength(0);
+    expect(RunCompletions.outstanding(TAB)[0].payload.images).toEqual([{ filename: "storyboard.png" }]);
+  });
+});
+
+describe("#1556: completionStatusFromHistoryEntry is fail-closed", () => {
+  it("success / interrupted / error from the shipped history shape", () => {
+    expect(
+      completionStatusFromHistoryEntry({
+        status: { status_str: "success", completed: true, messages: [] },
+      }),
+    ).toBe("success");
+    expect(
+      completionStatusFromHistoryEntry({
+        status: {
+          status_str: "error",
+          completed: false,
+          messages: [["execution_interrupted", { prompt_id: PID }]],
+        },
+      }),
+    ).toBe("interrupted");
+    expect(
+      completionStatusFromHistoryEntry({
+        status: {
+          status_str: "error",
+          completed: true,
+          messages: [["execution_error", { prompt_id: PID }]],
+        },
+      }),
+    ).toBe("error");
+  });
+
+  it("missing, unreadable, or still-running records are null — never a fabricated finish", () => {
+    expect(completionStatusFromHistoryEntry(undefined)).toBeNull();
+    expect(completionStatusFromHistoryEntry(null)).toBeNull();
+    expect(completionStatusFromHistoryEntry({})).toBeNull();
+    expect(
+      completionStatusFromHistoryEntry({
+        status: { status_str: "running", completed: false, messages: [] },
+      }),
+    ).toBeNull();
+  });
+
+  it("resolveHistoryCompletionStatus drives getHistory and returns null on an empty map", async () => {
+    expect(await resolveHistoryCompletionStatus(PID, async () => ({}))).toBeNull();
+    expect(await resolveHistoryCompletionStatus("", async () => ({}))).toBeNull();
+    expect(
+      await resolveHistoryCompletionStatus(PID, async (id) => ({
+        [id]: {
+          prompt: {},
+          outputs: {},
+          status: { status_str: "success", completed: true, messages: [] },
+        },
+      })),
+    ).toBe("success");
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -217,7 +217,12 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
-import { createRunCompletionWatchdog, resolveHistoryCompletionImages } from "./run-completion-watchdog.js";
+import {
+  createRunCompletionWatchdog,
+  resolveHistoryCompletionImages,
+  resolveHistoryCompletionStatus,
+  type RunCompletionWatchdog,
+} from "./run-completion-watchdog.js";
 import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
@@ -3796,6 +3801,11 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
   }
 
+  // Assigned next to the queue-status timer below. Declared here so the hello
+  // path can reconcile owed panel_run tickets the moment the panel reconnects
+  // (#1556) without waiting for that timer to construct it.
+  let runCompletionWatchdog: RunCompletionWatchdog | undefined;
+
   bridge.onPanelMessage = (event) => {
     // Connect ack: the instant a panel tab connects, the orchestrator announces
     // itself so "connected" means "a real agent is attending" — not merely "a
@@ -4283,6 +4293,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // are change-only, so a tab connecting MID-render would otherwise wait for
       // the next state transition to learn a job is already running.
       bridge.push(buildQueueStatusFrame(QueueMonitor.snapshot()), panelTab);
+      // #1556 — a hello is a reconnect (or the first chance after a missed
+      // ComfyUI WS frame). Look up every still-owed panel_run in /history NOW
+      // and journal a completion if ComfyUI already finished it, instead of
+      // waiting the synthesis grace. Exactly-once: the journal skips a run it
+      // already holds.
+      void runCompletionWatchdog?.reconcile(RunCompletions.owedCompletions().map((t) => t.promptId));
       // Seed the RunPod control panel too — a tab that just connected gets the
       // current pod-status frame (or a cleared one when nothing is watched).
       const rpFrame = getRunpodWatcher()?.current();
@@ -6376,9 +6392,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   // after the grace is synthesised into the SAME journal the real frame uses.
   // See run-completion-watchdog.ts for why it waits, and why the panel's frame
   // still wins whenever it is coming.
-  const runCompletionWatchdog = createRunCompletionWatchdog({
+  const wd = createRunCompletionWatchdog({
     awaiting: (promptId) => RunCompletions.awaitingCompletion(promptId),
     resolveOutputs: (promptId) => resolveHistoryCompletionImages(promptId),
+    lookupStatus: (promptId) => resolveHistoryCompletionStatus(promptId),
     deliver: (payload, ticket) => {
       // The SAME arrival path the panel's frame takes: correlated once, here,
       // against the ticket that is still open — so the agent is told this is the
@@ -6393,6 +6410,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       flushRunCompletions(ticket.tabId);
     },
   });
+  runCompletionWatchdog = wd;
   const queueStatusBroadcaster = createQueueStatusBroadcaster(
     () => QueueMonitor.snapshot(),
     (frame) => void bridge.push(frame),
@@ -6401,7 +6419,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // again — a second call would race and each consumer would see only half.
     () => {
       const completions = QueueMonitor.drainCompletions();
-      runCompletionWatchdog.observe(completions);
+      wd.observe(completions);
       return completions;
     },
   );
@@ -6416,7 +6434,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // …and only THEN expire the watchdog's arms: the broadcaster tick is what
       // feeds it (the drain tee above), so ticking it first would let an
       // observation sit a whole extra second before it is even armed. #1789.
-      runCompletionWatchdog.tick();
+      wd.tick();
     });
   }, 1000);
   queueStatusTimer.unref?.();

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1151,6 +1151,22 @@ export class RunCompletionJournalImpl {
     return ticket;
   }
 
+  /**
+   * Every run still owed the completion `panel_run` promised it (#1556).
+   *
+   * The reconnect recovery looks these up in ComfyUI `/history` immediately
+   * rather than waiting for QueueMonitor to re-observe the finish. Same
+   * predicate as `awaitingCompletion` — one implementation, iterated.
+   */
+  owedCompletions(): RunTicket[] {
+    const out: RunTicket[] = [];
+    for (const promptId of this.tickets.keys()) {
+      const ticket = this.awaitingCompletion(promptId);
+      if (ticket) out.push(ticket);
+    }
+    return out;
+  }
+
   /** Is ANY completion still undelivered anywhere? The orchestrator's
    *  self-restart gate reads this: the journal is in-memory, so restarting while
    *  an entry is outstanding would silently drop a render result the agent was

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -37,16 +37,16 @@
 //                real frame would have used.
 //
 // WHY A GRACE RATHER THAN IMMEDIATELY. The panel's frame is the better one — it
-// carries the output images, the duration and the metadata. Ours used to carry
-// only a terminal status and a pointer (#1789); #1853 fills the images from
-// the same completed /history record JobWatcher already parses, so a dropped
-// panel frame still yields the output filenames. Never fabricated: no history
-// entry, no usable media refs, or a fetch failure ⇒ images stay []. The normal
-// path lands within a second or two, and the panel's OWN recovery sweep
-// re-reconciles every 20 s, so a grace comfortably past both lets the real
-// frame win every time it is coming. Past the grace there are exactly two
-// shapes, and NEITHER loses anything — stated precisely, because the coalescing
-// one is the narrower case, not the general one (gate finding):
+// carries duration and metadata the history record does not. #1853 already
+// fills images from that record, so a dropped panel frame is not a missing
+// output. The normal path lands within a second or two; that is the only race
+// the grace has to win. Waiting past the panel's own 20 s recovery sweep
+// (#1789) left a successful run silent for 45 s when that sweep also missed
+// (#1556). A reconnect / missed-WS recovery does not wait at all: reconcile()
+// looks the still-owed prompt ids up in /history and synthesises immediately.
+// Past the grace there are exactly two shapes, and NEITHER loses anything —
+// stated precisely, because the coalescing one is the narrower case, not the
+// general one (gate finding):
 //   • nothing took the synthesised entry (no live agent at that instant), so it
 //     is still `pending` — the journal COALESCES the real payload onto it
 //     (record()), and the agent sees ONE turn, with the images. This is the only
@@ -92,18 +92,25 @@ export interface RunCompletionWatchdogDeps {
    * is the #1789 status-only notice, never a fabricated image.
    */
   resolveOutputs?: (promptId: string) => Promise<CompletionPayload["images"]>;
-  /** How long to let the panel's own frame (and its 20 s reconcile sweep) win
-   *  before filling in. */
+  /**
+   * Terminal status of a prompt in ComfyUI history, or null if it is missing /
+   * still running / unreadable. Wired to `resolveHistoryCompletionStatus` in
+   * production. Used by reconcile() so a reconnect does not have to wait for
+   * QueueMonitor to observe the same finish again.
+   */
+  lookupStatus?: (promptId: string) => Promise<CompletionStatus | null>;
+  /** How long to let the panel's own in-flight frame win before filling in. */
   graceMs?: number;
   now?: () => number;
 }
 
 /**
- * Longer than the panel's own run-reconcile sweep period (20 s) plus a full
- * reconcile round trip, so the panel's recovery — which delivers the IMAGES —
- * is given every chance before we fill in with a pointer.
+ * Past the panel's normal 1–2 s `executed` frame, not past its 20 s recovery
+ * sweep. #1853 already attaches history outputs, so waiting for that sweep
+ * only prolonged the silence when the sweep itself was the thing that missed
+ * (#1556). Reconnect skips this entirely (see reconcile()).
  */
-export const DEFAULT_SYNTHESIS_GRACE_MS = 45_000;
+export const DEFAULT_SYNTHESIS_GRACE_MS = 5_000;
 
 /** Cap on armed observations. A run's arm is dropped the moment it expires, so
  *  this only ever bounds a burst of self-queued renders finishing at once. */
@@ -114,6 +121,14 @@ export interface RunCompletionWatchdog {
   observe(events: ReadonlyArray<{ promptId: string; status: CompletionStatus }>): void;
   /** Expire armed observations; synthesise for the ones still unanswered. */
   tick(): Promise<void>;
+  /**
+   * #1556 — deliver NOW for still-owed runs that ComfyUI history already
+   * shows finished. Used on panel hello/reconnect (and any other missed-WS
+   * recovery) so the agent is not left idle for the grace. Already-armed
+   * observations are flushed immediately even without a history lookup.
+   * Never throws. Exactly-once: a run the journal already holds is skipped.
+   */
+  reconcile(promptIds: readonly string[]): Promise<void>;
   /** Diagnostics/tests: how many completions are currently armed. */
   armedCount(): number;
 }
@@ -222,6 +237,46 @@ export async function resolveHistoryCompletionImages(
 }
 
 /**
+ * Terminal status of a /history record, or null when the run is not proven
+ * finished. Fail-closed: a missing entry, a missing status, or a still-running
+ * record must not synthesise a completion. Interrupted is recognised from the
+ * execution_interrupted message even when status_str is not "interrupted".
+ */
+export function completionStatusFromHistoryEntry(entry: unknown): CompletionStatus | null {
+  if (!entry || typeof entry !== "object") return null;
+  const st = (entry as { status?: unknown }).status;
+  if (!st || typeof st !== "object") return null;
+  const status = st as { status_str?: unknown; completed?: unknown; messages?: unknown };
+  const messages = Array.isArray(status.messages) ? status.messages : [];
+  const has = (type: string) => messages.some((m) => Array.isArray(m) && m[0] === type);
+  if (has("execution_interrupted")) return "interrupted";
+  if (has("execution_error") || status.status_str === "error") return "error";
+  if (status.completed === true || status.status_str === "success") return "success";
+  return null;
+}
+
+/**
+ * Fetch `/history/<promptId>` and return its terminal status, or null when the
+ * record is missing, unreadable, or not yet complete. Never invents a finish.
+ */
+export async function resolveHistoryCompletionStatus(
+  promptId: string,
+  fetchHistory: (id: string) => Promise<Record<string, HistoryEntry>> = getHistory,
+): Promise<CompletionStatus | null> {
+  const id = typeof promptId === "string" ? promptId.trim() : "";
+  if (!id) return null;
+  try {
+    const history = await fetchHistory(id);
+    return completionStatusFromHistoryEntry(history?.[id]);
+  } catch (err) {
+    logger.debug(
+      `[run-completion-watchdog] history status for ${id} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
  * Compose the synthesised completion payload.
  *
  * Every claim in it is one the orchestrator actually observed. Output refs are
@@ -291,6 +346,7 @@ export function createRunCompletionWatchdog({
   awaiting,
   deliver,
   resolveOutputs,
+  lookupStatus,
   graceMs = DEFAULT_SYNTHESIS_GRACE_MS,
   now = () => Date.now(),
 }: RunCompletionWatchdogDeps): RunCompletionWatchdog {
@@ -299,23 +355,98 @@ export function createRunCompletionWatchdog({
    *  re-reported completion would never expire and the agent would wait
    *  forever — the exact failure being fixed). */
   const armed = new Map<string, ArmedCompletion>();
+  /** promptIds currently being synthesised. Reconcile must not re-arm one
+   *  tick() has already spent — that would double-deliver if the history
+   *  fetch is still in flight. */
+  const inflight = new Set<string>();
+
+  const arm = (promptId: string, status: CompletionStatus, observedAt: number): void => {
+    if (armed.has(promptId) || inflight.has(promptId)) return;
+    armed.set(promptId, { promptId, status, observedAt });
+    while (armed.size > MAX_ARMED) {
+      const oldest = armed.keys().next().value;
+      if (oldest === undefined) break;
+      armed.delete(oldest);
+    }
+  };
+
+  const expire = async (ignoreGrace: boolean): Promise<void> => {
+    if (armed.size === 0) return;
+    const at = now();
+    for (const entry of [...armed.values()]) {
+      if (!ignoreGrace && at - entry.observedAt < graceMs) continue;
+      // Disarm FIRST and unconditionally: whatever happens below, this
+      // observation is spent. Leaving it armed on a throwing deliver() would
+      // re-fire it on every later tick.
+      armed.delete(entry.promptId);
+      inflight.add(entry.promptId);
+      let ticket: RunTicket | undefined;
+      try {
+        ticket = awaiting(entry.promptId);
+      } catch (err) {
+        inflight.delete(entry.promptId);
+        logger.debug(
+          `[run-completion-watchdog] could not re-check prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        continue;
+      }
+      // The panel's own frame landed inside the grace — the normal case, and
+      // the one this must stay quiet for.
+      if (!ticket) {
+        inflight.delete(entry.promptId);
+        continue;
+      }
+      try {
+        let images: CompletionImage[] = [];
+        if (resolveOutputs) {
+          try {
+            images = usableHistoryImages(await resolveOutputs(entry.promptId));
+          } catch (err) {
+            logger.debug(
+              `[run-completion-watchdog] history outputs for ${entry.promptId} unavailable: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          // A panel frame that landed DURING the fetch still wins.
+          try {
+            ticket = awaiting(entry.promptId);
+          } catch (err) {
+            logger.debug(
+              `[run-completion-watchdog] could not re-check prompt ${entry.promptId} after history fetch: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            continue;
+          }
+          if (!ticket) continue;
+        }
+        // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
+        // only detector of a lost completion was a human noticing the agent had
+        // gone quiet.
+        logger.warn(
+          `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
+            (at - entry.observedAt) / 1000,
+          )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
+        );
+        deliver(synthesizeCompletionPayload(entry, { deliveredAt: at, images }), ticket);
+      } catch (err) {
+        logger.warn(
+          `[run-completion-watchdog] could not deliver the synthesised completion for prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } finally {
+        inflight.delete(entry.promptId);
+      }
+    }
+  };
 
   return {
     observe(events) {
       for (const ev of events ?? []) {
         try {
           const promptId = typeof ev?.promptId === "string" ? ev.promptId.trim() : "";
-          if (!promptId || armed.has(promptId)) continue;
+          if (!promptId) continue;
           // Only runs THIS session queued and is still owed a completion for.
           // A foreign render (the user pressed Queue Prompt) has no ticket and
           // was never promised anything, so it must never wake the agent.
           if (!awaiting(promptId)) continue;
-          armed.set(promptId, { promptId, status: ev.status, observedAt: now() });
-          while (armed.size > MAX_ARMED) {
-            const oldest = armed.keys().next().value;
-            if (oldest === undefined) break;
-            armed.delete(oldest);
-          }
+          arm(promptId, ev.status, now());
         } catch (err) {
           logger.debug(
             `[run-completion-watchdog] observe skipped an event: ${err instanceof Error ? err.message : String(err)}`,
@@ -325,61 +456,44 @@ export function createRunCompletionWatchdog({
     },
 
     async tick() {
-      if (armed.size === 0) return;
-      const at = now();
-      for (const entry of [...armed.values()]) {
-        if (at - entry.observedAt < graceMs) continue;
-        // Disarm FIRST and unconditionally: whatever happens below, this
-        // observation is spent. Leaving it armed on a throwing deliver() would
-        // re-fire it on every later tick.
-        armed.delete(entry.promptId);
-        let ticket: RunTicket | undefined;
-        try {
-          ticket = awaiting(entry.promptId);
-        } catch (err) {
-          logger.debug(
-            `[run-completion-watchdog] could not re-check prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          continue;
-        }
-        // The panel's own frame landed inside the grace — the normal case, and
-        // the one this must stay quiet for.
-        if (!ticket) continue;
-        try {
-          let images: CompletionImage[] = [];
-          if (resolveOutputs) {
+      await expire(false);
+    },
+
+    async reconcile(promptIds) {
+      try {
+        if (lookupStatus) {
+          for (const raw of promptIds ?? []) {
             try {
-              images = usableHistoryImages(await resolveOutputs(entry.promptId));
+              const promptId = typeof raw === "string" ? raw.trim() : "";
+              if (!promptId || armed.has(promptId) || inflight.has(promptId)) continue;
+              if (!awaiting(promptId)) continue;
+              let status: CompletionStatus | null = null;
+              try {
+                status = await lookupStatus(promptId);
+              } catch (err) {
+                logger.debug(
+                  `[run-completion-watchdog] history status for ${promptId} unavailable: ${err instanceof Error ? err.message : String(err)}`,
+                );
+                continue;
+              }
+              if (!status) continue;
+              // A panel frame that landed DURING the lookup still wins.
+              if (!awaiting(promptId)) continue;
+              // observedAt = now: we just learned it finished. expire(true)
+              // skips the grace; waitedS in the note is the lookup latency.
+              arm(promptId, status, now());
             } catch (err) {
               logger.debug(
-                `[run-completion-watchdog] history outputs for ${entry.promptId} unavailable: ${err instanceof Error ? err.message : String(err)}`,
+                `[run-completion-watchdog] reconcile skipped a prompt: ${err instanceof Error ? err.message : String(err)}`,
               );
             }
-            // A panel frame that landed DURING the fetch still wins.
-            try {
-              ticket = awaiting(entry.promptId);
-            } catch (err) {
-              logger.debug(
-                `[run-completion-watchdog] could not re-check prompt ${entry.promptId} after history fetch: ${err instanceof Error ? err.message : String(err)}`,
-              );
-              continue;
-            }
-            if (!ticket) continue;
           }
-          // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
-          // only detector of a lost completion was a human noticing the agent had
-          // gone quiet.
-          logger.warn(
-            `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
-              (at - entry.observedAt) / 1000,
-            )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
-          );
-          deliver(synthesizeCompletionPayload(entry, { deliveredAt: at, images }), ticket);
-        } catch (err) {
-          logger.warn(
-            `[run-completion-watchdog] could not deliver the synthesised completion for prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,
-          );
         }
+        await expire(true);
+      } catch (err) {
+        logger.debug(
+          `[run-completion-watchdog] reconcile failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     },
 


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1556

A render queued through panel_run could finish in ComfyUI history while the sidebar panel never sent its `executed` event. The orchestrator already synthesised a completion from history, but only after a 45s grace meant to outwait the panel's 20s recovery sweep — the same sweep that missed.

- On panel hello/reconnect, look up every still-owed panel_run prompt id in ComfyUI `/history` and journal a completion immediately (exactly once; a run the journal already holds is skipped).
- Cut the history-fallback grace from 45s to 5s (past the normal 1–2s panel frame, not past a sweep that may never come). Images still come from the completed history record.
