### PR TITLE
release: v0.52.56 — panel_show_media inlines /view refs for a phone reached via a scope address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.56] - 2026-08-22
+
 ### Fixed
 
 - **`panel_show_media` inlines a `/view` ref for the tab the frame will actually
@@ -20,6 +22,12 @@ All notable changes to this project are documented here. This project adheres to
   (`show_media` is the one buffered command; see #2013). A concrete tab that is
   merely offline is still judged by sticky `isHeadless` — that id names the
   mailbox recipient.
+
+### MCP
+
+#### Fixed
+- panel_show_media inlines /view refs for a phone reached via a scope address (#2039)
+
 
 ## [0.52.55] - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.55",
+  "version": "0.52.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.55",
+      "version": "0.52.56",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.55",
+  "version": "0.52.56",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.56** from `main` (after v0.52.55).

Carries:

- #2039 / #2012 — `panel_show_media` inlines `/view` refs for a phone reached via a scope address

Held out: show_media PRs #2041/#2042 conflicting after #2039; hygiene/docs #2003; panel#1472 lint-red; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.56` tag on the version commit).