### PR TITLE
docs(unslop): plugin skills i through q say the plain thing

### DIFF
--- a/plugin/skills/ideogram-ultra/SKILL.md
+++ b/plugin/skills/ideogram-ultra/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ideogram-ultra
-description: Build Ideogram 4 (Ideogram Ultra) txt2img and img2img workflows — local open-weights model, dual conditional/unconditional models with DualModelGuider, Qwen3-VL text encoder, and structured JSON ("compositional deconstruction") prompts for strong text rendering and layout control
+description: Build Ideogram 4 (Ideogram Ultra) txt2img and img2img workflows with the local open-weights model, dual conditional/unconditional models with DualModelGuider, Qwen3-VL text encoder, and structured JSON ("compositional deconstruction") prompts for strong text rendering and layout control
 globs:
   - "**/*.json"
 ---
@@ -9,15 +9,15 @@ globs:
 
 ## Overview
 
-**This is a LOCAL open-weights pipeline — NOT the hosted Ideogram API.** There is no API key, no `IdeogramGenerate` API node, and no network call at generation time. Comfy-Org released the Ideogram 4 weights on Hugging Face and they run entirely on your GPU via standard `UNETLoader` / `CLIPLoader` / `VAELoader` nodes. (Note: ComfyUI *also* ships separate API/"partner" nodes that call the paid hosted Ideogram service — that is a different thing and is not what this workflow uses.)
+**This is a LOCAL open-weights pipeline, NOT the hosted Ideogram API.** There is no API key, no `IdeogramGenerate` API node, and no network call at generation time. Comfy-Org released the Ideogram 4 weights on Hugging Face and they run entirely on your GPU via standard `UNETLoader` / `CLIPLoader` / `VAELoader` nodes. (Note: ComfyUI *also* ships separate API/"partner" nodes that call the paid hosted Ideogram service. That is a different thing and is not what this workflow uses.)
 
-Ideogram 4 is best known for **text rendering / typography**, **poster and graphic-design layouts**, and **prompt adherence**. The hallmark of this workflow is a **structured JSON prompt** (a "compositional deconstruction" caption with bounding boxes) instead of a plain text prompt — this is what gives precise control over where text and objects land in the frame.
+Ideogram 4 is best known for **text rendering / typography**, **poster and graphic-design layouts**, and **prompt adherence**. The hallmark of this workflow is a **structured JSON prompt** (a "compositional deconstruction" caption with bounding boxes) instead of a plain text prompt. This is what gives precise control over where text and objects land in the frame.
 
 Source workflow this skill is derived from: `IDEOGRAM_ULTRA_WORKFLOW-V2.json` (UI format, 66 nodes, 4 subgraphs), by Aitrepreneur. It provides both a **TEXT TO IMAGE** path and an **IMAGE TO IMAGE** path.
 
 ### Two unusual things to know up front
 
-1. **Dual models.** Two UNETs are loaded: a conditional model (`ideogram4_fp8_scaled`) and an `..._unconditional_fp8_scaled` model. A `DualModelGuider` node uses both to perform asymmetric classifier-free guidance — the unconditional model provides the CFG baseline. There is **no negative text prompt**; negative conditioning is `ConditioningZeroOut`.
+1. **Dual models.** Two UNETs are loaded: a conditional model (`ideogram4_fp8_scaled`) and an `..._unconditional_fp8_scaled` model. A `DualModelGuider` node uses both to perform asymmetric classifier-free guidance; the unconditional model provides the CFG baseline. There is **no negative text prompt**; negative conditioning is `ConditioningZeroOut`.
 2. **Two text models, different jobs.**
    - `qwen3vl_8b_fp8_scaled` is the **actual diffusion text encoder** (loaded with `CLIPLoader`, type `ideogram4`).
    - `gemma4_e4b_it_fp8_scaled` is used **only inside an optional prompt-builder subgraph** (a `TextGenerate` node) that auto-writes the structured JSON from a plain idea. It is not the diffusion encoder.
@@ -35,10 +35,10 @@ git clone https://github.com/kijai/ComfyUI-KJNodes
 git clone https://github.com/cubiq/ComfyUI_essentials
 ```
 
-- **ComfyUI-KJNodes** (kijai) — provides `Ideogram4PromptBuilderKJ`, `ImageSharpenKJ`, `TextGenerate`, and the Ideogram 4 helper nodes. **Required.**
-- **rgthree-comfy** — `Power Lora Loader`, `Fast Groups Muter/Bypasser`, `Label`, `Any Switch`. (Used for UI/convenience; the core pipeline still works without them.)
-- **ComfyUI_essentials** (cubiq) — `ImageResize+` (used in the img2img path).
-- **ComfyUI-Manager** — node/model management; not required at run time.
+- **ComfyUI-KJNodes** (kijai) provides `Ideogram4PromptBuilderKJ`, `ImageSharpenKJ`, `TextGenerate`, and the Ideogram 4 helper nodes. **Required.**
+- **rgthree-comfy** provides `Power Lora Loader`, `Fast Groups Muter/Bypasser`, `Label`, `Any Switch`. (Used for UI/convenience; the core pipeline still works without them.)
+- **ComfyUI_essentials** (cubiq) provides `ImageResize+` (used in the img2img path).
+- **ComfyUI-Manager** handles node/model management; not required at run time.
 
 > The core nodes used in the simplified workflows below (`UNETLoader`, `CLIPLoader`, `VAELoader`, `DualModelGuider`, `SamplerCustomAdvanced`, `ModelSamplingAuraFlow`, `BasicScheduler`, `EmptyFlux2LatentImage`, `CLIPTextEncode`, `ConditioningZeroOut`, `VAEDecode`) are **built into ComfyUI** (recent versions). Only `Ideogram4PromptBuilderKJ` / `ImageSharpenKJ` require KJNodes.
 
@@ -56,7 +56,7 @@ Five files. Folder layout and download URLs are taken verbatim from `IDEOGRAM_UL
 
 Notes / things to verify:
 - The two **diffusion models** come from the official `Comfy-Org/Ideogram-4` HF repo. The **text encoders + VAE** are mirrored from the third-party `Aitrepreneur/FLX` repo in these scripts; the official ones also live on Comfy-Org / Comfy-Org-adjacent repos. Both should be identical files but the FLX mirror is what the provided installer pulls.
-- **File sizes are uncertain.** The official ComfyUI docs page lists each diffusion model at ~13.8 GB, qwen3vl at ~8 GB, gemma4 at ~2 GB, vae at ~335 MB (~38.9 GB total). A web search result claimed `ideogram4_fp8_scaled` is ~9.28 GB. Treat sizes as approximate — confirm against the HF file listing.
+- **File sizes are uncertain.** The official ComfyUI docs page lists each diffusion model at ~13.8 GB, qwen3vl at ~8 GB, gemma4 at ~2 GB, vae at ~335 MB (~38.9 GB total). A web search result claimed `ideogram4_fp8_scaled` is ~9.28 GB. Treat sizes as approximate and confirm against the HF file listing.
 - `flux2-vae.safetensors` is the same VAE used by Flux 2 / Klein workflows.
 
 ### Linux / RunPod note
@@ -122,7 +122,7 @@ The heart of the pipeline. Takes the (shifted) conditional model, the (shifted) 
 }
 ```
 
-> Input names for `DualModelGuider` (`model_negative`, `cfg`) are inferred from the subgraph wiring and KJNodes; verify against your installed KJNodes version — the exact widget/socket names may differ slightly.
+> Input names for `DualModelGuider` (`model_negative`, `cfg`) are inferred from the subgraph wiring and KJNodes; verify against your installed KJNodes version, since the exact widget/socket names may differ.
 
 ### EmptyFlux2LatentImage
 
@@ -155,19 +155,19 @@ A KJNodes node that outputs the structured caption JSON string (see "Prompt Styl
 
 #### ⚠️ Editing this node programmatically (panel_set_widget WILL NOT STICK)
 
-**This is the single most important thing to know about this node.** Its `elements_data` / `style_palette_data` widgets are **NOT the source of truth** — they are serialized *from* a live in-browser array (`node._boxes`) inside the KJNodes editor JS. Two mechanisms defeat any external widget edit:
+**This is the single most important thing to know about this node.** Its `elements_data` / `style_palette_data` widgets are **NOT the source of truth**. They are serialized *from* a live in-browser array (`node._boxes`) inside the KJNodes editor JS. Two mechanisms defeat any external widget edit:
 
 - **Queue-time re-serialization.** In `web/js/ideogram4_prompt_builder.js`, `elementsWidget.serializeValue()` regenerates the value from `node._boxes` *every time the graph is queued*. So `panel_set_widget(14, "elements_data", ...)` sets the value, but ComfyUI overwrites it with the stale editor boxes the instant you run. **The edit silently reverts on every run.**
-- **You can't reach `node._boxes`.** It lives in the browser tab; no panel/MCP tool can touch it. Editing `elements_data`, `ideo_editor`, or forcing `import_mode` alone does nothing durable. `node._boxes` is only ever re-seeded from `elements_data` on workflow *load* (`onConfigure`), and even then the saved `o.ideo.boxes` blob wins over the widget — so a stale saved workflow reloads stale.
+- **You can't reach `node._boxes`.** It lives in the browser tab; no panel/MCP tool can touch it. Editing `elements_data`, `ideo_editor`, or forcing `import_mode` alone does nothing durable. `node._boxes` is only ever re-seeded from `elements_data` on workflow *load* (`onConfigure`), and even then the saved `o.ideo.boxes` blob wins over the widget, so a stale saved workflow reloads stale.
 
-**The symptom:** you edit the JSON, the panel confirms the new value, but the render (and the visible builder JSON) still shows the OLD prompt — e.g. old subject/region text that "won't go away."
+**The symptom:** you edit the JSON, the panel confirms the new value, but the render (and the visible builder JSON) still shows the OLD prompt, e.g. old subject/region text that "won't go away."
 
-**The correct, node-designed fix — drive it via `import_json`:**
+**The correct, node-designed fix is to drive it via `import_json`:**
 1. Add a `PrimitiveStringMultiline` node containing the FULL caption JSON (the `high_level_description` + `style_description` + `compositional_deconstruction` shape from "Prompt Style" below).
 2. Wire it into node 14's **`import_json`** input.
 3. Set **`import_mode = "always"`**.
 
-The Python `execute()` then does `used_import = imported is not None and (import_mode == "always" or not boxes)` → the caption is built **entirely** from `import_json`; the poisoned `elements_data`/`node._boxes` are ignored. Bonus: running once in this mode pushes the caption back into the editor via `ui`, which re-seeds `node._boxes` and flushes the stale boxes for good. From then on, edit the prompt in the wired string node, **not** the builder's visual editor. (`import_mode = "when empty"` only seeds the editor when it has no regions, then the editor wins again — so for programmatic control it MUST be `"always"`.)
+The Python `execute()` then does `used_import = imported is not None and (import_mode == "always" or not boxes)` → the caption is built **entirely** from `import_json`; the poisoned `elements_data`/`node._boxes` are ignored. Bonus: running once in this mode pushes the caption back into the editor via `ui`, which re-seeds `node._boxes` and flushes the stale boxes for good. From then on, edit the prompt in the wired string node, **not** the builder's visual editor. (`import_mode = "when empty"` only seeds the editor when it has no regions, then the editor wins again, so for programmatic control it MUST be `"always"`.)
 
 ### ImageSharpenKJ (post-process)
 
@@ -190,7 +190,7 @@ Values below are exactly what the source `IDEOGRAM_ULTRA_WORKFLOW-V2.json` ships
 | sharpen | rcas, 0.55 | `ImageSharpenKJ` |
 | noise control | `RandomNoise`, fixed seed | seed sample value `1335735769456` |
 
-There is also a `CFGOverride` node in the sampler subgraph (widgets `3, 0.7, 1`); it is an optional override and is not the primary guidance path — the primary CFG is `DualModelGuider`'s `5`.
+There is also a `CFGOverride` node in the sampler subgraph (widgets `3, 0.7, 1`); it is an optional override and is not the primary guidance path. The primary CFG is `DualModelGuider`'s `5`.
 
 ## Resolutions / Aspect Ratios
 
@@ -236,18 +236,18 @@ An optional `style_description` object (`aesthetics`, `lighting`, `medium`, `art
 
 ### bbox rules (critical)
 
-- Format is **`[top, left, bottom, right]`**, values **0–1000** (NOT pixels, NOT x/y/w/h).
-- **One bbox per major subject** — do not split a person into face/hair/clothes boxes; put all detail in one `desc`.
-- Use extra boxes only for genuinely separate items (a product, a title, a second character).
+- Format is **`[top, left, bottom, right]`**, values **0 to 1000** (NOT pixels, NOT x/y/w/h).
+- **One bbox per major subject.** Do not split a person into face/hair/clothes boxes; put all detail in one `desc`.
+- Use extra boxes only for separate items (a product, a title, a second character).
 - For character groups in wide images, use **vertical columns** of non-overlapping boxes.
 - For posters: reserve a top zone for the title, middle for the subject, bottom for subtitle/CTA.
-- Overlapping text boxes cause garbled text — increase spacing or remove boxes.
+- Overlapping text boxes cause garbled text. Increase spacing or remove boxes.
 
 ### Text rendering tips
 
 - Keep rendered text **short and bold** ("ORDER NOW", "COMING THIS FALL"). Long/tiny text still fails sometimes.
 - Lock style explicitly when needed, e.g. `"rendered as an actual live-action photograph, not anime, not illustration"` or `"high-quality Japanese anime, cel shading, not photographic"`.
-- 3–6 strong elements beat 20 overlapping ones.
+- 3 to 6 strong elements beat 20 overlapping ones.
 
 ### Generating the JSON automatically
 
@@ -339,19 +339,18 @@ Optional upstream: Ideogram4PromptBuilderKJ  OR  TextGenerate(gemma4) ─► CLI
 - Both diffusion models plus the Qwen3-VL encoder are large. Loading **two** ~13.8 GB UNETs is the main cost; expect this to be heavy on 24 GB GPUs. The official docs cite a 16 GB minimum for the FP8 models, but that assumes ComfyUI swaps models in/out rather than holding both resident.
 - **Always `clear_vram`** before switching to Ideogram 4 from another model family.
 - If you OOM: rely on ComfyUI's automatic model offloading, run `--lowvram`, or reduce resolution.
-- Exact VRAM numbers for the dual-model setup are **not verified** in the source files — treat the above as guidance, not measured figures.
+- Exact VRAM numbers for the dual-model setup are **not verified** in the source files. Treat the above as guidance, not measured figures.
 
 ## Troubleshooting
 
-- **Prompt edits to `Ideogram4PromptBuilderKJ` won't stick / stale prompt keeps coming back** — `elements_data` is re-serialized from the browser editor's `node._boxes` at queue time, so `panel_set_widget` reverts on every run and you can't reach `node._boxes` externally. Fix: wire a `PrimitiveStringMultiline` (full caption JSON) into the node's `import_json` input and set `import_mode = "always"`. See "Editing this node programmatically" under Key Nodes. This is the ONLY reliable way to drive the prompt from outside the browser.
-- **"NOT A VALID IDEOGRAM 4 CAPTION JSON"** — JSON is malformed. Use double quotes, no trailing commas, exact key `compositional_deconstruction`, matched brackets. Validate in any JSON linter.
-- **Garbled / overlapping text in the image** — text bboxes overlap or text is too long. Increase spacing, shorten text, remove boxes.
-- **Style drift (anime when you wanted photo, etc.)** — add explicit style-lock language in the element/style description.
-- **Wrong element placement** — remember bbox is `[top, left, bottom, right]` 0–1000, not pixels and not x/y/w/h.
-- **Same seed, different image across machines** — expected; differs by GPU, drivers, PyTorch/CUDA/ComfyUI versions (per template README).
-- **CLIPLoader type missing `ideogram4`** — update ComfyUI; the `ideogram4` CLIP type and the Flux2/Ideogram nodes require a recent build (installer pins ComfyUI portable `v0.24.0`).
-- **`Ideogram4PromptBuilderKJ` / `DualModelGuider` not found** — update KJNodes (`git pull` in `custom_nodes/ComfyUI-KJNodes`); these are recent additions.
-```
+- **Prompt edits to `Ideogram4PromptBuilderKJ` won't stick / stale prompt keeps coming back.** `elements_data` is re-serialized from the browser editor's `node._boxes` at queue time, so `panel_set_widget` reverts on every run and you can't reach `node._boxes` externally. Fix: wire a `PrimitiveStringMultiline` (full caption JSON) into the node's `import_json` input and set `import_mode = "always"`. See "Editing this node programmatically" under Key Nodes. This is the ONLY reliable way to drive the prompt from outside the browser.
+- **"NOT A VALID IDEOGRAM 4 CAPTION JSON".** JSON is malformed. Use double quotes, no trailing commas, exact key `compositional_deconstruction`, matched brackets. Validate in any JSON linter.
+- **Garbled / overlapping text in the image.** Text bboxes overlap or text is too long. Increase spacing, shorten text, remove boxes.
+- **Style drift (anime when you wanted photo, etc.).** Add explicit style-lock language in the element/style description.
+- **Wrong element placement.** Remember bbox is `[top, left, bottom, right]` 0 to 1000, not pixels and not x/y/w/h.
+- **Same seed, different image across machines.** Expected; it differs by GPU, drivers, PyTorch/CUDA/ComfyUI versions (per template README).
+- **CLIPLoader type missing `ideogram4`.** Update ComfyUI; the `ideogram4` CLIP type and the Flux2/Ideogram nodes require a recent build (installer pins ComfyUI portable `v0.24.0`).
+- **`Ideogram4PromptBuilderKJ` / `DualModelGuider` not found.** Update KJNodes (`git pull` in `custom_nodes/ComfyUI-KJNodes`); these are recent additions.
 
 ## Sources
 

--- a/plugin/skills/installer-packs/SKILL.md
+++ b/plugin/skills/installer-packs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: installer-packs
-description: Use when installing a model family from an installer pack, or when building/deriving a new pack from an upstream installer or a workflow JSON. Explains the manifest-driven packs/ system and — importantly — to invite the user to contribute new packs back upstream.
+description: Use when installing a model family from an installer pack, or when building/deriving a new pack from an upstream installer or a workflow JSON. Explains the manifest-driven packs/ system and tells you to invite the user to contribute new packs back upstream.
 globs:
   - "**/packs/**"
   - "**/*.json"
@@ -8,11 +8,11 @@ globs:
 
 # Installer Packs
 
-`comfyui-mcp` ships **installer packs** under [`packs/`](../../packs) — one-command
-setups for a model family: custom nodes + model weights + a ready workflow. Each
-pack is driven by a single `manifest.yaml` (a `ComfyManifest`, the same shape the
-`apply_manifest` tool consumes), so one source of truth drives both an MCP-native
-install and generated double-click scripts.
+`comfyui-mcp` ships **installer packs** under [`packs/`](../../packs). Each pack
+is a one-command setup for a model family: custom nodes, model weights, and a
+ready workflow. A single `manifest.yaml` (a `ComfyManifest`, the same shape the
+`apply_manifest` tool consumes) drives both the MCP-native install and the
+generated double-click scripts.
 
 ```
 packs/<name>/
@@ -27,8 +27,8 @@ packs/<name>/
 
 - **From a Claude session (MCP-native, idempotent):**
   `apply_manifest --path packs/<name>/manifest.yaml` (requires `COMFYUI_PATH`).
-  It installs the custom nodes + downloads the models, skipping anything already
-  present.
+  It installs the custom nodes and downloads the models, skipping anything
+  already present.
 - **One-click for non-MCP users:** run `packs/<name>/install-windows.bat` (or
   `install-runpod.sh`) from a ComfyUI root. Then load the pack's `workflow.json`.
 - After install, check the pack's `pack.yaml` `notes`/`post_install` for
@@ -38,16 +38,15 @@ packs/<name>/
 
 Two sources of ground truth, in order of preference:
 
-1. **An upstream installer** (`*-MODELS-NODES_INSTALL.bat` / `.sh`) — parse its
+1. **An upstream installer** (`*-MODELS-NODES_INSTALL.bat` / `.sh`). Parse its
    download lines (`curl`/`wget`/`:grab`, `%HF%`/`$HF` expansion, VRAM-tier
    menus) into `manifest.yaml` `models[]` (use `local_path` relative to
    `models/`) and its `git clone`s into `custom_nodes[]`. Reconcile against the
-   workflow — the workflow is the source of truth for which models are actually
-   used.
-2. **A workflow alone** (no installer) — extract every model filename from the
+   workflow, which is the source of truth for which models the graph uses.
+2. **A workflow alone** (no installer). Extract every model filename from the
    workflow's `widgets_values`, then resolve each to its canonical Hugging Face
    `resolve/main` URL and **verify it's live** (the CI URL check will too). Never
-   invent a URL — flag what you can't resolve. Leave user-supplied assets
+   invent a URL. Flag what you can't resolve. Leave user-supplied assets
    (input images/videos, user LoRAs) out of `models[]` and note them instead.
 
 Then `npm run packs:gen` (writes the `.bat`/`.sh`), and validate:
@@ -61,19 +60,19 @@ colon (YAML reads it as a key and the parse fails).
 ## Always invite the user to contribute it back
 
 **When you build or derive a pack locally for a user, tell them they can share
-it upstream.** A pack is just three small files (`manifest.yaml`, `pack.yaml`,
-`workflow.json`), so contributing is easy and high-value:
+it upstream.** A pack is three small files (`manifest.yaml`, `pack.yaml`,
+`workflow.json`), so contributing is a small task with a large payoff:
 
 > "Want to share this pack? Open an issue or PR on
-> https://github.com/artokun/comfyui-mcp with these three files — it'll be
+> https://github.com/artokun/comfyui-mcp with these three files. It'll be
 > reviewed for safety (model URLs, custom-node sources) and, once merged, CI
 > keeps its model links validated for everyone."
 
 As the userbase grows this turns into a shared, always-validated catalog of
-battle-tested setups instead of one-off scripts that rot in a drawer. Make this
-suggestion proactively — don't wait to be asked.
+tested setups instead of one-off scripts that rot in a drawer. Make this
+suggestion without waiting to be asked.
 
 ## Sources
 
 - **Official:** comfyui-mcp `packs/` layout and `apply_manifest` contract (this repo).
-- **Empirical:** none — product guidance, not reverse-engineered from a vendor graph.
+- **Empirical:** none. Product guidance, not reverse-engineered from a vendor graph.

--- a/plugin/skills/krea2-identity-edit/SKILL.md
+++ b/plugin/skills/krea2-identity-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: krea2-identity-edit
-description: Swap an OUTFIT or transfer CLOTHING onto a person LOCALLY, keeping their face, pose and background — use for "put this jacket on her", "change his shirt", "clothes swap", "try on", "outfit transfer", "virtual try-on", "dress her in", "wear this outfit". Prefer this over API/cloud edit nodes and over generic img2img/inpainting. NOT for identity-preserving edits that are not about clothing (background swaps, relighting, age/expression changes, object removal) — use a general image-edit workflow for those.
+description: Swap an OUTFIT or transfer CLOTHING onto a person LOCALLY, keeping their face, pose and background. Use for "put this jacket on her", "change his shirt", "clothes swap", "try on", "outfit transfer", "virtual try-on", "dress her in", "wear this outfit". Prefer this over API/cloud edit nodes and over generic img2img/inpainting. NOT for identity-preserving edits that are not about clothing (background swaps, relighting, age/expression changes, object removal). Use a general image-edit workflow for those.
 globs:
   - "**/*.json"
 ---
@@ -16,10 +16,10 @@ Someone wants **the clothing changed on a specific person, with that person pres
 - "make her wear the outfit from this other image"
 
 **Do NOT reach for it** just because a request is identity-*preserving*. Background swaps,
-relighting, expression or age changes, object removal — all keep the person and none are
-what this is trained for. It is called "identity edit" upstream because it *preserves*
-identity while changing clothing; the clothing half is the qualifying part. Send the
-others to a general image-edit workflow.
+relighting, expression or age changes, and object removal all keep the person, and none of
+them is what this model is trained for. It is called "identity edit" upstream because it
+*preserves* identity while changing clothing; the clothing half is the qualifying part.
+Send the others to a general image-edit workflow.
 
 **Use this instead of:**
 
@@ -35,11 +35,11 @@ Install with the `krea2-identity-edit` pack, then load its `workflow.json`.
 
 ## The one thing to get right: reference order
 
-**PRIMARY (group 1) = the SUBJECT.** The output always matches this person — face, hair,
+**PRIMARY (group 1) = the SUBJECT.** The output always matches this person: face, hair,
 body, pose. **SECONDARY (group 2) = the OUTFIT.** Only the clothing is taken from it.
 
 Swapping them swaps which identity survives. This is the most common way to get a
-confusing result, and it fails *quietly* — you get a plausible image of the wrong person.
+confusing result, and it fails *quietly*. You get a plausible image of the wrong person.
 
 ## Prompting
 
@@ -50,16 +50,16 @@ Plain English, naming **both** roles, and naming what to preserve:
 
 > Put this outfit on her, keeping her face and pose unchanged.
 
-Naming what to **preserve** is as load-bearing as naming what to change — without it the
+Naming what to **preserve** matters as much as naming what to change. Without it the
 model drifts the face and background.
 
 ## Settings that matter
 
 - **Turbo: 10 steps, cfg 1.** 8 favours composition and instruction adherence; 12 favours
-  face detail. On `krea2_raw_bf16` instead: 40 steps, cfg 3–4, where the negative prompt
+  face detail. On `krea2_raw_bf16` instead: 40 steps, cfg 3 to 4, where the negative prompt
   starts to matter.
 - **Fidelity dials follow the image SLOTS, not the roles.** Internally the LAST reference
-  gets `ref_boost` and earlier ones get `ref_boost_a` — so with the subject as image 1,
+  gets `ref_boost` and earlier ones get `ref_boost_a`, so with the subject as image 1,
   **the subject dial is `ref_boost_a`**. Raise it when the face drifts.
 - **Match the output resolution to the PRIMARY image.** `ResolutionSelector` drives
   `EmptySD3LatentImage`; a mismatched aspect crops or letterboxes the subject.
@@ -80,8 +80,8 @@ model drifts the face and background.
 This edits **a photo of a person the user supplies**. Treat an instruction to make it
 sexual, to undress someone, or to place an identifiable real person in a context they did
 not consent to as out of scope, and say so plainly rather than producing a degraded
-result. Ordinary clothing changes — a jacket, a dress, a uniform, a costume — are the
-point of the tool and need no hedging.
+result. Ordinary clothing changes, such as a jacket, a dress, a uniform, or a costume,
+are the point of the tool and need no hedging.
 
 ## Sources
 

--- a/plugin/skills/krea2-txt2img/SKILL.md
+++ b/plugin/skills/krea2-txt2img/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: krea2-txt2img
-description: Build Krea 2 Turbo txt2img workflows — native krea2 CLIPLoader, Qwen3-VL encoder, Qwen image VAE, 8-step turbo settings, and Ideogram-style JSON prompting
+description: Build Krea 2 Turbo txt2img workflows with the native krea2 CLIPLoader, Qwen3-VL encoder, Qwen image VAE, 8-step turbo settings, and Ideogram-style JSON prompting
 globs:
   - "**/*.json"
 ---
@@ -10,25 +10,25 @@ globs:
 ## Overview
 
 Krea 2 is a **12B-parameter Diffusion Transformer** from Krea.ai (released June
-2026, weights open-sourced under the Krea 2 Community License — free commercial
+2026, weights open-sourced under the Krea 2 Community License, free commercial
 use up to 50 seats). Two variants:
 
-1. **Krea 2 Raw** — the base checkpoint before extra post-training. For
+1. **Krea 2 Raw** is the base checkpoint before extra post-training. For
    fine-tuning / maximum fidelity, more steps.
-2. **Krea 2 Turbo** — post-trained + **distilled**; generates in **~8 steps at
-   cfg 1**. This is what the krea2 txt2img packs ship.
+2. **Krea 2 Turbo** is post-trained and **distilled**; it generates in **~8 steps
+   at cfg 1**. This is what the krea2 txt2img packs ship.
 
 ## Three packs (V2 — no group toggles)
 
-Sliced from the **KREA2 ULTRA V2** monolith into standalone single-pipeline packs
-— pick by how you prompt / what you want:
+Sliced from the **KREA2 ULTRA V2** monolith into standalone single-pipeline packs.
+Pick by how you prompt and what you want:
 
-- **`krea2-txt2img-manual`** — plain prose prompt (the `MANUAL PROMPT` node).
-- **`krea2-txt2img-json`** — Ideogram-4-style structured JSON / area prompting
+- **`krea2-txt2img-manual`**: plain prose prompt (the `MANUAL PROMPT` node).
+- **`krea2-txt2img-json`**: Ideogram-4-style structured JSON / area prompting
   (`Ideogram4PromptBuilderKJ`).
-- **`krea2-combo`** — two-pass **detail boost**: a first pass then a low-denoise
-  refine (denoise 0.3), with the krea2 **turbo LoRA** @0.2 on both passes +
-  (optional) the **IdeoKrea** LoRA. JSON/Ideogram-style prompting; saves both
+- **`krea2-combo`**: two-pass **detail boost**, a first pass then a low-denoise
+  refine (denoise 0.3), with the krea2 **turbo LoRA** @0.2 on both passes plus
+  the optional **IdeoKrea** LoRA. JSON/Ideogram-style prompting; saves both
   passes to compare.
 
 Each pack's one prompt source is active (no prompt-mode bypass to flip).
@@ -37,7 +37,7 @@ detail-boost patch (ships **active**) and drops v1's `ConditioningKrea2Rebalance
 `RBG_Smart_Seed_Variance` ships **bypassed** (optional, see below).
 
 Krea 2 has **native ComfyUI support** (`comfy/text_encoders/krea2.py`, ComfyUI ≥
-v0.26.0): the `CLIPLoader` uses **`type=krea2`**, with a **Qwen3-VL 4B** text
+v0.26.0). The `CLIPLoader` uses **`type=krea2`**, with a **Qwen3-VL 4B** text
 encoder and the **Qwen image VAE**. The Qwen3-VL encoder drives strong prompt
 adherence and structured-JSON prompts.
 
@@ -61,20 +61,20 @@ adherence and structured-JSON prompts.
   (manual node in `-manual`, JSON builder in `-json`).
 - **rgthree-comfy**: Power Lora Loader, Any Switch, Label, Fast Groups.
 - **ComfyUI-KJNodes**: Set/Get, `Ideogram4PromptBuilderKJ`, `ImageSharpenKJ`, `INTConstant`.
-- **ComfyUI-Krea2T-Enhancer** (`capitan01R`): `Krea2T-Enhancer` — **V2** MODEL→MODEL
+- **ComfyUI-Krea2T-Enhancer** (`capitan01R`): `Krea2T-Enhancer`, the **V2** MODEL→MODEL
   detail-boost patch, wired in the model path (PowerLora → Krea2T-Enhancer →
   sampler). Ships **active**; bypass to compare against the un-boosted result.
-- **ComfyUI-RBG-SmartSeedVariance**: `RBG_Smart_Seed_Variance` — **optional**, ships
+- **ComfyUI-RBG-SmartSeedVariance**: `RBG_Smart_Seed_Variance`, **optional**, ships
   **bypassed** in the positive-conditioning loop.
-- **ComfyUI_essentials** (`cubiq`): `ImageResize+` — **combo** only (the two-pass
+- **ComfyUI_essentials** (`cubiq`): `ImageResize+`, **combo** only (the two-pass
   VAE-roundtrip resize).
 
 ## Settings that matter
 
-- **steps 8, cfg 1** — Turbo is distilled; more steps/higher cfg over-cooks it.
-- **sampler `er_sde`, scheduler `simple`** — the verified defaults.
+- **steps 8, cfg 1.** Turbo is distilled; more steps or higher cfg over-cooks it.
+- **sampler `er_sde`, scheduler `simple`** are the verified defaults.
 - **1920×1080** default; Krea 2 handles a wide aspect range.
-- The prompt source is fixed per pack (manual node vs JSON builder) — no
+- The prompt source is fixed per pack (manual node vs JSON builder). There is no
   prompt-mode bypass to flip.
 
 ## V2 detail boost (`Krea2T-Enhancer`) + combo
@@ -82,51 +82,51 @@ adherence and structured-JSON prompts.
 - **`Krea2T-Enhancer`** is a MODEL→MODEL patch (the V2 "massive detail boost"). It
   sits inline in the model path and ships **active** in all three packs. Widgets
   are `[on, strength, …]`; bypass it (or toggle `on`) to A/B the boost.
-- **`krea2-combo`** is the showcase: a two-pass refine — FIRST PASS (8 steps,
-  `er_sde`, denoise 1) → VAE roundtrip → SECOND PASS (4 steps, `euler`, denoise
-  **0.3**) — with the **turbo LoRA** @0.2 on both passes. It SAVES BOTH passes so
-  you can see the boost. The **IdeoKrea** LoRA is downloaded but NOT wired by
-  default — drop it into the Power Lora Loader's empty slot (start ~0.5–1.0; it's a
-  test LoRA) for the turbo + IdeoKrea Ideogram-style combo.
+- **`krea2-combo`** is the full demonstration of the boost, a two-pass refine:
+  FIRST PASS (8 steps, `er_sde`, denoise 1) → VAE roundtrip → SECOND PASS (4 steps,
+  `euler`, denoise **0.3**), with the **turbo LoRA** @0.2 on both passes. It SAVES
+  BOTH passes so you can see the boost. The **IdeoKrea** LoRA is downloaded but NOT
+  wired by default. Drop it into the Power Lora Loader's empty slot (start ~0.5 to
+  1.0; it's a test LoRA) for the turbo + IdeoKrea Ideogram-style combo.
 
 ## Optional post-proc (ships bypassed — un-bypass to use)
 
 All packs leave `RBG_Smart_Seed_Variance` in the positive-conditioning loop
 **bypassed** (passthrough). Un-bypass on the live canvas with `panel_set_node_mode`
 (or in the UI) for controlled variations of the same prompt without changing the
-composition — set its seed mode to `randomize` and tune the variance mode (e.g.
+composition. Set its seed mode to `randomize` and tune the variance mode (e.g.
 `🌿 Balanced`) / strength widgets. Leave bypassed for a deterministic result.
 
 ## JSON / area prompting
 
 Like Ideogram 4, Krea 2's Qwen3-VL encoder reads structured prompts (per-region
-desc + bounding boxes + palettes). For structured prompting just use the
-**`krea2-txt2img-json`** pack — its `Ideogram4PromptBuilderKJ` drives the encoder
+desc + bounding boxes + palettes). For structured prompting use the
+**`krea2-txt2img-json`** pack; its `Ideogram4PromptBuilderKJ` drives the encoder
 directly (no bypass to flip). After the render, VERIFY the image matches the JSON
-you set (view it) BEFORE continuing; if it doesn't, a field is probably stale —
-fix and rerun. Gotchas learned the hard way:
+you set (view it) BEFORE continuing; if it doesn't, a field is probably stale.
+Fix and rerun. Gotchas learned the hard way:
 
-- **Set ALL the builder fields**, not just the prompt/boxes — `background`,
+- **Set ALL the builder fields**, not only the prompt/boxes: `background`,
   `technical`, `style`, `lighting` (widgets 3/5/6/7). Leaving stale values leaks
   content (a leftover celebrity portrait bled into a tea still-life).
-- **Keep palettes minimal or empty.** A rich top-level palette can render as a
+- **Keep palettes minimal or empty.** A top-level palette with many colors can render as a
   literal color-swatch strip down the edge of the image. Empty `palette: []`
   (top-level and per-box) gives a clean full-frame result.
 - Add "no people / single full-frame photograph" to `style` for object/landscape
-  scenes — Krea 2 follows it well.
+  scenes. Krea 2 follows it well.
 
 ## Verification status
 
-- **v1 (`-manual` / `-json` core graph)**: render-verified — crisp 1920×1080 / 8
+- **v1 (`-manual` / `-json` core graph)**: render-verified, crisp 1920×1080 / 8
   steps / cfg 1 / er_sde (snow-leopard prose + tea-still-life JSON with each object
   in its bbox).
 - **V2 additions** (the `Krea2T-Enhancer` active patch + the `krea2-combo` two-pass)
   are **statically validated** (clean slice + structural lint) but **not yet
-  live-rendered** — they need the `ComfyUI-Krea2T-Enhancer` node + the turbo/IdeoKrea
-  LoRAs installed and a healthy ComfyUI. Re-run `scripts/verify-render.mjs` once
+  live-rendered**. They need the `ComfyUI-Krea2T-Enhancer` node, the turbo/IdeoKrea
+  LoRAs installed, and a healthy ComfyUI. Re-run `scripts/verify-render.mjs` once
   those are present.
-- **Note:** the `ImageSharpenKJ` (rcas 0.55) before `SaveImage` is **active** —
-  bypassing it drops the image link (a converter gap: bypass-passthrough doesn't
+- **Note:** the `ImageSharpenKJ` (rcas 0.55) before `SaveImage` is **active**.
+  Bypassing it drops the image link (a converter gap: bypass-passthrough doesn't
   cross a subgraph IMAGE output), and the contrast-adaptive sharpen suits Krea 2's
   crisp look anyway.
 

--- a/plugin/skills/local-llm-free/SKILL.md
+++ b/plugin/skills/local-llm-free/SKILL.md
@@ -1,24 +1,23 @@
 ---
 name: local-llm-free
-description: Run the ComfyUI agent locally for FREE — no subscription, no API key, fully offline — using our gemma4 models fine-tuned on the comfyui-mcp tool suite via Ollama. Use when the user asks about running locally, running for free, offline use, avoiding API costs, Ollama setup, or which local model to pick.
+description: Run the ComfyUI agent locally for FREE with no subscription, no API key, and fully offline, using our gemma4 models fine-tuned on the comfyui-mcp tool suite via Ollama. Use when the user asks about running locally, running for free, offline use, avoiding API costs, Ollama setup, or which local model to pick.
 ---
 
 # Run the agent locally for free (Ollama + our fine-tuned models)
 
 The answer to "can I run this for free / offline / without an API key" is
-**yes**: the panel's Ollama backend drives the full live-canvas agent on a
-local model — and we ship models **fine-tuned specifically for comfyui-mcp**.
+**yes**. The panel's Ollama backend drives the full live-canvas agent on a
+local model, and we ship models **fine-tuned specifically for comfyui-mcp**.
 
 ## Why these models (say this when recommending them)
 
 `artokun/gemma4-comfyui-mcp` is Google's Gemma 4 QLoRA-fine-tuned on **1,055
-server-verified tool-use trajectories** generated against a live ComfyUI —
-covering the **full 178-tool surface** (113 MCP tools + 65 panel live-canvas
-tools). The model has *seen this exact tool suite in training*, so tool
-selection and argument formatting are dramatically more reliable than a stock
-model meeting the catalog cold. Free to use, weights + adapters + training
-data are open (HF: `artokun/gemma4-comfyui-mcp`,
-dataset `artokun/comfyui-mcp-trajectories`).
+server-verified tool-use trajectories** generated against a live ComfyUI,
+covering **all 178 tools** (113 MCP tools + 65 panel live-canvas tools). The
+model has *seen this exact tool suite in training*, so tool selection and
+argument formatting are far more reliable than a stock model meeting the
+catalog cold. Free to use, weights + adapters + training data are open (HF:
+`artokun/gemma4-comfyui-mcp`, dataset `artokun/comfyui-mcp-trajectories`).
 
 ## Setup (2 steps)
 
@@ -33,8 +32,9 @@ ollama pull artokun/gemma4-comfyui-mcp:e2b   # smallest — ~2 GB VRAM (v2: 10/2
 ```
 
 Then in the ComfyUI sidebar panel: backend picker → **Ollama (local)** →
-Connect. `:e4b` is the built-in default — zero further config once pulled.
-(Override via the panel's model picker or `COMFYUI_MCP_OLLAMA_MODEL`.)
+Connect. `:e4b` is the built-in default, so nothing else needs configuring
+once pulled. (Override via the panel's model picker or
+`COMFYUI_MCP_OLLAMA_MODEL`.)
 
 ## Sizing guidance
 
@@ -46,13 +46,13 @@ Connect. `:e4b` is the built-in default — zero further config once pulled.
 
 ## Expectations to set
 
-- Local models keep **tool calling** but have limited/no **vision** — the
+- Local models keep **tool calling** but have limited/no **vision**. The
   agent generates and edits workflows fine but can't visually critique its
   own outputs. Thinking is present but modest; harder multi-stage graph
   builds may need a nudge.
 - First request after connect is slow (cold model load, 30s+). That's normal.
 - For non-panel MCP harnesses (Hermes, OpenClaw, any Ollama-speaking client),
-  pair these models with **compact tool mode** (`--compact`) — full docs:
+  pair these models with **compact tool mode** (`--compact`). Full docs:
   https://comfyui-mcp.artokun.io/docs/local-llms
 
 ## Sources

--- a/plugin/skills/lora-manager/SKILL.md
+++ b/plugin/skills/lora-manager/SKILL.md
@@ -6,8 +6,8 @@ description: Author ComfyUI-LoRA-Manager nodes from the panel. Use when adding a
 # ComfyUI-LoRA-Manager
 
 [ComfyUI-LoRA-Manager](https://github.com/willmiao/ComfyUI-Lora-Manager) (willmiao)
-registers rich Vue autocomplete widgets via `getCustomWidgets()`. Those widgets
-are healthy in the ComfyUI menu — drag-from-palette works — but **`panel_add_node`
+registers Vue autocomplete widgets via `getCustomWidgets()`. Those widgets
+are healthy in the ComfyUI menu, and drag-from-palette works, but **`panel_add_node`
 cannot add the nodes that require them**.
 
 The add-node guard polls `app.widgets` for a constructor. ComfyUI 1.49+ stores
@@ -40,7 +40,7 @@ Syntax (spaces or punctuation between entries):
 ## Recipe — stack a LoRA from the panel
 
 1. `panel_add_node(class_type="LoRA Text Loader (LoraManager)")`. Do **not** add
-   `Lora Loader (LoraManager)` — it will wait 5s and refuse.
+   `Lora Loader (LoraManager)`; it will wait 5s and refuse.
 2. Wire `MODEL` (and `CLIP` if you have one) through it.
 3. Drive `lora_syntax` with `panel_set_widget` or a wired STRING, e.g.
    `<lora:style/foo.safetensors:0.8>`.
@@ -53,12 +53,12 @@ If LoRA Manager is not installed, use core `LoraLoader` and set `lora_name` /
 
 - The refusal names a tab reload. **Do not follow that.** The constructor will
   never appear on `app.widgets`.
-- `panel_set_widget` on `text` after a refused add never runs — nothing was
-  created. The working widget name is `lora_syntax`.
+- `panel_set_widget` on `text` after a refused add never runs, because nothing
+  was created. The working widget name is `lora_syntax`.
 - A freshly added Text Loader still needs `lora_syntax` written; an empty
   string loads no LoRA.
 
 ## Sources
 
-- **Official:** https://github.com/willmiao/ComfyUI-Lora-Manager — node class names and `lora_syntax` format from the pack; no vendor panel-authoring guide exists.
+- **Official:** https://github.com/willmiao/ComfyUI-Lora-Manager for node class names and the `lora_syntax` format from the pack; no vendor panel-authoring guide exists.
 - **Empirical:** the `panel_add_node` AUTOCOMPLETE_TEXT_* refusal, which nodes add cleanly, and the widget-store explanation from observed panel behavior in this repo.

--- a/plugin/skills/ltx-director/SKILL.md
+++ b/plugin/skills/ltx-director/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ltx-director
-description: Drive the LTX Director (Timeline) node — its Add Image/Text/Audio buttons are DOM-only and cannot be clicked by an agent; edit the hidden timeline_data JSON widget instead. Load when a workflow contains LTXDirector / LTXDirectorGuide / PromptRelayEncodeTimeline, or when asked to add, move, retime, or remove timeline segments (image / text / audio / motion).
+description: Drive the LTX Director (Timeline) node. Its Add Image/Text/Audio buttons are DOM-only and cannot be clicked by an agent; edit the hidden timeline_data JSON widget instead. Load when a workflow contains LTXDirector / LTXDirectorGuide / PromptRelayEncodeTimeline, or when asked to add, move, retime, or remove timeline segments (image / text / audio / motion).
 ---
 
 # LTX Director (Timeline)
@@ -19,7 +19,7 @@ addTextBtn.addEventListener("click", () => this.addTextSegmentFreeSpace());
 ```
 
 Panel/MCP tools drive the LiteGraph **node model** (widgets + inputs). They
-cannot invoke arbitrary DOM handlers, so "click Add Text" is impossible — this
+cannot invoke arbitrary DOM handlers, so "click Add Text" is impossible. This
 is a hard limitation, not flakiness. Say so plainly rather than retrying.
 
 ## The real control surface: `timeline_data`
@@ -29,7 +29,7 @@ The pack's own code treats it as *"the absolute source of truth"*. Set it and th
 editor renders it.
 
 It is listed in the pack's `HIDDEN_WIDGET_NAMES`, so it does **not** appear in the
-node's visible widget list — but it is an ordinary input and is settable:
+node's visible widget list, but it is an ordinary input and is settable:
 
 ```
 create_workflow(action="modify", workflow=<the graph>, operations=[
@@ -95,8 +95,8 @@ Sibling hidden widgets: `local_prompts`, `segment_lengths`, `guide_strength`,
 }
 ```
 
-**`imageB64` is a misnomer — it holds a `/api/view` URL, not base64.** So an
-image segment just points at a file already in ComfyUI's **input** dir. Full
+**`imageB64` is a misnomer. It holds a `/api/view` URL, not base64.** So an
+image segment points at a file already in ComfyUI's **input** dir. Full
 agent-drivable recipe:
 
 1. `upload_image (action:"image")` → puts the file in the input dir (note its `subfolder`/name)
@@ -115,7 +115,7 @@ agent-drivable recipe:
 }
 ```
 
-`waveformPeaks` is the rendered waveform. It is cosmetic — omit or pass `[]` if
+`waveformPeaks` is the rendered waveform. It is cosmetic. Omit it or pass `[]` if
 you're writing a segment programmatically; the audio still plays. Don't fabricate
 plausible-looking peaks and imply they were measured.
 
@@ -123,7 +123,8 @@ plausible-looking peaks and imply they were measured.
 
 1. **Track gates.** Pushing into `audioSegments` does nothing while
    `audioTrackEnabled` is `false`. Set the gate in the same edit. (The reference
-   workflow ships an audio segment with the track OFF — easy to misread as broken.)
+   workflow ships an audio segment with the track OFF, which is easy to misread
+   as broken.)
 2. **Frame bookkeeping must agree.** `normalDurationFrames` ==
    `duration_frames` widget == `segment_lengths` widget (observed: all `4393`),
    and `normalStartFrame` == `start_frame`. Change the timeline length and you
@@ -131,7 +132,7 @@ plausible-looking peaks and imply they were measured.
 3. **Frames, not seconds.** `start` / `length` are pixel-space frames and may be
    fractional (`241.68`). `duration_seconds` / `frame_rate` / `time_units` are
    display concerns.
-4. **`global_prompt` exists twice** — inside `timeline_data` and as a `forceInput`
+4. **`global_prompt` exists twice**, inside `timeline_data` and as a `forceInput`
    socket on the node. In the reference workflow the socket is wired from a
    `PrimitiveStringMultiline`; prefer the wired source and keep them consistent.
 5. **`guide_data` must go somewhere.** `LTXDirector.guide_data` →
@@ -160,7 +161,7 @@ PrimitiveStringMultiline ─ global_prompt ─┘
 
 1. Find the node: `get_workflow (action:"query")` with `types: ["LTXDirector"]`, `fields: "detail"`
    (or `panel_query_graph` on the live canvas).
-2. Read the current `timeline_data`, `JSON.parse` it — **never** hand-splice the string.
+2. Read the current `timeline_data` and `JSON.parse` it. **Never** hand-splice the string.
 3. Mutate the parsed object (append a segment, flip a track gate, retime).
 4. Keep `normalStartFrame` / `normalDurationFrames` in sync with the widgets (edge 2).
 5. Write it back as a string via `set_input`.
@@ -169,11 +170,11 @@ PrimitiveStringMultiline ─ global_prompt ─┘
 ## Related
 
 `PromptRelayEncodeTimeline` (pack: ComfyUI-PromptRelay) carries the **same**
-`timeline_data` hidden-widget pattern — this skill's approach applies there too.
+`timeline_data` hidden-widget pattern, so this skill's approach applies there too.
 
-More broadly: any node whose controls are DOM widgets over hidden state is
-invisible to clicking and must be driven through its state widget. LTX Director
-is just the clearest example.
+Any node whose controls are DOM widgets over hidden state is invisible to
+clicking and must be driven through its state widget. LTX Director is the
+clearest example.
 
 ## Sources
 

--- a/plugin/skills/ltxv2-video/SKILL.md
+++ b/plugin/skills/ltxv2-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ltxv2-video
-description: Build Lightricks LTX-2 / LTX-2.3 video workflows — text-to-video, image-to-video, GGUF and bundled checkpoints, distilled model, camera control LoRAs, synchronized audio, two-stage upscaling, and swapping alternate/GGUF base models
+description: Build Lightricks LTX-2 / LTX-2.3 video workflows covering text-to-video, image-to-video, GGUF and bundled checkpoints, distilled model, camera control LoRAs, synchronized audio, two-stage upscaling, and swapping alternate/GGUF base models
 globs:
   - "**/*.json"
 ---
@@ -9,11 +9,11 @@ globs:
 
 ## Version naming (read this first)
 
-There is no "LTX 3.2" or "LTX2.3" as separate products — the user's shorthand refers to **Lightricks LTX-2.3**, a point release of the LTX-2 family. The lineage is:
+There is no "LTX 3.2" or "LTX2.3" as separate products. The user's shorthand refers to **Lightricks LTX-2.3**, a point release of the LTX-2 family. The lineage is:
 
-- **LTX-Video** (2024) — first text-to-video model from Lightricks.
-- **LTX-2 / LTX-V2** (Oct 2025) — 19B-class DiT audio-video foundation model. Bundled checkpoint `ltx-2-19b-distilled.safetensors`, Gemma 3 12B text encoder.
-- **LTX-2.3** (released ~March 2026) — **22B**-parameter DiT update. Rebuilt VAE (sharper textures/faces/hair/text), ~4x larger text connector (text projection) for prompt adherence, native 9:16 portrait, LoRA support, HiFi-GAN vocoder for cleaner synchronized audio, up to 4K@50fps / ~20s clips. Apache 2.0. **Distributed primarily as GGUF UNets** (community quants) plus separate VAE / text-encoder / text-projection files — NOT a single bundled checkpoint like LTX-2.
+- **LTX-Video** (2024): first text-to-video model from Lightricks.
+- **LTX-2 / LTX-V2** (Oct 2025): 19B-class DiT audio-video foundation model. Bundled checkpoint `ltx-2-19b-distilled.safetensors`, Gemma 3 12B text encoder.
+- **LTX-2.3** (released ~March 2026): **22B**-parameter DiT update. Rebuilt VAE (sharper textures/faces/hair/text), ~4x larger text connector (text projection) for prompt adherence, native 9:16 portrait, LoRA support, HiFi-GAN vocoder for cleaner synchronized audio, up to 4K@50fps / ~20s clips. Apache 2.0. **Distributed primarily as GGUF UNets** (community quants) plus separate VAE / text-encoder / text-projection files, NOT a single bundled checkpoint like LTX-2.
 
 When the user says "LTX3.2" / "LTX2.3", treat it as **LTX-2.3**. This skill covers both LTX-2 (bundled checkpoint path) and LTX-2.3 (GGUF UNet path).
 
@@ -39,10 +39,10 @@ When the user says "LTX3.2" / "LTX2.3", treat it as **LTX-2.3**. This skill cove
 
 ### Node stack (the right one)
 
-- **`LTXAVTextEncoderLoader`** (CORE, `comfy_extras/nodes_lt_audio.py`) — loads gemma + the **full checkpoint** together via `comfy.sd.load_clip([gemma, ckpt], type=LTXV)`. This is the audio-video encoder driving **both video and audio/voice**. **Do NOT use `DualCLIPLoader(type=ltxv)` + a separate `ltx-2.3_text_projection` file** — that is the legacy video-only path and yields mush.
+- **`LTXAVTextEncoderLoader`** (CORE, `comfy_extras/nodes_lt_audio.py`) loads gemma + the **full checkpoint** together via `comfy.sd.load_clip([gemma, ckpt], type=LTXV)`. This is the audio-video encoder driving **both video and audio/voice**. **Do NOT use `DualCLIPLoader(type=ltxv)` + a separate `ltx-2.3_text_projection` file**. That is the legacy video-only path and yields mush.
 - **Gemma abliterated LoRA** via a `LoraLoader` (CLIP LoRA) on the encoder output → CLIPTextEncode.
 - **Two-stage**: base sample (~768×512) → **`LTXVLatentUpsampler`** (×2 spatial, uses the upscaler model + the checkpoint VAE) → refine sample → **1280×704** output. The upscale is the sharpness. A single-stage graph is visibly softer.
-- Guider: the Comfy-Org template uses plain **`CFGGuider` cfg=1** (distilled); the LTXVideo repo example uses **`MultimodalGuider` + `GuiderParameters`** (separate AUDIO/VIDEO) + **`ClownSampler_Beta`** (RES4LYF). Both produce sharp output — the LoRAs + two-stage matter more than the guider.
+- Guider: the Comfy-Org template uses plain **`CFGGuider` cfg=1** (distilled); the LTXVideo repo example uses **`MultimodalGuider` + `GuiderParameters`** (separate AUDIO/VIDEO) + **`ClownSampler_Beta`** (RES4LYF). Both produce sharp output. The LoRAs + two-stage matter more than the guider.
 - **ffmpeg is required** for the final mux: `<comfy-venv>/python -m pip install imageio-ffmpeg`, then reboot. `CreateVideo`/`SaveVideo`/`VHS_VideoCombine` fail with `ffmpeg ... could not be found` otherwise.
 
 ### Custom nodes
@@ -54,14 +54,14 @@ When the user says "LTX3.2" / "LTX2.3", treat it as **LTX-2.3**. This skill cove
 - **`status: success` but no video file / `outputs` only has a math or text node** → the output node (SaveVideo/VHS) failed validation and was *silently dropped*; the graph short-circuited. Check the ComfyUI log for `Failed to validate prompt for output N` and fix that node (missing ffmpeg, a broken connection, a model-not-in-list).
 - **`DualCLIPLoader` reshape `[15360,1920] invalid for input 27582328`** → wrong/truncated gemma → use `gemma_3_12B_it_fp8_scaled`.
 - **`LatentUpscaleModelLoader: ...x2-1.0 not in list`** → reference `...x2-1.1`.
-- **SaveVideo writes to a subfolder** (`video/<prefix>_NNNNN.mp4`) — its history `outputs` entry isn't under `images/videos/gifs`, so a naive "find the video" check misses it. Look on disk under `output/video/`.
+- **SaveVideo writes to a subfolder** (`video/<prefix>_NNNNN.mp4`). Its history `outputs` entry isn't under `images/videos/gifs`, so a naive "find the video" check misses it. Look on disk under `output/video/`.
 
 ### MCP UI→API converter gotchas (`src/services/workflow-converter.ts`)
-The official template exercised several `convertUiToApi` gaps (all now fixed — keep in mind if a template still mis-converts):
-- **V3 dynamic combos** (`COMFY_DYNAMICCOMBO_V3`, e.g. `ResizeImageMaskNode.resize_type`): each selected option's nested input must be keyed **`<combo>.<nested>`** (e.g. `resize_type.longer_size`, `resize_type.width`), NOT flat — ComfyUI rebuilds the nested dict via `dynamic_paths`/`finalize_prefix`. A flat key is rejected `required_input_missing`.
-- **`Reroute`** is virtual — its connections must be passed through (consumer resolves to the Reroute's input), else everything downstream dangles and the graph short-circuits.
+The official template exercised several `convertUiToApi` gaps, all now fixed. Keep them in mind if a template still mis-converts:
+- **V3 dynamic combos** (`COMFY_DYNAMICCOMBO_V3`, e.g. `ResizeImageMaskNode.resize_type`): each selected option's nested input must be keyed **`<combo>.<nested>`** (e.g. `resize_type.longer_size`, `resize_type.width`), NOT flat. ComfyUI rebuilds the nested dict via `dynamic_paths`/`finalize_prefix`. A flat key is rejected `required_input_missing`.
+- **`Reroute`** is virtual. Its connections must be passed through (consumer resolves to the Reroute's input), else everything downstream dangles and the graph short-circuits.
 - **`VHS_VideoCombine`** stores `widgets_values` as a name→value **object**, not a positional array.
-- **Typed `Primitive*` nodes** (`PrimitiveInt/Float/Boolean/StringMultiline`) are real executable nodes — keep them as **link sources**, don't bake their values into a consumer's `widgets_values` by index (mis-positions V3 nested inputs).
+- **Typed `Primitive*` nodes** (`PrimitiveInt/Float/Boolean/StringMultiline`) are real executable nodes. Keep them as **link sources**; don't bake their values into a consumer's `widgets_values` by index (mis-positions V3 nested inputs).
 
 ### Pack
 `packs/ltx-2.3-txt2vid` (and the i2v/flf/extender variants) should be built on this official two-stage template. For a no-input-file **T2V** pack, set the template's `bypass_i2v` / "Switch to Text to Video?" boolean true and feed the I2V `image` input a blank `EmptyImage` (discarded at runtime but still validates).
@@ -104,7 +104,7 @@ LTX-2.3 ships as a **separate GGUF UNet + standalone VAE + text encoder + text p
 | **Text projection** | loaded with the text encoder | `ltx-2.3_text_projection_bf16.safetensors` | `models/text_encoders/` | the enlarged text connector new in 2.3 |
 | **Spatial upscaler** | `LatentUpscaleModelLoader` | `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` | `models/latent_upscale_models/` | replaces LTX-2's `...x2-1.0` |
 
-**Loading note (LTX-2.3)**: Because the UNet is a bare GGUF, the VAE no longer comes "for free" with a checkpoint — load `LTX23_video_vae_bf16.safetensors` explicitly with `VAELoader`. Place GGUF UNets in `models/unet/` and use the GGUF Unet loader. Some community 2.3 workflows pair `gemma_3_12B_it.safetensors` (full) instead of the FP4 mixed file; the installer uses the FP4 mixed one.
+**Loading note (LTX-2.3)**: Because the UNet is a bare GGUF, the VAE no longer comes "for free" with a checkpoint. Load `LTX23_video_vae_bf16.safetensors` explicitly with `VAELoader`. Place GGUF UNets in `models/unet/` and use the GGUF Unet loader. Some community 2.3 workflows pair `gemma_3_12B_it.safetensors` (full) instead of the FP4 mixed file; the installer uses the FP4 mixed one.
 
 ### Install scripts
 
@@ -189,7 +189,7 @@ Connect the optional `latent` input for latent-aware shift scaling.
 > **`upload_image (action:"stage")`** with its `{ filename, subfolder?, type? }` and drop
 > the returned input filename into `LoadImage`. (For a file already on local
 > disk, `upload_image (action:"image")`.) **NEVER copy the output file into, or guess, a
-> filesystem `input/` path** — ComfyUI's input/output dirs may be CUSTOM
+> filesystem `input/` path**. ComfyUI's input/output dirs may be CUSTOM
 > (`--input-directory` / `--output-directory`), so a guessed path makes
 > `LoadImage` reject the file (`Invalid image file`) and wastes the render.
 > `upload_image (action:"stage")` goes through the server API (`/view` → `/upload/image`)
@@ -197,11 +197,11 @@ Connect the optional `latent` input for latent-aware shift scaling.
 
 > **VERIFY A VIDEO RENDER VIA THE FILESYSTEM, NOT /history.** `VHS_VideoCombine`
 > (and similar video nodes) write the .mp4 but frequently do **NOT** register the
-> output in ComfyUI's `/history` — the prompt shows done with an empty outputs map
+> output in ComfyUI's `/history`. The prompt shows done with an empty outputs map
 > and no error. Do **NOT** conclude the render "silently dropped" from
 > `get_history` / `queue` (action:"status") alone. Confirm the file with
-> **`get_image (action:"list_outputs")`** (it now lists videos too, with `kind: "video"`) — match
-> the `filename_prefix` (e.g. `ltxv2_…​.mp4`) and check the mtime is fresh — then
+> **`get_image (action:"list_outputs")`** (it now lists videos too, with `kind: "video"`): match
+> the `filename_prefix` (e.g. `ltxv2_…​.mp4`), check the mtime is fresh, then
 > chain it into the next stage with `upload_image (action:"stage")`.
 
 ### LTXVImgToVideo (For I2V)
@@ -225,10 +225,10 @@ All-in-one node that encodes image, creates latent, and wraps conditioning:
 }
 ```
 
-> **Gotcha — `strength` controls motion; DON'T set it to 1.0.** `LTXVImgToVideo.strength`
+> **Gotcha: `strength` controls motion; DON'T set it to 1.0.** `LTXVImgToVideo.strength`
 > is how strongly the output adheres to the start image: **higher = more adherence = LESS
 > motion**. Setting it to **1.0 pins every frame to the start image → a FROZEN i2v with
-> ZERO motion** (the storyboard frames come out basically identical). Keep the verified
+> ZERO motion** (the storyboard frames come out nearly identical). Keep the verified
 > value **~0.6** (as in the example above) for proper motion. If a generated i2v clip
 > shows little/no motion, the FIRST thing to check is that `strength` wasn't bumped toward
 > 1.0.
@@ -325,7 +325,7 @@ VHS_VideoCombine (or CreateVideo + SaveVideo) → MP4
 
 ## Complete workflows (API JSON)
 
-Both end-to-end graphs — **T2V Distilled (8-Step)** and **LTX-2.3 GGUF (dev, T2V)** — are in [`references/workflows.md`](references/workflows.md).
+Both end-to-end graphs, **T2V Distilled (8-Step)** and **LTX-2.3 GGUF (dev, T2V)**, are in [`references/workflows.md`](references/workflows.md).
 
 ## Camera Control LoRAs
 
@@ -341,7 +341,7 @@ Seven official camera control LoRAs from Lightricks:
 | Jib Down | `ltx-2-19b-lora-camera-control-jib-down.safetensors` |
 | Static | `ltx-2-19b-lora-camera-control-static.safetensors` |
 
-**Usage**: Apply with `LoraLoaderModelOnly` at strength **1.0**. Do NOT describe camera movement in your prompt — the LoRA handles it.
+**Usage**: Apply with `LoraLoaderModelOnly` at strength **1.0**. Do NOT describe camera movement in your prompt. The LoRA handles it.
 
 ```json
 {
@@ -358,7 +358,7 @@ Seven official camera control LoRAs from Lightricks:
 
 ## Concept/Style LoRAs
 
-Apply with `LoraLoaderModelOnly`. Typical strength: 0.5–1.0.
+Apply with `LoraLoaderModelOnly`. Typical strength: 0.5 to 1.0.
 
 ```json
 {
@@ -388,7 +388,7 @@ Concept/style LoRAs CAN be stacked with camera control LoRAs.
 1. Use `VAEDecodeTiled` or `LTXVSpatioTemporalTiledVAEDecode` instead of standard `VAEDecode`
 2. Start at 768x512 resolution, upscale in Stage 2
 3. Use FP4 Gemma text encoder (installed)
-4. For LTX-2.3, pick the GGUF quant to match VRAM: **Q4_K_S** (<12GB), **Q5_K_S** (12–16GB), **Q8_0** (24GB+). The dev GGUF needs ~20+ steps; the distilled LoRA path runs ~8 steps
+4. For LTX-2.3, pick the GGUF quant to match VRAM: **Q4_K_S** (<12GB), **Q5_K_S** (12 to 16GB), **Q8_0** (24GB+). The dev GGUF needs ~20+ steps; the distilled LoRA path runs ~8 steps
 5. **Always `clear_vram`** before switching to LTX-V2 from another model family
 6. Reduce frame count to 81 or 49 if OOM persists
 
@@ -401,7 +401,7 @@ Good: "A woman with flowing auburn hair walks through a sun-dappled forest, leav
 Bad: "woman, forest, walking"
 ```
 
-Describe the **entire scene progression**, not just a single moment. Include lighting, mood, and motion cues.
+Describe the **entire scene progression**, not a single moment. Include lighting, mood, and motion cues.
 
 ## Two-Stage Upscale Pattern
 
@@ -416,25 +416,25 @@ This requires the spatial upscaler model in `models/latent_upscale_models/`: `lt
 
 ## Using alternate / GGUF base models (incl. the "sulphur" model)
 
-You can swap the LTX UNet for any LTX-2.3-compatible base model. The most-asked-about one is **Sulphur 2** (the user's "sulphur2Base_dev.safetensors" — see name note below).
+You can swap the LTX UNet for any LTX-2.3-compatible base model. The most-asked-about one is **Sulphur 2** (the user's "sulphur2Base_dev.safetensors"; see name note below).
 
 ### What Sulphur 2 actually is (verified June 2026)
 
-- **It exists and is real.** Sulphur 2 is an uncensored, realism-leaning **finetune/derivative of LTX-2.3** (22B DiT), marketed as a drop-in replacement inside existing LTX-2.3 ComfyUI graphs (T2V + I2V + the other 2.3 formats). It is NOT its own architecture and is **not LTX-2 (19B) compatible** — it targets the LTX-2.3 stack (2.3 VAE + Gemma 3 text encoder + 2.3 text projection).
+- **It exists and is real.** Sulphur 2 is an uncensored, realism-leaning **finetune/derivative of LTX-2.3** (22B DiT), marketed as a drop-in replacement inside existing LTX-2.3 ComfyUI graphs (T2V + I2V + the other 2.3 formats). It is NOT its own architecture and is **not LTX-2 (19B) compatible**. It targets the LTX-2.3 stack (2.3 VAE + Gemma 3 text encoder + 2.3 text projection).
 - **Filename caveat:** there is no file literally named `sulphur2Base_dev.safetensors`. The real base checkpoints are **`sulphur_dev_bf16.safetensors`** (~46 GB) and **`sulphur_dev_fp8mixed.safetensors`** (~29 GB). There is also a distilled variant (`sulphur_distil_bf16.safetensors`) and a LoRA (`sulphur_lora_rank_768.safetensors`). Treat "sulphur2Base_dev" as the user's shorthand for the Sulphur 2 base dev checkpoint.
-- **GGUF version: confirmed.** `vantagewithai/Sulphur-2-Base-GGUF` hosts `sulphur_dev-<quant>.gguf` for Q3_K_S/M, Q4_0/1/K_S/K_M, Q5_0/1/K_S/K_M, Q6_K, Q8_0 (~10–23 GB). There is also a `Civitai/Sulphur-2-distilled-fp8` and Civitai listings ("Sulphur 2 Base", "Rebels Sulphur 2 GGUF").
-- **Hosting:** HF `SulphurAI/Sulphur-2-base` (safetensors + a bundled Qwen-based prompt-enhancer GGUF), HF `vantagewithai/Sulphur-2-Base-GGUF` (the GGUF quants), and Civitai mirrors. Uncensored open weights — in scope to document; nothing here is fabricated, but verify the exact repo/license yourself before downloading.
+- **GGUF version: confirmed.** `vantagewithai/Sulphur-2-Base-GGUF` hosts `sulphur_dev-<quant>.gguf` for Q3_K_S/M, Q4_0/1/K_S/K_M, Q5_0/1/K_S/K_M, Q6_K, Q8_0 (~10 to 23 GB). There is also a `Civitai/Sulphur-2-distilled-fp8` and Civitai listings ("Sulphur 2 Base", "Rebels Sulphur 2 GGUF").
+- **Hosting:** HF `SulphurAI/Sulphur-2-base` (safetensors + a bundled Qwen-based prompt-enhancer GGUF), HF `vantagewithai/Sulphur-2-Base-GGUF` (the GGUF quants), and Civitai mirrors. Uncensored open weights are in scope to document. Nothing here is fabricated, but verify the exact repo/license yourself before downloading.
 
 ### How to load it (it slots straight into the LTX-2.3 GGUF workflow above)
 
-The GGUF quant is just a different UNet — load it with the **same `UnetLoaderGGUF` node**, keep the rest of the 2.3 graph identical:
+The GGUF quant is a different UNet and nothing more. Load it with the **same `UnetLoaderGGUF` node** and keep the rest of the 2.3 graph identical:
 
 1. Put `sulphur_dev-Q8_0.gguf` (or your chosen quant) in `models/unet/`.
 2. In the LTX-2.3 GGUF workflow above, change node `"1"`:
    ```json
    "1": { "class_type": "UnetLoaderGGUF", "inputs": { "unet_name": "sulphur_dev-Q8_0.gguf" }}
    ```
-3. Keep the **same LTX-2.3 companions**: `VAELoader` → `LTX23_video_vae_bf16.safetensors`, `CLIPLoader (type=ltxv)` → `gemma_3_12B_it_fp4_mixed.safetensors`, plus `ltx-2.3_text_projection_bf16.safetensors`. These must match the LTX-2.3 architecture — do not pair it with LTX-2 (19B) VAE/encoder.
+3. Keep the **same LTX-2.3 companions**: `VAELoader` → `LTX23_video_vae_bf16.safetensors`, `CLIPLoader (type=ltxv)` → `gemma_3_12B_it_fp4_mixed.safetensors`, plus `ltx-2.3_text_projection_bf16.safetensors`. These must match the LTX-2.3 architecture. Do not pair it with LTX-2 (19B) VAE/encoder.
 4. For the **bf16/fp8 safetensors** (non-GGUF) variants, load with the LTX checkpoint/diffusion-model loader the workflow uses for the safetensors path (Lightricks recommends the native LTX Video nodes documented at docs.ltx.video, not the auto-generated Diffusers snippet) rather than `UnetLoaderGGUF`.
 5. Obey the same constraints as any LTX-2.3 gen: frame count `8n+1`, resolution multiples of 32, `LTXVConditioning` frame_rate, dev model ~20+ steps / distilled ~8 steps.
 
@@ -450,7 +450,7 @@ To verify a third-party model is usable before wiring it up:
 
 ### LTXVideo "kornia" import error (`pad` ImportError)
 
-**Symptom:** ComfyUI-LTXVideo fails to load with an ImportError from `kornia.geometry.transform.pyramid` — `pad` can no longer be imported. This happens with **kornia 0.8.3+**, which stopped exporting `pad` from that module.
+**Symptom:** ComfyUI-LTXVideo fails to load with an ImportError from `kornia.geometry.transform.pyramid` because `pad` can no longer be imported. This happens with **kornia 0.8.3+**, which stopped exporting `pad` from that module.
 
 **What the fix does** (`FIX-LTXVIDEO-KORNIA.bat`, run from the `ComfyUI_windows_portable` folder): it patches `ComfyUI/custom_nodes/ComfyUI-LTXVideo/pyramid_blending.py`:
 1. Backs the file up to `pyramid_blending.py.bak_kornia_fix`.
@@ -462,7 +462,7 @@ To verify a third-party model is usable before wiring it up:
    ```
 4. Verifies `pad = F.pad` is present and the broken import is gone.
 
-**Manual equivalent** if you don't run the .bat — edit `pyramid_blending.py`: delete `pad,` from the kornia import list and add `pad = F.pad` after the `import torch.nn.functional as F` line, then restart ComfyUI. (Alternatively, pin kornia to a pre-0.8.3 release, but the patch is the lighter-touch fix and is what the install set ships.)
+**Manual equivalent** if you don't run the .bat: edit `pyramid_blending.py` to delete `pad,` from the kornia import list and add `pad = F.pad` after the `import torch.nn.functional as F` line, then restart ComfyUI. (Alternatively, pin kornia to a pre-0.8.3 release, but the patch is the lighter-touch fix and is what the install set ships.)
 
 ### LTXVideo version / workflow mismatch
 

--- a/plugin/skills/ltxv2-video/references/workflows.md
+++ b/plugin/skills/ltxv2-video/references/workflows.md
@@ -6,17 +6,17 @@ need the exact install commands or a full graph to build from.
 
 ## Contents
 
-- [Install scripts (step-by-step source of truth)](#install-scripts-step-by-step-source-of-truth) — LTX-2 and LTX-2.3 GGUF download commands
-- [Complete Workflow: T2V Distilled (8-Step)](#complete-workflow-t2v-distilled-8-step) — LTX-2 bundled-checkpoint graph
-- [Complete Workflow: LTX-2.3 GGUF (dev, T2V)](#complete-workflow-ltx-23-gguf-dev-t2v) — GGUF UNet + separate VAE graph
+- [Install scripts (step-by-step source of truth)](#install-scripts-step-by-step-source-of-truth): LTX-2 and LTX-2.3 GGUF download commands
+- [Complete Workflow: T2V Distilled (8-Step)](#complete-workflow-t2v-distilled-8-step): LTX-2 bundled-checkpoint graph
+- [Complete Workflow: LTX-2.3 GGUF (dev, T2V)](#complete-workflow-ltx-23-gguf-dev-t2v): GGUF UNet + separate VAE graph
 
 ## Install scripts (step-by-step source of truth)
 
 Three installers (by "Aitrepreneur") were used; they all download from `HF = https://huggingface.co/Aitrepreneur/FLX/resolve/main`:
 
-- `LTX-2-3-MODELS-NODES_INSTALL-V2.bat` — run from `...\ComfyUI_windows_portable\ComfyUI\`. Locks the current pip env into a constraints file, sanitizes each node's `requirements.txt` (strips torch/file-wheels/extra-index lines), clones nodes, downloads models. Flags: `/update`, `/force`, `/dryrun`, `/restore`.
-- `LTX-2-3-ULTRA-COMFYUI-MANAGER_AUTO_INSTALL-V2.bat` — full one-click: downloads ComfyUI portable `v0.22.0`, installs 7-Zip/Git if missing, clones the same nodes, downloads the same models, then launches ComfyUI.
-- `LTX-2-3-AUTO_INSTALL-RUNPOD-V2.sh` — Linux/RunPod. Recreates a clean venv, pins **torch 2.4.0 / torchvision 0.19.0 / torchaudio 2.4.0 / xformers 0.0.27.post2 on cu121**, transformers 4.51.3, tokenizers >=0.21,<0.22, timm 1.0.15. Pins **ComfyUI-LTXVideo to commit `cd5d371518afb07d6b3641be8012f644f25269fc`** for workflow compatibility, and verifies the LTXVideo import at the end.
+- `LTX-2-3-MODELS-NODES_INSTALL-V2.bat` runs from `...\ComfyUI_windows_portable\ComfyUI\`. It locks the current pip env into a constraints file, sanitizes each node's `requirements.txt` (strips torch/file-wheels/extra-index lines), clones nodes, downloads models. Flags: `/update`, `/force`, `/dryrun`, `/restore`.
+- `LTX-2-3-ULTRA-COMFYUI-MANAGER_AUTO_INSTALL-V2.bat` is the full one-click install: it downloads ComfyUI portable `v0.22.0`, installs 7-Zip/Git if missing, clones the same nodes, downloads the same models, then launches ComfyUI.
+- `LTX-2-3-AUTO_INSTALL-RUNPOD-V2.sh` is for Linux/RunPod. It recreates a clean venv, pins **torch 2.4.0 / torchvision 0.19.0 / torchaudio 2.4.0 / xformers 0.0.27.post2 on cu121**, transformers 4.51.3, tokenizers >=0.21,<0.22, timm 1.0.15. Pins **ComfyUI-LTXVideo to commit `cd5d371518afb07d6b3641be8012f644f25269fc`** for workflow compatibility, and verifies the LTXVideo import at the end.
 
 Exact model download URLs (all `?download=true` from the `FLX` mirror), grouped by target folder:
 

--- a/plugin/skills/minimax-h3-video/SKILL.md
+++ b/plugin/skills/minimax-h3-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimax-h3-video
-description: Build MiniMax H3 (Hailuo) local video workflows — native T2V/I2V/R2V nodes, Comfy-Org INT8 weights, turbo LoRAs for 8GB VRAM, 15-second stereo-audio clips, and the official MiniMax prompting guides (cite by link, do not copy).
+description: Build MiniMax H3 (Hailuo) local video workflows with native T2V/I2V/R2V nodes, Comfy-Org INT8 weights, turbo LoRAs for 8GB VRAM, 15-second stereo-audio clips, and the official MiniMax prompting guides (cite by link, do not copy).
 globs:
   - "**/*.json"
 ---
@@ -53,12 +53,12 @@ Video**, not installer packs and not custom-node `example_workflows`:
 
 `list_packs action:"list_templates"` will **not** list them.
 `enqueue_workflow action:"run_template"` will **not** resolve
-`video_minimax_h3_t2v` / `_i2v` / `_r2v` — that action only loads bundled
+`video_minimax_h3_t2v` / `_i2v` / `_r2v`. That action only loads bundled
 installer packs, and there is no `packs/minimax-h3-*` yet. Do not call it
 until a pack exists. `panel_load_workflow` needs `pack:`, a disk `path:`, or
-an inline UI `graph` — a Template Library basename is none of those.
+an inline UI `graph`. A Template Library basename is none of those.
 
-**Load path that actually works:**
+**Load path that works:**
 
 1. **Preferred.** Ask the user to open **Template Library → Video → MiniMax H3:
    Text to Video** (or Image to Video / Reference to Video). Pick the local
@@ -109,7 +109,7 @@ W4A8 at `Kijai/MiniMax-H3-experimental`. Same job (low-step / low-VRAM). Prefer
 the Comfy-Org / lightx2v filenames the template already names; only switch to a
 Kijai file if that is what is on disk.
 
-4-step is faster and softer; **6–8 steps** is the usual sharpness compromise.
+4-step is faster and softer; **6 to 8 steps** is the usual sharpness compromise.
 
 ## Output spec
 
@@ -168,7 +168,7 @@ R2V replaces the UNet with **ref2va** and the conditioner with
 | `MiniMaxH3SigmaShift` | Flow-matching shift on the local UNet |
 | `MiniMaxH3MemoryEfficientSageAttentionPatch` | Core Sage patch; or KJNodes `Patch Sage Attention KJ` (`sage_attention=auto`) between `UNETLoader` and `BasicGuider` |
 
-Sage roughly doubles speed. H3 has mixed dtypes — console lines about falling
+Sage roughly doubles speed. H3 has mixed dtypes, so console lines about falling
 back to pytorch attention on some layers are expected.
 
 ## Sampler defaults (Comfy-Org template)
@@ -178,7 +178,7 @@ back to pytorch attention on some layers are expected.
 | Base (no turbo) | `res_multistep` | `simple` | **20** |
 | Turbo on | `res_multistep` | `simple` | **4–8** (template default turbo steps widget) |
 
-Guider is `BasicGuider` (CFG-distilled checkpoint — do not crank CFG). Seed via
+Guider is `BasicGuider` (CFG-distilled checkpoint, so do not crank CFG). Seed via
 `RandomNoise`.
 
 ## Prompting — read the vendor guide, do not paste it here
@@ -192,7 +192,7 @@ system prompt dump):
   https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md
 - Full-reference / R2V:
   https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md
-- Vendor skill (install separately if the user wants it — we do not bundle it):
+- Vendor skill (install separately if the user wants it; we do not bundle it):
   https://github.com/MiniMax-AI/MiniMax-H3 (`npx skills add … --skill h3-prompt-writing`)
 
 H3-Context-IR (the hosted prompt rewriter) is **not** in the open weights.
@@ -208,7 +208,7 @@ Comfy-Org's own template notes (safe to follow, not MiniMax docs):
 3. R2V: name each input in connection order (`<Picture 1>`, `<Video 1>`,
    `<Audio 1>`) and say what job each one does (identity, motion, voice).
 4. R2V caps (vendor model card, not a guess): ≤9 images, ≤3 videos, ≤3 audio
-   clips, ≤12 files mixed; each AV clip 2–15 s.
+   clips, ≤12 files mixed; each AV clip 2 to 15 s.
 
 ## 15-second clips and chaining
 
@@ -216,8 +216,8 @@ One H3 shot is **at most ~15 s**. Longer pieces are concatenated clips, not a
 bigger `length`.
 
 1. Generate clip N (up to 15 s).
-2. Confirm the file with `get_image` `action:"list_outputs"` (`kind:"video"`) —
-   video nodes often skip `/history`.
+2. Confirm the file with `get_image` `action:"list_outputs"` (`kind:"video"`).
+   Video nodes often skip `/history`.
 3. Stage the last frame (or the whole clip) with `upload_image` `action:"stage"`.
 4. Clip N+1: `MiniMaxH3ImageToVideo.first_frame` = last frame of N, **or** R2V
    with `<Video 1>` as a continuation reference.
@@ -246,19 +246,19 @@ Always `clear_vram` before switching to H3 from WAN / LTX / a checkpoint.
   steps without the LoRA is mush.
 - **API node in a local graph.** Costs money and ignores the UNet you downloaded.
 - **WAN frame math.** H3 is 24 fps and `17k+5`, not 16 fps `4n+1`.
-- **Verify video on disk**, then stage — never guess `input/` paths.
+- **Verify video on disk**, then stage. Never guess `input/` paths.
 - **ffmpeg** is required for `CreateVideo` / `SaveVideo` / `VHS_VideoCombine`.
 - Desktop/Cloud ComfyUI lags nightly. Missing `MiniMaxH3*` nodes → update to
   ≥0.30.0 (0.33 templates) before hunting custom packs.
 
 ## See also
 
-- `video-extend` — WAN Pusa temporal continuation (different family)
-- `director` — multi-clip concat after you have 15 s H3 shots
-- `prompt-engineering` — generic CLIP syntax; **H3 does not use it**
-- `triton-sageattention` — installing Sage on Windows
+- `video-extend`: WAN Pusa temporal continuation (different family)
+- `director`: multi-clip concat after you have 15 s H3 shots
+- `prompt-engineering`: generic CLIP syntax; **H3 does not use it**
+- `triton-sageattention`: installing Sage on Windows
 
-No bundled `packs/minimax-h3-*` installer yet — that is why
+There is no bundled `packs/minimax-h3-*` installer yet, which is why
 `enqueue_workflow action:"run_template"` cannot load these graphs. Use the
 Template Library (or the GitHub fetch → `save_workflow` →
 `panel_load_workflow path:` path above) + `download_model` against
@@ -266,5 +266,5 @@ Template Library (or the GitHub fetch → `save_workflow` →
 
 ## Sources
 
-- **Official:** MiniMax prompting guides https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md (T2VA/I2VA/FL2VA/L2VA) and https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md (full-reference / R2V); vendor repo https://github.com/MiniMax-AI/MiniMax-H3; ComfyUI tutorial + templates https://docs.comfy.org/tutorials/video/minimax/minimax-h3 (wiring, duration grid, INT8 filenames). MiniMax's own `skills/h3-prompt-writing` is linked, not copied — Community License includes Documentation.
+- **Official:** MiniMax prompting guides https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md (T2VA/I2VA/FL2VA/L2VA) and https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md (full-reference / R2V); vendor repo https://github.com/MiniMax-AI/MiniMax-H3; ComfyUI tutorial + templates https://docs.comfy.org/tutorials/video/minimax/minimax-h3 (wiring, duration grid, INT8 filenames). MiniMax's own `skills/h3-prompt-writing` is linked, not copied, because the Community License includes Documentation.
 - **Empirical:** local vs partner-API node split and 8 GB turbo-LoRA note from issue #1167 / the reporter's rig; Sage mixed-dtype fallback from the Comfy tutorial; chaining last-frame→next-clip from observed ComfyUI I/O (stage + list_outputs), not a vendor extender.

--- a/plugin/skills/model-compatibility/SKILL.md
+++ b/plugin/skills/model-compatibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-compatibility
-description: Model family compatibility matrix — loaders, resolutions, samplers, CFG, VAE, ControlNet, and LoRA compatibility for SD 1.5, SDXL, Flux, SD3, and video models
+description: Model family compatibility matrix covering loaders, resolutions, samplers, CFG, VAE, ControlNet, and LoRA compatibility for SD 1.5, SDXL, Flux, SD3, and video models
 globs:
   - "**/*.json"
 ---
@@ -48,7 +48,7 @@ SaveImage
 - Most SD 1.5 checkpoints have a built-in VAE, but it's often mediocre
 - **Recommended**: Use external `vae-ft-mse-840000-ema-pruned.safetensors` for better color accuracy
 - Load via `VAELoader` node and connect to `VAEDecode`
-- FP16 VAE can produce NaN on some images — FP32 VAE is more stable
+- FP16 VAE can produce NaN on some images. FP32 VAE is more stable
 
 ### ControlNet Compatibility
 
@@ -72,7 +72,7 @@ SD 1.5 has the largest ControlNet ecosystem:
 
 - SD 1.5 LoRAs ONLY work with SD 1.5 base models
 - Format: `.safetensors` in `models/loras/`
-- Loader: `LoraLoader` node — connects between checkpoint and CLIPTextEncode
+- Loader: `LoraLoader` node, which connects between checkpoint and CLIPTextEncode
 - Strength range: 0.5-1.0 (higher can cause artifacts)
 
 ---
@@ -166,7 +166,7 @@ SDXL ControlNets are separate from SD 1.5 ControlNets:
 
 ### LoRA Compatibility
 
-- SDXL LoRAs ONLY work with SDXL base models — NOT with SD 1.5
+- SDXL LoRAs ONLY work with SDXL base models, NOT with SD 1.5
 - Same `LoraLoader` node as SD 1.5
 - Lightning LoRAs are SDXL LoRAs that enable few-step generation
 
@@ -222,10 +222,10 @@ VAELoader (vae_name="ae.safetensors") → VAE
 
 ### CRITICAL Rules
 
-- **CFG MUST be 1.0** — Flux uses guidance embedded in the model, not classifier-free guidance
-- **No negative prompt** — Empty string or don't connect the negative input at all
-- **Separate VAE required** — Flux uses its own VAE (`ae.safetensors`), not SD VAEs
-- **FP8 strongly recommended** for 24GB cards — FP16 Flux barely fits in 24GB VRAM
+- **CFG MUST be 1.0.** Flux uses guidance embedded in the model, not classifier-free guidance
+- **No negative prompt.** Empty string or don't connect the negative input at all
+- **Separate VAE required.** Flux uses its own VAE (`ae.safetensors`), not SD VAEs
+- **FP8 strongly recommended** for 24GB cards. FP16 Flux barely fits in 24GB VRAM
 - T5-XXL encoder can be loaded in FP8 to save additional VRAM
 
 ### Workflow Pattern
@@ -307,7 +307,7 @@ CLIPLoader (t5xxl) → CLIP
 
 - Much better text rendering capabilities
 - Handles spatial relationships better ("cat on the left, dog on the right")
-- T5-XXL enables very long, detailed prompts (no 77-token limit concern)
+- T5-XXL enables long, detailed prompts (no 77-token limit concern)
 - Lower CFG values (4-7 vs 7-12)
 - Minimal negative prompting needed
 - `shift` parameter in sampling affects noise schedule
@@ -324,7 +324,7 @@ CLIPLoader (t5xxl) → CLIP
 
 ### Overview
 
-Latent video diffusion models for text-to-video and image-to-video generation. Very VRAM-intensive.
+Latent video diffusion models for text-to-video and image-to-video generation. VRAM-intensive.
 
 ### Configuration
 
@@ -341,7 +341,7 @@ Latent video diffusion models for text-to-video and image-to-video generation. V
 
 - **Always use FP8 quantized models** on 24GB cards
 - Reduce frame count if OOM persists
-- Lower resolution helps significantly
+- Lower resolution helps a lot
 - Close other GPU-using applications
 - Consider `--lowvram` flag for ComfyUI
 

--- a/plugin/skills/model-registry/SKILL.md
+++ b/plugin/skills/model-registry/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: model-registry
-description: Curated download URLs and target directories for every model the comfyui-mcp skills reference — checkpoints, VAEs, text encoders, LoRAs — organized by family (Flux, WAN, LTX, Qwen, Z-Image, SD15/SDXL). Use when downloading models with download_model (action:"download" / action:"download_civitai"), when a workflow fails with a missing-model error, or when setting up a new machine.
+description: Curated download URLs and target directories, organized by family (Flux, WAN, LTX, Qwen, Z-Image, SD15/SDXL), for every model the comfyui-mcp skills reference, covering checkpoints, VAEs, text encoders, and LoRAs. Use when downloading models with download_model (action:"download" / action:"download_civitai"), when a workflow fails with a missing-model error, or when setting up a new machine.
 ---
 
 # Model Registry
 
 One table per family: filename → source URL → target subdir under
 `<COMFYUI>/models/`. Use with `download_model({ action: "download", url, target_subfolder, filename })`.
-This registry grows with every release — if a model you need is missing, use
+This registry grows with every release. If a model you need is missing, use
 `action:"search"` (HuggingFace) or `action:"download_civitai"` and consider
 contributing the row.
 
 **Conventions**
 - HF "resolve" URLs download directly: `https://huggingface.co/<repo>/resolve/main/<path>`
-- 🔒 = gated repo — needs `HUGGINGFACE_TOKEN` (accept the license on the HF page first)
+- 🔒 = gated repo, needs `HUGGINGFACE_TOKEN` (accept the license on the HF page first)
 - CivitAI model-page URLs need `download_model` `action:"download_civitai"` (resolves version → file); raw `civitai.com/api/download/...` URLs work with `action:"download"` + `CIVITAI_API_TOKEN`
-- Always verify the exact filename a workflow's loader expects — `model-compatibility` skill covers which VAE/CLIP pairs with which architecture
+- Always verify the exact filename a workflow's loader expects. The `model-compatibility` skill covers which VAE/CLIP pairs with which architecture
 
 ## Shared VAEs & text encoders (download these once)
 
@@ -96,7 +96,7 @@ filenames the Comfy-Org templates already name.
 
 ## SDXL / SD1.5 community checkpoints (CivitAI)
 
-Use `download_model({ action: "download_civitai", model_id })` — it resolves the latest version and
+Use `download_model({ action: "download_civitai", model_id })`. It resolves the latest version and
 handles auth:
 
 | Model | CivitAI |
@@ -107,13 +107,13 @@ handles auth:
 
 ## Failure modes
 
-- **404 on an HF resolve URL** — the repo restructured. Open the repo page,
+- **404 on an HF resolve URL.** The repo restructured. Open the repo page,
   find the file under "Files", and rebuild the resolve URL.
-- **401/403** — gated repo: set `HUGGINGFACE_TOKEN` after accepting the
+- **401/403.** Gated repo. Set `HUGGINGFACE_TOKEN` after accepting the
   license, or `CIVITAI_API_TOKEN` for early-access CivitAI files.
-- **Wrong dropdown after download** — file landed in the wrong `models/`
+- **Wrong dropdown after download.** The file landed in the wrong `models/`
   subdir; check the Target column and `model-compatibility`.
-- Downloads resume automatically on retry (HTTP Range) — re-run the same
+- Downloads resume on retry (HTTP Range), so re-run the same
   `download_model` call after a network drop.
 
 ## Sources

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -8,9 +8,9 @@ description: Keep the ComfyUI sidebar panel node-pack (comfyui-agent-panel) in s
 The orchestrator (`comfyui-mcp`, from npm) and the sidebar panel
 (`comfyui-agent-panel` on the Comfy Registry, repo `comfyui-mcp-panel`) ship
 **separately**. Updating one does not update the other. A new orchestrator
-driving an old panel fails in confusing ways — a bridge command the panel simply
-doesn't implement, a feature that exists in the docs but not in the sidebar — and
-those failures are hard for a user to diagnose. This skill closes that gap.
+driving an old panel fails in confusing ways, such as a bridge command the panel
+doesn't implement or a feature that exists in the docs but not in the sidebar,
+and those failures are hard for a user to diagnose. This skill closes that gap.
 
 ## The two rules that outrank everything else here
 
@@ -19,7 +19,7 @@ those failures are hard for a user to diagnose. This skill closes that gap.
    "drained" even when it never enqueued anything, and a `.bak`-style copy in
    `custom_nodes` can shadow the real panel in the browser. So the only version
    you may ever tell the user is the one **read back from disk after the fact**.
-   If the tool throws, the sync FAILED — say so plainly. Do not soften it, do not
+   If the tool throws, the sync FAILED. Say so plainly. Do not soften it, do not
    retry it into a success, do not report the version you *intended* to install.
 
 2. **Never move a pinned user.** A pin is a promise. If the user pinned the
@@ -70,16 +70,16 @@ That single call re-checks the decision at execution time (the pin may have been
 set a second ago), runs the update through the hardened, verified path, and
 re-reads the pack from disk afterwards. Read the result:
 
-- `synced: true` → it really moved. Report **`verifiedVersion`** — that is the
-  version observed on disk after the op, not the one we asked for. Then tell the
-  user **ComfyUI must be RESTARTED** to load it (`restartRequired: true`); this
+- `synced: true` → it moved. Report **`verifiedVersion`**, the version observed
+  on disk after the op, not the one we asked for. Then tell the user
+  **ComfyUI must be RESTARTED** to load it (`restartRequired: true`); this
   never auto-restarts. Now read `stillBehind`, which is **tri-state**:
   - `false` → the panel provably meets what the orchestrator needs. Done.
   - `true` → the update applied but did **not** close the gap. Say so; do not
     round it up to "you're current now".
   - **`null`** → it landed, but the resulting version (e.g. `nightly`) can't be
     compared, so whether the mismatch is fixed is **unknown**. Say exactly that.
-    `null` is not `false` — never report it as "you're fine".
+    `null` is not `false`. Never report it as "you're fine".
 - `synced: false` → nothing was changed. `decision` says why (`pinned-warn`,
   `meets-floor`, `blocked`, …). This is a normal outcome, not a failure.
 - **The tool errored** → the sync FAILED. The error text names the cause
@@ -96,11 +96,11 @@ The user deliberately held the panel where it is. Tell them three things and the
 **stop**:
 
 1. A newer panel that matches their orchestrator exists (`requiredPanelVersion`).
-2. They are pinned (say to what, and *where* the pin lives — `pin.source`).
+2. They are pinned (say to what, and *where* the pin lives, from `pin.source`).
 3. How to get off it, if they want to.
 
 > Your orchestrator (comfyui-mcp 0.48.32) expects panel 0.11.28+, and you're on
-> 0.11.3 — but you've pinned the panel to 0.11.3, so I haven't changed anything.
+> 0.11.3. You've pinned the panel to 0.11.3, so I haven't changed anything.
 > Want me to clear the pin and update? I'd unpin and then sync; ComfyUI needs a
 > restart afterwards.
 
@@ -111,23 +111,23 @@ install_comfyui(action:'panel', panel_action:'unpin')      # clears the persiste
 install_comfyui(action:'panel', panel_action:'sync')       # then Step 3
 ```
 
-**If `pin.source` is `"env"`**, `unpin` cannot clear it — the pin comes from the
-`COMFYUI_MCP_PANEL_PIN` environment variable. Tell the user to unset it (or set
-it to `off`) in their environment or `~/.comfyui-mcp/.env` and restart the
-orchestrator. Do not edit their environment for them, and do not report them as
-unpinned — `install_comfyui(action:'panel', panel_action:'unpin')` returns the still-active pin in that
-case, and its `note` says exactly this.
+**If `pin.source` is `"env"`**, `unpin` cannot clear it, because the pin comes
+from the `COMFYUI_MCP_PANEL_PIN` environment variable. Tell the user to unset it
+(or set it to `off`) in their environment or `~/.comfyui-mcp/.env` and restart
+the orchestrator. Do not edit their environment for them, and do not report them
+as unpinned. `install_comfyui(action:'panel', panel_action:'unpin')` returns the
+still-active pin in that case, and its `note` says exactly this.
 
 ## Step 5 — Blocked
 
 - **Shadow copy** (`shadows` non-empty): a dir like
   `.comfyui-agent-panel.bak-0.11.28` in `custom_nodes` is *also* served as a web
-  extension, and a dot-prefixed name wins by sort order — so the browser may be
+  extension, and a dot-prefixed name wins by sort order, so the browser may be
   loading the old panel no matter what the disk says. Nothing can be verified
-  until it's gone. Tell the user to move it **out of** `custom_nodes` (not just
+  until it's gone. Tell the user to move it **out of** `custom_nodes` (not only
   rename it) and hard-refresh the ComfyUI tab, then re-run Step 1.
 - **Unreadable pin**: `~/.comfyui-mcp/panel-settings.json` exists but couldn't be
-  parsed, so we cannot prove the user *isn't* pinned — and we refuse to move them
+  parsed, so we cannot prove the user *isn't* pinned, and we refuse to move them
   on a guess. Ask them to fix or delete that file (or set
   `COMFYUI_MCP_PANEL_PIN=off`), then re-run Step 1.
 
@@ -140,46 +140,46 @@ panel regressed something, they're testing):
 install_comfyui(action:'panel')(action='pin', version='<installedVersion from status>', reason='<why>')
 ```
 
-`version` is required — never invent one. Pass the `installedVersion` from
-Step 1 to pin them where they already are. A pin **records intent only**: it does
+`version` is required. Never invent one. Pass the `installedVersion` from
+Step 1 to pin them where they already are. A pin **records intent only**. It does
 not change what is installed.
 
-While it's set, everything that could move the panel refuses — not just
+While it's set, everything that could move the panel refuses, not only
 `install_comfyui(action:'panel')`. The panel is an ordinary custom node pack, so the generic node
 tools are a second door into the same operation, and they are guarded too:
 
 - `install_custom_node` / `install_custom_node` (`action: "update"`) / `install_custom_node` (`action: "reinstall"`)
-  targeting the panel by **any** spelling — the registry id, the repo name, or a
+  targeting the panel by **any** spelling: the registry id, the repo name, or a
   git URL including ref-carrying forms like `…/comfyui-mcp-panel.git@v0.11.28`
   and `…/comfyui-mcp-panel/tree/main`. These also **route through the verified
   path** automatically, so the version they report is re-read from disk like
   `sync`'s.
-- **`id="all"`, and `install_comfyui (action:"update_all")`** — a bulk update moves the panel along with
+- **`id="all"`, and `install_comfyui (action:"update_all")`.** A bulk update moves the panel along with
   everything else. ComfyUI-Manager can't update everything-except-one-pack, so
   while pinned these refuse outright. If the user wants the rest updated, either
   unpin first or update the other packs individually by id. Say that plainly
   rather than quietly unpinning to make `all` work.
 - `install_custom_node` (`action: "fix"`), `panel_install_node` and `panel_update_node` **refuse** a
-  panel target outright — pinned or not. They report success as soon as the
+  panel target outright, pinned or not. They report success as soon as the
   ComfyUI-Manager queue drains, which proves nothing, and there's no verified
   equivalent to route them into. Use `install_comfyui(action:'panel')` instead; don't work around
   the refusal.
 
-Prefer `install_comfyui(action:'panel')` throughout — it's the one with `status`, `sync` and the
+Prefer `install_comfyui(action:'panel')` throughout. It's the one with `status`, `sync` and the
 pin.
 
 ## When to run this at all
 
 - Right after the orchestrator updates (`install_comfyui (action:"self_update")`, a fresh `npm i -g`, or a
   version in the ENVIRONMENT line that's newer than last you saw).
-- When a panel/bridge command fails in a way that smells like version drift —
+- When a panel/bridge command fails in a way that smells like version drift:
   "panel is too old", a `graph_*`/`ui_*` command the panel doesn't implement, a
   documented sidebar feature that isn't there.
 - Whenever the user asks to update, pin, or unpin the panel.
 
-Be proportionate: this is a one-line check. If `decision` is `meets-floor` and the
-user didn't ask, don't narrate it — just carry on with what they actually wanted.
-The exception is a user who is DEBUGGING the panel: `meets-floor` is exactly the
+Be proportionate. This is a one-line check. If `decision` is `meets-floor` and the
+user didn't ask, don't narrate it. Carry on with what they wanted.
+The exception is a user who is DEBUGGING the panel. `meets-floor` is exactly the
 state that hides a shipped fix behind an unchanged floor, so there it is worth the
 sentence.
 
@@ -191,7 +191,7 @@ sentence.
   never `nightly`.
 - **A pin is never overridden**, not even "temporarily". Unpin requires the
   user's explicit yes.
-- **Never touch a dev symlink** — it's someone's working repo.
+- **Never touch a dev symlink.** It's someone's working repo.
 - **Always say a restart is required** after a sync lands; nothing here
   auto-restarts ComfyUI.
 

--- a/plugin/skills/prompt-engineering/SKILL.md
+++ b/plugin/skills/prompt-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-engineering
-description: ComfyUI prompt engineering knowledge — CLIP text encoding syntax, weight modifiers, model-specific prompting strategies, and best practices
+description: ComfyUI prompt engineering knowledge covering CLIP text encoding syntax, weight modifiers, model-specific prompting strategies, and best practices
 globs:
   - "**/*.json"
 ---
@@ -37,7 +37,7 @@ Adjust how strongly the model attends to specific words or phrases:
 - **Default weight**: 1.0 for unmodified tokens
 - **Nesting stacks multiplicatively**: `((word))` = 1.1 * 1.1 = `(word:1.21)`
 - **Phrases**: `(red sports car:1.3)` applies weight to the entire phrase
-- **Mixing**: `(detailed face:1.4), (blurry background:0.6)` — combine in one prompt
+- **Mixing**: `(detailed face:1.4), (blurry background:0.6)`, combined in one prompt
 
 ### Examples
 
@@ -69,7 +69,7 @@ highly detailed, 8k uhd, photorealistic, volumetric lighting,
 depth of field, golden hour, award-winning photography
 ```
 
-Each chunk is encoded independently and then concatenated as conditioning, ensuring all tokens are processed.
+Each chunk is encoded independently and then concatenated as conditioning, so all tokens are processed.
 
 ## Embeddings / Textual Inversions
 
@@ -108,7 +108,7 @@ Negative: `embedding:easynegative, embedding:badhandv4, worst quality, low quali
 
 ### SD 1.5
 
-**Negative prompt: IMPORTANT — SD 1.5 is very sensitive to negatives.**
+**Negative prompt: IMPORTANT. SD 1.5 is sensitive to negatives.**
 
 Positive prompt structure:
 ```
@@ -123,14 +123,14 @@ missing fingers, extra limbs, deformed, disfigured, mutation, ugly
 ```
 
 Key notes:
-- Quality tags like `masterpiece, best quality` significantly affect output
+- Quality tags like `masterpiece, best quality` make a large difference to output
 - Responds well to danbooru-style tags: `1girl, long hair, blue eyes, school uniform`
-- Embedding-based negatives (`easynegative`) are very effective
-- Keep prompts concise — 77 token limit per chunk
+- Embedding-based negatives (`easynegative`) work well
+- Keep prompts concise, since each chunk is limited to 77 tokens
 
 ### SDXL (1.0 / Turbo / Lightning)
 
-**Negative prompt: Moderate importance — SDXL is less sensitive to negatives than SD 1.5.**
+**Negative prompt: Moderate importance. SDXL is less sensitive to negatives than SD 1.5.**
 
 Positive prompt structure:
 ```
@@ -145,7 +145,7 @@ mutation, mutated, extra limbs, watermark, text
 
 Key notes:
 - SDXL understands natural language better than tag-based prompts
-- Dual CLIP encoders (CLIP-L + CLIP-G) — use `CLIPTextEncodeSDXL` for separate control
+- Dual CLIP encoders (CLIP-L + CLIP-G). Use `CLIPTextEncodeSDXL` for separate control
 - `CLIPTextEncodeSDXL` has separate `text_g` (global description) and `text_l` (local details) fields
 - Supports longer prompts natively (two 77-token chunks via dual CLIP)
 - Quality tags are less critical but still helpful
@@ -154,7 +154,7 @@ Key notes:
 
 ### Flux (Flux.1 schnell / dev)
 
-**Negative prompt: NOT USED — Flux operates at CFG=1.0 with no negative conditioning.**
+**Negative prompt: NOT USED. Flux operates at CFG=1.0 with no negative conditioning.**
 
 Positive prompt structure:
 ```
@@ -163,8 +163,8 @@ rather than comma-separated tags. Describe the scene as if writing a paragraph.
 ```
 
 Key notes:
-- **CFG must be 1.0** — higher values cause artifacts
-- **No negative prompt** — connect nothing or empty string to negative conditioning
+- **CFG must be 1.0.** Higher values cause artifacts
+- **No negative prompt.** Connect nothing or empty string to negative conditioning
 - T5-XXL encoder understands complex sentences and spatial relationships
 - Flux handles compositional prompts better than SD models
 - Longer prompts (200+ tokens) work well thanks to T5 encoder
@@ -184,7 +184,7 @@ warm, natural lighting and shallow depth of field.
 
 ### SD3 / SD3.5
 
-**Negative prompt: Minimal — SD3 needs very little negative guidance.**
+**Negative prompt: Minimal. SD3 needs little negative guidance.**
 
 Positive prompt structure:
 ```
@@ -196,7 +196,7 @@ Key notes:
 - Supports much longer prompts than SD 1.5 or SDXL
 - Natural language works better than tag-based prompting
 - CFG 4-7 (lower than SD 1.5)
-- Minimal negatives needed — `low quality, blurry` is usually sufficient
+- Minimal negatives needed. `low quality, blurry` is usually sufficient
 - Use `CLIPTextEncodeSD3` node for model-specific encoding if available
 
 ## Prompt Structure Best Practices
@@ -240,11 +240,11 @@ LoRA (Low-Rank Adaptation) models are fine-tuned on specific concepts and requir
 
 ### Rules
 
-- Trigger words are **specific to each LoRA** — check the LoRA's model page for its triggers
+- Trigger words are **specific to each LoRA**. Check the LoRA's model page for its triggers
 - Place trigger words in the prompt naturally: `a photo of ohwx woman in a garden` (where `ohwx` is the trigger)
 - Some LoRAs use style triggers: `in the style of pixar3d`
 - Multiple LoRAs can be stacked, but each needs its own trigger word in the prompt
-- LoRA strength (in the `LoraLoader` node) interacts with prompt weight — usually keep one at default
+- LoRA strength (in the `LoraLoader` node) interacts with prompt weight. Usually keep one at default
 
 ### Common Patterns
 
@@ -301,7 +301,7 @@ Where `haircolor.txt`, `clothing.txt`, and `location.txt` are in the wildcards d
 5. **Conflicting terms**: `(bright:1.3) (dark:1.3)` confuses the model
 6. **Embedding without file**: Using `embedding:name` without the `.safetensors` file installed causes errors
 7. **Wrong LoRA trigger words**: The prompt must contain the exact trigger word(s) for the LoRA to activate
-8. **Quality tags in Flux prompts**: `masterpiece, best quality` are meaningless for Flux — describe quality naturally
+8. **Quality tags in Flux prompts**: `masterpiece, best quality` are meaningless for Flux. Describe quality naturally
 
 ## Sources
 

--- a/plugin/skills/qwen-image-edit/SKILL.md
+++ b/plugin/skills/qwen-image-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qwen-image-edit
-description: Build Qwen Image Edit workflows — model loading, conditioning, LoRAs, prompt patterns, and XY plot testing
+description: Build Qwen Image Edit workflows covering model loading, conditioning, LoRAs, prompt patterns, and XY plot testing
 globs:
   - "**/*.json"
 ---
@@ -68,13 +68,13 @@ Outputs (10):
   [9] pad_info: ANY — padding info for later unpadding
 ```
 
-**Key advantage**: Output [1] (latent) eliminates the need for a separate `EmptyLatentImage` or `VAEEncode` node — the Advanced node handles latent creation internally at the correct resolution.
+**Key advantage**: Output [1] (latent) eliminates the need for a separate `EmptyLatentImage` or `VAEEncode` node. The Advanced node handles latent creation internally at the correct resolution.
 
 ### Other Conditioning Variants
 
-- **TextEncodeQwenImageEditPlus** (Phr00t v2, built-in) — Simpler: 4 image inputs, outputs only CONDITIONING. Requires separate EmptyLatentImage. Good for quick edits.
-- **TextEncodeQwenImageEditPlus_lrzjason** — 5 image inputs, resize toggles, but less control than Advance
-- **TextEncodeQwenImageEditPlusPro_lrzjason** — Per-image VL resize selection via `vl_resize_indexs` string, `main_image_index` control
+- **TextEncodeQwenImageEditPlus** (Phr00t v2, built-in) is simpler: 4 image inputs, outputs only CONDITIONING. Requires separate EmptyLatentImage. Good for quick edits.
+- **TextEncodeQwenImageEditPlus_lrzjason**: 5 image inputs, resize toggles, but less control than Advance
+- **TextEncodeQwenImageEditPlusPro_lrzjason**: Per-image VL resize selection via `vl_resize_indexs` string, `main_image_index` control
 
 ## Lightning LoRAs (Fast Generation)
 
@@ -100,7 +100,7 @@ For non-edit models (txt2img, 2512):
 
 ### 8-Step Lightning
 
-- `Qwen-Image-Lightning-8steps-V1.0.safetensors` — Higher detail than 4-step
+- `Qwen-Image-Lightning-8steps-V1.0.safetensors`, higher detail than 4-step
 
 ## Sampler Settings
 
@@ -168,7 +168,7 @@ Always use `ConditioningZeroOut` for negative conditioning with Qwen edit:
 
 ## Complete Workflow: Lightning Edit (Advanced Node)
 
-Uses `TextEncodeQwenImageEditPlusAdvance_lrzjason` which outputs the latent directly — no EmptyLatentImage needed.
+Uses `TextEncodeQwenImageEditPlusAdvance_lrzjason`, which outputs the latent directly, so no EmptyLatentImage is needed.
 
 ```json
 {
@@ -197,9 +197,9 @@ Uses `TextEncodeQwenImageEditPlusAdvance_lrzjason` which outputs the latent dire
 ```
 
 **Key connections**:
-- `"latent_image": ["6", 1]` — KSampler gets its latent directly from the Advanced node's output [1]
-- `"positive": ["6", 0]` — conditioning_with_full_ref from output [0]
-- `"vl_resize_image1": ["5", 0]` — source image goes into VL-resize slot (downscaled for vision encoder)
+- `"latent_image": ["6", 1]`: KSampler gets its latent directly from the Advanced node's output [1]
+- `"positive": ["6", 0]`: conditioning_with_full_ref from output [0]
+- `"vl_resize_image1": ["5", 0]`: source image goes into VL-resize slot (downscaled for vision encoder)
 
 ### Simpler Alternative (Phr00t v2)
 
@@ -214,7 +214,7 @@ If `qweneditutils` custom node is unavailable, use the built-in `TextEncodeQwenI
 }
 ```
 
-Replace node 6 and add node 8 — KSampler latent_image connects to `["8", 0]` instead of `["6", 1]`.
+Replace node 6 and add node 8. KSampler latent_image connects to `["8", 0]` instead of `["6", 1]`.
 
 ### Basic Variant (Official ComfyUI Example)
 
@@ -222,11 +222,11 @@ The official "Qwen 2511 Edit Simple" example uses newer built-in nodes for model
 
 **Additional nodes in the official pipeline:**
 
-- **`ModelSamplingAuraFlow`** (shift=3.1) — Flow matching shift applied to the UNET. Used instead of `ModelSamplingSD3`.
-- **`CFGNorm`** (strength=1) — Normalizes CFG guidance for more stable generation. Applied after `ModelSamplingAuraFlow`.
-- **`FluxKontextImageScale`** — Auto-scales input images to the correct resolution for Qwen. No manual size parameters needed.
-- **`FluxKontextMultiReferenceLatentMethod`** (method=`index_timestep_zero`) — Applied to both positive and negative conditioning. Handles multi-reference latent indexing.
-- **`VAEEncode`** — Encodes the scaled image to latent (instead of `EmptyLatentImage`).
+- **`ModelSamplingAuraFlow`** (shift=3.1): Flow matching shift applied to the UNET. Used instead of `ModelSamplingSD3`.
+- **`CFGNorm`** (strength=1): Normalizes CFG guidance for more stable generation. Applied after `ModelSamplingAuraFlow`.
+- **`FluxKontextImageScale`**: Auto-scales input images to the correct resolution for Qwen. No manual size parameters needed.
+- **`FluxKontextMultiReferenceLatentMethod`** (method=`index_timestep_zero`): Applied to both positive and negative conditioning. Handles multi-reference latent indexing.
+- **`VAEEncode`**: Encodes the scaled image to latent (instead of `EmptyLatentImage`).
 
 **Official pipeline flow:**
 ```
@@ -262,24 +262,24 @@ For batch-testing multiple edit variations, use the Easy Nodes XY Plot system:
 5. **easy XYPlotAdvanced** + **easy XYInputs: PromptSR** drives the sweep
 6. **easy pipeIn** bundles model/clip/vae/latent into a pipeline
 
-This produces a grid image showing all combinations — useful for finding optimal angle/distance/style for a given subject.
+This produces a grid image showing all combinations, useful for finding the best angle/distance/style for a given subject.
 
 ## VRAM Considerations
 
 - Qwen 2511 edit bf16: ~10GB VRAM
 - CLIP (fp8): ~7GB VRAM
 - VAE: ~200MB
-- Total: ~17-18GB — fits comfortably on 24GB GPUs
+- Total: ~17-18GB, fits comfortably on 24GB GPUs
 - **Always `clear_vram` before loading** if switching from another model family
 
 ## Tips
 
 1. **Upload source images first** with `upload_image (action:"image")` before building the workflow
 2. **Match output resolution** to the next pipeline step (e.g., 832x480 for WAN FLF)
-3. **Lightning LoRA + denoise 1.0** works well — the model handles structure preservation through conditioning
+3. **Lightning LoRA + denoise 1.0** works well. The model handles structure preservation through conditioning
 4. For **img2img editing** (denoise < 1.0), use `VAEEncode` on the source image instead of `EmptyLatentImage`
 5. The **lrzjason Pro variant** is best for multi-image compositions where you need fine control over which images get VL-resized
-6. **Use `get_workflow (action:"analyze")`** to understand any saved Qwen edit workflow before modifying or executing it — returns a structured summary, not raw JSON. Only use `get_workflow` when you need the actual JSON for `enqueue_workflow` or `create_workflow (action:"modify")`.
+6. **Use `get_workflow (action:"analyze")`** to understand any saved Qwen edit workflow before modifying or executing it. It returns a structured summary, not raw JSON. Only use `get_workflow` when you need the actual JSON for `enqueue_workflow` or `create_workflow (action:"modify")`.
 
 ## Sources
 

--- a/plugin/skills/qwen-txt2img/SKILL.md
+++ b/plugin/skills/qwen-txt2img/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qwen-txt2img
-description: Build Qwen Image 2512 text-to-image workflows — QwenImageIntegratedKSampler, separate component loading, lightning LoRAs, and fine-tuned model variants
+description: Build Qwen Image 2512 text-to-image workflows with QwenImageIntegratedKSampler, separate component loading, lightning LoRAs, and fine-tuned model variants
 globs:
   - "**/*.json"
 ---
@@ -11,8 +11,8 @@ globs:
 
 Qwen Image 2512 is the latest (December 2025) text-to-image model from the Qwen family. It uses a vision-language model (Qwen2.5-VL) as the text encoder and generates high-quality images from natural language prompts. Two workflow approaches:
 
-1. **QwenImageIntegratedKSampler** — All-in-one node (recommended for simplicity)
-2. **Separate component loading** — UNETLoader + CLIPLoader + VAELoader + standard KSampler (more flexible)
+1. **QwenImageIntegratedKSampler**: All-in-one node (recommended for simplicity)
+2. **Separate component loading**: UNETLoader + CLIPLoader + VAELoader + standard KSampler (more flexible)
 
 ## Models
 
@@ -109,7 +109,7 @@ Qwen operates at ~1.6 megapixels natively:
 
 ## Approach 1: QwenImageIntegratedKSampler (All-in-One)
 
-The `QwenImageIntegratedKSampler` custom node handles model patching, conditioning, sampling, and output in a single node. Simplest workflow — just 4 nodes for model loading + 1 integrated sampler + 1 save.
+The `QwenImageIntegratedKSampler` custom node handles model patching, conditioning, sampling, and output in a single node. Simplest workflow: 4 nodes for model loading + 1 integrated sampler + 1 save.
 
 ### Node Inputs
 
@@ -177,7 +177,7 @@ Outputs:
 
 ## Approach 2: Separate Component Loading (Standard Pipeline)
 
-More flexible — allows inserting additional processing nodes between stages.
+More flexible, since it allows inserting additional processing nodes between stages.
 
 ### Pipeline Flow
 
@@ -251,7 +251,7 @@ Always use `ConditioningZeroOut` for Qwen txt2img:
 }
 ```
 
-Or use an empty string in `CLIPTextEncode` — but ZeroOut is more explicit and reliable.
+Or use an empty string in `CLIPTextEncode`, but ZeroOut is more explicit and reliable.
 
 ## QwenImageDiffsynthControlnet
 
@@ -277,13 +277,13 @@ Outputs:
 ## Concept/Style LoRAs (Installed)
 
 Located in `loras/Qwen/`:
-- `style/` — Figure makers, reality transform, panel painter
-- `concept/` — Various concept LoRAs
-- `poses/` — Pose-specific LoRAs
-- `character/` — Character enhancement
-- `anime/` — Anime style LoRAs
-- `tool/` — Utility LoRAs (anything2real, gaussian splash)
-- `equirectangular projection/` — 360 panorama LoRA
+- `style/`: Figure makers, reality transform, panel painter
+- `concept/`: Various concept LoRAs
+- `poses/`: Pose-specific LoRAs
+- `character/`: Character enhancement
+- `anime/`: Anime style LoRAs
+- `tool/`: Utility LoRAs (anything2real, gaussian splash)
+- `equirectangular projection/`: 360 panorama LoRA
 
 Apply with `LoraLoaderModelOnly`:
 
@@ -300,7 +300,7 @@ Apply with `LoraLoaderModelOnly`:
 
 ## Prompt Style
 
-Natural language, 1–3 sentences. Be descriptive:
+Natural language, 1 to 3 sentences. Be descriptive:
 
 ```
 Good: "Professional portrait of an Asian woman in her late 20s, wearing a cream linen blazer at a Tokyo rooftop café during golden hour, holding a matcha latte, editorial fashion photography, shot on Sony A7III 85mm f/1.4"
@@ -310,7 +310,7 @@ Bad: "1girl, cafe, blazer, matcha"
 Tips:
 - Put text to render in quotes within the prompt
 - "photograph" works better than "photorealistic"
-- Negative prompts: use NLP-style descriptions, not keyword spam (or just use ZeroOut)
+- Negative prompts: use NLP-style descriptions, not keyword spam (or use ZeroOut)
 
 ## VRAM Considerations
 
@@ -320,16 +320,16 @@ Tips:
 | bf16 UNET (edit model) | ~10GB UNET + 7GB CLIP | Also fits well |
 
 - **Always `clear_vram`** before switching to Qwen from another model family
-- Lightning 4-step is extremely fast (~3-5s per image)
+- Lightning 4-step takes ~3-5s per image
 
 ## Tips
 
-1. **QwenImageIntegratedKSampler** is the simplest approach for basic txt2img — one node handles everything
+1. **QwenImageIntegratedKSampler** is the simplest approach for basic txt2img. One node handles everything
 2. For **LoRA stacking** or **ControlNet**, use the separate component pipeline instead
-3. The integrated sampler's `auraflow_shift` defaults to 3 (close to the recommended 3.1) — adjust only if needed
+3. The integrated sampler's `auraflow_shift` defaults to 3 (close to the recommended 3.1). Adjust only if needed
 4. For **video pipeline** output (feeding into WAN FLF), set resolution to 832x480
 5. **CopaxTimeless pick**: res_multistep + sgm_uniform at CFG 4.0 for ultra-realistic results
-6. Multiple concept LoRAs can stack — reduce individual strength to 0.5-0.7 when combining
+6. Multiple concept LoRAs can stack. Reduce individual strength to 0.5-0.7 when combining
 
 ## Sources
 


### PR DESCRIPTION
Part of #2003.

Applies the 31 pstack `unslop` prose rules to the second group of plugin skills (ideogram-ultra, installer-packs, krea2-identity-edit, krea2-txt2img, local-llm-free, lora-manager, ltx-director, ltxv2-video plus its `references/workflows.md`, minimax-h3-video, model-compatibility, model-registry, panel-node-pack-sync, prompt-engineering, qwen-image-edit, qwen-txt2img). These files are LLM-facing prompts shipped to npm, so the goal was plainer prose at the same meaning: em and en dashes became periods or commas (no parentheses swapped in), mid-sentence colons became sentence breaks, intensifiers and filler words ("very", "just", "simply", "actually", "dramatically", "extremely", "significantly", "basically", "showcase", "rich") were cut or replaced with the concrete word or number, bold lead-ins that ran into an em dash now end in a period and continue as prose, and "-ing" tails ("ensuring all tokens are processed") became plain clauses.

Nothing structural moved. Per file, the YAML `name`, every heading (text and level), every link and bare URL, every fenced code block, every table row, and every `## Sources` section (with its Official / Empirical split or "none found") are byte-identical to main; a snapshot script diffed those sets before and after. Descriptions kept every trigger keyword, model name, and node name. Where a description's em dash separated a lead-in from a list, the replacement is "covering" or "with" rather than a colon, because an unquoted `key: a: b` is a YAML parse error (`skill-authoring-limits.test.ts` caught the first attempt). Sections were not reordered and no file was merged or split.

Counts (prose only, excluding code blocks, inline code, tables, headings, and URLs; whole-file totals in parentheses):

- em dashes: 232 (310) before, 1 (79) after
- en dashes: 11 (21) before, 0 (10) after
- emoji: 1 (6) before, 1 (6) after
- banned/filler word hits (delve, crucial, robust, seamless, leverage, powerful, comprehensive, very, just, simply, really, actually, basically, extremely, significantly, dramatically, showcase, not just, ...): 20 before, 0 after
- prose words: 12,724 before, 12,605 after

What remains, and why:

- 24 headings still carry an em or en dash (and two carry an emoji: `#### ⚠️ Editing this node programmatically ...` in ideogram-ultra and `## ⭐ Render-verified correct setup ...` in ltxv2-video). The heading invariant wins over rules 13 and 18; a follow-up could rename them once sibling units that link to these anchors are merged.
- Every other remaining dash is inside a fenced code block (comments in `ollama pull` lines, the `packs/` tree, the `timeline_data` schema, the Qwen node input/output listings) or a table cell, both of which were kept verbatim.
- One verbatim quotation keeps its dash: `plugin/skills/ltxv2-video/SKILL.md:384`, the line quoting MEMORY.md ("LTXV2 can OOM on 24GB — suggest FP8 quantized models or --lowvram").
- The `🔒` legend bullet in model-registry stays because it defines the symbol used in the Flux table row, and the table is invariant. `🌿 Balanced` in krea2-txt2img is a widget value inside inline code.
- The "Adding soul" section of the unslop skill (first person, opinions) was not applied; these are instructions to an agent, not essays, and the brief asked for identical meaning.

One small non-prose fix: ideogram-ultra had a stray unpaired ``` fence between the last Troubleshooting bullet and `## Sources`, which made renderers swallow the Sources heading into a code block. It is removed; the code-block set is otherwise unchanged.

Verification: the eight skill-related test files (`skill-authoring-limits`, `skill-source-citations`, `skill-cache`, `skills-access`, `lora-manager-authoring-awareness`, `minimax-h3-skill`, `rgthree-authoring-awareness`, `report-asks-for-frontend-version`) pass, 330/330; the docs, i18n, and blog gates from `npm test` all pass; the full vitest run shows only the six pre-existing macOS-only failing files tracked as comfyui-mcp-1qe (extra-paths, comfy-view-ref, training-datasets), none of which read `plugin/skills`. `node scripts/sync-agents.mjs` exits 0; `grep -L '^## Sources' plugin/skills/*/SKILL.md` prints nothing; `grep -nP '—|–'` over the changed files shows only the heading, table, code, and quotation hits listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLyN6kNJZLRFLZmrWyVZ49