### PR TITLE
fix(1999): a drained ComfyUI-Manager queue is not a completed one — report what the task actually did

### DIFF
--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -89,6 +89,7 @@ const {
   queueUpdateAllCustomNodes,
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
+  fetchManagerTaskHistoryEntry,
 } = await import("../../services/node-management.js");
 const {
   resetManagerApiCache,
@@ -426,6 +427,74 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // … and the queue is started (drained) exactly once, on the live prefix.
     expect(countOf(calls, "/manager/queue/start")).toBe(1);
     expect(countOf(calls, "/v2/manager/queue/start")).toBe(0);
+  });
+
+  // #1999 — the single-pack update must HAND BACK the ui_id it enqueued under.
+  // Without it a drained v4 queue can never be correlated to what our task did:
+  // `/v2/manager/queue/history?ui_id=` is keyed on exactly this value, and the
+  // queue-wide counters read identically for a task that succeeded and one that
+  // errored. This asserts the CALL SITE (updateCustomNodeImpl passing the id
+  // out), not just that the tracked helper exists.
+  it("a single-pack update returns the ui_id it actually enqueued under (#1999)", async () => {
+    const calls = stubServer({ persona: () => "v4" });
+
+    const res = await updateCustomNode({ id: "comfyui-foo" });
+
+    const enqueue = calls.find((c) => c.path === "/v2/manager/queue/task");
+    const sentUiId = (enqueue?.body as { ui_id?: string } | undefined)?.ui_id;
+    expect(sentUiId).toBeTruthy();
+    // The id on the result is the id the Manager was actually given.
+    expect(res.taskUiId).toBe(sentUiId);
+  });
+
+  // The bulk path deliberately does NOT expose one: v4 derives a separate
+  // per-pack task id there, so handing the bare enqueue id to a history lookup
+  // would answer "no such task" about tasks that really ran.
+  it("update-all does NOT claim a correlatable ui_id (#1999)", async () => {
+    stubServer({ persona: () => "v4" });
+    const res = await updateCustomNode({ id: "all" });
+    expect(res.taskUiId).toBeUndefined();
+  });
+
+  // #1999 — the per-task record's STRUCTURED verdict must survive the read.
+  // `result` is free prose; `status.status_str` is Manager's own OperationResult
+  // enum and is the field the classifier decides on, so dropping it would leave
+  // every real failure looking like an unreadable answer. The payload below is
+  // byte-for-byte what a live ComfyUI-Manager 4.2.2 returned for a failing
+  // pack update on this rig.
+  it("reads status.status_str out of the v4 per-task history record (#1999)", async () => {
+    const HISTORY = {
+      history: {
+        ui_id: "task-abc",
+        client_id: "comfyui-mcp",
+        kind: "update",
+        result: "An error occurred while updating 'mcp1999-repro'.",
+        status: {
+          status_str: "error",
+          completed: true,
+          messages: ["An error occurred while updating 'mcp1999-repro'."],
+        },
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string): Promise<Response> => {
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
+        if (path === "/v2/manager/is_legacy_manager_ui") {
+          return jsonResponse({ is_legacy_manager_ui: false });
+        }
+        if (path === "/v2/manager/queue/history") return jsonResponse(HISTORY);
+        return new Response("", { status: 200 });
+      }),
+    );
+
+    await expect(fetchManagerTaskHistoryEntry("task-abc", BASE)).resolves.toEqual({
+      uiId: "task-abc",
+      kind: "update",
+      result: "An error occurred while updating 'mcp1999-repro'.",
+      statusStr: "error",
+    });
   });
 
   it("keeps a dialect self-heal retry and drain on its original target after retarget", async () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -3186,6 +3186,17 @@ describe("#1999 drained Manager queue: report what was observed", () => {
       );
     });
 
+    it("clamps a runaway Manager result, and SAYS it clamped it", () => {
+      // An unhandled Manager exception puts a full Python repr in `result` — one
+      // measured on the rig ran to several hundred characters of
+      // QueueTaskItem(...). Quoting it whole buries the diagnostic; truncating
+      // it silently is its own small dishonesty.
+      const huge = "E".repeat(900);
+      const text = describeManagerTaskVerdict({ kind: "failed", result: huge }, counts, false);
+      expect(text.length).toBeLessThan(huge.length);
+      expect(text).toMatch(/truncated — the full text is in the ComfyUI server log/);
+    });
+
     it("a failure quotes the Manager's own result and never claims success", () => {
       const text = describeManagerTaskVerdict(
         { kind: "failed", result: "An error occurred while updating 'comfyui-mcp-panel'." },

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -3315,6 +3315,46 @@ describe("#1999 drained Manager queue: report what was observed", () => {
     expect(String(err?.message ?? err)).not.toMatch(/RAN the task and it FAILED/);
   });
 
+  // The branches above all leave through the #724/#824 git fallback (the panel
+  // dir is a checkout). A registry-ZIP install has no `previousRev`, so it
+  // leaves through finalizeUpdate instead — a SEPARATE narrator that made the
+  // same false claim, and would keep making it if only the fallback were fixed.
+  it("registry-ZIP install (no git): finalizeUpdate names the real failure too", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      // No `revs` entry → no git-HEAD → not a checkout → no fallback to take.
+      updateDetails: V4_DRAINED,
+      managerTaskRecord: FAILED_RECORD,
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/did NOT apply/);
+    expect(msg).toMatch(/RAN the task and it FAILED/);
+    expect(msg).toMatch(/An error occurred while updating 'comfyui-mcp-panel'\./);
+    // The remedy follows the evidence: fix what Manager reported, not "your
+    // ComfyUI-Manager is stale" — the advice this issue was handed four times.
+    expect(msg).toMatch(/traceback is in the ComfyUI server log/);
+    expect(msg).not.toMatch(/never actually enqueued/);
+    expect(msg).not.toMatch(/stale ComfyUI-Manager 3\.x silent no-op/);
+  });
+
+  it("registry-ZIP install with NO readable record: finalizeUpdate says UNKNOWN", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      updateDetails: V4_DRAINED,
+      managerTaskRecord: undefined,
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/could NOT be established/);
+    expect(msg).toMatch(/queue\/history\?ui_id=/);
+    expect(msg).not.toMatch(/RAN the task and it FAILED/);
+    expect(msg).not.toMatch(/never actually enqueued/);
+  });
+
   it("a PROVEN update still succeeds — the lookup never vetoes disk evidence", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -43,6 +43,8 @@ import {
   looksLikePanelBackupName,
   readQueueCounts,
   isProvenQuiescentQueue,
+  classifyManagerTaskRecord,
+  describeManagerTaskVerdict,
   PanelInstallError,
   PANEL_REGISTRY_ID,
   PANEL_VERSION,
@@ -50,6 +52,7 @@ import {
   type PanelInstallerDeps,
 } from "../../services/panel-installer.js";
 import type { PanelPinState } from "../../services/panel-settings.js";
+import type { ManagerTaskHistoryEntry } from "../../services/node-management.js";
 
 const COMFY = "/fake/comfy";
 const CUSTOM_NODES = join(COMFY, "custom_nodes");
@@ -67,6 +70,8 @@ interface Harness {
   gitPulls: string[];
   /** Live call counts for the stubs that answer in sequence. */
   counters: { liveQueueProbes: number };
+  /** #1999 — every ui_id the per-task history lookup was asked about. */
+  taskRecordLookups: string[];
 }
 
 function makeDeps(opts: {
@@ -83,6 +88,20 @@ function makeDeps(opts: {
   pin?: PanelPinState;
   /** Raw ComfyUI-Manager queue status the `update` mock returns as details. */
   updateDetails?: unknown;
+  /**
+   * #1999 — the `ui_id` the `update` mock reports its Manager task was enqueued
+   * under. Defaults to a fixed id so the correlated lookup is exercised;
+   * `null` models a path that could not capture one at all.
+   */
+  updateTaskUiId?: string | null;
+  /**
+   * #1999 — what the Manager's per-task history answers for that ui_id.
+   * `undefined` (the default) is "could not be trusted / pre-v4"; `null` is the
+   * Manager PROVING no such completed task exists.
+   */
+  managerTaskRecord?: ManagerTaskHistoryEntry | null;
+  /** #1999 — make the per-task lookup THROW, to prove it is contained. */
+  managerTaskRecordThrows?: string;
   /** Queue status the `install`/`reinstall` mocks return as details. */
   installDetails?: unknown;
   reinstallDetails?: unknown;
@@ -163,6 +182,7 @@ function makeDeps(opts: {
   // Call counters the sequenced stubs above index into, and that #824 cases
   // assert on (the live re-probe must actually have been taken).
   const counters: Harness["counters"] = { liveQueueProbes: 0 };
+  const taskRecordLookups: Harness["taskRecordLookups"] = [];
   let statusCalls = 0;
 
   const deps: PanelInstallerDeps = {
@@ -186,6 +206,11 @@ function makeDeps(opts: {
       return statusCalls < (opts.gitStatusSeq?.length ?? 0)
         ? (opts.gitStatusSeq as string[])[statusCalls++]
         : ((statusCalls++, opts.gitStatus) ?? "");
+    },
+    fetchManagerTaskRecord: async (uiId: string) => {
+      taskRecordLookups.push(uiId);
+      if (opts.managerTaskRecordThrows) throw new Error(opts.managerTaskRecordThrows);
+      return opts.managerTaskRecord;
     },
     fetchLiveQueueCounts: async () => {
       const i = counters.liveQueueProbes++;
@@ -234,6 +259,8 @@ function makeDeps(opts: {
         mechanism: "manager-http",
         message: "updated",
         details: opts.updateDetails,
+        taskUiId:
+          opts.updateTaskUiId === null ? undefined : (opts.updateTaskUiId ?? "task-1999"),
       };
     },
     reinstall: async (o) => {
@@ -242,7 +269,7 @@ function makeDeps(opts: {
       return { mechanism: "manager-http", message: "reinstalled", details: opts.reinstallDetails };
     },
   };
-  return { deps, installs, updates, reinstalls, gitPulls, counters };
+  return { deps, installs, updates, reinstalls, gitPulls, counters, taskRecordLookups };
 }
 
 beforeEach(() => {
@@ -846,9 +873,14 @@ describe("runPanelAction", () => {
       files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
       reinstallDetails: { total_count: 0, done_count: 2, is_processing: false },
     });
-    await expect(runPanelAction("reinstall", h.deps)).rejects.toThrow(
-      /did NOT execute|stale ComfyUI-Manager/,
+    // #1999 — it must still fail closed, and it must NOT assert the stale-3.x
+    // cause: `total_count:0` is what an idle ComfyUI-Manager v4 always reports.
+    const err = await runPanelAction("reinstall", h.deps).then(
+      () => undefined,
+      (e: unknown) => e as Error,
     );
+    expect(String(err?.message ?? err)).toMatch(/did NOT change the pack on disk/);
+    expect(String(err?.message ?? err)).not.toMatch(/stale ComfyUI-Manager 3\.x silent no-op/);
   });
 
   it("#639: install on a PRE-EXISTING panel + stale no-op counts → throws (present ≠ executed)", async () => {
@@ -859,9 +891,13 @@ describe("runPanelAction", () => {
       files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
       installDetails: { total_count: 0, done_count: 2, is_processing: false },
     });
-    await expect(runPanelAction("install", h.deps)).rejects.toThrow(
-      /did NOT execute|stale ComfyUI-Manager/,
+    // #1999 — same: fail closed, but do not name a cause the counters cannot show.
+    const err = await runPanelAction("install", h.deps).then(
+      () => undefined,
+      (e: unknown) => e as Error,
     );
+    expect(String(err?.message ?? err)).toMatch(/did NOT change the pack on disk/);
+    expect(String(err?.message ?? err)).not.toMatch(/stale ComfyUI-Manager 3\.x silent no-op/);
   });
 
   it("#639: reinstall that ACTUALLY moves the version SUCCEEDS despite stale queue-wide counts", async () => {
@@ -1074,7 +1110,10 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(r.restartRequired).toBe(false);
     expect(r.message).toMatch(/already at the upstream tip/);
     // The cause named must be the incoherent counts, never the unproven stale-3.x no-op.
-    expect(r.message).toMatch(/incoherent/);
+    // #1999 — the counters are reported as the queue-WIDE drain counters they
+    // are, not as a contradiction: on ComfyUI-Manager v4 `done > total` is the
+    // ordinary drained state (total_count is live-only, done_count cumulative).
+    expect(r.message).toMatch(/cannot say what this task did/);
     expect(r.message).not.toMatch(/stale legacy 3\.x/);
     expect(r.result.message).toBe(r.message);
   });
@@ -1100,7 +1139,10 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(r.installedVersion).toBe("0.11.35");
     expect(r.restartRequired).toBe(true);
     expect(r.message).toMatch(/git merge --ff-only/);
-    expect(r.message).toMatch(/incoherent/);
+    // #1999 — the counters are reported as the queue-WIDE drain counters they
+    // are, not as a contradiction: on ComfyUI-Manager v4 `done > total` is the
+    // ordinary drained state (total_count is live-only, done_count cumulative).
+    expect(r.message).toMatch(/cannot say what this task did/);
     expect(r.message).not.toMatch(/stale legacy 3\.x/);
   });
 
@@ -1186,7 +1228,7 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(err).toBeInstanceOf(PanelInstallError);
     expect(String(err?.message ?? err)).toMatch(/UNCOMMITTED|dirty checkout/);
     // The refusal must not assert the stale-3.x cause it cannot prove.
-    expect(String(err?.message ?? err)).toMatch(/incoherent/);
+    expect(String(err?.message ?? err)).toMatch(/cannot say what this task did/);
     expect(String(err?.message ?? err)).not.toMatch(/stale legacy 3\.x/);
     expect(h.gitPulls).toEqual([]);
   });
@@ -3043,5 +3085,251 @@ describe("resolveGitRevision (real fs)", () => {
     mkdirSync(join(root, ".git", "refs", "heads"), { recursive: true });
     writeFileSync(join(root, ".git", "refs", "heads", "main"), "deadbee\n"); // 7 hex
     expect(resolveGitRevision(root)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1999 — a DRAINED queue is not a COMPLETED one, and on ComfyUI-Manager v4 the
+// counters cannot tell the two apart.
+//
+// Every payload below is the shape a live ComfyUI-Manager 4.2.2 actually
+// produced when driven on the rig (see the block comment in panel-installer.ts):
+// an idle v4 answers `total_count:0` with a `done_count` that is the CUMULATIVE
+// session history length, so `{total:0, done:4}` is the ordinary drained state
+// and reads identically whether the tasks succeeded or failed. The four
+// `error`s and one `success` recorded in that same session were distinguishable
+// ONLY through the per-task history route.
+// ---------------------------------------------------------------------------
+describe("#1999 drained Manager queue: report what was observed", () => {
+  const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+  const pyPath = join(dir, "pyproject.toml");
+  const REV_A = "a".repeat(40);
+  /** The reporter's exact wire payload, captured from a live v4.2.2 host. */
+  const V4_DRAINED = {
+    total_count: 0,
+    done_count: 4,
+    in_progress_count: 0,
+    pending_count: 0,
+    is_processing: false,
+  };
+  /** The per-task record a live v4.2.2 returned for a failing pack update. */
+  const FAILED_RECORD = {
+    uiId: "task-1999",
+    kind: "update",
+    result: "An error occurred while updating 'comfyui-mcp-panel'.",
+    statusStr: "error",
+  };
+
+  describe("classifyManagerTaskRecord", () => {
+    it("a structured error status is a FAILURE, and carries the cause", () => {
+      expect(classifyManagerTaskRecord(FAILED_RECORD)).toEqual({
+        kind: "failed",
+        result: "An error occurred while updating 'comfyui-mcp-panel'.",
+      });
+      expect(
+        classifyManagerTaskRecord({ uiId: "x", statusStr: "failed", result: "boom" }),
+      ).toEqual({ kind: "failed", result: "boom" });
+    });
+
+    it("a structured success/skip status is a SUCCESS", () => {
+      expect(
+        classifyManagerTaskRecord({ uiId: "x", statusStr: "success", result: "success" }),
+      ).toEqual({ kind: "succeeded", result: "success" });
+      expect(classifyManagerTaskRecord({ uiId: "x", statusStr: "skip" })).toEqual({
+        kind: "succeeded",
+        result: "skip",
+      });
+    });
+
+    it("`null` (Manager proved no such completed task) is NEVER-RAN", () => {
+      expect(classifyManagerTaskRecord(null)).toEqual({ kind: "never-ran" });
+    });
+
+    it("`undefined` (pre-v4 / untrustworthy answer) is UNKNOWN, not a failure", () => {
+      expect(classifyManagerTaskRecord(undefined)).toEqual({ kind: "unknown" });
+    });
+
+    it("ASYMMETRY: unrecognised prose is UNKNOWN, never inferred as a failure", () => {
+      // No structured status, and a `result` that is not one of Manager's two
+      // literal success values. Guessing "failed" here would be the mirror
+      // image of the fabricated-success bug.
+      expect(
+        classifyManagerTaskRecord({ uiId: "x", result: "Installation reserved: pack" }),
+      ).toEqual({ kind: "unknown" });
+      expect(classifyManagerTaskRecord({ uiId: "x", statusStr: "weird" })).toEqual({
+        kind: "unknown",
+      });
+      // …but the two literals task_worker itself compares against still count.
+      expect(classifyManagerTaskRecord({ uiId: "x", result: "success" })).toEqual({
+        kind: "succeeded",
+        result: "success",
+      });
+    });
+  });
+
+  describe("describeManagerTaskVerdict", () => {
+    const counts = { total: 0, done: 4, inProgress: 0, pending: 0 };
+
+    it("v4 drained counts are NOT narrated as incoherent or as a stale-3.x no-op", () => {
+      const text = describeManagerTaskVerdict({ kind: "unknown" }, counts, false);
+      expect(text).not.toMatch(/incoherent/);
+      expect(text).not.toMatch(/never enqueued/);
+      expect(text).not.toMatch(/stale legacy ComfyUI-Manager 3\.x/);
+      expect(text).toMatch(/could NOT be established/);
+      expect(text).toMatch(/queue\/history\?ui_id=/);
+    });
+
+    it("an all-zero counter set may still OFFER the legacy-3.x cause", () => {
+      const zero = { total: 0, done: 0, inProgress: 0, pending: 0 };
+      expect(describeManagerTaskVerdict({ kind: "unknown" }, zero, true)).toMatch(
+        /no record of running ANY task/,
+      );
+    });
+
+    it("a failure quotes the Manager's own result and never claims success", () => {
+      const text = describeManagerTaskVerdict(
+        { kind: "failed", result: "An error occurred while updating 'comfyui-mcp-panel'." },
+        counts,
+        false,
+      );
+      expect(text).toMatch(/RAN the task and it FAILED/);
+      expect(text).toMatch(/An error occurred while updating 'comfyui-mcp-panel'\./);
+    });
+  });
+
+  it("v4 drained counts + a FAILED task record → the refusal names the real failure", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      managerTaskRecord: FAILED_RECORD,
+      // The reporter's checkout was dirty, so the git fallback correctly refuses.
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    // The correlated lookup used the ui_id the update result carried.
+    expect(h.taskRecordLookups).toEqual(["task-1999"]);
+    // What Manager actually did is now IN the message…
+    expect(msg).toMatch(/RAN the task and it FAILED/);
+    expect(msg).toMatch(/An error occurred while updating 'comfyui-mcp-panel'\./);
+    // …and the claims it could never support are gone.
+    expect(msg).not.toMatch(/incoherent/);
+    expect(msg).not.toMatch(/never enqueued/);
+    expect(msg).not.toMatch(/stale legacy 3\.x/);
+    // The dirty-checkout refusal is UNCHANGED — still refused, still no pull.
+    expect(msg).toMatch(/UNCOMMITTED/);
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("v4 drained counts with NO readable task record → says the outcome is UNKNOWN, claims neither", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      // Pre-v4 Manager, or an answer that could not be trusted.
+      managerTaskRecord: undefined,
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/cannot say what this task did/);
+    // Neither verdict may be asserted from an absence of evidence.
+    expect(msg).not.toMatch(/RAN the task and it FAILED/);
+    expect(msg).not.toMatch(/Panel updated/);
+    expect(msg).not.toMatch(/incoherent/);
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("a task record proving NEVER-RAN is reported as such, not as a failure", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      // {"history": {}} — the Manager PROVING it holds no such completed task.
+      managerTaskRecord: null,
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/holds NO completed task under the id/);
+    expect(msg).not.toMatch(/RAN the task and it FAILED/);
+  });
+
+  it("a task Manager recorded as SUCCESS that moved nothing is not called a failure", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      managerTaskRecord: { uiId: "task-1999", statusStr: "success", result: "success" },
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/recorded this task as "success"/);
+    expect(msg).toMatch(/could NOT be established/);
+    expect(msg).not.toMatch(/FAILED/);
+  });
+
+  it("a THROWING history lookup is contained — the outcome degrades to unknown", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      managerTaskRecordThrows: "ECONNREFUSED",
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    expect(msg).toMatch(/UNCOMMITTED/);
+    expect(msg).toMatch(/cannot say what this task did/);
+  });
+
+  it("an update path that captured NO ui_id never looks the task up at all", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      updateTaskUiId: null,
+      managerTaskRecord: FAILED_RECORD,
+      gitStatus: " M web/js/comfyui-mcp-panel.js",
+      onGitPull: () => "merge output",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    // No id means no correlation: asking about someone else's task, or about
+    // nothing at all, must never produce a verdict about OURS.
+    expect(h.taskRecordLookups).toEqual([]);
+    expect(String(err?.message ?? err)).not.toMatch(/RAN the task and it FAILED/);
+  });
+
+  it("a PROVEN update still succeeds — the lookup never vetoes disk evidence", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.13.6") },
+      revs: { [dir]: REV_A },
+      updateDetails: V4_DRAINED,
+      // Manager errored on some OTHER task in the same session; the disk moved.
+      managerTaskRecord: FAILED_RECORD,
+      onUpdate: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.15.32");
+      },
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(r.message).toMatch(/Panel updated \(0\.13\.6 → 0\.15\.32\)/);
+    // Nothing moved-on-disk ever consults the history, so it was not asked.
+    expect(h.taskRecordLookups).toEqual([]);
   });
 });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -146,6 +146,16 @@ export interface NodeOpResult {
    * at the SAME server even if the global target was retargeted in between.
    */
   managerBase?: string;
+  /**
+   * #1999 — the `ui_id` the Manager task was ACTUALLY enqueued under, when this
+   * result came from the unified task queue. It is the ONLY key that correlates
+   * a drained queue back to what our specific task did: Manager v4 keeps the
+   * per-task record at `/v2/manager/queue/history?ui_id=…` while the queue-wide
+   * counts say nothing about it (see readQueueCounts / fetchManagerTaskHistoryEntry).
+   * Absent on the cm-cli and git-clone mechanisms, and on paths that never
+   * enqueued a single correlatable task.
+   */
+  taskUiId?: string;
 }
 
 export interface ParsedGitUrl {
@@ -1018,6 +1028,13 @@ export interface ManagerTaskHistoryEntry {
   uiId: string;
   kind?: string;
   result?: string;
+  /**
+   * `status.status_str` — Manager's own STRUCTURED verdict for the task, one of
+   * success/failed/skipped/error/skip (OperationResult in its data models). This
+   * is the field to classify on; `result` is free prose whose only stable values
+   * are the literals "success"/"skip" (measured against Manager 4.2.2).
+   */
+  statusStr?: string;
 }
 
 /**
@@ -1057,10 +1074,17 @@ export async function fetchManagerTaskHistoryEntry(
   // history) must never prove anything about OUR task — least of all clear
   // its marker as already-drained (#689 round 4).
   if (h.ui_id !== uiId) return undefined;
+  const status = h.status;
+  const statusStr =
+    status && typeof status === "object" &&
+    typeof (status as Record<string, unknown>).status_str === "string"
+      ? ((status as Record<string, unknown>).status_str as string)
+      : undefined;
   return {
     uiId: h.ui_id,
     kind: typeof h.kind === "string" ? h.kind : undefined,
     result: typeof h.result === "string" ? h.result : undefined,
+    statusStr,
   };
 }
 
@@ -1147,20 +1171,46 @@ async function queueManagerTask(
   params: ManagerTaskParams,
   base = managerBaseUrl(),
 ): Promise<QueueStatus> {
+  return (await queueManagerTaskTracked(kind, params, base)).status;
+}
+
+/**
+ * #1999 — the same enqueue+drain, but it also HANDS BACK the `ui_id` the task
+ * was enqueued under. A drained queue's counts are queue-wide and, on Manager
+ * v4, identical for a task that succeeded and one that errored (measured: an
+ * idle v4 answers `total_count:0` with a `done_count` that is the CUMULATIVE
+ * session history length). The ui_id is the only handle that can ask Manager
+ * what OUR task actually did — see fetchManagerTaskHistoryEntry.
+ *
+ * Callers that don't correlate keep using queueManagerTask above; nothing about
+ * the enqueue, drain, dialect self-heal or timeout behaviour differs.
+ */
+async function queueManagerTaskTracked(
+  kind: ManagerTaskKind,
+  params: ManagerTaskParams,
+  base = managerBaseUrl(),
+): Promise<{ status: QueueStatus; uiId: string }> {
   // Normalize to a resolver so every attempt builds its body for the dialect it
   // is about to speak — a few operations (git installs) have dialect-specific
   // params, and a self-heal retry must rebuild them, not just re-route them.
   const resolve: ManagerParamsResolver =
     typeof params === "function" ? params : () => params;
+  // The id is minted PER ATTEMPT, exactly as before. A self-heal retry is a
+  // genuinely second enqueue, so it gets its own id; the one recorded here is
+  // therefore the id of the attempt that LANDED (a failed attempt throws, so it
+  // never reaches the drain, and a v2→v2-batch downgrade inside a single attempt
+  // reuses that attempt's id).
+  let uiId = "";
   // This is a mutation transaction, so freeze its target before the first await.
   // A later setComfyuiTarget() selects where NEW calls go; it must not redirect a
   // retry, queue start, or verification of a request the user already made.
-  const used = await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
-    enqueueManagerTask(api, kind, resolve, randomUUID(), base, epoch),
-    base,
-  );
+  const used = await enqueueWithDialectSelfHeal(kind, (api, epoch) => {
+    uiId = randomUUID();
+    return enqueueManagerTask(api, kind, resolve, uiId, base, epoch);
+  }, base);
   // Thread the kind so a model download gets the model budget, not the node one (#817).
-  return runManagerQueue(used, base, kind);
+  const status = await runManagerQueue(used, base, kind);
+  return { status, uiId };
 }
 
 /** Params for a Manager task: a fixed body, or a resolver invoked with the
@@ -3606,6 +3656,12 @@ async function updateCustomNodeImpl(
   if (!all && isManagerSelfTarget(id)) return updateManagerSelf(id);
 
   let status: QueueStatus;
+  /** #1999 — set only on the single-pack branch; see NodeOpResult.taskUiId. The
+   *  update-all branch deliberately leaves it undefined: v4 derives a SEPARATE
+   *  per-pack task id (`${uiId}_${pack}`) there, so the bare enqueue id would
+   *  never resolve in queue history and handing it out would invite a lookup
+   *  that answers "no such task" about a task that really ran. */
+  let taskUiId: string | undefined;
   // Freeze the target BEFORE the first await (queueManagerTask does the same):
   // a mid-op retarget must not split the enqueue and the post-op verification
   // across two servers. The base travels back on the result so callers (the
@@ -3629,7 +3685,13 @@ async function updateCustomNodeImpl(
     // resolves nowhere is refused with NOTHING queued.
     const tracked = await resolveTrackedForOp(id, "update", base, presenceCtx);
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
-    status = await queueManagerTask("update", { node_name: tracked.module }, base);
+    const queued = await queueManagerTaskTracked(
+      "update",
+      { node_name: tracked.module },
+      base,
+    );
+    status = queued.status;
+    taskUiId = queued.uiId;
     // VERIFY (#730): the drain passes trivially for an id Manager never
     // enqueued (total_count 0 — the "Queued + updated" lie in the issue).
     // Require the pack to resolve SOMEWHERE post-op before claiming success.
@@ -3642,6 +3704,7 @@ async function updateCustomNodeImpl(
       : `Queued + updated "${id}" via ComfyUI-Manager.`,
     details: status,
     managerBase: base,
+    taskUiId,
   };
 }
 

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -47,6 +47,7 @@ import {
   reinstallCustomNode,
   nonInteractiveGitEnv,
   type NodeOpResult,
+  type ManagerTaskHistoryEntry,
 } from "./node-management.js";
 import { getSystemStats } from "../comfyui/client.js";
 import {
@@ -291,6 +292,19 @@ export interface PanelInstallerDeps {
    * the real fetchManagerQueueCounts; tests stub it.
    */
   fetchLiveQueueCounts?: ((base?: string) => Promise<LiveQueueCounts | undefined>) | undefined;
+  /**
+   * #1999 — look up ONE Manager task by the exact `ui_id` it was enqueued
+   * under. Manager v4 keeps a per-task record (result + a structured
+   * status_str) for the whole session; the queue-wide counts do not. Resolves
+   * to the entry, `null` when the Manager PROVES there is no such completed
+   * task, and `undefined` when the answer cannot be trusted — a pre-v4 dialect
+   * that has no such route, or an unreadable response. Callers must treat
+   * `undefined` as "the outcome is unknown", never as either verdict. Default
+   * is the real fetchManagerTaskHistoryEntry; tests stub it.
+   */
+  fetchManagerTaskRecord?:
+    | ((uiId: string, base?: string) => Promise<ManagerTaskHistoryEntry | null | undefined>)
+    | undefined;
   /** Is the target ComfyUI reachable right now? Never throws. */
   isReachable: () => Promise<boolean>;
   install: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
@@ -2273,6 +2287,201 @@ function describeLiveQueue(c: LiveQueueCounts | undefined): string {
     : `the live queue could not be read at all`;
 }
 
+// ---------------------------------------------------------------------------
+// #1999 — WHAT DID *OUR* TASK ACTUALLY DO?
+//
+// The queue counts cannot answer that, and on ComfyUI-Manager v4 they are not
+// even the shape this file historically read them as. Measured against
+// ComfyUI-Manager 4.2.2 (`glob/manager_server.py`, class TaskQueue):
+//
+//   total_count = len(pending_tasks) + len(running_tasks)   <- LIVE only
+//   done_count  = len(history_tasks)                        <- CUMULATIVE, whole session
+//
+// They count different populations, so on v4 an idle queue ALWAYS reports
+// `total_count:0` alongside a `done_count` equal to however many tasks have
+// ever run in that session. Driven live against a v4.2.2 host, one FAILING
+// update drained to `{total_count:0, done_count:1, in_progress_count:0,
+// pending_count:0, is_processing:false}`; four tasks later the same shape read
+// `done_count:5`, and the per-task history held four `error`s and one
+// `success`. The counts were BYTE-IDENTICAL across both outcomes.
+//
+// So on v4 `total_count:0` is not "nothing was ever enqueued", and
+// `done_count > total_count` is not a contradiction — it is simply the drained
+// state. Narrating either as the stale-3.x silent no-op asserts an outcome that
+// was never observed. (On legacy 3.x the counters really do all collapse to 0
+// at drain, which is why isProvenLegacyEmptyQueue additionally requires
+// done_count === 0 and is dialect-gated at the sites that mutate.)
+//
+// What CAN answer the question is the per-task record, keyed by the exact ui_id
+// we enqueued under: GET /v2/manager/queue/history?ui_id=... carries the task's
+// `result` and a structured `status.status_str`. v4 only — the legacy-UI
+// history route knows only a file-based `?id=` form and rejects this query — so
+// on anything older the honest answer stays "unknown", with the way to find out.
+// ---------------------------------------------------------------------------
+
+/**
+ * What ComfyUI-Manager recorded for OUR task. `unknown` is a first-class
+ * outcome, not a failure: it is the answer whenever the Manager cannot be asked
+ * (pre-v4), was not asked (no correlatable id), or did not answer in a shape
+ * that can be trusted.
+ */
+export type ManagerTaskVerdict =
+  | { kind: "failed"; result: string }
+  | { kind: "succeeded"; result: string }
+  | { kind: "never-ran" }
+  | { kind: "unknown" };
+
+/**
+ * Turn a queue-history record into a verdict.
+ *
+ * Deliberately ASYMMETRIC. `status.status_str` is Manager's own structured enum
+ * (OperationResult: success | failed | skipped | error | skip) and is the only
+ * field classified on. When it is absent — it is Optional in Manager's model,
+ * so an older v4 may omit it — a `result` that is EXACTLY the literal "success"
+ * or "skip" is still accepted, because those two literals are what Manager's
+ * own task_worker compares against to decide the status it would have written.
+ * Nothing else is accepted: an unrecognised `result` is free prose, and
+ * inferring FAILURE from prose would commit the mirror image of the bug this
+ * file exists to prevent — reporting a failure that was never observed.
+ * Unrecognised means `unknown`.
+ */
+export function classifyManagerTaskRecord(
+  record: ManagerTaskHistoryEntry | null | undefined,
+): ManagerTaskVerdict {
+  // `undefined` = we could not ask, or could not trust the answer.
+  if (record === undefined) return { kind: "unknown" };
+  // `null` = the Manager PROVED it holds no completed task under that id.
+  if (record === null) return { kind: "never-ran" };
+  const status = record.statusStr?.trim().toLowerCase();
+  const result = record.result?.trim();
+  if (status === "success" || status === "skip" || status === "skipped") {
+    return { kind: "succeeded", result: result || status };
+  }
+  if (status === "failed" || status === "error") {
+    // The prose is the only place the CAUSE lives, so it is quoted — but the
+    // decision to call this a failure came from the structured field.
+    return { kind: "failed", result: result || status };
+  }
+  if (status === undefined && (result === "success" || result === "skip")) {
+    return { kind: "succeeded", result };
+  }
+  return { kind: "unknown" };
+}
+
+/**
+ * The Manager-side clause that every "nothing moved" message narrates around.
+ *
+ * It states what was OBSERVED and nothing more. The stale-3.x cause is asserted
+ * only where it is actually proven (`provenLegacyEmptyQueue`); everywhere else
+ * the counters are reported as the drain counters they are, and the sentence
+ * ends in an honest "could not be determined" plus the way to determine it.
+ */
+export function describeManagerTaskVerdict(
+  verdict: ManagerTaskVerdict,
+  counts: QueueCounts,
+  provenLegacyEmptyQueue: boolean,
+): string {
+  const c =
+    `total_count=${counts.total ?? "?"}, done_count=${counts.done ?? "?"}, ` +
+    `pending_count=${counts.pending ?? "?"}, in_progress_count=${counts.inProgress ?? "?"}`;
+  switch (verdict.kind) {
+    case "failed":
+      return (
+        `ComfyUI-Manager RAN the task and it FAILED — its own per-task record ` +
+        `reports: "${verdict.result}". The queue drained afterwards (${c}), which ` +
+        `is why the drain on its own looked like a success`
+      );
+    case "succeeded":
+      return (
+        `ComfyUI-Manager recorded this task as "${verdict.result}", yet nothing ` +
+        `moved on disk (${c}) — the task ran, and whether it changed anything ` +
+        `could NOT be established`
+      );
+    case "never-ran":
+      return (
+        `ComfyUI-Manager holds NO completed task under the id this operation was ` +
+        `enqueued with, so it never ran (${c})`
+      );
+    default:
+      return provenLegacyEmptyQueue
+        ? `ComfyUI-Manager has no record of running ANY task: every queue counter ` +
+          `is zero (${c}). On a legacy ComfyUI-Manager 3.x that is the known silent ` +
+          `no-op (#639/#424) — the enqueue is accepted and nothing runs`
+        : `ComfyUI-Manager's queue drained (${c}) and what THIS task did could NOT ` +
+          `be established. Those are queue-WIDE drain counters, not a per-task ` +
+          `result: on ComfyUI-Manager v4 an idle queue always reports ` +
+          `total_count=0 with done_count as the whole session's history length, so ` +
+          `they read identically whether the task succeeded or failed. The record ` +
+          `that would say (GET /v2/manager/queue/history?ui_id=...) could not be ` +
+          `read here, and ComfyUI-Manager older than v4 does not keep one at all`;
+  }
+}
+
+/**
+ * The remedy half of the message, chosen by what was OBSERVED rather than by a
+ * single assumed cause. Sending a user to "update ComfyUI-Manager, it is stale"
+ * when the Manager in fact ran the task and reported an error is what made
+ * #1999 unfixable from the report: the advice named a cause the evidence did
+ * not support, and the evidence that did exist was never read.
+ */
+export function describeManagerTaskRemedy(
+  verdict: ManagerTaskVerdict,
+  dir: string | undefined,
+): string {
+  const gitPull = `update the panel repo manually (git pull in ${dir ?? "the panel's custom_nodes dir"})`;
+  switch (verdict.kind) {
+    case "failed":
+      return (
+        `Fix what ComfyUI-Manager reported — its full traceback is in the ComfyUI ` +
+        `server log next to that message — then retry. If the pack is a git ` +
+        `checkout, ${gitPull} is the direct route, and a checkout with local ` +
+        `modifications must be committed or stashed first. Then RESTART ComfyUI.`
+      );
+    case "succeeded":
+      return (
+        `RESTART ComfyUI and re-check the version with ` +
+        `${describeInstallPanelAction("status", "a re-check on the ComfyUI host")}: ` +
+        `ComfyUI-Manager cannot swap a directory the running server is serving, so ` +
+        `it may have reserved the switch for the next startup. Do NOT reinstall ` +
+        `from source before checking that.`
+      );
+    default:
+      return (
+        `Check the ComfyUI server log for what ComfyUI-Manager did with the task, ` +
+        `and confirm what is on disk with ` +
+        `${describeInstallPanelAction("status", "a re-check on the ComfyUI host")}. ` +
+        `Then either update ComfyUI-Manager on the host (pip install -U ` +
+        `comfyui_manager, or git pull in custom_nodes/ComfyUI-Manager) and retry, ` +
+        `or ${gitPull}. Then RESTART ComfyUI.`
+      );
+  }
+}
+
+/**
+ * Ask ComfyUI-Manager what OUR task did. NEVER throws: any failure — and any
+ * answer that cannot be correlated — is `{kind:"unknown"}`, which callers
+ * report as an unknown outcome and never as either verdict.
+ *
+ * A missing `uiId` is `unknown` too, never `never-ran`: a path that did not
+ * capture an id has proved nothing about whether a task ran.
+ */
+async function readManagerTaskVerdict(
+  deps: PanelInstallerDeps,
+  uiId: string | undefined,
+  base: string | undefined,
+): Promise<ManagerTaskVerdict> {
+  if (!uiId) return { kind: "unknown" };
+  try {
+    if (deps.fetchManagerTaskRecord) {
+      return classifyManagerTaskRecord(await deps.fetchManagerTaskRecord(uiId, base));
+    }
+    const { fetchManagerTaskHistoryEntry } = await import("./node-management.js");
+    return classifyManagerTaskRecord(await fetchManagerTaskHistoryEntry(uiId, base));
+  } catch {
+    return { kind: "unknown" };
+  }
+}
+
 export type UpdateOutcome =
   | "updated" // version OR git-HEAD moved on disk → the update definitely applied.
   | "downgraded" // the version PROVABLY went backwards — applied, but not an update.
@@ -2405,14 +2614,29 @@ export function classifyPanelUpdate(
  * confirmed") — replacing a working could-not-determine with a false definite
  * is a regression whichever definite you pick.
  */
-/** Turn an update verdict into an honest result — or throw when it did not apply. */
+/** Turn an update verdict into an honest result — or throw when it did not apply.
+ *
+ * `taskVerdict` (#1999) is what ComfyUI-Manager recorded for the EXACT task this
+ * update enqueued, where that could be established. It is the only evidence that
+ * can explain a drained queue which moved nothing, so both fail-closed branches
+ * narrate it instead of asserting a cause from the queue-wide counters. Callers
+ * that could not correlate a task pass `{kind:"unknown"}`, which reports the
+ * outcome as undetermined and says how to determine it — never as a failure and
+ * never as a success. */
 function finalizeUpdate(
   verdict: UpdateVerdict,
   post: PanelDetection,
   result: NodeOpResult,
+  taskVerdict: ManagerTaskVerdict = { kind: "unknown" },
 ): PanelActionResult {
   const { outcome, previousVersion, installedVersion, counts } = verdict;
   const dirNote = post.dir ? ` at ${post.dir}` : "";
+  const managerSaid = () =>
+    describeManagerTaskVerdict(
+      taskVerdict,
+      counts,
+      isProvenLegacyEmptyQueue(result.details),
+    );
 
   if (outcome === "updated") {
     const from = verdict.previousVersion ?? verdict.previousRev?.slice(0, 8) ?? "?";
@@ -2479,14 +2703,8 @@ function finalizeUpdate(
   if (outcome === "no-op") {
     throw new PanelInstallError(
       `Panel update did NOT apply: nothing changed on disk${dirNote} (installed ` +
-        `version still ${previousVersion ?? "unknown"}) after ComfyUI-Manager ` +
-        `reported the queue drained. Manager reported done_count=` +
-        `${counts.done ?? "?"} with total_count=${counts.total ?? "?"} — it never ` +
-        `actually enqueued the update. This is the stale ComfyUI-Manager 3.x silent ` +
-        `no-op (#639, same root cause as #424). Fix: update ComfyUI-Manager on the ` +
-        `host (git pull in custom_nodes/ComfyUI-Manager, or pip install -U ` +
-        `comfyui_manager) and retry, or reinstall the panel from source (git pull ` +
-        `the panel dir / reinstall the pack), then RESTART ComfyUI.`,
+        `version still ${previousVersion ?? "unknown"}). ${managerSaid()}. NOT ` +
+        `reporting success. ${describeManagerTaskRemedy(taskVerdict, post.dir)}`,
     );
   }
 
@@ -2494,11 +2712,9 @@ function finalizeUpdate(
   throw new PanelInstallError(
     `Could not verify the panel update applied: the installed version ` +
       `(${installedVersion ?? "unreadable"}) and git-HEAD did not change` +
-      `${dirNote} after ComfyUI-Manager reported the queue drained. NOT reporting ` +
-      `success — an unchanged checkout can't prove you are at the latest nightly ` +
-      `versus a silent no-op. You may already be current; otherwise ComfyUI-Manager ` +
-      `may be stale (#424). RESTART ComfyUI and re-check the version, or reinstall ` +
-      `the panel from source.`,
+      `${dirNote}. ${managerSaid()}. NOT reporting success — an unchanged checkout ` +
+      `cannot prove you are at the latest nightly versus a silent no-op, and you ` +
+      `may already be current. ${describeManagerTaskRemedy(taskVerdict, post.dir)}`,
   );
 }
 
@@ -2729,9 +2945,12 @@ async function updateViaGitCheckoutFallback(opts: {
         `${porcelain}\ncomfyui-mcp never mutates a dirty checkout — a ` +
         `fast-forward could carry or clobber that local state. Commit, stash, or ` +
         `discard the changes (or update the panel repo manually), then retry. ` +
-        `(The Manager path also produced no update here — ${managerReason} — so ` +
-        `updating ComfyUI-Manager on the host restores that path: git pull in ` +
-        `custom_nodes/ComfyUI-Manager, or pip install -U comfyui_manager.)`,
+        // #1999 — this used to end "so updating ComfyUI-Manager on the host
+        // restores that path", which asserts that a stale Manager is the cause.
+        // It sometimes is; when the Manager in fact RAN the task and reported an
+        // error, upgrading it fixes nothing and sends the user down a dead end.
+        // State the Manager's own reason and let it name its own remedy.
+        `(The Manager path also produced no update here — ${managerReason}.)`,
     );
   }
 
@@ -5797,6 +6016,10 @@ async function runPanelActionCore(
       },
       result.details,
     );
+    /** #1999 — what ComfyUI-Manager recorded for THIS update's task, once the
+     *  on-disk check has shown nothing moved. Stays `unknown` on every path
+     *  that never got that far, and on every Manager that cannot answer. */
+    let managerTaskVerdict: ManagerTaskVerdict = { kind: "unknown" };
     // A PROVEN REGRESSION SHORT-CIRCUITS EVERYTHING. It must not fall through
     // to the no-op/zip fallbacks: those would quietly re-install over the top
     // and the user would never learn that ComfyUI-Manager had just moved them
@@ -5825,6 +6048,18 @@ async function runPanelActionCore(
     // change on disk a leftover line would describe some earlier reservation,
     // not this update — "moved-unknown-direction" keeps its own verdict.
     if (verdict.outcome === "no-op" || verdict.outcome === "unverified") {
+      // #1999 — NOTHING MOVED, so ask the one surface that can say why: the
+      // per-task record for the EXACT ui_id this update was enqueued under.
+      // Read here, once, before any fallback narrates a cause — a drained queue
+      // on ComfyUI-Manager v4 reads the same whether our task succeeded or
+      // errored, and this is the only place the difference survives. It never
+      // throws and it never changes what any branch DOES; it changes only what
+      // they are able to say (and on a pre-v4 Manager it honestly says nothing).
+      managerTaskVerdict = await readManagerTaskVerdict(
+        deps,
+        result.taskUiId,
+        result.managerBase,
+      );
       const reservation = readManagerReservation(comfyPath, PANEL_REGISTRY_ID, deps);
       if (reservation === "reserved") {
         assertSameTarget("before reporting a staged panel update");
@@ -5866,16 +6101,27 @@ async function runPanelActionCore(
       // field is unproven, not contradictory).
       const countsContradict =
         c.total !== undefined && c.done !== undefined && c.done > c.total;
-      const managerReason = provenLegacyEmptyQueue
-        ? `ComfyUI-Manager never enqueued the update (the stale legacy 3.x silent no-op, #639/#724)`
-        : countsContradict
-          ? `ComfyUI-Manager's drained-queue counts are incoherent (total=` +
-            `${c.total ?? "?"}, done=${c.done ?? "?"}, pending=${c.pending ?? "?"}, ` +
-            `in_progress=${c.inProgress ?? "?"}) and can neither confirm nor explain the no-op`
-          : `ComfyUI-Manager's drained-queue status is partial (total=` +
-            `${c.total ?? "?"}, done=${c.done ?? "?"}, pending=${c.pending ?? "?"}, ` +
-            `in_progress=${c.inProgress ?? "?"} — fields the status contract requires ` +
-            `are missing or malformed) and can neither confirm nor explain the no-op`;
+      // #1999 — the per-task record OUTRANKS the counters whenever it exists.
+      // `done > total` was narrated here as "incoherent … can neither confirm
+      // nor explain", which is what the reporter was handed four times. On
+      // ComfyUI-Manager v4 those counters are not contradictory at all
+      // (total_count is live-only, done_count is the session history length),
+      // and the thing that CAN explain the no-op — the task's own error — was
+      // sitting one request away the whole time.
+      const managerReason =
+        managerTaskVerdict.kind !== "unknown"
+          ? describeManagerTaskVerdict(managerTaskVerdict, c, provenLegacyEmptyQueue)
+          : provenLegacyEmptyQueue
+            ? `ComfyUI-Manager never enqueued the update (the stale legacy 3.x silent no-op, #639/#724)`
+            : countsContradict
+              ? `ComfyUI-Manager's drained queue reported done_count=${c.done ?? "?"} ` +
+                `against total_count=${c.total ?? "?"} (pending=${c.pending ?? "?"}, ` +
+                `in_progress=${c.inProgress ?? "?"}) — queue-WIDE drain counters that ` +
+                `cannot say what this task did, and no per-task record was readable`
+              : `ComfyUI-Manager's drained-queue status is partial (total=` +
+                `${c.total ?? "?"}, done=${c.done ?? "?"}, pending=${c.pending ?? "?"}, ` +
+                `in_progress=${c.inProgress ?? "?"} — fields the status contract requires ` +
+                `are missing or malformed) and can neither confirm nor explain the no-op`;
       if (!provenLegacyEmptyQueue) {
         // #824 — SIGNATURE GATE, second form. An incoherent/partial signature
         // (e.g. total 0, done 1) is not proof of the stale-3.x no-op, so it
@@ -6005,7 +6251,7 @@ async function runPanelActionCore(
       });
     }
     assertSameTarget("before reporting the update verdict");
-    return finalizeUpdate(verdict, post, result);
+    return finalizeUpdate(verdict, post, result, managerTaskVerdict);
   }
 
   // install / reinstall. Same final pin check as the update path above.
@@ -6026,14 +6272,25 @@ async function runPanelActionCore(
   // with its specific remedy, even when the canonical install itself did not land.
   assertNoPanelShadow(action, post.dir, deps);
   if (!post.installed || !post.version) {
+    // #1999 — the queue drained; that alone never said WHY the pack is not
+    // there, and asserting the stale-3.x no-op unconditionally named a cause the
+    // counters cannot establish (on ComfyUI-Manager v4 a drained queue always
+    // reports total_count=0, whatever the task did). Report the counters as the
+    // drain counters they are, and only offer the 3.x cause where the whole
+    // counter set is zero.
     throw new PanelInstallError(
       `Panel ${action} did NOT land: the pack is ${
         post.installed ? "present but its version is unreadable" : "not present"
-      } in custom_nodes after ComfyUI-Manager reported the queue drained. This is ` +
-        `the stale ComfyUI-Manager 3.x silent no-op (#639, same root cause as #424): ` +
-        `NOT reporting success. Fix: update ComfyUI-Manager on the host (git pull in ` +
-        `custom_nodes/ComfyUI-Manager, or pip install -U comfyui_manager) and retry, ` +
-        `or install the panel from source, then RESTART ComfyUI.`,
+      } in custom_nodes. ` +
+        `${describeManagerTaskVerdict(
+          { kind: "unknown" },
+          readQueueCounts(result.details),
+          isProvenLegacyEmptyQueue(result.details),
+        )}. NOT reporting success. Check the ComfyUI server log for what ` +
+        `ComfyUI-Manager did with the task, then either update ComfyUI-Manager on ` +
+        `the host (pip install -U comfyui_manager, or git pull in ` +
+        `custom_nodes/ComfyUI-Manager) and retry, or install the panel from ` +
+        `source. Then RESTART ComfyUI.`,
     );
   }
 
@@ -6087,17 +6344,24 @@ async function runPanelActionCore(
     // Nothing provably changed. Use the stale-3.x no-op count signature ONLY here
     // (not as a veto above) to sharpen the failure diagnostic.
     if (looksLikeManagerNoOp(result.details)) {
-      const c = readQueueCounts(result.details);
+      // #1999 — same correction as the branch above. `total_count === 0` is the
+      // stale-3.x signature ONLY when the rest of the counter set is zero too;
+      // on ComfyUI-Manager v4 it is simply what an idle queue reports, so
+      // "without actually enqueuing the task" was asserting an outcome that had
+      // not been observed. The counters still fail this closed — they just no
+      // longer testify to a cause they cannot see.
       throw new PanelInstallError(
-        `Panel ${action} did NOT execute: ComfyUI-Manager reported the queue ` +
-          `drained without actually enqueuing the task (total_count=` +
-          `${c.total ?? "?"}, done_count=${c.done ?? "?"}), so the pack on disk ` +
-          `(${PANEL_REGISTRY_ID} ${post.version}) is unchanged — likely a stale ` +
-          `pre-existing copy. This is the stale ComfyUI-Manager 3.x silent no-op ` +
-          `(#639, same root cause as #424): NOT reporting success. Fix: update ` +
-          `ComfyUI-Manager on the host (git pull in custom_nodes/ComfyUI-Manager, ` +
-          `or pip install -U comfyui_manager) and retry, or install the panel from ` +
-          `source, then RESTART ComfyUI.`,
+        `Panel ${action} did NOT change the pack on disk (${PANEL_REGISTRY_ID} ` +
+          `${post.version}) — likely a stale pre-existing copy. ` +
+          `${describeManagerTaskVerdict(
+            { kind: "unknown" },
+            readQueueCounts(result.details),
+            isProvenLegacyEmptyQueue(result.details),
+          )}. NOT reporting success. Check the ComfyUI server log for what ` +
+          `ComfyUI-Manager did with the task, then either update ComfyUI-Manager ` +
+          `on the host (pip install -U comfyui_manager, or git pull in ` +
+          `custom_nodes/ComfyUI-Manager) and retry, or install the panel from ` +
+          `source. Then RESTART ComfyUI.`,
       );
     }
     throw new PanelInstallError(

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2381,6 +2381,16 @@ export function describeManagerTaskVerdict(
   counts: QueueCounts,
   provenLegacyEmptyQueue: boolean,
 ): string {
+  // Manager's `result` is whatever the failing handler produced, and on an
+  // unhandled exception that is a full Python repr — one measured here ran to
+  // several hundred characters of QueueTaskItem(...). Quoting it whole turns a
+  // diagnostic into a wall. Clamp it and SAY it is clamped, with the log named
+  // as the place the rest lives: a silently truncated error message is its own
+  // small dishonesty.
+  const quote = (v: string): string =>
+    v.length <= 400
+      ? v
+      : `${v.slice(0, 400)}… (truncated — the full text is in the ComfyUI server log)`;
   const c =
     `total_count=${counts.total ?? "?"}, done_count=${counts.done ?? "?"}, ` +
     `pending_count=${counts.pending ?? "?"}, in_progress_count=${counts.inProgress ?? "?"}`;
@@ -2388,12 +2398,14 @@ export function describeManagerTaskVerdict(
     case "failed":
       return (
         `ComfyUI-Manager RAN the task and it FAILED — its own per-task record ` +
-        `reports: "${verdict.result}". The queue drained afterwards (${c}), which ` +
+        `reports: "${quote(verdict.result)}". The queue drained afterwards (${c}), ` +
+        `which ` +
         `is why the drain on its own looked like a success`
       );
     case "succeeded":
       return (
-        `ComfyUI-Manager recorded this task as "${verdict.result}", yet nothing ` +
+        `ComfyUI-Manager recorded this task as "${quote(verdict.result)}", yet ` +
+        `nothing ` +
         `moved on disk (${c}) — the task ran, and whether it changed anything ` +
         `could NOT be established`
       );


### PR DESCRIPTION
Fixes #1999.

## What the reporter saw

Automatic panel sync dispatched ComfyUI-Manager update tasks, then read a drained queue reporting `total_count=0` with `done_count` 3 and later 4, and told the user the counts were **"incoherent"** and could **"neither confirm nor explain the no-op"**. The panel stayed at 0.13.6. The git fallback correctly refused (dirty checkout), so the loop repeated. A newer panel's queue-status surface later showed that all four Manager tasks had **failed**.

## What Manager actually reports — established by execution, not by reading

Driven against a live **ComfyUI-Manager 4.2.2** (pip, `--enable-manager`, `/v2/manager/version` → `V4.2.2`, `is_legacy_manager_ui: false`) on this rig, with a throwaway custom-node pack whose git remote points at an unreachable host so `unified_update` fails for real:

| stage | `/v2/manager/queue/status` |
|---|---|
| fresh session, idle | `{total_count:0, done_count:0, in_progress_count:0, pending_count:0, is_processing:false}` |
| task enqueued, worker not started | `{total_count:1, done_count:0, in_progress_count:0, pending_count:1, is_processing:false}` |
| running | `{total_count:0, done_count:1, in_progress_count:0, pending_count:0, is_processing:true}` |
| **drained, task FAILED** | `{total_count:0, done_count:1, in_progress_count:0, pending_count:0, is_processing:false}` |
| **drained, 5 tasks: 4 error + 1 success** | `{total_count:0, done_count:5, in_progress_count:0, pending_count:0, is_processing:false}` |

The last two rows are the finding. From `glob/manager_server.py`:

```python
def done_count(self):  return len(self.history_tasks)                       # CUMULATIVE, session-wide
def total_count(self): return len(self.pending_tasks) + len(self.running_tasks)  # LIVE only
```

They count **different populations**. On v4, `total_count=0` alongside a non-zero `done_count` is not a contradiction and not "nothing was enqueued" — it is simply what an idle queue looks like, with `done_count` equal to however many tasks have ever run in that session. **The counts were byte-identical whether the tasks succeeded or failed.** The reporter's `total=0, done=3` then `4` is exactly this, reproduced.

The per-task record is where the outcome survives — `GET /v2/manager/queue/history?ui_id=…`, observed live:

```json
{"history": {"ui_id": "…", "kind": "update", "result": "An error occurred while updating 'mcp1999-repro'.",
             "status": {"status_str": "error", "completed": true, "messages": ["…"]}}}
```

and for a task that succeeded, `"result": "success", "status": {"status_str": "success"}`. An unknown id answers `{"history": {}}`.

**Which Managers have it** (all three confirmed on this machine):
- **v4 normal ("v2" dialect)** — has it, keyed by `ui_id`, held for the whole session (`MAXIMUM_HISTORY_SIZE = 10000`).
- **v4 legacy-UI ("v2-batch")** — `legacy/manager_server.py` requires `?id=` (a batch history *file*) and returns 400 for a `ui_id` query.
- **3.x** (`custom_nodes/ComfyUI-Manager` 3.41, verified running here) — registers no `queue/history` route at all.

`fetchManagerTaskHistoryEntry` was already v4-gated, so the two older dialects degrade to "unknown" rather than to a guess.

## The bug

Two claims were being made that the data cannot support:

1. `looksLikeManagerNoOp()` treats `total_count === 0` as the stale-3.x "never enqueued" signature. On v4 that is true for **every** drained queue, so the panel update landed in `outcome:"no-op"` and the message asserted *"it never actually enqueued the update. This is the stale ComfyUI-Manager 3.x silent no-op (#639…)"* — an outcome never observed. The same false assertion sat in two more branches on the install/reinstall path.
2. The git fallback narrated `done > total` as *"incoherent … can neither confirm nor explain the no-op"* — the exact sentence in the report. It was neither incoherent nor unexplainable; the explanation was one request away and the ui_id that keys it was minted inside `queueManagerTask` and thrown away.

## The fix

- **`node-management.ts`** — `queueManagerTaskTracked` hands back the `ui_id` the enqueue actually landed under (minted per attempt, exactly as before, so a self-heal retry's id is the one recorded). `updateCustomNode` carries it on `NodeOpResult.taskUiId` for the **single-pack** update only; update-all deliberately does not, because v4 derives per-pack ids (`${uiId}_${pack}`) there and a bare id would answer "no such task" about tasks that really ran. `fetchManagerTaskHistoryEntry` now also reads the structured `status.status_str`.
- **`panel-installer.ts`** — when the on-disk re-read shows nothing moved, the exact task is looked up and the message narrates what Manager recorded. `classifyManagerTaskRecord` is deliberately **asymmetric**: a failure is read only from the structured status (or Manager's own two literal success values when an older v4 omits `status`), never inferred from prose — inferring failure from an unrecognised `result` is the mirror image of the fabricated-success bug. An absent or untrustworthy answer degrades to **"outcome unknown, and here is how to check"**, never to either verdict. The remedy now follows the evidence too, instead of always saying "your ComfyUI-Manager is stale".

**Nothing about what any branch DOES changed** — only what the messages assert. Specifically untouched: the dirty-checkout refusal, `isProvenLegacyEmptyQueue`, the `isProvenQuiescentQueue` gate on the #824 git fallback, and the legacy-dialect gate. A test asserts the dirty refusal still fires with `gitPulls === []`.

## Live verification (loaded modules, real server)

`dist/` imported and **called** against the running v4.2.2, with a fresh failing task:

```
live drained status  : {"total_count":0,"done_count":6,"in_progress_count":0,"pending_count":0,"is_processing":false}
looksLikeManagerNoOp : true          <- the old path would say "stale 3.x, never enqueued"
isProvenLegacyEmpty  : false
fetchManagerTaskHistoryEntry -> {"uiId":"…","kind":"update",
    "result":"An error occurred while updating 'mcp1999-repro'.","statusStr":"error"}
classifyManagerTaskRecord    -> {"kind":"failed","result":"An error occurred while updating …"}
unknown ui_id -> null -> {"kind":"never-ran"}
```

and the sentence the user now gets:

> ComfyUI-Manager RAN the task and it FAILED — its own per-task record reports: "An error occurred while updating 'mcp1999-repro'.". The queue drained afterwards (total_count=0, done_count=6, pending_count=0, in_progress_count=0), which is why the drain on its own looked like a success

versus, when nothing can be correlated (pre-v4, or the lookup failed):

> ComfyUI-Manager's queue drained (…) and what THIS task did could NOT be established. Those are queue-WIDE drain counters, not a per-task result: on ComfyUI-Manager v4 an idle queue always reports total_count=0 with done_count as the whole session's history length, so they read identically whether the task succeeded or failed. The record that would say (GET /v2/manager/queue/history?ui_id=…) could not be read here, and ComfyUI-Manager older than v4 does not keep one at all

## Mutation evidence — every piece deleted, a named test dies

| mutation | test killed |
|---|---|
| M1 `updateCustomNode` stops carrying `taskUiId` (**call site**) | `returns the ui_id it actually enqueued under (#1999)` |
| M2 `queueManagerTaskTracked` stops recording the landed id | same |
| M3 history entry drops `status_str` | `reads status.status_str out of the v4 per-task history record (#1999)` |
| M4 `runPanelActionCore` stops looking the task up (**call site**) | 4 of the `#1999` integration tests |
| M5 `finalizeUpdate` no longer receives the verdict (**call site**) | `registry-ZIP install (no git): finalizeUpdate names the real failure too` |
| M6 the git fallback ignores the per-task verdict | 3 `#1999` tests |
| M7 asymmetry removed (prose inferred as FAILURE) | `ASYMMETRY: unrecognised prose is UNKNOWN, never inferred as a failure` |
| M8 the v4 drained shape called "incoherent" again | 2 `#1999` tests |

Three of the eight are one-line wiring, mutated at the call site rather than in a helper.

## Tests

`npm run lint` clean. Targeted: 792 passed across the 10 files that touch this area. Full suite in the fix worktree: **4 failed files / 7 failed tests**; a clean `origin/main` worktree run of the same suite: **7 failed files / 9 failed tests**. The failing set varies run to run (30s timeouts under machine load) and none of it is in a file this PR touches. `check:unknown-collapse` (#796), `check:vocabulary`, `vocab:export --check` and `asset-counts --check` all pass.

## Deliberately NOT done

- **`looksLikeManagerNoOp` was left as-is.** It is only ever used to fail *closed*, and on v4 "the counters cannot prove work happened" is still true — it is the narration built on top of it that was lying. Narrowing it would change which branch runs, which is a behaviour change this report does not justify.
- **No ui_id threading for install / reinstall / update-all.** `installCustomNodeImpl` has several forks and its own clone fallback; `reinstall` is two queue cycles. Those paths get the corrected *narration* (they no longer assert the stale-3.x cause) but not the correlated lookup. If a report lands on one of them, the tracked helper is already there.
- **No browser suite.** This changes orchestrator-side message text only — no panel JS. Per the brief I am saying that rather than implying coverage I do not have.
- **The `is_processing:true` with `in_progress_count:0` window** was observed mid-run and is not modelled; nothing here reads that combination.

## Review

**Review is PENDING — not gated, not approved.** Requested from grok in a comment below, naming the load-bearing claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
