### PR TITLE
release: v0.52.58 — panel_* tools reappear after panel_restart_comfyui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.58] - 2026-08-22
+
 ### Fixed
 
 - **Codex `panel_*` tools reappear after `panel_restart_comfyui` / a mid-session MCP drop (#1524).**
@@ -25,6 +27,12 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - Codex panel_* tools reappear after panel_restart_comfyui (#1524)
+
+### MCP
+
+#### Fixed
+- panel_* tools reappear after panel_restart_comfyui (#2066)
+
 
 ## [0.52.57] - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.57",
+  "version": "0.52.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.57",
+      "version": "0.52.58",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.57",
+  "version": "0.52.58",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.58** from `main` (after v0.52.57).

Carries:

- #2066 / #1524 — `panel_*` tools reappear after `panel_restart_comfyui`

Held out: #2042/#2017 conflicting after #2066; P2 #1645 in-flight; new P2s #2067/#2068/#2069; panel #1582/#1634; hygiene #2003; panel#1472 lint-red; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.58` tag on the version commit).