### PR TITLE
fix(2007): schema-guarded panel edits retry a timed-out object_info instead of staying blocked

### DIFF
--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -366,6 +366,29 @@ describe("panel_graph_outline does not keep advertising mutations_ready after a 
     expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(true);
   });
 
+  it("a frontend-only add does not prove backend schema readiness", async () => {
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_outline") return outlineOk;
+      if (cmd.cmd === "graph_add_node" && cmd.class_type === "LoadImage") {
+        throw new Error(ADD_UNAVAILABLE);
+      }
+      if (cmd.cmd === "graph_add_node" && cmd.class_type === "MarkdownNote") {
+        return { ok: true, node_id: 30, type: "MarkdownNote" };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const add = defs.find((d) => d.name === "panel_add_node");
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    if (!add || !outline) throw new Error("tools missing");
+
+    await add.handler({ class_type: "LoadImage" } as never, ctx);
+    await add.handler({ class_type: "MarkdownNote" } as never, ctx);
+
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(false);
+  });
+
   it("keys readiness to the live tab, not a stable scope route", async () => {
     const scope = "orchestrator::test";
     let liveTab = "panel-a";

--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -1,0 +1,308 @@
+// #2007 — panel mutations blocked by fixed /object_info timeouts on a healthy
+// large install.
+//
+// Reported: panel_graph_outline succeeds with backend_socket=up and
+// mutations_ready=true, then panel_add_node("LoadImage"), panel_refresh_nodes,
+// and panel_set_widget all fail because /object_info did not answer inside the
+// panel's fixed 10s/5s shares. The canvas is readable; schema-guarded edits are
+// not. refresh_nodes also CLEARS the last-known schema, so calling it as the
+// recovery makes the next widget write worse.
+//
+// These drive the real tool defs. The panel's 5s/10s shares live in the other
+// repo; this process can still (1) retry a before-create/before-write refusal
+// without dispatching refresh_nodes, (2) stop advertising mutations_ready:true
+// once that refusal has been observed, (3) say not to refresh_nodes.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetPanelSchemaReadinessForTest,
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/** The reporter's exact panel_add_node refusal (issue #2007). */
+const ADD_UNAVAILABLE =
+  `cannot verify node type "LoadImage" against the ComfyUI backend ` +
+  `(object_info is unavailable — the backend is unreachable or the fetch failed). ` +
+  `Refusing to add rather than trust a possibly-stale node cache (#458). Reconnect ComfyUI and retry.`;
+
+/** The reporter's exact panel_set_widget refusal (issue #2007). */
+const SET_WIDGET_BUDGET =
+  `Cannot set widget "text" on node 12: no usable /object_info schema was obtained. ` +
+  `api.getNodeDefs() exceeded 10000ms share; GET /object_info exceeded 5000ms share; ` +
+  `no whole schema observed.`;
+
+const STALE_SCHEMA =
+  `"LoadImage" required input "image" was added or retyped since this page loaded its node ` +
+  `schema, so creating it now would build the OLD shape. Call panel_refresh_nodes and retry.`;
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+function parseJson(res: ToolResult): Record<string, unknown> {
+  const text = res.content.find((c) => c.type === "text")?.text;
+  return JSON.parse(text ?? "{}") as Record<string, unknown>;
+}
+
+function bridge(send: (cmd: Record<string, unknown>) => Promise<unknown>) {
+  const calls: string[] = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      return send(cmd);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+  send: (cmd: Record<string, unknown>) => Promise<unknown>,
+): Promise<{ res: ToolResult; calls: string[]; text: string }> {
+  const { b, calls } = bridge(send);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  const res = await def.handler(args as never, ctx);
+  return { res, calls, text: textOf(res) };
+}
+
+beforeEach(() => {
+  __resetPanelSchemaReadinessForTest();
+});
+
+describe("panel_add_node retries a schema-budget refusal without refresh_nodes (#2007)", () => {
+  it("THE REPORTED CASE: LoadImage add that times out then succeeds on the retry", async () => {
+    let adds = 0;
+    const { res, calls, text } = await callTool(
+      "panel_add_node",
+      { class_type: "LoadImage" },
+      async (cmd) => {
+        if (cmd.cmd !== "graph_add_node") return { ok: true };
+        adds += 1;
+        if (adds === 1) throw new Error(ADD_UNAVAILABLE);
+        return { ok: true, node_id: 20, type: "LoadImage" };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(2);
+    expect(calls).not.toContain("refresh_nodes");
+    expect(text).not.toMatch(/object_info is unavailable/);
+    expect(JSON.stringify(parseJson(res))).toContain("LoadImage");
+  });
+
+  it("retries EXACTLY once — a still-timed-out add is not looped, and names the budget", async () => {
+    const { res, calls, text } = await callTool(
+      "panel_add_node",
+      { class_type: "LoadImage" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_add_node") throw new Error(ADD_UNAVAILABLE);
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(2);
+    expect(calls).not.toContain("refresh_nodes");
+    expect(text).toContain("object_info is unavailable");
+    expect(text).toMatch(/already retried ONCE/);
+    expect(text).toMatch(/Do NOT call panel_refresh_nodes/);
+    expect(text).toMatch(/mutations_ready/);
+    expect(text).not.toMatch(/FRONTEND-ONLY/);
+  });
+
+  it("does not retry a frontend-only type — that is #2000's note, not a second add", async () => {
+    const markdown =
+      `cannot verify node type "MarkdownNote" against the ComfyUI backend ` +
+      `(object_info is unavailable — the backend is unreachable or the fetch failed). ` +
+      `Refusing to add rather than trust a possibly-stale node cache (#458). Reconnect ComfyUI and retry.`;
+    const { res, calls, text } = await callTool(
+      "panel_add_node",
+      { class_type: "MarkdownNote" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_add_node") throw new Error(markdown);
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(1);
+    expect(calls).not.toContain("refresh_nodes");
+    expect(text).toMatch(/FRONTEND-ONLY/);
+  });
+
+  it("an UNRELATED failure is never retried", async () => {
+    const { res, calls } = await callTool(
+      "panel_add_node",
+      { class_type: "LoadImage" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_add_node") throw new Error("node id 12 is not on the canvas");
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(1);
+    expect(calls).not.toContain("refresh_nodes");
+  });
+
+  it("the #1329 stale-schema path still dispatches refresh_nodes", async () => {
+    let adds = 0;
+    const { res, calls } = await callTool(
+      "panel_add_node",
+      { class_type: "LoadImage" },
+      async (cmd) => {
+        if (cmd.cmd === "refresh_nodes") return { refreshed: true };
+        if (cmd.cmd !== "graph_add_node") return { ok: true };
+        adds += 1;
+        if (adds === 1) throw new Error(STALE_SCHEMA);
+        return { ok: true, node_id: 20 };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes", "graph_add_node"]);
+  });
+});
+
+describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
+  it("THE REPORTED CASE: share-timeout write then succeeds on the retry", async () => {
+    let writes = 0;
+    const { res, calls, text } = await callTool(
+      "panel_set_widget",
+      { node_id: 12, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd !== "graph_set_widget") return { ok: true };
+        writes += 1;
+        if (writes === 1) throw new Error(SET_WIDGET_BUDGET);
+        return { ok: true, node_id: 12, widget: "text", previous: "", value: "hello" };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(calls.filter((c) => c === "graph_set_widget")).toHaveLength(2);
+    expect(calls).not.toContain("refresh_nodes");
+    expect(text).not.toMatch(/no whole schema/);
+  });
+
+  it("retries EXACTLY once and says not to refresh_nodes", async () => {
+    const { res, calls, text } = await callTool(
+      "panel_set_widget",
+      { node_id: 12, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_set_widget") throw new Error(SET_WIDGET_BUDGET);
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_set_widget")).toHaveLength(2);
+    expect(text).toMatch(/already retried ONCE/);
+    expect(text).toMatch(/Do NOT call panel_refresh_nodes/);
+  });
+});
+
+describe("panel_refresh_nodes names a timed-out whole-schema fetch (#2007)", () => {
+  it("THE REPORTED CASE: refreshed:false / object_info_fetch_failed is not a down backend", async () => {
+    const { res, text } = await callTool("panel_refresh_nodes", {}, async (cmd) => {
+      if (cmd.cmd === "refresh_nodes") {
+        return { refreshed: false, reason: "object_info_fetch_failed" };
+      }
+      return { ok: true };
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("object_info_fetch_failed");
+    expect(text).toMatch(/CLEARS the last-known schema/i);
+    expect(text).toMatch(/not down/i);
+  });
+});
+
+describe("panel_graph_outline does not keep advertising mutations_ready after a schema-budget miss (#2007)", () => {
+  const outlineOk = {
+    outline: "12 LoadImage",
+    node_count: 19,
+    backend_socket: "up",
+    mutations_ready: true,
+  };
+
+  it("leaves mutations_ready:true when no schema-budget refusal has been observed", async () => {
+    const { res } = await callTool("panel_graph_outline", {}, async (cmd) => {
+      if (cmd.cmd === "graph_outline") return outlineOk;
+      return { ok: true };
+    });
+
+    expect(res.isError).toBeFalsy();
+    const payload = parseJson(res);
+    expect(payload.mutations_ready).toBe(true);
+    expect(payload.schema_ready).toBeUndefined();
+  });
+
+  it("THE REPORTED SEQUENCE: outline says ready, LoadImage add times out, next outline does not", async () => {
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_outline") return outlineOk;
+      if (cmd.cmd === "graph_add_node") throw new Error(ADD_UNAVAILABLE);
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    const add = defs.find((d) => d.name === "panel_add_node");
+    if (!outline || !add) throw new Error("tools missing");
+
+    const first = parseJson(await outline.handler({} as never, ctx));
+    expect(first.mutations_ready).toBe(true);
+    expect(first.backend_socket).toBe("up");
+
+    const added = await add.handler({ class_type: "LoadImage" } as never, ctx);
+    expect(added.isError).toBe(true);
+
+    const second = parseJson(await outline.handler({} as never, ctx));
+    expect(second.mutations_ready).toBe(false);
+    expect(second.schema_ready).toBe(false);
+    expect(String(second.schema_ready_note)).toMatch(/Do not call panel_refresh_nodes/i);
+    expect(second.backend_socket).toBe("up");
+    expect(second.outline).toBe("12 LoadImage");
+  });
+
+  it("a later successful add restores mutations_ready on the next outline", async () => {
+    let adds = 0;
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_outline") return outlineOk;
+      if (cmd.cmd === "graph_add_node") {
+        adds += 1;
+        if (adds <= 2) throw new Error(ADD_UNAVAILABLE);
+        return { ok: true, node_id: 21, type: "LoadImage" };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    const add = defs.find((d) => d.name === "panel_add_node");
+    if (!outline || !add) throw new Error("tools missing");
+
+    await add.handler({ class_type: "LoadImage" } as never, ctx);
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(false);
+
+    const okAdd = await add.handler({ class_type: "LoadImage" } as never, ctx);
+    expect(okAdd.isError).toBeFalsy();
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -38,6 +38,14 @@ const SET_WIDGET_BUDGET =
   `api.getNodeDefs() exceeded 10000ms share; GET /object_info exceeded 5000ms share; ` +
   `no whole schema observed.`;
 
+const SET_WIDGET_STARVATION =
+  `Cannot set widget on node 12 ("OpenAICompatibleLLM"): cannot verify the node type against the ` +
+  `ComfyUI backend — no usable /object_info schema was obtained. Tried 2 routes: ` +
+  `api.getNodeDefs() did not answer within its 10000ms share of the 20000ms budget; ` +
+  `GET /object_info did not answer within its 5000ms share of the 20000ms budget. ` +
+  `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
+  `Reconnect ComfyUI and retry.`;
+
 const STALE_SCHEMA =
   `"LoadImage" required input "image" was added or retyped since this page loaded its node ` +
   `schema, so creating it now would build the OLD shape. Call panel_refresh_nodes and retry.`;
@@ -216,6 +224,36 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
     expect(text).toMatch(/already retried ONCE/);
     expect(text).toMatch(/Do NOT call panel_refresh_nodes/);
   });
+
+  it("records a starvation refusal so the next outline does not advertise readiness", async () => {
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_set_widget") throw new Error(SET_WIDGET_STARVATION);
+      if (cmd.cmd === "graph_outline") {
+        return {
+          outline: "12 OpenAICompatibleLLM",
+          node_count: 1,
+          backend_socket: "up",
+          mutations_ready: true,
+        };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const setWidget = defs.find((d) => d.name === "panel_set_widget");
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    if (!setWidget || !outline) throw new Error("tools missing");
+
+    const refused = await setWidget.handler(
+      { node_id: 12, widget: "system_prompt", value: "hello" } as never,
+      ctx,
+    );
+    expect(refused.isError).toBe(true);
+    expect(textOf(refused)).toMatch(/refresh TIMEOUT, not a missing node/i);
+
+    const next = parseJson(await outline.handler({} as never, ctx));
+    expect(next.mutations_ready).toBe(false);
+  });
 });
 
 describe("panel_refresh_nodes names a timed-out whole-schema fetch (#2007)", () => {
@@ -231,6 +269,28 @@ describe("panel_refresh_nodes names a timed-out whole-schema fetch (#2007)", () 
     expect(text).toContain("object_info_fetch_failed");
     expect(text).toMatch(/CLEARS the last-known schema/i);
     expect(text).toMatch(/not down/i);
+  });
+
+  it("does not clear a blocked connection on a non-authoritative register failure", async () => {
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_add_node") throw new Error(ADD_UNAVAILABLE);
+      if (cmd.cmd === "refresh_nodes") return { refreshed: false, reason: "register_failed" };
+      if (cmd.cmd === "graph_outline") {
+        return { outline: "12 LoadImage", node_count: 1, backend_socket: "up", mutations_ready: true };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const add = defs.find((d) => d.name === "panel_add_node");
+    const refresh = defs.find((d) => d.name === "panel_refresh_nodes");
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    if (!add || !refresh || !outline) throw new Error("tools missing");
+
+    await add.handler({ class_type: "LoadImage" } as never, ctx);
+    await refresh.handler({} as never, ctx);
+
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(false);
   });
 });
 
@@ -304,5 +364,39 @@ describe("panel_graph_outline does not keep advertising mutations_ready after a 
     const okAdd = await add.handler({ class_type: "LoadImage" } as never, ctx);
     expect(okAdd.isError).toBeFalsy();
     expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(true);
+  });
+
+  it("keys readiness to the live tab, not a stable scope route", async () => {
+    const scope = "orchestrator::test";
+    let liveTab = "panel-a";
+    const calls: string[] = [];
+    const b = {
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push(String(cmd.cmd));
+        if (cmd.cmd === "graph_add_node") throw new Error(ADD_UNAVAILABLE);
+        if (cmd.cmd === "graph_outline") return outlineOk;
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: liveTab, title: liveTab, connected_at: 0 }],
+      resolveSharedTabId: () => liveTab,
+      resolveActiveTabId: () => liveTab,
+      tabIncarnation: (tabId: string) => `${tabId}-incarnation`,
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(b, scope, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const add = defs.find((d) => d.name === "panel_add_node");
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    if (!add || !outline) throw new Error("tools missing");
+
+    await add.handler({ class_type: "LoadImage" } as never, ctx);
+    liveTab = "panel-b";
+
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(true);
+    expect(calls.filter((cmd) => cmd === "graph_add_node")).toHaveLength(2);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4229,7 +4229,13 @@ async function annotateAddNodeRefusal(
   // #2007 — a schema-budget refusal is evidence that schema-guarded edits cannot
   // obtain /object_info, even when the backend socket is up. Remember it so the
   // next panel_graph_outline does not keep advertising mutations_ready:true.
-  trackSchemaToolResult(res, ctx);
+  // Frontend-only nodes are deliberately accepted without consulting /object_info;
+  // their success therefore cannot clear a refusal observed on a backend node.
+  trackSchemaToolResult(
+    res,
+    ctx,
+    !(typeof classType === "string" && PANEL_ADD_NODE_FRONTEND_ONLY_TYPES.has(classType)),
+  );
   return withFrontendOnlyPanelSkewNote(
     withLoraManagerAutocompleteNote(await withLiveSocketProducerNote(res, classType, ctx)),
     classType,
@@ -4444,7 +4450,12 @@ export function __resetPanelSchemaReadinessForTest(): void {
   panelSchemaBlockedTabs.clear();
 }
 
-function trackSchemaToolResult(res: ToolResult, ctx: PanelToolCtx): ToolResult {
+function trackSchemaToolResult(
+  res: ToolResult,
+  ctx: PanelToolCtx,
+  schemaGuarded = true,
+): ToolResult {
+  if (!schemaGuarded) return res;
   const key = panelSchemaKey(ctx);
   if (!res.isError) markPanelSchemaReady(key);
   else if (isObjectInfoBudgetRefusal(res)) markPanelSchemaBlocked(key);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4221,6 +4221,10 @@ async function annotateAddNodeRefusal(
   classType: unknown,
   ctx: PanelToolCtx,
 ): Promise<ToolResult> {
+  // #2007 — a schema-budget refusal is evidence that schema-guarded edits cannot
+  // obtain /object_info, even when the backend socket is up. Remember it so the
+  // next panel_graph_outline does not keep advertising mutations_ready:true.
+  trackSchemaToolResult(res, ctx);
   return withFrontendOnlyPanelSkewNote(
     withLoraManagerAutocompleteNote(await withLiveSocketProducerNote(res, classType, ctx)),
     classType,
@@ -4307,9 +4311,10 @@ function isObjectInfoStarvationRefusal(res: ToolResult): boolean {
   if (!res.isError) return false;
   const text = textOfToolResult(res);
   return (
-    /no usable \/object_info schema was obtained/i.test(text) ||
-    (/api\.getNodeDefs\(\) did not answer/i.test(text) &&
-      /GET \/object_info did not answer/i.test(text))
+    /no usable \/object_info schema was obtained/i.test(text) &&
+    (/Tried \d+ routes:/i.test(text) ||
+      (/api\.getNodeDefs\(\) did not answer/i.test(text) &&
+        /GET \/object_info did not answer/i.test(text)))
   );
 }
 
@@ -4372,6 +4377,115 @@ async function settleWorkflowSaveTimeout(
     /* keep the timeout refusal; the note below is the honest remainder */
   }
   return appendToolResultText(res, SAVE_TIMEOUT_OUTCOME_UNKNOWN);
+}
+
+/**
+ * #2007 — the schema-budget refusal, covering every wording the panel uses when
+ * a healthy ComfyUI does not answer /object_info inside the fixed 10s/5s shares.
+ *
+ * Broader than {@link isObjectInfoUnavailableRefusal}: that matcher is the #2000
+ * frontend-only note, keyed on one sentence. This one also has to catch
+ * panel_set_widget ("did not answer within its Nms share" / "no whole schema")
+ * so a LoadImage add and a widget write take the same recovery.
+ *
+ * Matched on the panel's own words because that is all it sends here. Used to
+ * RETRY a mutation the guard refused BEFORE creating/writing anything, and to
+ * stop advertising mutations_ready:true after we have observed that schema
+ * edits cannot obtain /object_info. A miss costs a missing retry; a false
+ * positive would re-issue a mutation, so this stays off transport timeouts
+ * (those are tagged, not text-matched) and off any success.
+ */
+function isObjectInfoBudgetRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return (
+    isObjectInfoUnavailableRefusal(res) ||
+    /no usable \/?object_info|no whole (?:\/object_info|schema)|object_info_fetch_failed|did not answer within its \d+ms share|exceeded \d+ms share/i.test(
+      textOfToolResult(res),
+    )
+  );
+}
+
+/**
+ * Per-tab: the last schema-guarded panel mutation we observed could not obtain
+ * /object_info. Socket-up is not the same fact — that is why panel_graph_outline
+ * reported mutations_ready:true while panel_add_node(LoadImage) then refused.
+ *
+ * Ready is stored as ABSENCE from the set: we never claim the schema is fetched,
+ * only that we have not observed a budget refusal since the last successful
+ * schema-guarded write.
+ */
+const panelSchemaBlockedTabs = new Set<string>();
+
+function markPanelSchemaBlocked(tabId: string): void {
+  if (tabId) panelSchemaBlockedTabs.add(tabId);
+}
+
+function markPanelSchemaReady(tabId: string): void {
+  if (tabId) panelSchemaBlockedTabs.delete(tabId);
+}
+
+/** Test seam: schema readiness is process-wide, so each file that mutates it resets. */
+export function __resetPanelSchemaReadinessForTest(): void {
+  panelSchemaBlockedTabs.clear();
+}
+
+function trackSchemaToolResult(res: ToolResult, ctx: PanelToolCtx): ToolResult {
+  if (!res.isError) markPanelSchemaReady(ctx.tabId);
+  else if (isObjectInfoBudgetRefusal(res)) markPanelSchemaBlocked(ctx.tabId);
+  return res;
+}
+
+function objectInfoBudgetNote(kind: "add" | "widget"): string {
+  const verb = kind === "add" ? "add" : "widget write";
+  return (
+    `\n\nNOTE: ComfyUI itself is healthy — this is the panel's fixed /object_info fetch ` +
+    `budget (api.getNodeDefs() 10s share, GET /object_info 5s share). A large custom-node ` +
+    `install can exceed those shares while /system_stats and live graph reads still work. ` +
+    `panel_graph_outline's mutations_ready flag means the backend SOCKET is up, not that a ` +
+    `schema-guarded ${verb} can obtain /object_info. This ${verb} was already retried ONCE. ` +
+    `Do NOT call panel_refresh_nodes — that command CLEARS the last-known schema at the ` +
+    `start of the run and then retries the same whole-document fetch, which is how the ` +
+    `next panel_set_widget also finds no snapshot. Wait a few seconds for the tab's ` +
+    `startup seed (it is not cancelled by the timed-out tool) and retry; if it keeps ` +
+    `refusing, reload the ComfyUI browser tab so node defs can finish loading without ` +
+    `the 5s/10s cap.`
+  );
+}
+
+/**
+ * #2007 — panel_graph_outline reported mutations_ready:true (backend socket up)
+ * while every schema-guarded edit then failed to obtain /object_info. The panel
+ * computes that flag from the websocket alone. Once THIS process has observed a
+ * schema-budget refusal on this tab, the outline must not keep advertising that
+ * mutations will work.
+ *
+ * Does not invent mutations_ready on a panel that never sent it, and does not
+ * claim schema_ready:true — absence of a refusal is not proof the next fetch
+ * will land.
+ */
+function withSchemaMutationReadiness(res: ToolResult, ctx: PanelToolCtx): ToolResult {
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  if (payload.mutations_ready !== true) return res;
+  if (!panelSchemaBlockedTabs.has(ctx.tabId)) return res;
+  payload.mutations_ready = false;
+  payload.schema_ready = false;
+  payload.schema_ready_note =
+    "mutations_ready was reported true because the ComfyUI backend socket is up, " +
+    "but a schema-guarded edit on this tab already failed to obtain /object_info " +
+    "inside the panel's fixed 10s/5s fetch shares. Graph reads still work; " +
+    "panel_add_node / panel_set_widget / panel_refresh_nodes will keep failing " +
+    "until that whole-schema fetch lands. Do not call panel_refresh_nodes to " +
+    "clear it (it drops the last-known schema). Wait, then retry the edit; " +
+    "reload the ComfyUI tab if it persists.";
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: JSON.stringify(payload, null, 2) } : c,
+    ),
+  };
 }
 
 function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
@@ -13084,10 +13198,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // unbounded outline reaches the caller who asked for a bound.
             enforceOutlineBudget(
               // #1184 — an empty outline is re-verified before it is believed.
-              await confirmEmptyOutline(
+              withSchemaMutationReadiness(
+                await confirmEmptyOutline(
+                  ctx,
+                  await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+                  () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+                ),
                 ctx,
-                await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
-                () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
               ),
               args.max_chars,
             ),
@@ -13426,6 +13543,32 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         const first = await add();
         if (!isStaleNodeSchemaRefusal(first)) {
+          // #2007 — the reporter's LoadImage add: live graph reads work, the
+          // backend socket is up, but the panel's fixed 10s/5s /object_info
+          // shares did not produce a schema, so the guard refused BEFORE
+          // creating anything. Same duplicate-safety as #1329. Do NOT dispatch
+          // refresh_nodes here — that command CLEARS the last-known schema at
+          // the start of the run and then retries the same whole-document
+          // fetch, which is how the next panel_set_widget also found no
+          // snapshot. Retry the add once; the tab's unbounded startup seed is
+          // still running and a second attempt often lands once the server is
+          // no longer serving the first download. Frontend-only types stay on
+          // the #2000 note (a second add cannot put MarkdownNote into /object_info).
+          if (
+            isObjectInfoBudgetRefusal(first) &&
+            typeof args.class_type === "string" &&
+            !PANEL_ADD_NODE_FRONTEND_ONLY_TYPES.has(args.class_type)
+          ) {
+            const second = await add();
+            if (!isObjectInfoBudgetRefusal(second)) {
+              return annotateAddNodeRefusal(second, args.class_type, ctx);
+            }
+            return annotateAddNodeRefusal(
+              appendToolResultText(second, objectInfoBudgetNote("add")),
+              args.class_type,
+              ctx,
+            );
+          }
           return annotateAddNodeRefusal(first, args.class_type, ctx);
         }
 
@@ -14011,8 +14154,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             ),
             echoFull,
           );
-        const first = await write(args.node_id, args.widget as string);
+        let first = await write(args.node_id, args.widget as string);
         if (!first.isError) {
+          markPanelSchemaReady(ctx.tabId);
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);
         }
         // #2004 — both whole-schema routes timed out. The panel refused BEFORE
@@ -14082,6 +14226,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         );
         if (ambiguous && String(ambiguous.nodeId) === String(args.node_id)) {
           return explainAmbiguousPromotedWidgetRefusal(first, args, ctx);
+        }
+
+        if (isObjectInfoBudgetRefusal(first)) {
+          // #2007 — same schema-budget refusal as panel_add_node, same
+          // before-write fail-closed, same "do not refresh_nodes" recovery.
+          markPanelSchemaBlocked(ctx.tabId);
+          const retried = await write(args.node_id, args.widget as string);
+          if (!retried.isError) {
+            markPanelSchemaReady(ctx.tabId);
+            return persistUnpromotedControlAfterGenerate(retried, ctx, args.node_id);
+          }
+          first = isObjectInfoBudgetRefusal(retried)
+            ? appendToolResultText(retried, objectInfoBudgetNote("widget"))
+            : retried;
         }
 
         // #1655 — the panel listed this widget as promoted while refusing it as
@@ -14912,11 +15070,34 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_refresh_nodes",
       "Re-pull the live ComfyUI server's /object_info and rebuild every combo/loader option list in the user's open tab, so an asset that appeared server-side AFTER the tab loaded becomes SELECTABLE without a manual reload (the 'press R' step) or a restart. Use this right after upload_image (action:\"stage\") (chaining a stage's output into a LoadImage / VHS_LoadVideo / LoadAudio loader — the returned filename won't be in the loader's dropdown until you refresh), after downloading a model / LoRA / VAE (a freshly downloaded file is otherwise 'not a valid option' in its loader), or after installing a node pack. Then panel_set_widget / panel_add_node will accept the new value. Non-destructive: it only re-registers node defs and refreshes combo option lists — it does NOT change your graph and is undo-neutral. Idempotent (safe to call repeatedly). Returns whether the refresh authoritatively fetched fresh defs.",
       {},
-      async (_args, ctx) =>
+      async (_args, ctx) => {
         // Same bounded ack budget as the refresh-before-validate writes (#599): a
         // fresh /object_info on a large install routinely exceeds the 6000 ms
         // default, and this command's WHOLE purpose is to await that fetch.
-        ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS),
+        const res = await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);
+        // #2007 — a failed whole-schema refresh is not a down backend. It is also
+        // worse than a no-op: the panel CLEARS the last-known schema at the start
+        // of the run, so a timed-out refresh is why the next panel_set_widget
+        // reports "no whole schema observed".
+        const refreshSchemaNote =
+          "NOTE: refreshed:false / object_info_fetch_failed on a healthy install means " +
+          "the whole /object_info document did not fit this command's fetch budget " +
+          "(megabytes on a large custom-node set). The backend is not down. This " +
+          "command also CLEARS the last-known schema at the start of the run, so a " +
+          "failed refresh can make the next panel_set_widget worse. Wait, then retry " +
+          "the widget write rather than refreshing again.";
+        if (isObjectInfoBudgetRefusal(res)) {
+          markPanelSchemaBlocked(ctx.tabId);
+          return appendReplyNote(res, refreshSchemaNote);
+        }
+        const payload = parseToolResultJson(res);
+        if (payload && payload.refreshed === false && payload.reason === "object_info_fetch_failed") {
+          markPanelSchemaBlocked(ctx.tabId);
+          return appendReplyNote(res, refreshSchemaNote);
+        }
+        if (!res.isError) markPanelSchemaReady(ctx.tabId);
+        return res;
+      },
     ),
     def(
       "panel_reload",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -67,7 +67,12 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge, PanelVersionReading } from "../services/ui-bridge.js";
-import { requiredPanelVersion, SEMVER_RE, LATE_ASK_TTL_MS } from "../services/ui-bridge.js";
+import {
+  requiredPanelVersion,
+  SEMVER_RE,
+  LATE_ASK_TTL_MS,
+  tabIncarnationSlot,
+} from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
 import {
@@ -3893,7 +3898,7 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
  */
 function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined {
   const b = ctx.bridge as { tabIncarnation?: (t: string) => string | undefined };
-  return typeof b.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
+  return typeof b?.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
 }
 
 async function settleDroppedEnqueue(
@@ -4416,12 +4421,22 @@ function isObjectInfoBudgetRefusal(res: ToolResult): boolean {
  */
 const panelSchemaBlockedTabs = new Set<string>();
 
-function markPanelSchemaBlocked(tabId: string): void {
-  if (tabId) panelSchemaBlockedTabs.add(tabId);
+/**
+ * Scope addresses (wf:...) are stable workflow routes, not browser tabs. The
+ * panel that currently owns one can change while the tool session remains
+ * alive, so schema readiness must follow the live tab plus its incarnation.
+ */
+function panelSchemaKey(ctx: PanelToolCtx): string {
+  const tabId = journalTabFor(ctx);
+  return tabIncarnationSlot(tabId, panelIncarnation(ctx, tabId));
 }
 
-function markPanelSchemaReady(tabId: string): void {
-  if (tabId) panelSchemaBlockedTabs.delete(tabId);
+function markPanelSchemaBlocked(key: string): void {
+  if (key) panelSchemaBlockedTabs.add(key);
+}
+
+function markPanelSchemaReady(key: string): void {
+  if (key) panelSchemaBlockedTabs.delete(key);
 }
 
 /** Test seam: schema readiness is process-wide, so each file that mutates it resets. */
@@ -4430,8 +4445,9 @@ export function __resetPanelSchemaReadinessForTest(): void {
 }
 
 function trackSchemaToolResult(res: ToolResult, ctx: PanelToolCtx): ToolResult {
-  if (!res.isError) markPanelSchemaReady(ctx.tabId);
-  else if (isObjectInfoBudgetRefusal(res)) markPanelSchemaBlocked(ctx.tabId);
+  const key = panelSchemaKey(ctx);
+  if (!res.isError) markPanelSchemaReady(key);
+  else if (isObjectInfoBudgetRefusal(res)) markPanelSchemaBlocked(key);
   return res;
 }
 
@@ -4467,7 +4483,7 @@ function withSchemaMutationReadiness(res: ToolResult, ctx: PanelToolCtx): ToolRe
   const payload = parseToolResultJson(res);
   if (!payload) return res;
   if (payload.mutations_ready !== true) return res;
-  if (!panelSchemaBlockedTabs.has(ctx.tabId)) return res;
+  if (!panelSchemaBlockedTabs.has(panelSchemaKey(ctx))) return res;
   payload.mutations_ready = false;
   payload.schema_ready = false;
   payload.schema_ready_note =
@@ -14156,13 +14172,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         let first = await write(args.node_id, args.widget as string);
         if (!first.isError) {
-          markPanelSchemaReady(ctx.tabId);
+          markPanelSchemaReady(panelSchemaKey(ctx));
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);
         }
         // #2004 — both whole-schema routes timed out. The panel refused BEFORE
         // mutating, so this is not outcome-unknown. Name the timeout rather than
         // leaving "cannot verify the node type" as "the type is missing".
         if (isObjectInfoStarvationRefusal(first)) {
+          markPanelSchemaBlocked(panelSchemaKey(ctx));
           return appendToolResultText(first, objectInfoStarvationNote());
         }
 
@@ -14231,10 +14248,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (isObjectInfoBudgetRefusal(first)) {
           // #2007 — same schema-budget refusal as panel_add_node, same
           // before-write fail-closed, same "do not refresh_nodes" recovery.
-          markPanelSchemaBlocked(ctx.tabId);
+          markPanelSchemaBlocked(panelSchemaKey(ctx));
           const retried = await write(args.node_id, args.widget as string);
           if (!retried.isError) {
-            markPanelSchemaReady(ctx.tabId);
+            markPanelSchemaReady(panelSchemaKey(ctx));
             return persistUnpromotedControlAfterGenerate(retried, ctx, args.node_id);
           }
           first = isObjectInfoBudgetRefusal(retried)
@@ -15087,15 +15104,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           "failed refresh can make the next panel_set_widget worse. Wait, then retry " +
           "the widget write rather than refreshing again.";
         if (isObjectInfoBudgetRefusal(res)) {
-          markPanelSchemaBlocked(ctx.tabId);
+          markPanelSchemaBlocked(panelSchemaKey(ctx));
           return appendReplyNote(res, refreshSchemaNote);
         }
         const payload = parseToolResultJson(res);
         if (payload && payload.refreshed === false && payload.reason === "object_info_fetch_failed") {
-          markPanelSchemaBlocked(ctx.tabId);
+          markPanelSchemaBlocked(panelSchemaKey(ctx));
           return appendReplyNote(res, refreshSchemaNote);
         }
-        if (!res.isError) markPanelSchemaReady(ctx.tabId);
+        if (payload?.refreshed === true) markPanelSchemaReady(panelSchemaKey(ctx));
         return res;
       },
     ),


### PR DESCRIPTION
The 5s/10s `/object_info` shares live in the panel. This process cannot enlarge them, but it can stop treating a timed-out schema fetch on a healthy backend as a dead end.

**What the reporter hit**

`panel_graph_outline` returned `backend_socket=up` and `mutations_ready=true`. `panel_add_node("LoadImage")`, `panel_set_widget`, and `panel_refresh_nodes` then all failed because the panel did not obtain a whole `/object_info` inside its fixed 10s `getNodeDefs` / 5s GET shares. Graph reads still worked.

Calling `panel_refresh_nodes` as the recovery made the next widget write worse: that command clears the last-known schema at the start of the run.

**What this PR changes**

- `panel_add_node` / `panel_set_widget`: on a schema-budget refusal (the guard threw *before* creating or writing), retry once. Do **not** dispatch `refresh_nodes`. Frontend-only types stay on the #2000 note.
- `panel_graph_outline`: once a schema-budget miss has been observed on this tab, do not keep advertising `mutations_ready: true`. Socket-up is not schema-ready.
- `panel_refresh_nodes`: `refreshed:false, reason:object_info_fetch_failed` now says the backend is not down and that this command dropped the last-known schema.

Fixes #2007
