### PR TITLE
fix(559): a long self-queued render is no longer called foreign backlog

### DIFF
--- a/src/__tests__/orchestrator/panel-run-backpressure.test.ts
+++ b/src/__tests__/orchestrator/panel-run-backpressure.test.ts
@@ -111,6 +111,26 @@ describe("panel_run backpressure note (#559)", () => {
     expect(qm.selfQueuedIds.has("p-batch-2")).toBe(true);
   });
 
+  it("a long self-owned render with stale extra depth is still YOUR own, not 'didn't queue' (#559 recurrence)", async () => {
+    // queueRemaining=2 while the only visible id is the one this session queued;
+    // the timestamp has aged past the 10-minute window. The old incomplete-
+    // accounting path called that foreign and recommended clear_pending.
+    QueueMonitor.markSelfQueued("p-long");
+    qm.lastSelfQueueTs = Date.now() - 11 * 60 * 1000;
+    qm.state.runningPromptId = "p-long";
+    qm.state.pendingPromptIds = [];
+    qm.state.queueRemaining = 2;
+
+    const ctx = makeCtx({ queued: true, prompt_id: "p-next" });
+    const res = await defByName("panel_run").handler({ allow_duplicate: true }, ctx);
+    const text = firstText(res);
+
+    expect(res.isError).not.toBe(true);
+    expect(text).toContain("your own");
+    expect(text).not.toContain("didn't queue");
+    expect(text).not.toContain("[QUEUE WARNING]");
+  });
+
   it("an unaccounted-for job running ahead → REFUSED before dispatch, running prompt named (#862)", async () => {
     // The reconnect-duplicate case: the self-queue ledger is in-memory, so after
     // an orchestrator restart the agent's OWN still-running render reads as

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -239,7 +239,8 @@ import { dedupeAudioRefs, splitAudioAttachments } from "./audio-attachment.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
-import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
+import { QueueMonitor } from "../services/queue-monitor.js";
+import { formatQueueNote } from "./queue-note.js";
 import {
   RunCompletions,
   describe as describeCorrelation,
@@ -542,36 +543,6 @@ function stallThresholdMs(): number {
   if (liveStallSeconds != null) return liveStallSeconds * 1000;
   const s = Number(process.env.COMFYUI_MCP_STALL_S);
   return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 180000;
-}
-
-/** Build a one-line agent note from a stall/backlog report, or null when the
- *  queue is healthy. Stall takes priority over a plain backlog. */
-function formatQueueNote(rep: StallReport): string | null {
-  if (rep.stalled) {
-    const secs = Math.round(rep.stalledForMs / 1000);
-    return (
-      `⚠️ The current ComfyUI render appears STALLED: ` +
-      `${rep.currentNode ? `node ${rep.currentNode} ` : ""}${rep.progress ? `(progress ${rep.progress}) ` : ""}` +
-      `on prompt ${rep.runningPromptId ?? "?"} has not advanced for ~${secs}s. ComfyUI only checks interrupts ` +
-      `BETWEEN steps, so a stuck step can ignore a cancel. If it's wedged: call queue (action:"cancel") with ` +
-      `clear_pending:true; if it reports the job still wedged, restart_comfyui / panel_restart_comfyui. ` +
-      `Do NOT queue another run on top.`
-    );
-  }
-  // A plain backlog (depth > 1) is NOT evidence of a wedge — deliberately queuing
-  // a batch is a normal workflow. Suppress the note entirely when the in-flight
-  // work is this session's own recent jobs, and when it isn't, report it NEUTRALLY
-  // (no false "you likely queued behind a stuck job" diagnosis, no destructive
-  // clear_pending as the headline). A genuinely stalled job is handled above (#559).
-  if (rep.backlog && !rep.selfAttributed) {
-    const pending = Math.max(0, rep.queueDepth - 1);
-    return (
-      `ℹ️ ComfyUI queue: ${rep.queueDepth} tasks in flight (1 running + ${pending} pending) that this session ` +
-      `didn't queue. This is only a problem if the running one is stuck — inspect with queue (action:"list"). ` +
-      `queue (action:"cancel_queued") drops a single pending item; queue (action:"cancel") with clear_pending:true resets everything.`
-    );
-  }
-  return null;
 }
 
 /**

--- a/src/orchestrator/queue-note.test.ts
+++ b/src/orchestrator/queue-note.test.ts
@@ -1,0 +1,101 @@
+// queue-note.test.ts — the turn-start stall/backlog note (#559).
+//
+// Drives the shipped composition the injector uses: QueueMonitor.report() →
+// formatQueueNote(). The 2026-08-22 recurrence: a long self-queued panel_run
+// (prompt in selfQueuedIds) got "two tasks in flight that this session did not
+// queue" because queueRemaining was stale-high and the timestamp window had
+// aged. That wording + the clear_pending remedy must not fire unless a VISIBLE
+// in-flight id is actually foreign.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { QueueMonitor } from "../services/queue-monitor.js";
+import { formatQueueNote } from "./queue-note.js";
+
+type Priv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastActivityTs: number | null;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const priv = QueueMonitor as unknown as Priv;
+
+const STALL_MS = 180_000;
+const OWN = "a248c804-1111-2222-3333-444444444444";
+
+beforeEach(() => {
+  priv.url = "http://127.0.0.1:9999";
+  priv.stopped = false;
+  priv.selfQueuedIds.clear();
+  priv.lastSelfQueueTs = null;
+  priv.state.connected = true;
+  priv.state.runningPromptId = null;
+  priv.state.pendingPromptIds = [];
+  priv.state.queueRemaining = 0;
+  priv.state.lastActivityTs = Date.now();
+  priv.state.lastServerAliveTs = Date.now();
+  priv.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  priv.selfQueuedIds.clear();
+  priv.lastSelfQueueTs = null;
+  priv.stopped = true;
+  priv.url = null;
+});
+
+describe("formatQueueNote ← QueueMonitor.report (#559 recurrence)", () => {
+  it("does not claim a self-owned long render is foreign work just because depth is stale", () => {
+    QueueMonitor.markSelfQueued(OWN);
+    priv.lastSelfQueueTs = Date.now() - 11 * 60 * 1000;
+    priv.state.runningPromptId = OWN;
+    priv.state.pendingPromptIds = [];
+    priv.state.queueRemaining = 2;
+
+    const note = formatQueueNote(QueueMonitor.report(STALL_MS));
+    expect(note).toBeNull();
+  });
+
+  it("does not claim foreign work when extra depth has no visible foreign id (unproven)", () => {
+    // Depth-only, no prompt ids at all — the original #559 "gate on staleness,
+    // not count": depth alone is not evidence of a wedge or of foreign work.
+    priv.state.runningPromptId = null;
+    priv.state.pendingPromptIds = [];
+    priv.state.queueRemaining = 2;
+
+    const note = formatQueueNote(QueueMonitor.report(STALL_MS));
+    expect(note).toBeNull();
+  });
+
+  it("still names foreign work when a VISIBLE in-flight id is not ours", () => {
+    QueueMonitor.markSelfQueued(OWN);
+    priv.state.runningPromptId = OWN;
+    priv.state.pendingPromptIds = ["p-foreign"];
+    priv.state.queueRemaining = 2;
+
+    const note = formatQueueNote(QueueMonitor.report(STALL_MS));
+    expect(note).toMatch(/didn't queue/);
+    expect(note).toMatch(/queue \(action:"list"\)/);
+    // clear_pending is a last-resort option, not a "the queue is stuck" headline.
+    expect(note).not.toMatch(/You likely queued behind/);
+    expect(note).not.toMatch(/\[QUEUE WARNING\]/);
+  });
+
+  it("a self-owned batch of several visible ids is silent", () => {
+    QueueMonitor.markSelfQueued("p-1");
+    QueueMonitor.markSelfQueued("p-2");
+    priv.state.runningPromptId = "p-1";
+    priv.state.pendingPromptIds = ["p-2"];
+    priv.state.queueRemaining = 2;
+
+    expect(formatQueueNote(QueueMonitor.report(STALL_MS))).toBeNull();
+  });
+});

--- a/src/orchestrator/queue-note.ts
+++ b/src/orchestrator/queue-note.ts
@@ -1,0 +1,40 @@
+// Turn-start stall/backlog note for the panel orchestrator (#559).
+//
+// Kept as a named export so tests can drive the SAME wording the injector
+// prepends — QueueMonitor.report() → formatQueueNote() — without booting the
+// orchestrator. A mutation that reintroduces "this session didn't queue" for
+// a self-owned render (or pairs a routine batch with clear_pending) must fail
+// here, not only in production.
+
+import type { StallReport } from "../services/queue-monitor.js";
+
+/** Build a one-line agent note from a stall/backlog report, or null when the
+ *  queue is healthy. Stall takes priority over a plain backlog. */
+export function formatQueueNote(rep: StallReport): string | null {
+  if (rep.stalled) {
+    const secs = Math.round(rep.stalledForMs / 1000);
+    return (
+      `⚠️ The current ComfyUI render appears STALLED: ` +
+      `${rep.currentNode ? `node ${rep.currentNode} ` : ""}${rep.progress ? `(progress ${rep.progress}) ` : ""}` +
+      `on prompt ${rep.runningPromptId ?? "?"} has not advanced for ~${secs}s. ComfyUI only checks interrupts ` +
+      `BETWEEN steps, so a stuck step can ignore a cancel. If it's wedged: call queue (action:"cancel") with ` +
+      `clear_pending:true; if it reports the job still wedged, restart_comfyui / panel_restart_comfyui. ` +
+      `Do NOT queue another run on top.`
+    );
+  }
+  // A plain backlog (depth > 1) is NOT evidence of a wedge — deliberately queuing
+  // a batch is a normal workflow. Suppress the note entirely when the in-flight
+  // work is this session's own jobs, and when extra depth has no VISIBLE foreign
+  // id (stale queueRemaining vs a poll that already listed every real job).
+  // Claiming "this session didn't queue" is only honest when a visible in-flight
+  // id is not one we recorded. A genuinely stalled job is handled above (#559).
+  if (rep.backlog && rep.foreignVisible) {
+    const pending = Math.max(0, rep.queueDepth - 1);
+    return (
+      `ℹ️ ComfyUI queue: ${rep.queueDepth} tasks in flight (1 running + ${pending} pending) that this session ` +
+      `didn't queue. This is only a problem if the running one is stuck — inspect with queue (action:"list"). ` +
+      `queue (action:"cancel_queued") drops a single pending item; queue (action:"cancel") with clear_pending:true resets everything.`
+    );
+  }
+  return null;
+}

--- a/src/services/queue-monitor.self-attribution.test.ts
+++ b/src/services/queue-monitor.self-attribution.test.ts
@@ -123,14 +123,26 @@ describe("self-attribution of the in-flight queue (#559)", () => {
     expect(QueueMonitor.snapshot().selfAttributed).toBe(true);
   });
 
-  it("incomplete accounting with NO recent self-queue → NOT ours (an unseen item may be foreign)", () => {
-    QueueMonitor.markSelfQueued("p-mine");
-    priv.lastSelfQueueTs = Date.now() - 11 * 60 * 1000; // aged past the window
-    priv.state.runningPromptId = "p-mine"; // the one job we can see is ours…
+  it("stale extra depth with every VISIBLE id ours is still ours, even after the window (#559 recurrence)", () => {
+    // Reporter: a long self-queued render was in selfQueuedIds; queueRemaining=2
+    // from a status frame while /queue showed that one prompt running and nothing
+    // pending. Once lastSelfQueueTs aged past the window, the old incomplete-
+    // accounting path classified it as non-self and the turn note claimed this
+    // session did not queue the work. Extra depth without a visible foreign id
+    // is stale accounting, not a foreign job.
+    const id = "a248c804-1111-2222-3333-444444444444";
+    QueueMonitor.markSelfQueued(id);
+    priv.lastSelfQueueTs = Date.now() - 11 * 60 * 1000;
+    priv.state.runningPromptId = id;
     priv.state.pendingPromptIds = [];
-    priv.state.queueRemaining = 3; // …but 2 more are in flight, unaccounted
+    priv.state.queueRemaining = 2;
 
-    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(true);
+    const rep = QueueMonitor.report(STALL_MS);
+    expect(rep.selfAttributed).toBe(true);
+    expect(rep.foreignVisible).toBe(false);
+    // The duplicate fence stays strict: extra depth is still not PROVEN.
+    expect(QueueMonitor.snapshot().selfAttributedProven).toBe(false);
   });
 
   it("attribution expires after the window (a stale self-queue no longer covers a new foreign job)", () => {

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -96,6 +96,11 @@ export interface StallReport {
    *  queued, or a very recent self-queue) — a deliberate batch, not a foreign or
    *  stuck job. The backlog warning is suppressed in that case (#559). */
   selfAttributed: boolean;
+  /** True when a VISIBLE in-flight prompt id is not one this session queued.
+   *  Extra queueRemaining with no such id is stale accounting, not proof of
+   *  foreign work — the turn note must not claim "this session didn't queue"
+   *  unless this is true (#559 recurrence). */
+  foreignVisible: boolean;
   runningPromptId: string | null;
   currentNode: string | null;
   /** running + pending, from ComfyUI's own queue_remaining. */
@@ -383,6 +388,15 @@ class QueueMonitorImpl {
     return "unknown";
   }
 
+  /** Prompt ids the monitor can currently SEE (running + poll-derived pending).
+   *  Distinct from queueRemaining, which status frames can leave stale/high. */
+  private inFlightPromptIds(): string[] {
+    const ids: string[] = [];
+    if (this.state.runningPromptId) ids.push(this.state.runningPromptId);
+    ids.push(...this.state.pendingPromptIds);
+    return ids;
+  }
+
   /** True when the ENTIRE in-flight queue is attributable to this session — i.e.
    *  every visible prompt (the running one plus every pending one) is an id we
    *  queued. That is the only safe basis for suppressing the backlog warning: a
@@ -394,11 +408,16 @@ class QueueMonitorImpl {
    *  to match against (the panel reply never carried a prompt_id) OR nothing is yet
    *  identifiable do we fall back to the coarse "did we self-queue very recently"
    *  heuristic — so a recent self-queue can NOT mask a job whose id we can see is
-   *  not ours. */
+   *  not ours.
+   *
+   *  Extra queueRemaining beyond the visible ids is NOT treated as foreign. Status
+   *  frames can leave that counter high after the poll has already listed every
+   *  real job (the #559 recurrence: one self-owned running prompt, pending empty,
+   *  queueRemaining=2). After the 10-minute window the 1 Hz poll has had hundreds
+   *  of chances to name a real extra job; if it hasn't, the extra slot is stale
+   *  accounting. The duplicate fence still uses the strict proven form. */
   private isSelfAttributed(): boolean {
-    const inFlight: string[] = [];
-    if (this.state.runningPromptId) inFlight.push(this.state.runningPromptId);
-    inFlight.push(...this.state.pendingPromptIds);
+    const inFlight = this.inFlightPromptIds();
     const recentSelfQueue =
       this.lastSelfQueueTs != null && Date.now() - this.lastSelfQueueTs < SELF_QUEUE_WINDOW_MS;
 
@@ -406,20 +425,20 @@ class QueueMonitorImpl {
       // We receive a prompt id for every job we queue, so any VISIBLE in-flight id
       // that isn't one of ours is definitively a foreign job → not our batch.
       if (inFlight.some((id) => !this.selfQueuedIds.has(id))) return false;
-      // Every VISIBLE in-flight job is ours. The pending ids are poll-derived and can
-      // lag a rapid burst of queues, so queueRemaining (updated live by status frames)
-      // may exceed what we've captured. If the poll has fully accounted for the depth,
-      // the whole queue is provably ours; if some items aren't captured yet, only
-      // treat them as ours when we self-queued recently (the reported case — queuing a
-      // batch faster than the 1 Hz poll). A stale unseen item with NO recent self-queue
-      // is treated as possibly-foreign so the warning still fires.
-      const depth = Math.max(inFlight.length, Math.max(0, this.state.queueRemaining));
-      if (inFlight.length >= depth) return true;
-      return recentSelfQueue;
+      // Every VISIBLE in-flight job is ours. Rapid bursts can leave pending ids
+      // lagging queueRemaining; a long self-owned render can leave queueRemaining
+      // stale-high after the timestamp window. Neither is a foreign job.
+      return true;
     }
     // No ids to match against (the panel never surfaced one) or nothing identifiable
     // in flight yet → fall back to the coarse recent-self-queue timestamp.
     return recentSelfQueue;
+  }
+
+  /** True when at least one visible in-flight prompt id is not one we queued.
+   *  Empty visibility (depth from status frames only) is unproven, not foreign. */
+  private isForeignVisible(): boolean {
+    return this.inFlightPromptIds().some((id) => !this.selfQueuedIds.has(id));
   }
 
   /** The STRICT form of isSelfAttributed, for the panel_run duplicate fence
@@ -436,9 +455,7 @@ class QueueMonitorImpl {
    *  refused with the allow_duplicate override named — a false refusal with an
    *  actionable remedy, never a silent duplicate. */
   private isSelfAttributedProven(): boolean {
-    const inFlight: string[] = [];
-    if (this.state.runningPromptId) inFlight.push(this.state.runningPromptId);
-    inFlight.push(...this.state.pendingPromptIds);
+    const inFlight = this.inFlightPromptIds();
     if (this.selfQueuedIds.size === 0 || inFlight.length === 0) return false;
     if (inFlight.some((id) => !this.selfQueuedIds.has(id))) return false;
     const depth = Math.max(inFlight.length, Math.max(0, this.state.queueRemaining));
@@ -930,6 +947,7 @@ class QueueMonitorImpl {
       stalled,
       backlog: queueDepth > 1,
       selfAttributed: this.isSelfAttributed(),
+      foreignVisible: this.isForeignVisible(),
       runningPromptId: this.state.runningPromptId,
       currentNode: this.state.currentNode,
       queueDepth,


### PR DESCRIPTION
Fixes #559

A long self-queued `panel_run` no longer gets a turn-start note claiming the work is foreign (and recommending `queue` `action:"cancel"` with `clear_pending:true`).

The 2026-08-22 recurrence: prompt `a248c804-…` was in `selfQueuedIds`, `/api/queue` showed that one self-owned job running and nothing pending, but `queueRemaining=2` from a status frame. Once `lastSelfQueueTs` aged past the 10-minute window, the incomplete-accounting path classified it as non-self and `formatQueueNote` said this session did not queue those tasks.

## What changed

- Every **visible** in-flight prompt id this session queued is treated as our own, even when status-frame `queueRemaining` is stale-high after the window. Extra depth without a named foreign id is stale accounting, not a foreign job.
- The turn note claims "this session didn't queue" only when a **visible** in-flight id is not one we recorded. Depth-only / unproven extra slots produce no note.
- `selfAttributedProven` (the `#862` duplicate fence) stays strict.

## Tests

Drive `QueueMonitor.report()` → `formatQueueNote()` on the reporter's state, plus the existing `#559` self-attribution / `panel_run` backpressure paths.
