### PR TITLE
release: v0.52.44 — desk auto-update, subgraph widgets, late restart confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.44] - 2026-08-21
+
 ### Added
 
 - **Transport-aware auto-update (#1963).** At the desk (LAN / no pairing tunnel)
@@ -19,6 +21,16 @@ All notable changes to this project are documented here. This project adheres to
   cannot open the gate. Pair time carries a toggle defaulted ON ("Don't update
   while my phone is paired") and an `apply_updates_now` affordance for when the
   user is back at the desk. Relay and LAN remain safe to apply.
+
+### MCP
+
+#### Added
+- check+apply auto-update at the desk, check-only on a mobile tunnel (#1971)
+
+#### Fixed
+- promoted subgraph widget values persist when control_after_generate is randomize (#1966)
+- a restart confirmation the user gave late is claimed by the next attempt, not discarded (#1957)
+
 
 ## 0.51.35
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.43",
+  "version": "0.52.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.43",
+      "version": "0.52.44",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.43",
+  "version": "0.52.44",
   "mcpName": "io.github.artokun/comfyui-mcp",
-  "description": "Local-first, agent-native control plane for ComfyUI \u2014 MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
+  "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts **0.52.44** from `main` (after v0.52.43).

Carries:

- #1971 / #1963 — check+apply auto-update at the desk, check-only on a mobile tunnel
- #1966 / panel#1558 — promoted subgraph widget values persist when `control_after_generate` is randomize
- #1957 / panel#1554 — a restart confirmation the user gave late is claimed by the next attempt, not discarded

Held out: mcp#1961 PR #1967 (CI red); mcp#1968/#1969/#1972/#1973 claimed this cycle; panel#1559 parked on MCP-side follow-up; panel#1472 typescript 5→7 (blocked).

Do **not** squash-merge. Merge-commit (keeps the `v0.52.44` tag on the version commit). Tag is local; push `v0.52.44` after merge.
