### PR TITLE
fix(2069): panel_get_errors answers during concurrent panel reads

### DIFF
--- a/src/__tests__/orchestrator/get-errors-concurrent-reads.test.ts
+++ b/src/__tests__/orchestrator/get-errors-concurrent-reads.test.ts
@@ -1,0 +1,254 @@
+// #2069 — panel_get_errors timed out at 30 000 ms while concurrent read-only
+// panel operations against the SAME live tab (panel_query_graph, panel_graph_outline,
+// panel_screenshot) completed. The tab was neither backgrounded nor frozen: the
+// siblings returned current live state. graph_get_errors is the long graph read,
+// and concurrent graph frames on one tab can leave it unanswered.
+//
+// The property under test is the SHIPPED tool: these run the real panel_get_errors
+// def (and the reporter's sibling tools) against a real UiBridge + a mock panel
+// that drops graph_get_errors when it arrives in the same burst as other graph
+// reads — the collision the live frontend exhibits. Serialization in send() is
+// what makes that mock answer. The timeout diagnosis is the message dispatch()
+// actually mints, not a reimplementation of it.
+
+import { createServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { UiBridge, isReplyTimeoutTagged } from "../../services/ui-bridge.js";
+import { buildPanelToolDefs, makePanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const TAB = "wf:workflows/video_minimax_h3_i2v.json";
+const WORKFLOW_UUID = "11111111-1111-4111-8111-111111111111";
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+let bridge: UiBridge;
+let port: number;
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<void> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    port = await freePort();
+    bridge = new UiBridge(port);
+    bridge.start();
+    if (await bridge.whenReady()) {
+      bridge.setTabWorkflowUuidResolver(() => WORKFLOW_UUID);
+      return;
+    }
+    lastErr = `bind to ${port} lost a close→rebind race`;
+    await bridge.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: TAB,
+          title: "video_minimax_h3_i2v",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function viewing() {
+  return { kind: "root", workflow: "video_minimax_h3_i2v.json", workflow_uuid: WORKFLOW_UUID };
+}
+
+function replyBody(cmd: string): Record<string, unknown> {
+  if (cmd === "graph_screenshot") return { image: PNG_1X1, mimeType: "image/png" };
+  if (cmd === "graph_get_errors") {
+    return {
+      viewing: viewing(),
+      node_count: 3,
+      errored_count: 0,
+      nodes: [],
+      last_execution_error: null,
+      node_errors: null,
+    };
+  }
+  if (cmd === "graph_outline") {
+    return { viewing: viewing(), outline: "1 KSampler", node_count: 1 };
+  }
+  if (cmd === "graph_query") {
+    return { viewing: viewing(), nodes: [{ id: 1, type: "KSampler" }], node_count: 1 };
+  }
+  if (cmd === "graph_serialize") return { nodes: [] };
+  if (cmd === "get_todo") return { items: [] };
+  return { cmd, ok: true };
+}
+
+/** Drop graph_get_errors when it shares a burst with other graph_* frames —
+ *  the collision the live panel exhibits under concurrent reads. */
+function attachCollisionPanel(sock: WebSocket): { dropped: string[]; received: string[] } {
+  const dropped: string[] = [];
+  const received: string[] = [];
+  let batch: Array<Record<string, unknown>> = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const flush = () => {
+    timer = null;
+    const msgs = batch;
+    batch = [];
+    const siblingGraph = msgs.some(
+      (m) => typeof m.cmd === "string" && m.cmd.startsWith("graph_") && m.cmd !== "graph_get_errors",
+    );
+    for (const msg of msgs) {
+      if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") continue;
+      if (msg.cmd === "graph_get_errors" && siblingGraph) {
+        dropped.push(msg.cmd);
+        continue;
+      }
+      sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: replyBody(msg.cmd) }));
+    }
+  };
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+    if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+    received.push(msg.cmd);
+    batch.push(msg);
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(flush, 15);
+  });
+  return { dropped, received };
+}
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} is not registered`);
+  return def;
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+beforeEach(async () => {
+  await startBridge();
+});
+
+afterEach(async () => {
+  await bridge.stop();
+});
+
+describe("panel_get_errors during concurrent panel reads (#2069)", () => {
+  it("returns on a live tab while query/outline/screenshot run in the same burst", async () => {
+    const sock = await connectPanel();
+    const { dropped } = attachCollisionPanel(sock);
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const [query, outline, errors, screenshot] = await Promise.all([
+      defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx),
+      defByName("panel_graph_outline").handler({} as never, ctx),
+      defByName("panel_get_errors").handler({} as never, ctx),
+      defByName("panel_screenshot").handler({} as never, ctx),
+    ]);
+
+    expect(dropped).toEqual([]);
+    expect(query.isError).not.toBe(true);
+    expect(outline.isError).not.toBe(true);
+    expect(screenshot.isError).not.toBe(true);
+    expect(errors.isError).not.toBe(true);
+    expect(textOf(errors)).not.toMatch(/did not reply/);
+    expect(textOf(errors)).not.toMatch(/backgrounded or frozen/);
+    const payload = JSON.parse(textOf(errors)) as Record<string, unknown>;
+    expect(typeof payload.errored_count).toBe("number");
+    sock.close();
+  });
+
+  it("does not write graph_get_errors until a sibling graph read on the tab has been answered", async () => {
+    const sock = await connectPanel();
+    const order: string[] = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+      order.push(`recv:${msg.cmd}`);
+      setTimeout(() => {
+        order.push(`ack:${msg.cmd}`);
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: replyBody(msg.cmd) }));
+      }, 20);
+    });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    await Promise.all([
+      defByName("panel_query_graph").handler({ ids: [1], fields: "ids" } as never, ctx),
+      defByName("panel_get_errors").handler({} as never, ctx),
+    ]);
+
+    expect(order.filter((e) => e === "recv:graph_get_errors").length).toBeGreaterThan(0);
+    let inflight = 0;
+    for (const e of order) {
+      if (e.startsWith("recv:graph_")) {
+        expect(inflight, `overlapping graph recv: ${order.join(" ")}`).toBe(0);
+        inflight += 1;
+      } else if (e.startsWith("ack:graph_")) {
+        inflight = Math.max(0, inflight - 1);
+      }
+    }
+    sock.close();
+  });
+
+  it("a no-reply timeout does not claim the tab is frozen when a sibling on the same tab just answered", async () => {
+    const sock = await connectPanel();
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+      if (msg.cmd === "graph_get_errors") return;
+      sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: replyBody(msg.cmd) }));
+    });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+
+    const todo = bridge.send({ cmd: "get_todo" }, { tabId: TAB, timeoutMs: 1000 });
+    const errors = bridge.send({ cmd: "graph_get_errors" }, { tabId: TAB, timeoutMs: 180 });
+    await expect(todo).resolves.toMatchObject({ items: [] });
+    await expect(errors).rejects.toSatisfy((err: unknown) => {
+      expect(isReplyTimeoutTagged(err)).toBe(true);
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toMatch(/did not reply to "graph_get_errors"/);
+      expect(msg).toMatch(/the tab is not frozen/);
+      expect(msg).toMatch(/answered "get_todo"/);
+      expect(msg).not.toMatch(/backgrounded or frozen/);
+      return true;
+    });
+    sock.close();
+  });
+
+  it("a no-reply timeout still names a frozen tab when nothing else answered", async () => {
+    const sock = await connectPanel();
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+    await expect(
+      bridge.send({ cmd: "graph_get_errors" }, { tabId: TAB, timeoutMs: 80 }),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(isReplyTimeoutTagged(err)).toBe(true);
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toMatch(/did not reply to "graph_get_errors"/);
+      expect(msg).toMatch(/the ComfyUI tab may be backgrounded or frozen/);
+      expect(msg).not.toMatch(/the tab is not frozen/);
+      return true;
+    });
+    sock.close();
+  });
+});

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -107,6 +107,14 @@ type SendCtx = {
    *  with no established workflow identity (old panel / relay) → no client-side fence. */
   workflowUuid?: string;
   onDispatchedRid?: (rid: string) => void;
+  /**
+   * #2069 — command name of a sibling on the same tab that answered WHILE this
+   * one was still waiting. A timeout that observed that must not claim the tab
+   * may be backgrounded or frozen: the reporter's concurrent query/outline/
+   * screenshot replies proved the tab was alive, and only graph_get_errors
+   * missed its correlation slot.
+   */
+  siblingReply?: string;
 };
 
 type Pending = {
@@ -1437,6 +1445,31 @@ function mutatedButUnacked(ctx: SendCtx): string {
 }
 
 /**
+ * #2069 — the clause after "within N ms". A sibling reply during the wait is
+ * proof the tab is servicing the socket, so "backgrounded or frozen" is a
+ * false diagnosis (the reporter's concurrent graph reads completed).
+ */
+function replyTimeoutSuffix(ctx: SendCtx): string {
+  if (ctx.siblingReply) {
+    return (
+      ` — the tab is not frozen: it answered "${ctx.siblingReply}" while this command was still waiting. ` +
+      `Retry "${ctx.command.cmd}" on its own; concurrent graph reads on the same tab can leave this command unanswered`
+    );
+  }
+  return ` — the ComfyUI tab may be backgrounded or frozen${mutatedButUnacked(ctx)}`;
+}
+
+function noReplyTimeoutMessage(tabId: string, ctx: SendCtx): string {
+  return `Panel tab ${tabId} did not reply to "${ctx.command.cmd}" within ${ctx.timeoutMs} ms${replyTimeoutSuffix(ctx)}`;
+}
+
+/** Graph commands share one frontend handler/main thread per tab. Concurrent
+ *  frames can leave graph_get_errors unanswered (#2069). */
+function usesGraphCommandLane(cmd: string): boolean {
+  return cmd.startsWith("graph_");
+}
+
+/**
  * A mutation the panel acknowledged AFTER its reply timeout (#694, #1175).
  *
  * `result` is the panel's own reply body, present only when it was retained (see
@@ -1765,6 +1798,14 @@ export class UiBridge {
   private missedFrames = new Map<string, Record<string, unknown>[]>();
   private static readonly MAX_MISSED_FRAMES = 100;
   private pending = new Map<string, Pending>();
+  /**
+   * #2069 — per-tab chain of `graph_*` dispatches. The panel's WS listener is
+   * async-per-message, so concurrent graph frames share the main thread and the
+   * /object_info coalescer; graph_get_errors is the one that then misses its
+   * reply window while query/outline/screenshot succeed. Timeout clocks start
+   * at dispatch (after the predecessor settles), not at enqueue.
+   */
+  private graphLane = new Map<string, Promise<unknown>>();
   /** ask_user card sends (rid → {ask_id, ts}): lets a reply that validates AFTER
    *  the reply timer fired (dropped from `pending`) still be buffered for the
    *  caller, instead of being discarded as a "late reply for a timed-out command"
@@ -2885,6 +2926,7 @@ export class UiBridge {
           // an unrelated tab reusing the id can never be granted the veto.
           const served = this.liveConnForTab(p.ctx.tabId, sock);
           served?.provenSupportedCmds.add(p.cmd);
+          this.noteSiblingSuccess(p.ctx, rid);
           p.resolve(msg.result);
         } else {
           // #1529 — carry the panel's STRUCTURED refusal onto the error.
@@ -5005,37 +5047,90 @@ export class UiBridge {
         markDispatched(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`), false),
       );
     }
-    return new Promise((resolve, reject) => {
-      const ctx: SendCtx = {
-        resolve,
-        reject,
-        command: cmd,
-        timeoutMs,
-        // Canonical id of the resolved connection (NOT the caller's possibly-prefix
-        // or migration-alias tabId) — the key the reconnect hello will use, so a
-        // parked read is found and resumed.
-        tabId: conn.tabId,
-        mutating: !UiBridge.READONLY_CMDS.has(cmd.cmd),
-        deadline: Date.now() + timeoutMs,
-        // #570 — graph ops resolve from the CALLER'S intended tab (opts.tabId), NOT
-        // the canonical conn.tabId: after a same-socket switch the two differ, and
-        // we must stamp the workflow the command was ISSUED FOR (so the panel, now
-        // showing a different one, declines it) — never the workflow it happens to
-        // have landed on. #884: for the SHARED SCOPE the orchestrator's resolver
-        // answers with the current TURN's issue-time workflow — same rule,
-        // conversation-level.
-        //
-        // #1815 — Manager / recovery / navigation commands do not act on that
-        // workflow. They take the routed tab's advertised identity so a stale
-        // conversation stamp cannot refuse a search, an install, a reboot, or the
-        // workflow_list the documented rebind needs.
-        workflowUuid:
-          this.resolveTabWorkflowUuid?.(commandStampAddress(cmd, opts.tabId, conn.tabId)) ??
-          undefined,
-        onDispatchedRid: opts.onDispatchedRid,
-      };
-      this.dispatch(conn, ctx);
+    const launch = (): Promise<unknown> => {
+      // Re-resolve after a graph-lane wait: the tab may have migrated while a
+      // predecessor occupied the lane. Gates above already ran against `conn`.
+      let live: Conn;
+      try {
+        live = this.resolveTarget(opts.tabId);
+      } catch (err) {
+        return Promise.reject(
+          markDispatched(err instanceof Error ? err : new Error(String(err)), false),
+        );
+      }
+      if (live.sock.readyState !== WebSocket.OPEN) {
+        if (opts.tabId && UiBridge.isMailboxable(cmd)) {
+          this.storeMailbox(opts.tabId, cmd);
+          return Promise.resolve(this.mailboxReceipt(opts.tabId));
+        }
+        return Promise.reject(
+          markDispatched(new Error(`Panel tab ${live.tabId.slice(0, 8)} is not open`), false),
+        );
+      }
+      return new Promise((resolve, reject) => {
+        const ctx: SendCtx = {
+          resolve,
+          reject,
+          command: cmd,
+          timeoutMs,
+          // Canonical id of the resolved connection (NOT the caller's possibly-prefix
+          // or migration-alias tabId) — the key the reconnect hello will use, so a
+          // parked read is found and resumed.
+          tabId: live.tabId,
+          mutating: !UiBridge.READONLY_CMDS.has(cmd.cmd),
+          // Timeout starts at DISPATCH, not enqueue: waiting for a sibling graph
+          // read cannot itself produce the reporter's 30 s false timeout (#2069).
+          deadline: Date.now() + timeoutMs,
+          // #570 — graph ops resolve from the CALLER'S intended tab (opts.tabId), NOT
+          // the canonical conn.tabId: after a same-socket switch the two differ, and
+          // we must stamp the workflow the command was ISSUED FOR (so the panel, now
+          // showing a different one, declines it) — never the workflow it happens to
+          // have landed on. #884: for the SHARED SCOPE the orchestrator's resolver
+          // answers with the current TURN's issue-time workflow — same rule,
+          // conversation-level.
+          //
+          // #1815 — Manager / recovery / navigation commands do not act on that
+          // workflow. They take the routed tab's advertised identity so a stale
+          // conversation stamp cannot refuse a search, an install, a reboot, or the
+          // workflow_list the documented rebind needs.
+          workflowUuid:
+            this.resolveTabWorkflowUuid?.(commandStampAddress(cmd, opts.tabId, live.tabId)) ??
+            undefined,
+          onDispatchedRid: opts.onDispatchedRid,
+        };
+        this.dispatch(live, ctx);
+      });
+    };
+    if (usesGraphCommandLane(cmd.cmd)) {
+      return this.enqueueGraphLane(conn.tabId, launch);
+    }
+    return launch();
+  }
+
+  /** Serialize `graph_*` dispatches per tab so concurrent reads cannot occupy
+   *  the panel at once (#2069). Failures still release the lane. */
+  private enqueueGraphLane<T>(tabId: string, run: () => Promise<T>): Promise<T> {
+    const prev = this.graphLane.get(tabId) ?? Promise.resolve();
+    const next = prev.then(run, run);
+    const tail: Promise<unknown> = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.graphLane.set(tabId, tail);
+    void tail.then(() => {
+      if (this.graphLane.get(tabId) === tail) this.graphLane.delete(tabId);
     });
+    return next;
+  }
+
+  /** Record that `ctx`'s command answered, so any still-waiting sibling on the
+   *  same tab can refuse the frozen-tab diagnosis (#2069). */
+  private noteSiblingSuccess(ctx: SendCtx, exceptRid: string): void {
+    for (const [rid, p] of this.pending) {
+      if (rid === exceptRid) continue;
+      if (p.ctx.tabId !== ctx.tabId) continue;
+      p.ctx.siblingReply ??= ctx.command.cmd;
+    }
   }
 
   /** Write one attempt of a command to a live socket and arm its reply timer.
@@ -5048,13 +5143,7 @@ export class UiBridge {
     // deadline — clamp the reply timeout to the time remaining.
     const remaining = ctx.deadline - Date.now();
     if (remaining <= 0) {
-      ctx.reject(
-        markReplyTimeout(
-          new Error(
-            `Panel tab ${conn.tabId} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen${mutatedButUnacked(ctx)}`,
-          ),
-        ),
-      );
+      ctx.reject(markReplyTimeout(new Error(noReplyTimeoutMessage(conn.tabId, ctx))));
       return;
     }
     const replyTimeoutMs = Math.min(ctx.timeoutMs, remaining);
@@ -5138,12 +5227,7 @@ export class UiBridge {
       // id CONTAINING SPACES (`wf:workflows/Untitled 2026-08-04.json`) still matches.
       ctx.reject(
         markReplyTimeout(
-          markDispatched(
-            new Error(
-              `Panel tab ${conn.tabId} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen${mutatedButUnacked(ctx)}`,
-            ),
-            true,
-          ),
+          markDispatched(new Error(noReplyTimeoutMessage(conn.tabId, ctx)), true),
         ),
       );
     }, replyTimeoutMs);


### PR DESCRIPTION
Fixes #2069

## What the user hit

`panel_get_errors` timed out at 30s (`did not reply to "graph_get_errors"` / "tab may be backgrounded or frozen") while `panel_query_graph`, `panel_graph_outline`, and `panel_screenshot` against the same live tab completed. The tab was not frozen — the siblings returned current live state.

## Root cause

The panel's WS listener is async-per-message. Concurrent `graph_*` frames on one tab share the frontend main thread and the `/object_info` coalescer; `graph_get_errors` is the long one and can miss its reply window. Each request already had its own `rid` in the bridge pending map — the miss was occupancy, not lost correlation in `pending`.

## What changes

- Per-tab `graph_*` lane in `UiBridge.send()`: one graph command in flight at a time. The 30s ack clock starts at dispatch (after the predecessor settles), not at enqueue, so waiting in the lane cannot itself produce the reported timeout.
- A no-reply timeout that observed a sibling on the same tab answering during the wait no longer claims the tab may be backgrounded or frozen. It names the sibling and says to retry `graph_get_errors` on its own. A genuine silent tab still gets the frozen diagnosis.

Non-graph commands (`get_todo`, `workflow_list`, …) stay concurrent with the lane.

## Verification

`get-errors-concurrent-reads.test.ts` drives the real `panel_get_errors` / query / outline / screenshot defs against a live `UiBridge` and a mock panel that drops overlapping `graph_get_errors` (the reporter's collision):

- the four-tool burst returns; `graph_get_errors` is not dropped
- `graph_get_errors` is not written while another graph read is unanswered
- a timeout with a sibling reply does not say frozen
- a timeout with no sibling still does

Also green: `get-errors-ack-budget`, `get-errors-call-budget`, `graph-read-during-render`, `mutating-reply-timeout-disclosure`, `ui-bridge` (213).
