### PR TITLE
fix(2001): the synthesis grace is read off the panel's own send bounds, and the notice stops claiming the panel never sent one

### DIFF
--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -826,34 +826,4 @@ describe("#2001: the grace is read off the panel's own send bounds", () => {
     expect(delivered[0].payload.prompt_id).toBe(PID);
     expect(wd.armedCount()).toBe(0);
   });
-
-  it("a storyboard grace shorter than the ordinary one can never make an extended arm fire sooner", async () => {
-    const clock = { t: 35_000_000 };
-    const entry = saveVideoHistoryEntry(PID);
-    const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
-    const wd = createRunCompletionWatchdog({
-      awaiting: (id) => RunCompletions.awaitingCompletion(id),
-      deliver: (payload, ticket) => {
-        delivered.push({ payload, ticket });
-        RunCompletions.record(ticket.tabId, payload, { conversation: ticket.conversation ?? CONV });
-      },
-      resolveOutputs: (id) =>
-        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
-      graceMs: 10_000,
-      storyboardGraceMs: 1_000, // misconfigured: SHORTER than the ordinary grace
-      now: () => clock.t,
-    });
-    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
-    wd.observe([{ promptId: PID, status: "success" }]);
-
-    clock.t += 10_000;
-    await wd.tick();
-    // Extended, and the floor holds: it is due at max(grace, storyboardGrace),
-    // i.e. still 10 s from the observation — which has just passed, so the very
-    // next tick delivers rather than the arm being stranded or fired early.
-    expect(delivered).toHaveLength(0);
-    expect(wd.armedCount()).toBe(1);
-    await wd.tick();
-    expect(delivered).toHaveLength(1);
-  });
 });

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -26,6 +26,7 @@ import {
   completionStatusFromHistoryEntry,
   historyOutputRefsFromEntry,
   DEFAULT_SYNTHESIS_GRACE_MS,
+  DEFAULT_STORYBOARD_GRACE_MS,
 } from "../../orchestrator/run-completion-watchdog.js";
 import type { CompletionStatus } from "../../services/queue-monitor.js";
 import { RunCompletions, type CompletionPayload, type RunTicket } from "../../orchestrator/run-completion-journal.js";
@@ -227,8 +228,10 @@ describe("#1789: a completion the panel never reported is filled in from ComfyUI
 describe("#1789: awaitingCompletion answers 'is this run still owed its notification?'", () => {
   it("#1556: the grace no longer waits for a panel sweep that may never come", () => {
     // The panel's own recovery sweep is 20 s. Waiting past it is what left the
-    // reporter's successful SaveImage silent for 45 s. 5 s is past the normal
-    // 1–2 s frame; reconnect skips even that.
+    // reporter's successful SaveImage silent for 45 s, so the grace stays under
+    // it and reconnect skips even that (reconcile()). #2001 raised the number
+    // from 5 s to 10 s because 5 s was under the panel's OWN still-probe bound —
+    // see the #2001 block below for the behaviour that pins it.
     expect(DEFAULT_SYNTHESIS_GRACE_MS).toBeLessThan(20_000);
     expect(DEFAULT_SYNTHESIS_GRACE_MS).toBeGreaterThan(1_000);
   });
@@ -270,7 +273,17 @@ describe("#1789: the synthesised note claims only what was observed", () => {
     const note = String(payload.note);
     expect(note).toContain(PID);
     expect(note).toContain("46s");
-    expect(note).toContain("the panel never delivered its completion");
+    // #2001 — WHAT WAS OBSERVED, NOT WHAT THE PANEL DID. This used to read "the
+    // panel never delivered its completion event", which the orchestrator cannot
+    // know: all it saw is that no completion reached IT. A panel still composing
+    // its frame (bounded at 8 s per still probe, 25 s per video storyboard) was
+    // reported as a broken panel, and #2001 is that notice, filed as a bug.
+    expect(note).toContain("No completion for it reached the orchestrator");
+    expect(note).not.toContain("the panel never delivered");
+    // …and the agent is told what the late panel frame it may still get MEANS,
+    // so one render is not reported as two.
+    expect(note).toContain("possible repeat");
+    expect(note).toContain("not a second render");
     // It must NOT pretend to carry pixels it never fetched.
     expect(payload.images).toEqual([]);
     expect(note).toContain('get_image (action:"list_outputs")');
@@ -361,7 +374,14 @@ describe("#1853: a dropped panel frame still yields the completed prompt's histo
     expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
 
     wd.observe([{ promptId: PID, status: "success" }]);
+    // #2001 — a SaveVideo run is one the panel has to storyboard before it can
+    // send, and it bounds that at 25 s. The ordinary grace must NOT pre-empt it.
     clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+    expect(wd.armedCount()).toBe(1);
+
+    clock.t += DEFAULT_STORYBOARD_GRACE_MS - DEFAULT_SYNTHESIS_GRACE_MS;
     await wd.tick();
 
     expect(delivered).toHaveLength(1);
@@ -666,5 +686,174 @@ describe("#1556: completionStatusFromHistoryEntry is fail-closed", () => {
         },
       })),
     ).toBe("success");
+  });
+});
+
+// #2001 — THE ORCHESTRATOR MUST NOT ANNOUNCE A SILENCE THE PANEL HAS NOT REACHED.
+//
+// #1556 cut the grace to 5 s on the premise that the panel's frame "lands within
+// a second or two". The panel composes ONE consolidated frame and sends nothing
+// until every part of it resolves, and its own code bounds that work past 5 s:
+// 8 s per still probe (`fetchImageBytes` / `fetchImageDimensions`) and 25 s per
+// video storyboard (`videoStoryboardTimeoutMs`). At 5 s the orchestrator was
+// therefore pre-empting a working panel and telling the agent, in words, that
+// the panel "never delivered its completion event" — which is what #2001
+// reported, twice, five seconds after two clean SaveImage renders.
+//
+// Both halves are pinned by BEHAVIOUR with literal millisecond bounds, not by
+// re-reading the constants under test: put the old 5 s back, or drop the
+// storyboard extension, and these fail.
+describe("#2001: the grace is read off the panel's own send bounds", () => {
+  /** A completed stills-only run — nothing here needs a storyboard. */
+  const stillsHistory = (promptId: string): HistoryEntry =>
+    ({
+      prompt: {},
+      outputs: { "9": { images: [{ filename: "ComfyUI_00042_.png", type: "output" }] } },
+      status: {
+        status_str: "success",
+        completed: true,
+        messages: [["execution_success", { prompt_id: promptId, timestamp: 2_000 }]],
+      },
+    }) as HistoryEntry;
+
+  const stillsWatchdog = (clock: { t: number }) =>
+    makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: stillsHistory(promptId) })),
+    });
+
+  it("a stills run is still composing at 8 s — the panel's own probe bound — so nothing is synthesised", async () => {
+    const clock = { t: 30_000_000 };
+    const { wd, delivered } = stillsWatchdog(clock);
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    // 8 000 ms is the panel's OWN bound on each of the two per-output probes it
+    // awaits before it sends. A grace at or under this races a healthy panel.
+    clock.t += 8_000;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+    expect(wd.armedCount()).toBe(1);
+
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS - 8_000;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+  });
+
+  it("a stills run is NOT given the storyboard extension — it lands on the ordinary grace", async () => {
+    const clock = { t: 31_000_000 };
+    const { wd, delivered } = stillsWatchdog(clock);
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(wd.armedCount()).toBe(0);
+  });
+
+  it("a run the panel must storyboard is held past 25 s, then answered — the extension is granted ONCE", async () => {
+    const clock = { t: 32_000_000 };
+    const entry = saveVideoHistoryEntry(PID);
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+
+    // 25 000 ms is the panel's own storyboard bound; still inside it.
+    clock.t += 25_000 - DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+    expect(wd.armedCount()).toBe(1);
+
+    // Past it — the panel has abandoned the storyboard and sent its note-only
+    // fallback by now, so silence is no longer explained by composing.
+    clock.t += DEFAULT_STORYBOARD_GRACE_MS - 25_000;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    // ONCE: nothing is left armed to be extended a second time.
+    expect(wd.armedCount()).toBe(0);
+
+    // …and a further tick long afterwards adds nothing.
+    clock.t += DEFAULT_STORYBOARD_GRACE_MS * 4;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+  });
+
+  it("the panel's own frame landing during the extension wins — nothing is synthesised at all", async () => {
+    const clock = { t: 33_000_000 };
+    const entry = saveVideoHistoryEntry(PID);
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+
+    // The panel finishes its storyboard at 18 s and sends the real frame.
+    RunCompletions.record(TAB, { kind: "executed", prompt_id: PID }, { conversation: CONV });
+
+    clock.t += DEFAULT_STORYBOARD_GRACE_MS;
+    await wd.tick();
+    expect(delivered).toHaveLength(0);
+    expect(wd.armedCount()).toBe(0);
+  });
+
+  it("reconcile() does NOT wait for the storyboard bound — a missed-WS recovery answers now", async () => {
+    const clock = { t: 34_000_000 };
+    const entry = saveVideoHistoryEntry(PID);
+    const { wd, delivered } = makeWatchdog(clock, {
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
+      lookupStatus: async (id) => resolveHistoryCompletionStatus(id, async (pid) => ({ [pid]: entry })),
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+
+    await wd.reconcile(RunCompletions.owedCompletions().map((t) => t.promptId));
+
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+    expect(wd.armedCount()).toBe(0);
+  });
+
+  it("a storyboard grace shorter than the ordinary one can never make an extended arm fire sooner", async () => {
+    const clock = { t: 35_000_000 };
+    const entry = saveVideoHistoryEntry(PID);
+    const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
+    const wd = createRunCompletionWatchdog({
+      awaiting: (id) => RunCompletions.awaitingCompletion(id),
+      deliver: (payload, ticket) => {
+        delivered.push({ payload, ticket });
+        RunCompletions.record(ticket.tabId, payload, { conversation: ticket.conversation ?? CONV });
+      },
+      resolveOutputs: (id) =>
+        resolveHistoryCompletionImages(id, async (promptId) => ({ [promptId]: entry })),
+      graceMs: 10_000,
+      storyboardGraceMs: 1_000, // misconfigured: SHORTER than the ordinary grace
+      now: () => clock.t,
+    });
+    RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV });
+    wd.observe([{ promptId: PID, status: "success" }]);
+
+    clock.t += 10_000;
+    await wd.tick();
+    // Extended, and the floor holds: it is due at max(grace, storyboardGrace),
+    // i.e. still 10 s from the observation — which has just passed, so the very
+    // next tick delivers rather than the arm being stranded or fired early.
+    expect(delivered).toHaveLength(0);
+    expect(wd.armedCount()).toBe(1);
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
   });
 });

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -402,10 +402,6 @@ export function createRunCompletionWatchdog({
   storyboardGraceMs = DEFAULT_STORYBOARD_GRACE_MS,
   now = () => Date.now(),
 }: RunCompletionWatchdogDeps): RunCompletionWatchdog {
-  /** The extended bound can only ever be LONGER than the ordinary one: a caller
-   *  that passes a shorter storyboard grace must not make an extended arm fire
-   *  sooner than an un-extended one (#2001). */
-  const extendedGraceMs = Math.max(graceMs, storyboardGraceMs);
   /** promptId → the observation we are holding. FIRST observation wins: a
    *  re-observation must not push the deadline out (that is how a repeatedly
    *  re-reported completion would never expire and the agent would wait
@@ -430,7 +426,12 @@ export function createRunCompletionWatchdog({
     if (armed.size === 0) return;
     const at = now();
     for (const entry of [...armed.values()]) {
-      const dueAfter = entry.extended ? extendedGraceMs : graceMs;
+      // An extended arm is due at `storyboardGraceMs` measured from the SAME
+      // observation, never from the extension: the extension is only granted
+      // once `graceMs` has already elapsed, so a storyboardGraceMs below it
+      // simply means the next tick delivers. There is deliberately no floor —
+      // one would be unreachable (proved by mutating it: nothing changed).
+      const dueAfter = entry.extended ? storyboardGraceMs : graceMs;
       if (!ignoreGrace && at - entry.observedAt < dueAfter) continue;
       // Disarm FIRST and unconditionally: whatever happens below, this
       // observation is spent. Leaving it armed on a throwing deliver() would
@@ -494,7 +495,7 @@ export function createRunCompletionWatchdog({
             armed.set(entry.promptId, { ...entry, extended: true });
             logger.debug(
               `[run-completion-watchdog] prompt ${entry.promptId} produced media the panel has to storyboard — holding the synthesis until ${Math.round(
-                extendedGraceMs / 1000,
+                storyboardGraceMs / 1000,
               )}s after the finish instead of ${Math.round(graceMs / 1000)}s (#2001)`,
             );
             continue;

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -39,11 +39,32 @@
 // WHY A GRACE RATHER THAN IMMEDIATELY. The panel's frame is the better one — it
 // carries duration and metadata the history record does not. #1853 already
 // fills images from that record, so a dropped panel frame is not a missing
-// output. The normal path lands within a second or two; that is the only race
-// the grace has to win. Waiting past the panel's own 20 s recovery sweep
-// (#1789) left a successful run silent for 45 s when that sweep also missed
-// (#1556). A reconnect / missed-WS recovery does not wait at all: reconcile()
-// looks the still-owed prompt ids up in /history and synthesises immediately.
+// output. Waiting past the panel's own 20 s recovery sweep (#1789) left a
+// successful run silent for 45 s when that sweep also missed (#1556). A
+// reconnect / missed-WS recovery does not wait at all: reconcile() looks the
+// still-owed prompt ids up in /history and synthesises immediately.
+//
+// HOW LONG, AND WHY IT IS NOT A GUESS (#2001). #1556 replaced 45 s with 5 s on
+// the premise that the panel's frame "lands within a second or two; that is the
+// only race the grace has to win". It is not. The panel composes ONE
+// consolidated frame and does not send until every part of it resolves, and the
+// panel's OWN code bounds that work well past 5 s:
+//   • stills — per output it HEADs /view for Content-Length and loads the image
+//     to read its natural size, each bounded by an 8 s timeout
+//     (`fetchImageBytes` / `fetchImageDimensions` in comfyui-mcp-panel);
+//   • video — a storyboard contact sheet per segment, bounded at 25 s
+//     (`videoStoryboardTimeoutMs`).
+// So a 5 s grace pre-empts a panel that is merely still working, and the notice
+// it then writes says in so many words that the panel "never delivered its
+// completion event" — which #2001 reported as a panel bug, twice, five seconds
+// after two clean SaveImage renders. Back-to-back renders are exactly the shape
+// that stalls those probes: ComfyUI serves /view from the same process that is
+// already sampling the next job.
+//
+// The two defaults below are therefore READ OFF the panel's own bounds instead
+// of estimated, and the longer one is spent only on a run whose /history record
+// shows media the panel has to build a storyboard for. A stills run — #1556's
+// case and #2001's — is still answered in 10 s, not 45.
 // Past the grace there are exactly two shapes, and NEITHER loses anything —
 // stated precisely, because the coalescing one is the narrower case, not the
 // general one (gate finding):
@@ -77,6 +98,14 @@ interface ArmedCompletion {
   status: CompletionStatus;
   /** Monotonic-ish ms (the injected clock) when WE observed the finish. */
   observedAt: number;
+  /**
+   * This arm reached the stills grace and /history showed media the panel has
+   * to build a storyboard for, so it was re-armed ONCE against the longer
+   * bound. Set on the re-arm and never cleared: the extension is granted at
+   * most once per run, so a panel frame that is never coming still lands at
+   * `storyboardGraceMs` rather than being deferred again and again (#2001).
+   */
+  extended?: true;
 }
 
 export interface RunCompletionWatchdogDeps {
@@ -101,16 +130,35 @@ export interface RunCompletionWatchdogDeps {
   lookupStatus?: (promptId: string) => Promise<CompletionStatus | null>;
   /** How long to let the panel's own in-flight frame win before filling in. */
   graceMs?: number;
+  /** The extended bound for a run whose outputs the panel has to storyboard
+   *  before it can send (#2001). Never applies to reconcile(), which is a
+   *  missed-WS recovery and does not wait at all. */
+  storyboardGraceMs?: number;
   now?: () => number;
 }
 
 /**
- * Past the panel's normal 1–2 s `executed` frame, not past its 20 s recovery
- * sweep. #1853 already attaches history outputs, so waiting for that sweep
- * only prolonged the silence when the sweep itself was the thing that missed
- * (#1556). Reconnect skips this entirely (see reconcile()).
+ * Past the panel's own bounded STILLS compose — two 8 s probes per output, run
+ * in parallel (`fetchImageBytes` / `fetchImageDimensions`) — and not past its
+ * 20 s recovery sweep. #1853 already attaches history outputs, so waiting for
+ * that sweep only prolonged the silence when the sweep itself was the thing
+ * that missed (#1556). Reconnect skips this entirely (see reconcile()).
+ *
+ * #2001 — this was 5 s, which is SHORTER than the panel's own bound, so one
+ * stalled HEAD against a ComfyUI busy with the next render was enough for the
+ * orchestrator to declare the panel silent while it was still composing.
  */
-export const DEFAULT_SYNTHESIS_GRACE_MS = 5_000;
+export const DEFAULT_SYNTHESIS_GRACE_MS = 10_000;
+
+/**
+ * The longer bound, spent ONLY on a run whose /history record carries media
+ * that cannot be attached inline — i.e. exactly the runs for which the panel is
+ * building a video storyboard before it sends. Read off the panel's own
+ * `videoStoryboardTimeoutMs` (25 s), past which the panel abandons the
+ * storyboard and sends its note-only fallback, so beyond this "still composing"
+ * has stopped being a possible explanation for the silence (#2001).
+ */
+export const DEFAULT_STORYBOARD_GRACE_MS = 30_000;
 
 /** Cap on armed observations. A run's arm is dropped the moment it expires, so
  *  this only ever bounds a burst of self-queued renders finishing at once. */
@@ -336,9 +384,12 @@ export function synthesizeCompletionPayload(
     completion_source: "orchestrator-history-watchdog",
     run_status: armed.status,
     note:
-      `The render you queued (prompt ${armed.promptId}) ${outcome}, but the panel never delivered its ` +
-      `completion event, so this notice was synthesised by the orchestrator from ComfyUI itself — its ` +
-      `execution event or its history record — about ${waitedS}s after the run finished. ${next}`,
+      `The render you queued (prompt ${armed.promptId}) ${outcome}. No completion for it reached the ` +
+      `orchestrator in the ${waitedS}s after that finish was observed here, so this notice was ` +
+      `synthesised from ComfyUI itself — its execution event or its history record. That is all this ` +
+      `orchestrator observed: the panel may never have sent its own completion, or it may still be ` +
+      `composing one. If a completion for this same prompt id arrives later, flagged a possible repeat, ` +
+      `it is THIS run and not a second render — do not report it twice. ${next}`,
   };
 }
 
@@ -348,8 +399,13 @@ export function createRunCompletionWatchdog({
   resolveOutputs,
   lookupStatus,
   graceMs = DEFAULT_SYNTHESIS_GRACE_MS,
+  storyboardGraceMs = DEFAULT_STORYBOARD_GRACE_MS,
   now = () => Date.now(),
 }: RunCompletionWatchdogDeps): RunCompletionWatchdog {
+  /** The extended bound can only ever be LONGER than the ordinary one: a caller
+   *  that passes a shorter storyboard grace must not make an extended arm fire
+   *  sooner than an un-extended one (#2001). */
+  const extendedGraceMs = Math.max(graceMs, storyboardGraceMs);
   /** promptId → the observation we are holding. FIRST observation wins: a
    *  re-observation must not push the deadline out (that is how a repeatedly
    *  re-reported completion would never expire and the agent would wait
@@ -374,7 +430,8 @@ export function createRunCompletionWatchdog({
     if (armed.size === 0) return;
     const at = now();
     for (const entry of [...armed.values()]) {
-      if (!ignoreGrace && at - entry.observedAt < graceMs) continue;
+      const dueAfter = entry.extended ? extendedGraceMs : graceMs;
+      if (!ignoreGrace && at - entry.observedAt < dueAfter) continue;
       // Disarm FIRST and unconditionally: whatever happens below, this
       // observation is spent. Leaving it armed on a throwing deliver() would
       // re-fire it on every later tick.
@@ -416,6 +473,32 @@ export function createRunCompletionWatchdog({
             continue;
           }
           if (!ticket) continue;
+          // #2001 — DO NOT ANNOUNCE A SILENCE THE PANEL HAS NOT REACHED YET.
+          //
+          // Media that cannot be attached inline (a SaveVideo .mp4) is exactly
+          // the shape for which the panel is building a storyboard contact
+          // sheet before it sends its ONE consolidated frame, and the panel
+          // bounds that at 25 s — past our ordinary grace. Re-arm this
+          // observation ONCE against that bound rather than pre-empt it. The
+          // extension is granted at most once (`extended` is never cleared), so
+          // a frame that is genuinely never coming is still answered at
+          // `storyboardGraceMs`, never later.
+          //
+          // Deliberately NOT applied on reconcile(): that path is a missed-WS /
+          // hello recovery whose whole point is that it does not wait (#1556).
+          if (
+            !ignoreGrace &&
+            !entry.extended &&
+            partitionAttachableMedia(images).other.length > 0
+          ) {
+            armed.set(entry.promptId, { ...entry, extended: true });
+            logger.debug(
+              `[run-completion-watchdog] prompt ${entry.promptId} produced media the panel has to storyboard — holding the synthesis until ${Math.round(
+                extendedGraceMs / 1000,
+              )}s after the finish instead of ${Math.round(graceMs / 1000)}s (#2001)`,
+            );
+            continue;
+          }
         }
         // #1789 item 3 — the failure is OBSERVABLE from here on. Until now the
         // only detector of a lost completion was a human noticing the agent had
@@ -423,7 +506,7 @@ export function createRunCompletionWatchdog({
         logger.warn(
           `[run-completion-watchdog] prompt ${entry.promptId} finished (${entry.status}) ${Math.round(
             (at - entry.observedAt) / 1000,
-          )}s ago and the panel NEVER reported its completion — synthesising one from the orchestrator's own ComfyUI observation so the agent that was told to end its turn and wait is not left idle (#1789)`,
+          )}s ago and NO completion for it has reached the orchestrator — synthesising one from its own ComfyUI observation so the agent that was told to end its turn and wait is not left idle. The panel may never have sent one or may still be composing it; either way this run is answered now (#1789/#2001)`,
         );
         deliver(synthesizeCompletionPayload(entry, { deliveredAt: at, images }), ticket);
       } catch (err) {


### PR DESCRIPTION
Fixes #2001.

## What the report is

Two consecutive `panel_run` renders finished cleanly, and the agent was told — in
words — that "the panel never delivered its completion event", **about five
seconds** after each finish. Render and `/history` were healthy. It was filed as a
panel bug.

## Why five seconds is the whole story

That number is not incidental. `DEFAULT_SYNTHESIS_GRACE_MS` was cut from 45 s to
**5 s** three commits before the reporter's version:

| | |
|---|---|
| grace cut 45 s → 5 s | `1b909d4` — fix(panel#1556) (#1960) |
| first release carrying it | **v0.52.43** |
| reporter's version | **0.52.45** |

The premise stated in that change is:

> The normal path lands within a second or two; that is the only race the grace
> has to win.

It is not. The panel composes **one** consolidated `executed` frame and sends
nothing until every part of it resolves, and the panel's own code bounds that
work well past 5 s:

- **stills** — per output it HEADs `/view` for `Content-Length` and loads the
  image to read its natural size, each bounded by an **8 000 ms** timeout
  (`fetchImageBytes` / `fetchImageDimensions`, `web/js/comfyui-mcp-panel.js`);
- **video** — a storyboard contact sheet per segment, bounded at **25 000 ms**
  (`videoStoryboardTimeoutMs`, `web/js/lib/run-completion-frame.js`).

So a 5 s grace is **shorter than the panel's own bound on the work it is doing**,
and the orchestrator started winning a race it was built to lose. Two
back-to-back renders are exactly the shape that stalls those probes: ComfyUI
serves `/view` from the same process that is already sampling the next job.

Nothing is lost when this happens — the journal never suppresses the panel's
later frame, it delivers it flagged a possible repeat (`run-completion-journal.ts`,
"ALREADY-DELIVERED IS A LABEL, NEVER A VETO"). The damage is that the agent gets
a notice asserting a panel failure that did not happen, then a second turn for the
same render — and, in this case, files a bug about it.

## The change

**1. The grace is read off the panel's bounds instead of estimated.**
`DEFAULT_SYNTHESIS_GRACE_MS` 5 s → **10 s** — past the panel's 8 s still-probe
bound, still well under the 20 s recovery sweep #1556 correctly refused to wait
for.

**2. A run the panel has to storyboard gets the panel's own bound, once.**
At expiry the watchdog already fetches `/history` for the outputs. If that record
carries media that cannot be attached inline — i.e. exactly the runs for which the
panel is building a video storyboard — the arm is re-armed **once** against
`DEFAULT_STORYBOARD_GRACE_MS` (30 s, past the panel's 25 s bound, beyond which it
abandons the storyboard and sends its note-only fallback). `extended` is never
cleared, so a frame that is genuinely never coming is still answered at 30 s and
never deferred again.

**3. The notice states what the orchestrator observed, not what the panel did.**
It cannot know whether the panel sent anything; it knows only that no completion
for that prompt id reached *it*. The note now says that, and tells the agent that a
later possible-repeat frame for the same prompt id is **this** run, not a second
render — which is the confusion the 5 s race actually produces.

`reconcile()` — #1556's real fix, delivering immediately for owed prompt ids on a
panel hello / missed-WS recovery — is untouched and never waits for either bound.

## Evidence

**Mutation, on the committed fix** (each mutant reverted after):

| mutation | result |
|---|---|
| `DEFAULT_SYNTHESIS_GRACE_MS` back to `5_000` | **1 failed / 40 passed** — `#2001 … a stills run is still composing at 8 s` |
| storyboard extension block deleted | **4 failed / 37 passed** — the three `#2001` storyboard tests **and** `#1853 … NAMES SaveVideo outputs` |
| note re-asserts "the panel never delivered its completion event" | **1 failed / 39 passed** — `#1789: the synthesised note claims only what was observed` |

Each mutant is killed by the test named for it, and the rest of the file survives
every one — so the pins are not passing for a shared reason.

**A mutation that survived, and what I did with it.** My first cut had
`extendedGraceMs = Math.max(graceMs, storyboardGraceMs)` as a floor, with a test
for a caller passing a shorter storyboard grace. Mutating the floor away changed
**nothing** — an arm is only extended *after* `graceMs` has already elapsed, so
`at - observedAt >= graceMs` holds for the whole rest of its life and the `max`
can never decide anything. The floor was dead code dressed as a guard. It and its
test are gone (`15fe09e`), and the reason is written where the branch is.

**Reachability.** `src/orchestrator/index.ts:6504` constructs the watchdog with
neither `graceMs` nor `storyboardGraceMs`, so both defaults apply in production,
and it wires `resolveOutputs`, which is the branch the storyboard extension lives
in. No production caller overrides either (`grep graceMs` across `src/` outside
tests and this module).

**Suite.** `vitest run` in this worktree: **616 files / 11 352 tests passed**. Two
files fail, both pre-existing on `origin/main` — I ran them on a pristine detached
`origin/main` worktree to check rather than assume:
`node-id-union-message.test.ts` (3 failed there too, #1889) and
`package-hooks.test.ts` (`expected [ 'dist' ] to deeply equal []` — the unbuilt-worktree
`dist` miss). `tsc --noEmit` (the repo's `lint`) is clean.

**Environment.** The reporting rig is this machine — RTX 4090 / 25.7 GB,
ComfyUI 0.33.2, frontend 1.49.6, mcp 0.52.45 — which is how the 5 s number and
the panel bounds could be checked against the build that produced the report.

## What I deliberately did not do

- **I did not reproduce it live.** The diagnosis is circumstantial-but-tight: the
  reported delay is exactly the constant, the constant is provably shorter than
  the panel's own bound on the work it does before sending, and the reported shape
  (back-to-back renders) is the one that stalls that work. If #2001 recurs at
  10 s / 30 s, the cause is elsewhere and this should be reopened.
- **I did not add a "the panel is still composing" signal.** The honest fix would
  be for the panel to say so, or for the watchdog to use the ticket tab's live
  bridge connection to tell "composing" from "gone". Both are real; both are
  bigger than a P2 under the freeze, and the second adds a wiring point.
- **I did not touch the panel.** No panel code changes, so the panel's Playwright
  suite was not run — this changes only when the orchestrator synthesises an
  `agent_event`, not anything the sidebar renders. Stating that rather than
  implying coverage.
- **A separate defect I found and left alone:** `observe()` discards a
  QueueMonitor completion whose `panel_run` ticket is not open yet
  (`run-completion-watchdog.ts`, `if (!awaiting(promptId)) continue`).
  `drainCompletions()` splices, so that observation is spent forever and the
  fallback can never fire for that run. The ordering is real —
  `run-completion-journal.ts:582` (#1327) records a reported 0.1 s fully-cached
  render whose completion "lands here BEFORE openRun", and the journal grew
  `claimRaced` for it while the watchdog did not. Different bug, filed as **#2021**
  rather than smuggled in here.

## Review

**Pending.** Not gated, not reviewed. The load-bearing claims a reviewer should
attack, in order:

1. **The 8 s / 25 s derivation.** Both numbers are read out of the panel repo, not
   this one. If `fetchImageBytes` / `fetchImageDimensions` / `videoStoryboardTimeoutMs`
   are not the bounds that gate the panel's *send*, the whole choice of 10 s / 30 s
   is arbitrary and this is a guess wearing a citation.
2. **Whether deferring a storyboard run to 30 s re-opens #1556.** #1556's complaint
   was a successful run silent for 45 s. A video run is now silent for up to 30 s
   when the panel really is gone — better than 45 s, worse than 5 s, and
   `reconcile()` still short-circuits it on any hello. Is that the right trade, or
   should the extension be gated on something stronger than "the outputs are not
   inline-attachable"?
3. **The extension state machine.** `extended` is set on the re-arm and never
   cleared, and the re-arm goes straight into `armed` rather than through `arm()`.
   I believe that cannot loop and cannot exceed `MAX_ARMED` (the entry was just
   deleted), but that is the part I am least sure of.
4. **The note wording.** It is agent-facing and now longer. Does the
   "possible repeat / not a second render" sentence actually stop the double-report,
   or does it invite an agent to *suppress* a genuinely different render?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
