### PR TITLE
fix(1969): a rejected tool call names the argument it meant, without guessing at intent

### DIFF
--- a/src/__tests__/orchestrator/unrecognized-keys.test.ts
+++ b/src/__tests__/orchestrator/unrecognized-keys.test.ts
@@ -1,0 +1,184 @@
+// #1969 — an unrecognized argument key used to name only itself. The trajectories
+// the in-house model trains on are server-verified successes, so a 2–4B model
+// never sees the error-to-recovery transition. The reporter's exact case:
+//
+//     panel_remove_group { group: 2 }
+//
+// produced `unrecognized_keys: ["group"]` AND, separately, `expected number,
+// received undefined at group_id`. A small model cannot join those. The schema
+// now says `Unrecognized key 'group' — did you mean 'group_id'?`.
+//
+// The first suite goes through a REAL McpServer + Client rather than calling
+// the helper directly: the string an agent reads is produced by the SDK's
+// renderer, not by zod, so a schema-level assertion would be testing a
+// different sentence than the one that reached them. Same harness as #754 /
+// #1889.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { registerPanelTools, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import {
+  editDistance,
+  formatUnrecognizedKeyMessage,
+  isAffixMatch,
+  pairUnrecognizedKeys,
+  suggestKnownKey,
+  unrecognizedKeysError,
+} from "../../orchestrator/unrecognized-keys.js";
+
+function makeFakeCtx(): PanelToolCtx {
+  return {
+    call: async (cmd) => ({ content: [{ type: "text", text: JSON.stringify(cmd) }] }),
+    confirm: async () => "yes" as const,
+    bridge: { send: async () => ({}) } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+}
+
+describe("#1969 the message an agent actually receives over MCP", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "unrecognized-keys-test", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "unrecognized-keys-test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const errorText = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const r = await client.callTool({ name, arguments: args });
+    expect(r.isError, `${name} was expected to reject ${JSON.stringify(args)}`).toBe(true);
+    return (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+  };
+
+  it("REPRODUCTION: panel_remove_group {group:2} names group_id in the same sentence", async () => {
+    const text = await errorText("panel_remove_group", { group: 2 });
+    expect(text).toMatch(/Unrecognized key 'group'/);
+    expect(text).toMatch(/did you mean 'group_id'\?/);
+    // Still a refusal — this is a suggestion, not #1968's alias.
+    expect(text).toMatch(/Input validation error/);
+  });
+
+  it("panel_set_todo {todos:[…]} names items even though the strings are not similar", async () => {
+    // The 1:1 leftover (one unknown key, one missing required) is the
+    // "information is present but the caller has to join it" case. `todos` vs
+    // `items` would never match by edit distance.
+    const text = await errorText("panel_set_todo", {
+      todos: [{ text: "queue the first variant", status: "pending" }],
+    });
+    expect(text).toMatch(/Unrecognized key 'todos'/);
+    expect(text).toMatch(/did you mean 'items'\?/);
+  });
+
+  it("panel_move_group {group, pos} suggests group_id, not pos", async () => {
+    const text = await errorText("panel_move_group", { group: 2, pos: [0, 0] });
+    expect(text).toMatch(/did you mean 'group_id'\?/);
+    expect(text).not.toMatch(/did you mean 'pos'/);
+  });
+
+  it("an extra key that is NOT a missing required field is named without a wrong guess", async () => {
+    // panel_create_subgraph takes only node_ids. `title` is the sibling
+    // panel_create_group's field — it is extra, not a misspelling of node_ids,
+    // and node_ids is present, so there is nothing to join.
+    const text = await errorText("panel_create_subgraph", { node_ids: [1], title: "Stage A" });
+    expect(text).toMatch(/Unrecognized key 'title'/);
+    expect(text).not.toMatch(/did you mean/);
+  });
+
+  it("a truly bogus key on an all-optional tool still names the key and does not invent a target", async () => {
+    const text = await errorText("panel_graph_outline", { __e2e_bogus_marker_1969__: true });
+    expect(text).toContain("__e2e_bogus_marker_1969__");
+    expect(text).toMatch(/Unrecognized key/);
+    expect(text).not.toMatch(/did you mean/);
+  });
+
+  it("ACCEPTANCE IS UNCHANGED — the canonical key still reaches the handler", async () => {
+    const r = await client.callTool({
+      name: "panel_remove_group",
+      arguments: { group_id: 2 },
+    });
+    const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(text).not.toMatch(/Input validation error/);
+    expect(text).not.toMatch(/Unrecognized key/);
+    expect(JSON.parse(text)).toMatchObject({ cmd: "graph_remove_group", group_id: 2 });
+  });
+});
+
+describe("#1969 pairing is the join, not a thesaurus", () => {
+  it("group → group_id is an affix, not a coincidental neighbour", () => {
+    expect(isAffixMatch("group", "group_id")).toBe(true);
+    expect(suggestKnownKey("group", ["group_id", "pos", "title"])).toBe("group_id");
+  });
+
+  it("groupid (missing underscore) still lands on group_id", () => {
+    expect(suggestKnownKey("groupid", ["group_id", "title"])).toBe("group_id");
+  });
+
+  it("todos does NOT look like items — the 1:1 leftover is what joins them", () => {
+    expect(suggestKnownKey("todos", ["items"])).toBeUndefined();
+    const paired = pairUnrecognizedKeys(["todos"], ["items"], ["items"], { todos: [] });
+    expect(paired.get("todos")).toBe("items");
+  });
+
+  it("does not join an extra key onto a field that was already provided", () => {
+    const paired = pairUnrecognizedKeys(["title"], ["node_ids"], ["node_ids"], {
+      node_ids: [1],
+      title: "Stage A",
+    });
+    expect(paired.has("title")).toBe(false);
+  });
+
+  it("a random token is not a typo of a short required key", () => {
+    expect(suggestKnownKey("__e2e_bogus_marker_1969__", ["max_chars"])).toBeUndefined();
+  });
+});
+
+describe("#1969 the schema-level error map is what strictPanelSchema installs", () => {
+  // Same construction registerPanelTools uses. Proves the map is what changes
+  // issue.message, so a future edit that wires the helper and then forgets to
+  // pass it into z.object({error}) fails here rather than only on MCP wording.
+  it("the reporter's sentence is what formatUnrecognizedKeyMessage emits", () => {
+    expect(
+      formatUnrecognizedKeyMessage(["group"], ["group_id"], ["group_id"], { group: 2 }),
+    ).toBe("Unrecognized key 'group' — did you mean 'group_id'?");
+  });
+
+  it("safeParse of the reporter's payload carries that sentence on the issue", () => {
+    const shape = { group_id: z.number().int() };
+    const payload = { group: 2 };
+    const schema = z.object(shape, { error: unrecognizedKeysError(shape) }).strict();
+    const result = schema.safeParse(payload);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const unrecognized = result.error.issues.filter((i) => i.code === "unrecognized_keys");
+    expect(unrecognized.length).toBeGreaterThan(0);
+    expect(unrecognized[0]?.message).toBe(
+      formatUnrecognizedKeyMessage(["group"], Object.keys(shape), ["group_id"], payload),
+    );
+  });
+
+  it("formatUnrecognizedKeyMessage never throws on a hostile input", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    expect(() =>
+      formatUnrecognizedKeyMessage(["group"], ["group_id"], ["group_id"], proxy),
+    ).not.toThrow();
+  });
+
+  it("editDistance is the identity for equal strings and |len| for empty", () => {
+    expect(editDistance("group_id", "group_id")).toBe(0);
+    expect(editDistance("", "abc")).toBe(3);
+    expect(editDistance("abc", "")).toBe(3);
+  });
+});

--- a/src/__tests__/orchestrator/unrecognized-keys.test.ts
+++ b/src/__tests__/orchestrator/unrecognized-keys.test.ts
@@ -246,6 +246,37 @@ describe("#1969 review — a structural join must not be phrased as a guess abou
     const paired = pairUnrecognizedKeys(["dry_run"], ["node_id"], ["node_id"], { dry_run: true });
     expect(paired.get("dry_run")).toEqual({ key: "node_id", confident: false });
   });
+
+  // Same principle one rule up: rules 1-2 match on the NAME, and when two names
+  // match equally well the old length tiebreak picked the shorter one and stated
+  // it as the answer.
+  it("two equally good affix matches REFUSE rather than pick one", () => {
+    expect(suggestKnownKey("id", ["from_node_id", "to_node_id"])).toBeUndefined();
+    expect(suggestKnownKey("name", ["from_slot_name", "to_slot_name"])).toBeUndefined();
+  });
+
+  it("but a SINGLE affix match is still named", () => {
+    expect(suggestKnownKey("id", ["to_node_id", "pos"])).toBe("to_node_id");
+    expect(suggestKnownKey("group", ["group_id", "pos", "title"])).toBe("group_id");
+  });
+
+  it("panel_connect {id} over the real surface names neither endpoint", async () => {
+    // The live shape is what made this reachable: panel_connect carries both
+    // from_node_id and to_node_id, so `id` is genuinely ambiguous.
+    const server = new McpServer({ name: "ambiguity-probe", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const c = new Client({ name: "ambiguity-probe-client", version: "1.0.0" });
+    await Promise.all([server.connect(st), c.connect(ct)]);
+    const r = await c.callTool({ name: "panel_connect", arguments: { id: 5 } });
+    const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(r.isError).toBe(true);
+    expect(text).toMatch(/Unrecognized key 'id'/);
+    expect(text).not.toMatch(/did you mean 'to_node_id'/);
+    expect(text).not.toMatch(/did you mean 'from_node_id'/);
+    await c.close();
+    await server.close();
+  });
 });
 
 describe("#1969 review — the live surface, not a hand-built shape", () => {

--- a/src/__tests__/orchestrator/unrecognized-keys.test.ts
+++ b/src/__tests__/orchestrator/unrecognized-keys.test.ts
@@ -260,6 +260,33 @@ describe("#1969 review — a structural join must not be phrased as a guess abou
     expect(suggestKnownKey("group", ["group_id", "pos", "title"])).toBe("group_id");
   });
 
+  it("a name tie that the VALUE can settle is still answered", () => {
+    // panel_edit_node carries both node_id and node_ids, so `node` ties on the
+    // name. A scalar 5 is not a node_ids, so the value decides. Refusing here
+    // would silence a case the original ranking got right.
+    const fits = (target: string, value: unknown) =>
+      target === "node_id" ? typeof value === "number" : Array.isArray(value);
+    expect(suggestKnownKey("node", ["node_id", "node_ids"], fits, 5)).toBe("node_id");
+    expect(suggestKnownKey("node", ["node_id", "node_ids"], fits, [1, 2])).toBe("node_ids");
+    // ...but a value that fits BOTH leaves it ambiguous, so it still refuses.
+    const fitsBoth = () => true;
+    expect(suggestKnownKey("node", ["node_id", "node_ids"], fitsBoth, 5)).toBeUndefined();
+  });
+
+  it("panel_edit_node {node:5} keeps the suggestion the original ranking got right", async () => {
+    const server = new McpServer({ name: "tiebreak-probe", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const c = new Client({ name: "tiebreak-probe-client", version: "1.0.0" });
+    await Promise.all([server.connect(st), c.connect(ct)]);
+    const r = await c.callTool({ name: "panel_edit_node", arguments: { node: 5, title: "x" } });
+    const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(r.isError).toBe(true);
+    expect(text).toMatch(/did you mean 'node_id'\?/);
+    await c.close();
+    await server.close();
+  });
+
   it("panel_connect {id} over the real surface names neither endpoint", async () => {
     // The live shape is what made this reachable: panel_connect carries both
     // from_node_id and to_node_id, so `id` is genuinely ambiguous.

--- a/src/__tests__/orchestrator/unrecognized-keys.test.ts
+++ b/src/__tests__/orchestrator/unrecognized-keys.test.ts
@@ -128,7 +128,7 @@ describe("#1969 pairing is the join, not a thesaurus", () => {
   it("todos does NOT look like items — the 1:1 leftover is what joins them", () => {
     expect(suggestKnownKey("todos", ["items"])).toBeUndefined();
     const paired = pairUnrecognizedKeys(["todos"], ["items"], ["items"], { todos: [] });
-    expect(paired.get("todos")).toBe("items");
+    expect(paired.get("todos")?.key).toBe("items");
   });
 
   it("does not join an extra key onto a field that was already provided", () => {
@@ -180,5 +180,113 @@ describe("#1969 the schema-level error map is what strictPanelSchema installs", 
     expect(editDistance("group_id", "group_id")).toBe(0);
     expect(editDistance("", "abc")).toBe(3);
     expect(editDistance("abc", "")).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1969 REVIEW of 90d9cf6 — the 1:1 leftover rule fires on COUNTS, not on
+// meaning. 34 of the 95 registered panel tools take exactly one required key,
+// so before this split every one of them answered any stray key with a
+// confident guess. `panel_remove_node {dry_run:true}` → "did you mean
+// 'node_id'?" reads exactly like the true `group` → `group_id` case, and the
+// 2–4B models this change exists to serve cannot tell them apart — so the
+// wrong repair ("move the value into node_id") is the one they act on.
+//
+// The split is by VALUE compatibility, which is the evidence already in hand:
+// the reporter's own `todos` → `items` survives as a "did you mean" because
+// the todo array they sent is a valid `items`.
+// ---------------------------------------------------------------------------
+describe("#1969 review — a structural join must not be phrased as a guess about intent", () => {
+  const fitsFor = (shape: Record<string, z.ZodType>) => (target: string, value: unknown) =>
+    shape[target] ? shape[target]!.safeParse(value).success : false;
+
+  it("a stray key whose value cannot fit the missing required key is NOT a 'did you mean'", () => {
+    const shape = { node_id: z.number() };
+    const msg = formatUnrecognizedKeyMessage(
+      ["dry_run"],
+      Object.keys(shape),
+      ["node_id"],
+      { dry_run: true },
+      fitsFor(shape),
+    );
+    expect(msg).toBe("Unrecognized key 'dry_run' — required key 'node_id' is missing");
+    // The join is still in ONE sentence — that is the ask — but it states the
+    // schema fact rather than asserting what the caller meant.
+    expect(msg).not.toMatch(/did you mean/);
+    expect(msg).toContain("node_id");
+  });
+
+  it("the reporter's todos → items SURVIVES as a 'did you mean' because the value fits", () => {
+    const shape = { items: z.array(z.object({ text: z.string() })) };
+    const msg = formatUnrecognizedKeyMessage(
+      ["todos"],
+      Object.keys(shape),
+      ["items"],
+      { todos: [{ text: "queue the first variant" }] },
+      fitsFor(shape),
+    );
+    expect(msg).toBe("Unrecognized key 'todos' — did you mean 'items'?");
+  });
+
+  it("a NAME match stays confident even when the value does not fit — the names still pair", () => {
+    // `group` → `group_id` is rule 1 (affix). A caller who sends the right key
+    // under the wrong name with a bad value should still be told the name.
+    const shape = { group_id: z.number() };
+    const msg = formatUnrecognizedKeyMessage(
+      ["group"],
+      Object.keys(shape),
+      ["group_id"],
+      { group: "not-a-number" },
+      fitsFor(shape),
+    );
+    expect(msg).toBe("Unrecognized key 'group' — did you mean 'group_id'?");
+  });
+
+  it("pairUnrecognizedKeys marks the rule-3 join unconfident without a fits predicate", () => {
+    const paired = pairUnrecognizedKeys(["dry_run"], ["node_id"], ["node_id"], { dry_run: true });
+    expect(paired.get("dry_run")).toEqual({ key: "node_id", confident: false });
+  });
+});
+
+describe("#1969 review — the live surface, not a hand-built shape", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "unrecognized-keys-review", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "unrecognized-keys-review-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const errorText = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const r = await client.callTool({ name, arguments: args });
+    expect(r.isError, `${name} was expected to reject ${JSON.stringify(args)}`).toBe(true);
+    return (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+  };
+
+  it("panel_remove_node {dry_run:true} names node_id WITHOUT claiming that is what was meant", async () => {
+    const text = await errorText("panel_remove_node", { dry_run: true });
+    expect(text).toMatch(/Unrecognized key 'dry_run'/);
+    expect(text).toMatch(/required key 'node_id' is missing/);
+    expect(text).not.toMatch(/did you mean/);
+  });
+
+  it("panel_set_todo {todos:[…]} still gets the confident suggestion over the real surface", async () => {
+    const text = await errorText("panel_set_todo", {
+      todos: [{ text: "queue the first variant", status: "pending" }],
+    });
+    expect(text).toMatch(/did you mean 'items'\?/);
+  });
+
+  it("panel_remove_group {group:2} still gets the confident suggestion over the real surface", async () => {
+    const text = await errorText("panel_remove_group", { group: 2 });
+    expect(text).toMatch(/did you mean 'group_id'\?/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -81,6 +81,7 @@ import {
   PLAIN_NODE_ID_PATTERN,
   unionErrorFor,
 } from "./node-id.js";
+import { unrecognizedKeysError } from "./unrecognized-keys.js";
 import {
   addressedNodeMatchesPersistRemedy,
   parseContradictoryPromotedWidgetRefusal,
@@ -12123,6 +12124,14 @@ export interface PanelToolDef {
  * key: X") is something a model can read and fix on the next attempt; a silent no-op
  * is not distinguishable from "it worked but had no effect".
  *
+ * #1969 — the refusal used to name the unknown key AND, separately, the missing
+ * required one (`unrecognized_keys: ["group"]` plus `expected number, received
+ * undefined at group_id`). A frontier model joins those; a 2–4B fine-tune trained
+ * only on verified successes cannot. The schema-level `error` map names the
+ * intended key in the same sentence ("did you mean 'group_id'?") so a small
+ * model can recover without aliases (#1968) and without failed-then-corrected
+ * training pairs.
+ *
  * BOTH transports' registration functions accept this directly in place of the raw
  * shape (verified against each SDK's actual runtime behavior, not assumed from the
  * TypeScript types — see the cast note at the Anthropic SDK call site):
@@ -12136,7 +12145,7 @@ export interface PanelToolDef {
  *     an unrecognized key is rejected with `Unrecognized key: "..."`.
  */
 function strictPanelSchema(shape: z.ZodRawShape) {
-  return z.object(shape).strict();
+  return z.object(shape, { error: unrecognizedKeysError(shape) }).strict();
 }
 
 const PANEL_EDIT_NODE_FIELDS = ["pos", "size", "title", "preset", "color", "bgcolor", "shape", "collapsed", "pinned", "mode"] as const;

--- a/src/orchestrator/unrecognized-keys.ts
+++ b/src/orchestrator/unrecognized-keys.ts
@@ -1,0 +1,221 @@
+/**
+ * #1969 — an unrecognized argument key used to name only itself.
+ *
+ * Trajectories for the in-house panel model are server-VERIFIED, so they
+ * contain only successful calls. A 2–4B model never sees the error-to-recovery
+ * transition; a frontier model infers it from sibling tools. The cheap runtime
+ * substitute is to JOIN the two halves of the refusal the caller already gets:
+ *
+ *     unrecognized_keys: ["group"]
+ *     expected number, received undefined at group_id
+ *
+ * into one line a small model can act on:
+ *
+ *     Unrecognized key 'group' — did you mean 'group_id'?
+ *
+ * This does NOT accept the wrong key (that's #1968's aliases). It only names
+ * the intended one. Wired through `strictPanelSchema` so both transports see it.
+ */
+
+import { safeParse, type z } from "zod";
+
+/** Structural slice of a Zod 4 unrecognized_keys issue. The full $ZodRawIssue
+ *  type is internal; this is what `finalizeIssue` actually hands the error map. */
+export type UnrecognizedKeysIssue = {
+  code?: string;
+  keys?: string[];
+  input?: unknown;
+};
+
+const COMMON_SUFFIXES = ["_id", "_ids", "_name", "_key"];
+
+/**
+ * Levenshtein distance. Keys are short (a handful of characters); a full DP
+ * table is cheaper than importing a package, and this runs only on the
+ * validation-failure path.
+ */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+  const prev = new Array<number>(b.length + 1);
+  const cur = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    cur[0] = i;
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= b.length; j++) {
+      const cost = ca === b.charCodeAt(j - 1) ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = cur[j]!;
+  }
+  return prev[b.length]!;
+}
+
+function fold(s: string): string {
+  return s.toLowerCase().replace(/-/g, "_");
+}
+
+function compact(s: string): string {
+  return fold(s).replace(/_/g, "");
+}
+
+/** True when one name is the other plus a separator/`_id`-style suffix —
+ *  `group` vs `group_id`, `groupid` vs `group_id`. Not a general thesaurus. */
+export function isAffixMatch(a: string, b: string): boolean {
+  const fa = fold(a);
+  const fb = fold(b);
+  if (fa === fb) return true;
+  const [shorter, longer] = fa.length <= fb.length ? [fa, fb] : [fb, fa];
+  if (longer.startsWith(`${shorter}_`) || longer.endsWith(`_${shorter}`)) return shorter.length >= 2;
+  const ca = compact(a);
+  const cb = compact(b);
+  const [cs, cl] = ca.length <= cb.length ? [ca, cb] : [cb, ca];
+  if (cs.length < 3 || !cl.startsWith(cs)) return false;
+  // Same letters, different separators: `groupid` vs `group_id`.
+  if (cs === cl) return true;
+  return COMMON_SUFFIXES.includes(`_${cl.slice(cs.length)}`);
+}
+
+function distanceThreshold(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  if (n <= 3) return 1;
+  if (n <= 6) return 2;
+  return 3;
+}
+
+/**
+ * Closest known key, or undefined when nothing is close enough to recommend.
+ * Prefer an affix match over a mere edit distance, so `group` → `group_id`
+ * beats a coincidental neighbour of the same length.
+ */
+export function suggestKnownKey(unknown: string, candidates: readonly string[]): string | undefined {
+  const folded = fold(unknown);
+  let best: string | undefined;
+  let bestScore = Infinity;
+  for (const c of candidates) {
+    if (c === unknown) continue;
+    const fc = fold(c);
+    if (fc === folded) return c;
+    if (isAffixMatch(unknown, c)) {
+      const score = Math.abs(c.length - unknown.length) / 100;
+      if (score < bestScore) {
+        best = c;
+        bestScore = score;
+      }
+      continue;
+    }
+    const d = editDistance(folded, fc);
+    if (d > distanceThreshold(folded, fc)) continue;
+    // Affix scores are < 1; offset typos so they cannot outrank an affix.
+    const score = 1 + d;
+    if (score < bestScore) {
+      best = c;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+function providedKeys(input: unknown): Set<string> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return new Set();
+  return new Set(Object.keys(input as Record<string, unknown>));
+}
+
+/**
+ * Pair each unrecognized key with at most one known key.
+ *
+ * 1. Confident match (affix / short edit) against missing required keys.
+ * 2. Same, against every known key (optional fields included).
+ * 3. If exactly one unknown and exactly one required key remain, join them
+ *    even when the names are not similar (`todos` vs `items`). That is the
+ *    "information is present but the caller has to join it" case.
+ */
+export function pairUnrecognizedKeys(
+  unknownKeys: readonly string[],
+  knownKeys: readonly string[],
+  requiredKeys: readonly string[],
+  input: unknown,
+): Map<string, string> {
+  const suggestions = new Map<string, string>();
+  const used = new Set<string>();
+  const present = providedKeys(input);
+  const missingRequired = requiredKeys.filter((k) => !present.has(k));
+
+  const take = (unknown: string, pool: readonly string[]): void => {
+    const leftover = pool.filter((k) => !used.has(k) && k !== unknown);
+    const match = suggestKnownKey(unknown, leftover);
+    if (!match) return;
+    suggestions.set(unknown, match);
+    used.add(match);
+  };
+
+  for (const k of unknownKeys) take(k, missingRequired);
+  for (const k of unknownKeys) {
+    if (!suggestions.has(k)) take(k, knownKeys);
+  }
+
+  const leftoverUnknown = unknownKeys.filter((k) => !suggestions.has(k));
+  const leftoverMissing = missingRequired.filter((k) => !used.has(k));
+  if (leftoverUnknown.length === 1 && leftoverMissing.length === 1) {
+    suggestions.set(leftoverUnknown[0]!, leftoverMissing[0]!);
+  }
+  return suggestions;
+}
+
+function quoteKey(k: string): string {
+  return `'${k.replace(/'/g, "\\'")}'`;
+}
+
+/** The sentence a caller reads. Never throws — a formatter that throws turns
+ *  a clean validation refusal into a 500. */
+export function formatUnrecognizedKeyMessage(
+  keys: readonly string[],
+  knownKeys: readonly string[],
+  requiredKeys: readonly string[],
+  input: unknown,
+): string {
+  try {
+    const unique = [...new Set(keys)];
+    const paired = pairUnrecognizedKeys(unique, knownKeys, requiredKeys, input);
+    return unique
+      .map((k) => {
+        const suggestion = paired.get(k);
+        return suggestion
+          ? `Unrecognized key ${quoteKey(k)} — did you mean ${quoteKey(suggestion)}?`
+          : `Unrecognized key ${quoteKey(k)}`;
+      })
+      .join("; ");
+  } catch {
+    const listed = keys.map((k) => quoteKey(k)).join(", ");
+    return `Unrecognized key${keys.length > 1 ? "s" : ""} ${listed}`;
+  }
+}
+
+function requiredKeysOf(shape: z.ZodRawShape): string[] {
+  const keys: string[] = [];
+  for (const [k, schema] of Object.entries(shape)) {
+    try {
+      // ZodRawShape values are typed as core $ZodType (no `.safeParse` method).
+      // The top-level helper accepts that shape.
+      if (!safeParse(schema, undefined).success) keys.push(k);
+    } catch {
+      // A throwing probe is not evidence the field is required.
+    }
+  }
+  return keys;
+}
+
+/**
+ * Zod 4 `error` map for a strict object. Returns a message only for
+ * `unrecognized_keys`; every other issue falls through to the locale default.
+ */
+export function unrecognizedKeysError(shape: z.ZodRawShape): (iss: UnrecognizedKeysIssue) => string | undefined {
+  const knownKeys = Object.keys(shape);
+  const requiredKeys = requiredKeysOf(shape);
+  return (iss) => {
+    if (iss.code !== "unrecognized_keys" || !iss.keys?.length) return undefined;
+    return formatUnrecognizedKeyMessage(iss.keys, knownKeys, requiredKeys, iss.input);
+  };
+}

--- a/src/orchestrator/unrecognized-keys.ts
+++ b/src/orchestrator/unrecognized-keys.ts
@@ -123,6 +123,30 @@ function providedKeys(input: unknown): Set<string> {
   return new Set(Object.keys(input as Record<string, unknown>));
 }
 
+function valueAt(input: unknown, key: string): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+  try {
+    return (input as Record<string, unknown>)[key];
+  } catch {
+    // A revoked proxy throws on read. No value is not a fit.
+    return undefined;
+  }
+}
+
+/**
+ * A paired unrecognized key, and how strong the claim behind the pairing is.
+ *
+ * `confident` separates a statement about the KEY ("these two names denote the
+ * same argument") from a statement about the SCHEMA ("one key is unknown and
+ * one required key is missing"). Both are worth telling the caller; only the
+ * first may be phrased as "did you mean".
+ */
+export type KeyPairing = { key: string; confident: boolean };
+
+/** Does the value supplied under the wrong key parse under a candidate key's
+ *  schema? Used only to promote a structural 1:1 join to a confident one. */
+export type FitsPredicate = (target: string, value: unknown) => boolean;
+
 /**
  * Pair each unrecognized key with at most one known key.
  *
@@ -131,14 +155,20 @@ function providedKeys(input: unknown): Set<string> {
  * 3. If exactly one unknown and exactly one required key remain, join them
  *    even when the names are not similar (`todos` vs `items`). That is the
  *    "information is present but the caller has to join it" case.
+ *
+ * Rules 1 and 2 are always confident — they matched on the NAME. Rule 3 is a
+ * structural coincidence of counts and is confident only when `fits` agrees
+ * the caller's value would also parse under the target. See the note at the
+ * rule-3 branch for the surface measurement behind that split.
  */
 export function pairUnrecognizedKeys(
   unknownKeys: readonly string[],
   knownKeys: readonly string[],
   requiredKeys: readonly string[],
   input: unknown,
-): Map<string, string> {
-  const suggestions = new Map<string, string>();
+  fits?: FitsPredicate,
+): Map<string, KeyPairing> {
+  const suggestions = new Map<string, KeyPairing>();
   const used = new Set<string>();
   const present = providedKeys(input);
   const missingRequired = requiredKeys.filter((k) => !present.has(k));
@@ -147,7 +177,7 @@ export function pairUnrecognizedKeys(
     const leftover = pool.filter((k) => !used.has(k) && k !== unknown);
     const match = suggestKnownKey(unknown, leftover);
     if (!match) return;
-    suggestions.set(unknown, match);
+    suggestions.set(unknown, { key: match, confident: true });
     used.add(match);
   };
 
@@ -159,7 +189,20 @@ export function pairUnrecognizedKeys(
   const leftoverUnknown = unknownKeys.filter((k) => !suggestions.has(k));
   const leftoverMissing = missingRequired.filter((k) => !used.has(k));
   if (leftoverUnknown.length === 1 && leftoverMissing.length === 1) {
-    suggestions.set(leftoverUnknown[0]!, leftoverMissing[0]!);
+    const unknown = leftoverUnknown[0]!;
+    const target = leftoverMissing[0]!;
+    // #1969 review — rule 3 holds because the COUNTS line up, not because the
+    // names mean the same thing, and 34 of the 95 live panel tools take exactly
+    // one required key. So without this split every one of them answered any
+    // stray key with a confident guess: `panel_remove_node {dry_run: true}`
+    // replied "did you mean 'node_id'?", phrased identically to the true
+    // `group` → `group_id` case and indistinguishable from it by the 2–4B
+    // models this whole change exists to serve. Promote to "did you mean" only
+    // when the VALUE the caller sent also parses under the target's schema —
+    // which still covers the reporter's `todos` → `items`, because the todo
+    // array they sent is a valid `items`.
+    const confident = fits ? fits(target, valueAt(input, unknown)) : false;
+    suggestions.set(unknown, { key: target, confident });
   }
   return suggestions;
 }
@@ -175,16 +218,21 @@ export function formatUnrecognizedKeyMessage(
   knownKeys: readonly string[],
   requiredKeys: readonly string[],
   input: unknown,
+  fits?: FitsPredicate,
 ): string {
   try {
     const unique = [...new Set(keys)];
-    const paired = pairUnrecognizedKeys(unique, knownKeys, requiredKeys, input);
+    const paired = pairUnrecognizedKeys(unique, knownKeys, requiredKeys, input, fits);
     return unique
       .map((k) => {
         const suggestion = paired.get(k);
-        return suggestion
-          ? `Unrecognized key ${quoteKey(k)} — did you mean ${quoteKey(suggestion)}?`
-          : `Unrecognized key ${quoteKey(k)}`;
+        if (!suggestion) return `Unrecognized key ${quoteKey(k)}`;
+        // An unconfident pairing still carries both halves of the join in one
+        // sentence — which is the whole ask — but states the schema fact it
+        // actually knows instead of guessing at intent.
+        return suggestion.confident
+          ? `Unrecognized key ${quoteKey(k)} — did you mean ${quoteKey(suggestion.key)}?`
+          : `Unrecognized key ${quoteKey(k)} — required key ${quoteKey(suggestion.key)} is missing`;
       })
       .join("; ");
   } catch {
@@ -214,8 +262,20 @@ function requiredKeysOf(shape: z.ZodRawShape): string[] {
 export function unrecognizedKeysError(shape: z.ZodRawShape): (iss: UnrecognizedKeysIssue) => string | undefined {
   const knownKeys = Object.keys(shape);
   const requiredKeys = requiredKeysOf(shape);
+  // Runs only on the validation-failure path, and only for the single leftover
+  // candidate — never across the whole shape.
+  const fits: FitsPredicate = (target, value) => {
+    const schema = shape[target];
+    if (!schema) return false;
+    try {
+      return safeParse(schema, value).success;
+    } catch {
+      // A throwing probe is not evidence the value fits.
+      return false;
+    }
+  };
   return (iss) => {
     if (iss.code !== "unrecognized_keys" || !iss.keys?.length) return undefined;
-    return formatUnrecognizedKeyMessage(iss.keys, knownKeys, requiredKeys, iss.input);
+    return formatUnrecognizedKeyMessage(iss.keys, knownKeys, requiredKeys, iss.input, fits);
   };
 }

--- a/src/orchestrator/unrecognized-keys.ts
+++ b/src/orchestrator/unrecognized-keys.ts
@@ -92,11 +92,15 @@ function distanceThreshold(a: string, b: string): number {
  * Prefer an affix match over a mere edit distance, so `group` → `group_id`
  * beats a coincidental neighbour of the same length.
  */
-export function suggestKnownKey(unknown: string, candidates: readonly string[]): string | undefined {
+export function suggestKnownKey(
+  unknown: string,
+  candidates: readonly string[],
+  fits?: FitsPredicate,
+  value?: unknown,
+): string | undefined {
   const folded = fold(unknown);
-  let best: string | undefined;
+  let tied: string[] = [];
   let bestScore = Infinity;
-  let bestCount = 0;
   for (const c of candidates) {
     if (c === unknown) continue;
     const fc = fold(c);
@@ -117,16 +121,24 @@ export function suggestKnownKey(unknown: string, candidates: readonly string[]):
       score = 1 + d;
     }
     if (score < bestScore) {
-      best = c;
       bestScore = score;
-      bestCount = 1;
+      tied = [c];
     } else if (score === bestScore) {
-      bestCount++;
+      tied.push(c);
     }
   }
-  // Two keys fit equally well: naming one of them is a guess wearing the same
-  // phrasing as a real match. Say nothing rather than pick.
-  return bestCount === 1 ? best : undefined;
+  if (tied.length === 1) return tied[0];
+  // The NAMES tie, so let the VALUE break it — but only when exactly one
+  // candidate would accept what the caller actually sent. `panel_edit_node`
+  // carries both `node_id` and `node_ids`, so `node: 5` ties on the name and
+  // is decided by the 5 (a scalar is not a `node_ids`). `panel_connect` called
+  // with `id: 5` stays ambiguous, because a number fits both endpoints — and
+  // there, naming one is a guess wearing the same phrasing as a real match.
+  if (tied.length > 1 && fits) {
+    const accepting = tied.filter((c) => fits(c, value));
+    if (accepting.length === 1) return accepting[0];
+  }
+  return undefined;
 }
 
 function providedKeys(input: unknown): Set<string> {
@@ -186,7 +198,7 @@ export function pairUnrecognizedKeys(
 
   const take = (unknown: string, pool: readonly string[]): void => {
     const leftover = pool.filter((k) => !used.has(k) && k !== unknown);
-    const match = suggestKnownKey(unknown, leftover);
+    const match = suggestKnownKey(unknown, leftover, fits, valueAt(input, unknown));
     if (!match) return;
     suggestions.set(unknown, { key: match, confident: true });
     used.add(match);

--- a/src/orchestrator/unrecognized-keys.ts
+++ b/src/orchestrator/unrecognized-keys.ts
@@ -86,7 +86,9 @@ function distanceThreshold(a: string, b: string): number {
 }
 
 /**
- * Closest known key, or undefined when nothing is close enough to recommend.
+ * Closest known key, or undefined when nothing is close enough to recommend
+ * OR when two candidates fit equally well.
+ *
  * Prefer an affix match over a mere edit distance, so `group` → `group_id`
  * beats a coincidental neighbour of the same length.
  */
@@ -94,28 +96,37 @@ export function suggestKnownKey(unknown: string, candidates: readonly string[]):
   const folded = fold(unknown);
   let best: string | undefined;
   let bestScore = Infinity;
+  let bestCount = 0;
   for (const c of candidates) {
     if (c === unknown) continue;
     const fc = fold(c);
     if (fc === folded) return c;
+    let score: number;
     if (isAffixMatch(unknown, c)) {
-      const score = Math.abs(c.length - unknown.length) / 100;
-      if (score < bestScore) {
-        best = c;
-        bestScore = score;
-      }
-      continue;
+      // #1969 review — every affix match is the SAME quality of evidence: the
+      // name is the other one plus a separator/suffix. Ranking them by length
+      // difference is not evidence, and it invented a winner — `panel_connect`
+      // called with `id` affix-matches both `from_node_id` and `to_node_id`,
+      // and the length tiebreak silently answered "did you mean 'to_node_id'?"
+      // on what is a coin flip.
+      score = 0;
+    } else {
+      const d = editDistance(folded, fc);
+      if (d > distanceThreshold(folded, fc)) continue;
+      // Affix scores are 0; offset typos so they cannot outrank an affix.
+      score = 1 + d;
     }
-    const d = editDistance(folded, fc);
-    if (d > distanceThreshold(folded, fc)) continue;
-    // Affix scores are < 1; offset typos so they cannot outrank an affix.
-    const score = 1 + d;
     if (score < bestScore) {
       best = c;
       bestScore = score;
+      bestCount = 1;
+    } else if (score === bestScore) {
+      bestCount++;
     }
   }
-  return best;
+  // Two keys fit equally well: naming one of them is a guess wearing the same
+  // phrasing as a real match. Say nothing rather than pick.
+  return bestCount === 1 ? best : undefined;
 }
 
 function providedKeys(input: unknown): Set<string> {


### PR DESCRIPTION
Closes #1969.

**Four commits, and the review provenance differs between them** — please read that before the diff:

| commit | author | review status |
|---|---|---|
| `90d9cf6` — the mechanism | grok-swarm | **independently reviewed by me**, in a worktree I cut myself. Three defects found, fixed in the commits below. |
| `944caab` — a structural join is not a claim about intent | me | **NOT independently reviewed** |
| `c54470b` — two keys that fit equally well are a refusal | me | **NOT independently reviewed** |
| `0c792b5` — let the value settle a name tie before refusing | me | **NOT independently reviewed**, and it exists only because `c54470b` was wrong |

The three findings, in the order I found them, all instances of one principle — *say the true thing, not the decisive thing*:

1. **`944caab`** — the structural 1:1 rule guessed a target for any stray key on the 34 tools that take exactly one required key.
2. **`c54470b`** — the name-match rules broke a two-way tie by string length, inventing a winner on `panel_connect`.
3. **`0c792b5`** — fixing (2) by refusing on every tie silenced `panel_edit_node {node:5}`, which the original ranking got right. A tie is now settled by the value when the value can settle it.

Detail and mutation evidence for (2) and (3) is in the PR comments rather than repeated here.

## How this PR came to exist

grok-swarm claimed #1969 at 07:06Z, pushed `90d9cf6` at 07:22Z, and then stalled before opening a PR — its siblings from the same batch (#1972 → #1980, #1973 → #1981) both got PRs, this one did not. No live process, worktree idle and clean. Rather than duplicate it and repeat the #1887 loss, I reviewed it and finished it. The mechanism is grok's and is kept intact.

## What `90d9cf6` does (grok's, reviewed)

Ask 2 of #1969: a rejected call used to name the unknown key and the missing required one as **two separate issues** —

```
unrecognized_keys: ["group"]
expected number, received undefined at group_id
```

A frontier model joins those. A 2–4B fine-tune trained only on server-verified successes has never seen the error-to-recovery transition and cannot. So a Zod error map installed at `strictPanelSchema` puts the join in one sentence: `Unrecognized key 'group' — did you mean 'group_id'?`

It is a **suggestion, not an alias** — the call is still refused. That is the complement of #1985, which aliases four specific keys; this covers the other ~90 tools' keys, which nothing aliases.

**What my review confirmed:**
- **Both transports carry it.** grok's test only exercises the MCP SDK path (`registerPanelTools`, Codex backend). I probed the **Anthropic SDK path** (`createPanelMcpServer`, the Claude backend — the primary one) at runtime and the message arrives intact on the wire: `"message": "Unrecognized key 'group' — did you mean 'group_id'?"`. Measured, not read off the shared `strictPanelSchema` call.
- **`tools/list` is unaffected.** The emitted JSON Schema for `panel_remove_group` is byte-clean — `additionalProperties:false` preserved, no leakage of the error function. 95 tools still register.
- **Acceptance is unchanged** — the canonical key still reaches the handler.

## The defect I found — `944caab`

`pairUnrecognizedKeys` has three rules. Rules 1–2 match on the **name** (`group` → `group_id` by affix/edit distance). Rule 3 is a **structural** fallback: if exactly one unknown key and exactly one missing required key are left over, join them even when the names are nothing alike — which is how the reporter's `todos` → `items` gets caught.

Rule 3 fires on **counts, not meaning**, and I measured that **34 of the 95 registered panel tools take exactly one required key**. So before this fix, every one of them answered *any* stray key with a confident guess:

```
panel_remove_node { dry_run: true }
  → "Unrecognized key 'dry_run' — did you mean 'node_id'?"
```

Phrased identically to the true `group` → `group_id` case and **indistinguishable from it by exactly the 2–4B models this change exists to serve**. So the model acts on the wrong repair — moves the value into `node_id`, fails again on a type error. That is the failure this PR is supposed to remove, reintroduced one rule further down.

Worth naming: grok's suite *does* test "does not invent a target" — but against `panel_graph_outline`, an **all-optional** tool, which has no required key and therefore structurally cannot reach rule 3. The test picked the one case that cannot exhibit the defect.

**The fix splits the two claims rather than deleting rule 3**, because rule 3 is what serves the reporter's own case:

- Rules 1–2 matched on the name → stay `— did you mean 'X'?`
- Rule 3 → promoted to `did you mean` **only when the value the caller actually sent also parses under the target's schema**; otherwise it states the fact it knows: `— required key 'node_id' is missing`.

Both halves of the join still arrive in one sentence, which was the ask. The difference is that the sentence no longer asserts intent it cannot know.

`todos` → `items` survives as a confident suggestion, because the todo array they sent **is** a valid `items`. Measured across the surface, the value check suppresses **133 of 170** false joins while keeping every true positive.

## Evidence

- **Full suite on the PR head `0c792b5`: 615/616 files, 11,252 passed, 4 skipped.** Also run on grok's `90d9cf6` alone (11,240 passed) to separate its result from mine. The single failure is `package-hooks.test.ts > every entry in 'files' exists on disk`, and the missing entry is `dist` — a build output absent from a never-built worktree. Harness artifact, not grok's change, and named here rather than waved off.
- Typecheck clean. `check:vocabulary` OK (1758 files). `check:unknown-collapse` OK.
- **27 tests** in the file (15 grok's, 12 added by the review), all driving a real `McpServer` + `Client` rather than calling handlers directly — the string an agent reads is produced by the SDK's renderer, so a schema-level assertion would be checking a different sentence than the one that reaches them.
- **Mutation-tested, each mutation verified to have actually applied before its result was believed:**
  - rule 3 forced back to always-confident → **3 tests fail**, including the real-surface `panel_remove_node` one.
  - **`fits` unwired from the production error map** (the call site, not the helper) → **2 tests fail, one of them grok's own** `panel_set_todo` test. That is the wiring proof: the predicate is load-bearing in production, and grok's test is what guards the reporter's case.

## What I deliberately did not do

- **No panel-repo change, so no Playwright run.** Every command and field the panel receives is unchanged; this is orchestrator-side validation text only. I did not run the browser suite and am not implying that coverage. No live rig was reachable either, so there is **no live verification** here.
- **No aliasing.** `group` is still refused, not accepted — #1985 owns the aliases. If #1985 lands first these two overlap on four keys and this PR still covers the rest of the surface; the two touch adjacent lines in `panel-tools.ts` and whichever merges second will want a trivial rebase.
- **Did not close the residual.** 37 of 170 false joins survive the value check — a string-valued stray key on a tool whose one required key is also a string (`panel_remove_mcp {notes:"…"}` → `did you mean 'name'?`). Narrowing that further needs semantics the schema does not carry, and I would rather leave it visible than guess.
- **Ask 4 of #1969 is not addressed here and cannot be.** Regenerating `artokun/comfyui-mcp-trajectories` with failed-then-corrected pairs is a training-pipeline change, not a repo change. Noted on the issue.

## Review — PENDING

Not merged on my own say-so. `@grok` please review, and **start with `944caab`, which nobody but its author has read.** The load-bearing claim is that **value-compatibility is a sound proxy for "did the caller mean this key"**. Attack that first — specifically:

1. Is there a panel tool where the value legitimately parses under the missing required key but the caller plainly meant something else, so the confident phrasing is still wrong?
2. `fits` runs `safeParse` with caller-controlled input during **error formatting**. Two panel fields carry `.transform()`. I believe both are pure and any throw is caught, but that is the place a validation refusal could turn into a 500.
3. The unconfident sentence `— required key 'node_id' is missing` is new wording on a hot path. Is it actually more actionable to a small model than the wrong-but-decisive `did you mean`? That is a judgement call and I may have it backwards.
