### PR TITLE
release: v0.52.46 — frontend-only add without object_info, Ollama audio gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.46] - 2026-08-21
+
 ### Fixed
 
 - **`panel_show_media` no longer repeats a claim its client did not support (#2010).**
@@ -45,6 +47,21 @@ All notable changes to this project are documented here. This project adheres to
   the newly-selected model's image slot along with the earlier "you can hear them"
   note. That audio is now dropped, with a note telling the incoming model plainly
   that it did not hear it.
+
+### MCP
+
+#### Fixed
+- a frontend-only type refused for an unavailable object_info says so (#2019)
+- a rejected tool call names the argument it meant, without guessing at intent (#1986)
+- the synthesis grace is read off the panel's own send bounds, and the notice stops claiming the panel never sent one (#2020)
+- a stock RunPod pod gets the container disk and CUDA host its image actually needs (#2022)
+- a show_media reply establishes only what it accounts for (#2018)
+- a drained ComfyUI-Manager queue is not a completed one — report what the task actually did (#2005)
+- a boot slower than the readiness budget no longer forfeits the post-restart reconnect wait (#1997)
+- install_comfyui(action:"panel") reports whether a NEWER panel is published, not only whether it clears the floor (#1995)
+- Ollama refuses audio unless the model is a verified listener (#1980)
+- retire the restart confirmation wherever the CARD LEAVES THE SCREEN (review fix for #1957) (#1982)
+
 
 ## [0.52.45] - 2026-08-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.45",
+  "version": "0.52.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.45",
+      "version": "0.52.46",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.45",
+  "version": "0.52.46",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.46** from `main` (after v0.52.45).

Carries:

- #2019 / #2000 — frontend-only `panel_add_node` (MarkdownNote) is not refused when `/object_info` is unavailable
- #1986 / #1969 — a rejected tool call names the argument it meant
- #2020 / #2001 — synthesis grace is read off the panel's own send bounds
- #2022 / #2014 / #2016 — stock RunPod pod gets the container disk and CUDA host the image needs
- #2018 / #2010 — `show_media` reply establishes only what it accounts for
- #2005 / #1999 — a drained ComfyUI-Manager queue is not a completed one
- #1997 / #1996 — a boot slower than the readiness budget no longer forfeits post-restart reconnect
- #1995 / #1983 — `install_comfyui(action:"panel")` reports whether a newer panel is published
- #1980 / #1972 — Ollama refuses audio unless the model is a verified listener
- #1982 / panel#1554 — retire restart confirmation wherever the card leaves the screen

Held out: #1967/#1961 CI+conflicts; #1985/#1968 conflicts; #1981/#1973 conflicts; hygiene/docs PRs.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.46` tag on the version commit).