### PR TITLE
release: v0.52.45 — segmented download short-write accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.45] - 2026-08-21
+
+### MCP
+
+#### Fixed
+- segmented downloads can write a hole INSIDE a segment — the review landed one minute after the merge (#1977)
+
+
 ## [0.52.44] - 2026-08-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.44",
+  "version": "0.52.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.44",
+      "version": "0.52.45",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.44",
+  "version": "0.52.45",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.45** from `main` (after v0.52.44).

Carries:

- #1977 / #1697 — segmented downloads no longer treat a short `filehandle.write` as a full drain (`bytesWritten` is the cursor; fail closed on a lying count)

v0.52.44 was cut two minutes before #1977 landed, so the published 0.52.42/0.52.44 tags still have the hole. This patch is that follow-up.

Held out: #1967/#1961 CI red; hygiene/docs PRs; panel#1472 typescript 5→7.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.45` tag on the version commit).