### PR TITLE
fix(1996): a boot slower than the readiness budget no longer forfeits the post-restart reconnect wait

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -443,3 +443,117 @@ describe("#1996 an unconfirmed managed restart still watches for the tab", () =>
     expect(out.ready).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1996 review round 1 (codex P1) — the reserve did not follow to THIS path.
+//
+// The bound path's readiness deadline is clamped by
+// `readinessDeadlineWithReconnectReserve` so the observation cannot eat the tab
+// reconnect wait. The headless/legacy path computed its own deadline as
+//
+//   const proofDeadline = Math.min(Date.now() + legacyProofWindow, overallDeadline);
+//
+// with no reserve — so the identical starvation survives here. The arithmetic,
+// from the file's own constants: OVERALL_MAX_MS 255s, legacyProofWindow 140s
+// (LEGACY_SYNC_WORST_CASE_MS 40s + LEGACY_COLD_START_OBS_MS 100s), reconnect
+// wait 35s. A confirmation answered at ~90s leaves 165s, the admission gate
+// (>=140s) lets the restart run, the proof window claims 140 of those 165, and
+// the tab wait is handed the 25s residual — LESS than the 35s a tab is allowed.
+// A tab that re-registers at 30s is then reported `panel_tab_reconnected:false`.
+//
+// REACHABILITY is not hypothetical. Of the three callers of
+// runHeadlessManagedRestart, the #1671 crash-recovery one is entered precisely
+// BECAUSE the confirmation card went unanswered — which costs the full
+// RESTART_CONFIRM_TIMEOUT_MS (90s) plus the ~6s decline probe before this path
+// even starts. The 90s in this test is the cheap case, not the worst one.
+//
+// HOW THIS RUNS FAST. Only `Date` is faked; timers stay real. The confirmation
+// advances the clock 90s, and each health probe advances it 20s, so the 140s
+// proof window is consumed in ~7 probes and ~1.4s of wall clock. Nothing here
+// re-implements the production arithmetic — the handler computes its own
+// deadlines from its own constants, and the test only observes the budget the
+// reconnect wait is actually handed.
+describe("#1996 r1 (codex P1): the headless path must reserve the reconnect wait too", () => {
+  // The harness's virtual clock advances in discrete PROBE_STEP_MS jumps, so the
+  // observation always overshoots its deadline by up to one step before noticing.
+  // In production that overshoot is one real probe interval (200ms) and is
+  // invisible; here it is the resolution limit of the measurement, so it is named
+  // and subtracted rather than absorbed into a looser number. 5s keeps it well
+  // clear of the 10s that separates the fixed residual from the broken one.
+  const PROBE_STEP_MS = 5_000;
+
+  /** Drive the headless path with `elapsedBeforeMs` already burned on the card,
+   *  and report the budget the tab-reconnect wait was actually handed. */
+  async function runWithSlowConfirm(elapsedBeforeMs: number, tabReturnsAfterMs: number) {
+    const prevInterval = process.env.COMFYUI_PANEL_REBOOT_INTERVAL_S;
+    vi.useFakeTimers({ toFake: ["Date"] });
+    __panelToolsTestHooks.setPanelRebootTiming(null); // REAL 140s legacy proof window
+    // Shrink only the REAL sleep between probes (floored at 50ms by observeRecovery);
+    // the virtual clock still advances PROBE_STEP_MS per probe, so the full 140s
+    // window is consumed in ~28 probes and ~1.4s of wall clock.
+    process.env.COMFYUI_PANEL_REBOOT_INTERVAL_S = "0.01";
+    try {
+      // The endpoint never comes back, so the proof window runs to its deadline —
+      // the case where the residual handed to the tab wait is smallest.
+      __panelToolsTestHooks.setHealthProbe(async () => {
+        vi.setSystemTime(Date.now() + PROBE_STEP_MS);
+        return "down";
+      });
+      const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+      ctx.confirm = (async () => {
+        vi.setSystemTime(Date.now() + elapsedBeforeMs);
+        return "yes" as const;
+      }) as PanelToolCtx["confirm"];
+      ctx.panelConnectionIdentity = () => ({ generation: 1, tabSessionId: "browser-tab-a" });
+      let handedBudgetMs = -1;
+      // A perfectly ordinary tab: it re-registers `tabReturnsAfterMs` after being
+      // asked for, and comes back if — and only if — it is given that long.
+      ctx.awaitPostRestartReachable = async (_before, budgetMs?: number) => {
+        handedBudgetMs = budgetMs ?? 0;
+        return handedBudgetMs >= tabReturnsAfterMs;
+      };
+      ctx.tabCanMutateGraph = () => true;
+
+      const res = (await restartTool().handler({}, ctx)) as ToolResult;
+      const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+      return { handedBudgetMs, out };
+    } finally {
+      vi.useRealTimers();
+      if (prevInterval === undefined) delete process.env.COMFYUI_PANEL_REBOOT_INTERVAL_S;
+      else process.env.COMFYUI_PANEL_REBOOT_INTERVAL_S = prevInterval;
+    }
+  }
+
+  it("a confirmation answered at ~90s must NOT starve the tab wait below its own budget", async () => {
+    // 255s overall − 90s on the card = 165s left. The admission gate (≥140s) lets the
+    // restart run, and pre-fix the 140s proof window claimed all but ~25 of those.
+    const allowed = __panelToolsTestHooks.getReconnectWaitTiming().budgetMs; // 35s
+    const { handedBudgetMs, out } = await runWithSlowConfirm(90_000, 28_000);
+
+    // THE DEFECT, as the observation rather than the arithmetic: the wait is handed
+    // less than a tab is allowed to take. Pre-fix ~20–25s here; the reserve makes it
+    // the full budget, less one step of the harness's own clock resolution.
+    expect(handedBudgetMs).toBeGreaterThanOrEqual(allowed - PROBE_STEP_MS);
+    // …and the consequence that makes it a P1 rather than a rounding error: a tab
+    // that came back normally, at 28s, is no longer reported as never having come
+    // back. 28s is outside the pre-fix residual and inside the post-fix one, so this
+    // separates the two behaviours rather than restating the number above.
+    expect(out.panel_tab_reconnected).toBe(true);
+    // The refusal is untouched — the endpoint genuinely never answered.
+    expect(out.server_ready).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+
+  it("the #1671 caller's own timings — an UNANSWERED card — keep the tab wait whole too", async () => {
+    // Reachability is not hypothetical. runHeadlessManagedRestart's #1671 caller is
+    // entered BECAUSE the confirmation card went unanswered, which costs the full
+    // RESTART_CONFIRM_TIMEOUT_MS (90s) plus the ~6s decline probe. Modelling that
+    // 96s here (through the same no-endpoint route, which shares the code under
+    // test) leaves 159s — still admitted, and pre-fix the residual was ~19s.
+    const allowed = __panelToolsTestHooks.getReconnectWaitTiming().budgetMs;
+    const { handedBudgetMs, out } = await runWithSlowConfirm(96_000, 28_000);
+
+    expect(handedBudgetMs).toBeGreaterThanOrEqual(allowed - PROBE_STEP_MS);
+    expect(out.panel_tab_reconnected).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -392,3 +392,54 @@ describe("#654 an unwatched reconnect is reported as unknown, and is still not r
     expect(String(out.note)).not.toMatch(/could NOT be determined/);
   });
 });
+
+// #1996 — the headless path carried the SAME coupling the bound path did:
+//
+//   const tabBack = recovery.ready ? await ctx.awaitPostRestartReachable(…) : false;
+//
+// so a kill+relaunch whose cold start outran the observation window never looked at
+// the tab, and then reported a bare `false` about it. The bound path's version of this
+// is covered behaviourally in panel-restart-slow-boot-reconnect.test.ts; this file owns
+// the scaffolding that reaches the HEADLESS reply, so its half lives here.
+describe("#1996 an unconfirmed managed restart still watches for the tab", () => {
+  it("watches the tab even when OUR observation never certified the cycle", async () => {
+    // The endpoint never goes down, so the managed restart is honestly
+    // couldn't-confirm — and the tab is watched anyway.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    let watched = 0;
+    ctx.panelConnectionIdentity = () => ({ generation: 1, tabSessionId: "browser-tab-a" });
+    ctx.awaitPostRestartReachable = async () => {
+      watched++;
+      return true;
+    };
+    ctx.tabCanMutateGraph = () => true;
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+    expect(watched).toBe(1); // 0 before the fix — the wait was never entered
+    expect(out.panel_tab_reconnected).toBe(true);
+    // AND THE REFUSAL IS INTACT. A reconnected browser socket is not a booted
+    // ComfyUI: `ready` must stay false or this fix has manufactured a success.
+    expect(out.server_ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(String(out.note)).toMatch(/did NOT become healthy within/);
+  });
+
+  it("a watched tab that did not come back is a real false here too", async () => {
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.panelConnectionIdentity = () => ({ generation: 1, tabSessionId: "browser-tab-a" });
+    ctx.awaitPostRestartReachable = async () => false;
+    ctx.tabCanMutateGraph = () => true;
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
@@ -280,13 +280,31 @@ describe("#1996 WIRING: the bound readiness deadline goes through the reserve", 
     // Reading the reserve from reconnectWaitTiming() is what keeps it correct when a
     // user raises COMFYUI_PANEL_RECONNECT_WAIT_S; a hard-coded 35_000 would silently
     // under-reserve for them.
-    expect((s.match(/reserveMs: reconnectWaitTiming\(\)\.budgetMs/g) ?? []).length).toBe(1);
     // Exactly ONE unreserved `gate.deadline` assignment survives: the REMOTE branch,
     // which returns without ever waiting for a tab, so it has nothing to reserve for.
     expect(
       (s.match(/gate\.deadline = Math\.min\(Date\.now\(\) \+ timing\.budgetMs, overallDeadline\);/g) ?? [])
         .length,
     ).toBe(1);
+  });
+
+  it("BOTH restart paths clamp their observation with the SAME reserve (r1 codex P1)", () => {
+    // The review finding was not that the reserve was wrong — it was that it did not
+    // FOLLOW to the legacy/headless path, whose `proofDeadline` computed its own
+    // unreserved `Math.min(Date.now() + legacyProofWindow, overallDeadline)` and
+    // reproduced the identical starvation. This is the per-call-site adoption gap that
+    // left #1971's version probe unreached for releases, so it is pinned as a COUNT of
+    // adopting call sites rather than as "the bound one is correct".
+    const s = src();
+    expect((s.match(/readinessDeadlineWithReconnectReserve\(\{/g) ?? []).length).toBe(2);
+    // Both read the LIVE reconnect budget rather than a hard-coded 35_000, so raising
+    // COMFYUI_PANEL_RECONNECT_WAIT_S reserves more on BOTH paths, not one.
+    expect((s.match(/reserveMs: reconnectWaitTiming\(\)\.budgetMs/g) ?? []).length).toBe(2);
+    // The exact pre-fix expression on the headless path must be gone entirely.
+    expect(
+      /const proofDeadline = Math\.min\(Date\.now\(\) \+ legacyProofWindow, overallDeadline\);/.test(s),
+      "the headless proof deadline is unreserved again",
+    ).toBe(false);
   });
 
   it("neither restart path gates the reconnect wait on the readiness verdict any more", () => {

--- a/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
@@ -1,0 +1,297 @@
+// #1996 — `panel_restart_comfyui` on a 200+ pack install reported
+//
+//   rebooting:true ready:false confirmed_cycle:false
+//   recovered_ms:127254  probes:603  saw_down:true
+//
+// and then every `panel_*` call failed with "no connected tab … Connected: none"
+// until the browser tab was refreshed by hand. ComfyUI itself was fine: a health
+// check taken afterwards answered 0.33.0 with the freshly installed node present.
+//
+// WHAT THE NUMBERS ESTABLISH. 603 probes over 127.25 s is ~211 ms per iteration
+// against `intervalMs` 200 ms and `probeTimeoutMs` 2000 ms — ~11 ms per probe,
+// i.e. fast connection refusals, not timeouts (a hung probe would have produced
+// ~63 iterations, not 603). The observer did NOT see a healthy server and call it
+// unhealthy; the port was closed for the whole window and the observer STOPPED
+// LOOKING at `COMFYUI_PANEL_REBOOT_BUDGET_S`, default 120 s, while the same file
+// declares `MAX_REBOOT_BUDGET_MS = 240_000` safe.
+//
+// THE COUPLING, which is the half that hurts. `awaitPostRestartReachable` — the
+// bounded wait for the tab to re-register, and the only thing on this path that
+// calls `ensureReachable()` to heal the session binding onto the returning tab —
+// sat AFTER `if (!recovery.ready) return …`. So a boot slower than the budget did
+// not merely lose the readiness answer: it forfeited the reconnect wait as well.
+// One number denied two independent things.
+//
+// These tests drive the real handler. The first one is the reproduction: on the
+// pre-fix code `awaitPostRestartReachable` is never entered at all.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+const getSystemStats = vi.fn(async () => {
+  throw new Error("ECONNRESET");
+});
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  getSystemStats: () => getSystemStats(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const parse = (res: ToolResult): Record<string, unknown> =>
+  JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+interface ReconnectCall {
+  before: { generation: number; tabSessionId: string } | undefined;
+  budgetMs: number | undefined;
+}
+
+function makeCtx(opts: {
+  /** What the (spied) post-restart reconnect wait resolves to. */
+  tabReturns: boolean;
+  /** Omit the pre-restart identity, i.e. nothing was ever watched. */
+  noBaseline?: boolean;
+}): { ctx: PanelToolCtx; reconnectCalls: ReconnectCall[] } {
+  const reconnectCalls: ReconnectCall[] = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "comfy_reboot") return { rebooting: true };
+      return {};
+    },
+    tabOrigin: () => BOOT_BASE,
+    tabServerOrigin: () => BOOT_BASE,
+    tabIsLocal: () => true,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = {
+    call: async () => {
+      throw new Error("ctx.call must not be used by reboot readiness");
+    },
+    confirm: async () => "yes" as const,
+    ensureReachable: () => {},
+    bridge,
+    tabId: "bound-tab",
+    panelConnectionIdentity: () =>
+      opts.noBaseline ? undefined : { generation: 7, tabSessionId: "sess-1996" },
+    awaitPostRestartReachable: async (
+      before: { generation: number; tabSessionId: string } | undefined,
+      budgetMs?: number,
+    ) => {
+      reconnectCalls.push({ before, budgetMs });
+      return opts.tabReturns;
+    },
+    tabCanMutateGraph: () => true,
+  } as unknown as PanelToolCtx;
+  return { ctx, reconnectCalls };
+}
+
+function rebootHandler() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def.handler;
+}
+
+beforeEach(() => {
+  resetClient.mockClear();
+  resetObjectInfoCache.mockClear();
+  getSystemStats.mockReset();
+  getSystemStats.mockImplementation(async () => {
+    throw new Error("ECONNRESET");
+  });
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  // A budget the boot outruns: the endpoint is refused for the whole window,
+  // which is the reporter's shape scaled down from 127 s to 120 ms.
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 120,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+  __panelToolsTestHooks.setHealthProbe(async () => "down");
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setReconnectWaitTiming(null);
+});
+
+describe("#1996 a boot slower than the readiness budget must not forfeit the tab-reconnect wait", () => {
+  it("REPRODUCTION: the reconnect wait is ENTERED even though readiness expired", async () => {
+    // Pre-fix this array is EMPTY: `awaitPostRestartReachable` sits after
+    // `if (!recovery.ready) return …`, so the reporter's 127 s window did not
+    // merely fail to certify the boot — it never looked at the tab at all, and
+    // never ran the `ensureReachable()` heal that rebinds the session onto a
+    // returning tab.
+    const { ctx, reconnectCalls } = makeCtx({ tabReturns: false });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(reconnectCalls.length).toBe(1);
+    // Watched with a REAL budget, not a starved zero — the readiness observation
+    // must leave room for it inside the whole-handler deadline.
+    expect(reconnectCalls[0]!.budgetMs ?? 0).toBeGreaterThan(0);
+    // …and it was handed the identity captured BEFORE the dispatch, so a stale
+    // pre-restart socket can never satisfy it.
+    expect(reconnectCalls[0]!.before).toEqual({ generation: 7, tabSessionId: "sess-1996" });
+
+    // THE REFUSAL IS UNCHANGED. An unobserved boot is still an unobserved boot.
+    expect(out.ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(out.server_ready).toBe(false);
+    expect(out.saw_down).toBe(true);
+    expect(String(out.note)).toMatch(/has not become healthy within/);
+    expect(String(out.note)).toMatch(/do NOT assume it is back/);
+    // The tab was watched and did not come back — a real observation, reported.
+    expect(out.panel_tab_reconnected).toBe(false);
+  });
+
+  it("a tab that DOES re-register is reported, without upgrading the boot to a success", async () => {
+    // The dangerous fix here is turning an honest refusal into a false success.
+    // A returning tab says the panel socket is routable again; it says NOTHING
+    // about whether THIS ComfyUI instance completed a down→up cycle, which is the
+    // only thing `confirmed_cycle`/`server_ready` may ever assert.
+    const { ctx, reconnectCalls } = makeCtx({ tabReturns: true });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(reconnectCalls.length).toBe(1);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(out.server_ready).toBe(false);
+    expect(out.ready).toBe(false); // graph tools stay withheld on an unproven boot
+    expect(String(out.note)).toMatch(/do NOT assume it is back/);
+    // It must not claim the server is healthy anywhere.
+    expect(String(out.note)).not.toMatch(/healthy again/);
+  });
+
+  it("no pre-restart baseline ⇒ the reconnect stays 'unknown', never a bare false", async () => {
+    // #654's distinction survives the reordering: `false` must keep meaning
+    // "watched, did not come back" and never "nothing was watched".
+    const { ctx } = makeCtx({ tabReturns: false, noBaseline: true });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(out.panel_tab_reconnected).toBe("unknown");
+    expect(out.ready).toBe(false);
+  });
+});
+
+describe("#1996 the readiness budget", () => {
+  it("defaults above the window the reporter measured as still-down", () => {
+    const prev = process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+    try {
+      delete process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+      const t = __panelToolsTestHooks.computeRebootTimingFromEnv();
+      // The reporter's own measurement: the port was still refused at 127.25 s.
+      // A default of 120 s could not have observed that boot however healthy it
+      // became a second later.
+      expect(t.budgetMs).toBeGreaterThan(127_254);
+      expect(t.budgetMs).toBe(180_000);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+      else process.env.COMFYUI_PANEL_REBOOT_BUDGET_S = prev;
+    }
+  });
+
+  it("still fits the whole-handler deadline WITH the reconnect wait reserved", () => {
+    const prev = process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+    try {
+      delete process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+      const t = __panelToolsTestHooks.computeRebootTimingFromEnv();
+      const reconnect = __panelToolsTestHooks.getReconnectWaitTiming();
+      // OVERALL_MAX_MS is 255 s. Readiness + the reconnect wait it must not eat,
+      // plus a ≥30 s allowance for the confirmation card, the reboot ack and the
+      // post-restart argv read, has to stay inside it — this is the arithmetic
+      // that picks 180 s rather than the 240 s env ceiling.
+      expect(t.budgetMs + reconnect.budgetMs + 30_000).toBeLessThanOrEqual(255_000);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_PANEL_REBOOT_BUDGET_S;
+      else process.env.COMFYUI_PANEL_REBOOT_BUDGET_S = prev;
+    }
+  });
+
+  it("the env ceiling can no longer starve the reconnect wait", () => {
+    // 240 s of readiness inside a 255 s handler leaves 15 s, and the pre-fix code
+    // handed `overallDeadline - Date.now()` straight to the reconnect wait — so
+    // the value the file called safe was exactly the one that silently zeroed it.
+    // The reservation is what makes the ceiling honest.
+    const overallDeadline = 255_000;
+    const reserve = 35_000;
+    expect(
+      __panelToolsTestHooks.readinessDeadlineWithReconnectReserve({
+        now: 0,
+        budgetMs: 240_000,
+        overallDeadline,
+        reserveMs: reserve,
+      }),
+    ).toBe(overallDeadline - reserve);
+    // It never pushes the deadline into the past, and it never EXTENDS a budget
+    // that already fits.
+    expect(
+      __panelToolsTestHooks.readinessDeadlineWithReconnectReserve({
+        now: 0,
+        budgetMs: 180_000,
+        overallDeadline,
+        reserveMs: reserve,
+      }),
+    ).toBe(180_000);
+    expect(
+      __panelToolsTestHooks.readinessDeadlineWithReconnectReserve({
+        now: 250_000,
+        budgetMs: 180_000,
+        overallDeadline,
+        reserveMs: reserve,
+      }),
+    ).toBe(250_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WIRING. The reservation is a ONE-LINE assignment at the call site, and a
+// helper-only suite survives that call site being reverted to
+// `Math.min(Date.now() + timing.budgetMs, overallDeadline)` — which type-checks,
+// reads exactly like the code it replaced, and restores the starvation in full.
+// (#1971 in this repo sat unreached for releases for precisely that reason.) The
+// behavioural half of this cannot be driven without a ~250s handler, so the call
+// site is asserted directly.
+// ---------------------------------------------------------------------------
+describe("#1996 WIRING: the bound readiness deadline goes through the reserve", () => {
+  const src = (): string => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+  };
+
+  it("the bound path assigns gate.deadline via the reserve, with the LIVE reconnect budget", () => {
+    const s = src();
+    expect((s.match(/gate\.deadline = readinessDeadlineWithReconnectReserve\(\{/g) ?? []).length).toBe(1);
+    // Reading the reserve from reconnectWaitTiming() is what keeps it correct when a
+    // user raises COMFYUI_PANEL_RECONNECT_WAIT_S; a hard-coded 35_000 would silently
+    // under-reserve for them.
+    expect((s.match(/reserveMs: reconnectWaitTiming\(\)\.budgetMs/g) ?? []).length).toBe(1);
+    // Exactly ONE unreserved `gate.deadline` assignment survives: the REMOTE branch,
+    // which returns without ever waiting for a tab, so it has nothing to reserve for.
+    expect(
+      (s.match(/gate\.deadline = Math\.min\(Date\.now\(\) \+ timing\.budgetMs, overallDeadline\);/g) ?? [])
+        .length,
+    ).toBe(1);
+  });
+
+  it("neither restart path gates the reconnect wait on the readiness verdict any more", () => {
+    // The exact pre-fix shape on the headless path. Its behavioural coverage lives in
+    // panel-restart-legacy-fallback.test.ts; this catches a re-introduction anywhere.
+    expect(/const tabBack = recovery\.ready\s*\n?\s*\?/.test(src())).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
+++ b/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
@@ -34,30 +34,44 @@ import { classifyTabReconnect } from "../../orchestrator/panel-tools.js";
 describe("#654 a reconnect that was never watched is not a failed reconnect", () => {
   it("no baseline captured ⇒ unknown, even though the server came back", () => {
     // The reporter's exact state.
-    expect(classifyTabReconnect({ serverReady: true, baselineCaptured: false, tabBack: false })).toBe("unknown");
+    expect(classifyTabReconnect({ tabWatched: true, baselineCaptured: false, tabBack: false })).toBe("unknown");
   });
 
   it("baseline captured and the tab did not return ⇒ a real false", () => {
     // The honest negative must survive: this is a genuine observation.
-    expect(classifyTabReconnect({ serverReady: true, baselineCaptured: true, tabBack: false })).toBe(false);
+    expect(classifyTabReconnect({ tabWatched: true, baselineCaptured: true, tabBack: false })).toBe(false);
   });
 
   it("the tab returned ⇒ true, however the baseline went", () => {
     for (const baselineCaptured of [true, false]) {
-      expect(classifyTabReconnect({ serverReady: true, baselineCaptured, tabBack: true })).toBe(true);
+      expect(classifyTabReconnect({ tabWatched: true, baselineCaptured, tabBack: true })).toBe(true);
     }
   });
 
-  it("server never came back ⇒ unknown, because the tab is only watched after it does", () => {
-    // Reporting `false` here would blame the tab for the server's failure.
+  it("a tab NOBODY watched ⇒ unknown, whatever the baseline says (#1996)", () => {
+    // Reporting `false` here would blame the tab for an observation never made.
+    //
+    // #1996 renamed this input. It was `serverReady`, justified as "the tab is only
+    // watched after the server comes back" — true when it was written, and false the
+    // moment the reconnect wait moved ahead of the readiness return. A parameter that
+    // is a PROXY for the real question keeps answering after its premise dies; this one
+    // now asks the question directly, so the honest "unknown" survives only where
+    // nothing was actually watched.
     for (const baselineCaptured of [true, false]) {
-      expect(classifyTabReconnect({ serverReady: false, baselineCaptured, tabBack: false })).toBe("unknown");
+      expect(classifyTabReconnect({ tabWatched: false, baselineCaptured, tabBack: false })).toBe("unknown");
     }
+  });
+
+  it("a WATCHED tab that did not come back is a real false, even on an unproven boot (#1996)", () => {
+    // The case the old `serverReady` input could not express: the readiness budget
+    // expired, the reconnect wait ran anyway, and the tab genuinely did not return.
+    // That is an observation, not an absence of one.
+    expect(classifyTabReconnect({ tabWatched: true, baselineCaptured: true, tabBack: false })).toBe(false);
   });
 
   it("a returned tab is never downgraded by an unhealthy server reading", () => {
     // Defensive: tabBack:true is a positive observation and outranks everything.
-    expect(classifyTabReconnect({ serverReady: false, baselineCaptured: true, tabBack: true })).toBe(true);
+    expect(classifyTabReconnect({ tabWatched: false, baselineCaptured: true, tabBack: true })).toBe(true);
   });
 });
 
@@ -71,7 +85,7 @@ describe("#654 the strictness of ready/graph_tools_ready is untouched", () => {
     // classification, so an unproven reconnect still withholds graph tools. If a
     // refactor ever routes the gate through the classification, "unknown" must
     // not become truthy — this is the assertion that would catch it.
-    const verdict = classifyTabReconnect({ serverReady: true, baselineCaptured: false, tabBack: false });
+    const verdict = classifyTabReconnect({ tabWatched: true, baselineCaptured: false, tabBack: false });
     expect(verdict).not.toBe(true);
     // …and it is explicitly not a bare false either, which is the whole fix.
     expect(verdict).toBe("unknown");
@@ -90,16 +104,21 @@ describe("#654 WIRING: both restart replies report the classification", () => {
     return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
   };
 
-  it("neither reply emits the bare boolean any more", () => {
+  it("no reply emits the bare boolean any more", () => {
     const s = src();
     expect(/panel_tab_reconnected: tabBack\b/.test(s), "a reply still emits the raw boolean").toBe(false);
-    expect((s.match(/panel_tab_reconnected: tabReconnect\b/g) ?? []).length).toBe(2);
+    // Two `tabReconnect` emitters (the headless reply and the confirmed-cycle reply) plus
+    // #1996's third one on the NOT-confirmed reply, which names its own local because it
+    // is computed in a different scope. Counted as "every emitter is a classification",
+    // not as a fixed number of replies.
+    expect((s.match(/panel_tab_reconnected: (?:tabReconnect|unreadyTabReconnect)\b/g) ?? []).length).toBe(3);
   });
 
-  it("both call sites derive baselineCaptured from the pre-restart identity", () => {
+  it("every call site derives baselineCaptured from the pre-restart identity", () => {
     // The mutation this catches is `baselineCaptured: true` — which type-checks,
     // reads plausibly, and restores the bug exactly.
-    expect((src().match(/baselineCaptured: preRestartPanelIdentity != null/g) ?? []).length).toBe(2);
+    // 3 since #1996: the unconfirmed-boot reply reports a reconnect too.
+    expect((src().match(/baselineCaptured: preRestartPanelIdentity != null/g) ?? []).length).toBe(3);
   });
 
   it("the undetermined note tells the reader what to do INSTEAD of refreshing", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16920,7 +16920,31 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           const legacyProofWindow = panelRebootTimingOverride
             ? headlessTiming.settleMs + headlessTiming.budgetMs
             : LEGACY_RESTART_MIN_BUDGET_MS;
-          const proofDeadline = Math.min(Date.now() + legacyProofWindow, overallDeadline);
+          // #1996 r1 (codex P1): the SAME reserve as the bound path, applied here rather
+          // than a second mechanism — one rule, two call sites. Without it this path
+          // reproduced the exact starvation this issue is about: a confirmation answered
+          // at ~90s leaves 165s, the 140s proof window claims all but 25 of them, and the
+          // tab wait below is handed less than the 35s a tab is allowed to take — so a tab
+          // that re-registers normally is reported `panel_tab_reconnected:false`. The
+          // #1671 caller makes that the COMMON case, not a corner: it is entered because
+          // the confirmation card went unanswered, which costs the full 90s
+          // RESTART_CONFIRM_TIMEOUT_MS plus the ~6s decline probe before this even starts.
+          //
+          // The ADMISSION gate above is deliberately NOT raised to 175s to match. Doing
+          // that would refuse the #1671 crash recovery outright at ~96s elapsed — telling
+          // a user whose ComfyUI just died to retry, instead of restarting it — which is
+          // strictly worse than the trade this clamp makes. What the clamp costs is
+          // cold-start observation time (140s → as little as 105s at the admission floor,
+          // i.e. the 40s unpreemptible sync plus 65s rather than 100s of watching). That
+          // is the same asymmetry the bound path turns on: a short observation returns an
+          // honest `did NOT become healthy within Ns` that the caller can retry, while a
+          // starved reconnect wait silently drops the rebind and cannot be retried into.
+          const proofDeadline = readinessDeadlineWithReconnectReserve({
+            now: Date.now(),
+            budgetMs: legacyProofWindow,
+            overallDeadline,
+            reserveMs: reconnectWaitTiming().budgetMs,
+          });
           const proofPromise = observeRecovery(headlessTiming, proofDeadline, { healthBase });
           const restartBudget = Math.max(1, overallDeadline - Date.now());
           let restart: Awaited<ReturnType<typeof restartComfyUI>> | undefined;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -17888,10 +17888,17 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               (recovery.sawDown
                 ? `Reboot was dispatched and ComfyUI went down, but it has not become healthy within ${waited}s — it may still be starting or the restart failed. Verify with get_system_stats (action:"health") / panel_node_queue_status before retrying; do NOT assume it is back.`
                 : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with get_system_stats (action:"health") / panel_node_queue_status; do NOT assume it restarted.`) +
+              // Careful with BOTH of these sentences (adversarial re-read of this very
+              // diff). The positive one must not claim a REBIND: `awaitPostRestartReachable`
+              // returns true on a newer hello from the same browser-tab session, which
+              // usually needed no rebinding at all — `ensureReachable()` only runs when the
+              // old tab id stopped resolving. And the negative one must not send the reader
+              // to a browser refresh first, which is the manual step #654 is about: the
+              // cheap rebind check comes before it.
               (unreadyTabReconnect === true
-                ? " Separately: the panel tab DID re-register and this session was rebound onto it, so panel_* calls should route again. That is a fact about the browser socket only — it does not say ComfyUI finished booting."
+                ? " Separately: the panel tab DID re-register (a newer hello from the same browser-tab session), so panel_* calls should route again. That is a fact about the panel's socket to this orchestrator, which never traverses ComfyUI — it does not say ComfyUI finished booting."
                 : unreadyTabReconnect === false
-                  ? " The panel tab was also watched for a re-register and did not come back in that time, so panel_* calls may still report \"Connected: none\"; retry once the server answers, or reload the ComfyUI browser tab."
+                  ? " The panel tab was also watched for a re-register and did not come back in that window, so panel_* calls may still report \"Connected: none\". Retry once the server answers, or rebind with panel_set_workflow_target({mode:\"current\"}); reload the ComfyUI browser tab only if that also fails."
                   : "") +
               (preflightNote ? ` ${preflightNote}` : ""),
           });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -881,7 +881,35 @@ let panelRebootTimingOverride: PanelRebootTiming | null = null;
 // ready:false in time instead of being killed as a bare 300s timeout — even if the
 // COMFYUI_PANEL_REBOOT_* env overrides are set absurdly high (coordinator codex P2).
 const MAX_REBOOT_SETTLE_MS = 10_000; // 10s
-const MAX_REBOOT_BUDGET_MS = 240_000; // 240s  → settle+budget ≤ 250s < 300s outer
+// #1996: this ceiling stays 240s as the ENV escape hatch for an install slower still,
+// but the comment it used to carry ("settle+budget ≤ 250s < 300s outer") did the
+// arithmetic against the outer tools/call limit ONLY. It never counted the tab-reconnect
+// wait that runs AFTER readiness inside the SAME 255s whole-handler budget — so 240s of
+// readiness leaves 15s, and the reconnect wait was handed `overallDeadline - now`
+// directly. The value the file called safe was exactly the one that silently zeroed the
+// reconnect wait. readinessDeadlineWithReconnectReserve is what makes it honest now:
+// readiness is clamped so the reconnect wait always keeps its own budget.
+const MAX_REBOOT_BUDGET_MS = 240_000; // 240s env ceiling; the reserve below protects the reconnect wait
+
+/** The readiness observation's deadline, clamped so it can NEVER consume the budget the
+ *  post-restart tab-reconnect wait needs (#1996).
+ *
+ *  Both waits live inside ONE `overallDeadline` (OVERALL_MAX_MS, 255s). Before this,
+ *  readiness took `min(now + budgetMs, overallDeadline)` and the reconnect wait took
+ *  whatever was left — which is zero whenever readiness ran to the cap. Reserving the
+ *  reconnect budget up front means a slow confirmation card costs readiness time (which
+ *  is recoverable: the caller retries) instead of silently deleting the reconnect wait
+ *  (which is not: it is the only thing that heals the session binding onto the returning
+ *  tab). Never returns a deadline in the past, and never EXTENDS a budget that fits. */
+function readinessDeadlineWithReconnectReserve(args: {
+  now: number;
+  budgetMs: number;
+  overallDeadline: number;
+  reserveMs: number;
+}): number {
+  const { now, budgetMs, overallDeadline, reserveMs } = args;
+  return Math.max(now, Math.min(now + budgetMs, overallDeadline - reserveMs));
+}
 
 // #404: hard ceiling on how long the panel_restart_comfyui CONFIRMATION card waits for
 // a yes/no answer. A restart is user-initiated, so a present user answers in seconds;
@@ -928,9 +956,21 @@ function computeRebootTimingFromEnv(): PanelRebootTiming {
       MAX_REBOOT_SETTLE_MS,
       Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_REBOOT_SETTLE_S", 3) * 1000),
     ),
+    // #1996: 180s, not the old 120s. The reporter's install was STILL refusing
+    // connections at 127.25s (603 probes, ~11ms each — refusals, not timeouts) while
+    // 200+ packs imported, and came back healthy on its own; 120s could not have
+    // observed that boot however fast it finished afterwards. 180s is not a guess at
+    // that install's true boot time (nobody measured it) — it is the largest value the
+    // handler's own envelope allows while still preserving the things that share it:
+    // 180 readiness + 35 reconnect wait + a ≥30s allowance for the confirmation card,
+    // the reboot ack and the post-restart argv read = 245s ≤ OVERALL_MAX_MS (255s).
+    // THE COST, stated rather than slipped in: a server that is genuinely never coming
+    // back is now reported as unconfirmed ~60s later than before (plus the reconnect
+    // wait that is no longer skipped). That cost is bounded and it buys the far more
+    // common case — a big install that boots slowly and is then declared dead.
     budgetMs: Math.min(
       MAX_REBOOT_BUDGET_MS,
-      Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_REBOOT_BUDGET_S", 120) * 1000),
+      Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_REBOOT_BUDGET_S", 180) * 1000),
     ),
     intervalMs: Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_REBOOT_INTERVAL_S", 0.2) * 1000),
     probeTimeoutMs: Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_REBOOT_PROBE_S", 2) * 1000),
@@ -1029,6 +1069,9 @@ export const __panelToolsTestHooks = {
   loopbackProbeUrl,
   /** Compute reboot timing from env WITH the P2 hard caps (bypasses any override). */
   computeRebootTimingFromEnv,
+  /** #1996: the clamp that stops the readiness observation eating the tab-reconnect
+   *  wait's share of the whole-handler deadline. */
+  readinessDeadlineWithReconnectReserve,
   /** #404: the hard ceiling on the panel_restart_comfyui confirmation-card wait. */
   RESTART_CONFIRM_TIMEOUT_MS,
   /** Zero out the post-drop retry settle so retry-once tests don't sleep. */
@@ -2005,22 +2048,29 @@ async function probeDeclineRecovery(
  * distinction (`stale: true | "unknown"`), rather than inventing a second field
  * that a reader could miss while still acting on the misleading boolean.
  *
- * `serverReady:false` is undetermined too, and for the same reason: the tab is
- * only watched once the server is back, so nothing was observed about it.
+ * #1996 — this input used to be `serverReady`, and the reason given for it was
+ * "the tab is only watched once the server is back". That was a PROXY for the
+ * real question, and the proxy outlived its proof: an unconfirmed boot now runs
+ * the reconnect wait too, so `serverReady:false` no longer implies nothing was
+ * watched. The parameter says what it actually means — WAS THE TAB WATCHED —
+ * so that a future path which skips the wait still reports "unknown" and a path
+ * that runs it reports the observation it really made. Nothing else changes:
+ * `tabBack:true` still outranks everything, and a missing baseline is still
+ * "unknown" rather than a bare false.
  */
 export type TabReconnectReport = true | false | "unknown";
 
 export function classifyTabReconnect({
-  serverReady,
+  tabWatched,
   baselineCaptured,
   tabBack,
 }: {
-  serverReady: boolean;
+  tabWatched: boolean;
   baselineCaptured: boolean;
   tabBack: boolean;
 }): TabReconnectReport {
   if (tabBack === true) return true; // a newer hello from the same tab was seen
-  if (!serverReady) return "unknown"; // never watched — the server never came back
+  if (!tabWatched) return "unknown"; // nothing was watched, so nothing was observed
   return baselineCaptured ? false : "unknown";
 }
 
@@ -16937,22 +16987,31 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // the same workflow-stamp capability the bridge requires before it dispatches a
           // mutation. Without this, updating the panel pack followed by a headless restart can
           // falsely report ready while the browser is still running stale panel JS (#709).
-          const tabBack = recovery.ready
-            ? ctx.awaitPostRestartReachable
-              ? await ctx.awaitPostRestartReachable(
-                  preRestartPanelIdentity,
-                  Math.max(0, overallDeadline - Date.now()),
-                )
-              : ctx.awaitReachable
-                ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
-                : true
-            : false;
-          const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
+          //
+          // #1996: watched on BOTH outcomes. This path carried the same coupling as the
+          // bound one — `recovery.ready ? … : false` — so a managed kill+relaunch whose
+          // cold start outran the observation window forfeited the reconnect wait too,
+          // and reported a bare `false` for a tab nobody had looked at.
+          const tabBack = ctx.awaitPostRestartReachable
+            ? await ctx.awaitPostRestartReachable(
+                preRestartPanelIdentity,
+                Math.max(0, overallDeadline - Date.now()),
+              )
+            : ctx.awaitReachable
+              ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
+              : true;
+          // #1996: `recovery.ready &&` is LOAD-BEARING now that the wait above runs on
+          // both outcomes. Without it a tab that re-registered while the server was still
+          // unproven would report ready:true — turning the honest refusal this path
+          // already gives into a false success, which is the one thing this fix must not
+          // do. A reconnected browser socket is not a booted ComfyUI.
+          const graphToolsReady =
+            recovery.ready && tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
           // #654 — `ready`/`graph_tools_ready` still come from the BOOLEAN, so an
           // undetermined reconnect withholds graph tools exactly as before. Only
           // the reported observation changes.
           const tabReconnect = classifyTabReconnect({
-            serverReady: recovery.ready,
+            tabWatched: true,
             baselineCaptured: preRestartPanelIdentity != null,
             tabBack,
           });
@@ -17758,29 +17817,22 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // Both fired and dropped are AMBIGUOUS (the panel emits rebooting:true even when it
         // only INFERS a reboot from a dropped fetch), so certification requires an OBSERVED
         // down→up, which the observer has been (and continues) watching for.
-        gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
+        // #1996: RESERVE the reconnect wait's budget out of the whole-handler deadline
+        // before the readiness observation claims it. Without the reserve a readiness
+        // window that runs to `overallDeadline` leaves the wait below exactly 0ms, so
+        // raising the budget would have traded one silent forfeit for another.
+        gate.deadline = readinessDeadlineWithReconnectReserve({
+          now: Date.now(),
+          budgetMs: timing.budgetMs,
+          overallDeadline,
+          reserveMs: reconnectWaitTiming().budgetMs,
+        });
         const recovery = await recoveryPromise!;
         // #742 r4/r5/r15: the dispatched restart was observed back — clear the
         // record, CLEAR-IF-SAME: only when the session still holds the token
         // THIS dispatch stamped (a concurrent dispatch's newer record survives).
         if (recovery.ready && acceptedDispatchToken != null) {
           clearSessionRestartDispatchIfSame(ctx, acceptedDispatchToken);
-        }
-        if (!recovery.ready) {
-          const waited = Math.round(recovery.waited_ms / 1000);
-          return ok({
-            rebooting: true,
-            ready: false,
-            confirmed_cycle: false,
-            recovered_ms: recovery.waited_ms,
-            probes: recovery.attempts,
-            saw_down: recovery.sawDown,
-            note:
-              (recovery.sawDown
-                ? `Reboot was dispatched and ComfyUI went down, but it has not become healthy within ${waited}s — it may still be starting or the restart failed. Verify with get_system_stats (action:"health") / panel_node_queue_status before retrying; do NOT assume it is back.`
-                : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with get_system_stats (action:"health") / panel_node_queue_status; do NOT assume it restarted.`) +
-              (preflightNote ? ` ${preflightNote}` : ""),
-          });
         }
         // #400/#709: ComfyUI is healthy, but the panel's browser tab re-registers its own
         // socket a moment later. The old socket can still be reachable after dispatch, so
@@ -17792,6 +17844,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // Connected:none window (codex). `server_ready` carries the certified cycle either
         // way. A production PanelToolCtx supplies the generation waiter; an explicitly
         // lightweight context retains the historical reachability-only test contract.
+        //
+        // #1996: this runs BEFORE the `!recovery.ready` return, not after it. The two
+        // questions are independent — "did THIS ComfyUI instance complete a down→up
+        // cycle" and "is the panel tab routable again" — and one budget expiring used to
+        // deny both. That is the reporter's shape: a 127s boot lost the readiness answer
+        // it honestly could not give AND the reconnect wait it could have given, which is
+        // the only thing on this path that calls `ensureReachable()` to heal the session
+        // binding onto the returning tab. An unconfirmed boot now still gets watched.
         const tabBack = ctx.awaitPostRestartReachable
           ? await ctx.awaitPostRestartReachable(
               preRestartPanelIdentity,
@@ -17800,6 +17860,42 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           : ctx.awaitReachable
             ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
             : true;
+        if (!recovery.ready) {
+          const waited = Math.round(recovery.waited_ms / 1000);
+          // #1996: the refusal itself is NOT the defect and is left exactly as it was.
+          // A window that ended with the port closed is not evidence the server is back,
+          // and a tab that re-registered is not evidence either — the panel's bridge
+          // socket runs browser→orchestrator and never traverses ComfyUI, so it says the
+          // ROUTE is alive and nothing at all about the boot. `ready`, `server_ready` and
+          // `confirmed_cycle` therefore all stay false on every branch here, exactly as
+          // before. What is added is the observation that used to be thrown away.
+          const unreadyTabReconnect = classifyTabReconnect({
+            tabWatched: true,
+            baselineCaptured: preRestartPanelIdentity != null,
+            tabBack,
+          });
+          return ok({
+            rebooting: true,
+            ready: false,
+            graph_tools_ready: false,
+            server_ready: false,
+            confirmed_cycle: false,
+            recovered_ms: recovery.waited_ms,
+            probes: recovery.attempts,
+            saw_down: recovery.sawDown,
+            panel_tab_reconnected: unreadyTabReconnect,
+            note:
+              (recovery.sawDown
+                ? `Reboot was dispatched and ComfyUI went down, but it has not become healthy within ${waited}s — it may still be starting or the restart failed. Verify with get_system_stats (action:"health") / panel_node_queue_status before retrying; do NOT assume it is back.`
+                : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with get_system_stats (action:"health") / panel_node_queue_status; do NOT assume it restarted.`) +
+              (unreadyTabReconnect === true
+                ? " Separately: the panel tab DID re-register and this session was rebound onto it, so panel_* calls should route again. That is a fact about the browser socket only — it does not say ComfyUI finished booting."
+                : unreadyTabReconnect === false
+                  ? " The panel tab was also watched for a re-register and did not come back in that time, so panel_* calls may still report \"Connected: none\"; retry once the server answers, or reload the ComfyUI browser tab."
+                  : "") +
+              (preflightNote ? ` ${preflightNote}` : ""),
+          });
+        }
         // A recovered socket does NOT mean graph mutations are usable: an already-open
         // browser tab can reconnect after ComfyUI restarts while still serving stale panel
         // JS, which lacks the #570 workflow-stamp fence. Report the same capability the
@@ -17811,7 +17907,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // `ready`/`graph_tools_ready` still key off the boolean, so an undetermined
         // reconnect still withholds graph tools. Only the reported observation changes.
         const tabReconnect = classifyTabReconnect({
-          serverReady: true, // this branch only runs on a confirmed healthy cycle
+          tabWatched: true, // the reconnect wait above ran on this path
           baselineCaptured: preRestartPanelIdentity != null,
           tabBack,
         });


### PR DESCRIPTION
Fixes #1996.

Review is **pending** — requested from grok in a comment below. Nothing here has been reviewed by anyone but its author.

## What I took, and what I left

The issue separates what was ESTABLISHED (the budget gives up early; the reconnect wait sits downstream of the readiness verdict) from what was NOT (why the panel socket never re-registered). I took the first and left the second explicitly open — see the last section. I did not turn a lead into a cause.

## 1. The coupling — the half that actually costs the user something

`awaitPostRestartReachable` sat **after** `if (!recovery.ready) return …`, so a boot slower than the budget did not merely lose the readiness answer it honestly could not give. It also forfeited the reconnect wait, which on this path is the **only** thing that calls `ensureReachable()` to heal the session binding onto a returning tab. One number denied two independent questions:

* did **this** ComfyUI instance complete a down→up cycle, and
* is the panel tab routable again.

The wait now runs on both outcomes. The same shape existed on the headless managed-restart path (`const tabBack = recovery.ready ? await … : false`) and is fixed there too.

**Reproduced by execution before anything was written.** `panel-restart-slow-boot-reconnect.test.ts` drives the real handler with a health probe that refuses for the whole window — the reporter's shape scaled from 127 s to 120 ms — and counts the calls into a spied `awaitPostRestartReachable`. On `origin/main` that count is **0**, and `panel_tab_reconnected` is **absent from the reply entirely**.

## 2. The budget: 120 s → 180 s, and why that number

The reporter's own numbers establish that the observer **stopped looking** rather than misread a healthy server: 603 probes over 127.25 s is ~211 ms per iteration against `intervalMs` 200 ms, i.e. ~11 ms per probe — fast connection refusals, not timeouts. A hung probe would have produced ~63 iterations, not 603. The port was closed for the entire window while 200+ packs imported, and the install was healthy when checked afterwards.

So 120 s is **provably too small for that install**. What 180 s is *not* is a guess at its true boot time — nobody measured it, and I could not. It is the largest value the handler's own envelope allows while preserving everything that shares it:

```
180  readiness
 35  tab-reconnect wait (COMFYUI_PANEL_RECONNECT_WAIT_S default)
 30  allowance: confirmation card + reboot ack + post-restart argv read
---
245  ≤ OVERALL_MAX_MS (255 s)
```

**The 240 s the file already called safe is not available**, and that is worth stating because it is the obvious alternative. `MAX_REBOOT_BUDGET_MS = 240_000` carried the comment `settle+budget ≤ 250s < 300s outer` — arithmetic done against the outer `tools/call` limit only. It never counted the reconnect wait that runs *after* readiness inside the same 255 s handler budget. 240 s of readiness leaves 15 s, and the reconnect wait was handed `overallDeadline - Date.now()` directly. The value the file declared safe was **exactly the one that silently zeroed the reconnect wait**.

`MAX_REBOOT_BUDGET_MS` stays 240 s as the env escape hatch for an install slower still — it is now safe to use, because of:

## 3. The reserve

`readinessDeadlineWithReconnectReserve` clamps the readiness deadline to `overallDeadline - reconnectWaitTiming().budgetMs`. Without it, raising the budget would have traded one silent forfeit for another: a slow confirmation card followed by a full readiness window leaves the reconnect wait 0 ms and it returns `false` without waiting for anything. With it, a slow card costs readiness time (recoverable — the caller retries) rather than deleting the reconnect wait (not recoverable in that call). The reserve reads `reconnectWaitTiming()`, not a hard-coded 35 000, so raising `COMFYUI_PANEL_RECONNECT_WAIT_S` reserves more.

No regression in realistic cases: with a 90 s confirmation card (the `RESTART_CONFIRM_TIMEOUT_MS` ceiling) readiness still gets 130 s, more than today's 120 s.

## 4. What this deliberately does NOT do: turn a refusal into a success

Reporting "not confirmed" about a boot nobody observed is correct, and the refusal text is unchanged. On every unconfirmed branch `ready`, `server_ready`, `graph_tools_ready` and `confirmed_cycle` all stay `false`.

The specific trap here is that a re-registered tab looks like good news. It is not evidence about the boot: the panel's bridge socket runs browser→orchestrator and **never traverses ComfyUI**, so it says the route is alive and nothing else. The reply says exactly that:

> Separately: the panel tab DID re-register and this session was rebound onto it, so `panel_*` calls should route again. That is a fact about the browser socket only — it does not say ComfyUI finished booting.

On the headless path the guard is a literal `recovery.ready &&` in `graphToolsReady`, added because the reordering would otherwise let a reconnected tab report `ready:true` under an unproven boot. It has its own mutation below.

## 5. `classifyTabReconnect`'s `serverReady` input is renamed `tabWatched`

Its documented justification was *"the tab is only watched once the server is back"* — a **proxy**, true when written and false the moment the wait moved ahead of the readiness return. Left alone, an unconfirmed boot whose tab was watched and genuinely did not return would report `"unknown"` — an absence of observation — when a real observation had been made. The parameter now asks the question directly. `tabBack:true` still outranks everything; a missing baseline is still `"unknown"` and never a bare `false`; `ready`/`graph_tools_ready` still key off the boolean, so #654's gate is untouched.

## Mutation evidence

Committed first, then each mutation applied to the **call site**, run, reverted. The mutator refuses on any occurrence count ≠ 1, because the working copy is CRLF and a pattern that silently matches nothing reads as a survived mutation.

| # | Mutation (call site unless noted) | Result |
|---|---|---|
| M1 | restore `if (!recovery.ready) return …` above the reconnect wait (bound path) | **5 fail**, incl. `REPRODUCTION: the reconnect wait is ENTERED even though readiness expired` |
| M2 | budget default `180` → `120` | **1 fail**: `defaults above the window the reporter measured as still-down` |
| M3 | `gate.deadline = readinessDeadlineWithReconnectReserve(…)` → `Math.min(Date.now() + timing.budgetMs, overallDeadline)` | **1 fail**: `the bound path assigns gate.deadline via the reserve, with the LIVE reconnect budget` |
| M4 | restore `const tabBack = recovery.ready ? … : false` (headless path) | **2 fail**, incl. behavioural `watches the tab even when OUR observation never certified the cycle` |
| M5 | drop `recovery.ready &&` from headless `graphToolsReady` | **3 fail**, incl. two pre-existing #425 tests |
| M6 | `tabWatched: true` → `false` on the unconfirmed reply | **1 fail**: the REPRODUCTION test |

M3 is the one that argues for the source-level wiring assertion: the reserve is a **one-line assignment**, its helper has its own unit tests, and those unit tests survive the call site being reverted in full. Its behavioural half cannot be driven without a ~250 s handler.

## Tests

Full suite in a worktree cut from `origin/main` @ `26bfd3b`:

* **baseline** (clean `origin/main`): `5 failed | 11231 passed` — the 4 known pre-existing (`package-hooks` #1597, three in `node-id-union-message` #1889) plus one **load flake**, `panel-restart-configured-command > the issue's wedge …`, which passes on its own (`1 passed (1)`).
* **this branch**: `4 failed | 11243 passed | 4 skipped` — exactly the 4 known. The flake did not recur.
* All 13 restart-related files together: `195 passed`.
* `tsc --noEmit` clean; `check:vocabulary` OK.

## What I deliberately did not do

* **The re-registration question is left OPEN, by design.** Why the panel socket never re-registered is not established here and I did not promote a lead to a cause. The #654 re-advertise shipped in panel v0.15.10 against a reporter on 0.15.24; it is edge-triggered on ComfyUI's `reconnected` and gated on `bridgeConnected === true`, with the other branch falling to `connectAgent()`, which early-returns on an already-open socket; neither side has a time-based backstop. Both tests in `bridge-reregisters-after-restart.spec.ts` pass on clean main, so the mechanism works and what is unproven is that the reporter's rig **reached** it. Establishing that needs a real large install and a real browser, and this rig has neither — there is no ComfyUI listening on 8188/8000 here.
  * What this PR does contribute to it: the reconnect wait now runs on the unconfirmed path, so the next report of this shape carries `panel_tab_reconnected: true | false | "unknown"` — an actual observation of the tab across that window instead of silence. That is a measurement the previous code could not produce.
* **No browser gate.** Nothing panel-rendered changed (the diff is `src/orchestrator/panel-tools.ts` plus tests), and there is no ComfyUI on this machine to run the Playwright suite against. Saying so rather than implying coverage I do not have.
* **The remote branch keeps its unreserved deadline.** It returns without ever waiting for a tab, so it has nothing to reserve for; the wiring test pins that exactly one unreserved assignment survives.
* **I did not touch the sibling budget in `process-control.ts`.** `getRemoteRebootTiming()` defaults `COMFYUI_REMOTE_REBOOT_BUDGET_S` to 120 s and, per its own docstring, serves **both** the remote target and a locally-installed ComfyUI **Desktop** instance — so the same 200+ pack import could in principle outrun it by the `restart_comfyui` route. I am recording that rather than fixing it, because I have not reproduced it: all I have is a grep showing the same number, which is exactly the "plausible premise nobody measured" this issue asked me not to act on. It also sits in a different envelope with different callers, and it has no reconnect wait downstream, so it is the budget half only. Worth its own ticket with a measurement attached.
* **The reconnect wait is NOT gated on `saw_down`.** Gating it would spare the no-op case (tab closed mid-command, server stays healthy) up to 35 s — but that case already burns the *entire* readiness budget probing a healthy endpoint, so the addition is ~19% on a call that was already slow, and gating would reintroduce a smaller version of the coupling this PR is about.

## The cost, stated plainly

A server that is genuinely never coming back is now reported as unconfirmed later: ~180 s instead of ~120 s, plus up to the 35 s reconnect wait that is no longer skipped. Bounded, inside the handler's existing 255 s envelope, and it buys the case the report is actually about — a large install that boots slowly and gets declared dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Review round 1 — codex NO-SHIP, P1 fixed in `db71042`

> [P1] `panel-tools.ts:16995` — the legacy/headless restart path does not reserve the reconnect budget.

**Upheld in full, and it is this fix's own blind spot.** I introduced `readinessDeadlineWithReconnectReserve` for the bound path and did not carry it to `runHeadlessManagedRestart`, which computed its own `Math.min(Date.now() + legacyProofWindow, overallDeadline)` and reproduced the identical starvation — on a path this PR *had already modified* (M4/M5 touch its `recovery.ready ? … : false` shape). The reserve simply did not follow. That is the per-call-site adoption gap that left #1971's version probe unreached for releases.

Fixed with the **same helper at the second call site**, not a second mechanism.

## Reproduced by execution before changing anything

`panel-restart-legacy-fallback.test.ts` now drives the real headless path with the clock advanced through a slow confirmation. Measured, not derived:

| | budget handed to the tab wait | tab that re-registers at 28 s |
|---|---|---|
| before `db71042` | **5 s** (25 s once the harness clock was fine enough to resolve it) | `panel_tab_reconnected: false` — **false negative** |
| after | **35 s** (full budget, less one harness clock step) | `panel_tab_reconnected: true` |

The harness fakes `Date` only — timers stay real — and advances the clock from the confirm and from each health probe, so a 140 s window is consumed in ~1.4 s of wall clock. Its discrete step is named `PROBE_STEP_MS` and **subtracted from the assertion** rather than absorbed by loosening it; in production that overshoot is one 200 ms probe interval. My first attempt used a 20 s step, could not resolve 35 s from 25 s, and I tightened the *harness* rather than the assertion.

**Reachability is not hypothetical.** Of the three callers of `runHeadlessManagedRestart`, the #1671 crash-recovery one is entered *because* the confirmation card went unanswered — which costs the full 90 s `RESTART_CONFIRM_TIMEOUT_MS` plus the ~6 s decline probe before this path starts. ~96 s elapsed is its ordinary case, not its corner. Both 90 s and 96 s are pinned as tests.

## The envelope for THIS path — recomputed, not inherited

The 240s-is-safe comment was wrong because it counted against the wrong ceiling. Not repeating that: these are the headless path's own numbers, and they are **not** the bound path's.

```
OVERALL_MAX_MS        255s   (shared)
admission gate       ≥140s remaining  = LEGACY_SYNC_WORST_CASE_MS 40s
                                       + LEGACY_COLD_START_OBS_MS 100s
proof window          140s
reconnect wait         35s
```

Both at full size need **175 s**, i.e. arrival by `handlerStart + 80 s`. The #1671 route arrives at ~96 s and **cannot** meet that. So one of the three has to give:

* **Raising admission to 175 s — rejected.** It would refuse the crash recovery outright at ~96 s, telling a user whose ComfyUI just died to retry instead of restarting it. Strictly worse than the defect being fixed.
* **Leaving the proof window unreserved — the defect.**
* **Clamping the proof window — taken.** It costs cold-start observation: 140 s down to **105 s at the admission floor** (the 40 s unpreemptible sync plus 65 s rather than 100 s of watching).

That trade is the same asymmetry the bound path turns on and states: a short observation returns an honest `did NOT become healthy within Ns` the caller can retry; a starved reconnect wait silently drops the rebind and cannot be retried into. I am flagging the shortened cold-start window as the thing to argue with if you disagree — it is a real cost, deliberately taken, not an oversight.

## Mutation, round 1

| # | Mutation | Result |
|---|---|---|
| M7 | **new call site:** revert `proofDeadline` to `Math.min(Date.now() + legacyProofWindow, overallDeadline)` | **3 fail** — both behavioural reproductions *and* the wiring assertion |

The wiring assertion is now a **count of adopting call sites** (`readinessDeadlineWithReconnectReserve` × 2, `reserveMs: reconnectWaitTiming().budgetMs` × 2) rather than "the bound one is correct" — the shape that would have caught this finding in the first place.

## Suite, round 1

This machine picked up a live ComfyUI and ~101 node processes between rounds, so the full run is noisy. Triaged per-file rather than off the summary:

* Two consecutive full runs failed **9** and **10** tests — and the sets **shifted** (one file went 3 → 1; `vocabulary` and `ui-bridge` appeared only in the second). A shifting set is load, not a defect.
* Every newly-flagged file passes in isolation: `vocabulary`, `ui-bridge`, `gen-changelog-dedupe`, `tool-surface-filter`, `panel-pin-guard` → **419/420, then 109/109 alone**. `panel-pin-guard` also passes alone on a clean `origin/main` checkout, so it is not this branch.
* Stable across both runs: exactly the **4 known** (`package-hooks` #1597, three `node-id-union-message` #1889).
* The four restart files are green in every run: **76 passed**.
* `tsc --noEmit` clean.

CI on a clean runner is the arbiter here, not this box.
