### PR TITLE
release: v0.52.48 — bridge 9199, tunnel bound host, subgraph widget scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.48] - 2026-08-21
+
 ### Fixed
 
 - **Bridge port 9180 collides with Logitech G HUB — default is now 9199 (#2030).**
@@ -23,6 +25,14 @@ All notable changes to this project are documented here. This project adheres to
   moved. 9180-era pairing on 9182 still answers. The orchestrator advertises
   `ws://127.0.0.1:<bound-port>` on `advertise_bridge` so the panel can follow
   (companion: [comfyui-mcp-panel#1596](https://github.com/artokun/comfyui-mcp-panel/issues/1596)).
+
+### MCP
+
+#### Fixed
+- target tunnels at the bound host (#2023) (#2036)
+- recover subgraph widget write scope (#2037)
+- default the panel bridge to 9199 and never kill a foreign holder (#2034)
+
 
 ## [0.52.47] - 2026-08-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.47",
+  "version": "0.52.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.47",
+      "version": "0.52.48",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.47",
+  "version": "0.52.48",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.48** from `main` (after v0.52.47).

Carries:

- #2034 / #2030 — default the panel bridge to 9199 and never kill a foreign holder (Logitech G HUB)
- #2037 / #2015 — recover subgraph widget write scope
- #2036 / #2023 — target tunnels at the bound host

Held out: #2028/#2007 conflicts; #2029/#2006 CI red; #1985/#1968 macos red; show_media PRs #2038–2042 conflicting; hygiene/docs.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.48` tag on the version commit).