### PR TITLE
fix(2068): resolve_missing reports unavailable custom-node LoRA combos

### DIFF
--- a/src/__tests__/services/missing-models.test.ts
+++ b/src/__tests__/services/missing-models.test.ts
@@ -100,6 +100,63 @@ describe("findMissingModels", () => {
     expect(out).toHaveLength(1);
     expect(out[0]!.directory).toBeUndefined(); // unknown, but NOT dropped
   });
+
+  // #2068 — ComfyUI 0.33 serialises custom-node combos as ["COMBO", {options}]
+  // (add_to_dict_v1). The V1-only parser treated that as "not a combo" and
+  // resolve_missing returned "No missing models" while panel_get_errors
+  // correctly listed DonutLoRAStack lora_name_N files as unavailable.
+  it("reports unavailable custom-node LoRA combo values against a V3 COMBO option list", () => {
+    const wanted = [
+      "krea2/general-purpose/realism_engine_krea2_v1.safetensors",
+      "krea2/Krea2-realism-V2.safetensors",
+      "krea2/general-purpose/Krea2_HMNSFW_AIO.safetensors",
+      "krea2/Krea2_NSFW_Aesthetics_V1.safetensors",
+    ];
+    const installed = ["None", "already-have.safetensors"];
+    const v3 = (options: string[]) => ["COMBO", { options }];
+    const oi: ObjectInfoLike = {
+      DonutLoRAStack: {
+        input: {
+          required: {
+            model_type: v3(["Auto", "KREA2"]),
+            switch_1: v3(["Off", "On"]),
+            lora_name_1: v3(installed),
+            lora_name_2: v3(installed),
+            lora_name_3: v3(installed),
+          },
+        },
+      },
+    };
+    const wf = {
+      "10": {
+        class_type: "DonutLoRAStack",
+        inputs: {
+          model_type: "KREA2",
+          switch_1: "On",
+          lora_name_1: wanted[0],
+          lora_name_2: wanted[1],
+          lora_name_3: "None",
+        },
+      },
+      "11": {
+        class_type: "DonutLoRAStack",
+        inputs: {
+          switch_1: "On",
+          lora_name_1: wanted[2],
+          lora_name_2: wanted[3],
+          lora_name_3: installed[1],
+        },
+      },
+    };
+    const out = findMissingModels(wf, oi);
+    const names = out.map((m) => m.name);
+    for (const file of wanted) expect(names).toContain(file);
+    expect(names).not.toContain("None");
+    expect(names).not.toContain(installed[1]);
+    expect(out.every((m) => m.node_type === "DonutLoRAStack")).toBe(true);
+    expect(out.every((m) => m.directory === "loras")).toBe(true);
+    expect(out).toHaveLength(wanted.length);
+  });
 });
 
 describe("classifyPrecision", () => {

--- a/src/__tests__/tools/missing-models.test.ts
+++ b/src/__tests__/tools/missing-models.test.ts
@@ -6,12 +6,22 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../comfyui/client.js", () => ({
-  getObjectInfo: async () => ({
+const objectInfo = vi.hoisted(() => ({
+  current: {
     CheckpointLoaderSimple: {
       input: { required: { ckpt_name: [["already-have.safetensors"], {}] } },
     },
-  }),
+  } as Record<string, unknown>,
+}));
+
+const DEFAULT_OBJECT_INFO = {
+  CheckpointLoaderSimple: {
+    input: { required: { ckpt_name: [["already-have.safetensors"], {}] } },
+  },
+};
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: async () => objectInfo.current,
   getSystemStats: async () => ({ devices: [{ vram_total: 16 * 1024 ** 3 }] }),
 }));
 
@@ -52,6 +62,7 @@ const WORKFLOW = {
 beforeEach(() => {
   providers.civitaiDown = true;
   providers.hfDown = true;
+  objectInfo.current = structuredClone(DEFAULT_OBJECT_INFO);
 });
 
 describe('action:"resolve_missing" never calls a failed lookup an empty one', () => {
@@ -78,5 +89,56 @@ describe('action:"resolve_missing" never calls a failed lookup an empty one', ()
     const text = res.content[0]!.text as string;
     expect(text).toMatch(/No candidates found on CivitAI or HuggingFace/);
     expect(text).not.toMatch(/lookup FAILED/);
+  });
+});
+
+// #2068 — download_model action:"resolve_missing" must surface custom-node
+// LoRA combo values that /object_info does not list, the same way
+// panel_get_errors reports unavailable_widget_values. ComfyUI 0.33 publishes
+// those slots as V3 ["COMBO", {options}], which the V1-only parser skipped.
+describe('action:"resolve_missing" reports unavailable custom-node LoRA combos', () => {
+  it("DonutLoRAStack lora_name_N absent from a V3 COMBO list is missing, not healthy", async () => {
+    const wanted = [
+      "krea2/general-purpose/realism_engine_krea2_v1.safetensors",
+      "krea2/Krea2-realism-V2.safetensors",
+      "krea2/general-purpose/Krea2_HMNSFW_AIO.safetensors",
+      "krea2/Krea2_NSFW_Aesthetics_V1.safetensors",
+    ];
+    const installed = ["None", "already-have.safetensors"];
+    const v3 = (options: string[]) => ["COMBO", { options }];
+    objectInfo.current = {
+      DonutLoRAStack: {
+        input: {
+          required: {
+            lora_name_1: v3(installed),
+            lora_name_2: v3(installed),
+            lora_name_3: v3(installed),
+          },
+        },
+      },
+    };
+    const workflow = {
+      "10": {
+        class_type: "DonutLoRAStack",
+        inputs: { lora_name_1: wanted[0], lora_name_2: wanted[1], lora_name_3: "None" },
+      },
+      "11": {
+        class_type: "DonutLoRAStack",
+        inputs: { lora_name_1: wanted[2], lora_name_2: wanted[3], lora_name_3: "None" },
+      },
+    };
+
+    providers.civitaiDown = false;
+    providers.hfDown = false;
+    const res = await captureHandler()({ workflow });
+    const text = res.content[0]!.text as string;
+
+    expect(text).not.toMatch(/No missing models/);
+    expect(text).toMatch(new RegExp(`${wanted.length} missing model`));
+    for (const file of wanted) {
+      expect(text).toContain(file);
+    }
+    expect(text).toMatch(/DonutLoRAStack · lora_name_/);
+    expect(text).toMatch(/models\/loras\//);
   });
 });

--- a/src/services/missing-models.ts
+++ b/src/services/missing-models.ts
@@ -44,6 +44,15 @@ const DIR_BY_WIDGET: Record<string, string> = {
   ipadapter_file: "ipadapter",
 };
 
+/** DonutLoRAStack / LoRA Stacker V2 / similar: `lora_name_1`, `lora_name_2`, … */
+const NUMBERED_LORA_WIDGET = /^lora_name_\d+$/i;
+
+function directoryForWidget(widget: string): string | undefined {
+  if (Object.prototype.hasOwnProperty.call(DIR_BY_WIDGET, widget)) return DIR_BY_WIDGET[widget];
+  if (NUMBERED_LORA_WIDGET.test(widget)) return DIR_BY_WIDGET.lora_name;
+  return undefined;
+}
+
 export type Precision = "fp32" | "fp16" | "bf16" | "fp8" | "gguf" | "nf4" | "unknown";
 
 export interface MissingModel {
@@ -173,12 +182,33 @@ interface ApiNode {
   inputs?: Record<string, unknown>;
 }
 
-/** The combo option list for an input spec, or null when it isn't a combo. */
+/**
+ * The option list for an input spec, in either schema form, or null when this
+ * pass has no authority over it.
+ *
+ * ComfyUI serialises a V1 combo as `[[...allowed], {cfg}]` and a V3 one as
+ * `["COMBO", {options: [...], ...}]` (`add_to_dict_v1` writes
+ * `(io_type, as_dict())`). Both are the live inventory `panel_get_errors`
+ * already reads. The V1-only parser skipped every V3 custom-node combo — so
+ * DonutLoRAStack `lora_name_N` values absent from /object_info were reported
+ * as "No missing models" (#2068). A MULTISELECT combo is refused: its stored
+ * value is a selection of several options, so membership in the list is the
+ * wrong question.
+ */
 function comboOptions(spec: unknown): string[] | null {
   if (!Array.isArray(spec) || spec.length === 0) return null;
-  const first = spec[0];
-  if (!Array.isArray(first)) return null;
-  return first.filter((o): o is string => typeof o === "string");
+  const cfg =
+    spec[1] && typeof spec[1] === "object" && !Array.isArray(spec[1])
+      ? (spec[1] as Record<string, unknown>)
+      : null;
+  if (cfg?.multiselect) return null;
+  const type = spec[0];
+  if (Array.isArray(type)) return type.filter((v): v is string => typeof v === "string");
+  if (typeof type !== "string" || !/COMBO/i.test(type) || /DYNAMIC/i.test(type)) return null;
+  const opts = cfg?.options;
+  if (!Array.isArray(opts)) return null;
+  const strings = opts.filter((v): v is string => typeof v === "string");
+  return strings.length === opts.length ? strings : null;
 }
 
 /**
@@ -231,7 +261,7 @@ export function findMissingModels(
         node_type: classType,
         widget,
         name: value,
-        directory: DIR_BY_WIDGET[widget],
+        directory: directoryForWidget(widget),
       });
     }
   }


### PR DESCRIPTION
Fixes #2068

## What was already true

`download_model` `action:"resolve_missing"` finds missing weights by comparing each workflow combo value against the `/object_info` option list the connected ComfyUI actually publishes. That is supposed to cover custom-pack model widgets with no per-node mapping. `panel_get_errors` already judges both combo shapes ComfyUI serialises: V1 `[[...allowed], {cfg}]` and V3 `["COMBO", {options}]` (`add_to_dict_v1`).

## What the reporter saw

A graph with two DonutLoRAStack nodes whose `lora_name_1` / `lora_name_2` / `lora_name_3` values were four LoRA files absent from the live combo inventory. `panel_get_errors` listed all four as unavailable. `resolve_missing` returned "No missing models".

## Root cause

`findMissingModels` only read the V1 combo form. A V3 custom-node COMBO is `["COMBO", {options: [...]}]`, so `spec[0]` is the string `"COMBO"` and the parser treated the widget as "not a combo" and skipped it. Numbered LoRA slots (`lora_name_1`, …) also had no models/ subdirectory hint.

## What changes

- Read V3 `["COMBO", {options}]` the same way `panel_get_errors` already does (and still refuse MULTISELECT / DYNAMIC combos).
- Map `lora_name_N` widgets to `models/loras/` so a chosen candidate has a landing directory.
- V1 combos and non-model enums are unchanged.

## Verification

- `findMissingModels` with the reporter's four DonutLoRAStack filenames against a V3 option list that does not include them: all four missing, `"None"` and an installed file not reported, directory `loras`.
- `resolveMissingModelsAction` on that graph no longer says "No missing models"; it lists the four files and `models/loras/`.
- Existing missing-model + download_model dispatch suites still green.
