### PR TITLE
fix(panel#1555): panel_open_workflow no longer false-mismatches the already-open canvas after restart

### DIFF
--- a/src/__tests__/orchestrator/open-reconnect-false-mismatch.test.ts
+++ b/src/__tests__/orchestrator/open-reconnect-false-mismatch.test.ts
@@ -1,0 +1,272 @@
+// panel#1555 — immediately after a ComfyUI restart, panel_open_workflow reported
+// a content-mismatch / fence warning for the v3 workflow that was already the
+// active canvas. A subsequent panel_query_graph showed that graph and the newly
+// loaded custom-node schema. The open-path content comparison ran before
+// workflow_list.active_confirmed and the live serialize finished one
+// synchronized handshake.
+//
+// Tests drive panel_open_workflow. Dest file comes through the same userdata
+// read that handler uses; live canvas comes from graph_serialize.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const destByKey = new Map<string, Record<string, unknown>>();
+
+vi.mock("../../services/userdata-library.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/userdata-library.js")>();
+  return {
+    ...actual,
+    userdataFetch: async (route: string) => {
+      for (const [key, graph] of destByKey) {
+        if (route.includes(encodeURIComponent(key)) || route.includes(key)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(graph),
+          } as Response;
+        }
+      }
+      throw new Error(`no dest fixture for ${route}`);
+    },
+  };
+});
+
+const { buildPanelToolDefs, makePanelToolCtx, __openWorkflowTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+
+const TAB = "wf:workflows/v3.json";
+const PATH = "workflows/v3.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+const PRIOR = "11111111-1111-4111-8111-111111111111";
+
+const IDENTITY_PROVEN =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded, and the panel cannot tell whether the ComfyUI ` +
+  `frontend merely normalized it (node sizes, widget values) or the load only partly applied. ` +
+  `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing. You are NOT ` +
+  `on the wrong workflow: ${PATH} IS the active one. This reply carries NO fence refresh.`;
+
+function destGraph() {
+  return {
+    nodes: [
+      {
+        id: 1,
+        type: "CustomPackNode",
+        widgets_values: ["ckpt.safetensors"],
+        widgets_values_named: { ckpt_name: "ckpt.safetensors" },
+      },
+      {
+        id: 2,
+        type: "SaveImage",
+        widgets_values: ["out"],
+        widgets_values_named: { filename_prefix: "out" },
+      },
+    ],
+    links: [[1, 1, 0, 2, 0, "IMAGE"]],
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+  };
+}
+
+function liveGraph() {
+  return {
+    nodes: [
+      {
+        id: 1,
+        type: "CustomPackNode",
+        size: [280, 140],
+        properties: { "Node name for S&R": "CustomPackNode" },
+        widgets_values: ["ckpt.safetensors"],
+        widgets_values_named: { ckpt_name: "ckpt.safetensors" },
+        inputs: [],
+        outputs: [{ name: "IMAGE", type: "IMAGE", links: [1] }],
+      },
+      {
+        id: 2,
+        type: "SaveImage",
+        widgets_values: ["out"],
+        widgets_values_named: { filename_prefix: "out" },
+      },
+    ],
+    links: [[1, 1, 0, 2, 0, "IMAGE"]],
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+  };
+}
+
+function emptyGraph() {
+  return { nodes: [] as unknown[], links: [] as unknown[] };
+}
+
+function listReply(opts: { confirmed: boolean; uuid: string; path?: string }) {
+  const path = opts.path ?? PATH;
+  const active = { path, routing_key: `wf:${path}`, workflow_uuid: opts.uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: opts.confirmed };
+}
+
+type GraphQuery = "answers" | "mismatch";
+
+function bridge(opts: {
+  stamp: string;
+  graphQuery: GraphQuery;
+  /** First N workflow_list replies are unconfirmed; then confirmed. */
+  unconfirmedLists?: number;
+  /** First N graph_serialize replies are the empty settling snapshot. */
+  emptySerializes?: number;
+  listPath?: string;
+  listUuid?: string;
+}) {
+  const calls: string[] = [];
+  let stamp: string | undefined = opts.stamp;
+  let listCalls = 0;
+  let serializeCalls = 0;
+  const unconfirmedLists = opts.unconfirmedLists ?? 0;
+  const emptySerializes = opts.emptySerializes ?? 0;
+  const listPath = opts.listPath ?? PATH;
+  const listUuid = opts.listUuid ?? LIVE;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        return listReply({
+          confirmed: listCalls > unconfirmedLists,
+          uuid: listUuid,
+          path: listPath,
+        });
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(IDENTITY_PROVEN);
+      if (cmd.cmd === "graph_query") {
+        if (opts.graphQuery === "mismatch") {
+          throw new Error(
+            `workflow instance mismatch: issued for workflow instance ${PRIOR} but canvas is ${LIVE}`,
+          );
+        }
+        return { ids: [1, 2], node_count: 2 };
+      }
+      if (cmd.cmd === "graph_serialize") {
+        serializeCalls += 1;
+        const graph = serializeCalls > emptySerializes ? liveGraph() : emptyGraph();
+        return { workflow: graph, node_count: Array.isArray(graph.nodes) ? graph.nodes.length : 0 };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "v3", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls, stampOf: () => stamp };
+}
+
+beforeEach(() => {
+  destByKey.clear();
+  destByKey.set(PATH, destGraph());
+  __openWorkflowTestHooks.setOpenContentHandshakeStepsMs([0]);
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+afterEach(() => {
+  destByKey.clear();
+  __openWorkflowTestHooks.setOpenContentHandshakeStepsMs(null);
+  const qm = QueueMonitor as unknown as { state: { runningPromptId: string | null } };
+  qm.state.runningPromptId = null;
+});
+
+async function openWorkflow(opts: Parameters<typeof bridge>[0]) {
+  const { b, calls, stampOf } = bridge(opts);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+    stamp: stampOf(),
+  };
+}
+
+describe("panel_open_workflow does not false-mismatch the already-active canvas after restart (panel#1555)", () => {
+  it("the reporter's case: unconfirmed list + settling serialize, then dest is on the canvas", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow({
+      // Post-reconnect hello already stamped the live instance.
+      stamp: LIVE,
+      graphQuery: "answers",
+      unconfirmedLists: 2,
+      emptySerializes: 2,
+    });
+
+    expect(isError).toBe(false);
+    expect(calls).toContain("workflow_list");
+    expect(calls).toContain("graph_serialize");
+    expect(stamp).toBe(LIVE);
+    expect(text).toMatch(/content_normalized/);
+    expect(text).toMatch(/Opened/);
+    expect(text).not.toMatch(/CONTENT MISMATCH/);
+    expect(text).not.toMatch(/PREVIOUS workflow/);
+    expect(text).not.toMatch(/Treat the canvas as UNKNOWN/);
+  });
+
+  it("the reminted-uuid restart: fence mismatch, then dest matches after handshake", async () => {
+    const { text, isError, stamp } = await openWorkflow({
+      stamp: PRIOR,
+      graphQuery: "mismatch",
+      unconfirmedLists: 0,
+      emptySerializes: 1,
+    });
+
+    expect(isError).toBe(false);
+    expect(stamp).toBe(LIVE);
+    expect(text).toMatch(/content_normalized/);
+    expect(text).not.toMatch(/CONTENT MISMATCH/);
+    expect(text).not.toMatch(/PREVIOUS workflow/);
+  });
+
+  it("does not emit a hard mismatch while active_confirmed is still unknown", async () => {
+    const { text, isError } = await openWorkflow({
+      stamp: LIVE,
+      graphQuery: "answers",
+      // Never confirms, serialize never settles.
+      unconfirmedLists: 99,
+      emptySerializes: 99,
+    });
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/UNCONFIRMED/);
+    expect(text).toMatch(/expected routing wf:workflows\/v3\.json/);
+    expect(text).toMatch(/observed routing wf:workflows\/v3\.json/);
+    expect(text).not.toMatch(/CONTENT MISMATCH/);
+    expect(text).not.toMatch(/PREVIOUS workflow/);
+  });
+
+  it("a confirmed DIFFERENT instance still answering is still the previous workflow (#1639)", async () => {
+    const { text, isError, stamp } = await openWorkflow({
+      stamp: PRIOR,
+      graphQuery: "answers",
+      unconfirmedLists: 0,
+      emptySerializes: 99,
+      listUuid: LIVE,
+    });
+
+    expect(isError).toBe(true);
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/CONTENT MISMATCH/);
+    expect(text).toMatch(/PREVIOUS workflow/);
+    expect(text).toMatch(/expected routing wf:workflows\/v3\.json/);
+    expect(text).toMatch(/observed routing wf:workflows\/v3\.json/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5732,13 +5732,16 @@ function openedNormalizedContentResult(destPath: string): ToolResult {
 async function tryAcceptNormalizedOpenContent(
   ctx: PanelToolCtx,
   destPath: string,
+  liveGraph?: Record<string, unknown> | null,
 ): Promise<{ status: "accepted" } | { status: "skipped" }> {
-  let live: Record<string, unknown> | null = null;
-  try {
-    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
-    live = workflowFromSerializeReply(parseToolResultJson(serialized));
-  } catch {
-    return { status: "skipped" };
+  let live = liveGraph ?? null;
+  if (!live) {
+    try {
+      const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+      live = workflowFromSerializeReply(parseToolResultJson(serialized));
+    } catch {
+      return { status: "skipped" };
+    }
   }
   if (!live) return { status: "skipped" };
 
@@ -5755,16 +5758,206 @@ async function tryAcceptNormalizedOpenContent(
   return { status: "accepted" };
 }
 
-function identityClaimedButLiveGraphUnchangedNote(ctx: PanelToolCtx): string {
+/**
+ * panel#1555 — post-reconnect handshake before treating an identity-proven
+ * content warning as a hard PREVIOUS-workflow mismatch.
+ *
+ * After a ComfyUI restart the tab can answer `workflow_open` (and even
+ * `graph_query`) before `workflow_list.active_confirmed` and the live serialize
+ * have finished one synchronized handshake. Comparing content in that window
+ * produced a false CONTENT MISMATCH for the workflow that was already the
+ * active canvas; a later panel_query_graph showed the requested graph.
+ *
+ * Same cost-on-failure discipline as #1292: this runs only after dest-vs-live
+ * already missed. dest-vs-live itself is unchanged; the wait only buys a
+ * confirmed list + readable serialize to judge.
+ */
+const OPEN_CONTENT_HANDSHAKE_STEPS_MS = [400, 900, 1600] as const;
+let openContentHandshakeStepsMsOverride: readonly number[] | null = null;
+
+function openContentHandshakeStepsMs(): readonly number[] {
+  return openContentHandshakeStepsMsOverride ?? OPEN_CONTENT_HANDSHAKE_STEPS_MS;
+}
+
+function workflowRoutingKey(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const rec = value as { routing_key?: unknown; path?: unknown; key?: unknown };
+  if (typeof rec.routing_key === "string" && rec.routing_key) return rec.routing_key;
+  const fromPath = canonicalRequestedSavedIdentity(rec.path);
+  if (fromPath) return fromPath;
+  if (typeof rec.path === "string" && rec.path) return rec.path;
+  if (typeof rec.key === "string" && rec.key) return rec.key;
+  return null;
+}
+
+function openMismatchRoutingNote(
+  expected: string | null,
+  observed: string | null,
+  uuid?: string,
+): string {
+  const exp = expected ?? "(none)";
+  const obs = observed ?? "(none)";
+  const id = uuid ? `, workflow_uuid ${uuid}` : "";
+  return `expected routing ${exp}; observed routing ${obs}${id}`;
+}
+
+type LiveSerializeRead =
+  | { status: "graph"; live: Record<string, unknown> }
+  | { status: "answered" }
+  | { status: "unread" };
+
+async function readLiveSerialize(ctx: PanelToolCtx): Promise<LiveSerializeRead> {
+  try {
+    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+    if (serialized?.isError) {
+      const text = toolResultText(serialized);
+      if (isAckTimeout(serialized) || /did not reply/i.test(text)) return { status: "unread" };
+      const live = workflowFromSerializeReply(parseToolResultJson(serialized));
+      return live ? { status: "graph", live } : { status: "answered" };
+    }
+    const live = workflowFromSerializeReply(parseToolResultJson(serialized));
+    return live ? { status: "graph", live } : { status: "answered" };
+  } catch (err) {
+    if (isWorkflowInstanceMismatch(err)) return { status: "answered" };
+    return { status: "unread" };
+  }
+}
+
+interface OpenContentHandshake {
+  list: Record<string, unknown> | null;
+  live: Record<string, unknown> | null;
+  confirmed: boolean;
+  expectedRouting: string | null;
+  observedRouting: string | null;
+  observedUuid: string | undefined;
+}
+
+async function waitForOpenContentHandshake(
+  ctx: PanelToolCtx,
+  destPath: string,
+): Promise<OpenContentHandshake> {
+  const expectedRouting = canonicalRequestedSavedIdentity(destPath) ?? destPath;
+
+  const attempt = async (): Promise<OpenContentHandshake & { settles: boolean; liveUnread: boolean }> => {
+    let list: Record<string, unknown> | null = null;
+    try {
+      const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+      if (!res?.isError) list = parseToolResultJson(res);
+    } catch {
+      list = null;
+    }
+    // `active_confirmed:false` is the post-restart window. Fence-adoption
+    // corroboration (empty/mixed `workflows`) is a different question — waiting
+    // on that here would add the #1292 budget to every identity-proven failure
+    // whose list is merely incomplete.
+    const unconfirmed = list?.active_confirmed === false;
+    const confirmed = Boolean(list && !unconfirmed && list.active);
+    const serialize = await readLiveSerialize(ctx);
+    const live = serialize.status === "graph" ? serialize.live : null;
+    const active = list?.active;
+    return {
+      list,
+      live,
+      confirmed,
+      expectedRouting,
+      observedRouting: workflowRoutingKey(active),
+      observedUuid: responseWorkflowUuid(active),
+      settles: !list || unconfirmed,
+      liveUnread: serialize.status === "unread",
+    };
+  };
+
+  let last = await attempt();
+  if (last.confirmed && !last.liveUnread) return last;
+  for (const waitMs of openContentHandshakeStepsMs()) {
+    if (last.confirmed && !last.liveUnread) break;
+    if (!last.settles && !last.liveUnread) break;
+    await sleep(waitMs);
+    last = await attempt();
+  }
+  return last;
+}
+
+type IdentityProvenHandshakeKind = "previous" | "same" | "unconfirmed";
+
+function identityProvenOpenAfterHandshake(
+  ctx: PanelToolCtx,
+  destPath: string,
+  handshake: OpenContentHandshake,
+): IdentityProvenHandshakeKind {
+  if (!handshake.confirmed) return "unconfirmed";
+  const reading = readOpenActiveAgainstTarget(
+    handshake.list?.active,
+    destPath,
+    handshake.list?.active_confirmed,
+  );
+  if (reading === "indeterminate") return "unconfirmed";
+  const fence = currentWorkflowFence(ctx);
+  const answeringIsListed =
+    fence.known &&
+    Boolean(fence.uuid) &&
+    Boolean(handshake.observedUuid) &&
+    fence.uuid === handshake.observedUuid;
+  // Graph still answers THIS session's stamp. That stamp names dest only when
+  // it equals the confirmed live uuid. Otherwise the previous instance is what
+  // answered (#1639). After restart of the SAME file, hello (or this session's
+  // existing fence) already names dest — that is not the previous workflow.
+  if (reading === "same" && answeringIsListed) return "same";
+  if (reading === "different" || !answeringIsListed) return "previous";
+  return "unconfirmed";
+}
+
+async function acceptNormalizedOpenContentAfterHandshake(
+  ctx: PanelToolCtx,
+  destPath: string,
+): Promise<{ status: "accepted"; handshake: OpenContentHandshake } | { status: "skipped"; handshake: OpenContentHandshake }> {
+  const handshake = await waitForOpenContentHandshake(ctx, destPath);
+  if (!handshake.live) return { status: "skipped", handshake };
+  const accepted = await tryAcceptNormalizedOpenContent(ctx, destPath, handshake.live);
+  return accepted.status === "accepted"
+    ? { status: "accepted", handshake }
+    : { status: "skipped", handshake };
+}
+
+function identityClaimedActiveUnconfirmedNote(handshake: OpenContentHandshake): string {
+  return (
+    `\n\nFENCE: NOT cleared (active identity UNCONFIRMED after reconnect handshake). The panel ` +
+    `asserted the canvas IS bound to the requested workflow, but the frontend workflow list and ` +
+    `active-canvas graph have not completed one synchronized handshake yet ` +
+    `(${openMismatchRoutingNote(handshake.expectedRouting, handshake.observedRouting, handshake.observedUuid)}). ` +
+    `active_confirmed is still unknown, so this is NOT a proven content mismatch and NOT the ` +
+    `previous workflow. Retry panel_open_workflow or read the graph (panel_query_graph) once ` +
+    `the tab finishes reconciling after restart.`
+  );
+}
+
+function identityClaimedSameWorkflowContentUnknownNote(handshake: OpenContentHandshake): string {
+  return (
+    `\n\nFENCE: NOT cleared (same workflow still answers). The canvas identity matches the ` +
+    `requested workflow after the reconnect handshake ` +
+    `(${openMismatchRoutingNote(handshake.expectedRouting, handshake.observedRouting, handshake.observedUuid)}), ` +
+    `but dest-vs-live content still does not match. This is NOT the previous workflow. ` +
+    `Re-read the graph (panel_query_graph / panel_graph_outline) before editing.`
+  );
+}
+
+function identityClaimedButLiveGraphUnchangedNote(
+  ctx: PanelToolCtx,
+  handshake?: OpenContentHandshake,
+): string {
   const fence = currentWorkflowFence(ctx);
   const fenceTxt =
     fence.known && fence.uuid
       ? `under this session's existing fence (${fence.uuid})`
       : `without being refused by a workflow-instance fence`;
+  const routing =
+    handshake
+      ? ` (${openMismatchRoutingNote(handshake.expectedRouting, handshake.observedRouting, handshake.observedUuid)})`
+      : "";
   return (
     `\n\nFENCE: NOT cleared (live graph still answers). CONTENT MISMATCH: the panel asserted the ` +
     `canvas IS bound to the requested workflow, but a live graph read still answers ${fenceTxt} — ` +
-    `the graph on screen is the PREVIOUS workflow, not the one just opened. That is the failure ` +
+    `the graph on screen is the PREVIOUS workflow, not the one just opened.${routing} That is the failure ` +
     `the fence exists to prevent: clearing it here would let later reads of this graph succeed ` +
     `as if they were the opened file. Do NOT trust "you are on the right workflow" / ` +
     `"You are NOT on the wrong workflow". Do NOT edit or save expecting the opened file. ` +
@@ -5799,6 +5992,31 @@ async function clearFenceOnIdentityProvenOpen(
       if (accepted.status === "accepted") {
         return { res: openedNormalizedContentResult(requestedPath), repaired: true };
       }
+      // panel#1555 — dest-vs-live missed, possibly because the post-restart
+      // list/graph handshake had not finished. Wait for one synchronized
+      // snapshot, then compare again. A confirmed DIFFERENT identity is still
+      // #1639 (previous workflow). An unconfirmed active is not a hard mismatch.
+      const after = await acceptNormalizedOpenContentAfterHandshake(ctx, requestedPath);
+      if (after.status === "accepted") {
+        return { res: openedNormalizedContentResult(requestedPath), repaired: true };
+      }
+      const kind = identityProvenOpenAfterHandshake(ctx, requestedPath, after.handshake);
+      if (kind === "unconfirmed") {
+        return {
+          res: appendToolResultText(res, identityClaimedActiveUnconfirmedNote(after.handshake)),
+          repaired: false,
+        };
+      }
+      if (kind === "same") {
+        return {
+          res: appendToolResultText(res, identityClaimedSameWorkflowContentUnknownNote(after.handshake)),
+          repaired: false,
+        };
+      }
+      return {
+        res: appendToolResultText(res, identityClaimedButLiveGraphUnchangedNote(ctx, after.handshake)),
+        repaired: false,
+      };
     }
     return { res: appendToolResultText(res, identityClaimedButLiveGraphUnchangedNote(ctx)), repaired: false };
   }
@@ -5837,6 +6055,12 @@ async function clearFenceOnIdentityProvenOpen(
   if (repaired && requestedPath) {
     const accepted = await tryAcceptNormalizedOpenContent(ctx, requestedPath);
     if (accepted.status === "accepted") {
+      return { res: openedNormalizedContentResult(requestedPath), repaired: true };
+    }
+    // panel#1555 — same post-restart handshake as the still-answering path:
+    // list identity and the live serialize can settle one snapshot later.
+    const after = await acceptNormalizedOpenContentAfterHandshake(ctx, requestedPath);
+    if (after.status === "accepted") {
       return { res: openedNormalizedContentResult(requestedPath), repaired: true };
     }
   }
@@ -8207,6 +8431,10 @@ export const __openWorkflowTestHooks = {
   /** Inject fast open-verify timing so tests don't wait the real ~6s budget. */
   setOpenVerifyTiming(timing: OpenVerifyTiming | null): void {
     openVerifyTimingOverride = timing;
+  },
+  /** Inject fast panel#1555 handshake rechecks so tests don't wait ~2.9s. */
+  setOpenContentHandshakeStepsMs(steps: readonly number[] | null): void {
+    openContentHandshakeStepsMsOverride = steps;
   },
   isAckTimeout,
   activeMatchesTarget,


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1555

After a ComfyUI restart, panel_open_workflow of the already-active workflow reported a content-mismatch / fence warning even though a later panel_query_graph showed the requested graph.

The identity-proven open path compared content before workflow_list active_confirmed and the live serialize finished one handshake, and treated a still-answering stamp as the previous workflow even when that stamp already named dest.

On that failing path the orchestrator now waits for a synchronized list+graph snapshot, retries dest-vs-live, and only emits a hard PREVIOUS-workflow mismatch when the answering fence uuid is a different instance. An unconfirmed active is not a hard mismatch; expected/observed routing keys are included on the remaining error.
