### PR TITLE
release: v0.52.49 — fast render completion fence, opaque graph audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.49] - 2026-08-21
+
+### MCP
+
+#### Fixed
+- refresh retry completion fence
+- retain and fence fast completion arms
+- retain fast render completions before ticketing
+- keep audit completion on rebound route
+- require workflow identity for completion
+- refuse opaque root graph completion
+
+
 ## [0.52.48] - 2026-08-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.48",
+  "version": "0.52.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.48",
+      "version": "0.52.49",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.48",
+  "version": "0.52.49",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.49** from \main\ (after v0.52.48).

Carries:

- #2035 / #2021 — retain and fence fast render completions before ticketing
- #2033 / #1973 — refuse opaque root graph completion; keep audit completion on rebound route

Held out: #2028/#2007 conflicts; #2029/#2006 CI red; #1985/#1968 macos red; show_media PRs #2038–2042 conflicting; hygiene/docs.

Do **not** squash-merge. Merge-commit (keeps the \0.52.49\ tag on the version commit).