### PR TITLE
fix(2017): a stale panel is refused instead of painting audio as a broken image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
+- **`panel_show_media` refuses a kind a stale panel cannot paint (#2017).** A
+  pre-#710 panel has no audio painter: everything that is not video is drawn
+  with `<img>`, so a `.wav` (as a /view ref today, or as `kind:"audio"` once
+  the allowlist lands) becomes a broken-image card that still reports success.
+  The tool now asserts the panel can render the kind BEFORE dispatch. A hello
+  `show_media_kinds` list is the authority when present; otherwise a parseable
+  advertised version below panel 0.11.43 (the first release that shipped #710)
+  is proof. Missing, inherited, or unparseable versions fail open — same
+  tri-state as the command gate — so a current panel that omitted the field is
+  never told to update. Image and video skip the check. The refusal names the
+  advertised version and the upgrade, and tells the user to hard-refresh; a
+  restart alone leaves cached JS running.
 - **Restart does not report graph tools ready on a transient panel reconnect (#2067).**
   `panel_restart_comfyui` accepted the first fresh original-tab hello as
   `graph_tools_ready:true`. That socket can drop a moment later, so the next

--- a/src/__tests__/orchestrator/panel-show-media-kind-compat.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-kind-compat.test.ts
@@ -1,0 +1,268 @@
+// #2017 — panel_show_media sends a kind a stale panel cannot paint.
+//
+// A pre-#710 panel has no audio branch: everything that is not video is painted
+// with `<img>`. The orchestrator and the panel ship separately, so an updated
+// comfyui-mcp talking to a stale comfyui-mcp-panel is the normal state right
+// after an npm update. Sending `kind:"audio"` (or a /view ref the panel will
+// classify as audio) becomes a broken-image card, and the panel reports it as
+// painted.
+//
+// The current origin/main path that already reaches the panel is the /view-ref
+// branch — `{ filename: "voice.wav" }` is never extension-gated, so this needs
+// none of PR #2002. A pre-#710 panel paints that ref as `<img>` too.
+//
+// The gate is a PROVEN-unable check, not a destination guess:
+//   - hello `show_media_kinds` is the authority when present
+//   - otherwise a parseable advertised version below the #710 floor (0.11.43)
+//   - missing / inherited / unparseable version FAIL-OPEN (same tri-state as
+//     the #392 command gate) so a current panel that omitted the field is
+//     never told to update
+// Image and video skip the check. Nothing is refused on a current panel.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { buildPanelToolDefs, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import {
+  SHOW_MEDIA_KIND_MIN_PANEL_VERSION,
+  paintedShowMediaKind,
+  panelSupportsShowMediaKind,
+  readHelloShowMediaKinds,
+  showMediaItemsPanelCannotPaint,
+  type PanelVersionReading,
+} from "../../services/ui-bridge.js";
+
+type Forwarded = Record<string, unknown>;
+
+function makeCtx(opts: {
+  version?: PanelVersionReading;
+  kinds?: readonly string[];
+} = {}): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    bridge: {
+      isHeadless: () => false,
+      advertisedPanelVersion: () => opts.version ?? {},
+      tabShowMediaKinds: () => opts.kinds,
+    } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(
+  items: Array<Record<string, unknown>>,
+  opts: { version?: PanelVersionReading; kinds?: readonly string[] } = {},
+): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx(opts);
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+const textOf = (res: ToolResult): string => res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+const OLD = { raw: "0.11.41", version: "0.11.41" } satisfies PanelVersionReading;
+const FLOOR = { raw: "0.11.43", version: "0.11.43" } satisfies PanelVersionReading;
+const CURRENT = { raw: "0.15.11", version: "0.15.11" } satisfies PanelVersionReading;
+const WAV = [{ source: { filename: "voice.wav", type: "output" } }];
+const PNG = [{ source: { filename: "plate.png", type: "output" } }];
+const MP4 = [{ source: { filename: "clip.mp4", type: "output" } }];
+
+describe("#2017 the floor is the first release that actually paints audio", () => {
+  it("audio shipped in panel 0.11.43 — after the 0.11.42 release, with #710", () => {
+    // Verified against the panel repo: #710 merged after the 0.11.42 release
+    // commit (b81b10dd) and first shipped in 0.11.43 (a1ac583f). A 0.11.42
+    // floor would allow the published 0.11.42 build, which has no audio painter.
+    expect(SHOW_MEDIA_KIND_MIN_PANEL_VERSION.audio).toBe("0.11.43");
+    expect(SHOW_MEDIA_KIND_MIN_PANEL_VERSION.image).toBeUndefined();
+    expect(SHOW_MEDIA_KIND_MIN_PANEL_VERSION.video).toBeUndefined();
+  });
+});
+
+describe("#2017 panel_show_media refuses audio on a proven-old panel", () => {
+  it("the reporter case — a .wav /view ref is NOT dispatched to panel 0.11.41", async () => {
+    // Kills: deleting the showMediaItemsPanelCannotPaint(...) call site.
+    const { res, calls } = await showMedia(WAV, { version: OLD });
+    expect(res.isError).toBe(true);
+    expect(calls.find((c) => c.cmd === "show_media")).toBeUndefined();
+    const text = textOf(res);
+    expect(text).toMatch(/cannot paint "audio"/);
+    expect(text).toContain("0.11.41");
+    expect(text).toContain("0.11.43");
+    expect(text).toContain("voice.wav");
+    expect(text).toMatch(/HARD-REFRESH/);
+    expect(text).toMatch(/broken-image/);
+  });
+
+  it("names the upgrade, not just the age", async () => {
+    const text = textOf((await showMedia(WAV, { version: OLD })).res);
+    expect(text).toMatch(/install_comfyui\(action:'panel', panel_action:'update'\)|update the ComfyUI-MCP panel via ComfyUI Manager/);
+    expect(text).toMatch(/≥0\.11\.43/);
+  });
+
+  it("at the #710 floor the same .wav IS dispatched", async () => {
+    const { res, calls } = await showMedia(WAV, { version: FLOOR });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+    expect(textOf(res)).not.toMatch(/cannot paint/);
+  });
+
+  it("a current panel is not gated", async () => {
+    const { res, calls } = await showMedia(WAV, { version: CURRENT });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+});
+
+describe("#2017 image and video stay on the hot path — even on an old panel", () => {
+  it("an image /view ref is dispatched to 0.11.41", async () => {
+    const { res, calls } = await showMedia(PNG, { version: OLD });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+
+  it("a video /view ref is dispatched to 0.11.41", async () => {
+    const { res, calls } = await showMedia(MP4, { version: OLD });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+});
+
+describe("#2017 unproven age is not a refusal — fail open", () => {
+  it("no advertised version still dispatches the .wav (the #2010 path)", async () => {
+    // Kills: treating a missing version as too old. #2010's handler tests mock
+    // no advertisedPanelVersion at all; this gate must not start refusing them.
+    const { res, calls } = await showMedia(WAV, { version: {} });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+
+  it("an INHERITED version is not treated as this tab's age", async () => {
+    const { res, calls } = await showMedia(WAV, {
+      version: { inherited: "0.11.41" },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+
+  it("an unparseable advertised version (nightly) is not called too old", async () => {
+    const { res, calls } = await showMedia(WAV, { version: { raw: "nightly" } });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+});
+
+describe("#2017 a hello capability list is the authority", () => {
+  it("a current panel that did NOT list audio still refuses the .wav", async () => {
+    // Kills: ignoring show_media_kinds and trusting version alone. A capability
+    // list does not need a version table — that is the point of advertising one.
+    const { res, calls } = await showMedia(WAV, {
+      version: CURRENT,
+      kinds: ["image", "video"],
+    });
+    expect(res.isError).toBe(true);
+    expect(calls.find((c) => c.cmd === "show_media")).toBeUndefined();
+    expect(textOf(res)).toMatch(/advertised the kinds it can paint/);
+    expect(textOf(res)).toContain("voice.wav");
+  });
+
+  it("an old panel that DID list audio is allowed — the hello outranks the floor", async () => {
+    const { res, calls } = await showMedia(WAV, {
+      version: OLD,
+      kinds: ["image", "video", "audio"],
+    });
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.cmd === "show_media")).toBeTruthy();
+  });
+});
+
+describe("#2017 a mixed batch is refused as a whole — nothing is dispatched", () => {
+  it("png + wav on 0.11.41 sends neither", async () => {
+    const { res, calls } = await showMedia(
+      [
+        { source: { filename: "plate.png", type: "output" } },
+        { source: { filename: "voice.wav", type: "output" } },
+      ],
+      { version: OLD },
+    );
+    expect(res.isError).toBe(true);
+    expect(calls.find((c) => c.cmd === "show_media")).toBeUndefined();
+    expect(textOf(res)).toContain("voice.wav");
+    expect(textOf(res)).not.toMatch(/plate\.png \(audio\)/);
+  });
+});
+
+// -- decision function: cases the handler cannot yet produce on origin/main --
+// Explicit `kind:"audio"` is PR #2002's allowlist. The gate has to be ready for
+// it without stealing that issue; these drive the same function the handler
+// calls, with the item shape the allowlist will dispatch.
+describe("#2017 explicit kind:\"audio\" is refused on a proven-old panel", () => {
+  const AUDIO_ITEM = {
+    kind: "audio",
+    dataUrl: "data:audio/wav;base64,AA==",
+    filename: "voice.wav",
+  };
+
+  it("paintedShowMediaKind trusts the orchestrator's own kind first", () => {
+    expect(paintedShowMediaKind(AUDIO_ITEM)).toBe("audio");
+    expect(paintedShowMediaKind({ kind: "viewRef", viewRef: { filename: "voice.wav" } })).toBe(
+      "audio",
+    );
+    expect(paintedShowMediaKind({ kind: "image", filename: "x.wav" })).toBe("image");
+  });
+
+  it("panelSupportsShowMediaKind refuses audio below 0.11.43 and allows at/above", () => {
+    expect(panelSupportsShowMediaKind("audio", { reading: OLD }).supported).toBe(false);
+    expect(panelSupportsShowMediaKind("audio", { reading: FLOOR }).supported).toBe(true);
+    expect(panelSupportsShowMediaKind("image", { reading: OLD }).supported).toBe(true);
+    expect(panelSupportsShowMediaKind("video", { reading: OLD }).supported).toBe(true);
+  });
+
+  it("showMediaItemsPanelCannotPaint names the audio item and no other", () => {
+    const blocked = showMediaItemsPanelCannotPaint(
+      [AUDIO_ITEM, { kind: "image", filename: "plate.png" }],
+      { reading: OLD },
+    );
+    expect(blocked).toEqual([
+      expect.objectContaining({ filename: "voice.wav", kind: "audio", reason: "too_old", needed: "0.11.43" }),
+    ]);
+  });
+});
+
+describe("#2017 readHelloShowMediaKinds screens garbage as omitted", () => {
+  it("a well-formed list is kept, order-preserving and de-duplicated", () => {
+    expect(readHelloShowMediaKinds(["image", "video", "audio", "image"])).toEqual([
+      "image",
+      "video",
+      "audio",
+    ]);
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["not an array", "audio"],
+    ["empty", []],
+    ["a blank entry", ["image", "  "]],
+    ["a non-string entry", ["image", 1]],
+  ])("%s is undefined — fall back to the version floor", (_label, raw) => {
+    expect(readHelloShowMediaKinds(raw)).toBeUndefined();
+  });
+});
+
+describe("#2017 the hello handler INSTALLS the capability list", () => {
+  it("wires showMediaKinds from readHelloShowMediaKinds, never inherits", () => {
+    // Kills: deleting the Conn field assignment. A helper-level suite survives
+    // that one-line wiring mutation; this does not.
+    const src = readFileSync(new URL("../../services/ui-bridge.ts", import.meta.url), "utf8");
+    expect(src).toMatch(/showMediaKinds:\s*readHelloShowMediaKinds\s*\(/);
+    expect(src).toMatch(/show_media_kinds/);
+    expect(src).toMatch(/tabShowMediaKinds\s*\(/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -66,12 +66,14 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { UiBridge, PanelVersionReading } from "../services/ui-bridge.js";
+import type { UiBridge, PanelVersionReading, UnsupportedShowMediaItem } from "../services/ui-bridge.js";
 import {
   requiredPanelVersion,
   SEMVER_RE,
   LATE_ASK_TTL_MS,
   tabIncarnationSlot,
+  SHOW_MEDIA_KIND_MIN_PANEL_VERSION,
+  showMediaItemsPanelCannotPaint,
 } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
@@ -4706,6 +4708,61 @@ function tabAdvertisedPanelVersion(ctx: PanelToolCtx): string | undefined {
   }
   const v = reading?.version;
   return typeof v === "string" && SEMVER_RE.test(v.trim()) ? v.trim() : undefined;
+}
+
+function tabPanelVersionReading(ctx: PanelToolCtx): PanelVersionReading {
+  const fn = ctx.bridge.advertisedPanelVersion;
+  if (typeof fn !== "function") return {};
+  try {
+    return fn.call(ctx.bridge, ctx.tabId) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function tabAdvertisedShowMediaKinds(ctx: PanelToolCtx): readonly string[] | undefined {
+  const fn = ctx.bridge.tabShowMediaKinds;
+  if (typeof fn !== "function") return undefined;
+  try {
+    return fn.call(ctx.bridge, ctx.tabId);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * #2017 — refuse a kind this panel is proven unable to paint, rather than send
+ * an item that becomes a broken-image card and reports success.
+ *
+ * Names the advertised version (when we have one) and the upgrade; a restart
+ * alone leaves cached JS running, so the hard-refresh is part of the remedy.
+ */
+function formatShowMediaKindUnsupported(blocked: readonly UnsupportedShowMediaItem[]): string {
+  const kinds = [...new Set(blocked.map((b) => b.kind))];
+  const kindList = kinds.map((k) => `"${k}"`).join(", ");
+  const needed =
+    blocked.find((b) => b.needed)?.needed ??
+    kinds.map((k) => SHOW_MEDIA_KIND_MIN_PANEL_VERSION[k]).find((v) => typeof v === "string");
+  const version = blocked.find((b) => b.version)?.version;
+  const items = blocked.map((b) => `  - ${b.filename} (${b.kind})`).join("\n");
+  const update = describeInstallPanelAction(
+    "update",
+    "update the ComfyUI-MCP panel via ComfyUI Manager",
+  );
+  const floor = needed ? ` to ≥${needed}` : " to a build that can paint it";
+  const detected = version ? ` This tab announced panel ${version}.` : "";
+  const why = blocked.some((b) => b.reason === "not_in_hello")
+    ? `The panel advertised the kinds it can paint and ${kindList} ${kinds.length === 1 ? "is" : "are"} not among them.`
+    : `kind ${kindList} ${kinds.length === 1 ? "is" : "are"} only understood by panels from #710 onward` +
+      (needed ? ` (first shipped in ${needed})` : "") +
+      ".";
+  return (
+    `This panel cannot paint ${kindList}.${detected} ${why} ` +
+    `Sending ${blocked.length === 1 ? "it" : "them"} would show a broken-image card and report success.\n` +
+    `Items not sent:\n${items}\n` +
+    `${update}${floor}, then HARD-REFRESH the browser tab (Ctrl+Shift+R, or Cmd+Shift+R on macOS); ` +
+    `a restart alone leaves the tab running cached old JS.`
+  );
 }
 
 /**
@@ -19516,6 +19573,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               });
             }
           }
+        }
+
+        // #2017 — do not send a painter kind this panel is proven unable to
+        // render. A pre-#710 panel paints `audio` as `<img>` and reports
+        // success; refusing with the version and the upgrade is strictly better
+        // than a broken-image card. Fail-OPEN when the version is unknown or
+        // inherited (same tri-state as the #392 command gate) so a current
+        // panel that omitted the field is never told to update. Image/video
+        // skip the check entirely.
+        const blocked = showMediaItemsPanelCannotPaint(resolved, {
+          reading: tabPanelVersionReading(ctx),
+          advertisedKinds: tabAdvertisedShowMediaKinds(ctx),
+        });
+        if (blocked.length > 0) {
+          return fail(formatShowMediaKindUnsupported(blocked));
         }
 
         // #2010 — the reply below is the CLIENT's, and one of the two clients

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -219,6 +219,14 @@ interface Conn {
    *  updated — a wall of text traded for nothing at all, which is the worse failure. When
    *  this is false the caller falls back to a visible `say`. */
   acceptsAgentNotes: boolean;
+  /**
+   * Painter kinds THIS hello advertised the panel can render (`show_media_kinds`
+   * array). Re-read per hello, never inherited — a reconnect may be a different
+   * build. Undefined when the hello omitted the field (every panel today) or
+   * sent a malformed value; callers then fall back to the version floor in
+   * {@link SHOW_MEDIA_KIND_MIN_PANEL_VERSION} (#2017).
+   */
+  showMediaKinds?: readonly string[];
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
    *  here, every later call is gated proactively — rejected before it ever
@@ -344,6 +352,28 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   enforces_workflow_stamp_at_write: "0.11.35",
 };
 
+/**
+ * The panel version each `show_media` *painter kind* was actually introduced in.
+ *
+ * Separate from {@link BRIDGE_CAPABILITY_MIN_PANEL_VERSION} on purpose: that
+ * table feeds the aggregate sync floor, and a media-kind floor must not move
+ * "is the install current?" just because we learned a new painter. `show_media`
+ * itself predates every entry here — old panels accept the command; they just
+ * paint an unknown kind as `<img>` and report success (#2017 / panel #710).
+ *
+ * Fallback only. A hello that carries `show_media_kinds` is the authority and
+ * does not consult this table (a capability list does not need a version
+ * lookup). Image and video have no entry: every panel that answers show_media
+ * has always painted those.
+ */
+export const SHOW_MEDIA_KIND_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
+  // panel #710 — `paintAudio` + `unrenderable` accounting. Merged AFTER the
+  // 0.11.42 release commit (panel `b81b10dd`) and first shipped in 0.11.43
+  // (panel `a1ac583f`). A 0.11.42 floor would allow the published 0.11.42
+  // build, which does not have the painter.
+  audio: "0.11.43",
+};
+
 /** The minimum panel version that supports `cmd`. For a command WITH an
  *  authoritative BRIDGE_CMD_MIN_PANEL_VERSION entry this is its true introduction
  *  version; for anything else it is the 0.11.4 full-set baseline FLOOR — a lower
@@ -456,6 +486,189 @@ export function connPanelVersionReading(conn: {
   if (conn.panelVersionAdvertised) return readPanelVersion(conn.panelVersion);
   const carried = typeof conn.panelVersion === "string" ? conn.panelVersion.trim() : "";
   return carried ? { inherited: carried } : {};
+}
+
+/**
+ * Screen a hello `show_media_kinds` value into a list of painter kinds.
+ *
+ * Absent, non-array, empty, or any non-string/blank element → `undefined`
+ * (treat as omitted). A garbage field must not look like a claim that the
+ * panel can paint nothing, which would refuse image/video on a typo.
+ */
+export function readHelloShowMediaKinds(raw: unknown): readonly string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const kinds: string[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (typeof item !== "string") return undefined;
+    const kind = item.trim();
+    if (!kind) return undefined;
+    if (!seen.has(kind)) {
+      seen.add(kind);
+      kinds.push(kind);
+    }
+  }
+  return kinds.length > 0 ? kinds : undefined;
+}
+
+/** Why a panel cannot paint a `show_media` kind, when we can prove it. */
+export type ShowMediaKindUnsupportedReason = "too_old" | "not_in_hello";
+
+export type ShowMediaKindSupport =
+  | { supported: true }
+  | {
+      supported: false;
+      kind: string;
+      reason: ShowMediaKindUnsupportedReason;
+      version?: string;
+      needed?: string;
+    };
+
+/**
+ * The kind the panel will pick a painter for — the field `classifyShowMediaItem`
+ * on the panel (panel #710) consults, in the same order:
+ *
+ *   1. an explicit orchestrator `kind` of image/video/audio
+ *   2. a /view ref's filename extension (the path audio takes on origin/main)
+ *   3. a data URL's declared MIME
+ *
+ * Image and video are universal (every show_media panel paints them). Audio is
+ * the kind a pre-#710 panel paints as `<img>` and counts as success (#2017).
+ * Anything else is returned as-is so a future kind can grow a floor without
+ * this function having to learn it.
+ */
+export function paintedShowMediaKind(item: Record<string, unknown>): string {
+  const kind = typeof item.kind === "string" ? item.kind : "";
+  if (kind === "image" || kind === "video" || kind === "audio") return kind;
+
+  let name = "";
+  if (kind === "viewRef" && item.viewRef && typeof item.viewRef === "object") {
+    const filename = (item.viewRef as { filename?: unknown }).filename;
+    if (typeof filename === "string") name = filename;
+  }
+  if (!name && typeof item.filename === "string") name = item.filename;
+  const ext = showMediaFilenameExt(name);
+  if (SHOW_MEDIA_AUDIO_PAINT_EXTS.has(ext)) return "audio";
+  if (SHOW_MEDIA_VIDEO_PAINT_EXTS.has(ext)) return "video";
+  if (SHOW_MEDIA_IMAGE_PAINT_EXTS.has(ext)) return "image";
+
+  if (typeof item.dataUrl === "string") {
+    const m = /^data:(image|video|audio)\//i.exec(item.dataUrl);
+    if (m) return m[1]!.toLowerCase();
+  }
+  return kind || "unknown";
+}
+
+/** Panel `AUDIO_EXTENSIONS` (`web/js/lib/media-preview.js`) — what `<audio>` paints. */
+const SHOW_MEDIA_AUDIO_PAINT_EXTS = new Set([
+  ".wav",
+  ".mp3",
+  ".flac",
+  ".ogg",
+  ".oga",
+  ".opus",
+  ".m4a",
+  ".aac",
+]);
+const SHOW_MEDIA_VIDEO_PAINT_EXTS = new Set([".mp4", ".webm", ".mov", ".mkv", ".m4v", ".avi"]);
+const SHOW_MEDIA_IMAGE_PAINT_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+
+function showMediaFilenameExt(filename: string): string {
+  const stem = filename.split("#")[0]!.split("?")[0]!;
+  const m = /\.([A-Za-z0-9]+)$/.exec(stem);
+  return m ? `.${m[1]!.toLowerCase()}` : "";
+}
+
+function showMediaItemFilename(item: Record<string, unknown>): string {
+  if (typeof item.filename === "string" && item.filename.trim()) return item.filename;
+  if (item.viewRef && typeof item.viewRef === "object") {
+    const filename = (item.viewRef as { filename?: unknown }).filename;
+    if (typeof filename === "string" && filename.trim()) return filename;
+  }
+  return "(unnamed)";
+}
+
+/**
+ * Can this panel paint `kind`?
+ *
+ * Fail-OPEN when we cannot prove it cannot: missing/unparseable/inherited
+ * version, and no hello list, are not evidence of an old panel — telling
+ * someone to update a current one is the wrong remedy (same tri-state as
+ * {@link panelVersionProvesUnsupported}).
+ *
+ * Image and video are always supported. An advertised `show_media_kinds` list
+ * is the authority for every other kind (a capability does not need a version
+ * table). Without a list, only a parseable advertised version below a tabled
+ * floor is proof.
+ */
+export function panelSupportsShowMediaKind(
+  kind: string,
+  opts: {
+    reading: PanelVersionReading;
+    advertisedKinds?: readonly string[];
+  },
+): ShowMediaKindSupport {
+  if (kind === "image" || kind === "video") return { supported: true };
+  // A source kind / unclassified item is not a painter the old panel lacks.
+  if (kind === "viewRef" || kind === "unknown" || kind === "") return { supported: true };
+
+  const advertised = opts.advertisedKinds;
+  if (advertised && advertised.length > 0) {
+    if (advertised.includes(kind)) return { supported: true };
+    return {
+      supported: false,
+      kind,
+      reason: "not_in_hello",
+      version: opts.reading.version,
+      needed: SHOW_MEDIA_KIND_MIN_PANEL_VERSION[kind],
+    };
+  }
+
+  const needed = SHOW_MEDIA_KIND_MIN_PANEL_VERSION[kind];
+  if (!needed) return { supported: true };
+  const version = opts.reading.version;
+  if (!version || !SEMVER_RE.test(version.trim())) return { supported: true };
+  if (compareSemver(version, needed) < 0) {
+    return { supported: false, kind, reason: "too_old", version, needed };
+  }
+  return { supported: true };
+}
+
+export type UnsupportedShowMediaItem = {
+  filename: string;
+  kind: string;
+  reason: ShowMediaKindUnsupportedReason;
+  version?: string;
+  needed?: string;
+};
+
+/**
+ * Items of a `show_media` batch this panel is proven unable to paint.
+ *
+ * Empty for the common case (current panel, image/video only, or unproven
+ * version) — the hot path is a kind scan and no version compare.
+ */
+export function showMediaItemsPanelCannotPaint(
+  items: readonly Record<string, unknown>[],
+  opts: {
+    reading: PanelVersionReading;
+    advertisedKinds?: readonly string[];
+  },
+): UnsupportedShowMediaItem[] {
+  const blocked: UnsupportedShowMediaItem[] = [];
+  for (const item of items) {
+    const kind = paintedShowMediaKind(item);
+    const verdict = panelSupportsShowMediaKind(kind, opts);
+    if (verdict.supported) continue;
+    blocked.push({
+      filename: showMediaItemFilename(item),
+      kind: verdict.kind,
+      reason: verdict.reason,
+      version: verdict.version,
+      needed: verdict.needed,
+    });
+  }
+  return blocked;
 }
 
 /**
@@ -2703,6 +2916,12 @@ export class UiBridge {
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
+          // #2017 — painter kinds THIS hello claimed. Never inherited: an omitted
+          // list on a reconnect must fall back to the version floor, not to a
+          // previous connection's claim.
+          showMediaKinds: readHelloShowMediaKinds(
+            (msg as { show_media_kinds?: unknown }).show_media_kinds,
+          ),
           // Fresh per hello — see the field's doc comment (#236).
           unsupportedCmds: new Set<string>(),
           // INHERITED across a reconnect (the panel code did not get older) so a command
@@ -3259,6 +3478,19 @@ export class UiBridge {
       return connPanelVersionReading(this.resolveTarget(tabId));
     } catch {
       return {};
+    }
+  }
+
+  /**
+   * Painter kinds THIS connection advertised in its own hello (`show_media_kinds`).
+   * Undefined when the hello omitted the field or the tab cannot be resolved —
+   * callers then fall back to {@link SHOW_MEDIA_KIND_MIN_PANEL_VERSION} (#2017).
+   */
+  tabShowMediaKinds(tabId: string): readonly string[] | undefined {
+    try {
+      return this.resolveTarget(tabId).showMediaKinds;
+    } catch {
+      return undefined;
     }
   }
 


### PR DESCRIPTION
Fixes #2017

## The defect

`panel_show_media` dispatches items with a painter `kind`, and the panel picks `<img>` / `<video>` / `<audio>` from it. `kind:"audio"` (and a `/view` ref the panel will classify as audio) is only understood from panel **#710** / **0.11.43** onward. A pre-#710 panel has no audio branch: everything that is not video is painted with `<img>`, so the take becomes a broken-image card that still reports success.

The orchestrator and the panel ship separately — an updated `comfyui-mcp` talking to a stale `comfyui-mcp-panel` is the normal state right after an npm update.

## What the user now observes

On a panel whose hello proves it cannot paint the kind, `panel_show_media` **refuses** before dispatch. The refusal names the advertised panel version, the #710 floor (0.11.43), and the upgrade + hard-refresh. Nothing is sent, so nothing paints as a broken image and nothing reports success.

Image and video are unchanged. A missing, inherited, or unparseable version still fail-opens (same tri-state as the #392 command gate) so a current panel that omitted the field is never told to update.

## The gate

- A hello `show_media_kinds` list is the authority when present (future-proof; no version table needed).
- Otherwise a parseable advertised version below 0.11.43 is proof. That is the first **release** that contains panel #710 — the merge landed after the 0.11.42 release commit.
- The current origin/main path this already fires on is the `/view` ref branch (`{ filename: "voice.wav" }`), which was never extension-gated. Explicit `kind:"audio"` is covered by the same function so PR #2002 does not reintroduce the skew.

Deliberately not stolen: the audio allowlist (#2002 / panel#1572), the post-reply claim correction (#2010), address-vs-destination (#2012), or the mailbox (#2013).
