### PR TITLE
fix(2010): a show_media reply establishes only what it accounts for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ All notable changes to this project are documented here. This project adheres to
   (no `isHeadless` guess, no extension sniffing) — it reads the reply that came
   back, so there is no address to resolve, no await to be stale across and no
   buffered `show_media` (#2013) to mis-classify. A panel older than #710 (#2017)
-  is covered by the same rule without being named in it.
+  is covered by the same rule without being named in it. Two things the rule has
+  to get right, both found by review: a reply that DECLARES failure (`ok:false`)
+  is left exactly as it arrived — it is not claiming a success, and rewriting it
+  as a dispatch would be the same over-claim with the sign flipped — and an
+  account only counts when it covers the batch that was sent, so a well-formed
+  reply about one item can no longer stand in for a two-item call and lose the
+  second in silence. A reply whose own numbers contradict each other is reported
+  as that, rather than as a short count.
 
 - **Ollama refuses audio unless the model is a verified listener (#1972).** Native
   `/api/chat` carries audio in `message.images[]`. Most models HTTP 400 (fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
+- **`panel_show_media` no longer repeats a claim its client did not support (#2010).**
+  The tool returns the CLIENT's reply, and the two clients that answer it do not
+  answer the same question. The sidebar panel replies with the #710 per-item
+  contract (`count`/`painted`/`unrenderable`) — it read the items and says what
+  became of each. The mobile / remote pseudo-panel replies `{"shown": true}` to
+  any `show_media` without reading the items at all, and it has no audio player:
+  an audio take became a broken image card while the agent was told it played.
+  A reply that does not account for the items now establishes acceptance and
+  nothing more — the tool answers with what it dispatched, keeps the client's own
+  words under `client_reply`, and says plainly that the user must not be told
+  what they saw or heard. Nothing is refused and nothing is withheld; the items
+  are dispatched exactly as before. This asks no question about the destination
+  (no `isHeadless` guess, no extension sniffing) — it reads the reply that came
+  back, so there is no address to resolve, no await to be stale across and no
+  buffered `show_media` (#2013) to mis-classify. A panel older than #710 (#2017)
+  is covered by the same rule without being named in it.
+
 - **Ollama refuses audio unless the model is a verified listener (#1972).** Native
   `/api/chat` carries audio in `message.images[]`. Most models HTTP 400 (fail
   closed). `huihui_ai/gemma-4-abliterated:E4b-qat` accepts the payload and

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -35,6 +35,7 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import {
+  readShowMediaAck,
   showMediaReplyAccountsForItems,
   unaccountedShowMediaNote,
 } from "../../services/comfy-view-ref.js";
@@ -72,12 +73,12 @@ const ITEM = [{ filename: "voice.wav", kind: "viewRef" }];
 describe("#2010 which replies ACCOUNT for the items they were given", () => {
   it("the sidebar panel's #710 reply accounts for them", () => {
     // Kills: making showMediaReplyAccountsForItems always false.
-    expect(showMediaReplyAccountsForItems(PANEL_REPLY)).toBe(true);
+    expect(showMediaReplyAccountsForItems(PANEL_REPLY, 1)).toBe(true);
   });
 
   it("the mobile client's bare {shown:true} does not", () => {
     // Kills: making showMediaReplyAccountsForItems always true.
-    expect(showMediaReplyAccountsForItems(MOBILE_REPLY)).toBe(false);
+    expect(showMediaReplyAccountsForItems(MOBILE_REPLY, 1)).toBe(false);
   });
 
   it("count+painted with no `unrenderable` does NOT account — that is the pre-#710 panel (#2017)", () => {
@@ -86,9 +87,9 @@ describe("#2010 which replies ACCOUNT for the items they were given", () => {
     // from "I was handed a kind I have no player for" — it paints audio as a
     // broken <img> and counts it as painted. Its count+painted are therefore
     // exactly as unearned as {shown:true}.
-    expect(showMediaReplyAccountsForItems({ ok: true, count: 1, painted: 1, unconfirmed: 0 })).toBe(
-      false,
-    );
+    expect(
+      showMediaReplyAccountsForItems({ ok: true, count: 1, painted: 1, unconfirmed: 0 }, 1),
+    ).toBe(false);
   });
 
   it.each([
@@ -101,7 +102,7 @@ describe("#2010 which replies ACCOUNT for the items they were given", () => {
     ["painted as a string", { count: 1, painted: "1", unrenderable: [] }],
     ["count missing", { painted: 1, unrenderable: [] }],
   ])("%s does not account", (_label, reply) => {
-    expect(showMediaReplyAccountsForItems(reply)).toBe(false);
+    expect(showMediaReplyAccountsForItems(reply, 1)).toBe(false);
   });
 });
 
@@ -281,13 +282,161 @@ describe("#2010 panel_show_media's handler INSTALLS the correction", () => {
 
 describe("#2010 the note builder", () => {
   it("says nothing when nothing was dispatched", () => {
-    expect(unaccountedShowMediaNote([], MOBILE_REPLY)).toBe("");
+    expect(unaccountedShowMediaNote([], readShowMediaAck(MOBILE_REPLY, 0))).toBe("");
   });
 
   it("caps the item list and says how many it left out", () => {
     const many = Array.from({ length: 10 }, (_, i) => ({ filename: `t${i}.wav`, kind: "audio" }));
-    const t = unaccountedShowMediaNote(many, MOBILE_REPLY);
+    const t = unaccountedShowMediaNote(many, readShowMediaAck(MOBILE_REPLY, 10));
     expect(t).toMatch(/and 2 more/);
     expect(t).not.toMatch(/t9\.wav/);
+  });
+});
+
+// -- gate round 1, P1 #1: a reply that DECLARES failure ---------------------
+// `{ok:false, ...}` in the reply BODY (no transport isError) is the client
+// saying it did not do the thing. Rewriting that as `dispatched:true` and
+// "re-sending is the wrong next step" manufactures the exact over-claim this
+// correction exists to remove — with the sign flipped.
+describe("#2010 r2 — a client that declares failure is not rewritten as a dispatch", () => {
+  const REFUSAL = { ok: false, delivered: "unknown", error: "no open surface" };
+
+  it("the reply is returned byte-identical", () => {
+    // Kills: dropping the `ok === false` branch.
+    const original = okResult(REFUSAL);
+    const out = annotateShowMediaAck(original, ITEM);
+    expect(out).toBe(original);
+    expect(doc(out)).toEqual(REFUSAL);
+  });
+
+  it("it is never described as dispatched-and-do-not-re-send", () => {
+    const t = textOf(annotateShowMediaAck(okResult(REFUSAL), ITEM));
+    expect(t).not.toMatch(/re-sending is the wrong next step/);
+    expect(t).not.toMatch(/"dispatched": true/);
+  });
+
+  it("the verdict names it, so a caller can branch on it", () => {
+    expect(readShowMediaAck(REFUSAL, 1).reason).toBe("declared_failure");
+    expect(readShowMediaAck(REFUSAL, 1).accounted).toBe(false);
+  });
+
+  it("through the real handler too", async () => {
+    const { res } = await showMedia(
+      [{ source: { filename: "voice.wav", type: "output" } }],
+      REFUSAL,
+    );
+    expect(doc(res)).toEqual(REFUSAL);
+    expect(textOf(res)).not.toMatch(/did NOT establish/);
+  });
+});
+
+// -- gate round 1, P1 #2: accounting that does not COVER the batch ----------
+// `{ok:true,count:1,painted:1,unrenderable:[]}` is a well-formed #710 reply and
+// says nothing whatever about the second item of a two-item batch. Accepting it
+// loses that item in silence.
+describe("#2010 r2 — accounting has to be about the batch that was sent", () => {
+  const COVERS_ONE = { ok: true, count: 1, painted: 1, unconfirmed: 0, unrenderable: [] };
+  const TWO = [
+    { filename: "voice.wav", kind: "viewRef" },
+    { filename: "take2.wav", kind: "audio" },
+  ];
+
+  it("a reply about 1 item does not account for a 2-item batch", () => {
+    // Kills: dropping the `count !== dispatchedCount` clause.
+    expect(showMediaReplyAccountsForItems(COVERS_ONE, 2)).toBe(false);
+    expect(readShowMediaAck(COVERS_ONE, 2).reason).toBe("partial_accounting");
+    // …and still accounts for a 1-item batch, so the clause is a coverage
+    // check and not a blanket refusal.
+    expect(showMediaReplyAccountsForItems(COVERS_ONE, 1)).toBe(true);
+  });
+
+  it("the second item is NOT lost — every dispatched item is listed", () => {
+    const d = doc(annotateShowMediaAck(okResult(COVERS_ONE), TWO));
+    expect(d.unaccounted).toEqual([
+      { filename: "voice.wav", kind: "viewRef" },
+      { filename: "take2.wav", kind: "audio" },
+    ]);
+    expect(d.count).toBe(2);
+  });
+
+  it("the note says how many the reply covered, and that it cannot say which", () => {
+    // Kills: reusing the no_accounting wording. "It did not read the items" is
+    // false here — it read SOME. What the caller needs is the shortfall.
+    const t = textOf(annotateShowMediaAck(okResult(COVERS_ONE), TWO));
+    expect(t).toMatch(/accounts for 1 item\(s\), but 2 were sent/);
+    expect(t).toMatch(/does not say WHICH/);
+    expect(t).not.toMatch(/did not read the items/);
+  });
+
+  it("a reply whose numbers contradict themselves is reported as such, not as a short count", () => {
+    // Kills: folding incoherent_accounting into partial_accounting. When the
+    // reply's count EQUALS the dispatch, "it accounts for 2 but 2 were sent" is
+    // nonsense prose; the real fault is that its own parts exceed its count.
+    const CONTRADICTS = { ok: true, count: 2, painted: 3, unconfirmed: 0, unrenderable: [] };
+    const TWO2 = [
+      { filename: "a.png", kind: "image" },
+      { filename: "b.png", kind: "image" },
+    ];
+    expect(readShowMediaAck(CONTRADICTS, 2).reason).toBe("incoherent_accounting");
+    const out = annotateShowMediaAck(okResult(CONTRADICTS), TWO2);
+    expect(doc(out).unaccounted_because).toBe("incoherent_accounting");
+    const t = textOf(out);
+    expect(t).toMatch(/its own numbers do not add up/);
+    expect(t).not.toMatch(/accounts for 2 item\(s\), but 2 were sent/);
+  });
+
+  it("parts that exceed the reply's own count are incoherent, not an account", () => {
+    // Kills: dropping the arithmetic clause. painted+unconfirmed+unrenderable
+    // can be FEWER than count (the panel's `dropped` is not a field) — never more.
+    expect(showMediaReplyAccountsForItems({ count: 2, painted: 3, unrenderable: [] }, 2)).toBe(false);
+    expect(
+      showMediaReplyAccountsForItems({ count: 2, painted: 1, unconfirmed: 2, unrenderable: [] }, 2),
+    ).toBe(false);
+    expect(
+      showMediaReplyAccountsForItems({ count: 2, painted: 1, unrenderable: [{}, {}] }, 2),
+    ).toBe(false);
+    // Fewer is fine: the panel's `dropped` items live only in its note.
+    expect(showMediaReplyAccountsForItems({ count: 2, painted: 1, unrenderable: [] }, 2)).toBe(true);
+  });
+
+  it.each([
+    ["a negative count", { count: -1, painted: 0, unrenderable: [] }],
+    ["a fractional count", { count: 1.5, painted: 0, unrenderable: [] }],
+    ["a negative painted", { count: 1, painted: -1, unrenderable: [] }],
+  ])("%s is not an account", (_l, reply) => {
+    expect(showMediaReplyAccountsForItems(reply, 1)).toBe(false);
+  });
+
+  it("a mailbox receipt carrying counts is still MAILBOXED, not an account", () => {
+    // Order matters: #2013's buffered command has been seen by no client, so a
+    // count on it cannot be a record of a presentation.
+    const boxed = { ok: true, mailboxed: true, count: 1, painted: 1, unrenderable: [] };
+    expect(readShowMediaAck(boxed, 1).reason).toBe("mailboxed");
+    expect(showMediaReplyAccountsForItems(boxed, 1)).toBe(false);
+  });
+
+  it("the structured reason reaches the document", () => {
+    expect(doc(annotateShowMediaAck(okResult(COVERS_ONE), TWO)).unaccounted_because).toBe(
+      "partial_accounting",
+    );
+    expect(doc(annotateShowMediaAck(okResult(MOBILE_REPLY), ITEM)).unaccounted_because).toBe(
+      "no_accounting",
+    );
+    expect(
+      doc(annotateShowMediaAck(okResult({ ok: true, mailboxed: true }), ITEM)).unaccounted_because,
+    ).toBe("mailboxed");
+  });
+
+  it("through the real handler: two items, a reply about one", async () => {
+    // Kills: computing dispatched.length from the reply instead of the dispatch.
+    const { res } = await showMedia(
+      [
+        { source: { filename: "voice.wav", type: "output" } },
+        { source: { filename: "take2.wav", type: "output" } },
+      ],
+      COVERS_ONE,
+    );
+    expect(doc(res).count).toBe(2);
+    expect(doc(res).unaccounted_because).toBe("partial_accounting");
   });
 });

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -1,0 +1,293 @@
+// #2010 — a headless (mobile/remote) client renders audio as a broken image card
+// and reports it as SHOWN.
+//
+// REPRODUCED against the unmodified origin/main handler, via the /view-ref
+// branch (which was never extension-gated, so this needs none of PR #2002):
+// a headless session dispatching `{filename:"voice.wav"}` got back, as the whole
+// of the tool's answer,
+//
+//     { "shown": true }
+//
+// which is the mobile client's literal reply — `bridge_client.dart`:
+// `replyOk(frame.rid, {'shown': true})` for ANY show_media, items unread. Its
+// `MediaCard.build` is `if (item.isVideo) _video(context) else _still(context)`;
+// `MediaItem.isVideo` is false for `audio/wav` and `.wav`, so the take becomes a
+// `MemoryImage`/`NetworkImage` that cannot decode and degrades to a caption row
+// with an image icon. (That client half is READ, not executed — Dart/Flutter is
+// not installed on this rig.)
+//
+// The correction here asks NOTHING about the destination. Three previous
+// attempts guarded on `isHeadless(ctx.tabId)` before dispatch and each drew a
+// fresh P1 of one class — judging an ADDRESS and predicting a destination
+// (#2012), across an await (stale), with "unroutable" wrongly read as safe
+// (#2013: show_media is the one BUFFERED command). This runs after the reply,
+// on the reply: there is no address to resolve, no await to be stale across and
+// no mailbox to mis-classify.
+//
+// Every test below names the mutation it exists to kill.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  showMediaReplyAccountsForItems,
+  unaccountedShowMediaNote,
+} from "../../services/comfy-view-ref.js";
+
+const { annotateShowMediaAck } = __panelToolsTestHooks;
+
+/** The mobile / remote pseudo-panel's literal reply (bridge_client.dart:206). */
+const MOBILE_REPLY = { shown: true } as const;
+
+/** The sidebar panel's real #710 reply — composeShowMediaReply's return
+ *  (comfyui-mcp-panel `web/js/lib/media-preview.js`), copied field for field. */
+const PANEL_REPLY = {
+  ok: true,
+  count: 1,
+  painted: 1,
+  unconfirmed: 0,
+  unrenderable: [] as unknown[],
+  previews: [] as unknown[],
+  note: "1 audio player was placed in the panel chat for the USER. You cannot hear the audio.",
+};
+
+const okResult = (value: unknown): ToolResult => ({
+  content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+});
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+const doc = (res: ToolResult): Record<string, unknown> =>
+  JSON.parse((res.content[0] as { text: string }).text) as Record<string, unknown>;
+
+const ITEM = [{ filename: "voice.wav", kind: "viewRef" }];
+
+// -- the reply predicate ----------------------------------------------------
+describe("#2010 which replies ACCOUNT for the items they were given", () => {
+  it("the sidebar panel's #710 reply accounts for them", () => {
+    // Kills: making showMediaReplyAccountsForItems always false.
+    expect(showMediaReplyAccountsForItems(PANEL_REPLY)).toBe(true);
+  });
+
+  it("the mobile client's bare {shown:true} does not", () => {
+    // Kills: making showMediaReplyAccountsForItems always true.
+    expect(showMediaReplyAccountsForItems(MOBILE_REPLY)).toBe(false);
+  });
+
+  it("count+painted with no `unrenderable` does NOT account — that is the pre-#710 panel (#2017)", () => {
+    // Kills: dropping the Array.isArray(unrenderable) clause. A panel older than
+    // #710 has no `unrenderable` field BECAUSE it cannot tell "I presented this"
+    // from "I was handed a kind I have no player for" — it paints audio as a
+    // broken <img> and counts it as painted. Its count+painted are therefore
+    // exactly as unearned as {shown:true}.
+    expect(showMediaReplyAccountsForItems({ ok: true, count: 1, painted: 1, unconfirmed: 0 })).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ["a bare ok", { ok: true }],
+    ["a mailboxed receipt", { ok: true, mailboxed: true }],
+    ["a bare boolean", true],
+    ["an array", [{ count: 1, painted: 1, unrenderable: [] }]],
+    ["a string", "shown"],
+    ["null", null],
+    ["painted as a string", { count: 1, painted: "1", unrenderable: [] }],
+    ["count missing", { painted: 1, unrenderable: [] }],
+  ])("%s does not account", (_label, reply) => {
+    expect(showMediaReplyAccountsForItems(reply)).toBe(false);
+  });
+});
+
+// -- the correction itself --------------------------------------------------
+describe("#2010 an unaccounted reply no longer answers with the client's claim", () => {
+  it("the top-level document does NOT assert shown/painted for a bare {shown:true}", () => {
+    // Kills: returning `res` untouched for an unaccounted reply — i.e. the bug.
+    const out = annotateShowMediaAck(okResult(MOBILE_REPLY), ITEM);
+    const d = doc(out);
+    expect(d.shown).toBeUndefined();
+    expect(d.painted).toBeUndefined();
+    expect(d.dispatched).toBe(true);
+  });
+
+  it("`presented_confirmed` is null, never 0 — nothing either way was observed", () => {
+    // Kills: presented_confirmed: 0. Zero is a measurement ("I looked and found
+    // none"); this call did not look.
+    const d = doc(annotateShowMediaAck(okResult(MOBILE_REPLY), ITEM));
+    expect(d.presented_confirmed).toBeNull();
+    expect(d.presented_confirmed).not.toBe(0);
+  });
+
+  it("the client's own words are preserved verbatim under client_reply", () => {
+    // Kills: dropping client_reply. Deleting what the client said would be its
+    // own dishonesty; it is demoted, not discarded.
+    const d = doc(annotateShowMediaAck(okResult(MOBILE_REPLY), ITEM));
+    expect(d.client_reply).toEqual({ shown: true });
+  });
+
+  it("names every dispatched item and the kind it went out as", () => {
+    // Kills: emitting a bare count with no item list.
+    const d = doc(
+      annotateShowMediaAck(okResult(MOBILE_REPLY), [
+        { filename: "voice.wav", kind: "viewRef" },
+        { filename: "take2.wav", kind: "audio" },
+      ]),
+    );
+    expect(d.unaccounted).toEqual([
+      { filename: "voice.wav", kind: "viewRef" },
+      { filename: "take2.wav", kind: "audio" },
+    ]);
+    expect(d.count).toBe(2);
+  });
+
+  it("the note tells the agent not to narrate it, and not to re-send", () => {
+    // Kills: weakening the note to a neutral caveat. "Unconfirmed" read as
+    // "failed" makes an agent loop on a delivery that already happened.
+    const t = textOf(annotateShowMediaAck(okResult(MOBILE_REPLY), ITEM));
+    expect(t).toMatch(/did NOT establish/);
+    expect(t).toMatch(/do not tell the user what they saw or heard/);
+    expect(t).toMatch(/NOT a failure report and re-sending is the wrong next step/);
+    expect(t).toMatch(/voice\.wav/);
+  });
+
+  it("a MAILBOXED reply is described as queued-for-nobody, not as a silent client (#2013)", () => {
+    // Kills: deleting the mailboxed branch. show_media is the ONE command the
+    // bridge buffers instead of refusing, so "a client took it and said nothing"
+    // would be a false description of a command no client has seen.
+    const t = textOf(annotateShowMediaAck(okResult({ ok: true, mailboxed: true }), ITEM));
+    expect(t).toMatch(/QUEUED, not delivered/);
+    expect(t).not.toMatch(/The client acknowledged the command/);
+  });
+
+  it("a non-JSON reply is still corrected, and is kept as text", () => {
+    const out = annotateShowMediaAck({ content: [{ type: "text", text: "shown" }] }, ITEM);
+    expect(doc(out).client_reply).toBe("shown");
+  });
+});
+
+describe("#2010 the honest client is left ALONE — the correction does not over-fire", () => {
+  it("the panel's #710 reply is returned byte-identical", () => {
+    // Kills: applying the correction unconditionally. The panel already reports
+    // painted/unrenderable per item; rewriting it would delete the only honest
+    // account in the system.
+    const original = okResult(PANEL_REPLY);
+    const out = annotateShowMediaAck(original, ITEM);
+    expect(out).toBe(original);
+    expect(doc(out)).toEqual(PANEL_REPLY);
+  });
+
+  it("an errored dispatch is left alone — it has no claim to correct", () => {
+    const errored: ToolResult = {
+      content: [{ type: "text", text: "Error: no connected tab" }],
+      isError: true,
+    };
+    expect(annotateShowMediaAck(errored, ITEM)).toBe(errored);
+  });
+
+  it("nothing dispatched -> nothing to say", () => {
+    const original = okResult(MOBILE_REPLY);
+    expect(annotateShowMediaAck(original, [])).toBe(original);
+  });
+});
+
+// -- the CALL SITE, not just the helper -------------------------------------
+// A helper-level suite survives deleting the one line that installs it. These
+// drive panel_show_media's real handler.
+type Cmd = Record<string, unknown>;
+
+function makeCtx(reply: unknown, headless: boolean): { ctx: PanelToolCtx; calls: Cmd[] } {
+  const calls: Cmd[] = [];
+  const ctx = {
+    // Exactly what makePanelToolCtx does: `ok(await sendRouted(...))`.
+    call: async (cmd: Cmd) => {
+      calls.push(cmd);
+      return okResult(reply);
+    },
+    confirm: async () => "yes" as const,
+    bridge: { isHeadless: () => headless } as unknown as PanelToolCtx["bridge"],
+    tabId: "phone-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(
+  items: Array<Record<string, unknown>>,
+  reply: unknown,
+  headless = true,
+): Promise<{ res: ToolResult; calls: Cmd[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx(reply, headless);
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+describe("#2010 panel_show_media's handler INSTALLS the correction", () => {
+  it("the reported repro — a .wav to a headless client no longer answers {shown:true}", async () => {
+    // Kills: removing the annotateShowMediaAck(...) wrapper at the ctx.call site.
+    // This is the one-line wiring mutation; every helper test above survives it.
+    const { res } = await showMedia(
+      [{ source: { filename: "voice.wav", type: "output" }, caption: "take 3" }],
+      MOBILE_REPLY,
+    );
+    expect(res.isError).toBeFalsy();
+    const d = doc(res);
+    expect(d.shown).toBeUndefined();
+    expect(d.presented_confirmed).toBeNull();
+    expect(d.client_reply).toEqual({ shown: true });
+    expect(textOf(res)).toMatch(/did NOT establish/);
+  });
+
+  it("the item was still DISPATCHED — this corrects a claim, it does not refuse", async () => {
+    // Kills: turning the correction into a pre-dispatch refusal (what main does
+    // today for a `{path}` .wav, and what this issue exists NOT to re-create).
+    const { res, calls } = await showMedia(
+      [{ source: { filename: "voice.wav", type: "output" } }],
+      MOBILE_REPLY,
+    );
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { items: unknown[] }).items).toHaveLength(1);
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("the #941 view-ref note still lands AFTER the corrected document", async () => {
+    // Kills: prepending the correction, or replacing the whole content array —
+    // either would drop the notes the handler appends afterwards.
+    const { res } = await showMedia(
+      [{ source: { filename: "voice.wav", type: "output" } }],
+      MOBILE_REPLY,
+    );
+    const blocks = res.content.map((c) => ("text" in c ? c.text : ""));
+    expect(blocks[0]).toMatch(/"dispatched": true/);
+    expect(blocks.slice(1).join("\n")).toMatch(/sent to the panel as a ComfyUI \/view REFERENCE/);
+  });
+
+  it("a sidebar panel session is unaffected end to end", async () => {
+    const { res } = await showMedia(
+      [{ source: { filename: "voice.wav", type: "output" } }],
+      PANEL_REPLY,
+      false,
+    );
+    expect(doc(res)).toEqual(PANEL_REPLY);
+    expect(textOf(res)).not.toMatch(/did NOT establish/);
+  });
+});
+
+describe("#2010 the note builder", () => {
+  it("says nothing when nothing was dispatched", () => {
+    expect(unaccountedShowMediaNote([], MOBILE_REPLY)).toBe("");
+  });
+
+  it("caps the item list and says how many it left out", () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({ filename: `t${i}.wav`, kind: "audio" }));
+    const t = unaccountedShowMediaNote(many, MOBILE_REPLY);
+    expect(t).toMatch(/and 2 more/);
+    expect(t).not.toMatch(/t9\.wav/);
+  });
+});

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -399,12 +399,33 @@ describe("#2010 r2 — accounting has to be about the batch that was sent", () =
     expect(showMediaReplyAccountsForItems({ count: 2, painted: 1, unrenderable: [] }, 2)).toBe(true);
   });
 
+  // gate r2, P1: non-negative is NOT enough. `{count:1, painted:0.5}` satisfies
+  // `0.5 <= 1` and would be relayed as a trustworthy account of one item. A
+  // fraction of a card was never painted.
   it.each([
     ["a negative count", { count: -1, painted: 0, unrenderable: [] }],
     ["a fractional count", { count: 1.5, painted: 0, unrenderable: [] }],
     ["a negative painted", { count: 1, painted: -1, unrenderable: [] }],
+    ["a FRACTIONAL painted", { count: 1, painted: 0.5, unconfirmed: 0, unrenderable: [] }],
+    ["a FRACTIONAL unconfirmed", { count: 1, painted: 0, unconfirmed: 0.5, unrenderable: [] }],
+    ["a negative unconfirmed", { count: 1, painted: 1, unconfirmed: -1, unrenderable: [] }],
+    ["NaN painted", { count: 1, painted: Number.NaN, unrenderable: [] }],
+    ["Infinity count", { count: Number.POSITIVE_INFINITY, painted: 0, unrenderable: [] }],
   ])("%s is not an account", (_l, reply) => {
     expect(showMediaReplyAccountsForItems(reply, 1)).toBe(false);
+  });
+
+  it("a fractional painted is reported as INCOHERENT, and the claim is corrected", () => {
+    // Kills: checking only `>= 0` on painted/unconfirmed (gate r2, P1). The
+    // dangerous half of that bug is that it returns accounted:TRUE — the reply
+    // is relayed verbatim and the safeguard never runs at all.
+    const FRACTION = { ok: true, count: 1, painted: 0.5, unconfirmed: 0, unrenderable: [] };
+    expect(readShowMediaAck(FRACTION, 1).accounted).toBe(false);
+    expect(readShowMediaAck(FRACTION, 1).reason).toBe("incoherent_accounting");
+    const out = annotateShowMediaAck(okResult(FRACTION), ITEM);
+    expect(doc(out).unaccounted_because).toBe("incoherent_accounting");
+    expect(doc(out).client_reply).toEqual(FRACTION);
+    expect(textOf(out)).toMatch(/did NOT establish/);
   });
 
   it("a mailbox receipt carrying counts is still MAILBOXED, not an account", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -40,7 +40,7 @@ import {
   resolveServableViewRef,
   stageFileIntoServedDir,
   stagedForDisplayNote,
-  showMediaReplyAccountsForItems,
+  readShowMediaAck,
   unaccountedShowMediaNote,
   unverifiedViewRefNote,
   type DispatchedMediaItem,
@@ -3721,9 +3721,13 @@ function annotateShowMediaAck(
   // A dispatch that FAILED already says so, and has no claim to correct.
   if (res.isError || dispatched.length === 0) return res;
   const parsed = parseToolResultJson(res);
-  // The sidebar panel's #710 reply accounts for every item it was given. It is
-  // the honest one and is left EXACTLY as it arrived — including its own note.
-  if (showMediaReplyAccountsForItems(parsed)) return res;
+  const verdict = readShowMediaAck(parsed, dispatched.length);
+  // Two replies are left EXACTLY as they arrived. The sidebar panel's #710 reply
+  // accounts for every item it was given — it is the honest one and nothing here
+  // improves on it. A reply that DECLARES failure (`ok:false`) is not claiming a
+  // success either, and rewriting it as `dispatched:true` with "do not re-send"
+  // would manufacture the over-claim this exists to remove (gate r1, P1).
+  if (verdict.accounted || verdict.reason === "declared_failure") return res;
   return {
     ...res,
     content: [
@@ -3741,6 +3745,12 @@ function annotateShowMediaAck(
             /** Deliberately null, not 0: this call did not observe zero
              *  renderings, it observed nothing either way. */
             presented_confirmed: null,
+            /** Why the reply could not settle it — "no_accounting",
+             *  "partial_accounting" or "mailboxed". Structured so a caller can
+             *  branch on it without reading the prose. */
+            unaccounted_because: verdict.reason,
+            /** EVERY dispatched item, even under partial accounting: a reply
+             *  that covers 1 of 2 does not say WHICH, so none can be settled. */
             unaccounted: dispatched.map((d) => ({ filename: d.filename, kind: d.kind })),
             client_reply: parsed ?? toolResultText(res),
           },
@@ -3748,7 +3758,7 @@ function annotateShowMediaAck(
           2,
         ),
       },
-      { type: "text", text: unaccountedShowMediaNote(dispatched, parsed) },
+      { type: "text", text: unaccountedShowMediaNote(dispatched, verdict) },
       ...res.content.slice(1),
     ],
   };

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -40,7 +40,10 @@ import {
   resolveServableViewRef,
   stageFileIntoServedDir,
   stagedForDisplayNote,
+  showMediaReplyAccountsForItems,
+  unaccountedShowMediaNote,
   unverifiedViewRefNote,
+  type DispatchedMediaItem,
   type ForwardedByReference,
   type StagedForDisplay,
   type UnverifiedViewRef,
@@ -1040,6 +1043,10 @@ export const __panelToolsTestHooks = {
    *  tool-handler suite never reaches must still fail. */
   annotateFreeVramAck,
   deviceStillPinned,
+  /** #2010 — the show_media claim correction, driven directly so a mutation of
+   *  it fails even where the handler suite does not reach. The handler CALL SITE
+   *  is covered separately (deleting the wiring must also fail a named test). */
+  annotateShowMediaAck,
   /** Direct access to the #742 decline recheck loop so its hard-deadline
    *  guarantee (codex gate r2) can be unit-tested with a custom deadline. */
   probeDeclineRecovery,
@@ -3680,6 +3687,71 @@ async function annotateFreeVramAck(ctx: PanelToolCtx, res: ToolResult): Promise<
     });
   }
   return res;
+}
+
+/**
+ * #2010 — `panel_show_media` returns the CLIENT's reply. One of the two clients
+ * that answer it lies: the mobile / remote pseudo-panel replies `{shown: true}`
+ * to any show_media without reading the items, and it has no audio player, so
+ * an audio take is acknowledged as delivered while the user hears nothing and
+ * sees a broken image card. That false success is worse than the refusal it
+ * replaced — a user who cannot hear a take KNOWS they cannot; an agent told
+ * `shown: true` believes it played and stops trying.
+ *
+ * The correction is not a guard on the destination. Three attempts at that
+ * (spike/1572-headless-audio-guard) each drew a fresh P1 of one class: they
+ * asked a question about `ctx.tabId` — an ADDRESS — before dispatch, and had to
+ * PREDICT where the frame would land (#2012: scope addresses, live rebinds and
+ * sticky headlessness all defeat it; #2013: an unroutable command is BUFFERED,
+ * not refused). This asks nothing about the destination. It runs AFTER the
+ * reply, on the reply, so there is nothing left to predict — no address to
+ * resolve, no await to be stale across, no mailbox to mis-classify. A wrong
+ * answer here is not even possible in the dangerous direction: the only thing
+ * it can do is decline to repeat a claim the client did not support.
+ *
+ * Same family as annotateFreeVramAck (#1866): the panel's acknowledgement is
+ * not a receipt, and the honest reply is one that says which of the two it got.
+ * Nothing is refused, nothing is withheld, and the client's own words are kept
+ * verbatim under `client_reply`.
+ */
+function annotateShowMediaAck(
+  res: ToolResult,
+  dispatched: readonly DispatchedMediaItem[],
+): ToolResult {
+  // A dispatch that FAILED already says so, and has no claim to correct.
+  if (res.isError || dispatched.length === 0) return res;
+  const parsed = parseToolResultJson(res);
+  // The sidebar panel's #710 reply accounts for every item it was given. It is
+  // the honest one and is left EXACTLY as it arrived — including its own note.
+  if (showMediaReplyAccountsForItems(parsed)) return res;
+  return {
+    ...res,
+    content: [
+      {
+        type: "text",
+        // The claim the caller reads first must not be the one this call could
+        // not support. `shown: true` is preserved — it is what the client said
+        // and dropping it would be its own kind of dishonesty — but it is
+        // demoted to `client_reply`, where it reads as evidence rather than as
+        // the answer.
+        text: JSON.stringify(
+          {
+            dispatched: true,
+            count: dispatched.length,
+            /** Deliberately null, not 0: this call did not observe zero
+             *  renderings, it observed nothing either way. */
+            presented_confirmed: null,
+            unaccounted: dispatched.map((d) => ({ filename: d.filename, kind: d.kind })),
+            client_reply: parsed ?? toolResultText(res),
+          },
+          null,
+          2,
+        ),
+      },
+      { type: "text", text: unaccountedShowMediaNote(dispatched, parsed) },
+      ...res.content.slice(1),
+    ],
+  };
 }
 
 // ---- panel_install_node: accepted-but-never-enqueued (#1129) ---------------
@@ -18324,7 +18396,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           }
         }
 
-        const res = await ctx.call({ cmd: "show_media", items: resolved }, 60000);
+        // #2010 — the reply below is the CLIENT's, and one of the two clients
+        // that answer show_media says `{shown:true}` without reading the items.
+        // Correct the claim against what the reply actually accounted for BEFORE
+        // any of the notes below are appended, so they annotate the honest
+        // document rather than the client's word for it.
+        const res = annotateShowMediaAck(
+          await ctx.call({ cmd: "show_media", items: resolved }, 60000),
+          resolved.map((r) => ({
+            filename: typeof r.filename === "string" ? r.filename : "(unnamed)",
+            // As SENT, never re-derived: "image"/"video" for inlined bytes,
+            // "viewRef" for a ComfyUI reference whose media kind only the
+            // client's own classifier decides.
+            kind: typeof r.kind === "string" ? r.kind : "(unknown)",
+          })) satisfies DispatchedMediaItem[],
+        );
         // Why an item the caller passed as a PATH came back described as a
         // reference — the panel cannot say, because it never saw the path or the
         // size. Appended as a separate block so the panel's own reply (which is

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -911,11 +911,16 @@ export function readShowMediaAck(reply: unknown, dispatchedCount: number): ShowM
     return { accounted: false, reason: "no_accounting", covered: null };
   }
   const unconfirmed = typeof r.unconfirmed === "number" ? r.unconfirmed : 0;
+  // EVERY number here must be a whole non-negative one. Non-negative alone is
+  // not enough: `{count:1, painted:0.5}` satisfies `0.5 <= 1` and would be
+  // relayed as a trustworthy account of one item (gate r2, P1). A fraction of a
+  // card was never painted; a reply that says so is malformed, and malformed
+  // accounting is not accounting.
+  const whole = (n: number): boolean => Number.isInteger(n) && n >= 0;
   const coherent =
-    Number.isInteger(count) &&
-    count >= 0 &&
-    painted >= 0 &&
-    unconfirmed >= 0 &&
+    whole(count) &&
+    whole(painted) &&
+    whole(unconfirmed) &&
     // `dropped` is described in the panel's note but not carried as a field, so
     // the parts can be FEWER than the count. They can never be more.
     painted + unconfirmed + unrenderable.length <= count;

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -838,28 +838,97 @@ export type DispatchedMediaItem = {
   kind: string;
 };
 
+/** Why a `show_media` reply did or did not establish that its items were
+ *  presented. Each value changes what the caller may honestly say. */
+export type ShowMediaAckReason =
+  /** The #710 per-item contract, covering the batch that was actually sent. */
+  | "accounted"
+  /** The reply DECLARES failure (`ok:false`). Nothing needs correcting: the
+   *  client is not claiming a success, it is reporting the opposite. */
+  | "declared_failure"
+  /** #2013 — buffered by the bridge because it could not route. No client has
+   *  seen it, so no client can have presented it. */
+  | "mailboxed"
+  /** No per-item accounting at all — `{shown:true}`, `{ok:true}`, a string. */
+  | "no_accounting"
+  /** Well-formed accounting about a DIFFERENT number of items than were sent. */
+  | "partial_accounting"
+  /** Accounting whose own numbers do not add up — `painted + unconfirmed +
+   *  unrenderable.length` exceeds the `count` it declares, or the count is not
+   *  a whole non-negative number. A reply that contradicts itself establishes
+   *  nothing, and it is a different thing to report than a short one. */
+  | "incoherent_accounting";
+
+export type ShowMediaAckVerdict = {
+  /** True only when the reply establishes presentation for the WHOLE batch. */
+  accounted: boolean;
+  reason: ShowMediaAckReason;
+  /** How many items the reply itself claims to be about, when it says at all;
+   *  null when it does not. A COUNT, never an identity — a reply covering 1 of
+   *  2 items does not say WHICH one, so nothing downstream can name it. */
+  covered: number | null;
+};
+
 /**
- * Does this `show_media` reply ACCOUNT FOR the items it was given?
+ * What a `show_media` reply established about the items it was given.
  *
- * True only for the #710 contract: a numeric `count`, a numeric `painted`, and
- * an `unrenderable` array. All three are required and each is load-bearing —
- * `count`+`painted` are the arithmetic (`painted + unconfirmed +
- * unrenderable.length + dropped === count`), and `unrenderable` is the field a
- * client only has once it can tell "I presented this" from "I was handed a kind
- * I have no player for". A reply missing any of them did not do the accounting,
- * whatever else it says about itself.
+ * `accounted` is true only for the #710 contract — a numeric `count`, a numeric
+ * `painted`, and an `unrenderable` array — AND only when that accounting is
+ * about the batch that was actually dispatched. Every clause is load-bearing:
+ *
+ *  - `count`+`painted` are the arithmetic the panel documents
+ *    (`painted + unconfirmed + unrenderable.length + dropped === count`);
+ *  - `unrenderable` is the field a client only has once it can tell "I presented
+ *    this" from "I was handed a kind I have no player for" — a panel older than
+ *    #710 has the first two and not this one (#2017);
+ *  - the COVERAGE check is the difference between an account and a coincidence.
+ *    `{count:1, painted:1, unrenderable:[]}` is a perfectly well-formed #710
+ *    reply and it establishes nothing whatever about the SECOND item of a
+ *    two-item batch. Without it the extra item is lost in silence — which is
+ *    the same defect this module exists to remove, one layer in (gate r1, P1).
  *
  * Note what is NOT accepted: `{shown: true}`, `{ok: true}`, `{mailboxed: true}`,
  * a bare `true`, an array, a string. None of them names an item.
  */
-export function showMediaReplyAccountsForItems(reply: unknown): boolean {
-  if (!reply || typeof reply !== "object" || Array.isArray(reply)) return false;
+export function readShowMediaAck(reply: unknown, dispatchedCount: number): ShowMediaAckVerdict {
+  if (!reply || typeof reply !== "object" || Array.isArray(reply)) {
+    return { accounted: false, reason: "no_accounting", covered: null };
+  }
   const r = reply as Record<string, unknown>;
-  return (
-    typeof r.count === "number" &&
-    typeof r.painted === "number" &&
-    Array.isArray(r.unrenderable)
-  );
+  // A reply that DECLARES failure is left alone. This exists to stop an
+  // unearned claim of SUCCESS; `ok:false` is the client claiming the opposite,
+  // and rewriting it as `dispatched:true` — telling the caller not to re-send —
+  // would manufacture the very over-claim it is here to remove (gate r1, P1).
+  if (r.ok === false) return { accounted: false, reason: "declared_failure", covered: null };
+  // #2013 — buffered rather than refused. Checked BEFORE the shape test so a
+  // mailbox receipt that happened to carry counts could not be read as an
+  // account of a presentation no client has had the chance to make.
+  if (r.mailboxed === true) return { accounted: false, reason: "mailboxed", covered: null };
+  const count = r.count;
+  const painted = r.painted;
+  const unrenderable = r.unrenderable;
+  if (typeof count !== "number" || typeof painted !== "number" || !Array.isArray(unrenderable)) {
+    return { accounted: false, reason: "no_accounting", covered: null };
+  }
+  const unconfirmed = typeof r.unconfirmed === "number" ? r.unconfirmed : 0;
+  const coherent =
+    Number.isInteger(count) &&
+    count >= 0 &&
+    painted >= 0 &&
+    unconfirmed >= 0 &&
+    // `dropped` is described in the panel's note but not carried as a field, so
+    // the parts can be FEWER than the count. They can never be more.
+    painted + unconfirmed + unrenderable.length <= count;
+  if (!coherent) return { accounted: false, reason: "incoherent_accounting", covered: count };
+  if (count !== dispatchedCount) {
+    return { accounted: false, reason: "partial_accounting", covered: count };
+  }
+  return { accounted: true, reason: "accounted", covered: count };
+}
+
+/** Thin boolean over {@link readShowMediaAck}, for a call site that only gates. */
+export function showMediaReplyAccountsForItems(reply: unknown, dispatchedCount: number): boolean {
+  return readShowMediaAck(reply, dispatchedCount).accounted;
 }
 
 /**
@@ -873,10 +942,17 @@ export function showMediaReplyAccountsForItems(reply: unknown): boolean {
  * Re-sending is called out explicitly as the WRONG next step. The identical
  * reply comes back the second time, and an agent that reads "unconfirmed" as
  * "failed" will loop on a delivery that already happened.
+ *
+ * The three unaccounted reasons are genuinely different diagnoses and are not
+ * given one wording. "The client took it and said nothing" is false of a
+ * mailboxed command that no client has seen (#2013), and false again of a reply
+ * that accounted for a DIFFERENT number of items than were sent — there the
+ * client did read items, just not all of these, and the shortfall is the thing
+ * the caller has to be told about (gate r1, P1).
  */
 export function unaccountedShowMediaNote(
   dispatched: readonly DispatchedMediaItem[],
-  reply: unknown,
+  verdict: ShowMediaAckVerdict,
 ): string {
   if (dispatched.length === 0) return "";
   const one = dispatched.length === 1;
@@ -886,20 +962,36 @@ export function unaccountedShowMediaNote(
     .join("\n");
   const more = dispatched.length > 8 ? `\n  - …and ${dispatched.length - 8} more` : "";
 
-  // #2013 — `show_media` is the ONE command the bridge buffers instead of
-  // refusing when it cannot route. `mailboxed: true` therefore means no client
-  // has seen this at all yet, which is a different (and weaker) fact than "a
-  // client took it and said nothing about it". Say which one happened.
-  const mailboxed =
-    reply && typeof reply === "object" && (reply as Record<string, unknown>).mailboxed === true;
-
-  const what = mailboxed
-    ? `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. It will be handed ` +
-      `to whichever client connects next, and nothing here says that client can present it.`
-    : `The client acknowledged the command but did not report what it rendered — its reply carries no ` +
+  let what: string;
+  if (verdict.reason === "mailboxed") {
+    // #2013 — `show_media` is the ONE command the bridge buffers instead of
+    // refusing when it cannot route. No client has seen this at all yet, which
+    // is a weaker fact than "a client took it and said nothing about it".
+    what =
+      `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. It will be handed ` +
+      `to whichever client connects next, and nothing here says that client can present it.`;
+  } else if (verdict.reason === "partial_accounting") {
+    // A count is not an identity: a reply about 1 of 2 items does not say WHICH
+    // one, so every item is listed and none can be marked settled.
+    what =
+      `The client's reply accounts for ${verdict.covered ?? "an unstated number of"} item(s), but ` +
+      `${dispatched.length} were sent — so it is not an account of this batch. It does not say WHICH ` +
+      `of them it was about, so none of them can be treated as settled.`;
+  } else if (verdict.reason === "incoherent_accounting") {
+    // Said apart from the short-count case on purpose: the numbers here are
+    // about the right batch and still cannot be true, and "it covered N of M"
+    // would be nonsense prose when N and M are equal.
+    what =
+      `The client's reply is shaped like a per-item account but its own numbers do not add up ` +
+      `(\`painted\` + \`unconfirmed\` + \`unrenderable\` exceeds the \`count\` it declares, or that ` +
+      `count is not a whole number). A reply that contradicts itself establishes nothing.`;
+  } else {
+    what =
+      `The client acknowledged the command but did not report what it rendered — its reply carries no ` +
       `per-item accounting (\`count\`/\`painted\`/\`unrenderable\`), so it did not read the items. ` +
       `The mobile / remote client answers \`{"shown": true}\` to any show_media without looking at them, ` +
       `and it has no audio player at all.`;
+  }
 
   return (
     `NOTE — this call did NOT establish that ${one ? "this item was" : "these items were"} presented ` +

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -792,3 +792,122 @@ export function unverifiedViewRefNote(
     `which is verified and inlined as bytes.`
   );
 }
+
+// ---------------------------------------------------------------------------
+// #2010 — what a `show_media` reply actually ESTABLISHED
+// ---------------------------------------------------------------------------
+//
+// `panel_show_media` dispatches items to whatever client the session is bound
+// to and returns that client's reply verbatim. Two clients answer it, and they
+// do not answer the same question:
+//
+//   • the sidebar panel replies with the #710 per-item contract —
+//     `{ok, count, painted, unconfirmed, unrenderable, previews, note}` — where
+//     `painted` counts only what the person can SEE or HEAR and a kind it has no
+//     player for is reported in `unrenderable` instead. That reply read the
+//     items and says what became of each one.
+//
+//   • the mobile / remote pseudo-panel replies `{'shown': true}` to ANY
+//     show_media, without reading the items at all
+//     (comfyui-mcp-mobile `bridge_client.dart`: `replyOk(frame.rid, {'shown':
+//     true})`). Its `MediaCard.build` is `if (item.isVideo) _video else _still`
+//     — two branches, no audio one — so an audio item becomes an `<Image>` that
+//     fails to decode. The reply says it was shown; nothing looked.
+//
+// Relaying the second one is this repo's own worst failure mode: a tool
+// reporting an outcome it did not observe. The rule below states the narrowest
+// true thing instead, and it asks NO question about the destination — no
+// "is this tab headless", no extension sniffing, no client guess. It reads the
+// reply that came back. A client earns the claim by accounting for the items;
+// one that does not account for them establishes acceptance and nothing more.
+//
+// That is deliberately kind-agnostic. Audio is what surfaced it, but "the
+// client did not say what it rendered" is exactly as true of an image, and a
+// rule that fired only for audio would be a guess about the other kinds wearing
+// a narrower coat. It also, without naming them, covers a panel older than #710
+// (whose reply predates `unrenderable` and which paints audio as a broken
+// `<img>` — the client in #2017) and any future client this bridge meets.
+
+/** One item `panel_show_media` actually dispatched, as it went on the wire. */
+export type DispatchedMediaItem = {
+  filename: string;
+  /** The `kind` field on the dispatched item — "image"/"video" for inlined
+   *  bytes, "viewRef" for a ComfyUI reference. Reported as sent, never
+   *  re-derived here: a guess about the media kind is the thing this module is
+   *  refusing to make. */
+  kind: string;
+};
+
+/**
+ * Does this `show_media` reply ACCOUNT FOR the items it was given?
+ *
+ * True only for the #710 contract: a numeric `count`, a numeric `painted`, and
+ * an `unrenderable` array. All three are required and each is load-bearing —
+ * `count`+`painted` are the arithmetic (`painted + unconfirmed +
+ * unrenderable.length + dropped === count`), and `unrenderable` is the field a
+ * client only has once it can tell "I presented this" from "I was handed a kind
+ * I have no player for". A reply missing any of them did not do the accounting,
+ * whatever else it says about itself.
+ *
+ * Note what is NOT accepted: `{shown: true}`, `{ok: true}`, `{mailboxed: true}`,
+ * a bare `true`, an array, a string. None of them names an item.
+ */
+export function showMediaReplyAccountsForItems(reply: unknown): boolean {
+  if (!reply || typeof reply !== "object" || Array.isArray(reply)) return false;
+  const r = reply as Record<string, unknown>;
+  return (
+    typeof r.count === "number" &&
+    typeof r.painted === "number" &&
+    Array.isArray(r.unrenderable)
+  );
+}
+
+/**
+ * The disclosure an unaccounted-for `show_media` reply has to carry.
+ *
+ * Written to be un-mistakable for a failure report, because it is not one: the
+ * items were dispatched and the client took them. What is missing is the part
+ * that would let this tool say the person perceived them — so the one thing the
+ * caller must not do is narrate the audio, or the picture, as though it landed.
+ *
+ * Re-sending is called out explicitly as the WRONG next step. The identical
+ * reply comes back the second time, and an agent that reads "unconfirmed" as
+ * "failed" will loop on a delivery that already happened.
+ */
+export function unaccountedShowMediaNote(
+  dispatched: readonly DispatchedMediaItem[],
+  reply: unknown,
+): string {
+  if (dispatched.length === 0) return "";
+  const one = dispatched.length === 1;
+  const lines = dispatched
+    .slice(0, 8)
+    .map((d) => `  - ${d.filename} (dispatched as ${d.kind})`)
+    .join("\n");
+  const more = dispatched.length > 8 ? `\n  - …and ${dispatched.length - 8} more` : "";
+
+  // #2013 — `show_media` is the ONE command the bridge buffers instead of
+  // refusing when it cannot route. `mailboxed: true` therefore means no client
+  // has seen this at all yet, which is a different (and weaker) fact than "a
+  // client took it and said nothing about it". Say which one happened.
+  const mailboxed =
+    reply && typeof reply === "object" && (reply as Record<string, unknown>).mailboxed === true;
+
+  const what = mailboxed
+    ? `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. It will be handed ` +
+      `to whichever client connects next, and nothing here says that client can present it.`
+    : `The client acknowledged the command but did not report what it rendered — its reply carries no ` +
+      `per-item accounting (\`count\`/\`painted\`/\`unrenderable\`), so it did not read the items. ` +
+      `The mobile / remote client answers \`{"shown": true}\` to any show_media without looking at them, ` +
+      `and it has no audio player at all.`;
+
+  return (
+    `NOTE — this call did NOT establish that ${one ? "this item was" : "these items were"} presented ` +
+    `to the user:\n${lines}${more}\n` +
+    `${what}\n` +
+    `So: do not tell the user what they saw or heard here, and do not describe the contents of a file ` +
+    `on the basis of this reply. Ask them whether ${one ? "it" : "they"} appeared, if you need to know.\n` +
+    `This is NOT a failure report and re-sending is the wrong next step — the same reply comes back. ` +
+    `A sidebar panel answers with a real per-item account; this client does not.`
+  );
+}


### PR DESCRIPTION
Fixes #2010. Unblocks #2002, which is held behind it.

## The defect, reproduced by execution

`panel_show_media` returns the **client's** reply. Two clients answer it and they do not answer the same question.

The sidebar panel replies with the #710 per-item contract — `{ok, count, painted, unconfirmed, unrenderable, previews, note}` — where `painted` counts only what the person can *see or hear*, and a kind it has no player for goes to `unrenderable` instead. That reply read the items.

The mobile / remote pseudo-panel replies `{'shown': true}` to **any** `show_media`, without reading the items:

```dart
// comfyui-mcp-mobile bridge_client.dart:206
if (frame.isShowMedia) {
  replyOk(frame.rid, {'shown': true});
}
```

and it has no audio player — `MediaCard.build` is `if (item.isVideo) _video(context) else _still(context)`, two branches, and `MediaItem.isVideo` is false for `audio/wav` and `.wav`. So a voice take becomes a `MemoryImage`/`NetworkImage` that cannot decode and degrades to a caption row with an image icon.

**Measured on the unmodified `origin/main` handler**, in this worktree, before any change. The `/view`-ref branch was never extension-gated, so this needs **none** of PR #2002:

```
=== DISPATCHED TO THE PHONE ===
{ "cmd": "show_media", "items": [ { "kind": "viewRef",
    "viewRef": {"filename":"voice.wav","type":"output"},
    "filename": "voice.wav", "caption": "take 3" } ] }

=== WHAT THE AGENT IS TOLD ===
isError: false
{
  "shown": true
}
```

That document is the whole of the tool's answer. The agent believes the take played and stops trying.

## The fix

A `show_media` reply establishes rendering **only for the items it accounts for**.

```ts
export function readShowMediaAck(reply: unknown, dispatchedCount: number): ShowMediaAckVerdict
//   accounted             — the #710 contract, COVERING the batch that was sent
//   declared_failure      — `ok:false`; the client is not claiming a success
//   mailboxed             — #2013, buffered; no client has seen it at all
//   no_accounting         — `{shown:true}`, `{ok:true}`, a string, an array
//   partial_accounting    — well-formed, but about a different number of items
//   incoherent_accounting — its own parts exceed the count it declares
```

`accounted` requires a numeric `count`, a numeric `painted`, an `unrenderable` array, **and** that the reply's own `count` equals what was dispatched, **and** that `painted + unconfirmed + unrenderable.length` does not exceed it (`dropped` lives only in the panel's note, so the parts may be fewer — never more).

Two of those states are returned **byte-identical**: `accounted` (the panel already told the truth and nothing here improves on it) and `declared_failure` (a client saying it did *not* do the thing is not claiming a success — rewriting that as a dispatch would be the same over-claim with the sign flipped). The other three are demoted: the tool answers with what it dispatched, keeps the client's own words verbatim under `client_reply`, tags the reason as `unaccounted_because`, and says plainly that the user must not be told what they saw or heard.

**Nothing is refused and nothing is withheld.** The items are dispatched exactly as before; this corrects a claim, it does not re-create `main`'s pre-dispatch refusal.

Each unaccounted reason gets its own wording, because they are different diagnoses. "The client did not read the items" is false of a partial account — it read *some* — so that note says how many the reply covered and states outright that **a count is not an identity**: a reply about 1 of 2 does not say WHICH, so every item stays listed and none is treated as settled.

## Same call, same fixture, three clients

| | dispatched | `isError` | top-level `shown` | top-level `painted` | `presented_confirmed` | warns |
|---|---|---|---|---|---|---|
| **A** headless, current mobile build (`{shown:true}`) | yes, `kind:viewRef` | false | *absent* | *absent* | `null` | **yes** |
| **B** headless, mobile build with [comfyui-mcp-mobile#39](https://github.com/artokun/comfyui-mcp-mobile/pull/39) | yes | false | `true` | `1` | — | no |
| **C** sidebar panel (#710 contract) | yes | false | — | `1` | — | no |

Row A's document:

```json
{
  "dispatched": true,
  "count": 1,
  "presented_confirmed": null,
  "unaccounted_because": "no_accounting",
  "unaccounted": [{ "filename": "voice.wav", "kind": "viewRef" }],
  "client_reply": { "shown": true }
}
```

`presented_confirmed` is `null`, never `0`. Zero is a measurement — "I looked and found none". This call did not look.

## Why this is not a fourth per-site guard

Three attempts at one lived on `spike/1572-headless-audio-guard`, and each drew a fresh gate P1 of a single class: they asked a question about `ctx.tabId` — an **address** — *before* dispatch, and therefore had to **predict** where the frame would land.

1. **Address vs destination** (#2012): a scope address (`orchestrator::codex`) is a plain lookup miss in `conns`, so `isHeadless` answers `false` for a session sitting on a phone.
2. **Stale across an await**: the check ran before the oversized-file `await` and was never revalidated.
3. **Unroutable treated as safe** (#2013): `show_media` is the *one* command the bridge **buffers** rather than refuses.

This asks nothing about the destination. It runs **after the reply, on the reply** — so there is no address to resolve, no await to be stale across and no mailbox to mis-classify. The dangerous direction is not reachable at all: the only thing a wrong answer here can do is decline to repeat a claim the client did not support. `mailboxed:true` is handled explicitly and described as *queued, not delivered*, rather than as a silent client.

It is the same family as `annotateFreeVramAck` (#1866, #1895) already in this file: an acknowledgement is not a receipt, and the honest reply is the one that says which of the two it got.

## Kind-agnostic, on purpose

Audio surfaced this, but *"the client did not say what it rendered"* is exactly as true of an image, and a rule that fired only for audio would be a guess about the other kinds wearing a narrower coat.

The over-fire this admits is stated plainly: **an image sent to a current mobile build is now reported as unconfirmed too.** It genuinely was not confirmed — that client's `{shown:true}` is accidentally right for images and wrong for audio, and the reply cannot tell them apart. The note is written so an agent does not read "unconfirmed" as "failed":

> This is NOT a failure report and re-sending is the wrong next step — the same reply comes back.

The remedy is the client reporting, which is [comfyui-mcp-mobile#39](https://github.com/artokun/comfyui-mcp-mobile/pull/39); once a phone runs it, row B above is what the agent sees.

`unrenderable` being required is load-bearing rather than cosmetic: it is the field a client only has **once it can tell "I presented this" from "I was handed a kind I have no player for"**. A panel older than #710 — which paints `kind:"audio"` as a broken `<img>` and counts it as painted, the client in #2017 — has `count` and `painted` but not `unrenderable`, so the same rule covers it without naming it. There is a named test for exactly that shape.

## Server-side or does it need a client release? Both, and they are separable

- **Server-side, useful today, every client:** the report is honest now. On `origin/main` an audio take to a phone is announced as shown; on this branch it is not. That is what unblocks #2002 — the trade it was held over ("an honest refusal became a false success") disappears, because the success is no longer claimed.
- **Needs a client release to make the user *hear* it:** [comfyui-mcp-mobile#39](https://github.com/artokun/comfyui-mcp-mobile/pull/39) adds the audio branch and the per-item reply. Until a phone runs that build, a LAN-paired phone gets no player and this PR reports so honestly. **This PR does not give the mobile user audio today.** It stops lying about it today.

## Gate rounds

**Round 1 returned NO-SHIP with two P1s.** Both were real; both are fixed in `6d5be65`, each with named tests and its own mutation:

1. *"structured client refusals are rewritten as successful dispatches"* — `{ok:false, delivered:"unknown"}` carries no transport `isError`, so it fell through to the unaccounted branch and came back as `dispatched:true` with *"re-sending is the wrong next step"*. The client said it had **not** done the thing and the tool answered that it had. Such a reply is now returned untouched.
2. *"accounting is accepted without checking coverage"* — `{ok:true,count:1,painted:1,unrenderable:[]}` passed unchanged for a **two**-item batch, losing the second in silence. Coverage is now checked against the dispatch, and the reply's internal arithmetic against itself.

While fixing (2) I split `incoherent_accounting` out of `partial_accounting`: when the reply's count *equals* the dispatch but its parts exceed it, "it accounts for 2 but 2 were sent" is nonsense prose, and the real fault is a reply contradicting itself.

**Round 2 returned NO-SHIP with one P1**, also real, fixed in `a190842`: `painted` and `unconfirmed` were checked `>= 0` but not for integrality, so `{count:1, painted:0.5, unconfirmed:0, unrenderable:[]}` satisfied `0.5 <= 1`, matched the dispatched count, and came back `accounted: true`. The dangerous half is not the arithmetic — an `accounted` verdict RELAYS the reply verbatim, so malformed accounting reached the caller as trustworthy and the correction never ran. All three numbers now go through one `whole()` predicate, which also closes NaN and Infinity.

## Mutation evidence

Twenty-one mutations, each **verified applied** (an anchor that does not match reads as a survivor) and each **KILLED**:

| # | mutation | killed |
|---|---|---|
| **M1** | **drop the `annotateShowMediaAck(...)` wrapper — the CALL SITE** | **2** |
| M2 | predicate always TRUE (every reply "accounts") | 19 |
| M3 | predicate always FALSE (correct even the honest panel) | 3 |
| M4 | drop the `unrenderable` clause (a pre-#710 panel would "account") | 1 |
| M5 | delete the #2013 mailboxed branch | 1 |
| M6 | `presented_confirmed: 0` instead of `null` | 2 |
| M7 | drop `client_reply` (discard what the client said) | 3 |
| M8 | drop the per-item `unaccounted` list | 1 |
| M9 | soften the note — remove the do-not-narrate instruction | 1 |
| M10 | drop the do-not-re-send clause | 1 |
| M11 | drop the `declared_failure` branch (gate r1 P1a) | 4 |
| M11b | handler stops honouring `declared_failure` | 3 |
| M12 | drop the COVERAGE check, count vs dispatched (gate r1 P1b) | 5 |
| M13 | drop the parts-cannot-exceed-count arithmetic | 2 |
| M14 | `partial_accounting` reuses the `no_accounting` wording | 1 |
| M15 | drop the structured `unaccounted_because` | 3 |
| **M16** | **feed the coverage check from the REPLY's own count instead of the dispatch** | **4** |
| M17 | fold `incoherent_accounting` into `partial_accounting` | 2 |
| M18 | drop the incoherent note branch | 1 |
| M19 | relax `whole()` back to `>= 0` (gate r2 P1) | 3 |
| M20 | drop the whole-number check on painted/unconfirmed | 3 |

**M1 is the one-line wiring mutation.** Every helper-level test above it survives M1; the call-site tests do not. **M16 is the one that matters most for the r1 finding**: reading the batch size out of the reply being judged would make the coverage check tautological, and it is killed.

## Test evidence

- New: `src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts` — 48 tests, each naming the mutation it exists to kill. Both the helper and `panel_show_media`'s real handler are driven; the panel's reply fixture is `composeShowMediaReply`'s return copied field for field from `comfyui-mcp-panel web/js/lib/media-preview.js`, not invented.
- Baseline on a clean `origin/main` worktree: **617 files / 11303 passed / 4 skipped / 0 failed**.
- This branch: **618 files / 11343 passed / 4 skipped**, plus one unrelated failure per run under machine load. Two full runs, two *different* single failures, each **passing in isolation**: `panel-pin-guard.test.ts` (109/109 alone) and `unstamped-reads-claim.test.ts` (11/11 alone). Neither file is touched by this diff — panel locks and workflow stamps have nothing to do with `show_media` — and two swarms plus a codex gate were running on this rig at the time.
- `npm run i18n:check` OK · `npm run check:vocabulary` OK (1759 files, no live references) · `tsc --noEmit` clean.

## Where to look hardest

- **`readShowMediaAck`** is the load-bearing predicate. If it is too generous, a lying client keeps its claim; too strict, and the panel's honest reply gets rewritten. Both directions have named tests and both are mutated (M2/M3/M4). The **ordering** inside it is deliberate: `ok:false` and `mailboxed` are checked *before* the shape test, so a mailbox receipt that happened to carry counts cannot be read as a record of a presentation no client has had the chance to make.
- **Where the batch size comes from.** The coverage check compares the reply's `count` to `dispatched.length` — the array this handler built, not anything the reply says about itself. M16 mutates exactly that.
- **The `res.content` splice** in `annotateShowMediaAck`: the handler pushes the #941 / #802 / #648 notes onto `res.content` *after* this runs, so prepending or replacing the array would drop them. Pinned by a test that asserts block 0 is the corrected document and the view-ref note still lands after it.
- **The over-fire on images to a current mobile build** is deliberate and argued above rather than hidden. If the judgement is that it should be narrowed, the place to narrow it is a client-declared capability, not a kind list here.

## Deliberately NOT done

- **The headless inline branch is untouched.** Widening it to `audio/*` is what a *tunnelled* (non-LAN) phone needs — `deriveComfyuiBase` maps the bridge host to `:8188`, which a tunnel does not expose, so a `/view` ref is unreachable there. Doing it here would mean either shipping up to 20 MB of base64 to clients that cannot use it, or adding a client-capability check **at the exact `isHeadless(ctx.tabId)` call site #2012 names** — a fourth per-site guard. It belongs on top of #2012's shared resolver; noted on #2010.
- **No refusal, anywhere.** `main`'s pre-dispatch `unsupported file type ".wav"` on the `{path}` branch is untouched; #2002 owns that.
- **#2013 is not solved**, only described correctly: the mailbox's scope-keyed recipient is still unknown at queue time.
- **#2017 is not closed.** The same rule covers its client, but that issue asks a broader question about old-panel compatibility.
- **No panel Playwright run.** No panel code changed here; the diff is entirely in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
