### PR TITLE
fix(panel#1554): retire the restart confirmation wherever the CARD LEAVES THE SCREEN (review fix for #1957)

### DIFF
--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1038,7 +1038,11 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // setter, not an adder) would silently replace this one and un-ship #486.
     const takeoverAt = src.indexOf("bridge.setTabTakenOverListener(");
     expect(takeoverAt, "takeover listener not found").toBeGreaterThan(-1);
-    expect(src.slice(takeoverAt, takeoverAt + 300)).toContain("AskAnswers.closeAsks(tabId)");
+    // A STATEMENT, not a substring: `toContain` is satisfied by a COMMENTED-OUT call,
+    // so the guarantee would survive its own removal (review finding).
+    expect(src.slice(takeoverAt, takeoverAt + 300)).toMatch(
+      /^\s*AskAnswers\.closeAsks\(tabId\);\s*$/m,
+    );
     // …and exactly one is installed, which is what makes the body the whole story.
     expect(src.split("bridge.setTabTakenOverListener(").length - 1).toBe(1);
     expect(src).toContain("AskAnswers.setIncarnationResolver(");

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -125,6 +125,12 @@ async function abandonOnce(h: Harness, question = QUESTION, header = HEADER): Pr
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => (c as { text?: string }).text ?? "").join("\n");
 
+const restartDef = () => {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui is not registered");
+  return def;
+};
+
 describe("panel#1554 a late confirmation is claimed, not discarded", () => {
   beforeEach(() => resetAbandonedConfirmCards());
 
@@ -221,6 +227,34 @@ describe("panel#1554 a late confirmation is claimed, not discarded", () => {
     expect(h.drained).toHaveLength(0);
   });
 
+  it("NEW CHAT: the next restart on the same wf: tab paints a FRESH card", async () => {
+    // The pin the review asked for, by name and at the TOOL level rather than at
+    // confirm's: "next restart on the same `wf:` tab must paint a fresh card". New chat
+    // blanks the feed (`newChat()` → `resetFeed()`), so the card the answer belongs to is
+    // no longer on screen; claiming it would restart the server showing the user nothing.
+    const h = harness();
+
+    // A real first attempt: card dispatched, nobody answers inside the budget.
+    expect(textOf(await restartDef().handler({} as never, h.ctx))).toContain(
+      "No confirmation received within",
+    );
+    expect(h.cards).toHaveLength(1);
+    // …then they click it.
+    h.late.set(String(h.cards[0].ask_id), "Yes, go ahead");
+
+    // New chat: exactly what the `new_session` handler does for each member tab.
+    forgetAbandonedConfirmCards(TAB);
+
+    // A SECOND CARD, not a silent restart on the strength of the first one.
+    const second = textOf(await restartDef().handler({} as never, h.ctx));
+    expect(h.cards).toHaveLength(2);
+    expect(second).toContain("No confirmation received within");
+    expect(second).not.toContain("NO NEW CONFIRMATION CARD WAS SHOWN");
+    // The click is left where it was rather than consumed by a conversation that
+    // never showed it.
+    expect(h.late.get(String(h.cards[0].ask_id))).toBe("Yes, go ahead");
+  });
+
   it("a TAKEOVER of the route key drops it — the newcomer never answered that card", async () => {
     // `wf:` keys recur: close the browser tab, open the same workflow elsewhere, and the
     // newcomer inherits the address. #486 calls that a conversation boundary and retires
@@ -308,12 +342,6 @@ describe("panel#1554 a late confirmation is claimed, not discarded", () => {
 
 describe("panel#1554 the recovered decision is disclosed, not slipped in", () => {
   beforeEach(() => resetAbandonedConfirmCards());
-
-  const restartDef = () => {
-    const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
-    if (!def) throw new Error("panel_restart_comfyui is not registered");
-    return def;
-  };
 
   it("THE CALL SITE opts in — the helper alone proves nothing about production", async () => {
     // Verified by mutation: dropping the options object from the ctx.confirm(...) call

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -250,12 +250,46 @@ describe("panel#1554 a late confirmation is claimed, not discarded", () => {
     expect(await h.ctx.confirm(QUESTION, HEADER, 500, RECOVER)).toBe("yes");
   });
 
+  it("WIRING: every boundary that BLANKS THE FEED retires the confirmation too", () => {
+    // A review found the boundary I originally chose (takeover only) was too narrow, and
+    // for a reason my own argument had missed. The leak is not attribution — a restart
+    // consent is not conversation content — it is VISIBILITY. New chat blanks the feed
+    // (the panel's newChat() calls resetFeed()), a rewind discards everything after the
+    // anchor, and resume_session repaints the log from another thread. In all three the
+    // card is gone from the screen, so acting on its answer afterwards restarts the
+    // server on a surface showing nothing the user can point at.
+    //
+    // Behavioural tests cannot see WHICH handlers call it, and this is a set that is
+    // easy to silently shrink back to one, so the call sites are what is pinned.
+    const src = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+    for (const event of ["new_session", "rewind", "resume_session"]) {
+      const at = src.indexOf(`event.type === "${event}"`);
+      expect(at, `${event} handler not found`).toBeGreaterThan(-1);
+      // Bounded to the handler: the next one starts at the following `event.type ===`.
+      const next = src.indexOf("event.type === ", at + 20);
+      const block = src.slice(at, next > at ? next : at + 4000);
+      expect(block, `${event} must retire the abandoned confirmation`).toMatch(
+        /^\s*forgetAbandonedConfirmCards\(t\);\s*$/m,
+      );
+      // …and it stays alongside #486's retirement, not instead of it.
+      expect(block, `${event} must still retire ask state`).toContain("AskAnswers.closeAsks(t)");
+    }
+    // A PROVIDER SWITCH is deliberately absent: it leaves the card painted, so the
+    // consent is still on screen and still answerable. Asserted so that adding it later
+    // is a deliberate act rather than a copy-paste.
+    const providerAt = src.indexOf("if (providerSwitched) AskAnswers.closeAsks(panelTab);");
+    expect(providerAt).toBeGreaterThan(-1);
+    expect(src.slice(providerAt, providerAt + 200)).not.toContain("forgetAbandonedConfirmCards");
+  });
+
   it("WIRING: the takeover listener retires confirmations as well as asks", () => {
     // The bridge takes ONE takeover listener (a setter, not an adder), so this fix had
     // to join the existing call rather than add a second one — a second
     // setTabTakenOverListener would have silently replaced #486's and un-shipped it.
     // Behavioural tests above cannot see that; this is the shape of the call site.
-    const src = readFileSync("src/orchestrator/index.ts", "utf8");
+    // Resolved from THIS module, not from the cwd — a cwd-relative read passes or fails
+    // on where vitest was launched rather than on what the source says.
+    const src = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
     const at = src.indexOf("bridge.setTabTakenOverListener(");
     expect(at).toBeGreaterThan(-1);
     const call = src.slice(at, at + 200);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5487,6 +5487,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       for (const t of conversationMemberTabs(tabId)) {
         RunCompletions.closeRuns(t, key);
         AskAnswers.closeAsks(t);
+        // panel#1554 — this feed is being blanked/replaced, so the confirmation card
+        // goes with it. Acting on its answer afterwards would restart the server on a
+        // surface showing nothing the user can point at (see forgetAbandonedConfirmCards).
+        forgetAbandonedConfirmCards(t);
       }
       pushToConversation(key, { type: "session", session_id: null });
       // The write outcome is OBSERVABLE (codex confirming-gate P1: a swallowed
@@ -5541,7 +5545,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // kept and still reported — closeAsks downgrades, it does not delete.
       // #884: the boundary is conversation-wide (any participating tab's card).
       if (ok) {
-        for (const t of conversationMemberTabs(tabId)) AskAnswers.closeAsks(t);
+        // panel#1554 — the discarded branch takes the confirmation card off screen with
+        // it; its answer must not silently authorise a restart afterwards.
+        for (const t of conversationMemberTabs(tabId)) {
+          AskAnswers.closeAsks(t);
+          forgetAbandonedConfirmCards(t);
+        }
       }
       bridge.push({ type: "ack", ok, kind: "rewind" }, tabId);
       logger.info(`[panel-orchestrator] tab ${tabId.slice(0, 8)} rewind (anchor=${anchor ? anchor.slice(0, 8) : "fresh"}, ok=${ok})`);
@@ -5590,6 +5599,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       for (const t of conversationMemberTabs(tabId)) {
         RunCompletions.closeRuns(t, key);
         AskAnswers.closeAsks(t);
+        // panel#1554 — this feed is being blanked/replaced, so the confirmation card
+        // goes with it. Acting on its answer afterwards would restart the server on a
+        // surface showing nothing the user can point at (see forgetAbandonedConfirmCards).
+        forgetAbandonedConfirmCards(t);
       }
       if (sid) manager.setResume(key, sid);
       // Persist the selection NOW (not at first onSession) so a restart inside

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9482,15 +9482,29 @@ export function takeRecoveredConfirmAnswer(
 }
 
 /**
- * A DIFFERENT browser tab has taken this recurring route key over (#486’s takeover
- * event) — drop anything this key was holding.
+ * THE CARD IS NO LONGER IN FRONT OF THE USER on this tab — drop anything this key
+ * was holding.
  *
- * The key is the route key, not the browser tab, and `wf:` keys recur: close the tab,
- * open the same workflow somewhere else, and the newcomer inherits the address. It did
- * not answer the previous occupant’s card, so it must not inherit that answer either.
- * A RECONNECT is deliberately not this event — the same browser tab returns under the
- * same incarnation and no takeover fires — which is what keeps the reporter’s case
+ * Two kinds of event reach here, and the SECOND is the one a review caught:
+ *
+ *  1. A DIFFERENT browser tab has taken this recurring route key over (#486’s takeover
+ *     event). `wf:` keys recur: close the tab, open the same workflow somewhere else,
+ *     and the newcomer inherits the address without ever having seen the card.
+ *
+ *  2. THE FEED THE CARD WAS PAINTED INTO IS GONE — New chat (`new_session` → the panel’s
+ *     newChat() calls resetFeed()), a rewind (everything after the anchor is discarded),
+ *     or a switch to a historical chat (`resume_session` repaints the log from that
+ *     thread). The consent is not conversation CONTENT, so #486’s reasoning does not
+ *     apply — but acting on it would restart the server on a surface that shows nothing
+ *     the user can point at. VISIBILITY, not attribution, is what these three take away.
+ *
+ * A provider switch is deliberately NOT here: it leaves the card painted, so the consent
+ * is still on screen and still answerable.
+ *
+ * A RECONNECT is not any of these — the same browser tab returns under the same
+ * incarnation with its feed intact — which is what keeps the reporter’s case
  * (“do not lose it across agent/panel reconnect”) working.
+ *
  */
 export function forgetAbandonedConfirmCards(tabId: string): void {
   const prefix = `${tabId}\u0000`;
@@ -10826,7 +10840,7 @@ export function makePanelToolCtx(
     // state the orchestrator's own #952 wording has to apologise for ("the user may
     // see two — tell them which one to answer"). See AbandonedConfirmCard.
     if (opts?.recoverAbandonedAnswer) {
-      const recovered = takeRecoveredConfirmAnswer(bridge, ctx.tabId, header, question);
+      const recovered = takeRecoveredConfirmAnswer(bridge, journalTabFor(ctx), header, question);
       if (recovered) {
         toolPolicyLogger.info(
           `[panel-tools] confirm "${header}" answered on an earlier card ` +
@@ -10893,7 +10907,7 @@ export function makePanelToolCtx(
         // bridge will buffer whatever the user clicks. Remember the id so the next
         // attempt at this same confirmation drains it instead of asking again.
         if (opts?.recoverAbandonedAnswer) {
-          rememberAbandonedConfirmCard(ctx.tabId, header, question, askId);
+          rememberAbandonedConfirmCard(journalTabFor(ctx), header, question, askId);
         }
         return "timeout";
       }
@@ -16555,8 +16569,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                   `ago (WHEN they clicked is not known here, only that it was after that). Their ` +
                   `answer landed ` +
                   `after this tool had stopped waiting for it, so it was claimed now instead of ` +
-                  `being discarded. Tell the user that is what you acted on, and check with them ` +
-                  `if anything has changed since.`,
+                  `being discarded. This call has ALREADY acted on it — do not ask the user to ` +
+                  `confirm again, and do not present this as a pending decision. Just tell them ` +
+                  `plainly which answer it went on.`,
               ),
           },
         );


### PR DESCRIPTION
**Follow-up to #1957, which merged at `84cc751` while its review was still running.** Two reviews landed on that PR; one APPROVE, one REQUEST_CHANGES. The REQUEST_CHANGES carried a specific, falsifiable claim, I tested it, and it was **right** — but the merge had already happened, so its fix never shipped. This is that fix.

Nothing here is new design. It is the review's findings, applied.

## 1. The confirmed defect: a silent restart on a surface showing no consent

#1957 remembers an abandoned restart-confirmation card so the *next* `panel_restart_comfyui` can claim the answer the user gave after the 90s wait expired, and retires it when a different browser tab **takes over** the recurring `wf:` route key.

I had argued takeover was the *only* boundary that should retire it: #486 retires asks because an **answer is conversation content**, and a restart consent is a machine-level gate, not a quoted pick — so New chat / rewind / provider-switch do not mean "I withdraw consent to restart ComfyUI". The reviewer agreed with that distinction and said it is not the whole rule. The leak is **visibility**.

Verified rather than assumed, in `comfyui-mcp-panel/web/js/comfyui-mcp-panel.js`:

```js
function newChat({ notifyBackend = true } = {}) {
  …
  resetFeed();          // ← the feed the card was painted into is blanked
```

So after a New chat the card is **gone from the screen** while the buffered answer survives, and the next call would restart the server with nothing painted that the user can point at. That is worse than one extra card. The same is true of two siblings: a **rewind** discards everything after the anchor, and **`resume_session`** repaints the log from another thread.

`forgetAbandonedConfirmCards` therefore now rides **all four** boundaries — takeover, `new_session`, `rewind`, `resume_session` — pinned by a wiring test, because a set of four call sites is easy to silently shrink back to one.

**A provider switch stays excluded, and is now pinned as excluded**: it leaves the card painted, so the consent is still on screen and still answerable. That was the reviewer's own line, and I would rather adding it later fail a test than happen by copy-paste.

**A reconnect is none of the four** — same browser tab, same incarnation, feed intact — so the reporter's "do not lose it across agent/panel reconnect" case still works. That is the property the narrow boundary was protecting, and it survives the widening.

## 2. A scope-address key bug neither review named

While fixing the above I found that the entry was keyed by the raw `ctx.tabId`. For a **scope-addressed** session that is a scope address, not the tab the card renders on — and all four retirement sites pass real tab ids. So a scope-bound session's entry could never have been retired by any of them, including the takeover that #1957 did ship.

Now keyed by `journalTabFor(ctx)`, which is the convention #486 already uses for exactly this reason.

## 3. A pin that could survive its own removal

`expect(...).toContain("AskAnswers.closeAsks(tabId)")` — the relaxation #1957 made to #486's test — is satisfied by a **commented-out** call. Tightened to a statement:

```js
expect(src.slice(takeoverAt, takeoverAt + 300)).toMatch(
  /^\s*AskAnswers\.closeAsks\(tabId\);\s*$/m,
);
```

Also: the recovery test's `readFileSync` was cwd-relative and would have passed or failed on where vitest was launched — now `import.meta.url`.

## 4. The disclosure note

It ended "check with them if anything has changed since", which invites an intercession into something already dispatched. It now states the call has **already acted**, not to re-confirm, and not to present it as a pending decision.

## Evidence

| # | Mutation | Result |
|---|---|---|
| M10 | `new_session` stops calling `forgetAbandonedConfirmCards` | RED: the boundary-wiring test |
| M11 | `AskAnswers.closeAsks(tabId)` commented out in the takeover listener | RED: **#486's own** test — green under the old `toContain` |

Full suite on this branch: **615 files / 11227 tests green**.

## Coverage I do NOT have, stated plainly

The `journalTabFor` key fix is **not separately covered**. Every recovery test uses a real `wf:` tab id, so nothing would fail if it went back to `ctx.tabId`. Covering it needs a fixture that fakes `resolveSharedTabId`; I would rather say the coverage is missing than imply it exists.

Also, as on #1957: no panel/web code changed, so the Playwright suite covers nothing here and I did not run it.

## Process note

#1957 merged 6 minutes before I pushed this fix, on a review that had already been requested and was already in flight. The APPROVE and the REQUEST_CHANGES disagreed; the specific claim beat the general approval, as it did the last time these two disagreed. Worth saying out loud because the merge itself was the failure mode, not the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
