### PR TITLE
release: v0.52.47 — restart ready, DictGetNode sibling, uncollapse, get_errors budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.47] - 2026-08-21
+
 ### Fixed
 
 - **`panel_get_errors` no longer presents a clean `errored_count: 0` while most of
@@ -23,6 +25,15 @@ All notable changes to this project are documented here. This project adheres to
   abstains rather than guessing wherever the panel's own scanner would have —
   notably on UPLOAD inputs, whose values ComfyUI's combo list structurally cannot
   enumerate and which it has no `/view` probe to adjudicate.
+
+### MCP
+
+#### Fixed
+- panel_get_errors no longer reports a clean 0 while execution nodes stay unchecked (#1981)
+- uncollapse expands a title-chip; schema and save timeouts are named honestly (#2027)
+- panel_add_node names the live ConvertAny2Dict sibling instead of a missing-DICT dead end (#2026)
+- restart_comfyui reports a serving server as ready, not a failed start (#2025)
+
 
 ## [0.52.46] - 2026-08-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.46",
+  "version": "0.52.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.46",
+      "version": "0.52.47",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.46",
+  "version": "0.52.47",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.47** from `main` (after v0.52.46).

Carries:

- #2025 / #2009 — `restart_comfyui` reports a serving server as ready, not a failed start
- #2026 / #2008 — `panel_add_node` names the live ConvertAny2Dict sibling instead of a missing-DICT dead end
- #2027 / #2004 — uncollapse expands a title-chip; schema and save timeouts are named honestly
- #1981 / #1973 — `panel_get_errors` no longer reports a clean 0 while execution nodes stay unchecked

Held out: #2028/#2007 now conflicts with #2027; #2029/#2006 windows CI red; #1985/#1968 macos CI red; hygiene/docs PRs.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.47` tag on the version commit).