### PR TITLE
fix(2008): panel_add_node names the live ConvertAny2Dict sibling instead of a missing-DICT dead end

### DIFF
--- a/src/__tests__/orchestrator/add-node-dictgetnode-sibling.test.ts
+++ b/src/__tests__/orchestrator/add-node-dictgetnode-sibling.test.ts
@@ -1,0 +1,154 @@
+// #2008 — panel_add_node("DictGetNode") is refused even when ConvertAny2Dict is
+// already on the live canvas outputting DICT. The add-node guard's socket proof
+// reads producers off a single-class /object_info payload (or a whole-schema
+// widen that still cannot see a typed converter whose LIVE output is DICT while
+// its schema/wildcard slot is `*`), so the sibling looks missing.
+//
+// The orchestrator must keep the panel's refusal, consult the live graph the
+// reporter used, and name ConvertAny2Dict — including when the live slot type
+// is still the wildcard `*` and the declared output name is DICT.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/** The reporter's exact panel refusal (issue #2008), in the panel's real wording. */
+const REPORTER_REFUSAL =
+  `Cannot add DictGetNode: required input py_dict (DICT) has no widget; ` +
+  `no installed node outputs DICT.`;
+
+/** Canonical panel wording for the same guard (quotes + 5s wait). */
+const CANONICAL_REFUSAL =
+  `Cannot add "DictGetNode": 1 required input type had no widget after 5.8s ` +
+  `waiting for node extensions to register.\n` +
+  `- input "py_dict" (declared type "DICT"): no installed node outputs ` +
+  `"DICT" and no frontend widget is registered for it.`;
+
+function convertAny2Dict(outputType: string) {
+  return {
+    matches: [
+      {
+        id: 285,
+        type: "ConvertAny2Dict",
+        outputs: [{ slot: 0, name: "DICT", type: outputType, links: 1 }],
+        matched_on: [`output:DICT(${outputType})`],
+      },
+    ],
+    count: 1,
+  };
+}
+
+function bridge(opts: {
+  message: string;
+  producers?: (output: string) => { matches: unknown[]; count: number } | "throw";
+}) {
+  const calls: Array<Record<string, unknown>> = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(cmd);
+      if (cmd.cmd === "graph_find_nodes") {
+        const output = typeof cmd.output === "string" ? cmd.output : "";
+        const reply = (opts.producers ?? ((o: string) =>
+          o === "DICT" ? convertAny2Dict("DICT") : { matches: [], count: 0 }))(output);
+        if (reply === "throw") throw new Error("graph_find_nodes failed");
+        return reply;
+      }
+      throw new Error(opts.message);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function addNode(
+  classType: string,
+  message: string,
+  producers?: (output: string) => { matches: unknown[]; count: number } | "throw",
+) {
+  const { b, calls } = bridge({ message, producers });
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+  if (!def) throw new Error("panel_add_node is not registered");
+  const res: ToolResult = await def.handler({ class_type: classType } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("panel_add_node names a live ConvertAny2Dict sibling for DictGetNode (#2008)", () => {
+  it("the reporter's case: keeps the refusal and names ConvertAny2Dict already on the canvas", async () => {
+    const { text, isError, calls } = await addNode("DictGetNode", REPORTER_REFUSAL);
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_REFUSAL);
+    expect(text).toContain("ConvertAny2Dict #285");
+    expect(text).toMatch(/DICT/);
+    expect(text).toMatch(/live canvas ALREADY has nodes that output/i);
+    expect(text).toMatch(/single-class \/object_info/);
+    expect(text).toMatch(/Retrying panel_add_node will keep failing/);
+    expect(text).toMatch(/Do not retry this class_type/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_add_node", "graph_find_nodes"]);
+    expect(calls.filter((c) => c.cmd === "graph_add_node")).toHaveLength(1);
+    expect(calls).not.toContainEqual(expect.objectContaining({ cmd: "refresh_nodes" }));
+  });
+
+  it("a typed converter whose live slot is still wildcard * still counts as DICT", async () => {
+    const { text, isError, calls } = await addNode("DictGetNode", CANONICAL_REFUSAL, (output) =>
+      output === "DICT" ? convertAny2Dict("*") : { matches: [], count: 0 },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toContain(CANONICAL_REFUSAL);
+    expect(text).toContain("ConvertAny2Dict #285");
+    expect(text).toMatch(/live canvas ALREADY has nodes that output/i);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_add_node", "graph_find_nodes"]);
+  });
+
+  it("does not retry or refresh — those re-run the same stale proof", async () => {
+    const { calls } = await addNode("DictGetNode", REPORTER_REFUSAL);
+    expect(calls.filter((c) => c.cmd === "graph_add_node")).toHaveLength(1);
+    expect(calls.some((c) => c.cmd === "refresh_nodes")).toBe(false);
+  });
+
+  it("asks the live graph for the unproven DICT output type", async () => {
+    const { calls } = await addNode("DictGetNode", REPORTER_REFUSAL);
+    const finds = calls.filter((c) => c.cmd === "graph_find_nodes");
+    expect(finds.map((c) => c.output)).toEqual(["DICT"]);
+  });
+
+  it("leaves a genuine missing-producer refusal alone when the live graph has none", async () => {
+    const { text, isError, calls } = await addNode("DictGetNode", REPORTER_REFUSAL, () => ({
+      matches: [],
+      count: 0,
+    }));
+
+    expect(isError).toBe(true);
+    expect(text).toContain(REPORTER_REFUSAL);
+    expect(text).not.toMatch(/live canvas ALREADY has nodes that output/i);
+    expect(text).not.toContain("ConvertAny2Dict");
+    expect(calls.filter((c) => c.cmd === "graph_add_node")).toHaveLength(1);
+  });
+
+  it("the tool description names DICT beside the other custom-link refusals", () => {
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+    if (!def) throw new Error("panel_add_node is not registered");
+    expect(def.description).toMatch(/no installed node outputs/);
+    expect(def.description).toMatch(/DICT/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4018,34 +4018,37 @@ function isLoraManagerAutocompleteRefusal(res: ToolResult): boolean {
 }
 
 /**
- * #1944 — the panel's add-node socket proof read "which datatypes does some
- * installed node output?" off a single-class `/object_info/<class_type>`
+ * #1944 / #2008 — the panel's add-node socket proof read "which datatypes does
+ * some installed node output?" off a single-class `/object_info/<class_type>`
  * payload (or a whole-schema widen that did not land). Custom link types a
- * SIBLING node produces — SeedVR2LoadDiTModel → SEEDVR2_DIT — then look
- * unproven, and the refusal claims "no installed node outputs X" while that
- * very node sits on the canvas. Retrying the add re-runs the same proof;
- * panel_refresh_nodes re-registers the class, which is what arms the
- * single-class path. The live graph is the authority the guard did not consult.
+ * SIBLING node produces — SeedVR2LoadDiTModel → SEEDVR2_DIT, ConvertAny2Dict →
+ * DICT — then look unproven, and the refusal claims "no installed node outputs
+ * X" while that very node sits on the canvas. Retrying the add re-runs the
+ * same proof; panel_refresh_nodes re-registers the class, which is what arms
+ * the single-class path. The live graph is the authority the guard did not
+ * consult.
+ *
+ * #2008's DictGetNode refusal is a SHORTER sentence of the same guard
+ * (`required input py_dict (DICT) has no widget; no installed node outputs
+ * DICT`) and must not be keyed on the 5s-wait wording #1944 used.
  */
 function isMissingInstalledOutputsRefusal(res: ToolResult): boolean {
   if (!res.isError) return false;
-  const text = textOfToolResult(res);
-  return (
-    /had no widget after .+ waiting for node extensions to register/i.test(text) &&
-    /no installed node outputs/i.test(text)
-  );
+  return /no installed node outputs/i.test(textOfToolResult(res));
 }
 
-/** Types the panel named as unproven in a #1944-shaped refusal. */
+/** Types the panel named as unproven in a #1944/#2008-shaped refusal. */
 function parseUnprovenSocketTypes(text: string): string[] {
   const types: string[] = [];
   const add = (raw: string) => {
-    const v = raw.trim();
+    const v = raw.trim().replace(/^"+|"+$/g, "");
     if (v && !types.includes(v)) types.push(v);
   };
   for (const re of [
     /no installed node outputs "([^"]+)"/gi,
     /declared type "([^"]+)": no installed node outputs/gi,
+    /no installed node outputs ([A-Za-z0-9_*]+)/gi,
+    /required input \S+ \(([^)]+)\)/gi,
   ]) {
     re.lastIndex = 0;
     let m: RegExpExecArray | null;
@@ -4054,23 +4057,46 @@ function parseUnprovenSocketTypes(text: string): string[] {
   return types;
 }
 
+function isWildcardSocketType(t: string): boolean {
+  const v = t.trim();
+  return v === "*" || v.toUpperCase() === "ANY";
+}
+
+function socketTypeMatches(declared: string, socketType: string): boolean {
+  if (declared === socketType) return true;
+  return declared.split(",").map((part) => part.trim()).includes(socketType);
+}
+
 function nodeOutputDeclaresType(node: Record<string, unknown>, socketType: string): boolean {
   const outputs = node.outputs;
   if (Array.isArray(outputs)) {
     for (const out of outputs) {
       if (!out || typeof out !== "object" || Array.isArray(out)) continue;
-      const t = (out as { type?: unknown }).type;
-      if (typeof t !== "string" || !t) continue;
-      if (t === socketType) return true;
-      if (t.split(",").map((part) => part.trim()).includes(socketType)) return true;
+      const rec = out as { type?: unknown; name?: unknown };
+      const t = rec.type;
+      const name = typeof rec.name === "string" ? rec.name : "";
+      if (typeof t === "string" && t) {
+        if (socketTypeMatches(t, socketType)) return true;
+        // Typed converter (ConvertAny2Dict): the live slot can still be wildcard
+        // `*` while the declared output NAME is the type the guard asked for.
+        if (isWildcardSocketType(t) && name === socketType) return true;
+      }
     }
   }
   const matchedOn = node.matched_on;
   if (!Array.isArray(matchedOn)) return false;
   const needle = `(${socketType.toLowerCase()})`;
-  return matchedOn.some(
-    (entry) => typeof entry === "string" && entry.toLowerCase().includes(needle),
-  );
+  return matchedOn.some((entry) => {
+    if (typeof entry !== "string") return false;
+    const parsed = /^output:([^(]*)\(([^)]*)\)$/i.exec(entry);
+    if (parsed) {
+      const slotName = parsed[1];
+      const slotType = parsed[2];
+      if (socketTypeMatches(slotType, socketType)) return true;
+      if (isWildcardSocketType(slotType) && slotName === socketType) return true;
+    }
+    return entry.toLowerCase().includes(needle);
+  });
 }
 
 type LiveSocketProducer = { id: string; type: string };
@@ -4147,6 +4173,8 @@ async function withLiveSocketProducerNote(
   if (!isMissingInstalledOutputsRefusal(res)) return res;
   // #1708 is a Vue-widget miss, not a sibling-producer miss. Querying the
   // canvas for AUTOCOMPLETE_TEXT_* would only delay the named remedy.
+  // Checked AFTER the #1944/#2008 shape so a LoRA Manager wait (which also
+  // says "no installed node outputs") stays on its own note.
   if (isLoraManagerAutocompleteRefusal(res)) return res;
   const missing = parseUnprovenSocketTypes(textOfToolResult(res));
   if (!missing.length) return res;
@@ -13037,7 +13065,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_add_node",
-      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values. Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' — the supported way to ANNOTATE a workflow with on-canvas instructions (add the node, then put the text in its 'text' widget via panel_set_widget) — plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry, so they legitimately bypass the backend class_type check. ComfyUI-LoRA-Manager's 'Lora Loader (LoraManager)' (and other AUTOCOMPLETE_TEXT_* nodes) cannot be added: the pack is healthy, but the add-node guard cannot see its Vue autocomplete widget. Use 'LoRA Text Loader (LoraManager)' — same outputs, lora_syntax is a STRING — or core LoraLoader; reload/retry will not clear it. A 'no installed node outputs' refusal for a custom link type (SEEDVR2_DIT, SEEDVR2_VAE, …) after sibling producer nodes were just added is the guard looking at a single-class /object_info, not the live graph; retry/refresh will not clear it — copy the node from another workflow (panel_copy_nodes / panel_paste_nodes) or reload the tab. ADD NODES ONE AT A TIME, not as a parallel batch: each add carries a fresh /object_info payload and those register SERIALLY, so N concurrent adds become N sequential refresh cycles. On a large install that outruns the 30s per-command deadline and the later adds time out WHILE STILL QUEUED — they then apply when their turn arrives, leaving nodes you were told had failed (panel#767). Sequential adds each get the refresh to themselves and stay well inside the deadline.",
+      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values. Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' — the supported way to ANNOTATE a workflow with on-canvas instructions (add the node, then put the text in its 'text' widget via panel_set_widget) — plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry, so they legitimately bypass the backend class_type check. ComfyUI-LoRA-Manager's 'Lora Loader (LoraManager)' (and other AUTOCOMPLETE_TEXT_* nodes) cannot be added: the pack is healthy, but the add-node guard cannot see its Vue autocomplete widget. Use 'LoRA Text Loader (LoraManager)' — same outputs, lora_syntax is a STRING — or core LoraLoader; reload/retry will not clear it. A 'no installed node outputs' refusal for a custom link type (SEEDVR2_DIT, SEEDVR2_VAE, DICT, …) after sibling producer nodes were just added (ConvertAny2Dict on the canvas while DictGetNode is refused) is the guard looking at a single-class /object_info, not the live graph; retry/refresh will not clear it — copy the node from another workflow (panel_copy_nodes / panel_paste_nodes) or reload the tab. ADD NODES ONE AT A TIME, not as a parallel batch: each add carries a fresh /object_info payload and those register SERIALLY, so N concurrent adds become N sequential refresh cycles. On a large install that outruns the 30s per-command deadline and the later adds time out WHILE STILL QUEUED — they then apply when their turn arrives, leaving nodes you were told had failed (panel#767). Sequential adds each get the refresh to themselves and stay well inside the deadline.",
       {
         class_type: z.string().describe("Exact ComfyUI node class_type to create."),
         pos: xy()


### PR DESCRIPTION
Fixes #2008

## What the user now observes

After `ConvertAny2Dict` is on the live canvas outputting DICT, `panel_add_node` for `DictGetNode` still cannot create the node (the panel socket proof is unchanged). The refusal no longer ends on a false "no installed node outputs DICT" dead end: it consults the live graph, names `ConvertAny2Dict` as the sibling producer, and says retry / `panel_refresh_nodes` will keep failing — including when the converter's live slot type is still the wildcard `*` and the declared output name is DICT.

Workaround: copy an existing `DictGetNode` from another open workflow and paste (`panel_copy_nodes` / `panel_paste_nodes`), or reload the ComfyUI tab.

## Why

The panel add-node guard proves custom link types by scanning `/object_info` outputs. On the already-registered path that is a **single-class** payload, so a sibling producer added earlier in the same session is invisible. A typed converter whose schema/wildcard slot is `*` is also invisible even when the live graph shows DICT.

#1947 already named SeedVR2-style siblings, but only for the 5s-wait refusal with quoted types, and only when `outputs[].type` was exactly the missing type. The reporter's DictGetNode sentence (`required input py_dict (DICT) has no widget; no installed node outputs DICT`) never reached that path, and a `ConvertAny2Dict` whose live slot is still `*` was filtered out.

The panel itself cannot be patched from this repo. The orchestrator now matches that shorter refusal, parses unquoted `DICT`, treats a wildcard slot whose declared name is DICT as a live producer, and appends the live-graph diagnosis. An unreadable graph or a genuine missing producer is fail-open (original refusal unchanged). LoRA Manager AUTOCOMPLETE_TEXT_* stays the #1708 note.

## Tests

`src/__tests__/orchestrator/add-node-dictgetnode-sibling.test.ts` drives shipped `panel_add_node`:

- reporter refusal + live ConvertAny2Dict → original text preserved, producer named, no add-retry, no refresh
- ConvertAny2Dict whose live slot type is still `*` still counts as DICT
- empty live graph → original refusal, no invented producers
- tool description names DICT
