### PR TITLE
release: v0.52.50 — code-mode survives a stale WinGet Node path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.50] - 2026-08-21
+
+### MCP
+
+#### Fixed
+- first code-mode call survives a stale WinGet Node host path (#2046)
+
+
 ## [0.52.49] - 2026-08-21
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.49",
+  "version": "0.52.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.49",
+      "version": "0.52.50",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.49",
+  "version": "0.52.50",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.50** from `main` (after v0.52.49).

Carries:

- #2046 / #2045 — first code-mode call survives a stale WinGet Node host path and file lock

Held out: #2028/#2007 conflicts; #2029/#2006 CI red; #1985/#1968 macos red; show_media PRs #2038–2042 conflicting; hygiene/docs.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.50` tag on the version commit).