### PR TITLE
docs(unslop): plugin skills a through f say the plain thing

### DIFF
--- a/plugin/skills/ai-toolkit-trainer/SKILL.md
+++ b/plugin/skills/ai-toolkit-trainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-toolkit-trainer
-description: Train custom LoRAs with ostris AI-Toolkit — covers WAN 2.2/2.1 (people, styles, video motion) and Z-Image (Turbo & Base, low-VRAM image LoRAs). Use when the user wants to train a WAN or Z-Image LoRA; covers local + RunPod setup, dataset prep, key params, and using the result in a ComfyUI workflow.
+description: Train custom LoRAs with ostris AI-Toolkit. Covers WAN 2.2/2.1 (people, styles, video motion) and Z-Image (Turbo & Base, low-VRAM image LoRAs). Use when the user wants to train a WAN or Z-Image LoRA; covers local + RunPod setup, dataset prep, key params, and using the result in a ComfyUI workflow.
 globs:
   - "**/*.json"
 ---
@@ -9,26 +9,26 @@ globs:
 
 ## Overview
 
-**AI-Toolkit** by **ostris** is "the ultimate training toolkit for finetuning diffusion models" (MIT license) — a **standalone trainer with its own web UI**, NOT a ComfyUI custom node. It runs a Node.js UI front end over a Python (`run.py`) training backend, and trains LoRAs for many model families — here we cover **WAN 2.2 / 2.1** video models and **Z-Image** (Turbo & Base).
+AI-Toolkit by ostris is an MIT-licensed trainer for finetuning diffusion models. It is a standalone trainer with its own web UI, not a ComfyUI custom node. It runs a Node.js UI front end over a Python (`run.py`) training backend and trains LoRAs for many model families. This skill covers the WAN 2.2 / 2.1 video models and Z-Image (Turbo & Base).
 
-- Repo: **`https://github.com/ostris/ai-toolkit`** (cloned by the installers).
-- Backend: `python run.py config/<job>.yml`. UI: a Node.js app under `ui/` that schedules/monitors jobs (you don't have to keep the UI open while a job runs).
+- Repo: `https://github.com/ostris/ai-toolkit` (cloned by the installers).
+- Backend: `python run.py config/<job>.yml`. UI: a Node.js app under `ui/` that schedules and monitors jobs. You do not have to keep the UI open while a job runs.
 - Output: a standard `.safetensors` LoRA you drop into ComfyUI `models/loras/` and load with `LoraLoaderModelOnly`.
 
-**Best for:**
-- **WAN LoRAs** — a person/character, an art style, or a specific **camera/video motion** (image *or* video clip datasets). For *using* WAN see **wan-t2v-video** / **wan-flf-video**.
-- **Z-Image LoRAs** — fast, **very low-VRAM** image LoRAs (faces, characters, outfits, styles) on the 6B Z-Image base/turbo. For *using* Z-Image see **z-image-base** / **z-image-turbo** (and the **z-image-xy-plot** pack to compare trained LoRAs).
+Best for:
+- WAN LoRAs. A person or character, an art style, or a specific camera or video motion, trained from image or video clip datasets. For *using* WAN see wan-t2v-video / wan-flf-video.
+- Z-Image LoRAs. Fast, very low-VRAM image LoRAs (faces, characters, outfits, styles) on the 6B Z-Image base/turbo. For *using* Z-Image see z-image-base / z-image-turbo, and the z-image-xy-plot pack to compare trained LoRAs.
 
-For low-VRAM anime image LoRAs on a different stack (kohya `sd-scripts`), see the sibling **anima-lora-trainer**.
+For low-VRAM anime image LoRAs on a different stack (kohya `sd-scripts`), see the sibling anima-lora-trainer.
 
-> **Two LoRA kinds (WAN):** a **WAN image LoRA** trains on still images (cheaper, ~24GB-class, good for identity/style); a **WAN video LoRA** trains on short clips (heavier — best on cloud — good for *motion*). **Z-Image** is image-only.
+> Two LoRA kinds for WAN. A WAN image LoRA trains on still images; it is cheaper (~24GB-class) and suits identity or style. A WAN video LoRA trains on short clips; it is heavier, best run on cloud, and suits *motion*. Z-Image is image-only.
 
 ## Install
 
-The installer comes in two generations — both clone `ostris/ai-toolkit`, set up Torch for your GPU, and launch the web UI. Put it in a folder whose **full path has NO spaces** (e.g. `C:\AI-Toolkit`).
+The installer comes in two generations. Both clone `ostris/ai-toolkit`, set up Torch for your GPU, and launch the web UI. Put it in a folder whose full path has no spaces (e.g. `C:\AI-Toolkit`).
 
-- **V1 — `AI-TOOLKIT_AUTO_INSTALL.bat`**: expects **Git**, **Python 3.10.x**, and **Node 18+** already in PATH.
-- **V2 — `AI-TOOLKIT_AUTO_INSTALL-V2.bat`** (recommended): uses an **embedded Python 3.10.11**, **auto-installs Git + Node**, builds a clean PATH without your system Python, and adds aggressive pip/curl retries — far fewer prerequisites and the more robust choice. (Used for the Z-Image Turbo LoRA training release.)
+- V1, `AI-TOOLKIT_AUTO_INSTALL.bat`, expects Git, Python 3.10.x, and Node 18+ already in PATH.
+- V2, `AI-TOOLKIT_AUTO_INSTALL-V2.bat` (recommended), uses an embedded Python 3.10.11, auto-installs Git and Node, builds a clean PATH without your system Python, and adds aggressive pip/curl retries. It has far fewer prerequisites and fails less often. The Z-Image Turbo LoRA training release used it.
 
 Both are CUDA-aware and select the Torch wheel by GPU generation:
 
@@ -37,25 +37,25 @@ Both are CUDA-aware and select the Torch wheel by GPU generation:
 | 1 | RTX 50-series (Blackwell) | **12.8** | `https://download.pytorch.org/whl/cu128` | `torch==2.7.0 torchvision==0.22.0` |
 | 2 | RTX 40 / 30 / 20 and older | **12.6** | `https://download.pytorch.org/whl/cu126` | `torch==2.7.0 torchvision==0.22.0` |
 
-Each then: clones `ostris/ai-toolkit`; downloads two launcher scripts (`LAUNCHER-TOOLKIT.bat`, `SECURE_LAUNCHER-TOOLKIT.bat`, from `https://huggingface.co/Aitrepreneur/FLX/resolve/main/`); makes the venv; installs Torch from the chosen index; `pip install -r requirements.txt`; then `cd ui && npm run build_and_start`.
+Each then clones `ostris/ai-toolkit`, downloads two launcher scripts (`LAUNCHER-TOOLKIT.bat`, `SECURE_LAUNCHER-TOOLKIT.bat`, from `https://huggingface.co/Aitrepreneur/FLX/resolve/main/`), makes the venv, installs Torch from the chosen index, runs `pip install -r requirements.txt`, then `cd ui && npm run build_and_start`.
 
 ### RunPod / Linux — `AI-TOOLKIT_AUTO_INSTALL-RUNPOD.sh` (and `-V2.sh`)
 
-Installs into the persistent volume `/workspace/ai-toolkit`; **idempotent** (re-run just relaunches the UI). Use RunPod's **PyTorch 2.8.0** template, **100GB** disk. It installs apt deps, clones the repo, makes a venv, installs Torch (`torchaudio` included), installs **nvm + Node 22**, then builds/starts the UI.
+Installs into the persistent volume `/workspace/ai-toolkit`. It is idempotent; a re-run just relaunches the UI. Use RunPod's PyTorch 2.8.0 template and a 100GB disk. It installs apt deps, clones the repo, makes a venv, installs Torch (`torchaudio` included), installs nvm + Node 22, then builds and starts the UI.
 
 | Choice | GPU | Stream | Torch spec |
 |--------|-----|--------|-----------|
 | 1 | RTX 5000-series (Blackwell) | `cu128` | `torch==2.7.0+cu128 torchvision==0.22.0+cu128 torchaudio==2.7.0+cu128` |
 | 2 | Ada / Hopper / Ampere, older | `cu126` | `torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0` |
 
-**Ports & auth:** UI on **8675**, Jupyter on **8888**. Set **`AI_TOOLKIT_AUTH`** (UI password) before launch. Reach it at `https://${RUNPOD_POD_ID}-8675.proxy.runpod.net`. **GPU recs:** RTX **4090/5090** for image (WAN t2i/t2v, Z-Image) LoRAs; **RTX 6000 Pro (Blackwell)** for heavy WAN video / high-res / high-rank jobs.
+The UI listens on 8675 and Jupyter on 8888. Set `AI_TOOLKIT_AUTH` (UI password) before launch. Reach it at `https://${RUNPOD_POD_ID}-8675.proxy.runpod.net`. Use an RTX 4090/5090 for image (WAN t2i/t2v, Z-Image) LoRAs and an RTX 6000 Pro (Blackwell) for heavy WAN video, high-res, or high-rank jobs.
 
 ## Launching the web UI
 
-- **Windows:** run `LAUNCHER-TOOLKIT.bat` (local) or `SECURE_LAUNCHER-TOOLKIT.bat` (password-protected) from the `ai-toolkit` folder.
-- **RunPod:** rerun the `.sh` — it detects the install and starts the UI instantly on **:8675**.
+- On Windows, run `LAUNCHER-TOOLKIT.bat` (local) or `SECURE_LAUNCHER-TOOLKIT.bat` (password-protected) from the `ai-toolkit` folder.
+- On RunPod, rerun the `.sh`. It detects the install and starts the UI on :8675.
 
-In the UI: create a **Job**, point it at a dataset folder, pick the model (WAN variant or Z-Image), set params, start. Jobs run in the Python backend, so you can close the browser. (Or bypass the UI: copy a `config/examples/*.yml`, edit, `python run.py config/<job>.yml`.)
+In the UI, create a Job, point it at a dataset folder, pick the model (WAN variant or Z-Image), set params, and start. Jobs run in the Python backend, so you can close the browser. To bypass the UI, copy a `config/examples/*.yml`, edit it, and run `python run.py config/<job>.yml`.
 
 ## Dataset preparation
 
@@ -67,16 +67,16 @@ my_dataset/
   001.png  001.txt
   002.jpg  002.txt
 ```
-- Captions: natural-language; include a **unique trigger word** for a person/character.
-- ~15–40 varied images for a person; more for a broad style.
+- Captions are natural language. Include a unique trigger word for a person or character.
+- Use about 15 to 40 varied images for a person, more for a broad style.
 
 ### Video LoRA (WAN motion only)
-Short clips + a `.txt` per clip; caption the **motion/camera move**. Per-clip frames via the job's `num_frames` (e.g. **81**). Markedly heavier — prefer cloud GPUs.
+Short clips plus a `.txt` per clip; caption the motion or camera move. Set per-clip frames via the job's `num_frames` (e.g. 81). This is markedly heavier, so prefer cloud GPUs.
 
 ## Key training params
 
 ### WAN 2.2
-WAN 2.2 14B is a Mixture-of-Experts with a **high-noise** expert (structure/motion) and a **low-noise** expert (detail). AI-Toolkit trains both via **Multi-stage**.
+WAN 2.2 14B is a Mixture-of-Experts with a high-noise expert (structure/motion) and a low-noise expert (detail). AI-Toolkit trains both via Multi-stage.
 
 | Param | Default | Notes |
 |-------|---------|-------|
@@ -90,7 +90,7 @@ WAN 2.2 14B is a Mixture-of-Experts with a **high-noise** expert (structure/moti
 | Optimizer / Quant | AdamW8bit / 4-bit ARA or float8 | fits 14B on consumer cards |
 
 ### Z-Image (Turbo & Base)
-Z-Image is a ~6B **single-stream** model — **no hi/lo multi-stage** (leave Multi-stage OFF; you train one model). It's the lightest target here: the headline of the Z-Image releases is training on very low VRAM.
+Z-Image is a ~6B single-stream model with no hi/lo multi-stage. Leave Multi-stage OFF; you train one model. It is the lightest target here. The headline of the Z-Image releases is training on very low VRAM.
 
 | Param | Starting point | Notes |
 |-------|----------------|-------|
@@ -101,48 +101,48 @@ Z-Image is a ~6B **single-stream** model — **no hi/lo multi-stage** (leave Mul
 | Multi-stage | **OFF** | single-stream model, not WAN's MoE |
 | Optimizer / Quant | AdamW8bit / float8 | enables sub-12GB training |
 
-> **Train on Base, deploy anywhere.** Z-Image **Base** is the finetuning-friendly model; a LoRA trained on Base generally applies to the Turbo workflow too. Use the **z-image-xy-plot** pack to grid-compare your trained LoRAs.
+> Train on Base, deploy anywhere. Z-Image Base is the finetuning-friendly model; a LoRA trained on Base generally applies to the Turbo workflow too. Use the z-image-xy-plot pack to grid-compare your trained LoRAs.
 
-> Param tables are aggregated starting points (community/training-guide sources), **not** read from the repo's `config/examples/*.yml` — open the actual WAN / Z-Image example config in your clone and tune. See "Unverified".
+> The param tables are aggregated starting points from community and training-guide sources, not read from the repo's `config/examples/*.yml`. Open the actual WAN / Z-Image example config in your clone and tune. See "Unverified".
 
 ## VRAM / GPU guidance
 
-- **Z-Image image LoRA:** the lightest — trainable on modest consumer GPUs with quantization (the releases tout very-low-VRAM training); a 4090 is comfortable, smaller cards work with float8 + 512–768 res.
-- **WAN image LoRA (t2i/t2v):** **24GB+** locally with quantization; below that, use RunPod.
-- **WAN video LoRA / high res / high rank:** heavier — cloud (RTX 5090, or RTX 6000 Pro Blackwell / H100).
-- Memory savers: quantization, batch size 1, 512 res, and (WAN) raise **Switch Every**.
+- Z-Image image LoRA is the lightest. It trains on modest consumer GPUs with quantization (the releases describe very-low-VRAM training); a 4090 is comfortable, and smaller cards work with float8 at 512 to 768 res.
+- WAN image LoRA (t2i/t2v) needs 24GB+ locally with quantization. Below that, use RunPod.
+- WAN video LoRA, high res, or high rank is heavier. Use cloud (RTX 5090, or RTX 6000 Pro Blackwell / H100).
+- Memory savers: quantization, batch size 1, 512 res, and (WAN) raising Switch Every.
 
 ## Using the trained LoRA in ComfyUI
 
-1. Copy `<your_lora>.safetensors` into ComfyUI **`models/loras/`**.
-2. Load with **`LoraLoaderModelOnly`**:
-   - **WAN 2.2** is **dual hi/lo** — apply the LoRA to **both** the HighNoise and LowNoise model branches (like lightning/concept LoRAs in **wan-t2v-video**). Typical strength **0.5–1.0**.
-   - **Z-Image** is a **single model** — one `LoraLoaderModelOnly` on the Z-Image model path (see the **z-image-base** / **z-image-turbo** packs). Strength **0.7–1.0**.
+1. Copy `<your_lora>.safetensors` into ComfyUI `models/loras/`.
+2. Load with `LoraLoaderModelOnly`:
+   - WAN 2.2 is dual hi/lo. Apply the LoRA to both the HighNoise and LowNoise model branches (like lightning/concept LoRAs in wan-t2v-video). Typical strength 0.5 to 1.0.
+   - Z-Image is a single model. Use one `LoraLoaderModelOnly` on the Z-Image model path (see the z-image-base / z-image-turbo packs). Strength 0.7 to 1.0.
    ```json
    { "class_type": "LoraLoaderModelOnly",
      "inputs": { "model": ["<base_model>", 0],
                  "lora_name": "<your_lora>.safetensors",
                  "strength_model": 1.0 } }
    ```
-3. Prompt using the **trigger word / caption style** you trained with (for WAN motion LoRAs, describe the same camera/motion).
+3. Prompt using the trigger word or caption style you trained with. For WAN motion LoRAs, describe the same camera or motion.
 
 ## Troubleshooting
 
-- **`No module named 'torchaudio'` when starting a job (AI-Toolkit).** The venv's Torch stack is mismatched. **Fix:** activate the AI-Toolkit venv (`venv\Scripts\activate`), then `pip uninstall torch torchaudio torchvision -y` and `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121` (or your CUDA's index). Only affects the AI-Toolkit install, not ComfyUI.
+- **`No module named 'torchaudio'` when starting a job (AI-Toolkit).** The venv's Torch stack is mismatched. Activate the AI-Toolkit venv (`venv\Scripts\activate`), then `pip uninstall torch torchaudio torchvision -y` and `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121` (or your CUDA's index). This only affects the AI-Toolkit install, not ComfyUI.
 - **`self and mat2 must have the same dtype` (ComfyUI-WanVideoWrapper, WAN usage).** Re-clone `ComfyUI-WanVideoWrapper` in `custom_nodes/` and reinstall its `requirements.txt`, then restart ComfyUI.
 - **5000-series (Blackwell) onnxruntime "QuickGelu" / CUDA error.** `pip install onnxruntime==1.20.1` in the affected venv.
-- **Pascal/Maxwell GPUs (GTX 9xx/10xx).** Recent Torch (cu128/cu130) dropped them — reinstall the **cu126** Torch build into the venv.
+- **Pascal/Maxwell GPUs (GTX 9xx/10xx).** Recent Torch (cu128/cu130) dropped them. Reinstall the cu126 Torch build into the venv.
 - **Path with spaces (Windows).** Keep the install path space-free or the build/launch fails.
 - **OOM during training.** Quantization (4-bit ARA / float8), 512 res, batch 1, (WAN) raise Switch Every, or a bigger RunPod GPU.
-- **RunPod UI won't load / asks for a password.** Confirm `AI_TOOLKIT_AUTH` is set and you're on the **8675** proxy URL.
+- **RunPod UI won't load / asks for a password.** Confirm `AI_TOOLKIT_AUTH` is set and you're on the 8675 proxy URL.
 
 ## Unverified / verify before relying
 
-- The **param tables** (both WAN and Z-Image) are synthesized starting points, **not** read from the repo's `config/examples/*.yml`. Open the actual example config in your clone and adjust.
-- **Z-Image VRAM floor** for training is described qualitatively ("very low VRAM") in the release notes — confirm against your card; quantization + 512–768 res is the lever.
-- **Ports:** Windows UI port is whatever the launcher binds (the installer doesn't print it — check the launcher window). RunPod **8675**/**8888** are per the template.
-- The launcher `.bat` files are downloaded from a **third-party HuggingFace repo** (`Aitrepreneur/FLX`); review before running on a security-sensitive machine.
-- Model weights are fetched at job time by AI-Toolkit/HF, not by the installer — confirm the model selector lists your target WAN variant or Z-Image model before a long run.
+- The param tables (both WAN and Z-Image) are synthesized starting points, not read from the repo's `config/examples/*.yml`. Open the actual example config in your clone and adjust.
+- The release notes describe the Z-Image training VRAM floor only qualitatively ("very low VRAM"). Confirm against your card; quantization plus 512 to 768 res is the lever.
+- The Windows UI port is whatever the launcher binds (the installer doesn't print it; check the launcher window). RunPod 8675/8888 are per the template.
+- The launcher `.bat` files are downloaded from a third-party HuggingFace repo (`Aitrepreneur/FLX`); review before running on a security-sensitive machine.
+- Model weights are fetched at job time by AI-Toolkit/HF, not by the installer. Confirm the model selector lists your target WAN variant or Z-Image model before a long run.
 
 ## Sources
 

--- a/plugin/skills/anima-base/SKILL.md
+++ b/plugin/skills/anima-base/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anima-base
-description: Anime/illustration text-to-image (ANIMA 1.0, ~2B Cosmos DiT) — use for anime, manga, illustrated characters; accepts Danbooru tags + natural language; runs/trains on <6GB VRAM; includes anime inpainting via Anima-LLLite ControlNet
+description: Anime/illustration text-to-image (ANIMA 1.0, ~2B Cosmos DiT). Use for anime, manga, illustrated characters; accepts Danbooru tags + natural language; runs/trains on <6GB VRAM; includes anime inpainting via Anima-LLLite ControlNet
 globs:
   - "**/*.json"
 ---
@@ -9,14 +9,14 @@ globs:
 
 ## Overview
 
-**Anima** is a ~2B-parameter anime / illustration text-to-image base model from **CircleStone Labs** (in collaboration with Comfy Org). It is **not** SDXL-lineage: the architecture is **NVIDIA Cosmos-Predict2-2B-Text2Image (a DiT / flow model)**, trained on several million anime images plus ~800k non-anime artistic images. It is **best for anime, manga, and illustrated characters/styles** (not realism).
+Anima is a ~2B-parameter anime / illustration text-to-image base model from CircleStone Labs, made in collaboration with Comfy Org. It is not SDXL-lineage. The architecture is NVIDIA Cosmos-Predict2-2B-Text2Image (a DiT / flow model), trained on several million anime images plus ~800k non-anime artistic images. It suits anime, manga, and illustrated characters and styles, not realism.
 
 Key traits:
-- Accepts **Danbooru-style tags AND/OR natural language** in the same prompt.
-- Very low VRAM — generates (and trains) on **<6GB VRAM**; runs on any PC that can run SDXL/Illustrious.
-- License: **CircleStone Labs Non-Commercial License** (with NVIDIA Open Model License terms on the weights/derivatives). Generated images are usable commercially per the model card — verify the current license text before relying on this.
+- Accepts Danbooru-style tags and/or natural language in the same prompt.
+- Very low VRAM. It generates and trains on <6GB VRAM and runs on any PC that can run SDXL/Illustrious.
+- License: CircleStone Labs Non-Commercial License, with NVIDIA Open Model License terms on the weights and derivatives. Generated images are usable commercially per the model card. Verify the current license text before relying on this.
 
-Loaded in ComfyUI with **standard split-file loaders** (not a single checkpoint):
+ComfyUI loads it with standard split-file loaders, not a single checkpoint:
 
 | Component | Node | Model file | Folder | Notes |
 |-----------|------|-----------|--------|-------|
@@ -24,11 +24,11 @@ Loaded in ComfyUI with **standard split-file loaders** (not a single checkpoint)
 | **Text encoder** | `CLIPLoader` | `qwen_3_06b_base.safetensors` | `models/text_encoders/` | Qwen3-0.6B base; **`type": "stable_diffusion"`** in this pack |
 | **VAE** | `VAELoader` | `qwen_image_vae.safetensors` | `models/vae/` | Qwen-Image VAE (~254MB) |
 
-> **Verified from the pack's workflow JSON:** `CLIPLoader` widget values are `["qwen_3_06b_base.safetensors", "stable_diffusion", "default"]`. (The HF model card describes standard loaders; the exact CLIP `type` string `stable_diffusion` is what the Aitrepreneur "Anima Base Ultra" workflow ships — use it as-is.)
+> Verified from the pack's workflow JSON: `CLIPLoader` widget values are `["qwen_3_06b_base.safetensors", "stable_diffusion", "default"]`. The HF model card describes standard loaders; the exact CLIP `type` string `stable_diffusion` is what the Aitrepreneur "Anima Base Ultra" workflow ships. Use it as-is.
 
 ## Installation
 
-The "Anima Base Ultra" pack (by Aitrepreneur) installs custom nodes and downloads all models. Models are mirrored on `https://huggingface.co/Aitrepreneur/FLX/resolve/main` (the official source is `https://huggingface.co/circlestone-labs/Anima`).
+The "Anima Base Ultra" pack (by Aitrepreneur) installs custom nodes and downloads all models. Models are mirrored on `https://huggingface.co/Aitrepreneur/FLX/resolve/main`; the official source is `https://huggingface.co/circlestone-labs/Anima`.
 
 ### Custom nodes (git clone into `ComfyUI/custom_nodes/`)
 
@@ -68,7 +68,7 @@ Base `$HF = https://huggingface.co/Aitrepreneur/FLX/resolve/main`, `$YOLO11 = ht
 | `ultralytics/segm/` | `yolo11m-seg.pt` | `$YOLO11` |
 | `sams/` | `sam_vit_b_01ec64.pth` | `$HF` |
 
-The DWPreprocessor/DepthAnythingV2 aux models (`dw-ll_ucoco_384_bs5.torchscript.pt`, `yolox_l.onnx`, `depth_anything_v2_vitl.pth`) are auto-fetched by `comfyui_controlnet_aux` on first use.
+`comfyui_controlnet_aux` fetches the DWPreprocessor/DepthAnythingV2 aux models (`dw-ll_ucoco_384_bs5.torchscript.pt`, `yolox_l.onnx`, `depth_anything_v2_vitl.pth`) on first use.
 
 ## Key Nodes
 
@@ -82,17 +82,17 @@ The DWPreprocessor/DepthAnythingV2 aux models (`dw-ll_ucoco_384_bs5.torchscript.
 ```
 
 ### Anima Turbo LoRA (the shipped default — 12-step fast mode)
-Applied with rgthree `Power Lora Loader`. The plain ComfyUI equivalent is `LoraLoaderModelOnly`:
+The pack applies it with rgthree `Power Lora Loader`. The plain ComfyUI equivalent is `LoraLoaderModelOnly`:
 ```json
 {
   "class_type": "LoraLoaderModelOnly",
   "inputs": { "model": ["1", 0], "lora_name": "anima-turbo-lora-v0.1.safetensors", "strength_model": 1.0 }
 }
 ```
-Other LoRAs the pack ships (toggle on/off in Power Lora Loader): `anima-highres-aesthetic-boost`, `anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`. In the **non-turbo** groups these three are enabled and the turbo LoRA is off; in the **turbo** groups only the turbo LoRA is on.
+The pack ships three other LoRAs you can toggle in Power Lora Loader: `anima-highres-aesthetic-boost`, `anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`. In the non-turbo groups these three are enabled and the turbo LoRA is off; in the turbo groups only the turbo LoRA is on.
 
 ### AnimaLLLiteApply (ControlNet + inpainting — from ComfyUI-Anima-LLLite)
-Patches the **MODEL** (Anima uses LLLite-style control, not standard `ControlNetApply` conditioning). Inputs: `model`, `image`, `mask`; widget order `[lllite_name, strength, start_percent, end_percent]`; output: patched `MODEL`.
+Patches the MODEL. Anima uses LLLite-style control, not standard `ControlNetApply` conditioning. Inputs: `model`, `image`, `mask`; widget order `[lllite_name, strength, start_percent, end_percent]`; output: patched `MODEL`.
 ```json
 {
   "class_type": "AnimaLLLiteApply",
@@ -108,7 +108,7 @@ Patches the **MODEL** (Anima uses LLLite-style control, not standard `ControlNet
 
 ## Settings
 
-The base model and the turbo-LoRA path want **different** settings:
+The base model and the turbo-LoRA path want different settings:
 
 | Mode | Steps | CFG | Sampler | Scheduler | Denoise | Notes |
 |------|-------|-----|---------|-----------|---------|-------|
@@ -116,11 +116,11 @@ The base model and the turbo-LoRA path want **different** settings:
 | **Turbo LoRA (shipped default)** | 12 | 1.0 | `er_sde` | `simple` | 1.0 | `anima-turbo-lora-v0.1` enabled |
 | Upscale pass (UltimateSDUpscale) | 12 | 1.0 | `er_sde` | `simple` | 0.28 | `4x_foolhardy_Remacri.pth`, scale 2x |
 
-**Sampler character (from model card):** `er_sde` = neutral style, flat colors, sharp lines; `euler_ancestral` = softer/thinner lines; `dpmpp_2m_sde_gpu` = similar with more variety. Optional `beta57` scheduler for painterly looks.
+Sampler character, from the model card: `er_sde` gives a neutral style, flat colors, sharp lines; `euler_ancestral` gives softer, thinner lines; `dpmpp_2m_sde_gpu` is similar with more variety. The optional `beta57` scheduler gives painterly looks.
 
 ## Resolutions
 
-The base model supports 512²–1536². The pack recommends these to avoid distortion:
+The base model supports 512² to 1536². The pack recommends these to avoid distortion:
 
 | Aspect | Resolution |
 |--------|-----------|
@@ -132,7 +132,7 @@ The base model supports 512²–1536². The pack recommends these to avoid disto
 
 ## Prompt Style
 
-Anima accepts **Danbooru tags + natural language together**. The pack's recommended formula:
+Anima accepts Danbooru tags and natural language together. The pack's recommended formula:
 
 ```
 masterpiece, best quality, score_7, safe, highres, official art,
@@ -145,15 +145,15 @@ She wears a black futuristic jacket with glowing blue details. Medium close-up, 
 reflections, soft background blur, cinematic lighting.
 ```
 
-Structure: **quality tags → subject/count tags → optional `@artist name` → anime style tags → 2–4 natural-language sentences** describing subject, outfit, pose, composition, background, lighting, mood. Use lowercase tags with spaces (not underscores), except score tags like `score_7`. Artist tags use `@artist name`; browse names at the community Anima Style Explorer (`https://thetacursed.github.io/Anima-Style-Explorer/`).
+The order is quality tags, then subject/count tags, then an optional `@artist name`, then anime style tags, then 2 to 4 natural-language sentences describing subject, outfit, pose, composition, background, lighting, and mood. Use lowercase tags with spaces (not underscores), except score tags like `score_7`. Artist tags use `@artist name`; browse names at the community Anima Style Explorer (`https://thetacursed.github.io/Anima-Style-Explorer/`).
 
-**Negative prompt (recommended):**
+Recommended negative prompt:
 ```
 worst quality, low quality, score_1, score_2, score_3, artist name, bad anatomy, bad hands,
 missing fingers, extra fingers, extra arms, extra legs, duplicate, twins, text, watermark,
 signature, simple background
 ```
-Unlike Flux/Qwen, Anima **does** use a real negative prompt via a second `CLIPTextEncode` (CFG > 1 in base mode).
+Unlike Flux/Qwen, Anima does use a real negative prompt via a second `CLIPTextEncode` (CFG > 1 in base mode).
 
 ## Complete Workflow: Text-to-Image (Turbo, 12-step)
 
@@ -178,11 +178,11 @@ Unlike Flux/Qwen, Anima **does** use a real negative prompt via a second `CLIPTe
 }
 ```
 
-**Base-quality variant (no turbo):** drop node 4 (feed `["1", 0]` into KSampler), set `steps: 30`, `cfg: 4.5`. Optionally enable the three quality LoRAs (`anima-highres-aesthetic-boost`, `anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`) by chaining `LoraLoaderModelOnly` nodes.
+For the base-quality variant (no turbo), drop node 4 (feed `["1", 0]` into KSampler), set `steps: 30`, `cfg: 4.5`. Optionally enable the three quality LoRAs (`anima-highres-aesthetic-boost`, `anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`) by chaining `LoraLoaderModelOnly` nodes.
 
 ## Complete Workflow: Anime Inpainting (Anima-LLLite ControlNet)
 
-The pack's "INPAINTING CONTROLNET" group: load an image with a painted mask, `VAEEncode` it, apply `SetLatentNoiseMask`, patch the model with the **inpainting LLLite** (fed the same image + mask), then sample. The mask region is regenerated from the prompt while the rest is preserved.
+The pack's "INPAINTING CONTROLNET" group loads an image with a painted mask, `VAEEncode`s it, applies `SetLatentNoiseMask`, patches the model with the inpainting LLLite (fed the same image and mask), then samples. The mask region is regenerated from the prompt and the rest is preserved.
 
 ```json
 {
@@ -212,34 +212,34 @@ The pack's "INPAINTING CONTROLNET" group: load an image with a painted mask, `VA
 }
 ```
 
-**Other LLLite ControlNets** (same `AnimaLLLiteApply` node, swap `lllite_name`, feed a preprocessed control image; mask can be a full-white/blank mask when not inpainting):
+The other LLLite ControlNets use the same `AnimaLLLiteApply` node. Swap `lllite_name` and feed a preprocessed control image; the mask can be a full-white/blank mask when not inpainting:
 - `anima-lllite-pose-1.safetensors` ← `DWPreprocessor` (OpenPose)
 - `anima-lllite-depth-1.safetensors` ← `DepthAnythingV2Preprocessor`
 - `anima-lllite-lineart-1.safetensors` / `anima-lllite-any-test-like-1-step2000.safetensors` ← lineart / generic control
 
 ## Upscaling (optional)
 
-The pack upscales with `UltimateSDUpscale` (`4x_foolhardy_Remacri.pth`, 2x, **denoise 0.28**, 12 steps, er_sde/simple) and refines faces/hands/eyes with Impact-Pack `FaceDetailer` driven by `UltralyticsDetectorProvider` (`face_yolov9c.pt`, `hand_yolov9c.pt`, `Eyeful_v2-Paired.pt`) + SAM (`sam_vit_b_01ec64.pth`).
+The pack upscales with `UltimateSDUpscale` (`4x_foolhardy_Remacri.pth`, 2x, denoise 0.28, 12 steps, er_sde/simple) and refines faces, hands, and eyes with Impact-Pack `FaceDetailer` driven by `UltralyticsDetectorProvider` (`face_yolov9c.pt`, `hand_yolov9c.pt`, `Eyeful_v2-Paired.pt`) + SAM (`sam_vit_b_01ec64.pth`).
 
 ## VRAM
 
-- Anima is ~2B params → generates in **<6GB VRAM** (runs anywhere SDXL/Illustrious runs).
-- Text encoder (Qwen3-0.6B) and VAE are both small.
-- A **GGUF** quantized build exists for even lower memory (`Abiray/Anima-base-v1.0-GGUF`) — would need a GGUF loader node (e.g. ComfyUI-GGUF), not included in this pack. *Unverified against this workflow.*
+- Anima is ~2B params, so it generates in <6GB VRAM and runs anywhere SDXL/Illustrious runs.
+- The text encoder (Qwen3-0.6B) and VAE are both small.
+- A GGUF quantized build exists for even lower memory (`Abiray/Anima-base-v1.0-GGUF`). It needs a GGUF loader node (e.g. ComfyUI-GGUF), which this pack does not include. *Unverified against this workflow.*
 
 ## Troubleshooting
 
-1. **Weird/distorted images** → use a recommended resolution (1024x1024, 896x1152, 832x1216, 768x1344, 640x1536).
-2. **Turbo result looks washed/flat** → that's turbo at CFG 1; for max quality switch to base mode (drop turbo LoRA, 30–50 steps, CFG 4–5).
-3. **`AnimaLLLiteApply` missing** → install `ComfyUI-Anima-LLLite`; it is **not** a standard ControlNet node.
-4. **CLIP loads but output is garbage** → confirm `CLIPLoader` `type` is `stable_diffusion` and the file is `qwen_3_06b_base.safetensors` (the Qwen3-0.6B *base*, not the chat/edit Qwen models).
-5. **Inpainting ignores the mask** → ensure both `SetLatentNoiseMask` AND the inpainting `AnimaLLLiteApply` receive the painted mask; encode the *source* image with `VAEEncode` (denoise 1.0 is fine because the noise mask preserves unmasked pixels).
+1. **Weird/distorted images.** Use a recommended resolution (1024x1024, 896x1152, 832x1216, 768x1344, 640x1536).
+2. **Turbo result looks washed/flat.** That's turbo at CFG 1. For max quality switch to base mode (drop turbo LoRA, 30 to 50 steps, CFG 4 to 5).
+3. **`AnimaLLLiteApply` missing.** Install `ComfyUI-Anima-LLLite`; it is not a standard ControlNet node.
+4. **CLIP loads but output is garbage.** Confirm `CLIPLoader` `type` is `stable_diffusion` and the file is `qwen_3_06b_base.safetensors` (the Qwen3-0.6B *base*, not the chat/edit Qwen models).
+5. **Inpainting ignores the mask.** Ensure both `SetLatentNoiseMask` and the inpainting `AnimaLLLiteApply` receive the painted mask, and encode the *source* image with `VAEEncode`. Denoise 1.0 is fine because the noise mask preserves unmasked pixels.
 
 ## Training custom LoRAs
 
-To train your own Anima LoRA (character/style) on <6GB VRAM, use the **Citron Anima LoRA Trainer** — see the `anima-lora-trainer` skill. Trained `.safetensors` LoRAs drop into `models/loras/` and load via `Power Lora Loader` / `LoraLoaderModelOnly` exactly like the bundled LoRAs above.
+To train your own Anima LoRA (character/style) on <6GB VRAM, use the Citron Anima LoRA Trainer; see the `anima-lora-trainer` skill. Trained `.safetensors` LoRAs drop into `models/loras/` and load via `Power Lora Loader` / `LoraLoaderModelOnly` exactly like the bundled LoRAs above.
 
 ## Sources
 
-- **Official:** model weights at https://huggingface.co/circlestone-labs/Anima — no vendor prompting guide cited.
+- **Official:** model weights at https://huggingface.co/circlestone-labs/Anima; no vendor prompting guide cited.
 - **Empirical:** tag-order / @artist prompting and sampler wiring from working graphs; Anima Style Explorer is community, not vendor docs.

--- a/plugin/skills/anima-lora-trainer/SKILL.md
+++ b/plugin/skills/anima-lora-trainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anima-lora-trainer
-description: Train a custom anime LoRA on the ANIMA base model — Citron's local Gradio trainer (kohya sd-scripts), <6GB VRAM, character/style LoRAs; covers setup, dataset prep, training params, and using the result in the anima-base workflow
+description: Train a custom anime LoRA on the ANIMA base model with Citron's local Gradio trainer (kohya sd-scripts), <6GB VRAM, character/style LoRAs; covers setup, dataset prep, training params, and using the result in the anima-base workflow
 globs:
   - "**/*.py"
   - "**/*.toml"
@@ -11,27 +11,27 @@ globs:
 
 ## Overview
 
-**Citron's Anima LoRA Trainer** (`app.py` = "🍋 Citron's Anima LoRA Trainer") is a local **Gradio** UI for training LoRA adapters on the **Anima** diffusion model using **kohya-ss/sd-scripts**. It trains on **~6GB VRAM** with the default settings — same low-VRAM profile as Anima generation.
+Citron's Anima LoRA Trainer (`app.py`, titled "Citron's Anima LoRA Trainer" in the UI) is a local Gradio UI for training LoRA adapters on the Anima diffusion model using kohya-ss/sd-scripts. It trains on ~6GB VRAM with the default settings, the same low-VRAM profile as Anima generation.
 
-- Created by **Citron Legacy**; UI repo: `https://github.com/citronlegacy/citron-anima-lora-trainer-ui`. The Aitrepreneur adaptive installers clone the fork `https://github.com/aitrepreneur/citron-anima-lora-trainer-ui`.
+- Created by Citron Legacy; UI repo: `https://github.com/citronlegacy/citron-anima-lora-trainer-ui`. The Aitrepreneur adaptive installers clone the fork `https://github.com/aitrepreneur/citron-anima-lora-trainer-ui`.
 - Training backend: `kohya-ss/sd-scripts` (`https://github.com/kohya-ss/sd-scripts`), launched via `accelerate launch`.
-- Trains LoRAs for **Anima DiT** (Cosmos-2B). Uses Anima's own components: DiT weights + Qwen3-0.6B text encoder + Qwen-Image VAE.
-- Output: standard `.safetensors` LoRA usable directly in the **anima-base** ComfyUI workflow.
+- Trains LoRAs for Anima DiT (Cosmos-2B). Uses Anima's own components: DiT weights + Qwen3-0.6B text encoder + Qwen-Image VAE.
+- Output: a standard `.safetensors` LoRA usable directly in the anima-base ComfyUI workflow.
 
-> Network module is `networks.lora_anima` and the training script is `sd-scripts/anima_train_network.py` (an Anima-specific kohya script the installer expects). Confirm these exist after the installer's `git clone` of sd-scripts — they are referenced by `app.py` but pulled from the upstream repo at install time.
+> The network module is `networks.lora_anima` and the training script is `sd-scripts/anima_train_network.py` (an Anima-specific kohya script the installer expects). Confirm these exist after the installer's `git clone` of sd-scripts. `app.py` references them, but they are pulled from the upstream repo at install time.
 
 ## Setup
 
 ### Windows
 Run `CITRON_ANIMA_LORA_TRAINER-V2.bat`. It:
-1. Ensures **Git** and **Python 3.10** (via winget if missing).
-2. Detects the NVIDIA GPU/driver and picks a matching **PyTorch CUDA wheel** automatically:
+1. Ensures Git and Python 3.10 are present (via winget if missing).
+2. Detects the NVIDIA GPU/driver and picks a matching PyTorch CUDA wheel automatically:
    - Blackwell (RTX 50xx) → cu128, bf16
    - Modern (RTX 20/30/40, etc.) → cu128/cu126/cu118 by driver, bf16 (fp16 on Turing)
-   - Pascal/Maxwell (GTX 10/9xx) → cu126/cu118, **fp16**
+   - Pascal/Maxwell (GTX 10/9xx) → cu126/cu118, fp16
    - Kepler/older → unsupported
 3. Clones the UI repo, patches `app.py` defaults (`base_model` → `anima-preview3-base`, `mixed_precision` → detected value), writes `app_configs/accelerate_gpu.yaml`.
-4. Creates `.venv`, installs PyTorch, clones+installs `sd-scripts`, installs app `requirements.txt`.
+4. Creates `.venv`, installs PyTorch, clones and installs `sd-scripts`, installs app `requirements.txt`.
 5. Downloads models into `models/anima/{dit,text_encoder,vae}/` from `https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/...`:
    - `dit/anima-base-v1.0.safetensors` (~4GB)
    - `text_encoder/qwen_3_06b_base.safetensors` (~1.19GB)
@@ -39,14 +39,14 @@ Run `CITRON_ANIMA_LORA_TRAINER-V2.bat`. It:
 6. Writes and launches `run_anima_base_windows.bat`.
 
 ### RunPod / Linux
-Run `CITRON_ANIMA_LORA_TRAINER-RUNPOD-V2.sh`. Same flow into `/workspace/citron-anima-lora-trainer-ui`; patches `server_name` to `0.0.0.0`; expose **HTTP port 7860** and open `Connect → HTTP Service 7860` (or `https://${RUNPOD_POD_ID}-7860.proxy.runpod.net`).
+Run `CITRON_ANIMA_LORA_TRAINER-RUNPOD-V2.sh`. Same flow into `/workspace/citron-anima-lora-trainer-ui`; it patches `server_name` to `0.0.0.0`. Expose HTTP port 7860 and open `Connect → HTTP Service 7860` (or `https://${RUNPOD_POD_ID}-7860.proxy.runpod.net`).
 
 ### Launch
-`app.py` runs Gradio on **`0.0.0.0:7860`** → open **http://127.0.0.1:7860**. Re-launch later with `run_anima_base_windows.bat` (Win) or `./run_anima_base_runpod.sh` (RunPod). The DiT base model **auto-downloads on first "Start Training"** if not already present (uses `wget`).
+`app.py` runs Gradio on `0.0.0.0:7860`, so open http://127.0.0.1:7860. Re-launch later with `run_anima_base_windows.bat` (Win) or `./run_anima_base_runpod.sh` (RunPod). The DiT base model auto-downloads on the first "Start Training" if not already present (uses `wget`).
 
 ## Dataset preparation
 
-A **flat folder** of images, each with a matching `.txt` caption of the same basename (image-side captioning, kohya style):
+A flat folder of images, each with a matching `.txt` caption of the same basename (image-side captioning, kohya style):
 ```
 my_dataset/
   001.png      001.txt
@@ -57,7 +57,7 @@ my_dataset/
 - Captions are Danbooru-style tags / natural language (same prompt style as Anima generation). The trainer warns about any image missing a `.txt`.
 - `caption_extension = .txt`; `shuffle_caption = false`; `caption_dropout_rate` default `0.1` (set per dataset).
 
-The UI tab "Training" takes **Image Directory** (the flat folder above) and **Output Directory** (where the LoRA is saved). "Configure Training" validates the dataset, prints a **step estimate** (`steps_per_epoch = ceil(images × repeats / (batch × grad_accum))`, `total = spe × epochs`), then writes two TOMLs into `configs/`.
+The UI tab "Training" takes Image Directory (the flat folder above) and Output Directory (where the LoRA is saved). "Configure Training" validates the dataset, prints a step estimate (`steps_per_epoch = ceil(images × repeats / (batch × grad_accum))`, `total = spe × epochs`), then writes two TOMLs into `configs/`.
 
 ## Key training parameters (defaults from `app.py`)
 
@@ -103,7 +103,7 @@ Fixed in the generated training TOML (not exposed): `network_module = networks.l
 
 ## Generated config files
 
-`configs/<project>_training_<timestamp>.toml` — references the DiT (`pretrained_model_name_or_path`), `qwen3` text encoder, and `vae` paths from `models/anima/`, plus all params above.
+`configs/<project>_training_<timestamp>.toml` references the DiT (`pretrained_model_name_or_path`), `qwen3` text encoder, and `vae` paths from `models/anima/`, plus all params above.
 
 `configs/<project>_dataset_<timestamp>.toml`:
 ```toml
@@ -126,7 +126,7 @@ caption_dropout_rate = 0.1
 
 ## The sd-scripts command
 
-"Start Training" runs (streaming logs live to the UI and to `logs/<project>_<timestamp>.log`):
+"Start Training" runs the following and streams logs live to the UI and to `logs/<project>_<timestamp>.log`:
 ```bash
 accelerate launch \
   --config_file app_configs/accelerate_gpu.yaml \
@@ -140,26 +140,26 @@ accelerate launch \
 
 ## Output & using the LoRA
 
-- The trained LoRA is saved to your **Output Directory** as `<project_name>.safetensors` (plus per-epoch checkpoints, last `save_last_n_epochs` kept).
-- Copy it into ComfyUI `models/loras/` and load it in the **anima-base** workflow via `LoraLoaderModelOnly` (or rgthree `Power Lora Loader`):
+- The trained LoRA is saved to your Output Directory as `<project_name>.safetensors`, plus per-epoch checkpoints (the last `save_last_n_epochs` are kept).
+- Copy it into ComfyUI `models/loras/` and load it in the anima-base workflow via `LoraLoaderModelOnly` (or rgthree `Power Lora Loader`):
   ```json
   { "class_type": "LoraLoaderModelOnly",
     "inputs": { "model": ["<unet>", 0], "lora_name": "<project_name>.safetensors", "strength_model": 1.0 } }
   ```
-- Use the same prompt style you captioned with. Typical strength 0.7–1.0; stack with the turbo LoRA for fast 12-step generation.
+- Use the same prompt style you captioned with. Typical strength 0.7 to 1.0; stack with the turbo LoRA for fast 12-step generation.
 
 ## VRAM & tips
 
-- Defaults train on **~6GB VRAM** (network_dim 32, res 768, batch 1, gradient checkpointing + latent/TE caching).
-- **OOM?** The trainer suggests `network_dim=8` and/or `resolution=512`. Also keep batch 1 and use AdamW8bit.
-- GTX 1060 6GB works but is slow; 3GB cards are not realistic. Older-than-Pascal GPUs are unsupported.
+- Defaults train on ~6GB VRAM (network_dim 32, res 768, batch 1, gradient checkpointing + latent/TE caching).
+- On OOM, the trainer suggests `network_dim=8` and/or `resolution=512`. Also keep batch 1 and use AdamW8bit.
+- A GTX 1060 6GB works but is slow; 3GB cards are not realistic. GPUs older than Pascal are unsupported.
 - Step count rule of thumb: `images × repeats × epochs / (batch × grad_accum)`. The UI prints the exact estimate before you train.
-- Logs stream to the UI and `logs/`. Training config + last paths persist in `config.json` so you can re-run.
+- Logs stream to the UI and `logs/`. Training config and last paths persist in `config.json` so you can re-run.
 
 ## Unverified / verify before relying
 
-- `sd-scripts/anima_train_network.py` and `networks.lora_anima` come from the kohya fork pulled at install time — present per `app.py`'s expectations but not in the local downloaded files here.
-- Exact LoRA output filename is `<project_name>.safetensors` per `output_name`; confirm in your Output Directory after a run.
+- `sd-scripts/anima_train_network.py` and `networks.lora_anima` come from the kohya fork pulled at install time. `app.py` expects them, but they are not in the local downloaded files here.
+- The exact LoRA output filename is `<project_name>.safetensors` per `output_name`; confirm in your Output Directory after a run.
 
 ## Sources
 

--- a/plugin/skills/civitai/SKILL.md
+++ b/plugin/skills/civitai/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: civitai
-description: Discover Civitai models with the BUILT-IN download_model action:"search_civitai" and install/generate them locally — find a checkpoint/LoRA/embedding on Civitai, download it into ComfyUI, and use its trigger words. Optionally pair the official Civitai MCP for community features (images browsing, posting, collections).
+description: Discover Civitai models with the BUILT-IN download_model action:"search_civitai" and install/generate them locally. Find a checkpoint/LoRA/embedding on Civitai, download it into ComfyUI, and use its trigger words. Optionally pair the official Civitai MCP for community features (images browsing, posting, collections).
 ---
 
 # Civitai + comfyui-mcp
 
-comfyui-mcp has **native Civitai search built in** — `download_model` `action:"search_civitai"` —
+comfyui-mcp has native Civitai search built in (`download_model` `action:"search_civitai"`)
 plus the local half of the loop: download, wire, queue, tag. The full flow
-(find → install → generate) needs no other server, no API key, and works on
-EVERY backend, including small local models behind the compact router.
+(find, install, generate) needs no other server and no API key, and works on
+every backend, including small local models behind the compact router.
 
 ## The built-in flow (default path)
 
@@ -22,30 +22,30 @@ download_model({ action: "download_civitai", model_version_id, target_subfolder:
 list_local_models({ action: "list" })  →  panel_add_node loader / generate_image   # use it
 ```
 
-- **ALWAYS filter `base_models`** when the user's checkpoint family is known —
-  a Flux LoRA will not load on an SDXL checkpoint (see `model-compatibility`).
+- ALWAYS filter `base_models` when the user's checkpoint family is known.
+  A Flux LoRA will not load on an SDXL checkpoint (see `model-compatibility`).
   CivitAI labels: `Flux.1 D`, `SDXL 1.0`, `SD 1.5`, `Pony`, `Illustrious`,
   `Wan Video`.
 - `target_subfolder` must match the model type: `checkpoints`, `loras`, `vae`,
-  `controlnet`, `embeddings`, `upscale_models`, …
-- Results are **SFW-only by default** (`nsfw: true` to opt in).
-- Each hit carries **trigger words** — put them in the prompt after installing.
-- Prefer `model_version_id` over `model_id` — a Civitai page can list several
+  `controlnet`, `embeddings`, `upscale_models`, and so on.
+- Results are SFW-only by default (`nsfw: true` to opt in).
+- Each hit carries trigger words. Put them in the prompt after installing.
+- Prefer `model_version_id` over `model_id`. A Civitai page can list several
   versions and the user usually means a specific one.
 
-**API key (optional).** Search needs none. `CIVITAI_API_TOKEN` (from
-civitai.com/user/account) unlocks **gated/early-access downloads** and gated
-search results — set it once (panel Settings › "Set CivitAI token…" or env).
+Search needs no API key. `CIVITAI_API_TOKEN` (from
+civitai.com/user/account) unlocks gated/early-access downloads and gated
+search results. Set it once, in panel Settings under "Set CivitAI token…" or in env.
 
 ## Recipes
 
 **"Find me a good anime LoRA for Flux and install it"**
 1. `download_model({ action: "search_civitai", query: "anime style", types: ["LORA"], base_models: ["Flux.1 D"] })`.
-2. Present the top 3–5 with name, creator, base model, downloads, and the
+2. Present the top 3 to 5 with name, creator, base model, downloads, and the
    version id. Let the user pick.
 3. `download_model({ action: "download_civitai", model_version_id, target_subfolder: "loras" })`.
-4. In the panel: `panel_add_node` a `LoraLoader`, `panel_set_widget` the
-   `lora_name`, wire it between checkpoint and sampler — and use the hit's
+4. In the panel, `panel_add_node` a `LoraLoader`, `panel_set_widget` the
+   `lora_name`, wire it between checkpoint and sampler, and use the hit's
    trigger words in the prompt. Headless: `generate_image(action="image")` / build the workflow.
 
 **"Download this Civitai page for me"** (user pastes a URL)
@@ -56,9 +56,9 @@ search results — set it once (panel Settings › "Set CivitAI token…" or env
 
 ## Optional: the official Civitai MCP (community surface)
 
-For features beyond search→install — browsing example **images** and their
-generation params, collections, posting, reviews, bounties — pair the official
-remote server (no longer auto-bundled; add it once):
+For features beyond search and install (browsing example images and their
+generation params, collections, posting, reviews, bounties), pair the official
+remote server. It is no longer auto-bundled; add it once:
 
 ```bash
 claude mcp add --transport http civitai https://mcp.civitai.com/mcp \
@@ -68,17 +68,17 @@ claude mcp add --transport http civitai https://mcp.civitai.com/mcp \
 Then `mcp__civitai__*` tools appear alongside comfyui-mcp's. Its discovery
 results hand off identically (`modelVersions[].id` → `action:"download_civitai"`).
 
-**Boundaries:** that server also exposes **write/social** tools (post,
-comment, review, DM, follow). Those publish on the user's behalf — surface
-what you're about to post and get an explicit yes first. This skill is about
-discovery → local install → generation; don't post or message without being
+That server also exposes write/social tools (post,
+comment, review, DM, follow). Those publish on the user's behalf, so show
+what you're about to post and get an explicit yes first. This skill covers
+discovery, local install, and generation; don't post or message without being
 asked.
 
 ## See also
 
-- `model-registry` — curated direct download URLs (HF + Civitai notes)
-- `model-compatibility` — base-model / VAE / CLIP pairing (why a LoRA won't load)
-- `prompt-engineering` — Civitai image params are a prompt goldmine
+- `model-registry` for curated direct download URLs (HF + Civitai notes)
+- `model-compatibility` for base-model / VAE / CLIP pairing (why a LoRA won't load)
+- `prompt-engineering` because Civitai image params are a prompt goldmine
 
 ## Sources
 

--- a/plugin/skills/color-correction/SKILL.md
+++ b/plugin/skills/color-correction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: color-correction
-description: Diagnose and fix video/image color OBJECTIVELY with the get_image (action:"analyze_color") tool (scopes/stats — black/white points, contrast, saturation, clipping, cast) instead of eyeballing a contact sheet. Covers the "washed out" signature, why reference color-match (mkl/ColorMatch/ColorMatchAdobe) CAN'T add contrast a flat source lacks, the levels/contrast-stretch fix (core AdjustContrast / CurveEditor), the measure→fix→re-measure loop, the side-by-side sandbox pattern, and where to place the fix in a render graph (after decode, before save). Use when a render looks washed out / flat / dull / over-saturated / color-cast, or when deciding between a color-match and a contrast/levels fix.
+description: Diagnose and fix video/image color OBJECTIVELY with the get_image (action:"analyze_color") tool (scopes/stats such as black/white points, contrast, saturation, clipping, cast) instead of eyeballing a contact sheet. Covers the "washed out" signature, why reference color-match (mkl/ColorMatch/ColorMatchAdobe) CAN'T add contrast a flat source lacks, the levels/contrast-stretch fix (core AdjustContrast / CurveEditor), the measure→fix→re-measure loop, the side-by-side sandbox pattern, and where to place the fix in a render graph (after decode, before save). Use when a render looks washed out / flat / dull / over-saturated / color-cast, or when deciding between a color-match and a contrast/levels fix.
 globs:
   - "**/*.json"
   - "**/packs/**"
@@ -10,10 +10,10 @@ globs:
 
 ## The core principle
 
-**You cannot reliably judge color from a storyboard / contact sheet.** "Is it washed
-out?" flip-flops by eye, especially on AI-gen video. Make color **measurable** with the
-`get_image (action:"analyze_color")` MCP tool, read the numbers like a colorist reads scopes, then pick the
-fix the data points to — and re-measure to confirm. The whole skill is this loop:
+You cannot reliably judge color from a storyboard or contact sheet. "Is it washed
+out?" flip-flops by eye, especially on AI-gen video. Make color measurable with the
+`get_image (action:"analyze_color")` MCP tool, read the numbers like a colorist reads scopes, pick the
+fix the data points to, then re-measure to confirm. The whole skill is this loop:
 
 ```
 extract a frame ─► get_image (action:"analyze_color") ─► read black/white points + contrast + saturation
@@ -24,15 +24,15 @@ extract a frame ─► get_image (action:"analyze_color") ─► read black/whit
 
 > Origin: on a WAN-Animate render we argued for many turns over whether the clip was
 > "washed out." The instant we measured it, the answer was unambiguous and the *correct*
-> fix (a contrast stretch, NOT the color-match nodes we'd been adding) fell straight out.
+> fix (a contrast stretch, not the color-match nodes we'd been adding) fell straight out.
 
 ---
 
 ## The `get_image (action:"analyze_color")` tool
 
 Read-only. Source = `asset_id`, a ComfyUI output ref (`filename`/`subfolder`/`type`), or
-an image `path` (absolute, or under the output dir). It returns per-image stats + heuristic
-flags + a one-line verdict, and (optional) an overlaid R/G/B/luma **histogram PNG**.
+an image `path` (absolute, or under the output dir). It returns per-image stats, heuristic
+flags, a one-line verdict, and optionally an overlaid R/G/B/luma histogram PNG.
 
 ```
 get_image({ action: "analyze_color", filename: "render_00007_.png" })       # absolute numbers
@@ -40,7 +40,7 @@ get_image({ action: "analyze_color", path: "frame.png", reference_path: "src.jpg
 get_image({ action: "analyze_color", filename: "x.png", histogram: true })  # + histogram image
 ```
 
-**Videos:** `get_image (action:"analyze_color")` is image-only (no ffmpeg dep). Extract a frame first with the
+For videos, `get_image (action:"analyze_color")` is image-only (no ffmpeg dep). Extract a frame first with the
 ComfyUI venv's cv2:
 
 ```bash
@@ -48,7 +48,7 @@ ComfyUI venv's cv2:
   c.set(1, n//2); _,f=c.read(); cv2.imwrite(r'frame.png', f)"
 ```
 
-(grab the middle frame, or frame 0; for window-drift checks grab a frame from each window.)
+Grab the middle frame, or frame 0. For window-drift checks grab a frame from each window.
 
 ### What the numbers mean (8-bit)
 
@@ -68,42 +68,42 @@ Flags: `washedOut, lowContrast, liftedBlacks, dimHighlights, lowSaturation, colo
 
 ## The "washed out" signature
 
-Washed out = **compressed tonal range**, and it has an exact fingerprint:
+Washed out means compressed tonal range, and it has an exact fingerprint:
 
-- `whitePoint` well below 255 (e.g. **191**) — highlights never reach white
-- `blackPoint` lifted off 0 (e.g. **45**) — milky shadows
+- `whitePoint` well below 255 (e.g. 191), so highlights never reach white
+- `blackPoint` lifted off 0 (e.g. 45), giving milky shadows
 - `contrast` low (std < 45)
-- often *normal* saturation — **washout is usually NOT a saturation problem.**
+- often *normal* saturation. Washout is usually not a saturation problem.
 
-If you see that, the fix is a **levels / contrast stretch**, not a color match. (Real case:
-a WAN-Animate frame measured blackPoint 45 / whitePoint 191 / contrast 43 — clearly a range
-problem; saturation 0.25 was fine.)
+If you see that, the fix is a levels / contrast stretch, not a color match. In a real case,
+a WAN-Animate frame measured blackPoint 45 / whitePoint 191 / contrast 43, clearly a range
+problem; saturation 0.25 was fine.
 
 ---
 
 ## The load-bearing insight: a reference-match can't add contrast the source lacks
 
 The instinct is to "match the render to the input photo" with a color-match node
-(`ColorMatchV2` mkl/hm, `ImageColorMatchAdobe+`, easy `imageColorMatch`). **Measure the
-reference first.** If the reference is itself flat (e.g. a casual phone selfie:
-blackPoint 40, contrast 44), matching to it **cannot** produce punch — you'll match your way
+(`ColorMatchV2` mkl/hm, `ImageColorMatchAdobe+`, easy `imageColorMatch`). Measure the
+reference first. If the reference is itself flat (e.g. a casual phone selfie with
+blackPoint 40, contrast 44), matching to it cannot produce punch; you'll match your way
 to the *same* flat numbers. In the real case, mkl and Adobe matches both left the frame
-flagged `washedOut` (whitePoint only crept 191→~218).
+flagged `washedOut` (whitePoint only crept from 191 to ~218).
 
 So:
 
-- **Use a reference-match** (`ColorMatchV2`, `ImageColorMatchAdobe+`) when you want to *match
-  a known-good graded frame / shot-match across clips*, and the reference is actually good.
-- **Use a levels / contrast stretch** when the defect is compressed range (the washout case)
-  — it targets full range *regardless* of the reference. This is usually the real fix.
+- Use a reference-match (`ColorMatchV2`, `ImageColorMatchAdobe+`) when you want to *match
+  a known-good graded frame or shot-match across clips*, and the reference is actually good.
+- Use a levels / contrast stretch when the defect is compressed range (the washout case).
+  It targets full range *regardless* of the reference. This is usually the real fix.
 
 ---
 
 ## The fix: contrast / levels stretch (core nodes, no install)
 
-`AdjustContrast` (core `comfy_extras.nodes_dataset`, category *image/adjustments*) — one
-`factor` (1.0 = none, >1 = more). Pivots around mid-gray, so it pushes the white point up
-and the black point down together. Tune it **by measurement**, not feel. Real measured sweep
+`AdjustContrast` (core `comfy_extras.nodes_dataset`, category *image/adjustments*) has one
+`factor` (1.0 = none, >1 = more). It pivots around mid-gray, so it pushes the white point up
+and the black point down together. Tune it by measurement, not feel. A real measured sweep
 on the washout frame:
 
 | factor | blackPoint | whitePoint | contrast | sat | clippedHigh | verdict |
@@ -112,16 +112,16 @@ on the washout frame:
 | ~1.4 | ~20 | ~247 | ~60 | ~0.38 | ~1–2% | ✅ **sweet spot** |
 | 1.6 | 7 | 254 | 67 | 0.44 | **7.2%** ⚠️ | punchy but blows highlights |
 
-Pick the factor that lands **whitePoint ~248–255 with `clippedHighPct` < ~2%**. Going too far
-(1.6 here) blows highlights *and* over-warms (per-channel contrast drops blue more than red →
-`castHint` worsens). Sweet spot was ~1.4.
+Pick the factor that lands whitePoint ~248 to 255 with `clippedHighPct` < ~2%. Going too far
+(1.6 here) blows highlights *and* over-warms, because per-channel contrast drops blue more than red and
+`castHint` worsens. The sweet spot was ~1.4.
 
 Other levers when contrast alone isn't enough:
-- `CurveEditor` (core, *utilities*) → feeds a CURVE for precise black/white-point + gamma
+- `CurveEditor` (core, *utilities*) feeds a CURVE for precise black/white-point and gamma
   control (a true levels curve) when you need more than a single contrast pivot.
-- `AdjustContrast` + a small saturation/brightness adjust (same *image/adjustments* family)
+- `AdjustContrast` plus a small saturation/brightness adjust (same *image/adjustments* family)
   to fine-tune after the stretch.
-- A **mild** reference-match *after* the stretch only if you genuinely need to shot-match.
+- A mild reference-match *after* the stretch, only if you need to shot-match.
 
 ---
 
@@ -140,19 +140,19 @@ LoadImage (the reference, if shot-matching)
         └─► ImageColorMatchAdobe+(LAB)─► SaveImage "balance_adobe"
 ```
 
-Run once, then `get_image (action:"analyze_color")` **every** output (+ the reference + the untouched frame) and
+Run once, then `get_image (action:"analyze_color")` every output, plus the reference and the untouched frame, and
 compare blackPoint / whitePoint / contrast / saturation / clippedHigh. Whichever lands the
-numbers in range wins; interpolate the factor (1.3 vs 1.6 → 1.4) and confirm with one more
-pass. Stage the frame into the ComfyUI **input** dir first (cp the extracted PNG there) so
-`LoadImage` can see it — input/output dirs may be custom, so don't guess paths.
+numbers in range wins; interpolate the factor (1.3 vs 1.6 gives 1.4) and confirm with one more
+pass. Stage the frame into the ComfyUI input dir first (cp the extracted PNG there) so
+`LoadImage` can see it. Input and output dirs may be custom, so don't guess paths.
 
 ---
 
 ## Porting the fix into a render graph
 
-Place the chosen correction **after decode, before the save** — for a WAN/video graph that's
+Place the chosen correction after decode, before the save. For a WAN/video graph that's
 right after `WanVideoDecode` (or the per-chunk color-match) and feeding the
-`VHS_VideoCombine`/save node. One `AdjustContrast` node is usually the whole fix; keep it as a
+`VHS_VideoCombine`/save node. One `AdjustContrast` node is usually the whole fix. Keep it as a
 single inline node (or a small bypassable group) so it's easy to toggle and re-tune. Re-render
 a clip, extract a frame, `get_image (action:"analyze_color")` it, and nudge the factor to hit whitePoint ~250.
 
@@ -160,16 +160,16 @@ a clip, extract a frame, `get_image (action:"analyze_color")` it, and nudge the 
 
 ## Video-specific gotchas
 
-- **Per-window drift (WAN long video):** WAN-Animate/long clips render in temporal windows and
-  can desaturate/dim across them. Measure a frame from the *first* window and a *late* window —
-  if they differ, that's drift, not a global grade issue (use the embeds' between-window
-  `colormatch`, not a final stretch).
-- **Relight LoRA ≠ levels:** a WanAnimate relight LoRA changes *lighting*, not black/white
-  points — it won't fix a compressed-range washout. Measure before and after to prove it.
-- **Don't over-stretch:** watch `clippedHighPct` — blown highlights are unrecoverable. Prefer
+- **Per-window drift (WAN long video).** WAN-Animate/long clips render in temporal windows and
+  can desaturate or dim across them. Measure a frame from the *first* window and a *late* window.
+  If they differ, that's drift, not a global grade issue; use the embeds' between-window
+  `colormatch`, not a final stretch.
+- **Relight LoRA is not levels.** A WanAnimate relight LoRA changes *lighting*, not black/white
+  points. It won't fix a compressed-range washout. Measure before and after to prove it.
+- **Don't over-stretch.** Watch `clippedHighPct`; blown highlights are unrecoverable. Prefer
   the lower factor that still clears `dimHighlights`.
-- **Cast is often inherited:** if the reference has the same warm/cool cast (festival/sunset
-  light), a matching cast on the render is *correct* — don't "fix" it.
+- **Cast is often inherited.** If the reference has the same warm/cool cast (festival/sunset
+  light), a matching cast on the render is *correct*. Don't "fix" it.
 
 ---
 
@@ -184,8 +184,8 @@ get_image (action:"analyze_color") on the frame
   └─ blackPoint/whitePoint already 0/255, sat ok .... color is healthy — stop touching it
 ```
 
-Always **re-measure after the fix.** If `get_image (action:"analyze_color")` still flags it, the fix was wrong —
-adjust and measure again. Numbers over vibes.
+Always re-measure after the fix. If `get_image (action:"analyze_color")` still flags it, the fix was wrong.
+Adjust and measure again. Numbers over vibes.
 
 ## Sources
 

--- a/plugin/skills/comfyui-core/SKILL.md
+++ b/plugin/skills/comfyui-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comfyui-core
-description: Core ComfyUI knowledge — workflow format, node types, pipeline patterns, and MCP tool usage
+description: Core ComfyUI knowledge covering workflow format, node types, pipeline patterns, and MCP tool usage
 globs:
   - "**/*.json"
 ---
@@ -9,7 +9,7 @@ globs:
 
 ## Workflow JSON Format (API Format)
 
-ComfyUI workflows are JSON objects mapping **string node IDs** to node definitions:
+ComfyUI workflows are JSON objects mapping string node IDs to node definitions:
 
 ```json
 {
@@ -28,13 +28,13 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 
 ### Key Rules
 
-- **Node IDs** are strings of integers (`"1"`, `"2"`, etc.)
-- **`class_type`** is the exact Python class name of the node
-- **`inputs`** contains both widget values (scalars) and connections (arrays)
-- **Connections** use the format `["sourceNodeId", outputIndex]` — a 2-element array where:
-  - First element: string node ID of the source node
-  - Second element: integer index into the source node's `output` list (0-based)
-- **`_meta`** is optional, used for display titles only
+- Node IDs are strings of integers (`"1"`, `"2"`, etc.)
+- `class_type` is the exact Python class name of the node
+- `inputs` contains both widget values (scalars) and connections (arrays)
+- Connections use the format `["sourceNodeId", outputIndex]`, a 2-element array where:
+  - the first element is the string node ID of the source node
+  - the second element is the integer index into the source node's `output` list (0-based)
+- `_meta` is optional and used for display titles only
 
 ### Connection Examples
 
@@ -49,20 +49,20 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 
 ### Important: API Format vs Web UI Format
 
-- **API format** (for execution/analysis): `{ "1": { class_type, inputs }, "2": { ... } }` — compact, used by `enqueue_workflow`, `create_workflow (action:"validate")`, `create_workflow (action:"modify")`, etc.
-- **Web UI format** (for saving and frontend editing): `{ "nodes": [...], "links": [...] }` — includes layout positions, sizes, groups, and visual metadata so ComfyUI's canvas can open and edit it
-- Execution tools expect and return **API format**
-- **Save in Web UI format** so saved workflows stay readable and editable in the ComfyUI frontend. A raw API-format save is NOT canvas-editable — it "exists" in the library but loads blank in the canvas, which strands users (and tempts agents into creating yet another new workflow instead of reopening the old one). Because of this, `save_workflow` auto-converts API-format input to Web UI format with a generated layout — but prefer passing real Web UI format (from `get_workflow(action="get", filename=…, format="ui")`) since a generated layout loses the original node positions/groups <!-- API-vs-UI save-format clarification adapted from 1696762169/comfyui-mcp@3da56c9 -->
+- API format (for execution/analysis) is `{ "1": { class_type, inputs }, "2": { ... } }`. It is compact and used by `enqueue_workflow`, `create_workflow (action:"validate")`, `create_workflow (action:"modify")`, etc.
+- Web UI format (for saving and frontend editing) is `{ "nodes": [...], "links": [...] }`. It includes layout positions, sizes, groups, and visual metadata so ComfyUI's canvas can open and edit it
+- Execution tools expect and return API format
+- Save in Web UI format so saved workflows stay readable and editable in the ComfyUI frontend. A raw API-format save is not canvas-editable. It "exists" in the library but loads blank in the canvas, which strands users and tempts agents into creating yet another new workflow instead of reopening the old one. Because of this, `save_workflow` auto-converts API-format input to Web UI format with a generated layout. Prefer passing real Web UI format (from `get_workflow(action="get", filename=…, format="ui")`), since a generated layout loses the original node positions and groups <!-- API-vs-UI save-format clarification adapted from 1696762169/comfyui-mcp@3da56c9 -->
 - `get_workflow` defaults to `format="api"` for analysis/execution; use `format="ui"` when loading a workflow to re-save or edit in the canvas
-- Muted/bypassed nodes are preserved with `_meta.mode: "muted"` — these are inactive but visible for understanding the workflow
+- Muted/bypassed nodes are preserved with `_meta.mode: "muted"`. They are inactive but visible for understanding the workflow
 - Get/Set virtual wire nodes are preserved with `_meta.title` and `Constant` key for tracing data flow
 
 ### Workflow Library Tools
 
-- **`get_workflow(action="analyze", filename=…)`** — **use this first** to understand any saved workflow. Returns a structured text summary with sections, node IDs, key settings, virtual wires, and connection graph. No raw JSON — just what you need to reason about the workflow. Supports views: summary (default), overview (mermaid), detail (section mermaid), list, flat.
-- **`get_workflow (action:"list")`** — list all saved workflows in ComfyUI's user library
-- **`get_workflow(action="get", filename=…)`** — load raw workflow JSON. Only use when you need the actual JSON for `enqueue_workflow`, `create_workflow (action:"modify")`, or `save_workflow`. Use `action="analyze"` instead for understanding. **When the JSON is headed back to `save_workflow`, request `format="ui"`** so the workflow stays editable in the frontend.
-- **`save_workflow(action="save", filename=…, workflow=…)`** — save a workflow to the user library. **Pass Web UI format (`{ nodes, links }`)** so it keeps its real layout in ComfyUI's canvas. API-format graphs are accepted and are **auto-converted to Web UI format** (with a generated layout) precisely because a raw API-format save is not canvas-editable — the frontend cannot open it. When re-saving an existing workflow, load it with `get_workflow(action="get", filename=…, format="ui")` and edit that, so positions/groups survive.
+- `get_workflow(action="analyze", filename=…)` is the first call for understanding any saved workflow. It returns a structured text summary with sections, node IDs, key settings, virtual wires, and connection graph. No raw JSON, just what you need to reason about the workflow. Supports views: summary (default), overview (mermaid), detail (section mermaid), list, flat.
+- `get_workflow (action:"list")` lists all saved workflows in ComfyUI's user library
+- `get_workflow(action="get", filename=…)` loads raw workflow JSON. Only use it when you need the actual JSON for `enqueue_workflow`, `create_workflow (action:"modify")`, or `save_workflow`. Use `action="analyze"` instead for understanding. When the JSON is headed back to `save_workflow`, request `format="ui"` so the workflow stays editable in the frontend.
+- `save_workflow(action="save", filename=…, workflow=…)` saves a workflow to the user library. Pass Web UI format (`{ nodes, links }`) so it keeps its real layout in ComfyUI's canvas. API-format graphs are accepted and auto-converted to Web UI format (with a generated layout) precisely because a raw API-format save is not canvas-editable; the frontend cannot open it. When re-saving an existing workflow, load it with `get_workflow(action="get", filename=…, format="ui")` and edit that, so positions and groups survive.
 
 ## Data Types
 
@@ -106,7 +106,7 @@ Same as txt2img but replace `EmptyLatentImage` with:
 LoadImage → IMAGE
 VAEEncode (pixels, vae) → LATENT → KSampler.latent_image
 ```
-Set `KSampler.denoise` to 0.5–0.8 (lower = closer to input image).
+Set `KSampler.denoise` to 0.5 to 0.8 (lower = closer to input image).
 
 ### Upscale
 
@@ -130,34 +130,34 @@ SetLatentNoiseMask (samples, mask) → LATENT → KSampler.latent_image
 ### Quick Generation
 
 1. `create_workflow` with template `"txt2img"` and your params
-2. `enqueue_workflow(action="enqueue")` with the returned JSON — returns `prompt_id` immediately
+2. `enqueue_workflow(action="enqueue")` with the returned JSON. It returns `prompt_id` immediately
 3. Poll `queue` (action:"status") with the `prompt_id` until `done` is true
 4. Use `get_image (action:"list_outputs")` (limit 1) to find the generated image, then `Read` to display it
 
 ### Inspect & Modify
 
-- `create_workflow (action:"node_info")` — query what nodes are available and their schemas
-- `create_workflow (action:"modify")` — patch an existing workflow (set_input, add_node, remove_node, connect, insert_between)
-- `visualize_workflow` — see a workflow as a mermaid diagram
+- `create_workflow (action:"node_info")` queries what nodes are available and their schemas
+- `create_workflow (action:"modify")` patches an existing workflow (set_input, add_node, remove_node, connect, insert_between)
+- `visualize_workflow` shows a workflow as a mermaid diagram
 
 ### Reverse Engineering
 
-- `visualize_workflow` — workflow JSON → mermaid diagram
-- `visualize_workflow (action:"mermaid")` — mermaid diagram → workflow JSON (uses `/object_info` for schema resolution)
+- `visualize_workflow` turns workflow JSON into a mermaid diagram
+- `visualize_workflow (action:"mermaid")` turns a mermaid diagram into workflow JSON (uses `/object_info` for schema resolution)
 
 ### Model Management
 
-- `list_local_models` — see what's installed
-- `download_model` `action:"search"` — find models on HuggingFace
-- `download_model` — download to ComfyUI's models directory
+- `list_local_models` shows what's installed
+- `download_model` `action:"search"` finds models on HuggingFace
+- `download_model` downloads to ComfyUI's models directory
 
-**Important**: Never ask the user to manually download models. If a required model is missing, proactively search for it and download it yourself:
+Never ask the user to manually download models. If a required model is missing, search for it and download it yourself:
 
 1. Check `list_local_models` first
 2. If missing, search HuggingFace via `download_model` `action:"search"` or CivitAI via their REST API
 3. Use `download_model` to install it directly to the correct subfolder
 
-**CivitAI API** (when `CIVITAI_API_TOKEN` env var is available):
+CivitAI API (when the `CIVITAI_API_TOKEN` env var is available):
 - Search: `GET https://civitai.com/api/v1/models?query={query}&types=Checkpoint&sort=Most+Downloaded&limit=5`
 - Details: `GET https://civitai.com/api/v1/models/{modelId}`
 - Download: `GET https://civitai.com/api/download/models/{modelVersionId}?token={token}`
@@ -167,16 +167,16 @@ HuggingFace is preferred for official/base models (SDXL, Flux, SD 1.5).
 
 ### Custom Nodes
 
-- `search_custom_nodes` — search the ComfyUI Registry (`action: "search"`), or get one pack's details (`action: "details"`)
-- `list_packs` (`action: "generate_skill"`) — auto-generate a skill file for a node pack
+- `search_custom_nodes` searches the ComfyUI Registry (`action: "search"`) or gets one pack's details (`action: "details"`)
+- `list_packs` (`action: "generate_skill"`) auto-generates a skill file for a node pack
 
 ### Workflow Execution
 
-`enqueue_workflow` submits to ComfyUI's queue and returns `prompt_id` + queue position immediately. It does NOT block.
+`enqueue_workflow` submits to ComfyUI's queue and returns `prompt_id` + queue position immediately. It does not block.
 
 ### Background Progress Monitoring
 
-After enqueuing one or more workflows, use a **background Bash task** to monitor progress silently:
+After enqueuing one or more workflows, use a background Bash task to monitor progress silently:
 
 ```bash
 # Single job
@@ -193,44 +193,44 @@ The script connects to ComfyUI's WebSocket and reports:
 - Success with output filenames and timing
 - Errors with node details and messages
 
-**Standard generation pattern:**
+The standard generation pattern:
 1. `create_workflow` or build workflow JSON + `enqueue_workflow(action="enqueue")` (repeat for batch)
 2. Start background monitor with all prompt_ids
-3. Continue conversation — results appear when jobs finish
+3. Continue conversation. Results appear when jobs finish
 4. Use `get_image (action:"list_outputs")` or `Read` to display the generated images
 
-**Do NOT** poll `queue` (action:"status") in a loop. The background monitor replaces polling entirely.
+Do not poll `queue` (action:"status") in a loop. The background monitor replaces polling entirely.
 
-**Fallback**: If the monitor script is unavailable, use `queue` (action:"status") to poll until `done` is true.
+If the monitor script is unavailable, fall back to `queue` (action:"status") and poll until `done` is true.
 
 ### Queue Management
 
 One tool, `queue`, driven by its `action` parameter:
 
-- `queue` (action:"list") — shows running/pending job counts and prompt_ids
-- `queue` (action:"status") — check if a specific prompt_id is running, pending, or done
-- `queue` (action:"cancel") — interrupt a running job (pass optional `prompt_id` to target a specific one)
-- `queue` (action:"cancel_queued") — remove a specific pending job from the queue by `prompt_id`
-- `queue` (action:"clear") — remove all pending jobs (does NOT stop the currently running job)
+- `queue` (action:"list") shows running/pending job counts and prompt_ids
+- `queue` (action:"status") checks if a specific prompt_id is running, pending, or done
+- `queue` (action:"cancel") interrupts a running job (pass optional `prompt_id` to target a specific one)
+- `queue` (action:"cancel_queued") removes a specific pending job from the queue by `prompt_id`
+- `queue` (action:"clear") removes all pending jobs (does not stop the currently running job)
 
-**When to use queue tools:**
-- To check status: `queue` (action:"status") for a quick boolean check (prefer background monitor for ongoing tracking)
-- To abort: `queue` (action:"cancel") stops what's running now; `queue` (action:"cancel_queued") removes a pending one
-- To start fresh: `queue` (action:"clear") then optionally `queue` (action:"cancel")
+When to use queue tools:
+- To check status, use `queue` (action:"status") for a quick boolean check (prefer the background monitor for ongoing tracking)
+- To abort, `queue` (action:"cancel") stops what's running now and `queue` (action:"cancel_queued") removes a pending one
+- To start fresh, `queue` (action:"clear") then optionally `queue` (action:"cancel")
 
 ### Monitoring & Recovery
 
-- `get_system_stats` — GPU, VRAM, Python version, OS details
-- `queue` (action:"list") — see running/pending jobs (also listed above under Queue Management)
+- `get_system_stats` reports GPU, VRAM, Python version, OS details
+- `queue` (action:"list") shows running/pending jobs (also listed above under Queue Management)
 
-**When ComfyUI is unresponsive or crashed:**
-1. Try `get_system_stats` — if it fails, ComfyUI is down
+When ComfyUI is unresponsive or crashed:
+1. Try `get_system_stats`. If it fails, ComfyUI is down
 2. Use `restart_comfyui` with `action: "restart"` (preserves launch args from a prior `action: "stop"`)
 3. If restart fails (no saved process info), use `restart_comfyui` with `action: "start"` or ask the user to start it manually
 4. After ComfyUI is back, re-enqueue any failed/lost workflows
 
-**When a job appears hung (monitor shows `[STALL]`):**
-1. Check `get_system_stats` — look at VRAM usage (OOM causes hangs)
+When a job appears hung (monitor shows `[STALL]`):
+1. Check `get_system_stats` and look at VRAM usage (OOM causes hangs)
 2. Try `queue` (action:"cancel") to interrupt the stuck job
 3. If cancel fails, use `restart_comfyui` to force-restart
 4. Use `clear_vram` after restart to free GPU memory before retrying
@@ -250,20 +250,20 @@ One tool, `queue`, driven by its `action` parameter:
 
 The `visualize_workflow` tool produces mermaid flowcharts with:
 
-- **Subgraphs** grouping nodes by category: `loading`, `conditioning`, `sampling`, `image`, `output`
-- **Edge labels** showing data types: `-->|MODEL|`, `-->|CLIP|`, `-->|LATENT|`, etc.
-- **Node labels** showing class_type and optionally widget values
-- **Direction**: `LR` (left-to-right) by default, `TB` (top-to-bottom) for large workflows
+- Subgraphs grouping nodes by category: `loading`, `conditioning`, `sampling`, `image`, `output`
+- Edge labels showing data types: `-->|MODEL|`, `-->|CLIP|`, `-->|LATENT|`, etc.
+- Node labels showing class_type and optionally widget values
+- Direction `LR` (left-to-right) by default, `TB` (top-to-bottom) for large workflows
 
 The `visualize_workflow (action:"mermaid")` tool parses mermaid back into workflow JSON, using connection type labels to resolve the correct input/output slots via `/object_info` schemas.
 
 ## Common Mistakes to Avoid
 
-1. **Wrong connection format**: Use `["1", 0]` not `[1, 0]` — node IDs are strings
-2. **Web UI format**: Don't pass `{ nodes: [], links: [] }` — use API format
-3. **Missing VAE**: CheckpointLoaderSimple has 3 outputs — MODEL(0), CLIP(1), VAE(2)
-4. **Wrong output index**: Check the node's output list order via `create_workflow (action:"node_info")`
-5. **Seed handling**: `enqueue_workflow` randomizes seeds by default unless `disable_random_seed: true`
+1. **Wrong connection format.** Use `["1", 0]` not `[1, 0]`; node IDs are strings
+2. **Web UI format.** Don't pass `{ nodes: [], links: [] }`; use API format
+3. **Missing VAE.** CheckpointLoaderSimple has 3 outputs: MODEL(0), CLIP(1), VAE(2)
+4. **Wrong output index.** Check the node's output list order via `create_workflow (action:"node_info")`
+5. **Seed handling.** `enqueue_workflow` randomizes seeds by default unless `disable_random_seed: true`
 
 ## Sources
 

--- a/plugin/skills/comfyui-core/references/common-nodes.md
+++ b/plugin/skills/comfyui-core/references/common-nodes.md
@@ -5,13 +5,13 @@ See [`../SKILL.md`](../SKILL.md) for how these wire together into a graph.
 
 ## Contents
 
-- [Checkpoint & Model Loading](#checkpoint--model-loading) — `CheckpointLoaderSimple`, `UNETLoader`, `CLIPLoader`, `DualCLIPLoader`, `VAELoader`, `LoraLoader`, `UpscaleModelLoader`
-- [Text Encoding](#text-encoding) — `CLIPTextEncode`, `CLIPSetLastLayer`
-- [Latent Space](#latent-space) — `EmptyLatentImage`, `VAEEncode`, `VAEDecode`, `SetLatentNoiseMask`, `LatentUpscale`
-- [Sampling](#sampling) — `KSampler`, `KSamplerAdvanced`
-- [Image Operations](#image-operations) — `LoadImage`, `SaveImage`, `PreviewImage`, `ImageUpscaleWithModel`, `ImageScale`, `ImageInvert`, `ImageBatch`
-- [ControlNet](#controlnet) — `ControlNetLoader`, `ControlNetApply`, `ControlNetApplyAdvanced`
-- [Conditioning](#conditioning) — `ConditioningCombine`, `ConditioningSetArea`
+- [Checkpoint & Model Loading](#checkpoint--model-loading): `CheckpointLoaderSimple`, `UNETLoader`, `CLIPLoader`, `DualCLIPLoader`, `VAELoader`, `LoraLoader`, `UpscaleModelLoader`
+- [Text Encoding](#text-encoding): `CLIPTextEncode`, `CLIPSetLastLayer`
+- [Latent Space](#latent-space): `EmptyLatentImage`, `VAEEncode`, `VAEDecode`, `SetLatentNoiseMask`, `LatentUpscale`
+- [Sampling](#sampling): `KSampler`, `KSamplerAdvanced`
+- [Image Operations](#image-operations): `LoadImage`, `SaveImage`, `PreviewImage`, `ImageUpscaleWithModel`, `ImageScale`, `ImageInvert`, `ImageBatch`
+- [ControlNet](#controlnet): `ControlNetLoader`, `ControlNetApply`, `ControlNetApplyAdvanced`
+- [Conditioning](#conditioning): `ConditioningCombine`, `ConditioningSetArea`
 
 ## Checkpoint & Model Loading
 

--- a/plugin/skills/comfyui-frontend-extensions/SKILL.md
+++ b/plugin/skills/comfyui-frontend-extensions/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: comfyui-frontend-extensions
-description: Authoring ComfyUI v2 frontend extensions with @comfyorg/extension-api — defineNode/defineExtension/defineWidget, shell UI (sidebar tabs, commands, hotkeys), typed events, and handles. Use when writing or editing ComfyUI web-UI extension code (custom node JS, sidebar panels, widgets).
+description: Authoring ComfyUI v2 frontend extensions with @comfyorg/extension-api, covering defineNode/defineExtension/defineWidget, shell UI (sidebar tabs, commands, hotkeys), typed events, and handles. Use when writing or editing ComfyUI web-UI extension code (custom node JS, sidebar panels, widgets).
 ---
 
 # ComfyUI v2 Frontend Extension API
 
-The **v2 extension API** is the published npm package `@comfyorg/extension-api`. It
+The v2 extension API is the published npm package `@comfyorg/extension-api`. It
 replaces the legacy `app.registerExtension()` / `nodeType.prototype` monkey-patching
 model with a typed, tree-shakeable, import-based API.
 
@@ -28,7 +28,7 @@ Core principles baked into the API:
 
 - **Import, don't reach for globals.** `import { defineNode } from '@comfyorg/extension-api'`. No `window.app` dependency at module evaluation time.
 - **Read via getters, write via command-dispatch setters.** `getValue()` reads; `setValue()` dispatches an undo-able, serializable command. Read-only invariants (set at construction) are `readonly` accessors (`node.type`, `widget.name`).
-- **Observe via typed `on(...)` subscriptions.** Each returns an `Unsubscribe` cleanup function. No Vue refs/signals are ever exposed — Vue reactivity is the internal engine only.
+- **Observe via typed `on(...)` subscriptions.** Each returns an `Unsubscribe` cleanup function. No Vue refs/signals are ever exposed; Vue reactivity is the internal engine only.
 - **Everything is disposable.** Every `defineX` returns a `DisposableHandle` with an idempotent, synchronous `dispose()`.
 
 ## Registration entry points
@@ -48,18 +48,18 @@ All imported from `@comfyorg/extension-api`:
 | `defineSetting(opts)` | Add a settings-menu entry | `DisposableHandle` |
 | `defineAboutBadge(opts)` | Add a badge to the About page | `DisposableHandle` |
 
-Imperative carve-outs (fire-and-forget, NOT `defineX`, no handle): `toast`, `notify`.
+Imperative carve-outs (fire-and-forget, not `defineX`, no handle): `toast`, `notify`.
 
-A single extension file typically exports a **default** `defineExtension`/`defineNode`
-result and calls the shell-UI `defineX` functions inside `setup()` (or at module scope —
-they queue safely before the app boots).
+A single extension file typically exports a default `defineExtension`/`defineNode`
+result and calls the shell-UI `defineX` functions inside `setup()` or at module scope.
+They queue safely before the app boots.
 
 ## `defineNode` — the primary entry point
 
 Reacts to node lifecycle. `nodeCreated` fires once per node instance (typed in, pasted,
 duplicated, or loaded without an existing workflow). `loadedGraphNode` fires once when a
 node is restored from a saved workflow (widget values already populated). Exactly one of
-them fires per node entity — never both.
+them fires per node entity, never both.
 
 ```ts
 import { defineNode, onNodeMounted, onNodeRemoved } from '@comfyorg/extension-api'
@@ -110,9 +110,9 @@ export default defineNode({
 | `on('configured', fn)` | method | Loaded from saved workflow (after widget values restored). |
 | `on('beforeSerialize', fn)` | method | **Deprecated** — use widget-level `beforeSerialize` (ADR-0010). |
 
-> Position/size/title/mode getters and slot/connection events are **deferred in Phase A**. Do not rely on `getPosition`, `setSize`, `getMode`, `on('connected')`.
+> Position/size/title/mode getters and slot/connection events are deferred in Phase A. Do not rely on `getPosition`, `setSize`, `getMode`, `on('connected')`.
 >
-> Nodes **cannot enumerate or reference their widgets** (`node.getWidget(name)` was removed). Use `defineWidget` and the `mount` context's `ctx.widget` handle.
+> Nodes cannot enumerate or reference their widgets (`node.getWidget(name)` was removed). Use `defineWidget` and the `mount` context's `ctx.widget` handle.
 
 ## `defineExtension` — app lifecycle + shell UI
 
@@ -143,23 +143,23 @@ export default defineExtension({
 })
 ```
 
-> **`setup()` signature note.** The source-of-truth surface uses *implicit-context*
+> A note on the `setup()` signature. The source-of-truth API uses *implicit-context*
 > hooks: import `onMounted`/`onNodeMounted`/etc. and call them synchronously inside
 > `setup()` (mirrors Vue's Composition API). An early package draft showed a
 > `setup(ctx) { ctx.onNodeMounted(...) }` context-argument style; prefer the imported-hook
 > form above, which is what the current API exports.
 
-Context-scoped lifecycle hooks are imported and called **synchronously inside
-`defineExtension`'s `setup()`**: `onBeforeMount`, `onMounted`, `onUnmounted`,
-`onActivated`, `onDeactivated`. Note: `defineSidebarTab`/`defineBottomPanelTab` take **no
-`setup` field** — don't add one (it's a type error). `onActivated`/`onDeactivated` fire
-when the surrounding tab/panel is shown/hidden.
+Context-scoped lifecycle hooks are imported and called synchronously inside
+`defineExtension`'s `setup()`: `onBeforeMount`, `onMounted`, `onUnmounted`,
+`onActivated`, `onDeactivated`. `defineSidebarTab`/`defineBottomPanelTab` take no
+`setup` field; adding one is a type error. `onActivated`/`onDeactivated` fire
+when the surrounding tab or panel is shown or hidden.
 
 ## `defineWidget` — custom widget types with DOM
 
-Widgets are **declared in the Python node's `INPUT_TYPES`**, never created at runtime
+Widgets are declared in the Python node's `INPUT_TYPES`, never created at runtime
 (`node.addWidget` is forbidden). `defineWidget` registers a *type* and the DOM `mount`
-hook the runtime invokes against a host `<div>` it owns. `mount` is optional — omit it
+hook the runtime invokes against a host `<div>` it owns. `mount` is optional; omit it
 for value-only widgets that render through the native renderer.
 
 ```ts
@@ -191,7 +191,7 @@ export default defineWidget({
 
 `WidgetMountContext` also exposes `onUnmount(fn)`, `onBeforeRemount(fn)`, and
 `onAfterRemount(fn => ...)` for host-move scenarios (graph↔app mode, subgraph
-promotion). The `mount` body is **not** re-invoked across a remount — only the
+promotion). The `mount` body is not re-invoked across a remount; only the
 remount hooks fire.
 
 ### `WidgetHandle` surface
@@ -249,7 +249,7 @@ server.on('my-org.my-node.update', (e) => console.log(e))
 off()
 ```
 
-Payloads default to `unknown` today. Narrow them with **TS module augmentation**:
+Payloads default to `unknown` today. Narrow them with TS module augmentation:
 
 ```ts
 declare module '@comfyorg/extension-api' {
@@ -322,7 +322,7 @@ cmd.dispose() // idempotent + synchronous
 
 ## `defineSidebarTab` — embedded panels (e.g. a chat panel)
 
-A sidebar tab is the substrate for a rich embedded UI such as a chat panel. Two flavors:
+A sidebar tab hosts a rich embedded UI such as a chat panel. It comes in two flavors:
 `type: 'vue'` (mount a Vue component) or `type: 'custom'` (imperative `render(container)` /
 `destroy()`). Both share the base fields `id`, `title`, optional `icon`, `iconBadge`,
 `tooltip`, `label`.
@@ -432,13 +432,13 @@ toast.show({ severity: 'error', summary: 'Workflow failed', detail: err.message,
 toast.removeAll()
 ```
 
-`notify({ kind, message, detail, life })` is a deprecated 1:1 wrapper over `toast.show` —
-prefer `toast.show` directly.
+`notify({ kind, message, detail, life })` is a deprecated 1:1 wrapper over `toast.show`.
+Prefer `toast.show` directly.
 
 ## Node identity helpers
 
 For referencing nodes across subgraph boundaries or execution runs, use the branded
-identity primitives rather than raw integer node IDs:
+identity types rather than raw integer node IDs:
 
 ```ts
 import {
@@ -459,18 +459,18 @@ if (isNodeLocatorId(maybe)) {
 ```
 
 `NodeLocatorId` arrives from workflow JSON; `NodeExecutionId` arrives from websocket
-frames. You **receive** these from event payloads — that's why they're public (unlike the
+frames. You receive these from event payloads, which is why they're public (unlike the
 internal `*EntityId` brands, which are not exported).
 
 ## Disposal contract
 
 Every `defineX` returns `DisposableHandle { dispose(): void }`:
 
-- **Idempotent** — calling `dispose()` again is a safe no-op.
-- **Synchronous** — teardown happens synchronously inside `dispose()`.
-- **Independent** — disposing handle A does not affect B or C. Sequence calls
+- **Idempotent.** Calling `dispose()` again is a safe no-op.
+- **Synchronous.** Teardown happens synchronously inside `dispose()`.
+- **Independent.** Disposing handle A does not affect B or C. Sequence calls
   explicitly when teardown order matters (e.g. drop a hotkey before its command).
-- **Pre-mount safe** — disposing before the app boots removes the spec from the
+- **Pre-mount safe.** Disposing before the app boots removes the spec from the
   pending queue so it never mounts.
 
 ```ts
@@ -485,19 +485,19 @@ for (const h of handles.reverse()) h.dispose()
 
 ## Common mistakes
 
-1. **Calling lifecycle hooks after `await`.** `onNodeMounted` / `onMounted` / `onUnmounted` rely on implicit scope context and **must** be called synchronously inside the `setup()`/`nodeCreated` body. After an `await` the scope is gone — throws in dev, silent no-op in prod. Kick off async work in the body, but register hooks first.
+1. **Calling lifecycle hooks after `await`.** `onNodeMounted` / `onMounted` / `onUnmounted` rely on implicit scope context and must be called synchronously inside the `setup()`/`nodeCreated` body. After an `await` the scope is gone: it throws in dev and is a silent no-op in prod. Kick off async work in the body, but register hooks first.
 2. **Reaching for `window.app` or `app.*`.** v2 has no `window.app` dependency at module-eval time. Import everything from `@comfyorg/extension-api`.
 3. **Patching `nodeType.prototype`.** Replaced by `defineNode` + `node.on(...)`. Prototype patching does not interoperate with the v2 handle model.
-4. **Mutating reads.** `node.getInputs()`, `widget.options`, and `Point`/`Size` tuples are frozen/`Readonly` — assignment raises TS errors. Use the setter methods (`widget.setOption`, `widget.setValue`).
-5. **Assigning `widget.value` / `widget.callback` / `widget.serializeValue`.** Use `setValue()`, `on('valueChange')`, and `on('beforeSerialize')`. `serializeValue` is read-only on the v2 surface.
+4. **Mutating reads.** `node.getInputs()`, `widget.options`, and `Point`/`Size` tuples are frozen/`Readonly`; assignment raises TS errors. Use the setter methods (`widget.setOption`, `widget.setValue`).
+5. **Assigning `widget.value` / `widget.callback` / `widget.serializeValue`.** Use `setValue()`, `on('valueChange')`, and `on('beforeSerialize')`. `serializeValue` is read-only in v2.
 6. **Trying to disable widget serialization.** There is no `serialize: false` and no `skip()` in v2. If a widget should not contribute to the payload, it should not be a widget. The only serialization interface is `widget.on('beforeSerialize', fn)` + `e.setSerializedValue(v)`.
 7. **Creating widgets at runtime.** `node.addWidget(...)` / `node.addDOMWidget(...)` are removed. Declare widgets in the Python `INPUT_TYPES`; render custom DOM via `defineWidget({ mount })`.
 8. **Enumerating widgets from a node.** `node.getWidget(name)` / `node.getWidgets()` were removed (nodes cannot reference widgets). Use a `defineWidget` mount context's `ctx.widget`, or share state via the `server` event bus.
 9. **Using node-level `beforeSerialize`.** Deprecated (ADR-0010). Store extension state in a widget and use widget-level `beforeSerialize`.
 10. **Forgetting to dispose.** Long-lived subscriptions made outside a `setup()` context, and every `defineX` handle, leak unless you call the returned `Unsubscribe` / `dispose()`. Inside `setup()` they auto-dispose on unmount.
-11. **Relying on deferred Phase A surface.** Position/size/title/mode getters and slot/connection events are not yet exported. Don't write code against them.
+11. **Relying on deferred Phase A exports.** Position/size/title/mode getters and slot/connection events are not yet exported. Don't write code against them.
 
 ## Sources
 
 - **Official:** npm package `@comfyorg/extension-api` at https://www.npmjs.com/package/@comfyorg/extension-api
-- **Empirical:** none — API surface transcribed from the published package, not reverse-engineered from a working graph.
+- **Empirical:** none; the API was transcribed from the published package, not reverse-engineered from a working graph.

--- a/plugin/skills/comfyui-frontend-extensions/references/migrate-v1-to-v2.md
+++ b/plugin/skills/comfyui-frontend-extensions/references/migrate-v1-to-v2.md
@@ -6,21 +6,21 @@ equivalents. See [`../SKILL.md`](../SKILL.md) for full authoring patterns.
 
 ## Contents
 
-- [The big picture](#the-big-picture) — what v2 split apart, and why
-- [Top-level registration](#top-level-registration) — `registerExtension` → `defineExtension`
-- [Lifecycle hooks](#lifecycle-hooks) — `setup`/`init` → `onLoad`/`onUnload`
+- [The big picture](#the-big-picture): what v2 split apart, and why
+- [Top-level registration](#top-level-registration): `registerExtension` → `defineExtension`
+- [Lifecycle hooks](#lifecycle-hooks): `setup`/`init` → `onLoad`/`onUnload`
 - [Node prototype patching → `NodeHandle` events](#node-prototype-patching--nodehandle-events)
-- [Widgets](#widgets) — `addWidget`/`widget.callback` → typed widget handles
+- [Widgets](#widgets): `addWidget`/`widget.callback` → typed widget handles
 - [Events: `api.addEventListener` → typed namespaces](#events-apiaddeventlistener--typed-namespaces)
-- [Shell UI](#shell-ui) — sidebar tabs, commands, keybindings, settings, toasts
-- [Cleanup / teardown](#cleanup--teardown) — disposers replace manual unpatching
-- [Migration checklist](#migration-checklist) — the ordered pass to run over an extension
+- [Shell UI](#shell-ui): sidebar tabs, commands, keybindings, settings, toasts
+- [Cleanup / teardown](#cleanup--teardown): disposers replace manual unpatching
+- [Migration checklist](#migration-checklist): the ordered pass to run over an extension
 
 ## The big picture
 
 v1 packed everything into a single `app.registerExtension({...})` mega-call with
 mixed concerns (node patching, commands, keybindings, settings, UI). v2 splits each
-concern into its own `defineX` — independently importable, testable, and disposable.
+concern into its own `defineX`, each independently importable, testable, and disposable.
 
 ```ts
 // ── v1 ──────────────────────────────────────────────────────────────────
@@ -222,7 +222,7 @@ defineAboutBadge({ label: 'GitHub', url: 'https://…', icon: 'pi-github' })
 ## Migration checklist
 
 1. Replace `import { app } from '../../scripts/app.js'` with named imports from `@comfyorg/extension-api`.
-2. Split the single `registerExtension` object: node concerns → `defineNode`; app lifecycle → `defineExtension`; each UI surface → its own `defineX`.
+2. Split the single `registerExtension` object: node concerns → `defineNode`; app lifecycle → `defineExtension`; each UI concern → its own `defineX`.
 3. Convert `beforeRegisterNodeDef` filtering to `defineNode({ nodeTypes: [...] })`.
 4. Replace every `nodeType.prototype.onX = ...` with `node.on('x', fn)` inside `nodeCreated` / `loadedGraphNode`.
 5. Replace `widget.value =` with `setValue`, `widget.callback =` with `on('valueChange')`, `widget.options.k =` with `setOption`.
@@ -230,5 +230,5 @@ defineAboutBadge({ label: 'GitHub', url: 'https://…', icon: 'pi-github' })
 7. Move all serialization logic to widget-level `on('beforeSerialize')`; drop `serialize: false` usages.
 8. Replace `api.addEventListener('...')` with the matching `execution` / `graph` / `server` / `workbench` namespace; augment payload interfaces for types.
 9. Move validation from `app.queuePrompt` patches to `widget.on('beforeQueue', e => e.reject(...))`.
-10. Ensure lifecycle hooks (`onMounted`, `onNodeMounted`, `onNodeRemoved`) are called **synchronously** — never after an `await`.
+10. Ensure lifecycle hooks (`onMounted`, `onNodeMounted`, `onNodeRemoved`) are called synchronously, never after an `await`.
 11. Track every `Unsubscribe` / `DisposableHandle` you create outside a `setup()` context and dispose them on teardown.

--- a/plugin/skills/comfyui-launch-flags/SKILL.md
+++ b/plugin/skills/comfyui-launch-flags/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comfyui-launch-flags
-description: Pick the right ComfyUI startup flags for VRAM, attention, caching, and speed — the full decision matrix for OOM (--novram / --cache-none / --disable-smart-memory), shared-VRAM creep on Windows (--reserve-vram N), model-switching with big text encoders (--cache-none), high-VRAM throughput (--gpu-only / --highvram), and attention-backend selection (--use-sage-attention for speed, --use-pytorch-cross-attention as the highest-quality / Z-Image-safe fallback). Also the acceleration-stack + Blackwell/RTX 5000 (sm_120) notes. Use when a graph OOMs (especially long video like LTX 2 / WAN), when the GPU spills into shared VRAM and slows to a crawl, when switching between models eats all RAM, when Z-Image produces black/garbled output under Sage, or when deciding which attention backend to launch with. Flag names verified against upstream comfy/cli_args.py — see Sources.
+description: Pick the right ComfyUI startup flags for VRAM, attention, caching, and speed. The full decision matrix for OOM (--novram / --cache-none / --disable-smart-memory), shared-VRAM creep on Windows (--reserve-vram N), model-switching with big text encoders (--cache-none), high-VRAM throughput (--gpu-only / --highvram), and attention-backend selection (--use-sage-attention for speed, --use-pytorch-cross-attention as the highest-quality / Z-Image-safe fallback). Also the acceleration-stack + Blackwell/RTX 5000 (sm_120) notes. Use when a graph OOMs (especially long video like LTX 2 / WAN), when the GPU spills into shared VRAM and slows to a crawl, when switching between models eats all RAM, when Z-Image produces black/garbled output under Sage, or when deciding which attention backend to launch with. Flag names verified against upstream comfy/cli_args.py; see Sources.
 globs:
   - "**/*.json"
   - "**/packs/**"
@@ -10,10 +10,10 @@ globs:
 
 ## Overview
 
-ComfyUI's runtime behavior is controlled by CLI flags passed to `main.py`
+CLI flags passed to `main.py` control ComfyUI's runtime behavior
 (e.g. `python main.py --reserve-vram 2 --use-sage-attention`). The three that
-matter most for making a graph *run* — rather than OOM or crawl — are the
-**VRAM strategy**, the **attention backend**, and the **cache mode**. This skill
+matter most for making a graph *run* rather than OOM or crawl are the
+VRAM strategy, the attention backend, and the cache mode. This skill
 is the decision matrix for choosing them.
 
 > ⚠️ **Verification note (August 2026).** Every flag below was checked against
@@ -28,12 +28,12 @@ is the decision matrix for choosing them.
 > support, not only the kitchen version. Use `kitchen` / `panel_kitchen` to see
 > what this GPU can actually run.
 
-> ℹ️ **How to apply today.** The MCP's `restart_comfyui` (with `action: "start"`)
-> currently *replays the exact argv of the previous run* — it does not compose
+> How to apply today. The MCP's `restart_comfyui` (with `action: "start"`)
+> currently *replays the exact argv of the previous run*. It does not compose
 > fresh flags. So set these when you launch ComfyUI yourself (the
 > `python main.py …` line, a `run.bat`/shell alias, or the SwarmUI backend args
-> box), and the tool will preserve them on restart. (Injecting flags through the
-> tool is a tracked follow-up.)
+> box), and the tool will preserve them on restart. Injecting flags through the
+> tool is a tracked follow-up.
 
 ---
 
@@ -55,7 +55,7 @@ Sage gives black output on some models              ▶ --use-pytorch-cross-atte
 ROCm, kitchen present, triton ≥ 3.7                  ▶ --enable-triton-backend
 ```
 
-VRAM strategy and attention backend are each **mutually exclusive groups** —
+VRAM strategy and attention backend are each mutually exclusive groups, so
 pass at most one from each. You can combine one VRAM flag + one attention flag +
 one cache flag (e.g. `--novram --use-sage-attention --cache-none`).
 
@@ -74,14 +74,14 @@ one cache flag (e.g. `--novram --use-sage-attention --cache-none`).
 
 Modifiers (combine with the above):
 
-- **`--reserve-vram N`** — reserve N GB for the OS / other apps. The fix for the
-  Windows failure mode where the GPU quietly starts using **shared** VRAM and
-  throughput collapses. Typical `2`–`4`; bump to `10` for heavy video decode.
-- **`--disable-smart-memory`** — force aggressive offload to regular RAM instead
+- `--reserve-vram N` reserves N GB for the OS and other apps. It is the fix for the
+  Windows failure mode where the GPU quietly starts using shared VRAM and
+  throughput collapses. Typical `2` to `4`; bump to `10` for heavy video decode.
+- `--disable-smart-memory` forces aggressive offload to regular RAM instead
   of keeping models cached in VRAM. Reach for this when a run gets *stuck* or
-  OOMs intermittently. Slightly slower, much more robust.
-- **`--async-offload`** — async weight offload streams (default on where
-  supported); `--disable-async-offload` to turn off if it misbehaves.
+  OOMs intermittently. Slightly slower, much more reliable.
+- `--async-offload` enables async weight offload streams (default on where
+  supported); `--disable-async-offload` turns it off if it misbehaves.
 
 ---
 
@@ -96,16 +96,16 @@ Modifiers (combine with the above):
 | `--use-pytorch-cross-attention` | PyTorch SDPA. **Highest quality, always available, no extra deps.** The safe default and the correct fallback. |
 | `--use-split-cross-attention` / `--use-quad-cross-attention` | Memory-optimized math attention for older/low-VRAM cards. |
 
-**Two gotchas worth memorizing:**
+Two gotchas worth memorizing:
 
-1. **Z-Image + Sage = broken.** Z-Image (Turbo/Base) does **not** sample
-   correctly under `--use-sage-attention` — you get black or garbled output.
-   Launch Z-Image with **`--use-pytorch-cross-attention`** instead. See
+1. **Z-Image + Sage = broken.** Z-Image (Turbo/Base) does not sample
+   correctly under `--use-sage-attention`; you get black or garbled output.
+   Launch Z-Image with `--use-pytorch-cross-attention` instead. See
    [`z-image-txt2img`](../z-image-txt2img/SKILL.md).
 2. **Sage black output on other models.** If a model outputs black *only* with
    Sage, either switch to `--use-pytorch-cross-attention`, or (SwarmUI) set
    Advanced Sampling → Preferred DType = Default (16-bit). Sage-on vs Sage-off
-   also produces *slightly different* images — expect non-identical seeds.
+   also produces *slightly different* images, so expect non-identical seeds.
 
 > When a graph hard-crashes with `No module named 'sageattention'` /
 > `triton: unavailable`, the fix is the sdpa / no-compile fallback in
@@ -126,13 +126,13 @@ Modifiers (combine with the above):
 
 ## Speed / precision
 
-- **`--fast`** — enables experimental, potentially quality-degrading
+- `--fast` enables experimental, potentially quality-degrading
   optimizations. Accepts specific `PerformanceFeature` values:
   `fp16_accumulation`, `fp8_matrix_mult`, `cublas_ops`, `autotune`. Bare `--fast`
   turns them all on. Test output quality before committing to it.
-- **UNet/VAE/text-encoder dtype casts** exist too
+- UNet/VAE/text-encoder dtype casts exist too
   (`--fp8_e4m3fn-unet`, `--fp16-unet`, `--bf16-unet`, `--fp32-unet`, …) for
-  forcing a compute precision; usually the model/loader picks the right one, so
+  forcing a compute precision. Usually the model or loader picks the right one, so
   only reach for these to work around a specific dtype error.
 
 ---
@@ -160,10 +160,10 @@ per-model VRAM math in [`troubleshooting`](../troubleshooting/SKILL.md) and
 
 ## Acceleration stack & GPU coverage (context)
 
-The attention/compile accelerators are **version-locked to your exact
-torch + CUDA + Python**. A mismatched wheel doesn't just fail to import — it can
+The attention/compile accelerators are version-locked to your exact
+torch + CUDA + Python. A mismatched wheel doesn't just fail to import; it can
 break the torch install. A known-good, mutually-compatible stack for late-2025 /
-2026 NVIDIA (including **Blackwell / RTX 5000, `sm_120`**) looks like:
+2026 NVIDIA (including Blackwell / RTX 5000, `sm_120`) looks like:
 
 | Component | Role | Notes |
 |-----------|------|-------|
@@ -176,30 +176,30 @@ break the torch install. A known-good, mutually-compatible stack for late-2025 /
 
 Operational facts worth carrying:
 
-- **No system-wide CUDA toolkit is required** to *run* ComfyUI — an up-to-date
-  NVIDIA driver + prebuilt wheels are enough. A full CUDA/MSVC/cuDNN toolchain is
+- No system-wide CUDA toolkit is required to *run* ComfyUI. An up-to-date
+  NVIDIA driver plus prebuilt wheels is enough. A full CUDA/MSVC/cuDNN toolchain is
   only needed to *compile* kernels yourself.
-- **Broad arch coverage** when building wheels:
+- For broad arch coverage when building wheels,
   `TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;12.0+PTX` spans RTX 20xx→50xx
   and datacenter (A100/H100/B200). `+PTX` lets newer archs JIT.
-- **DeepSpeed has no wheels for Python 3.13**; several accel wheels lag the
-  newest Python — 3.10–3.12 is the safe range for the full stack.
-- **Clear the Triton cache** (`~/.triton` / `%USERPROFILE%\.triton` and temp)
+- DeepSpeed has no wheels for Python 3.13, and several accel wheels lag the
+  newest Python. 3.10 to 3.12 is the safe range for the full stack.
+- Clear the Triton cache (`~/.triton` / `%USERPROFILE%\.triton` and temp)
   when you hit stale-kernel Triton errors after an upgrade.
-- Prefer **`uv pip install`** over pip for the venv — dramatically faster
-  resolves/downloads. `install_comfyui` already supports this via `preferUv`.
-- **A single bad custom node can crash all of ComfyUI at startup.** Install/test
+- Prefer `uv pip install` over pip for the venv. Resolves and downloads are
+  dramatically faster. `install_comfyui` already supports this via `preferUv`.
+- A single bad custom node can crash all of ComfyUI at startup. Install and test
   acceleration and new node packs on a fresh/known-good install, not before a
   deadline. See [`troubleshooting`](../troubleshooting/SKILL.md).
 
 ## Quantization quick take
 
-- **FP8-*scaled*** (per-tensor scaled) is markedly higher quality than plain
+- FP8-*scaled* (per-tensor scaled) is markedly higher quality than plain
   base FP8, ~half the size of BF16, and usually faster.
-- **Prefer FP8-scaled over GGUF when you have enough system RAM** — ComfyUI's
+- Prefer FP8-scaled over GGUF when you have enough system RAM. ComfyUI's
   block-swap streams from RAM, so BF16/FP8 can run on 24GB GPUs given ample RAM.
   Fall back to GGUF (Q8→Q4) only when RAM is the constraint.
-- **NVFP4 / NVFP8** are markedly faster on Blackwell (RTX 5000) at near-BF16
+- NVFP4 / NVFP8 are markedly faster on Blackwell (RTX 5000) at near-BF16
   quality for supported models; LoRA support on NVFP4 is still partial.
 
 ---

--- a/plugin/skills/comfyui-node-registry/SKILL.md
+++ b/plugin/skills/comfyui-node-registry/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: comfyui-node-registry
-description: Authoring & publishing ComfyUI custom nodes to the Comfy Registry — node structure, pyproject.toml spec, comfy-cli publishing, and CI
+description: Authoring & publishing ComfyUI custom nodes to the Comfy Registry, covering node structure, pyproject.toml spec, comfy-cli publishing, and CI
 ---
 
 # Authoring & Publishing ComfyUI Custom Nodes
 
-This skill covers writing a ComfyUI custom node pack and publishing it to the **Comfy Registry** (registry.comfy.org), the public catalog that powers ComfyUI-Manager. For *using* existing nodes in workflows, see the `comfyui-core` skill instead.
+This skill covers writing a ComfyUI custom node pack and publishing it to the Comfy Registry (registry.comfy.org), the public catalog that powers ComfyUI-Manager. For *using* existing nodes in workflows, see the `comfyui-core` skill instead.
 
 ## Minimal Node Pack Structure
 
@@ -86,14 +86,14 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 | `RETURN_NAMES` | no | Friendly names for outputs (defaults to lowercased types). |
 | `OUTPUT_NODE` | no | `True` marks a terminal node that produces a result (save/preview). |
 
-**Input type widgets** — the options dict drives the UI widget:
+The options dict drives the UI widget for each input type:
 - `("INT", {"default": 0, "min": 0, "max": 100, "step": 1})`
 - `("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.1})`
 - `("STRING", {"default": "", "multiline": True})`
-- `(["a", "b", "c"],)` — a literal list becomes a dropdown
-- `("IMAGE",)`, `("LATENT",)`, `("MODEL",)` etc. — typed connections (no widget)
+- `(["a", "b", "c"],)`, a literal list, becomes a dropdown
+- `("IMAGE",)`, `("LATENT",)`, `("MODEL",)` etc. are typed connections (no widget)
 
-The executing method **must return a tuple** matching `RETURN_TYPES`, even for a single output (`return (result,)`).
+The executing method must return a tuple matching `RETURN_TYPES`, even for a single output (`return (result,)`).
 
 ## `pyproject.toml` — Registry Metadata
 
@@ -145,14 +145,14 @@ requires-comfyui = ">=1.0.0"                   # optional ComfyUI version constr
 
 ### Controlling the published archive
 
-- **`.comfyignore`** — uses `.gitignore` syntax; files listed are **excluded** from the published archive. Use it to drop tests, examples, large assets, and dev files.
-- **`[tool.comfy].includes`** — the inverse: force-includes folders that would otherwise be skipped (e.g. a bundled `web/dist`).
+- `.comfyignore` uses `.gitignore` syntax; files listed are excluded from the published archive. Use it to drop tests, examples, large assets, and dev files.
+- `[tool.comfy].includes` is the inverse: it force-includes folders that would otherwise be skipped (e.g. a bundled `web/dist`).
 
 ## Registry Setup (one-time)
 
-1. Go to **registry.comfy.org** and create a **publisher**.
-2. Your **Publisher ID** is the value after the `@` on your profile page. It is **globally unique and cannot be changed** — use it for `PublisherId` in `pyproject.toml`.
-3. In the publisher's section, **create an API key**. Name it and **save it somewhere safe — if you lose it you must create a new one** (it is not recoverable).
+1. Go to registry.comfy.org and create a publisher.
+2. Your Publisher ID is the value after the `@` on your profile page. It is globally unique and cannot be changed. Use it for `PublisherId` in `pyproject.toml`.
+3. In the publisher's section, create an API key. Name it and save it somewhere safe. If you lose it you must create a new one; it is not recoverable.
 
 ## CLI Publishing Flow
 
@@ -167,11 +167,11 @@ pip install comfy-cli
 | `comfy node init` | Scaffolds `pyproject.toml` with registry metadata in the current node pack folder. Fill in the required fields (esp. `PublisherId` and `Repository`). |
 | `comfy node publish` | Validates and uploads the current version to the registry. **Prompts for your API key.** Prints the registry URL on success. |
 
-**Version immutability:** once a `version` is published it **cannot be modified or overwritten**. To ship changes, bump `version` and publish again. To pull a bad version, **deprecate it on the website** (More Actions > Deprecate), which prompts users to upgrade rather than deleting it.
+Versions are immutable. Once a `version` is published it cannot be modified or overwritten. To ship changes, bump `version` and publish again. To pull a bad version, deprecate it on the website (More Actions > Deprecate), which prompts users to upgrade rather than deleting it.
 
 ## CI Publishing (GitHub Actions)
 
-Automate publishing on every version bump. Add the API key as a repo secret named **`REGISTRY_ACCESS_TOKEN`** (Settings > Secrets and variables > Actions), then create `.github/workflows/publish_action.yml`:
+Automate publishing on every version bump. Add the API key as a repo secret named `REGISTRY_ACCESS_TOKEN` (Settings > Secrets and variables > Actions), then create `.github/workflows/publish_action.yml`:
 
 ```yaml
 name: Publish to Comfy registry
@@ -196,26 +196,26 @@ jobs:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
 ```
 
-- Triggers on **push to `main`** but only when **`pyproject.toml`** changes (i.e. when you bump `version`). `workflow_dispatch` allows manual runs.
+- Triggers on push to `main` but only when `pyproject.toml` changes (i.e. when you bump `version`). `workflow_dispatch` allows manual runs.
 - If your default branch isn't `main`, update the `branches:` list.
-- The action reads the version from `pyproject.toml` and publishes it — so the typical flow is: bump `version`, commit, push to `main`, done.
+- The action reads the version from `pyproject.toml` and publishes it, so the typical flow is bump `version`, commit, push to `main`, done.
 
 ## Optional Frontend Extension
 
-If your pack adds custom UI (widgets, sidebar tabs, menu items), set `WEB_DIRECTORY` in `__init__.py` and ship JS there. New frontend extensions should target the modern **`@comfyorg/extension-api`** rather than poking at legacy globals; pull in `@comfyorg/comfyui-frontend-types` for TypeScript types (`npm install -D @comfyorg/comfyui-frontend-types`). For the full frontend authoring workflow (`defineExtension`/`defineNode`/`defineWidget` and the `defineSidebarTab`/`defineCommand`/`defineSetting` shell APIs), see the sibling **`comfyui-frontend-extensions`** skill.
+If your pack adds custom UI (widgets, sidebar tabs, menu items), set `WEB_DIRECTORY` in `__init__.py` and ship JS there. New frontend extensions should target the modern `@comfyorg/extension-api` rather than poking at legacy globals; pull in `@comfyorg/comfyui-frontend-types` for TypeScript types (`npm install -D @comfyorg/comfyui-frontend-types`). For the full frontend authoring workflow (`defineExtension`/`defineNode`/`defineWidget` and the `defineSidebarTab`/`defineCommand`/`defineSetting` shell APIs), see the sibling `comfyui-frontend-extensions` skill.
 
 ## Common Mistakes
 
-1. **Forgetting the return tuple** — the `FUNCTION` method must `return (value,)`, not `return value`, even for one output.
-2. **Single-element `RETURN_TYPES` without a comma** — `("IMAGE")` is a string, not a tuple. Write `("IMAGE",)`.
-3. **`INPUT_TYPES` not a `@classmethod`** — ComfyUI calls it on the class; missing the decorator breaks node loading.
-4. **Trying to overwrite a published version** — versions are immutable. Bump `version` instead; deprecate bad ones on the website.
-5. **Renaming `name` after publishing** — it's immutable and globally unique. Pick a good name (no "ComfyUI" prefix) up front.
-6. **Missing `[project.urls].Repository`** — it's required; publishing fails without a valid repo URL.
-7. **Wrong `PublisherId`** — use the id after the `@` on your profile, not your display name.
-8. **Oversized icon** — must be square and ≤ 400×400px; larger images are rejected.
-9. **Renaming class keys in `NODE_CLASS_MAPPINGS`** — the key is the `class_type` stored in workflow JSON. Changing it breaks every saved workflow that used the node.
-10. **Committing the API key** — store it as the `REGISTRY_ACCESS_TOKEN` secret; never in `pyproject.toml` or the repo.
+1. **Forgetting the return tuple.** The `FUNCTION` method must `return (value,)`, not `return value`, even for one output.
+2. **Single-element `RETURN_TYPES` without a comma.** `("IMAGE")` is a string, not a tuple. Write `("IMAGE",)`.
+3. **`INPUT_TYPES` not a `@classmethod`.** ComfyUI calls it on the class; missing the decorator breaks node loading.
+4. **Trying to overwrite a published version.** Versions are immutable. Bump `version` instead; deprecate bad ones on the website.
+5. **Renaming `name` after publishing.** It's immutable and globally unique. Pick a good name (no "ComfyUI" prefix) up front.
+6. **Missing `[project.urls].Repository`.** It's required; publishing fails without a valid repo URL.
+7. **Wrong `PublisherId`.** Use the id after the `@` on your profile, not your display name.
+8. **Oversized icon.** Must be square and ≤ 400×400px; larger images are rejected.
+9. **Renaming class keys in `NODE_CLASS_MAPPINGS`.** The key is the `class_type` stored in workflow JSON. Changing it breaks every saved workflow that used the node.
+10. **Committing the API key.** Store it as the `REGISTRY_ACCESS_TOKEN` secret; never in `pyproject.toml` or the repo.
 
 ## Sources
 

--- a/plugin/skills/debug-render/SKILL.md
+++ b/plugin/skills/debug-render/SKILL.md
@@ -1,43 +1,43 @@
 ---
 name: debug-render
-description: Debug a WRONG or imperfect render (not a hard error) by inspecting inputs and intermediate steps with run-to-node — render one branch up to an output, preview-tap latents/masks/preprocessor maps, localize the first bad stage, then fix. Use when a final image/video comes out wrong — artifacts, wrong subject/pose/composition/color, blur, a ControlNet/IPAdapter/mask/LoRA not taking, a two-stage refiner or upscale degrading the result — rather than the run failing with an error (for errors/OOM/missing nodes use the troubleshooting skill).
+description: Debug a WRONG or imperfect render (not a hard error) by inspecting inputs and intermediate steps with run-to-node. Render one branch up to an output, preview-tap latents/masks/preprocessor maps, localize the first bad stage, then fix. Use when a final image/video completes but looks wrong, such as artifacts, wrong subject/pose/composition/color, blur, a ControlNet/IPAdapter/mask/LoRA not taking, or a two-stage refiner or upscale degrading the result. For errors/OOM/missing nodes use the troubleshooting skill.
 ---
 
 # Debugging renders with run-to-node
 
-When a final asset looks **wrong** (not when it errors), don't re-roll the whole
-graph and hope. **Localize the fault**: render only as far as one stage and LOOK
+When a final asset looks wrong (not when it errors), don't re-roll the whole
+graph and hope. Localize the fault. Render only as far as one stage and look
 at what that stage actually produces. The wrong-looking output is downstream of a
-*first* bad step — find that step, fix it there, and everything after it follows.
+*first* bad step. Find that step, fix it there, and everything after it follows.
 
-The tool for this is **`panel_run` with `to_node_id`** ("run to node"), which uses
-ComfyUI's native **partial execution**: only the target output node plus
+The tool for this is `panel_run` with `to_node_id` ("run to node"), which uses
+ComfyUI's native partial execution. Only the target output node plus
 everything upstream of it renders; every other branch is skipped. That makes each
-probe **fast and cheap**, and the output is delivered to you automatically (same
-as any run — don't poll).
+probe fast and cheap, and the output is delivered to you automatically, same
+as any run. Don't poll.
 
 ## When to reach for this
 
 - A final image/video is wrong: artifacts, wrong subject/pose/composition, off
   color, soft/blurry, melted hands, wrong style.
-- A conditioner isn't "taking": ControlNet, IPAdapter, a mask, an inpaint, a
-  LoRA — and you can't tell if the *input* to it is wrong or the *node* is wrong.
+- A conditioner isn't "taking" (ControlNet, IPAdapter, a mask, an inpaint, a
+  LoRA) and you can't tell if the *input* to it is wrong or the *node* is wrong.
 - A multi-stage pipeline (base → refiner, txt2img → upscale, decode → post)
-  degrades: you need to see which stage introduces the problem.
-- You only want to test **one** branch of a multi-output graph without paying for
+  degrades, and you need to see which stage introduces the problem.
+- You only want to test one branch of a multi-output graph without paying for
   the others.
 
-If instead the run **fails** (red error, OOM, missing node, black image from a
-crash) → use the **troubleshooting** skill; this skill is for outputs that
+If instead the run fails (red error, OOM, missing node, black image from a
+crash), use the troubleshooting skill. This skill is for outputs that
 *complete* but look wrong.
 
 ## The one hard rule: `to_node_id` must be an OUTPUT node
 
-ComfyUI can only run *to* an **output node** — SaveImage, PreviewImage, SaveVideo,
+ComfyUI can only run *to* an output node: SaveImage, PreviewImage, SaveVideo,
 SaveAudio, etc. (these show `is_output: true` in `panel_query_graph` detail rows). A bare
-KSampler / VAEDecode / preprocessor is **not** an output node, so you can't target
-it directly. To inspect a point that isn't already an output, **add a preview
-tap** there:
+KSampler / VAEDecode / preprocessor is not an output node, so you can't target
+it directly. To inspect a point that isn't already an output, add a preview
+tap there:
 
 | You want to see… | Wire type | Tap to add | Wiring |
 |---|---|---|---|
@@ -52,56 +52,56 @@ Build a tap with `panel_add_node` + `panel_connect`, run to it, inspect, then
 
 ## The loop
 
-1. **Read the graph.** `panel_graph_outline` (then `panel_query_graph` for specifics) — note node ids, the output nodes
-   (`is_output: true`), and every node's **mode**. A node in `bypass`/`mute` on
-   the path is OFF and is a top cause of wrong renders — fix modes first with
+1. **Read the graph.** `panel_graph_outline` (then `panel_query_graph` for specifics). Note node ids, the output nodes
+   (`is_output: true`), and every node's mode. A node in `bypass`/`mute` on
+   the path is OFF and is a top cause of wrong renders. Fix modes first with
    `panel_set_node_mode` before you blame anything else.
 2. **Pick a probe point** roughly in the middle of the suspect chain (bisect).
-3. **Get an output there** — target an existing output node, or add a preview tap
+3. **Get an output there.** Target an existing output node, or add a preview tap
    (table above).
 4. **`panel_run(to_node_id = that output node)`.** Only that branch renders.
 5. **Look at what's delivered.** Is *this* stage already wrong, or still fine?
-   - Still fine → move the probe **downstream**; the fault is later.
-   - Already wrong → move the probe **upstream**; the fault is earlier.
-6. Repeat until you find the **first** stage whose output is bad. That node (or
-   its inputs/widgets) is what to fix — `panel_set_widget`, `panel_set_node_mode`,
-   a rewire, a different model — then run-to-node there again to confirm the fix
-   **before** running the full graph.
+   - Still fine: move the probe downstream; the fault is later.
+   - Already wrong: move the probe upstream; the fault is earlier.
+6. Repeat until you find the first stage whose output is bad. That node (or
+   its inputs/widgets) is what to fix, via `panel_set_widget`, `panel_set_node_mode`,
+   a rewire, or a different model. Then run-to-node there again to confirm the fix
+   before running the full graph.
 7. **Clean up** temporary preview taps (`panel_remove_node`) and do a final full
    `panel_run` to produce the real saved asset.
 
 ## Symptom → where to probe first
 
-- **Whole image wrong subject/style** → preview the conditioning's source (the
+- **Whole image wrong subject/style.** Preview the conditioning's source (the
   text/prompt node, the sampler's positive input via a decode of its latent).
-- **ControlNet ignored / wrong structure** → preview the **preprocessor map**
-  (the depth/pose/canny IMAGE going into the ControlNet). A blank or wrong map =
+- **ControlNet ignored / wrong structure.** Preview the preprocessor map
+  (the depth/pose/canny IMAGE going into the ControlNet). A blank or wrong map means
   the problem is the preprocessor or its input, not the sampler.
-- **IPAdapter/reference not taking** → preview the reference image after any
+- **IPAdapter/reference not taking.** Preview the reference image after any
   resize/crop the IPAdapter chain applies.
-- **Inpaint/outpaint bleeding** → `MaskToImage`-preview the mask actually reaching
+- **Inpaint/outpaint bleeding.** `MaskToImage`-preview the mask actually reaching
   the sampler (mask misalignment is the usual culprit).
-- **Refiner/upscale degrades it** → preview the base latent (VAEDecode tap)
-  *before* the refiner vs after: if the base is good and the result is bad, the
+- **Refiner/upscale degrades it.** Preview the base latent (VAEDecode tap)
+  *before* the refiner vs after. If the base is good and the result is bad, the
   refiner/upscale stage is at fault.
-- **Right content, bad quality only** → it's late (sampler steps/cfg, VAE,
-  post) — probe near the end first.
+- **Right content, bad quality only.** The fault is late (sampler steps/cfg, VAE,
+  post), so probe near the end first.
 
 ## Gotchas
 
 - **Output-node only.** If you target a non-output node, the run is rejected with
-  a message saying so — add a preview tap instead.
+  a message saying so. Add a preview tap instead.
 - **Modes matter.** A bypassed/muted node on the probed path silently changes what
   renders. Check modes in step 1.
 - **Auto-delivery.** The probe's output node fires an `executed` event and the
-  image is delivered to you inline — including PreviewImage taps, which arrive
+  image is delivered to you inline, including PreviewImage taps, which arrive
   labeled as a *preview* (temporary, not a saved file). Don't poll; just end the
   turn and read the delivered image. A preview tap with no SaveImage means "no
-  saved output ran" — that's expected for a probe.
-- **Shared queue.** Each run-to-node queues a real (small) job; don't stack
-  probes — run one, read it, then the next.
-- **Subgraphs.** Output nodes nested inside a subgraph can't be targeted yet;
-  probe at the root graph (add the tap outside the subgraph, fed by an exposed
+  saved output ran", which is expected for a probe.
+- **Shared queue.** Each run-to-node queues a real (small) job. Don't stack
+  probes. Run one, read it, then the next.
+- **Subgraphs.** Output nodes nested inside a subgraph can't be targeted yet.
+  Probe at the root graph (add the tap outside the subgraph, fed by an exposed
   output rail).
 
 ## Sources

--- a/plugin/skills/director/SKILL.md
+++ b/plugin/skills/director/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: director
-description: Full production pipeline — story to scenes, Z-Image start frames, Qwen Edit end frames, WAN FLF video clips, ffmpeg concatenation
+description: Full production pipeline covering story to scenes, Z-Image start frames, Qwen Edit end frames, WAN FLF video clips, ffmpeg concatenation
 globs:
   - "**/*.json"
 ---
@@ -9,13 +9,13 @@ globs:
 
 ## Overview
 
-The Director skill orchestrates a complete short film production from a text story. It breaks the story into scenes, generates start/end frames for each, creates video clips from frame pairs, and concatenates everything into a final video.
+The Director skill runs a complete short film production from a text story. It breaks the story into scenes, generates start/end frames for each, creates video clips from frame pairs, and concatenates everything into a final video.
 
-**Pipeline**: Story Planning → Z-Image Hero + Character Refs → Qwen Edit Chain (all frames) → WAN 2.2 FLF Video Clips → ffmpeg Concatenation
+The pipeline runs Story Planning → Z-Image Hero + Character Refs → Qwen Edit Chain (all frames) → WAN 2.2 FLF Video Clips → ffmpeg Concatenation.
 
-**Key architectural decisions**:
-- **1 hero frame + edit chain** for character consistency (NEVER independent Z-Image per scene)
-- **Inter-scene frame continuity**: Scene N's end frame IS Scene N+1's start frame (same image file, no edit gap)
+Key architectural decisions:
+- 1 hero frame + edit chain for character consistency (NEVER independent Z-Image per scene)
+- Inter-scene frame continuity. Scene N's end frame IS Scene N+1's start frame (same image file, no edit gap)
 - Character reference images fed into Qwen Edit's extra image slots
 - State file persists to disk for context compaction survival
 - Each scene is independently retryable without affecting others
@@ -25,19 +25,19 @@ The Director skill orchestrates a complete short film production from a text sto
 
 This pipeline drives the user's live canvas across many stages, so two habits are non-negotiable:
 
-- **Inspect node modes before each render.** After loading any pack/template/subgraph and before `panel_run`, check each node's `mode` (`panel_graph_outline` marks [bypass]/[mute]; `panel_query_graph` detail rows carry it). A `bypass` node is skipped (passes input through); a `mute` node and everything downstream don't execute. If the path/branch/switch you need is bypassed or muted, enable it with `panel_set_node_mode` (set the wanted node `active`, the unwanted one `bypass`/`mute`). Never assume a switch or route is already active.
-- **Verify the output matches before moving on.** Every Phase-N render is a gate: actually LOOK at the produced frame/clip (view it) and confirm it matches the intent BEFORE advancing or reporting progress. If it's wrong, diagnose (wrong prompt path? a bypassed/muted builder or switch? wrong widget? wrong ref image?), fix, and rerun. Do NOT declare a phase done or report progress you haven't verified.
-- **Confirm VIDEO renders via the filesystem, not /history.** For a `VHS_VideoCombine` / LTX / WAN clip, do NOT rely on `get_history` / `queue` (action:"status") to confirm it exists — VHS-style video nodes write the .mp4 but frequently do NOT register an output in ComfyUI's `/history` (prompt shows done, empty outputs, no error). Confirm the file with `get_image (action:"list_outputs")` (now lists videos too, tagged `kind: "video"`) by `filename_prefix` + fresh mtime, then chain it forward with `upload_image (action:"stage")`.
-- **Bypass completed stages before queuing the next one.** If you build the multi-stage pipeline on ONE canvas (e.g. Krea2 → LTX → WAN) rather than running each phase in isolation, once a stage has run and its output is captured/staged, `panel_set_node_mode(mode:"bypass")` that stage's nodes BEFORE you `panel_run` the next stage — otherwise `panel_run` re-executes the whole graph and you pay for / wait on already-finished work (a real, costly failure mode). Keep only the active stage live; feed the prior output forward with `upload_image (action:"stage")` (bypass the producer, feed its captured output to the consumer's loader).
+- **Inspect node modes before each render.** After loading any pack/template/subgraph and before `panel_run`, check each node's `mode` (`panel_graph_outline` marks [bypass]/[mute]; `panel_query_graph` detail rows carry it). A `bypass` node is skipped (passes input through); a `mute` node and everything downstream don't execute. If the path, branch, or switch you need is bypassed or muted, enable it with `panel_set_node_mode` (set the wanted node `active`, the unwanted one `bypass`/`mute`). Never assume a switch or route is already active.
+- **Verify the output matches before moving on.** Every Phase-N render is a gate. Look at the produced frame or clip (view it) and confirm it matches the intent BEFORE advancing or reporting progress. If it's wrong, diagnose (wrong prompt path? a bypassed/muted builder or switch? wrong widget? wrong ref image?), fix, and rerun. Do NOT declare a phase done or report progress you haven't verified.
+- **Confirm VIDEO renders via the filesystem, not /history.** For a `VHS_VideoCombine` / LTX / WAN clip, do NOT rely on `get_history` / `queue` (action:"status") to confirm it exists. VHS-style video nodes write the .mp4 but frequently do NOT register an output in ComfyUI's `/history` (prompt shows done, empty outputs, no error). Confirm the file with `get_image (action:"list_outputs")` (now lists videos too, tagged `kind: "video"`) by `filename_prefix` + fresh mtime, then chain it forward with `upload_image (action:"stage")`.
+- **Bypass completed stages before queuing the next one.** If you build the multi-stage pipeline on ONE canvas (e.g. Krea2 → LTX → WAN) rather than running each phase in isolation, once a stage has run and its output is captured/staged, `panel_set_node_mode(mode:"bypass")` that stage's nodes BEFORE you `panel_run` the next stage. Otherwise `panel_run` re-executes the whole graph and you pay for and wait on already-finished work, a real and costly failure mode. Keep only the active stage live; feed the prior output forward with `upload_image (action:"stage")` (bypass the producer, feed its captured output to the consumer's loader).
 
 ## CRITICAL: Character Consistency
 
-**Independent Z-Image generations per scene produce different-looking characters.** This was the #1 problem discovered during testing. The solution:
+Independent Z-Image generations per scene produce different-looking characters. This was the #1 problem discovered during testing. The solution:
 
-1. Generate **ONE hero frame** with Z-Image — establishes the main character, setting, and lighting
-2. Generate **character reference images** — close-up portraits of each character, key props, and the background
-3. **ALL other scene frames** are created via Qwen Edit chain from the hero, with character refs in extra image slots
-4. This ensures the same face, clothing, and environment across every frame
+1. Generate ONE hero frame with Z-Image. It establishes the main character, setting, and lighting
+2. Generate character reference images: close-up portraits of each character, key props, and the background
+3. Create ALL other scene frames via the Qwen Edit chain from the hero, with character refs in extra image slots
+4. This keeps the same face, clothing, and environment across every frame
 
 ## 8-Phase Pipeline
 
@@ -103,23 +103,23 @@ Saved at `~/code/comfyui-mcp/workflows/director_state_{project_id}.json`. Update
 | 4: Edit Chain | Qwen Edit | `qwen_image_edit_2511_bf16.safetensors` + Lightning LoRA | ~17-18GB |
 | 6: Video Clips | WAN 2.2 I2V | Remix NSFW Hi+Lo (built-in lightning) | ~22-24GB |
 
-**CRITICAL**: `clear_vram` between every model family switch.
+CRITICAL: `clear_vram` between every model family switch.
 
 ## Phase 1: Story Planning
 
-Break the story into 2-6 scenes. For each scene, identify:
-- **description**: What happens (1-2 sentences)
-- **start frame**: What the opening frame looks like
-- **end frame**: What the closing frame looks like
-- **video_prompt**: Motion description for FLF transition
+Break the story into 2 to 6 scenes. For each scene, identify:
+- description: what happens (1 to 2 sentences)
+- start frame: what the opening frame looks like
+- end frame: what the closing frame looks like
+- video_prompt: motion description for FLF transition
 
-Identify a **hero frame** — the single most representative scene image that establishes the main character and setting. This hero will anchor all other frames via Qwen Edit.
+Identify a hero frame, the single most representative scene image that establishes the main character and setting. This hero will anchor all other frames via Qwen Edit.
 
-Also identify which **character reference images** are needed (portraits of each character, key props, background).
+Also identify which character reference images are needed (portraits of each character, key props, background).
 
 ### CRITICAL: Inter-Scene Frame Continuity
 
-**The end frame of Scene N must be the EXACT same image file as the start frame of Scene N+1.** Do NOT create separate Qwen-edited start frames for subsequent scenes — this causes visible jumps at scene boundaries when the videos are concatenated.
+The end frame of Scene N must be the EXACT same image file as the start frame of Scene N+1. Do NOT create separate Qwen-edited start frames for subsequent scenes. That causes visible jumps at scene boundaries when the videos are concatenated.
 
 The frame chain for video generation:
 ```
@@ -134,10 +134,10 @@ Only Scene 1 needs a unique start frame. All other scenes inherit their start fr
 
 ### Edit Chain Planning
 
-The edit chain produces **only end frames** (plus Scene 1's unique start frame). Map which end frame derives from which source:
+The edit chain produces only end frames (plus Scene 1's unique start frame). Map which end frame derives from which source:
 - Some end frames edit directly from the hero
 - Later end frames may chain from earlier end frames
-- Keep chains shallow (max 4-5 deep) to minimize drift
+- Keep chains shallow (max 4 to 5 deep) to minimize drift
 
 Example chain:
 ```
@@ -153,9 +153,9 @@ Hero (man+cat on bed)
 
 Generate with Z-Image RedCraft DX1 (10 steps, CFG 1, euler/simple):
 
-1. **Hero frame**: The establishing shot with main character + key elements
-2. **Character ref portraits**: Close-up of each character (man, woman, animal, etc.)
-3. **Background ref**: The setting without characters
+1. Hero frame: the establishing shot with main character + key elements
+2. Character ref portraits: close-up of each character (man, woman, animal, etc.)
+3. Background ref: the setting without characters
 
 Add to negative prompts for character refs to exclude wrong subjects (e.g., "woman, female" when generating man portrait).
 
@@ -186,11 +186,11 @@ Show hero frame and all character refs. User approves or requests regeneration w
 
 ### CRITICAL: Consistency Rules for Edit Prompts
 
-1. **Always explicitly anchor clothing**: "The man wears his grey t-shirt" in EVERY prompt
-2. **Always state what doesn't change**: "Same bedroom, same warm lighting, same clothing"
-3. **Use strong emotion words**: "extremely shocked and startled" >> "surprised"
-4. **Include proportionality**: "Her head and body should be proportional and natural looking"
-5. **Prevent head enlargement**: In embrace/close-up poses, Qwen Edit tends to enlarge heads. Add explicit: "do not enlarge her head, keep the same small natural size as in the original image"
+1. **Always explicitly anchor clothing.** "The man wears his grey t-shirt" in EVERY prompt
+2. **Always state what doesn't change.** "Same bedroom, same warm lighting, same clothing"
+3. **Use strong emotion words.** "extremely shocked and startled" >> "surprised"
+4. **Include proportionality.** "Her head and body should be proportional and natural looking"
+5. **Prevent head enlargement.** In embrace/close-up poses, Qwen Edit tends to enlarge heads. Add an explicit "do not enlarge her head, keep the same small natural size as in the original image"
 6. **Describe the transformation, not just the end state**
 
 ### Workflow Template (with Character Reference Slots)
@@ -222,13 +222,13 @@ Show hero frame and all character refs. User approves or requests regeneration w
 }
 ```
 
-**Key: slots 5b and 5c** — feed character reference and background reference into `vl_resize_image2` and `vl_resize_image3`. This helps the vision encoder maintain character appearance across edits.
+Slots 5b and 5c matter. Feed character reference and background reference into `vl_resize_image2` and `vl_resize_image3`. This helps the vision encoder maintain character appearance across edits.
 
 ### Chain Execution
 
-Edits are **sequential** — each depends on the previous output:
+Edits are sequential; each depends on the previous output:
 1. Run edit, wait for completion
-2. **Stage the output as the next stage's input with `upload_image (action:"stage")`** (pass the output's `{ filename, subfolder?, type? }`); it returns the registered input filename
+2. Stage the output as the next stage's input with `upload_image (action:"stage")` (pass the output's `{ filename, subfolder?, type? }`); it returns the registered input filename
 3. Use that returned filename as the `image` in the next edit's `LoadImage`
 4. Update state file after each edit
 
@@ -236,7 +236,7 @@ Independent edits (both from hero) can run in parallel.
 
 ### CRITICAL: feeding an output into the next loader (don't guess paths)
 
-To pipe ANY stage's output into the next stage's loader (`LoadImage` here, `VHS_LoadVideo` / `LoadAudio` in the video phases), call **`upload_image (action:"stage")`** with the output's `{ filename, subfolder?, type? }` and drop the returned input filename into the loader's `image`/`video`/`audio` widget. For a file already on local disk, use `upload_image` with action `"image"` / `"video"` / `"audio"`. **NEVER copy the output file into, or guess, a filesystem `input/` path** — ComfyUI's input and output directories may be CUSTOM (`--input-directory` / `--output-directory`), so a guessed path makes the loader reject the file (`Invalid image file`) and wastes the render. `upload_image (action:"stage")` goes through the server API (`/view` → `/upload/image`), which resolves the real dirs correctly.
+To pipe ANY stage's output into the next stage's loader (`LoadImage` here, `VHS_LoadVideo` / `LoadAudio` in the video phases), call `upload_image (action:"stage")` with the output's `{ filename, subfolder?, type? }` and drop the returned input filename into the loader's `image`/`video`/`audio` widget. For a file already on local disk, use `upload_image` with action `"image"` / `"video"` / `"audio"`. NEVER copy the output file into, or guess, a filesystem `input/` path. ComfyUI's input and output directories may be CUSTOM (`--input-directory` / `--output-directory`), so a guessed path makes the loader reject the file (`Invalid image file`) and wastes the render. `upload_image (action:"stage")` goes through the server API (`/view` → `/upload/image`), which resolves the real dirs correctly.
 
 ### Timing
 
@@ -251,7 +251,7 @@ For each frame, show via `Read` for visual inspection. User approves or provides
 
 ### Workflow Template
 
-(Same as wan-flf-video skill — Remix NSFW Hi+Lo, 4-stack LoRA, ImageResizeKJv2, dual KSamplerAdvanced)
+(Same as wan-flf-video skill: Remix NSFW Hi+Lo, 4-stack LoRA, ImageResizeKJv2, dual KSamplerAdvanced)
 
 Key settings:
 - Portrait: width=480, height=720
@@ -262,16 +262,16 @@ Key settings:
 ### Morph LoRA
 
 For transformation scenes (e.g., cat→woman), add morph LoRA to Hi/Lo Common stacks:
-- `wan2.2_i2v_magical_morph_highnoise.safetensors` → Hi Common slot 1 (strength **1.0**)
-- `wan2.2_i2v_magical_morph_lownoise.safetensors` → Lo Common slot 1 (strength **1.0**)
+- `wan2.2_i2v_magical_morph_highnoise.safetensors` → Hi Common slot 1 (strength 1.0)
+- `wan2.2_i2v_magical_morph_lownoise.safetensors` → Lo Common slot 1 (strength 1.0)
 
-Use **1.0 strength** — tested without sparkle issues. Lower values (0.7-0.85) produce weaker morph effects that may look like a dissolve rather than a true morph.
+Use 1.0 strength; it tested without sparkle issues. Lower values (0.7-0.85) produce weaker morph effects that may look like a dissolve rather than a true morph.
 
 ### Per-Scene Changes
 
 Swap per scene: start/end image filenames, positive prompt text, noise_seed, filename_prefix.
 
-All 5 clips can be queued at once — they run sequentially in ComfyUI, sharing loaded models.
+All 5 clips can be queued at once. They run sequentially in ComfyUI, sharing loaded models.
 
 ## Phase 7: Video Review
 
@@ -285,7 +285,7 @@ printf "file 'director_s1_00001.mp4'\nfile 'director_s2_00001.mp4'\n..." > conca
 ffmpeg -f concat -safe 0 -i concat_list.txt -c copy director_final_{project_id}.mp4
 ```
 
-All clips share resolution/codec/framerate — copy-concat works without re-encoding.
+All clips share resolution/codec/framerate, so copy-concat works without re-encoding.
 
 ## Resumption Protocol
 
@@ -325,7 +325,7 @@ Use distinctive visual elements that transfer between characters/forms to create
 - Assume clothing/setting will be preserved automatically
 - Use mild emotion words ("surprised" → use "extremely shocked" instead)
 - Chain more than 5-6 edits deep without branching back to hero
-- Assume head proportions stay correct in embrace/hug poses — always add explicit size anchoring
+- Assume head proportions stay correct in embrace/hug poses; always add explicit size anchoring
 
 ### WAN Video Prompts
 - Use motion verbs: "walks", "turns", "reaches", "sits up", "leans in"

--- a/plugin/skills/ernie-image/SKILL.md
+++ b/plugin/skills/ernie-image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ernie-image
-description: Build Baidu ERNIE-Image / ERNIE-Image-Turbo workflows — primarily TEXT-TO-IMAGE. Pick ERNIE when you need precise multilingual text rendering, posters/signage, manga/anime multi-panel layouts, or strong instruction following for complex multi-object scenes. Also supports denoise-based image-to-image refine (NOT instruction-grounded editing — use Qwen-Image-Edit or Flux Kontext for "change X in this photo" edits).
+description: Build Baidu ERNIE-Image / ERNIE-Image-Turbo workflows, primarily TEXT-TO-IMAGE. Pick ERNIE when you need precise multilingual text rendering, posters/signage, manga/anime multi-panel layouts, or strong instruction following for complex multi-object scenes. Also supports denoise-based image-to-image refine (NOT instruction-grounded editing; use Qwen-Image-Edit or Flux Kontext for "change X in this photo" edits).
 globs:
   - "**/*.json"
 ---
@@ -9,19 +9,19 @@ globs:
 
 ## What this is (read first)
 
-**ERNIE-Image is Baidu's open-weight TEXT-TO-IMAGE model** — an ~8B single-stream Diffusion Transformer (DiT), Apache-2.0, released April 2026, repackaged for ComfyUI by Comfy-Org. It is **not** an instruction-based image editor.
+ERNIE-Image is Baidu's open-weight TEXT-TO-IMAGE model, an ~8B single-stream Diffusion Transformer (DiT), Apache-2.0, released April 2026 and repackaged for ComfyUI by Comfy-Org. It is not an instruction-based image editor.
 
-- **ERNIE-Image** (base): ~50 steps for peak quality.
-- **ERNIE-Image-Turbo**: distilled (Distribution Matching Distillation + RL), high-fidelity in **~8 steps, cfg 1**. The downloaded pack uses **Turbo** (`ernie-image-turbo-*.gguf`).
+- ERNIE-Image (base): ~50 steps for peak quality.
+- ERNIE-Image-Turbo: distilled (Distribution Matching Distillation + RL), high-fidelity in ~8 steps at cfg 1. The downloaded pack uses Turbo (`ernie-image-turbo-*.gguf`).
 
-**Pick ERNIE when** the job is: precise text/typography rendering (multilingual, including Chinese), posters/signage/UI mockups, manga/anime storyboards and multi-panel layouts, or structured multi-object scenes from a complex prompt.
-**Do NOT pick ERNIE for** "edit this photo / change the shirt / swap the background" — that is instruction-grounded editing, which ERNIE does **not** do. Use `qwen-image-edit` or Flux Kontext for those. ERNIE's "image-to-image" here is plain denoise-based refinement (style pass / detail pass), not reference-grounded editing.
+Pick ERNIE when the job is precise text/typography rendering (multilingual, including Chinese), posters/signage/UI mockups, manga/anime storyboards and multi-panel layouts, or structured multi-object scenes from a complex prompt.
+Do not pick ERNIE for "edit this photo / change the shirt / swap the background". That is instruction-grounded editing, which ERNIE does not do. Use `qwen-image-edit` or Flux Kontext for those. ERNIE's "image-to-image" here is plain denoise-based refinement (style pass / detail pass), not reference-grounded editing.
 
-> Niche vs siblings: ERNIE = best open-weight **text rendering + layout** T2I. Qwen-Image-Edit = instruction editing. Flux Kontext = reference editing. Z-Image Turbo = fast general T2I (and this same pack pairs the two — see Combo pipelines).
+> Niche vs siblings. ERNIE is the best open-weight text rendering + layout T2I. Qwen-Image-Edit does instruction editing. Flux Kontext does reference editing. Z-Image Turbo does fast general T2I, and this same pack pairs the two; see Combo pipelines.
 
 ## Separated packs (render-verified)
 
-The original `ernie` monolith was a single toggle-template graph (every pipeline shipped bypassed; you activated one via the rgthree group toggles). It's now split into standalone, single-purpose packs — each a clean activated graph that renders headlessly with no group-toggling:
+The original `ernie` monolith was a single toggle-template graph (every pipeline shipped bypassed; you activated one via the rgthree group toggles). It's now split into standalone, single-purpose packs, each a clean activated graph that renders headlessly with no group-toggling:
 
 | Pack | Use | Models | VRAM |
 |------|-----|--------|------|
@@ -29,21 +29,21 @@ The original `ernie` monolith was a single toggle-template graph (every pipeline
 | `ernie-img2img` | denoise refine of a source image | ERNIE only (4) | <8GB |
 | `ernie-combo` | ERNIE × Z-Image-Turbo combo pipelines | ERNIE + Z-Image (7, ~32GB) | 12GB+ |
 
-Working details verified live: the **prompt-enhancer LLM is OFF by default** (the `ENHANCE PROMPT` boolean is false; leave it off unless you want the 3B enhancer to rewrite the prompt). The grain/sharpen post-proc (`FastFilmGrain`/`FastLaplacianSharpen`, comfyui-vrgamedevgirl) needs **librosa** installed. In `ernie-combo` the Z-Image half's VAE is saved as **`z-image-ae.safetensors`** (its weights differ from Flux/ERNIE's `ae.safetensors` despite the same size — avoids a filename clash).
+Working details verified live: the prompt-enhancer LLM is OFF by default (the `ENHANCE PROMPT` boolean is false; leave it off unless you want the 3B enhancer to rewrite the prompt). The grain/sharpen post-proc (`FastFilmGrain`/`FastLaplacianSharpen`, comfyui-vrgamedevgirl) needs librosa installed. In `ernie-combo` the Z-Image half's VAE is saved as `z-image-ae.safetensors`; its weights differ from Flux/ERNIE's `ae.safetensors` despite the same size, and the rename avoids a filename clash.
 
 ## Source of truth & a provenance warning
 
 This skill is derived from the actual pack files in `C:\Users\Artokun\Downloads\`:
-- `ERNIE-IMAGE-ULTRA-WORKFLOW.json` (authoritative — the ComfyUI graph)
+- `ERNIE-IMAGE-ULTRA-WORKFLOW.json` (authoritative; the ComfyUI graph)
 - `ERNIE-IMAGE_ULTRA-MODELS-NODES_INSTALL.bat`, `...-COMFYUI-MANAGER_AUTO_INSTALL.bat`, `...-AUTO_INSTALL-RUNPOD.sh`
 
-> **Installer warning (verified):** the three install scripts are copy-pasted from a **Z-Image** pack. Their headers literally say "Z-IMAGE-BASE"/"Z-IMAGE Base", and they download **both** ERNIE *and* Z-Image files. The model URLs/folders below are taken from those scripts but mirror this confusion — they pull `z_image_turbo-*.gguf`, `Qwen3-4B-*.gguf`, and `ae.safetensors` which belong to the **Z-Image** half of the combo, not ERNIE. The ERNIE-only files are flagged below. All weights come from a third-party mirror `huggingface.co/Aitrepreneur/FLX`, **not** the official `huggingface.co/Comfy-Org/ERNIE-Image` (which hosts the same filenames — see Official sources).
+> Installer warning (verified). The three install scripts are copy-pasted from a Z-Image pack. Their headers literally say "Z-IMAGE-BASE"/"Z-IMAGE Base", and they download both ERNIE *and* Z-Image files. The model URLs/folders below are taken from those scripts but mirror this confusion. They pull `z_image_turbo-*.gguf`, `Qwen3-4B-*.gguf`, and `ae.safetensors`, which belong to the Z-Image half of the combo, not ERNIE. The ERNIE-only files are flagged below. All weights come from a third-party mirror `huggingface.co/Aitrepreneur/FLX`, not the official `huggingface.co/Comfy-Org/ERNIE-Image` (which hosts the same filenames; see Official sources).
 
 ## Models
 
 ### ERNIE-Image (the files ERNIE actually uses)
 
-Confirmed from the workflow's virtual wires (`Set_*`/`GetNode`): the nodes tagged **"ERNIE"** resolve to these exact files.
+Confirmed from the workflow's virtual wires (`Set_*`/`GetNode`): the nodes tagged "ERNIE" resolve to these exact files.
 
 | Component | Node (type) | File (in workflow) | Folder | Notes |
 |-----------|-------------|--------------------|--------|-------|
@@ -52,11 +52,11 @@ Confirmed from the workflow's virtual wires (`Set_*`/`GetNode`): the nodes tagge
 | **VAE** | `VAELoader` | `flux2-vae.safetensors` | `models/vae/` | ERNIE reuses the **Flux 2 VAE** |
 | **Prompt enhancer** | `CLIPLoader` (type=`flux2`) → `TextGenerate` | `ernie-image-prompt-enhancer.safetensors` | `models/text_encoders/` | 3B LLM that auto-expands a short prompt into a rich description (see Prompt enhancer). Optional, toggled per-pipeline |
 
-> Quant guidance from the installer: **Q5_K_S** GPUs <8 GB · **Q6_K** 8–12 GB · **Q8_0** 12–16 GB+.
+> Quant guidance from the installer: Q5_K_S for GPUs <8 GB · Q6_K for 8 to 12 GB · Q8_0 for 12 to 16 GB+.
 
 ### Z-Image Turbo (bundled in the same pack — the "ZIT" half)
 
-The workflow also wires a parallel Z-Image Turbo pipeline for ERNIE→ZIT / ZIT→ERNIE combos. These files are **Z-Image's, not ERNIE's** — do not confuse them:
+The workflow also wires a parallel Z-Image Turbo pipeline for ERNIE→ZIT / ZIT→ERNIE combos. These files are Z-Image's, not ERNIE's. Do not confuse them:
 
 | Component | Node | File | Folder |
 |-----------|------|------|--------|
@@ -66,7 +66,7 @@ The workflow also wires a parallel Z-Image Turbo pipeline for ERNIE→ZIT / ZIT�
 
 ### LoRAs (referenced in the Power Lora Loader, off by default)
 
-`hirohiko-araki-style-ERNIE_000001250.safetensors`, `ernie-anime-v1.safetensors` — community ERNIE style LoRAs, loaded via `Power Lora Loader (rgthree)` (both toggled **off** in the shipped graph). Not in the installer; user-supplied.
+`hirohiko-araki-style-ERNIE_000001250.safetensors` and `ernie-anime-v1.safetensors` are community ERNIE style LoRAs, loaded via `Power Lora Loader (rgthree)` (both toggled off in the shipped graph). Not in the installer; user-supplied.
 
 ### Upscalers / post (shared)
 
@@ -90,7 +90,7 @@ All three installers clone the same set:
 | comfyui-vrgamedevgirl | `https://github.com/vrgamegirl19/comfyui-vrgamedevgirl` | `FastFilmGrain`, `FastLaplacianSharpen` |
 | RES4LYF | `https://github.com/ClownsharkBatwing/RES4LYF` | advanced samplers |
 
-The graph also uses `TextGenerate`, `TextBox1`, `StringReplace`, `ComfySwitchNode`, `PreviewAny`, `SetNode`/`GetNode`, `PrimitiveBoolean`, `ModelSamplingAuraFlow`, `ConditioningZeroOut`, `EmptySD3LatentImage`, `EmptyFlux2LatentImage` — most are builtin or come from the packs above. `SetNode`/`GetNode` are from KJNodes. `TextGenerate` (runs the prompt-enhancer LLM) — verify which pack provides it via ComfyUI-Manager if it shows as missing (**unverified pack origin**).
+The graph also uses `TextGenerate`, `TextBox1`, `StringReplace`, `ComfySwitchNode`, `PreviewAny`, `SetNode`/`GetNode`, `PrimitiveBoolean`, `ModelSamplingAuraFlow`, `ConditioningZeroOut`, `EmptySD3LatentImage`, `EmptyFlux2LatentImage`. Most are builtin or come from the packs above. `SetNode`/`GetNode` are from KJNodes. `TextGenerate` (runs the prompt-enhancer LLM) has an unverified pack origin; verify which pack provides it via ComfyUI-Manager if it shows as missing.
 
 ### Model downloads (exact URLs from the installer)
 
@@ -115,7 +115,7 @@ upscale_models/RealESRGAN_x4plus_anime_6B.pth   <HF>/RealESRGAN_x4plus_anime_6B.
 
 ### Official sources (prefer these over the mirror)
 
-The same filenames are hosted officially at **`huggingface.co/Comfy-Org/ERNIE-Image`** (`unet|diffusion_models/`, `text_encoders/`, `vae/`). Apache-2.0. Original model: `github.com/baidu/ERNIE-Image`. Comfy day-0 docs: `docs.comfy.org/tutorials/image/ernie-image/ernie-image`. The official repo also ships non-GGUF `ernie-image.safetensors` / `ernie-image-turbo.safetensors` (load with `UNETLoader` instead of `UnetLoaderGGUF`).
+The same filenames are hosted officially at `huggingface.co/Comfy-Org/ERNIE-Image` (`unet|diffusion_models/`, `text_encoders/`, `vae/`). Apache-2.0. Original model: `github.com/baidu/ERNIE-Image`. Comfy day-0 docs: `docs.comfy.org/tutorials/image/ernie-image/ernie-image`. The official repo also ships non-GGUF `ernie-image.safetensors` / `ernie-image-turbo.safetensors` (load with `UNETLoader` instead of `UnetLoaderGGUF`).
 
 ## How the pipeline works (at a glance)
 
@@ -131,13 +131,13 @@ EmptySD3LatentImage (1920×1088) ──► LATENT
 KSampler (steps≈8–9, cfg=1, euler, simple, denoise=1) ──► VAEDecode ──► SaveImage / post
 ```
 
-**Prompt enhancer path (optional):** the short user prompt + `{width}`/`{height}` are templated into a Chinese system prompt, fed to `TextGenerate` (which runs `ernie-image-prompt-enhancer`), and a `ComfySwitchNode` chooses raw prompt (switch=false) vs. enhanced prompt (switch=true) before `CLIPTextEncode`.
+In the optional prompt enhancer path, the short user prompt + `{width}`/`{height}` are templated into a Chinese system prompt, fed to `TextGenerate` (which runs `ernie-image-prompt-enhancer`), and a `ComfySwitchNode` chooses raw prompt (switch=false) vs. enhanced prompt (switch=true) before `CLIPTextEncode`.
 
-**Image-to-image (refine) path — NOT editing:** the graph's "ERNIE IMAGE TO IMAGE" groups take a `LoadImage → ImageResize+ (1024, keep proportion, lanczos)` and `VAEEncode` it, then run KSampler at **low denoise (0.35–0.4)** to refine/restyle. This is a denoise pass over a single source image; it does not follow edit instructions.
+The image-to-image (refine) path is not editing. The graph's "ERNIE IMAGE TO IMAGE" groups take a `LoadImage → ImageResize+ (1024, keep proportion, lanczos)` and `VAEEncode` it, then run KSampler at low denoise (0.35 to 0.4) to refine or restyle. This is a denoise pass over a single source image; it does not follow edit instructions.
 
-**About the ~5 LoadImage + ~5 VAEEncode nodes:** they are **not** multi-reference compositing. Each LoadImage feeds a *separate* pipeline variant (single-image img2img, or the combo refine stages). One source image per pipeline. The extra VAEEncodes are the encode steps for those independent img2img / two-pass refine chains.
+About the ~5 LoadImage + ~5 VAEEncode nodes: they are not multi-reference compositing. Each LoadImage feeds a *separate* pipeline variant (single-image img2img, or the combo refine stages). One source image per pipeline. The extra VAEEncodes are the encode steps for those independent img2img / two-pass refine chains.
 
-**Combo pipelines (ERNIE↔ZIT):** group titles `ERNIE ---> ZIT COMBO`, `ZIT ---> ERNIE COMBO`, `TWO TIMES COMBO ...` chain ERNIE and Z-Image Turbo as a two-pass generate→refine, with optional film-grain (`FastFilmGrain`) or sharpening (`FastLaplacianSharpen`) finishing and `SIMPLE UPSCALE`.
+The combo pipelines (ERNIE↔ZIT), with group titles `ERNIE ---> ZIT COMBO`, `ZIT ---> ERNIE COMBO`, `TWO TIMES COMBO ...`, chain ERNIE and Z-Image Turbo as a two-pass generate→refine, with optional film-grain (`FastFilmGrain`) or sharpening (`FastLaplacianSharpen`) finishing and `SIMPLE UPSCALE`.
 
 ## Settings (extracted from the shipped KSamplers)
 
@@ -147,14 +147,14 @@ KSampler (steps≈8–9, cfg=1, euler, simple, denoise=1) ──► VAEDecode �
 | ERNIE image-to-image refine | 8 | 1 | euler | simple | **0.4** | 3.1 |
 | Combo refine pass (2nd stage) | 9 | 1 | euler | simple | **0.25–0.35** | 3.1 |
 
-- **`ModelSamplingAuraFlow` shift = 3.1** is applied to the ERNIE model before sampling (flow-matching shift). Keep it.
-- **CFG = 1** for Turbo → negative conditioning is effectively inert; the graph still wires a `ConditioningZeroOut` as the negative.
-- **Resolution:** shipped latent is **1920×1088** (`EmptySD3LatentImage`). ERNIE is a high-res-capable DiT; 1024–2048 on the long edge is reasonable. Use `EmptySD3LatentImage` for ERNIE latents.
-- Base (non-Turbo) `ernie-image`: bump steps to ~50 and raise cfg (e.g. 3.5–5) since it is not distilled.
+- `ModelSamplingAuraFlow` shift = 3.1 is applied to the ERNIE model before sampling (flow-matching shift). Keep it.
+- CFG = 1 for Turbo, so negative conditioning is effectively inert; the graph still wires a `ConditioningZeroOut` as the negative.
+- The shipped latent is 1920×1088 (`EmptySD3LatentImage`). ERNIE is a high-res-capable DiT; 1024 to 2048 on the long edge is reasonable. Use `EmptySD3LatentImage` for ERNIE latents.
+- For base (non-Turbo) `ernie-image`, bump steps to ~50 and raise cfg (e.g. 3.5 to 5) since it is not distilled.
 
 ## Prompt / instruction style
 
-ERNIE rewards **descriptive, structured natural-language prompts**, and is unusually strong at **literal text rendering**. Write the exact text you want to appear in quotes.
+ERNIE rewards descriptive, structured natural-language prompts, and is unusually strong at literal text rendering. Write the exact text you want to appear in quotes.
 
 ```
 A vintage travel poster of Kyoto in autumn, bold title text reading "KYOTO" at the top,
@@ -165,14 +165,14 @@ A 3-panel manga page: panel 1 a samurai drawing his sword, panel 2 close-up of h
 panel 3 a wide shot of cherry blossoms falling, black-and-white ink, speech bubble "参る"
 ```
 
-- For **typography/signage**: state the literal string ("a neon sign that says 'OPEN'"), placement, and font feel.
-- For **layout**: name the panel/grid structure and what goes in each region.
-- Multilingual prompts (incl. Chinese) work — the built-in enhancer's system prompt is Chinese.
-- This is **txt2img phrasing**, not edit phrasing. Do not write "change the…/remove the…" expecting grounded edits.
+- For typography/signage, state the literal string ("a neon sign that says 'OPEN'"), placement, and font feel.
+- For layout, name the panel/grid structure and what goes in each region.
+- Multilingual prompts (incl. Chinese) work; the built-in enhancer's system prompt is Chinese.
+- This is txt2img phrasing, not edit phrasing. Do not write "change the…/remove the…" expecting grounded edits.
 
 ## Complete API-format workflow (ERNIE-Image-Turbo text-to-image)
 
-Derived from the source graph, flattened to API format (no subgraphs/virtual wires). Enhancer omitted for clarity — `CLIPTextEncode` takes the prompt directly.
+Derived from the source graph, flattened to API format (no subgraphs/virtual wires). The enhancer is omitted for clarity; `CLIPTextEncode` takes the prompt directly.
 
 ```json
 {
@@ -194,7 +194,7 @@ Derived from the source graph, flattened to API format (no subgraphs/virtual wir
 
 ### Image-to-image (refine) variant
 
-Replace the empty latent with an encoded source image and lower denoise. **This restyles/refines a single image; it is not instruction editing.**
+Replace the empty latent with an encoded source image and lower denoise. This restyles or refines a single image; it is not instruction editing.
 
 ```json
 {
@@ -211,30 +211,29 @@ Insert a `Power Lora Loader (rgthree)` between the UNet loader and `ModelSamplin
 
 ## VRAM
 
-- ERNIE-Image-Turbo GGUF: **Q5_K_S** <8 GB · **Q6_K** 8–12 GB · **Q8_0** 12–16 GB+ (installer's own guidance).
-- Ministral-3-3B encoder + Flux2 VAE add a few GB. The graph includes `easy cleanGpuUsed` / `easy clearCacheAll` nodes between stages — keep them for the combo/two-pass pipelines so VRAM is freed before swapping models.
-- Running the ERNIE↔ZIT combos loads **two** UNets; budget for both or run the single-model ERNIE group only.
+- ERNIE-Image-Turbo GGUF: Q5_K_S for <8 GB · Q6_K for 8 to 12 GB · Q8_0 for 12 to 16 GB+ (installer's own guidance).
+- The Ministral-3-3B encoder + Flux2 VAE add a few GB. The graph includes `easy cleanGpuUsed` / `easy clearCacheAll` nodes between stages. Keep them for the combo/two-pass pipelines so VRAM is freed before swapping models.
+- Running the ERNIE↔ZIT combos loads two UNets; budget for both or run the single-model ERNIE group only.
 
 ## Troubleshooting
 
-- **`UnetLoaderGGUF` / `CLIPLoaderGGUF` missing** → install **ComfyUI-GGUF** (city96).
-- **`Power Lora Loader` / `Image Comparer` / `Label` missing** → install **rgthree-comfy**.
-- **`ImageResize+` missing** → install **ComfyUI_essentials**.
-- **`TextGenerate` missing** (prompt enhancer) → install via ComfyUI-Manager search; pack origin unverified. If unavailable, just set the `ComfySwitchNode` to use the raw prompt (switch=false) and skip enhancement.
-- **CLIP type error on ministral** → ensure `CLIPLoader` `type` is **`flux2`** (not `qwen_image`/`lumina2`). The `lumina2` type belongs to the Z-Image (Qwen3) encoder, not ERNIE.
-- **Wrong VAE artifacts** → ERNIE must use **`flux2-vae.safetensors`**; `ae.safetensors` is the Z-Image VAE.
-- **Blurry / undercooked output** → confirm `ModelSamplingAuraFlow shift=3.1` is wired and steps ≥8 for Turbo; for base `ernie-image` use ~50 steps + higher cfg.
-- **You wanted to EDIT a photo and it ignored the instruction** → expected. ERNIE is txt2img; use the `qwen-image-edit` skill or Flux Kontext for grounded edits.
-- **Installer pulled Z-Image files too** → expected (the scripts are Z-Image-derived). Harmless; those files only feed the combo pipelines.
+- **`UnetLoaderGGUF` / `CLIPLoaderGGUF` missing.** Install ComfyUI-GGUF (city96).
+- **`Power Lora Loader` / `Image Comparer` / `Label` missing.** Install rgthree-comfy.
+- **`ImageResize+` missing.** Install ComfyUI_essentials.
+- **`TextGenerate` missing** (prompt enhancer). Install via ComfyUI-Manager search; pack origin unverified. If unavailable, set the `ComfySwitchNode` to use the raw prompt (switch=false) and skip enhancement.
+- **CLIP type error on ministral.** Ensure `CLIPLoader` `type` is `flux2` (not `qwen_image`/`lumina2`). The `lumina2` type belongs to the Z-Image (Qwen3) encoder, not ERNIE.
+- **Wrong VAE artifacts.** ERNIE must use `flux2-vae.safetensors`; `ae.safetensors` is the Z-Image VAE.
+- **Blurry / undercooked output.** Confirm `ModelSamplingAuraFlow shift=3.1` is wired and steps ≥8 for Turbo; for base `ernie-image` use ~50 steps + higher cfg.
+- **You wanted to EDIT a photo and it ignored the instruction.** Expected. ERNIE is txt2img; use the `qwen-image-edit` skill or Flux Kontext for grounded edits.
+- **Installer pulled Z-Image files too.** Expected (the scripts are Z-Image-derived). Harmless; those files only feed the combo pipelines.
 
 ## Tips
 
-1. Lead with the **literal text** you want rendered, in quotes — that's ERNIE's headline strength.
-2. Use the **prompt enhancer** for short/lazy prompts; turn it off (`ComfySwitchNode` false) when you've written a detailed prompt yourself.
-3. Use **`get_workflow (action:"analyze")`** before executing the shipped graph — it has dozens of group-boxed variants gated by `Fast Groups Bypasser (rgthree)`; the analyzer summary is far easier than reading raw JSON.
-4. Most groups are **bypassed (mode 4)** by default in the source file — enable only the pipeline you want via the group bypasser, or build the clean API workflow above.
-5. To choose a model: **ERNIE = text/layout T2I**, **Z-Image Turbo = fast general T2I**, **Qwen-Image-Edit / Flux Kontext = actual editing**.
-```
+1. Lead with the literal text you want rendered, in quotes. That's ERNIE's headline strength.
+2. Use the prompt enhancer for short/lazy prompts; turn it off (`ComfySwitchNode` false) when you've written a detailed prompt yourself.
+3. Use `get_workflow (action:"analyze")` before executing the shipped graph. It has dozens of group-boxed variants gated by `Fast Groups Bypasser (rgthree)`; the analyzer summary is far easier than reading raw JSON.
+4. Most groups are bypassed (mode 4) by default in the source file. Enable only the pipeline you want via the group bypasser, or build the clean API workflow above.
+5. To choose a model: ERNIE for text/layout T2I, Z-Image Turbo for fast general T2I, Qwen-Image-Edit / Flux Kontext for actual editing.
 
 ## Sources
 

--- a/plugin/skills/flux-txt2img/SKILL.md
+++ b/plugin/skills/flux-txt2img/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flux-txt2img
-description: Build Flux txt2img workflows — Flux.1 Dev (SRPO), Flux 2 Klein 9B, Turbo LoRAs, FluxGuidance, and DualCLIPLoader patterns
+description: Build Flux txt2img workflows with Flux.1 Dev (SRPO), Flux 2 Klein 9B, Turbo LoRAs, FluxGuidance, and DualCLIPLoader patterns
 globs:
   - "**/*.json"
 ---
@@ -11,9 +11,9 @@ globs:
 
 Flux is a guidance-distilled diffusion model family from Black Forest Labs. It uses a separate `FluxGuidance` node instead of KSampler CFG (which must always be 1.0). Three variants are available locally:
 
-1. **Flux.1 Dev SRPO** — Fine-tuned Flux.1 Dev with SRPO alignment. Uses DualCLIPLoader (T5XXL + CLIP-L). BF16 only.
-2. **Flux 2 Klein 9B** — Distilled Flux 2 variant. Uses single CLIPLoader (Qwen3-8B) + `flux2-vae.safetensors`. Fast 4-step generation.
-3. **Flux 2 Turbo LoRA** — Applied to Flux.1 Dev for 4-step generation.
+1. **Flux.1 Dev SRPO.** Fine-tuned Flux.1 Dev with SRPO alignment. Uses DualCLIPLoader (T5XXL + CLIP-L). BF16 only.
+2. **Flux 2 Klein 9B.** Distilled Flux 2 variant. Uses single CLIPLoader (Qwen3-8B) + `flux2-vae.safetensors`. Fast 4-step generation.
+3. **Flux 2 Turbo LoRA.** Applied to Flux.1 Dev for 4-step generation.
 
 ## Models
 
@@ -33,7 +33,7 @@ Flux is a guidance-distilled diffusion model family from Black Forest Labs. It u
 | **CLIP** | `CLIPLoader` (type=`flux2`) | `qwen_3_8b_fp8mixed.safetensors` | Qwen3-8B in text_encoders/ (8.3GB). Use `flux2`, NOT `flux` — both exist in the enum and `flux` fails at the sampler |
 | **VAE** | `VAELoader` | `flux2-vae.safetensors` | Flux 2 specific VAE (321MB) |
 
-**Klein 9B vs Flux.1 Dev**: Klein uses Qwen3-8B text encoder (not T5XXL + CLIP-L). It has a different VAE (`flux2-vae.safetensors`). 9B distilled runs in 4 steps; 9B base needs ~50 steps at CFG 5.0. Fits in ~20GB VRAM with FP8.
+Klein 9B vs Flux.1 Dev: Klein uses the Qwen3-8B text encoder (not T5XXL + CLIP-L). It has a different VAE (`flux2-vae.safetensors`). 9B distilled runs in 4 steps; 9B base needs ~50 steps at CFG 5.0. Fits in ~20GB VRAM with FP8.
 
 ### Flux 2 Turbo LoRA (applied to Flux.1 Dev)
 
@@ -60,7 +60,7 @@ Provides separate prompt fields for each text encoder:
 }
 ```
 
-`clip_l` captures key semantic features. `t5xxl` expands and refines descriptions. For simple use, put the same prompt in both fields. **Guidance is built into this node** — no separate FluxGuidance needed.
+`clip_l` captures key semantic features. `t5xxl` expands and refines descriptions. For simple use, put the same prompt in both fields. Guidance is built into this node, so no separate FluxGuidance is needed.
 
 ### FluxGuidance (Alternative)
 
@@ -87,7 +87,7 @@ If using standard `CLIPTextEncode` instead of `CLIPTextEncodeFlux`, apply guidan
 
 ### Negative Conditioning
 
-Flux does NOT support traditional negative prompts (guidance-distilled, CFG=1.0). Use `ConditioningZeroOut`:
+Flux does not support traditional negative prompts (guidance-distilled, CFG=1.0). Use `ConditioningZeroOut`:
 
 ```json
 {
@@ -96,7 +96,7 @@ Flux does NOT support traditional negative prompts (guidance-distilled, CFG=1.0)
 }
 ```
 
-Or simply use an empty `CLIPTextEncode` for the negative input.
+Or use an empty `CLIPTextEncode` for the negative input.
 
 ## Sampler Settings
 
@@ -111,7 +111,7 @@ Or simply use an empty `CLIPTextEncode` for the negative input.
 | guidance | 3.5 | Via CLIPTextEncodeFlux or FluxGuidance |
 | denoise | 1.0 | |
 
-**SRPO note**: The ipndm/beta combo is specifically recommended by the SRPO author. Standard Flux settings (euler/simple) also work but ipndm/beta gives better results with this fine-tune.
+The SRPO author recommends the ipndm/beta combo. Standard Flux settings (euler/simple) also work, but ipndm/beta gives better results with this fine-tune.
 
 ### Flux 2 Klein 9B (Distilled)
 
@@ -212,12 +212,12 @@ Bad: "masterpiece, best quality, 1girl, cafe, paris"
 }
 ```
 
-**Klein note**: Uses single `CLIPLoader` (not DualCLIPLoader) with `type: "flux2"` and the Qwen3-8B text encoder from `text_encoders/`. The CLIP loader path resolves from `models/text_encoders/`.
+Klein uses a single `CLIPLoader` (not DualCLIPLoader) with `type: "flux2"` and the Qwen3-8B text encoder from `text_encoders/`. The CLIP loader path resolves from `models/text_encoders/`.
 
-**Two Flux-2-specific gotchas** (both fail at the KSampler, not at the loader, so the error points at the wrong node):
-- `type` must be **`flux2`**, not `flux`. Both values exist in the CLIPLoader enum, so `flux` loads without complaint and then dies during sampling.
-- Use **`EmptyFlux2LatentImage`**, not `EmptyLatentImage` — Flux 2 uses a different latent channel count.
-- Klein **9B** pairs with the **Qwen3-8B** encoder (`qwen_3_8b*` from `Comfy-Org/vae-text-encorder-for-flux-klein-9b`). The similarly-named `qwen_3_4b` ships in the klein-**4b** repo and is for the 4B model. Mismatching them raises `mat1 and mat2 shapes cannot be multiplied (512x7680 and 12288x4096)` — 7680 = 2560x3 (4B hidden size) vs 12288 = 4096x3 (8B) — which reads as a confusing CLIP error rather than a wrong-file error.
+Flux-2-specific gotchas, all of which fail at the KSampler rather than the loader, so the error points at the wrong node:
+- `type` must be `flux2`, not `flux`. Both values exist in the CLIPLoader enum, so `flux` loads without complaint and then dies during sampling.
+- Use `EmptyFlux2LatentImage`, not `EmptyLatentImage`. Flux 2 uses a different latent channel count.
+- Klein 9B pairs with the Qwen3-8B encoder (`qwen_3_8b*` from `Comfy-Org/vae-text-encorder-for-flux-klein-9b`). The similarly-named `qwen_3_4b` ships in the klein-4b repo and is for the 4B model. Mismatching them raises `mat1 and mat2 shapes cannot be multiplied (512x7680 and 12288x4096)`, where 7680 = 2560x3 (4B hidden size) and 12288 = 4096x3 (8B). It reads as a confusing CLIP error rather than a wrong-file error.
 
 ## Complete Workflow: Flux.1 Dev + Turbo LoRA (4-Step)
 
@@ -266,8 +266,8 @@ Apply Flux LoRAs with `LoraLoaderModelOnly` between UNET and KSampler:
 
 ### Klein LoRAs
 
-Klein 9B LoRAs go in `loras/Flux.2 Klein 9B/` subfolder:
-- `klein_slider_detail.safetensors` — Detail slider LoRA
+Klein 9B LoRAs go in the `loras/Flux.2 Klein 9B/` subfolder:
+- `klein_slider_detail.safetensors`, a detail slider LoRA
 
 ## VRAM Considerations
 
@@ -277,17 +277,17 @@ Klein 9B LoRAs go in `loras/Flux.2 Klein 9B/` subfolder:
 | Klein 9B FP8 + Qwen3-8B | ~20GB | Fits comfortably on 4090 |
 | SRPO + Turbo LoRA | ~24GB | Same as SRPO base |
 
-- **Always `clear_vram`** before switching to Flux from another model family
-- T5XXL is the main VRAM consumer alongside the UNET — both stay loaded during sampling
+- Always `clear_vram` before switching to Flux from another model family
+- T5XXL is the main VRAM consumer alongside the UNET; both stay loaded during sampling
 - CLIP-L is small (235MB) and negligible
 
 ## Tips
 
-1. **KSampler CFG must always be 1.0** — all guidance is through `CLIPTextEncodeFlux` or `FluxGuidance`
-2. **SRPO requires BF16** — the FP8 quantization is known to produce broken results with this fine-tune
-3. For **short prompts** (1-2 sentences), increase guidance to 3.5–4.0. For **long prompts** (paragraph), decrease to 1.0–1.5
-4. Flux generates excellent text in images — put text to render in quotes within your prompt
-5. Klein 9B is the fastest option at 4 steps — use it for rapid iteration, then switch to SRPO for final quality
+1. KSampler CFG must always be 1.0. All guidance is through `CLIPTextEncodeFlux` or `FluxGuidance`
+2. SRPO requires BF16. The FP8 quantization is known to produce broken results with this fine-tune
+3. For short prompts (1 to 2 sentences), increase guidance to 3.5 to 4.0. For long prompts (paragraph), decrease to 1.0 to 1.5
+4. Flux generates excellent text in images. Put text to render in quotes within your prompt
+5. Klein 9B is the fastest option at 4 steps. Use it for rapid iteration, then switch to SRPO for final quality
 
 ## Sources
 


### PR DESCRIPTION
Part of #2003.

Applies the full 31-rule pstack-claude `unslop` pass to the first 13 plugin skills (ai-toolkit-trainer, anima-base, anima-lora-trainer, civitai, color-correction, comfyui-core, comfyui-frontend-extensions, comfyui-launch-flags, comfyui-node-registry, debug-render, director, ernie-image, flux-txt2img), including their `references/*` markdown. These are LLM-facing prompts shipped to npm, so the goal is plainer prose at identical meaning: fewer tokens, same instructions.

What changed in the prose: em and en dashes are gone from sentences (restructured, not swapped for parentheses); numeric ranges read "15 to 40" instead of "15–40"; mid-sentence colons are gone except before lists and code; bold is off proper nouns, model names, and restating lead-ins; the decorative emoji (⚠️, ℹ️, 🍋) are gone from blockquotes and the trainer title; "robust", "substrate", "primitives", and prose "surface" are replaced with plain words; filler and hedging are cut. Frontmatter `name` is unchanged in every file; `description` keeps every trigger keyword, model name, and node name verbatim and stays on one line with no `: ` (the sync-agents parser and YAML both need that).

What did not change: every heading (text and level), code block, JSON, table, node name, model filename, URL, widget name, and numeric parameter is byte-identical to main, verified by a script that diffs heading sets, link sets, fenced-block contents, and table rows per file. Every `## Sources` section is present with its Official / Empirical lines. Section order, file boundaries, and `references/pyproject.toml` (a code file) are untouched.

Counts across the 16 files, before to after: em dashes 292 to 53, en dashes 43 to 19, emoji 6 to 3, curly quotes 0 to 0, banned-word hits 21 to 5. Every remaining dash sits inside a fenced code block, a table cell, a heading, or a URL (a second script that strips those and scans the rest reports 0 prose hits). The remaining emoji are the two ✅ and one ⚠️ in the color-correction `AdjustContrast` sweep table, which is frozen content. The remaining banned-word hits are frozen content too: `ENHANCE PROMPT` is a widget name, "Enhance" is inside the pyproject.toml example description string, "Landscape" is a flux aspect-ratio row, "seamlessly" is a quoted WAN prompt literal the director skill recommends, and "surface" is in three headings.

Two small side effects worth calling out. ernie-image had a stray lone ``` fence right before `## Sources` that opened an unclosed code block and swallowed the Sources heading when rendered; it is removed. flux-txt2img said "Two Flux-2-specific gotchas" above a three-item list; the count word is dropped rather than corrected so no claim is added.

Gates: `node scripts/sync-agents.mjs` exits 0, `grep -L '^## Sources' plugin/skills/*/SKILL.md` prints nothing, and the i18n, docs-links, docs-locale, docs-mdx, and all four blog gates pass. vitest: 11093 passed, 16 failed in 5 files unrelated to these markdown files (main CI is green on the same suite); a full rerun is in progress and this note will be updated with the file list and whether they reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49