### PR TITLE
fix(2014,2016): a stock RunPod pod gets the container disk and CUDA host its image actually needs

### DIFF
--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -585,6 +585,23 @@ describe("#2014/#2016 — the CONSOLE deploy path states the floors it cannot en
     expect(req).toContain(RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS[0]);
   });
 
+  it("says NOTHING when the link points at a CUSTOM template — not our floors to state", async () => {
+    // runpodDeployLink() carries RUNPOD_TEMPLATE_ID. If the user repointed it,
+    // the console form is seeded by THEIR image and our 30 GB / CUDA 12.8 would
+    // be wrong advice — the same scoping the API-path defaults use.
+    vi.resetModules();
+    const saved = process.env.RUNPOD_TEMPLATE_ID;
+    process.env.RUNPOD_TEMPLATE_ID = "someone-elses-template";
+    try {
+      const mod = await import("../../services/runpod-client.js");
+      expect(mod.runpodDeployRequirements()).toBe("");
+    } finally {
+      if (saved === undefined) delete process.env.RUNPOD_TEMPLATE_ID;
+      else process.env.RUNPOD_TEMPLATE_ID = saved;
+      vi.resetModules();
+    }
+  });
+
   it("every site that hands out the deploy LINK also hands out the REQUIREMENTS", async () => {
     // Count the adopting call sites rather than spot-checking deploy_link: a
     // second place that surfaces the link (an empty-account hint, an error

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import {
   createPod,
   resumePod,
   RUNPOD_STOCK_CONTAINER_DISK_GB,
+  RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS,
+  runpodDeployRequirements,
   getPod,
   isProvablyNotCreatedError,
   runpodDeployLink,
@@ -560,5 +562,43 @@ describe("#2014/#2016 wiring — EVERY deploy attempt adopts the floors, not jus
     const src = await readFile(new URL("../../services/runpod-client.ts", import.meta.url), "utf8");
     const deployMutations = src.match(/podFindAndDeployOnDemand\s*\(/g) ?? [];
     expect(deployMutations).toHaveLength(1);
+  });
+});
+
+describe("#2014/#2016 — the CONSOLE deploy path states the floors it cannot enforce", () => {
+  it("names BOTH floors, derived from the same constants the API path sends", () => {
+    const req = runpodDeployRequirements();
+    // Disk: the README floor, and the 20 GB the template still defaults to, so
+    // a user who reads only this knows what to change and from what.
+    expect(req).toContain("30 GB");
+    expect(req).toContain("20 GB");
+    // CUDA: the image's floor, and the console control that applies it.
+    expect(req).toContain("12.8");
+    expect(req).toMatch(/CUDA/i);
+    // It must read as REQUIRED, not as a tip — the pod is billed either way.
+    expect(req).toMatch(/not optional|at least/i);
+  });
+
+  it("stays in step with the API path — the advice cannot drift from the behaviour", () => {
+    const req = runpodDeployRequirements();
+    expect(req).toContain(`${RUNPOD_STOCK_CONTAINER_DISK_GB} GB`);
+    expect(req).toContain(RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS[0]);
+  });
+
+  it("every site that hands out the deploy LINK also hands out the REQUIREMENTS", async () => {
+    // Count the adopting call sites rather than spot-checking deploy_link: a
+    // second place that surfaces the link (an empty-account hint, an error
+    // path) would otherwise send a user to the console with no floors named.
+    const dir = new URL("../../tools/", import.meta.url);
+    const files = (await readdir(dir)).filter((f) => f.endsWith(".ts"));
+    let links = 0;
+    let requirements = 0;
+    for (const f of files) {
+      const src = await readFile(new URL(f, dir), "utf8");
+      links += (src.match(/runpodDeployLink\(\)/g) ?? []).length;
+      requirements += (src.match(/runpodDeployRequirements\(\)/g) ?? []).length;
+    }
+    expect(links).toBeGreaterThan(0);
+    expect(requirements).toBe(links);
   });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFile } from "node:fs/promises";
 import {
   createPod,
+  resumePod,
+  RUNPOD_STOCK_CONTAINER_DISK_GB,
   getPod,
   isProvablyNotCreatedError,
   runpodDeployLink,
@@ -411,5 +414,151 @@ describe("deadman switch (#269)", () => {
     }) as unknown as typeof fetch;
     await expect(beatDeadman({ id: "abc123", name: "dm-pod" })).resolves.toBe(false);
     await expect(beatDeadman({ id: "abc123", name: null })).resolves.toBe(false);
+  });
+});
+
+// ── #2014 / #2016 — the stock image's deploy floors ──────────────────────────
+// Both defects shipped a pod that RunPod created and BILLED and that never
+// became usable (desiredStatus RUNNING, `runtime` null, no ports). They are
+// independent — an undersized container disk and an unconstrained CUDA host —
+// so they keep independent tests.
+const deployInputs = (fetchMock: ReturnType<typeof vi.fn>) =>
+  fetchMock.mock.calls
+    .map((c) => JSON.parse((c[1] as { body: string }).body))
+    .filter((b) => b.query.includes("podFindAndDeployOnDemand"))
+    .map((b) => b.variables.input as Record<string, unknown>);
+const firstDeployInput = (fetchMock: ReturnType<typeof vi.fn>) => deployInputs(fetchMock)[0];
+
+describe("#2014 — stock deploys get the container disk the image documents", () => {
+  it("sends 30 GB on the stock template (docker/runpod/README.md requires >= 30 GB)", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "disk-stock" });
+    // The literal floor, NOT a value recomputed from the code under test — an
+    // assertion derived from the constant would move with a mutation of it.
+    expect(firstDeployInput(fetchMock).containerDiskInGb).toBe(30);
+    expect(RUNPOD_STOCK_CONTAINER_DISK_GB).toBe(30);
+  });
+
+  it("leaves a CUSTOM template on the pre-#2014 default — we cannot size an image we did not build", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "disk-custom", templateId: "some-other-template" });
+    expect(firstDeployInput(fetchMock).containerDiskInGb).toBe(20);
+  });
+
+  it("an explicit containerDiskInGb still wins on the stock template", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "disk-explicit", containerDiskInGb: 50 });
+    expect(firstDeployInput(fetchMock).containerDiskInGb).toBe(50);
+  });
+});
+
+describe("#2016 — stock deploys pin the host CUDA version", () => {
+  it("sends allowedCudaVersions covering 12.8+ and NOTHING below the image's floor", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-stock" });
+    const sent = firstDeployInput(fetchMock).allowedCudaVersions as string[];
+    expect(sent).toContain("12.8"); // driver >= 570 == CUDA 12.8 (Dockerfile MIN_DRIVER_DEFAULT)
+    // The incident host was CUDA 12.6; every version below the floor must be absent.
+    for (const bad of ["11.8", "12.0", "12.4", "12.6", "12.7"]) expect(sent).not.toContain(bad);
+    // Over-narrow is the dangerous direction: a list matching no host makes the
+    // pod unschedulable. Newer CUDA than we knew about at build time must pass.
+    for (const good of ["12.9", "13.0", "13.5", "14.0"]) expect(sent).toContain(good);
+  });
+
+  it("sends NO CUDA filter for a CUSTOM template — its image may need a different one", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-custom", templateId: "some-other-template" });
+    expect(firstDeployInput(fetchMock)).not.toHaveProperty("allowedCudaVersions");
+  });
+
+  it("an explicit list wins, and [] OMITS the field entirely (never sends an empty allow-list)", async () => {
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-explicit", allowedCudaVersions: ["12.8", "12.9"] });
+    expect(firstDeployInput(fetchMock).allowedCudaVersions).toEqual(["12.8", "12.9"]);
+
+    const { fetchMock: fm2 } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod2")));
+    await createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-none", allowedCudaVersions: [] });
+    // `allowedCudaVersions: []` would match NO host — worse than no filter.
+    expect(firstDeployInput(fm2)).not.toHaveProperty("allowedCudaVersions");
+  });
+
+  it("RUNPOD_ALLOWED_CUDA_VERSIONS overrides the built-in list (escape hatch for a fleet we guessed wrong)", async () => {
+    vi.resetModules();
+    process.env.RUNPOD_ALLOWED_CUDA_VERSIONS = "12.8, 12.9";
+    try {
+      const mod = await import("../../services/runpod-client.js");
+      const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+      await mod.createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-env" });
+      expect(firstDeployInput(fetchMock).allowedCudaVersions).toEqual(["12.8", "12.9"]);
+    } finally {
+      delete process.env.RUNPOD_ALLOWED_CUDA_VERSIONS;
+      vi.resetModules();
+    }
+  });
+
+  it("an EMPTY RUNPOD_ALLOWED_CUDA_VERSIONS disables the filter (opt out without editing code)", async () => {
+    vi.resetModules();
+    process.env.RUNPOD_ALLOWED_CUDA_VERSIONS = "";
+    try {
+      const mod = await import("../../services/runpod-client.js");
+      const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
+      await mod.createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-env-off" });
+      expect(firstDeployInput(fetchMock)).not.toHaveProperty("allowedCudaVersions");
+    } finally {
+      delete process.env.RUNPOD_ALLOWED_CUDA_VERSIONS;
+      vi.resetModules();
+    }
+  });
+
+  it("names the CUDA filter when every slot came back empty (unschedulable is not a capacity crunch)", async () => {
+    mockGql((b) => (b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] }));
+    await expect(createPod({ gpuTypeIds: ["GPU-A"], name: "cuda-starved" })).rejects.toThrow(
+      /RUNPOD_ALLOWED_CUDA_VERSIONS/,
+    );
+  });
+
+  it("sends NO CUDA filter on resume — PodResumeInput has no such field (#2016)", async () => {
+    // Probed against the live api.runpod.io schema on 2026-08-21 (wrong-typed
+    // podId, so coercion failed and the resolver never ran): every candidate
+    // name — allowedCudaVersions, cudaVersion, cudaVersions, allowedCudaVersion,
+    // minCudaVersion — came back `is not defined by type "PodResumeInput"`,
+    // while the known field gpuCount drew no such error. runpod-python agrees.
+    // docs.runpod.io shows a podResume example WITH allowedCudaVersions; that
+    // example is wrong, and adopting it turns every runpod action:"start" into
+    // a GraphQL validation failure. This test is the guard against that.
+    const { fetchMock } = mockGql(() => ({ data: { podResume: { id: "pod1", desiredStatus: "RUNNING" } } }));
+    await resumePod("pod1", 1);
+    const input = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body).variables.input;
+    expect(input).toEqual({ podId: "pod1", gpuCount: 1 });
+    for (const k of Object.keys(input)) expect(k.toLowerCase()).not.toContain("cuda");
+  });
+});
+
+describe("#2014/#2016 wiring — EVERY deploy attempt adopts the floors, not just the first", () => {
+  it("applies both floors on every GPU x cloud slot the fallback loop tries", async () => {
+    // The fallback loop calls deployOnce once per (cloudType x gpuType). A fix
+    // applied at one call site only would pass a spot-check of attempt #1 and
+    // still ship an undersized/unconstrained pod on the slot that wins.
+    const gpuTypeIds = ["GPU-A", "GPU-B", "GPU-C"];
+    const { fetchMock } = mockGql((b) =>
+      b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] },
+    );
+    await expect(createPod({ gpuTypeIds, name: "wiring" })).rejects.toThrow();
+    const inputs = deployInputs(fetchMock);
+    // 3 GPU types x 2 cloud types — count the ADOPTING sites, never spot-check one.
+    expect(inputs).toHaveLength(gpuTypeIds.length * 2);
+    const adoptingDisk = inputs.filter((i) => i.containerDiskInGb === 30);
+    const adoptingCuda = inputs.filter((i) => (i.allowedCudaVersions as string[] | undefined)?.includes("12.8"));
+    expect(adoptingDisk).toHaveLength(inputs.length);
+    expect(adoptingCuda).toHaveLength(inputs.length);
+  });
+
+  it("only ONE code path issues podFindAndDeployOnDemand — a second must be wired too", async () => {
+    // Behavioural coverage above rides on createPod being the sole deploy path.
+    // If someone adds another, this fails and forces them to extend that test
+    // rather than silently shipping a deploy that skips both floors.
+    const src = await readFile(new URL("../../services/runpod-client.ts", import.meta.url), "utf8");
+    const deployMutations = src.match(/podFindAndDeployOnDemand\s*\(/g) ?? [];
+    expect(deployMutations).toHaveLength(1);
   });
 });

--- a/src/__tests__/tools/runpod.test.ts
+++ b/src/__tests__/tools/runpod.test.ts
@@ -38,6 +38,10 @@ vi.mock("../../services/runpod-client.js", () => ({
     (pod.runtime?.ports ?? []).some((p) => p.privatePort === 3000 && p.type === "http"),
   runpodProxyUrl: (id: string, port = 3000) => `https://${id}-${port}.proxy.runpod.net`,
   runpodDeployLink: () => "https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b",
+  // Sentinel, not the real text: this pins that the tool RENDERS whatever the
+  // client says the console deploy requires. What that text actually names is
+  // asserted against the real function in runpod-client.test.ts.
+  runpodDeployRequirements: () => "CONSOLE-DEPLOY-REQUIREMENTS-SENTINEL",
   GPU_CLI_CREDIT: "Pod control inspired by gpu-cli.sh (https://gpu-cli.sh) — a cloud-GPU CLI worth checking out.",
 }));
 
@@ -438,6 +442,15 @@ describe("runpod actions call the same services with the same arguments", () => 
   it('action:"deploy_link" returns the referral deploy link', async () => {
     const t = text(await runpod()({ action: "deploy_link" }));
     expect(t).toContain("console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b");
+  });
+
+  it('action:"deploy_link" also states what the CONSOLE deploy must set by hand (#2014/#2016)', async () => {
+    // createPod sends the disk + CUDA floors on the API path, but the console
+    // path never reaches createPod — the user fills RunPod's form, seeded by a
+    // template that is still registered at 20 GB with no CUDA constraint. The
+    // link alone therefore reproduces both defects on a pod the user pays for.
+    const t = text(await runpod()({ action: "deploy_link" }));
+    expect(t).toContain("CONSOLE-DEPLOY-REQUIREMENTS-SENTINEL");
   });
 });
 

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -434,6 +434,11 @@ export const RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS: string[] = cudaVersionsAtLeast(
  *  closes the gap from here is saying so. Built from the SAME constants the API
  *  path sends, so the advice can never drift from the behaviour. */
 export function runpodDeployRequirements(): string {
+  // Scoped to the stock template exactly like the API-path defaults are: the
+  // link carries RUNPOD_TEMPLATE_ID, and if that points at someone else's
+  // image these are not our floors to state. Empty string = nothing to add;
+  // callers must not render a stray blank block for it.
+  if (RUNPOD_TEMPLATE_ID !== DEFAULT_TEMPLATE_ID) return "";
   return (
     `Two settings on that page are NOT optional for this image — the template's own defaults ` +
     `are below both, and a pod that misses either boots into an unusable state you still pay for:\n` +

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -421,6 +421,29 @@ export const RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS: string[] = cudaVersionsAtLeast(
   STOCK_MIN_CUDA_MINOR,
 );
 
+/** What a CONSOLE deploy must set BY HAND, for anywhere we hand out
+ *  runpodDeployLink() (codex gate, #2014/#2016).
+ *
+ *  createPod sends both floors on the API path, but the console path does not
+ *  go through createPod: the user fills RunPod's own deploy form, seeded by the
+ *  template — and the template itself is still registered at containerDiskInGb
+ *  20 with no CUDA constraint, so following the link with its defaults
+ *  reproduces BOTH defects on a pod the user pays for. RunPod documents no
+ *  query parameters that would let the link carry overrides, and the template
+ *  lives on the RunPod account rather than in this repo, so the only thing that
+ *  closes the gap from here is saying so. Built from the SAME constants the API
+ *  path sends, so the advice can never drift from the behaviour. */
+export function runpodDeployRequirements(): string {
+  return (
+    `Two settings on that page are NOT optional for this image — the template's own defaults ` +
+    `are below both, and a pod that misses either boots into an unusable state you still pay for:\n` +
+    `  • Container disk: at least ${RUNPOD_STOCK_CONTAINER_DISK_GB} GB (the template still defaults to ` +
+    `${RUNPOD_DEFAULT_CONTAINER_DISK_GB} GB).\n` +
+    `  • CUDA version: ${RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS[0]} or newer — filter by "CUDA Version" on the ` +
+    `deploy screen. The image is a cu128 build and refuses to start on an older host.`
+  );
+}
+
 /** Escape hatch for a fleet whose CUDA strings we guessed wrong, and the only
  *  way to widen/narrow the filter without a code change. Comma-separated
  *  ("12.8,12.9"); set it EMPTY to send no filter at all. Unset = use the

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -236,7 +236,26 @@ export async function listPods(): Promise<RunpodPod[]> {
 }
 
 /** Resume (start) a stopped/exited pod. gpuCount defaults to 1. Returns the pod's
- *  new desiredStatus (RUNNING) — the container still needs time to boot after. */
+ *  new desiredStatus (RUNNING) — the container still needs time to boot after.
+ *
+ *  NO CUDA FILTER HERE, DELIBERATELY (#2016). A resumed pod can be placed on
+ *  different hardware than it was created on, so the CUDA floor createPod
+ *  enforces does NOT carry across a stop/start — but RunPod's API exposes no
+ *  lever to re-assert it: `PodResumeInput` has NO CUDA field under any name.
+ *  Probed against the live api.runpod.io schema on 2026-08-21 by sending each
+ *  candidate with a wrong-typed `podId`, so variable coercion failed and the
+ *  resolver never ran (no pod was resumed):
+ *
+ *    allowedCudaVersions → Field "allowedCudaVersions" is not defined by type "PodResumeInput".
+ *    cudaVersion / cudaVersions / allowedCudaVersion / minCudaVersion → same
+ *    gpuCount → accepted (control: a KNOWN field draws no such error)
+ *
+ *  runpod-python's `generate_pod_resume_mutation` agrees — it sends only podId
+ *  and gpuCount. docs.runpod.io/sdks/graphql/manage-pods shows an example with
+ *  `allowedCudaVersions` on podResume; that example is WRONG, and copying it
+ *  turns every start into a GraphQL validation failure. Adding the field here
+ *  BREAKS `runpod action:"start"` outright — the test
+ *  "sends NO CUDA filter on resume — PodResumeInput has no such field" pins it. */
 export async function resumePod(podId: string, gpuCount = 1): Promise<{ id: string; desiredStatus: string }> {
   const data = await runpodGql<{ podResume: { id: string; desiredStatus: string } }>(
     `mutation Resume($input: PodResumeInput!) { podResume(input: $input) { id desiredStatus } }`,
@@ -345,6 +364,73 @@ export const RUNPOD_DEFAULT_GPU_TYPES: string[] = (
   ]
 );
 
+// ── Stock-image deploy floors (#2014, #2016) ─────────────────────────────────
+// Both of these describe OUR image, so both apply only when the deploy targets
+// the STOCK template — same scoping rule the dead-man switch uses below. A user
+// pointing RUNPOD_TEMPLATE_ID / opts.templateId at their own image may
+// legitimately want a smaller disk or a different CUDA floor, and we cannot
+// verify what their image needs.
+
+/** Container disk (GB) a STOCK-template deploy gets. docker/runpod/README.md's
+ *  "Deploy on RunPod" table requires **>= 30 GB** ("the baked ComfyUI + venv +
+ *  cu128 torch + any runtime-installed nodes/caches, which are ephemeral").
+ *  We used to send 20 — matching the RunPod template's own setting, which is
+ *  ALSO below the documented floor — and the pod was created, billed, and never
+ *  came up: desiredStatus RUNNING, `runtime` null, no ports, unreachable. */
+export const RUNPOD_STOCK_CONTAINER_DISK_GB = 30;
+
+/** Container disk (GB) sent for a NON-stock template. Unchanged from the value
+ *  every deploy used before #2014 — raising it for images we did not build
+ *  would silently bill those users for disk they may not need. */
+export const RUNPOD_DEFAULT_CONTAINER_DISK_GB = 20;
+
+/** The host CUDA floor the STOCK image needs: driver >= 570 == CUDA 12.8. Set
+ *  by docker/runpod/Dockerfile (`MIN_DRIVER_DEFAULT=570`, cu128 torch) and
+ *  enforced pod-side by docker/runpod/post_start.sh's driver preflight, which
+ *  refuses to launch and holds the pod open on an older host. */
+const STOCK_MIN_CUDA_MAJOR = 12;
+const STOCK_MIN_CUDA_MINOR = 8;
+
+/** RunPod matches `allowedCudaVersions` as an ALLOW-LIST of exact "major.minor"
+ *  strings against the host's CUDA version — there is no ">=" form and no way
+ *  to enumerate what the fleet reports (GraphQL introspection is disabled;
+ *  Query/GpuType/PodMachineInfo expose no CUDA field). So the list is GENERATED
+ *  from the floor rather than pinned to the versions that happen to exist today.
+ *
+ *  Why generate past 13.x: an OVER-NARROW list is the dangerous direction. Too
+ *  broad reproduces #2016 (a pod on an incompatible host); too narrow matches
+ *  NO host, every GPU/cloud slot comes back "no capacity", and one-tap deploy
+ *  stops working entirely the day RunPod's fleet moves to a CUDA we did not
+ *  foresee. Version strings that do not exist are inert, not an error — probed
+ *  against the live schema, `allowedCudaVersions` is a free-form [String] that
+ *  accepts "banana" without complaint, and an unmatched entry simply never
+ *  selects a host. Padding forward therefore costs nothing and buys durability. */
+const CUDA_ALLOWLIST_MAX_MAJOR = 14;
+function cudaVersionsAtLeast(minMajor: number, minMinor: number): string[] {
+  const out: string[] = [];
+  for (let major = minMajor; major <= CUDA_ALLOWLIST_MAX_MAJOR; major++) {
+    // CUDA has never shipped a minor above 9 (12.0-12.9, then 13.0).
+    for (let minor = major === minMajor ? minMinor : 0; minor <= 9; minor++) out.push(`${major}.${minor}`);
+  }
+  return out;
+}
+
+/** Host CUDA versions a STOCK-template deploy will accept (>= 12.8). */
+export const RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS: string[] = cudaVersionsAtLeast(
+  STOCK_MIN_CUDA_MAJOR,
+  STOCK_MIN_CUDA_MINOR,
+);
+
+/** Escape hatch for a fleet whose CUDA strings we guessed wrong, and the only
+ *  way to widen/narrow the filter without a code change. Comma-separated
+ *  ("12.8,12.9"); set it EMPTY to send no filter at all. Unset = use the
+ *  stock default above (and no filter for a custom template). An explicit
+ *  value applies to custom templates too — the user is asserting it. */
+export const RUNPOD_ALLOWED_CUDA_VERSIONS: string[] | undefined =
+  process.env.RUNPOD_ALLOWED_CUDA_VERSIONS === undefined
+    ? undefined
+    : process.env.RUNPOD_ALLOWED_CUDA_VERSIONS.split(",").map((s) => s.trim()).filter(Boolean);
+
 export interface RunpodCreateOptions {
   /** GPU types to try in order (default RUNPOD_DEFAULT_GPU_TYPES). */
   gpuTypeIds?: string[];
@@ -353,8 +439,15 @@ export interface RunpodCreateOptions {
   cloudType?: "COMMUNITY" | "SECURE";
   name?: string; // default "comfyui-mcp"
   templateId?: string; // default RUNPOD_TEMPLATE_ID (our image)
-  containerDiskInGb?: number; // default 20 (matches our template)
-  volumeInGb?: number; // default 60 (matches our template; /workspace)
+  /** default RUNPOD_STOCK_CONTAINER_DISK_GB (30) on the stock template — the
+   *  floor docker/runpod/README.md documents — and 20 on a custom template. */
+  containerDiskInGb?: number;
+  volumeInGb?: number; // default 60 (/workspace; README states no minimum — "size for your models")
+  /** Host CUDA versions RunPod may schedule this pod onto. Defaults to
+   *  RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS on the stock template (whose image
+   *  needs CUDA >= 12.8) and to NO filter on a custom template. Pass `[]` to
+   *  send no filter. Create-only: RunPod's podResume takes no CUDA field. */
+  allowedCudaVersions?: string[];
   /** SSH public key injected as PUBLIC_KEY (trainer drives the pod over ssh). */
   publicKey?: string;
   /** Arm the pod-side dead-man watchdog (default RUNPOD_DEADMAN_DEFAULT): adds
@@ -363,6 +456,29 @@ export interface RunpodCreateOptions {
    *  it. The stop is authorized by RunPod's auto-injected POD-SCOPED key — the
    *  owner's account key is never added to the pod env. */
   deadman?: boolean;
+}
+
+/** Which template a deploy targets — the stock-only defaults key off this. */
+function targetTemplateId(opts: RunpodCreateOptions): string {
+  return opts.templateId ?? RUNPOD_TEMPLATE_ID;
+}
+
+/** Container disk (GB) this deploy will request (#2014). ONE source of truth:
+ *  deployOnce sends it and the tests assert against it. */
+export function effectiveContainerDiskGb(opts: RunpodCreateOptions): number {
+  if (opts.containerDiskInGb !== undefined) return opts.containerDiskInGb;
+  return targetTemplateId(opts) === DEFAULT_TEMPLATE_ID
+    ? RUNPOD_STOCK_CONTAINER_DISK_GB
+    : RUNPOD_DEFAULT_CONTAINER_DISK_GB;
+}
+
+/** The CUDA allow-list this deploy will send, or undefined/[] for no filter
+ *  (#2016). ONE source of truth: deployOnce sends it AND createPod's
+ *  everything-failed error explains it, so the two can never disagree. */
+export function effectiveAllowedCudaVersions(opts: RunpodCreateOptions): string[] | undefined {
+  if (opts.allowedCudaVersions !== undefined) return opts.allowedCudaVersions;
+  if (RUNPOD_ALLOWED_CUDA_VERSIONS !== undefined) return RUNPOD_ALLOWED_CUDA_VERSIONS;
+  return targetTemplateId(opts) === DEFAULT_TEMPLATE_ID ? RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS : undefined;
 }
 
 async function deployOnce(
@@ -378,6 +494,8 @@ async function deployOnce(
   // Overrides need an explicit deadman:true — the caller is asserting their
   // image ships the watchdog.
   const deadman = opts.deadman ?? (templateId === DEFAULT_TEMPLATE_ID && RUNPOD_DEADMAN_DEFAULT);
+  const containerDiskInGb = effectiveContainerDiskGb(opts);
+  const allowedCudaVersions = effectiveAllowedCudaVersions(opts);
   const data = await runpodGql<{ podFindAndDeployOnDemand: RunpodPod | null }>(
     `mutation Deploy($input: PodFindAndDeployOnDemandInput!) {
        podFindAndDeployOnDemand(input: $input) {
@@ -391,9 +509,13 @@ async function deployOnce(
         gpuTypeId,
         templateId,
         name: podName,
-        containerDiskInGb: opts.containerDiskInGb ?? 20,
+        containerDiskInGb,
         volumeInGb: opts.volumeInGb ?? 60,
         volumeMountPath: "/workspace",
+        // Keep RunPod off hosts the image cannot run on (#2016). Omitted
+        // entirely when empty — sending `allowedCudaVersions: []` would match
+        // no host and make the pod unschedulable.
+        ...(allowedCudaVersions?.length ? { allowedCudaVersions } : {}),
         // Guarantee ComfyUI is reachable through RunPod's HTTP proxy even if
         // the template's port config drifts — AND expose ssh (22/tcp) so the
         // pod-native trainer can drive ai-toolkit over it (codex finding:
@@ -594,10 +716,20 @@ export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodP
       }
     }
   }
+  // Name the CUDA filter when one was applied (#2016). It restricts which hosts
+  // can match, so "no capacity everywhere" has a second possible cause now — and
+  // an unschedulable pod would otherwise look exactly like a capacity crunch.
+  const cuda = effectiveAllowedCudaVersions(opts);
+  const cudaNote = cuda?.length
+    ? `\nThis deploy also required host CUDA ${cuda[0]}+ (allowedCudaVersions), which our image needs — ` +
+      `if RunPod reports a CUDA version outside [${cuda.join(", ")}], set RUNPOD_ALLOWED_CUDA_VERSIONS ` +
+      `to the versions your fleet offers (empty to send no filter).`
+    : "";
   throw new Error(
     `Could not deploy a pod on any of [${gpuTypeIds.join(", ")}] in ${cloudTypes.join("/")}. RunPod reported:\n` +
       attempts.map((a) => `  • ${a}`).join("\n") +
       `\nTry again shortly (capacity fluctuates), set RUNPOD_GPU_TYPES to other GPUs, ` +
-      `or deploy from the console with runpod action:"deploy_link".`,
+      `or deploy from the console with runpod action:"deploy_link".` +
+      cudaNote,
   );
 }

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -465,7 +465,7 @@ function targetTemplateId(opts: RunpodCreateOptions): string {
 
 /** Container disk (GB) this deploy will request (#2014). ONE source of truth:
  *  deployOnce sends it and the tests assert against it. */
-export function effectiveContainerDiskGb(opts: RunpodCreateOptions): number {
+function effectiveContainerDiskGb(opts: RunpodCreateOptions): number {
   if (opts.containerDiskInGb !== undefined) return opts.containerDiskInGb;
   return targetTemplateId(opts) === DEFAULT_TEMPLATE_ID
     ? RUNPOD_STOCK_CONTAINER_DISK_GB
@@ -475,7 +475,7 @@ export function effectiveContainerDiskGb(opts: RunpodCreateOptions): number {
 /** The CUDA allow-list this deploy will send, or undefined/[] for no filter
  *  (#2016). ONE source of truth: deployOnce sends it AND createPod's
  *  everything-failed error explains it, so the two can never disagree. */
-export function effectiveAllowedCudaVersions(opts: RunpodCreateOptions): string[] | undefined {
+function effectiveAllowedCudaVersions(opts: RunpodCreateOptions): string[] | undefined {
   if (opts.allowedCudaVersions !== undefined) return opts.allowedCudaVersions;
   if (RUNPOD_ALLOWED_CUDA_VERSIONS !== undefined) return RUNPOD_ALLOWED_CUDA_VERSIONS;
   return targetTemplateId(opts) === DEFAULT_TEMPLATE_ID ? RUNPOD_STOCK_ALLOWED_CUDA_VERSIONS : undefined;

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -12,6 +12,7 @@ import {
   comfyuiPortExposed,
   runpodProxyUrl,
   runpodDeployLink,
+  runpodDeployRequirements,
   RUNPOD_COMFYUI_PORT,
   RUNPOD_DEFAULT_GPU_TYPES,
   GPU_CLI_CREDIT,
@@ -507,7 +508,7 @@ export function registerRunpodTools(server: McpServer): void {
               content: [
                 {
                   type: "text",
-                  text: `Deploy a new comfyui-mcp pod here (pre-loaded with our template; the link carries our referral so your usage supports the project):\n\n${runpodDeployLink()}\n\nAfter it deploys, grab the pod ID from the RunPod console and use runpod action:"connect" to point this session at it.\n\n${GPU_CLI_CREDIT}`,
+                  text: `Deploy a new comfyui-mcp pod here (pre-loaded with our template; the link carries our referral so your usage supports the project):\n\n${runpodDeployLink()}\n\n${runpodDeployRequirements()}\n\nAfter it deploys, grab the pod ID from the RunPod console and use runpod action:"connect" to point this session at it.\n\n${GPU_CLI_CREDIT}`,
                 },
               ],
             };

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -504,11 +504,13 @@ export function registerRunpodTools(server: McpServer): void {
 
           // ── DEPLOY LINK (referral) ─────────────────────────────────────────
           case "deploy_link": {
+            // Empty for a custom RUNPOD_TEMPLATE_ID — render no blank block then.
+            const requirements = runpodDeployRequirements();
             return {
               content: [
                 {
                   type: "text",
-                  text: `Deploy a new comfyui-mcp pod here (pre-loaded with our template; the link carries our referral so your usage supports the project):\n\n${runpodDeployLink()}\n\n${runpodDeployRequirements()}\n\nAfter it deploys, grab the pod ID from the RunPod console and use runpod action:"connect" to point this session at it.\n\n${GPU_CLI_CREDIT}`,
+                  text: `Deploy a new comfyui-mcp pod here (pre-loaded with our template; the link carries our referral so your usage supports the project):\n\n${runpodDeployLink()}\n\n${requirements ? `${requirements}\n\n` : ""}After it deploys, grab the pod ID from the RunPod console and use runpod action:"connect" to point this session at it.\n\n${GPU_CLI_CREDIT}`,
                 },
               ],
             };


### PR DESCRIPTION
Fixes #2014
Fixes #2016

Both come from the same incident and the same argument builder (`deployOnce` in `src/services/runpod-client.ts`), and both end the same way: **RunPod creates the pod, bills it, and it never becomes usable** — `desiredStatus` RUNNING, `runtime` null, no ports, unreachable. They are independent defects and keep independent tests.

## Reproduction — by executing the builder, not reading it

`global.fetch` stubbed, so **no RunPod request was made and no pod was created**. This is the exact `podFindAndDeployOnDemand` input for a stock-template deploy.

**Before**

```jsonc
{
  "cloudType": "COMMUNITY", "gpuCount": 1, "gpuTypeId": "NVIDIA RTX A6000",
  "templateId": "bnqtkvcer3", "name": "repro-stock",
  "containerDiskInGb": 20,          // #2014 — README requires >= 30
  "volumeInGb": 60, "volumeMountPath": "/workspace",
  "ports": "3000/http,22/tcp,8189/http",
  // #2016 — no allowedCudaVersions at all
  "env": [ /* DEADMAN_TOKEN, DEADMAN_BOOT_GRACE_S, DEADMAN_BEAT_GRACE_S */ ]
}
```

**After**

```jsonc
{
  "cloudType": "COMMUNITY", "gpuCount": 1, "gpuTypeId": "NVIDIA RTX A6000",
  "templateId": "bnqtkvcer3", "name": "repro-stock",
  "containerDiskInGb": 30,
  "volumeInGb": 60, "volumeMountPath": "/workspace",
  "allowedCudaVersions": ["12.8","12.9","13.0","13.1","13.2","13.3","13.4","13.5","13.6",
                          "13.7","13.8","13.9","14.0","14.1","14.2","14.3","14.4","14.5",
                          "14.6","14.7","14.8","14.9"],
  "ports": "3000/http,22/tcp,8189/http",
  "env": [ /* unchanged */ ]
}
```

A **custom** template is byte-identical to before: `containerDiskInGb: 20`, no `allowedCudaVersions`.

## #2014 — where the 30 GB came from

`docker/runpod/README.md:405`, the "Deploy on RunPod" table — **not** the issue:

| **Container disk** | ≥ 30 GB (the baked ComfyUI + venv + cu128 torch + any runtime-installed nodes/caches, which are ephemeral) |

Two things I checked rather than assumed:

- **Volume disk has no minimum.** README:406 says "e.g. 100 GB+ … size for your models" — a sizing hint, not a floor. `volumeInGb: 60` is **left alone**; raising it would bill users for storage the repo never required.
- **The image size and the README do not obviously agree.** Docker Hub reports `artokun/comfyui-mcp-runpod:1.14` at 23,611,058,094 bytes **compressed** (23.61 GB), confirming the reporter's figure. RunPod's docs do not state whether the unpacked image counts against container disk, so I could not establish that 30 GB is comfortably sufficient — only that it is the floor this repo documents. **I followed the README** because it is the repo's own tested requirement; picking a larger number would be inventing a figure and billing the user for it. If 30 GB still proves tight in practice, the README figure is what needs revisiting, and that is a separate change.

## #2016 — the value, and how I established it

`allowedCudaVersions` is an **allow-list of exact `"major.minor"` strings**. There is no `>=` form. Probed against the live `api.runpod.io` schema:

- GraphQL **introspection is disabled** on RunPod's endpoint.
- `Query`, `GpuType`, and `PodMachineInfo` expose **no CUDA field**, so the fleet's version strings cannot be enumerated.
- The field is a **free-form `[String]`** — it accepts `["banana"]` without complaint. A version that does not exist is **inert**, not an error.

The floor comes from the repo: `docker/runpod/Dockerfile` sets `MIN_DRIVER_DEFAULT=570` with cu128 torch, `post_start.sh` preflights it, and `README.md:411` states "driver >= 570 (CUDA 12.8) for the default image". So the requirement is **CUDA >= 12.8**.

Because the list cannot express `>=` and the fleet cannot be enumerated, it is **generated from the floor** instead of pinned to the three versions that exist today. **Over-narrow is the dangerous direction** — the brief's own concern. Too broad reproduces #2016; too narrow matches *no* host, every GPU × cloud slot reports "no capacity", and one-tap deploy silently stops working the day RunPod's fleet moves to a CUDA we did not foresee. Since non-existent strings cost nothing, padding forward to 14.9 buys durability for free.

`RUNPOD_ALLOWED_CUDA_VERSIONS` overrides the list (empty ⇒ no filter), and `createPod`'s everything-failed error now **names the filter**, so an unschedulable deploy no longer reads as a capacity crunch.

## create vs resume — and a correction to the issue

**#2016 asks for `allowedCudaVersions` on `podResume` too. RunPod's API does not have that field, and adding it breaks `runpod action:"start"` outright.**

Probed against the live schema by sending each candidate with a **wrong-typed `podId`**, so GraphQL variable coercion failed and **the resolver never ran — nothing was resumed**:

```
allowedCudaVersions → Field "allowedCudaVersions" is not defined by type "PodResumeInput".
cudaVersion / cudaVersions / allowedCudaVersion / minCudaVersion → same
gpuCount            → accepted   (control: a KNOWN field draws no such error)
zzzDefinitelyNotAField → "is not defined"  (control: the probe can detect unknown fields)
```

The same probe against `PodFindAndDeployOnDemandInput` shows `allowedCudaVersions` **is** accepted — so the differential is real, not a broken probe. `runpod-python`'s `generate_pod_resume_mutation` agrees: it sends only `podId` and `gpuCount`. **`docs.runpod.io/sdks/graphql/manage-pods` shows a `podResume` example carrying `allowedCudaVersions`; that example is wrong.** The issue cites that page in good faith, and the locally-patched `dist` described in #2016 would have made every start fail GraphQL validation — strictly worse than the bug it was fixing.

So `resumePod` is deliberately unchanged, and a test pins the omission so nobody "completes" the fix later. The underlying exposure is real and now documented rather than silently unaddressed: a resumed pod **can** be placed on different hardware, and RunPod offers no lever to constrain it.

## Coverage is counted, not spot-checked

`deployOnce` runs once per (cloudType × gpuType). A fix applied at one call site would pass a spot-check of attempt #1 and still ship a broken pod on the slot that wins — the per-call-site adoption gap that has produced several defects here. The wiring test **counts adopting call sites**:

```ts
expect(inputs).toHaveLength(gpuTypeIds.length * 2);
expect(adoptingDisk).toHaveLength(inputs.length);
expect(adoptingCuda).toHaveLength(inputs.length);
```

plus a guard that `podFindAndDeployOnDemand` still has exactly **one** code path, so a second deploy path cannot be added without extending that test.

## Mutation evidence — 16 mutations, 16 killed, 0 survivors

Each was asserted to have **changed the file** before running (the source is CRLF; three patterns silently failed to apply on the first pass and were re-run — a mutation that never applies reads exactly like one that survived).

| Mutation | Killed by |
|---|---|
| M1 constant back to 20 | `sends 30 GB on the stock template` + wiring |
| **M2 call site** hardcodes `containerDiskInGb: 20` | 3 tests incl. wiring |
| **M3 call site** stops spreading `allowedCudaVersions` | 4 tests incl. wiring |
| M4 no CUDA default for stock | 3 tests |
| M5 disk floor leaks onto custom templates | `leaves a CUSTOM template on the pre-#2014 default` |
| M6 **the reporter's patch** — send the field on `podResume` | `sends NO CUDA filter on resume` |
| M7 CUDA applied only on the COMMUNITY slot | **wiring test only** — the single-attempt tests all pass |
| M8 allow-list pinned to exactly 12.8 | `NOTHING below the image's floor` (over-narrow arm) |
| M9 CUDA floor leaks onto custom templates | `sends NO CUDA filter for a CUSTOM template` |
| M10 env override ignored | 2 escape-hatch tests |
| **N1 call site** — `deploy_link` stops rendering the requirements | tool test + the link/requirements count |
| N2 the advice hardcodes the old disk number | both drift tests |
| N3 the advice drops the CUDA floor | both drift tests |
| P1 stock advice leaks onto a CUSTOM template link | `says NOTHING … for a CUSTOM template` |
| P2 scoping inverted — stock gets no advice | 3 tests |
| **P3 call site** — the tool ignores the requirements again | tool test |

M7 is the one that earns the wiring test its place: every per-attempt assertion still passes under it.

## Where to look hardest

- **The generated allow-list ceiling (`CUDA_ALLOWLIST_MAX_MAJOR = 14`).** This is the load-bearing judgement call. It is right only because unmatched strings are inert — which I probed, but on RunPod's *current* behaviour. If RunPod ever validates the list against a known set, padding to 14.9 would start rejecting deploys.
- **Scoping to the stock template.** A user who points `RUNPOD_TEMPLATE_ID` at their own *rebuild of our image* keeps the old 20 GB and no CUDA filter, and nothing tells them. I followed the dead-man switch's existing precedent (defaults apply only to `DEFAULT_TEMPLATE_ID`) and the instruction not to change behaviour for non-stock templates, but this is a genuine trade-off.
- **`RUNPOD_ALLOWED_CUDA_VERSIONS` is not in `docs/`.** Deliberate: the docs tree is locale-mirrored across 12 languages and this is a bug fix under the freeze. The error message names the variable at the moment a user needs it.

## Verification status — read this before trusting the fix

**No real pod was created, resumed, or billed at any point.** This is verified **at the payload level only**: the arguments the connector now sends are correct against RunPod's documented and probed API contract. **I did not prove that a real deploy succeeds and becomes healthy** — that requires a billed pod, which the brief ruled out. The claim "a pod now comes up" is *not* being made here.

Read-only/never-executing GraphQL calls I did make against the live API: schema-field probes (coercion failures, resolver never reached), and one `podTemplates` read.

Suite: a full run against a clean `origin/main` worktree baselines at **4 failed files / 6 failed tests** (`node-id-union-message`, `package-hooks`, `tool-surface-filter`, `vocabulary` — all pre-existing). This branch fails a **subset** of those, plus `panel-pin-guard` on the last run, which passes **109/109 in isolation** — a wall-clock flake in its fsync/lock timings under parallel load, triaged per file rather than off the parallel summary. No new failures.


## codex gate — round 1 finding, fixed

**[P1] `runpod action:"deploy_link"` bypassed both new floors.** Correct, and it was the real gap in the first cut: `createPod` sends the floors on the API path, but the console path never reaches `createPod` — the user fills RunPod's own deploy form, seeded by the template, and that template is still registered at `containerDiskInGb: 20` with no CUDA constraint (read live). Following the link with its defaults reproduced **both** defects on a pod the user pays for.

RunPod documents no query parameters that would let the deploy link carry overrides, and the template lives on the RunPod account rather than in this repo — so I did not invent a URL parameter. `deploy_link` now **states both floors**, built from the same constants the API path sends so the advice cannot drift from the behaviour, and a wiring test **counts** the adopting sites: every `runpodDeployLink()` call site in `src/tools` must also call `runpodDeployRequirements()`.

Three more mutations cover it: dropping the call site kills 2 tests, and hardcoding either floor kills the drift tests.

Self-review of that fix then caught one more: `runpodDeployLink()` carries `RUNPOD_TEMPLATE_ID`, so a user who repointed it gets a link to **their** template — and stating our floors there is wrong advice about an image we did not build. The requirements text is now scoped exactly like the API-path defaults, and `deploy_link` renders no blank block when there is nothing to say (3 further mutations, all killed).

This also **downgrades** the follow-up noted below — the console path is now signposted rather than silently broken — but editing the template itself is still an owner action.

## Follow-up that is NOT in this PR

**The RunPod template `bnqtkvcer3` is itself still registered at `containerDiskInGb: 20` with no CUDA constraint** (read live from `podTemplates`). The connector overrides both on the API path, and `deploy_link` now tells a console user what to change — but the template's own defaults remain wrong, so the console form still *starts* undersized. **Editing that template is an owner action on the RunPod account and outside this repo**; I did not touch it. Fixing it there would make the `deploy_link` advice redundant rather than load-bearing, which is the better end state.

Two other things I deliberately did **not** do: raise `volumeInGb` (the README states no minimum), and add `RUNPOD_ALLOWED_CUDA_VERSIONS` to `docs/` (locale-mirrored across 12 languages, under a feature freeze — the error message names it at the point of need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
