### PR TITLE
fix: retain fast render completions before ticketing (#2021)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -6642,6 +6642,41 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
       }
     });
 
+    it("refreshes the watchdog dispatch fence for the scoped retry (#2021)", async () => {
+      __panelToolsTestHooks.setRetrySettleMs(0);
+      const promptId = "p-2021-retry-fence";
+      let dispatches = 0;
+      let retryStarted = false;
+      const now = vi.spyOn(Date, "now").mockImplementation(() => (retryStarted ? 2000 : 1000));
+      const ctx: PanelToolCtx = {
+        call: async (cmd) => {
+          if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
+          dispatches += 1;
+          if (dispatches === 1) {
+            // The first refusal is the certified-not-queued boundary. Any arm
+            // observed after this point must not be accepted by the retry ticket.
+            retryStarted = true;
+            return { content: [{ type: "text", text: JSON.stringify({ error: RACE }) }] };
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify({ queued: true, prompt_id: promptId }) }],
+          };
+        },
+        confirm: async () => "yes" as const,
+        bridge: {} as unknown as PanelToolCtx["bridge"],
+        tabId: "test-tab",
+      };
+      try {
+        const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+        expect(res.isError).toBeFalsy();
+        expect(dispatches).toBe(2);
+        expect(RunCompletions.ticketFor(promptId)?.dispatchedAt).toBe(2000);
+      } finally {
+        now.mockRestore();
+        __panelToolsTestHooks.setRetrySettleMs(0);
+      }
+    });
+
     it("still re-issues EXACTLY once when the pause does not save it", async () => {
       const { ctx, runs } = runCtx([{ error: RACE }, { error: RACE }]);
       const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -281,7 +281,7 @@ describe("WIRING: panel_run stamps the dispatch time before dispatching (#1327)"
     const { readFile } = await import("node:fs/promises");
     const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
 
-    const stamp = src.indexOf("const runDispatchedAt = Date.now();");
+    const stamp = src.indexOf("let runDispatchedAt = Date.now();");
     const call = src.indexOf("let res = await ctx.call(runCmd", stamp);
     expect(stamp).toBeGreaterThan(-1);
     expect(call).toBeGreaterThan(stamp); // stamped first

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -127,6 +127,43 @@ describe("#1789: a completion the panel never reported is filled in from ComfyUI
     expect(delivered[0].ticket.promptId).toBe(PID);
   });
 
+  it("#2021 promotes a fast-render arm so a completion burst cannot evict it", async () => {
+    const clock = { t: 1_600_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    wd.observe([{ promptId: PID, status: "success" }]);
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+    wd.markTicketed([PID]);
+
+    for (let i = 0; i < 300; i++) {
+      wd.observe([{ promptId: `burst-${i}`, status: "success" }]);
+    }
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+  });
+
+  it("#2021 refuses an unknown arm observed before a reused prompt dispatch", async () => {
+    const clock = { t: 1_700_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+    wd.observe([{ promptId: PID, status: "success" }]);
+    clock.t += 100;
+    expect(
+      RunCompletions.openRun(PID, {
+        tabId: TAB,
+        conversation: CONV,
+        dispatchedAt: clock.t,
+      }),
+    ).toBe(true);
+    wd.markTicketed([PID]);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+
+    expect(delivered).toHaveLength(0);
+    expect(RunCompletions.awaitingCompletion(PID)).toBeTruthy();
+  });
+
   it("the synthesised completion is CORRELATED as the run the agent queued, and reaches an agent", () => {
     const clock = { t: 2_000_000 };
     const { wd } = makeWatchdog(clock);

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -49,6 +49,7 @@ function makeWatchdog(
   const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
   const wd = createRunCompletionWatchdog({
     awaiting: (id) => RunCompletions.awaitingCompletion(id),
+    knownTicket: (id) => RunCompletions.ticketFor(id),
     deliver: (payload, ticket) => {
       delivered.push({ payload, ticket });
       RunCompletions.record(ticket.tabId, payload, {
@@ -107,6 +108,25 @@ describe("#1789: a completion the panel never reported is filled in from ComfyUI
     expect(wd.armedCount()).toBe(0);
   });
 
+  it("#2021 holds a fast-render completion until panel_run opens its ticket", async () => {
+    const clock = { t: 1_500_000 };
+    const { wd, delivered } = makeWatchdog(clock);
+
+    // QueueMonitor drained the completion before graph_run's reply reached
+    // panel_run. There is no ticket at the instant observe() sees it.
+    wd.observe([{ promptId: PID, status: "success" }]);
+    expect(wd.armedCount()).toBe(1);
+    expect(delivered).toHaveLength(0);
+
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+    clock.t += DEFAULT_SYNTHESIS_GRACE_MS;
+    await wd.tick();
+
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.prompt_id).toBe(PID);
+    expect(delivered[0].ticket.promptId).toBe(PID);
+  });
+
   it("the synthesised completion is CORRELATED as the run the agent queued, and reaches an agent", () => {
     const clock = { t: 2_000_000 };
     const { wd } = makeWatchdog(clock);
@@ -147,15 +167,16 @@ describe("#1789: a completion the panel never reported is filled in from ComfyUI
     expect(RunCompletions.outstanding(TAB)[0].payload.images).toHaveLength(1);
   });
 
-  it("stays silent for a run this session never queued (a render the USER started)", () => {
+  it("stays silent for a run this session never queued (a render the USER started)", async () => {
     const clock = { t: 4_000_000 };
     const { wd, delivered } = makeWatchdog(clock);
-    // No openRun at all — there is no promise to keep, and waking the agent for
-    // a foreign render is the failure #889/#559 already paid for.
+    // No openRun at all — hold the observation briefly in case it is the
+    // #2021 dispatch/reply race, but never wake the agent for a foreign render.
     wd.observe([{ promptId: "p-foreign", status: "success" }]);
-    expect(wd.armedCount()).toBe(0);
+    expect(wd.armedCount()).toBe(1);
     clock.t += DEFAULT_SYNTHESIS_GRACE_MS + 1;
-    wd.tick();
+    await wd.tick();
+    expect(wd.armedCount()).toBe(0);
     expect(delivered).toHaveLength(0);
   });
 

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -204,8 +204,36 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
     // A cancelled queued message's origin dies with it.
     expect(src).toContain("turnOrigins.cancelMid(mid);");
     // The panel MCP servers bind the backend-QUALIFIED scope address so the
-    // per-conversation stamp is recoverable from the caller id.
-    expect(src).toContain("createPanelMcpServer(bridge, key, workflowTargets)");
+    // per-conversation stamp is recoverable from the caller id. Keep these
+    // assertions structural: the production calls are intentionally multiline,
+    // and the callback is the join that promotes a fast completion arm when
+    // panel_run opens its journal ticket (#2021).
+    expect(src).toMatch(
+      /createPanelMcpServer\(\s*bridge,\s*key,\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\)/s,
+    );
+    expect(src).toMatch(
+      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\)/s,
+    );
+    expect(src.match(/runCompletionWatchdog\?\.markTicketed\(promptIds\)/g) ?? []).toHaveLength(2);
+
+    const panelHttpSrc = readFileSync(
+      new URL("../../orchestrator/panel-mcp-http.ts", import.meta.url),
+      "utf8",
+    );
+    expect(panelHttpSrc).toMatch(
+      /registerPanelTools\(\s*server,\s*makePanelToolCtx\(\s*bridge,\s*tabId,\s*workflowTargets,\s*onRunTicketOpened\s*\)\s*\)/s,
+    );
+
+    const panelToolsSrc = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf8",
+    );
+    expect(panelToolsSrc).toMatch(
+      /const ctx = makePanelToolCtx\(bridge, tabId, workflowTargets, onRunTicketOpened\);/s,
+    );
+    expect(panelToolsSrc).toMatch(
+      /if \(ticketedPromptIds\.length\) ctx\.onRunTicketOpened\?\.\(ticketedPromptIds\);/s,
+    );
     expect(src).toContain("makeHttpBackendMcpServers(key)");
   });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -6301,10 +6301,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // observation went only to the `queue_status` UI broadcast. This watchdog is
   // the join: an observed completion whose panel_run ticket is still unanswered
   // after the grace is synthesised into the SAME journal the real frame uses.
+  // A fast completion may precede the ticket itself, so the watchdog also holds
+  // unknown ids briefly and re-checks them after panel_run's reply can arrive.
   // See run-completion-watchdog.ts for why it waits, and why the panel's frame
   // still wins whenever it is coming.
   const wd = createRunCompletionWatchdog({
     awaiting: (promptId) => RunCompletions.awaitingCompletion(promptId),
+    knownTicket: (promptId) => RunCompletions.ticketFor(promptId),
     resolveOutputs: (promptId) => resolveHistoryCompletionImages(promptId),
     lookupStatus: (promptId) => resolveHistoryCompletionStatus(promptId),
     deliver: (payload, ticket) => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2022,7 +2022,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   {
     const panelMcpPort = Number(process.env.COMFYUI_MCP_PANEL_MCP_PORT) || ports.panelMcp;
     try {
-      panelMcpHttp = await startPanelMcpHttpServer(bridge, panelMcpPort, "127.0.0.1", workflowTargets);
+      panelMcpHttp = await startPanelMcpHttpServer(
+        bridge,
+        panelMcpPort,
+        "127.0.0.1",
+        workflowTargets,
+        (promptIds) => runCompletionWatchdog?.markTicketed(promptIds),
+      );
     } catch (err) {
       logger.error(
         `[panel-orchestrator] could not start the panel HTTP MCP on :${panelMcpPort} — codex/gemini tabs will lack live-graph tools: ${err instanceof Error ? err.message : String(err)}`,
@@ -2444,7 +2450,12 @@ export async function runPanelOrchestrator(): Promise<void> {
     // one issue-time stamp).
     makePanelServer: (key) =>
       backendOf(key) === "claude"
-        ? createPanelMcpServer(bridge, key, workflowTargets)
+        ? createPanelMcpServer(
+            bridge,
+            key,
+            workflowTargets,
+            (promptIds) => runCompletionWatchdog?.markTicketed(promptIds),
+          )
         : undefined,
     mcpServers: buildMcpServers(),
     // Per-KEY factory — spawns must reflect live state (the Blind gate) and

--- a/src/orchestrator/panel-mcp-http.ts
+++ b/src/orchestrator/panel-mcp-http.ts
@@ -81,6 +81,7 @@ export function startPanelMcpHttpServer(
   port: number,
   host = "127.0.0.1",
   workflowTargets?: WorkflowTargetStore,
+  onRunTicketOpened?: (promptIds: readonly string[]) => void,
 ): Promise<PanelMcpHttpServer> {
   // tabId -> (sessionId -> Session). A tab can hold multiple Codex sessions
   // across reconnects; each is its own server+transport over the SAME tab ctx.
@@ -103,7 +104,7 @@ export function startPanelMcpHttpServer(
     );
     // Tab-bound context: every tool forwards to the bridge for THIS tab — the
     // same surface the Claude in-process server exposes (shared defs).
-    registerPanelTools(server, makePanelToolCtx(bridge, tabId, workflowTargets));
+    registerPanelTools(server, makePanelToolCtx(bridge, tabId, workflowTargets, onRunTicketOpened));
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       // Defense in depth against DNS rebinding (a malicious page resolving its own

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9963,6 +9963,9 @@ export interface PanelToolCtx {
    *  (image screenshots, secret collection). */
   bridge: UiBridge;
   tabId: string;
+  /** Notifies the completion watchdog when panel_run opens a ticket after a
+   * fast completion was already observed. Optional for lightweight contexts. */
+  onRunTicketOpened?: (promptIds: readonly string[]) => void;
   /** Per-tab workflow pin store (optional for tests). */
   workflowTarget?: WorkflowTargetStore;
   /**
@@ -10065,6 +10068,7 @@ export function makePanelToolCtx(
   bridge: UiBridge,
   tabId: string,
   workflowTargets?: WorkflowTargetStore,
+  onRunTicketOpened?: (promptIds: readonly string[]) => void,
 ): PanelToolCtx {
   // The routing tab id is held on the returned ctx object (NOT captured by
   // value) so an explicit rebind can re-point this session in place: call/
@@ -10073,6 +10077,7 @@ export function makePanelToolCtx(
     bridge,
     tabId,
     workflowTarget: workflowTargets,
+    onRunTicketOpened,
   } as PanelToolCtx;
 
   // AUTO-HEAL an orphaned session in place. When THIS session's captured tabId no
@@ -14515,10 +14520,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // Every id gets its own ticket. `correlatable` stays the promise the
         // anti-poll note is allowed to make — true only if at least one run can
         // actually be correlated back.
+        const ticketedPromptIds: string[] = [];
         const correlatable =
           queuedIds.length === 0
             ? RunCompletions.openRun(undefined, ticketOpts)
-            : queuedIds.map((id) => RunCompletions.openRun(id, ticketOpts)).some(Boolean);
+            : queuedIds.map((id) => {
+                const opened = RunCompletions.openRun(id, ticketOpts);
+                if (opened) ticketedPromptIds.push(id);
+                return opened;
+              }).some(Boolean);
+        // A fast QueueMonitor observation can be held before the panel reply
+        // returns. Promote that in-memory arm immediately after its journal
+        // ticket opens, so a completion burst cannot evict this owed run.
+        if (ticketedPromptIds.length) ctx.onRunTicketOpened?.(ticketedPromptIds);
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         //
@@ -18894,8 +18908,9 @@ export function createPanelMcpServer(
   bridge: UiBridge,
   tabId: string,
   workflowTargets?: WorkflowTargetStore,
+  onRunTicketOpened?: (promptIds: readonly string[]) => void,
 ): McpSdkServerConfigWithInstance {
-  const ctx = makePanelToolCtx(bridge, tabId, workflowTargets);
+  const ctx = makePanelToolCtx(bridge, tabId, workflowTargets, onRunTicketOpened);
   // #873 — THE SECOND PANEL REGISTRATION PATH. This one serves the Anthropic Agent SDK
   // (Claude backend, in-process transport); registerPanelTools serves the MCP SDK. They
   // build from the SAME buildPanelToolDefs(), so filtering only the other one left

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14352,7 +14352,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // instant belongs to this run: the id did not exist before this call created
         // it. Without the timestamp the journal has no way to tell the agent's own
         // 0.1s render from a stranger's, and reported it as UNDETERMINED.
-        const runDispatchedAt = Date.now();
+        let runDispatchedAt = Date.now();
         // #1175 — the rid of the dispatch we are about to make, so an unanswered
         // one can be reconciled against the panel's late acknowledgement. Rebound
         // by the re-issue below, deliberately: the entry that matters is always
@@ -14416,6 +14416,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // nothing more. A graph still moving after it (a user actively editing)
             // races again and is SURFACED, never re-raced.
             await sleep(retrySettleMs());
+            // The retry is a new dispatch boundary. A watchdog arm observed after the
+            // first certified refusal but before this re-issue belongs to neither
+            // attempt; keep the ticket fence at the dispatch that actually minted its
+            // prompt id rather than allowing that stale arm to be synthesized (#2021).
+            runDispatchedAt = Date.now();
             res = await ctx.call(runCmd, 20000, observeRunRid);
             // #1175 — the re-issue can miss its window exactly as the first
             // dispatch can, and this is the one whose outcome is genuinely open

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -122,6 +122,9 @@ export interface RunTicket {
    */
   conversation?: string;
   queuedAt: number;
+  /** Timestamp captured immediately before panel dispatch. The watchdog uses
+   * this to reject an unknown completion observed before this run existed. */
+  dispatchedAt?: number;
   toNodeId?: number;
   /**
    * Generation of THIS ticket. Bumped whenever the id is opened again (a fresh
@@ -708,6 +711,8 @@ export class RunCompletionJournalImpl {
       if (meta.conversation !== undefined) existing.conversation = meta.conversation;
       else delete existing.conversation;
       existing.queuedAt = Date.now();
+      if (typeof meta.dispatchedAt === "number") existing.dispatchedAt = meta.dispatchedAt;
+      else delete existing.dispatchedAt;
       existing.seq = ++this.ticketSeq; // a NEW generation of this id
       // The id no longer identifies ONE run. Every completion for it from here
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
@@ -738,6 +743,7 @@ export class RunCompletionJournalImpl {
       ...(meta.conversation !== undefined ? { conversation: meta.conversation } : {}),
       seq,
       queuedAt: Date.now(),
+      ...(typeof meta.dispatchedAt === "number" ? { dispatchedAt: meta.dispatchedAt } : {}),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
       settled: false,
       ...(hasHistory ? { reused: true } : {}),

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -182,6 +182,9 @@ const MAX_ARMED = 256;
 export interface RunCompletionWatchdog {
   /** Feed QueueMonitor's drained completions in. Never throws. */
   observe(events: ReadonlyArray<{ promptId: string; status: CompletionStatus }>): void;
+  /** Mark a just-opened panel_run ticket so a fast completion arm cannot be
+   * evicted as an unknown observation during a completion burst. */
+  markTicketed(promptIds: readonly string[]): void;
   /** Expire armed observations; synthesise for the ones still unanswered. */
   tick(): Promise<void>;
   /**
@@ -491,6 +494,14 @@ export function createRunCompletionWatchdog({
         inflight.delete(entry.promptId);
         continue;
       }
+      // An unknown arm observed before this dispatch cannot be the run whose
+      // ticket just opened. The journal's claimRaced timestamp guard already
+      // applies to journaled entries; apply the same fail-closed boundary to
+      // the watchdog's in-memory, not-yet-journaled arm (#2021).
+      if (typeof ticket.dispatchedAt === "number" && entry.observedAt < ticket.dispatchedAt) {
+        inflight.delete(entry.promptId);
+        continue;
+      }
       try {
         let images: CompletionImage[] = [];
         if (resolveOutputs) {
@@ -586,6 +597,15 @@ export function createRunCompletionWatchdog({
             `[run-completion-watchdog] observe skipped an event: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
+      }
+    },
+
+    markTicketed(promptIds) {
+      for (const raw of promptIds ?? []) {
+        const promptId = typeof raw === "string" ? raw.trim() : "";
+        if (!promptId) continue;
+        const entry = armed.get(promptId);
+        if (entry) entry.ticketedAtObservation = true;
       }
     },
 

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -29,8 +29,10 @@
 // promised was in the orchestrator's hands and thrown away.
 //
 // This module is the join, and only the join:
-//   observe()  — a QueueMonitor completion whose prompt id has an UNANSWERED
-//                panel_run ticket is armed with the time we saw it.
+//   observe()  — a QueueMonitor completion is held with the time we saw it. An
+//                already-open panel_run ticket is the normal case, but a fast
+//                render may arrive before panel_run can open its ticket, so the
+//                expiry check below re-asks whether the run became ours.
 //   tick()     — once the grace has elapsed, ask AGAIN. Still unanswered ⇒ the
 //                panel is never going to report it: synthesise the completion
 //                from what ComfyUI told us and hand it to the same journal the
@@ -99,6 +101,13 @@ interface ArmedCompletion {
   /** Monotonic-ish ms (the injected clock) when WE observed the finish. */
   observedAt: number;
   /**
+   * Whether a live ticket existed when this observation arrived. Unticketed
+   * observations are retained for the dispatch/reply race (#2021), but are
+   * preferred for eviction when the bounded arm set is full. A later
+   * `awaiting()` check at expiry is authoritative.
+   */
+  ticketedAtObservation?: true;
+  /**
    * This arm reached the stills grace and /history showed media the panel has
    * to build a storyboard for, so it was re-armed ONCE against the longer
    * bound. Set on the re-arm and never cleared: the extension is granted at
@@ -113,6 +122,12 @@ export interface RunCompletionWatchdogDeps {
    *  to arm, once at expiry — because the whole point is the state changing in
    *  between (the panel's real frame landing). */
   awaiting: (promptId: string) => RunTicket | undefined;
+  /**
+   * Distinguishes an already-known but no-longer-owed ticket from a prompt id
+   * that has never been ticketed. The latter can be the #2021 dispatch/reply
+   * race; the former is a duplicate observation the journal already owns.
+   */
+  knownTicket?: (promptId: string) => RunTicket | undefined;
   /** Journal + flush a synthesised completion for `ticket`. */
   deliver: (payload: CompletionPayload, ticket: RunTicket) => void;
   /**
@@ -395,6 +410,7 @@ export function synthesizeCompletionPayload(
 
 export function createRunCompletionWatchdog({
   awaiting,
+  knownTicket,
   deliver,
   resolveOutputs,
   lookupStatus,
@@ -412,11 +428,32 @@ export function createRunCompletionWatchdog({
    *  fetch is still in flight. */
   const inflight = new Set<string>();
 
-  const arm = (promptId: string, status: CompletionStatus, observedAt: number): void => {
-    if (armed.has(promptId) || inflight.has(promptId)) return;
-    armed.set(promptId, { promptId, status, observedAt });
+  const arm = (
+    promptId: string,
+    status: CompletionStatus,
+    observedAt: number,
+    ticketedAtObservation = false,
+  ): void => {
+    const existing = armed.get(promptId);
+    if (existing) {
+      // A repeated QueueMonitor observation after panel_run received its reply
+      // upgrades the arm's eviction priority without moving its deadline.
+      if (ticketedAtObservation) existing.ticketedAtObservation = true;
+      return;
+    }
+    if (inflight.has(promptId)) return;
+    armed.set(promptId, {
+      promptId,
+      status,
+      observedAt,
+      ...(ticketedAtObservation ? { ticketedAtObservation: true } : {}),
+    });
     while (armed.size > MAX_ARMED) {
-      const oldest = armed.keys().next().value;
+      // Unknown/foreign completions are only held for the ticket-opening race;
+      // do not let a burst of them evict arms that were already owed by a
+      // panel_run ticket. If every arm is ticketed, retain FIFO eviction.
+      const unticketed = [...armed.entries()].find(([, entry]) => !entry.ticketedAtObservation);
+      const oldest = unticketed?.[0] ?? armed.keys().next().value;
       if (oldest === undefined) break;
       armed.delete(oldest);
     }
@@ -526,11 +563,24 @@ export function createRunCompletionWatchdog({
         try {
           const promptId = typeof ev?.promptId === "string" ? ev.promptId.trim() : "";
           if (!promptId) continue;
-          // Only runs THIS session queued and is still owed a completion for.
-          // A foreign render (the user pressed Queue Prompt) has no ticket and
-          // was never promised anything, so it must never wake the agent.
-          if (!awaiting(promptId)) continue;
-          arm(promptId, ev.status, now());
+          // Usually this is an open ticket. A fast render can finish before the
+          // panel's graph_run reply returns its prompt id to panel_run (#2021),
+          // though, so retain an unticketed observation until expiry and ask
+          // again there. A genuinely foreign render is then discarded silently.
+          let ticketedAtObservation = false;
+          try {
+            ticketedAtObservation = Boolean(awaiting(promptId));
+            // `awaiting()` is intentionally false once the journal has a
+            // completion, including after ACK. Do not retain those duplicate
+            // observations; only a prompt id with no known ticket is a
+            // candidate for the pre-openRun race.
+            if (!ticketedAtObservation && knownTicket?.(promptId)) continue;
+          } catch (err) {
+            logger.debug(
+              `[run-completion-watchdog] could not check prompt ${promptId} while observing: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          arm(promptId, ev.status, now(), ticketedAtObservation);
         } catch (err) {
           logger.debug(
             `[run-completion-watchdog] observe skipped an event: ${err instanceof Error ? err.message : String(err)}`,
@@ -565,7 +615,7 @@ export function createRunCompletionWatchdog({
               if (!awaiting(promptId)) continue;
               // observedAt = now: we just learned it finished. expire(true)
               // skips the grace; waitedS in the note is the lookup latency.
-              arm(promptId, status, now());
+              arm(promptId, status, now(), true);
             } catch (err) {
               logger.debug(
                 `[run-completion-watchdog] reconcile skipped a prompt: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary\n- Preserve fast render completions that arrive before the completion watchdog tickets them.\n- Add focused regression coverage.\n\nRecovered eligible P2 issue #2021; implementation agent committed and pushed this branch. Please review against current main.