### PR TITLE
Require stable panel reconnect before restart reports graph tools ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- **Restart does not report graph tools ready on a transient panel reconnect (#2067).**
+  `panel_restart_comfyui` accepted the first fresh original-tab hello as
+  `graph_tools_ready:true`. That socket can drop a moment later, so the next
+  `panel_get_errors` failed with Connected: none. The reconnect wait now
+  requires the new identity to remain present for a short stability window
+  (same check after conservative rebind) before it reports the tab durable.
+
+### MCP
+
+#### Fixed
+- restart waits for a stable panel reconnect before graph tools are ready (#2067)
+
 ## [0.52.58] - 2026-08-22
 
 ### Fixed

--- a/src/__tests__/orchestrator/panel-restart-stable-reconnect.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-stable-reconnect.test.ts
@@ -1,0 +1,215 @@
+// #2067 — after panel_restart_comfyui returned ready:true / graph_tools_ready:true /
+// panel_tab_reconnected:true, the next panel_get_errors failed with Connected: none.
+//
+// The restart readiness path accepted the first newer original-tab hello immediately.
+// A ComfyUI restart can hello and drop that socket a moment later, so the first
+// generation bump is not durable graph-tool readiness. awaitPostRestartReachable now
+// requires that identity to remain present for a stability window (same check after
+// conservative rebind).
+//
+// These tests drive the shipped function via makePanelToolCtx, and the restart
+// handler that reports graph_tools_ready from it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+const TAB = "bound-tab";
+const SESSION = "browser-tab-a";
+
+const parse = (res: ToolResult): Record<string, unknown> =>
+  JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+function restartHandler() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def.handler;
+}
+
+/** Mutable original-tab identity the test can flap mid-wait. */
+function originalTabState() {
+  const live = new Set<string>([TAB]);
+  const ident = { generation: 1, tabSessionId: SESSION };
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "comfy_reboot") return { rebooting: true };
+      const id = TAB;
+      if (!live.has(id)) throw new Error(`no connected tab with id "${id}". Connected: none`);
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => live.has(id),
+    tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+    resolveActiveTabId: () => {
+      if (live.size === 1) return [...live][0]!;
+      if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+      throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+    },
+    tabOrigin: () => BOOT_BASE,
+    tabServerOrigin: () => BOOT_BASE,
+    tabIsLocal: () => true,
+    tabConnectionIdentity: (id: string) => (live.has(id) ? { ...ident } : undefined),
+    tabCanMutateGraph: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  return { live, ident, bridge };
+}
+
+beforeEach(() => {
+  resetClient.mockClear();
+  resetObjectInfoCache.mockClear();
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 250, intervalMs: 10, stableMs: 80 });
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 80,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setReconnectWaitTiming(null);
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+});
+
+describe("#2067 awaitPostRestartReachable requires a stable original-tab hello", () => {
+  it("returns false when the first fresh hello drops before the stability window", async () => {
+    const { live, ident, bridge } = originalTabState();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const before = ctx.panelConnectionIdentity!();
+    ident.generation = 2;
+    setTimeout(() => live.delete(TAB), 20);
+
+    await expect(ctx.awaitPostRestartReachable!(before)).resolves.toBe(false);
+  });
+
+  it("returns true when the same fresh hello stays through the window", async () => {
+    const { ident, bridge } = originalTabState();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const before = ctx.panelConnectionIdentity!();
+    ident.generation = 2;
+
+    await expect(ctx.awaitPostRestartReachable!(before)).resolves.toBe(true);
+  });
+});
+
+describe("#2067 panel_restart_comfyui does not report graph tools ready on a flap", () => {
+  it("the reporter: first fresh hello then drop ⇒ graph_tools_ready:false", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]!);
+
+    const { live, ident, bridge } = originalTabState();
+    const origSend = bridge.send;
+    bridge.send = async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+      if (cmd.cmd === "comfy_reboot") {
+        live.delete(TAB);
+        setTimeout(() => {
+          ident.generation = 2;
+          live.add(TAB);
+          setTimeout(() => live.delete(TAB), 20);
+        }, 30);
+        return { rebooting: true };
+      }
+      return origSend!(cmd, opts);
+    };
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await restartHandler()({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+
+  it("a hello that stays is graph_tools_ready:true", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]!);
+
+    const { live, ident, bridge } = originalTabState();
+    const origSend = bridge.send;
+    bridge.send = async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+      if (cmd.cmd === "comfy_reboot") {
+        live.delete(TAB);
+        setTimeout(() => {
+          ident.generation = 2;
+          live.add(TAB);
+        }, 30);
+        return { rebooting: true };
+      }
+      return origSend!(cmd, opts);
+    };
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await restartHandler()({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(out.graph_tools_ready).toBe(true);
+    expect(out.ready).toBe(true);
+  });
+
+  it("the same window applies after conservative rebind onto a new routing tab id", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]!);
+
+    const live = new Set<string>([TAB]);
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "comfy_reboot") {
+          live.delete(TAB);
+          setTimeout(() => {
+            live.add("reconnected-tab");
+            setTimeout(() => live.delete("reconnected-tab"), 20);
+          }, 30);
+          return { rebooting: true };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => {
+        if (live.size === 1) return [...live][0]!;
+        if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      },
+      tabOrigin: () => BOOT_BASE,
+      tabServerOrigin: () => BOOT_BASE,
+      tabIsLocal: () => true,
+      tabConnectionIdentity: (id: string) =>
+        live.has(id)
+          ? { generation: id === "reconnected-tab" ? 2 : 1, tabSessionId: SESSION }
+          : undefined,
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await restartHandler()({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1181,7 +1181,9 @@ export const __panelToolsTestHooks = {
     retrySettleMsOverride = ms;
   },
   /** Inject fast reconnect-wait timing so #400/#402 tests don't wait the real ~35s. */
-  setReconnectWaitTiming(timing: { budgetMs: number; intervalMs: number } | null): void {
+  setReconnectWaitTiming(
+    timing: { budgetMs: number; intervalMs: number; stableMs?: number } | null,
+  ): void {
     reconnectWaitTimingOverride = timing;
   },
   /** Shrink the #1292 / #2059 corroboration rechecks so tests don't wait ~2.9s / ~9.4s. */
@@ -1192,7 +1194,7 @@ export const __panelToolsTestHooks = {
     fenceMissingActiveRecheckStepsOverride = steps;
   },
   /** The reconnect wait the tools actually use (env/default, or the test override). */
-  getReconnectWaitTiming(): { budgetMs: number; intervalMs: number } {
+  getReconnectWaitTiming(): { budgetMs: number; intervalMs: number; stableMs?: number } {
     return reconnectWaitTiming();
   },
   /** Shrink the #1175 late-acknowledgement grace so a reconcile test doesn't wait 10s. */
@@ -1742,6 +1744,12 @@ interface ReconnectWaitTiming {
   budgetMs: number;
   /** Interval between canReach polls. */
   intervalMs: number;
+  /**
+   * How long a fresh original-tab hello must remain before we call it durable.
+   * A restart that returns at the first newer generation reports graph tools
+   * ready while that socket can still drop (#2067).
+   */
+  stableMs?: number;
 }
 let reconnectWaitTimingOverride: ReconnectWaitTiming | null = null;
 /** Bounded wait for a browser tab to (re)connect after a full ComfyUI restart or a
@@ -1757,6 +1765,8 @@ const RECONNECT_WAIT_MAX_MS = 60_000;
  *  healthy (panel#654): `panel_graph_outline` reported Connected: none and only a
  *  hard refresh restored the tab. 35s covers those recoveries; the 60s ceiling stays. */
 const RECONNECT_WAIT_DEFAULT_S = 35;
+/** Fresh original-tab hello must persist this long before graph tools are ready (#2067). */
+const POST_RESTART_RECONNECT_STABLE_MS = 2000;
 function reconnectWaitTiming(): ReconnectWaitTiming {
   if (reconnectWaitTimingOverride) return reconnectWaitTimingOverride;
   return {
@@ -10424,6 +10434,9 @@ export interface PanelToolCtx {
    * browser-tab session that received the restart dispatch. This is distinct
    * from awaitReachable: an old tab can still be reachable while ComfyUI is
    * rebooting, and a different browser tab can reuse the same saved-workflow id.
+   * A first newer generation is not enough: the identity must remain present
+   * for a short stability window so a transient hello is not reported as
+   * durable graph-tool readiness (#2067).
    */
   awaitPostRestartReachable?: (
     before: { generation: number; tabSessionId: string } | undefined,
@@ -10612,6 +10625,11 @@ export function makePanelToolCtx(
   // fresh hello can keep the same tab/socket id or arrive under a new one; in the
   // latter case only rebind after the old target is gone, preserving strict
   // multi-tab routing and never guessing away from a still-live pre-restart tab.
+  //
+  // #2067 — the first newer generation is not durable. A ComfyUI restart can
+  // hello, then drop the socket a moment later; returning true there reports
+  // graph_tools_ready while the next graph call sees Connected: none. The same
+  // identity must still be present after a short stability window.
   const awaitPostRestartReachable = async (
     before: { generation: number; tabSessionId: string } | undefined,
     budgetMs?: number,
@@ -10624,6 +10642,7 @@ export function makePanelToolCtx(
     const timing = reconnectWaitTiming();
     const budget = Math.max(0, budgetMs != null ? Math.min(budgetMs, timing.budgetMs) : timing.budgetMs);
     const deadline = Date.now() + budget;
+    const stableMs = Math.max(0, timing.stableMs ?? POST_RESTART_RECONNECT_STABLE_MS);
     const isOriginalTabReconnected = (): boolean => {
       const current = panelConnectionIdentity();
       return (
@@ -10632,14 +10651,21 @@ export function makePanelToolCtx(
         current.tabSessionId === before.tabSessionId
       );
     };
+    const originalTabStayedReconnected = async (): Promise<boolean> => {
+      if (!isOriginalTabReconnected()) return false;
+      const left = deadline - Date.now();
+      if (left <= 0) return false;
+      await sleep(Math.min(stableMs, left));
+      return isOriginalTabReconnected();
+    };
     for (;;) {
-      if (isOriginalTabReconnected()) return true;
+      if (await originalTabStayedReconnected()) return true;
       // A new tab id cannot resolve through the retired binding. Once that binding is
       // actually gone, the existing conservative rebind can follow the sole new tab.
       if (!bridge.canReach(ctx.tabId)) {
         const interactive = interactiveTabIds() ?? [];
         if (interactive.length > 0) ensureReachable();
-        if (isOriginalTabReconnected()) return true;
+        if (await originalTabStayedReconnected()) return true;
       }
       const left = deadline - Date.now();
       if (left <= 0) return false;


### PR DESCRIPTION
Fixes #2067

`panel_restart_comfyui` accepted the first fresh original-tab hello as `graph_tools_ready:true`. That socket can drop a moment later, so the next graph tool (`panel_get_errors`) failed with Connected: none.

`awaitPostRestartReachable` now requires the new original-tab identity to remain present for a short stability window (same check after conservative rebind) before reporting the tab durable.

## Test plan
- [x] `src/__tests__/orchestrator/panel-restart-stable-reconnect.test.ts` drives the shipped `awaitPostRestartReachable` via `makePanelToolCtx` and the restart handler: a flap is not ready; a hello that stays is; the rebind path uses the same window.
- [x] Existing restart/reconnect suites still pass (`panel-session-rebind-residuals`, `panel-restart-readiness`, `panel-restart-slow-boot-reconnect`, `restart-tab-reconnect-unknown`, `panel-restart-legacy-fallback`, `panel-restart-cancel-truth`, `fence-rebind-transient`).
