### PR TITLE
chore(hygiene): stop shipping 13 test files in the tarball; drop dead eslint directives and test:integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,6 @@ npm install
 | `npm run build` | Compile TypeScript to `dist/` |
 | `npm start` | Run compiled output |
 | `npm test` | Run unit tests (vitest) |
-| `npm run test:integration` | Run integration tests (requires running ComfyUI) |
 | `npm run lint` | Type-check without emitting |
 | `npm run generations:stats` | Show local generation tracking statistics |
 | `npm run sync-agents` | Sync Claude skills/commands/hooks to Google Antigravity, OpenCode, and other AI IDE formats that supports .agents files |

--- a/README.md
+++ b/README.md
@@ -758,6 +758,7 @@ npm install
 | `npm run build` | Compile TypeScript to `dist/` |
 | `npm start` | Run compiled output |
 | `npm test` | Run unit tests (vitest) |
+| `npm run test:integration` | Run integration tests (requires running ComfyUI) |
 | `npm run lint` | Type-check without emitting |
 | `npm run generations:stats` | Show local generation tracking statistics |
 | `npm run sync-agents` | Sync Claude skills/commands/hooks to Google Antigravity, OpenCode, and other AI IDE formats that supports .agents files |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run --passWithNoTests && npm run i18n:check && npm run check:docs-links && npm run check:docs-locale && npm run check:docs-mdx && npm run check:blog && npm run check:blog-packs && npm run check:blog-stale && npm run check:blog-structure",
     "smoke": "npm run build && node scripts/smoke-install.mjs",
     "test:watch": "vitest",
+    "test:integration": "cross-env COMFYUI_INTEGRATION=true vitest run",
     "test:agent": "npm run build && node scripts/test-agent.mjs",
     "test:local-llm": "npm run build && node scripts/test-local-llm.mjs",
     "arena": "npm run build && node scripts/llm-arena.mjs",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test": "vitest run --passWithNoTests && npm run i18n:check && npm run check:docs-links && npm run check:docs-locale && npm run check:docs-mdx && npm run check:blog && npm run check:blog-packs && npm run check:blog-stale && npm run check:blog-structure",
     "smoke": "npm run build && node scripts/smoke-install.mjs",
     "test:watch": "vitest",
-    "test:integration": "cross-env COMFYUI_INTEGRATION=true vitest run",
     "test:agent": "npm run build && node scripts/test-agent.mjs",
     "test:local-llm": "npm run build && node scripts/test-local-llm.mjs",
     "arena": "npm run build && node scripts/llm-arena.mjs",

--- a/src/__tests__/i18n/catalogs.test.ts
+++ b/src/__tests__/i18n/catalogs.test.ts
@@ -22,7 +22,7 @@ import { displayWidth, RULE_MAX } from "../../i18n/terminal-layout.js";
 
 afterEach(() => __resetI18nForTest());
 
-const ROOT = join(import.meta.dirname, "..", "..", "..");
+const ROOT = process.cwd();
 const TRANSLATED = LOCALES.filter((l) => l !== "en");
 
 function flatten(node: unknown, prefix = "", out: Record<string, string> = {}): Record<string, string> {

--- a/src/__tests__/i18n/catalogs.test.ts
+++ b/src/__tests__/i18n/catalogs.test.ts
@@ -17,12 +17,12 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { trFor, LOCALES, __resetI18nForTest } from "./index.js";
-import { displayWidth, RULE_MAX } from "./terminal-layout.js";
+import { trFor, LOCALES, __resetI18nForTest } from "../../i18n/index.js";
+import { displayWidth, RULE_MAX } from "../../i18n/terminal-layout.js";
 
 afterEach(() => __resetI18nForTest());
 
-const ROOT = join(import.meta.dirname, "..", "..");
+const ROOT = join(import.meta.dirname, "..", "..", "..");
 const TRANSLATED = LOCALES.filter((l) => l !== "en");
 
 function flatten(node: unknown, prefix = "", out: Record<string, string> = {}): Record<string, string> {

--- a/src/__tests__/i18n/i18n.test.ts
+++ b/src/__tests__/i18n/i18n.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { tr, trFor, resolveLocale, processLocale, LOCALES, __resetI18nForTest } from "./index.js";
+import { tr, trFor, resolveLocale, processLocale, LOCALES, __resetI18nForTest } from "../../i18n/index.js";
 
 afterEach(() => __resetI18nForTest());
 
@@ -113,7 +113,7 @@ describe("packaging", () => {
     // Without this the whole feature works perfectly on a dev machine and ships DEAD to every
     // npm user: the catalogs simply are not in the package, so `trFor` finds no file and
     // every language silently renders English. Nothing else would catch it.
-    const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "..", "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "..", "..", "..", "package.json"), "utf8"));
     expect(pkg.files).toContain("locales");
   });
 

--- a/src/__tests__/i18n/i18n.test.ts
+++ b/src/__tests__/i18n/i18n.test.ts
@@ -113,7 +113,7 @@ describe("packaging", () => {
     // Without this the whole feature works perfectly on a dev machine and ships DEAD to every
     // npm user: the catalogs simply are not in the package, so `trFor` finds no file and
     // every language silently renders English. Nothing else would catch it.
-    const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "..", "..", "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8"));
     expect(pkg.files).toContain("locales");
   });
 

--- a/src/__tests__/orchestrator/codex-error.test.ts
+++ b/src/__tests__/orchestrator/codex-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatCodexTurnError } from "./codex-error.js";
+import { formatCodexTurnError } from "../../orchestrator/codex-error.js";
 
 describe("formatCodexTurnError (#2112)", () => {
   it("turns the reported JSON-string Bad Request into an actionable unknown-400 diagnosis", () => {

--- a/src/__tests__/orchestrator/error-text.test.ts
+++ b/src/__tests__/orchestrator/error-text.test.ts
@@ -3,7 +3,7 @@
 // (issues #176, #175).
 
 import { describe, expect, it } from "vitest";
-import { errorText, messageText, promptText } from "./error-text.js";
+import { errorText, messageText, promptText } from "../../orchestrator/error-text.js";
 
 describe("errorText (#176)", () => {
   it("returns the message of an Error", () => {

--- a/src/__tests__/orchestrator/oauth-bridge.test.ts
+++ b/src/__tests__/orchestrator/oauth-bridge.test.ts
@@ -9,9 +9,9 @@ import {
   handleOAuthStatus,
   handleOAuthSignout,
   type OAuthBridgeDeps,
-} from "./oauth-bridge.js";
-import type { OAuthProviderConfig, OAuthTokens } from "../services/oauth-flow.js";
-import type { OAuthStatusRecord } from "../services/panel-secrets.js";
+} from "../../orchestrator/oauth-bridge.js";
+import type { OAuthProviderConfig, OAuthTokens } from "../../services/oauth-flow.js";
+import type { OAuthStatusRecord } from "../../services/panel-secrets.js";
 
 const CODEX: OAuthProviderConfig = {
   id: "codex",

--- a/src/__tests__/orchestrator/queue-note.test.ts
+++ b/src/__tests__/orchestrator/queue-note.test.ts
@@ -8,8 +8,8 @@
 // in-flight id is actually foreign.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { QueueMonitor } from "../services/queue-monitor.js";
-import { formatQueueNote } from "./queue-note.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { formatQueueNote } from "../../orchestrator/queue-note.js";
 
 type Priv = {
   url: string | null;

--- a/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
+++ b/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
@@ -99,7 +99,6 @@ describe("#654 the strictness of ready/graph_tools_ready is untouched", () => {
 
 describe("#654 WIRING: both restart replies report the classification", () => {
   const src = () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { readFileSync } = require("node:fs") as typeof import("node:fs");
     return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
   };

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -341,7 +341,6 @@ describe("run completion across automatic goal continuation (#468)", () => {
       async prepare() {
         throw new Error("endpoint rejected the key (http 401)");
       },
-      // eslint-disable-next-line require-yield
       async *run(): AsyncGenerator<AgentEvent> {
         throw new Error("never runs");
       },
@@ -848,7 +847,6 @@ describe("run completion across automatic goal continuation (#468)", () => {
       async prepare() {
         throw new Error("endpoint rejected the key (http 401)");
       },
-      // eslint-disable-next-line require-yield
       async *run(): AsyncGenerator<AgentEvent> {
         throw new Error("never runs");
       },
@@ -885,7 +883,6 @@ describe("run completion across automatic goal continuation (#468)", () => {
       async prepare() {
         throw new Error("endpoint rejected the key (http 401)");
       },
-      // eslint-disable-next-line require-yield
       async *run(): AsyncGenerator<AgentEvent> {
         throw new Error("never runs");
       },
@@ -1096,7 +1093,6 @@ describe("run completion across automatic goal continuation (#468)", () => {
       async prepare() {
         throw new Error("endpoint rejected the key (http 401)");
       },
-      // eslint-disable-next-line require-yield
       async *run(): AsyncGenerator<AgentEvent> {
         throw new Error("never runs");
       },
@@ -1128,7 +1124,6 @@ describe("run completion across automatic goal continuation (#468)", () => {
       id: "claude" as const,
       capabilities: CLAUDE_CAPABILITIES,
       // A session that ends immediately, every time, without reading the channel.
-      // eslint-disable-next-line require-yield
       async *run(): AsyncGenerator<AgentEvent> {
         starts += 1;
         return;

--- a/src/__tests__/orchestrator/start-failure-per-tab.test.ts
+++ b/src/__tests__/orchestrator/start-failure-per-tab.test.ts
@@ -42,7 +42,6 @@ class Rejecting401Backend implements AgentBackend {
     throw new Error("endpoint https://api.moonshot.ai/v1 rejected the key (http 401)");
   }
 
-  // eslint-disable-next-line require-yield
   async *run(): AsyncGenerator<AgentEvent> {
     throw new Error("run() must never be reached when prepare() rejects");
   }
@@ -82,7 +81,6 @@ class InstantlyDroppingBackend implements AgentBackend {
   readonly capabilities = CLAUDE_CAPABILITIES;
   runCount = 0;
 
-  // eslint-disable-next-line require-yield
   async *run(): AsyncGenerator<AgentEvent> {
     this.runCount += 1;
     // Return immediately: "session ended" with zero events.

--- a/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
+++ b/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
@@ -49,7 +49,6 @@ class GatedPrepareBackend implements AgentBackend {
     this.release(new Error(message));
   }
 
-  // eslint-disable-next-line require-yield
   async *run(): AsyncGenerator<AgentEvent> {
     throw new Error("run() must never be reached when prepare() rejects");
   }

--- a/src/__tests__/services/a2ui-spec.test.ts
+++ b/src/__tests__/services/a2ui-spec.test.ts
@@ -6,7 +6,7 @@
 // INSTANCE counting for both the 64-component cap and the 4-image cap, and the
 // chart x-array length cap).
 import { describe, expect, it } from "vitest";
-import { A2UI_CAPS, validateA2UISpecServer } from "./a2ui-spec.js";
+import { A2UI_CAPS, validateA2UISpecServer } from "../../services/a2ui-spec.js";
 
 const minimal = () => ({
   root: "c1",

--- a/src/__tests__/services/code-provider-auth-redact.test.ts
+++ b/src/__tests__/services/code-provider-auth-redact.test.ts
@@ -7,7 +7,7 @@
 // thrown message, for all three refresh paths (Grok, Codex/OpenAI, Kimi),
 // plus the adjacent "2xx but malformed JSON" path.
 import { describe, expect, it, vi } from "vitest";
-import { __testing } from "./code-provider-auth.js";
+import { __testing } from "../../services/code-provider-auth.js";
 
 const { refreshGrokTokens, refreshOpenAICodexTokens, refreshKimiCodeTokens } = __testing;
 

--- a/src/__tests__/services/env-store-atomic-write.test.ts
+++ b/src/__tests__/services/env-store-atomic-write.test.ts
@@ -1112,7 +1112,6 @@ function withPlatform(platform: string, fn: () => void): void {
 
 function readdirSyncSafe(d: string): string[] {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     return (require("node:fs") as typeof import("node:fs")).readdirSync(d);
   } catch {
     return [];

--- a/src/__tests__/services/oauth-flow.test.ts
+++ b/src/__tests__/services/oauth-flow.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { pkcePair, assertAllowedTokenHost, runLoopbackPKCE, OAUTH_PROVIDERS } from "../../services/oauth-flow.js";
-import { beginDeviceCode, pollDeviceToken } from "../../services/oauth-flow.js";
+import {
+  pkcePair,
+  assertAllowedTokenHost,
+  runLoopbackPKCE,
+  OAUTH_PROVIDERS,
+  beginDeviceCode,
+  pollDeviceToken,
+} from "../../services/oauth-flow.js";
 import { createHash } from "node:crypto";
 
 describe("pkcePair", () => {
@@ -185,7 +191,6 @@ describe("device-code", () => {
   });
 
   it("copilot registry entry is experimental", async () => {
-    const { OAUTH_PROVIDERS } = await import("../../services/oauth-flow.js");
     expect(OAUTH_PROVIDERS.copilot.experimental).toBe(true);
     expect(OAUTH_PROVIDERS.copilot.clientId).toBe("Iv1.b507a08c87ecfe98");
   });

--- a/src/__tests__/services/oauth-flow.test.ts
+++ b/src/__tests__/services/oauth-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { pkcePair, assertAllowedTokenHost, runLoopbackPKCE, OAUTH_PROVIDERS } from "./oauth-flow.js";
-import { beginDeviceCode, pollDeviceToken } from "./oauth-flow.js";
+import { pkcePair, assertAllowedTokenHost, runLoopbackPKCE, OAUTH_PROVIDERS } from "../../services/oauth-flow.js";
+import { beginDeviceCode, pollDeviceToken } from "../../services/oauth-flow.js";
 import { createHash } from "node:crypto";
 
 describe("pkcePair", () => {
@@ -185,7 +185,7 @@ describe("device-code", () => {
   });
 
   it("copilot registry entry is experimental", async () => {
-    const { OAUTH_PROVIDERS } = await import("./oauth-flow.js");
+    const { OAUTH_PROVIDERS } = await import("../../services/oauth-flow.js");
     expect(OAUTH_PROVIDERS.copilot.experimental).toBe(true);
     expect(OAUTH_PROVIDERS.copilot.clientId).toBe("Iv1.b507a08c87ecfe98");
   });

--- a/src/__tests__/services/oauth-landing.test.ts
+++ b/src/__tests__/services/oauth-landing.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, readFileSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { persistOAuthResult, readOAuthStatus, clearOAuth } from "../../services/code-provider-auth.js";
 
 let home: string;
+let savedSecretsPath: string | undefined;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "oauth-land-"));
+  savedSecretsPath = process.env.COMFYUI_MCP_PANEL_SECRETS;
   process.env.COMFYUI_MCP_PANEL_SECRETS = join(home, "panel-secrets.json");
+});
+afterEach(() => {
+  if (savedSecretsPath === undefined) delete process.env.COMFYUI_MCP_PANEL_SECRETS;
+  else process.env.COMFYUI_MCP_PANEL_SECRETS = savedSecretsPath;
 });
 
 it("codex: writes ~/.codex/auth.json in tokens{} shape + a status mirror without token material", async () => {

--- a/src/__tests__/services/oauth-landing.test.ts
+++ b/src/__tests__/services/oauth-landing.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach } from "vitest";
 import { mkdtempSync, readFileSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { persistOAuthResult, readOAuthStatus, clearOAuth } from "./code-provider-auth.js";
+import { persistOAuthResult, readOAuthStatus, clearOAuth } from "../../services/code-provider-auth.js";
 
 let home: string;
 beforeEach(() => {

--- a/src/__tests__/services/queue-monitor.poll.test.ts
+++ b/src/__tests__/services/queue-monitor.poll.test.ts
@@ -10,8 +10,8 @@
 //   • GET /history tail diff → completions with success/error status, including
 //     runs that started AND finished entirely between polls (#259).
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { QueueMonitor, type CompletionEvent } from "./queue-monitor.js";
-import { logger } from "../utils/logger.js";
+import { QueueMonitor, type CompletionEvent } from "../../services/queue-monitor.js";
+import { logger } from "../../utils/logger.js";
 
 // Reach into the singleton the same way queue-status-broadcast.test.ts does —
 // no real WS is opened (start() is never called here).

--- a/src/__tests__/services/queue-monitor.self-attribution.test.ts
+++ b/src/__tests__/services/queue-monitor.self-attribution.test.ts
@@ -11,7 +11,7 @@
 // job we did NOT queue drives the warning. Here we drive the singleton's state and
 // assert snapshot()/report() attribution.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { QueueMonitor } from "./queue-monitor.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
 
 type Priv = {
   url: string | null;

--- a/src/__tests__/services/queue-monitor.stall.test.ts
+++ b/src/__tests__/services/queue-monitor.stall.test.ts
@@ -13,7 +13,7 @@
 // TrainLoraNode & co. emit no per-step progress frames for hours by design, so
 // the floor fired on every healthy long training run.
 import { beforeEach, describe, expect, it } from "vitest";
-import { QueueMonitor, type CompletionEvent, type StallReport } from "./queue-monitor.js";
+import { QueueMonitor, type CompletionEvent, type StallReport } from "../../services/queue-monitor.js";
 
 type Priv = {
   url: string | null;

--- a/src/__tests__/services/queue-status-broadcast.test.ts
+++ b/src/__tests__/services/queue-status-broadcast.test.ts
@@ -7,12 +7,12 @@
 //   • current() always returns the live frame (the on-hello seed for a tab that
 //     connects mid-render).
 import { describe, expect, it } from "vitest";
-import type { QueueSnapshot } from "./queue-monitor.js";
+import type { QueueSnapshot } from "../../services/queue-monitor.js";
 import {
   buildQueueStatusFrame,
   createQueueStatusBroadcaster,
   type QueueStatusFrame,
-} from "./queue-status-broadcast.js";
+} from "../../services/queue-status-broadcast.js";
 
 const idle = (): QueueSnapshot => ({
   connected: true,
@@ -209,7 +209,7 @@ describe("QueueMonitor snapshot plumbing", () => {
   // ComfyUI frames, and assert the NEW snapshot fields carry node + progress —
   // the exact plumbing queue_status broadcasts to the phone.
   it("exposes currentNode + progress from live ComfyUI frames", async () => {
-    const { QueueMonitor } = await import("./queue-monitor.js");
+    const { QueueMonitor } = await import("../../services/queue-monitor.js");
     const onMessage = (
       QueueMonitor as unknown as { onMessage(text: string): void }
     ).onMessage.bind(QueueMonitor);
@@ -238,7 +238,7 @@ describe("QueueMonitor snapshot plumbing", () => {
   // watchdog sees just the broadcast frames: status / progress / progress_state.
   // The run state must be derivable from those alone.
   it("derives running state from broadcast-only frames (modern ComfyUI)", async () => {
-    const { QueueMonitor } = await import("./queue-monitor.js");
+    const { QueueMonitor } = await import("../../services/queue-monitor.js");
     const onMessage = (
       QueueMonitor as unknown as { onMessage(text: string): void }
     ).onMessage.bind(QueueMonitor);

--- a/src/__tests__/services/queue-status-broadcast.test.ts
+++ b/src/__tests__/services/queue-status-broadcast.test.ts
@@ -7,7 +7,7 @@
 //   • current() always returns the live frame (the on-hello seed for a tab that
 //     connects mid-render).
 import { describe, expect, it } from "vitest";
-import type { QueueSnapshot } from "../../services/queue-monitor.js";
+import { QueueMonitor, type QueueSnapshot } from "../../services/queue-monitor.js";
 import {
   buildQueueStatusFrame,
   createQueueStatusBroadcaster,
@@ -209,7 +209,6 @@ describe("QueueMonitor snapshot plumbing", () => {
   // ComfyUI frames, and assert the NEW snapshot fields carry node + progress —
   // the exact plumbing queue_status broadcasts to the phone.
   it("exposes currentNode + progress from live ComfyUI frames", async () => {
-    const { QueueMonitor } = await import("../../services/queue-monitor.js");
     const onMessage = (
       QueueMonitor as unknown as { onMessage(text: string): void }
     ).onMessage.bind(QueueMonitor);
@@ -238,7 +237,6 @@ describe("QueueMonitor snapshot plumbing", () => {
   // watchdog sees just the broadcast frames: status / progress / progress_state.
   // The run state must be derivable from those alone.
   it("derives running state from broadcast-only frames (modern ComfyUI)", async () => {
-    const { QueueMonitor } = await import("../../services/queue-monitor.js");
     const onMessage = (
       QueueMonitor as unknown as { onMessage(text: string): void }
     ).onMessage.bind(QueueMonitor);

--- a/src/__tests__/test-mirror-is-complete.test.ts
+++ b/src/__tests__/test-mirror-is-complete.test.ts
@@ -1,0 +1,30 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// vitest.config.ts includes only `src/__tests__/**`, and tsconfig.json excludes only
+// `src/__tests__`. The two are a matched pair, and the pair has a silent failure mode:
+// a `*.test.ts` written anywhere else under src/ is invisible to vitest AND compiled
+// into dist/. It does not fail — it simply stops being a test, and the suite still
+// reports green. This turns that silence into a failure.
+const SRC = join(process.cwd(), "src");
+const MIRROR = join(SRC, "__tests__");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (full === MIRROR) continue;
+      walk(full, out);
+    } else if (/\.(test|spec)\.ts$/.test(entry)) {
+      out.push(relative(SRC, full).split(sep).join("/"));
+    }
+  }
+  return out;
+}
+
+describe("the __tests__ mirror is the only place tests live", () => {
+  it("finds no test file outside src/__tests__", () => {
+    expect(walk(SRC)).toEqual([]);
+  });
+});

--- a/src/__tests__/tools/node-bisect-tool.test.ts
+++ b/src/__tests__/tools/node-bisect-tool.test.ts
@@ -41,7 +41,6 @@ async function register(): Promise<Registered[]> {
       tools.push({ name, description, shape, handler });
       return { update() {}, remove() {}, enable() {}, disable() {} };
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
   registerNodeBisectTools(server);
   return tools;

--- a/src/__tests__/tools/node-snapshots-tool.test.ts
+++ b/src/__tests__/tools/node-snapshots-tool.test.ts
@@ -58,7 +58,6 @@ async function register(): Promise<Registered[]> {
       tools.push({ name, description, shape, handler });
       return { update() {}, remove() {}, enable() {}, disable() {} };
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
   registerNodeSnapshotsTools(server);
   return tools;

--- a/src/__tests__/tools/report-issue.test.ts
+++ b/src/__tests__/tools/report-issue.test.ts
@@ -19,7 +19,6 @@ function getReportIssueHandler(): ToolHandler {
       handler = h;
     },
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registerReportIssueTools(fakeServer as any);
   if (!handler) throw new Error("report_issue handler not registered");
   return handler;

--- a/src/__tests__/tools/report-issue.test.ts
+++ b/src/__tests__/tools/report-issue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach, afterAll } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA, WORKER_MAX_BODY_LEN } from "./report-issue.js";
+import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA, WORKER_MAX_BODY_LEN } from "../../tools/report-issue.js";
 
 const noSleep = async () => {};
 

--- a/src/__tests__/tools/truncation-remedies.test.ts
+++ b/src/__tests__/tools/truncation-remedies.test.ts
@@ -771,7 +771,6 @@ describe("#809 truncation remedies name a lever that actually exists", () => {
           ],
         ],
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     const tb = err?.traceback ?? "";
     expect(err?.traceback_truncated).toBe(true);

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -166,7 +166,6 @@ export function parseGoDurationMs(s: string): number | null {
 
 /** Strip ANSI escape sequences (agy's TUI heritage may color even -p output). */
 function stripAnsi(s: string): string {
-  // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
 }
 

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -180,7 +180,6 @@ export function parsePiDurationMs(s: string): number | null {
  *  The ESC byte (\x1b) is part of the match — without it a colored token keeps
  *  its leading control char and fails id validation. */
 function stripAnsi(s: string): string {
-  // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
 }
 

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -915,7 +915,6 @@ function encodeEnvLine(key: string, value: string): string {
   //     gate, round 3, finding 4). A confirmed save that delivers something else
   //     is the worst outcome of all;
   //   - any other C0 control: same class of hazard, no credential contains one.
-  // eslint-disable-next-line no-control-regex
   // Written with \u escapes on purpose: a literal control byte in this
   // source would make the file read as a binary blob to git, unreviewable
   // in a diff.

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -51,7 +51,6 @@ async function loadRawFromSource(
   path: string | undefined,
   filename: string | undefined,
   graph: Record<string, unknown> | undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const provided = [path, filename, graph].filter((v) => v != null).length;
   if (provided !== 1) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ import { defineConfig } from "vitest/config";
 // by background agents), polluting the run.
 export default defineConfig({
   test: {
-    include: ["src/**/*.{test,spec}.ts"],
+    // Matched pair with tsconfig.json's `exclude: ["src/__tests__"]`: a test outside that tree would
+    // ship in dist/ yet never run here, so neither file admits one.
+    include: ["src/__tests__/**/*.{test,spec}.ts"],
     // Redirect the home directory to a throwaway temp dir in EVERY worker
     // before any module under test is imported (#879, #866). Without this the
     // full suite intermittently rewrites the developer's real


### PR DESCRIPTION
Part of #2003.

The headline is not the tidy-up: on `main`, `npm pack --dry-run | grep -c '\.test\.'` reports **26**. Thirteen test files sat beside their subjects instead of under `src/__tests__/`, and because `tsconfig.json` excludes only `src/__tests__`, `tsc` compiled them into `dist/` and npm shipped them with their source maps in every release. After this PR the count is **0**. The release workflow does a fresh checkout and build, so the fix reaches real publishes on the next tag.

**What moved.** `src/i18n/{catalogs,i18n}.test.ts`, `src/orchestrator/{error-text,oauth-bridge}.test.ts`, eight under `src/services/` (`a2ui-spec`, `code-provider-auth-redact`, `oauth-flow`, `oauth-landing`, `queue-monitor.{poll,self-attribution,stall}`, `queue-status-broadcast`), and `src/tools/report-issue.test.ts`, each `git mv`'d to `src/__tests__/<same subpath>/`. The first commit changes only what depends on file depth: 22 import specifiers and the two `import.meta.dirname` walks in the i18n tests. `git diff -M --stat` shows 13 renames, 24 lines.

**What the move costs.** These thirteen files are no longer type-checked by `npm run lint`, because that is what the tsconfig exclude means for everything else under `src/__tests__/`. That is the same footing as the other ~590 tests, but it is a real loss for these files specifically, so I type-checked them once with a throwaway tsconfig before committing (0 errors, which vitest alone would not prove: it erases `import type`, and `oauth-bridge.test.ts` has two type-only imports whose paths changed).

**The rule is now enforced, not just documented.** The fourth commit narrows `vitest.config.ts`'s `include` from `src/**` to `src/__tests__/**` with a one-line comment naming it as the matched pair of tsconfig's exclude: a colocated test is now both invisible to vitest and compiled into the tarball, so it cannot pass locally while drifting. Collected file count is 605 before and after. The same commit carries the review follow-ups: the two i18n tests find the repo root with `process.cwd()` like `package-hooks`/`check-pack-models` do, instead of a re-counted `../..` chain; `oauth-landing.test.ts` saves and restores `COMFYUI_MCP_PANEL_SECRETS` in `afterEach` as `panel-secrets-receipt.test.ts` does, rather than leaving the override set for the worker; and the duplicate/dynamic imports in `oauth-flow.test.ts` and `queue-status-broadcast.test.ts` collapse to top-level imports (neither file uses `vi.mock` or `resetModules`, so the dynamic form returned the already-loaded module; both pass unchanged). Nothing about `vitest.global-setup.ts` or the home-dir redirection changed.

**ESLint directives nobody reads.** There is no ESLint here: no config, no `eslint`/`@typescript-eslint` dependency, no CI step. The `// eslint-disable-next-line …` comments addressed a tool that never runs and implied one does. The brief counted five (files outside `src/__tests__/`); the grep it prescribes finds eighteen, all equally dead, so all eighteen go. Each was a standalone line; the rationale comments beside some of them (the control-character block at `panel-secrets.ts:900-912`, the "session that ends immediately" note in `run-completion-continuation.test.ts`) are on their own lines and untouched. Eighteen deletions, zero insertions, `tsc --noEmit` clean.

**`test:integration` was `npm test` in disguise.** It ran `cross-env COMFYUI_INTEGRATION=true vitest run`, and nothing under `src/`, `scripts/`, `docs/`, `README.md`, or `CONTRIBUTING.md` reads that variable, so it gated nothing. The README table called it "integration tests (requires running ComfyUI)", which was not true. Script and table row are gone; `cross-env` stays for the three scripts that use it. The README row is one line in the "Scripts" table and another branch in this batch is rewriting README prose, so expect a trivial conflict there if both land.

**Follow-ups, deliberately not in this PR.**
- A `tsconfig.test.json` that type-checks `src/__tests__/` in CI would restore the coverage the move gives up for these thirteen and extend it to every other test; that is the ratchet this PR's finding argues for.
- `design/node-dev-tools.md:84` and `design/comfyui-settings-tools.md:79` still mention `COMFYUI_INTEGRATION`; `design/` is off-limits for this batch, so they are listed here instead of edited.
- A developer with a stale local `dist/` keeps the thirteen orphaned `dist/**/*.test.js` files until they rebuild clean, because `tsc` never deletes outputs; `rm -rf dist && npm run build` clears them. CI and release are unaffected (fresh checkouts).
- Private mirrors of this tree inherit the narrowed `include`; any colocated test they carry stops running until moved.

**Observation, not changed:** `ci.yml` and `packs.yml` pin Node 22 while `release.yml` pins Node 24, so the published artifact is built and smoke-tested on a different major than the one CI exercises.

**Verification.** `npm run build && npm test`: 605 files collected, 11092 tests passed, 17 failed; 16 of those are the known macOS-only failures in `src/__tests__/services/{extra-paths*,comfy-view-ref,training-datasets}` that fail identically on `main` (comfyui-mcp-1qe), and the 17th (`panel-restart-legacy-fallback.test.ts`, #709, a file this PR does not touch) passes 22/22 in isolation and failed only while a second full suite ran on the same machine. The i18n/docs-links/docs-locale/docs-mdx/blog gates ran. `npm run smoke` packs the tarball, installs it into a throwaway project, and gets a `tools/list` reply over stdio: 37 core + 3 compact-mode tools, 95 panel tools matching the build. `npm pack --dry-run | grep -c '\.test\.'` is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49