### PR TITLE
release: v0.52.52 — honest object_info timeouts, reachable RunPod ads, scanned node_pack roots, settled VRAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.52] - 2026-08-21
+
 ### Fixed
 
 - **`node_pack` scaffolds into the custom_nodes directory the running ComfyUI
@@ -16,6 +18,15 @@ All notable changes to this project are documented here. This project adheres to
   Authoring (scaffold / write / read / patch / git / verify / publish-by-name)
   now shares one scan-root resolver: `--base-directory` when the runtime reports
   one (Desktop, #1770), else the live checkout.
+
+### MCP
+
+#### Fixed
+- report settled clear_vram readings honestly
+- scaffold node packs into ComfyUI scanned roots
+- make RunPod tunnel and origin advertisements reachable
+- keep panel schema readiness honest after object_info timeouts
+
 
 ## [0.52.51] - 2026-08-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.51",
+  "version": "0.52.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.51",
+      "version": "0.52.52",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.51",
+  "version": "0.52.52",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.52** from `main` (after v0.52.51).

Carries:

- #2007 — panel schema readiness stays honest after object_info timeouts
- #2023 — RunPod tunnel and origin advertisements are reachable
- #2031 — node_pack scaffolds into ComfyUI scanned roots
- #2050 — clear_vram reports settled VRAM readings

Held out: #2029/#2006 CI red; show_media PRs #2038–2042 conflicting; hygiene/docs.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.52` tag on the version commit).