### PR TITLE
test(anti-slop): comfyui tests build typed fakes instead of double-casting mock objects

### DIFF
--- a/src/__tests__/comfyui/backfill-object-info.test.ts
+++ b/src/__tests__/comfyui/backfill-object-info.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { jsonResponse, type JsonValue } from "../helpers/fake-fetch.js";
 
 // backfillObjectInfo honors the LIVE /object_info/<Type> registration key even
 // when it differs from the requested string in case, namespace, or
@@ -24,8 +25,8 @@ vi.mock("../../comfyui/fetch.js", () => ({
 
 const { backfillObjectInfo } = await import("../../comfyui/client.js");
 
-function okJson(body: unknown) {
-  return { ok: true, json: async () => body } as unknown as Response;
+function okJson(body: JsonValue): Response {
+  return jsonResponse(body);
 }
 
 describe("backfillObjectInfo (#404)", () => {
@@ -36,10 +37,7 @@ describe("backfillObjectInfo (#404)", () => {
     comfyuiFetch.mockResolvedValueOnce(
       okJson({ DetectorForNSFW: { input: {}, name: "DetectorForNSFW" } }),
     );
-    const merged = (await backfillObjectInfo(
-      {} as never,
-      ["DetectorForNSFW"],
-    )) as unknown as Record<string, unknown>;
+    const merged = await backfillObjectInfo({} as never, ["DetectorForNSFW"]);
     expect(merged.DetectorForNSFW).toBeDefined();
   });
 
@@ -52,10 +50,7 @@ describe("backfillObjectInfo (#404)", () => {
         "utils-nodes/DetectorForNSFW": { input: {}, name: "DetectorForNSFW" },
       }),
     );
-    const merged = (await backfillObjectInfo(
-      {} as never,
-      ["DetectorForNSFW"],
-    )) as unknown as Record<string, unknown>;
+    const merged = await backfillObjectInfo({} as never, ["DetectorForNSFW"]);
     expect(merged["utils-nodes/DetectorForNSFW"]).toBeDefined();
     // A case-insensitive substring filter (what create_workflow (action:"node_info") uses) now finds it.
     const hit = Object.keys(merged).some((k) =>
@@ -75,10 +70,7 @@ describe("backfillObjectInfo (#404)", () => {
 
   it("leaves the node missing when the endpoint returns an empty object", async () => {
     comfyuiFetch.mockResolvedValueOnce(okJson({}));
-    const merged = (await backfillObjectInfo(
-      {} as never,
-      ["Ghost"],
-    )) as unknown as Record<string, unknown>;
+    const merged = await backfillObjectInfo({} as never, ["Ghost"]);
     expect(Object.keys(merged)).toHaveLength(0);
   });
 });

--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -51,7 +51,7 @@ function serve(...responses: Array<() => Response>): void {
     const make = responses[Math.min(i, responses.length - 1)];
     i += 1;
     return make();
-  }) as unknown as typeof fetch;
+  });
 }
 
 beforeEach(() => {
@@ -267,7 +267,7 @@ describe("a first-hand diagnosis still wins over a retry blip", () => {
         });
       }
       throw Object.assign(new TypeError("fetch failed"), { code: "ECONNREFUSED" });
-    }) as unknown as typeof fetch;
+    });
 
     const err = await getObjectInfo().then(
       () => null,

--- a/src/__tests__/comfyui/client-ownership-race.test.ts
+++ b/src/__tests__/comfyui/client-ownership-race.test.ts
@@ -14,22 +14,26 @@ vi.mock("../../config.js", async () => {
   };
 });
 
-const instances = vi.hoisted(() => [] as Array<{ closed: boolean }>);
+const instances = vi.hoisted(
+  () => [] as Array<{ closed: boolean; _impl: () => Promise<unknown> }>,
+);
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
     // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
     // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
-    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
-    // back through its own `fetchApi`, so every existing impl and spy in this
-    // file keeps working and keeps asserting the same route.
+    // 4xx instead of having `fetchApi` throw it away. This double has no HTTP
+    // route at all — the tests stub the SDK method directly — so a comfyApiFetch
+    // call reaching it is a wiring mistake and is named as one, rather than
+    // failing as "this.fetchApi is not a function" through a cast that claimed
+    // the method existed.
     apiURL(p: string) {
       return p;
     }
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string): Promise<Response> {
+      throw new Error(`Client double has no HTTP route for ${u}; stub the SDK method instead`);
     }
     closed = false;
     _impl: () => Promise<unknown> = () => Promise.reject(new Error("unset"));
@@ -46,10 +50,19 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
 const { getObjectInfo, resetObjectInfoCache, resetClient, resetClientIfCurrent, getClient } =
   await import("../../comfyui/client.js");
 
-type FakeClient = {
-  closed: boolean;
-  _impl: () => Promise<unknown>;
-};
+type FakeClient = (typeof instances)[number];
+
+/**
+ * The double behind a `getClient()` result, found by identity in the list the
+ * double's constructor appends to. Looking it up rather than casting keeps the
+ * typed surface the one the double actually has, and fails loudly if getClient
+ * ever hands back something the double did not construct.
+ */
+function fakeOf(client: ReturnType<typeof getClient>): FakeClient {
+  const fake = instances.find((i) => Object.is(i, client));
+  if (!fake) throw new Error("getClient() returned an object the Client double did not construct");
+  return fake;
+}
 
 describe("client ownership race", () => {
   beforeEach(() => {
@@ -59,15 +72,15 @@ describe("client ownership race", () => {
   });
 
   it("resetClientIfCurrent only resets when the argument is still the current client", () => {
-    const c1 = getClient() as unknown as FakeClient;
+    const c1 = getClient();
     resetClient(); // c1 closed, singleton cleared
-    const c2 = getClient() as unknown as FakeClient;
+    const c2 = getClient();
     // c1 is stale — must NOT close the newer c2.
-    expect(resetClientIfCurrent(c1 as never)).toBe(false);
-    expect(c2.closed).toBe(false);
+    expect(resetClientIfCurrent(c1)).toBe(false);
+    expect(fakeOf(c2).closed).toBe(false);
     // c2 is current — resets.
-    expect(resetClientIfCurrent(c2 as never)).toBe(true);
-    expect(c2.closed).toBe(true);
+    expect(resetClientIfCurrent(c2)).toBe(true);
+    expect(fakeOf(c2).closed).toBe(true);
     // null never resets.
     expect(resetClientIfCurrent(null)).toBe(false);
   });
@@ -75,7 +88,7 @@ describe("client ownership race", () => {
   it("a stale request's delayed rejection does NOT close the newer client", async () => {
     // Request A starts on client C1 with a first attempt that rejects LATER.
     let rejectA!: (e: unknown) => void;
-    const c1 = getClient() as unknown as FakeClient;
+    const c1 = fakeOf(getClient());
     c1._impl = () => new Promise((_res, rej) => (rejectA = rej));
     const pA = getObjectInfo(); // inflight on C1, epoch N
 
@@ -84,7 +97,7 @@ describe("client ownership race", () => {
     resetObjectInfoCache();
 
     // Request B creates C2 and succeeds.
-    const c2 = getClient() as unknown as FakeClient;
+    const c2 = fakeOf(getClient());
     c2._impl = () => Promise.resolve({ NewNode: {} });
     await expect(getObjectInfo()).resolves.toEqual({ NewNode: {} });
     expect(c2.closed).toBe(false);

--- a/src/__tests__/comfyui/cloud-client.test.ts
+++ b/src/__tests__/comfyui/cloud-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fakeFetch } from "../helpers/fake-fetch.js";
 
 // Stub config helpers BEFORE importing the module under test.
 vi.mock("../../config.js", async () => {
@@ -32,14 +33,13 @@ describe("cloud-client", () => {
 
   beforeEach(() => {
     calls = [];
-    global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+    global.fetch = fakeFetch(async (url, init) => {
       calls.push({ url, init });
       return new Response("{}", {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as unknown as typeof fetch;
+    });
   });
 
   afterEach(() => {
@@ -76,7 +76,7 @@ describe("cloud-client", () => {
       new Response(JSON.stringify({ outputs: { "9": { images: [] } } }), {
         status: 200,
       }),
-    ) as unknown as typeof fetch;
+    );
     const result = await getHistory("abc-123");
     expect(result["abc-123"]).toBeDefined();
     expect(result["abc-123"]).toMatchObject({ outputs: { "9": { images: [] } } });
@@ -115,7 +115,7 @@ describe("cloud-client", () => {
       new Response(JSON.stringify({ status: "in_progress", prompt_id: "x" }), {
         status: 200,
       }),
-    ) as unknown as typeof fetch;
+    );
     const s = await getJobStatus("x");
     expect(s.status).toBe("in_progress");
   });
@@ -127,7 +127,7 @@ describe("cloud-client", () => {
         status: 200,
         headers: { "content-type": "image/png" },
       }),
-    ) as unknown as typeof fetch;
+    );
     const r = await fetchImage("out.png");
     expect(r.mimeType).toBe("image/png");
     expect(r.base64).toBe(Buffer.from(bytes).toString("base64"));
@@ -136,7 +136,7 @@ describe("cloud-client", () => {
   it("wraps non-2xx responses in a ComfyUIError with status code", async () => {
     global.fetch = vi.fn(async () =>
       new Response("forbidden", { status: 403, statusText: "Forbidden" }),
-    ) as unknown as typeof fetch;
+    );
     await expect(getHistory("abc")).rejects.toMatchObject({
       code: "CLOUD_API_ERROR",
     });

--- a/src/__tests__/comfyui/enqueue-error-redaction.test.ts
+++ b/src/__tests__/comfyui/enqueue-error-redaction.test.ts
@@ -31,15 +31,10 @@ vi.mock("../../comfyui/fetch.js", () => ({
 
 const { enqueuePrompt } = await import("../../comfyui/client.js");
 
+// A real Response: buildEnqueueError reads status, statusText and text() once,
+// which the platform constructor serves exactly.
 function res(status: number, body: string, statusText = "Bad Request"): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    statusText,
-    text: async () => body,
-    json: async () => JSON.parse(body),
-    headers: new Map(),
-  } as unknown as Response;
+  return new Response(body, { status, statusText });
 }
 
 beforeEach(() => comfyuiFetch.mockReset());

--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -23,16 +23,12 @@ vi.mock("../../comfyui/fetch.js", () => ({
 
 const { enqueuePrompt } = await import("../../comfyui/client.js");
 
+// A real Response. A string body is sent verbatim (the empty and HTML cases);
+// anything else is serialised as JSON. readComfyJson trusts the body over the
+// content-type header, so the platform default of text/plain changes nothing.
 function res(status: number, body: unknown, statusText = "Bad Request"): Response {
   const text = typeof body === "string" ? body : JSON.stringify(body);
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    statusText,
-    text: async () => text,
-    json: async () => JSON.parse(text),
-    headers: new Map(),
-  } as unknown as Response;
+  return new Response(text, { status, statusText });
 }
 
 const validationBody = {

--- a/src/__tests__/comfyui/get-logs-retry.test.ts
+++ b/src/__tests__/comfyui/get-logs-retry.test.ts
@@ -27,8 +27,8 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string, init?: RequestInit) {
+      return this.fetchApi(u, init);
     }
     fetchApi = fetchApi;
     close() {}

--- a/src/__tests__/comfyui/history-non-json.test.ts
+++ b/src/__tests__/comfyui/history-non-json.test.ts
@@ -24,8 +24,8 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string) {
+      return this.fetchApi(u);
     }
     async fetchApi(p: string) {
       return fetchApi.impl(p);

--- a/src/__tests__/comfyui/json-guard.test.ts
+++ b/src/__tests__/comfyui/json-guard.test.ts
@@ -14,6 +14,7 @@
 // instead of being handed on as data.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fakeFetch } from "../helpers/fake-fetch.js";
 
 // The body prefix is diagnostic, but a gateway that REFLECTS the request could
 // put our own ComfyUI credential in it — and the prefix goes into an error the
@@ -956,7 +957,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
             status: 200,
             headers: { "content-type": "text/html" },
           }),
-      ) as unknown as typeof fetch;
+      );
       const reflecting = new SyntaxError(
         `Unexpected token '<', "<html>Bearer echoed-secret-token-here</html>" is not valid JSON`,
       );
@@ -975,7 +976,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
           status: 200,
           headers: { "content-type": "text/html" },
         }),
-    ) as unknown as typeof fetch;
+    );
 
     await expect(rethrowWithJsonDiagnosis(ORIGINAL, PROBE_URL)).rejects.toSatisfy((e: unknown) => {
       if (!isNonJsonResponseError(e)) return false;
@@ -995,7 +996,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
           status: 200,
           headers: { "content-type": "application/json" },
         }),
-    ) as unknown as typeof fetch;
+    );
 
     await expect(rethrowWithJsonDiagnosis(ORIGINAL, PROBE_URL)).rejects.toBe(ORIGINAL);
   });
@@ -1011,7 +1012,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
             status: 200,
             headers: { "content-type": "application/json" },
           }),
-      ) as unknown as typeof fetch;
+      );
       const reflecting = new SyntaxError(
         `Unexpected token '<', "<html>Bearer echoed-secret-token-here</html>" is not valid JSON`,
       );
@@ -1033,7 +1034,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
     try {
       global.fetch = vi.fn(async () => {
         throw new Error("fetch failed");
-      }) as unknown as typeof fetch;
+      });
       const reflecting = new SyntaxError(
         `Unexpected token '<', "<html>Bearer echoed-secret-token-here</html>" is not valid JSON`,
       );
@@ -1054,7 +1055,7 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
     try {
       global.fetch = vi.fn(async () => {
         throw new Error("fetch failed");
-      }) as unknown as typeof fetch;
+      });
       const reflecting = new SyntaxError(
         `Unexpected token '<', "<html>Bearer echoed-secret-token-here</html>" is not valid JSON`,
       );
@@ -1069,13 +1070,17 @@ describe("rethrowWithJsonDiagnosis never asserts a cause it did not prove (#828)
   it("rethrows the ORIGINAL untouched when the probe itself fails", async () => {
     global.fetch = vi.fn(async () => {
       throw new Error("fetch failed");
-    }) as unknown as typeof fetch;
+    });
     await expect(rethrowWithJsonDiagnosis(ORIGINAL, PROBE_URL)).rejects.toBe(ORIGINAL);
   });
 
   it("does not probe at all for an error that is not markup-parsed-as-JSON", async () => {
-    const spy = vi.fn();
-    global.fetch = spy as unknown as typeof fetch;
+    // A fetch that must not run: named so that a regression fails on the call
+    // itself, not only on the count.
+    const spy = fakeFetch(async (url) => {
+      throw new Error(`unexpected fetch of ${url}`);
+    });
+    global.fetch = spy;
     const transport = new Error("fetch failed");
     await expect(rethrowWithJsonDiagnosis(transport, PROBE_URL)).rejects.toBe(transport);
     expect(spy).not.toHaveBeenCalled();

--- a/src/__tests__/comfyui/log-select-order.test.ts
+++ b/src/__tests__/comfyui/log-select-order.test.ts
@@ -43,8 +43,8 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string, init?: RequestInit) {
+      return this.fetchApi(u, init);
     }
     fetchApi = fetchApi;
     close() {}

--- a/src/__tests__/comfyui/object-info-cache.test.ts
+++ b/src/__tests__/comfyui/object-info-cache.test.ts
@@ -18,17 +18,19 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
     // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
     // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
-    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
-    // back through its own `fetchApi`, so every existing impl and spy in this
-    // file keeps working and keeps asserting the same route.
+    // 4xx instead of having `fetchApi` throw it away. This double has no HTTP
+    // route at all — the tests stub the SDK method directly — so a comfyApiFetch
+    // call reaching it is a wiring mistake and is named as one, rather than
+    // failing as "this.fetchApi is not a function" through a cast that claimed
+    // the method existed.
     apiURL(p: string) {
       return p;
     }
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string): Promise<Response> {
+      throw new Error(`Client double has no HTTP route for ${u}; stub the SDK method instead`);
     }
     getNodeDefs = getNodeDefs;
     close() {}

--- a/src/__tests__/comfyui/object-info-non-json.test.ts
+++ b/src/__tests__/comfyui/object-info-non-json.test.ts
@@ -6,23 +6,26 @@
 // user to check whether ComfyUI is running (codex gate, round 8, finding 2).
 
 import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fakeFetch } from "../helpers/fake-fetch.js";
 
 const nodeDefs = vi.hoisted(() => ({ impl: async () => ({}) as unknown }));
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
     // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
     // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
-    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
-    // back through its own `fetchApi`, so every existing impl and spy in this
-    // file keeps working and keeps asserting the same route.
+    // 4xx instead of having `fetchApi` throw it away. This double has no HTTP
+    // route at all — the tests stub the SDK method directly — so a comfyApiFetch
+    // call reaching it is a wiring mistake and is named as one, rather than
+    // failing as "this.fetchApi is not a function" through a cast that claimed
+    // the method existed.
     apiURL(p: string) {
       return p;
     }
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string): Promise<Response> {
+      throw new Error(`Client double has no HTTP route for ${u}; stub the SDK method instead`);
     }
     async getNodeDefs() {
       return nodeDefs.impl();
@@ -70,7 +73,7 @@ describe("getObjectInfo reports the attempt that PROVED a non-JSON answer (#828)
           status: 200,
           headers: { "content-type": "text/html" },
         }),
-    ) as unknown as typeof fetch;
+    );
 
     await expect(getObjectInfo()).rejects.toSatisfy((e: unknown) => {
       if (!isNonJsonResponseError(e)) return false;
@@ -88,7 +91,7 @@ describe("getObjectInfo reports the attempt that PROVED a non-JSON answer (#828)
           status: 200,
           headers: { "content-type": "text/html" },
         }),
-    ) as unknown as typeof fetch;
+    );
     await expect(getObjectInfo()).rejects.toSatisfy((e: unknown) => isNonJsonResponseError(e));
   });
 
@@ -96,8 +99,10 @@ describe("getObjectInfo reports the attempt that PROVED a non-JSON answer (#828)
     nodeDefs.impl = async () => {
       throw new Error("fetch failed");
     };
-    const probe = vi.fn();
-    global.fetch = probe as unknown as typeof fetch;
+    const probe = fakeFetch(async (url) => {
+      throw new Error(`unexpected fetch of ${url}`);
+    });
+    global.fetch = probe;
     await expect(getObjectInfo()).rejects.toThrow(/fetch failed/);
     expect(probe).not.toHaveBeenCalled(); // no speculative re-probe
   });

--- a/src/__tests__/comfyui/object-info-ttl.test.ts
+++ b/src/__tests__/comfyui/object-info-ttl.test.ts
@@ -29,17 +29,19 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
     // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
     // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
-    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
-    // back through its own `fetchApi`, so every existing impl and spy in this
-    // file keeps working and keeps asserting the same route.
+    // 4xx instead of having `fetchApi` throw it away. This double has no HTTP
+    // route at all — the tests stub the SDK method directly — so a comfyApiFetch
+    // call reaching it is a wiring mistake and is named as one, rather than
+    // failing as "this.fetchApi is not a function" through a cast that claimed
+    // the method existed.
     apiURL(p: string) {
       return p;
     }
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string): Promise<Response> {
+      throw new Error(`Client double has no HTTP route for ${u}; stub the SDK method instead`);
     }
     getNodeDefs = getNodeDefs;
     close() {}

--- a/src/__tests__/comfyui/settings-unreadable.test.ts
+++ b/src/__tests__/comfyui/settings-unreadable.test.ts
@@ -45,8 +45,8 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string, init?: RequestInit) {
+      return this.fetchApi(u, init);
     }
     fetchApi = fetchApi;
     close() {}

--- a/src/__tests__/comfyui/system-stats-non-json.test.ts
+++ b/src/__tests__/comfyui/system-stats-non-json.test.ts
@@ -6,6 +6,7 @@
 // system stats and must not be handed on as though it were.
 
 import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fakeFetch } from "../helpers/fake-fetch.js";
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
@@ -32,7 +33,7 @@ describe("getSystemStats against a non-ComfyUI responder (#828)", () => {
           status: 200,
           headers: { "content-type": "text/html" },
         }),
-    ) as unknown as typeof fetch;
+    );
 
     await expect(getSystemStats()).rejects.toSatisfy((e: unknown) => {
       if (!isNonJsonResponseError(e)) return false;
@@ -53,7 +54,7 @@ describe("getSystemStats against a non-ComfyUI responder (#828)", () => {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
-    ) as unknown as typeof fetch;
+    );
 
     await expect(getSystemStats()).rejects.toThrow(
       /valid JSON that is not a ComfyUI \/system_stats document/,
@@ -67,12 +68,9 @@ describe("getSystemStats against a non-ComfyUI responder (#828)", () => {
           JSON.stringify({ system: { comfyui_version: "0.3.0" }, devices: [{ name: "cuda:0" }] }),
           { status: 200, headers: { "content-type": "application/json" } },
         ),
-    ) as unknown as typeof fetch;
+    );
 
-    const stats = (await getSystemStats()) as unknown as {
-      system: { comfyui_version: string };
-      devices: unknown[];
-    };
+    const stats = await getSystemStats();
     expect(stats.system.comfyui_version).toBe("0.3.0");
     expect(stats.devices).toHaveLength(1);
   });
@@ -84,19 +82,19 @@ describe("getSystemStats against a non-ComfyUI responder (#828)", () => {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
-    ) as unknown as typeof fetch;
+    );
     await expect(getSystemStats()).resolves.toBeTruthy();
   });
 
   it("hits the base URL's /system_stats route (path prefix preserved)", async () => {
-    const spy = vi.fn(
+    const spy = fakeFetch(
       async () =>
         new Response(JSON.stringify({ devices: [] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
     );
-    global.fetch = spy as unknown as typeof fetch;
+    global.fetch = spy;
     await getSystemStats();
     expect(String(spy.mock.calls[0][0])).toBe("http://remote.example:8188/system_stats");
   });

--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -21,6 +21,7 @@
 // reverting a call site to `client.fetchApi` fails them.
 
 import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fakeFetch } from "../helpers/fake-fetch.js";
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
@@ -48,7 +49,7 @@ function answer(status: number, body: string | null, contentType?: string): void
     const headers: Record<string, string> = {};
     if (contentType) headers["content-type"] = contentType;
     return new Response(body, { status, headers });
-  }) as unknown as typeof fetch;
+  });
 }
 
 beforeEach(() => {
@@ -190,10 +191,10 @@ describe("comfyApiFetch keeps the library's routing", () => {
     // multi-user target resolves exactly as it did through fetchApi. Losing
     // this would be a silent routing change on someone else's deployment.
     const seen: string[] = [];
-    global.fetch = vi.fn(async (input: unknown) => {
-      seen.push(String(input));
+    global.fetch = fakeFetch(async (url) => {
+      seen.push(url);
       return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
-    }) as unknown as typeof fetch;
+    });
 
     await comfyApiFetch("/settings");
     expect(seen[0]).toContain("remote.example:8188");

--- a/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
+++ b/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
@@ -33,8 +33,8 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
     apiHeaders(init?: { headers?: unknown }) {
       return (init && init.headers) || {};
     }
-    async fetch(u: string, init?: unknown) {
-      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    async fetch(u: string, init?: RequestInit) {
+      return this.fetchApi(u, init);
     }
     fetchApi = fetchApi;
     close() {}

--- a/src/__tests__/comfyui/upload-too-large.test.ts
+++ b/src/__tests__/comfyui/upload-too-large.test.ts
@@ -33,7 +33,7 @@ function answer(status: number, body: string, contentType: string, statusText?: 
       statusText: statusText ?? "",
       headers: { "content-type": contentType },
     });
-  }) as unknown as typeof fetch;
+  });
 }
 
 beforeEach(() => {

--- a/src/__tests__/helpers/fake-fetch.test.ts
+++ b/src/__tests__/helpers/fake-fetch.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { fakeFetch, jsonResponse, targetUrl } from "./fake-fetch.js";
+
+/**
+ * The contract the comfyui tests lean on, and nothing more: the impl sees a string
+ * target whatever the caller passed, the spy records real fetch calls, and the JSON
+ * response is a genuine platform Response rather than a shape that resembles one.
+ */
+describe("fakeFetch", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("hands the impl the target as a string for a string, a URL and a Request", async () => {
+    const seen: string[] = [];
+    global.fetch = fakeFetch(async (url) => {
+      seen.push(url);
+      return new Response("");
+    });
+    await fetch("http://a.test/x");
+    await fetch(new URL("http://b.test/y"));
+    await fetch(new Request("http://c.test/z"));
+    expect(seen).toEqual(["http://a.test/x", "http://b.test/y", "http://c.test/z"]);
+  });
+
+  it("forwards init untouched and records the call with fetch's own parameter types", async () => {
+    const spy = fakeFetch(async () => new Response(""));
+    global.fetch = spy;
+    const init: RequestInit = { method: "POST", headers: { "x-probe": "1" } };
+    await fetch("http://a.test/x", init);
+    // Typed as `string | URL | Request` and `RequestInit | undefined` — the point of the
+    // helper. A zero-arg `vi.fn()` records `[]` here and the index is a type error.
+    const [input, recordedInit] = spy.mock.calls[0];
+    expect(String(input)).toBe("http://a.test/x");
+    expect(recordedInit).toBe(init);
+  });
+
+  it("propagates a rejection from the impl as fetch would", async () => {
+    global.fetch = fakeFetch(async () => {
+      throw Object.assign(new TypeError("fetch failed"), { code: "ECONNREFUSED" });
+    });
+    await expect(fetch("http://a.test/x")).rejects.toMatchObject({ code: "ECONNREFUSED" });
+  });
+});
+
+describe("targetUrl", () => {
+  it("uses a Request's url rather than its [object Request] string form", () => {
+    expect(targetUrl(new Request("http://c.test/z?q=1"))).toBe("http://c.test/z?q=1");
+    expect(targetUrl(new URL("http://b.test/y"))).toBe("http://b.test/y");
+    expect(targetUrl("relative/path")).toBe("relative/path");
+  });
+});
+
+describe("jsonResponse", () => {
+  it("is a real Response: ok, 200, application/json, and a body that parses back", async () => {
+    const res = jsonResponse({ prompt_id: "p-1", number: 3 });
+    expect(res).toBeInstanceOf(Response);
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    await expect(res.json()).resolves.toEqual({ prompt_id: "p-1", number: 3 });
+  });
+
+  it("keeps the caller's status, statusText and headers, adding content-type only when absent", () => {
+    const res = jsonResponse({ error: "nope" }, {
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: { "content-type": "text/plain", "x-served-by": "proxy" },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(502);
+    expect(res.statusText).toBe("Bad Gateway");
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(res.headers.get("x-served-by")).toBe("proxy");
+  });
+
+  it("has a single-use body like the platform's — reading twice is an error, not a quiet repeat", async () => {
+    // This is the one behaviour a `{ json: async () => body }` literal got wrong, and
+    // the reason a real Response is the more honest double.
+    const res = jsonResponse({});
+    await res.text();
+    await expect(res.text()).rejects.toThrow();
+  });
+});

--- a/src/__tests__/helpers/fake-fetch.ts
+++ b/src/__tests__/helpers/fake-fetch.ts
@@ -1,0 +1,75 @@
+import { vi, type Mock } from "vitest";
+
+/**
+ * Typed doubles for `global.fetch` and the Response it resolves.
+ *
+ * ## Why these exist
+ *
+ * Almost every test under `src/__tests__/comfyui` replaces `global.fetch`, and until
+ * the anti-slop pilot every one of them did it the same way:
+ *
+ *     global.fetch = vi.fn(async () => new Response("{}")) as unknown as typeof fetch;
+ *
+ * The double cast was cargo-culted from one file to the next. It is NOT needed for a
+ * zero-argument impl — `Mock<() => Promise<Response>>` is assignable to `typeof fetch`
+ * as it stands — and where it WAS needed it was hiding a lie: a spy declared with no
+ * parameters records its calls as `[]`, so `spy.mock.calls[0][0]` is a type error that
+ * the cast kept the compiler from ever reporting (system-stats-non-json.test.ts, #101 of
+ * the pilot). Vitest strips types without checking them, so nothing else would have.
+ *
+ * `fakeFetch` gives a test a spy whose recorded calls carry the real `fetch` parameter
+ * types, while letting the impl be written against the one thing tests actually look
+ * at — the request target as a string. The `string | URL | Request` union is the
+ * REAL fetch contract, and the impl signature narrowing it to `string` is exactly what
+ * made the casts necessary in the first place (parameter contravariance: an impl that
+ * accepts only `string` is not a `fetch`). So the widening happens HERE, once, with the
+ * normalisation spelled out, instead of in every file as `(input as Request).url`.
+ *
+ * `jsonResponse` replaces the `{ ok: true, json: async () => body } as unknown as
+ * Response` object literals. A real `Response` is strictly more honest than a partial
+ * one: it has the `headers`, `statusText`, `text()` and single-use body that the code
+ * under test may read, and it cannot drift from the platform type because it IS the
+ * platform type. Where a test needs a response the constructor cannot express (a body
+ * that reads twice, a `json()` that throws a specific error) it should say so at the
+ * site rather than teach this helper to lie.
+ */
+
+/** What a test's fetch impl receives: the request target as a plain string. */
+export type FakeFetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * The request target as a string, however the caller spelled it.
+ *
+ * `String(url)` is `url.href`; a `Request` stringifies to `[object Request]`, which is
+ * why it is the one case that needs its own branch.
+ */
+export function targetUrl(input: string | URL | Request): string {
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+/**
+ * A `fetch` spy whose impl sees the target as a string and whose recorded calls are
+ * typed as real `fetch` calls — so `spy.mock.calls[0][0]` type-checks and
+ * `global.fetch = fakeFetch(...)` needs no cast.
+ */
+export function fakeFetch(impl: FakeFetchImpl): Mock<typeof fetch> {
+  return vi.fn<typeof fetch>((input, init) => impl(targetUrl(input), init));
+}
+
+/**
+ * What `JSON.stringify` can carry faithfully. Narrower than `unknown` on purpose: a
+ * function or `undefined` at the top level stringifies to `undefined`, which the
+ * Response constructor would accept as a body of the literal text "undefined".
+ */
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+/**
+ * A real `Response` carrying `body` as JSON, with `content-type: application/json`
+ * unless the caller set one. `status` defaults to 200 via the platform constructor.
+ */
+export function jsonResponse(body: JsonValue, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  return new Response(JSON.stringify(body), { ...init, headers });
+}


### PR DESCRIPTION
Part of #2003.

Pilot for the anti-slop `no-chained-type-assertions` rule, scoped to `src/__tests__/comfyui/**`. Every `x as unknown as T` in that tree is gone — 46 → 0 — with no test assertion changed and 422/422 tests still passing. The output of this PR is as much the data below as the code: it is meant to tell us whether the remaining ~514 test casts (orchestrator 320, services 155, tools 35) deserve the same treatment or a ratchet.

What changed, by cast shape:

| Shape | Before | After | Fix | Helper |
|---|---:|---:|---|---|
| `vi.fn(async () => …) as unknown as typeof fetch` (zero-arg impl) | 21 | 0 | delete the cast — a zero-arg `Mock` is already assignable to `typeof fetch` | none |
| `vi.fn(impl that reads the request)` / bare spy `as unknown as typeof fetch` | 5 | 0 | `fakeFetch(impl)` | `fakeFetch` |
| `(this as unknown as { fetchApi }).fetchApi(u, init)` — double defines `fetchApi` | 5 | 0 | `this.fetchApi(u, init)`; it type-checked all along | none |
| same, but the double defines no `fetchApi` at all | 4 | 0 | explicit throw naming the wiring mistake | none |
| `getClient() as unknown as FakeClient` | 4 | 0 | identity lookup in the hoisted `instances` list (`fakeOf`) | local to the file |
| `{ ok, json, … } as unknown as Response` | 3 | 0 | a real `Response` (`jsonResponse`, or the constructor directly) | `jsonResponse` |
| result `as unknown as Record<string, unknown>` / inline shape | 4 | 0 | delete — the function already returns an indexable type | none |
| **Total** | **46** | **0** | | |

Genuine double casts that had to stay: **0**. I went in expecting the private-surface and malformed-value cases to need a commented `as unknown as T`; none in this directory did. The private-surface casts here were doubles casting `this` to reach a method they themselves defined (or, in four files, did not define — the cast asserted a `fetchApi` that did not exist, and a call would have failed as "this.fetchApi is not a function").

Helpers added, in `src/__tests__/helpers/fake-fetch.ts` with `fake-fetch.test.ts` (7 tests):

- `fakeFetch(impl)` → `Mock<typeof fetch>`: absorbed 5 casts (cloud-client, unreachable-status-branches, system-stats-non-json, json-guard, object-info-non-json). The impl sees the target as a `string`; the spy records real fetch calls.
- `jsonResponse(body: JsonValue, init?)` → a real `Response`: absorbed 1 cast directly (backfill) and is the shape the other two `Response` literals now use via the constructor.
- `targetUrl(input)`: the `string | URL | Request` → `string` normalisation, done once instead of as `(input as Request).url` per file.

What the casts were hiding, which is the finding I would weight most:

- `src/__tests__` is not in `tsconfig.json`, and vitest strips types without checking them, so **the test tree does not type-check today**. A scratch tsconfig over `comfyui/` + `helpers/` reports 17 errors in 6 files before this PR and 16 in 5 after. The one fixed is exactly a cast site: `system-stats-non-json` declared its spy with no parameters, so `spy.mock.calls[0][0]` indexes an empty tuple, and `as unknown as typeof fetch` kept tsc from ever saying so. The other 16 are pre-existing in files the pilot did not touch (`fetch.test.ts` 10, `fetch-failure-diagnostics` 3, and one each in `loopback-alias-origin`, `system-stats-timeout-honesty`, `timeout-panel-origin-drift`) and are out of scope here. Without a typecheck gate for tests, "typed fake" is a claim nobody verifies.
- 25 of 46 casts (the 21 zero-arg fetch spies plus the 4 result casts) were never needed at all — removing the text is the whole fix. The rule is right that they discard evidence; it is just that the evidence was already there.
- Side effect on the other anti-slop rules in this tree (oxlint, same config): `require-safety-comment-for-type-assertion` 214 → 119, `no-unknown-parameters` 77 → 59, `no-unknown-returns` 11 → 2, `no-unsafe-dictionary-type` 3 → 0, `no-runtime-typeof` 4 → 3. Total anti-slop diagnostics 414 → 240. The helper itself adds zero.

Time: about 35 minutes wall-clock for 46 casts end to end, so ~7–8 min per 10 casts. Almost all of it was reading — which source path reads `text()` vs `json()`, whether a real `Response`'s single-use body could break a test that used to read twice, whether the double's `fetchApi` was a field or a method. The editing itself was ~6 minutes for all 46 once the shapes were understood; the mechanical shapes went by regex.

Whether to do the remaining 514: **not as a bulk migration, with one exception.** Profiling the rest by target type:

| Target | Count | Read |
|---|---:|---|
| `PanelToolCtx["bridge"]` (a `UiBridge` fake) | 190 | one shape, one factory — `fakeBridge(overrides)` would absorb 37% of everything left. `UiBridge` is a class, so the honest version is either a `BridgeLike` interface as a tiny seam in `panel-tools.ts`, or one documented single cast inside the factory. Worth a second pilot. |
| whole `PanelToolCtx` | 58 | same factory family; `fakePanelToolCtx(overrides)`. |
| inline `{ … }` private surfaces (`QMPriv` and friends) | ~99 | each one is a design decision (seam vs. named interface vs. leave it). Ratchet, fix on touch. |
| `typeof fetch` | 56 | expect most to be deletable outright, like the 21 here. An hour with a regex and `fakeFetch`. |
| `Record<…>`, `Response`, `WorkflowJSON`, `ObjectInfo`, `HistoryEntry` | ~55 | mostly deletable or a real constructor, like here. |
| long tail (`never`, `Parameters`, `typeof import("node:fs")`, `typeof process.kill`, …) | ~55 | leave under the ratchet. |

So my recommendation, in order: (1) add a tests tsconfig and a `lint:tests` gate, ratcheted to its current error count — that is the check the casts were defeating and it is cheap; (2) ratchet `no-chained-type-assertions` per directory at today's counts so no new ones land; (3) run the `PanelToolCtx`/`bridge` factory as a second pilot, since 248 casts behind one shape is the only place a bulk pass clearly pays; (4) sweep `typeof fetch` and the other mechanical shapes opportunistically; (5) leave the private-surface casts to fix-on-touch. For the other OSS repos the user maintains, the transferable lesson is (1): a rule about discarded type evidence only bites if the tests are type-checked at all.

Verification: `npm run build` clean; vitest 11100 passed / 16 failed, where all 16 are in five `services/` files this PR does not touch (`comfy-view-ref`, `extra-paths*`, `training-datasets`) and fail identically at main's `1a1703ef` on this machine — a macOS `/var` vs `/private/var` tmpdir realpath mismatch, not a regression; the docs/i18n/blog gates that `npm test` chains after vitest were run separately and pass; `npm run smoke` boots the packed tarball and registers 37 core + 3 compact + 95 panel tools; and the oxlint command from the unit brief (`-c oxlintrc.json -A all --format json src/__tests__/comfyui src/__tests__/helpers`) counts `anti-slop(no-chained-type-assertions)` 46 before / 0 after. No non-test source under `src/` was touched; no test seam was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49