### PR TITLE
fix(panel#1209): stamp a download continuation with the live canvas, not the previous workflow

### DIFF
--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -357,6 +357,63 @@ describe("TurnOriginTracker — inherited origins for tab-less turns (gate 3, P1
     expect(warnings.join("\n")).not.toMatch(/FAILS CLOSED/);
   });
 
+  // panel#1209 recurrence on mcp 0.52.51 / panel 0.15.32: panel_new_workflow
+  // (same-socket replacement, NEW instance uuid) → successful
+  // panel_set_workflow_target({mode:"current"}) → a later download_done
+  // continuation stamped graph commands with workflow A's frozen uuid.
+  // panel_get_errors failed closed; rebinding repaired that turn; the next
+  // completion repeated it.
+  //
+  // uuidOfTab is the production seam (index.ts: tabCommandWorkflowUuid.get) —
+  // hello and refreshWorkflowUuid write the live instance there. Inheritance
+  // must read THAT, not lastOrigin.uuid frozen at the previous user turn.
+  it("a download_done turn after a same-socket replacement stamps the LIVE canvas uuid, not the frozen previous instance (panel#1209)", async () => {
+    const { tracker, tabBackends, tabUuids, tabAliases } = makeTracker();
+    tabBackends.set("tab-a", "claude");
+    tabUuids.set("tab-a", "uuid-a");
+    tracker.recordForMid("m-user", "uuid-a", "tab-a");
+    tracker.onSeen(KEY, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY);
+
+    // Same socket, new workflow instance (panel_new_workflow / in-place load).
+    // Hello + mode:"current" refresh write the new uuid under the live id.
+    tabAliases.set("tab-a", "tab-b");
+    tabBackends.delete("tab-a");
+    tabBackends.set("tab-b", "claude");
+    tabUuids.set("tab-b", "uuid-b");
+    tracker.setStamp(KEY, "uuid-b");
+
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY, mid);
+    await flushMicrotasks();
+
+    expect(tracker.pinOf(KEY)).toBe("tab-a");
+    expect(tracker.stampOf(KEY)).toBe("uuid-b");
+    expect(tracker.resolvedPinOf(KEY)).toBe("tab-a");
+  });
+
+  it("a download_done turn after an in-place uuid remint (same tab id) also takes the live stamp (panel#1209)", async () => {
+    const { tracker, tabBackends, tabUuids } = makeTracker();
+    tabBackends.set("tab-a", "claude");
+    tabUuids.set("tab-a", "uuid-a");
+    tracker.recordForMid("m-user", "uuid-a", "tab-a");
+    tracker.onSeen(KEY, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY);
+
+    // loadGraphData reminted the instance under the same handle; the poll
+    // re-hello / mode:"current" published the new uuid onto this tab id.
+    tabUuids.set("tab-a", "uuid-b");
+
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(KEY, mid);
+    await flushMicrotasks();
+
+    expect(tracker.pinOf(KEY)).toBe("tab-a");
+    expect(tracker.stampOf(KEY)).toBe("uuid-b");
+  });
+
   it("inheritance after a migration still refuses when the tab genuinely changed hands (panel#1292 keeps gate 3 closed)", async () => {
     // Same shape as above, but the migrated surface is now on ANOTHER backend.
     // Routing through the alias must not become a way to adopt it.

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -166,6 +166,26 @@ export class TurnOriginTracker {
     return this.deps.liveTabOf ? (this.deps.liveTabOf(tab) ?? tab) : tab;
   }
 
+  /**
+   * Stamp an origin-less turn with the LIVE uuid of the tab it inherits.
+   *
+   * lastOrigin keeps the TAB the conversation last agreed on (never "whatever
+   * is active"). The canvas under that tab can still be replaced in place —
+   * panel_new_workflow, a load into the open tab, ComfyUI restoring at startup —
+   * and hello / panel_set_workflow_target({mode:"current"}) write the new
+   * instance onto uuidOfTab. Reusing the uuid frozen when the origin was
+   * established stamps the continuation for the PREVIOUS instance while the
+   * canvas already reports the new one (panel#1209: download_done after a
+   * successful mode:"current" rebind kept workflow A's fence).
+   *
+   * Missing live evidence falls back to the frozen uuid: an unread stamp is not
+   * proof the inherited one is wrong, and an absent stamp refuses harder (#1331).
+   */
+  private inheritedStampOf(last: { tab: string; uuid: string | undefined }): string | undefined {
+    const live = this.deps.uuidOfTab(this.routedTabOf(last.tab));
+    return typeof live === "string" && live ? live : last.uuid;
+  }
+
   /** Record a message's issue-time origin, keyed by its mid, to be applied at
    *  dequeue. Captures the tab's backend NOW so the application can verify the
    *  tab still belongs to the same conversation then. `injected` marks an
@@ -376,10 +396,10 @@ export class TurnOriginTracker {
           // "whatever tab is active" (confirming gate 2, P0). The inherited tab
           // must STILL belong to this conversation's backend (confirming gate
           // 3, P0); no established/valid origin at all → refuse. A follow-up
-          // mutation stays honest: it is stamped with the inherited origin's
-          // issue-time uuid, so the panel fence (and the dispatch-time
-          // stamp-target agreement gate, #1656) refuse it loudly if the routed
-          // canvas is not the one the stamp names.
+          // mutation stays honest: it is stamped with the LIVE uuid of that
+          // inherited tab at THIS turn's start (panel#1209), so the panel fence
+          // (and the dispatch-time stamp-target agreement gate, #1656) refuse
+          // it loudly if the routed canvas is not the one the stamp names.
           //
           // Ownership is judged on the tab the inherited origin ROUTES to
           // today (routedTabOf), NOT on the id it was recorded under — the
@@ -402,7 +422,7 @@ export class TurnOriginTracker {
           // resolves nowhere still falls back to its raw id and fails closed.
           const last = this.lastOriginByKey.get(key);
           if (last && this.deps.backendForTab(this.routedTabOf(last.tab)) === this.deps.backendOfKey(key)) {
-            this.lastTurnUuidByKey.set(key, last.uuid);
+            this.lastTurnUuidByKey.set(key, this.inheritedStampOf(last));
             this.turnTargetTabByKey.set(key, last.tab);
             if (closed.routes.size > 1) {
               this.deps.warn(


### PR DESCRIPTION
Does not close an MCP issue. Lands the remaining graph-fence hole from [panel#1209](https://github.com/artokun/comfyui-mcp-panel/issues/1209).

## What was already shipped

Panel #1279 (v0.14.44) re-hellos when the live instance uuid drifts without a tab-id change. That is still in main. The 2026-08-22 recurrence on **mcp 0.52.51 / panel 0.15.32** is a different half: the orchestrator kept *stamping* origin-less continuations with the uuid frozen when the previous user message established the origin.

## Recurrence

`panel_new_workflow` → build/save workflow B → successful `panel_set_workflow_target({mode:"current"})` → a model-download completion starts an automatic continuation whose graph commands are stamped with workflow A's UUID. `panel_get_errors` fails closed with a workflow-instance mismatch. Rebinding to current repairs that turn; the next completion repeats it.

## Why

`download_done` uses `mintInheritedOrigin()`. At batch close that inherits the conversation's last established origin — the TAB the last user message agreed on, never "whatever is active" (#884). The stamp was the uuid frozen onto that origin at the previous user turn.

Hello and `refreshWorkflowUuid` (the `mode:"current"` path) already write the live instance onto `uuidOfTab` (`tabCommandWorkflowUuid`). Inheritance never read it. After a same-socket replacement the pin still routes to the live canvas, but the continuation was stamped for the previous instance.

## The change

`TurnOriginTracker` still inherits the last established TAB. It now stamps that turn with the live uuid of the tab the origin *routes to* (`uuidOfTab(routedTabOf(last.tab))`). Missing live evidence falls back to the frozen uuid (#1331: an absent stamp refuses harder).

Mutations stay fail-closed. Rewind / `dropBranch` / `repinTo` inheritance is unchanged: those paths either have no last origin (refuse) or still inherit the last *message* origin.

## Evidence

`src/__tests__/orchestrator/turn-origins.test.ts` — two new tests drive the shipping `mintInheritedOrigin` + `onSeen` path on the real tracker:

- same-socket replacement (new instance uuid under the live id) → continuation stamped with the live uuid
- in-place remint (same tab id, new uuid) → continuation stamped with the live uuid

Existing rewind / repin / panel#1292 inheritance tests still pass.

```
npx vitest run src/__tests__/orchestrator/turn-origins.test.ts --maxWorkers=4
# 49 tests, 0 fail

npx vitest run src/__tests__/orchestrator/shared-session-invariant.test.ts \
  src/__tests__/orchestrator/download-done-event.test.ts \
  src/__tests__/orchestrator/turn-pin-vs-current-target.test.ts --maxWorkers=4
# 32 tests, 0 fail
```
