### PR TITLE
feat(1963): check+apply auto-update at the desk, check-only on a mobile tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Added
+
+- **Transport-aware auto-update (#1963).** At the desk (LAN / no pairing tunnel)
+  the orchestrator still checks and applies, and the sidebar panel is checked
+  against the published pyproject — not just the floor — so a pack three
+  versions behind is no longer reported healthy. While a phone is paired over a
+  cloudflared quick-tunnel, both checks still run and a one-line notice says an
+  update is waiting, but APPLY (disk mutate + restart) does not: that restart
+  rotates the hostname and disconnects the phone. Pairing is sticky on the
+  tunnel handle, not the live socket, so a locked screen or a 5G/wifi handoff
+  cannot open the gate. Pair time carries a toggle defaulted ON ("Don't update
+  while my phone is paired") and an `apply_updates_now` affordance for when the
+  user is back at the desk. Relay and LAN remain safe to apply.
+
 ## 0.51.35
 
 ### Fixed

--- a/src/__tests__/orchestrator/auto-update-gate.test.ts
+++ b/src/__tests__/orchestrator/auto-update-gate.test.ts
@@ -1,0 +1,137 @@
+// #1963 — auto-update is check+apply at the desk, check-only on a mobile tunnel.
+//
+// The reporter's formula, not a heuristic:
+//   applyUpdate = updateAvailable && !(activeTransport === "quick-tunnel" && pairingActive)
+//
+// These tests drive the shipped gate. They do not reimplement it.
+
+import { describe, expect, it } from "vitest";
+import {
+  autoUpdateApplyAllowed,
+  deferredAutoUpdateNote,
+  pairAutoUpdateDisclosure,
+  pairingActiveOf,
+  pairingTransportOf,
+  DEFER_WHILE_PAIRED_TOGGLE_LABEL,
+  type AutoUpdateApplyInput,
+} from "../../services/auto-update-gate.js";
+
+describe("autoUpdateApplyAllowed — the reporter's table (#1963)", () => {
+  it("applies at the desk with no pairing tunnel", () => {
+    expect(
+      autoUpdateApplyAllowed({ activeTransport: undefined, pairingActive: false }),
+    ).toBe(true);
+  });
+
+  it("applies on LAN even while a phone is paired — a LAN URL survives a restart", () => {
+    expect(
+      autoUpdateApplyAllowed({ activeTransport: "lan", pairingActive: true }),
+    ).toBe(true);
+  });
+
+  it("applies on relay — a stable URL is not rotated by a restart", () => {
+    expect(
+      autoUpdateApplyAllowed({ activeTransport: "relay", pairingActive: true }),
+    ).toBe(true);
+  });
+
+  it("does NOT apply while paired over a quick-tunnel — that is the disconnect", () => {
+    expect(
+      autoUpdateApplyAllowed({ activeTransport: "quick-tunnel", pairingActive: true }),
+    ).toBe(false);
+  });
+
+  it("applies on a leftover quick-tunnel handle that is no longer paired", () => {
+    expect(
+      autoUpdateApplyAllowed({ activeTransport: "quick-tunnel", pairingActive: false }),
+    ).toBe(true);
+  });
+
+  it("the pair-time toggle OFF opens the gate even under a live quick-tunnel", () => {
+    expect(
+      autoUpdateApplyAllowed({
+        activeTransport: "quick-tunnel",
+        pairingActive: true,
+        deferWhilePaired: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("the toggle defaults ON — omitting it is the same as true", () => {
+    const base: AutoUpdateApplyInput = {
+      activeTransport: "quick-tunnel",
+      pairingActive: true,
+    };
+    expect(autoUpdateApplyAllowed(base)).toBe(
+      autoUpdateApplyAllowed({ ...base, deferWhilePaired: true }),
+    );
+    expect(autoUpdateApplyAllowed(base)).toBe(false);
+  });
+});
+
+describe("pairingActive is sticky on the tunnel handle, not a live socket (#1963)", () => {
+  it("a minted tunnel is paired — a locked-screen phone has no socket, but is still paired", () => {
+    expect(pairingActiveOf({ url: "https://rand.trycloudflare.com", stop: () => {} })).toBe(true);
+    expect(pairingTransportOf({ url: "https://rand.trycloudflare.com" })).toBe("quick-tunnel");
+  });
+
+  it("no tunnel handle means desk/LAN — APPLY is allowed", () => {
+    expect(pairingActiveOf(null)).toBe(false);
+    expect(pairingTransportOf(null)).toBeUndefined();
+    expect(
+      autoUpdateApplyAllowed({
+        activeTransport: pairingTransportOf(null),
+        pairingActive: pairingActiveOf(null),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("pairAutoUpdateDisclosure — what the QR modal is told", () => {
+  it("check is always true; apply follows the gate; toggle defaults ON", () => {
+    const d = pairAutoUpdateDisclosure({
+      activeTransport: "quick-tunnel",
+      pairingActive: true,
+    });
+    expect(d.check).toBe(true);
+    expect(d.apply).toBe(false);
+    expect(d.defer_while_paired).toBe(true);
+    expect(d.toggle_default_on).toBe(true);
+    expect(d.toggle_label).toBe(DEFER_WHILE_PAIRED_TOGGLE_LABEL);
+  });
+
+  it("LAN pairing still checks AND applies", () => {
+    const d = pairAutoUpdateDisclosure({
+      activeTransport: "lan",
+      pairingActive: true,
+    });
+    expect(d.check).toBe(true);
+    expect(d.apply).toBe(true);
+  });
+});
+
+describe("deferredAutoUpdateNote names why the desk is not moving", () => {
+  it("names the versions and the tunnel, and points at Update now", () => {
+    const note = deferredAutoUpdateNote({
+      component: "orchestrator",
+      from: "0.52.41",
+      to: "0.52.42",
+    });
+    expect(note).toContain("0.52.41");
+    expect(note).toContain("0.52.42");
+    expect(note).toMatch(/mobile tunnel/i);
+    expect(note).toMatch(/Update now/);
+    expect(note).toContain(DEFER_WHILE_PAIRED_TOGGLE_LABEL.slice(0, 20));
+  });
+
+  it("the panel path names the panel, not the npm package", () => {
+    const note = deferredAutoUpdateNote({
+      component: "panel",
+      from: "0.15.28",
+      to: "0.15.31",
+    });
+    expect(note).toMatch(/panel/i);
+    expect(note).toContain("0.15.28");
+    expect(note).toContain("0.15.31");
+  });
+});

--- a/src/__tests__/orchestrator/pair-update-prefs.test.ts
+++ b/src/__tests__/orchestrator/pair-update-prefs.test.ts
@@ -1,0 +1,56 @@
+// #1963 — the pair-time "Don't update while my phone is paired" toggle.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadPairUpdatePrefs,
+  pairUpdatePrefsPath,
+  savePairUpdatePrefs,
+} from "../../orchestrator/pair-update-prefs.js";
+
+let dir: string;
+let file: string;
+const OLD = process.env.COMFYUI_MCP_PAIR_UPDATE_PREFS;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-pairupd-"));
+  file = join(dir, "pair-update-prefs.json");
+  process.env.COMFYUI_MCP_PAIR_UPDATE_PREFS = file;
+});
+
+afterEach(() => {
+  if (OLD === undefined) delete process.env.COMFYUI_MCP_PAIR_UPDATE_PREFS;
+  else process.env.COMFYUI_MCP_PAIR_UPDATE_PREFS = OLD;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("pair-update prefs default ON (#1963)", () => {
+  it("a missing file is defer-while-paired ON — applying would disconnect the phone", () => {
+    expect(existsSync(file)).toBe(false);
+    expect(loadPairUpdatePrefs()).toEqual({ deferWhilePaired: true });
+    expect(pairUpdatePrefsPath()).toBe(file);
+  });
+
+  it("persists an explicit OFF and reads it back", () => {
+    const saved = savePairUpdatePrefs({ deferWhilePaired: false });
+    expect(saved.deferWhilePaired).toBe(false);
+    expect(loadPairUpdatePrefs().deferWhilePaired).toBe(false);
+    expect(JSON.parse(readFileSync(file, "utf-8")).deferWhilePaired).toBe(false);
+  });
+
+  it("an unreadable file fails CLOSED to ON, never opens the gate", () => {
+    writeFileSync(file, "not-json");
+    expect(loadPairUpdatePrefs().deferWhilePaired).toBe(true);
+  });
+
+  it("a non-boolean value fails CLOSED to ON — the string \"false\" must not apply", () => {
+    writeFileSync(file, JSON.stringify({ deferWhilePaired: "false" }));
+    expect(loadPairUpdatePrefs().deferWhilePaired).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/pair-url-durability.test.ts
+++ b/src/__tests__/orchestrator/pair-url-durability.test.ts
@@ -62,6 +62,14 @@ describe("#875: what the pairing URL actually promises", () => {
     expect(d.note).toMatch(/will not help here/);
   });
 
+  it("tells a tunnel user updates are check-only while the pairing is active (#1963)", () => {
+    const d = pairUrlDurability({ mode: "tunnel", stableToken: true, autoRestart: true });
+    expect(d.note).toMatch(/CHECK-ONLY/);
+    expect(d.note).toMatch(/Don't update while my phone is paired/);
+    expect(d.note).toMatch(/Update now/);
+    expect(d.note).not.toMatch(/DEFERRED until it disconnects/);
+  });
+
   // A warning about spontaneous restarts is false when they are switched off.
   it("only blames automatic restarts when they are actually armed", () => {
     const on = pairUrlDurability({ mode: "lan", stableToken: false, autoRestart: true });

--- a/src/__tests__/orchestrator/transport-aware-auto-update-wiring.test.ts
+++ b/src/__tests__/orchestrator/transport-aware-auto-update-wiring.test.ts
@@ -1,0 +1,36 @@
+// #1963 — the restarter APPLY gate must be the sticky pairing handle, not a
+// live socket. A backgrounded phone has no socket; keying on one is how a
+// locked screen used to rotate the tunnel hostname.
+//
+// The behaviour is tested through autoUpdateApplyAllowed / SelfRestarter.
+// This file pins the WIRING so a later edit cannot silently put
+// hasLiveHeadlessClient back on the restart path.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const INDEX = join(HERE, "../../orchestrator/index.ts");
+
+describe("orchestrator wires the #1963 gate, not the live-socket predicate", () => {
+  const src = readFileSync(INDEX, "utf-8");
+
+  it("APPLY is autoUpdateApplyAllowed over the sticky pairTunnel handle", () => {
+    expect(src).toContain("pairingActiveOf(pairTunnel)");
+    expect(src).toContain("pairingTransportOf(pairTunnel)");
+    expect(src).toContain("applyAllowed: applyAutoUpdateAllowed");
+    expect(src).toContain("tickPanelAutoUpdate");
+  });
+
+  it("does not put hasLiveHeadlessClient on the restarter path", () => {
+    expect(src).not.toMatch(/hasLiveHeadlessClient/);
+  });
+
+  it("exposes the pair-time toggle and Update now", () => {
+    expect(src).toContain("set_pair_update_pref");
+    expect(src).toContain("apply_updates_now");
+    expect(src).toContain("pairAutoUpdateDisclosure");
+  });
+});

--- a/src/__tests__/services/panel-auto-update.test.ts
+++ b/src/__tests__/services/panel-auto-update.test.ts
@@ -1,0 +1,159 @@
+// #1963 — panel auto-update: CHECK always, APPLY only when the caller says so.
+//
+// The reporter sat on panel 0.15.28 vs 0.15.31 while the floor-only sync
+// reported healthy. This path asks the published pyproject, not the floor.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  getLatestPublishedPanelVersion,
+  tickPanelAutoUpdate,
+  PANEL_PYPROJECT_RAW_URL,
+  type PanelAutoUpdateDeps,
+} from "../../services/panel-auto-update.js";
+import { PANEL_REGISTRY_ID, type PanelStatus } from "../../services/panel-installer.js";
+import { deferredAutoUpdateNote } from "../../services/auto-update-gate.js";
+import type { PanelPinState } from "../../services/panel-settings.js";
+
+const UNPINNED: PanelPinState = { pinned: false, source: "none" };
+
+function status(over: Partial<PanelStatus> = {}): PanelStatus {
+  return {
+    applicable: true,
+    installed: true,
+    dir: "/fake/comfy/custom_nodes/comfyui-mcp-panel",
+    installedVersion: "0.15.28",
+    isDevSymlink: false,
+    targetVersion: "nightly",
+    shadows: [],
+    pin: UNPINNED,
+    note: "",
+    ...over,
+  };
+}
+
+function makeDeps(opts: {
+  status?: PanelStatus;
+  latest?: string | undefined;
+  env?: NodeJS.ProcessEnv;
+  updateTo?: string;
+}): { deps: PanelAutoUpdateDeps; updates: number } {
+  const updates = { n: 0 };
+  const deps: PanelAutoUpdateDeps = {
+    env: () => opts.env ?? {},
+    panelStatus: async () => opts.status ?? status(),
+    latestVersion: async () => opts.latest,
+    updatePanel: async () => {
+      updates.n += 1;
+      return { installedVersion: opts.updateTo ?? opts.latest };
+    },
+  };
+  return {
+    deps,
+    get updates() {
+      return updates.n;
+    },
+  } as { deps: PanelAutoUpdateDeps; updates: number };
+}
+
+describe("tickPanelAutoUpdate — check vs apply (#1963)", () => {
+  it("the reported case: 0.15.28 vs 0.15.31, APPLY off → deferred, pack untouched", async () => {
+    const h = makeDeps({ latest: "0.15.31" });
+    const res = await tickPanelAutoUpdate({ apply: false, deps: h.deps });
+    expect(res.action).toBe("deferred");
+    expect(res.from).toBe("0.15.28");
+    expect(res.to).toBe("0.15.31");
+    expect(h.updates).toBe(0);
+    expect(res.note).toBe(
+      deferredAutoUpdateNote({ component: "panel", from: "0.15.28", to: "0.15.31" }),
+    );
+  });
+
+  it("the same versions at the desk (APPLY on) → update runs", async () => {
+    const h = makeDeps({ latest: "0.15.31", updateTo: "0.15.31" });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("updated");
+    expect(h.updates).toBe(1);
+    expect(res.from).toBe("0.15.28");
+    expect(res.to).toBe("0.15.31");
+    expect(res.note).toMatch(/Restart ComfyUI/);
+  });
+
+  it("already current → no mutation", async () => {
+    const h = makeDeps({
+      status: status({ installedVersion: "0.15.31" }),
+      latest: "0.15.31",
+    });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("up-to-date");
+    expect(h.updates).toBe(0);
+  });
+
+  it("a pin is a promise — never moves the pack, even at the desk", async () => {
+    const h = makeDeps({
+      status: status({ pin: { pinned: true, source: "settings", version: "0.15.28" } }),
+      latest: "0.15.31",
+    });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("skipped-pin");
+    expect(h.updates).toBe(0);
+  });
+
+  it("a dev symlink is never touched", async () => {
+    const h = makeDeps({
+      status: status({ isDevSymlink: true }),
+      latest: "0.15.31",
+    });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("skipped-dev");
+    expect(h.updates).toBe(0);
+  });
+
+  it("COMFYUI_MCP_PANEL_AUTOINSTALL=0 disables unattended apply", async () => {
+    const h = makeDeps({
+      latest: "0.15.31",
+      env: { COMFYUI_MCP_PANEL_AUTOINSTALL: "0" },
+    });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("skipped-disabled");
+    expect(h.updates).toBe(0);
+  });
+
+  it("an unknown latest version does NOT churn nightly just in case", async () => {
+    const h = makeDeps({ latest: undefined });
+    const res = await tickPanelAutoUpdate({ apply: true, deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(h.updates).toBe(0);
+    expect(res.note).toMatch(/NOT evidence that you are up to date/);
+  });
+});
+
+describe("getLatestPublishedPanelVersion drives parsePyproject on the real URL", () => {
+  it("accepts this pack's pyproject and returns its version", async () => {
+    const toml = `[project]\nname = "${PANEL_REGISTRY_ID}"\nversion = "0.15.31"\n`;
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(PANEL_PYPROJECT_RAW_URL);
+      return {
+        ok: true,
+        text: async () => toml,
+      } as Response;
+    }) as unknown as typeof fetch;
+    await expect(getLatestPublishedPanelVersion(fetchImpl)).resolves.toBe("0.15.31");
+  });
+
+  it("refuses a body that is not this pack — a wrong-repo response is not latest", async () => {
+    const toml = `[project]\nname = "some-other-pack"\nversion = "9.9.9"\n`;
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      text: async () => toml,
+    })) as unknown as typeof fetch;
+    await expect(getLatestPublishedPanelVersion(fetchImpl)).resolves.toBeUndefined();
+  });
+
+  it("an HTTP error is undetermined, not a version", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+    })) as unknown as typeof fetch;
+    await expect(getLatestPublishedPanelVersion(fetchImpl)).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/services/self-restart.test.ts
+++ b/src/__tests__/services/self-restart.test.ts
@@ -29,6 +29,8 @@ function makeHarness(opts: {
   spawnOk?: boolean;
   mtime?: number;
   releasePanelLock?: () => void;
+  applyAllowed?: () => boolean;
+  panelTick?: SelfRestartDeps["panelTick"];
 }): Harness {
   const calls: string[] = [];
   const spawns: Array<{ npxVersion?: string }> = [];
@@ -53,6 +55,8 @@ function makeHarness(opts: {
     latestVersion: async () => opts.latest,
     entryMtime: () => mtime,
     allIdle: () => idle,
+    applyAllowed: opts.applyAllowed ?? (() => true),
+    panelTick: opts.panelTick,
     announce: (t) => announces.push(t),
     teardown: async () => {
       calls.push("teardown");
@@ -184,6 +188,94 @@ describe("SelfRestarter — published installs", () => {
     h.restarter.start();
     await h.restarter.updateTick();
     expect(h.calls).toEqual([]);
+  });
+});
+
+describe("SelfRestarter — transport-aware check vs apply (#1963)", () => {
+  it("a quick-tunnel pairing CHECKs but does not APPLY (no disk mutate, no restart)", async () => {
+    const h = makeHarness({
+      mode: "global",
+      currentVersion: "0.52.41",
+      latest: "0.52.42",
+      updateResult: { action: "updated", mode: "global", from: "0.52.41", to: "0.52.42" },
+      applyAllowed: () => false,
+    });
+    h.restarter.start();
+    await h.restarter.updateTick();
+    await Promise.resolve();
+    expect(h.calls).toEqual([]); // latestVersion is a probe, checkAndSelfUpdate is APPLY
+    expect(h.announces.some((a) => a.includes("0.52.41") && a.includes("0.52.42"))).toBe(true);
+    expect(h.announces.some((a) => /mobile tunnel/i.test(a))).toBe(true);
+  });
+
+  it("npx: check-only while the gate is closed — no respawn", async () => {
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "1.0.0",
+      latest: "2.0.0",
+      applyAllowed: () => false,
+    });
+    h.restarter.start();
+    await h.restarter.updateTick();
+    await Promise.resolve();
+    expect(h.calls).toEqual([]);
+    expect(h.announces.some((a) => a.includes("1.0.0") && a.includes("2.0.0"))).toBe(true);
+  });
+
+  it("forceApply bypasses the gate — the Update now path", async () => {
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "1.0.0",
+      latest: "2.0.0",
+      applyAllowed: () => false,
+    });
+    h.restarter.start();
+    await h.restarter.updateTick({ forceApply: true });
+    await Promise.resolve();
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
+    expect(h.spawns[0]?.npxVersion).toBe("2.0.0");
+  });
+
+  it("an armed restart still refuses to fire after a phone pairs", async () => {
+    let allowed = true;
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "1.0.0",
+      latest: "2.0.0",
+      applyAllowed: () => allowed,
+    });
+    h.restarter.start();
+    h.setIdle(false);
+    await h.restarter.updateTick(); // arms, but busy
+    expect(h.calls).toEqual([]);
+    allowed = false; // phone pairs over the tunnel before idle
+    h.setIdle(true);
+    h.restarter.tryRestart();
+    await Promise.resolve();
+    expect(h.calls).toEqual([]); // still held
+    allowed = true;
+    h.restarter.requestApplyPolicyRefresh();
+    await Promise.resolve();
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
+  });
+
+  it("the same tick checks the panel with the same apply bit", async () => {
+    const panel: Array<{ apply: boolean }> = [];
+    const h = makeHarness({
+      mode: "global",
+      currentVersion: "1.0.0",
+      latest: "1.1.0",
+      applyAllowed: () => false,
+      panelTick: async ({ apply }) => {
+        panel.push({ apply });
+        return { action: "deferred", from: "0.15.28", to: "0.15.31" };
+      },
+    });
+    h.restarter.start();
+    await h.restarter.updateTick();
+    expect(panel).toEqual([{ apply: false }]);
+    expect(h.calls).toEqual([]); // orchestrator not applied
+    expect(h.announces.some((a) => /panel/i.test(a) && a.includes("0.15.28"))).toBe(true);
   });
 });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -51,8 +51,17 @@ import { panelRecoveryContext } from "../services/panel-recovery.js";
 import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
 import { releaseOwnedPanelLock } from "../services/panel-pin-guard.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
+import { tickPanelAutoUpdate } from "../services/panel-auto-update.js";
 import { pairUrlDurability } from "./pair-durability.js";
 import { loadOrCreatePairToken } from "./pair-token-store.js";
+import {
+  autoUpdateApplyAllowed,
+  pairAutoUpdateDisclosure,
+  pairingActiveOf,
+  pairingTransportOf,
+  type AutoUpdateApplyInput,
+} from "../services/auto-update-gate.js";
+import { loadPairUpdatePrefs, savePairUpdatePrefs } from "./pair-update-prefs.js";
 import { SessionStore, workflowIdentityParts, carryWorkflowCommandStamp } from "./session-store.js";
 import { unreachableReason, noPanelTabReason, identityReason } from "./fence-refusal.js";
 import {
@@ -1238,20 +1247,25 @@ export async function runPanelOrchestrator(): Promise<void> {
   let pairToken: string | null = envPairToken;
   let pairListenerStarted = false;
   let pairTunnel: { url: string; stop: () => void } | null = null;
+  // Forward declaration — assigned after teardownCore exists. Declared here so
+  // pair / apply_updates_now handlers can refresh the restarter without hitting
+  // the TDZ if a frame arrives before that assignment.
+  let selfRestarter: SelfRestarter | null = null;
   /**
-   * #875 — is a phone paired over a TUNNEL right now?
+   * #1963 — APPLY gate for auto-update. Checking still runs.
    *
-   * Gates the self-restarter (see its allIdle below). A tunnel URL cannot survive
-   * a restart: cloudflared mints a fresh quick-tunnel hostname per run and there
-   * is no way to pin it, so restarting under a live tunnel breaks a phone that is
-   * connected at that moment. A LAN URL is fine — the token persists now — which
-   * is why this is narrowed to the tunnel rather than to pairing in general.
+   * pairingActive is STICKY on `pairTunnel` (the handle exists from mint until
+   * process exit). A live-socket test is the hole a locked-screen phone falls
+   * through: the OS has closed the socket, the gate opened, the hostname
+   * rotated. The pair-time toggle (default ON) is how a desk session applies
+   * anyway; apply_updates_now is the one-shot override.
    */
-  // Requires BOTH: a tunnel exists AND a client is connected through it right
-  // now. `pairTunnel` alone is not liveness — nothing stops the tunnel until the
-  // process exits, so gating on it would postpone every future update after a
-  // single pairing, rather than deferring to the next disconnect as intended.
-  const tunnelPairingLive = (): boolean => pairTunnel !== null && bridge.hasLiveHeadlessClient();
+  const autoUpdateGateInput = (): AutoUpdateApplyInput => ({
+    activeTransport: pairingTransportOf(pairTunnel),
+    pairingActive: pairingActiveOf(pairTunnel),
+    deferWhilePaired: loadPairUpdatePrefs().deferWhilePaired,
+  });
+  const applyAutoUpdateAllowed = (): boolean => autoUpdateApplyAllowed(autoUpdateGateInput());
   // #875 — the token is PERSISTED, not per-session. It used to be minted fresh on
   // every run, so a self-restart (on by default, hourly npm check) invalidated the
   // URL the phone had saved. The reporter experienced that as "updating the npm
@@ -4925,6 +4939,21 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (event.type === "pair" && event.tab_id) {
       const mode = (event as { mode?: unknown }).mode === "tunnel" ? "tunnel" : "lan";
       const tabId = event.tab_id;
+      // Pair-time toggle, default ON. An explicit boolean is the only thing we
+      // persist — a missing field leaves the last saved (or default) value.
+      const rawDefer = (event as { defer_while_paired?: unknown }).defer_while_paired;
+      if (typeof rawDefer === "boolean") {
+        try {
+          savePairUpdatePrefs({ deferWhilePaired: rawDefer });
+        } catch (err) {
+          logger.warn(
+            `[panel-orchestrator] could not persist pair-update prefs: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+        selfRestarter?.requestApplyPolicyRefresh();
+      }
       void (async () => {
         const token = await ensurePairListener();
         let url: string;
@@ -4971,13 +5000,66 @@ export async function runPanelOrchestrator(): Promise<void> {
               ? "survives restart"
               : `rotates on restart: ${durability.rotates.join(", ")}`),
         );
-        bridge.push({ type: "pair_url", mode, url, durability }, tabId);
+        const auto_update = pairAutoUpdateDisclosure(autoUpdateGateInput());
+        bridge.push({ type: "pair_url", mode, url, durability, auto_update }, tabId);
       })().catch((err) => {
         bridge.push(
           { type: "pair_error", mode, error: err instanceof Error ? err.message : String(err) },
           tabId,
         );
       });
+      return;
+    }
+
+    // #1963 — flip the pair-time "Don't update while my phone is paired" toggle
+    // after the URL is already minted (the checkbox on the QR modal).
+    if (event.type === "set_pair_update_pref" && event.tab_id) {
+      const tabId = event.tab_id;
+      const rawDefer = (event as { defer_while_paired?: unknown }).defer_while_paired;
+      if (typeof rawDefer !== "boolean") {
+        bridge.push(
+          { type: "pair_update_pref", ok: false, error: "defer_while_paired must be a boolean" },
+          tabId,
+        );
+        return;
+      }
+      try {
+        const prefs = savePairUpdatePrefs({ deferWhilePaired: rawDefer });
+        bridge.push(
+          {
+            type: "pair_update_pref",
+            ok: true,
+            defer_while_paired: prefs.deferWhilePaired,
+            apply: autoUpdateApplyAllowed({
+              ...autoUpdateGateInput(),
+              deferWhilePaired: prefs.deferWhilePaired,
+            }),
+          },
+          tabId,
+        );
+        selfRestarter?.requestApplyPolicyRefresh();
+      } catch (err) {
+        bridge.push(
+          {
+            type: "pair_update_pref",
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          tabId,
+        );
+      }
+      return;
+    }
+
+    // #1963 — "Update now" from the desk (or from the deferred-update notice).
+    // One-shot: ignores the tunnel gate for this tick only.
+    if (event.type === "apply_updates_now") {
+      const tabId = event.tab_id;
+      logger.info("[panel-orchestrator] apply_updates_now — checking and applying updates (bypass tunnel gate)");
+      void selfRestarter?.updateTick({ forceApply: true });
+      if (tabId) {
+        bridge.push({ type: "ack", ok: true, kind: "apply_updates_now" }, tabId);
+      }
       return;
     }
 
@@ -6709,9 +6791,6 @@ export async function runPanelOrchestrator(): Promise<void> {
   );
 
   let shuttingDown = false;
-  // Forward declaration — assigned right after teardownCore exists; teardownCore
-  // stops its timers so no update-check tick can fire mid-teardown.
-  let selfRestarter: SelfRestarter | null = null;
   /** Everything shutdown does EXCEPT exiting — shared with the self-restarter,
    *  which spawns its replacement first and exits itself after this settles. */
   const teardownCore = async () => {
@@ -6832,24 +6911,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // …and the same for an ask answer the user actually gave that has not
       // reached the agent yet (#486). Restarting would destroy it silently.
       !AskAnswers.hasOutstanding() &&
-      !QueueMonitor.isBusy() &&
-      // #875 — a LIVE TUNNEL PAIRING SESSION defers the restart to the next
-      // disconnect. The token now persists, so a LAN URL survives a restart; a
-      // tunnel URL cannot, because cloudflared mints a fresh quick-tunnel
-      // hostname every run and there is no way to pin it. Restarting under a live
-      // tunnel therefore breaks a phone that is connected RIGHT NOW, to install
-      // an update nobody asked for at that moment — which is what the reporter
-      // experienced and (reasonably) blamed on the npm version.
-      //
-      // Deferral, not cancellation: the update check still runs and the restart
-      // stays armed, so it fires as soon as the tunnel goes away. The cost is
-      // that a tunnel left up indefinitely postpones updates indefinitely, so it
-      // is DISCLOSED — in pair-durability's tunnel note, which the panel shows at
-      // pair time. Deliberately not announced from here: this is a predicate the
-      // restarter polls, and emitting from it would either fire repeatedly or
-      // need its own state to suppress itself. Pair time is also where the user
-      // is actually looking (#1077: an orchestrator log may be unreachable).
-      !tunnelPairingLive(),
+      !QueueMonitor.isBusy(),
+    // #1963 — transport gate is applyAllowed, not allIdle. Idle is in-flight
+    // work; this is "would a restart rotate the phone's tunnel hostname?"
+    // Checking still runs; APPLY (disk + restart, and the panel pack) does not.
+    applyAllowed: applyAutoUpdateAllowed,
+    panelTick: async ({ apply }) => tickPanelAutoUpdate({ apply }),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,
   });

--- a/src/orchestrator/pair-durability.ts
+++ b/src/orchestrator/pair-durability.ts
@@ -97,13 +97,13 @@ export function pairUrlDurability(input: PairDurabilityInput): PairUrlDurability
       "quick tunnel, and COMFYUI_MCP_TUNNEL_BACKEND=relay does not apply to it. To keep a link " +
       "that survives restarts, pair over LAN (the token is persisted, so a LAN URL keeps " +
       "working); otherwise re-pair from the panel after a restart. " +
-      // #875 — the reassurance that matters mid-session: an automatic restart
-      // will NOT yank this tunnel out from under a connected phone. Stated here
-      // because pair time is where the user is looking; the deferral itself is a
-      // gate on the self-restarter, and a log would not reach them.
-      "While a phone is connected over this tunnel, automatic update-restarts are DEFERRED until " +
-      "it disconnects, so an update cannot break the link mid-session (a tunnel left connected " +
-      "indefinitely therefore postpones updates indefinitely)." +
+      // #1963 — CHECK still runs (and the panel is told); APPLY does not, because
+      // a restart mints a new hostname. Sticky on the pairing itself, not the
+      // live socket: a locked screen is still paired. The pair-time toggle
+      // (default ON) and Update now are how a desk session moves forward.
+      "While this tunnel pairing is active, automatic updates are CHECK-ONLY — they will not " +
+      "restart and disconnect this device. They apply when you are back at the desk, when you " +
+      "turn off “Don't update while my phone is paired”, or when you choose Update now." +
       (rotates.includes("token")
         ? " (Pinning COMFYUI_MCP_PAIR_TOKEN alone will not help here — the hostname still rotates.)"
         : "")

--- a/src/orchestrator/pair-update-prefs.ts
+++ b/src/orchestrator/pair-update-prefs.ts
@@ -1,0 +1,73 @@
+/**
+ * #1963 — the pair-time toggle "Don't update while my phone is paired".
+ *
+ * Default ON. Persisted next to the pair token so a desk machine that paired
+ * a phone this morning still knows not to apply (and rotate the tunnel) after
+ * the socket has been suspended. Turning it off, or sending apply_updates_now,
+ * is the explicit "I am back at the desk" signal.
+ *
+ * Fail closed: a missing, unreadable, or malformed file means the toggle is
+ * ON — applying while unsure would disconnect the phone, which is the
+ * failure this record exists to prevent.
+ */
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { writeFileDurable } from "../utils/durable-write.js";
+import { logger } from "../utils/logger.js";
+import { assertNotWritingRealHomeInTests } from "../services/test-isolation-guard.js";
+
+export interface PairUpdatePrefs {
+  /** Default true. When true, a sticky quick-tunnel pairing blocks APPLY. */
+  deferWhilePaired: boolean;
+}
+
+const DEFAULTS: PairUpdatePrefs = { deferWhilePaired: true };
+
+export function pairUpdatePrefsPath(): string {
+  return (
+    process.env.COMFYUI_MCP_PAIR_UPDATE_PREFS ||
+    join(homedir(), ".comfyui-mcp", "pair-update-prefs.json")
+  );
+}
+
+function asPrefs(raw: unknown): PairUpdatePrefs | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const v = (raw as { deferWhilePaired?: unknown }).deferWhilePaired;
+  // Absent key → default ON. Explicit boolean only otherwise — a string
+  // "false" must not open the gate.
+  if (v === undefined) return { ...DEFAULTS };
+  if (typeof v !== "boolean") return null;
+  return { deferWhilePaired: v };
+}
+
+export function loadPairUpdatePrefs(): PairUpdatePrefs {
+  const path = pairUpdatePrefsPath();
+  if (!existsSync(path)) return { ...DEFAULTS };
+  try {
+    const raw = readFileSync(path, "utf-8");
+    if (raw.length === 0) return { ...DEFAULTS };
+    const parsed = asPrefs(JSON.parse(raw) as unknown);
+    return parsed ?? { ...DEFAULTS };
+  } catch (err) {
+    logger.warn(
+      `[pair-update-prefs] could not read ${path}: ${
+        err instanceof Error ? err.message : String(err)
+      } — defaulting to defer-while-paired ON`,
+    );
+    return { ...DEFAULTS };
+  }
+}
+
+export function savePairUpdatePrefs(patch: Partial<PairUpdatePrefs>): PairUpdatePrefs {
+  const next: PairUpdatePrefs = {
+    ...loadPairUpdatePrefs(),
+    ...patch,
+  };
+  const path = pairUpdatePrefsPath();
+  assertNotWritingRealHomeInTests(path, "the pair-update prefs");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileDurable(path, JSON.stringify(next, null, 2));
+  return next;
+}

--- a/src/services/auto-update-gate.ts
+++ b/src/services/auto-update-gate.ts
@@ -1,0 +1,112 @@
+/**
+ * #1963 — auto-update is conditional on how the user is currently connected.
+ *
+ * A restart severs a cloudflared quick-tunnel with certainty (the hostname
+ * rotates per run). A restart does not sever a LAN session with a stable pair
+ * token, and a relay URL is stable too. That is a property of the transport,
+ * not a guess about intent, so the gate is exact:
+ *
+ *   applyUpdate = updateAvailable && !(activeTransport === "quick-tunnel" && pairingActive)
+ *
+ * Checking is always allowed (a few KB, safe on a metered link). Applying —
+ * writing the new package and restarting — is what must be gated.
+ *
+ * pairingActive is STICKY: it is "a tunnel was opened for this process and has
+ * not been torn down", not "a socket is open right now". A backgrounded phone
+ * has no live socket (#1961 / #1176); keying the gate on the socket is how a
+ * locked screen and a 5G/wifi handoff used to rotate the hostname anyway.
+ *
+ * The pair-time toggle `deferWhilePaired` (default ON) is the user-facing
+ * override: turning it off, or sending apply_updates_now, lets an update
+ * through even while the tunnel is up.
+ */
+
+export type AutoUpdateTransport = "lan" | "quick-tunnel" | "relay";
+
+export interface AutoUpdateApplyInput {
+  /**
+   * How the phone is paired right now. Undefined = no pairing tunnel (desk /
+   * LAN listener only). Pairing always uses a quick tunnel today; `relay` is
+   * in the type so a future pairing backend that actually honours
+   * COMFYUI_MCP_TUNNEL_BACKEND=relay is treated as safe without rewriting the
+   * formula.
+   */
+  activeTransport: AutoUpdateTransport | undefined;
+  /**
+   * Sticky pairing intent. True once a quick-tunnel has been minted for this
+   * process and until it is torn down — survives a locked screen.
+   */
+  pairingActive: boolean;
+  /**
+   * Pair-time toggle, default ON: "Don't update while my phone is paired".
+   * Explicit `false` is the only way this gate opens under a live quick-tunnel
+   * pairing (besides apply_updates_now, which bypasses the gate at the
+   * restarter).
+   */
+  deferWhilePaired?: boolean;
+}
+
+/** Pair-time checkbox copy. English, and the identifier the panel renders. */
+export const DEFER_WHILE_PAIRED_TOGGLE_LABEL =
+  "Don't update while my phone is paired — updating restarts the orchestrator, which changes your tunnel address and disconnects this device.";
+
+/**
+ * May we APPLY (disk mutate + restart) this update?
+ *
+ * Check is not this function's job and is always allowed. `updateAvailable` is
+ * the caller's: this answers only the transport half of the formula.
+ */
+export function autoUpdateApplyAllowed(input: AutoUpdateApplyInput): boolean {
+  if (input.deferWhilePaired === false) return true;
+  return !(input.activeTransport === "quick-tunnel" && input.pairingActive);
+}
+
+/**
+ * pairingActive from the pairing tunnel handle. STICKY on purpose: the handle
+ * exists from the moment the URL is minted until process exit (nothing stops
+ * the tunnel earlier). A live-socket test is exactly the hole a pocketed phone
+ * falls through.
+ */
+export function pairingActiveOf(pairTunnel: unknown): boolean {
+  return pairTunnel != null;
+}
+
+/** Phone pairing's tunnel is always a quick tunnel today (startQuickTunnel). */
+export function pairingTransportOf(pairTunnel: unknown): AutoUpdateTransport | undefined {
+  return pairTunnel != null ? "quick-tunnel" : undefined;
+}
+
+export interface PairAutoUpdateDisclosure {
+  check: true;
+  apply: boolean;
+  defer_while_paired: boolean;
+  toggle_default_on: true;
+  toggle_label: string;
+}
+
+/** What the pair_url frame carries so the panel can paint the toggle. */
+export function pairAutoUpdateDisclosure(input: AutoUpdateApplyInput): PairAutoUpdateDisclosure {
+  const deferWhilePaired = input.deferWhilePaired !== false;
+  return {
+    check: true,
+    apply: autoUpdateApplyAllowed({ ...input, deferWhilePaired }),
+    defer_while_paired: deferWhilePaired,
+    toggle_default_on: true,
+    toggle_label: DEFER_WHILE_PAIRED_TOGGLE_LABEL,
+  };
+}
+
+export function deferredAutoUpdateNote(opts: {
+  component: "orchestrator" | "panel";
+  from?: string;
+  to?: string;
+}): string {
+  const who = opts.component === "panel" ? "ComfyUI-MCP panel" : "comfyui-mcp";
+  const versions =
+    opts.from && opts.to ? ` ${opts.from} → ${opts.to}` : opts.to ? ` ${opts.to}` : "";
+  return (
+    `⬆️ ${who}${versions} is available but not applied — a phone is paired over a mobile ` +
+    `tunnel, and applying would change the tunnel address and disconnect it. Update from ` +
+    `the desk, turn off “Don't update while my phone is paired”, or choose Update now.`
+  );
+}

--- a/src/services/panel-auto-update.ts
+++ b/src/services/panel-auto-update.ts
@@ -1,0 +1,186 @@
+/**
+ * #1963 — periodic panel version check, with APPLY gated the same way as the
+ * orchestrator self-update.
+ *
+ * Hello-time panel-sync is a FLOOR check (the minimum this orchestrator
+ * needs). Most panel fixes never raise that floor, so a pack three versions
+ * behind still reads "healthy". This path asks the published pyproject for
+ * the newest panel, which is a few KB and safe on a metered link, and only
+ * runs the verified `runPanelAction("update")` when the caller says APPLY.
+ *
+ * Pin / dev-symlink / auto-install-off / remote still refuse to touch the
+ * pack. A failed latest-version probe never applies — we do not churn nightly
+ * just because GitHub did not answer.
+ */
+
+import { parsePyproject } from "./node-authoring.js";
+import {
+  isPanelAutoInstallDisabled,
+  PANEL_REGISTRY_ID,
+  panelStatus,
+  runPanelAction,
+  type PanelStatus,
+} from "./panel-installer.js";
+import { isNewer } from "./self-update.js";
+import { unreachableHostMessage } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+import { deferredAutoUpdateNote } from "./auto-update-gate.js";
+
+/** Raw pyproject — the pack's published version, not GitHub Releases (those lag). */
+export const PANEL_PYPROJECT_RAW_URL =
+  "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/pyproject.toml";
+
+const LATEST_TIMEOUT_MS = 5_000;
+
+export type PanelAutoUpdateAction =
+  | "up-to-date"
+  | "deferred"
+  | "updated"
+  | "skipped-disabled"
+  | "skipped-dev"
+  | "skipped-pin"
+  | "unavailable";
+
+export interface PanelAutoUpdateResult {
+  action: PanelAutoUpdateAction;
+  from?: string;
+  to?: string;
+  note?: string;
+}
+
+export interface PanelAutoUpdateDeps {
+  env: () => NodeJS.ProcessEnv;
+  panelStatus: () => Promise<PanelStatus>;
+  latestVersion: () => Promise<string | undefined>;
+  updatePanel: () => Promise<{ installedVersion?: string }>;
+}
+
+async function defaultLatestVersion(): Promise<string | undefined> {
+  return getLatestPublishedPanelVersion();
+}
+
+const defaultDeps: PanelAutoUpdateDeps = {
+  env: () => process.env,
+  panelStatus: () => panelStatus(),
+  latestVersion: defaultLatestVersion,
+  updatePanel: async () => {
+    await runPanelAction("update");
+    const after = await panelStatus();
+    return { installedVersion: after.installedVersion };
+  },
+};
+
+/**
+ * Published panel version from the pack's pyproject on main. Never throws.
+ * Refuses a body that is not this pack — a hijacked / wrong-repo response
+ * must not become "latest".
+ */
+export async function getLatestPublishedPanelVersion(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | undefined> {
+  let res: Response;
+  try {
+    res = await fetchImpl(PANEL_PYPROJECT_RAW_URL, {
+      signal: AbortSignal.timeout(LATEST_TIMEOUT_MS),
+      headers: { accept: "text/plain" },
+    });
+  } catch (err) {
+    logger.debug(
+      `[panel-auto-update] latest-version probe unreachable: ${
+        unreachableHostMessage(err, PANEL_PYPROJECT_RAW_URL, "the panel version check").message
+      }`,
+    );
+    return undefined;
+  }
+  if (!res.ok) {
+    logger.debug(
+      `[panel-auto-update] latest-version probe HTTP ${res.status} (host answered)`,
+    );
+    return undefined;
+  }
+  try {
+    const toml = await res.text();
+    const parsed = parsePyproject(toml);
+    if (parsed.projectName !== PANEL_REGISTRY_ID) return undefined;
+    const v = parsed.version?.trim();
+    return v || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * One periodic tick: CHECK always (when we can), APPLY only when `apply` is
+ * true. The caller owns the transport gate — this function must not re-derive
+ * it, or the two will drift.
+ */
+export async function tickPanelAutoUpdate(
+  opts: { apply: boolean; deps?: Partial<PanelAutoUpdateDeps> } = { apply: true },
+): Promise<PanelAutoUpdateResult> {
+  const deps: PanelAutoUpdateDeps = { ...defaultDeps, ...opts.deps };
+  try {
+    if (isPanelAutoInstallDisabled(deps.env())) {
+      return { action: "skipped-disabled", note: "Panel auto-update disabled via COMFYUI_MCP_PANEL_AUTOINSTALL." };
+    }
+
+    const status = await deps.panelStatus();
+    if (!status.applicable) {
+      return { action: "unavailable", note: status.note || "Panel auto-update does not apply here." };
+    }
+    if (status.isDevSymlink) {
+      return {
+        action: "skipped-dev",
+        from: status.installedVersion,
+        note: "Dev symlink — panel auto-update will not modify it.",
+      };
+    }
+    if (status.pin?.pinned) {
+      return {
+        action: "skipped-pin",
+        from: status.installedVersion,
+        note: "Panel is pinned — auto-update will not move it.",
+      };
+    }
+
+    const latest = await deps.latestVersion();
+    const current = status.installedVersion;
+    if (!latest || !current) {
+      return {
+        action: "unavailable",
+        from: current,
+        to: latest,
+        note: "Could not determine the latest published panel version. This is NOT evidence that you are up to date.",
+      };
+    }
+    if (!isNewer(latest, current)) {
+      return { action: "up-to-date", from: current, to: latest };
+    }
+
+    if (!opts.apply) {
+      return {
+        action: "deferred",
+        from: current,
+        to: latest,
+        note: deferredAutoUpdateNote({ component: "panel", from: current, to: latest }),
+      };
+    }
+
+    const after = await deps.updatePanel();
+    return {
+      action: "updated",
+      from: current,
+      to: after.installedVersion ?? latest,
+      note:
+        `Updated ComfyUI-MCP panel ${current} → ${after.installedVersion ?? latest}. ` +
+        `Restart ComfyUI to load it.`,
+    };
+  } catch (err) {
+    logger.debug(
+      `[panel-auto-update] tick failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return {
+      action: "unavailable",
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/services/self-restart.ts
+++ b/src/services/self-restart.ts
@@ -48,6 +48,7 @@ import {
 } from "./self-update.js";
 import { releaseOwnedPanelLock } from "./panel-pin-guard.js";
 import { logger } from "../utils/logger.js";
+import { deferredAutoUpdateNote } from "./auto-update-gate.js";
 
 /** Registry re-check period. An hour keeps update latency low at ~24 tiny
  *  registry GETs a day; override for tuning/tests. */
@@ -73,6 +74,26 @@ export interface SelfRestartDeps {
   entryMtime: () => number | undefined;
   /** Every agent idle + nothing queued (caller may fold in extra gates). */
   allIdle: () => boolean;
+  /**
+   * #1963 — may we APPLY (disk mutate + restart)? Checking still runs when this
+   * is false. Default true so MCP-stdio / tests without a pairing context apply
+   * as they always have. The orchestrator wires the transport gate here; it is
+   * NOT folded into allIdle, because idle is about in-flight work and this is
+   * about a phone whose tunnel URL would die on a restart.
+   */
+  applyAllowed: () => boolean;
+  /**
+   * Same periodic tick as the orchestrator check, for the sidebar panel. The
+   * restarter passes the same `apply` bit so a tunnel pairing cannot update
+   * one and not the other. Optional: stdio / tests without a panel skip it.
+   * The restarter owns deferred/updated announcements so they fire once.
+   */
+  panelTick?: (opts: { apply: boolean }) => Promise<{
+    action: string;
+    from?: string;
+    to?: string;
+    note?: string;
+  } | void>;
   /** Broadcast a chat line to every panel tab. */
   announce: (text: string) => void;
   /** Clean teardown (close bridge/listeners, stop agents) — NO process.exit. */
@@ -139,6 +160,7 @@ export const defaultSelfRestartDeps: SelfRestartDeps = {
   latestVersion: () => getLatestPublishedVersion(),
   entryMtime: defaultEntryMtime,
   allIdle: () => true,
+  applyAllowed: () => true,
   announce: () => {},
   teardown: async () => {},
   spawnReplacement: defaultSpawnReplacement,
@@ -181,6 +203,8 @@ export class SelfRestarter {
   private restarting = false;
   /** Versions already announced when restart is disabled — once each. */
   private announced = new Set<string>();
+  /** apply_updates_now: one tick (and its armed restart) may ignore the gate. */
+  private forceApply = false;
   stopped = false;
 
   constructor(deps: Partial<SelfRestartDeps> = {}) {
@@ -249,15 +273,50 @@ export class SelfRestarter {
     this.arm({ reason: "a new dev build landed" });
   }
 
-  /** PUBLISHED: run the self-update policy engine; arm a restart on change. */
-  async updateTick(): Promise<void> {
+  /**
+   * Re-evaluate after the pair-time toggle flips. An armed restart that was
+   * waiting on the tunnel gate can fire; otherwise a fresh check runs so an
+   * update found while deferred is not stuck until the next hourly tick.
+   */
+  requestApplyPolicyRefresh(): void {
+    this.tryRestart();
+    if (!this.pending && !this.restarting && !this.stopped) {
+      void this.updateTick();
+    }
+  }
+
+  /** PUBLISHED: CHECK the registry; APPLY only when the transport gate allows. */
+  async updateTick(opts: { forceApply?: boolean } = {}): Promise<void> {
     if (this.stopped || this.pending || this.restarting) return;
+    if (opts.forceApply) this.forceApply = true;
+    const apply = this.forceApply || this.deps.applyAllowed();
     try {
+      if (this.deps.panelTick) {
+        const panelRes = await this.deps.panelTick({ apply });
+        if (panelRes?.action === "deferred" && panelRes.from && panelRes.to) {
+          this.noteDeferred("panel", panelRes.from, panelRes.to);
+        } else if (panelRes?.action === "updated" && panelRes.note) {
+          this.deps.announce(`⬆️ ${panelRes.note}`);
+        }
+      }
+      if (!apply) {
+        // CHECK-ONLY. Must not call checkAndSelfUpdate — that mutates on disk.
+        const latest = await this.deps.latestVersion();
+        const current = this.info.currentVersion;
+        if (latest && current && isNewer(latest, current)) {
+          this.noteDeferred("orchestrator", current, latest);
+        }
+        this.forceApply = false;
+        return;
+      }
       if (this.info.mode === "npx") {
         // npx can't be updated on disk — respawn pinned to the new version.
         const latest = await this.deps.latestVersion();
         const current = this.info.currentVersion;
-        if (!latest || !current || !isNewer(latest, current)) return;
+        if (!latest || !current || !isNewer(latest, current)) {
+          if (!this.pending) this.forceApply = false;
+          return;
+        }
         this.arm({ reason: `updating ${current} → ${latest}`, npxVersion: latest });
         return;
       }
@@ -266,10 +325,22 @@ export class SelfRestarter {
       const res = await this.deps.checkAndSelfUpdate();
       if (res.action === "updated") {
         this.arm({ reason: `updated ${res.from ?? "?"} → ${res.to ?? "?"}` });
+      } else if (!this.pending) {
+        this.forceApply = false;
       }
     } catch (err) {
+      if (!this.pending) this.forceApply = false;
       logger.debug(`[self-restart] update check failed: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  private noteDeferred(component: "orchestrator" | "panel", from: string, to: string): void {
+    const key = `deferred:${component}:${from}:${to}`;
+    if (this.announced.has(key)) return;
+    this.announced.add(key);
+    const note = deferredAutoUpdateNote({ component, from, to });
+    logger.info(`[self-restart] ${note}`);
+    this.deps.announce(note);
   }
 
   /** Record the restart intent. With AUTORESTART off, notify once instead. */
@@ -293,6 +364,10 @@ export class SelfRestarter {
   tryRestart(): void {
     if (!this.pending || this.restarting || this.stopped) return;
     if (this.deps.uptimeMs() < MIN_UPTIME_MS) return;
+    // #1963 — a restart armed at the desk must still refuse to fire after a
+    // phone pairs over a quick-tunnel. Pending stays set; the next policy
+    // refresh or disconnect (pairTunnel cleared) lets it through.
+    if (!this.forceApply && !this.deps.applyAllowed()) return;
     if (!this.deps.allIdle()) return;
     this.restarting = true;
     const { reason, npxVersion } = this.pending;
@@ -311,6 +386,7 @@ export class SelfRestarter {
       logger.error("[self-restart] could not spawn the replacement — staying on the current process");
       this.deps.announce("⚠️ Restart failed to launch a replacement — still running the current version.");
       this.restarting = false;
+      this.forceApply = false;
       return;
     }
     // The successor is already running. Drop any panel-op.lock we still hold


### PR DESCRIPTION
Fixes #1963

Auto-update is no longer all-or-nothing. Checking is always allowed; applying (disk mutate + restart) follows the transport:

```
applyUpdate = updateAvailable && !(activeTransport === "quick-tunnel" && pairingActive)
```

- **At the desk** (LAN / no pairing tunnel, and relay): check **and** apply, for the orchestrator **and** the panel.
- **On a mobile quick-tunnel**: check, and a one-line notice says an update is waiting; **never apply** — that restart rotates the cloudflared hostname and disconnects the phone.

`pairingActive` is sticky on the tunnel handle (`pairTunnel != null`), not a live socket. A locked screen / 5G handoff no longer opens the gate. Pair time carries a toggle defaulted ON ("Don't update while my phone is paired") and an `apply_updates_now` affordance for when the user is back at the desk.

The panel path asks the published pyproject (not the floor), so a pack three versions behind is no longer reported healthy. Pins, dev symlinks, and `COMFYUI_MCP_PANEL_AUTOINSTALL=0` still refuse to move it.
