### PR TITLE
fix(1972): Ollama refuses audio unless the model is a verified listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- **Ollama refuses audio unless the model is a verified listener (#1972).** Native
+  `/api/chat` carries audio in `message.images[]`. Most models HTTP 400 (fail
+  closed). `huihui_ai/gemma-4-abliterated:E4b-qat` accepts the payload and
+  returns a fluent, run-to-run-varying fabricated transcript instead — `/api/show`
+  listing `audio` is an architecture flag, not proof these weights can hear.
+  The panel now also requires the tag to be one of the Ollama-tested set
+  (`gemma4:e2b`, `gemma4:e4b`, `nemotron3:33b`) before putting bytes on that
+  carrier, and refuses namespaced forks (including the default fine-tune) out
+  loud with a pull command.
+
 ## [0.52.44] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ All notable changes to this project are documented here. This project adheres to
   The panel now also requires the tag to be one of the Ollama-tested set
   (`gemma4:e2b`, `gemma4:e4b`, `nemotron3:33b`) before putting bytes on that
   carrier, and refuses namespaced forks (including the default fine-tune) out
-  loud with a pull command.
+  loud with a pull command. The gate also covers the HISTORY: Ollama is stateless
+  per request, so a live model switch used to replay already-delivered audio into
+  the newly-selected model's image slot along with the earlier "you can hear them"
+  note. That audio is now dropped, with a note telling the incoming model plainly
+  that it did not hear it.
 
 ## [0.52.44] - 2026-08-21
 

--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -181,6 +181,13 @@ because a silently dropped attachment is worse than a refused one:
     /api/tags` also returns a `capabilities` array and is **not** the same
     answer — the same model reported no audio there and audio from `/api/show`
     — so only `/api/show` is consulted.
+  - **The `audio` flag is not a hearing guarantee.** It is inherited from the
+    architecture. A namespaced Gemma 4 fork can list `audio`, accept a WAV in
+    `images[]` with HTTP 200, and return a fluent fabricated transcript
+    (`huihui_ai/gemma-4-abliterated:E4b-qat`, #1972). Native Ollama therefore
+    also requires the model tag to be one of the Ollama-tested set above;
+    anything else — including `artokun/gemma4-comfyui-mcp` — is refused before
+    bytes hit the image slot.
   - The capability is re-checked on every turn that carries audio, because an
     Ollama tag is mutable: `ollama pull` can replace the weights under the same
     name, and a cached verdict could outlive the model it described.

--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -122,6 +122,15 @@ for a model that can hear — rather than being dropped into the request where
 the model would answer from your text alone. The same applies to a file that
 isn't an audio format, or that is present but zero bytes.
 
+That `/api/show` flag is not enough on its own. Native Ollama carries audio in
+`message.images[]` (the picture slot), and a model that merely **accepts** that
+payload can still invent a transcript — measured on
+`huihui_ai/gemma-4-abliterated:E4b-qat`, which returned a fluent, different
+fabrication on every run instead of HTTP 400. Audio is therefore sent only to
+the Ollama-tested tags (`gemma4:e2b`, `gemma4:e4b`, `nemotron3:33b`). A
+namespaced fork, including `artokun/gemma4-comfyui-mcp`, is refused by name
+with a pull command for a model that can hear.
+
 Delivering the bytes is not quite the whole job. Measured live against
 `gemma4:e2b`: with the WAV demonstrably in context (555 prompt tokens,
 `/api/show` reporting `audio`), the model still answered *"I do not have the

--- a/plugin/skills/local-llm-free/SKILL.md
+++ b/plugin/skills/local-llm-free/SKILL.md
@@ -50,6 +50,12 @@ Connect. `:e4b` is the built-in default — zero further config once pulled.
   agent generates and edits workflows fine but can't visually critique its
   own outputs. Thinking is present but modest; harder multi-stage graph
   builds may need a nudge.
+- **Audio:** these fine-tunes cannot hear. Native Ollama puts audio in the
+  image slot; a namespaced Gemma 4 fork (e.g. `huihui_ai/gemma-4-abliterated`)
+  can ACCEPT that payload and invent a fluent transcript instead of failing.
+  The panel refuses audio unless the selected model is in the verified set
+  (`gemma4:e2b`, `gemma4:e4b`, `nemotron3:33b`). Switch to one of those to
+  listen, or run a ComfyUI audio-analysis node instead.
 - First request after connect is slow (cold model load, 30s+). That's normal.
 - For non-panel MCP harnesses (Hermes, OpenClaw, any Ollama-speaking client),
   pair these models with **compact tool mode** (`--compact`) — full docs:
@@ -59,3 +65,4 @@ Connect. `:e4b` is the built-in default — zero further config once pulled.
 
 - **Official:** https://ollama.com/download and https://comfyui-mcp.artokun.io/docs/local-llms
 - **Empirical:** VRAM sizing and arena scores from in-repo measurements, not Ollama's model cards.
+  Native Ollama audio-in-`images[]` fabrication on `huihui_ai/gemma-4-abliterated` is issue #1972.

--- a/src/__tests__/orchestrator/audio-attachment.test.ts
+++ b/src/__tests__/orchestrator/audio-attachment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  AUDIO_CAPABLE_OLLAMA_MODELS,
   AUDIO_MIME_BY_EXT,
   MAX_AUDIO_BYTES,
   audioMimeForFilename,
@@ -7,8 +8,10 @@ import {
   audioUserNotice,
   fetchAudioAttachment,
   isDeliverableAudioMime,
+  isKnownAudioCapableOllamaModel,
   looksLikeAudioFilename,
   modelLacksAudioText,
+  modelNotVerifiedAudioText,
   noAudioPartText,
   openAiAudioFormat,
   dedupeAudioRefs,
@@ -54,6 +57,24 @@ describe("audio mime classification", () => {
     expect(openAiAudioFormat("audio/mpeg")).toBe("mp3");
     expect(openAiAudioFormat("audio/flac")).toBe("flac");
     expect(openAiAudioFormat("audio/mp4")).toBe("m4a");
+  });
+});
+
+describe("isKnownAudioCapableOllamaModel — native images[] allowlist", () => {
+  it("accepts every tag in the verified set, and the official library/ prefix", () => {
+    for (const model of AUDIO_CAPABLE_OLLAMA_MODELS) {
+      expect(isKnownAudioCapableOllamaModel(model)).toBe(true);
+      expect(isKnownAudioCapableOllamaModel(`library/${model}`)).toBe(true);
+      expect(isKnownAudioCapableOllamaModel(model.toUpperCase())).toBe(true);
+    }
+  });
+
+  it("rejects the #1972 fabrication model even though it is a Gemma 4 fork", () => {
+    expect(isKnownAudioCapableOllamaModel("huihui_ai/gemma-4-abliterated:E4b-qat")).toBe(false);
+  });
+
+  it("rejects the default fine-tune — that tag HTTP 400s on audio in images[]", () => {
+    expect(isKnownAudioCapableOllamaModel("artokun/gemma4-comfyui-mcp:e4b")).toBe(false);
   });
 });
 
@@ -134,6 +155,19 @@ describe("refusal texts name a remedy", () => {
     expect(t).toContain("qwen3:4b");
     expect(t).toContain("completion, tools");
     expect(t).toContain("ollama pull");
+  });
+
+  it("an unverified native model names the image-slot risk AND a pull command, without claiming the server said no audio", () => {
+    // #1972: /api/show may list `audio` (architecture) while the weights invent
+    // a transcript. The refusal must not quote a "no audio" verdict we did not
+    // get; it must name the verified set the user can switch to.
+    const t = modelNotVerifiedAudioText("huihui_ai/gemma-4-abliterated:E4b-qat", "song.wav");
+    expect(t).toContain("huihui_ai/gemma-4-abliterated:E4b-qat");
+    expect(t).toContain("song.wav");
+    expect(t).toContain("invent a transcript");
+    expect(t).toContain("ollama pull");
+    expect(t).not.toContain("no audio");
+    for (const known of AUDIO_CAPABLE_OLLAMA_MODELS) expect(t).toContain(known);
   });
 
   it("an unsupported format lists the formats that would work", () => {

--- a/src/__tests__/orchestrator/ollama-audio.test.ts
+++ b/src/__tests__/orchestrator/ollama-audio.test.ts
@@ -317,6 +317,39 @@ describe("#1972 — a model that ACCEPTS audio in images[] is not a model that c
     const audioPart = user.content.find((p) => p.type === "input_audio");
     expect(audioPart?.input_audio).toEqual({ data: RIFF_B64, format: "wav" });
   });
+
+  it("a live model SWITCH does not replay delivered audio into the new model's images[]", async () => {
+    // The attach-time gate only sees the turn the audio arrives on. Ollama is
+    // stateless per request, so history is re-serialized every turn and
+    // toOllamaMessages merges `audios` into `images[]` — measured: turn 2 to
+    // huihui_ai/gemma-4-abliterated:E4b-qat carried ["UklGRg=="] plus the
+    // earlier "you can hear them" note, with no new attachment anywhere in it.
+    // Reachable from panel-agent.ts setModel, which switches live and keeps
+    // history.
+    const backend = nativeBackend("gemma4:e2b"); // allowlisted: turn 1 delivers
+    await collect(backend, turnsOf(AUDIO_TURN));
+    const t1 = (chatRequests[0].messages as Array<Record<string, unknown>>).find((m) => m.role === "user") as {
+      images?: string[];
+    };
+    expect(t1.images).toEqual([RIFF_B64]); // baseline — the gate let this through
+
+    await backend.setModel("huihui_ai/gemma-4-abliterated:E4b-qat");
+    await collect(backend, turnsOf({ text: "and now?" })); // TEXT only — no new audio
+
+    const t2 = chatRequests[1];
+    expect(t2.model).toBe("huihui_ai/gemma-4-abliterated:E4b-qat");
+    const replayed = (t2.messages as Array<Record<string, unknown>>).filter((m) =>
+      Array.isArray((m as { images?: string[] }).images),
+    );
+    for (const m of replayed) expect((m as { images: string[] }).images).not.toContain(RIFF_B64);
+    // The stale "you can hear them" note is still in that message, so silence is
+    // not enough — the new model must be told the audio is NOT in its context.
+    const stale = (t2.messages as Array<Record<string, unknown>>).find((m) =>
+      String((m as { content: string }).content).includes("what do you hear?"),
+    ) as { content: string };
+    expect(stale.content).toContain("You did NOT hear this audio");
+    expect(stale.content).toContain("no longer applies");
+  });
 });
 
 describe("#790 — an UNSUPPORTED attachment type", () => {

--- a/src/__tests__/orchestrator/ollama-audio.test.ts
+++ b/src/__tests__/orchestrator/ollama-audio.test.ts
@@ -263,6 +263,62 @@ describe("#790 — a MODEL that cannot take audio", () => {
   });
 });
 
+describe("#1972 — a model that ACCEPTS audio in images[] is not a model that can hear", () => {
+  function viewFetches(): number {
+    return fetchMock.mock.calls.filter((c) => String(c[0]).includes("/view?")).length;
+  }
+
+  it("REFUSES gemma-4-abliterated even when /api/show lists audio, and never puts bytes on images[]", async () => {
+    // Live: this tag returns HTTP 200 plus a fluent fabricated transcript that
+    // changes every run. The architecture flag is not a hearing guarantee, so
+    // native Ollama must fail closed rather than ship a WAV in the image slot.
+    showCapabilities = ["completion", "vision", "audio", "tools", "thinking"];
+    const model = "huihui_ai/gemma-4-abliterated:E4b-qat";
+    const events = await collect(nativeBackend(model), turnsOf(AUDIO_TURN));
+    const said = assistantText(events);
+    expect(said).toContain(model);
+    expect(said).toContain("invent a transcript");
+    expect(said).toContain("ollama pull");
+    expect(said).not.toContain("cannot confirm");
+    const user = (chatRequests[0].messages as Array<Record<string, unknown>>).find((m) => m.role === "user") as {
+      images?: string[];
+      content: string;
+    };
+    expect(user.images).toBeUndefined();
+    expect(user.content).toContain("did NOT hear");
+    // Refused before fetch — we do not pull ComfyUI bytes we will not send.
+    expect(viewFetches()).toBe(0);
+  });
+
+  it("REFUSES the default fine-tune the same way — that tag HTTP 400s on the image slot", async () => {
+    showCapabilities = ["completion", "vision", "audio", "tools", "thinking"];
+    const events = await collect(nativeBackend("artokun/gemma4-comfyui-mcp:e4b"), turnsOf(AUDIO_TURN));
+    const user = (chatRequests[0].messages as Array<Record<string, unknown>>).find((m) => m.role === "user") as {
+      images?: string[];
+    };
+    expect(user.images).toBeUndefined();
+    expect(assistantText(events)).toContain("artokun/gemma4-comfyui-mcp:e4b");
+    expect(viewFetches()).toBe(0);
+  });
+
+  it("does NOT apply the allowlist on the OpenAI dialect — that path uses input_audio, not images[]", async () => {
+    const backend = new OllamaBackend({
+      api: "openai",
+      host: "http://127.0.0.1:9999/v1",
+      apiKey: "sk-test",
+      model: "huihui_ai/gemma-4-abliterated:E4b-qat",
+      comfyuiUrl: "http://127.0.0.1:8188",
+      connectToolClients: async () => ({ comfyui: fakeMcpClient() }),
+    });
+    await collect(backend, turnsOf(AUDIO_TURN));
+    const user = (openaiChatRequests[0].messages as Array<Record<string, unknown>>).find(
+      (m) => m.role === "user",
+    ) as { content: Array<{ type: string; input_audio?: { data: string; format: string } }> };
+    const audioPart = user.content.find((p) => p.type === "input_audio");
+    expect(audioPart?.input_audio).toEqual({ data: RIFF_B64, format: "wav" });
+  });
+});
+
 describe("#790 — an UNSUPPORTED attachment type", () => {
   it("REFUSES a non-audio file and lists the formats that would work", async () => {
     const events = await collect(
@@ -515,7 +571,7 @@ describe("#790 — a later error must not fabricate a delivery failure", () => {
     // reported rather than swallowed by what the previous model accepted.
     const backend = nativeBackend();
     await collect(backend, turnsOf(AUDIO_TURN)); // gemma4:e2b accepts it
-    await backend.setModel("qwen3:4b");
+    await backend.setModel("gemma4:e4b");
     showCapabilities = "http-error"; // unverified, so delivery is attempted
     rejectNextChatWith = "unsupported media type";
     const said = assistantText(await collect(backend, turnsOf(AUDIO_TURN)));

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -467,7 +467,7 @@ export const OLLAMA_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // attempted for every model; graceful strip-and-retry on rejection
-  audio: true, // native /api/chat images[] and openai input_audio, both live-verified; per-model gate via /api/show (#790)
+  audio: true, // native /api/chat images[] and openai input_audio, both live-verified; per-model gate via /api/show (#790) plus verified-tag allowlist on the native image slot (#1972)
   turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 

--- a/src/orchestrator/audio-attachment.ts
+++ b/src/orchestrator/audio-attachment.ts
@@ -173,6 +173,7 @@ export const MAX_AUDIO_BYTES = 24 * 1024 * 1024;
 export type AudioRefusalReason =
   | "backend-has-no-audio-part"
   | "model-lacks-audio-capability"
+  | "model-not-verified-audio"
   | "unsupported-format"
   | "empty-file"
   | "too-large"
@@ -279,8 +280,35 @@ export function audioUserNotice(
 /** Audio-capable local models we have a concrete, checkable pull command for.
  *  Ollama's own release integration tests pin these as the audio-tested set
  *  (integration/reg_release_test.go: releaseAudioModels), which is why they are
- *  named here rather than a general "try a multimodal model" hand-wave. */
+ *  named here rather than a general "try a multimodal model" hand-wave.
+ *
+ *  This is also the native-Ollama SEND allowlist (#1972). `/api/show` reporting
+ *  `audio` is an architecture flag, not a guarantee these weights can hear: a
+ *  namespaced Gemma 4 fork accepts a WAV in `message.images[]` and returns a
+ *  fluent fabricated transcript. Only these tags may ride that carrier. */
 export const AUDIO_CAPABLE_OLLAMA_MODELS = ["gemma4:e2b", "gemma4:e4b", "nemotron3:33b"] as const;
+
+function normalizeOllamaAudioModelId(model: string): string {
+  let s = model.trim().toLowerCase();
+  if (s.startsWith("library/")) s = s.slice("library/".length);
+  return s;
+}
+
+/**
+ * True when `model` is one of the Ollama tags we have actually verified can
+ * hear — not merely a tag whose architecture reports an `audio` capability.
+ *
+ * Native Ollama has no separate audio field; bytes ride `message.images[]`.
+ * "The endpoint took it" is therefore not "the model heard it" (#1972).
+ * A user/org namespace is a different weight set even when `/api/show`
+ * inherits the flag, so `library/` is the only prefix that still matches.
+ */
+export function isKnownAudioCapableOllamaModel(model: string): boolean {
+  const normalized = normalizeOllamaAudioModelId(model);
+  return (AUDIO_CAPABLE_OLLAMA_MODELS as readonly string[]).some(
+    (known) => normalizeOllamaAudioModelId(known) === normalized,
+  );
+}
 
 /** Refusal text: this backend has no audio content part at all. Names the
  *  providers that DO, so the remedy is reachable from where the user is. */
@@ -306,6 +334,23 @@ export function modelLacksAudioText(model: string, capabilities: string[], filen
     `I can't send ${filename} to ${model}: the server reports its capabilities as [${caps}] — no audio. ` +
     `Pull a model that can hear and select it, e.g. \`ollama pull ${AUDIO_CAPABLE_OLLAMA_MODELS[0]}\` ` +
     `(others: ${AUDIO_CAPABLE_OLLAMA_MODELS.slice(1).join(", ")}). Until then I have not heard this file ` +
+    `and won't pretend otherwise.`
+  );
+}
+
+/** Refusal text: native Ollama would put audio in the image slot, and this
+ *  model is not one we have verified can hear.
+ *
+ *  Distinct from `modelLacksAudioText`: the server may well list an `audio`
+ *  capability (architecture flag) even when the weights invent a transcript.
+ *  Quoting that flag as "no audio" would be a lie; this names the actual
+ *  reason we are not sending. */
+export function modelNotVerifiedAudioText(model: string, filename: string): string {
+  return (
+    `I can't send ${filename} to ${model}: native Ollama carries audio in the image slot, and a model ` +
+    `that merely ACCEPTS that payload can still invent a transcript. ${model} is not in the verified-audio ` +
+    `set, so I am not sending the bytes. Pull a model that can hear, e.g. \`ollama pull ${AUDIO_CAPABLE_OLLAMA_MODELS[0]}\` ` +
+    `(others: ${AUDIO_CAPABLE_OLLAMA_MODELS.slice(1).join(", ")}), and re-send. Until then I have not heard this file ` +
     `and won't pretend otherwise.`
   );
 }

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -39,7 +39,9 @@ import {
   audioUnverifiedModelNote,
   audioUserNotice,
   fetchAudioAttachment,
+  isKnownAudioCapableOllamaModel,
   modelLacksAudioText,
+  modelNotVerifiedAudioText,
   openAiAudioFormat,
   tooManyAudioText,
 } from "./audio-attachment.js";
@@ -1316,6 +1318,13 @@ export class OllamaBackend implements AgentBackend {
    * Order matters: establish the model's capability BEFORE fetching anything, so
    * a model that cannot hear produces a refusal naming a model that can rather
    * than a download plus a shrug.
+   *
+   * Native `/api/chat` then has a second gate (#1972). Audio rides
+   * `message.images[]` — the same slot as pictures — so a model that ACCEPTS
+   * the payload is not a model that can hear. `/api/show` reporting `audio` is
+   * an architecture flag inherited by namespaced forks; at least one such fork
+   * returns a fluent fabricated transcript instead of HTTP 400. Bytes go on
+   * that carrier only for the Ollama-tested allowlist.
    */
   protected async attachAudio(
     userMsg: ChatMessage,
@@ -1334,8 +1343,24 @@ export class OllamaBackend implements AgentBackend {
       }
       return { outcomes, confidence: "established" };
     }
-    // caps === null → the probe could not run. That is not a refusal (a guard
-    // that fails is not a verdict): attempt delivery and mark it unconfirmed.
+    // Native images[] is a picture slot. A model outside the verified set is
+    // refused even when /api/show lists `audio`, and even when the probe could
+    // not run — sending would be hoping, which is how a fabricated transcript
+    // reaches the user as if it were heard.
+    if (this.api === "ollama" && !isKnownAudioCapableOllamaModel(this.model)) {
+      for (const ref of refs) {
+        outcomes.push({
+          status: "refused",
+          filename: ref.filename,
+          reason: "model-not-verified-audio",
+          text: modelNotVerifiedAudioText(this.model, ref.filename),
+        });
+      }
+      return { outcomes, confidence: "established" };
+    }
+    // caps === null → the probe could not run. On the OpenAI dialect (and on
+    // an allowlisted native tag) that is not a refusal: a guard that fails is
+    // not a verdict. Attempt delivery and mark it unconfirmed.
     const confidence: AudioConfidence = caps ? "established" : "unverified";
     for (const [i, ref] of refs.entries()) {
       if (i >= MAX_AUDIO_ATTACHMENTS) {

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -1249,6 +1249,38 @@ export class OllamaBackend implements AgentBackend {
   }
 
   /**
+   * Drop audio the ACTIVE model must not be handed (#1972).
+   *
+   * The attach-time allowlist only governs the turn the audio arrives on. Ollama
+   * is stateless per request, so the whole history is re-serialized every turn
+   * and `toOllamaMessages` merges `audios` into `images[]` unconditionally —
+   * audio delivered under a verified tag is therefore re-sent to whatever model
+   * is selected NOW. A live switch hands the fabricating tag from #1972 both the
+   * bytes and the earlier "you can hear them" note, which by then names a model
+   * that is no longer selected and forbids the very "I cannot hear" reply that
+   * would be truthful.
+   *
+   * Run at the top of every turn rather than from `setModel`, because
+   * `this.model` has a second mutation site (the `opts.model` adoption in
+   * `start`) that never passes through `setModel`: a guard installed on one of
+   * them is not installed on the other.
+   */
+  private stripUnverifiedAudioFromHistory(): void {
+    if (this.api !== "ollama" || isKnownAudioCapableOllamaModel(this.model)) return;
+    for (const m of this.history) {
+      if (!m.audios?.length) continue;
+      delete m.audios;
+      delete m.audioMimes;
+      m.content +=
+        `\n[note: the audio attached to this message was removed. The active model (${this.model}) is not a ` +
+        `verified listener, and native Ollama carries audio in the IMAGE slot, where a model can accept the ` +
+        `bytes and invent a transcript. You did NOT hear this audio: do not describe, transcribe or guess at ` +
+        `its contents. An earlier note in this message may claim the audio is in your context and that you can ` +
+        `hear it — that note described a different model and no longer applies.]`;
+    }
+  }
+
+  /**
    * Capabilities the SERVER reports for the active model (#790), or null when we
    * could not establish them.
    *
@@ -1391,6 +1423,9 @@ export class OllamaBackend implements AgentBackend {
     // should get. Reconcile BEFORE buildModelTools reads the catalog, and here
     // rather than in setModel because nothing is in flight at this point.
     await this.reconcileToolModeForModel();
+    // #1972 — same reason, for audio the history is still carrying: the model
+    // selected NOW may not be the one that was verified when it was attached.
+    this.stripUnverifiedAudioFromHistory();
     const tools = this.buildModelTools();
     // Vision is a per-MODEL property (gemma4 sees images, qwen3 doesn't;
     // DeepSeek's API rejects image parts outright), so ALWAYS attempt delivery:


### PR DESCRIPTION
Fixes #1972

Native Ollama carries audio in `message.images[]`. Most models HTTP 400 (fail closed). `huihui_ai/gemma-4-abliterated:E4b-qat` accepts the payload and returns a fluent, run-to-run-varying fabricated transcript instead — `/api/show` listing `audio` is an architecture flag, not proof these weights can hear.

The panel now refuses native audio unless the tag is in the Ollama-tested set (`gemma4:e2b`, `gemma4:e4b`, `nemotron3:33b`) *and* `/api/show` reports audio. Namespaced forks, including the default fine-tune, are refused out loud with a pull command. Bytes never hit the image slot.

The OpenAI dialect is unchanged: it uses a real `input_audio` part, not `images[]`.


---

## Second commit — `2a177b8`, from an independent review of `ccc72ec`

The gate above governs the turn audio is **attached** on. It did not govern the **history
replay**, and Ollama is stateless per request, so `toOllamaMessages` re-serialized `audios` into
`images[]` every turn for whatever model was selected at that moment.

Measured on the review worktree, not inferred:

```
TURN1 model: gemma4:e2b                              images: ["UklGRg=="]   ← allowlisted, correct
TURN2 model: huihui_ai/gemma-4-abliterated:E4b-qat   images: ["UklGRg=="]   ← leak
LEAKED AUDIO BYTES TO NON-ALLOWLISTED MODEL: true
```

Turn 2 carried no new attachment, so `attachAudio` never ran. The fabricating tag received the
WAV *plus* the replayed note `you can hear them - the server reports that gemma4:e2b has the
audio capability ... Do NOT reply that you cannot process audio` — naming a model no longer
selected, and forbidding the truthful reply the reporter had explicitly offered. Reachable via
`panel-agent.ts:3685 → backend.setModel`, which switches live with no session restart and keeps
history.

`stripUnverifiedAudioFromHistory` runs at the top of `runTurn` rather than from `setModel`,
because `this.model` has a second post-construction mutation site (`opts.model` adoption, line
1168) that never passes through `setModel`. `chatStream` has exactly one caller, inside
`runTurn`, so that is the whole native send path.

### Evidence

- Call-site mutation of `ccc72ec`'s gate → exactly its 2 named tests fail, 40 pass.
- Call-site mutation of `2a177b8`'s strip → exactly the new test fails
  (`expected [ 'UklGRg==' ] to not include 'UklGRg=='`), 42 pass.
- Orchestrator suite after merging `origin/main`: **213 files / 3425 tests pass**; `tsc --noEmit`,
  `check:vocabulary`, `check:unknown-collapse`, `check:docs-mdx` clean.
- Allowlist source verified upstream: `ollama/ollama@main integration/reg_release_test.go`
  defines `releaseAudioModels = "nemotron3:33b", "gemma4:e2b", "gemma4:e4b"` — exactly the three
  tags used here.
- Built in a tree with a clean `npm ci`, re-run after merging main changed the lockfile.

### Review status

`ccc72ec` has had a real independent review (the finding above is what produced `2a177b8`).
`2a177b8` was written by that reviewer, so **it has not itself been independently reviewed** —
review requested and **pending**. The Copilot review on this PR is a quota-limit stub and is not
a verdict.

### Deliberately not done

- No live Ollama run against any tag (no instance allocated for this run) — the fabrication
  evidence remains the reporter's, and the allowlist rests on upstream's test list.
- No Playwright run: nothing here renders in the panel; the change is orchestrator-side.
- `stripUnverifiedAudioFromHistory` is **destructive** (matching `stripImagesFromHistory`), so
  switching away and back loses the bytes. Flagged for the reviewer rather than changed
  unilaterally.
- The stale "you can hear them" note is contradicted by an appended correction rather than
  rewritten at its source; whether a small model obeys the later of two conflicting instructions
  is unmeasured.
