### PR TITLE
fix(2000): a frontend-only type refused for an unavailable object_info says so

### DIFF
--- a/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
+++ b/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
@@ -139,3 +139,86 @@ describe("panel_add_node names panel version skew for allowlisted frontend-only 
     expect(text).not.toMatch(/Ctrl\+Shift\+R/);
   });
 });
+
+// #2000 — the OTHER refusal shape, and the one an old panel emits on a HEALTHY
+// ComfyUI: panel_refresh_nodes timed out fetching /object_info, and the next
+// panel_add_node "MarkdownNote" was refused because the panel's guard checked
+// /object_info AVAILABILITY before consulting its frontend-only allowlist. The
+// panel-side fix is comfyui-mcp-panel#1586; this note is what reaches a user who
+// has not updated the panel yet, and the orchestrator ships far more often.
+
+/** The reporter's exact panel refusal (issue #2000). */
+const UNAVAILABLE_REFUSAL =
+  `cannot verify node type "MarkdownNote" against the ComfyUI backend ` +
+  `(object_info is unavailable — the backend is unreachable or the fetch failed). ` +
+  `Refusing to add rather than trust a possibly-stale node cache (#458). Reconnect ComfyUI and retry.`;
+
+describe("#2000 frontend-only type refused for an unavailable /object_info", () => {
+  it("THE REPORTED CASE: names the fact that /object_info never lists this type, and says not to reinstall", async () => {
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.20");
+    expect(r.isError).toBe(true);
+    // The panel's own refusal is KEPT — the note is appended, never a replacement.
+    expect(r.text).toContain("object_info is unavailable");
+    expect(r.text).toContain("FRONTEND-ONLY");
+    expect(r.text).toMatch(/never lists it in \/object_info by design/i);
+    expect(r.text).toMatch(/Do NOT reinstall a pack/i);
+    // A healthy-but-slow ComfyUI produces this exact state; say so.
+    expect(r.text).toMatch(/merely SLOW/i);
+  });
+
+  it("adds the version sentence ONLY when the tab actually advertised a version below the floor", async () => {
+    // The floor is read to pick an INPUT, never to compute an expectation — a floor
+    // that moves must not silently change what this test proves.
+    const BELOW = "0.0.1";
+    expect(compareSemver(BELOW, requiredPanelVersion())).toBeLessThan(0);
+    const below = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, BELOW);
+    expect(below.text).toContain(BELOW);
+    expect(below.text).toMatch(/HARD-REFRESH/i);
+
+    // No advertised version = no evidence of skew. The note still explains the type,
+    // but must NOT assert a stale panel — panel#612: no definite verdicts from
+    // absent evidence.
+    const unknown = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL);
+    expect(unknown.text).toContain("FRONTEND-ONLY");
+    expect(unknown.text).not.toMatch(/below this orchestrator's floor/i);
+    expect(unknown.text).not.toMatch(/HARD-REFRESH/i);
+    // …and it still gives the caller something to do.
+    expect(unknown.text).toMatch(/wait a moment and retry/i);
+  });
+
+  it("THE REPORTER'S OWN VERSION is ABOVE the floor — so the note must not depend on skew", async () => {
+    // Measured, and it is the reason this note is not gated on the version floor at
+    // all: the reporter ran panel 0.15.20 while the floor is lower, because the floor
+    // tracks BRIDGE CAPABILITY requirements, not "the version with the latest fixes".
+    // Gating on it would have made this hint fire for almost nobody — and it is also
+    // why #1828's skew note could never have fired for this reporter.
+    const REPORTER_VERSION = "0.15.20";
+    expect(compareSemver(REPORTER_VERSION, requiredPanelVersion())).toBeGreaterThan(0);
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, REPORTER_VERSION);
+    expect(r.text).toContain("FRONTEND-ONLY");
+    expect(r.text).toMatch(/merely SLOW/i);
+    // No skew evidence ⇒ no skew claim.
+    expect(r.text).not.toMatch(/below this orchestrator's floor/i);
+  });
+
+  it("does NOT tell a REAL backend type that it is frontend-only", async () => {
+    // The same refusal shape for a type that genuinely needs /object_info must keep
+    // the panel's wording untouched — this is the false-positive direction.
+    const r = await addNode(
+      "KSampler",
+      UNAVAILABLE_REFUSAL.replace("MarkdownNote", "KSampler"),
+      "0.15.20",
+    );
+    expect(r.isError).toBe(true);
+    expect(r.text).toContain("object_info is unavailable");
+    expect(r.text).not.toMatch(/FRONTEND-ONLY/);
+    expect(r.text).not.toMatch(/Do NOT reinstall/i);
+  });
+
+  it("the two refusal shapes stay mutually exclusive — #1828 keeps its own note", async () => {
+    const skew = await addNode(REPORTER_TYPE, REPORTER_REFUSAL, REPORTER_PANEL);
+    expect(skew.text).toMatch(/NOT a missing backend pack/i);
+    // The #2000 note must not also fire on the #1828 shape.
+    expect(skew.text).not.toMatch(/merely SLOW/i);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4133,6 +4133,25 @@ function isUnknownBackendNodeRefusal(res: ToolResult): boolean {
   );
 }
 
+/**
+ * #2000 — the OTHER refusal shape a frontend-only type can come back with, and the
+ * one an old panel emits on a perfectly healthy ComfyUI: the panel's add-node guard
+ * checked /object_info AVAILABILITY before consulting its frontend-only allowlist, so
+ * a /object_info fetch that merely TIMED OUT refused "MarkdownNote" — a type that
+ * fetch could never have spoken to, since the backend never lists it by design.
+ *
+ * Matched on the panel's own wording rather than a structured field because that is
+ * all the panel sends here; it is used ONLY to APPEND advice to a refusal the panel
+ * already made, never to authorize anything, so a miss costs a missing hint and a
+ * false positive costs an extra paragraph on an unrelated error.
+ */
+function isObjectInfoUnavailableRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return /object_info is unavailable|cannot verify (?:the )?node type/i.test(
+    textOfToolResult(res),
+  );
+}
+
 function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
   const fn = ctx.bridge.advertisedPanelVersion;
   if (typeof fn !== "function") return undefined;
@@ -4153,14 +4172,57 @@ function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
  * the pack update + hard-refresh; a restart alone leaves cached JS running the
  * old guard.
  */
+/**
+ * #2000 — what to tell the caller when an allowlisted FRONTEND-ONLY type is refused
+ * for an unavailable /object_info.
+ *
+ * The load-bearing sentence is the FACT, not a diagnosis: this type is never in
+ * /object_info, so a fetch that did not answer withheld nothing about it. Both causes
+ * are then named WITHOUT picking one — the panel repo deliberately stopped asserting
+ * definite verdicts from absent evidence (panel#612), and nothing here can tell a stale
+ * guard apart from a baseline that has not loaded yet. The version sentence is added
+ * only when the tab actually ADVERTISED a version below this orchestrator's floor,
+ * which is real evidence; otherwise it is left out entirely.
+ */
+function frontendOnlyUnavailableNote(classType: string, ctx: PanelToolCtx): string {
+  const advertised = tabAdvertisedPanelVersion(ctx);
+  const required = requiredPanelVersion();
+  let skew = "";
+  if (advertised && compareSemver(advertised, required) < 0) {
+    skew =
+      ` This tab announced panel ${advertised}, which is below this orchestrator's ` +
+      `floor of ${required} — ${describeInstallPanelAction(
+        "update",
+        "update the panel pack on the ComfyUI host",
+      )}, restart ComfyUI, then HARD-REFRESH the browser tab (Ctrl+Shift+R, or ` +
+      `Cmd+Shift+R on macOS); a restart alone leaves the tab running cached old JS.`;
+  }
+  return (
+    `
+
+NOTE: "${classType}" is a FRONTEND-ONLY node type. The ComfyUI backend never ` +
+    `lists it in /object_info by design, so an /object_info fetch that failed or timed ` +
+    `out says nothing about whether this type is addable — a healthy ComfyUI produces ` +
+    `exactly this state when /object_info is merely SLOW. Do NOT reinstall a pack and ` +
+    `do NOT treat this as a missing node.${skew} If the panel is already current, the ` +
+    `tab's node-type baseline has not finished loading: wait a moment and retry, and ` +
+    `reload the ComfyUI tab if it persists.`
+  );
+}
+
 function withFrontendOnlyPanelSkewNote(
   res: ToolResult,
   classType: unknown,
   ctx: PanelToolCtx,
 ): ToolResult {
   if (typeof classType !== "string") return res;
-  if (!isUnknownBackendNodeRefusal(res)) return res;
   if (!PANEL_ADD_NODE_FRONTEND_ONLY_TYPES.has(classType)) return res;
+  // #2000 — a DIFFERENT refusal shape with the same cause, handled first because the
+  // two are mutually exclusive and this one carries no version evidence of its own.
+  if (isObjectInfoUnavailableRefusal(res)) {
+    return appendToolResultText(res, frontendOnlyUnavailableNote(classType, ctx));
+  }
+  if (!isUnknownBackendNodeRefusal(res)) return res;
   const advertised = tabAdvertisedPanelVersion(ctx);
   if (!advertised) return res;
   const required = requiredPanelVersion();


### PR DESCRIPTION
Orchestrator half of #2000. The panel-side fix is **artokun/comfyui-mcp-panel#1586**; this is what reaches a user who has not updated the panel yet — and the orchestrator ships far more often than the pack does.

## The bug

On a healthy live canvas, `panel_refresh_nodes` timed out fetching `/object_info`, and the very next `panel_add_node "MarkdownNote"` was refused:

> cannot verify node type "MarkdownNote" against the ComfyUI backend (object_info is unavailable …). Refusing to add.

The panel's add-node guard checked `/object_info` **availability** before consulting its frontend-only allowlist, so a fetch that merely timed out vetoed a type that fetch could never have spoken to — the backend never lists `Note`/`MarkdownNote`/`Reroute`/`PrimitiveNode`, by design.

## What this PR adds

An appended note on that refusal, for allowlisted frontend-only types only. It leads with the **fact**, not a diagnosis:

- the backend never lists this type in `/object_info`, so a failed fetch says nothing about whether it is addable;
- a healthy-but-**slow** ComfyUI produces exactly this state;
- so do **not** reinstall a pack and do not treat it as a missing node.

Then it names both causes **without picking one**. Nothing on this side can tell a stale panel guard apart from a node-type baseline that has not finished loading, and panel#612 is explicit that a definite verdict must not be asserted from absent evidence. The version sentence is added **only** when the tab actually advertised a version below this orchestrator's floor — real evidence — and omitted entirely otherwise.

## The measurement that shaped the design

I nearly gated this on the panel version floor, the way #1828 does. That would have been wrong, and the test that caught it is in the diff:

```
reporter's panel  = 0.15.20
requiredPanelVersion() = 0.15.11     ⇒ compareSemver(...) = +1, ABOVE the floor
```

**The floor tracks bridge-capability requirements, not "the version carrying the latest fixes."** Gating on it would have made this hint fire for almost nobody — and it means **#1828's own skew note could never have fired for this reporter either**, which is worth knowing independently of this PR.

So the note is not version-gated; only the optional skew sentence is.

## Structure

Extends the existing #1828 appender rather than adding a fifth wrapper, so **all four `panel_add_node` call sites** are covered with no wiring change and the two refusal shapes cannot drift apart. Purely additive: it appends text to a result the panel already marked as an error, and can never change a verdict.

I did reorder two pure guards inside that function (allowlist check before refusal-shape check). The 5 pre-existing #1828 tests pass unchanged, and a dedicated test asserts the two shapes stay mutually exclusive.

## Evidence

Mutation results — the tests drive the **real `panel_add_node` handler** end to end, not the helper:

| mutant | result |
|---|---|
| remove the unavailable-refusal branch | **3 killed** |
| drop the frontend-only allowlist gate | **3 killed** |
| always claim version skew | **2 killed** |

10/10 in `add-node-frontend-only-skew.test.ts` (5 pre-existing #1828 + 5 new). Full suite result posted below once it finishes.

The false-positive direction is covered explicitly: a **real** backend type (`KSampler`) hitting the identical refusal keeps the panel's wording untouched and is never told it is frontend-only.

## Review status: PENDING

**Where to look first:**

1. **The reorder inside `withFrontendOnlyPanelSkewNote`.** I moved the allowlist check above the refusal-shape check. Both are pure and both must pass on the old path, so I believe it is behaviour-preserving — but it is the one place this PR touches existing logic, and "obviously equivalent" is exactly what a self-review gets wrong.
2. **Matching on panel prose.** `isObjectInfoUnavailableRefusal` regexes the panel's wording, which this repo normally refuses to do. My justification is that it only ever *appends advice* to a refusal the panel already made — it authorizes nothing, so a miss costs a missing hint and a false positive costs a paragraph. If that line is in the wrong place, say so.
3. **Whether this note is worth shipping at all** once panel#1586 lands. I argue yes: the pack updates far more slowly than the orchestrator, and after the panel fix this shape can still occur for a pending/unseeded baseline — where the advice is still correct.

Fixes the underlying cause reported in #2000 alongside panel#1586.
