### PR TITLE
release: v0.52.43 — connected-panel strip, panel_run completion delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.43] - 2026-08-20
+
 ### MCP
 
 #### Fixed
@@ -777,6 +779,15 @@ All notable changes to this project are documented here. This project adheres to
   reconnects. A dead or ambiguous pin plus exactly one live canvas is adopted
   even when that hello joined the default backend — idle (no pin) unique-foreign
   still refuses, so another conversation's tab is not stolen.
+
+### MCP
+
+#### Fixed
+- current-workflow rebind restores the live canvas after reconnect (#1964)
+- panel_open_workflow no longer false-mismatches the already-open canvas after restart (#1962)
+- a successful panel_run completion is no longer left silent for 45s (#1960)
+- panel_strip_workflow strips a pack against the connected panel, not localhost (#1959)
+
 
 ## [0.52.42] - 2026-08-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.42",
+  "version": "0.52.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.42",
+      "version": "0.52.43",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.42",
+  "version": "0.52.43",
   "mcpName": "io.github.artokun/comfyui-mcp",
-  "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
+  "description": "Local-first, agent-native control plane for ComfyUI \u2014 MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts **0.52.43** from `main` (after v0.52.42).

Carries:

- #1964 / panel#1557 — `panel_set_workflow_target({mode:"current"})` rebinds the live canvas after reconnect
- #1962 / panel#1555 — `panel_open_workflow` no longer false-mismatches the already-open canvas after restart
- #1960 / panel#1556 — a successful `panel_run` completion is no longer left silent for 45s
- #1959 / #1421 — `panel_strip_workflow` strips a pack against the connected panel, not localhost

Held out: panel#1554 PR #1957 still draft; mcp#1961/#1963 and panel#1558/#1559 claimed this cycle; panel#1472 typescript 5→7 (blocked).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.43` tag on the version commit). Tag is local; push `v0.52.43` after merge.

Note: a prior macos run on this PR failed on `download-segments.test.ts` (#1697, 30s timeout). That test shipped in v0.52.42. Re-run if it flakes again.
