### PR TITLE
fix(2004): uncollapse expands a title-chip; schema and save timeouts are named honestly

### DIFF
--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -1,0 +1,311 @@
+// #2004 — panel widget writes blocked by object_info starvation; uncollapse
+// rejects stored zero height; a save budget timeout can land after the reply.
+//
+// All three cases drive the shipped panel_* handlers on the real dispatch path
+// (ctx.call → graph_set_widget / graph_edit_node / workflow_save). The panel's
+// sizeSane and schema oracle live in the other repo; these compensations are
+// what this orchestrator can still do for a caller who has not updated the panel.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_NODE_BODY_HEIGHT,
+  DEFAULT_NODE_WIDTH,
+} from "../../orchestrator/create-group-membership.js";
+import {
+  needsUncollapseSizeRestore,
+  restoredUncollapseSize,
+} from "../../orchestrator/edit-node-uncollapse.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found in buildPanelToolDefs()`);
+  return def;
+}
+
+function jsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function errorResult(message: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+/** Reporter's collapsed node: size [228, 0], uncollapse without an explicit size. */
+const COLLAPSED = {
+  id: 12,
+  type: "OpenAICompatibleLLM",
+  pos: [400, 200],
+  size: [228, 0] as [number, number],
+  collapsed: true,
+  full_height: 30,
+};
+
+/** The panel's own starvation wording (assertTypeAgainstFreshBackend + oracle note). */
+const STARVATION =
+  `Cannot set widget on node 12 ("OpenAICompatibleLLM"): cannot verify the node type against the ` +
+  `ComfyUI backend — no usable /object_info schema was obtained. Tried 2 routes: ` +
+  `api.getNodeDefs() did not answer within its 10000ms share of the 20000ms budget; ` +
+  `GET /object_info did not answer within its 5000ms share of the 20000ms budget. ` +
+  `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
+  `Reconnect ComfyUI and retry.`;
+
+const SAVE_TIMEOUT =
+  `workflow_save did not finish within 13s for "graph". ` +
+  `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
+  `The save may still complete in the background. The same tab reports modified:true persisted:true. ` +
+  `modified:true means the canvas has not been marked clean, so the write has not been acknowledged as landed. ` +
+  `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`;
+
+describe("restored uncollapse size (#2004)", () => {
+  it("a stored [228, 0] is not sizeSane and restores keeping the width", () => {
+    expect(needsUncollapseSizeRestore([228, 0])).toBe(true);
+    expect(restoredUncollapseSize([228, 0])).toEqual([228, DEFAULT_NODE_BODY_HEIGHT]);
+  });
+
+  it("a positive stored size is left alone", () => {
+    expect(needsUncollapseSizeRestore([228, 140])).toBe(false);
+    expect(restoredUncollapseSize([228, 140])).toEqual([228, 140]);
+  });
+
+  it("an unreadable size falls back to the panel's default extents", () => {
+    expect(needsUncollapseSizeRestore(undefined)).toBe(true);
+    expect(restoredUncollapseSize(undefined)).toEqual([DEFAULT_NODE_WIDTH, DEFAULT_NODE_BODY_HEIGHT]);
+  });
+});
+
+describe("panel_edit_node restores a collapsed zero height before dispatch (#2004)", () => {
+  it("THE REPORTED CASE: collapsed:false without size sends a positive size so the panel does not reject [228, 0]", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            total: 1,
+            matched: 1,
+            shown: 1,
+            text:
+              `1 match(es) of 1 in scope (viewing: 1 nodes)\n` +
+              JSON.stringify(COLLAPSED),
+          });
+        }
+        return jsonResult({ edited: [{ node_id: 12, collapsed: false, size: cmd.size }] });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_edit_node").handler(
+      { node_id: 12, collapsed: false },
+      ctx,
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_edit_node"]);
+    const edit = calls.find((c) => c.cmd === "graph_edit_node");
+    expect(edit).toMatchObject({
+      cmd: "graph_edit_node",
+      node_id: 12,
+      collapsed: false,
+      size: [228, DEFAULT_NODE_BODY_HEIGHT],
+    });
+    expect((edit?.size as number[])[1]).toBeGreaterThan(0);
+  });
+
+  it("does not invent a size when the stored height is already positive", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            text: JSON.stringify({ id: 12, pos: [0, 0], size: [228, 140], collapsed: true }),
+          });
+        }
+        return jsonResult({ edited: [{ node_id: 12 }] });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    await defByName("panel_edit_node").handler({ node_id: 12, collapsed: false }, ctx);
+    const edit = calls.find((c) => c.cmd === "graph_edit_node");
+    expect(edit?.size).toBeUndefined();
+  });
+
+  it("an explicit size is the caller's, even on a zero-height node", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({ edited: [{ node_id: 12 }] });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    await defByName("panel_edit_node").handler(
+      { node_id: 12, collapsed: false, size: [400, 200] },
+      ctx,
+    );
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_edit_node"]);
+    expect(calls[0]).toMatchObject({ size: [400, 200], collapsed: false });
+  });
+
+  it("a failed geometry probe leaves the original uncollapse command untouched", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") return errorResult("tab did not reply");
+        return jsonResult({ edited: [{ node_id: 12 }] });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    await defByName("panel_edit_node").handler({ node_id: 12, collapsed: false }, ctx);
+    const edit = calls.find((c) => c.cmd === "graph_edit_node");
+    expect(edit?.size).toBeUndefined();
+    expect(edit).toMatchObject({ collapsed: false, node_id: 12 });
+  });
+
+  it("a title-only edit does not query or rewrite size", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({ edited: [{ node_id: 12 }] });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    await defByName("panel_edit_node").handler({ node_id: 12, title: "LLM" }, ctx);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_edit_node"]);
+    expect(calls[0].size).toBeUndefined();
+  });
+});
+
+describe("panel_set_widget names object_info starvation (#2004)", () => {
+  it("THE REPORTED CASE: keeps the refusal and says this is a timeout, not a missing node", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_set_widget") return errorResult(STARVATION);
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 12, widget: "system_prompt", value: "You are a helpful assistant." },
+      ctx,
+    );
+
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain(STARVATION);
+    expect(text).toMatch(/refresh TIMEOUT, not a missing node/i);
+    expect(text).toMatch(/already on the canvas/i);
+    expect(text).toMatch(/Do NOT reinstall a pack/);
+    // The refusal is pre-mutation — do not re-issue a write that will pay the same 15s.
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("an unrelated set_widget refusal is not wrapped as starvation", async () => {
+    const ctx: PanelToolCtx = {
+      call: async () => errorResult('panel_set_widget refused "seed" on node 3 (KSampler): not a valid option'),
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "seed", value: 1 },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toMatch(/refresh TIMEOUT, not a missing node/i);
+  });
+});
+
+describe("panel_save_workflow acknowledges a save that landed after the budget (#2004)", () => {
+  it("THE REPORTED CASE: modified:false persisted:true after the 13s budget is treated as saved", async () => {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT);
+        if (cmd.cmd === "workflow_list") {
+          return jsonResult({
+            active: {
+              path: "workflows/graph.json",
+              filename: "graph",
+              modified: false,
+              persisted: true,
+            },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    const text = textOf(res);
+    expect(text).toMatch(/"saved": true/);
+    expect(text).toMatch(/"acknowledged_after_timeout": true/);
+    expect(calls[0]).toMatchObject({ cmd: "workflow_save" });
+    expect(calls.map((c) => c.cmd)).toContain("workflow_list");
+  });
+
+  it("modified:true persisted:true at follow-up is still outcome-unknown, not success", async () => {
+    // The timeout snapshot itself. Treating persisted:true as proof would have
+    // reported the reporter's still-dirty canvas as saved.
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT);
+        if (cmd.cmd === "workflow_list") {
+          return jsonResult({
+            active: { path: "workflows/graph.json", modified: true, persisted: true },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain(SAVE_TIMEOUT);
+    expect(text).toMatch(/OUTCOME UNKNOWN/);
+    expect(text).toMatch(/re-issue may write twice/);
+  });
+});

--- a/src/orchestrator/edit-node-uncollapse.ts
+++ b/src/orchestrator/edit-node-uncollapse.ts
@@ -1,0 +1,106 @@
+/**
+ * #2004 — panel_edit_node(collapsed:false) can reject a collapsed node's own
+ * stored height 0 ("size must be two positive numbers within a reasonable
+ * canvas range"). LiteGraph serializes a title-chip as size[1]===0; the panel
+ * then validates that stored pair when expanding if a size is supplied, and
+ * the verified workaround is to pass an explicit positive size.
+ *
+ * These helpers restore a usable [width, height] from the live query BEFORE
+ * graph_edit_node, so the caller does not have to re-supply geometry they
+ * never asked to change. Fail-open: an unreadable probe leaves the original
+ * command untouched.
+ *
+ * Fallback extents match create-group-membership / the panel's finiteExtent
+ * defaults (DEFAULT_NODE_WIDTH / DEFAULT_NODE_BODY_HEIGHT). full_height on a
+ * collapsed node is the 30px chip, not the pre-collapse body — do not use it.
+ */
+
+import {
+  DEFAULT_NODE_BODY_HEIGHT,
+  DEFAULT_NODE_WIDTH,
+  parseDetailNodesFromQueryText,
+} from "./create-group-membership.js";
+
+type ToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+type Call = (
+  cmd: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<ToolResultLike>;
+
+export function pairSize(size: unknown): [number, number] | null {
+  if (!Array.isArray(size) || size.length < 2) return null;
+  const w = Number(size[0]);
+  const h = Number(size[1]);
+  return Number.isFinite(w) && Number.isFinite(h) ? [w, h] : null;
+}
+
+/** True when the stored pair would fail the panel's sizeSane (both > 0). */
+export function needsUncollapseSizeRestore(size: unknown): boolean {
+  const p = pairSize(size);
+  return !p || !(p[0] > 0 && p[1] > 0);
+}
+
+export function restoredUncollapseSize(size: unknown): [number, number] {
+  const p = pairSize(size);
+  const w = p && p[0] > 0 ? p[0] : DEFAULT_NODE_WIDTH;
+  const h = p && p[1] > 0 ? p[1] : DEFAULT_NODE_BODY_HEIGHT;
+  return [w, h];
+}
+
+function parseToolJson(res: ToolResultLike): Record<string, unknown> | null {
+  if (!res || res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * When uncollapsing a SINGLE node without an explicit size, query the live
+ * geometry and restore a positive size if the stored height is 0 (or otherwise
+ * not sizeSane). Bulk node_ids keep one shared size, so they are left alone.
+ * Never throws.
+ */
+export async function sizeForUncollapse(
+  args: {
+    node_id?: unknown;
+    node_ids?: unknown;
+    collapsed?: unknown;
+    size?: unknown;
+  },
+  call: Call,
+): Promise<[number, number] | undefined> {
+  if (args.collapsed !== false) return undefined;
+  if (args.size !== undefined) return undefined;
+  if (args.node_ids !== undefined) return undefined;
+  if (args.node_id === undefined) return undefined;
+  try {
+    const query = await call(
+      {
+        cmd: "graph_query",
+        ids: [args.node_id],
+        fields: "detail",
+        limit: 1,
+      },
+      8000,
+    );
+    if (query.isError) return undefined;
+    const nodes = parseDetailNodesFromQueryText(parseToolJson(query)?.text);
+    const wanted = String(args.node_id);
+    const node = nodes.find((n) => String(n.id) === wanted) ?? nodes[0];
+    if (!node || !needsUncollapseSizeRestore(node.size)) return undefined;
+    return restoredUncollapseSize(node.size);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -93,6 +93,7 @@ import {
   type UnpromotedControlPersistRemedy,
 } from "./promoted-widget.js";
 import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
+import { sizeForUncollapse } from "./edit-node-uncollapse.js";
 import {
   fastGroupsFilterPropertyNote,
   isFastGroupsFilterProperty,
@@ -4233,6 +4234,85 @@ function isObjectInfoUnavailableRefusal(res: ToolResult): boolean {
   return /object_info is unavailable|cannot verify (?:the )?node type/i.test(
     textOfToolResult(res),
   );
+}
+
+/**
+ * #2004 — panel_set_widget refused an installed backend node because both
+ * whole-schema routes exhausted their budget. Matched on the panel's own
+ * wording (assertTypeAgainstFreshBackend / objectInfoOracleFailureNote) so a
+ * miss costs a missing hint and a false positive costs an extra paragraph.
+ * Used ONLY to APPEND advice to a refusal the panel already made — never to
+ * authorize a write, and never to consult COMFYUI_URL (#1359).
+ */
+function isObjectInfoStarvationRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  const text = textOfToolResult(res);
+  return (
+    /no usable \/object_info schema was obtained/i.test(text) ||
+    (/api\.getNodeDefs\(\) did not answer/i.test(text) &&
+      /GET \/object_info did not answer/i.test(text))
+  );
+}
+
+function objectInfoStarvationNote(): string {
+  return (
+    `\n\nThis is a live /object_info refresh TIMEOUT, not a missing node. ` +
+    `The write was refused before it mutated anything because the schema routes ` +
+    `exhausted their budget. The node is already on the canvas, so this type is in use. ` +
+    `Do NOT reinstall a pack. Retry panel_set_widget in a moment; if it keeps happening, ` +
+    `the tab's whole-schema snapshot was never populated — wait for a successful ` +
+    `panel_refresh_nodes, or reload the ComfyUI tab.`
+  );
+}
+
+/** #2004 — the panel's 13s save budget fired while the userdata write was still in flight. */
+function isWorkflowSaveBudgetTimeout(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return /workflow_save did not finish within \d+s/i.test(textOfToolResult(res));
+}
+
+/**
+ * modified:false AND persisted:true is the only follow-up observation that
+ * proves the in-flight save marked the canvas clean. persisted:true alone is
+ * the reporter's timeout snapshot (a previously-saved dirty workflow) and
+ * must not be read as "the write landed".
+ */
+function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
+  const active = list?.active;
+  if (!active || typeof active !== "object" || Array.isArray(active)) return false;
+  const rec = active as Record<string, unknown>;
+  return rec.modified === false && rec.persisted === true;
+}
+
+const SAVE_TIMEOUT_OUTCOME_UNKNOWN =
+  `\n\nOUTCOME UNKNOWN: the save was already in flight when this budget fired. ` +
+  `Confirm by reading the saved file (or panel_list_workflows) before retrying — a re-issue may write twice.`;
+
+/**
+ * #2004 — the panel's 13s budget fired while userdata PUT was still running.
+ * A follow-up list that now shows modified:false persisted:true is the save
+ * completing; anything else stays outcome-unknown. persisted:true alone is
+ * the timeout-time snapshot of a previously-saved dirty tab, not proof.
+ */
+async function settleWorkflowSaveTimeout(
+  res: ToolResult,
+  ctx: PanelToolCtx,
+): Promise<ToolResult> {
+  if (!isWorkflowSaveBudgetTimeout(res)) return res;
+  try {
+    const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
+    const list = parseToolResultJson(listRes);
+    if (saveLandedAfterTimeout(list)) {
+      return ok({
+        saved: true,
+        acknowledged_after_timeout: true,
+        active: list?.active,
+      });
+    }
+  } catch {
+    /* keep the timeout refusal; the note below is the honest remainder */
+  }
+  return appendToolResultText(res, SAVE_TIMEOUT_OUTCOME_UNKNOWN);
 }
 
 function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
@@ -13646,6 +13726,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (!first.isError) {
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);
         }
+        // #2004 — both whole-schema routes timed out. The panel refused BEFORE
+        // mutating, so this is not outcome-unknown. Name the timeout rather than
+        // leaving "cannot verify the node type" as "the type is missing".
+        if (isObjectInfoStarvationRefusal(first)) {
+          return appendToolResultText(first, objectInfoStarvationNote());
+        }
 
         // #1655 — the panel listed this widget as promoted while refusing it as
         // not promoted. The listing is node.widgets; the write looks up host
@@ -13845,12 +13931,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (args: A, ctx) => {
         const error = validatePanelEditNodeArgs(args);
         if (error) return fail(error);
+        // #2004 — uncollapse of a title-chip (stored size[1]===0) is refused by
+        // the panel's sizeSane unless a positive size rides along. Restore from
+        // the live query; an unreadable probe leaves the command as the caller
+        // wrote it.
+        const restoredSize = await sizeForUncollapse(args, ctx.call);
         return ctx.call({
           cmd: "graph_edit_node",
           node_id: args.node_id,
           node_ids: args.node_ids,
           pos: args.pos,
-          size: args.size,
+          size: restoredSize ?? args.size,
           title: args.title,
           preset: args.preset,
           color: args.color,
@@ -15405,6 +15496,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             }
           }
         }
+        if (res.isError && !args.name) res = await settleWorkflowSaveTimeout(res, ctx);
         if (res.isError) {
           // #1873 — named Save-As 409s by contract; the panel's "choose a different
           // name" is what forced a third file. Keep the 409 and name the rename path.


### PR DESCRIPTION
Fixes #2004

On a large custom-node install, three panel calls failed in one session: `panel_set_widget` because both `/object_info` routes exhausted their budget, `panel_edit_node(collapsed:false)` because a collapsed node stores `size[1]===0`, and `panel_save_workflow` because the 13s save budget fired while userdata PUT was still running.

What the caller now observes:

- `panel_edit_node({collapsed:false})` without an explicit size queries the live geometry and, when the stored height is 0, sends a positive `[width, 100]` so the panel's sizeSane does not reject the node's own title-chip. An explicit size, an already-positive height, a bulk `node_ids` edit, and a failed probe are left untouched.
- A `panel_set_widget` refusal that names `no usable /object_info schema was obtained` (or both schema routes timing out) keeps the panel's pre-mutation refusal and adds that this is a live refresh timeout, not a missing node — do not reinstall a pack. The write is not retried (that would pay the same 15s). Does not consult `COMFYUI_URL` (#1359).
- An in-place save whose 13s budget fired is followed by `workflow_list`. `modified:false` and `persisted:true` means the in-flight save landed and is reported as saved. `persisted:true` alone (the timeout-time snapshot of a previously-saved dirty tab) stays outcome-unknown so a retry does not write twice.
