### PR TITLE
fix(2013): an unroutable show_media names who it is queued for, not whoever hellos next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
+- **An unroutable `show_media` no longer reads as a delivery (#2013).**
+  `show_media` is the only command the bridge buffers when it cannot route —
+  a finished render survives a phone being away — and that receipt used to be
+  `{ok: true, mailboxed: true}` for both a concrete tab and a scope address.
+  A scope-keyed box then flushed to the first matching hello, which is how
+  "could not route" silently became "queued for whoever connects next". The
+  receipt now names the recipient when it knows one (`queued_for` is the
+  tab id, `recipient_known: true`) and says `recipient_known: false` /
+  `queued_for: null` when the box is scope-keyed. A flush to a client of the
+  wrong kind (a phone collecting a canvas-produced box, or the reverse) is
+  declined and the box stays queued for a matching reconnect. Untagged
+  (never-seen) boxes still flush to the first hello, which is the original
+  mailbox purpose.
 - **`panel_show_media` inlines a `/view` ref for the tab the frame will actually
   reach, not for the address the session holds (#2012).** `ctx.tabId` may be a
   scope (`orchestrator`, `orchestrator::<backend>`), an 8-char prefix, or a

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -166,6 +166,33 @@ describe("#2010 an unaccounted reply no longer answers with the client's claim",
     expect(t).not.toMatch(/The client acknowledged the command/);
   });
 
+  it("a scope-keyed mailbox (no queued_for) says whichever client connects next (#2013)", () => {
+    // Kills: describing every mailbox as waiting for a named tab — a scope
+    // address names nobody.
+    const t = textOf(
+      annotateShowMediaAck(okResult({ ok: true, mailboxed: true, queued_for: null, recipient_known: false }), ITEM),
+    );
+    expect(t).toMatch(/whichever client connects next/);
+    expect(t).not.toMatch(/waiting for tab /);
+    const d = doc(
+      annotateShowMediaAck(okResult({ ok: true, mailboxed: true, queued_for: null, recipient_known: false }), ITEM),
+    );
+    expect(d.recipient_known).toBe(false);
+    expect(d.queued_for).toBeNull();
+  });
+
+  it("a concrete-tab mailbox names the tab it is waiting for (#2013)", () => {
+    // Kills: using the scope wording for a knowable recipient.
+    const receipt = { ok: true, mailboxed: true, queued_for: "phone-stable-1", recipient_known: true };
+    const t = textOf(annotateShowMediaAck(okResult(receipt), ITEM));
+    expect(t).toMatch(/waiting for tab /);
+    expect(t).toMatch(/phone-st/);
+    expect(t).not.toMatch(/whichever client connects next/);
+    const d = doc(annotateShowMediaAck(okResult(receipt), ITEM));
+    expect(d.recipient_known).toBe(true);
+    expect(d.queued_for).toBe("phone-stable-1");
+  });
+
   it("a non-JSON reply is still corrected, and is kept as text", () => {
     const out = annotateShowMediaAck({ content: [{ type: "text", text: "shown" }] }, ITEM);
     expect(doc(out).client_reply).toBe("shown");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -337,7 +337,12 @@ describe("UiBridge (mailbox — offline render delivery)", () => {
       { cmd: "show_media", items: [{ filename: "a.png" }] },
       { tabId: "phone-stable-1" },
     );
-    expect(res).toMatchObject({ ok: true, mailboxed: true });
+    expect(res).toMatchObject({
+      ok: true,
+      mailboxed: true,
+      queued_for: "phone-stable-1",
+      recipient_known: true,
+    });
 
     // An INTERACTIVE command to an offline tab still rejects (not mailboxable).
     await expect(
@@ -393,6 +398,145 @@ describe("UiBridge (mailbox — offline render delivery)", () => {
     await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "nobody")).toBe(true));
     expect(got.find((m) => m.type === "mailbox_flush")).toBeUndefined();
     phone.close();
+  });
+
+  it("#2013 a scope-keyed mailbox names NO recipient — queued_for is null", async () => {
+    // Kills: returning the old `{ok:true, mailboxed:true}` with no recipient
+    // fields, which is how "queued for whoever connects next" read as delivered.
+    const res = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "a.png" }] },
+      { tabId: SHARED_SESSION_SCOPE },
+    );
+    expect(res).toMatchObject({
+      ok: true,
+      mailboxed: true,
+      queued_for: null,
+      recipient_known: false,
+    });
+  });
+
+  it("#2013 a canvas-produced scope box is NOT handed to a phone that hellos first", async () => {
+    // The reported "whoever connects next" path: a desktop was the last client,
+    // it left, show_media could not route, and a phone hellos first. Pre-fix
+    // the phone collected the box. Now the flush declines a kind mismatch and
+    // the desktop reconnect is who actually gets it.
+    const desk = await connectPanel("wf:desk.json", "desk");
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:desk.json")).toBe(true));
+    desk.close();
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:desk.json")).toBe(false));
+
+    const queued = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "plate.png" }] },
+      { tabId: SHARED_SESSION_SCOPE },
+    );
+    expect(queued).toMatchObject({ mailboxed: true, recipient_known: false });
+
+    const phoneGot: Array<Record<string, unknown>> = [];
+    const phone = await connectPanel();
+    phone.on("message", (buf) => phoneGot.push(JSON.parse(buf.toString())));
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-1", title: "mobile", headless: true }));
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-1")).toBe(true));
+    expect(phoneGot.find((m) => m.cmd === "show_media")).toBeUndefined();
+    expect(phoneGot.find((m) => m.type === "mailbox_flush")).toBeUndefined();
+
+    const deskGot: Array<Record<string, unknown>> = [];
+    const desk2 = await connectPanel();
+    desk2.on("message", (buf) => deskGot.push(JSON.parse(buf.toString())));
+    desk2.send(JSON.stringify({ type: "hello", tab_id: "wf:desk.json", title: "desk" }));
+    await waitFor(() => {
+      expect(deskGot.find((m) => m.cmd === "show_media")).toMatchObject({
+        mailbox: true,
+        items: [{ filename: "plate.png" }],
+      });
+    });
+    phone.close();
+    desk2.close();
+  });
+
+  it("#2013 a phone-produced scope box is NOT handed to a desktop that hellos first", async () => {
+    const phone = await connectHeadless("phone-was");
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-was")).toBe(true));
+    phone.close();
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-was")).toBe(false));
+
+    await bridge.send(
+      { cmd: "show_media", items: [{ filename: "from-phone.png" }] },
+      { tabId: SHARED_SESSION_SCOPE },
+    );
+
+    const deskGot: Array<Record<string, unknown>> = [];
+    const desk = await connectPanel();
+    desk.on("message", (buf) => deskGot.push(JSON.parse(buf.toString())));
+    desk.send(JSON.stringify({ type: "hello", tab_id: "wf:later.json", title: "desk" }));
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:later.json")).toBe(true));
+    expect(deskGot.find((m) => m.cmd === "show_media")).toBeUndefined();
+
+    const phoneGot: Array<Record<string, unknown>> = [];
+    const phone2 = await connectPanel();
+    phone2.on("message", (buf) => phoneGot.push(JSON.parse(buf.toString())));
+    phone2.send(
+      JSON.stringify({ type: "hello", tab_id: "phone-was", title: "mobile", headless: true }),
+    );
+    await waitFor(() => {
+      expect(phoneGot.find((m) => m.cmd === "show_media")).toMatchObject({ mailbox: true });
+    });
+    desk.close();
+    phone2.close();
+  });
+
+  it("#2013 an unknown-recipient scope box still flushes to the first hello (phone-away images)", async () => {
+    // Never-seen conversation: no last-disconnected kind, so the original
+    // mailbox purpose stands — a finished render is not lost just because
+    // nobody has helloed this process yet.
+    const queued = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "away.png" }] },
+      { tabId: SHARED_SESSION_SCOPE },
+    );
+    expect(queued).toMatchObject({ mailboxed: true, recipient_known: false });
+
+    const got: Array<Record<string, unknown>> = [];
+    const phone = await connectPanel();
+    phone.on("message", (buf) => got.push(JSON.parse(buf.toString())));
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-away", title: "mobile", headless: true }));
+    await waitFor(() => {
+      expect(got.find((m) => m.cmd === "show_media")).toMatchObject({ mailbox: true });
+    });
+    phone.close();
+  });
+
+  it("#2013 panel_show_media through the real handler surfaces a scope mailbox as queued-not-delivered", async () => {
+    // Drives the shipped tool, not a stubbed ctx.call: no tab connected, the
+    // session is orchestrator-scoped, the item is a real tiny PNG so nothing
+    // talks to ComfyUI. Kills: treating `{ok:true, mailboxed:true}` as a
+    // presentation, or describing a scope box as waiting for a named tab.
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-2013-"));
+    tempRoots.push(dir);
+    const png = join(dir, "plate.png");
+    writeFileSync(
+      png,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "base64",
+      ),
+    );
+    const ctx = makePanelToolCtx(bridge, SHARED_SESSION_SCOPE, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+    if (!def) throw new Error("panel_show_media not found");
+    const res = (await def.handler({ items: [{ source: { path: png } }] }, ctx)) as {
+      isError?: boolean;
+      content: Array<{ type: string; text?: string }>;
+    };
+    expect(res.isError).toBeFalsy();
+    const doc = JSON.parse(res.content[0].text!) as Record<string, unknown>;
+    expect(doc.unaccounted_because).toBe("mailboxed");
+    expect(doc.recipient_known).toBe(false);
+    expect(doc.queued_for).toBeNull();
+    expect(doc.presented_confirmed).toBeNull();
+    expect(doc.shown).toBeUndefined();
+    const text = res.content.map((c) => c.text ?? "").join("\n");
+    expect(text).toMatch(/QUEUED, not delivered/);
+    expect(text).toMatch(/whichever client connects next/);
+    expect(text).not.toMatch(/waiting for tab /);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3948,6 +3948,15 @@ function annotateShowMediaAck(
              *  "partial_accounting" or "mailboxed". Structured so a caller can
              *  branch on it without reading the prose. */
             unaccounted_because: verdict.reason,
+            /** #2013 — only on a mailbox receipt. A concrete tab id is a known
+             *  recipient; `null` means the box is scope-keyed (whoever hellos
+             *  next). Structured so a caller does not have to parse the prose. */
+            ...(verdict.reason === "mailboxed"
+              ? {
+                  queued_for: verdict.queuedFor ?? null,
+                  recipient_known: verdict.queuedFor != null,
+                }
+              : {}),
             /** EVERY dispatched item, even under partial accounting: a reply
              *  that covers 1 of 2 does not say WHICH, so none can be settled. */
             unaccounted: dispatched.map((d) => ({ filename: d.filename, kind: d.kind })),

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -867,6 +867,10 @@ export type ShowMediaAckVerdict = {
    *  null when it does not. A COUNT, never an identity — a reply covering 1 of
    *  2 items does not say WHICH one, so nothing downstream can name it. */
   covered: number | null;
+  /** #2013 — concrete tab id the mailbox named, when the recipient is knowable.
+   *  `null` when the box is scope-keyed (whoever hellos next). Present only
+   *  for reason `"mailboxed"`. */
+  queuedFor?: string | null;
 };
 
 /**
@@ -903,7 +907,11 @@ export function readShowMediaAck(reply: unknown, dispatchedCount: number): ShowM
   // #2013 — buffered rather than refused. Checked BEFORE the shape test so a
   // mailbox receipt that happened to carry counts could not be read as an
   // account of a presentation no client has had the chance to make.
-  if (r.mailboxed === true) return { accounted: false, reason: "mailboxed", covered: null };
+  if (r.mailboxed === true) {
+    const queuedFor =
+      typeof r.queued_for === "string" && r.queued_for.length > 0 ? r.queued_for : null;
+    return { accounted: false, reason: "mailboxed", covered: null, queuedFor };
+  }
   const count = r.count;
   const painted = r.painted;
   const unrenderable = r.unrenderable;
@@ -972,9 +980,20 @@ export function unaccountedShowMediaNote(
     // #2013 — `show_media` is the ONE command the bridge buffers instead of
     // refusing when it cannot route. No client has seen this at all yet, which
     // is a weaker fact than "a client took it and said nothing about it".
-    what =
-      `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. It will be handed ` +
-      `to whichever client connects next, and nothing here says that client can present it.`;
+    // A concrete tab is a known recipient; a scope-keyed box is not — saying
+    // "whichever client connects next" of a named tab would be a lie in the
+    // other direction.
+    if (verdict.queuedFor) {
+      const short =
+        verdict.queuedFor.length > 12 ? `${verdict.queuedFor.slice(0, 8)}…` : verdict.queuedFor;
+      what =
+        `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. ` +
+        `It is waiting for tab ${short} to reconnect, and nothing here says that client can present it.`;
+    } else {
+      what =
+        `${one ? "It was" : "They were"} QUEUED, not delivered: no client has this yet. It will be handed ` +
+        `to whichever client connects next, and nothing here says that client can present it.`;
+    }
   } else if (verdict.reason === "partial_accounting") {
     // A count is not an identity: a reply about 1 of 2 items does not say WHICH
     // one, so every item is listed and none can be marked settled.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1729,10 +1729,19 @@ export class UiBridge {
   /** Per-tab "mailbox" of undeliverable render deliveries (show_media), buffered
    *  while a client is OFFLINE and flushed on reconnect — so a finished render is
    *  never lost when the mobile app is backgrounded/killed mid-render. Keyed by a
-   *  STABLE tab id (the phone persists one). In-memory: survives disconnect ⇄
-   *  reconnect within an orchestrator run, not a full orchestrator restart.
-   *  Bounded per tab + TTL'd. */
-  private readonly mailbox = new Map<string, Array<{ cmd: BridgeCommand; ts: number }>>();
+   *  STABLE tab id (the phone persists one) OR a scope address (no tab was
+   *  routable). In-memory: survives disconnect ⇄ reconnect within an orchestrator
+   *  run, not a full orchestrator restart. Bounded per tab + TTL'd.
+   *
+   *  #2013 — `expectHeadless` is the kind of client the entry was produced for
+   *  (`true` phone/remote, `false` canvas, omitted when unknown). A scope-keyed
+   *  box used to flush to the first hello, which is how "could not route" became
+   *  "queued for whoever connects next". The flush now declines a mismatched
+   *  recipient and keeps the box for a matching reconnect. */
+  private readonly mailbox = new Map<
+    string,
+    Array<{ cmd: BridgeCommand; ts: number; expectHeadless?: boolean }>
+  >();
   private static readonly MAILBOX_MAX = 30;
   private static readonly MAILBOX_TTL_MS = 24 * 60 * 60 * 1000;
   /** Tab ids whose most recent connected socket was headless. Retained across a
@@ -3023,6 +3032,10 @@ export class UiBridge {
         if (this.conns.get(tabId)?.headless === true) {
           this.lastHeadlessDisconnectAt = performance.now();
         }
+        // #2013 — remember the kind that just left so a subsequent scope-keyed
+        // mailbox (zero live tabs) is tagged for that client, not for "whoever
+        // hellos next".
+        this.lastDisconnectedHeadless = this.conns.get(tabId)?.headless === true;
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
         // The mirrored desktop tab is gone — detach its viewers so their input
@@ -3765,6 +3778,12 @@ export class UiBridge {
    * has never seen a phone can never defer.
    */
   private lastHeadlessDisconnectAt: number | undefined;
+  /** Kind of the most recently departed PRIMARY tab (`true` headless, `false`
+   *  canvas). #2013 uses this when a scope-keyed mailbox is stored with ZERO
+   *  live tabs — the last client to leave is who the conversation was talking
+   *  to, and the flush declines a hello of the other kind. Undefined until a
+   *  primary has actually disconnected this process. */
+  private lastDisconnectedHeadless: boolean | undefined;
 
   /** Test seam: place the recency clock in the past without sleeping. Takes a
    *  `performance.now()`-based reading, matching the field. */
@@ -4346,18 +4365,74 @@ export class UiBridge {
   }
 
   /** Deliveries worth mailboxing when the target is offline (a finished render),
-   *  vs. interactive canvas ops that should just fail. */
+   *  vs. interactive canvas ops that should just fail.
+   *
+   *  #2013 — this is the ONE command that does not reject when `resolveTarget`
+   *  throws. Every other command surfaces `dispatched:false`. Callers that
+   *  reason "unroutable ⇒ not delivered" are wrong here: the frame is buffered
+   *  and the receipt is `{ok:true, mailboxed:true, …}`. */
   private static isMailboxable(cmd: BridgeCommand): boolean {
     return cmd.cmd === "show_media";
   }
 
+  /**
+   * #2013 — kind of client this mailbox entry is for. `true` = headless
+   * (phone/remote), `false` = canvas, `undefined` = unknown (never seen, or a
+   * scope address whose last client we cannot name). The flush declines a live
+   * client that does not match, rather than delivering blind.
+   */
+  private intendedMailboxKind(tabId: string): boolean | undefined {
+    if (!isScopeAddress(tabId)) {
+      if (this.conns.get(tabId)?.headless === true || this.headlessSeen.has(tabId)) return true;
+      if (this.conns.has(tabId) || this.seenTabs.has(tabId)) return false;
+      return undefined;
+    }
+    // Scope address: nobody is named. Prefer a UNIQUE live kind, else the kind
+    // that just left (zero tabs), else unknown — never a guess about who will
+    // hello.
+    let liveHeadless = false;
+    let liveCanvas = false;
+    for (const c of this.conns.values()) {
+      if (c.headless) liveHeadless = true;
+      else liveCanvas = true;
+    }
+    if (liveHeadless && !liveCanvas) return true;
+    if (liveCanvas && !liveHeadless) return false;
+    if (this.conns.size === 0) return this.lastDisconnectedHeadless;
+    return undefined;
+  }
+
+  /** #2013 — the receipt a mailboxed send returns. A concrete tab is a known
+   *  recipient (flushMailbox uses `conns.get(tabId)`). A scope address is not:
+   *  the box sits under the conversation key and used to drain to the first
+   *  matching hello. `queued_for: null` / `recipient_known: false` is how
+   *  "queued for whoever connects next" stops reading as a delivery. */
+  private mailboxReceipt(tabId: string): {
+    ok: true;
+    mailboxed: true;
+    queued_for: string | null;
+    recipient_known: boolean;
+  } {
+    const recipientKnown = !isScopeAddress(tabId);
+    return {
+      ok: true,
+      mailboxed: true,
+      queued_for: recipientKnown ? tabId : null,
+      recipient_known: recipientKnown,
+    };
+  }
+
   private storeMailbox(tabId: string, cmd: BridgeCommand): void {
     const box = this.mailbox.get(tabId) ?? [];
-    box.push({ cmd, ts: Date.now() });
+    const expectHeadless = this.intendedMailboxKind(tabId);
+    box.push(
+      expectHeadless === undefined ? { cmd, ts: Date.now() } : { cmd, ts: Date.now(), expectHeadless },
+    );
     while (box.length > UiBridge.MAILBOX_MAX) box.shift();
     this.mailbox.set(tabId, box);
     logger.info(
-      `[ui-bridge] mailboxed "${cmd.cmd}" for offline tab ${tabId.slice(0, 8)} (${box.length} queued)`,
+      `[ui-bridge] mailboxed "${cmd.cmd}" for offline tab ${tabId.slice(0, 8)} (${box.length} queued` +
+        `${expectHeadless === undefined ? ", recipient unknown" : expectHeadless ? ", for headless" : ", for canvas"})`,
     );
   }
 
@@ -4431,7 +4506,13 @@ export class UiBridge {
 
   /** Deliver any buffered render frames to a tab that just (re)connected, plus a
    *  `mailbox_flush` summary so the client can notify "N renders finished while
-   *  you were away". Expired items (past TTL) are dropped. */
+   *  you were away". Expired items (past TTL) are dropped.
+   *
+   *  #2013 — a box tagged for one kind of client is NOT handed to the other.
+   *  Declined entries stay queued for a matching reconnect rather than
+   *  disappearing into the first hello (the scope-keyed "whoever connects next"
+   *  path). Untagged entries (unknown recipient) still flush, which is the
+   *  original "phone was away, here is your render" behaviour. */
   private flushMailbox(tabId: string, deliverTo?: Conn): void {
     const box = this.mailbox.get(tabId);
     if (!box || box.length === 0) return;
@@ -4440,24 +4521,39 @@ export class UiBridge {
     // itself never owns a conn.
     const conn = deliverTo ?? this.conns.get(tabId);
     if (!conn) return;
-    this.mailbox.delete(tabId);
     const now = Date.now();
-    const fresh = box.filter((m) => now - m.ts <= UiBridge.MAILBOX_TTL_MS);
-    for (const m of fresh) {
+    const kept: typeof box = [];
+    let delivered = 0;
+    let declined = 0;
+    for (const m of box) {
+      if (now - m.ts > UiBridge.MAILBOX_TTL_MS) continue;
+      if (m.expectHeadless !== undefined && conn.headless !== m.expectHeadless) {
+        kept.push(m);
+        declined += 1;
+        continue;
+      }
       try {
         conn.sock.send(JSON.stringify({ rid: randomUUID(), ...m.cmd, mailbox: true }));
+        delivered += 1;
       } catch {
-        // socket raced closed; drop
+        // socket raced closed; drop this one like the pre-#2013 flush
       }
     }
-    if (fresh.length > 0) {
+    if (kept.length > 0) this.mailbox.set(tabId, kept);
+    else this.mailbox.delete(tabId);
+    if (delivered > 0) {
       try {
-        conn.sock.send(JSON.stringify({ type: "mailbox_flush", count: fresh.length }));
+        conn.sock.send(JSON.stringify({ type: "mailbox_flush", count: delivered }));
       } catch {
         /* best-effort */
       }
       logger.info(
-        `[ui-bridge] flushed ${fresh.length} mailboxed frame(s) to reconnected tab ${tabId.slice(0, 8)}`,
+        `[ui-bridge] flushed ${delivered} mailboxed frame(s) to reconnected tab ${tabId.slice(0, 8)}` +
+          (declined > 0 ? ` (${declined} held for a matching client)` : ""),
+      );
+    } else if (declined > 0) {
+      logger.info(
+        `[ui-bridge] held ${declined} mailboxed frame(s) past tab ${tabId.slice(0, 8)} — kind mismatch`,
       );
     }
   }
@@ -4492,7 +4588,7 @@ export class UiBridge {
         // failing, so the agent's "here's your image" isn't lost while the phone is away.
         if (opts.tabId && UiBridge.isMailboxable(cmd)) {
           this.storeMailbox(opts.tabId, cmd);
-          return { ok: true, mailboxed: true };
+          return this.mailboxReceipt(opts.tabId);
         }
         // resolveTarget threw BEFORE any socket write — no tab could be routed to (no
         // connected tab / ambiguous / multiple / not reachable), so nothing was
@@ -4901,7 +4997,7 @@ export class UiBridge {
     if (conn.sock.readyState !== WebSocket.OPEN) {
       if (opts.tabId && UiBridge.isMailboxable(cmd)) {
         this.storeMailbox(opts.tabId, cmd);
-        return Promise.resolve({ ok: true, mailboxed: true });
+        return Promise.resolve(this.mailboxReceipt(opts.tabId));
       }
       // The resolved socket is not OPEN — the command cannot be written, so nothing is
       // dispatched. Typed dispatched:false, same as the resolveTarget refusal above.


### PR DESCRIPTION
Fixes #2013.

Rebased onto `origin/main` after #2039 landed (`panel_show_media` inlines `/view` refs via `resolveClientKind` for a phone reached through a scope address). #2012's helper and #2011's family-mismatch probe stay; this PR only changes the mailbox receipt and flush.

## The fact

`show_media` is the only command that does not fail when it cannot route. Every other command is refused with `dispatched:false`. This one is buffered — `storeMailbox(opts.tabId, cmd)` — and answered `{ok: true, mailboxed: true}`, then replayed on the next hello.

That is the right behaviour for a **concrete tab id**: a finished render survives a phone being away, and `flushMailbox` uses `conns.get(tabId)`, so it goes to that exact tab.

It is the wrong behaviour for a **scope address** (`orchestrator`, `orchestrator::<backend>`). Those boxes flushed to *the first tab that hellos*, gated only by `scopeKeyMatchesHello`. The recipient was not knowable at queue time, and it could be a phone. `"could not route"` silently became `"queued for whoever connects next"`, which read as a delivery because the receipt was `ok: true`.

#2010 already stopped the tool from claiming a mailboxed reply as a presentation. This PR is the mailbox itself.

## What changes

1. **The receipt names the recipient.** A concrete tab returns `queued_for: <tabId>`, `recipient_known: true`. A scope address returns `queued_for: null`, `recipient_known: false`. `panel_show_media` surfaces those fields, and the note says "waiting for tab … to reconnect" vs "whichever client connects next" accordingly. `ok: true` / `mailboxed: true` stay — this is still not a failure, and re-sending still duplicates the queue.

2. **The flush declines a kind mismatch.** Each mailbox entry records the kind of client it was produced for (`true` headless, `false` canvas, omitted when unknown). A phone collecting a canvas-produced box — or a desktop collecting a phone-produced one — does not get it; the box stays queued for a matching reconnect.

3. **Unknown still flushes.** A conversation this process has never seen still delivers to the first hello. That is the original mailbox purpose (PR #182) and is left alone.

Not in this PR, deliberately: no audio refusal (#2010 already chose reply-accounting over a pre-dispatch gate), no change to `isMailboxable`. `resolveClientKind` (#2012) is already on main and is kept.

## Tests

Drive the shipped path: `UiBridge.send` over a real websocket, and `panel_show_media` through `makePanelToolCtx` + a real bridge (a tiny PNG, no ComfyUI).

- scope receipt is `recipient_known: false`
- canvas-produced scope box is held past a phone hello and delivered to the desktop reconnect
- the reverse (phone-produced, desktop hellos first)
- never-seen scope box still flushes to the first hello
- `panel_show_media` on an empty orchestrator-scoped session answers queued-not-delivered, not `shown`
- `#2012` `resolveClientKind` still inlines `/view` refs for a proven headless destination

```
npx vitest run src/__tests__/services/ui-bridge.test.ts src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts src/__tests__/orchestrator/panel-show-media-client-kind.test.ts --maxWorkers=4
# 280 passed
```
