### PR TITLE
fix(2057): download tray no longer announces FAILED while status still shows the transfer streaming

### DIFF
--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -30,7 +30,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   COMPLETION_DISAGREEMENT_NOTE,
+  FAILURE_DISAGREEMENT_NOTE,
   completionDisagreesWithRecord,
+  failureDisagreesWithRecord,
 } from "../../orchestrator/download-done-guard.js";
 
 /** A progress row: identified by the PROGRESS/TRAY id, as written on disk. */
@@ -85,6 +87,15 @@ describe("a completion the record disagrees with is DISCLOSED (#1574)", () => {
     expect(completionDisagreesWithRecord(row({ status: "error" }), [job()])).toBe(false);
   });
 
+  it("does not let a completion check stand in for a failure check", () => {
+    // #2057 is the failure direction. If this started returning true, the formatter
+    // would treat a contradicted FAILED as a contradicted completion and talk about
+    // bytes finishing — the wrong hedge.
+    expect(completionDisagreesWithRecord(row({ status: "error" }), [job({ status: "downloading" })])).toBe(
+      false,
+    );
+  });
+
   it("a terminal record other than downloading does not disagree", () => {
     for (const status of ["error", "cancelled", "done"]) {
       expect(completionDisagreesWithRecord(row(), [job({ status })]), status).toBe(false);
@@ -133,6 +144,7 @@ describe("the disagreement actually reaches the user (#1574)", () => {
   it("the tick FLAGS the disagreeing entries", async () => {
     const src = await read("index.ts");
     expect(src).toMatch(/settled\.filter\(\(d\) => completionDisagreesWithRecord\(d, records\)\)/);
+    expect(src).toMatch(/settled\.filter\(\(d\) => failureDisagreesWithRecord\(d, records\)\)/);
     expect(src).toMatch(/\.recordDisagrees = true/);
   });
 
@@ -253,5 +265,129 @@ describe("an exact (id, target) record wins over a targetless one (#1574)", () =
         job({ target: undefined, status: "downloading" }),
       ]),
     ).toBe(true);
+  });
+});
+
+// #2057 — the tray announced FAILED (and claimed nothing transferred) while the transfer
+// was still streaming. Same two stores as #1574, opposite terminal.
+//
+// The reporter's handles: job `07d14bb0c73bc007`, tray `31bba4a9cdb04e28`. Status at
+// t+106s was downloading 0.14/19.53 GB; the panel then emitted FAILED + NOTHING
+// transferred; status at t+163s was downloading 0.22/19.53 GB. Bytes advanced across
+// the failure notification, so the job record is the authority — not the tray row.
+//
+// #1150 could not see this: it only flags a failure whose FILENAME is still a live
+// tray row, and here the tray row itself was the error.
+
+const errorRow = (over: Record<string, unknown> = {}) =>
+  row({ id: "31bba4a9cdb04e28", status: "error", ...over });
+const liveJob = (over: Record<string, unknown> = {}) =>
+  job({ id: "07d14bb0c73bc007", trayId: "31bba4a9cdb04e28", status: "downloading", ...over });
+
+describe("a failure the record disagrees with is DISCLOSED (#2057)", () => {
+  it("flags the reported case: row says error, the job record still says downloading", () => {
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob()])).toBe(true);
+  });
+
+  it("matches on the PROGRESS identity, not the job's public id", () => {
+    expect(failureDisagreesWithRecord(errorRow({ id: "07d14bb0c73bc007" }), [liveJob()])).toBe(false);
+    expect(
+      failureDisagreesWithRecord(errorRow({ id: "prog-1" }), [liveJob({ progressId: "prog-1" })]),
+    ).toBe(true);
+    expect(
+      failureDisagreesWithRecord(errorRow({ id: "31bba4a9cdb04e28" }), [
+        liveJob({ progressId: "prog-1" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("says nothing when the record agrees the download failed", () => {
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ status: "error" })])).toBe(false);
+  });
+
+  it("says nothing when the record has no opinion", () => {
+    expect(failureDisagreesWithRecord(errorRow(), [])).toBe(false);
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ trayId: "someone-else" })])).toBe(false);
+  });
+
+  it("only looks at FAILURES — a completion row is untouched", () => {
+    expect(failureDisagreesWithRecord(errorRow({ status: "done" }), [liveJob()])).toBe(false);
+  });
+
+  it("a terminal record other than downloading does not disagree", () => {
+    for (const status of ["error", "cancelled", "done"]) {
+      expect(failureDisagreesWithRecord(errorRow(), [liveJob({ status })]), status).toBe(false);
+    }
+  });
+
+  it("junk never throws — this runs on the event path", () => {
+    for (const bad of [null, undefined, {}, { status: "error" }]) {
+      expect(() => failureDisagreesWithRecord(bad as never, [liveJob()])).not.toThrow();
+    }
+    expect(failureDisagreesWithRecord(errorRow(), null as never)).toBe(false);
+  });
+
+  it("the note tells the agent not to report a failure, and never says FAILED", () => {
+    expect(FAILURE_DISAGREEMENT_NOTE).toMatch(/still reports this transfer as downloading/i);
+    expect(FAILURE_DISAGREEMENT_NOTE).toMatch(/do NOT report it as failed/i);
+    expect(FAILURE_DISAGREEMENT_NOTE).not.toMatch(/FAILED/);
+  });
+
+  it("does not match a record for the same id at a DIFFERENT target", () => {
+    expect(
+      failureDisagreesWithRecord(errorRow({ target: "/local/models" }), [
+        liveJob({ target: "/pod/models" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches when the targets agree", () => {
+    expect(
+      failureDisagreesWithRecord(errorRow({ target: "/local/models" }), [
+        liveJob({ target: "/local/models" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("still matches when EITHER side has no target", () => {
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ target: "/pod/models" })])).toBe(true);
+    expect(failureDisagreesWithRecord(errorRow({ target: "/local" }), [liveJob()])).toBe(true);
+  });
+
+  it("does not let a targetless DOWNLOADING shadow the exact ERROR", () => {
+    expect(
+      failureDisagreesWithRecord(errorRow({ target: "/local/models" }), [
+        liveJob({ target: undefined, status: "downloading" }),
+        liveJob({ target: "/local/models", status: "error" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("…and finds the exact DOWNLOADING behind a targetless ERROR", () => {
+    expect(
+      failureDisagreesWithRecord(errorRow({ target: "/local/models" }), [
+        liveJob({ target: undefined, status: "error" }),
+        liveJob({ target: "/local/models", status: "downloading" }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("the failure disagreement actually reaches the user (#2057)", () => {
+  const read = async (file: string): Promise<string> => {
+    const { readFileSync } = await import("node:fs");
+    return readFileSync(new URL(`../../orchestrator/${file}`, import.meta.url), "utf-8");
+  };
+
+  it("the formatter keeps a contradicted failure out of the FAILED list", async () => {
+    const src = await read("panel-agent.ts");
+    expect(src).toMatch(/failedLiveRecord/);
+    expect(src).toMatch(/FAILURE_DISAGREEMENT_NOTE/);
+    // The NOTHING sentence is gated on there being a genuinely-dead failure
+    // and no live counterpart — otherwise the reporter's 0.22 GB transfer is
+    // described as having transferred nothing.
+    expect(src).toMatch(
+      /failedDead\.length && !failedRetried\.length && !failedLiveRecord\.length/,
+    );
   });
 });

--- a/src/__tests__/orchestrator/download-done-event.test.ts
+++ b/src/__tests__/orchestrator/download-done-event.test.ts
@@ -230,3 +230,59 @@ describe("a failed attempt superseded by a live retry (#1150)", () => {
     expect(t).toMatch(/EARLIER attempt failed for retried\.safetensors/);
   });
 });
+
+// #2057 — the tray said FAILED (and claimed nothing transferred) while
+// download_model action:"status" still showed the SAME id as downloading with
+// advancing bytes. #1150's supersededByLive hedge never fired: there was no
+// live tray row of that name, because the tray row itself was the error.
+describe("a failed tray row whose job record is still downloading (#2057)", () => {
+  it("does NOT present the reported filename as FAILED, and does not claim NOTHING transferred", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-2057", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-2057", {
+      kind: "download_done",
+      downloads: [
+        {
+          name: "minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+          status: "error",
+          recordDisagrees: true,
+        },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    expect(t).toContain("minimax_h3_fl2va_pruned_int8_convrot.safetensors");
+    expect(t).toMatch(/do NOT report it as failed/);
+    expect(t).toMatch(/still reports this transfer as downloading/);
+    expect(t).toContain('download_model action:"status"');
+    expect(t).not.toMatch(/FAILED: minimax_h3_fl2va_pruned_int8_convrot\.safetensors/);
+    expect(t).not.toMatch(/NOTHING is claimed to have transferred/);
+  });
+
+  it("still names a genuinely dead failure FAILED in the same batch", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-2057-mix", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-2057-mix", {
+      kind: "download_done",
+      downloads: [
+        { name: "gone.safetensors", status: "error" },
+        { name: "live.safetensors", status: "error", recordDisagrees: true },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    const failedList = /FAILED: ([^;]*)/.exec(t)?.[1] ?? "";
+    expect(failedList).toContain("gone.safetensors");
+    expect(failedList).not.toContain("live.safetensors");
+    expect(t).toMatch(/tray reported a failure for live\.safetensors/);
+    expect(t).not.toMatch(/NOTHING is claimed to have transferred/);
+  });
+});

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -1,34 +1,41 @@
 /**
- * #1574 — when the completion event and `download_model action:"status"` disagree, say so.
- *
- * The tray raised `transfer completed` for an 11.46GB download while
- * `download_model action:"status"` reported it still streaming, `list_local_models` showed the
- * file absent, and the category count only rose minutes later. The file landed AFTER the
- * event.
+ * #1574 / #2057 — when the tray event and `download_model action:"status"` disagree, say so.
  *
  * The completion event is built from a PROGRESS ROW read off disk each tick. `status` answers
  * from the JOB RECORD. Two stores, and the event consults only one — the same split #1545
  * documented from the other side.
  *
+ * #1574: the tray raised `transfer completed` for an 11.46GB download while status reported
+ * it still streaming. The file landed AFTER the event.
+ *
+ * #2057: the tray raised `Model download FAILED` (and claimed nothing transferred) for a
+ * 19.53GB HuggingFace fetch while status — same id — still said **downloading** with
+ * advancing bytes (0.14 → 0.22 GB). An agent that trusts FAILED re-issues into a live
+ * writer, which is the corruption hazard status itself warns about. #1150 only hedges
+ * when a LIVE TRAY ROW still shows that filename downloading; here the tray row itself
+ * was the error, so that hedge never fired. The job record is the same authority status
+ * reads, so a failure has to be checked against it the same way a completion is.
+ *
  * ## Why this ANNOTATES and never suppresses
  *
- * The first version of this dropped the contradicted event. Review killed it, correctly: a
- * terminal record may legitimately still read `downloading` until the ~15s persistence
- * heartbeat retries (see `persistDownloadJob`'s return value, #1545). The debounce bucket is
- * deleted before filtering and never requeued, so suppressing on a lagging record would
- * PERMANENTLY lose the completion notification for a download that genuinely finished.
+ * The first version of the completion guard dropped the contradicted event. Review killed
+ * it, correctly: a terminal record may legitimately still read `downloading` until the ~15s
+ * persistence heartbeat retries (see `persistDownloadJob`'s return value, #1545). The
+ * debounce bucket is deleted before filtering and never requeued, so suppressing on a
+ * lagging record would PERMANENTLY lose the notification.
  *
  * That trades a confusing message for a missing one, which is worse: the user is waiting on
- * that event. So the event always fires, and a disagreement is disclosed on it. The harm in
- * the report is a CONFIDENT false completion — "the natural next action is to use the file" —
- * and a hedge is precisely what removes that.
+ * that event. So the event always fires, and a disagreement is disclosed on it. For a
+ * completion the harm is a CONFIDENT false success; for a failure it is a CONFIDENT false
+ * FAILED — both removed by hedging, not by silence.
  *
  * ## Identity
  *
  * The two stores do not share an id. A progress row's `id` is the progress/tray identity;
- * the job's `id` is its public status handle (`6226e26ba97f8527` in the report, against tray
- * `93015fbfa0fa9933`). The row is matched against the job's `progressId ?? trayId`, which is
- * what writes those rows. An earlier version compared row id to job id and was therefore
+ * the job's `id` is its public status handle (`6226e26ba97f8527` in the #1574 report,
+ * against tray `93015fbfa0fa9933`; `07d14bb0c73bc007` against tray `31bba4a9cdb04e28` in
+ * #2057). The row is matched against the job's `progressId ?? trayId`, which is what
+ * writes those rows. An earlier version compared row id to job id and was therefore
  * INERT — it never matched anything, and its unit tests missed that because they fed
  * synthetic rows carrying whatever id the assertion wanted.
  */
@@ -58,6 +65,44 @@ function progressIdentityOf(job: JobLike): string | null {
 }
 
 /**
+ * The job record for this progress row, or null when nothing matches.
+ *
+ * (id, target) — the SAME key the supersession logic uses, and for the same reason: a
+ * concurrent LOCAL and POD transfer of one URL shares an id but is two transfers with two
+ * outcomes. Matching on id alone could annotate the wrong terminal, or miss a real
+ * disagreement by finding the other one first (review).
+ *
+ * A target is compared only when BOTH sides carry one. Rows and records that predate the
+ * field, or a route that never sets it, must not silently stop matching — that would make
+ * the check inert again, which is exactly how the first version shipped.
+ *
+ * PREFER THE EXACT (id, target) MATCH (review, round 3). Taking the first id match in
+ * array order let a TARGETLESS record shadow the exact one: a targetless "downloading"
+ * sitting before an exact-target terminal reported a disagreement that does not exist.
+ * The targetless record still stands in when nothing matches on target.
+ */
+function matchingRecord(row: RowLike, jobs: readonly JobLike[]): JobLike | null {
+  if (!row || typeof row !== "object") return null;
+  const id = typeof row.id === "string" ? row.id : null;
+  if (!id) return null;
+  if (!Array.isArray(jobs)) return null;
+  const target = typeof row.target === "string" ? row.target : null;
+  const sameId = jobs.filter((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
+  if (!sameId.length) return null;
+  return (
+    (target ? sameId.find((j) => j.target === target) : undefined) ??
+    sameId.find((j) => typeof j.target !== "string") ??
+    (target ? undefined : sameId[0]) ??
+    null
+  );
+}
+
+function recordStillDownloading(row: RowLike, jobs: readonly JobLike[]): boolean {
+  const record = matchingRecord(row, jobs);
+  return record != null && record.status === "downloading";
+}
+
+/**
  * Does the job record disagree with announcing this row as completed?
  *
  * True ONLY on a positive contradiction: a record exists for this exact progress identity and
@@ -66,37 +111,24 @@ function progressIdentityOf(job: JobLike): string | null {
  */
 export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
   if (!row || typeof row !== "object") return false;
-  // Only COMPLETIONS. A failure event carries its own hedged wording (#1150) and must be
-  // left entirely alone.
+  // Completions only. Failures have their own check (#2057); #1150's live-tray hedge
+  // stays a separate question (a different id writing the same filename).
   if (row.status !== "done") return false;
-  const id = typeof row.id === "string" ? row.id : null;
-  if (!id) return false;
-  if (!Array.isArray(jobs)) return false;
-  // (id, target) — the SAME key the supersession logic uses, and for the same reason: a
-  // concurrent LOCAL and POD transfer of one URL shares an id but is two transfers with two
-  // outcomes. Matching on id alone could annotate the wrong completion, or miss a real
-  // disagreement by finding the other one first (review).
-  //
-  // A target is compared only when BOTH sides carry one. Rows and records that predate the
-  // field, or a route that never sets it, must not silently stop matching — that would make
-  // the check inert again, which is exactly how the first version shipped.
-  const target = typeof row.target === "string" ? row.target : null;
-  const sameId = jobs.filter((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
-  if (!sameId.length) return false;
-  // PREFER THE EXACT (id, target) MATCH (review, round 3). Taking the first id match in
-  // array order let a TARGETLESS record shadow the exact one: a targetless "downloading"
-  // sitting before an exact-target "done" reported a disagreement that does not exist, and
-  // would have hedged a completion that was perfectly fine.
-  //
-  // The targetless record still stands in when nothing matches on target — that is what
-  // keeps rows and records predating the field from silently going unmatched, which would
-  // make the whole check inert again.
-  const record =
-    (target ? sameId.find((j) => j.target === target) : undefined) ??
-    sameId.find((j) => typeof j.target !== "string") ??
-    (target ? undefined : sameId[0]);
-  if (!record) return false;
-  return record.status === "downloading";
+  return recordStillDownloading(row, jobs);
+}
+
+/**
+ * Does the job record disagree with announcing this row as FAILED?
+ *
+ * Same identity and same positive-contradiction rule as {@link completionDisagreesWithRecord}.
+ * #1150 only looks at live TRAY rows of the same filename; this looks at the job RECORD
+ * `download_model action:"status"` reads. The reported case had no live tray row — the tray
+ * itself was the error — while status still showed the same id streaming and advancing.
+ */
+export function failureDisagreesWithRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
+  if (!row || typeof row !== "object") return false;
+  if (row.status !== "error") return false;
+  return recordStillDownloading(row, jobs);
 }
 
 /** The disclosure appended to a completion the record disagrees with. Deliberately states
@@ -107,3 +139,9 @@ export const COMPLETION_DISAGREEMENT_NOTE =
   "seconds, so this may simply be that — but a completion event has also been observed to " +
   "arrive minutes before the file existed (#1574). Check `download_model action:\"status\"` " +
   "and that the file is present before loading it.";
+
+/** Instruction for a FAILED tray row whose job record is still downloading (#2057).
+ *  Must not contain the word FAILED: that headline is what made the agent re-issue. */
+export const FAILURE_DISAGREEMENT_NOTE =
+  "`download_model action:\"status\"` still reports this transfer as downloading — " +
+  "do NOT report it as failed";

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -102,7 +102,7 @@ import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
-import { completionDisagreesWithRecord } from "./download-done-guard.js";
+import { completionDisagreesWithRecord, failureDisagreesWithRecord } from "./download-done-guard.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
 
@@ -6115,6 +6115,20 @@ export async function runPanelOrchestrator(): Promise<void> {
         logger.warn(
           "[panel-orchestrator] a download completion disagrees with the job record; disclosing rather than suppressing (#1574)",
           { ids: disagreeing.map((d) => String((d as { id?: unknown }).id ?? "")) },
+        );
+      }
+      // #2057 — the SAME split in the other direction. A tray ERROR while the job record
+      // still says downloading is how "Model download FAILED" + "NOTHING transferred"
+      // fired for a 19.53 GB fetch whose status (same id) was still streaming and
+      // advancing. #1150 only sees a live TRAY row of that filename; here the tray
+      // row itself was the error, so that hedge never ran. Flag it so the formatter
+      // will not say FAILED.
+      const failedDisagreeing = settled.filter((d) => failureDisagreesWithRecord(d, records));
+      for (const d of failedDisagreeing) (d as { recordDisagrees?: boolean }).recordDisagrees = true;
+      if (failedDisagreeing.length) {
+        logger.warn(
+          "[panel-orchestrator] a download failure disagrees with the job record; disclosing rather than announcing FAILED (#2057)",
+          { ids: failedDisagreeing.map((d) => String((d as { id?: unknown }).id ?? "")) },
         );
       }
       // #884 — a download has no originating TAB (its row names the owning

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,7 +23,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
-import { COMPLETION_DISAGREEMENT_NOTE } from "./download-done-guard.js";
+import { COMPLETION_DISAGREEMENT_NOTE, FAILURE_DISAGREEMENT_NOTE } from "./download-done-guard.js";
 import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
 import { orphanedByDeferredRespawnNote } from "../services/panel-secrets.js";
 import { errorText, promptText } from "./error-text.js";
@@ -1158,9 +1158,18 @@ export class PanelAgent {
       // download_model action:"status" showed streaming at 20% and 13% seconds
       // later. Naming them the same way as a real failure is what made the agent
       // report a false failure to the user.
-      const failedDead = dl.filter((d) => d.status !== "done" && !d.supersededByLive);
+      // #2057 — same headline, different store. The tray row is error, there is
+      // NO live tray row of that name, but the job RECORD status reads still
+      // says downloading. `recordDisagrees` is that check; it must not ride
+      // `failedDead` or the event says FAILED while status shows bytes moving.
+      const failedLiveRecord = dl.filter(
+        (d) => d.status !== "done" && d.recordDisagrees && !d.supersededByLive,
+      );
+      const failedDead = dl.filter(
+        (d) => d.status !== "done" && !d.supersededByLive && !d.recordDisagrees,
+      );
       const failedRetried = dl.filter((d) => d.status !== "done" && d.supersededByLive);
-      const failed = [...failedDead, ...failedRetried].map((d) => d.name);
+      const failed = [...failedDead, ...failedRetried, ...failedLiveRecord].map((d) => d.name);
       const parts: string[] = [];
       // This event is raised by the TRANSFER, which finishes BEFORE the placement
       // check against the connected ComfyUI does. Saying "finished" here would be a
@@ -1183,6 +1192,12 @@ export class PanelAgent {
             `NEWER download of that name is IN FLIGHT right now — do NOT report these as failed`,
         );
       }
+      if (failedLiveRecord.length) {
+        parts.push(
+          `the tray reported a failure for ${failedLiveRecord.map((d) => d.name).join(", ")}, but ` +
+            FAILURE_DISAGREEMENT_NOTE,
+        );
+      }
       const plural = dl.length > 1 ? "these downloads" : "it";
       text =
         `[panel event] Model download ${parts.join("; ")}. ` +
@@ -1202,11 +1217,17 @@ export class PanelAgent {
                 `but see the caveat above before relying on that; `
               : `The bytes finished transferring for the completed one${done.length > 1 ? "s" : ""}; `) +
             `whether the connected ComfyUI can actually LOAD ${plural} is confirmed separately. `
-          : `NOTHING is claimed to have transferred here. `) +
+          : // #2057 — "NOTHING is claimed to have transferred" was unconditional on
+            // !done.length, so a contradicted failure (status still streaming, bytes
+            // advancing) asserted zero bytes the process could have disproved. Only
+            // a genuinely-dead failure with no live counterpart may say this.
+            failedDead.length && !failedRetried.length && !failedLiveRecord.length
+              ? `NOTHING is claimed to have transferred here. `
+              : "") +
         `If you were waiting on ${plural} to continue a task, ` +
-        `call download_model action:"status" FIRST for the verified path and placement verdict${failed.length ? " or the error detail" : ""} — ` +
+        `call download_model action:"status" FIRST for the verified path and placement verdict${failedDead.length ? " or the error detail" : ""} — ` +
         `do not tell the user a model is ready until download_model action:"status" confirms it` +
-        (failedRetried.length
+        (failedRetried.length || failedLiveRecord.length
           ? `, and do not tell them one failed until status shows no live attempt for that name`
           : "") +
         `. Otherwise reply with ONE short sentence acknowledging it and no tool calls.`;


### PR DESCRIPTION
Fixes #2057

The download tray woke the panel with **Model download FAILED** (and claimed nothing transferred) while `download_model action:"status"` — same id — still reported **downloading** with advancing bytes.

The event is built from a progress row; status answers from the job record. #1574 already disclosed that split for a false *completion*. Failures were left to #1150, which only hedges when a *live tray row* of the same filename is still downloading. In the reported case the tray row itself was the error, so that hedge never ran.

The flush now checks a tray `error` against the same job record status reads. If that record still says downloading, the event no longer says FAILED and no longer claims nothing transferred; it tells the agent to check status and not report a failure.
