### PR TITLE
fix(2059): restore graph binding after restart when the active workflow record arrives late

### DIFF
--- a/src/__tests__/orchestrator/fence-rebind-transient.test.ts
+++ b/src/__tests__/orchestrator/fence-rebind-transient.test.ts
@@ -19,10 +19,11 @@
 // asserted here: the transient window is absorbed, AND a reply that stays
 // contradictory is still refused no matter how many times it is re-read.
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildPanelToolDefs,
   makePanelToolCtx,
+  __panelToolsTestHooks,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -174,6 +175,9 @@ describe("mode:'current' absorbs the post-restart reconciliation window (#1292)"
     expect(stamp).toBe(STALE);
     expect(res.isError).toBe(true);
     expect(text).toMatch(/UNCONFIRMED/);
+    // #2059 — UNCONFIRMED keeps the short 3-step budget; the longer missing-active
+    // wait must not leak onto this path or this recovery gets slower for nothing.
+    expect(listCalls, "1 initial + 3 short rechecks").toBe(4);
   });
 
   it("STOPS PRESCRIBING the retry it just performed", async () => {
@@ -242,5 +246,109 @@ describe("mode:'current' absorbs the post-restart reconciliation window (#1292)"
     expect(listCalls, "one read — there is nothing to wait for").toBe(1);
     expect(text).toMatch(/must be UPDATED/);
     expect(text).not.toMatch(/ALREADY TRIED/);
+  });
+});
+
+/**
+ * #2059 — after panel_restart_comfyui the sidebar can hello and answer
+ * workflow_list with NO top-level `active` record. The ordinary 3-step / ~2.9s
+ * window (1 initial + 3 rechecks = 4 reads) exhausted and left the session
+ * fenced to the previous instance. Rechecks for that reason now run longer,
+ * and a reconnect that replaces the tab mid-wait restarts the budget for the
+ * newly connected tab.
+ */
+function noActive(): Record<string, unknown> {
+  return {
+    workflows: [{ path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true }],
+    active_confirmed: true,
+  };
+}
+
+describe("mode:'current' waits for a missing active-workflow record after restart (#2059)", () => {
+  afterEach(() => {
+    __panelToolsTestHooks.setFenceMissingActiveRecheckSteps(null);
+    __panelToolsTestHooks.setFenceCorroborationRecheckSteps(null);
+  });
+
+  it("RECOVERS when the active record appears after the old 4-read window — the reported case", async () => {
+    // Four replies with no `active` is exactly what the 2.9s budget used to
+    // exhaust. The fifth is the record the frontend publishes once restore
+    // finishes. Shrunk so the suite does not wait the real extra seconds.
+    __panelToolsTestHooks.setFenceMissingActiveRecheckSteps([5, 5, 5, 5]);
+    listReplies = [noActive(), noActive(), noActive(), noActive(), settled(LIVE)];
+
+    const { res, text } = await setCurrent();
+
+    expect(stamp, "the live canvas's identity was adopted").toBe(LIVE);
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/"graph_binding": "bound"/);
+    expect(listCalls, "four misses, then the fifth read that carries active").toBe(5);
+  });
+
+  it("STILL REFUSES a permanently missing active record after the longer wait", async () => {
+    __panelToolsTestHooks.setFenceMissingActiveRecheckSteps([5, 5, 5, 5]);
+    listReplies = [noActive()];
+
+    const { res, text } = await setCurrent();
+
+    expect(stamp).toBe(STALE);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/no active-workflow record/);
+    expect(text).toMatch(/ALREADY TRIED: the panel was re-read 5 times/);
+    expect(listCalls).toBe(5);
+  });
+
+  it("restarts the wait when a newly connected tab replaces the socket mid-retry", async () => {
+    // Three rechecks — the ORIGINAL budget. Without tab-keying, the 4th read
+    // (new tab, still no active) would exhaust it and never see the 5th.
+    __panelToolsTestHooks.setFenceMissingActiveRecheckSteps([5, 5, 5]);
+
+    const OLD = "wf:workflows/old.json";
+    const NEW = "wf:workflows/a.json";
+    let liveTab = OLD;
+    let generation = 1;
+
+    const tabBridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_list") {
+          const n = listCalls;
+          listCalls += 1;
+          if (n === 2) {
+            // After the 3rd reply the old socket is gone; the next call's
+            // ensureReachable rebinds onto the newly connected tab.
+            liveTab = NEW;
+            generation = 2;
+          }
+          if (liveTab === NEW && n >= 4) return settled(LIVE);
+          return noActive();
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === liveTab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: liveTab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => liveTab,
+      tabConnectionIdentity: () => ({ generation, tabSessionId: "browser-tab-a" }),
+      refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+        stamp = uuid;
+        return true;
+      },
+      workflowUuidFor: () => ({ known: true, uuid: stamp }),
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+
+    const ctx = makePanelToolCtx(tabBridge, OLD, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+    if (!def) throw new Error("panel_set_workflow_target is not registered");
+    const res: ToolResult = await def.handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(ctx.tabId, "session rebound onto the newly connected tab").toBe(NEW);
+    expect(stamp, "the new tab's live identity was adopted").toBe(LIVE);
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/"graph_binding": "bound"/);
+    expect(listCalls, "old tab exhausted the original budget; new tab got its own wait").toBe(5);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1111,6 +1111,13 @@ export const __panelToolsTestHooks = {
   setReconnectWaitTiming(timing: { budgetMs: number; intervalMs: number } | null): void {
     reconnectWaitTimingOverride = timing;
   },
+  /** Shrink the #1292 / #2059 corroboration rechecks so tests don't wait ~2.9s / ~9.4s. */
+  setFenceCorroborationRecheckSteps(steps: readonly number[] | null): void {
+    fenceCorroborationRecheckStepsOverride = steps;
+  },
+  setFenceMissingActiveRecheckSteps(steps: readonly number[] | null): void {
+    fenceMissingActiveRecheckStepsOverride = steps;
+  },
   /** The reconnect wait the tools actually use (env/default, or the test override). */
   getReconnectWaitTiming(): { budgetMs: number; intervalMs: number } {
     return reconnectWaitTiming();
@@ -7271,7 +7278,7 @@ function corroborateActiveForFence(
    *  confirm the canvas" apart from "the canvas is a different one". A caller
    *  whose preserved fence equals this uuid is not broken, and telling them their
    *  graph tools will keep failing sends them to a hard refresh for nothing. */
-  | { ok: false; why: string; settles: boolean; seenUuid?: string } {
+  | { ok: false; why: string; settles: boolean; seenUuid?: string; missingActive?: true } {
   const active = parsed.active;
   // Read once, up front, so every failure branch below can report it. Undefined
   // whenever the record is missing, unreadable, or carries no usable uuid.
@@ -7282,7 +7289,16 @@ function corroborateActiveForFence(
   if (!active || typeof active !== "object") {
     // SETTLES: mid-restore the frontend genuinely has no active workflow yet —
     // that is #1184's finding in this reply's terms, and it is the window here.
-    return { ok: false, seenUuid, why: "the reply carried no active-workflow record", settles: true };
+    // #2059 — this is also the post-restart shape: the tab has hellod and will
+    // answer workflow_list, but the canvas has not published an active record.
+    // Rechecks for this reason use a longer, tab-keyed budget (see below).
+    return {
+      ok: false,
+      seenUuid,
+      why: "the reply carried no active-workflow record",
+      settles: true,
+      missingActive: true,
+    };
   }
   // #514: the panel says so itself when its active record is not confirmed. An
   // explicit `false` is the panel telling us the value is untrustworthy — never
@@ -7549,6 +7565,15 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
  * process reconnecting. The reporter's five seconds is an upper bound with a
  * human in it, not a measurement of the settle.
  *
+ * #2059 is the exception, and it is a different window. After `panel_restart_comfyui`
+ * the tab can hello and answer `workflow_list` while the frontend still has no
+ * active-workflow record at all — not UNCONFIRMED, absent. Four reads over 2.9s
+ * were not enough; the session stayed fenced to the previous instance. Rechecks
+ * for that one reason use `FENCE_MISSING_ACTIVE_RECHECK_STEPS_MS`, and the wait
+ * is keyed to the tab that answered (a reconnect that replaces the socket mid-
+ * wait restarts the budget for the new tab rather than spending the old tab's
+ * leftover milliseconds).
+ *
  * WHY ONLY `uncorroborated`: the sibling failure `no_uuid` means the installed
  * panel exposes no workflow identity at all. Rechecking a build that will never
  * answer differently just makes the same error slower — the distinction the
@@ -7560,6 +7585,34 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
  * happening here.
  */
 const FENCE_CORROBORATION_RECHECK_STEPS_MS = [400, 900, 1600] as const;
+/**
+ * #2059 — extra rechecks when the reply carries no active-workflow record.
+ *
+ * The first three steps match the ordinary reconciliation window so a record
+ * that appears on the second read costs the same as UNCONFIRMED. The two extra
+ * steps cover a post-restart frontend that hellos (and will answer) before it
+ * has restored an active canvas. Still far shorter than the 35s reconnect wait:
+ * the socket is already up; this is only workspace restore.
+ */
+const FENCE_MISSING_ACTIVE_RECHECK_STEPS_MS = [400, 900, 1600, 2500, 4000] as const;
+
+let fenceCorroborationRecheckStepsOverride: readonly number[] | null = null;
+let fenceMissingActiveRecheckStepsOverride: readonly number[] | null = null;
+
+function fenceCorroborationRecheckSteps(): readonly number[] {
+  return fenceCorroborationRecheckStepsOverride ?? FENCE_CORROBORATION_RECHECK_STEPS_MS;
+}
+
+function fenceMissingActiveRecheckSteps(): readonly number[] {
+  return fenceMissingActiveRecheckStepsOverride ?? FENCE_MISSING_ACTIVE_RECHECK_STEPS_MS;
+}
+
+function recheckStepsFor(
+  c: ReturnType<typeof corroborateActiveForFence>,
+): readonly number[] {
+  if (c.ok || !c.settles) return [];
+  return c.missingActive ? fenceMissingActiveRecheckSteps() : fenceCorroborationRecheckSteps();
+}
 
 /**
  * #1478 — NAME THE CAUSE OF A MISMATCH THE LOAD MAY HAVE CREATED.
@@ -7664,6 +7717,11 @@ async function rebindWorkflowFence(
     return { corroborated: corroborateActiveForFence(parsed) };
   };
 
+  const tabKeyOf = (): string => {
+    const gen = ctx.panelConnectionIdentity?.()?.generation;
+    return `${ctx.tabId}:${typeof gen === "number" ? String(gen) : ""}`;
+  };
+
   const first = await readAndCorroborate();
   if ("done" in first) return first.done;
   let corroborated = first.corroborated;
@@ -7675,14 +7733,30 @@ async function rebindWorkflowFence(
   // sharing no comparable identity field — will say exactly the same thing 2.9s
   // later, so retrying it just makes the identical error slower. That is the same
   // reasoning that keeps `no_uuid` out of this loop, applied one level down.
-  for (const waitMs of FENCE_CORROBORATION_RECHECK_STEPS_MS) {
-    if (corroborated.ok || !corroborated.settles) break;
+  //
+  // #2059 — the wait is keyed to the tab that answered. After a restart the
+  // socket that first replies may be replaced by a newly connected tab mid-loop;
+  // leftover milliseconds from the old tab are not a wait the new tab was given.
+  // A missing active-workflow record also uses a longer schedule: the frontend
+  // can hello (and answer) before it has restored an active canvas.
+  let keyedTab = tabKeyOf();
+  let steps = recheckStepsFor(corroborated);
+  let stepIndex = 0;
+  while (!corroborated.ok && corroborated.settles && stepIndex < steps.length) {
+    const waitMs = steps[stepIndex] ?? 0;
     await sleep(waitMs);
     waitedMs += waitMs;
+    stepIndex++;
     attempts++;
     const next = await readAndCorroborate();
     if ("done" in next) return next.done;
     corroborated = next.corroborated;
+    const nowTab = tabKeyOf();
+    if (nowTab !== keyedTab) {
+      keyedTab = nowTab;
+      steps = recheckStepsFor(corroborated);
+      stepIndex = 0;
+    }
   }
   if (!corroborated.ok) {
     return {


### PR DESCRIPTION
Fixes #2059.

## What happened

After `panel_restart_comfyui` completed an observed down/up cycle, the sidebar reconnected enough to answer `panel_set_workflow_target({mode:"current"})`, but `workflow_list` still carried no active-workflow record. The orchestrator re-read four times over ~2.9s, never corroborated, and left the session fenced to the previous workflow instance. Manual F5 / Ctrl+Shift+R was the only way out.

This is the same post-restart reconciliation family as #803 / #1292, but a different snapshot: not UNCONFIRMED, **absent**. Four reads over 2.9s was the whole budget.

## What changed

`panel_set_workflow_target({mode:"current"})` still fails closed on an uncorroborated record. For a **missing** active-workflow record it now:

- waits on a longer bounded schedule (the first three steps match the ordinary 2.9s window, then two extra steps cover frontend workspace restore after the socket is already up)
- keys that wait to the tab that answered (tab id + hello generation). A reconnect that replaces the socket mid-wait restarts the budget for the newly connected tab instead of spending the old tab's leftover milliseconds

UNCONFIRMED / mixed / empty-list rechecks stay on the short schedule. A permanently missing record still refuses after the longer wait and still names a manual refresh.

## Tests

Drives the shipped `panel_set_workflow_target` handler:

- four `workflow_list` replies with no `active` (the old budget), then a corroborated record → `graph_binding:"bound"`
- a reconnect that replaces the tab on the 4th read, still no `active`, then a 5th read on the new tab → bound (without tab-keying that 5th read never happens)
- a permanently missing record still fails
- UNCONFIRMED still uses 1 + 3 short rechecks
