### PR TITLE
fix(panel#1557): current-workflow rebind restores the live canvas after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_set_workflow_target({mode:"current"})` rebinds a Codex session after reconnect (panel#1557).**
+  After a ComfyUI restart/reload, Codex's live-canvas tools are scope-bound
+  (`orchestrator::codex`). The documented recovery refused with "no connected
+  tab belongs to this conversation's backend (codex)" and "did NOT restore this
+  session's graph binding": a scope ctx returns a refusal instead of throwing,
+  so the zero-tab DEFER path never fired, and a unique canvas that re-hello'd
+  without `backend` joined the default conversation so Codex could not adopt it.
+  The session stayed fenced to the previous workflow instance; retrying
+  `panel_graph_outline` failed identically until a manual browser refresh.
+
+  Zero connected tabs now DEFER the same way a real-tab session already did,
+  and the consent is kept so the next graph call binds the canvas that
+  reconnects. A dead or ambiguous pin plus exactly one live canvas is adopted
+  even when that hello joined the default backend — idle (no pin) unique-foreign
+  still refuses, so another conversation's tab is not stolen.
+
 ## [0.52.42] - 2026-08-20
 
 ### MCP
@@ -768,7 +787,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - self-restart no longer leaves an unreclaimable panel-op.lock (#1955)
-
 
 ## [0.52.41] - 2026-08-20
 

--- a/src/__tests__/orchestrator/codex-reconnect-rebind.test.ts
+++ b/src/__tests__/orchestrator/codex-reconnect-rebind.test.ts
@@ -1,0 +1,261 @@
+// panel#1557 — after a ComfyUI restart/reload, panel_graph_outline failed with
+// "no connected tab … Connected: none", and the documented recovery
+// panel_set_workflow_target({mode:"current"}) also failed: "no connected tab
+// belongs to this conversation's backend (codex)" and "did NOT restore this
+// session's graph binding". A retry of panel_graph_outline failed identically.
+//
+// Codex panel_* tools are SCOPE-bound (`orchestrator::codex` via the HTTP MCP
+// urlFor(agentKey)). The #474 zero-tab DEFER path only fired when
+// rebindToActiveTab THREW — a real-tab ctx. A scope ctx returns a refusal
+// object instead, so the recovery neither deferred nor rebound, and the
+// session stayed fenced to the previous (dead) workflow instance.
+//
+// Two remaining holes, both driven here on the shipped
+// panel_set_workflow_target / panel_graph_outline path with the real
+// TurnOriginTracker + makeScopeRepinHandler:
+//   1. ZERO interactive tabs: the recovery must DEFER like the tab-bound path,
+//      not fail as a backend-mismatch.
+//   2. UNIQUE live canvas after reconnect, attributed to the default backend
+//      (hello omitted `backend`): a dead/ambiguous Codex pin must ADOPT that
+//      canvas rather than refuse. Idle (no pin) unique-foreign still refuses —
+//      that is the P0 "never steal another conversation's tab".
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import { SHARED_SESSION_SCOPE } from "../../services/session-scope.js";
+import {
+  TurnOriginTracker,
+  makeScopeRepinHandler,
+  makeScopeTargetResolver,
+} from "../../orchestrator/turn-origins.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  __panelToolsTestHooks,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const SCOPE_KEY = `${SHARED_SESSION_SCOPE}::codex`;
+const LIVE = "wf:tab-live:workflows/a.json";
+const GONE = "wf:tab-gone:workflows/a.json";
+const PATH = "workflows/a.json";
+const UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join("\n");
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close→rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(port: number, tabId: string, title: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: tabId,
+          title,
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function autoReply(sock: WebSocket): void {
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString());
+    if (!msg.rid || !msg.cmd) return;
+    if (msg.cmd === "workflow_list") {
+      sock.send(
+        JSON.stringify({
+          rid: msg.rid,
+          ok: true,
+          result: {
+            active: {
+              path: PATH,
+              routing_key: `wf:${PATH}`,
+              workflow_uuid: UUID,
+              active: true,
+            },
+            workflows: [
+              {
+                path: PATH,
+                routing_key: `wf:${PATH}`,
+                workflow_uuid: UUID,
+                active: true,
+              },
+            ],
+            active_confirmed: true,
+          },
+        }),
+      );
+      return;
+    }
+    sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { from: "live", cmd: msg.cmd } }));
+  });
+}
+
+describe("panel#1557 Codex reconnect: mode:current binds the live canvas", () => {
+  let bridge: UiBridge;
+  let port: number;
+  let tracker: TurnOriginTracker;
+  let tabBackends: Map<string, string>;
+
+  beforeEach(async () => {
+    ({ bridge, port } = await startBridge());
+    bridge.setTabWorkflowUuidResolver(() => UUID);
+    tabBackends = new Map();
+    const backendOfKey = (key: string): string =>
+      key.includes("::") ? key.slice(key.lastIndexOf("::") + 2) : "claude";
+    const backendForTab = (tab: string): string => tabBackends.get(tab) ?? "claude";
+    tracker = new TurnOriginTracker({
+      backendForTab,
+      backendOfKey,
+      uuidOfTab: () => UUID,
+      liveTabOf: (tab) => bridge.liveTabIdFor(tab),
+      warn: () => {},
+    });
+    const scopeAgentKeyOf = (scopeId: string): string =>
+      scopeId === SHARED_SESSION_SCOPE ? SCOPE_KEY : scopeId;
+    bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker, scopeAgentKeyOf }));
+    bridge.setScopeRepinHandler(
+      makeScopeRepinHandler({
+        bridge,
+        tracker,
+        scopeAgentKeyOf,
+        backendForTab,
+        backendOfKey,
+        info: () => {},
+        claimTab: (tab, backend) => {
+          tabBackends.set(tab, backend);
+        },
+      }),
+    );
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 400, intervalMs: 20 });
+  });
+
+  afterEach(async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming(null);
+    await bridge.stop();
+  });
+
+  function tools() {
+    const defs = buildPanelToolDefs();
+    const ctx = makePanelToolCtx(bridge, SCOPE_KEY, new WorkflowTargetStore());
+    return {
+      ctx,
+      setTarget: defs.find((d) => d.name === "panel_set_workflow_target")!,
+      outline: defs.find((d) => d.name === "panel_graph_outline")!,
+    };
+  }
+
+  it("ZERO tabs: Codex mode:current DEFERS instead of failing as a backend-mismatch", async () => {
+    // The reporter's recovery while the browser socket had not re-hello'd.
+    tracker.repinTo(SCOPE_KEY, GONE);
+    const { ctx, setTarget } = tools();
+    const res = await setTarget.handler({ mode: "current" }, ctx);
+    const text = textOf(res as ToolResult);
+
+    expect(res.isError, text).toBeFalsy();
+    expect(JSON.parse(text)).toMatchObject({ deferred: true, mode: "current" });
+    expect(text).not.toMatch(/did NOT restore this session's graph binding/);
+    expect(text).not.toMatch(/no connected tab belongs to this conversation's backend/);
+    expect(text).toMatch(/reconnect/i);
+  });
+
+  it("UNIQUE live canvas attributed to the default backend is adopted for a DEAD Codex pin", async () => {
+    // Restart/reload: the previous wf: tab is gone, the canvas re-hellos under a
+    // new id without `backend`, so it joins the DEFAULT conversation (claude).
+    // Codex's recovery used to refuse; the live canvas is the one the user is
+    // looking at, and this conversation already had a pin to the previous instance.
+    const sock = await connectPanel(port, LIVE, "a");
+    autoReply(sock);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(LIVE, "claude");
+    tracker.repinTo(SCOPE_KEY, GONE);
+    expect(bridge.canReach(SCOPE_KEY)).toBe(false);
+
+    const { ctx, setTarget, outline } = tools();
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    const bindText = textOf(bindRes as ToolResult);
+
+    expect(bindRes.isError, bindText).toBeFalsy();
+    expect(bindText).not.toMatch(/did NOT restore this session's graph binding/);
+    expect(bindText).not.toMatch(/no connected tab belongs to this conversation's backend/);
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBe(LIVE);
+    expect(tabBackends.get(LIVE)).toBe("codex");
+    expect(bridge.canReach(SCOPE_KEY)).toBe(true);
+
+    const outlineRes = await outline.handler({}, ctx);
+    expect(outlineRes.isError, textOf(outlineRes as ToolResult)).toBeFalsy();
+    sock.close();
+  });
+
+  it("after a DEFER, a later graph_outline binds onto the unique canvas that reconnects", async () => {
+    tracker.repinTo(SCOPE_KEY, GONE);
+    const { ctx, setTarget, outline } = tools();
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    expect(bindRes.isError, textOf(bindRes as ToolResult)).toBeFalsy();
+    expect(JSON.parse(textOf(bindRes as ToolResult))).toMatchObject({ deferred: true });
+
+    const sock = await connectPanel(port, LIVE, "a");
+    autoReply(sock);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(LIVE, "claude");
+
+    const outlineRes = await outline.handler({}, ctx);
+    expect(outlineRes.isError, textOf(outlineRes as ToolResult)).toBeFalsy();
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBe(LIVE);
+    sock.close();
+  });
+
+  it("does NOT steal a unique foreign tab when this conversation has no pin to recover", async () => {
+    const sock = await connectPanel(port, LIVE, "a");
+    autoReply(sock);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(LIVE, "claude");
+    expect(tracker.pinOf(SCOPE_KEY)).toBeUndefined();
+
+    const { ctx, setTarget } = tools();
+    await setTarget.handler({ mode: "current" }, ctx);
+
+    // Idle (no turn pin) may still follow the active canvas for graph routing —
+    // that is not a steal. What must not happen is claiming the tab into THIS
+    // conversation's backend or writing a turn pin onto it.
+    expect(tracker.pinOf(SCOPE_KEY)).toBeUndefined();
+    expect(tabBackends.get(LIVE)).toBe("claude");
+    sock.close();
+  });
+});

--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -859,8 +859,11 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
       backendForTab: (tab) => tabBackends.get(tab) ?? "claude",
       backendOfKey: (key) => key.slice(key.lastIndexOf("::") + 2),
       info,
+      claimTab: (tab, backend) => {
+        tabBackends.set(tab, backend);
+      },
     });
-    return { tracker, bridge, repin, info };
+    return { tracker, tabBackends, bridge, repin, info };
   }
 
   it("REFUSES to displace a HEALTHY pin — even when another tab is last-active", async () => {
@@ -909,6 +912,18 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
     });
     expectDeclined(repin("orchestrator"));
     expect(tracker.pinOf(KEY)).toBeUndefined();
+  });
+
+  it("a DEAD pin adopts the unique live canvas even when hello attributed it to another backend (panel#1557)", () => {
+    const { tracker, tabBackends, repin } = makeRepinHarness({
+      tabs: [{ id: "live-tab", backend: "codex" }],
+      active: "live-tab",
+      reachable: (tab) => tab !== "tab-gone",
+    });
+    tracker.repinTo(KEY, "tab-gone");
+    expect(repin("orchestrator")).toBe("live-tab");
+    expect(tracker.pinOf(KEY)).toBe("live-tab");
+    expect(tabBackends.get("live-tab")).toBe("claude");
   });
 
   it("falls back to the backend's SOLE interactive tab when the active tab is foreign or headless", () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3200,6 +3200,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       backendForTab,
       backendOfKey: backendOf,
       info: (msg) => logger.info(msg),
+      // panel#1557 — a unique-canvas reconnect that hello'd without `backend`
+      // joined the default conversation; claiming puts it on this one so the
+      // pin we just wrote is not immediately invalidated at resolution.
+      claimTab: (tab, backend) => {
+        tabBackends.set(tab, backend);
+      },
     }),
   );
   // #884 P1 (confirming gate 2) — a hello whose `backend` is absent or unknown

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9016,6 +9016,14 @@ export interface PanelToolCtx {
     scopeRecoveryConsent?: boolean;
   }) => { previous: string; current: string; rebound: boolean; repinRefusal?: string };
   /**
+   * panel#1557 — set by `panel_set_workflow_target({mode:"current"})` when a
+   * SCOPE-bound recovery DEFERS because nothing is connected yet. The next
+   * graph call's `ensureReachable` consumes this as the same explicit consent,
+   * so a tab that reconnects a moment later is bound instead of staying fenced
+   * to the previous (dead) workflow instance.
+   */
+  pendingScopeRecoveryConsent?: boolean;
+  /**
    * Best-effort in-place self-heal for the handful of tools that call the bridge
    * DIRECTLY (not via `ctx.call`) — e.g. panel_request_adult_consent's ask_user
    * (#372) and the live-canvas graph_serialize. Silently rebinds an orphaned,
@@ -9139,7 +9147,23 @@ export function makePanelToolCtx(
     // pinned tab is gone the resolution THROWS loudly by design. Silently
     // picking another tab here would be exactly the mid-turn re-target the pin
     // forbids — and it would PERMANENTLY unbind this shared ctx.
-    if (isScopeAddress(ctx.tabId)) return;
+    //
+    // panel#1557 — the one exception is a STILL-VALID explicit mode:"current"
+    // consent that DEFERRED because nothing was connected yet. Consuming it
+    // here is the same recovery, just delayed until a canvas tab exists; it is
+    // not a silent re-target.
+    if (isScopeAddress(ctx.tabId)) {
+      if (ctx.pendingScopeRecoveryConsent) {
+        try {
+          const out = rebindToActiveTab({ scopeRecoveryConsent: true });
+          if (out.rebound) ctx.pendingScopeRecoveryConsent = false;
+          else if ((interactiveTabIds() ?? []).length > 0) ctx.pendingScopeRecoveryConsent = false;
+        } catch {
+          // still nothing bindable — keep the consent for the next attempt
+        }
+      }
+      return;
+    }
     if (typeof bridge.canReach !== "function") return; // lightweight test ctx
     if (bridge.canReach(ctx.tabId)) return; // healthy binding — leave untouched
     if (workflowTargets?.get(ctx.tabId)?.mode === "pinned") return; // stay strict
@@ -10338,6 +10362,17 @@ export function makePanelToolCtx(
       const repinned = typeof outcome === "string" ? outcome : undefined;
       const repinRefusal =
         outcome && typeof outcome === "object" ? outcome.reason : undefined;
+      // panel#1557 — a scope ctx used to RETURN the zero-tab refusal, so the
+      // #474 catch never fired and mode:"current" failed as a backend-mismatch
+      // instead of deferring. Throw the same "nothing connected" error the
+      // real-tab path throws so the documented recovery can DEFER and bind
+      // onto the first canvas that reconnects.
+      if (!repinned) {
+        const eligible = interactiveTabIds();
+        if (eligible && eligible.length === 0) {
+          throw new Error("Panel not reachable: no panel connected");
+        }
+      }
       return {
         previous,
         current: previous,
@@ -14708,11 +14743,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               // — the only caller that may escape a DEAD scope pin (a healthy pin
               // still stays put; see rebindToActiveTab's double gate).
               const rebind = ctx.rebindToActiveTab!({ scopeRecoveryConsent: true });
-              // #1077 Finding 2 — a scope repin that declined now says WHY.
-              if (rebind?.repinRefusal && !/pin was NOT moved/.test(rebindNote)) {
+              if (rebind?.rebound) {
+                currentModeTurnRepinned = true;
+              } else if (rebind?.repinRefusal && !/pin was NOT moved/.test(rebindNote)) {
+                // #1077 Finding 2 — a scope repin that declined now says WHY.
                 rebindNote += ` The session pin was NOT moved: ${rebind.repinRefusal}.`;
               }
-              if (rebind?.rebound) currentModeTurnRepinned = true;
             } catch (err) {
               // #474: with 2+ live tabs the rebind is AMBIGUOUS — fail so the user picks.
               // But with ZERO tabs connected (the "Connected: none" window right after a
@@ -14775,6 +14811,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           } finally {
             if (recoveringScope) ctx.bridge.endScopeRecovery?.(before);
           }
+          // panel#1557 — the consent survives a zero-tab DEFER so a graph call
+          // after the canvas reconnects can finish the recovery.
+          if (deferredBind && recoveringScope) ctx.pendingScopeRecoveryConsent = true;
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
           if (!deferredBind && ctx.tabId !== before) {

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -688,6 +688,13 @@ export function makeScopeRepinHandler(opts: {
   backendForTab: (tabId: string) => string;
   backendOfKey: (key: string) => string;
   info: (msg: string) => void;
+  /**
+   * panel#1557 — re-attribute a unique live canvas to this conversation when
+   * recovery adopts it. After a restart the reconnect hello often omits
+   * `backend`, so the tab joins the default conversation; without this, the
+   * pin we just wrote is immediately invalidated by {@link TurnOriginTracker.resolvedPinOf}.
+   */
+  claimTab?: (tabId: string, backend: string) => void;
 }): (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome {
   return (scopeId, preferredWorkflowPath) => {
     const key = opts.scopeAgentKeyOf(scopeId);
@@ -771,6 +778,25 @@ export function makeScopeRepinHandler(opts: {
     // experienced before refreshing and reopening the tab. Nothing in the old
     // reply hinted at either way out.
     if (!tab) {
+      const interactive = opts.bridge
+        .tabs()
+        .map((t) => t.tab_id)
+        .filter((t) => opts.bridge.isHeadless?.(t) !== true);
+      // panel#1557 — a DEAD or AMBIGUOUS pin plus exactly one live canvas is the
+      // post-restart reconnect of THIS conversation's tab. Hello after a reload
+      // often omits `backend`, so the canvas joins the default conversation and
+      // Codex finds 0 eligible tabs while the user is looking at it. Idle (no
+      // pin) still refuses: that is the P0 "never steal another backend's tab".
+      const recovering = existing === null || typeof existing === "string";
+      if (recovering && eligible.length === 0 && interactive.length === 1) {
+        const only = interactive[0];
+        opts.claimTab?.(only, backend);
+        opts.tracker.repinTo(key, only);
+        opts.info(
+          `[panel-orchestrator] ${key} re-pinned onto ${only.slice(0, 8)} by explicit target request (#884 recovery, panel#1557 unique-canvas reconnect)`,
+        );
+        return only;
+      }
       if (eligible.length === 0) {
         return {
           repinned: false,


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1557

After a ComfyUI restart/reload, `panel_graph_outline` failed with `Connected: none`. The documented recovery `panel_set_workflow_target({mode:"current"})` also failed: no connected tab belonged to the Codex backend, and the session stayed fenced to the previous workflow instance. Retrying `panel_graph_outline` failed identically until a manual browser refresh.

Codex panel_* tools are scope-bound (`orchestrator::codex`). The zero-tab DEFER path only fired when `rebindToActiveTab` threw, which a real-tab ctx does. A scope ctx returned a refusal object instead, so the recovery neither deferred nor rebound.

What the user now observes:
- With no canvas connected, `mode:"current"` defers (clears the stale binding) instead of failing as a backend-mismatch.
- That consent is kept, so the next graph call binds the canvas that reconnects.
- A dead/ambiguous pin plus exactly one live canvas is adopted even when that hello joined the default backend. Idle (no pin) unique-foreign still refuses.

Tests drive the shipped `panel_set_workflow_target` / `panel_graph_outline` path with the real `TurnOriginTracker` + `makeScopeRepinHandler`.
