### PR TITLE
release: v0.52.59 — restart waits for a stable panel reconnect before graph tools are ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.59] - 2026-08-22
+
 ### Fixed
 
 - **Restart does not report graph tools ready on a transient panel reconnect (#2067).**
@@ -19,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - restart waits for a stable panel reconnect before graph tools are ready (#2067)
+
+### MCP
+
+#### Fixed
+- panel_get_errors answers during concurrent panel reads (#2073)
+- resolve_missing reports unavailable custom-node LoRA combos (#2071)
+- restart waits for a stable panel reconnect before graph tools are ready (#2072)
+
 
 ## [0.52.58] - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.58",
+  "version": "0.52.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.58",
+      "version": "0.52.59",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.58",
+  "version": "0.52.59",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.59** from `main` (after v0.52.58).

Carries:

- #2072 / #2067 — restart waits for a stable panel reconnect before graph tools are ready
- #2071 / #2068 — `resolve_missing` reports unavailable custom-node LoRA combos
- #2073 / #2069 — `panel_get_errors` answers during concurrent panel reads

Held out: #2042/#2017 mergeability after this stack; P2 #1645 in-flight no PR; panel#1639/#1636 conflicting; hygiene #2003; panel#1472 lint-red; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.59` tag on the version commit).