### PR TITLE
fix(2050): clear_vram reports VRAM after CUDA release settles

### DIFF
--- a/src/__tests__/tools/clear-vram-stale-report.test.ts
+++ b/src/__tests__/tools/clear-vram-stale-report.test.ts
@@ -206,4 +206,17 @@ describe("clear_vram post-unload VRAM (#2050)", () => {
     expect(textOf(res)).toContain("VRAM cleared successfully (models unloaded, memory freed).");
     expect(textOf(res)).not.toContain("Current VRAM:");
   });
+
+  it("omits a stale first sample when a later stats read fails", async () => {
+    mocks.comfyApiFetch.mockResolvedValue(freeOk());
+    mocks.getSystemStats
+      .mockResolvedValueOnce(STALE)
+      .mockRejectedValue(new Error("ETIMEDOUT"));
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(textOf(res)).toContain("VRAM cleared successfully (models unloaded, memory freed).");
+    expect(textOf(res)).not.toContain("Current VRAM:");
+    expect(textOf(res)).not.toContain(STALE_LINE);
+  });
 });

--- a/src/__tests__/tools/clear-vram-stale-report.test.ts
+++ b/src/__tests__/tools/clear-vram-stale-report.test.ts
@@ -1,0 +1,209 @@
+// #2050 — clear_vram printed the /system_stats sample taken immediately after
+// POST /free, while CUDA was still releasing. The reporter's MiniMax H3 unload
+// showed `Current VRAM: 1205/24564 MB free`; a follow-up
+// get_system_stats (action:"stats") had vram_free: 23985913856.
+//
+// These tests drive the registered `clear_vram` handler. The mock /system_stats
+// answers as a lagging CUDA driver would: stale bytes until release completes,
+// then the follow-up counters. The handler must print the settled reading.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const mocks = vi.hoisted(() => ({
+  comfyApiFetch: vi.fn(),
+  getSystemStats: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  comfyApiFetch: (...args: unknown[]) => mocks.comfyApiFetch(...args),
+  getSystemStats: (...args: unknown[]) => mocks.getSystemStats(...args),
+}));
+
+import {
+  CLEAR_VRAM_SETTLE_INTERVAL_MS,
+  CLEAR_VRAM_SETTLE_MIN_MS,
+  CLEAR_VRAM_SETTLE_TIMEOUT_MS,
+  registerMemoryManagementTools,
+} from "../../tools/memory-management.js";
+import type { SystemStats } from "../../comfyui/types.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+interface Registered {
+  name: string;
+  shape: z.ZodRawShape;
+  handler: Handler;
+}
+
+function registered(): Registered[] {
+  const tools: Registered[] = [];
+  const server = {
+    tool: (name: string, _desc: string, shape: z.ZodRawShape, handler: Handler) => {
+      tools.push({ name, shape, handler });
+    },
+  };
+  registerMemoryManagementTools(server as never);
+  return tools;
+}
+
+function handler(): Handler {
+  const tools = registered();
+  expect(tools).toHaveLength(1);
+  expect(tools[0]!.name).toBe("clear_vram");
+  return tools[0]!.handler;
+}
+
+function call(args: Record<string, unknown>) {
+  const [{ shape }] = registered();
+  return handler()(z.object(shape).parse(args) as Record<string, unknown>);
+}
+
+const textOf = (res: Awaited<ReturnType<Handler>>) =>
+  res.content.map((c) => c.text).join(" ");
+
+/** Reporter's exact follow-up /system_stats bytes. */
+const SETTLED_FREE = 23_985_913_856;
+const TOTAL = 25_756_696_576;
+/** The 1205 MB free that clear_vram printed immediately after /free. */
+const STALE_FREE = 1205 * 1024 * 1024;
+const TORCH_FREE = 40 * 1024 * 1024;
+const TORCH_TOTAL = 64 * 1024 * 1024;
+
+function gpuStats(vramFree: number): SystemStats {
+  return {
+    system: {
+      os: "win32",
+      python_version: "3.12",
+      embedded_python: false,
+    },
+    devices: [
+      {
+        name: "cuda:0",
+        type: "cuda",
+        index: 0,
+        vram_total: TOTAL,
+        vram_free: vramFree,
+        torch_vram_total: TORCH_TOTAL,
+        torch_vram_free: TORCH_FREE,
+      },
+    ],
+  };
+}
+
+const STALE = gpuStats(STALE_FREE);
+const SETTLED = gpuStats(SETTLED_FREE);
+
+function mb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(0);
+}
+
+const STALE_LINE = `Current VRAM: ${mb(STALE_FREE)}/${mb(TOTAL)} MB free`;
+const SETTLED_LINE = `Current VRAM: ${mb(SETTLED_FREE)}/${mb(TOTAL)} MB free`;
+
+function freeOk(): Response {
+  return new Response(null, { status: 200 });
+}
+
+async function runClear(args: Record<string, unknown>) {
+  const pending = call(args);
+  await vi.advanceTimersByTimeAsync(
+    CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS,
+  );
+  return await pending;
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-21T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("clear_vram post-unload VRAM (#2050)", () => {
+  it("prints the settled follow-up VRAM, not the immediate 1205 MB sample", async () => {
+    // CUDA still reports the pre-release occupancy until 600ms after /free —
+    // inside the old single-read window, inside two 250ms polls, but before
+    // CLEAR_VRAM_SETTLE_MIN_MS. Without the min wait, two equal stale reads
+    // would print 1205 MB and return.
+    const freeAt = Date.now();
+    mocks.comfyApiFetch.mockResolvedValue(freeOk());
+    mocks.getSystemStats.mockImplementation(async () =>
+      Date.now() - freeAt < 600 ? STALE : SETTLED,
+    );
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(mocks.comfyApiFetch).toHaveBeenCalledWith(
+      "/free",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ unload_models: true, free_memory: true }),
+      }),
+    );
+    expect(textOf(res)).toContain("VRAM cleared successfully (models unloaded, memory freed).");
+    expect(textOf(res)).not.toContain(STALE_LINE);
+    expect(textOf(res)).toContain(SETTLED_LINE);
+    expect(mocks.getSystemStats.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("keeps polling while VRAM is still climbing past the min wait", async () => {
+    const freeAt = Date.now();
+    mocks.comfyApiFetch.mockResolvedValue(freeOk());
+    mocks.getSystemStats.mockImplementation(async () => {
+      const elapsed = Date.now() - freeAt;
+      // Still climbing at CLEAR_VRAM_SETTLE_MIN_MS; plateaus after 1.5s.
+      if (elapsed >= 1_500) return SETTLED;
+      const t = elapsed / 1_500;
+      return gpuStats(STALE_FREE + (SETTLED_FREE - STALE_FREE) * t);
+    });
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(textOf(res)).not.toContain(STALE_LINE);
+    expect(textOf(res)).toContain(SETTLED_LINE);
+  });
+
+  it("still reports an already-stable reading after the min wait", async () => {
+    const sampledAt: number[] = [];
+    mocks.comfyApiFetch.mockResolvedValue(freeOk());
+    mocks.getSystemStats.mockImplementation(async () => {
+      sampledAt.push(Date.now());
+      return SETTLED;
+    });
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(textOf(res)).toContain(SETTLED_LINE);
+    expect(sampledAt.length).toBeGreaterThan(1);
+    expect(sampledAt.at(-1)! - sampledAt[0]!).toBeGreaterThanOrEqual(CLEAR_VRAM_SETTLE_MIN_MS);
+  });
+
+  it("does not poll /system_stats when /free fails", async () => {
+    mocks.comfyApiFetch.mockResolvedValue(
+      new Response("OOM in unload", { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(mocks.getSystemStats).not.toHaveBeenCalled();
+    expect(textOf(res)).toMatch(/Failed to free VRAM/);
+    expect(textOf(res)).not.toContain("Current VRAM:");
+  });
+
+  it("still reports success when /system_stats never answers", async () => {
+    mocks.comfyApiFetch.mockResolvedValue(freeOk());
+    mocks.getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await runClear({ unload_models: true, free_memory: true });
+
+    expect(textOf(res)).toContain("VRAM cleared successfully (models unloaded, memory freed).");
+    expect(textOf(res)).not.toContain("Current VRAM:");
+  });
+});

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -52,7 +52,10 @@ async function readSettledSystemStats(): Promise<SystemStats | null> {
     try {
       current = await getSystemStats();
     } catch {
-      return last;
+      // A prior sample is not a valid substitute for the current one: /free may
+      // have released memory between the two reads, so returning `last` would
+      // print a known-stale VRAM figure as if it were current.
+      return null;
     }
 
     const sig = vramSignature(current);

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -2,9 +2,78 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
+import type { SystemStats } from "../comfyui/types.js";
 import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
 import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { logger } from "../utils/logger.js";
+
+/** Poll interval between /system_stats reads after /free (#2050). */
+export const CLEAR_VRAM_SETTLE_INTERVAL_MS = 250;
+/** Do not treat an unchanged first reading as settled — CUDA may not have started releasing yet. */
+export const CLEAR_VRAM_SETTLE_MIN_MS = 1_000;
+/** Hard cap so a card that never plateaus still returns a number. */
+export const CLEAR_VRAM_SETTLE_TIMEOUT_MS = 5_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** The counters `clear_vram` prints — device 0's VRAM + torch pool. */
+function vramSignature(stats: SystemStats): string {
+  const gpu = stats.devices?.[0];
+  if (!gpu) return "";
+  return `${gpu.vram_free}:${gpu.torch_vram_free}`;
+}
+
+function formatVramStats(stats: SystemStats): string {
+  const gpu = stats.devices?.[0];
+  if (!gpu) return "";
+  const vramFreeMB = (gpu.vram_free / 1024 / 1024).toFixed(0);
+  const vramTotalMB = (gpu.vram_total / 1024 / 1024).toFixed(0);
+  const torchFreeMB = (gpu.torch_vram_free / 1024 / 1024).toFixed(0);
+  const torchTotalMB = (gpu.torch_vram_total / 1024 / 1024).toFixed(0);
+  return `\n\nCurrent VRAM: ${vramFreeMB}/${vramTotalMB} MB free | Torch: ${torchFreeMB}/${torchTotalMB} MB free`;
+}
+
+/**
+ * /free answers when ComfyUI drops model refs; CUDA/driver release can lag.
+ * Poll until the displayed counters stop changing (or we hit the cap) so the
+ * printed value matches a follow-up get_system_stats (action:"stats") (#2050).
+ */
+async function readSettledSystemStats(): Promise<SystemStats | null> {
+  const started = Date.now();
+  const deadline = started + CLEAR_VRAM_SETTLE_TIMEOUT_MS;
+  let last: SystemStats | null = null;
+  let lastSig: string | null = null;
+  let sawChange = false;
+
+  for (;;) {
+    let current: SystemStats;
+    try {
+      current = await getSystemStats();
+    } catch {
+      return last;
+    }
+
+    const sig = vramSignature(current);
+    const elapsed = Date.now() - started;
+    if (lastSig !== null && sig !== lastSig) sawChange = true;
+    const stable = lastSig !== null && sig === lastSig;
+    last = current;
+    lastSig = sig;
+
+    if (stable && (sawChange || elapsed >= CLEAR_VRAM_SETTLE_MIN_MS)) {
+      return current;
+    }
+    if (elapsed >= CLEAR_VRAM_SETTLE_TIMEOUT_MS) {
+      return current;
+    }
+
+    const wait = Math.min(CLEAR_VRAM_SETTLE_INTERVAL_MS, Math.max(0, deadline - Date.now()));
+    if (wait <= 0) return current;
+    await sleep(wait);
+  }
+}
 
 export function registerMemoryManagementTools(server: McpServer): void {
   server.tool(
@@ -54,18 +123,11 @@ export function registerMemoryManagementTools(server: McpServer): void {
           };
         }
 
-        // Get updated stats
+        // Get updated stats — after CUDA release settles, not the first post-/free sample.
         let statsText = "";
         try {
-          const stats = await getSystemStats();
-          const gpu = stats.devices?.[0];
-          if (gpu) {
-            const vramFreeMB = (gpu.vram_free / 1024 / 1024).toFixed(0);
-            const vramTotalMB = (gpu.vram_total / 1024 / 1024).toFixed(0);
-            const torchFreeMB = (gpu.torch_vram_free / 1024 / 1024).toFixed(0);
-            const torchTotalMB = (gpu.torch_vram_total / 1024 / 1024).toFixed(0);
-            statsText = `\n\nCurrent VRAM: ${vramFreeMB}/${vramTotalMB} MB free | Torch: ${torchFreeMB}/${torchTotalMB} MB free`;
-          }
+          const stats = await readSettledSystemStats();
+          if (stats) statsText = formatVramStats(stats);
         } catch {
           // Best effort
         }


### PR DESCRIPTION
Fixes #2050

`clear_vram` printed the first `/system_stats` sample after `POST /free`. `/free` returns when ComfyUI drops model refs; CUDA can still be releasing, so that sample lagged a follow-up `get_system_stats (action:"stats")` (reporter: 1205 MB free vs `vram_free: 23985913856`).

After a successful `/free`, the tool now polls `/system_stats` until device 0's VRAM counters stop changing (min 1s so an unchanged first reading is not treated as settled, cap 5s) and prints that value.
