### PR TITLE
fix(1697): segmented downloads can write a hole INSIDE a segment — the review landed one minute after the merge

### DIFF
--- a/src/__tests__/services/download-segments-shortwrite.test.ts
+++ b/src/__tests__/services/download-segments-shortwrite.test.ts
@@ -21,6 +21,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 /** Every writev takes at most this many bytes, so a 1 MiB batch is always short. */
 const SHORT_WRITE_BYTES = 40_961; // deliberately not a chunk or batch multiple
 
+/** Flipped by the over-report test; the fs mock reads it on every writev. */
+const overReport = { on: false };
+
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return {
@@ -38,7 +41,10 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           capped.push(b.length <= budget ? b : b.subarray(0, budget));
           budget -= Math.min(b.length, budget);
         }
-        return realWritev(capped, position);
+        const r = await realWritev(capped, position);
+        // Claim MORE than we were offered — a filesystem the writer must refuse
+        // to believe rather than clamp.
+        return overReport.on ? { ...r, bytesWritten: r.bytesWritten + 1_000_000 } : r;
       };
       return fh;
     },
@@ -142,5 +148,65 @@ describe("segmented writer under short writes (#1697)", () => {
     expect(Buffer.concat(dropWritten([a, b, c], 3))).toEqual(Buffer.from([4, 5, 6, 7, 8, 9]));
     expect(Buffer.concat(dropWritten([a, b, c], 6))).toEqual(Buffer.from([7, 8, 9]));
     expect(dropWritten([a, b, c], 9)).toEqual([]);
+  });
+});
+
+// A filesystem that reports MORE bytes than it was offered would advance the
+// counter past what the file holds — the same over-reporting bug the short-write
+// loop exists to prevent, arriving by a different route. Clamping would hide it,
+// so the writer fails closed instead.
+describe("segmented writer under a nonsensical write count (#1697)", () => {
+  it("refuses rather than trusting a writev that claims more than it was given", async () => {
+    const { runSegmentedDownload, probeSegmentedRanges, planSegments } = await import(
+      "../../services/download-segments.js"
+    );
+    const body = payload(4 * 1024 * 1024);
+    server = createServer((req, res) => {
+      const m = /^bytes=(\d+)-(\d+)$/.exec(String(req.headers.range || ""));
+      if (!m) {
+        res.writeHead(200, { "content-length": String(body.length), "accept-ranges": "bytes" });
+        return void res.end(body);
+      }
+      const start = Number(m[1]);
+      const end = Number(m[2]);
+      const slice = body.subarray(start, end + 1);
+      res.writeHead(206, {
+        "content-length": String(slice.length),
+        "content-range": `bytes ${start}-${end}/${body.length}`,
+        "accept-ranges": "bytes",
+      });
+      res.end(slice);
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const u = `http://127.0.0.1:${(server.address() as AddressInfo).port}/m.safetensors`;
+
+    const segments = planSegments({
+      status: 200,
+      appendMode: false,
+      acceptRanges: "bytes",
+      contentEncoding: null,
+      contentLength: body.length,
+      expectedTotal: body.length,
+      requestHadRange: false,
+      policy: POLICY,
+    })!;
+    const opts = {
+      url: u,
+      headers: {},
+      targetPath: join(tempDir, "overreport.partial"),
+      totalBytes: body.length,
+      segments,
+      logUrl: u,
+      maxAttemptsPerSegment: 1,
+    };
+    overReport.on = true;
+    try {
+      const probe = await probeSegmentedRanges(opts);
+      await expect(runSegmentedDownload(opts, probe)).rejects.toThrow(
+        /the filesystem reported|Not finalizing/i,
+      );
+    } finally {
+      overReport.on = false;
+    }
   });
 });

--- a/src/__tests__/services/download-segments-shortwrite.test.ts
+++ b/src/__tests__/services/download-segments-shortwrite.test.ts
@@ -1,0 +1,146 @@
+// #1697 review finding: `filehandle.writev`/`write` resolve with the number of
+// bytes the OS ACTUALLY took and do not retry a short write. Advancing the
+// segment's byte counter by the REQUESTED count instead of the written count
+// lets the counter run ahead of the file — and every guard in the segmented
+// writer reads that counter, so the resulting gap is invisible to all of them:
+// the next write starts past it, a retry's Range skips it, `written === length`
+// and the total both pass, and `assertComplete`'s stat() cannot see a hole.
+//
+// This suite forces short writes and requires the landed bytes to be exact.
+// It lives in its own file because the fs mock has to be in place before
+// download-segments.js is imported.
+
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Every writev takes at most this many bytes, so a 1 MiB batch is always short. */
+const SHORT_WRITE_BYTES = 40_961; // deliberately not a chunk or batch multiple
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    default: actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const fh = await actual.open(...args);
+      const realWritev = fh.writev.bind(fh);
+      // @ts-expect-error deliberate partial-write injection
+      fh.writev = async (buffers: Buffer[], position?: number) => {
+        let budget = SHORT_WRITE_BYTES;
+        const capped: Buffer[] = [];
+        for (const b of buffers) {
+          if (budget <= 0) break;
+          capped.push(b.length <= budget ? b : b.subarray(0, budget));
+          budget -= Math.min(b.length, budget);
+        }
+        return realWritev(capped, position);
+      };
+      return fh;
+    },
+  };
+});
+
+import {
+  planSegments,
+  probeSegmentedRanges,
+  runSegmentedDownload,
+  dropWritten,
+  type SegmentedPolicy,
+} from "../../services/download-segments.js";
+
+const POLICY: SegmentedPolicy = { connections: 4, minBytes: 1024, maxAttemptsPerSegment: 3 };
+const sha = (b: Buffer): string => createHash("sha256").update(b).digest("hex");
+
+function payload(bytes: number): Buffer {
+  const buf = Buffer.alloc(bytes);
+  let x = 0x2f6e2b1;
+  for (let i = 0; i < bytes; i += 1) {
+    x = (x * 1103515245 + 12345) & 0x7fffffff;
+    buf[i] = (x >>> 16) & 0xff;
+  }
+  return buf;
+}
+
+let tempDir: string;
+let server: Server;
+let url: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "seg-short-"));
+});
+
+afterEach(async () => {
+  server?.closeAllConnections();
+  await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("segmented writer under short writes (#1697)", () => {
+  it("advances by the bytes the filesystem actually took, so no gap opens inside a segment", async () => {
+    const body = payload(6 * 1024 * 1024);
+    server = createServer((req, res) => {
+      const m = /^bytes=(\d+)-(\d+)$/.exec(String(req.headers.range || ""));
+      if (!m) {
+        res.writeHead(200, { "content-length": String(body.length), "accept-ranges": "bytes" });
+        return void res.end(body);
+      }
+      const start = Number(m[1]);
+      const end = Number(m[2]);
+      const slice = body.subarray(start, end + 1);
+      res.writeHead(206, {
+        "content-length": String(slice.length),
+        "content-range": `bytes ${start}-${end}/${body.length}`,
+        "accept-ranges": "bytes",
+      });
+      res.end(slice);
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/m.safetensors`;
+
+    const target = join(tempDir, "short.partial");
+    const segments = planSegments({
+      status: 200,
+      appendMode: false,
+      acceptRanges: "bytes",
+      contentEncoding: null,
+      contentLength: body.length,
+      expectedTotal: body.length,
+      requestHadRange: false,
+      policy: POLICY,
+    })!;
+    const opts = {
+      url,
+      headers: {},
+      targetPath: target,
+      totalBytes: body.length,
+      segments,
+      logUrl: url,
+    };
+    const probe = await probeSegmentedRanges(opts);
+    const result = await runSegmentedDownload(opts, probe);
+
+    // The load-bearing assertion: byte-identical. A counter that advanced by the
+    // REQUESTED length would skip ~96% of every batch, leaving zero-filled gaps
+    // that the size checks cannot see.
+    const landed = await readFile(target);
+    expect(landed.length).toBe(body.length);
+    expect(sha(landed)).toBe(sha(body));
+    expect(result.bytesWritten).toBe(body.length);
+  });
+
+  it("dropWritten resumes a partially-written buffer list at the exact byte", () => {
+    const a = Buffer.from([1, 2, 3]);
+    const b = Buffer.from([4, 5]);
+    const c = Buffer.from([6, 7, 8, 9]);
+    expect(Buffer.concat(dropWritten([a, b, c], 0))).toEqual(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    expect(Buffer.concat(dropWritten([a, b, c], 1))).toEqual(Buffer.from([2, 3, 4, 5, 6, 7, 8, 9]));
+    expect(Buffer.concat(dropWritten([a, b, c], 3))).toEqual(Buffer.from([4, 5, 6, 7, 8, 9]));
+    expect(Buffer.concat(dropWritten([a, b, c], 6))).toEqual(Buffer.from([7, 8, 9]));
+    expect(dropWritten([a, b, c], 9)).toEqual([]);
+  });
+});

--- a/src/__tests__/services/download-segments.test.ts
+++ b/src/__tests__/services/download-segments.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../config.js", () => {
 import { config } from "../../config.js";
 import {
   downloadWithCache,
-  __downloadCacheTestHooks,
+  stagedPartialPathForUrl,
 } from "../../services/download-cache.js";
 import {
   contiguousPrefix,
@@ -105,7 +105,19 @@ async function startServer(body: Buffer, mode: ServerMode): Promise<Rig> {
         "content-length": String(body.length),
         ...extra,
       });
-      res.end(body);
+      if (mode !== "slow-ranges") return void res.end(body);
+      // Pace the WHOLE-file response too, so the single-connection arm of a
+      // cancel comparison is actually still in flight when the abort lands.
+      // Without this it finishes instantly and the comparison is meaningless.
+      const step = Math.max(1, Math.floor(body.length / 64));
+      let off = 0;
+      const push = (): void => {
+        if (off >= body.length) return void res.end();
+        res.write(body.subarray(off, Math.min(off + step, body.length)));
+        off += step;
+        setTimeout(push, 25);
+      };
+      push();
     };
 
     if (mode === "no-ranges") return full();
@@ -309,8 +321,13 @@ describe("segmented download through downloadWithCache (#1697)", () => {
     expect(ranged.length).toBeGreaterThanOrEqual(4);
     expect(rig.maxConcurrent).toBeGreaterThan(1);
 
-    // The scratch file is gone — it only ever reaches the target by rename.
-    await expect(stat(segmentScratchPath(dest))).rejects.toThrow();
+    // The scratch file is gone — it only ever reaches the staged file by rename.
+    // Assert on the path the writer actually uses (beside the CACHE `.partial`);
+    // `dest + ".seg"` is a path that never exists either way, so checking it
+    // would pass whether or not the scratch was cleaned up.
+    const stagedPartial = stagedPartialPathForUrl(rig.url);
+    await expect(stat(segmentScratchPath(stagedPartial))).rejects.toThrow();
+    await expect(stat(stagedPartial)).rejects.toThrow();
   });
 
   it("is byte-identical to the same file fetched over ONE connection", async () => {
@@ -357,7 +374,10 @@ describe("segmented download through downloadWithCache (#1697)", () => {
     // It advertised ranges, so a probe WAS issued; the 200 answer sent us back to
     // the single-connection path rather than failing the download.
     expect(rig.requests.some((r) => r.range)).toBe(true);
-    await expect(stat(segmentScratchPath(dest))).rejects.toThrow();
+    // A declined probe must not have created a scratch at all.
+    await expect(
+      stat(segmentScratchPath(stagedPartialPathForUrl(rig.url))),
+    ).rejects.toThrow();
   });
 
   it("falls back when the 206's Content-Range does not describe what was asked for", async () => {
@@ -552,7 +572,7 @@ describe("segmented download over a stale partial (#1697)", () => {
     // the operation most likely to hit EPERM, so drive it explicitly.
     const body = payload(8 * 1024 * 1024);
     const rig = await rigFor(body, "ranges");
-    const staged = `${__downloadCacheTestHooks.cachePathForUrl(rig.url, {})}.partial`;
+    const staged = stagedPartialPathForUrl(rig.url);
     await mkdir(dirname(staged), { recursive: true });
     await writeFile(staged, payload(3 * 1024 * 1024));
     const dest = await destFor("restart.safetensors");
@@ -620,10 +640,22 @@ describe("cancelling a segmented download through downloadWithCache (#1697)", ()
     // The unit test on runSegmentedDownload covers the mechanism; this covers the
     // JOB contract — what a user's `download_model action:"cancel"` actually
     // leaves behind on the shared staged `.partial`.
+    //
+    // It keeps LESS than the single-connection path does, and that is a real,
+    // measured trade-off rather than an accident (see the PR body). Two causes,
+    // both inherent to segmenting:
+    //   - writes land in 1 MiB batches, so up to 1 MiB per segment is in memory
+    //     rather than on disk when the abort arrives;
+    //   - only the CONTIGUOUS prefix may be published, so segment 0's bytes are
+    //     all that survive even when every segment has written some.
+    // Measured on this rig, aborting mid-transfer: one connection keeps
+    // 1.8/2.6/3.4/5.0 MB at 200/300/400/600 ms; four connections keep nothing
+    // until the first flush lands and 1.0 MB at 600 ms. What is kept is always a
+    // valid prefix — never a hole — which is what this asserts.
     const body = payload(16 * 1024 * 1024);
     const rig = await rigFor(body, "slow-ranges");
     const dest = await destFor("cancelled.safetensors");
-    const staged = `${__downloadCacheTestHooks.cachePathForUrl(rig.url, {})}.partial`;
+    const staged = stagedPartialPathForUrl(rig.url);
     const ac = new AbortController();
 
     const run = downloadWithCache({
@@ -632,7 +664,10 @@ describe("cancelling a segmented download through downloadWithCache (#1697)", ()
       targetPath: dest,
       signal: ac.signal,
     });
-    await new Promise((r) => setTimeout(r, 400));
+    // Late enough that at least one 1 MiB batch has certainly flushed; earlier
+    // than that the honest answer is "nothing durable yet", which is covered by
+    // the measurement in the comment above rather than by an assertion here.
+    await new Promise((r) => setTimeout(r, 900));
     ac.abort();
     await expect(run).rejects.toThrow();
 
@@ -642,8 +677,12 @@ describe("cancelling a segmented download through downloadWithCache (#1697)", ()
     await expect(stat(segmentScratchPath(staged))).rejects.toThrow();
     // Whatever was kept is a strict, hole-free PREFIX of the real file — the
     // exact state a resume needs, and the state a holey file would fail.
-    const kept = await readFile(staged).catch(() => Buffer.alloc(0));
+    // Read it WITHOUT a catch: a missing staged file must fail this test rather
+    // than be read as "zero bytes kept" — that is how a wrong path passes
+    // vacuously.
+    const kept = await readFile(staged);
+    expect(kept.length).toBeGreaterThan(0);
     expect(kept.length).toBeLessThan(body.length);
-    if (kept.length > 0) expect(sha(kept)).toBe(sha(body.subarray(0, kept.length)));
+    expect(sha(kept)).toBe(sha(body.subarray(0, kept.length)));
   });
 });

--- a/src/__tests__/services/download-segments.test.ts
+++ b/src/__tests__/services/download-segments.test.ts
@@ -469,7 +469,11 @@ describe("runSegmentedDownload — the hole invariant and the byte sink (#1697)"
   });
 
   it("leaves a CONTIGUOUS prefix (never a hole) when a segment fails mid-transfer", async () => {
-    const body = payload(4 * 1024 * 1024);
+    // 16 MiB / 4 segments = 4 MiB each, and segment 0 hands over 2 MiB before it
+    // dies. Sized deliberately above the 1 MiB write batch: below it nothing is
+    // ever flushed, the preserved prefix is legitimately 0, and the assertion
+    // that a valid prefix SURVIVES would have no teeth.
+    const body = payload(16 * 1024 * 1024);
     // Segment 0 always dies part-way; the others would serve fine. Without the
     // prefix truncation the file would end up full-size with a zero-filled gap
     // where segment 0 should be — a correct SIZE over corrupt bytes.
@@ -492,8 +496,9 @@ describe("runSegmentedDownload — the hole invariant and the byte sink (#1697)"
         "accept-ranges": "bytes",
       });
       if (start < quarter) {
-        // Inside segment 0: hand over a little, then kill the connection.
-        res.write(slice.subarray(0, 4096));
+        // Inside segment 0: hand over 2 MiB — past the write batch, so a flush
+        // really happened — then kill the connection.
+        res.write(slice.subarray(0, 2 * 1024 * 1024));
         return void setTimeout(() => res.destroy(), 5);
       }
       res.end(slice);

--- a/src/__tests__/services/download-segments.test.ts
+++ b/src/__tests__/services/download-segments.test.ts
@@ -72,7 +72,9 @@ type ServerMode =
   /** Advertises ranges, 206s, but reports a Content-Range that is not what we asked for. */
   | "bad-content-range"
   /** 206 with a correct Content-Range, then a body that stops short of it. */
-  | "short-segment";
+  | "short-segment"
+  /** Correct, but paced slowly enough that a cancel can land mid-transfer. */
+  | "slow-ranges";
 
 interface Rig {
   server: Server;
@@ -143,13 +145,14 @@ async function startServer(body: Buffer, mode: ServerMode): Promise<Rig> {
     // Deliberately dribble the body so the segments genuinely overlap in time —
     // an instant end() could complete each request before the next one starts and
     // the concurrency assertion would pass without any parallelism.
-    const step = Math.max(1, Math.floor(slice.length / 4));
+    const slices = mode === "slow-ranges" ? 64 : 4;
+    const step = Math.max(1, Math.floor(slice.length / slices));
     let off = 0;
     const push = (): void => {
       if (off >= slice.length) return void res.end();
       res.write(slice.subarray(off, Math.min(off + step, slice.length)));
       off += step;
-      setTimeout(push, 5);
+      setTimeout(push, mode === "slow-ranges" ? 25 : 5);
     };
     push();
   });
@@ -609,5 +612,38 @@ describe("segmented download interference between processes (#1697)", () => {
     await expect(runSegmentedDownload(opts, probe)).rejects.toThrow(
       /Another process finished staging/i,
     );
+  });
+});
+
+describe("cancelling a segmented download through downloadWithCache (#1697)", () => {
+  it("leaves a hole-free resumable prefix at the staged file, and no scratch", async () => {
+    // The unit test on runSegmentedDownload covers the mechanism; this covers the
+    // JOB contract — what a user's `download_model action:"cancel"` actually
+    // leaves behind on the shared staged `.partial`.
+    const body = payload(16 * 1024 * 1024);
+    const rig = await rigFor(body, "slow-ranges");
+    const dest = await destFor("cancelled.safetensors");
+    const staged = `${__downloadCacheTestHooks.cachePathForUrl(rig.url, {})}.partial`;
+    const ac = new AbortController();
+
+    const run = downloadWithCache({
+      url: rig.url,
+      headers: {},
+      targetPath: dest,
+      signal: ac.signal,
+    });
+    await new Promise((r) => setTimeout(r, 400));
+    ac.abort();
+    await expect(run).rejects.toThrow();
+
+    // Nothing was landed at the destination under a false success.
+    await expect(stat(dest)).rejects.toThrow();
+    // The scratch never survives its own run.
+    await expect(stat(segmentScratchPath(staged))).rejects.toThrow();
+    // Whatever was kept is a strict, hole-free PREFIX of the real file — the
+    // exact state a resume needs, and the state a holey file would fail.
+    const kept = await readFile(staged).catch(() => Buffer.alloc(0));
+    expect(kept.length).toBeLessThan(body.length);
+    if (kept.length > 0) expect(sha(kept)).toBe(sha(body.subarray(0, kept.length)));
   });
 });

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2350,8 +2350,13 @@ async function streamUrlToFile(
   try {
     // #1697 — MULTI-CONNECTION BODY. One TCP flow is bounded by BDP and, on the
     // CDNs that serve model weights, routinely by a per-connection rate cap; N
-    // ranged GETs are what `aria2c -x4`/`hf_transfer` do and are worth 1.5-1.7x
-    // even on a link where one connection already sustains ~80 MB/s.
+    // ranged GETs are what `aria2c -x4`/`hf_transfer` do. Measured through
+    // `downloadWithCache` on a real 2.13 GB Hugging Face file: 1.56-1.84x at four
+    // connections. Under an explicit per-connection cap the gain is linear in the
+    // connection count (3.97x at four, 7.85x at eight) — that is the shape #1697's
+    // field reports describe. On a source fast enough to saturate the local disk
+    // (loopback, ~570 MB/s on one connection) it is 0.83x, which is why
+    // COMFYUI_DOWNLOAD_CONNECTIONS=1 exists.
     //
     // Engaged ONLY on a fresh 200 whose own Content-Length agrees with the size
     // we will verify against, that advertises `Accept-Ranges: bytes`, carries no

--- a/src/services/download-segments.ts
+++ b/src/services/download-segments.ts
@@ -332,6 +332,22 @@ async function openScratch(opts: SegmentedRunOptions): Promise<FileHandle> {
   }
 }
 
+/** Drop the first `n` bytes from a buffer list, so a short `writev` can be
+ *  resumed from exactly where the OS stopped. */
+export function dropWritten(buffers: Buffer[], n: number): Buffer[] {
+  let skip = n;
+  const out: Buffer[] = [];
+  for (const b of buffers) {
+    if (skip >= b.length) {
+      skip -= b.length;
+      continue;
+    }
+    out.push(skip > 0 ? b.subarray(skip) : b);
+    skip = 0;
+  }
+  return out;
+}
+
 /** Drain one 206 body into the scratch file at its absolute offset, advancing
  *  `state.written` as bytes land so a retry resumes mid-segment and a failure
  *  can be truncated to a contiguous prefix. */
@@ -362,16 +378,38 @@ async function drainSegmentBody(
   // this module exists to prevent.
   const flush = async (): Promise<void> => {
     if (pendingBytes === 0) return;
-    const buffers = pending;
-    const count = pendingBytes;
+    let buffers = pending;
+    let remaining = pendingBytes;
     pending = [];
     pendingBytes = 0;
-    await fh.writev(buffers, seg.start + state.written);
-    state.written += count;
+    // LOOP ON SHORT WRITES. `filehandle.writev`/`write` resolve with the number
+    // of bytes the OS actually took and do NOT retry a short write (only
+    // `writeFile` does). Advancing `state.written` by the requested count would
+    // let the counter run ahead of the file, and then every guard in this module
+    // reads the counter: the next write would start past an unwritten gap, a
+    // retry's Range would skip it, `written === length` and the total and
+    // `assertComplete`'s stat() would all pass, and `contiguousPrefix` would
+    // publish a "resumable prefix" with a hole inside it. Advance ONLY by what
+    // landed. (The single-connection path never had this: `createWriteStream`
+    // loops internally.)
+    while (remaining > 0) {
+      const { bytesWritten } = await fh.writev(buffers, seg.start + state.written);
+      if (!(bytesWritten > 0)) {
+        throw new ModelError(
+          `Download segment ${index} could not write to the staging file (the filesystem accepted ` +
+            `0 of ${remaining} bytes). Not finalizing.`,
+          { url: opts.logUrl, retryable: true },
+        );
+      }
+      state.written += bytesWritten;
+      remaining -= bytesWritten;
+      if (remaining > 0) buffers = dropWritten(buffers, bytesWritten);
+    }
   };
+  let nodeBody: Readable | undefined;
   try {
-    const body = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
-    for await (const chunk of body) {
+    nodeBody = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
+    for await (const chunk of nodeBody) {
       if (opts.signal?.aborted) throw abortError();
       const buf = chunk as Buffer;
       // Refuse to write past this segment's own range. A server that streams
@@ -393,6 +431,11 @@ async function drainSegmentBody(
     }
     await flush();
   } finally {
+    // Release this response on EVERY exit, not just a fully-drained one. A
+    // retryable failure part-way through leaves the body unread, and attempt 2
+    // opens a new socket while this one stays pinned until GC — the same leak
+    // fixed on the probe-setup path.
+    nodeBody?.destroy();
     await fh.close().catch(() => {});
   }
   if (state.written !== length) {
@@ -505,7 +548,13 @@ export async function runSegmentedDownload(
     // a large existing `.partial` would hold the old bytes AND the growing `.seg`
     // at once — up to double the peak disk the volume-space check upstream
     // reserved.
-    await truncate(opts.targetPath, 0).catch(() => {});
+    // ENOENT only: a fresh download has no target yet, and that is the one
+    // failure this may ignore. Swallowing anything else (a target that exists and
+    // cannot be truncated) would silently re-introduce the double-disk case the
+    // truncate exists to prevent.
+    await truncate(opts.targetPath, 0).catch((err: unknown) => {
+      if ((err as { code?: string })?.code !== "ENOENT") throw err;
+    });
   } catch (err) {
     // Nothing has read the probe's 206 yet, and nobody downstream will — release
     // its socket rather than leaving it pinned until GC.

--- a/src/services/download-segments.ts
+++ b/src/services/download-segments.ts
@@ -87,6 +87,10 @@ const DEFAULTS: SegmentedPolicy = {
  *  dominates and more connections stop paying. */
 const MIN_SEGMENT_BYTES = 1024 * 1024;
 
+/** How much of a segment to accumulate before issuing one positional `writev`.
+ *  See the measurement note in `drainSegmentBody`. */
+const SEGMENT_WRITE_BATCH_BYTES = 1024 * 1024;
+
 function envInt(name: string, fallback: number, min: number, max: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === "") return fallback;
@@ -340,6 +344,31 @@ async function drainSegmentBody(
 ): Promise<void> {
   const length = seg.end - seg.start + 1;
   const fh = await openScratch(opts);
+
+  // Coalesce arriving chunks into one positional `writev` rather than issuing an
+  // awaited write per ~64 KiB chunk. MEASURED on an out-of-process loopback
+  // origin, 512 MiB, arms alternating: a write per chunk ran 0.63x a single
+  // sequential stream, 1 MiB batches run 0.84x, and 4 MiB batches fall back to
+  // 0.52x. 1 MiB is the measured optimum, not a guess.
+  //
+  // This is NOT a stream highWaterMark and adds no pipeline stage — #1738/#1746
+  // stay closed. It changes how many syscalls a segment issues, nothing about
+  // how the single-connection pipe is buffered.
+  let pending: Buffer[] = [];
+  let pendingBytes = 0;
+  // Bytes count as WRITTEN only once they are on disk. Buffered-but-unflushed
+  // bytes must never advance `state.written`, or a failure would truncate to a
+  // "contiguous prefix" containing bytes the file does not hold — the very hole
+  // this module exists to prevent.
+  const flush = async (): Promise<void> => {
+    if (pendingBytes === 0) return;
+    const buffers = pending;
+    const count = pendingBytes;
+    pending = [];
+    pendingBytes = 0;
+    await fh.writev(buffers, seg.start + state.written);
+    state.written += count;
+  };
   try {
     const body = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
     for await (const chunk of body) {
@@ -348,17 +377,21 @@ async function drainSegmentBody(
       // Refuse to write past this segment's own range. A server that streams
       // more than its Content-Range promised would otherwise overwrite the NEXT
       // segment's bytes, producing a plausible size and no error.
-      if (state.written + buf.length > length) {
+      if (state.written + pendingBytes + buf.length > length) {
         throw new ModelError(
           `Download segment ${index} oversized: the server sent more than the ${length} bytes ` +
             `its Content-Range promised. Not finalizing.`,
           { url: opts.logUrl },
         );
       }
-      await fh.write(buf, 0, buf.length, seg.start + state.written);
-      state.written += buf.length;
+      pending.push(buf);
+      pendingBytes += buf.length;
+      // Report on ARRIVAL, not on flush, so the #470 stall watchdog sees liveness
+      // at chunk granularity rather than in batch-sized steps.
       opts.onBytes?.(buf.length);
+      if (pendingBytes >= SEGMENT_WRITE_BATCH_BYTES) await flush();
     }
+    await flush();
   } finally {
     await fh.close().catch(() => {});
   }

--- a/src/services/download-segments.ts
+++ b/src/services/download-segments.ts
@@ -394,10 +394,14 @@ async function drainSegmentBody(
     // loops internally.)
     while (remaining > 0) {
       const { bytesWritten } = await fh.writev(buffers, seg.start + state.written);
-      if (!(bytesWritten > 0)) {
+      // Fail closed on BOTH directions of a nonsensical count. Zero would spin
+      // forever; more than we offered would advance `state.written` past what the
+      // file holds, which is the same over-reporting bug by another route — and
+      // clamping it would hide a misbehaving filesystem rather than surface it.
+      if (!(bytesWritten > 0) || bytesWritten > remaining) {
         throw new ModelError(
-          `Download segment ${index} could not write to the staging file (the filesystem accepted ` +
-            `0 of ${remaining} bytes). Not finalizing.`,
+          `Download segment ${index} could not write to the staging file (the filesystem reported ` +
+            `${bytesWritten} of ${remaining} bytes). Not finalizing.`,
           { url: opts.logUrl, retryable: true },
         );
       }


### PR DESCRIPTION
Follow-up to #1956 (issue #1697). **Review is PENDING.**

## Why this exists

#1956 merged at **06:14:08Z**. grok's `REQUEST_CHANGES` on it landed at **06:12:53Z** — one minute earlier. The merge took `28652b9`, the head the review was asking to change, so **the defect the review caught is on `main` now** and shipped in 0.52.42.

Nothing here is new work in the sense of new behaviour: it is the fixes that were already written, tested and pushed to that branch between 06:12 and 07:0x, plus what re-reviewing my own tests turned up afterwards. `main` is missing all of it.

## 1. The blocking defect: a hole *inside* a segment (silent corruption)

`filehandle.write`/`writev` resolve with the number of bytes the OS **actually took**, and neither retries a short write — only `writeFile` does. On `main`, `state.written` is advanced by the **requested** count and the return value is discarded:

```js
await fh.write(buf, 0, buf.length, seg.start + state.written);
state.written += buf.length;   // ← claims the whole chunk regardless
```

Every guard in that module reads that counter, so a short write is invisible to all of them at once:

- the next write starts at `seg.start + inflatedWritten`, **skipping the unwritten gap**;
- a retry of the segment asks `Range: bytes=${seg.start + inflatedWritten}-…`, so it never fills it;
- `written === length`, the per-segment tally and the total all pass — they read the counter;
- `assertComplete`'s `stat()` passes — a hole does not change a file's size;
- and the failure path then publishes it: `truncate(scratch, contiguousPrefix())` + `rename` hands a "resumable prefix" **with a hole inside it** to the staged `.partial`, for a later 206 append to splice onto.

That is precisely the silent corruption #1956 claims to make unrepresentable, and it is the one shape none of its checks can see. The single-connection path never had it, because `createWriteStream` loops on short writes internally.

**Fix:** `flush()` loops until the batch is fully written, advances `state.written` **only** by the returned `bytesWritten`, and resumes the buffer list at the exact byte via `dropWritten()`. A `bytesWritten <= 0` becomes a retryable `ModelError` rather than an infinite loop.

**Pinned by a test that fails without it.** `download-segments-shortwrite.test.ts` mocks `node:fs/promises` `open` so every `writev` takes at most **40,961 bytes** — deliberately not a multiple of a chunk or of the batch, so every write is short and every buffer boundary is crossed mid-buffer — then requires a 6 MiB segmented download to come out byte-identical. Reverting the fix (advance by the requested count, ignore `bytesWritten`) fails that test **and nothing else**, so the test carries the claim rather than a neighbour.

## 2. Segmentation on `main` is SLOWER than one connection on a fast source

`main` issues one awaited positional write per ~64 KiB chunk. Measured against an out-of-process loopback origin — network free, only the write path differing — that is **0.63x** a single sequential stream. Segmentation is a *deficit* whenever the source outruns the disk.

Two dead ends ruled out by measurement, not argument: putting the origin in its own process changed nothing (still 0.6x — not a harness artifact), and the penalty was flat across connection counts (0.74x at 2, 0.79x at 4, 0.88x at 8 — not writer contention). Rebuilding the drain on `pipeline(…, filehandle.createWriteStream({start}))` gave 0.70x, no better.

Coalescing into 1 MiB `writev` calls fixes it. Sweep at 512 MiB, arms alternating:

| batch | 64 KB | 256 KB | 512 KB | **1 MiB** | 2 MiB | 4 MiB |
|---|---|---|---|---|---|---|
| ratio vs single | 0.63x | 0.68x | 0.73x | **0.84x** | 0.73x | 0.52x |

Not a stream highWaterMark, no new pipeline stage — #1738/#1746 stay closed. It only changes how many syscalls a segment issues.

Measured end-to-end through `downloadWithCache` with the batch in place (medians):

| regime | single | segmented | ratio |
|---|---|---|---|
| Real Hugging Face, 2.13 GB | 116-125 MB/s | 182-230 MB/s (×4) | **1.56-1.84x** |
| 8 MB/s per-connection cap | 5.2 MB/s | 20.6 / 40.7 MB/s (×4 / ×8) | **3.97x / 7.85x** |
| Loopback uncapped ~570 MB/s | 570 MB/s | 473 MB/s (×4) | 0.83x |

`distinct sha256 across all arms: 1` in every run; for the real HF file that digest is `e9476a13728cd75d8279f6ec8bad753a66a1957ca375a1464dc63b37db6e3916`, which is Hugging Face's own `X-Linked-Etag` — checked against upstream, not against itself.

## 3. Three assertions on `main` are vacuous

They re-derive the staged file as `cachePathForUrl(url) + '.partial'`. The writer **dot-prefixes the basename** — `.{hash}{ext}.partial`. So every "the scratch is gone" check on `main` is `stat`ing a path that never exists and passes whether or not the scratch was cleaned up.

Proof rather than assertion: I mutated the success path to deliberately leave a scratch file behind, and **all 21 tests still passed**. They now use the exported `stagedPartialPathForUrl()`, and the cancel test reads the staged file with **no** `.catch()`, so a wrong path fails instead of quietly reading as "zero bytes kept".

## 4. Two smaller review findings

- The probe segment's response was not released when its first attempt failed retryably — the socket stayed pinned until GC. `drainSegmentBody` now destroys the readable in its `finally`, so every exit releases it.
- `truncate(targetPath, 0).catch(() => {})` swallowed every error, including a real failure to truncate an existing target — which silently re-introduces the double-disk case the truncate exists to prevent. Narrowed to `ENOENT`.

## What is still a known trade-off, unfixed, and flagged for a decision

A cancelled segmented download keeps materially less resumable progress than the single-connection path. Measured on a paced loopback rig, bytes left on the staged `.partial`:

| abort at | 1 connection | 4 connections |
|---|---|---|
| 200 ms | 1.75 MB | nothing |
| 400 ms | 3.25 MB | nothing |
| 600 ms | 4.81 MB | 1.00 MB |

Two causes, both inherent: writes land in 1 MiB batches, and only the **contiguous** prefix may be published (segment 0's alone), which is the rule that makes a hole impossible. A user who cancels a 20 GB download at 50% resumes near 12.5%. Correctness is unaffected — what is kept is always a valid hole-free prefix — the cost is bandwidth and surprise. The real fix is an aria2-style per-segment control file, i.e. a new on-disk resume format beside the #343/#467 `.etag` machinery, which is bigger than what was asked for and not something to add under a freeze. A new test documents the measured behaviour rather than asserting parity that does not exist.

## Verification

- `npx vitest run` — **609 files, 11156 passed, 4 skipped**, with `panel-restart-configured-command` failing only under full parallel load (**6/6 in isolation**, unrelated to downloads — the known load-flake pattern).
- `npx tsc --noEmit` clean.
- Mutation: reverting the `bytesWritten` fix fails the short-write test and nothing else; leaving a scratch behind now fails the corrected assertions.
- Windows 11 / Node v24.16.0. macOS and Linux run the identical code path and CI builds/tests both; I did not measure throughput there and am not implying I did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
