### PR TITLE
fix(1996): a boot that starts listening during the reconnect wait is reported server_ready

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -442,6 +442,32 @@ describe("#1996 an unconfirmed managed restart still watches for the tab", () =>
     expect(out.panel_tab_reconnected).toBe(false);
     expect(out.ready).toBe(false);
   });
+
+  it("#1996 r2: a boot that starts listening during the tab wait is server_ready", async () => {
+    // Same recurrence as the bound path: dedicated observation expires still-down,
+    // then ComfyUI starts listening while we wait for the tab. A fresh observer
+    // would ignore that lone healthy (no new down); continuing the latch certifies.
+    let listening = false;
+    __panelToolsTestHooks.setHealthProbe(async () => (listening ? "healthy" : "down"));
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.awaitPostRestartReachable = async () => {
+      listening = true;
+      await new Promise((r) => setTimeout(r, 50));
+      return false;
+    };
+    ctx.tabCanMutateGraph = () => true;
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+    expect(out.server_ready).toBe(true);
+    expect(out.confirmed_cycle).toBe(true);
+    expect(out.via).toBe("observed-cycle");
+    expect(out.saw_down).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-slow-boot-reconnect.test.ts
@@ -61,6 +61,10 @@ function makeCtx(opts: {
   tabReturns: boolean;
   /** Omit the pre-restart identity, i.e. nothing was ever watched. */
   noBaseline?: boolean;
+  /** Wall-clock time the reconnect wait actually takes. Zero/omitted returns at once. */
+  tabDelayMs?: number;
+  /** Fires synchronously when the reconnect wait is entered, before the delay. */
+  onTabWait?: () => void;
 }): { ctx: PanelToolCtx; reconnectCalls: ReconnectCall[] } {
   const reconnectCalls: ReconnectCall[] = [];
   const bridge = {
@@ -88,6 +92,8 @@ function makeCtx(opts: {
       budgetMs?: number,
     ) => {
       reconnectCalls.push({ before, budgetMs });
+      opts.onTabWait?.();
+      if (opts.tabDelayMs) await new Promise((r) => setTimeout(r, opts.tabDelayMs));
       return opts.tabReturns;
     },
     tabCanMutateGraph: () => true,
@@ -311,5 +317,81 @@ describe("#1996 WIRING: the bound readiness deadline goes through the reserve", 
     // The exact pre-fix shape on the headless path. Its behavioural coverage lives in
     // panel-restart-legacy-fallback.test.ts; this catches a re-introduction anywhere.
     expect(/const tabBack = recovery\.ready\s*\n?\s*\?/.test(src())).toBe(false);
+  });
+
+  it("BOTH restart paths continue /system_stats during the tab wait (r2)", () => {
+    // A helper-only suite survives either call site going back to a bare
+    // `await ctx.awaitPostRestartReachable(…)` after observeRecovery has already
+    // returned — which type-checks, still watches the tab, and restores the
+    // 0.52.51 recurrence (server listening during that wait, reported unready).
+    expect((src().match(/awaitTabWhileContinuingRecovery\(\{/g) ?? []).length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1996 r2 — the 0.52.51 recurrence. After #1997 the reconnect wait ran on an
+// unconfirmed boot, but /system_stats was not consulted during it. A server that
+// started listening in that reserved window was reported server_ready:false
+// (`recovered_ms:184461`, saw_down:true) and then panel_graph_outline succeeded.
+// ---------------------------------------------------------------------------
+describe("#1996 r2: a boot that starts listening during the reconnect wait is reported server_ready", () => {
+  it("REPRODUCTION: down for the dedicated budget, then healthy during the tab wait", async () => {
+    let listening = false;
+    __panelToolsTestHooks.setHealthProbe(async () => (listening ? "healthy" : "down"));
+    const { ctx, reconnectCalls } = makeCtx({
+      tabReturns: false,
+      tabDelayMs: 50,
+      onTabWait: () => {
+        listening = true;
+      },
+    });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(reconnectCalls.length).toBe(1);
+    // THE DEFECT: pre-fix this is false — observation had already returned, and
+    // a fresh observer would also ignore a lone healthy (no new down).
+    expect(out.server_ready).toBe(true);
+    expect(out.confirmed_cycle).toBe(true);
+    expect(out.via).toBe("observed-cycle");
+    expect(out.saw_down).toBe(true);
+    // A tab that did not re-hello still withholds graph tools. The boot is what
+    // this recurrence misreported; the reconnect observation stays honest.
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+  });
+
+  it("that same window, with a tab that DOES re-register, is graph-tool ready", async () => {
+    let listening = false;
+    __panelToolsTestHooks.setHealthProbe(async () => (listening ? "healthy" : "down"));
+    const { ctx } = makeCtx({
+      tabReturns: true,
+      tabDelayMs: 50,
+      onTabWait: () => {
+        listening = true;
+      },
+    });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(out.ready).toBe(true);
+    expect(out.graph_tools_ready).toBe(true);
+  });
+
+  it("a server that STAYS down through the tab wait is still an honest refusal", async () => {
+    // Continuation must not invent a cycle. The probe never answers; the extra
+    // window is just more of the same observation.
+    const { ctx } = makeCtx({ tabReturns: true, tabDelayMs: 40 });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    expect(out.server_ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(String(out.note)).toMatch(/has not become healthy within/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2961,6 +2961,14 @@ interface ObserveRecoveryOpts {
    *  live deadline. Absent → legacy mode (started AFTER the restart's synchronous work;
    *  probe immediately against the fixed `deadline`). */
   gate?: DispatchObservationGate;
+  /**
+   * #1996 r2 — resume the SAME down→up observation after the dedicated readiness
+   * budget expired. A fresh observer would re-latch `sawDown` at false, so a
+   * server that started listening during the reconnect wait (healthy, no new
+   * down) would be ignored as a first-healthy no-op. Carry the latch and the
+   * elapsed clock; do not extend a budget that already certified.
+   */
+  continueFrom?: Pick<PanelReadyResult, "sawDown" | "attempts" | "waited_ms" | "lastStatus">;
 }
 
 /**
@@ -2994,16 +3002,17 @@ async function observeRecovery(
   deadline: number,
   opts: ObserveRecoveryOpts,
 ): Promise<PanelReadyResult> {
-  const start = Date.now();
+  const prior = opts.continueFrom;
+  const start = prior ? Date.now() - prior.waited_ms : Date.now();
   const gate = opts.gate;
   const intervalMs = panelRebootTimingOverride
     ? Math.max(1, timing.intervalMs)
     : Math.max(50, timing.intervalMs);
   const probe = healthProbeOverride ?? probeComfyEndpoint;
   const currentDeadline = () => gate?.deadline ?? deadline;
-  let sawDown = false;
-  let lastStatus: ProbeStatus | undefined;
-  let attempts = 0;
+  let sawDown = prior?.sawDown ?? false;
+  let lastStatus: ProbeStatus | undefined = prior?.lastStatus;
+  let attempts = prior?.attempts ?? 0;
   for (;;) {
     if (gate?.cancelled) break;
     if (currentDeadline() - Date.now() <= 0) break;
@@ -3055,6 +3064,78 @@ async function observeRecovery(
     await sleep(Math.min(intervalMs, left));
   }
   return { ready: false, waited_ms: Date.now() - start, attempts, sawDown, lastStatus };
+}
+
+function startPostRestartTabWait(
+  ctx: PanelToolCtx,
+  preRestartPanelIdentity: { generation: number; tabSessionId: string } | undefined,
+  overallDeadline: number,
+): Promise<boolean> {
+  const budgetMs = Math.max(0, overallDeadline - Date.now());
+  if (ctx.awaitPostRestartReachable) {
+    return ctx.awaitPostRestartReachable(preRestartPanelIdentity, budgetMs);
+  }
+  if (ctx.awaitReachable) return ctx.awaitReachable(budgetMs);
+  return Promise.resolve(true);
+}
+
+/**
+ * #1996 r2 — keep watching /system_stats during the post-restart tab wait.
+ *
+ * The dedicated readiness budget still expires first (so a dead server is not
+ * held until the whole-handler cap). The reconnect wait after it used to look
+ * ONLY at the tab, so a server that started listening in that reserved window
+ * was reported `server_ready:false` while the handler was still running — the
+ * 0.52.51 recurrence (`recovered_ms:184461`, ComfyUI already listening, then
+ * `panel_graph_outline` succeeded). Continue the SAME down→up observation in
+ * parallel; abort it when the tab wait finishes so an instant wait cannot
+ * stretch to `overallDeadline`.
+ *
+ * A later healthy sample still requires the earlier down (carried via
+ * `continueFrom`). A tab coming back still does not certify the boot.
+ */
+async function awaitTabWhileContinuingRecovery(args: {
+  recovery: PanelReadyResult;
+  timing: PanelRebootTiming;
+  healthBase: string;
+  overallDeadline: number;
+  ctx: PanelToolCtx;
+  preRestartPanelIdentity: { generation: number; tabSessionId: string } | undefined;
+}): Promise<{ recovery: PanelReadyResult; tabBack: boolean }> {
+  const tabWait = startPostRestartTabWait(
+    args.ctx,
+    args.preRestartPanelIdentity,
+    args.overallDeadline,
+  );
+  if (args.recovery.ready) {
+    return { recovery: args.recovery, tabBack: await tabWait };
+  }
+  const gate: DispatchObservationGate = {
+    dispatched: true,
+    dispatchedAt: 0,
+    cancelled: false,
+    deadline: args.overallDeadline,
+    waitDispatched: Promise.resolve(),
+  };
+  const extraPromise = observeRecovery(args.timing, args.overallDeadline, {
+    healthBase: args.healthBase,
+    gate,
+    continueFrom: args.recovery,
+  });
+  const tabBack = await tabWait;
+  gate.cancelled = true;
+  const extra = await extraPromise;
+  if (extra.ready) return { recovery: extra, tabBack };
+  return {
+    recovery: {
+      ready: false,
+      waited_ms: extra.waited_ms,
+      attempts: extra.attempts,
+      sawDown: args.recovery.sawDown || extra.sawDown,
+      lastStatus: extra.lastStatus ?? args.recovery.lastStatus,
+    },
+    tabBack,
+  };
 }
 
 // ---- workflow_open verify-after-timeout (#215/#319/#496/#661) --------------
@@ -17875,16 +17956,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           }
           // Otherwise (the process WAS stopped/started, or restartComfyUI's own readiness
           // poll merely expired — neither terminal) DEFER to OUR OWN observed DOWN→UP.
-          const recovery = await proofPromise;
-          // #742 r4/r5/r15: the managed restart was observed back — clear THIS
-          // session's record, CLEAR-IF-SAME: only when the session still holds
-          // the token THIS restart stamped (a concurrent dispatch's newer
-          // record survives). restartComfyUI also clears its own process-wide
-          // record on success; this covers only-observer-saw-it recoveries.
-          if (recovery.ready && headlessDispatchToken != null) {
-            clearSessionRestartDispatchIfSame(ctx, headlessDispatchToken);
-          }
-          const observed = recovery.via === "observed-cycle";
+          let recovery = await proofPromise;
           // The headless path restarts ComfyUI out-of-band too. Server recovery alone
           // is not graph-tool readiness: wait for the browser tab to reconnect, then verify
           // the same workflow-stamp capability the bridge requires before it dispatches a
@@ -17895,14 +17967,27 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // bound one — `recovery.ready ? … : false` — so a managed kill+relaunch whose
           // cold start outran the observation window forfeited the reconnect wait too,
           // and reported a bare `false` for a tab nobody had looked at.
-          const tabBack = ctx.awaitPostRestartReachable
-            ? await ctx.awaitPostRestartReachable(
-                preRestartPanelIdentity,
-                Math.max(0, overallDeadline - Date.now()),
-              )
-            : ctx.awaitReachable
-              ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
-              : true;
+          // #1996 r2: the tab wait also continues the health observation, so a boot
+          // that starts listening in this reserved window is not reported unready
+          // while the handler is still running.
+          let tabBack: boolean;
+          ({ recovery, tabBack } = await awaitTabWhileContinuingRecovery({
+            recovery,
+            timing: headlessTiming,
+            healthBase,
+            overallDeadline,
+            ctx,
+            preRestartPanelIdentity,
+          }));
+          // #742 r4/r5/r15: the managed restart was observed back — clear THIS
+          // session's record, CLEAR-IF-SAME: only when the session still holds
+          // the token THIS restart stamped (a concurrent dispatch's newer
+          // record survives). restartComfyUI also clears its own process-wide
+          // record on success; this covers only-observer-saw-it recoveries.
+          if (recovery.ready && headlessDispatchToken != null) {
+            clearSessionRestartDispatchIfSame(ctx, headlessDispatchToken);
+          }
+          const observed = recovery.via === "observed-cycle";
           // #1996: `recovery.ready &&` is LOAD-BEARING now that the wait above runs on
           // both outcomes. Without it a tab that re-registered while the server was still
           // unproven would report ready:true — turning the honest refusal this path
@@ -18730,13 +18815,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           overallDeadline,
           reserveMs: reconnectWaitTiming().budgetMs,
         });
-        const recovery = await recoveryPromise!;
-        // #742 r4/r5/r15: the dispatched restart was observed back — clear the
-        // record, CLEAR-IF-SAME: only when the session still holds the token
-        // THIS dispatch stamped (a concurrent dispatch's newer record survives).
-        if (recovery.ready && acceptedDispatchToken != null) {
-          clearSessionRestartDispatchIfSame(ctx, acceptedDispatchToken);
-        }
+        let recovery = await recoveryPromise!;
         // #400/#709: ComfyUI is healthy, but the panel's browser tab re-registers its own
         // socket a moment later. The old socket can still be reachable after dispatch, so
         // the generation waiter below requires a fresh hello before reporting readiness.
@@ -18755,14 +18834,24 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // it honestly could not give AND the reconnect wait it could have given, which is
         // the only thing on this path that calls `ensureReachable()` to heal the session
         // binding onto the returning tab. An unconfirmed boot now still gets watched.
-        const tabBack = ctx.awaitPostRestartReachable
-          ? await ctx.awaitPostRestartReachable(
-              preRestartPanelIdentity,
-              Math.max(0, overallDeadline - Date.now()),
-            )
-          : ctx.awaitReachable
-            ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
-            : true;
+        // #1996 r2: the wait also continues /system_stats, so a boot that starts
+        // listening in this reserved window is not reported unready while we are
+        // still inside the handler.
+        let tabBack: boolean;
+        ({ recovery, tabBack } = await awaitTabWhileContinuingRecovery({
+          recovery,
+          timing,
+          healthBase,
+          overallDeadline,
+          ctx,
+          preRestartPanelIdentity,
+        }));
+        // #742 r4/r5/r15: the dispatched restart was observed back — clear the
+        // record, CLEAR-IF-SAME: only when the session still holds the token
+        // THIS dispatch stamped (a concurrent dispatch's newer record survives).
+        if (recovery.ready && acceptedDispatchToken != null) {
+          clearSessionRestartDispatchIfSame(ctx, acceptedDispatchToken);
+        }
         if (!recovery.ready) {
           const waited = Math.round(recovery.waited_ms / 1000);
           // #1996: the refusal itself is NOT the defect and is left exactly as it was.


### PR DESCRIPTION
Fixes #1996.

## 0.52.52 / #2007 does not already make this case true

Checked on `origin/main` @ `9e11fd5` (0.52.52) before writing anything.

The recurrence (2026-08-22) is: on **0.52.51**, `panel_restart_comfyui` returned `ready:false`, `server_ready:false`, `graph_tools_ready:false`, `panel_tab_reconnected:false` after **184461 ms** (`saw_down:true`). ComfyUI logs showed it had completed startup and was listening on 127.0.0.1:8188; an immediate `panel_graph_outline` then succeeded. The reporter is below 0.52.52.

`cbcc4f5` (#2007, shipped in 0.52.52) keeps panel **schema** readiness honest after `/object_info` timeouts — `panel_graph_outline` no longer advertises `mutations_ready:true` once a schema-guarded edit has already failed to obtain `/object_info`, and those edits retry once. It does not touch `observeRecovery`, `COMFYUI_PANEL_REBOOT_BUDGET_S`, or `server_ready`. `git diff b4e9b83..9e11fd5 -- src/orchestrator/panel-tools.ts` has no restart-observation change. `server_ready` is still `recovery.ready` from `GET /system_stats` down→up. A 180 s dedicated budget that has already returned unready is unchanged by schema advertising.

So the recurrence is still this issue: #1997 raised the budget to 180 s and stopped skipping the reconnect wait, but that wait looked **only at the tab**. `/system_stats` was not consulted during it. A server that started listening in that reserved window — 184 s of observation, then listening, then `panel_graph_outline` succeeded — was still reported `server_ready:false` while the handler was still running.

## What it takes

After the dedicated readiness budget expires unready, continue the **same** down→up observation in parallel with the reconnect wait (bound path **and** headless managed-restart path).

- The down-latch is **carried** (`continueFrom`). A fresh observer would re-latch `sawDown` at false, so a lone healthy sample (server already listening, no new down) would be ignored as a first-healthy no-op — which is exactly this recurrence.
- The extra observer is **aborted** when the tab wait finishes, so an instant wait cannot stretch to the 255 s whole-handler cap.
- `ready` / `graph_tools_ready` still require a newer hello **and** the certified cycle. A tab coming back still does not promote an unproven boot; a proven boot with no re-hello still withholds graph tools. `server_ready` is what this recurrence misreported.

## Reproduction

`panel-restart-slow-boot-reconnect.test.ts` and `panel-restart-legacy-fallback.test.ts` drive the real `panel_restart_comfyui` handler. The probe stays `down` for the dedicated budget, then flips to `healthy` the instant the reconnect wait is entered. Pre-fix `server_ready` is false on both paths; post-fix it is true, `confirmed_cycle` is true, and a tab that did not re-hello still leaves `ready:false`. A server that stays down through that window is still an honest refusal.

Wiring: both restart paths call `awaitTabWhileContinuingRecovery` (count pinned). Dropping `continueFrom` or reverting either call site to a bare tab wait restores the recurrence.

## Cost

A genuinely dead server is already held for the reconnect wait after #1997. This adds probes during time we were already spending, not wall clock. A boot that comes up in that window is now reported as such instead of as unconfirmed.

The 180 s dedicated default is unchanged. An install that is still not listening when the whole remaining handler budget ends is still reported unconfirmed — that refusal is still honest.
