### PR TITLE
chore(hygiene): no non-test file crosses 1,000 lines without being named in the baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ npm test           # vitest
 ```
 
 - `npm run build` type-checks and compiles to `dist/` (`tsc`).
-- `npm run lint` type-checks only (`tsc --noEmit`).
+- `npm run lint` type-checks (`tsc --noEmit`) and runs the file-size ratchet (see [Conventions](#conventions)).
 - `npm test` and `npm run test:watch` run the vitest suite.
 - `npm run dev` runs the server from source via `tsx`.
 - `npm run docs:gen` rebuilds the docs tool reference from the live schemas (see [Docs](#documentation)).
@@ -63,6 +63,14 @@ Business logic lives in `src/services/<name>.ts`. The matching
   - Validate filesystem paths against traversal and symlink escapes (resolve the path, then check it stays inside the intended root).
   - Validate values that reach a subprocess argv (reject a leading `-` and control chars; use
     `--end-of-options` for git, and the equivalent for other tools).
+- **File size.** `npm run lint` fails if a non-test file under `src/` crosses 1,000 lines, or if
+  one of the files already past that mark (named with its line count in
+  `scripts/file-size-baseline.json`) grows at all. The way to extend a monolith is to split it,
+  never to append to it. A genuine exception, such as a generated table or a file mid-split, adds
+  or bumps its entry in the same PR with a one-line `"reason"`
+  (`{"path": …, "lines": …, "reason": "…"}`); the reason is what the reviewer reads. Shrinking a
+  baselined file makes the baseline stale: run `node scripts/check-file-size.mjs --baseline` (it
+  preserves reasons) and commit the result.
 - **Plugin skills.** Every skill (`plugin/skills/<name>/SKILL.md`) ends with a
   `## Sources` section that separates **Official** sources (vendor docs, node README,
   `/object_info`) from **Empirical** ones (working graphs, observed behaviour). A skill

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:local-llm": "npm run build && node scripts/test-local-llm.mjs",
     "arena": "npm run build && node scripts/llm-arena.mjs",
     "smoke:panel": "npm run build && node scripts/panel-smoke.mjs",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && node scripts/check-file-size.mjs",
     "docs:gen": "cross-env COMFYUI_URL=http://127.0.0.1:8188 tsx scripts/gen-tool-docs.ts",
     "tools:dump": "cross-env COMFYUI_URL=http://127.0.0.1:8188 tsx scripts/tools-dump.mts",
     "check:vocabulary": "tsx scripts/check-tool-vocabulary.mts",

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * comfyui-mcp-4x5 — the file-size ratchet.
+ *
+ * The rule, borrowed from pstack's code-quality review checklist: do not let a
+ * PR push a file from under 1,000 lines to over 1,000 lines without a very
+ * strong reason. This repo already has forty files past that mark, the largest
+ * at ~17,800 lines, and every one of them got there the same way — one more
+ * handler, one more branch, one more "it's only twenty lines" on top of a file
+ * that was already too big for anyone to hold. Nobody decided to write a
+ * 17,000-line file. The decision was made in increments, and no increment was
+ * ever the one worth refusing.
+ *
+ * A review rule that nobody enforces mechanically decays into a review rule that
+ * nobody enforces. So this is a CI gate, and it encodes the lesson rather than
+ * the reminder: the only way to extend a monolith is to split it.
+ *
+ * WHAT COUNTS. Raw lines: code, comments, and blanks alike. A "cleverer" count
+ * that skips comments invites gaming, and it would also be the wrong measure —
+ * the thing the rule protects is what a reader has to scroll through and what a
+ * reviewer has to hold in their head, and a comment is part of that. The number
+ * is what `wc -l` reports, so it can be checked by hand.
+ *
+ * THE RULES.
+ *
+ *   1. A file over 1,000 lines must be named in the baseline, with its count.
+ *   2. A baselined file may not grow beyond its baselined count. It may shrink.
+ *   3. A file not in the baseline must not cross 1,000 lines.
+ *   4. A baselined file that shrank, dropped under 1,000, or was deleted makes
+ *      the baseline STALE. That fails too, with the instruction to rewrite it —
+ *      otherwise the list stops describing the code, and a file could quietly
+ *      grow back up to a number it no longer needs.
+ *
+ * DIRECTION OF THE RATCHET. Same as #796's unknown-collapse gate: the baseline
+ * is the debt that existed when the gate landed, and debt lists only pay down.
+ * Rewriting is how the count goes DOWN after a split. It is never how a file
+ * is allowed to grow — a reviewer who sees a `lines` field increase in the diff
+ * is looking at exactly the thing this gate exists to surface.
+ *
+ * The exact-count ceiling has a cost worth naming: a PR that shrinks a baselined
+ * file must also touch the baseline, and a refactor INSIDE a baselined file that
+ * adds a line must first take one out. That is the trade the unknown-collapse
+ * ratchet already made, and one shape of ratchet that contributors know beats
+ * two that they have to learn — so the same shape is kept here deliberately.
+ *
+ * THE ESCAPE HATCH IS THE POINT. Sometimes a file genuinely has to cross the
+ * line or grow past its mark: a generated table, a vocabulary that is one list
+ * by design, a file mid-split where the second half lands in the next PR. Add
+ * or bump the entry in the same PR and give the reason in the entry:
+ *
+ *     { "path": "tools/vocabulary.ts", "lines": 2624,
+ *       "reason": "one flat list by design; split would scatter the lookup" }
+ *
+ * The reason is the deliverable. It is what the reviewer reads instead of
+ * re-deriving whether the growth is justified, and writing it is where an
+ * author notices that it is not. Unlike `unknown-ok:`, the reason lives in the
+ * baseline rather than at a site, because a file's size has no single site —
+ * and `--baseline` PRESERVES existing reasons, so rewriting after a split does
+ * not erase an explanation someone already wrote.
+ *
+ * Entries without a reason are the grandfathered forty. They are not wrong;
+ * they are debt, and the honest label for debt is no label at all.
+ *
+ * Usage:
+ *   node scripts/check-file-size.mjs            # gate; non-zero on failure
+ *   node scripts/check-file-size.mjs --list     # every file over the limit
+ *   node scripts/check-file-size.mjs --baseline # rewrite the baseline
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The limit is deliberately not a flag. A limit you can pass on the command
+ *  line is a limit CI can be told to ignore; this one is the rule. */
+const LIMIT = 1000;
+
+/** A problem with how the gate was INVOKED or with the baseline file itself —
+ *  as opposed to a finding about the tree. Reported as a one-line message and a
+ *  distinct exit code rather than a stack trace, because the fix is on the
+ *  command line or in the JSON, not in the script. */
+class UsageError extends Error {}
+
+/** `--src` and `--baseline-file` exist so the gate can be tested against fixture
+ *  trees. A gate nobody can test is a gate nobody trusts, and every rule above
+ *  — grow, shrink, delete, drop-under, reason survives rewriting — has to be
+ *  demonstrable rather than asserted. Both default to the real repo layout. */
+function flagValue(args, name, fallback) {
+  const i = args.indexOf(name);
+  if (i === -1) return fallback;
+  const v = args[i + 1];
+  // A named flag with no value is a USAGE ERROR, not a fallback. Falling back
+  // would point a fixture-shaped invocation at the real tree — and combined
+  // with `--baseline` that rewrites the real baseline from a typo.
+  if (v === undefined || v.startsWith("--")) throw new UsageError(`${name} needs a value`);
+  return v;
+}
+
+/** Same exclusions as the unknown-collapse gate. Tests are out of scope: a
+ *  long test file is a different (and smaller) problem than a long module, and
+ *  the existing suite has files that would trip this on day one for reasons
+ *  that have nothing to do with the lesson being encoded. */
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", ".git", "__tests__", "coverage"]);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue;
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (/\.m?ts$/.test(name) && !/\.d\.ts$/.test(name) && !/\.(test|spec)\.ts$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+/** What `wc -l` reports for a newline-terminated file, which is every file in
+ *  this repo. A file missing its final newline counts the partial last line,
+ *  since a reader still has to read it. CRLF is split the same as LF so a
+ *  Windows checkout (the CI matrix) does not double-count. */
+function countLines(text) {
+  if (text === "") return 0;
+  const parts = text.split(/\r?\n/);
+  return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}
+
+function scan(src) {
+  const over = [];
+  for (const file of walk(src)) {
+    const lines = countLines(readFileSync(file, "utf8"));
+    if (lines <= LIMIT) continue;
+    const rel = relative(src, file).split(sep).join("/");
+    over.push({ path: rel, lines });
+  }
+  return over.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+function readBaseline(baselineFile) {
+  let raw;
+  try {
+    raw = readFileSync(baselineFile, "utf8");
+  } catch (e) {
+    // Genuinely absent is different from unreadable. An absent baseline means
+    // "nothing is grandfathered", which is the correct first-run state; an
+    // unreadable or malformed one must FAIL LOUDLY rather than silently become
+    // empty, because empty would fail all forty files at once and send someone
+    // to rewrite a baseline that was fine.
+    if (e && e.code === "ENOENT") return new Map();
+    throw e;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new UsageError(`${baselineFile}: not valid JSON — ${e.message}`);
+  }
+  if (!parsed || !Array.isArray(parsed.files)) {
+    throw new UsageError(`${baselineFile}: expected an object with a "files" array`);
+  }
+  // The limit is written into the file so a reader knows what the counts are
+  // measured against. If it disagrees with the script, one of them was edited
+  // without the other and every count in the file is suspect.
+  if (parsed.limit !== undefined && parsed.limit !== LIMIT) {
+    throw new UsageError(`${baselineFile}: "limit" is ${parsed.limit} but this gate enforces ${LIMIT}`);
+  }
+  const out = new Map();
+  for (const entry of parsed.files) {
+    if (typeof entry?.path !== "string" || !Number.isInteger(entry.lines)) {
+      throw new UsageError(
+        `${baselineFile}: every entry needs a string "path" and an integer "lines": ${JSON.stringify(entry)}`,
+      );
+    }
+    out.set(entry.path, { lines: entry.lines, reason: typeof entry.reason === "string" ? entry.reason : undefined });
+  }
+  return out;
+}
+
+function list(over, baseline) {
+  for (const f of over) {
+    const reason = baseline.get(f.path)?.reason;
+    console.log(`${f.path}\t${f.lines}${reason ? `\t${reason}` : ""}`);
+  }
+  console.log(`\n${over.length} file(s) over ${LIMIT} lines`);
+  return 0;
+}
+
+function writeBaseline(over, baselineFile) {
+  // Carry every existing reason forward. A rewrite is how a count goes down
+  // after a split; it must not also be how an explanation disappears.
+  let previous;
+  try {
+    previous = readBaseline(baselineFile);
+  } catch (e) {
+    // The one place a malformed baseline must NOT simply throw: `--baseline` is
+    // the instruction the gate gives for fixing a stale file, and if the file
+    // is too broken to read, the author needs to be told that the reasons in
+    // it cannot be carried forward — not handed a stack trace.
+    if (!(e instanceof UsageError)) throw e;
+    console.error(`${e.message}\n\nThe existing baseline cannot be read, so its "reason" fields cannot be preserved.`);
+    console.error(`Fix or delete it, then run --baseline again.`);
+    return 1;
+  }
+  const files = over.map((f) => {
+    const reason = previous.get(f.path)?.reason;
+    return reason ? { path: f.path, lines: f.lines, reason } : { path: f.path, lines: f.lines };
+  });
+  const doc = {
+    "//": [
+      `comfyui-mcp-4x5 — non-test files under src/ that exceed ${LIMIT} lines, with their counts.`,
+      "A file named here may shrink and never grow; a file not named here may not cross the limit.",
+      "The way to extend one of these is to split it. A genuine exception adds or bumps its entry",
+      'in the same PR with a one-line "reason" — the reason is what the reviewer reads.',
+      "Entries without a reason are grandfathered debt from when the gate landed.",
+      "Rewrite deliberately:  node scripts/check-file-size.mjs --baseline  (reasons are preserved)",
+    ],
+    limit: LIMIT,
+    files,
+  };
+  writeFileSync(baselineFile, JSON.stringify(doc, null, 2) + "\n", "utf8");
+  console.log(`baseline written: ${files.length} file(s) over ${LIMIT} lines`);
+  return 0;
+}
+
+function gate(over, baseline) {
+  const seen = new Map(over.map((f) => [f.path, f]));
+
+  // Rule 3 — crossed the line without being named.
+  const crossed = over.filter((f) => !baseline.has(f.path));
+  // Rule 2 — named, but bigger than the name allows.
+  const grew = over
+    .filter((f) => baseline.has(f.path) && f.lines > baseline.get(f.path).lines)
+    .map((f) => ({ ...f, was: baseline.get(f.path).lines, reason: baseline.get(f.path).reason }));
+  // Rule 4 — the baseline describes a file that no longer matches it.
+  const stale = [...baseline]
+    .filter(([path, b]) => {
+      const now = seen.get(path);
+      // Shrank (including under the limit, where it vanishes from `seen`), or was
+      // deleted or moved. Either way the entry is claiming room the file no
+      // longer uses, and room nobody is using is room a file can grow back into.
+      return !now || now.lines < b.lines;
+    })
+    .map(([path, b]) => ({ path, was: b.lines, now: seen.get(path)?.lines ?? null }));
+
+  let failed = false;
+
+  if (crossed.length) {
+    failed = true;
+    console.error(`\ncomfyui-mcp-4x5 — ${crossed.length} file(s) crossed ${LIMIT} lines without being named in the baseline.\n`);
+    for (const f of crossed) console.error(`  ${f.path}  ${f.lines}`);
+    console.error(
+      "\nNobody decides to write a 17,000-line file; it happens one 'only twenty\n" +
+        "lines' at a time, and this is the increment where it gets refused. Split\n" +
+        "the file. If it genuinely has to be this big, add it to the baseline in\n" +
+        "this PR with a one-line \"reason\" field — that reason is what the reviewer\n" +
+        "reads instead of re-deriving whether the exception is warranted:\n\n" +
+        "    node scripts/check-file-size.mjs --baseline\n" +
+        "    then set \"reason\" on the new entry in scripts/file-size-baseline.json\n",
+    );
+  }
+
+  if (grew.length) {
+    failed = true;
+    console.error(`\ncomfyui-mcp-4x5 — ${grew.length} baselined file(s) grew past their baselined count.\n`);
+    for (const f of grew) {
+      console.error(`  ${f.path}  ${f.was} -> ${f.lines}  (+${f.lines - f.was})`);
+      if (f.reason) console.error(`      existing reason: ${f.reason}`);
+    }
+    console.error(
+      "\nThe baseline is a ceiling, not a record. A file on this list is already\n" +
+        "too big to hold, and the way to add to it is to move something OUT first\n" +
+        "so the net change is not growth. If the growth is genuinely warranted,\n" +
+        "bump the entry in this PR and say why in its \"reason\" field.\n",
+    );
+  }
+
+  if (stale.length) {
+    // Not a defect — a paid debt, or a moved file. But the entry has to go, or
+    // the list stops meaning anything and the file could grow back pre-approved.
+    failed = true;
+    console.error(`\ncomfyui-mcp-4x5 — ${stale.length} baseline entr(ies) no longer match the tree. Rewrite it:\n`);
+    for (const f of stale) {
+      const now = f.now === null ? `now under ${LIMIT} or gone` : `now ${f.now}`;
+      console.error(`  ${f.path}  ${f.was} -> ${now}`);
+    }
+    console.error(`\n  node scripts/check-file-size.mjs --baseline\n`);
+  }
+
+  if (!failed) console.log(`file-size gate: ${over.length} baselined file(s) over ${LIMIT} lines, none grew, nothing new crossed.`);
+  return failed ? 1 : 0;
+}
+
+function main(args) {
+  const src = flagValue(args, "--src", join(ROOT, "src"));
+  const baselineFile = flagValue(args, "--baseline-file", join(ROOT, "scripts", "file-size-baseline.json"));
+  const over = scan(src);
+  if (args.includes("--baseline")) return writeBaseline(over, baselineFile);
+  const baseline = readBaseline(baselineFile);
+  if (args.includes("--list")) return list(over, baseline);
+  return gate(over, baseline);
+}
+
+// `process.exitCode` rather than `process.exit()`: on Windows, piped stdout and
+// stderr are asynchronous, and an explicit exit can cut the message off before
+// CI has read it — leaving a red build with no reason attached.
+try {
+  process.exitCode = main(process.argv.slice(2));
+} catch (e) {
+  if (!(e instanceof UsageError)) throw e;
+  console.error(e.message);
+  process.exitCode = 2;
+}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -43,7 +43,7 @@
     },
     {
       "path": "orchestrator/index.ts",
-      "lines": 6980
+      "lines": 7009
     },
     {
       "path": "orchestrator/ollama-backend.ts",
@@ -59,7 +59,7 @@
     },
     {
       "path": "orchestrator/panel-tools.ts",
-      "lines": 22350
+      "lines": 22367
     },
     {
       "path": "orchestrator/qwen-backend.ts",

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -5,21 +5,21 @@
     "The way to extend one of these is to split it. A genuine exception adds or bumps its entry",
     "in the same PR with a one-line \"reason\" — the reason is what the reviewer reads.",
     "Entries without a reason are grandfathered debt from when the gate landed.",
-    "Regenerate deliberately:  node scripts/check-file-size.mjs --baseline  (reasons are preserved)"
+    "Rewrite deliberately:  node scripts/check-file-size.mjs --baseline  (reasons are preserved)"
   ],
   "limit": 1000,
   "files": [
     {
       "path": "comfyui/client.ts",
-      "lines": 1282
+      "lines": 1571
     },
     {
       "path": "comfyui/json-guard.ts",
-      "lines": 1445
+      "lines": 1450
     },
     {
       "path": "config.ts",
-      "lines": 1087
+      "lines": 1094
     },
     {
       "path": "orchestrator/ask-answer-journal.ts",
@@ -27,11 +27,11 @@
     },
     {
       "path": "orchestrator/claude-backend.ts",
-      "lines": 1339
+      "lines": 1337
     },
     {
       "path": "orchestrator/codex-backend.ts",
-      "lines": 1757
+      "lines": 2417
     },
     {
       "path": "orchestrator/gemini-backend.ts",
@@ -43,19 +43,23 @@
     },
     {
       "path": "orchestrator/index.ts",
-      "lines": 6849
+      "lines": 6980
     },
     {
       "path": "orchestrator/ollama-backend.ts",
-      "lines": 1920
+      "lines": 2171
     },
     {
       "path": "orchestrator/panel-agent.ts",
-      "lines": 3970
+      "lines": 4012
+    },
+    {
+      "path": "orchestrator/panel-console-http.ts",
+      "lines": 1216
     },
     {
       "path": "orchestrator/panel-tools.ts",
-      "lines": 17813
+      "lines": 22350
     },
     {
       "path": "orchestrator/qwen-backend.ts",
@@ -63,23 +67,27 @@
     },
     {
       "path": "orchestrator/run-completion-journal.ts",
-      "lines": 1561
+      "lines": 1587
+    },
+    {
+      "path": "services/comfy-view-ref.ts",
+      "lines": 1064
     },
     {
       "path": "services/download-cache.ts",
-      "lines": 3530
+      "lines": 3632
     },
     {
       "path": "services/download-jobs.ts",
-      "lines": 2207
+      "lines": 2401
     },
     {
       "path": "services/download-progress.ts",
-      "lines": 1182
+      "lines": 1216
     },
     {
       "path": "services/env-capabilities.ts",
-      "lines": 1151
+      "lines": 1158
     },
     {
       "path": "services/extra-paths.ts",
@@ -87,7 +95,11 @@
     },
     {
       "path": "services/image-management.ts",
-      "lines": 1185
+      "lines": 1428
+    },
+    {
+      "path": "services/kitchen.ts",
+      "lines": 1366
     },
     {
       "path": "services/lora-catalog.ts",
@@ -95,11 +107,11 @@
     },
     {
       "path": "services/manifest.ts",
-      "lines": 1479
+      "lines": 1625
     },
     {
       "path": "services/model-resolver.ts",
-      "lines": 3572
+      "lines": 3576
     },
     {
       "path": "services/node-dev.ts",
@@ -107,15 +119,23 @@
     },
     {
       "path": "services/node-management.ts",
-      "lines": 5211
+      "lines": 6021
     },
     {
       "path": "services/output-dir.ts",
-      "lines": 1351
+      "lines": 1359
+    },
+    {
+      "path": "services/panel-image-relay.ts",
+      "lines": 1456
     },
     {
       "path": "services/panel-installer.ts",
-      "lines": 6131
+      "lines": 6472
+    },
+    {
+      "path": "services/panel-launcher.ts",
+      "lines": 1582
     },
     {
       "path": "services/panel-pin-guard.ts",
@@ -123,7 +143,11 @@
     },
     {
       "path": "services/panel-secrets.ts",
-      "lines": 2887
+      "lines": 2909
+    },
+    {
+      "path": "services/panel-sync.ts",
+      "lines": 1051
     },
     {
       "path": "services/port-owner.ts",
@@ -131,7 +155,7 @@
     },
     {
       "path": "services/process-control.ts",
-      "lines": 5304
+      "lines": 6370
     },
     {
       "path": "services/self-update.ts",
@@ -143,7 +167,7 @@
     },
     {
       "path": "services/ui-bridge.ts",
-      "lines": 5560
+      "lines": 6317
     },
     {
       "path": "services/workflow-composer.ts",
@@ -151,23 +175,31 @@
     },
     {
       "path": "services/workflow-converter.ts",
-      "lines": 3682
+      "lines": 3722
     },
     {
       "path": "services/workspace-env.ts",
-      "lines": 2080
+      "lines": 2317
     },
     {
       "path": "tools/image-management.ts",
-      "lines": 1058
+      "lines": 1074
     },
     {
       "path": "tools/model-management.ts",
-      "lines": 1551
+      "lines": 1560
+    },
+    {
+      "path": "tools/skills-access.ts",
+      "lines": 1009
     },
     {
       "path": "tools/vocabulary.ts",
-      "lines": 2624
+      "lines": 2625
+    },
+    {
+      "path": "tools/workflow-library.ts",
+      "lines": 1025
     }
   ]
 }

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -1,0 +1,173 @@
+{
+  "//": [
+    "comfyui-mcp-4x5 — non-test files under src/ that exceed 1000 lines, with their counts.",
+    "A file named here may shrink and never grow; a file not named here may not cross the limit.",
+    "The way to extend one of these is to split it. A genuine exception adds or bumps its entry",
+    "in the same PR with a one-line \"reason\" — the reason is what the reviewer reads.",
+    "Entries without a reason are grandfathered debt from when the gate landed.",
+    "Regenerate deliberately:  node scripts/check-file-size.mjs --baseline  (reasons are preserved)"
+  ],
+  "limit": 1000,
+  "files": [
+    {
+      "path": "comfyui/client.ts",
+      "lines": 1282
+    },
+    {
+      "path": "comfyui/json-guard.ts",
+      "lines": 1445
+    },
+    {
+      "path": "config.ts",
+      "lines": 1087
+    },
+    {
+      "path": "orchestrator/ask-answer-journal.ts",
+      "lines": 1775
+    },
+    {
+      "path": "orchestrator/claude-backend.ts",
+      "lines": 1339
+    },
+    {
+      "path": "orchestrator/codex-backend.ts",
+      "lines": 1757
+    },
+    {
+      "path": "orchestrator/gemini-backend.ts",
+      "lines": 1169
+    },
+    {
+      "path": "orchestrator/grok-backend.ts",
+      "lines": 1657
+    },
+    {
+      "path": "orchestrator/index.ts",
+      "lines": 6849
+    },
+    {
+      "path": "orchestrator/ollama-backend.ts",
+      "lines": 1920
+    },
+    {
+      "path": "orchestrator/panel-agent.ts",
+      "lines": 3970
+    },
+    {
+      "path": "orchestrator/panel-tools.ts",
+      "lines": 17813
+    },
+    {
+      "path": "orchestrator/qwen-backend.ts",
+      "lines": 1123
+    },
+    {
+      "path": "orchestrator/run-completion-journal.ts",
+      "lines": 1561
+    },
+    {
+      "path": "services/download-cache.ts",
+      "lines": 3530
+    },
+    {
+      "path": "services/download-jobs.ts",
+      "lines": 2207
+    },
+    {
+      "path": "services/download-progress.ts",
+      "lines": 1182
+    },
+    {
+      "path": "services/env-capabilities.ts",
+      "lines": 1151
+    },
+    {
+      "path": "services/extra-paths.ts",
+      "lines": 1660
+    },
+    {
+      "path": "services/image-management.ts",
+      "lines": 1185
+    },
+    {
+      "path": "services/lora-catalog.ts",
+      "lines": 1130
+    },
+    {
+      "path": "services/manifest.ts",
+      "lines": 1479
+    },
+    {
+      "path": "services/model-resolver.ts",
+      "lines": 3572
+    },
+    {
+      "path": "services/node-dev.ts",
+      "lines": 1252
+    },
+    {
+      "path": "services/node-management.ts",
+      "lines": 5211
+    },
+    {
+      "path": "services/output-dir.ts",
+      "lines": 1351
+    },
+    {
+      "path": "services/panel-installer.ts",
+      "lines": 6131
+    },
+    {
+      "path": "services/panel-pin-guard.ts",
+      "lines": 1773
+    },
+    {
+      "path": "services/panel-secrets.ts",
+      "lines": 2887
+    },
+    {
+      "path": "services/port-owner.ts",
+      "lines": 1081
+    },
+    {
+      "path": "services/process-control.ts",
+      "lines": 5304
+    },
+    {
+      "path": "services/self-update.ts",
+      "lines": 1003
+    },
+    {
+      "path": "services/training-jobs.ts",
+      "lines": 1955
+    },
+    {
+      "path": "services/ui-bridge.ts",
+      "lines": 5560
+    },
+    {
+      "path": "services/workflow-composer.ts",
+      "lines": 1099
+    },
+    {
+      "path": "services/workflow-converter.ts",
+      "lines": 3682
+    },
+    {
+      "path": "services/workspace-env.ts",
+      "lines": 2080
+    },
+    {
+      "path": "tools/image-management.ts",
+      "lines": 1058
+    },
+    {
+      "path": "tools/model-management.ts",
+      "lines": 1551
+    },
+    {
+      "path": "tools/vocabulary.ts",
+      "lines": 2624
+    }
+  ]
+}

--- a/src/__tests__/scripts/check-file-size.test.ts
+++ b/src/__tests__/scripts/check-file-size.test.ts
@@ -1,0 +1,360 @@
+// comfyui-mcp-4x5 — the file-size ratchet.
+//
+// The rule is pstack's: no PR pushes a file from under 1,000 lines to over
+// 1,000 without a very strong reason. Forty files in this repo are already past
+// it, and every one got there by increments nobody refused. The gate refuses the
+// next increment.
+//
+// What is worth pinning is the DIRECTION. A debt list that can grow is not a
+// debt list; so growth fails, shrink-without-regenerating fails, and the reason
+// an author wrote for a genuine exception survives the regeneration that a later
+// split triggers. Each of those is a behaviour someone could quietly lose while
+// "simplifying" the script, and each would turn the gate into a formality.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Located relative to THIS file rather than `process.cwd()`, so the test does not
+// depend on where vitest was launched from.
+const SCRIPTS_DIR = fileURLToPath(new URL("../../../scripts/", import.meta.url));
+const SCRIPT = join(SCRIPTS_DIR, "check-file-size.mjs");
+const LIMIT = 1000;
+
+let dir: string;
+let src: string;
+let baselineFile: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "filesize-"));
+  src = join(dir, "src");
+  mkdirSync(src, { recursive: true });
+  baselineFile = join(dir, "baseline.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** A file of exactly `n` newline-terminated lines — what `wc -l` would report. */
+function write(name: string, n: number) {
+  const p = join(src, name);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, "export {};\n".repeat(n), "utf8");
+}
+
+/** Run the gate. Returns the exit code and the combined output — the gate's
+ *  MESSAGE is part of its contract, since a developer who cannot tell why it
+ *  fired will reach for the baseline instead of the split. */
+function spawn(...argv: string[]) {
+  try {
+    const out = execFileSync(process.execPath, [SCRIPT, ...argv], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status: number; stdout: string; stderr: string };
+    return { code: err.status, out: (err.stdout ?? "") + (err.stderr ?? "") };
+  }
+}
+
+function run(...extra: string[]) {
+  return spawn("--src", src, "--baseline-file", baselineFile, ...extra);
+}
+
+function baseline() {
+  const r = run("--baseline");
+  expect(r.code, r.out).toBe(0);
+  return JSON.parse(readFileSync(baselineFile, "utf8")) as {
+    limit: number;
+    files: Array<{ path: string; lines: number; reason?: string }>;
+  };
+}
+
+describe("comfyui-mcp-4x5 what the gate FLAGS", () => {
+  it("a file that crosses the limit without being named", () => {
+    write("big.ts", LIMIT + 1);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("1 file(s) crossed");
+    expect(r.out).toContain("big.ts");
+    expect(r.out).toContain(`${LIMIT + 1}`);
+    // The message sends the author to the split first, and to the baseline
+    // only with a reason — the two halves of the rule, in that order.
+    expect(r.out.indexOf("Split")).toBeLessThan(r.out.indexOf("--baseline"));
+    expect(r.out).toContain('"reason"');
+  });
+
+  it("a baselined file that grew by a single line", () => {
+    // The increment is the unit of the defect. A gate that tolerated "just one
+    // more" would be re-deriving the forty files it exists to stop.
+    write("mono.ts", 1500);
+    baseline();
+    write("mono.ts", 1501);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("1 baselined file(s) grew");
+    expect(r.out).toContain("mono.ts  1500 -> 1501  (+1)");
+  });
+
+  it("a file in a subdirectory, reported by its src-relative POSIX path", () => {
+    write(join("orchestrator", "deep", "thing.ts"), LIMIT + 5);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("orchestrator/deep/thing.ts");
+  });
+});
+
+describe("comfyui-mcp-4x5 what the gate must stay QUIET about", () => {
+  it("a file exactly AT the limit — over means over, not at", () => {
+    write("edge.ts", LIMIT);
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("0 baselined file(s)");
+  });
+
+  it("a baselined file that has not moved", () => {
+    write("mono.ts", 1500);
+    baseline();
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+  });
+
+  it("test files and __tests__ trees, however long", () => {
+    // A long test file is a different and smaller problem than a long module,
+    // and the suite already has files that would trip this on day one for
+    // reasons unrelated to the lesson being encoded.
+    write(join("__tests__", "huge.test.ts"), 3000);
+    write(join("__tests__", "helpers.ts"), 3000);
+    write("also.test.ts", 3000);
+    write("also.spec.ts", 3000);
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("0 baselined file(s)");
+  });
+
+  it("declaration files, and files that are not TypeScript", () => {
+    write("types.d.ts", 3000);
+    writeFileSync(join(src, "data.json"), "[\n" + "  1,\n".repeat(3000) + "]\n", "utf8");
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+  });
+
+  it("a file with no trailing newline is counted by what a reader reads", () => {
+    // `wc -l` would say 999 for a 1000-line file missing its last newline; the
+    // gate says 1000, because the partial last line is still a line. Pinned so
+    // nobody can slip under the limit by deleting a byte.
+    writeFileSync(join(src, "noeol.ts"), "export {};\n".repeat(LIMIT) + "export {};", "utf8");
+    const r = run();
+    expect(r.code, r.out).toBe(1);
+  });
+
+  it("CRLF line endings are not double-counted", () => {
+    // The CI matrix includes Windows. A checkout with autocrlf must produce the
+    // same count as the committed LF file, or the baseline only works on one OS.
+    writeFileSync(join(src, "crlf.ts"), "export {};\r\n".repeat(LIMIT), "utf8");
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+  });
+});
+
+describe("comfyui-mcp-4x5 the ratchet only pays down", () => {
+  it("a SHRUNK file fails until the baseline is regenerated", () => {
+    // Otherwise the entry keeps claiming room the file no longer uses, and room
+    // nobody is using is room the file can grow back into, pre-approved.
+    write("mono.ts", 1500);
+    baseline();
+    write("mono.ts", 1400);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("no longer match");
+    expect(r.out).toContain("mono.ts  1500 -> now 1400");
+    expect(r.out).toContain("--baseline");
+  });
+
+  it("a file that dropped UNDER the limit is stale, not silently fine", () => {
+    write("mono.ts", 1500);
+    baseline();
+    write("mono.ts", 900);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("mono.ts  1500 -> now under");
+    expect(r.out).toContain("--baseline");
+  });
+
+  it("a DELETED (or moved) file is stale", () => {
+    write("mono.ts", 1500);
+    baseline();
+    rmSync(join(src, "mono.ts"));
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("mono.ts");
+    expect(r.out).toContain("--baseline");
+  });
+
+  it("regenerating after the shrink clears it, and records the LOWER count", () => {
+    write("mono.ts", 1500);
+    baseline();
+    write("mono.ts", 1400);
+    const b = baseline();
+    expect(b.files).toEqual([{ path: "mono.ts", lines: 1400 }]);
+    const ok = run();
+    expect(ok.code, ok.out).toBe(0);
+    // ...and the new, lower count is now the ceiling.
+    write("mono.ts", 1401);
+    const grew = run();
+    expect(grew.code).toBe(1);
+    expect(grew.out).toContain("1400 -> 1401");
+  });
+
+  it("the baseline is sorted by path, so regenerating never reorders it", () => {
+    write("zeta.ts", 1100);
+    write("alpha.ts", 1100);
+    write(join("mid", "x.ts"), 1100);
+    const b = baseline();
+    expect(b.files.map((f) => f.path)).toEqual(["alpha.ts", "mid/x.ts", "zeta.ts"]);
+    expect(b.limit).toBe(LIMIT);
+  });
+});
+
+describe("comfyui-mcp-4x5 the reason — the deliverable of an exception", () => {
+  function setReason(path: string, reason: string) {
+    const doc = JSON.parse(readFileSync(baselineFile, "utf8"));
+    for (const f of doc.files) if (f.path === path) f.reason = reason;
+    writeFileSync(baselineFile, JSON.stringify(doc, null, 2) + "\n", "utf8");
+  }
+
+  it("an entry with a reason is accepted and the reason is shown in --list", () => {
+    write("vocab.ts", 2000);
+    baseline();
+    setReason("vocab.ts", "one flat list by design; a split would scatter the lookup");
+    const ok = run();
+    expect(ok.code, ok.out).toBe(0);
+    const r = run("--list");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("vocab.ts\t2000\tone flat list by design");
+  });
+
+  it("a reason SURVIVES regeneration after the file shrinks", () => {
+    // Regenerating is how a count goes down after a split. It must not also be
+    // how an explanation someone already wrote disappears.
+    write("vocab.ts", 2000);
+    baseline();
+    setReason("vocab.ts", "one flat list by design; a split would scatter the lookup");
+    write("vocab.ts", 1900);
+    const b = baseline();
+    expect(b.files).toEqual([
+      { path: "vocab.ts", lines: 1900, reason: "one flat list by design; a split would scatter the lookup" },
+    ]);
+  });
+
+  it("a reason does not license GROWTH past the recorded count", () => {
+    // The reason explains the number that is there. Growing past it is a new
+    // decision, and the diff of the bumped `lines` field is where it is made.
+    write("vocab.ts", 2000);
+    baseline();
+    setReason("vocab.ts", "one flat list by design; a split would scatter the lookup");
+    write("vocab.ts", 2001);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("existing reason: one flat list by design");
+  });
+
+  it("a hand-bumped entry is accepted when the count is exact", () => {
+    // The sanctioned exception path: grow the file, bump `lines` to match, add
+    // the reason — all in one PR, all visible in one diff.
+    write("vocab.ts", 2000);
+    baseline();
+    write("vocab.ts", 2010);
+    const doc = JSON.parse(readFileSync(baselineFile, "utf8"));
+    doc.files[0] = { path: "vocab.ts", lines: 2010, reason: "generated table; regenerated from the registry" };
+    writeFileSync(baselineFile, JSON.stringify(doc, null, 2) + "\n", "utf8");
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+  });
+});
+
+describe("comfyui-mcp-4x5 the baseline file itself", () => {
+  it("absent means nothing is grandfathered — the correct first-run state", () => {
+    write("small.ts", 10);
+    const ok = run();
+    expect(ok.code, ok.out).toBe(0);
+    write("big.ts", LIMIT + 1);
+    const bad = run();
+    expect(bad.code).toBe(1);
+  });
+
+  it("a flag with a MISSING value is a usage error, not a silent fallback", () => {
+    // `--src --baseline` must not scan the real tree and rewrite the real
+    // baseline because a fixture path was mistyped away.
+    write("mono.ts", 1500);
+    const r = spawn("--src", "--baseline");
+    expect(r.code).toBe(2);
+    expect(r.out).toContain("--src needs a value");
+    expect(r.out).not.toContain("at ");
+  });
+
+  it("a MALFORMED baseline fails --baseline with the path and an instruction, not a stack trace", () => {
+    // `--baseline` is what the gate tells people to run when the file is stale.
+    // If the file is too broken to read, the reasons in it cannot be carried
+    // forward, and the author needs to hear that — and the broken file must be
+    // left alone rather than silently replaced.
+    write("mono.ts", 1500);
+    writeFileSync(baselineFile, "{ not json", "utf8");
+    const r = run("--baseline");
+    expect(r.code).toBe(1);
+    expect(r.out).toContain(baselineFile);
+    expect(r.out).toContain("Fix or delete it, then run --baseline again");
+    expect(r.out).not.toContain("    at ");
+    expect(readFileSync(baselineFile, "utf8")).toBe("{ not json");
+  });
+
+  it("a baseline written against a DIFFERENT limit is refused", () => {
+    // The limit in the file is what the counts were measured against. If it
+    // disagrees with the script, one was edited without the other.
+    write("mono.ts", 1500);
+    writeFileSync(baselineFile, JSON.stringify({ limit: 500, files: [{ path: "mono.ts", lines: 1500 }] }), "utf8");
+    const r = run();
+    expect(r.code).toBe(2);
+    expect(r.out).toContain(`"limit" is 500 but this gate enforces ${LIMIT}`);
+  });
+
+  it("MALFORMED throws rather than silently becoming empty", () => {
+    // Empty would fail every grandfathered file at once and send someone to
+    // rewrite a baseline that was fine. Loud is the honest failure here.
+    write("mono.ts", 1500);
+    writeFileSync(baselineFile, "{ not json", "utf8");
+    const r = run();
+    expect(r.code).toBe(2);
+    expect(r.out).toContain(`${baselineFile}: not valid JSON`);
+    expect(r.out).not.toContain("crossed");
+    writeFileSync(baselineFile, JSON.stringify({ files: [{ path: "mono.ts" }] }), "utf8");
+    const r2 = run();
+    expect(r2.code).toBe(2);
+    expect(r2.out).toContain(`${baselineFile}: every entry needs`);
+    expect(r2.out).toContain('integer "lines"');
+  });
+});
+
+describe("comfyui-mcp-4x5 the real repo", () => {
+  it("the checked-in baseline matches the checked-in source", () => {
+    // Run against the actual defaults rather than a fixture: this is what CI
+    // runs, and it is the assertion that catches a baseline someone forgot to
+    // rewrite after a split, or a file that grew in a PR that did not notice.
+    const r = spawn();
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("none grew, nothing new crossed");
+  });
+
+  it("every checked-in entry is over the limit and ordered by path", () => {
+    const doc = JSON.parse(readFileSync(join(SCRIPTS_DIR, "file-size-baseline.json"), "utf8")) as {
+      limit: number;
+      files: Array<{ path: string; lines: number }>;
+    };
+    expect(doc.limit).toBe(LIMIT);
+    const paths = doc.files.map((f) => f.path);
+    expect(paths).toEqual([...paths].sort());
+    for (const f of doc.files) expect(f.lines, f.path).toBeGreaterThan(LIMIT);
+  });
+});


### PR DESCRIPTION
Part of #2003.

Encodes one rule from pstack's `thermo-nuclear-code-quality-review` checklist as a CI ratchet: do not let a PR push a file from under 1,000 lines to over 1,000 lines without a very strong reason. This repo has forty non-test files under `src/` already past that mark (`src/orchestrator/panel-tools.ts` is 17,813 lines), and every one of them got there by increments nobody refused. The gate refuses the next increment.

`scripts/check-file-size.mjs` is written in the exact idiom of `check-unknown-collapse.mjs`: a header that explains why, `--list` / `--baseline` modes, `--src` / `--baseline-file` so the gate can be tested against fixture trees, and a shrink-only direction. The rules: a file over 1,000 lines must be named in `scripts/file-size-baseline.json` with its count; a baselined file may not grow past that count (it may shrink, and a shrink makes the baseline stale, which also fails with the instruction to rewrite it); a file not in the baseline may not cross the line. Counts are raw `wc -l` lines, comments and blanks included, so the number can be checked by hand and cannot be gamed.

The baseline is JSON rather than the sibling's text format because each entry is a record: `{"path", "lines", "reason"?}`. The `reason` field is the escape hatch and the deliverable: a genuine exception adds or bumps its entry in the same PR and says why, and `--baseline` preserves existing reasons when it rewrites counts after a split. The forty grandfathered entries have no reason, which is the honest label for debt. Unlike `unknown-ok:`, the reason lives in the baseline rather than at a site, because a file's size has no single site.

The exact-count ceiling means a PR that shrinks a baselined file must also touch the baseline, and a refactor inside one that adds a line must first take one out. That is the trade the unknown-collapse ratchet already made, and one shape of ratchet beats two; the header says so.

Wiring: `lint` becomes `tsc --noEmit && node scripts/check-file-size.mjs`. The gate runs inside `npm run lint` only, so CI has one signal for it rather than a duplicate step; `ci.yml` is untouched. The vitest in `src/__tests__/scripts/check-file-size.test.ts` covers every rule (cross, grow by one, shrink, drop under, delete, reason survives rewrite, reason does not license growth, hand-bumped exact entry accepted, CRLF not double-counted, missing trailing newline still counted, `.test.ts` / `.spec.ts` / `__tests__` / `.d.ts` ignored, malformed baseline and `limit` mismatch fail loudly with the path, `--baseline` on a malformed file refuses without clobbering it, a flag with a missing value is a usage error rather than a silent fallback to the real tree) and asserts the checked-in baseline matches the checked-in source. CONTRIBUTING gets one Conventions bullet and its `npm run lint` line no longer claims "type-check only".

Verified locally: `npm run lint`, `npm run smoke` (37 core + 3 compact + 95 panel tools), `check:vocabulary`, `check:unknown-collapse`; a 1,426-line probe file fails the gate by name, deleting it goes green, appending one line to `panel-tools.ts` fails with `17813 -> 17814 (+1)`, reverting goes green. The full vitest run has 17 failures in `src/__tests__/services/{extra-paths*,training-datasets,comfy-view-ref}.test.ts` that are macOS-environment artifacts (`/private/var` vs `/var` realpath, and a worktree path tripping a dataset-root guard); none touch code this PR changes.

Coordination notes: the anti-slop foundation PR also edits the `lint` script on the same line; this PR keeps that edit to the one line. Follow-ups deliberately not done here: `scripts/tool-doc-examples.ts` is 1,202 lines and outside the `src/` scope of this gate; `walk`, `flagValue`, and the baseline-reading shape are now duplicated between the two ratchets and could move to `scripts/lib/`; README's lint-table row is owned by the README unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49