### PR TITLE
release: v0.52.55 — a long self-queued render is no longer called foreign backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.55] - 2026-08-22
+
 ### Fixed
 
 - **`panel_show_media`'s `/view` probe now asks whether the served family matches the filename (#2011).**
@@ -17,6 +19,18 @@ All notable changes to this project are documented here. This project adheres to
   image-or-video test to accept `audio/*` would have swapped the false alarm
   for a false clearance of `plate.png` serving `audio/wav`. The probe now
   compares families.
+
+### MCP
+
+#### Added
+- kitchen and panel_kitchen report what this GPU can run (#2029)
+
+#### Fixed
+- the /view probe flags a filename/body family mismatch, not a non-media body (#2038)
+- restore graph binding after restart when the active workflow record arrives late (#2062)
+- download tray no longer announces FAILED while status still shows the transfer streaming (#2061)
+- a long self-queued render is no longer called foreign backlog (#2060)
+
 
 ## [0.52.54] - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.54",
+  "version": "0.52.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.54",
+      "version": "0.52.55",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.54",
+  "version": "0.52.55",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.55** from `main` (after v0.52.54).

Carries:

- #2060 / #559 — a long self-queued render is no longer called foreign backlog
- #2029 / #2006 — `kitchen` and `panel_kitchen` report what this GPU can run
- #2061 / #2057 — download tray no longer announces FAILED while status still shows the transfer streaming
- #2062 / #2059 — restore graph binding after restart when the active workflow record arrives late
- #2038 / #2011 — the `/view` probe flags a filename/body family mismatch, not a non-media body

Held out: show_media PRs #2039/#2041/#2042 conflicting after #2038; hygiene/docs #2003; panel#1472 lint-red; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.55` tag on the version commit).