### PR TITLE
fix: target tunnels at the bound host (#2023)

### DIFF
--- a/src/__tests__/services/tunnel.test.ts
+++ b/src/__tests__/services/tunnel.test.ts
@@ -104,6 +104,21 @@ describe("startQuickTunnel", () => {
     },
   );
 
+  it.each(["::1", "2001:db8::7"])(
+    "brackets an IPv6 origin host for the tunnel URL (%s)",
+    async (host) => {
+      const promise = startQuickTunnel(9101, host);
+
+      await waitFor(() => expect(quickCalls).toHaveLength(1));
+      expect(quickCalls[0].url).toBe(`http://[${host}]:9101`);
+
+      state.lastTunnel!.emit("url", "https://ipv6.trycloudflare.com");
+      await expect(promise).resolves.toMatchObject({
+        url: "https://ipv6.trycloudflare.com",
+      });
+    },
+  );
+
   it("stop() tears down the tunnel and marks state stopped", async () => {
     const promise = startQuickTunnel(9000);
     await waitFor(() => expect(quickCalls).toHaveLength(1));

--- a/src/__tests__/services/tunnel.test.ts
+++ b/src/__tests__/services/tunnel.test.ts
@@ -89,6 +89,21 @@ describe("startQuickTunnel", () => {
     });
   });
 
+  it.each(["0.0.0.0", "::"])(
+    "uses IPv4 loopback when the server binds the wildcard address (%s)",
+    async (host) => {
+      const promise = startQuickTunnel(9100, host);
+
+      await waitFor(() => expect(quickCalls).toHaveLength(1));
+      expect(quickCalls[0].url).toBe("http://127.0.0.1:9100");
+
+      state.lastTunnel!.emit("url", "https://wildcard.trycloudflare.com");
+      await expect(promise).resolves.toMatchObject({
+        url: "https://wildcard.trycloudflare.com",
+      });
+    },
+  );
+
   it("stop() tears down the tunnel and marks state stopped", async () => {
     const promise = startQuickTunnel(9000);
     await waitFor(() => expect(quickCalls).toHaveLength(1));

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -286,7 +286,7 @@ async function openTunnelAndAnnounce(
   logger.info("[tunnel] starting cloudflared quick tunnel…");
   let publicUrl: string;
   try {
-    const tunnel = await startQuickTunnel(port);
+    const tunnel = await startQuickTunnel(port, host);
     publicUrl = tunnel.url;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -94,7 +94,7 @@ async function ensureBinary(): Promise<void> {
 }
 
 /**
- * Start a Cloudflare quick tunnel that exposes http://localhost:<port> on a
+ * Start a Cloudflare quick tunnel that exposes the local `<host>:<port>` on a
  * public HTTPS URL. Resolves once the `url` event fires; rejects if the
  * cloudflared process errors or exits before becoming ready.
  *
@@ -112,7 +112,12 @@ export async function startQuickTunnel(
   await ensureBinary();
   const { Tunnel } = await loadCloudflared();
 
-  const t = Tunnel.quick(`http://${host}:${port}`, {
+  // A wildcard is a bind address, not a useful origin for cloudflared. In
+  // particular, `localhost` can resolve to IPv6 while a 0.0.0.0 server is
+  // listening only on IPv4, so always route wildcard binds through IPv4
+  // loopback.
+  const originHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  const t = Tunnel.quick(`http://${originHost}:${port}`, {
     "--config": getCloudflaredConfigArg(),
     "--edge-ip-version": "4",
   });

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -116,7 +116,12 @@ export async function startQuickTunnel(
   // particular, `localhost` can resolve to IPv6 while a 0.0.0.0 server is
   // listening only on IPv4, so always route wildcard binds through IPv4
   // loopback.
-  const originHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  const originHost =
+    host === "0.0.0.0" || host === "::"
+      ? "127.0.0.1"
+      : host.includes(":") && !host.startsWith("[")
+        ? `[${host}]`
+        : host;
   const t = Tunnel.quick(`http://${originHost}:${port}`, {
     "--config": getCloudflaredConfigArg(),
     "--edge-ip-version": "4",


### PR DESCRIPTION
## Summary\n- Ensure tunnel commands target the host actually bound by the service.\n- Add focused regression coverage.\n\nRecovered eligible P2 issue #2023; implementation agent committed and pushed this branch. Please review against current main.