### PR TITLE
docs: unslop CONTRIBUTING, ROADMAP, llms-install, and plugin command/agent prompts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to comfyui-mcp
 
-Thanks for your interest in improving **comfyui-mcp** — an MCP server (and Claude Code plugin)
+Thanks for your interest in improving comfyui-mcp, an MCP server (and Claude Code plugin)
 that lets an AI agent drive [ComfyUI](https://github.com/comfyanonymous/ComfyUI). This guide covers
 the dev setup, project conventions, how to add a tool, and how releases work.
 
@@ -8,8 +8,8 @@ By contributing you agree your contributions are licensed under the project's [M
 
 ## Getting started
 
-Requirements: **Node ≥ 22** and npm (the repo is committed with `package-lock.json`; npm is the
-supported dev path).
+You need Node 22 or newer and npm. The repo is committed with `package-lock.json`, and npm is the
+supported dev path.
 
 ```bash
 git clone https://github.com/artokun/comfyui-mcp
@@ -19,17 +19,17 @@ npm run build      # tsc → dist/
 npm test           # vitest
 ```
 
-- **`npm run build`** — type-checks and compiles to `dist/` (`tsc`).
-- **`npm run lint`** — type-check only (`tsc --noEmit`).
-- **`npm test`** / **`npm run test:watch`** — the vitest suite.
-- **`npm run dev`** — run the server from source via `tsx`.
-- **`npm run docs:gen`** — rebuild the docs tool reference from the live schemas (see [Docs](#documentation)).
+- `npm run build` type-checks and compiles to `dist/` (`tsc`).
+- `npm run lint` type-checks only (`tsc --noEmit`).
+- `npm test` and `npm run test:watch` run the vitest suite.
+- `npm run dev` runs the server from source via `tsx`.
+- `npm run docs:gen` rebuilds the docs tool reference from the live schemas (see [Docs](#documentation)).
 
-> **pnpm users:** pnpm 10 blocks dependency build scripts unless allow-listed. The native deps are
-> already declared in `package.json` `pnpm.onlyBuiltDependencies` (`better-sqlite3`, `sharp`); if you
+> pnpm 10 blocks dependency build scripts unless they are allow-listed. The native deps are
+> already declared in `package.json` `pnpm.onlyBuiltDependencies` (`better-sqlite3`, `sharp`). If you
 > add a dependency that needs a build step at runtime, add it there too.
 
-Before opening a PR, make sure **`npm run build` and `npm test` both pass**.
+Before opening a PR, make sure `npm run build` and `npm test` both pass.
 
 ## Project layout
 
@@ -46,26 +46,26 @@ docs/           # Mintlify docs site (tool reference is GENERATED — see below)
 plugin/         # the Claude Code plugin (skills, agents, slash commands, hooks)
 ```
 
-**Separation of concerns:** business logic lives in `src/services/<name>.ts`; the matching
+Business logic lives in `src/services/<name>.ts`. The matching
 `src/tools/<name>.ts` is a thin wrapper that defines the MCP tool and calls the service.
 
 ## Conventions
 
-- **ESM** — this is an ESM package; **relative imports must use the `.js` extension**
+- **ESM.** This is an ESM package, so relative imports must use the `.js` extension
   (`import { foo } from "./foo.js"`), even from `.ts` files.
-- **Errors** — throw typed errors from `src/utils/errors.ts` (`ComfyUIError`, `ValidationError`,
-  `ProcessControlError`, …) and convert them at the tool boundary with `errorToToolResult(err)`.
-- **Local vs remote** — comfyui-mcp can target a remote ComfyUI (`--comfyui-url`). Tools that need a
-  local install must read `config.comfyuiPath` and throw a clear error when it's undefined.
-- **Security** (please respect these — they're enforced in review):
-  - Secrets (API tokens, registry keys, cloud credentials) travel in **headers or env**, never in
+- **Errors.** Throw typed errors from `src/utils/errors.ts` (`ComfyUIError`, `ValidationError`,
+  `ProcessControlError`, and the rest) and convert them at the tool boundary with `errorToToolResult(err)`.
+- **Local vs remote.** comfyui-mcp can target a remote ComfyUI (`--comfyui-url`). Tools that need a
+  local install must read `config.comfyuiPath` and throw a clear error when it is undefined.
+- **Security.** Review enforces these:
+  - Secrets (API tokens, registry keys, cloud credentials) travel in headers or env, never in
     URLs, argv, or logs. Redact secrets from any logged URL.
-  - Validate filesystem paths against traversal/symlink escapes (resolve + contain to the intended root).
-  - Validate values that reach a subprocess argv (reject leading `-` / control chars; use
-    `--end-of-options` for git, etc.).
-- **Plugin skills** (`plugin/skills/<name>/SKILL.md`) — every skill ends with a
-  `## Sources` section that distinguishes **Official** (vendor docs, node README,
-  `/object_info`) from **Empirical** (working graphs, observed behaviour). A skill
+  - Validate filesystem paths against traversal and symlink escapes (resolve the path, then check it stays inside the intended root).
+  - Validate values that reach a subprocess argv (reject a leading `-` and control chars; use
+    `--end-of-options` for git, and the equivalent for other tools).
+- **Plugin skills.** Every skill (`plugin/skills/<name>/SKILL.md`) ends with a
+  `## Sources` section that separates **Official** sources (vendor docs, node README,
+  `/object_info`) from **Empirical** ones (working graphs, observed behaviour). A skill
   with no vendor documentation says so (`none found`) rather than leaving the
   question unanswered. `list_packs` `action:"generate_skill"` emits this section
   automatically.
@@ -74,30 +74,30 @@ plugin/         # the Claude Code plugin (skills, agents, slash commands, hooks)
 
 Use `src/tools/registry-search.ts` and `src/tools/process-control.ts` as canonical examples.
 
-1. **Service** — add `src/services/<name>.ts` with the logic and an exported function. Keep network
-   in `fetch`, subprocess in `node:child_process`. Make I/O seams injectable so they're testable.
-2. **Tool** — add `src/tools/<name>.ts` exporting `registerXxxTools(server: McpServer): void`. Inside,
+1. **Service.** Add `src/services/<name>.ts` with the logic and an exported function. Keep network
+   in `fetch`, subprocess in `node:child_process`. Make I/O seams injectable so they are testable.
+2. **Tool.** Add `src/tools/<name>.ts` exporting `registerXxxTools(server: McpServer): void`. Inside,
    call `server.tool(name, description, zodShape, handler)`. Handlers return
    `{ content: [{ type: "text" as const, text }] }` and wrap failures with `errorToToolResult(err)`.
-3. **Wire it** — add one import and one `registerXxxTools(server);` call in `src/tools/index.ts`,
-   **before** `await registerAutoloadedWorkflows(server);`.
-4. **Categorize for docs** — add the new tool name to the right category in
-   `scripts/gen-tool-docs.ts` (`CATEGORIES`), then run `npm run docs:gen` (it warns about any
-   uncategorized tool).
-5. **Test** — add `src/__tests__/…` mirroring the source path. Mock `global.fetch`,
-   `node:child_process`, and `node:fs` — **no real network, disk, or process side effects**.
+3. **Wire it.** Add one import and one `registerXxxTools(server);` call in `src/tools/index.ts`,
+   before `await registerAutoloadedWorkflows(server);`.
+4. **Categorize for docs.** Add the new tool name to the right category in
+   `scripts/gen-tool-docs.ts` (`CATEGORIES`), then run `npm run docs:gen`. It warns about any
+   uncategorized tool.
+5. **Test.** Add `src/__tests__/…` mirroring the source path. Mock `global.fetch`,
+   `node:child_process`, and `node:fs`. No real network, disk, or process side effects.
 
 ### Tool descriptions matter
 
 Descriptions are the agent's only guide to a tool. Write them to answer three questions:
-**what it does to the world** (read-only? mutates disk? requires a running server? irreversible?),
-**when to use it vs. a sibling tool**, and **what each parameter means beyond its type**. Don't just
-restate the schema. (This is graded by Glama's TDQS — see the [blog post](https://comfyui-mcp.artokun.io/docs/blog/comfyui-mcp-tdqs-case-study).)
+what it does to the world (read-only? mutates disk? requires a running server? irreversible?),
+when to use it instead of a sibling tool, and what each parameter means beyond its type. Don't just
+restate the schema. Glama's TDQS grades this; see the [blog post](https://comfyui-mcp.artokun.io/docs/blog/comfyui-mcp-tdqs-case-study).
 
 ## Documentation
 
-The hosted docs live in `docs/` (Mintlify). The **Tool Reference is generated** from the live tool
-schemas — **do not hand-edit `docs/tools/*.mdx`**. After changing any tool (name, description,
+The hosted docs live in `docs/` (Mintlify). The Tool Reference is generated from the live tool
+schemas, so do not hand-edit `docs/tools/*.mdx`. After changing any tool (name, description,
 params), run:
 
 ```bash
@@ -109,51 +109,51 @@ Run `cd docs && npx mint broken-links` to validate links.
 
 ### Blog posts and translated pages
 
-`docs/blog/*.mdx` and `docs/<locale>/*.mdx` are covered by their own gates — a `## Licensing`
-section is required on model posts, model and script filenames are checked against the pack
+`docs/blog/*.mdx` and `docs/<locale>/*.mdx` have their own gates. Model posts need a `## Licensing`
+section, model and script filenames are checked against the pack
 that ships them, and translated pages are compared structurally to their English source. Those
 run in `npm test`.
 
-Two related checks do **not**: `node scripts/asset-counts.mjs --check` (advertised counts vs the
-live registry) runs in CI and needs a fresh `dist/`, and `node scripts/check-docs-deployed.mjs`
-(every nav page actually serves) runs only when you invoke it against a published site.
+Two related checks do not run there. `node scripts/asset-counts.mjs --check` (advertised counts against the
+live registry) runs in CI and needs a fresh `dist/`. `node scripts/check-docs-deployed.mjs`
+(every nav page serves) runs only when you invoke it against a published site.
 
-Read **[design/writing-blog-posts.md](design/writing-blog-posts.md)** before writing one. It
-also documents the Mintlify caveats that make a page fail to build — including the one page
-that has never built and why — and a short list of things previously believed about this build
+Read [design/writing-blog-posts.md](design/writing-blog-posts.md) before writing one. It
+also documents the Mintlify caveats that make a page fail to build, including the one page
+that has never built and why, and a short list of things previously believed about this build
 that turned out, on measurement, to be false.
 
 ## Optional / experimental dependencies
 
 Cloud storage (`@aws-sdk/client-s3`, `@azure/storage-blob`) and the experimental agent-panel POC
-(`ai`, `@ai-sdk/*`, `cloudflared`) power optional/flag-gated features. Keep new heavy or
-feature-specific dependencies out of the core hot path, and prefer lazy/dynamic imports so a base
-install stays lean.
+(`ai`, `@ai-sdk/*`, `cloudflared`) are only needed by optional, flag-gated features. Keep new heavy or
+feature-specific dependencies out of the core hot path, and prefer lazy or dynamic imports so a base
+install stays small.
 
 ## Commits & pull requests
 
-- **Branch** off `main` (`feat/…`, `fix/…`, `docs/…`).
-- Use **Conventional Commit** prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`).
+- Branch off `main` (`feat/…`, `fix/…`, `docs/…`).
+- Use Conventional Commit prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`).
 - Keep PRs focused; include tests for behavior changes.
-- **PR checklist:** `npm run build` ✓ · `npm test` ✓ · docs regenerated if tools changed ✓ ·
-  a clear description of what and why.
-- **When you add or touch a predicate, ask what it returns when the observation
-  FAILS.** If that is the same value it returns for a genuine negative, you have
-  written the most common defect in this codebase: "I could not determine this"
-  collapsing into "I determined it is not so." The user is then told a confident
-  wrong answer — a pack reported "not installed" by code that never reached the
+- Before opening the PR, check that `npm run build` passes, `npm test` passes, the docs are
+  regenerated if tools changed, and the description says what changed and why.
+- When you add or touch a predicate, ask what it returns when the observation
+  FAILS. If that is the same value it returns for a genuine negative, you have
+  written the most common defect in this codebase. "I could not determine this"
+  collapses into "I determined it is not so", and the user is told a confident
+  wrong answer. Examples from this repo: a pack reported "not installed" by code that never reached the
   disk, a port reported free by a lookup that failed, a download reported
   verified after an unverified server swap. Give unknown its own representation
-  (`yes | no | unknown`, or a tagged result), and **test the failed observation,
-  not just the negative answer** — every instance found so far had tests, and
+  (`yes | no | unknown`, or a tagged result), and test the failed observation,
+  not just the negative answer. Every instance found so far had tests, and
   none of them tested the probe failing. `npm run check:unknown-collapse` catches
-  the common written form; it cannot catch the shape, only you can.
+  the common written form. It cannot catch the shape; only you can.
 
-Open a GitHub issue first for large or potentially-breaking changes so we can align on the approach.
+Open a GitHub issue first for large or potentially breaking changes so we can align on the approach.
 
 ## Releases (maintainers)
 
-Releases are automated — **never `npm publish` manually**. Bump + tag, and pushing the `v*` tag
+Releases are automated. Never run `npm publish` by hand. Bump and tag; pushing the `v*` tag
 triggers the GitHub Actions workflow that publishes to npm with provenance (OIDC):
 
 ```bash
@@ -162,9 +162,9 @@ npm run release:minor  # minor
 npm run release:major  # major
 ```
 
-Each script runs `npm version <bump>` (creating the commit + tag) and `git push --follow-tags`.
+Each script runs `npm version <bump>` (creating the commit and tag) and `git push --follow-tags`.
 Update `CHANGELOG.md` (Keep a Changelog) and rebuild the docs before tagging.
 
 ## Questions
 
-Open a [GitHub issue](https://github.com/artokun/comfyui-mcp/issues) or start a discussion. Thanks for contributing! 🎨
+Open a [GitHub issue](https://github.com/artokun/comfyui-mcp/issues) or start a discussion. Thanks for contributing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,33 @@
 # ComfyUI MCP — Roadmap
 
-**Vision:** an agent can author, run, *fix*, and *ship* ComfyUI — from a prompt, to a working
-workflow, to an in-UI assistant that edits the graph live, to a published custom node. comfyui-mcp
-is the backend tool surface; the pieces below extend it up into the ComfyUI frontend and out to the
-Comfy Registry.
+The goal is an agent that can author, run, *fix*, and *ship* ComfyUI. It starts from a prompt,
+produces a working workflow, edits the graph live from an in-UI assistant, and ends at a published
+custom node. comfyui-mcp is the backend tool set; the pieces below extend it up into the ComfyUI
+frontend and out to the Comfy Registry.
 
-> Tracking: themes map to beads **epics**; items map to issues. Run `bd ready` for what's actionable.
+> Themes map to beads epics and items map to issues. Run `bd ready` for what is actionable.
 > This file is the human-readable map; beads is the source of truth for status.
 
 ---
 
 ## Status — 2026-05-26
 
-- **Released:** `0.7.0` on npm — Theme E stability/hardening (E1–E4, E7, E2-auth), custom-node
-  authoring tools, experimental agent-panel backend, hosted docs.
-- **Complete (on main, unreleased → queued for `0.8.0`):** Theme E additive (E5 `apply_manifest`,
+- **Released.** `0.7.0` on npm, carrying Theme E stability and hardening (E1 to E4, E7, E2-auth), custom-node
+  authoring tools, the experimental agent-panel backend, and hosted docs.
+- **Complete on main, unreleased, queued for `0.8.0`.** Theme E additive (E5 `apply_manifest`,
   E6/E2b cloud storage, E8 `get_image (action:"convert")`), Theme C (C3 `node_pack` (`action: "verify"`), C5 scaffold CI),
-  Theme D (D1 `comfy-researcher` + skill cache). **Epics A, C, D, E are closed.**
-- **Pending release:** cut **`0.8.0`** for the unreleased surface above — `comfyui-mcp-yrp` (see beads).
-- **Blocked:** **Theme B** (embedded agent panel UI, B3–B6) is gated on the upstream
-  **`@comfyorg/extension-api`** package being published to npm (PRs #12142–#12145 still open). The
-  panel *backend* POC (B1/B2) already shipped. Tracked by a watch bead under Epic B; resume the
+  Theme D (D1 `comfy-researcher` + skill cache). Epics A, C, D, E are closed.
+- **Pending release.** Cut `0.8.0` for the unreleased work above. Tracked as `comfyui-mcp-yrp` in beads.
+- **Blocked.** Theme B (embedded agent panel UI, B3 to B6) waits on the upstream
+  `@comfyorg/extension-api` package being published to npm (PRs #12142 to #12145 still open). The
+  panel *backend* POC (B1/B2) already shipped. A watch bead under Epic B tracks it; resume the
   codex build loop on B once the package lands.
 
 ---
 
-## ✅ Shipped (0.6.x)
+## Shipped (0.6.x)
 - comfy-cli capability port (custom-node mgmt, snapshots, bisect, workflow deps, install/update,
-  models, workspace/env, API nodes, manager config) — tools surface ~70+.
+  models, workspace/env, API nodes, manager config), which took the tool count past 70.
 - `upload_image (action:"video")` / `upload_image (action:"audio")`.
 - Mintlify docs site (schema-generated tool reference) at comfyui-mcp.artokun.io/docs.
 - Glama listing + TDQS A-grade pass; blog post (TDQS case study).
@@ -36,134 +36,134 @@ Comfy Registry.
 
 ## Theme A — Frontend extension authoring (enabler)
 The new ComfyUI frontend extension API (`@comfyorg/extension-api`, v2; replaces
-`app.registerExtension`) is brand-new and absent from model training data. Teach it so we (and any
-user) can write correct frontend extensions — the substrate for Theme B.
+`app.registerExtension`) is absent from model training data. Teach it so we (and any
+user) can write correct frontend extensions. Theme B builds on it.
 
-- **A1 — Skill: author v2 extensions.** `defineNode`/`defineExtension`/`defineWidget`,
+- **A1. Skill for authoring v2 extensions.** `defineNode`/`defineExtension`/`defineWidget`,
   `defineSidebarTab`, `NodeHandle`/`WidgetHandle`, event namespaces (`execution`/`graph`/`server`/
   `workbench`), `DisposableHandle` contract, identity helpers, the event+getter/setter idiom.
-- **A2 — Skill: migrate v1 → v2.** Map legacy `app.registerExtension` / prototype-patching patterns
+- **A2. Skill for migrating v1 to v2.** Map legacy `app.registerExtension` and prototype-patching patterns
   to the v2 API (the ecosystem dashboard's api-diff/patterns are the source). DrJKL collaboration hook.
-  > Source: `Comfy-Org/ComfyUI_frontend` PRs #12142–#12145; `src/extension-api/`. Package not yet on npm.
+  > Source: `Comfy-Org/ComfyUI_frontend` PRs #12142 to #12145; `src/extension-api/`. Package not yet on npm.
 
 ## Theme B — Embedded agent panel (north star)
-A ComfyUI **sidebar tab** (AI icon) hosting an [AI SDK](https://sdk.vercel.ai) chat window. You chat
-with Claude Code / Codex / Gemini and it reads + **fixes the live workflow in the UI**. Connection
-to the agent "app" is via a **cloudflared tunnel** (Ungate-style). Full design:
+A ComfyUI sidebar tab (AI icon) hosting an [AI SDK](https://sdk.vercel.ai) chat window. You chat
+with Claude Code, Codex, or Gemini and it reads and fixes the live workflow in the UI. The panel reaches
+the agent "app" through a cloudflared tunnel (Ungate-style). The full design is in
 [`design/embedded-agent-panel.md`](./design/embedded-agent-panel.md).
 
-- **B1 — Tunnel helper.** Port Ungate's `tunnel-manager` (the `cloudflared` npm lib:
+- **B1. Tunnel helper.** Port Ungate's `tunnel-manager` (the `cloudflared` npm lib;
   `Tunnel.quick(localUrl) → public https URL`) into our server as `startQuickTunnel(port)`, behind a flag.
-- **B2 — AI SDK chat endpoint.** `POST /api/chat` → `streamText(...).toUIMessageStreamResponse()`,
-  provider registry (Anthropic/OpenAI/Google), one real server-side tool end-to-end.
-- **B3 — Sidebar panel.** `defineSidebarTab` + AI SDK `useChat` pointed at the tunnel; render stream.
-- **B4 — Live graph edits.** Graph-mutation tools (`set_widget_value`, `add_node`, `connect`, …) as
-  AI SDK **client-side tools** resolved in the panel via extension-api (`NodeHandle`/`WidgetHandle`).
-  *This is the magic — "fix it in the UI."*
-- **B5 — Wire comfyui-mcp** as the server-side tool surface via AI SDK MCP client.
-- **B6 — Provider switch + connection/key UX + ship** as a node pack.
+- **B2. AI SDK chat endpoint.** `POST /api/chat` backed by `streamText(...).toUIMessageStreamResponse()`,
+  a provider registry (Anthropic/OpenAI/Google), and one real server-side tool end-to-end.
+- **B3. Sidebar panel.** `defineSidebarTab` + AI SDK `useChat` pointed at the tunnel; render stream.
+- **B4. Live graph edits.** Graph-mutation tools (`set_widget_value`, `add_node`, `connect`, and more) as
+  AI SDK client-side tools resolved in the panel via extension-api (`NodeHandle`/`WidgetHandle`).
+  *This is the payoff, "fix it in the UI."*
+- **B5. Wire comfyui-mcp** as the server-side tool set via the AI SDK MCP client.
+- **B6. Provider switch, connection/key UX, and ship** as a node pack.
 
 ## Theme C — Custom-node authoring lifecycle (NEW)
-Create a Python custom node from a template, install + restart to test, then publish to the
-[Comfy Registry](https://docs.comfy.org/registry/overview). The full "agent builds & ships a node" loop.
+Create a Python custom node from a template, install and restart to test, then publish to the
+[Comfy Registry](https://docs.comfy.org/registry/overview). The full "agent builds and ships a node" loop.
 
-- **C1 — Skill: ComfyUI Registry + custom-node authoring.** Minimal node structure
+- **C1. Skill for the ComfyUI Registry and custom-node authoring.** Minimal node structure
   (`__init__.py`, `NODE_CLASS_MAPPINGS`/`NODE_DISPLAY_NAME_MAPPINGS`, `INPUT_TYPES`/`RETURN_TYPES`/
-  `FUNCTION`/`CATEGORY`, optional `WEB_DIRECTORY`), `pyproject.toml` (`[project]` + `[tool.comfy]`:
+  `FUNCTION`/`CATEGORY`, optional `WEB_DIRECTORY`), `pyproject.toml` (`[project]` + `[tool.comfy]` with
   `PublisherId`/`DisplayName`/`Icon`), publisher + API key flow, `comfy node init`/`publish`, the
   `Comfy-Org/publish-node-action` CI workflow + `REGISTRY_ACCESS_TOKEN`.
-- **C2 — MCP `node_pack` (`action: "scaffold"`).** Generate a node pack into `custom_nodes/<name>/` from a
+- **C2. MCP `node_pack` (`action: "scaffold"`).** Generate a node pack into `custom_nodes/<name>/` from a
   template (prefer `comfy node init`; fall back to our own template). Local-only.
-- **C3 — Test loop.** Install → `restart_comfyui` (have it) → verify the new `class_type` appears in
-  `/object_info` → enqueue a smoke-test workflow using it.
-- **C4 — MCP `node_pack` (`action: "publish"`).** `comfy node publish` with token; validate `pyproject.toml`
+- **C3. Test loop.** Install, then `restart_comfyui` (have it), then verify the new `class_type` appears in
+  `/object_info`, then enqueue a smoke-test workflow using it.
+- **C4. MCP `node_pack` (`action: "publish"`).** `comfy node publish` with token; validate `pyproject.toml`
   metadata first. Token via env (never in URLs/logs), like the CivitAI pattern.
-- **C5 — Template + CI scaffold.** A spawnable starter (Python node + optional v2 frontend +
-  `publish_action.yml`) so `create → restart → test → publish` is one smooth path.
+- **C5. Template + CI scaffold.** A spawnable starter (Python node + optional v2 frontend +
+  `publish_action.yml`) so `create → restart → test → publish` is one path.
 
 ## Theme D — Discovery (from prior notes)
-- **D1 — `comfy-researcher` agent + skill cache.** Problem→packs research over the Registry +
-  HF + community, with a cached skill layer. (Folded in from `TODO.md`.)
+- **D1. `comfy-researcher` agent + skill cache.** Problem-to-packs research over the Registry,
+  HF, and the community, with a cached skill layer. (Folded in from `TODO.md`.)
 
 ## Theme E — Production hardening & I/O (from [Salad's comfyui-api](https://github.com/SaladTechnologies/comfyui-api), MIT)
 Harden existing tools and add production I/O, adapting patterns from comfyui-api. We are an
-agent-facing MCP, not a horizontally-scaled web service — so we cherry-pick and skip the
-stateless-server / Salad-specific bits (replicas, deletion-cost, k8s proxy).
+agent-facing MCP, not a horizontally scaled web service, so we cherry-pick and skip the
+stateless-server and Salad-specific bits (replicas, deletion-cost, k8s proxy).
 
 **Harden existing tools**
-- **E1 — Download cache + dedup.** Content-address downloads (SHA-256 of URL → cache dir + sidecar
-  `.meta`, symlink to target), reuse on hit, coalesce concurrent same-URL fetches, optional LRU
+- **E1. Download cache + dedup.** Content-address downloads (the SHA-256 of the URL names the cache dir entry
+  plus a sidecar `.meta`, symlinked to the target), reuse on hit, coalesce concurrent same-URL fetches, optional LRU
   eviction. Hardens `download_model` (`action:"download"` / `action:"download_civitai"`). (`remote-storage-manager.ts`, `utils.hashUrlBase64`)
-- **E2 — Download auth + storage backends.** Per-URL credential resolution (bearer/basic/header/
-  query/s3) and `s3://` / huggingface / azure-blob / http(s) sources for gated/private models.
+- **E2. Download auth + storage backends.** Per-URL credential resolution (bearer/basic/header/
+  query/s3) and `s3://`, huggingface, azure-blob, and http(s) sources for gated or private models.
   (`credential-resolver.ts`, `storage-providers/*`)
-- **E3 — ComfyUI supervision.** Auto-restart-on-crash + bounded startup readiness checks
-  (interval/max-tries) + a real readiness signal. Hardens `start/stop/restart_comfyui`. (`comfy.ts`)
-- **E4 — Rich errors + execution stats.** Surface ComfyUI `execution_error` (exception_type,
-  traceback, current_inputs — e.g. OOM) and per-node timing in job results. Hardens
+- **E3. ComfyUI supervision.** Auto-restart on crash, bounded startup readiness checks
+  (interval/max-tries), and a real readiness signal. Hardens `start/stop/restart_comfyui`. (`comfy.ts`)
+- **E4. Rich errors + execution stats.** Report ComfyUI `execution_error` (exception_type,
+  traceback, current_inputs, for example OOM) and per-node timing in job results. Hardens
   `queue` (action:"status")/completion reporting. (`event-emitters.ts`)
-- **E7 — Custom-node ref-pinning.** Install a node pack pinned to a commit/branch/tag across
-  GitHub/GitLab/Bitbucket URL formats. Hardens `install_custom_node` (reproducibility). (`git-url-parser.ts`)
-- **E11 — Unique output filenames.** Prefix a request id to output filenames to avoid collisions.
+- **E7. Custom-node ref-pinning.** Install a node pack pinned to a commit, branch, or tag across
+  GitHub, GitLab, and Bitbucket URL formats. Hardens `install_custom_node` (reproducibility). (`git-url-parser.ts`)
+- **E11. Unique output filenames.** Prefix a request id to output filenames to avoid collisions.
 
 **Additive capabilities**
-- **E5 — Declarative environment manifest.** `apply_manifest` (yaml/json): apt/pip/custom_nodes/
-  models (before/after start), idempotent — reproducible setups. Pairs with Theme C + workspace.
-- **E6 — Output upload to cloud storage.** Push generated outputs to S3 / Azure / HF / HTTP and
+- **E5. Declarative environment manifest.** `apply_manifest` (yaml/json) covers apt, pip, custom_nodes, and
+  models (before/after start) and is idempotent, so setups are reproducible. Pairs with Theme C + workspace.
+- **E6. Output upload to cloud storage.** Push generated outputs to S3, Azure, HF, or HTTP and
   return URLs. (`remote-storage-manager.ts`, `storage-providers/*`)
-- **E8 — Server-side image conversion.** `sharp` PNG↔JPEG↔WebP + quality options for compact outputs. (`image-tools.ts`)
-- **E9 — Dynamic model loading.** URL in a model-loading node → auto-download + cache before exec. (`comfy-node-preprocessors.ts`)
-- **E10 — Warmup.** Run a warmup workflow after `restart_comfyui (action:"start")` to preload models. (`comfy.warmupComfyUI`)
-- **E12 — Outbound webhooks (later).** Signed Standard Webhooks on completion/progress + retries —
+- **E8. Server-side image conversion.** `sharp` PNG↔JPEG↔WebP + quality options for compact outputs. (`image-tools.ts`)
+- **E9. Dynamic model loading.** A URL in a model-loading node triggers auto-download and caching before exec. (`comfy-node-preprocessors.ts`)
+- **E10. Warmup.** Run a warmup workflow after `restart_comfyui (action:"start")` to preload models. (`comfy.warmupComfyUI`)
+- **E12. Outbound webhooks (later).** Signed Standard Webhooks on completion/progress with retries,
   mainly for the headless/bridge path, not the interactive plugin. (`event-emitters.ts`)
 
-> License: comfyui-api is MIT (deps MIT/Apache-2.0; ComfyUI itself GPL-3.0). Patterns/code are safe
-> to adapt with attribution. Clone for reference: `~/code/salad-comfyui-api`.
+> comfyui-api is MIT (deps MIT/Apache-2.0; ComfyUI itself GPL-3.0). Patterns and code are safe
+> to adapt with attribution. A reference clone lives at `~/code/salad-comfyui-api`.
 
 ## Theme F — Agentic mobile / remote client (teased, not yet building)
-A purely **agent-driven** way to make things from your phone, backed by an agent that runs on your
-own machine. Most people should never see a node graph — you chat, the agent builds it; the canvas
-still exists under the hood, it just isn't the interface. Full vision:
+An agent-driven way to make things from your phone, backed by an agent that runs on your
+own machine. Most people should never see a node graph. You chat, the agent builds it; the canvas
+still exists under the hood, it just isn't the interface. The full vision is in
 [`design/mobile-agent-client.md`](./design/mobile-agent-client.md). Gated on the core (Themes B/E)
 hardening first; this is the "shape it with users before building" track.
 
-- **F1 — Desktop agent host (runs like Ollama).** A quiet always-on daemon that owns the agent loop,
-  talks to local ComfyUI, and uses the user's LLM (local or logged-in Claude/ChatGPT/Gemini). The
-  product surface; the phone is a thin remote into it.
-- **F2 — Secure tunnel out + "Remote control" pairing.** Tailscale/cloudflared-style encrypted
-  tunnel (reuse B1 `startQuickTunnel`) + a **Remote control button in the Agent Panel** that mints a
-  pairing token/QR (Claude `/remote-control`-style). **Token-based, no account required** — stays
+- **F1. Desktop agent host (runs like Ollama).** A quiet always-on daemon that owns the agent loop,
+  talks to local ComfyUI, and uses the user's LLM (local or logged-in Claude/ChatGPT/Gemini). This is
+  the product; the phone is a thin remote into it.
+- **F2. Secure tunnel out + "Remote control" pairing.** Tailscale/cloudflared-style encrypted
+  tunnel (reuse B1 `startQuickTunnel`) plus a Remote control button in the Agent Panel that mints a
+  pairing token/QR (Claude `/remote-control`-style). Token-based, no account required, and it stays
   inside the user's network.
-- **F3 — Two UIs, one spec.** Panel and mobile both generate + consume the *same* workflow spec, so a
-  piece built in one opens cleanly in the other (couch→desk handoff). The spec is the contract.
-- **F4 — Depth on demand (Apps → blocks → dials → graph).** Adopt ComfyUI's **Apps** feature as the
+- **F3. Two UIs, one spec.** Panel and mobile both generate and consume the *same* workflow spec, so a
+  piece built in one opens cleanly in the other (couch-to-desk handoff). The spec is the contract.
+- **F4. Depth on demand (Apps, then blocks, then dials, then graph).** Adopt ComfyUI's Apps feature as the
   shallow end (form over a workflow, nodes hidden); expand a block to all its widgets via the
-  **widget-promotion** path; drop to full manual/agentic node editing. Same spec at every zoom level.
-- **F5 — Subgraphs as blocks + a stocked library.** Ship **base subgraphs** (txt2img/img2img/upscale/
-  video) so a fresh install is useful day one, plus **utility subgraphs** (smart resolution, prompt
-  scaffolding, save+preview tail, model-swap adapters).
-- **F6 — CivitAI, first-class.** Browse/search/copy-prompts + an **Amazon-style cart** (queue N
-  resources, one tap, land on the rig via the aria2 path) + agent self-heal on missing models. Reuse
-  the decoded CivitAI API / login / account-management internals from `~/code/slutter` (Flutter).
-- **F7 — Flutter client (Android + iOS).** One codebase for the block / flow / Lego-snap-port
-  interactions; desktop/web later, which plays nicely with F3.
-- **F8 — Later: RunPod / cloud GPUs.** SSH tunnel + helper scripts for the annoying parts (logging
-  into Claude/Gemini/Codex on the pod, or standing up Ollama there). **Not** in the first release —
-  local-GPU-to-start keeps the surface small.
+  widget-promotion path; drop to full manual or agentic node editing. Same spec at every zoom level.
+- **F5. Subgraphs as blocks + a stocked library.** Ship base subgraphs (txt2img/img2img/upscale/
+  video) so a fresh install is useful day one, plus utility subgraphs (smart resolution, prompt
+  templates, save+preview tail, model-swap adapters).
+- **F6. CivitAI, first-class.** Browse, search, and copy prompts, plus an Amazon-style cart (queue N
+  resources, one tap, land on the rig via the aria2 path) and agent self-heal on missing models. Reuse
+  the decoded CivitAI API, login, and account-management internals from `~/code/slutter` (Flutter).
+- **F7. Flutter client (Android + iOS).** One codebase for the block, flow, and Lego-snap-port
+  interactions; desktop/web later, which fits F3.
+- **F8. RunPod / cloud GPUs, later.** SSH tunnel + helper scripts for the annoying parts (logging
+  into Claude/Gemini/Codex on the pod, or standing up Ollama there). Not in the first release;
+  starting local-GPU-only keeps the scope small.
 
-> Scope: **v1 = local GPU only.** Reference client internals: `~/code/slutter` (CivitAI Video
-> Scroller, Flutter — decoded CivitAI API, OAuth login, account management).
+> v1 is local GPU only. Reference client internals live in `~/code/slutter` (CivitAI Video
+> Scroller, Flutter, with a decoded CivitAI API, OAuth login, and account management).
 
 ## Theme G — Safety gates / enterprise hardening (deferred until needed)
 Declarative per-category safety gates (workflow-writes, model-deletes, process-control, git-writes,
-…) enforced at a single registration-time choke point, `COMFYUI_MCP_SAFE_MODE` lockdown for
-shared/untrusted deployments, structured `DISABLED_BY_CONFIG` refusals agents can self-correct
-from, and a `capability_audit` tool reporting gate + environment state. Full design already
-specced: [`design/safety-gates.md`](https://github.com/artokun/comfyui-mcp/blob/spec/safety-gates/docs/design/safety-gates.md)
-(spec PR #172, closed unmerged). **Closed as won't-do in issue #168**: comfyui-mcp's deployment
+and so on) enforced at a single registration-time choke point, `COMFYUI_MCP_SAFE_MODE` lockdown for
+shared or untrusted deployments, structured `DISABLED_BY_CONFIG` refusals agents can self-correct
+from, and a `capability_audit` tool reporting gate and environment state. The full design is already
+specced in [`design/safety-gates.md`](https://github.com/artokun/comfyui-mcp/blob/spec/safety-gates/docs/design/safety-gates.md)
+(spec PR #172, closed unmerged). Closed as won't-do in issue #168. comfyui-mcp's deployment
 reality is single-user (own panel, own box/pod), permissive-by-default is correct, and we don't
-build gate systems on spec for a shared/enterprise story that doesn't exist. This theme exists
-purely to keep the design findable if that reality ever changes. Until then, isolated write-risk tools ship with narrow inline env flags (e.g.
+build gate systems on spec for a shared or enterprise story that doesn't exist. This theme exists
+only to keep the design findable if that reality ever changes. Until then, isolated write-risk tools ship with narrow inline env flags (e.g.
 `COMFYUI_MCP_ALLOW_GIT_WRITES`) that Theme G will absorb.
 
 ---
@@ -178,11 +178,11 @@ purely to keep the design findable if that reality ever changes. Until then, iso
 | **Hardening — continuous** | Reliability + I/O from comfyui-api | E1, E2, E3, E4, E7, E11 |
 | **3 — mobile / remote (teased)** | Agent-driven phone client on your own rig | F1, F2, F3, F4, F5, F6, F7 (F8 later) |
 
-Phase 0 ships value immediately (skills + node tooling) and de-risks the panel (tunnel + streaming)
+Phase 0 ships skills and node tooling right away and de-risks the panel (tunnel + streaming)
 before any frontend work. Phase 1 needs the v2 package closer to publish for the panel UI.
 
 ## Google Antigravity Setup
 
-Google Antigravity support is integrated via the `.agents` and `.gemini` setup.
+Google Antigravity support comes from the `.agents` and `.gemini` setup.
 Run `npm run sync-agents` to transpile Claude Code plugins into Google Antigravity compatible skills, commands, and hooks.
 See [GEMINI.md](./GEMINI.md) for development notes.

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,42 +1,42 @@
 # comfyui-mcp — Install Guide for AI Agents
 
 This document tells an AI agent (Cline, Claude Code, Cursor, etc.) how to
-install and configure **comfyui-mcp** in one shot. It is a focused subset of
-the project [README](./README.md) — see that file for full documentation.
+install and configure comfyui-mcp in one shot. It is a focused subset of
+the project [README](./README.md); see that file for full documentation.
 
 ## What you are installing
 
 An MCP server that lets the user's AI assistant drive
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI): generate images, run and
 author workflows, manage models and custom nodes, and control the server.
-**86 MCP tools** across the categories shown in
+It exposes 86 MCP tools across the categories shown in
 [docs/tools/](https://comfyui-mcp.artokun.io/docs/tools/image-generation).
 
 ## Prerequisites
 
-- **Node.js ≥ 22.** Confirm with `node --version`; install via
-  [nodejs.org](https://nodejs.org/) or `nvm` if missing.
-- The package is published to npm as **`comfyui-mcp`** and runs via `npx` — no
-  global install required.
-- The server needs a ComfyUI to talk to. **Three options**, pick one with the
+- Node.js 22 or newer. Confirm with `node --version`; install it from
+  [nodejs.org](https://nodejs.org/) or with `nvm` if missing.
+- The package is published to npm as `comfyui-mcp` and runs via `npx`, so no
+  global install is required.
+- The server needs a ComfyUI to talk to. There are three options; pick one with the
   user (ask if unclear):
 
-  1. **Local ComfyUI** — the user is running ComfyUI on the same machine. The
-     server auto-detects the install path and port (8188 → 8000 fallback). No
+  1. **Local ComfyUI.** The user is running ComfyUI on the same machine. The
+     server auto-detects the install path and port (8188, falling back to 8000). No
      extra config needed.
-  2. **Remote ComfyUI** — the user runs ComfyUI on a different host
-     (RunPod, VPS, LAN box). Pass `--comfyui-url <url>` or set
-     `COMFYUI_URL` env. When the host is non-loopback, local-FS auto-detection
-     is suppressed.
-  3. **Comfy Cloud** — the user has a [cloud.comfy.org](https://cloud.comfy.org)
-     API key. Set `COMFYUI_API_KEY` env. The server routes HTTP primitives to
+  2. **Remote ComfyUI.** The user runs ComfyUI on a different host
+     (RunPod, VPS, LAN box). Pass `--comfyui-url <url>` or set the
+     `COMFYUI_URL` env var. When the host is non-loopback, the server skips
+     local-FS auto-detection.
+  3. **Comfy Cloud.** The user has a [cloud.comfy.org](https://cloud.comfy.org)
+     API key. Set the `COMFYUI_API_KEY` env var. The server routes HTTP calls to
      the cloud; local-only tools throw `CLOUD_UNSUPPORTED`.
 
 ## Add to the MCP client config
 
 ### Claude Code / Claude Desktop (`~/.claude/settings.json`)
 
-**Local ComfyUI** (most common):
+Local ComfyUI (most common):
 
 ```json
 {
@@ -49,7 +49,7 @@ author workflows, manage models and custom nodes, and control the server.
 }
 ```
 
-**Remote ComfyUI:**
+Remote ComfyUI:
 
 ```json
 {
@@ -62,7 +62,7 @@ author workflows, manage models and custom nodes, and control the server.
 }
 ```
 
-**RunPod:** expose the image's HTTP port **3000** (nginx proxies ComfyUI on
+RunPod: expose the image's HTTP port 3000 (nginx proxies ComfyUI on
 the pod's internal port 3001), then use the RunPod proxy URL:
 
 ```json
@@ -83,7 +83,7 @@ too; the startup banner will print the corresponding `wss://<pod-id>-<port>`
 URL instead of an unreachable container IP. `COMFYUI_MCP_PUBLIC_URL` is an
 explicit public-origin override for other reverse proxies.
 
-**Comfy Cloud:**
+Comfy Cloud:
 
 ```json
 {
@@ -101,66 +101,66 @@ explicit public-origin override for other reverse proxies.
 
 ### Cline / Cursor / generic MCP
 
-Use the same `command` + `args` shape (Cline expects `command` + `args` in
-its `cline_mcp_settings.json`; Cursor expects similar in its MCP settings
-panel).
+Use the same `command` + `args` shape. Cline expects `command` + `args` in
+its `cline_mcp_settings.json`; Cursor expects the same in its MCP settings
+panel.
 
 ## Optional environment variables
 
-Set in the `env` block above. None are required for the local-default flow.
+Set these in the `env` block above. None are required for the local-default flow.
 
-- `COMFYUI_HOST` / `COMFYUI_PORT` — override host/port (defaults: auto-detect)
-- `COMFYUI_MCP_PUBLIC_URL` — public origin to print for MCP, bridge, and pairing
+- `COMFYUI_HOST` / `COMFYUI_PORT` override the host and port (default is auto-detect)
+- `COMFYUI_MCP_PUBLIC_URL` is the public origin to print for MCP, bridge, and pairing
   URLs when the host is behind a reverse proxy
-- `COMFYUI_PATH` — explicit ComfyUI data/base path (also the checkout for a
+- `COMFYUI_PATH` sets an explicit ComfyUI data/base path (also the checkout for a
   conventional install; auto-detected on Mac / Linux / Windows when unset)
-- `COMFYUI_CODE_PATH` — optional checkout path for split installs whose
+- `COMFYUI_CODE_PATH` is an optional checkout path for split installs whose
   `main.py` and `.venv` are separate from data/model/user state; pip/venv/core
   updates use it while pack reads/writes stay on the live `--base-directory` /
   `COMFYUI_PATH` data root
-- `COMFYUI_DOWNLOAD_CACHE_DIR` — model download cache (default
+- `COMFYUI_DOWNLOAD_CACHE_DIR` sets the model download cache (default
   `~/.comfyui-mcp/cache`)
-- `COMFYUI_LRU_CACHE_SIZE_GB` — cap the cache; `0` disables eviction
-- `CIVITAI_API_TOKEN`, `HUGGINGFACE_TOKEN`, `GITHUB_TOKEN` — for gated
+- `COMFYUI_LRU_CACHE_SIZE_GB` caps the cache; `0` disables eviction
+- `CIVITAI_API_TOKEN`, `HUGGINGFACE_TOKEN`, and `GITHUB_TOKEN` unlock gated
   downloads and higher API rate limits
-- `REGISTRY_ACCESS_TOKEN` — Comfy Registry API key for `node_pack` (`action: "publish"`)
-- `COMFY_API_KEY` — comfy.org API key for hosted partner nodes (different
+- `REGISTRY_ACCESS_TOKEN` is the Comfy Registry API key for `node_pack` (`action: "publish"`)
+- `COMFY_API_KEY` is the comfy.org API key for hosted partner nodes (different
   from `COMFYUI_API_KEY`, which is for Comfy Cloud)
-- `COMFYUI_CLOUD_URL` — override the Comfy Cloud endpoint
+- `COMFYUI_CLOUD_URL` overrides the Comfy Cloud endpoint
   (default `https://cloud.comfy.org`)
 
-Full reference: [docs/configuration](https://comfyui-mcp.artokun.io/docs/configuration).
+The full reference is at [docs/configuration](https://comfyui-mcp.artokun.io/docs/configuration).
 
 ## Verify
 
-After updating the settings file, **restart the MCP client** (Claude Code: run
-`/mcp` to reconnect; Cline: toggle the server). Then ask the assistant:
+After updating the settings file, restart the MCP client (in Claude Code, run
+`/mcp` to reconnect; in Cline, toggle the server). Then ask the assistant:
 
 > What ComfyUI tools do you have?
 
-It should list ~86 tools across generation, workflow execution/authoring,
-models, custom nodes, etc. If the user wants a quick smoke test, ask:
+It should list about 86 tools across generation, workflow execution and authoring,
+models, custom nodes, and more. If the user wants a quick smoke test, ask:
 
 > Generate a 1024×1024 image of a red apple on a wooden table.
 
-That exercises the `generate_image` tool end-to-end (auto-selects a local
-checkpoint or uses defaults; returns an `asset_id` you can `get_image (action:"view")` to
-see).
+That exercises the `generate_image` tool end-to-end. It auto-selects a local
+checkpoint or uses defaults, and returns an `asset_id` you can pass to
+`get_image (action:"view")` to see the result.
 
 ## Common issues
 
-- **"ComfyUI not detected on ports 8188, 8000"** — ComfyUI isn't running. Tell
+- **"ComfyUI not detected on ports 8188, 8000".** ComfyUI isn't running. Tell
   the user to start it (Desktop app or `python main.py`).
-- **`CLOUD_UNSUPPORTED` errors** — `COMFYUI_API_KEY` is set, so the server is
+- **`CLOUD_UNSUPPORTED` errors.** `COMFYUI_API_KEY` is set, so the server is
   in cloud mode and a local-only tool was called. Either unset the key (to
   use a local install) or stick to cloud-compatible tools.
-- **Empty model lists** — `extra_model_paths.yaml` is misconfigured. Run
+- **Empty model lists.** `extra_model_paths.yaml` is misconfigured. Run
   `get_system_stats (action:"health")` for a diagnostic.
 
 ## License + repo
 
-- **License:** [MIT](./LICENSE)
-- **Repo:** https://github.com/artokun/comfyui-mcp
-- **npm:** https://www.npmjs.com/package/comfyui-mcp
-- **Docs:** https://comfyui-mcp.artokun.io/docs
-- **Issues:** https://github.com/artokun/comfyui-mcp/issues
+- License: [MIT](./LICENSE)
+- Repo: https://github.com/artokun/comfyui-mcp
+- npm: https://www.npmjs.com/package/comfyui-mcp
+- Docs: https://comfyui-mcp.artokun.io/docs
+- Issues: https://github.com/artokun/comfyui-mcp/issues

--- a/plugin/agents/debugger.md
+++ b/plugin/agents/debugger.md
@@ -10,7 +10,7 @@ You are an autonomous debugging agent that diagnoses and fixes ComfyUI workflow 
 
 ## Your Mission
 
-When a workflow fails or produces unexpected results, you will systematically identify the root cause and propose (or apply) a fix. You operate autonomously, gathering all evidence before making a diagnosis.
+When a workflow fails or produces unexpected results, identify the root cause and propose (or apply) a fix. Work on your own, and gather all the evidence before you diagnose.
 
 ## Debugging Workflow
 
@@ -66,7 +66,7 @@ If the failing node type is not found:
 
 1. **Search the registry**: `search_custom_nodes(action="search", query="NodeClassName")`
 2. **Check pack details**: `search_custom_nodes(action="details", id="pack-name")`
-3. **Check import errors in logs**: `get_system_stats (action:"logs")(keyword="import")` — a node pack may be installed but failing to load due to missing dependencies
+3. **Check import errors in logs**: `get_system_stats (action:"logs")(keyword="import")`; a node pack may be installed but failing to load because of missing dependencies
 4. **Verify installation**: Check if the custom node directory exists and contains the expected files
 
 ### Step 6: Analyze the Traceback
@@ -126,13 +126,13 @@ If the user requests it, apply the fix directly:
 ### Scenario: Wrong Colors / Artifacts
 
 1. Check if VAE matches the model family
-2. Check CFG — too high causes color saturation/artifacts
+2. Check CFG; too high causes color saturation/artifacts
 3. Check if LoRA is compatible with the base model
 4. Check if the model file is corrupted (compare file size to expected)
 
 ### Scenario: Custom Node Error
 
-1. Get the full traceback from `get_history(action="list")` — or `get_history(action="diagnose")`, which adds the missing models and node types
+1. Get the full traceback from `get_history(action="list")`, or from `get_history(action="diagnose")`, which adds the missing models and node types
 2. Check `get_system_stats (action:"logs")(keyword="import")` for load failures
 3. Search for the node pack: `search_custom_nodes` (`action: "search"`)
 4. Check if dependencies are met
@@ -164,7 +164,7 @@ Always structure your diagnosis as:
 
 ## Important Rules
 
-- Always gather evidence BEFORE diagnosing — never guess without data
+- Always gather evidence BEFORE diagnosing; never guess without data
 - Check the simplest causes first (missing model, wrong input) before complex ones
 - If you can't determine the cause from logs and history, ask the user for more context
 - When multiple issues exist, fix them in dependency order (model loading before sampling)

--- a/plugin/agents/explorer.md
+++ b/plugin/agents/explorer.md
@@ -1,21 +1,21 @@
 ---
 name: comfy-explorer
-description: Explores ComfyUI custom node packs and generates comprehensive skills
+description: Explores ComfyUI custom node packs and generates complete skills
 tools: Read, Write, Glob, Grep, Bash, WebFetch, WebSearch
 model: sonnet
 color: green
 ---
 
-You are an autonomous agent that explores ComfyUI custom node packs and generates comprehensive Claude skills for them. You have access to ComfyUI MCP tools (`mcp__comfyui__*`) for querying node info, searching the registry, and generating skills.
+You are an autonomous agent that explores ComfyUI custom node packs and generates complete Claude skills for them. You have access to ComfyUI MCP tools (`mcp__comfyui__*`) for querying node info, searching the registry, and generating skills.
 
 ## Your Mission
 
 Given a custom node pack name or GitHub URL, you will:
 
-1. **Research the pack** — find it in the ComfyUI registry and read its documentation
-2. **Analyze its nodes** — query `/object_info` for installed node definitions
-3. **Study examples** — find and understand example workflows
-4. **Generate a skill** — create a comprehensive SKILL.md that teaches Claude how to use this pack
+1. **Research the pack.** Find it in the ComfyUI registry and read its documentation
+2. **Analyze its nodes.** Query `/object_info` for installed node definitions
+3. **Study examples.** Find and understand example workflows
+4. **Generate a skill.** Create a complete SKILL.md that teaches Claude how to use this pack
 
 ## Workflow
 
@@ -35,7 +35,7 @@ Given a custom node pack name or GitHub URL, you will:
 
 - Use `create_workflow (action:"node_info")` with the node class names to get their exact input/output schemas from ComfyUI
 - If the nodes aren't installed locally, document what you found from the README and registry
-- Record each node's: class_type, required inputs (with types), optional inputs, outputs (with types)
+- Record for each node: class_type, required inputs (with types), optional inputs, outputs (with types)
 
 ### Step 4: Build Example Workflows
 
@@ -44,13 +44,13 @@ Given a custom node pack name or GitHub URL, you will:
 
 ### Step 5: Generate the Skill
 
-- Use `list_packs` with `action: "generate_skill"` to create the initial skill, OR write a comprehensive SKILL.md manually if you have richer information from your research
+- Use `list_packs` with `action: "generate_skill"` to create the initial skill, OR write the SKILL.md by hand if your research gave you richer information
 - The skill file should include:
   - **Overview**: What the pack does, when to use it
   - **Node Reference**: Every node with its class_type, inputs, outputs, and description
   - **Workflow Patterns**: Common ways to wire these nodes into pipelines
   - **Tips and Gotchas**: Common mistakes, required models, compatibility notes
-  - **Sources**: a `## Sources` section with `- **Official:**` (vendor URL, node README, or "none found") and `- **Empirical:**` (what was inferred from working graphs / observed behaviour). Cited vs uncited, not right vs wrong — never leave the question unanswered.
+  - **Sources**: a `## Sources` section with `- **Official:**` (vendor URL, node README, or "none found") and `- **Empirical:**` (what was inferred from working graphs / observed behaviour). The split is cited vs uncited, not right vs wrong. Never leave the question unanswered.
 
 ### Step 6: Save and Report
 

--- a/plugin/agents/optimizer.md
+++ b/plugin/agents/optimizer.md
@@ -10,7 +10,7 @@ You are an autonomous optimization agent that analyzes ComfyUI workflows for per
 
 ## Your Mission
 
-Given a ComfyUI workflow, analyze it for performance bottlenecks, redundant operations, VRAM waste, and model-specific misconfigurations. Produce a concrete optimization report with before/after comparisons and actionable fixes.
+Given a ComfyUI workflow, analyze it for performance bottlenecks, redundant operations, VRAM waste, and model-specific misconfigurations. Produce a concrete optimization report with before/after comparisons and fixes the user can apply.
 
 ## Optimization Workflow
 
@@ -51,7 +51,7 @@ Look for these common redundancies:
 
 #### Unused Nodes
 - Nodes whose outputs are not connected to anything downstream of SaveImage/PreviewImage
-- "Dead branches" — chains of nodes that don't contribute to any output
+- "Dead branches", chains of nodes that don't contribute to any output
 
 #### Duplicate Model Loading
 - **Multiple CheckpointLoaderSimple with the same model**: Wastes VRAM. Load once and branch.
@@ -64,11 +64,11 @@ Look for these common redundancies:
 ### Step 4: Check Model-Specific Settings
 
 #### Flux Optimizations
-- **CFG must be 1.0**: If CFG > 1.0, flag it — causes artifacts with no benefit
-- **No negative prompt**: If a negative CLIPTextEncode is connected, flag it — wastes compute
+- **CFG must be 1.0**: If CFG > 1.0, flag it; it causes artifacts with no benefit
+- **No negative prompt**: If a negative CLIPTextEncode is connected, flag it; it wastes compute
 - **FP8 model**: If using FP16 Flux on <=24GB VRAM, suggest FP8 variant
 - **T5-XXL in FP8**: If VRAM is tight, T5-XXL can be loaded in FP8 with minimal quality loss
-- **Steps for Schnell**: Should be 4, not 20+ — more steps don't improve Schnell
+- **Steps for Schnell**: Should be 4, not 20+; more steps don't improve Schnell
 
 #### SDXL Optimizations
 - **Resolution check**: Should be 1024x1024 or SDXL-native aspect ratios, not 512x512
@@ -86,7 +86,7 @@ Look for these common redundancies:
 1. **Model precision**: Is the model loaded in FP32 when FP16 would suffice?
    - FP32 uses 2x the VRAM of FP16
    - Most models produce identical results in FP16
-2. **VAE precision**: FP16 VAE can cause NaN — suggest FP32 VAE if issues are reported
+2. **VAE precision**: FP16 VAE can cause NaN; suggest FP32 VAE if issues are reported
 3. **FP8 availability**: For VRAM-constrained setups, check if FP8 model variants exist
 4. **Tiled VAE**: For resolutions above the native resolution, suggest `VAEDecodeTiled`:
    - Prevents OOM during VAE decode of high-res latents
@@ -97,7 +97,7 @@ Look for these common redundancies:
 
 1. **Repeated identical subgraphs**: If the same checkpoint + prompt + sampler settings are used multiple times, the first result could be cached
 2. **Static conditioning**: If positive/negative prompts don't change between runs, conditioning can be pre-computed
-3. **Model loading**: ComfyUI caches loaded models — but if the workflow loads many different models, cache eviction causes re-loading
+3. **Model loading**: ComfyUI caches loaded models, but if the workflow loads many different models, cache eviction causes re-loading
 
 ### Step 7: Check Sampler/Scheduler Optimization
 
@@ -176,8 +176,8 @@ This produces better results than generating directly at high resolution and use
 
 ### Multi-ControlNet Workflows
 
-- Each ControlNet adds VRAM overhead — limit to 2-3 simultaneous ControlNets
-- ControlNet strength < 0.5 has diminishing returns — consider removing low-strength ControlNets
+- Each ControlNet adds VRAM overhead; limit to 2-3 simultaneous ControlNets
+- ControlNet strength < 0.5 has diminishing returns; consider removing low-strength ControlNets
 - Use `ControlNetApplyAdvanced` for start/end step control to limit ControlNet influence range
 
 ### LoRA Stacking
@@ -190,7 +190,7 @@ This produces better results than generating directly at high resolution and use
 
 - Always check system stats before making VRAM-related recommendations
 - Never recommend settings that would reduce quality without explaining the tradeoff
-- If the workflow is already optimized, say so — don't invent unnecessary changes
+- If the workflow is already optimized, say so; don't invent changes
 - When suggesting FP8 models, verify they exist via `download_model` `action:"search"` before recommending
 - Always provide concrete `create_workflow (action:"modify")` operations, not vague suggestions
-- Preserve the user's creative intent — optimize the pipeline, not the artistic choices
+- Preserve the user's creative intent. Optimize the pipeline, not the artistic choices

--- a/plugin/agents/researcher.md
+++ b/plugin/agents/researcher.md
@@ -10,14 +10,14 @@ You are an autonomous discovery agent for ComfyUI custom node packs. You have ac
 
 ## Your Mission
 
-Given a problem statement, you will discover candidate custom node packs and return a ranked recommendation. You are the DISCOVERY angle: find the right pack for the user's need. For deep analysis of one known pack, delegate to `comfy-explorer` instead of duplicating its work.
+Given a problem statement, you will discover candidate custom node packs and return a ranked recommendation. You are the DISCOVERY angle. Find the right pack for the user's need. For deep analysis of one known pack, delegate to `comfy-explorer` instead of duplicating its work.
 
 ## Workflow
 
 ### Step 1: Translate the Problem
 
 - Extract the core capability the user needs, such as face detail, pose control, segmentation, upscaling, animation, prompt utilities, model loading, or workflow automation
-- Turn that into 2-4 concise registry search queries
+- Turn that into 2-4 short registry search queries
 - Keep the original user goal visible when ranking; do not optimize only for popularity
 
 ### Step 2: Search the Registry
@@ -25,7 +25,7 @@ Given a problem statement, you will discover candidate custom node packs and ret
 - Use `mcp__comfyui__search_custom_nodes` with `action: "search"` for each query
 - Shortlist 3-6 candidates with clear relevance
 - Prefer actively maintained packs with strong descriptions, useful node coverage, install count signal, and a repository URL
-- **Models, not nodes:** if the user actually needs a *checkpoint, LoRA, embedding, or VAE* (not a custom node pack) and the official Civitai MCP is connected (`mcp__civitai__*` tools present), prefer that server's own model search for discovery and hand the returned model-version id to `mcp__comfyui__download_model` with `action:"download_civitai"`. Fall back to `mcp__comfyui__download_model` with `action:"search"` (HuggingFace) when it isn't connected. See the `civitai` skill for the full handoff.
+- **Models, not nodes.** If the user needs a *checkpoint, LoRA, embedding, or VAE* (not a custom node pack) and the official Civitai MCP is connected (`mcp__civitai__*` tools present), prefer that server's own model search for discovery and hand the returned model-version id to `mcp__comfyui__download_model` with `action:"download_civitai"`. Fall back to `mcp__comfyui__download_model` with `action:"search"` (HuggingFace) when it isn't connected. See the `civitai` skill for the full handoff.
 
 ### Step 3: Evaluate Candidates
 
@@ -53,4 +53,4 @@ Return a ranked list. For each pack include:
 - Recommendations must be ranked, not just listed
 - Every recommended pack must have a concrete registry id or repository URL
 - Do not recommend installing a pack unless you can explain why it fits the user problem
-- Keep install and integration guidance concise enough to act on from the CLI
+- Keep install and integration guidance short enough to act on from the CLI

--- a/plugin/commands/batch.md
+++ b/plugin/commands/batch.md
@@ -5,7 +5,7 @@ argument-hint: "prompt, param:range (e.g. a cat, cfg:5-10, sampler:euler,dpmpp_2
 
 # /comfy-batch — Parameter Sweep Generation
 
-The user wants to generate multiple images while sweeping across different parameter values to compare results.
+The user wants to generate several images while sweeping parameter values, so they can compare the results.
 
 ## Instructions
 
@@ -18,20 +18,20 @@ The user wants to generate multiple images while sweeping across different param
    - **Parameter ranges**: identified by `param_name:values` syntax
 
 2. **Parse parameter range syntax.** Supported formats:
-   - `param:min-max` — integer range with step 1 (e.g., `cfg:5-10` produces 5, 6, 7, 8, 9, 10)
-   - `param:min-max:step` — range with explicit step (e.g., `cfg:4-12:2` produces 4, 6, 8, 10, 12)
-   - `param:val1,val2,val3` — explicit list (e.g., `sampler:euler,dpmpp_2m,dpmpp_sde`)
-   - `seed:N` — special: generate N different random seeds (e.g., `seed:4` produces 4 random seeds)
+   - `param:min-max`: integer range with step 1 (e.g., `cfg:5-10` produces 5, 6, 7, 8, 9, 10)
+   - `param:min-max:step`: range with explicit step (e.g., `cfg:4-12:2` produces 4, 6, 8, 10, 12)
+   - `param:val1,val2,val3`: explicit list (e.g., `sampler:euler,dpmpp_2m,dpmpp_sde`)
+   - `seed:N`: generate N different random seeds (e.g., `seed:4` produces 4 random seeds)
 
 3. **Supported sweep parameters:**
-   - `cfg` — CFG scale (float)
-   - `steps` — sampling steps (integer)
-   - `sampler` or `sampler_name` — sampler algorithm name
-   - `scheduler` — scheduler name
-   - `seed` — random seed count or explicit seeds
-   - `denoise` — denoising strength (float, 0.0-1.0)
-   - `width` — image width in pixels
-   - `height` — image height in pixels
+   - `cfg`: CFG scale (float)
+   - `steps`: sampling steps (integer)
+   - `sampler` or `sampler_name`: sampler algorithm name
+   - `scheduler`: scheduler name
+   - `seed`: random seed count or explicit seeds
+   - `denoise`: denoising strength (float, 0.0-1.0)
+   - `width`: image width in pixels
+   - `height`: image height in pixels
 
 4. **Calculate total combinations.** Multiply the count of values for each swept parameter. If the total exceeds 20, warn the user:
    - Show the total count and estimated time
@@ -54,7 +54,7 @@ The user wants to generate multiple images while sweeping across different param
    node "${CLAUDE_PLUGIN_ROOT}/scripts/monitor-progress.mjs" <prompt_id_1> <prompt_id_2> ... <prompt_id_N>
    ```
 
-   This monitors all jobs simultaneously via ComfyUI's WebSocket and reports step-by-step progress and completion for each. ComfyUI processes them sequentially from its queue. Continue the conversation while waiting.
+   This monitors all jobs at once via ComfyUI's WebSocket and reports step-by-step progress and completion for each. ComfyUI processes them sequentially from its queue. Continue the conversation while waiting.
 
    **Fallback**: If the script is unavailable, poll `queue` (action:"status") for each prompt_id until done.
 
@@ -85,6 +85,6 @@ Steps:
 
 - Always randomize seeds unless `seed` is explicitly specified in the sweep
 - Use sensible defaults for non-swept parameters (1024x1024 for SDXL, 20 steps, cfg 7)
-- Run workflows sequentially, not in parallel — ComfyUI processes one at a time anyway
-- If a single run fails, continue with the remaining combinations rather than stopping entirely
+- Run workflows sequentially, not in parallel. ComfyUI processes one at a time anyway
+- If a single run fails, continue with the remaining combinations rather than stopping
 - For large sweeps, suggest the user start with a smaller subset to test

--- a/plugin/commands/compare.md
+++ b/plugin/commands/compare.md
@@ -5,7 +5,7 @@ argument-hint: "Two file paths or workflow names separated by 'vs' (e.g. workflo
 
 # /comfy-compare — Compare Two Workflows
 
-The user wants to see the differences between two ComfyUI workflows — what nodes were added, removed, or changed.
+The user wants to see which nodes were added, removed, or changed between two ComfyUI workflows.
 
 ## Instructions
 
@@ -14,10 +14,10 @@ The user wants to see the differences between two ComfyUI workflows — what nod
    If no argument was provided, ask the user for two workflow sources.
 
    Split the argument on `" vs "` or `" VS "` to get two sources. Each source can be:
-   - **File path**: a path to a workflow JSON file — read it with the Read tool
-   - **Saved workflow name**: a name from ComfyUI's library — load with `get_workflow`
-   - **`last`**: the most recent execution — load from `get_history(action="list")`
-   - **Prompt ID**: a specific execution ID — load from `get_history(action="list")` with that ID
+   - **File path**: a path to a workflow JSON file; read it with the Read tool
+   - **Saved workflow name**: a name from ComfyUI's library; load it with `get_workflow`
+   - **`last`**: the most recent execution; load it from `get_history(action="list")`
+   - **Prompt ID**: a specific execution ID; load it from `get_history(action="list")` with that ID
 
 2. **Load both workflows.** Read/fetch both workflow sources. Label them **Workflow A** (first) and **Workflow B** (second).
 
@@ -37,7 +37,7 @@ The user wants to see the differences between two ComfyUI workflows — what nod
    - **Added inputs**: input present in B but not in A
    - **Removed inputs**: input present in A but not in B
 
-5. **Present the diff.** Format the comparison clearly:
+5. **Present the diff.** Format the comparison in this shape:
 
    ```
    === Workflow Comparison ===
@@ -76,8 +76,8 @@ Steps:
 
 ## Notes
 
-- Node matching is done first by node ID, then by class_type as a fallback if IDs were renumbered
+- Match nodes first by node ID, then by class_type as a fallback if IDs were renumbered
 - If both workflows have completely different node IDs but similar structure, attempt to match by class_type and position in the graph
-- Connection changes are shown as "Node X slot Y" references for clarity
+- Show connection changes as "Node X slot Y" references
 - This is a structural diff, not a visual/pixel diff of outputs
 - For workflows from `get_history`, the workflow is embedded in the history response under the output data

--- a/plugin/commands/convert.md
+++ b/plugin/commands/convert.md
@@ -22,11 +22,11 @@ The user wants to convert a ComfyUI workflow between the web UI format and the A
 3. **If converting UI format to API format:**
 
    a. Iterate over each node in the `"nodes"` array. Each node has:
-      - `id` (integer) — becomes the string key in API format
-      - `type` — becomes `class_type`
-      - `widgets_values` — ordered list of widget values
-      - `inputs` — array of input slots with `name`, `type`, and optional `link`
-      - `outputs` — array of output slots
+      - `id` (integer): becomes the string key in API format
+      - `type`: becomes `class_type`
+      - `widgets_values`: ordered list of widget values
+      - `inputs`: array of input slots with `name`, `type`, and optional `link`
+      - `outputs`: array of output slots
 
    b. For each node, call `create_workflow (action:"node_info")` with the node's `type` to get the input schema. This tells you:
       - The order and names of widget inputs (to map `widgets_values` correctly)
@@ -41,7 +41,7 @@ The user wants to convert a ComfyUI workflow between the web UI format and the A
 
 4. **If converting API format to UI format:**
 
-   Warn the user that API-to-UI conversion is lossy — layout positions, colors, groups, and notes will not be preserved. The converted workflow will load in ComfyUI but nodes will need to be manually arranged.
+   Warn the user that API-to-UI conversion is lossy. Layout positions, colors, groups, and notes are not preserved. The converted workflow will load in ComfyUI but the user will need to arrange the nodes by hand.
 
    a. For each API node, create a UI node object with:
       - `id`: integer version of the string key
@@ -72,7 +72,7 @@ Steps:
 ## Notes
 
 - UI-to-API conversion is the more common and reliable direction
-- Some widget values may be tricky to map if the node has dynamic inputs — flag these for the user
-- If `create_workflow (action:"node_info")` fails for a node type, it may be a custom node that isn't installed — warn the user
-- Large workflows (50+ nodes) may require many `create_workflow (action:"node_info")` calls; batch them efficiently
+- Some widget values may be tricky to map if the node has dynamic inputs; flag these for the user
+- If `create_workflow (action:"node_info")` fails for a node type, it may be a custom node that isn't installed; warn the user
+- Large workflows (50+ nodes) may require many `create_workflow (action:"node_info")` calls; batch them
 - The `"extra"` and `"config"` fields in UI format can be preserved but aren't needed for API format

--- a/plugin/commands/debug.md
+++ b/plugin/commands/debug.md
@@ -21,7 +21,7 @@ The user wants to find out why a ComfyUI workflow execution failed and get a sug
 
    If the execution succeeded (no error), tell the user it completed normally and show the output summary.
 
-3. **Get relevant logs.** Call `get_system_stats (action:"logs")` with a `keyword` filter matching the error — use the exception class name (e.g., "RuntimeError", "ValueError") or a distinctive phrase from the error message. Request up to 200 lines.
+3. **Get relevant logs.** Call `get_system_stats (action:"logs")` with a `keyword` filter matching the error. Use the exception class name (e.g., "RuntimeError", "ValueError") or a distinctive phrase from the error message. Request up to 200 lines.
 
 4. **Inspect the failing node.** Call `create_workflow (action:"node_info")` with the `node_type` of the failing node. Check:
    - What inputs does the node expect?
@@ -38,7 +38,7 @@ The user wants to find out why a ComfyUI workflow execution failed and get a sug
    - Call `search_custom_nodes` (`action: "search"`) with the node class name as `query` to find which pack provides it
    - Suggest installing the pack
 
-7. **Present the diagnosis.** Provide a clear summary:
+7. **Present the diagnosis.** Provide a summary:
    - **What failed**: node type, node ID, and a one-line description
    - **Why it failed**: root cause explanation in plain language
    - **Suggested fix**: concrete steps the user can take to resolve the issue
@@ -49,9 +49,9 @@ The user wants to find out why a ComfyUI workflow execution failed and get a sug
 - **OOM / CUDA out of memory**: Suggest reducing resolution, using FP8 models, or `clear_vram` before retrying
 - **Missing checkpoint/model file**: Show what's installed, offer to download the right one
 - **Missing custom node**: Identify the pack and suggest installation
-- **Shape mismatch**: Usually a resolution or latent size issue — check width/height are multiples of 8 (or 64 for some models)
-- **NaN/Inf in tensor**: Model corruption or extreme CFG values — suggest re-downloading the model or lowering CFG
-- **Connection type mismatch**: A node is receiving the wrong data type — check the workflow wiring
+- **Shape mismatch**: Usually a resolution or latent size issue; check that width/height are multiples of 8 (or 64 for some models)
+- **NaN/Inf in tensor**: Model corruption or extreme CFG values; suggest re-downloading the model or lowering CFG
+- **Connection type mismatch**: A node is receiving the wrong data type; check the workflow wiring
 
 ## Example
 
@@ -67,6 +67,6 @@ Steps:
 
 ## Notes
 
-- If multiple nodes errored, focus on the first failure in the execution chain — downstream errors are usually cascading
-- The traceback is Python-level; translate it into user-friendly language
-- If the error is ambiguous, suggest the user share their workflow JSON for deeper inspection
+- If multiple nodes errored, focus on the first failure in the execution chain; downstream errors usually cascade from it
+- The traceback is Python-level; translate it into plain language for the user
+- If the error is ambiguous, suggest the user share their workflow JSON for a closer look

--- a/plugin/commands/director.md
+++ b/plugin/commands/director.md
@@ -1,13 +1,13 @@
 ---
-description: Direct a short film from a story — generates scenes, frames, and video clips
+description: Direct a short film from a story. Generates scenes, frames, and video clips
 argument-hint: "A story or 'resume' to continue a previous project"
 ---
 
 # /comfy-director — Story-to-Video Production Pipeline
 
-The user wants to create a short film from a story description. This command orchestrates multiple model families (Z-Image, Qwen Edit, WAN FLF) to generate start frames, end frames, and video clips for each scene, then concatenates them into a final video.
+The user wants to create a short film from a story description. This command chains three model families (Z-Image, Qwen Edit, WAN FLF) to generate start frames, end frames, and video clips for each scene, then concatenates them into a final video.
 
-**Requires the `director`, `z-image-txt2img`, `qwen-image-edit`, and `wan-flf-video` skills** — load them before executing.
+**Requires the `director`, `z-image-txt2img`, `qwen-image-edit`, and `wan-flf-video` skills.** Load them before executing.
 
 ## Instructions
 
@@ -19,7 +19,7 @@ The user wants to create a short film from a story description. This command orc
 
 2. **Create the state file.** Generate a project ID from the current timestamp (e.g., `story_20260216_143022`). Initialize the state file at `~/code/comfyui-mcp/workflows/director_state_{project_id}.json` with the story text and empty scenes array.
 
-3. **Phase 1 — Story Planning.** Break the story into 2-6 scenes. For each scene, craft:
+3. **Phase 1: Story Planning.** Break the story into 2-6 scenes. For each scene, write:
    - **description**: What happens (1-2 sentences)
    - **start_prompt**: Detailed Z-Image prompt for the opening frame (natural language, descriptive, include camera/lighting/style cues)
    - **edit_prompt**: Qwen Edit instruction to transform the start frame into the end frame
@@ -31,13 +31,13 @@ The user wants to create a short film from a story description. This command orc
 
 4. **Ask orientation.** Ask the user if they prefer portrait (480x720 video, 832x1472 frames) or landscape (832x480 video, 1472x832 frames). Default to portrait for character-focused stories, landscape for environment/action stories.
 
-5. **Phase 2 — Start Frame Generation.**
+5. **Phase 2: Start Frame Generation.**
    - `clear_vram` first
    - For each scene, build and enqueue the Z-Image RedCraft DX1 workflow (see `director` skill, Phase 2 template)
    - Use `filename_prefix: "director_s{N}_start"` for each scene
    - After each generation completes, update the state file with the output filename and seed
 
-6. **Phase 3 — Start Frame Review.**
+6. **Phase 3: Start Frame Review.**
    - For each scene's start frame:
      - Find the output with `get_image(action:"list_outputs", pattern="director_s{N}_start")`
      - Read the image with `Read` to visually inspect it
@@ -46,7 +46,7 @@ The user wants to create a short film from a story description. This command orc
      - If rejected, re-generate with a new seed (or modified prompt if user provides feedback)
    - Update the state file after all reviews complete
 
-7. **Phase 4 — End Frame Generation.**
+7. **Phase 4: End Frame Generation.**
    - `clear_vram` first
    - For each scene with an approved start frame:
      - `upload_image (action:"image")` the start frame to make it available as `LoadImage` input
@@ -54,14 +54,14 @@ The user wants to create a short film from a story description. This command orc
      - Use `filename_prefix: "director_s{N}_end"`
    - After each generation, update state file
 
-8. **Phase 5 — End Frame Review.**
+8. **Phase 5: End Frame Review.**
    - Same protocol as Phase 3 but for end frames
    - If an end frame is rejected, the user can:
      - Retry with a new seed
      - Modify the edit prompt
      - Regenerate from a different start frame
 
-9. **Phase 6 — Video Clip Generation.**
+9. **Phase 6: Video Clip Generation.**
    - `clear_vram` first
    - For each scene with approved start AND end frames:
      - `upload_image (action:"image")` both the start and end frames
@@ -69,14 +69,14 @@ The user wants to create a short film from a story description. This command orc
      - Use `filename_prefix: "director_s{N}"`
      - **CRITICAL**: Use dual KSamplerAdvanced (Hi pass steps 0→2, Lo pass steps 2→4). NEVER use single KSampler.
    - After each clip completes, update state file
-   - Video generation takes ~140s per scene — inform the user of the wait
+   - Video generation takes ~140s per scene; tell the user about the wait
 
-10. **Phase 7 — Video Review.**
+10. **Phase 7: Video Review.**
     - Report each clip's filename and estimated duration
     - User can preview clips externally
     - If rejected, re-generate with new seed or modified video prompt
 
-11. **Phase 8 — Final Assembly.**
+11. **Phase 8: Final Assembly.**
     - Collect all approved video clip paths in scene order
     - Determine the ComfyUI output directory path for each clip
     - Create a concat list file and run ffmpeg:
@@ -86,7 +86,7 @@ The user wants to create a short film from a story description. This command orc
     - Report the final video path to the user
     - Update state file with `final_video` path
 
-12. **Save state after every phase.** Write the updated state JSON after each phase completes. This is critical for surviving context compaction.
+12. **Save state after every phase.** Write the updated state JSON after each phase completes. This is what lets the run survive context compaction.
 
 ## Resumption
 
@@ -127,8 +127,8 @@ Steps:
 - Always update the state file after any generation or approval
 - Each video clip is ~5 seconds at 81 frames / 16fps
 - A 4-scene production takes roughly 15 minutes of generation time on RTX 4090
-- VRAM management is critical: always `clear_vram` between model families
-- The Remix NSFW models have lightning baked in — no separate LoRA needed for WAN FLF
+- VRAM management is critical, so always `clear_vram` between model families
+- The Remix NSFW models have lightning baked in, so WAN FLF needs no separate LoRA
 - For the WAN FLF phase, both CLIP (via LoRA stacks) and CLIPVision must use the Hi Common stack's clip output
 - Negative prompt for WAN FLF is always the standard quality negative (see wan-flf-video skill)
 - If ffmpeg is not available, warn the user and provide individual clip paths instead

--- a/plugin/commands/gallery.md
+++ b/plugin/commands/gallery.md
@@ -27,7 +27,7 @@ The user wants to browse images that ComfyUI has generated, inspect their metada
 
 4. **Present image details.** For each image, show:
    - Filename
-   - File size (human-readable: KB/MB)
+   - File size (human-readable, KB/MB)
    - Creation/modification date and time
    - Use the Read tool to display the image thumbnail if the file is a supported image format
 
@@ -54,8 +54,8 @@ Steps:
 
 ## Notes
 
-- ComfyUI embeds workflow metadata in PNG files by default — this is what `get_workflow (action:"from_image")` reads
+- ComfyUI embeds workflow metadata in PNG files by default; that is what `get_workflow (action:"from_image")` reads
 - JPEG and WebP files may not have embedded metadata depending on ComfyUI settings
 - The output directory may contain subdirectories for different workflows or dates
 - If the output directory is empty, tell the user no images have been generated yet
-- Large galleries (100+ images) should be filtered to avoid overwhelming output
+- Filter large galleries (100+ images) so the output stays manageable

--- a/plugin/commands/gen.md
+++ b/plugin/commands/gen.md
@@ -15,17 +15,17 @@ The user wants to generate an image using ComfyUI. Their prompt is provided as t
 
 2. **Check available models.** Use the `list_local_models` tool with `model_type: "checkpoints"` to see what checkpoints are installed.
 
-3. **If no checkpoints are installed — acquire one automatically.**
+3. **If no checkpoints are installed, acquire one automatically.**
 
    Do NOT ask the user to download a model. Instead, find and download one yourself:
 
-   **Option A — CivitAI (preferred if CIVITAI_API_TOKEN is set):**
+   **Option A: CivitAI** (preferred if CIVITAI_API_TOKEN is set):
    - Use WebFetch to search CivitAI's REST API: `https://civitai.com/api/v1/models?query=SDXL&types=Checkpoint&sort=Most+Downloaded&limit=5`
    - Pick the top result that matches the user's needs (SDXL for general, Flux for quality, etc.)
    - Get the download URL from the model version: `https://civitai.com/api/download/models/{modelVersionId}?token={CIVITAI_API_TOKEN}`
    - Use `download_model` with `target_subfolder: "checkpoints"` to download it
 
-   **Option B — HuggingFace (default):**
+   **Option B: HuggingFace** (default):
    - Use `download_model` `action:"search"` to find a suitable checkpoint (e.g., query "SDXL" or "stable diffusion xl")
    - Find the direct `.safetensors` download URL from the model page (typically `https://huggingface.co/{repo}/resolve/main/{filename}`)
    - Use `download_model` with `target_subfolder: "checkpoints"` to download it
@@ -51,7 +51,7 @@ The user wants to generate an image using ComfyUI. Their prompt is provided as t
    node "${CLAUDE_PLUGIN_ROOT}/scripts/monitor-progress.mjs" <prompt_id>
    ```
 
-   This connects to ComfyUI's WebSocket and prints real-time step progress (e.g., `step 3/14 (21%)`), then reports completion with output filenames. You do NOT need to poll `queue` (action:"status") — the background task handles everything.
+   This connects to ComfyUI's WebSocket and prints real-time step progress (e.g., `step 3/14 (21%)`), then reports completion with output filenames. You do NOT need to poll `queue` (action:"status"); the background task handles it.
 
    Continue the conversation while waiting. Check the background task output when notified it completed.
 
@@ -61,7 +61,7 @@ The user wants to generate an image using ComfyUI. Their prompt is provided as t
 
 7. **Show the result.** Once the background monitor reports completion, use `get_image (action:"list_outputs")` (limit 1) to find the newest image. Read it with the Read tool to display it to the user.
 
-8. **Open the image.** Open the image so the user can see it immediately without navigating to the output folder. Use the Bash tool with the appropriate command for the OS:
+8. **Open the image.** Open the image so the user sees it right away without navigating to the output folder. Use the Bash tool with the appropriate command for the OS:
    - **macOS**: `open /path/to/image.png`
    - **Linux**: `xdg-open /path/to/image.png`
    - **Windows**: `start "" "/path/to/image.png"`
@@ -107,4 +107,4 @@ Steps:
 - If the user specifies dimensions, aspect ratio, steps, or other parameters, pass them through to `create_workflow`
 - For negative prompts, use a sensible default like "blurry, low quality, deformed" unless the user specifies one
 - If ComfyUI is not reachable, tell the user to check that it's running
-- After downloading a model, it's immediately available — no restart needed
+- A downloaded model is available right away; no restart needed

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -14,9 +14,9 @@ The user wants to install a ComfyUI custom node pack from the registry or a GitH
    If no argument was provided, ask the user what node pack they want to install.
 
    Determine the source type:
-   - **GitHub URL**: starts with `https://github.com/` — use directly
-   - **Registry ID**: a slug like `comfyui-impact-pack` — search for it
-   - **Descriptive name**: like "Impact Pack" or "ControlNet" — search for it
+   - **GitHub URL**: starts with `https://github.com/`; use it directly
+   - **Registry ID**: a slug like `comfyui-impact-pack`; search for it
+   - **Descriptive name**: like "Impact Pack" or "ControlNet"; search for it
 
 2. **Find the pack.** If not a direct GitHub URL:
    - Call `search_custom_nodes` (`action: "search"`) with the argument as `query`
@@ -62,7 +62,7 @@ Steps:
 ## Notes
 
 - Always use the ComfyUI venv Python for dependency installation, never the system Python
-- Some packs have complex dependencies (e.g., GroundingDINO, SAM) — if pip install fails, show the error and suggest manual intervention
+- Some packs have complex dependencies (e.g., GroundingDINO, SAM). If pip install fails, show the error and suggest the user finish the install by hand
 - If `git clone` fails due to the directory already existing, offer `git pull` to update instead
-- Some packs require additional model downloads after installation — check the pack README for post-install steps
+- Some packs require additional model downloads after installation; check the pack README for post-install steps
 - After installation and restart, verify the nodes loaded by calling `create_workflow (action:"node_info")` with one of the pack's node names

--- a/plugin/commands/node-skill.md
+++ b/plugin/commands/node-skill.md
@@ -12,7 +12,7 @@ The user wants to generate a Claude Code skill file for a ComfyUI custom node pa
 1. **Parse the argument.** The argument is: $ARGUMENTS
    - A ComfyUI Registry ID (e.g., `comfyui-impact-pack`)
    - A GitHub repository URL (e.g., `https://github.com/ltdrdata/ComfyUI-Impact-Pack`)
-   - Nothing — ask the user which node pack they want to generate a skill for
+   - Nothing, in which case ask the user which node pack they want to generate a skill for
 
 2. **Generate the skill.** Use the `list_packs` tool with:
    - `action`: `"generate_skill"`

--- a/plugin/commands/recipe.md
+++ b/plugin/commands/recipe.md
@@ -5,7 +5,7 @@ argument-hint: "Recipe name and prompt (e.g. 'portrait a woman with red hair')"
 
 # /comfy-recipe — Multi-Step Generation Recipes
 
-The user wants to run a predefined multi-step image generation pipeline. Each recipe chains multiple workflows together, passing the output of one step as input to the next.
+The user wants to run a predefined multi-step image generation pipeline. Each recipe chains several workflows together, passing the output of one step as input to the next.
 
 ## Instructions
 
@@ -19,58 +19,58 @@ The user wants to run a predefined multi-step image generation pipeline. Each re
 
 2. **Available recipes:**
 
-   - **`portrait`** — Generate a portrait and upscale it
-   - **`product-shot`** — Generate a product image with clean background
-   - **`hires-fix`** — Generate at low resolution, then upscale with img2img for more detail
-   - **`style-transfer`** — Apply a style prompt to an existing image via img2img
-   - **`morph`** — Generate two frames and create a smooth morph video between them
+   - `portrait`: generate a portrait and upscale it
+   - `product-shot`: generate a product image with clean background
+   - `hires-fix`: generate at low resolution, then upscale with img2img for more detail
+   - `style-transfer`: apply a style prompt to an existing image via img2img
+   - `morph`: generate two frames and create a smooth morph video between them
 
 3. **Check available models.** Call `list_local_models` with `model_type: "checkpoints"` to find a checkpoint. Also check `model_type: "upscale_models"` for upscale recipes. If models are missing, download appropriate ones before proceeding.
 
 4. **Execute the recipe.** For each step, create the workflow, run it, and chain the output.
 
 ### Portrait Recipe
-   - **Step 1 — Generate**: `create_workflow` with `txt2img`, prompt from user, 1024x1024, 25 steps, cfg 7
-   - **Step 2 — Upscale**: `create_workflow` with `upscale`, using the output image from Step 1, 2x upscale
+   - **Step 1: Generate.** `create_workflow` with `txt2img`, prompt from user, 1024x1024, 25 steps, cfg 7
+   - **Step 2: Upscale.** `create_workflow` with `upscale`, using the output image from Step 1, 2x upscale
    - Final output: 2048x2048 upscaled portrait
 
 ### Product-Shot Recipe
-   - **Step 1 — Generate**: `create_workflow` with `txt2img`, prompt from user (append "product photography, clean white background, studio lighting" to the prompt), 1024x1024, 25 steps, cfg 7
-   - **Step 2 — Remove background**: If a background removal node is available, create a workflow to remove the background. Otherwise, skip this step and note it for the user.
+   - **Step 1: Generate.** `create_workflow` with `txt2img`, prompt from user (append "product photography, clean white background, studio lighting" to the prompt), 1024x1024, 25 steps, cfg 7
+   - **Step 2: Remove background.** If a background removal node is available, create a workflow to remove the background. Otherwise, skip this step and note it for the user.
    - Final output: product image (with or without background removal)
 
 ### Hires-Fix Recipe
-   - **Step 1 — Low-res generation**: `create_workflow` with `txt2img`, prompt from user, 512x768 (or 768x512 for landscape), 20 steps, cfg 7
-   - **Step 2 — Upscale with img2img**: `create_workflow` with `img2img`, using Step 1 output, target 1024x1536 (or 1536x1024), denoise 0.4-0.5, same prompt, 20 steps
+   - **Step 1: Low-res generation.** `create_workflow` with `txt2img`, prompt from user, 512x768 (or 768x512 for landscape), 20 steps, cfg 7
+   - **Step 2: Upscale with img2img.** `create_workflow` with `img2img`, using Step 1 output, target 1024x1536 (or 1536x1024), denoise 0.4-0.5, same prompt, 20 steps
    - Final output: high-resolution image with more detail than direct high-res generation
 
 ### Style-Transfer Recipe
-   - **Step 1 — Load source image**: Ask the user for a source image path. Use `upload_image (action:"image")` to make it available.
-   - **Step 2 — img2img with style**: `create_workflow` with `img2img`, source image from Step 1, style prompt from user, denoise 0.5-0.7 (higher = more stylized, lower = more faithful to original), 25 steps
+   - **Step 1: Load source image.** Ask the user for a source image path. Use `upload_image (action:"image")` to make it available.
+   - **Step 2: img2img with style.** `create_workflow` with `img2img`, source image from Step 1, style prompt from user, denoise 0.5-0.7 (higher = more stylized, lower = more faithful to original), 25 steps
    - Final output: source image with the requested style applied
 
 ### Morph Recipe
    - This recipe generates two frames and creates a smooth morph video transitioning between them using WAN 2.2 First-Last-Frame with dual Hi-Lo architecture.
-   - **Requires the `wan-flf-video` and `qwen-image-edit` skills** — load them before executing.
+   - **Requires the `wan-flf-video` and `qwen-image-edit` skills.** Load them before executing.
 
-   **Frame Preparation — Anchor Frame Strategy:**
-   - Identify which frame is the "anchor" — the one with more complex composition (e.g., a person standing vs. a small animal). Generate the anchor first, then use Qwen Edit to create the second frame from it. This preserves proportions and scene consistency.
+   **Frame preparation, anchor frame strategy:**
+   - Identify which frame is the "anchor", meaning the one with the more complex composition (e.g., a person standing vs. a small animal). Generate the anchor first, then use Qwen Edit to create the second frame from it. This preserves proportions and scene consistency.
    - If the user provides two existing images, skip generation and go straight to Step 3.
 
-   - **Step 1 — Generate anchor frame**: Use Z-Image Turbo (or user's preferred model) to generate the primary frame. Use portrait orientation (832x1472) for standing subjects, landscape (1664x928) for wide scenes. Clear VRAM after.
-   - **Step 2 — Edit to create second frame**: Upload the anchor frame with `upload_image (action:"image")`. Use Qwen Image Edit (lightning 4-step) to transform it into the second frame. Prompt should describe the desired change while specifying relative size/position (e.g., "Replace the woman with a small cat sitting at the bottom of the image"). Clear VRAM after.
-   - **Step 3 — Generate morph video**: Upload both frames with `upload_image (action:"image")`. Build the WAN 2.2 dual Hi-Lo FLF workflow per the `wan-flf-video` skill:
+   - **Step 1: Generate anchor frame.** Use Z-Image Turbo (or user's preferred model) to generate the primary frame. Use portrait orientation (832x1472) for standing subjects, landscape (1664x928) for wide scenes. Clear VRAM after.
+   - **Step 2: Edit to create second frame.** Upload the anchor frame with `upload_image (action:"image")`. Use Qwen Image Edit (lightning 4-step) to transform it into the second frame. Prompt should describe the desired change while specifying relative size/position (e.g., "Replace the woman with a small cat sitting at the bottom of the image"). Clear VRAM after.
+   - **Step 3: Generate morph video.** Upload both frames with `upload_image (action:"image")`. Build the WAN 2.2 dual Hi-Lo FLF workflow per the `wan-flf-video` skill:
      - Two UNETs (Remix NSFW Hi+Lo with built-in lightning, or GGUF Q8 with lightning LoRAs)
      - `ModelSamplingSD3` shift=5 on both
      - `ImageResizeKJv2` to 480x720 (portrait) or 832x480 (landscape)
      - `WanFirstLastFrameToVideo` → dual `KSamplerAdvanced` (Hi: steps 0→2, Lo: steps 2→4, uni_pc/beta)
      - Optional: Apply morph LoRA (`wan2.2_i2v_magical_morph_{highnoise,lownoise}.safetensors`) to Hi/Lo Common stacks at strength 0.7-1.0 for smooth morphing instead of dissolve
      - `VHS_VideoCombine` at 16fps, h264-mp4
-   - **Step 4 (Optional) — Upscale**: Use `VRAM_Debug` to free VRAM, then `SeedVR2VideoUpscaler` to upscale to 1080p.
+   - **Step 4 (optional): Upscale.** Use `VRAM_Debug` to free VRAM, then `SeedVR2VideoUpscaler` to upscale to 1080p.
 
    **Prompt tips for morph videos:**
    - Describe the motion/transformation, not just start and end states
-   - **AVOID** "magical", "enchanted", "mystical" — causes literal sparkle effects
+   - **AVOID** "magical", "enchanted", "mystical"; they cause literal sparkle effects
    - **USE** clean motion language: "smoothly transforms", "seamlessly reshapes", "gradually morphs"
    - Include scale cues when subjects differ in size: "grows into", "expands upward"
    - Always include a full negative prompt (see `wan-flf-video` skill)
@@ -109,17 +109,17 @@ User: `/comfy-recipe morph a black cat sitting in front of a barn morphs into a 
 Steps:
 - Parse recipe: "morph", prompt: "a black cat sitting in front of a barn morphs into a woman standing tall"
 - Identify anchor frame: the woman (more complex, fills the frame)
-- Step 1: Z-Image Turbo txt2img — "Full body portrait of a woman standing in front of a rustic barn..." at 832x1472
-- Step 2: Qwen Edit — "Replace the woman with a small cat sitting at the bottom of the image, keep the barn background"
+- Step 1: Z-Image Turbo txt2img with "Full body portrait of a woman standing in front of a rustic barn..." at 832x1472
+- Step 2: Qwen Edit with "Replace the woman with a small cat sitting at the bottom of the image, keep the barn background"
 - Step 3: Clear VRAM, upload both frames, build WAN 2.2 dual Hi-Lo FLF workflow with morph LoRA
 - Present final morph video
 - Offer to adjust morph LoRA strength, frame count, or re-run with different seed
 
 ## Notes
 
-- Each step is a separate `enqueue_workflow(action="enqueue")` call — use a background monitor (`node "${CLAUDE_PLUGIN_ROOT}/scripts/monitor-progress.mjs" <prompt_id>` with `run_in_background: true`) to track completion. If a step fails, report the error and ask if the user wants to retry or skip
+- Each step is a separate `enqueue_workflow(action="enqueue")` call; use a background monitor (`node "${CLAUDE_PLUGIN_ROOT}/scripts/monitor-progress.mjs" <prompt_id>` with `run_in_background: true`) to track completion. If a step fails, report the error and ask if the user wants to retry or skip
 - For the portrait recipe, if no upscale model is installed, search for and download one (e.g., RealESRGAN_x2plus or 4x-UltraSharp)
-- The hires-fix denoise value is critical: too high (>0.6) loses the original composition, too low (<0.3) adds little detail. Default to 0.45.
-- For style-transfer, the user must provide a source image — if they don't, ask for one
+- The hires-fix denoise value matters. Too high (>0.6) loses the original composition, too low (<0.3) adds little detail. Default to 0.45.
+- For style-transfer, the user must provide a source image; if they don't, ask for one
 - Seed is randomized for Step 1 but preserved across subsequent steps for consistency (unless the user requests otherwise)
 - Always open the final image for the user using the OS-appropriate command (start/open/xdg-open)

--- a/plugin/commands/viz.md
+++ b/plugin/commands/viz.md
@@ -10,11 +10,11 @@ The user wants to visualize a ComfyUI workflow as a mermaid flowchart diagram.
 ## Instructions
 
 1. **Get the workflow JSON.** The argument may be: $ARGUMENTS
-   - A file path to a workflow JSON file — read it with the Read tool
+   - A file path to a workflow JSON file; read it with the Read tool
    - Inline JSON pasted directly as the argument
-   - Nothing — ask the user to provide a workflow file path or paste the JSON
+   - Nothing, in which case ask the user to provide a workflow file path or paste the JSON
 
-2. **Validate the input.** The workflow must be in ComfyUI's API format: an object where keys are node IDs and values have `class_type` and `inputs`. If it looks like the web UI format (has `nodes` and `links` arrays), tell the user it needs to be in API format and suggest they export it via "Save (API Format)" in ComfyUI.
+2. **Validate the input.** The workflow must be in ComfyUI's API format, an object where keys are node IDs and values have `class_type` and `inputs`. If it looks like the web UI format (has `nodes` and `links` arrays), tell the user it needs to be in API format and suggest they export it via "Save (API Format)" in ComfyUI.
 
 3. **Visualize.** Use the `visualize_workflow` tool with:
    - `workflow`: the parsed workflow JSON


### PR DESCRIPTION
Part of #2003.

Applies the full pstack `unslop` rule set (all 31 rules) to CONTRIBUTING.md, ROADMAP.md, llms-install.md, the 11 `plugin/commands/*.md` slash-command prompts, and the 4 `plugin/agents/*.md` agent prompts. Part of the overnight anti-slop / pstack evaluation, so the user can see how the prose rules net out on real docs and on LLM-facing prompts before adopting them elsewhere.

What changed in the prose: em and en dashes became periods, commas, or restructured sentences (no parentheses swapped in); mid-sentence connector colons are gone; bold label-with-colon lead-ins became period lead-ins (`**E1 — Download cache.**` is now `**E1. Download cache + dedup.**`, `**Step 1 — Generate**:` is now `**Step 1: Generate.**`); metaphor nouns got concrete words (`tool surface` is now `tool set`, `substrate` is gone, `HTTP primitives` is now `HTTP calls`, `prompt scaffolding` is now `prompt templates`); passives named their actor where it mattered; filler and adverbs (`efficiently`, `immediately`, `clearly`, `systematically`) were cut; `comprehensive` became `complete`; the trailing emoji in CONTRIBUTING and the checkmarks in its PR checklist are gone. The "predicate that returns the same value for a failed observation and a genuine negative" house rule in CONTRIBUTING keeps every claim and example; it is now plain sentences with the three examples introduced by a colon.

What did not change: every command, code block, link target, table, option/env/tool name, MCP tool name, argument name, and `$ARGUMENTS` placeholder. A script compared the multiset of inline code spans, the fenced blocks, the link set, and the heading set of each file against `main`; all are identical except one heading (below). In the plugin prompts every frontmatter key is intact and instruction meaning is unchanged; two `description` values were tightened (`director`: the em dash became a period; `explorer`: `comprehensive skills` became `complete skills`) with every trigger keyword kept.

Counts across the 18 files, before and after:

| metric | before | after |
| --- | --- | --- |
| em dashes (all) | 221 | 30 |
| em dashes in prose | 191 | 0 |
| en dashes | 4 | 0 |
| mid-sentence connector colons (hand count) | 15 | 0 |
| banned / metaphor words (`surface`, `comprehensive`, `substrate`, `scaffolding`, `primitives`, `seamlessly`) | 15 | 1 |
| emoji and checkmarks | 5 | 0 |
| curly quotes | 0 | 0 |

The 30 remaining em dashes, all outside prose and left deliberately:

- 22 in headings, which were preserved verbatim so the heading set stays identical: `# ComfyUI MCP — Roadmap`, `## Status — 2026-05-26`, the seven `## Theme X — ...` headings and `## "Roadmap to the roadmap" — sequencing` in ROADMAP.md; `# comfyui-mcp — Install Guide for AI Agents`; and the eleven `# /comfy-xxx — Title` H1s in `plugin/commands`. Those command H1s are also title case (rule 17); sentence-casing them would change the heading set, so they were left for a follow-up decision.
- 5 in the phase table cells of ROADMAP.md (`**0 — now (parallel)**` and so on); tables were preserved.
- 2 in comments inside the `Project layout` code block in CONTRIBUTING.md.
- 1 in the `## Output Format` template code block in `plugin/agents/debugger.md` (`**Failing Node**: [node_id] — [class_type]`); that block is the literal report shape the agent reproduces.

The one banned word left is `seamlessly` inside a quoted morph-video prompt suggestion in `plugin/commands/recipe.md` (`"smoothly transforms", "seamlessly reshapes", "gradually morphs"`); that is literal prompt text for the model, not prose.

One intentional heading change: `## ✅ Shipped (0.6.x)` in ROADMAP.md is now `## Shipped (0.6.x)` (rule 18, decorative emoji). Nothing in the repo links to that anchor.

Verification: `npm run check:docs-links`, `npm run check:docs-mdx`, and `npm run check:blog-structure` all pass; `node scripts/sync-agents.mjs` exits 0 and the regenerated `.gemini/commands/*.toml` and `.agents/skills/comfy-*/SKILL.md` carry the updated descriptions; `npm pack --dry-run` still lists all 15 plugin command and agent files; `npm test` runs with 16 failures in 5 path-guard test files (`extra-paths*`, `training-datasets`, `comfy-view-ref`, `panel-restart-legacy-fallback`) that fail identically on pristine `main` in this worktree with the markdown changes stashed, so they are environmental and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49