### PR TITLE
fix(1524): panel_* tools reappear after panel_restart_comfyui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,32 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- **Codex `panel_*` tools reappear after `panel_restart_comfyui` / a mid-session MCP drop (#1524).**
+  After a forced ComfyUI restart the Codex session resumed with the generic
+  comfyui gateway and no `mcp__panel__*` entries in `ALL_TOOLS`;
+  `tools.mcp__panel__panel_set_todo` then threw `TypeError: … is not a function`.
+  Codex does not auto-reconnect HTTP MCP (stdio `comfyui` is respawned by the
+  client; `panel` is not). The Codex lane now polls `mcpServerStatus/list` at
+  each turn end and reads `runtimeStatus` (cached `tools` do not prove the
+  thread is connected). When `panel` is down, one `config/mcpServer/reload`
+  is queued per down-episode — Codex's only reconnect verb, so a healthy
+  stdio `comfyui` child is bounced with it, between turns. Same bounded
+  recovery #1681 added for Claude. The drop's cause is still open; this is
+  the remaining user-visible half (re-register after the drop).
+
+### MCP
+
+#### Fixed
+- Codex panel_* tools reappear after panel_restart_comfyui (#1524)
+
 ## [0.52.57] - 2026-08-22
 
 ### MCP
 
 #### Fixed
 - an unroutable show_media names who it is queued for, not whoever hellos next (#2041)
-
 
 ## [0.52.56] - 2026-08-22
 

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -1,0 +1,349 @@
+// #1524 — Codex lane. After panel_restart_comfyui the session resumes with the
+// generic comfyui gateway and NO mcp__panel__* entries in ALL_TOOLS.
+// tools.mcp__panel__panel_set_todo then throws TypeError: is not a function.
+//
+// Claude got reconnectMcpServer() in #1681. Codex's control plane is different:
+// mcpServerStatus/list to see the drop, config/mcpServer/reload to re-init
+// (applied on the NEXT turn). Codex does not auto-reconnect HTTP MCP
+// (openai/codex#11489); stdio comfyui is respawned by the client, panel is not.
+//
+// These tests drive the live CodexBackend.run() path with a fake app-server
+// client, same seam as the code-mode host-retry suite.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { waitFor } from "../helpers/wait-for.js";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+type Backend = InstanceType<BackendModule["CodexBackend"]>;
+
+let CodexBackend: BackendModule["CodexBackend"];
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+});
+
+afterAll(() => vi.unstubAllEnvs());
+
+/** Live `mcpServerStatus/list` tools field is a name→schema map, not an array. */
+const CACHED_PANEL_TOOLS = { panel_graph_outline: {}, panel_set_todo: {} };
+const PANEL_UP = [
+  { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+  { name: "panel", runtimeStatus: "connected", tools: CACHED_PANEL_TOOLS },
+];
+/** Dropped HTTP panel: runtimeStatus failed, tools inventory still cached. */
+const PANEL_GONE = [
+  { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+  { name: "panel", runtimeStatus: "failed", tools: CACHED_PANEL_TOOLS },
+];
+const MCP_SERVERS = {
+  comfyui: { transport: "stdio" as const, command: "node", args: ["mcp.js"] },
+  panel: { transport: "http" as const, url: "http://127.0.0.1:9198/tab" },
+};
+
+const noticesOf = (events: AgentEvent[]) =>
+  events.filter(
+    (e): e is Extract<AgentEvent, { type: "error" }> =>
+      e.type === "error" && (e as { sessionNotice?: boolean }).sessionNotice === true,
+  );
+
+type Listing =
+  | Array<{
+      name: string;
+      runtimeStatus?: string;
+      authStatus?: string;
+      tools?: Record<string, unknown> | unknown[];
+    }>
+  | "throw";
+
+async function waitUntil(pred: () => boolean, timeoutMs = 500): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitUntil timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+interface Drive {
+  events: AgentEvent[];
+  reloadCalls: number;
+  polls: number;
+  pollParams: unknown[];
+  endTurn(): Promise<void>;
+  finish(): Promise<void>;
+}
+
+function startDrive(opts: {
+  listings: Listing[];
+  reloadThrows?: boolean;
+}): Drive {
+  const listings = [...opts.listings];
+  const events: AgentEvent[] = [];
+  let polls = 0;
+  let reloadCalls = 0;
+  let starts = 0;
+  const turnWaiters: Array<() => void> = [];
+  let waitingForTurn = false;
+
+  const client = {
+    notificationHandler: null as ((msg: unknown) => void) | null,
+    exitError: null as Error | null,
+    exitPromise: new Promise<void>(() => {}),
+    request: vi.fn(async (method: string, params?: unknown) => {
+      if (method === "thread/start" || method === "thread/resume") {
+        return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
+      }
+      if (method === "model/list") return { data: [{ id: "gpt-5.6-sol", hidden: false }] };
+      if (method === "turn/start") {
+        starts += 1;
+        waitingForTurn = true;
+        for (const w of turnWaiters.splice(0)) w();
+        return { turn: { id: `turn-${starts}` } };
+      }
+      if (method === "mcpServerStatus/list") {
+        polls += 1;
+        drive.polls = polls;
+        drive.pollParams.push(params);
+        if (listings.length === 0) throw new Error("no listing scripted");
+        const next = listings.length > 1 ? listings.shift()! : listings[0];
+        if (next === "throw") throw new Error("mcpServerStatus/list unavailable");
+        return { data: next, nextCursor: null };
+      }
+      if (method === "config/mcpServer/reload") {
+        reloadCalls += 1;
+        drive.reloadCalls = reloadCalls;
+        if (opts.reloadThrows) throw new Error("unknown method config/mcpServer/reload");
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    }),
+    close: vi.fn(async () => {}),
+  };
+
+  const turns: Array<{ text: string }> = [];
+  let turnResolve: (() => void) | null = null;
+  let finished = false;
+  let idle = false;
+  async function* channel() {
+    for (;;) {
+      idle = false;
+      while (turns.length) yield turns.shift()!;
+      if (finished) return;
+      idle = true;
+      await new Promise<void>((resolve) => {
+        turnResolve = resolve;
+      });
+    }
+  }
+
+  const backend: Backend = new CodexBackend({
+    model: "gpt-5.6-sol",
+    mcpServers: MCP_SERVERS,
+  });
+  Object.assign(backend, { client, liveCatalog: [{ id: "gpt-5.6-sol", supportsEffort: true }] });
+
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: channel() })) events.push(ev);
+  })();
+
+  const drive: Drive = {
+    events,
+    reloadCalls: 0,
+    polls: 0,
+    pollParams: [],
+    async endTurn() {
+      await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+      idle = false;
+      turns.push({ text: "continue" });
+      turnResolve?.();
+      turnResolve = null;
+      if (!waitingForTurn) {
+        await new Promise<void>((resolve) => turnWaiters.push(resolve));
+      }
+      await waitUntil(() => waitingForTurn && starts > 0);
+      waitingForTurn = false;
+      const turnId = `turn-${starts}`;
+      client.notificationHandler?.({
+        method: "turn/completed",
+        params: { threadId: "thread-1", turn: { id: turnId, status: "completed" } },
+      });
+      // The MCP watch runs AFTER the turn result, before the run loop waits
+      // for the next channel item. Idle is the barrier that it finished.
+      await waitFor(() => expect(idle).toBe(true));
+    },
+    async finish() {
+      finished = true;
+      turnResolve?.();
+      await done;
+    },
+  };
+  return drive;
+}
+
+describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
+  it("a drop the reload fixes is narrated once, as fixed, on the next turn", async () => {
+    // Reload is queued for the NEXT turn. Same-turn is silent; the following
+    // poll is the verdict, and that is the only line the user gets.
+    const drive = startDrive({ listings: [PANEL_GONE, PANEL_UP] });
+    await drive.endTurn();
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.pollParams[0]).toMatchObject({
+      detail: "toolsAndAuthOnly",
+      threadId: "thread-1",
+    });
+    expect(noticesOf(drive.events)).toHaveLength(0);
+
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(1);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toMatch(/reconnect brought it back/);
+  });
+
+  it("a drop the reload does NOT fix is reported once — not fought every turn", async () => {
+    const drive = startDrive({ listings: [PANEL_GONE] });
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.finish();
+
+    expect(drive.reloadCalls).toBe(1);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toMatch(/reconnect did not bring it back/);
+  });
+
+  it("a healthy listing never reloads", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(0);
+    expect(noticesOf(drive.events)).toHaveLength(0);
+  });
+
+  it("a poll that throws stays silent and never takes the turn down", async () => {
+    const drive = startDrive({ listings: ["throw"] });
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(0);
+    expect(noticesOf(drive.events)).toHaveLength(0);
+    expect(drive.events.some((e) => e.type === "result")).toBe(true);
+  });
+
+  it("a reload that throws is reported as unverified, not as a failed reconnect", async () => {
+    const drive = startDrive({ listings: [PANEL_GONE], reloadThrows: true });
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(1);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toMatch(/reconnect was attempted/);
+    expect(notices[0].message).toMatch(/could not be read back/);
+    expect(notices[0].message).not.toMatch(/did not bring it back/);
+  });
+
+  it("a second drop after recovery is a new episode, with its own reload", async () => {
+    const drive = startDrive({ listings: [PANEL_GONE, PANEL_UP, PANEL_UP, PANEL_GONE] });
+    await drive.endTurn(); // drop → queue reload
+    await drive.endTurn(); // up → recovered
+    await drive.endTurn(); // still up — silent
+    await drive.endTurn(); // drop again → queue reload
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(2);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toMatch(/reconnect brought it back/);
+  });
+
+  it("runtimeStatus=failed with omitted tools still reloads", async () => {
+    // Deleting the runtimeStatus→failed branch leaves this green if the
+    // mapper still keys on empty tools arrays — this fixture has neither.
+    const drive = startDrive({
+      listings: [
+        [
+          { name: "comfyui", runtimeStatus: "connected" },
+          { name: "panel", runtimeStatus: "failed" },
+        ],
+      ],
+    });
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.pollParams[0]).toMatchObject({ threadId: "thread-1", detail: "toolsAndAuthOnly" });
+  });
+
+  it("runtimeStatus=starting does not reload even with an empty tools map", async () => {
+    const drive = startDrive({
+      listings: [
+        [
+          { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+          { name: "panel", runtimeStatus: "starting", tools: {} },
+        ],
+      ],
+    });
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(0);
+  });
+
+  it("a needs-auth server is reported but never reloaded", async () => {
+    const drive = startDrive({
+      listings: [
+        [
+          { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+          { name: "panel", runtimeStatus: "authenticationRequired", tools: CACHED_PANEL_TOOLS },
+        ],
+      ],
+    });
+    await drive.endTurn();
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(0);
+    const notices = noticesOf(drive.events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toMatch(/cannot clear this status/);
+  });
+
+  it("does not poll when this session was given no MCP servers", async () => {
+    const client = {
+      notificationHandler: null as ((msg: unknown) => void) | null,
+      exitError: null,
+      exitPromise: new Promise<void>(() => {}),
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "thread-1" } };
+        if (method === "model/list") return { data: [] };
+        if (method === "turn/start") return { turn: { id: "turn-1" } };
+        throw new Error(`unexpected request: ${method}`);
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const backend: Backend = new CodexBackend({ model: "gpt-5.6-sol" });
+    Object.assign(backend, { client, liveCatalog: [{ id: "gpt-5.6-sol" }] });
+    async function* channel() {
+      yield { text: "hello" };
+    }
+    const iterator = backend.run({ channel: channel() });
+    await iterator.next(); // session
+    const pending = iterator.next();
+    await waitUntil(() => (backend as Backend & { turnId?: string }).turnId === "turn-1");
+    client.notificationHandler?.({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+    });
+    await pending;
+    const rest: unknown[] = [];
+    for await (const ev of iterator) rest.push(ev);
+    expect(client.request.mock.calls.some((c) => c[0] === "mcpServerStatus/list")).toBe(false);
+    expect(client.request.mock.calls.some((c) => c[0] === "config/mcpServer/reload")).toBe(false);
+    void rest;
+  });
+});

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -29,6 +29,7 @@ import {
   inspectMcpServers,
   reconnectableMcpStatus,
   recoveredMcpNotice,
+  reportedFromCodexMcpListing,
   unrecoveredMcpNotice,
 } from "../../orchestrator/mcp-session-health.js";
 
@@ -236,5 +237,102 @@ describe("recoveredMcpNotice — claims only what the status poll reported", () 
     const note = recoveredMcpNotice(["comfyui"], false);
     expect(note).toMatch(/connected again/);
     expect(note).not.toMatch(/reconnect brought/);
+  });
+});
+
+describe("reportedFromCodexMcpListing — live runtimeStatus, not cached tools (#1524)", () => {
+  const CACHED = { panel_graph_outline: {}, panel_set_todo: {} };
+
+  it("says nothing when the listing is absent or empty", () => {
+    expect(reportedFromCodexMcpListing(undefined)).toBeUndefined();
+    expect(reportedFromCodexMcpListing([])).toBeUndefined();
+  });
+
+  it("reads runtimeStatus=connected as connected", () => {
+    expect(
+      reportedFromCodexMcpListing([
+        { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+        { name: "panel", runtimeStatus: "connected", tools: CACHED },
+      ]),
+    ).toEqual([
+      { name: "comfyui", status: "connected" },
+      { name: "panel", status: "connected" },
+    ]);
+  });
+
+  it("treats runtimeStatus=failed as a drop even when tools are still cached", () => {
+    // The live app-server row after a dropped HTTP session: panel is named,
+    // tools inventory is cached, runtimeStatus is failed. Cached tools must
+    // not look like connected — that is the ALL_TOOLS gap in the report.
+    const reported = reportedFromCodexMcpListing([
+      { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+      { name: "panel", runtimeStatus: "failed", tools: CACHED },
+    ]);
+    expect(inspectMcpServers(CONFIGURED, reported)).toEqual({
+      degraded: [{ name: "panel", status: "failed" }],
+      pending: [],
+    });
+    expect(reconnectableMcpStatus("failed")).toBe(true);
+  });
+
+  it("treats runtimeStatus=failed with omitted tools as a drop", () => {
+    const reported = reportedFromCodexMcpListing([
+      { name: "comfyui", runtimeStatus: "connected" },
+      { name: "panel", runtimeStatus: "failed" },
+    ]);
+    expect(inspectMcpServers(CONFIGURED, reported).degraded).toEqual([
+      { name: "panel", status: "failed" },
+    ]);
+  });
+
+  it("maps the rest of the live runtimeStatus vocabulary", () => {
+    expect(reportedFromCodexMcpListing([{ name: "panel", runtimeStatus: "starting" }])).toEqual([
+      { name: "panel", status: "pending" },
+    ]);
+    expect(
+      reportedFromCodexMcpListing([{ name: "panel", runtimeStatus: "authenticationRequired" }]),
+    ).toEqual([{ name: "panel", status: "needs-auth" }]);
+    expect(reportedFromCodexMcpListing([{ name: "panel", runtimeStatus: "disabled" }])).toEqual([
+      { name: "panel", status: "disabled" },
+    ]);
+    expect(reportedFromCodexMcpListing([{ name: "panel", runtimeStatus: "notStarted" }])).toEqual([
+      { name: "panel", status: "failed" },
+    ]);
+    expect(reportedFromCodexMcpListing([{ name: "panel", runtimeStatus: "cancelled" }])).toEqual([
+      { name: "panel", status: "failed" },
+    ]);
+  });
+
+  it("starting with an empty tools map is pending, not a false drop", () => {
+    const reported = reportedFromCodexMcpListing([
+      { name: "panel", runtimeStatus: "starting", tools: {} },
+    ]);
+    expect(inspectMcpServers(["panel"], reported)).toEqual({ degraded: [], pending: ["panel"] });
+  });
+
+  it("treats a server MISSING from a populated listing as absent", () => {
+    const reported = reportedFromCodexMcpListing([
+      { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {} } },
+    ]);
+    expect(inspectMcpServers(CONFIGURED, reported)).toEqual({
+      degraded: [{ name: "panel", status: null }],
+      pending: [],
+    });
+  });
+
+  it("empty tools is a drop only when runtimeStatus is omitted", () => {
+    // Older app-servers, or a poll without threadId (runtimeStatus is null).
+    expect(reportedFromCodexMcpListing([{ name: "panel", tools: {} }])).toEqual([
+      { name: "panel", status: "failed" },
+    ]);
+    expect(reportedFromCodexMcpListing([{ name: "panel", tools: [] }])).toEqual([
+      { name: "panel", status: "failed" },
+    ]);
+  });
+
+  it("does not invent a failure from a listing that omits runtimeStatus and tools", () => {
+    expect(reportedFromCodexMcpListing([{ name: "panel" }])).toEqual([
+      { name: "panel", status: "connected" },
+    ]);
   });
 });

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -57,6 +57,15 @@ import {
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
 import { MAX_SESSION_PREVIEW_BYTES, previewByteBudgetLabel } from "./preview-budget.js";
+import {
+  inspectMcpServers,
+  reconnectableMcpStatus,
+  recoveredMcpNotice,
+  reportedFromCodexMcpListing,
+  unrecoveredMcpNotice,
+  type CodexMcpServerListing,
+  type DegradedMcpServer,
+} from "./mcp-session-health.js";
 
 function msgOf(err: unknown): string {
   return errorText(err);
@@ -851,6 +860,15 @@ export class CodexBackend implements AgentBackend {
   /** The live thread + turn ids — used for `turn/interrupt`. */
   private threadId: string | null = null;
   private turnId: string | null = null;
+  /** MCP servers this run currently knows are DOWN, name → reconnect attempted.
+   *  Codex does not auto-reconnect HTTP MCP (openai/codex#11489); we poll
+   *  `mcpServerStatus/list` at each turn end and queue one
+   *  `config/mcpServer/reload` per down-episode (#1524). */
+  private mcpDown = new Map<string, boolean>();
+  /** Names whose `config/mcpServer/reload` was queued this episode and has
+   *  not been judged yet. The app-server applies the refresh on the NEXT
+   *  turn, so the following poll is the verdict — not an immediate re-read. */
+  private mcpReloadPending = new Set<string>();
   /** The model requested for new turns (mutable for a future live setModel). */
   private model: string | undefined;
   /** The Codex reasoning effort for new turns, already mapped to a valid Codex
@@ -1116,6 +1134,8 @@ export class CodexBackend implements AgentBackend {
    * next batch (the channel async-iteration IS the turn-gate).
    */
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.mcpDown.clear();
+    this.mcpReloadPending.clear();
     await this.prepare();
     const client = this.client;
     if (!client) throw new Error("codex app-server not initialized");
@@ -1200,6 +1220,155 @@ export class CodexBackend implements AgentBackend {
       liveClient = this.client;
       yield* stampTurn(this.runTurn(liveClient, turn, opts.onActivity), ++turnSeq);
       if (!this.client) return;
+      liveClient = this.client;
+      try {
+        for (const ev of await this.checkMcpServers(liveClient)) yield ev;
+      } catch (err) {
+        logger.debug(`[codex-backend] checkMcpServers: ${msgOf(err)}`);
+      }
+    }
+  }
+
+  /**
+   * Watch the Codex toolset for a MID-SESSION drop and queue one reconnect
+   * (#1524). Codex's MCP client is one-shot (openai/codex#11489): stdio
+   * `comfyui` is respawned by the client, HTTP `panel` is not. After
+   * `panel_restart_comfyui` the session resumes with ALL_TOOLS missing every
+   * `mcp__panel__*` entry while the generic comfyui gateway remains.
+   *
+   * Detection is one `mcpServerStatus/list` poll per turn end (with this
+   * thread's id, so `runtimeStatus` is filled) against the servers this
+   * session was given. Cached `tools` do not prove connected. Recovery is
+   * `config/mcpServer/reload`, which the app-server applies on the NEXT
+   * turn — so this turn does not claim a verdict from an immediate re-read.
+   * The next poll is the verdict.
+   * One attempt per down-episode; `needs-auth` / `disabled` are reported
+   * and not retried. A poll or reload that throws leaves the session as
+   * informed as before and never takes the turn stream down.
+   */
+  private async checkMcpServers(client: AppServerClient): Promise<AgentEvent[]> {
+    const names = Object.keys(this.deps.mcpServers ?? {});
+    if (names.length === 0) return [];
+    const reported = await this.pollMcpStatus(client);
+    if (!reported) return [];
+    const events: AgentEvent[] = [];
+    const degraded = inspectMcpServers(names, reported).degraded;
+    const downNow = new Set(degraded.map((d) => d.name));
+
+    // Verdict on a reload queued at the previous turn end. The refresh is
+    // applied when the next turn starts, so THIS poll is the first honest read.
+    const pendingVerdict = [...this.mcpReloadPending];
+    this.mcpReloadPending.clear();
+
+    const backByUs: string[] = [];
+    const backOnItsOwn: string[] = [];
+    for (const name of [...this.mcpDown.keys()]) {
+      if (downNow.has(name)) continue;
+      const weTried = this.mcpDown.get(name) === true || pendingVerdict.includes(name);
+      this.mcpDown.delete(name);
+      (weTried ? backByUs : backOnItsOwn).push(name);
+    }
+    if (backByUs.length) {
+      logger.info(`[codex-backend] MCP reload brought back: ${backByUs.join(", ")}`);
+      events.push({ type: "error", sessionNotice: true, message: recoveredMcpNotice(backByUs, true) });
+    }
+    if (backOnItsOwn.length) {
+      logger.info(`[codex-backend] MCP servers connected again on their own: ${backOnItsOwn.join(", ")}`);
+      events.push({ type: "error", sessionNotice: true, message: recoveredMcpNotice(backOnItsOwn, false) });
+    }
+
+    const stillDownAfterReload = degraded.filter((d) => pendingVerdict.includes(d.name));
+    if (stillDownAfterReload.length) {
+      this.reportDegradedMcp(stillDownAfterReload, "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(stillDownAfterReload, "reconnect-failed"),
+      });
+    }
+
+    const triable = degraded.filter(
+      (d) =>
+        !pendingVerdict.includes(d.name) &&
+        this.mcpDown.get(d.name) !== true &&
+        reconnectableMcpStatus(d.status),
+    );
+    if (triable.length > 0) {
+      for (const d of triable) this.mcpDown.set(d.name, true);
+      try {
+        await client.request("config/mcpServer/reload", {});
+        for (const d of triable) this.mcpReloadPending.add(d.name);
+      } catch (err) {
+        logger.debug(`[codex-backend] config/mcpServer/reload: ${msgOf(err)}`);
+        this.reportDegradedMcp(triable, "lost");
+        events.push({
+          type: "error",
+          sessionNotice: true,
+          message: unrecoveredMcpNotice(triable, "unverified"),
+        });
+      }
+    }
+
+    const unreported = degraded.filter(
+      (d) =>
+        !pendingVerdict.includes(d.name) &&
+        !triable.some((t) => t.name === d.name) &&
+        !this.mcpDown.has(d.name),
+    );
+    const notRetriable = unreported.filter((d) => !reconnectableMcpStatus(d.status));
+    const unsupported = unreported.filter((d) => reconnectableMcpStatus(d.status));
+    for (const d of unreported) this.mcpDown.set(d.name, true);
+    if (notRetriable.length) {
+      this.reportDegradedMcp(notRetriable, "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(notRetriable, "not-retriable"),
+      });
+    }
+    if (unsupported.length) {
+      this.reportDegradedMcp(unsupported, "lost");
+      events.push({
+        type: "error",
+        sessionNotice: true,
+        message: unrecoveredMcpNotice(unsupported, "unsupported"),
+      });
+    }
+    return events;
+  }
+
+  private reportDegradedMcp(degraded: readonly DegradedMcpServer[], when: string): void {
+    logger.error(
+      `[codex-backend] session ${this.threadId?.slice(0, 8) ?? "?"} ${when} WITHOUT ` +
+        `${degraded.map((d) => `${d.name}=${d.status ?? "absent"}`).join(" ")}`,
+    );
+  }
+
+  private async pollMcpStatus(client: AppServerClient): Promise<
+    Array<{ name: string; status: string }> | undefined
+  > {
+    try {
+      const listed: CodexMcpServerListing[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page < 8; page++) {
+        const res = await client.request<{
+          data?: CodexMcpServerListing[];
+          nextCursor?: string | null;
+        }>("mcpServerStatus/list", {
+          detail: "toolsAndAuthOnly",
+          limit: 50,
+          ...(this.threadId ? { threadId: this.threadId } : {}),
+          ...(cursor ? { cursor } : {}),
+        });
+        if (!Array.isArray(res?.data)) break;
+        listed.push(...res.data);
+        cursor = res.nextCursor ?? undefined;
+        if (!cursor) break;
+      }
+      return reportedFromCodexMcpListing(listed);
+    } catch (err) {
+      logger.debug(`[codex-backend] mcpServerStatus/list: ${msgOf(err)}`);
+      return undefined;
     }
   }
 

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -112,6 +112,93 @@ export function inspectMcpServers(
 }
 
 /**
+ * One row of Codex app-server `mcpServerStatus/list` (`McpServerStatus` in
+ * app-server-protocol v2, camelCase on the wire).
+ *
+ * Live fields: `name`, `runtimeStatus`, `authStatus`, `tools` (a map, not an
+ * array), `serverInfo`, `pluginId`. There is no `status` and no `enabled`.
+ * Official docs: the tools inventory may be cached and does **not** prove the
+ * thread is connected; omit `threadId` and `runtimeStatus` is null.
+ *
+ * Mapped into `ReportedMcpServer` so `inspectMcpServers` is the only comparison.
+ */
+export interface CodexMcpServerListing {
+  name?: unknown;
+  runtimeStatus?: unknown;
+  authStatus?: unknown;
+  tools?: unknown;
+}
+
+/**
+ * Translate a Codex `mcpServerStatus/list` page into the report
+ * `inspectMcpServers` already understands.
+ *
+ * Returns `undefined` when the listing is absent or empty — same silence as
+ * an unpopulated Claude init report: a harness that did not answer tells us
+ * nothing, and reading that as failure would fire on every healthy session.
+ *
+ * `runtimeStatus` is the connection signal. Cached `tools` never override it:
+ * `{ name: "panel", runtimeStatus: "failed", tools: { panel_set_todo: … } }`
+ * is a drop, which is the reporter's ALL_TOOLS gap after panel_restart_comfyui.
+ * Empty tools is only a fallback when `runtimeStatus` is omitted (older
+ * app-servers, or a poll that forgot `threadId`).
+ */
+export function reportedFromCodexMcpListing(
+  listed: readonly CodexMcpServerListing[] | undefined,
+): ReportedMcpServer[] | undefined {
+  if (!Array.isArray(listed) || listed.length === 0) return undefined;
+  const out: ReportedMcpServer[] = [];
+  for (const entry of listed) {
+    if (!entry || typeof entry.name !== "string" || !entry.name) continue;
+    out.push({ name: entry.name, status: statusOfCodexListing(entry) });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Codex `McpServerConnectionStatus`: notStarted | starting | connected |
+ * authenticationRequired | failed | cancelled | disabled.
+ */
+function statusOfCodexListing(entry: CodexMcpServerListing): string {
+  const runtime =
+    typeof entry.runtimeStatus === "string" ? entry.runtimeStatus.trim().toLowerCase() : "";
+  if (runtime) {
+    if (runtime === "connected") return "connected";
+    if (runtime === "starting") return "pending";
+    if (runtime === "authenticationrequired") return "needs-auth";
+    if (runtime === "disabled") return "disabled";
+    // notStarted / failed / cancelled — drop shapes a reload can speak to.
+    if (
+      runtime === "failed" ||
+      runtime === "cancelled" ||
+      runtime === "notstarted" ||
+      runtime === "error"
+    ) {
+      return "failed";
+    }
+    // Unrecognized runtimeStatus: closed list, same as inspectMcpServers —
+    // a new value must not become an alarm.
+    return "connected";
+  }
+  const auth =
+    typeof entry.authStatus === "string" ? entry.authStatus.trim().toLowerCase() : "";
+  if (auth === "notloggedin") return "needs-auth";
+  // Older listing with no runtimeStatus: empty inventory is a drop, a
+  // populated (possibly cached) map is not proof of connected either, but
+  // without a runtime field we cannot tell a healthy row from a stale cache
+  // — silence, matching "omit threadId → runtimeStatus is null".
+  if (toolsInventoryEmpty(entry.tools)) return "failed";
+  return "connected";
+}
+
+/** Codex serializes `tools` as a name→schema map; older stubs used an array. */
+function toolsInventoryEmpty(tools: unknown): boolean {
+  if (Array.isArray(tools)) return tools.length === 0;
+  if (tools && typeof tools === "object") return Object.keys(tools).length === 0;
+  return false;
+}
+
+/**
  * Statuses that mean the server is not usable. Taken from the SDK's own
  * `McpServerStatus` union (`connected | failed | needs-auth | pending |
  * disabled`), plus `error` for a host that words it that way.


### PR DESCRIPTION
Fixes #1524

## What was already true

Bind-or-exit shipped in 0.51.35. #1596 made a stale HTTP session a 404. #1614 made a session that **starts** without an MCP server say so. #1681 met a mid-session drop with one bounded `reconnectMcpServer()` — **Claude lane only**. Codex was explicitly out of scope there.

Today's recurrence (0.52.47 / panel 0.15.32, Codex, Windows): after `panel_restart_comfyui({force:true})` and session resume, `ALL_TOOLS` had **no** `mcp__panel__*` entries while the generic comfyui gateway remained. `tools.mcp__panel__panel_set_todo` threw `TypeError: ... is not a function`. Current main (0.52.56) still has no Codex-side re-register.

## Root cause

Codex's MCP client does not auto-reconnect HTTP servers after a drop (openai/codex#11489). `comfyui` is **stdio** — the client owns the child and respawns it. `panel` is **http** — a stateful session against the orchestrator loopback MCP. After a ComfyUI restart that drops that session, Codex keeps the stdio half and never retries the HTTP half, so the next code-mode exec's `ALL_TOOLS` snapshot has no `mcp__panel__*` tools.

## What changes

`CodexBackend` gets the same turn-end watch #1681 added for Claude, on Codex's own control plane:

- **Detection** — one `mcpServerStatus/list` poll per completed turn, mapped through `reportedFromCodexMcpListing` into the existing `inspectMcpServers` comparison. A named server with `tools: []` is the reporter's ALL_TOOLS gap and counts as a drop.
- **Recovery** — one `config/mcpServer/reload` per down-episode. The app-server applies that refresh on the **next** turn, so this turn does not claim a verdict from an immediate re-read; the following poll is the verdict.
- **Honesty** — `needs-auth` / `disabled` are reported and not retried. A poll or reload that throws stays silent or unverified and never takes the turn stream down. A server that stays down is reported once, not fought.

## Scope

Codex lane only. Gemini/Grok/other HTTP-lane backends are the same transport family but have their own control planes; nothing here touches them. This does not explain **why** the panel HTTP session dropped — still open on the issue. It re-registers the tools after that drop, which is the remaining user-visible half.

## Verification

- `reportedFromCodexMcpListing` pins empty `tools: []` as the ALL_TOOLS gap, missing-from-listing as absent, omitted-tools as not a false alarm.
- `codex-mcp-reconnect.test.ts` drives `CodexBackend.run()` with a fake app-server: reload-fixes-drop narrated on the next turn; reload-fails reported once; healthy listing never reloads; poll throw silent; reload throw unverified; second drop is a new episode; needs-auth never reloaded; no poll when the session was given no MCP servers.
- Existing Codex code-mode host-retry and watchdog suites still green.
