### PR TITLE
refactor(orchestrator): remove every chained type assertion (anti-slop tier 1: 31 → 0)

### DIFF
--- a/src/__tests__/orchestrator/oauth-bridge.test.ts
+++ b/src/__tests__/orchestrator/oauth-bridge.test.ts
@@ -175,5 +175,6 @@ describe("handleOAuthSignout", () => {
   });
 });
 
-// deps type sanity — keeps the injected-deps surface honest at compile time.
-void (null as unknown as OAuthBridgeDeps);
+// deps type sanity — keeps the injected-deps surface honest at compile time: the
+// exact object the tests above inject must satisfy the deps contract.
+({ providers: PROVIDERS, clearOAuth: vi.fn() }) satisfies OAuthBridgeDeps;

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -117,6 +117,20 @@ export interface AgentCapabilities {
  * meter, the result subtype/contextWindow/cost, live thinking-token counts). A
  * non-Claude backend simply omits the optional fields it can't supply.
  */
+/**
+ * The per-response token counts the live context meter reads (panel-agent's
+ * reportStatus). A backend hands over its provider's own usage object — the
+ * Claude SDK's BetaUsage reports the cache counters as `number | null`, the
+ * OpenAI-dialect backends build a plain number map — so every counter here is
+ * optional and nullable, and any extra provider fields simply ride along unread.
+ */
+export interface AssistantUsage {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+}
+
 export type AgentEvent = (
   /** Session opened/continued; `model` is the SDK-reported active model, if any. */
   | { type: "session"; sessionId: string; model?: string }
@@ -130,7 +144,7 @@ export type AgentEvent = (
   | { type: "thinking"; tokens: number }
   /** A turn-ending assistant message; `uuid` (when present) is the rewind anchor.
    *  `id` matches the streamed preview; `usage` is that response's prompt usage. */
-  | { type: "assistant"; text: string; uuid?: string; id?: string; usage?: Record<string, number> }
+  | { type: "assistant"; text: string; uuid?: string; id?: string; usage?: AssistantUsage }
   | { type: "tool_call"; name: string; phase: "start" | "end"; detail?: unknown }
   /** A turn completed. `contextWindow`/`costUsd`/`subtype` are provider extras. */
   | {

--- a/src/orchestrator/ai-proposer.ts
+++ b/src/orchestrator/ai-proposer.ts
@@ -103,7 +103,7 @@ export async function proposeModelCard(
       // environment entirely. Pass the agent env (process.env MINUS tool-only
       // secrets) so RunPod/HF/CivitAI tokens never reach the LLM subprocess.
       env: buildAgentSpawnEnv(),
-    } as unknown as Parameters<typeof query>[0]["options"],
+    },
   });
 
   let text = "";

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -812,8 +812,9 @@ export class ClaudeBackend implements AgentBackend {
   /** Switch the model live (the SDK applies it to the next turn). */
   async setModel(model: string): Promise<void> {
     try {
-      // setModel is live: no session restart, the next turn uses it.
-      await (this.q as unknown as { setModel?: (m: string) => Promise<void> })?.setModel?.(model);
+      // setModel is live: no session restart, the next turn uses it. The optional
+      // call keeps an older SDK (or a test double) without setModel a silent no-op.
+      await this.q?.setModel?.(model);
     } catch (err) {
       logger.debug(`[claude-backend] setModel: ${msgOf(err)}`);
     }
@@ -998,7 +999,7 @@ export class ClaudeBackend implements AgentBackend {
         } else if (message.subtype === "thinking_tokens") {
           // Live extended-thinking token count → drives a "thinking… (N)" meter
           // so the user can see the agent reasoning (not stuck) before any text.
-          const t = (message as unknown as { estimated_tokens?: number }).estimated_tokens;
+          const t = message.estimated_tokens;
           if (typeof t === "number") {
             yield { type: "thinking", tokens: t };
           }
@@ -1012,9 +1013,11 @@ export class ClaudeBackend implements AgentBackend {
           // turn's result is classified as the failure it actually is, and
           // surface the reason now so the user never watches a turn silently
           // produce nothing.
+          // Older SDK builds spelled the flag in camelCase; the `in` probe reads
+          // it without claiming the typed message carries it.
           const prevent =
             message.prevent_continuation === true ||
-            (message as unknown as { preventContinuation?: unknown }).preventContinuation === true;
+            ("preventContinuation" in message && message.preventContinuation === true);
           const content = typeof message.content === "string" ? message.content.trim() : "";
           if (prevent) {
             const reason = content || "blocked by a hook";
@@ -1043,21 +1046,20 @@ export class ClaudeBackend implements AgentBackend {
         // Live partial output (includePartialMessages). Turn the raw Anthropic
         // stream events into thinking/reply deltas the panel renders token-by-
         // token. The authoritative text still commits via the `assistant` case.
-        const ev = (message as unknown as { event?: Record<string, unknown> }).event;
+        const ev = message.event;
         if (!ev) break;
-        const evType = ev.type as string | undefined;
-        if (evType === "message_start") {
-          const mid = (ev.message as { id?: string } | undefined)?.id;
+        if (ev.type === "message_start") {
+          const mid = ev.message?.id;
           yield { type: "stream_start", id: typeof mid === "string" ? mid : null };
-        } else if (evType === "content_block_delta") {
-          const d = ev.delta as { type?: string; text?: string; thinking?: string } | undefined;
+        } else if (ev.type === "content_block_delta") {
+          const d = ev.delta;
           if (!d) break;
           if (d.type === "thinking_delta" && typeof d.thinking === "string" && d.thinking) {
             yield { type: "assistant_delta", text: d.thinking, thinking: true };
           } else if (d.type === "text_delta" && typeof d.text === "string" && d.text) {
             yield { type: "assistant_delta", text: d.text };
           }
-        } else if (evType === "message_stop") {
+        } else if (ev.type === "message_stop") {
           yield { type: "stream_end" };
         }
         break;
@@ -1070,10 +1072,10 @@ export class ClaudeBackend implements AgentBackend {
         const turn = this.turns[this.turns.length - 1];
         if (turn) turn.hasContent = true;
         // Remember this message's UUID — it's the rewind anchor for the turn.
-        const auid = (message as unknown as { uuid?: string }).uuid;
+        const auid = message.uuid;
         // Each assistant API response carries the CURRENT context size — report
         // it live so the meter updates throughout the turn, not just at the end.
-        const u = (message.message as unknown as { usage?: Record<string, number> })?.usage;
+        const u = message.message?.usage;
         // Commit the authoritative reply text as ONE message. With streaming on,
         // the panel already showed a live preview (matched by this message id);
         // the commit replaces it with the final text. Without streaming (or for
@@ -1088,7 +1090,7 @@ export class ClaudeBackend implements AgentBackend {
           .map((b) => b.text as string)
           .join("\n\n")
           .trim();
-        const id = (message.message as unknown as { id?: string })?.id;
+        const id = message.message?.id;
         yield {
           type: "assistant",
           text,
@@ -1109,12 +1111,8 @@ export class ClaudeBackend implements AgentBackend {
       case "result": {
         // Cache the context window + cost from the result, then re-report using
         // the last assistant usage (the true current context).
-        const m = message as unknown as {
-          modelUsage?: Record<string, { contextWindow?: number }>;
-          total_cost_usd?: number;
-        };
         let contextWindow: number | undefined;
-        for (const mu of Object.values(m.modelUsage ?? {})) {
+        for (const mu of Object.values(message.modelUsage ?? {})) {
           if (mu?.contextWindow && (contextWindow === undefined || mu.contextWindow > contextWindow)) {
             contextWindow = mu.contextWindow;
           }
@@ -1323,7 +1321,7 @@ export class ClaudeBackend implements AgentBackend {
           ok,
           subtype: message.subtype,
           ...(contextWindow !== undefined ? { contextWindow } : {}),
-          ...(typeof m.total_cost_usd === "number" ? { costUsd: m.total_cost_usd } : {}),
+          ...(typeof message.total_cost_usd === "number" ? { costUsd: message.total_cost_usd } : {}),
           ...stamp,
         };
         break;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -261,7 +261,7 @@ import { resolveHttpLaneComfyToolMode } from "./http-backend-tools.js";
 import type { ToolMode } from "../transport/cli.js";
 import { dedupeAudioRefs, splitAudioAttachments } from "./audio-attachment.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
-import type { AgentBackend } from "./agent-backend.js";
+import type { AgentBackend, BackendId } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { formatQueueNote } from "./queue-note.js";
@@ -716,8 +716,16 @@ function getCallToolClient(): Promise<Client> {
  * so the epoch-stability test can build two frames without booting the
  * orchestrator.
  */
+/** One row of the panel's model picker. Claude's probe hands over the Agent
+ *  SDK's full ModelInfo; every other backend's probe produces only what the
+ *  panel's normalizeModels reads — the id, its label, and the effort control
+ *  (a plain string[] of levels, since the Codex scale is wider than Claude's). */
+type ModelRow = Pick<ModelInfo, "value" | "displayName" | "supportsEffort"> & {
+  supportedEffortLevels?: string[];
+};
+
 export function buildModelsPushFrame(
-  models: ModelInfo[],
+  models: ModelRow[],
   current: string | undefined,
   backend: string,
 ): Record<string, unknown> {
@@ -742,7 +750,7 @@ export function buildSessionEpochFrame(): Record<string, unknown> {
 export function pushModelsFrame(
   bridge: Pick<UiBridge, "push">,
   panelTabId: string,
-  models: ModelInfo[],
+  models: ModelRow[],
   current: string | undefined,
   backend: string,
 ): number {
@@ -2263,20 +2271,32 @@ export async function runPanelOrchestrator(): Promise<void> {
   // failure was: click the GLM chip keyless → uncaught ValidationError → FATAL
   // process exit. This stub satisfies AgentBackend and surfaces the original
   // error as a normal degraded probe / in-chat error instead.
-  const brokenBackend = (backend: string, msg: string): AgentBackend =>
-    ({
-      id: backend,
-      capabilities: { modelEnumeration: false },
-      async *run() {
-        yield { type: "assistant", text: `⚠️ ${msg}` };
-        yield { type: "result", ok: false, subtype: "backend_unavailable" };
-      },
-      interrupt: async () => {},
-      listModels: async () => {
-        throw new Error(msg);
-      },
-      close: async () => {},
-    }) as unknown as AgentBackend;
+  const brokenBackend = (backend: string, msg: string): AgentBackend => ({
+    // The id echoes the key segment the panel asked for — that is the only name
+    // the in-chat error can carry, whether or not it is a registered backend.
+    id: backend as BackendId,
+    // A backend that could not be built can do nothing: every capability is off.
+    capabilities: {
+      persistentChannel: false,
+      streamingDeltas: false,
+      interruptMidTurn: false,
+      forkAtAnchor: false,
+      inProcessMcp: false,
+      modelEnumeration: false,
+      slashCommands: false,
+      hooks: false,
+      vision: false,
+    },
+    async *run() {
+      yield { type: "assistant", text: `⚠️ ${msg}` };
+      yield { type: "result", ok: false, subtype: "backend_unavailable" };
+    },
+    interrupt: async () => {},
+    listModels: async () => {
+      throw new Error(msg);
+    },
+    close: async () => {},
+  });
 
   // ONE code path for the simple OpenAI-compatible api-key providers (glm,
   // moonshot, …): resolve the provider's key + base URL (throws if absent), then
@@ -3545,28 +3565,27 @@ export async function runPanelOrchestrator(): Promise<void> {
   // (Gemini's probe proves the CLI + ACP handshake but not Google sign-in, which
   // ACP only reports at session/new — so its "ready" is provisional; a signed-out
   // CLI surfaces a clear one-shot error on the first turn.)
-  const modelsByBackend = new Map<string, Promise<ModelInfo[]>>();
-  function ensureModels(backend: string): Promise<ModelInfo[]> {
+  const modelsByBackend = new Map<string, Promise<ModelRow[]>>();
+  function ensureModels(backend: string): Promise<ModelRow[]> {
     let p = modelsByBackend.get(backend);
     if (!p) {
       const pb = getProbeBackend(backend);
-      const probe: Promise<ModelInfo[]> = pb
+      const probe: Promise<ModelRow[]> = pb
         ? Promise.resolve(pb.prepare?.())
             .then(() => pb.listModels())
             .then((list) =>
               list.map(
-                (m) =>
-                  ({
-                    value: m.id,
-                    displayName: m.label ?? m.id,
-                    ...(m.supportsEffort != null ? { supportsEffort: m.supportsEffort } : {}),
-                    ...(m.supportedEffortLevels ? { supportedEffortLevels: m.supportedEffortLevels } : {}),
-                  }) as unknown as ModelInfo,
+                (m): ModelRow => ({
+                  value: m.id,
+                  displayName: m.label ?? m.id,
+                  ...(m.supportsEffort != null ? { supportsEffort: m.supportsEffort } : {}),
+                  ...(m.supportedEffortLevels ? { supportedEffortLevels: m.supportedEffortLevels } : {}),
+                }),
               ),
             )
             .catch((err) => {
               logger.warn(`[panel-orchestrator] ${backend} model probe failed: ${err instanceof Error ? err.message : String(err)}`);
-              return [] as ModelInfo[];
+              return [] as ModelRow[];
             })
         : fetchSupportedModels(model);
       p = probe.then((list) => {
@@ -3605,11 +3624,11 @@ export async function runPanelOrchestrator(): Promise<void> {
             const discovered = new Map(list.map((m) => [m.value, m] as const));
             list = [
               ...preferred.map(
-                (id) =>
-                  (discovered.get(id) ?? {
+                (id): ModelRow =>
+                  discovered.get(id) ?? {
                     value: id,
                     displayName: `${id} ★`,
-                  }) as unknown as ModelInfo,
+                  },
               ),
               ...list.filter((m) => !preferred.includes(m.value as string)),
             ];
@@ -5257,7 +5276,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // makes the SDK session hang on init. (Defense in depth; the panel only
         // sends ids from the live catalog.)
         if (nextModel) {
-          const known = await ensureModels(backendForTab(tabId)).catch(() => [] as ModelInfo[]);
+          const known = await ensureModels(backendForTab(tabId)).catch(() => [] as ModelRow[]);
           if (known.length && !known.some((m) => m.value === nextModel)) {
             logger.warn(`[panel-orchestrator] ignoring unknown model "${nextModel}" — keeping current`);
             nextModel = undefined;

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -249,8 +249,8 @@ function toOllamaMessages(messages: ChatMessage[]): Array<Record<string, unknown
   return messages.map((m) => {
     const { audios, audioMimes, ...rest } = m;
     void audioMimes; // native wire infers the container from the bytes
-    if (!audios?.length) return rest as unknown as Record<string, unknown>;
-    return { ...rest, images: [...(m.images ?? []), ...audios] } as unknown as Record<string, unknown>;
+    if (!audios?.length) return rest;
+    return { ...rest, images: [...(m.images ?? []), ...audios] };
   });
 }
 
@@ -685,7 +685,10 @@ export class OllamaBackend implements AgentBackend {
                 env: comfyuiSpawnEnv(spec.env, process.env, this.model),
               }),
             );
-            this.comfy = client as unknown as McpToolClient;
+            // A single narrowing to the slice this backend uses: the SDK Client's
+            // callTool can also resolve to the legacy `{ toolResult }` shape, which
+            // is what keeps it from being assignable to McpToolClient outright.
+            this.comfy = client as McpToolClient;
             // Recorded ONLY once the child is really up. This catch swallows
             // connect failures, so setting it earlier would leave a decision
             // describing a surface that does not exist — and reconcile would
@@ -696,7 +699,7 @@ export class OllamaBackend implements AgentBackend {
               "@modelcontextprotocol/sdk/client/streamableHttp.js"
             );
             await client.connect(new StreamableHTTPClientTransport(new URL(spec.url)));
-            this.panel = client as unknown as McpToolClient;
+            this.panel = client as McpToolClient;
           }
         } catch (err) {
           logger.warn(`[ollama-backend] could not connect MCP server '${name}': ${msgOf(err)}`);

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -38,7 +38,7 @@ import {
   type PreviewLedger,
 } from "./preview-budget.js";
 import type { SessionStore } from "./session-store.js";
-import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
+import type { AgentBackend, AgentEvent, AssistantUsage, NeutralTurn } from "./agent-backend.js";
 import { type AudioRef, dedupeAudioRefs, noAudioPartText } from "./audio-attachment.js";
 import { runErrorNotice } from "./cli-remedy.js";
 import { runCompletionDirective } from "./todo-state.js";
@@ -565,7 +565,7 @@ export class PanelAgent {
   /** Usage from the most recent assistant API response — the CURRENT context
    *  size (input + cache), as opposed to result.usage which sums every internal
    *  call in the turn and wildly overstates context fill. */
-  private lastUsage: Record<string, number> | null = null;
+  private lastUsage: AssistantUsage | null = null;
   /** Context window for the active model, cached from result.modelUsage. */
   private contextWindow = 0;
   /** The model the IN-FLIGHT turn was dispatched with. A live setModel can change
@@ -2403,7 +2403,7 @@ export class PanelAgent {
   /** Push a context/usage snapshot derived from a single API response's usage.
    *  `used` is that response's PROMPT size (fresh + cached input) = the current
    *  context fill — NOT cumulative, and NOT including output tokens. */
-  private reportStatus(usage: Record<string, number>, costUsd?: number): void {
+  private reportStatus(usage: AssistantUsage, costUsd?: number): void {
     if (!this.deps.onStatus) return;
     try {
       const used =

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -74,7 +74,7 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { UiBridge, PanelVersionReading, UnsupportedShowMediaItem } from "../services/ui-bridge.js";
+import type { UiBridge, PanelVersionReading, UnsupportedShowMediaItem, TabWorkflowUuidRead } from "../services/ui-bridge.js";
 import {
   requiredPanelVersion,
   SEMVER_RE,
@@ -8242,10 +8242,11 @@ function responseWorkflowUuid(value: unknown): string | undefined {
  *  stamp, so a value inherited on a same-socket re-hello stops being treated as
  *  inherited. Never throws, and can never move a fence (see the bridge method). */
 function corroborateTabStamp(ctx: PanelToolCtx, workflowUuid: string): boolean {
-  const fn = (ctx.bridge as unknown as { corroborateTabStamp?: unknown }).corroborateTabStamp;
+  const bridge: BridgeProbe = ctx.bridge;
+  const fn = bridge.corroborateTabStamp;
   if (typeof fn !== "function") return false;
   try {
-    return (fn as (t: string, u: string) => boolean).call(ctx.bridge, ctx.tabId, workflowUuid) === true;
+    return fn.call(ctx.bridge, ctx.tabId, workflowUuid) === true;
   } catch {
     return false;
   }
@@ -8280,7 +8281,8 @@ function reconcileStampTarget(
 
 function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
   const uuid = responseWorkflowUuid(value);
-  const refresh = (ctx.bridge as unknown as { refreshWorkflowUuid?: unknown }).refreshWorkflowUuid;
+  const bridge: BridgeProbe = ctx.bridge;
+  const refresh = bridge.refreshWorkflowUuid;
   return uuid && typeof refresh === "function" ? refresh.call(ctx.bridge, ctx.tabId, uuid) : false;
 }
 
@@ -8342,7 +8344,8 @@ function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): Workflo
 type FenceRead = { known: true; uuid?: string } | { known: false };
 
 function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
-  const read = (ctx.bridge as unknown as { workflowUuidFor?: unknown }).workflowUuidFor;
+  const bridge: BridgeProbe = ctx.bridge;
+  const read = bridge.workflowUuidFor;
   if (typeof read !== "function") return { known: false };
   try {
     const out = read.call(ctx.bridge, ctx.tabId) as unknown;
@@ -9262,10 +9265,9 @@ async function rebindWorkflowFence(
     // "refused" will keep refreshing a tab that can never recover.
     const why = ((): string | undefined => {
       try {
-        const read = (ctx.bridge as unknown as { lastFenceRefusal?: unknown }).lastFenceRefusal;
-        return typeof read === "function"
-          ? (read.call(ctx.bridge, ctx.tabId) as string | undefined)
-          : undefined;
+        const bridge: BridgeProbe = ctx.bridge;
+        const read = bridge.lastFenceRefusal;
+        return typeof read === "function" ? read.call(ctx.bridge, ctx.tabId) : undefined;
       } catch {
         return undefined; // a diagnostic must never replace the outcome
       }
@@ -11030,8 +11032,10 @@ async function listUserdataWorkflowKeys(): Promise<string[] | null> {
 }
 
 /** Validate a parsed value is a UI/litegraph workflow (a top-level `nodes`
- *  array), throwing a source-labelled error otherwise. */
-function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, unknown> {
+ *  array), throwing a source-labelled error otherwise. The value is parsed JSON,
+ *  so it is returned as BOTH the graph shape the converters consume and the open
+ *  record the file/identity helpers read by key. */
+function assertUiWorkflow(parsed: unknown, sourceLabel: string): UiWorkflow & Record<string, unknown> {
   if (!parsed || typeof parsed !== "object") {
     throw new Error(`${sourceLabel} did not parse to a workflow object.`);
   }
@@ -11041,7 +11045,7 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
         `Provide a UI/litegraph workflow JSON, not API/prompt format.`,
     );
   }
-  return parsed as Record<string, unknown>;
+  return parsed as UiWorkflow & Record<string, unknown>;
 }
 
 /**
@@ -11726,6 +11730,28 @@ export interface ConfirmOptions {
  * handler is transport-agnostic — it only ever talks to the bridge via `call` /
  * `confirm` / `bridge` and never knows which server invoked it.
  */
+/**
+ * The bridge members the panel tools PROBE for rather than require. The real
+ * UiBridge implements every one of them; the lightweight and mock bridges that
+ * tests hand in as `ctx.bridge` do not, and each caller has its own documented
+ * answer for that case (a `known:false` fence read, an unreported incarnation,
+ * an unrouted ask). Every member is optional here so the probe is an ordinary
+ * typed read — `UiBridge` satisfies this shape structurally, so a ctx.bridge can
+ * be assigned to it without any assertion, and the signatures are the bridge's own.
+ */
+interface BridgeProbe {
+  corroborateTabStamp?: (tabId: string, workflowUuid: string) => boolean;
+  refreshWorkflowUuid?: (tabId: string, workflowUuid: string) => boolean;
+  workflowUuidFor?: (tabId: string) => TabWorkflowUuidRead;
+  lastFenceRefusal?: (tabId: string) => string | undefined;
+  isHeadless?: (tabId: string) => boolean;
+  canReach?: (tabId: string) => boolean;
+  tabs?: () => Array<{ tab_id: string }>;
+  resolveActiveTabId?: () => string;
+  resolveSharedTabId?: (scopeId?: string) => string | undefined;
+  takeLateAskReply?: (askId: string) => unknown;
+}
+
 export interface PanelToolCtx {
   /** Forward a command to the panel and wrap the reply as a tool result. An
    *  optional observer receives the bridge request id after the frame is written,
@@ -13283,7 +13309,7 @@ export function makePanelToolCtx(
  *   - a synthetic links array + per-input `link` ids from `connected_from`.
  * Returns null when the reply has no usable nodes.
  */
-function reconstructUiFromState(reply: unknown): Record<string, unknown> | null {
+function reconstructUiFromState(reply: unknown): UiWorkflow | null {
   const r = reply as { nodes?: unknown[]; truncated?: boolean; node_count?: number } | null;
   const nodesIn = r?.nodes;
   if (!Array.isArray(nodesIn) || nodesIn.length === 0) return null;
@@ -13326,10 +13352,7 @@ function reconstructUiFromState(reply: unknown): Record<string, unknown> | null 
         type: o.type ?? "*",
         links: [] as number[],
       })),
-      widgets_values:
-        n.widgets && typeof n.widgets === "object"
-          ? (n.widgets as unknown as unknown[])
-          : ([] as unknown[]),
+      widgets_values: n.widgets && typeof n.widgets === "object" ? n.widgets : [],
       properties: {} as Record<string, unknown>,
       ...(n.title ? { title: n.title } : {}),
     };
@@ -13356,7 +13379,11 @@ function reconstructUiFromState(reply: unknown): Record<string, unknown> | null 
     });
   });
 
-  return { nodes: uiNodes, links } as unknown as Record<string, unknown>;
+  // `widgets_values` holds the name→value OBJECT described above — the shape the
+  // converter's name-keyed branch reads, and the one VHS-style nodes serialize
+  // natively — while UiNode declares only the positional array. This is the one
+  // place that difference is asserted past.
+  return { nodes: uiNodes, links } as UiWorkflow;
 }
 
 /**
@@ -13443,7 +13470,7 @@ async function resolveWorkflowInput(
   // POSITION — the caller surfaces these alongside the converter's warnings so an
   // unverified widget mapping is never presented as a verified one.
   notes?: string[],
-): Promise<Record<string, unknown>> {
+): Promise<UiWorkflow> {
   // panel#775 — every caller here (strip / flatten / slice) needs a UI
   // /litegraph graph, and NONE of them validated the shape. A pack or file
   // holding API/prompt format therefore reached them raw:
@@ -13571,7 +13598,7 @@ async function resolveWorkflowInput(
       notes.push(...applyCapturedWidgetValues(wf, stateReply).notes);
     }
   }
-  return wf as Record<string, unknown>;
+  return wf as UiWorkflow;
 }
 
 // ---- panel_ask surface + late-answer resilience (#300/#486) ----------------
@@ -13696,11 +13723,7 @@ function isReplyTimeoutError(err: unknown): boolean {
  * null so the normal send path surfaces its own clear error instead.
  */
 function askSurfaceError(ctx: PanelToolCtx): string | null {
-  const b = ctx.bridge as unknown as {
-    isHeadless?: (id: string) => boolean;
-    canReach?: (id: string) => boolean;
-    resolveActiveTabId?: () => string;
-  };
+  const b: BridgeProbe = ctx.bridge;
   if (typeof b.isHeadless !== "function") return null; // lightweight/unknown bridge
   let targetId = ctx.tabId;
   if (typeof b.canReach === "function" && !b.canReach(targetId)) {
@@ -13747,12 +13770,7 @@ function desktopCanvasRedirect(
   ctx: PanelToolCtx,
   label: string,
 ): { tabId?: string; error?: string } | null {
-  const b = ctx.bridge as unknown as {
-    isHeadless?: (id: string) => boolean;
-    tabs?: () => Array<{ tab_id: string }>;
-    resolveActiveTabId?: () => string;
-    resolveSharedTabId?: (scopeId?: string) => string | undefined;
-  };
+  const b: BridgeProbe = ctx.bridge;
   // Older / lightweight bridges can't classify tabs — leave routing exactly as-is.
   if (typeof b.isHeadless !== "function" || typeof b.tabs !== "function") return null;
   // Only intervene when THIS session is bound to a canvas-less (mobile/remote) client.
@@ -14160,8 +14178,8 @@ async function pollLateAskReply(
   timing: AskTiming,
   hardDeadline?: number,
 ): Promise<unknown | undefined> {
-  const take = (bridge as unknown as { takeLateAskReply?: (id: string) => unknown })
-    .takeLateAskReply;
+  const probe: BridgeProbe = bridge;
+  const take = probe.takeLateAskReply;
   if (typeof take !== "function") return undefined;
   const deadline = Math.min(
     Date.now() + timing.graceMs,
@@ -14462,7 +14480,7 @@ async function askUserWithGrace(
       ridCorrelated: opts.ridCorrelated,
     });
   try {
-    const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
+    const reply = await ctx.bridge.send(cmd, {
       tabId,
       timeoutMs: Math.max(1, Math.min(timing.deadlineMs, budgetEnd - Date.now())),
     });
@@ -14502,12 +14520,19 @@ export const __panelAskTestHooks = {
 
 /** One shared tool definition: name, description, zod raw-shape schema, and a
  *  transport-agnostic handler that receives parsed args + the tab-bound context. */
+/** A zod raw shape (object map of zod schemas), as accepted by BOTH the Anthropic
+ *  SDK `tool()` and the MCP SDK `registerTool({ inputSchema })`. Declared over the
+ *  classic `z.ZodType` the defs actually build with, not zod's core `$ZodType`
+ *  that `z.ZodRawShape` names: the Agent SDK infers a tool's argument type by
+ *  reading `_output` off each field, which only the classic type declares — over
+ *  the core type every argument infers as `never`, and the handler can then never
+ *  be typed against the SDK's own tool-list element. */
+type PanelToolArgSchemas = Record<string, z.ZodType>;
+
 export interface PanelToolDef {
   name: string;
   description: string;
-  // A zod raw shape (object map of zod schemas), as accepted by BOTH the Anthropic
-  // SDK `tool()` and the MCP SDK `registerTool({ inputSchema })`.
-  schema: z.ZodRawShape;
+  schema: PanelToolArgSchemas;
   handler: (args: Record<string, unknown>, ctx: PanelToolCtx) => Promise<ToolResult>;
 }
 
@@ -14538,7 +14563,7 @@ export interface PanelToolDef {
  *
  * BOTH transports' registration functions accept this directly in place of the raw
  * shape (verified against each SDK's actual runtime behavior, not assumed from the
- * TypeScript types — see the cast note at the Anthropic SDK call site):
+ * TypeScript types — see the note at the Anthropic SDK call site):
  *   - `@modelcontextprotocol/sdk`'s `registerTool({ inputSchema })` types `inputSchema`
  *     as `AnySchema | ZodRawShapeCompat`, so a full ZodObject is accepted as-is by the
  *     TYPE, and at runtime `normalizeObjectSchema` detects an already-built schema
@@ -15065,7 +15090,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   const def = (
     name: string,
     description: string,
-    schema: z.ZodRawShape,
+    schema: PanelToolArgSchemas,
     handler: (args: Record<string, unknown>, ctx: PanelToolCtx) => Promise<ToolResult>,
   ): PanelToolDef => ({ name, description, schema, handler });
 
@@ -15800,8 +15825,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // which nodes' widget values are UNVERIFIED, so they belong with the
         // conversion notes rather than being dropped.
         const captureNotes: string[] = [];
-        const raw = await resolveWorkflowInput(args, ctx, true, captureNotes);
-        const ui = raw as unknown as UiWorkflow;
+        const ui = await resolveWorkflowInput(args, ctx, true, captureNotes);
         // #1421 / #1359 — EVERY source takes definitions from the connected panel.
         //
         // #1359 wired the live canvas through `graph_get_object_info` and left
@@ -15918,7 +15942,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       },
       async (args: A, ctx) => {
         const raw = await resolveWorkflowInput(args, ctx);
-        const { graph, report } = flattenUiWorkflow(raw as never, {
+        const { graph, report } = flattenUiWorkflow(raw, {
           includeUe: args.include_ue !== false,
           includeGetSet: args.include_getset !== false,
         });
@@ -15999,7 +16023,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const groupList = Array.isArray(args.groups)
           ? (args.groups as string[])
           : String(args.groups ?? "").split(",");
-        const { workflow, stats } = sliceWorkflow(raw as unknown as UiWorkflow, groupList);
+        const { workflow, stats } = sliceWorkflow(raw, groupList);
 
         const flags =
           stats.badLinks || stats.orphanGets
@@ -22236,28 +22260,28 @@ export function createPanelMcpServer(
     );
   }
   // The Anthropic SDK's tool() accepts (name, description, zodRawShape, cb). The
-  // shared handler is transport-agnostic — bind it to this tab's ctx. Each def's
-  // schema is a distinct zod shape, so the produced tool generics differ; widen
-  // to the SDK's tool-list element type so the heterogeneous array type-checks.
-  type SdkTool = ReturnType<typeof tool>;
-  const tools = defs.map((d) =>
-    tool(
+  // shared handler is transport-agnostic — bind it to this tab's ctx.
+  const tools = defs.map((d) => {
+    const def = tool(
       d.name,
       d.description,
-      // #754 — strict() so an unrecognized arg key is a loud validation error,
-      // not a silent drop. tool()'s TS signature requires a bare ZodRawShape
-      // (`Schema extends AnyZodRawShape`), which a strict ZodObject instance does
-      // NOT structurally satisfy (it has methods like `.parse`, not just field
-      // schemas) — but at RUNTIME the SDK stores whatever is passed as
-      // `inputSchema` verbatim (confirmed by constructing a tool this way and
-      // calling `.safeParse` on the returned definition: unknown keys are
-      // rejected). The cast documents that the type is being widened past what
-      // TS can express here, not past what the SDK actually accepts.
-      strictPanelSchema(d.schema) as unknown as typeof d.schema,
+      d.schema,
       async (args: Record<string, unknown>) =>
         toolActionPolicyError(d.name, args, policy) ?? (await d.handler(args, ctx)),
-    ),
-  ) as unknown as SdkTool[];
+    );
+    // #754 — strict() so an unrecognized arg key is a loud validation error,
+    // not a silent drop. tool()'s TS signature requires a bare ZodRawShape
+    // (`Schema extends AnyZodRawShape`), which a strict ZodObject instance does
+    // NOT structurally satisfy (it has methods like `.parse`, not just field
+    // schemas) — but at RUNTIME the SDK stores whatever is passed as
+    // `inputSchema` verbatim (confirmed by constructing a tool this way and
+    // calling `.safeParse` on the returned definition: unknown keys are
+    // rejected). So build the definition with the raw shape tool() is typed
+    // for, then swap the strict object in: the element type stays what tool()
+    // produced apart from `inputSchema`, which createSdkMcpServer's tool list
+    // types as `any` because the server normalizes a schema or a shape itself.
+    return { ...def, inputSchema: strictPanelSchema(d.schema) };
+  });
   const server = createSdkMcpServer({
     name: "comfyui-panel",
     version: "1.0.0",


### PR DESCRIPTION
Part of #2003.

## Summary

Removes every `no-chained-type-assertions` (`x as unknown as T`) hit under `src/orchestrator/**` — the tier-1 anti-slop rule — by giving each value its real type instead of laundering it. Behavior is unchanged; these are type-level edits plus a handful of structural moves that keep the runtime objects byte-for-byte the same.

### Anti-slop counts (`src/orchestrator`, oxlint with the anti-slop plugin)

| rule | before | after |
|---|---:|---:|
| **no-chained-type-assertions (tier 1)** | **31** | **0** |
| require-safety-comment-for-type-assertion | 510 | 445 |
| no-unsafe-dictionary-type | 265 | 258 |
| no-known-value-widening | 94 | 91 |
| no-shape-in-symbol-names | 24 | 22 |
| no-conditional-empty-object-spread | 153 | 153 |
| no-runtime-typeof | 485 | 485 |
| no-unknown-parameters | 199 | 199 |
| no-unknown-returns | 11 | 11 |
| **total** | **1772** | **1667** |

No rule's count went up in any file. The other rules were not targeted; their drops are incidental to removing the chains they sat on.

### What changed, by commit

1. **claude-backend** — every `as unknown as` on an `SDKMessage` is replaced by the field the Agent SDK already declares (`thinking_tokens`, `stream_event` narrowed on `event.type`, `assistant.uuid` / `message.id` / `message.usage`, `result.modelUsage` / `total_cost_usd`, `Query.setModel`). The legacy camelCase `preventContinuation` is read with an `in` probe. The assistant `usage` was typed `Record<string, number>` while the SDK's `BetaUsage` reports cache counters as `number | null`; it is now `AssistantUsage` (the four counters `reportStatus` reads, optional and nullable), so the real object flows through untouched.
2. **panel-tools** — a named `BridgeProbe` interface (optional members `UiBridge` satisfies structurally) replaces ten `ctx.bridge as unknown as {...}` probes. `assertUiWorkflow` returns the `UiWorkflow` it validated, so `resolveWorkflowInput` is typed and the strip/flatten/slice casts disappear. The Anthropic SDK tool list is built by calling `tool()` with the raw shape it is typed for and spreading the strict `ZodObject` in afterwards (same keys, same order, no cast); `PanelToolDef.schema` is declared over classic `z.ZodType` so the SDK's `InferShape` yields `unknown`-valued args instead of `never`.
3. **index.ts** — `brokenBackend` is a real `AgentBackend` (all capabilities explicitly `false`; consumers only read these as booleans). Model-picker rows get a local `ModelRow` type instead of being cast to the SDK's `ModelInfo`, which they never satisfied (no `description`, wider effort scale).
4. **ollama-backend** — `toOllamaMessages` returns its rest/spread objects directly; the MCP SDK `Client` narrows to `McpToolClient` in one documented step (the legacy `{ toolResult }` result shape is what blocks plain assignment — verified with `tsc`).
5. **ai-proposer** — the `query()` options literal already satisfies the SDK's `Options`; the cast is gone.
6. **oauth-bridge.test** — `void (null as unknown as OAuthBridgeDeps)` becomes a `satisfies` check on the object the tests actually inject.

### Runtime-identical notes worth a reviewer's eye

- `createPanelMcpServer`: `{ ...tool(name, desc, rawShape, handler), inputSchema: strict }` produces the same object `tool()` did (`name, description, inputSchema, handler, annotations: undefined, _meta: undefined`, in that order); the strict object is still what the server validates with.
- `brokenBackend.capabilities` gains explicit `false` flags; nothing serializes that object, and every reader is a boolean check.
- `reconstructUiFromState` keeps the name-keyed `widgets_values` object the converter's name-keyed branch expects; that single remaining assertion is commented.

## Verification

- `npx tsc --noEmit` — clean
- oxlint anti-slop on `src/orchestrator` — 0 tier-1 diagnostics, no per-rule/per-file increases
- `npx vitest run src/__tests__/orchestrator src/orchestrator` — 208 files / 3385 tests passed
- `npm run check:vocabulary` — OK
- `npm run build && npm run smoke` — pack/install smoke passed

Pre-existing, unrelated: 16 tests across five `src/__tests__/services/*` files (comfy-view-ref, extra-paths*, training-datasets) fail identically on a clean `main` tree in this environment; this diff does not touch `src/services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)