### PR TITLE
fix: recover subgraph widget write scope (#2015)

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -24,7 +24,9 @@ import {
 import {
   isContradictoryPromotedWidgetRefusal,
   matchListedName,
+  parseAmbiguousPromotedWidgetRefusal,
   parseContradictoryPromotedWidgetRefusal,
+  parseSubgraphScopeRefusal,
   resolveInnerPromotedTarget,
 } from "../../orchestrator/promoted-widget.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
@@ -34,6 +36,14 @@ const TAB = "wf:krea2";
 const CONTRADICTORY =
   `Cannot set widget on subgraph node 78: "width" is not a promoted widget on this subgraph ` +
   `(promoted: width, height, seed, control_after_generate, steps, cfg, sampler_name, scheduler, denoise, batch_size).`;
+
+const AMBIGUOUS =
+  `promoted widget "text" is ambiguous - 2 promoted inputs match; refusing to guess.`;
+
+const SCOPE_REFUSAL =
+  `No node with id 188 in the current graph. Node 188 lives INSIDE a subgraph — ` +
+  `"New Subgraph" (node 190) — and the write applies there. ` +
+  `Enter it (panel_enter_subgraph(190)), then retry.`;
 
 const SUBGRAPH = {
   subgraph_of: { node_id: 78, title: "Krea2" },
@@ -54,6 +64,9 @@ function bridge(opts: {
   subgraph?: Record<string, unknown> | Error;
   enterFails?: boolean;
   exitFails?: boolean;
+  ambiguous?: boolean;
+  scopeLost?: boolean;
+  promotedDetail?: Record<string, unknown>;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -62,9 +75,13 @@ function bridge(opts: {
       calls.push({ ...cmd });
       if (cmd.cmd === "graph_set_widget") {
         writes += 1;
+        if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
+        if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
         const which =
           writes === 1
             ? (opts.firstWrite ?? "contradict")
+            : opts.scopeLost
+              ? (opts.innerWrite ?? "ok")
             : Number(cmd.node_id) === 76 || cmd.node_id === "76"
               ? (opts.innerWrite ?? "ok")
               : (opts.remappedWrite ?? "contradict");
@@ -83,6 +100,21 @@ function bridge(opts: {
       if (cmd.cmd === "graph_exit_subgraph") {
         if (opts.exitFails) throw new Error("could not confirm exit");
         return { scope: "root" };
+      }
+      if (cmd.cmd === "graph_query") {
+        return (
+          opts.promotedDetail ?? {
+            nodes: [
+              {
+                id: 190,
+                inputs: [
+                  { slot: 0, name: "text" },
+                  { slot: 1, name: "text_1", label: "text" },
+                ],
+              },
+            ],
+          }
+        );
       }
       return { ok: true };
     },
@@ -161,6 +193,24 @@ describe("parseContradictoryPromotedWidgetRefusal", () => {
     const parsed = parseContradictoryPromotedWidgetRefusal(CONTRADICTORY, "Width");
     expect(parsed?.widget).toBe("width");
   });
+
+  it("parses the promoted name/label ambiguity without selecting a target", () => {
+    expect(parseAmbiguousPromotedWidgetRefusal(AMBIGUOUS, "text", 190)).toEqual({
+      nodeId: "190",
+      widget: "text",
+      matches: 2,
+    });
+    expect(parseAmbiguousPromotedWidgetRefusal(AMBIGUOUS, "steps")).toBeNull();
+  });
+
+  it("parses only the panel-provided enter route from a lost-scope refusal", () => {
+    expect(parseSubgraphScopeRefusal(SCOPE_REFUSAL, 188)).toEqual({
+      nodeId: "188",
+      enterPath: ["190"],
+    });
+    expect(parseSubgraphScopeRefusal(SCOPE_REFUSAL, 189)).toBeNull();
+    expect(parseSubgraphScopeRefusal("No node with id 188 in the current graph", 188)).toBeNull();
+  });
 });
 
 describe("resolveInnerPromotedTarget", () => {
@@ -199,6 +249,49 @@ describe("resolveInnerPromotedTarget", () => {
 });
 
 describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
+  it("reports ambiguous promoted name/label candidates without a second write (#2015)", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 190, widget: "text", value: "hello" },
+      {
+        ambiguous: true,
+        promotedDetail: {
+          nodes: [
+            {
+              id: 190,
+              inputs: [
+                { slot: 1, name: "text" },
+                { slot: 2, name: "text_1", label: "text" },
+              ],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(text).toMatch(/slot:1, name:"text", label:null/);
+    expect(text).toMatch(/slot:2, name:"text_1", label:"text"/);
+    expect(text).toMatch(/no second write was attempted/i);
+  });
+
+  it("re-enters the panel-provided scope and retries the inner write once (#2015)", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 188, widget: "text", value: "hello" },
+      { scopeLost: true },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_set_widget",
+      "graph_enter_subgraph",
+      "graph_set_widget",
+    ]);
+    expect(calls[1]).toMatchObject({ node_id: "190" });
+    expect(calls[2]).toMatchObject({ node_id: 188, widget: "text", value: "hello" });
+    expect(text).toMatch(/route was re-entered and the write was retried once/i);
+  });
+
   it("the reporter's case: refuse → get_subgraph → enter → set inner → exit", async () => {
     const { text, isError, calls } = await setWidget({ node_id: 78, widget: "width", value: 1024 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -87,7 +87,9 @@ import {
 import { unrecognizedKeysError } from "./unrecognized-keys.js";
 import {
   addressedNodeMatchesPersistRemedy,
+  parseAmbiguousPromotedWidgetRefusal,
   parseContradictoryPromotedWidgetRefusal,
+  parseSubgraphScopeRefusal,
   parseUnpromotedControlPersistRemedy,
   resolveInnerPromotedTarget,
   type UnpromotedControlPersistRemedy,
@@ -4663,6 +4665,84 @@ async function persistUnpromotedControlAfterGenerate(
   return rewriteToolResultJson(
     res,
     pinnedControlPayload(payload, remedy, exits.failed ? exits.note : undefined),
+  );
+}
+
+type PromotedWidgetCandidate = {
+  slot: number;
+  name: string;
+  label: string | null;
+};
+
+function promotedWidgetCandidates(
+  payload: Record<string, unknown> | null,
+  nodeId: string,
+  requestedWidget: string,
+): PromotedWidgetCandidate[] {
+  if (!payload || !Array.isArray(payload.nodes)) return [];
+  const node = payload.nodes.find((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+    return String((entry as Record<string, unknown>).id) === nodeId;
+  });
+  if (!node || typeof node !== "object" || Array.isArray(node)) return [];
+  const inputs = (node as Record<string, unknown>).inputs;
+  if (!Array.isArray(inputs)) return [];
+
+  const wanted = requestedWidget.toLowerCase();
+  const candidates: PromotedWidgetCandidate[] = [];
+  for (let index = 0; index < inputs.length; index += 1) {
+    const input = inputs[index];
+    if (!input || typeof input !== "object" || Array.isArray(input)) continue;
+    const record = input as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : null;
+    if (!name) continue;
+    const label = typeof record.label === "string" ? record.label : null;
+    if (name.toLowerCase() !== wanted && label?.toLowerCase() !== wanted) continue;
+    const rawSlot = record.slot;
+    const slot = typeof rawSlot === "number" && Number.isSafeInteger(rawSlot) ? rawSlot : index;
+    candidates.push({ slot, name, label });
+  }
+  return candidates;
+}
+
+async function explainAmbiguousPromotedWidgetRefusal(
+  first: ToolResult,
+  args: Record<string, unknown>,
+  ctx: PanelToolCtx,
+): Promise<ToolResult> {
+  const refusal = parseAmbiguousPromotedWidgetRefusal(
+    textOfToolResult(first),
+    String(args.widget),
+    args.node_id as string | number,
+  );
+  if (!refusal || String(refusal.nodeId) !== String(args.node_id)) return first;
+
+  const detail = await ctx.call(
+    { cmd: "graph_query", ids: [args.node_id], fields: "detail", limit: 1 },
+    8000,
+  );
+  const candidates = promotedWidgetCandidates(
+    parseToolResultJson(detail),
+    refusal.nodeId,
+    refusal.widget,
+  );
+  const listed = candidates.length
+    ? candidates
+        .map(
+          (candidate) =>
+            `{slot:${candidate.slot}, name:${JSON.stringify(candidate.name)}, ` +
+            `label:${JSON.stringify(candidate.label)}}`,
+        )
+        .join("; ")
+    : "unavailable (the node detail query did not expose promoted input names)";
+  return appendToolResultText(
+    first,
+    `\n\n(The panel found ${refusal.matches} promoted inputs matching "${refusal.widget}". ` +
+      `The write was refused and no second write was attempted. Candidate ` +
+      `{slot,name,label} triples: ${listed}. ` +
+      `Use an unambiguous promoted input name if one is available; the MCP layer ` +
+      `cannot safely choose between a name and a label.)` +
+      (detail.isError ? ` Detail query FAILED: ${textOfToolResult(detail)}` : ""),
   );
 }
 
@@ -13776,6 +13856,68 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // leaving "cannot verify the node type" as "the type is missing".
         if (isObjectInfoStarvationRefusal(first)) {
           return appendToolResultText(first, objectInfoStarvationNote());
+        }
+
+        // #2015 — a panel pre-executor can reject an inner node because the
+        // tab has fallen back to the root graph even though the caller already
+        // entered that subgraph. The refusal contains the authoritative
+        // panel_enter_subgraph route. Reassert that route once, then retry the
+        // exact write; never infer an owner from an arbitrary node id.
+        const scopeRefusal = parseSubgraphScopeRefusal(
+          textOfToolResult(first),
+          args.node_id as string | number,
+        );
+        if (scopeRefusal) {
+          const entered: string[] = [];
+          for (const ownerNodeId of scopeRefusal.enterPath) {
+            const step = await ctx.call(
+              { cmd: "graph_enter_subgraph", node_id: ownerNodeId },
+              15000,
+            );
+            if (step.isError) {
+              const exits = await exitSubgraphLevels(ctx, entered.length);
+              return appendToolResultText(
+                first,
+                `\n\n(The panel said node ${scopeRefusal.nodeId} was outside the current ` +
+                  `subgraph. Re-entering panel_enter_subgraph(node_id=${ownerNodeId}) ` +
+                  `FAILED: ${textOfToolResult(step)}${exits.failed ? ` ${exits.note}` : ""}. ` +
+                  `The write was not retried.)`,
+              );
+            }
+            entered.push(ownerNodeId);
+          }
+
+          const retried = await write(args.node_id, args.widget as string);
+          if (!retried.isError) {
+            const persisted = await persistUnpromotedControlAfterGenerate(
+              retried,
+              ctx,
+              args.node_id,
+            );
+            return appendToolResultText(
+              persisted,
+              `\n\n(The panel reported node ${scopeRefusal.nodeId} outside the current ` +
+                `graph, so its own panel_enter_subgraph route was re-entered and the ` +
+                `write was retried once. The tab remains in that entered scope.)`,
+            );
+          }
+          return appendToolResultText(
+            retried,
+            `\n\n(The panel_enter_subgraph route was re-entered, but the exact write ` +
+              `still failed on its one allowed retry: ${textOfToolResult(retried)})`,
+          );
+        }
+
+        // #2015 — the panel's name/label ambiguity is a correctness refusal.
+        // Query detail only to expose the candidates; guessing a slot or
+        // writing an inner node would risk changing a different promoted rail.
+        const ambiguous = parseAmbiguousPromotedWidgetRefusal(
+          textOfToolResult(first),
+          args.widget as string,
+          args.node_id as string | number,
+        );
+        if (ambiguous && String(ambiguous.nodeId) === String(args.node_id)) {
+          return explainAmbiguousPromotedWidgetRefusal(first, args, ctx);
         }
 
         // #1655 — the panel listed this widget as promoted while refusing it as

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -28,8 +28,25 @@ export type InnerPromotedTarget = {
   widget: string;
 };
 
+export type AmbiguousPromotedWidgetRefusal = {
+  nodeId: string;
+  widget: string;
+  matches: number;
+};
+
+export type SubgraphScopeRefusal = {
+  nodeId: string;
+  enterPath: string[];
+};
+
 const CONTRADICTORY_RE =
   /Cannot set widget on subgraph node (\S+): "([^"]+)" is not a promoted widget on this subgraph \(promoted: ([^)]+)\)/i;
+
+const AMBIGUOUS_RE =
+  /(?:panel_set_widget refused "([^"]+)" on node (\S+)[\s\S]*?)?promoted widget "([^"]+)" is ambiguous\s*[—-]\s*(\d+)\s+promoted inputs? match/i;
+
+const SCOPED_NODE_RE = /No node with id (\S+) in the current graph[\s\S]*?lives INSIDE a subgraph/i;
+const ENTER_PATH_RE = /panel_enter_subgraph\((?:node_id=)?\s*([^)]+)\)/gi;
 
 /** Exact name first; a unique case-insensitive hit is accepted so a listed
  *  `width` still matches a caller who sent `Width`. Several CI hits refuse. */
@@ -37,6 +54,58 @@ export function matchListedName(wanted: string, listed: readonly string[]): stri
   if (listed.includes(wanted)) return wanted;
   const ci = listed.filter((n) => n.toLowerCase() === wanted.toLowerCase());
   return ci.length === 1 ? ci[0] : null;
+}
+
+/**
+ * Parse the panel's promoted-name/label ambiguity refusal. This is deliberately
+ * diagnostic-only: the refusal proves that a blind second write could target the
+ * wrong promoted rail, so callers must not turn the count into a guessed target.
+ */
+export function parseAmbiguousPromotedWidgetRefusal(
+  text: string,
+  requestedWidget?: string,
+  requestedNodeId?: number | string,
+): AmbiguousPromotedWidgetRefusal | null {
+  const m = AMBIGUOUS_RE.exec(text);
+  if (!m) return null;
+  const widget = m[3] ?? m[1];
+  if (!widget) return null;
+  if (requestedWidget != null && requestedWidget.toLowerCase() !== widget.toLowerCase()) {
+    return null;
+  }
+  const nodeId = m[2] ?? (requestedNodeId == null ? undefined : String(requestedNodeId));
+  if (!nodeId) return null;
+  const matches = Number(m[4]);
+  if (!Number.isSafeInteger(matches) || matches < 2) return null;
+  return { nodeId: nodeId.replace(/[,:]$/, ""), widget, matches };
+}
+
+/**
+ * Parse the panel's pre-executor scope diagnosis. The enter path is taken only
+ * from the panel's own `panel_enter_subgraph(...)` remedy, never inferred from a
+ * node id or from a generic missing-node error.
+ */
+export function parseSubgraphScopeRefusal(
+  text: string,
+  requestedNodeId?: number | string,
+): SubgraphScopeRefusal | null {
+  const missing = SCOPED_NODE_RE.exec(text);
+  if (!missing) return null;
+  const nodeId = missing[1].replace(/[,:]$/, "");
+  if (
+    requestedNodeId != null &&
+    String(requestedNodeId).replace(/[,:]$/, "") !== nodeId
+  ) {
+    return null;
+  }
+
+  const enterPath: string[] = [];
+  ENTER_PATH_RE.lastIndex = 0;
+  for (let m = ENTER_PATH_RE.exec(text); m; m = ENTER_PATH_RE.exec(text)) {
+    const id = m[1].trim().replace(/[,:]$/, "");
+    if (id) enterPath.push(id);
+  }
+  return enterPath.length > 0 ? { nodeId, enterPath } : null;
 }
 
 function parseListed(raw: string): string[] {


### PR DESCRIPTION
Recovered eligible P2 issue #2015. The implementation agent committed and pushed the narrow promoted-widget scope recovery fix with focused coverage. Please review against current main.