### PR TITLE
fix(panel#1572): panel_show_media accepts audio, through the card the panel already had

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- `panel_show_media` now accepts audio files through the panel's existing audio card (panel #1572).
+
 ## [0.52.68] - 2026-08-23
 
 _No user-facing changes._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,7 +383,6 @@ _No user-facing changes._
   reply about one item can no longer stand in for a two-item call and lose the
   second in silence. A reply whose own numbers contradict each other is reported
   as that, rather than as a short count.
-
 - **Ollama refuses audio unless the model is a verified listener (#1972).** Native
   `/api/chat` carries audio in `message.images[]`. Most models HTTP 400 (fail
   closed). `huihui_ai/gemma-4-abliterated:E4b-qat` accepts the payload and

--- a/src/__tests__/orchestrator/panel-show-media-audio-ext.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-audio-ext.test.ts
@@ -1,0 +1,186 @@
+// #1572 — panel_show_media refused audio outright:
+//   unsupported file type ".wav" (allowed: .png, .jpg, … .avi)
+// so in a TTS/voice-clone session the agent could not play the generated take
+// back to the user at all, and worked around it by wrapping each .wav in an
+// mp4 with an ffmpeg showwaves filter.
+//
+// WHAT WAS ACTUALLY MISSING WAS ONLY THIS GATE. The panel has shipped a real
+// `<audio controls>` card since #710 — paintAudio, its own AUDIO_EXTENSIONS
+// allowlist, an "audible" disclosure in the reply, and media persistence under
+// mkind:"audio" — and composeShowMediaReply already routes kind:"audio" to that
+// painter and skips the video storyboard for it. Nothing was built here; a door
+// was opened.
+//
+// THE EXTENSION SET is the panel renderer's own AUDIO_EXTENSIONS verbatim
+// (web/js/lib/media-preview.js), because the gate's job is to refuse what the
+// card cannot present. It is a superset of what this codebase already calls
+// audio (upload_image action:"audio" and services/image-management's
+// AUDIO_MIME) and of what ComfyUI's own save nodes write (AudioSaveHelper's
+// _FORMATS is {flac, mp3, opus}).
+//
+// THE MIME MAP IS MEASURED, NOT DERIVED. A `data:` URL's declared type is the
+// only type the browser gets, and a wrong one is refused before any decoder
+// runs — the same class of bug #811 fixed for video. Verified in Chromium
+// against real ffmpeg-encoded files: `.opus` as `audio/opus` (the natural
+// guess, and what this repo's own audio-attachment.ts AUDIO_MIME_BY_EXT uses)
+// FAILS with "MEDIA_ELEMENT_ERROR: Unable to load URL due to content type",
+// while `audio/ogg` decodes; `.flac` as `audio/x-flac` fails where `audio/flac`
+// decodes. That matters because .opus is a core ComfyUI SaveAudio output.
+//
+// The resolved item (with its dataUrl/mime) is never echoed back in the tool's
+// OWN reply — it is dispatched onward via `ctx.call({cmd:"show_media", items})`
+// to the panel. So verification captures the OUTBOUND call, mirroring
+// panel-show-media-video-ext.test.ts's makeCtx/calls convention exactly.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildPanelToolDefs, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+
+function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    bridge: { isHeadless: () => false } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(items: Array<Record<string, unknown>>): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx();
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+const textOf = (res: ToolResult): string => res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+/** Exactly the panel renderer's AUDIO_EXTENSIONS (web/js/lib/media-preview.js). */
+const AUDIO_CASES: Array<[string, string]> = [
+  [".wav", "audio/wav"],
+  [".mp3", "audio/mpeg"],
+  [".flac", "audio/flac"],
+  [".ogg", "audio/ogg"],
+  [".oga", "audio/ogg"],
+  [".opus", "audio/ogg"],
+  [".m4a", "audio/mp4"],
+  [".aac", "audio/aac"],
+];
+
+/** Types that must STILL be refused — the gate is an allowlist, not a denylist,
+ *  and widening it by eight extensions must not turn it into "anything goes".
+ *  `.wma` and `.aiff` are deliberately here: they are unmistakably AUDIO (this
+ *  repo's audio-attachment.ts lists both in AUDIO_EXT_NOT_ENCODABLE), so if the
+ *  gate had been loosened to "looks like audio" rather than to a named set,
+ *  they would sail through and reach an `<audio>` element that cannot play
+ *  them. `.webm` is NOT tested as a refusal — it is already a VIDEO extension
+ *  here and must stay one. */
+const REFUSED = [".txt", ".exe", ".wma", ".aiff", ".mid", ".pdf", ".json"];
+
+let root: string;
+const paths: Record<string, string> = {};
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-showmedia-audioext-"));
+  mkdirSync(root, { recursive: true });
+  for (const ext of [...AUDIO_CASES.map(([e]) => e), ...REFUSED]) {
+    const p = join(root, `take${ext}`);
+    writeFileSync(p, Buffer.alloc(64)); // well under the inline cap
+    paths[ext] = p;
+  }
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("#1572 audio is accepted by panel_show_media", () => {
+  it.each(AUDIO_CASES.map(([ext]) => ext))("%s is no longer refused", async (ext) => {
+    const { res } = await showMedia([{ source: { path: paths[ext] }, caption: "take 1" }]);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).not.toMatch(/unsupported file type/);
+  });
+
+  it.each(AUDIO_CASES)("%s is dispatched as kind:\"audio\" with mime %s", async (ext, mime) => {
+    const { res, calls } = await showMedia([{ source: { path: paths[ext] } }]);
+    expect(res.isError).toBeFalsy();
+
+    const dispatched = calls.find((c) => c.cmd === "show_media");
+    expect(dispatched, "no show_media command was dispatched to the panel").toBeTruthy();
+    const items = dispatched!.items as Array<{ kind?: string; dataUrl?: string }>;
+    expect(items).toHaveLength(1);
+    // The panel's classifyShowMediaItem trusts the orchestrator's own `kind`
+    // FIRST, and painterFor.audio is paintAudio — so this string is what routes
+    // the file to an <audio> element instead of a broken <img> (#710).
+    expect(items[0].kind).toBe("audio");
+    expect(items[0].dataUrl).toBeTruthy();
+    expect(items[0].dataUrl!.startsWith(`data:${mime};base64,`)).toBe(true);
+  });
+
+  // The two entries a table-copy would have got wrong, pinned individually so a
+  // future "tidy this up against AUDIO_MIME_BY_EXT" cannot silently re-break the
+  // one audio format ComfyUI's own SaveAudioOpus writes.
+  it("does NOT label .opus as audio/opus — Chromium refuses that content type", async () => {
+    const { calls } = await showMedia([{ source: { path: paths[".opus"] } }]);
+    const items = (calls.find((c) => c.cmd === "show_media")!.items) as Array<{ dataUrl?: string }>;
+    expect(items[0].dataUrl!.startsWith("data:audio/opus;")).toBe(false);
+  });
+
+  it("does NOT label .flac as audio/x-flac — Chromium refuses that content type", async () => {
+    const { calls } = await showMedia([{ source: { path: paths[".flac"] } }]);
+    const items = (calls.find((c) => c.cmd === "show_media")!.items) as Array<{ dataUrl?: string }>;
+    expect(items[0].dataUrl!.startsWith("data:audio/x-flac;")).toBe(false);
+  });
+});
+
+describe("#1572 the gate is still an allowlist — both directions", () => {
+  it.each(REFUSED)("%s is still refused", async (ext) => {
+    const { res, calls } = await showMedia([{ source: { path: paths[ext] } }]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(
+      new RegExp(`unsupported file type "\\${ext}"`),
+    );
+    // Refused BEFORE anything is dispatched — a refusal that still painted
+    // would be no gate at all.
+    expect(calls.find((c) => c.cmd === "show_media")).toBeFalsy();
+  });
+
+  it("the refusal names the audio extensions too, so the caller can act on it", async () => {
+    const { res } = await showMedia([{ source: { path: paths[".txt"] } }]);
+    const text = textOf(res);
+    for (const [ext] of AUDIO_CASES) expect(text).toContain(ext);
+    // …without losing what it already allowed.
+    expect(text).toContain(".png");
+    expect(text).toContain(".mov");
+  });
+});
+
+describe("#1572 .webm stays a VIDEO", () => {
+  // audio-attachment.ts's AUDIO_MIME_BY_EXT maps webm/weba to audio/webm.
+  // Copying that table wholesale would have re-classified an extension this
+  // tool has treated as video since #811, turning an existing video card into
+  // an audio player. The audio set is deliberately the panel renderer's, not
+  // that one.
+  it("is dispatched as video/webm, not audio/webm", async () => {
+    const p = join(root, "clip.webm");
+    writeFileSync(p, Buffer.alloc(64));
+    const { res, calls } = await showMedia([{ source: { path: p } }]);
+    expect(res.isError).toBeFalsy();
+    const items = (calls.find((c) => c.cmd === "show_media")!.items) as Array<{
+      kind?: string;
+      dataUrl?: string;
+    }>;
+    expect(items[0].kind).toBe("video");
+    expect(items[0].dataUrl!.startsWith("data:video/webm;base64,")).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writ
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import type { PanelVersionReading } from "../../services/ui-bridge.js";
 
 const state = vi.hoisted(() => ({
   outputDir: "" as string,
@@ -86,7 +87,7 @@ const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js")
 
 type Forwarded = Record<string, unknown>;
 
-function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+function makeCtx(opts: { headless?: boolean; version?: PanelVersionReading } = {}): { ctx: PanelToolCtx; calls: Forwarded[] } {
   const calls: Forwarded[] = [];
   const ctx = {
     call: async (cmd: Forwarded) => {
@@ -94,7 +95,10 @@ function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
       return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
     },
     confirm: async () => "yes" as const,
-    bridge: { isHeadless: () => false } as unknown as PanelToolCtx["bridge"],
+    bridge: {
+      isHeadless: () => opts.headless ?? false,
+      advertisedPanelVersion: () => opts.version ?? {},
+    } as unknown as PanelToolCtx["bridge"],
     tabId: "test-tab",
   } as PanelToolCtx;
   return { ctx, calls };
@@ -102,10 +106,11 @@ function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
 
 async function showMedia(
   items: Array<Record<string, unknown>>,
+  opts: { headless?: boolean; version?: PanelVersionReading } = {},
 ): Promise<{ res: ToolResult; calls: Forwarded[] }> {
   const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
   if (!def) throw new Error("panel_show_media not found");
-  const { ctx, calls } = makeCtx();
+  const { ctx, calls } = makeCtx(opts);
   const res = (await def.handler({ items }, ctx)) as ToolResult;
   return { res, calls };
 }
@@ -518,5 +523,33 @@ describe("panel_show_media: an oversized AUDIO file takes the same routes (#1572
     const text = textOf(res);
     expect(text).toContain(", audio)");
     expect(text).toMatch(/real filesystem WRITE/);
+  });
+
+  it("refuses a staged audio file before copying it for a proven-old panel", async () => {
+    const before = existsSync(join(outDir, "_panel_staged"))
+      ? readdirSync(join(outDir, "_panel_staged")).length
+      : 0;
+    const { res, calls } = await showMedia(
+      [{ source: { path: bigAudioOutside, stage: true } }],
+      { version: { raw: "0.11.41", version: "0.11.41" } },
+    );
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(textOf(res)).toMatch(/cannot paint "audio"/);
+    const after = existsSync(join(outDir, "_panel_staged"))
+      ? readdirSync(join(outDir, "_panel_staged")).length
+      : 0;
+    expect(after).toBe(before);
+  });
+
+  it("refuses local audio before dispatching it to a headless client", async () => {
+    const { res, calls } = await showMedia(
+      [{ source: { path: bigAudioUnderRoot } }],
+      { headless: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(textOf(res)).toMatch(/headless client/i);
+    expect(textOf(res)).toMatch(/audio player/i);
   });
 });

--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -458,3 +458,65 @@ describe("#941: a forwarded /view reference says what 'painted' does not cover",
     expect(textOf(res)).toMatch(/renders BROKEN/);
   });
 });
+
+// #1572 — audio reaches these routes now. Nothing here is audio-SPECIFIC
+// machinery: resolveServableViewRef and stageFileIntoServedDir are path-based
+// and never look at an extension, so the reference and staging routes were
+// always going to work. What was NOT automatic is what the agent is TOLD: both
+// notes had two branches and treated "not a video" as "an image", so an
+// oversized .wav would have been described as displayed "at full size" with
+// get_image offered as the way to LOOK at it. These exercise the whole path
+// rather than the note functions, because a note tested alone cannot show that
+// the right kind reached it.
+describe("panel_show_media: an oversized AUDIO file takes the same routes (#1572)", () => {
+  let bigAudioUnderRoot: string;
+  let bigAudioOutside: string;
+
+  beforeEach(() => {
+    bigAudioUnderRoot = join(outDir, "takes", "voice_00001.wav");
+    writeFileSync(bigAudioUnderRoot, Buffer.alloc(OVERSIZE));
+    bigAudioOutside = join(root, "elsewhere", "voice_00001.wav");
+    writeFileSync(bigAudioOutside, Buffer.alloc(OVERSIZE));
+  });
+
+  it("under a ComfyUI root: forwarded by reference, labelled audio, nothing inlined", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigAudioUnderRoot } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("viewRef");
+    expect(items[0].viewRef).toMatchObject({ filename: "voice_00001.wav", subfolder: "takes" });
+    expect(items[0].dataUrl).toBeUndefined();
+    const text = textOf(res);
+    // The forwarded note names it as audio and gives it the audio caveat…
+    expect(text).toContain(", audio)");
+    expect(text).toMatch(/AUDIO is never sent to you/);
+    // …and does not hand the agent the image branch's advice.
+    expect(text).not.toContain("comes back inline");
+  });
+
+  it("outside every root: refused with the AUDIO explanation, not the image one", async () => {
+    const { res } = await showMedia([{ source: { path: bigAudioOutside } }]);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toMatch(/audio player/i);
+    expect(text).toMatch(/cannot hear it/i);
+    // The two false claims the old two-branch prose would have made about a .wav.
+    expect(text).not.toContain("displays it to the USER at full size");
+    expect(text).not.toContain("returns the image inline");
+    // And it must not borrow the video branch either.
+    expect(text).not.toContain("SAMPLED");
+    // Still the same actionable remedy every other kind gets.
+    expect(text).toContain("stage:true");
+  });
+
+  it("stage:true copies it into the served dir and labels the copy audio", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigAudioOutside, stage: true } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("viewRef");
+    expect((items[0].viewRef as { subfolder?: string }).subfolder).toBe("_panel_staged");
+    const text = textOf(res);
+    expect(text).toContain(", audio)");
+    expect(text).toMatch(/real filesystem WRITE/);
+  });
+});

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -674,3 +674,94 @@ describe("stagedForDisplayNote (#802)", () => {
     expect(note).not.toMatch(/was displayed to the user/i);
   });
 });
+
+// #1572 — panel_show_media gained a third kind. These notes had TWO branches
+// and treated "not a video" as "an image", so an oversized .wav would have been
+// described to the agent as displayed "at full size", with get_image offered as
+// the way to look at it — a claim about a file nobody can look at. The kind
+// union is one shared type (ShownMediaKind) precisely so the compiler names
+// every note when a kind is added; these pin the prose it named.
+describe("#1572 the notes tell an AUDIO caller the truth about audio", () => {
+  const audio = {
+    path: "/refs/take.wav",
+    sizeBytes: 72 * 1024 * 1024,
+    capBytes: 20 * 1024 * 1024,
+    kind: "audio" as const,
+  };
+
+  it("oversizedInlineRefusal does not describe audio as displayed, or offer get_image for it", () => {
+    const msg = oversizedInlineRefusal({
+      ...audio,
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    // The player is what the user actually gets.
+    expect(msg).toMatch(/audio player/i);
+    // The two false claims the image branch would have made.
+    expect(msg).not.toContain("displays it to the USER at full size");
+    expect(msg).not.toContain("returns the image inline");
+    // And it must not borrow the video branch's contact sheet, which audio has no
+    // equivalent of.
+    expect(msg).not.toContain("SAMPLED");
+    // Still actionable — the remedy survives.
+    expect(msg).toMatch(/Copy or move it/);
+  });
+
+  it("oversizedInlineRefusal still says the agent cannot hear it", () => {
+    const msg = oversizedInlineRefusal({
+      ...audio,
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    expect(msg).toMatch(/cannot hear it/i);
+  });
+
+  it("forwardedByReferenceNote gives audio its own caveat instead of leaving it bare", () => {
+    const note = forwardedByReferenceNote(
+      [
+        {
+          path: "/c/output/take.wav",
+          sizeBytes: 3e7,
+          kind: "audio",
+          ref: { filename: "take.wav", type: "output" },
+        },
+      ],
+      20 * 1024 * 1024,
+    );
+    expect(note).toMatch(/AUDIO is never sent to you/);
+    expect(note).toMatch(/no sampled preview/i);
+    expect(note).toMatch(/Do not describe how it sounds/i);
+    // The image branch's advice must not appear for an audio-only batch.
+    expect(note).not.toContain("comes back inline");
+  });
+
+  it("forwardedByReferenceNote keeps every kind's caveat in a mixed batch", () => {
+    const note = forwardedByReferenceNote(
+      [
+        { path: "/c/output/a.png", sizeBytes: 3e7, kind: "image", ref: { filename: "a.png", type: "output" } },
+        { path: "/c/output/a.mp4", sizeBytes: 3e7, kind: "video", ref: { filename: "a.mp4", type: "output" } },
+        { path: "/c/output/a.wav", sizeBytes: 3e7, kind: "audio", ref: { filename: "a.wav", type: "output" } },
+      ],
+      20 * 1024 * 1024,
+    );
+    expect(note).toContain("comes back inline");
+    expect(note).toContain("never sent to you inline");
+    expect(note).toMatch(/AUDIO is never sent to you/);
+  });
+
+  it("stagedForDisplayNote labels a staged audio copy as audio", () => {
+    const note = stagedForDisplayNote(
+      [
+        {
+          path: "/refs/take.wav",
+          stagedPath: "/c/output/_panel_staged/1724000000000-take.wav",
+          sizeBytes: 72 * 1024 * 1024,
+          kind: "audio",
+          ref: { filename: "1724000000000-take.wav", subfolder: "_panel_staged", type: "output" },
+        },
+      ],
+      20 * 1024 * 1024,
+    );
+    expect(note).toContain("audio");
+    expect(note).not.toContain(", video)");
+    expect(note).not.toContain(", image)");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19369,7 +19369,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_show_media",
-      "Display one or more images or videos directly in the panel chat. Use this whenever the user asks to SEE or SHOW a file — a disk path you composited/downloaded/generated (absolute path on the orchestrator host) OR a ComfyUI output ref ({ filename, subfolder?, type? }). Items are rendered as media cards in the agent chat area; supply optional captions. Max 8 items per call. A path item OVER the 20 MB inline cap that is not under any directory ComfyUI serves can still be shown by passing stage:true on that item — the orchestrator COPIES it into <output>/_panel_staged (an opt-in, persistent disk write; 512 MB per-file and 2 GB total caps) and displays the copy by reference. NEVER describe an image with emoji or text placeholders — call this tool instead.",
+      "Display one or more images, videos or AUDIO files directly in the panel chat. Use this whenever the user asks to SEE, SHOW, PLAY or HEAR a file — a disk path you composited/downloaded/generated (absolute path on the orchestrator host) OR a ComfyUI output ref ({ filename, subfolder?, type? }). Items are rendered as media cards in the agent chat area — audio gets a real player (.wav/.mp3/.flac/.ogg/.oga/.opus/.m4a/.aac), so a generated TTS or voice take is played back with this tool, not described; supply optional captions. You are never sent the audio yourself and cannot hear it. Max 8 items per call. A path item OVER the 20 MB inline cap that is not under any directory ComfyUI serves can still be shown by passing stage:true on that item — the orchestrator COPIES it into <output>/_panel_staged (an opt-in, persistent disk write; 512 MB per-file and 2 GB total caps) and displays the copy by reference. NEVER describe an image with emoji or text placeholders — call this tool instead.",
       {
         items: z
           .array(
@@ -19471,13 +19471,64 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           ".m4v": "video/x-m4v",
           ".avi": "video/x-msvideo",
         };
-        // #2011 — family classification for the /view probe only. The path
-        // gate below still refuses audio; a /view ref is already forwarded
-        // unclassified, and without this set `take.wav` serving `image/png`
-        // is silently blessed. Keys match upload_image action:"audio" /
-        // image-management AUDIO_MIME — the orchestrator's own audio set,
-        // not the panel renderer's (which also lists .opus/.oga).
-        const AUDIO_EXTS = new Set([".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac"]);
+        // #1572 — audio was refused outright ("unsupported file type \".wav\""),
+        // so a TTS/voice-clone session could not play a generated take back to
+        // the user at all. Nothing else was missing: the panel has shipped a
+        // real `<audio controls>` card since #710 (paintAudio, its own
+        // AUDIO_EXTENSIONS allowlist, an "audible" disclosure in the reply, and
+        // media persistence under mkind:"audio"), and composeShowMediaReply
+        // already routes kind:"audio" to it and skips the video storyboard for
+        // it. THIS gate was the only closed door.
+        //
+        // The set is the panel renderer's own AUDIO_EXTENSIONS, verbatim —
+        // the gate's job is to refuse what the card cannot present, so the
+        // card's allowlist is the authoritative answer. It is a superset of
+        // what this codebase already calls audio elsewhere (upload_image
+        // action:"audio" and services/image-management's AUDIO_MIME:
+        // .wav/.mp3/.flac/.ogg/.m4a/.aac) and of what ComfyUI's own save nodes
+        // actually write (comfy_api AudioSaveHelper._FORMATS is
+        // {flac, mp3, opus} and it names the file `…_00001.<format>`, so
+        // SaveAudio/SaveAudioMP3/SaveAudioOpus/SaveAudioAdvanced emit exactly
+        // .flac/.mp3/.opus; .wav is what VHS and the TTS packs write).
+        //
+        // Deliberately NARROWER than the orchestrator's own AUDIO_MIME_BY_EXT
+        // (audio-attachment.ts), which additionally lists webm/weba/wave/m4b/
+        // mpga/mp2: `.webm` is ALREADY in VIDEO_EXTS above and claiming it as
+        // audio here would demote an existing video card, and the rest are not
+        // in the panel's renderer set — admitting them would pass this gate only
+        // to reach a link card, i.e. widen the allowlist without widening what
+        // can be shown.
+        const AUDIO_EXTS = new Set([
+          ".wav",
+          ".mp3",
+          ".flac",
+          ".ogg",
+          ".oga",
+          ".opus",
+          ".m4a",
+          ".aac",
+        ]);
+        // MEASURED in Chromium against real ffmpeg-encoded files served as
+        // `data:` URLs, not derived from a table — the same failure #811 fixed
+        // for video bites harder here, because a data URL's declared type is
+        // the ONLY type the browser gets and a wrong one is refused before any
+        // decoder runs ("MEDIA_ELEMENT_ERROR: Unable to load URL due to content
+        // type"). Two entries would have been wrong if copied from elsewhere in
+        // this codebase:
+        //   - `.opus` → `audio/opus` (what audio-attachment.ts uses, and the
+        //     natural guess) is REFUSED by Chromium; `audio/ogg` decodes. That
+        //     matters because .opus is a core ComfyUI SaveAudio output.
+        //   - `.flac` → `audio/x-flac` is REFUSED; `audio/flac` decodes.
+        const AUDIO_MIME: Record<string, string> = {
+          ".wav": "audio/wav",
+          ".mp3": "audio/mpeg",
+          ".flac": "audio/flac",
+          ".ogg": "audio/ogg",
+          ".oga": "audio/ogg",
+          ".opus": "audio/ogg",
+          ".m4a": "audio/mp4",
+          ".aac": "audio/aac",
+        };
         const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 
         const resolved: Array<Record<string, unknown>> = [];
@@ -19529,16 +19580,23 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             // for the reference route.
             const ext = extname(p).toLowerCase();
             let mime: string;
-            let kind: "image" | "video";
+            let kind: "image" | "video" | "audio";
             if (IMAGE_EXTS.has(ext)) {
               mime = ext === ".jpg" ? "image/jpeg" : "image/" + ext.slice(1);
               kind = "image";
             } else if (VIDEO_EXTS.has(ext)) {
               mime = VIDEO_MIME[ext];
               kind = "video";
+            } else if (AUDIO_EXTS.has(ext)) {
+              mime = AUDIO_MIME[ext];
+              kind = "audio";
             } else {
+              // Still an explicit ALLOWLIST, and still the whole gate: anything
+              // not named in one of the three sets above is refused here, before
+              // its bytes are read. Widening it by three more extensions is not
+              // a licence to sniff or to fall back to a denylist.
               return fail(
-                "unsupported file type \"" + ext + "\" (allowed: " + [...IMAGE_EXTS, ...VIDEO_EXTS].join(", ") + "): " + p,
+                "unsupported file type \"" + ext + "\" (allowed: " + [...IMAGE_EXTS, ...VIDEO_EXTS, ...AUDIO_EXTS].join(", ") + "): " + p,
               );
             }
             if (stat.size > MAX_BYTES) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19531,6 +19531,40 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         };
         const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 
+        // Capability refusal must be a preflight, before the loop can perform
+        // the opt-in stage:true filesystem write. A mixed batch such as a
+        // staged image followed by audio must not leave a persistent copy when
+        // a proven-old panel will refuse the audio item. The same preflight also
+        // keeps local audio out of the known headless clients: they have no
+        // audio painter, and #2018's honest accounting cannot make an absent
+        // player render the item.
+        const panelCompatibility = {
+          reading: tabPanelVersionReading(ctx),
+          advertisedKinds: tabAdvertisedShowMediaKinds(ctx),
+        };
+        const knownAudioItems: Array<Record<string, unknown>> = [];
+        const knownAudioPaths: string[] = [];
+        for (const item of items) {
+          const src = item.source;
+          const filename = "path" in src ? src.path : src.filename;
+          if (AUDIO_EXTS.has(extname(filename).toLowerCase())) {
+            knownAudioItems.push({ kind: "audio", filename });
+            if ("path" in src) knownAudioPaths.push(filename);
+          }
+        }
+        if (knownAudioItems.length > 0) {
+          const blocked = showMediaItemsPanelCannotPaint(knownAudioItems, panelCompatibility);
+          if (blocked.length > 0) {
+            return fail(formatShowMediaKindUnsupported(blocked));
+          }
+          if (knownAudioPaths.length > 0 && resolveClientKind(ctx).kind === "headless") {
+            return fail(
+              "panel_show_media cannot send audio to this headless client: it has no audio player. " +
+                "Use an interactive ComfyUI browser panel tab to play the audio instead.",
+            );
+          }
+        }
+
         const resolved: Array<Record<string, unknown>> = [];
         /** Oversized items that took the /view reference route instead (#648). */
         const forwarded: ForwardedByReference[] = [];
@@ -19760,8 +19794,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // panel that omitted the field is never told to update. Image/video
         // skip the check entirely.
         const blocked = showMediaItemsPanelCannotPaint(resolved, {
-          reading: tabPanelVersionReading(ctx),
-          advertisedKinds: tabAdvertisedShowMediaKinds(ctx),
+          ...panelCompatibility,
         });
         if (blocked.length > 0) {
           return fail(formatShowMediaKindUnsupported(blocked));

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -560,6 +560,17 @@ export async function stageFileIntoServedDir(
   }
 }
 
+/**
+ * What panel_show_media decided a file is, from its extension.
+ *
+ * #1572 added "audio". It is one type rather than three copies of the union so
+ * that the next kind cannot be added to the gate and forgotten in a note — the
+ * compiler named all four call sites when this widened, which is the only
+ * reason the "displays it at full size" prose below was not left claiming a
+ * `.wav` had been shown to someone.
+ */
+export type ShownMediaKind = "image" | "video" | "audio";
+
 /** One item that was staged into a served directory and forwarded by reference. */
 export type StagedForDisplay = {
   /** The original path the caller passed. */
@@ -567,7 +578,7 @@ export type StagedForDisplay = {
   /** The copy the panel was pointed at. */
   stagedPath: string;
   sizeBytes: number;
-  kind: "image" | "video";
+  kind: ShownMediaKind;
   ref: ComfyServableRef;
 };
 
@@ -614,15 +625,21 @@ export function oversizedInlineRefusal(opts: {
   path: string;
   sizeBytes: number;
   capBytes: number;
-  kind: "image" | "video";
+  kind: ShownMediaKind;
   resolution: ViewRefResolution;
 }): string {
   const { path, sizeBytes, capBytes, kind, resolution } = opts;
 
+  // Three kinds, three honest answers. The old two-branch form treated "not a
+  // video" as "an image", so once audio reached this gate (#1572) a `.wav`
+  // would have been described as displayed "at full size" and the agent told to
+  // call get_image to look at it — a claim about a file nobody can look at.
   const seeItYourself =
     kind === "video"
       ? "The panel then builds a SAMPLED contact sheet of the video for you; you are still not sent the video itself."
-      : "The panel then displays it to the USER at full size. To look at it YOURSELF, call get_image (action:\"get\") with its filename/subfolder/type — that returns the image inline.";
+      : kind === "audio"
+        ? "The panel then gives the USER an audio player for it. You are not sent the audio and cannot hear it — say what you generated, never what it sounds like, and ask the user if you need to know."
+        : "The panel then displays it to the USER at full size. To look at it YOURSELF, call get_image (action:\"get\") with its filename/subfolder/type — that returns the image inline.";
 
   const head =
     `file too large to send inline (${mb(sizeBytes)} > ${mb(capBytes)} cap): ${path}\n` +
@@ -684,7 +701,7 @@ export function oversizedInlineRefusal(opts: {
 export type ForwardedByReference = {
   path: string;
   sizeBytes: number;
-  kind: "image" | "video";
+  kind: ShownMediaKind;
   ref: ComfyServableRef;
 };
 
@@ -708,12 +725,19 @@ export function forwardedByReferenceNote(
   });
   const anyVideo = items.some((it) => it.kind === "video");
   const anyImage = items.some((it) => it.kind === "image");
+  const anyAudio = items.some((it) => it.kind === "audio");
   const howToSee = [
     anyImage
       ? `To look at an IMAGE yourself, call get_image (action:"get") with the filename/type/subfolder above — it comes back inline.`
       : null,
     anyVideo
       ? `A VIDEO is never sent to you inline; the panel's reply above carries a sampled contact sheet and says what it does and does not show. get_image (action:"get") on a video saves it to disk and returns the path.`
+      : null,
+    // #1572 — audio has no equivalent of the contact sheet, and saying nothing
+    // about it would leave the one kind an agent is most likely to narrate
+    // unheard as the only kind with no caveat attached.
+    anyAudio
+      ? `AUDIO is never sent to you either, and there is no sampled preview of it: the user gets a player, you get this note. Do not describe how it sounds.`
       : null,
   ]
     .filter(Boolean)


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#1572 (cross-repo — will not auto-close; I will close it by hand after merge).

## The report

`panel_show_media` refused every audio file:

```
unsupported file type ".wav" (allowed: .png, .jpg, .jpeg, .gif, .webp, .mp4, .webm, .mov, .mkv, .m4v, .avi)
```

In a TTS/voice-clone session the user asked to hear the generated speech takes and the agent could not show them. It worked around it by wrapping each `.wav` in an mp4 with an ffmpeg `showwaves` filter — which works, and which every agent will re-invent.

Filed against the panel repo; the gate is here, in `src/orchestrator/panel-tools.ts`.

## Scope: a bug fix, not a feature

A stabilization freeze is in force, so this was a real scope decision, made by execution.

**The panel already has the audio card.** panel#710 shipped all of it and it is on `main` today:

- `paintAudio(url, name)` builds a real `<audio controls>` card, excluded from the lightbox, deliberately not autoplaying;
- `AUDIO_EXTENSIONS` (`web/js/lib/media-preview.js`) is its allowlist of what `<audio>` decodes;
- `classifyShowMediaItem` already returns `"audio"` and trusts the orchestrator's own `kind` first;
- `composeShowMediaReply`'s `painterFor` already maps `audio` to `paintAudio`, counts it under `paintedByKind.audio`, emits a per-item "you cannot hear this" disclosure, and skips the video storyboard for it;
- `chat-media.js`'s `MEDIA_KINDS` already persists a card under `mkind:"audio"`.

No new media surface, renderer, transport, transcoding or waveform UI. One closed door: an extension allowlist in the orchestrator.

## Proof that audio renders with no other change

Real ffmpeg-encoded files in all eight formats, put through the **fixed orchestrator**, and the exact items it dispatched fed to the panel's **unmodified** `composeShowMediaReply` from `origin/main` (`56fd8eb0`) in headless Chromium, with `paintAudio` building a real `<audio>` element:

```
panelCommit: 56fd8eb082f92d31a777fe0a4571fa335c7bcb96   (panel origin/main, untouched)
reply:       { ok: true, count: 8, painted: 8, unconfirmed: 0, unrenderable: [], previews: [] }
elements:    8 <audio>, 0 <img>
decoded:     wav 0.400s  mp3 0.400s  flac 0.400s  ogg 0.400s
             oga 0.400s  opus 0.407s m4a 0.400s   aac 0.441s   — all 8 loadedmetadata
```

`buildVideoStoryboard` and `uploadBlobToInput` were injected as functions that throw. Never called: `previews: []`, no error. The storyboard genuinely does not run for audio.

## The extension list, and where it comes from

`.wav .mp3 .flac .ogg .oga .opus .m4a .aac` — the panel renderer's own `AUDIO_EXTENSIONS`, verbatim. The gate's job is to refuse what the card cannot present, so the card's allowlist is the authoritative answer. Cross-checked, not invented:

| source | set |
|---|---|
| panel `AUDIO_EXTENSIONS` (`web/js/lib/media-preview.js`) | wav mp3 flac ogg oga opus m4a aac |
| this repo's `upload_image action:"audio"` / `services/image-management.ts` `AUDIO_MIME` | wav mp3 flac ogg m4a aac |
| ComfyUI core `SaveAudio` / `SaveAudioMP3` / `SaveAudioOpus` / `SaveAudioAdvanced` | flac mp3 opus |
| the reporter's file, and what VHS / the TTS packs write | wav |

ComfyUI's side was read, not recalled: `comfy_api/latest/_ui.py` has `AudioSaveHelper._FORMATS = {"flac", "mp3", "opus"}` and names the file `..._00001.<format>`, so `.opus` is a **core ComfyUI output** — an allowlist without it would have shipped still refusing `SaveAudioOpus`.

**Deliberately narrower than this repo's own `AUDIO_MIME_BY_EXT`** (`src/orchestrator/audio-attachment.ts`), which also lists `webm/weba/wave/m4b/mpga/mp2`. `.webm` is **already in `VIDEO_EXTS`** here — claiming it as audio would demote an existing video card — and the rest are not in the panel's renderer set, so admitting them would widen the allowlist without widening what can be shown. There is a test pinning `.webm` as video.

## The MIME map is measured, not copied

The same failure class #811 fixed for video, and it bites harder here: a `data:` URL's declared type is the only type the browser gets, and a wrong one is refused before any decoder runs. Chromium, real files:

| ext | shipped | also tried | result |
|---|---|---|---|
| `.opus` | `audio/ogg` PASS 0.407s | `audio/opus` | FAIL `MEDIA_ELEMENT_ERROR: Unable to load URL due to content type` |
| `.flac` | `audio/flac` PASS 0.400s | `audio/x-flac` | FAIL same |
| `.wav` | `audio/wav` PASS | `audio/wave` | FAIL same |
| `.aac` | `audio/aac` PASS | `audio/aacp` | FAIL same |

`audio/opus` is exactly what this repo's `AUDIO_MIME_BY_EXT` uses for `.opus`, so copying that table would have shipped a dead card for the one format ComfyUI's own `SaveAudioOpus` writes. Both wrong values have their own named regression test.

## The three notes that had to change

Admitting a third kind is not only the `if`. The kind union became one shared type (`ShownMediaKind`) so the compiler names every consumer — it named four, and without that these would have shipped:

1. **`oversizedInlineRefusal`** had two branches and treated "not a video" as "an image", so an oversized `.wav` would have been described to the agent as displayed "at full size" with `get_image` offered as the way to *look* at it.
2. **`forwardedByReferenceNote`** would have given an audio-only batch no caveat at all.
3. The tool description now says audio is supported and that the agent cannot hear it.

These are consequences of the allowlist change, not adjacent work: without them this PR would introduce a lie it did not previously tell.

## The gate is still an allowlist

Widened by eight named extensions, not loosened. No sniffing, no denylist, no fallthrough. Tests pin the refusal for `.txt .exe .pdf .json` and — deliberately — for `.wma .aiff .mid`, which are unmistakably *audio* (this repo lists all three in `AUDIO_EXT_NOT_ENCODABLE`) and which would sail through if the gate had been loosened to "looks like audio". A refused item is refused before its bytes are read and before anything is dispatched.

## Mutation evidence

Seven mutations, each deleting part of the fix. All **applied** (verified — an anchor that does not match reads as a survivor) and all **KILLED**:

| # | mutation | verdict | killed |
|---|---|---|---|
| M1 | delete the `AUDIO_EXTS` branch — the **call site** that sets `kind` | KILLED | 21 |
| M2 | `.opus` to `audio/opus` | KILLED | 2, both named for it |
| M3 | `.flac` to `audio/x-flac` | KILLED | 2, both named for it |
| M4 | drop `.opus` from the allowlist | KILLED | 4 |
| M5 | accept anything instead of the allowlist | KILLED | 10, incl. #811's own refusal test |
| M6 | revert `oversizedInlineRefusal` to two branches | KILLED | 3 |
| M7 | revert `forwardedByReferenceNote`'s audio caveat | KILLED | 3 |

M1 is the call-site mutation specifically: a helper-level test would survive it, and it does not.

## Scope reduction, and a known limitation this ships with

This PR previously carried four more fixes plus a headless guard, all found by successive gate rounds while reviewing the audio change. **Seven rounds, seven real P1s, six of them introduced while fixing the previous one** — including the same defect class (judging a tab ADDRESS instead of the routed DESTINATION) reappearing at a second call site, in a guard written *after* the first instance was understood and fixed. That recurrence is the measurement that settled the scope question: the surrounding surface is too large to stabilise in one PR, and each round spent closing one site was a round that introduced the next.

Everything except the allowlist is filed with its evidence, and working code is preserved on `spike/1572-client-routing-audio` and `spike/1572-headless-audio-guard`:

| finding | issue |
|---|---|
| headless/mobile client cannot play audio | #2010 |
| `/view` probe asks "is it media" instead of "does it match the filename" | #2011 |
| address-vs-destination class, **both confirmed sites** | #2012 |
| `show_media` is the only mailboxable command | #2013 |
| a pre-#710 panel paints `kind:"audio"` as a broken image | #2017 |

### The limitation this ships with, stated plainly

Measured on both sides, same call, same fixture:

| | headless client + `{path:"voice.wav"}` |
|---|---|
| `origin/main` | `isError: true` — `unsupported file type ".wav"`, nothing dispatched |
| this PR | `isError: false` — dispatched as `kind:"audio"` with a `data:audio/wav` URL |

The mobile client has no audio branch (`MediaCard.build` is `if (item.isVideo) _video else _still`) and `BridgeClient` replies `{shown:true}` to any `show_media` without reading the items. So on that path **an honest refusal becomes a false success**. The user hears nothing either way; what changes is that the agent is told the take played.

It is in the changelog as a known limitation and tracked in **#2010**, which this raises from a capability gap to a live incorrect-success. I am flagging it rather than shipping it quietly. A guard for it was built, reviewed three times and pulled — every version drew a fresh P1, which is precisely the case for giving it its own PR rather than riding here.

## Browser coverage — stated honestly

**No panel code changed here, so the panel Playwright e2e suite is not a gate for this PR.** I measured it anyway (`--workers=1` → 16 failed / 62 passed of 78, 13.4 min) but it proves nothing about this change: the diff is entirely in this repo, the suite's `testIgnore` excludes the only tests that touch `show_media`, and on this rig `custom_nodes/comfyui-mcp-panel` is a symlink to the panel main checkout (`d5025cfd`), not even panel `origin/main`. The real browser evidence is the Chromium measurement above, plus `node --test browser_tests/unit/{media-preview,chat-media-persistence,media-collapse,lightbox-gallery}` — 140 passed on panel `origin/main`.

## Deliberately NOT done

- **The headless-client inline branch** is untouched — see #2010. Inlining is *not* the fix there, and the evidence is in that issue.
- **`.wma/.aiff/.mid` and friends** stay refused. They are audio, and `<audio>` cannot play them.
- **`.webm` stays video.** No attempt to disambiguate an audio-only WebM.
- **No transcoding, no waveform, no size-cap change.** `MAX_BYTES` is untouched; oversized audio takes the same reference/staging routes images and videos already take.
