### PR TITLE
fix(1961): a backgrounded phone keeps its tunnel hostname across auto-update

### DIFF
--- a/src/__tests__/services/headless-recency-window.test.ts
+++ b/src/__tests__/services/headless-recency-window.test.ts
@@ -1,23 +1,30 @@
-// #1176 — a BACKGROUNDED phone is not a departed phone.
+// #1176 / #1961 — a BACKGROUNDED phone is not a departed phone.
 //
 // #875 defers a self-restart while a paired phone is present, because a restart
 // mints a NEW cloudflared quick-tunnel hostname and the old one stops resolving.
 // The gate asked `hasLiveHeadlessClient()`, which reads currently-OPEN sockets —
 // and a phone at work with its screen off has had its socket suspended or closed
-// by the mobile OS. So the gate opened, the orchestrator self-updated
-// 0.50.39 → 0.50.41, and the reporter picked up their phone to:
+// by the mobile OS. So the gate opened, the orchestrator self-updated, and the
+// reporter picked up their phone to:
 //
 //   Failed host lookup: 'cameron-timing-face-spies.trycloudflare.com'
 //   (No address associated with hostname, errno = 7)
 //
 // A DNS failure, not a timeout or a refusal: the hostname no longer existed.
 //
-// The sticky isHeadless() was rejected for this gate and that was right — a phone
-// that paired once and left would defer updates forever. But those are not the
-// only two options, and the state between them is the NORMAL one for a phone.
+// #1176 folded a recency window into `hasLiveHeadlessClient`. That left
+// `tunnelPairingLive` looking live-only (the reading #1961 verified against
+// 0.52.41's dist) and chose thirty minutes — shorter than the hourly auto-update
+// check, so a pocketed phone still had its hostname rotated.
+//
+// The shipped function is `tunnelPairingLive`. These tests drive it.
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import { UiBridge, HEADLESS_RECENCY_MS } from "../../services/ui-bridge.js";
+import { tunnelPairingLive } from "../../orchestrator/tunnel-pairing-live.js";
+
+const TUNNEL = { url: "wss://test.trycloudflare.com", stop: () => {} };
 
 /** A bridge with its headless-disconnect clock placed at a chosen age. */
 function bridgeWithHeadlessGoneFor(ms: number | null): UiBridge {
@@ -30,34 +37,67 @@ function bridgeWithHeadlessGoneFor(ms: number | null): UiBridge {
   return b;
 }
 
-describe("the restart-deferral gate covers a pocketed phone (#1176)", () => {
+describe("the restart-deferral gate covers a pocketed phone (#1176, #1961)", () => {
   it("still defers seconds after the socket closed — the reported case", () => {
     // The mobile OS suspends a backgrounded socket within seconds.
-    expect(bridgeWithHeadlessGoneFor(5_000).hasLiveHeadlessClient()).toBe(true);
+    expect(tunnelPairingLive(TUNNEL, bridgeWithHeadlessGoneFor(5_000))).toBe(true);
   });
 
   it("still defers across a meeting", () => {
-    expect(bridgeWithHeadlessGoneFor(20 * 60_000).hasLiveHeadlessClient()).toBe(true);
+    expect(tunnelPairingLive(TUNNEL, bridgeWithHeadlessGoneFor(20 * 60_000))).toBe(true);
+  });
+
+  it("still defers across a work morning", () => {
+    // #1961: a phone in a pocket at work is hours, not minutes. Thirty minutes
+    // lapsed before the hourly auto-update check, and the hostname rotated.
+    expect(tunnelPairingLive(TUNNEL, bridgeWithHeadlessGoneFor(3 * 60 * 60_000))).toBe(true);
   });
 
   it("stops deferring once the phone has genuinely been gone", () => {
     // The property that killed the sticky option: this happens on its own, with
     // no unpairing step and no user action, so an install that lost its phone
     // still gets its updates.
-    expect(bridgeWithHeadlessGoneFor(HEADLESS_RECENCY_MS + 1).hasLiveHeadlessClient()).toBe(false);
+    expect(tunnelPairingLive(TUNNEL, bridgeWithHeadlessGoneFor(HEADLESS_RECENCY_MS + 1))).toBe(false);
   });
 
   it("never defers on an install that has never seen a headless client", () => {
     // The clock is undefined until a headless socket actually disconnects, so a
     // desktop-only install can never be held back by this.
-    expect(bridgeWithHeadlessGoneFor(null).hasLiveHeadlessClient()).toBe(false);
+    expect(tunnelPairingLive(TUNNEL, bridgeWithHeadlessGoneFor(null))).toBe(false);
   });
 
-  it("uses a window measured in minutes, not seconds", () => {
-    // The duration IS the fix. A window short enough to still lapse while a
-    // phone is in a pocket is the bug wearing the fix's shape — and the cost of
-    // being generous is only a delayed update, while the cost of being stingy is
-    // a phone that cannot get back in.
-    expect(HEADLESS_RECENCY_MS).toBeGreaterThanOrEqual(5 * 60_000);
+  it("never defers when there is no tunnel, even if a phone was seen recently", () => {
+    // LAN pairing survives a restart (persisted token). Recency is only for the
+    // hostname that cannot be pinned.
+    expect(tunnelPairingLive(null, bridgeWithHeadlessGoneFor(5_000))).toBe(false);
+  });
+
+  it("does not fold recency into hasLiveHeadlessClient", () => {
+    // Folding it in is how the gate kept looking live-only (#1961). Recency is
+    // a separate signal the GATE composes.
+    const gone = bridgeWithHeadlessGoneFor(5_000);
+    expect(gone.hasLiveHeadlessClient()).toBe(false);
+    expect(gone.headlessSeenWithin(HEADLESS_RECENCY_MS)).toBe(true);
+    expect(tunnelPairingLive(TUNNEL, gone)).toBe(true);
+  });
+
+  it("uses a window measured in hours, not minutes", () => {
+    // The duration IS the fix. Thirty minutes (#1176) still lapsed while a phone
+    // was in a pocket, before the hourly check — the bug wearing the fix's shape.
+    // The cost of being generous is only a delayed update; the cost of being
+    // stingy is a phone that cannot get back in. A few hours is the floor #1961
+    // asked for.
+    expect(HEADLESS_RECENCY_MS).toBeGreaterThanOrEqual(4 * 60 * 60_000);
+  });
+
+  it("SOURCE: the restarter gate calls tunnelPairingLive(pairTunnel, bridge)", () => {
+    // Recency composed only inside hasLiveHeadlessClient is how #1961 read as
+    // unfixed: grepping the gate still showed the live-only one-liner.
+    const src = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+    expect(src).toContain('from "./tunnel-pairing-live.js"');
+    expect(src).toMatch(/!tunnelPairingLive\(\s*pairTunnel,\s*bridge\s*\)/);
+    expect(src).not.toMatch(
+      /const tunnelPairingLive = \(\)(?:: boolean)? => pairTunnel !== null && bridge\.hasLiveHeadlessClient\(\)/,
+    );
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -22,6 +22,7 @@ import {
   unclassifiedGraphCommandsSeen,
   __resetUnclassifiedGraphCommands,
 } from "../../services/ui-bridge.js";
+import { tunnelPairingLive } from "../../orchestrator/tunnel-pairing-live.js";
 import { SHARED_SESSION_SCOPE, normalizeHelloBackend } from "../../services/session-scope.js";
 import {
   TurnOriginTracker,
@@ -5208,21 +5209,31 @@ describe("#875: hasLiveHeadlessClient reports the LIVE set, not the sticky one",
     await new Promise((r) => setTimeout(r, 80));
 
     expect(bridge.hasLiveHeadlessClient()).toBe(true);
+    const tunnel = { url: "wss://test.trycloudflare.com", stop: () => {} };
+    expect(tunnelPairingLive(tunnel, bridge)).toBe(true);
 
     sock.close();
     await new Promise((r) => setTimeout(r, 150));
-    // #1176 — 150ms after the socket closed is NOT "the phone is gone". It is
-    // exactly the backgrounded case: the mobile OS suspends the socket within
-    // seconds of the screen going off. This assertion used to demand `false`
-    // here, and that is the bug — a reporter's restart rotated the cloudflared
-    // hostname during a pocket interval and their phone came back to a dead URL.
-    expect(bridge.hasLiveHeadlessClient()).toBe(true);
+    // Live means live: the socket is gone, so the LIVE accessor is false. The
+    // sticky isHeadless() stays true (mailbox / inlining) and that is still
+    // wrong for the restart gate — using it would defer forever.
+    expect(bridge.hasLiveHeadlessClient()).toBe(false);
+    expect(bridge.isHeadless("phone-live")).toBe(true);
+
+    // #1176 / #1961 — 150ms after the socket closed is NOT "the phone is gone".
+    // It is exactly the backgrounded case: the mobile OS suspends the socket
+    // within seconds of the screen going off. The disconnect site must arm the
+    // recency clock HERE (unit tests that set the clock directly cannot see a
+    // dropped call site), and the GATE — not the live accessor — still defers.
+    expect(bridge.headlessSeenWithin(HEADLESS_RECENCY_MS)).toBe(true);
+    expect(tunnelPairingLive(tunnel, bridge)).toBe(true);
 
     // The property that killed the sticky isHeadless() is still intact: a phone
     // that has genuinely been gone longer than the window stops deferring, on
     // its own, with no unpairing step and no user action.
     bridge.markHeadlessDisconnectForTests(performance.now() - HEADLESS_RECENCY_MS - 1);
-    expect(bridge.hasLiveHeadlessClient()).toBe(false);
+    expect(bridge.headlessSeenWithin(HEADLESS_RECENCY_MS)).toBe(false);
+    expect(tunnelPairingLive(tunnel, bridge)).toBe(false);
   });
 
   it("is false for a connected NON-headless (canvas) tab", async () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -53,6 +53,7 @@ import { releaseOwnedPanelLock } from "../services/panel-pin-guard.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
 import { pairUrlDurability } from "./pair-durability.js";
 import { loadOrCreatePairToken } from "./pair-token-store.js";
+import { tunnelPairingLive } from "./tunnel-pairing-live.js";
 import { SessionStore, workflowIdentityParts, carryWorkflowCommandStamp } from "./session-store.js";
 import { unreachableReason, noPanelTabReason, identityReason } from "./fence-refusal.js";
 import {
@@ -1238,20 +1239,6 @@ export async function runPanelOrchestrator(): Promise<void> {
   let pairToken: string | null = envPairToken;
   let pairListenerStarted = false;
   let pairTunnel: { url: string; stop: () => void } | null = null;
-  /**
-   * #875 — is a phone paired over a TUNNEL right now?
-   *
-   * Gates the self-restarter (see its allIdle below). A tunnel URL cannot survive
-   * a restart: cloudflared mints a fresh quick-tunnel hostname per run and there
-   * is no way to pin it, so restarting under a live tunnel breaks a phone that is
-   * connected at that moment. A LAN URL is fine — the token persists now — which
-   * is why this is narrowed to the tunnel rather than to pairing in general.
-   */
-  // Requires BOTH: a tunnel exists AND a client is connected through it right
-  // now. `pairTunnel` alone is not liveness — nothing stops the tunnel until the
-  // process exits, so gating on it would postpone every future update after a
-  // single pairing, rather than deferring to the next disconnect as intended.
-  const tunnelPairingLive = (): boolean => pairTunnel !== null && bridge.hasLiveHeadlessClient();
   // #875 — the token is PERSISTED, not per-session. It used to be minted fresh on
   // every run, so a self-restart (on by default, hourly npm check) invalidated the
   // URL the phone had saved. The reporter experienced that as "updating the npm
@@ -6833,23 +6820,30 @@ export async function runPanelOrchestrator(): Promise<void> {
       // reached the agent yet (#486). Restarting would destroy it silently.
       !AskAnswers.hasOutstanding() &&
       !QueueMonitor.isBusy() &&
-      // #875 — a LIVE TUNNEL PAIRING SESSION defers the restart to the next
-      // disconnect. The token now persists, so a LAN URL survives a restart; a
-      // tunnel URL cannot, because cloudflared mints a fresh quick-tunnel
-      // hostname every run and there is no way to pin it. Restarting under a live
-      // tunnel therefore breaks a phone that is connected RIGHT NOW, to install
-      // an update nobody asked for at that moment — which is what the reporter
-      // experienced and (reasonably) blamed on the npm version.
+      // #875 / #1176 / #1961 — a TUNNEL pairing defers the restart while a phone
+      // is connected now OR was connected within the recency window. The token
+      // now persists, so a LAN URL survives a restart; a tunnel URL cannot,
+      // because cloudflared mints a fresh quick-tunnel hostname every run and
+      // there is no way to pin it. Restarting under a tunnel therefore breaks a
+      // phone that is using that URL, to install an update nobody asked for at
+      // that moment.
+      //
+      // Live-socket-only is the wrong signal: a phone in a pocket drops its
+      // socket and is still the user of this URL. Recency lives in
+      // tunnelPairingLive() (not folded into hasLiveHeadlessClient) so the gate
+      // itself names both halves. The window is hours, not minutes — thirty
+      // minutes was shorter than the hourly auto-update check, so a pocketed
+      // phone still had its hostname rotated (#1961).
       //
       // Deferral, not cancellation: the update check still runs and the restart
-      // stays armed, so it fires as soon as the tunnel goes away. The cost is
-      // that a tunnel left up indefinitely postpones updates indefinitely, so it
-      // is DISCLOSED — in pair-durability's tunnel note, which the panel shows at
+      // stays armed, so it fires once the window lapses. The cost is that a
+      // tunnel left up indefinitely postpones updates indefinitely, so it is
+      // DISCLOSED — in pair-durability's tunnel note, which the panel shows at
       // pair time. Deliberately not announced from here: this is a predicate the
       // restarter polls, and emitting from it would either fire repeatedly or
       // need its own state to suppress itself. Pair time is also where the user
       // is actually looking (#1077: an orchestrator log may be unreachable).
-      !tunnelPairingLive(),
+      !tunnelPairingLive(pairTunnel, bridge),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,
   });

--- a/src/orchestrator/tunnel-pairing-live.ts
+++ b/src/orchestrator/tunnel-pairing-live.ts
@@ -1,0 +1,44 @@
+/**
+ * #875 / #1176 / #1961 — should the self-restarter defer because a phone is
+ * paired over a TUNNEL?
+ *
+ * A tunnel URL cannot survive a restart: cloudflared mints a fresh quick-tunnel
+ * hostname per run and there is no way to pin it. Restarting under a live tunnel
+ * therefore breaks a phone that is using that URL. A LAN URL is fine (the token
+ * persists), which is why this is narrowed to the tunnel rather than to pairing
+ * in general.
+ *
+ * Requires BOTH a tunnel AND a headless client that is live-or-recent.
+ * `pairTunnel` alone is not liveness — nothing stops the tunnel until the
+ * process exits, so gating on it would postpone every future update after a
+ * single pairing.
+ *
+ * Live-socket-only (`hasLiveHeadlessClient`) is the wrong half of that AND.
+ * A phone in a pocket drops its socket (screen off, app backgrounded, wifi/5G
+ * handoff) and is still the user of this URL. #1176 folded a recency window
+ * *into* `hasLiveHeadlessClient`, which left this gate looking like the original
+ * live-only check — the exact reading #1961 verified against 0.52.41's dist —
+ * and chose thirty minutes, which is shorter than the hourly auto-update check,
+ * so a pocketed phone still had its hostname rotated.
+ *
+ * Recency belongs HERE, next to the tunnel, with a window measured in hours.
+ */
+
+import { HEADLESS_RECENCY_MS } from "../services/ui-bridge.js";
+
+export interface HeadlessLiveness {
+  hasLiveHeadlessClient(): boolean;
+  headlessSeenWithin(ms: number): boolean;
+}
+
+/** True when a tunnel exists AND a headless client is connected now, or was
+ *  within `HEADLESS_RECENCY_MS`. */
+export function tunnelPairingLive(
+  pairTunnel: unknown,
+  bridge: HeadlessLiveness,
+): boolean {
+  return (
+    pairTunnel !== null &&
+    (bridge.hasLiveHeadlessClient() || bridge.headlessSeenWithin(HEADLESS_RECENCY_MS))
+  );
+}

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1224,25 +1224,28 @@ export const BRIDGE_DEFAULT_TIMEOUT_MS = 20_000;
 
 /**
  * How long after a headless client's socket closes it still counts as present
- * for the #875 restart-deferral gate (#1176).
+ * for the #875 restart-deferral gate (#1176, #1961).
  *
  * Chosen from what the window has to cover and what it costs if it is wrong.
  *
  * It must cover: a phone whose screen went off, which the mobile OS suspends
  * within seconds and which reconnects when the user next picks it up. That is a
- * pocket interval — minutes to hours, unbounded in principle.
+ * pocket interval — minutes to hours, unbounded in principle. A work-day pocket
+ * is the EXPECTED condition for someone who paired the phone to use at work.
  *
  * It costs: a deferred auto-update, for this long, after a phone genuinely
  * leaves. Nothing is lost — the update applies at the next check — so the price
  * of being generous is a delay, while the price of being stingy is the reported
  * bug: a rotated tunnel hostname and a phone that cannot get back in.
  *
- * Asymmetric, so lean generous. Thirty minutes covers a meeting or a commute and
- * still lets an install that has truly lost its phone update within the hour,
- * with no unpairing step and no user action — which is the property that made the
- * sticky `isHeadless()` unacceptable for this gate.
+ * Asymmetric, so lean generous. Thirty minutes (#1176) was shorter than the
+ * hourly auto-update check, so a pocketed phone still had its hostname rotated
+ * (#1961). Eight hours covers a work day and still lets an install that has
+ * truly lost its phone update overnight, with no unpairing step and no user
+ * action — which is the property that made the sticky `isHeadless()`
+ * unacceptable for this gate.
  */
-export const HEADLESS_RECENCY_MS = 30 * 60_000;
+export const HEADLESS_RECENCY_MS = 8 * 60 * 60_000;
 
 /**
  * The first panel version whose save / new-workflow replies carry `workflow_uuid`
@@ -3687,8 +3690,6 @@ export class UiBridge {
     }
   }
 
-  /** True when the tab advertised itself as a canvas-less (mobile/remote) client
-   *  in its `hello`. Unknown tabs → false. */
   /**
    * #875 — is any CURRENTLY-CONNECTED client headless (a paired phone / mirror)?
    *
@@ -3698,37 +3699,25 @@ export class UiBridge {
    * rendering decisions and wrong for a LIVENESS gate — using it would report a
    * phone that paired once and left as still connected, and the self-restarter
    * would defer updates forever.
+   *
+   * Also deliberately NOT the recency window (#1176 / #1961). Folding "seen
+   * recently" into this accessor left the restart gate looking live-only — the
+   * exact reading #1961 verified against 0.52.41. Recency is `headlessSeenWithin`,
+   * composed at `tunnelPairingLive`.
    */
   hasLiveHeadlessClient(): boolean {
     for (const c of this.conns.values()) if (c.headless === true) return true;
-    // #1176 — A BACKGROUNDED PHONE IS NOT A DEPARTED PHONE.
-    //
-    // `conns` holds currently-OPEN sockets. A phone at work with its screen off
-    // has had its WebSocket suspended or closed by the mobile OS, so the loop
-    // above answers false and the restart gate opens — and the restart mints a
-    // NEW cloudflared hostname. A reporter picked their phone up to:
-    //
-    //   Failed host lookup: 'cameron-timing-face-spies.trycloudflare.com'
-    //   (No address associated with hostname, errno = 7)
-    //
-    // Not a timeout and not a refusal: the hostname no longer existed.
-    //
-    // The sticky `isHeadless()` was rejected for this gate, correctly — a phone
-    // that paired once and left would defer updates forever. But "socket open
-    // right now" and "ever paired" are not the only options, and the state
-    // between them is not an edge case: a phone in a pocket is the EXPECTED
-    // condition for someone who paired it to use at work.
-    //
-    // So: a bounded recency window. It keeps the property that killed the sticky
-    // option — a phone that genuinely left stops deferring, on its own, without
-    // anyone unpairing anything — while covering the normal mobile case.
-    return this.recentHeadlessWithin(HEADLESS_RECENCY_MS);
+    return false;
   }
 
-  /** Was a headless client connected within `ms`? (#1176) Reads the disconnect
-   *  clock, so it answers true for a phone whose socket the OS suspended and
-   *  false for one that has genuinely been gone longer than the window. */
-  private recentHeadlessWithin(ms: number): boolean {
+  /** Was a headless client connected within `ms`? (#1176, #1961)
+   *
+   *  Reads the disconnect clock, so it answers true for a phone whose socket the
+   *  OS suspended and false for one that has genuinely been gone longer than the
+   *  window. The restart gate ORs this with `hasLiveHeadlessClient` rather than
+   *  folding it in — a backgrounded phone is not a departed phone, and hiding
+   *  that fact inside the live accessor is how #1961 read as unfixed. */
+  headlessSeenWithin(ms: number): boolean {
     if (this.lastHeadlessDisconnectAt === undefined) return false;
     return performance.now() - this.lastHeadlessDisconnectAt < ms;
   }


### PR DESCRIPTION
Fixes #1961

## What was actually unfixed

#1176 / PR #1185 *did* ship a recency window in 0.50.50, and it is in the 0.52.41 dist. The reporter grepped for names that never existed (`hasRecentHeadless`, `lastHeadlessSeen`, `headlessGraceMs`) and reconstructed `hasLiveHeadlessClient` as `return false`. The compiled function is:

```js
hasLiveHeadlessClient() {
  for (const c of this.conns.values()) if (c.headless === true) return true;
  return this.recentHeadlessWithin(HEADLESS_RECENCY_MS);
}
```

Two remaining holes still produced the reported `Failed host lookup` on a pocketed phone:

1. Recency was folded *into* `hasLiveHeadlessClient`, so `tunnelPairingLive` still read as the live-only one-liner the reporter pasted from dist.
2. The window was **30 minutes**, shorter than the hourly auto-update check. An armed restart fires 30 minutes after the socket closes — a commute, a meeting, or a phone in a pocket at work.

## What the user now observes

A phone that backgrounds / locks (socket gone) still defers a tunnel-rotating self-restart for a work day. Reopening the app reaches the same `*.trycloudflare.com` hostname.

- `tunnelPairingLive(pairTunnel, bridge)` is now `pairTunnel !== null && (live || headlessSeenWithin(HEADLESS_RECENCY_MS))`.
- `hasLiveHeadlessClient` is live sockets only again (the name matches).
- `HEADLESS_RECENCY_MS` is 8 hours. The sticky `isHeadless()` is still rejected: a phone that has been gone longer than the window stops deferring on its own.

Not in this PR (separate issues): explicit "don't update while paired" toggle (#1963), stable tunnel hostname (#1151).
