### PR TITLE
fix(2009): restart_comfyui reports a serving server as ready, not a failed start

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -502,7 +502,47 @@ describe("process-control startup readiness", () => {
     expect(result.message).toMatch(/no readiness probe got a healthy response/i);
     expect(result.message).not.toMatch(/no readiness probe got a response\b/i);
     expect(result.message).toMatch(/the last one included/i);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Two scheduled probes, plus the #2009 extra look before a child-gone
+    // timeout is allowed to become `startup:"failed"`.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not report a failed start when the launched PID exits 0 and the port is serving (#2009)", async () => {
+    // Windows portable / trampoline: the process we spawned exits 0 after handing
+    // off, the scheduled probes miss the bind, and a look AFTER that loop sees a
+    // healthy /system_stats. Treating the wrapper's exit as "THIS RELAUNCH FAILED"
+    // is how an agent was told to tear down a server that had just started.
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    let fetches = 0;
+    const fetchMock = vi.fn(async () => {
+      fetches++;
+      if (fetches <= 2) {
+        children[0]?.emit("exit", 0, null);
+        throw new Error("ECONNREFUSED");
+      }
+      return { ok: true } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(10);
+    const result = await pending;
+
+    expect(result.ready).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.startup).toBe("unconfirmed");
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).not.toMatch(/not a slow start/i);
+    expect(result.message).not.toMatch(/launched process is alive/i);
+    expect(result.message).toMatch(/EXITED \(exit code 0\)/);
+    expect(result.message).toMatch(/could not be confirmed as the process this call launched/i);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("reports child process spawn errors without throwing", async () => {

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -2769,6 +2769,52 @@ n127.0.0.1:8188
     killSpy.mockRestore();
   });
 
+  it("does not report restart failed when the launched PID exits 0 and the port is serving (#2009)", async () => {
+    // The reporter's Windows-portable shape: scheduled probes miss the bind, the
+    // wrapper we spawned exits 0, then /system_stats answers. `restart_comfyui`
+    // used to return started:false / startup:"failed" / "it was not a slow start"
+    // and push an agent into tearing down a healthy server.
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    usePlainInstall();
+    mockLivePortThenFree();
+    const children = spawnCapturingChildren();
+    let fetches = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetches++;
+        if (fetches <= 2) {
+          children[0]?.emit("exit", 0, null);
+          throw new Error("ECONNREFUSED");
+        }
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.startup).toBe("unconfirmed");
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/could not be started/i);
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).not.toMatch(/not a slow start/i);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).not.toMatch(/launched process is alive/i);
+    expect(result.message).toMatch(/up and ready after the restart/i);
+    expect(result.message).toMatch(/could not be confirmed as the one serving the port/i);
+    expect(result.message).toMatch(/EXITED \(exit code 0\)/);
+    const serialized = JSON.parse(JSON.stringify(result));
+    expect(serialized.startup).toBe("unconfirmed");
+    expect(serialized.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  });
+
   it("states listener ownership on EVERY return path, including 'another launcher took the port'", async () => {
     // After our stop, a different launcher binds the port during the settle delay,
     // so restart_comfyui (action:"start") exits via its "already running" branch. That branch used to

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -3506,29 +3506,54 @@ export async function startComfyUI(anchor?: {
     };
   }
 
-  const readiness = startupResult.readiness;
+  let readiness = startupResult.readiness;
+  // WHAT A DEADLINE ACTUALLY ESTABLISHES (#367).
+  //
+  // The budget expiring is a fact about how long WE waited, not a fact about the
+  // server. It says startup was not confirmed WITHIN it. Only an observation of
+  // the launched process being GONE turns that into a failure — and we can make
+  // that observation, so the two stop sharing a verdict whose message asserted
+  // whichever it happened to name.
+  //
+  // The old branch reported the #776 failure shape (ComfyUI aborting during
+  // import) for BOTH, because for a dead child it was right and nobody separated
+  // the live one. #776's truthfulness is preserved exactly — a child that died
+  // still reports DOWN, with the same sentence — while the live child stops being
+  // told it failed.
+  //
+  // `launchedChildStillRunning` is tri-state on purpose: `undefined` is "cannot
+  // tell", and it must not be spent as either answer, so it falls on the
+  // unconfirmed side with the uncertainty stated. Only a DEFINITE death fails.
+  const childAlive = launchedChildStillRunning(launched.child);
+  const childIsGone =
+    launchedSpawnFailed || launchedChildExit != null || childAlive === false;
+  // #2009: the launched PID exiting is NOT proof the server is down. A Windows
+  // portable / venv trampoline / wrapper exits 0 after handing off, and the last
+  // scheduled probe can miss a bind that happened in the gap after it. Before
+  // declaring THIS CALL's launch failed, re-probe once. A healthy answer falls
+  // through to ownership classification (which already treats a departed child as
+  // unconfirmed unless serving argv positively differs). A spawn that never
+  // happened is not a handoff — skip the extra look.
+  if (!readiness.ready && childIsGone && !launchedSpawnFailed) {
+    const extra = await waitForApiReady({
+      intervalMs: 0,
+      maxTries: 1,
+      probeUrl: readiness.probe_url,
+    });
+    if (extra.ready) {
+      readiness = {
+        ready: true,
+        timed_out: false,
+        attempts: readiness.attempts + extra.attempts,
+        max_tries: readiness.max_tries,
+        interval_ms: readiness.interval_ms,
+        waited_ms: readiness.waited_ms + extra.waited_ms,
+        probe_url: readiness.probe_url,
+      };
+    }
+  }
   if (!readiness.ready) {
     const env = launchEnvInfo(info);
-    // WHAT A DEADLINE ACTUALLY ESTABLISHES (#367).
-    //
-    // The budget expiring is a fact about how long WE waited, not a fact about the
-    // server. It says startup was not confirmed WITHIN it. Only an observation of
-    // the launched process being GONE turns that into a failure — and we can make
-    // that observation, so the two stop sharing a verdict whose message asserted
-    // whichever it happened to name.
-    //
-    // The old branch reported the #776 failure shape (ComfyUI aborting during
-    // import) for BOTH, because for a dead child it was right and nobody separated
-    // the live one. #776's truthfulness is preserved exactly — a child that died
-    // still reports DOWN, with the same sentence — while the live child stops being
-    // told it failed.
-    //
-    // `launchedChildStillRunning` is tri-state on purpose: `undefined` is "cannot
-    // tell", and it must not be spent as either answer, so it falls on the
-    // unconfirmed side with the uncertainty stated. Only a DEFINITE death fails.
-    const childAlive = launchedChildStillRunning(launched.child);
-    const childIsGone =
-      launchedSpawnFailed || launchedChildExit != null || childAlive === false;
     const waitedS = seconds(readiness.waited_ms);
     if (childIsGone) {
       return {
@@ -3725,8 +3750,12 @@ export async function startComfyUI(anchor?: {
         : "") +
       // Undecidable ownership is stated, never implied away: the caller learns that
       // "our relaunch is the healthy server" is unconfirmed rather than proven.
+      // #2009: a departed child is the trampoline/wrapper shape — saying it is
+      // ALIVE would be the same over-claim as calling the relaunch failed.
       (ownershipUnconfirmed
-        ? ` (Could not map the process owning port ${port}, so this could not be confirmed as the process this call launched — the launched process is alive and the API is ready.)`
+        ? launchedChildExit
+          ? ` (The process this call launched EXITED (${exitCause(launchedChildExit)}), so this could not be confirmed as the process this call launched — a wrapper or trampoline can hand off and still leave a healthy server. The API is ready; listener ownership is unconfirmed.)`
+          : ` (Could not map the process owning port ${port}, so this could not be confirmed as the process this call launched — the launched process is alive and the API is ready.)`
         : "") +
       // The port was never observed free, so a healthy API is not evidence WE
       // produced it — it may be the server that was already there.


### PR DESCRIPTION
`restart_comfyui` was telling agents to tear down a ComfyUI that had just started.

## The bug

On a Windows portable install, `restart_comfyui` (`action:"restart"`) returned:

```
stopped: true, started: false, startup: "failed", ready: false
"The process this call launched EXITED (exit code 0), so THIS RELAUNCH FAILED — it was not a slow start."
```

The same call's launch log already ended with `Starting server` / `To see the GUI go to: http://127.0.0.1:8188`, and an immediate `curl` of the probed `/system_stats` was healthy. A live `python_embeded\python.exe … main.py --windows-standalone-build --use-sage-attention --fast` was serving.

The launched PID's exit 0 was treated as proof this relaunch failed. On a portable / trampoline / wrapper that hands off and exits, that exit does not mean the server died. The 60 scheduled probes can also miss a bind that happens in the gap after the last one; the retry budget *was* spent (`60/60`, `waited_ms: 59631`), then the failure verdict was issued without looking again.

That false failure is also the plausible cause of the follow-on stale-tab symptom: the orchestrator concluded the server was dead at the same moment the panel reconnected to the instance that was actually alive, and the tab was recreated (`workflow_uuid` changing every turn) from a pre-edit snapshot while disk kept the save.

## What this PR changes

In `startComfyUI` (the path `restart_comfyui` actually waits on):

1. **Before returning `startup:"failed"` for a departed child**, re-probe the target URL once. A healthy answer falls through to the existing ownership classifier, which already treats a departed child as `listener_ownership: "unconfirmed"` unless serving argv positively differs.
2. **Do not claim the launched process is still alive** on that unconfirmed-ready path. The wrapper exited; the API is ready; ownership is unconfirmed.

A spawn that never happened is not a handoff — that path is unchanged. A child that exits *and* still has nothing serving still reports `startup:"failed"` with the #776 wording.

The reporter then sees `started: true`, `ready: true`, `startup: "unconfirmed"`, `listener_ownership: "unconfirmed"`, and "up and ready after the restart" — not "could not be started" / "it was not a slow start".

## Tests

Drive the shipped functions (`startComfyUI` / `restartComfyUI`) on the reporter's shape: scheduled probes miss, the launched PID exits 0, then `/system_stats` answers.

- `process-control.test.ts`: `startComfyUI` does not report a failed start
- `restart-launcher-env.test.ts`: `restartComfyUI` does not report `could not be started`

The existing "child died with exit 1 and nothing answers" tests still assert `THIS RELAUNCH FAILED`.

Fixes #2009
