### PR TITLE
release: v0.52.60 — a stale panel is refused instead of painting audio as a broken image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.60] - 2026-08-22
+
+### MCP
+
+#### Fixed
+- a stale panel is refused instead of painting audio as a broken image (#2042)
+
+
 ## [0.52.59] - 2026-08-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.59",
+  "version": "0.52.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.59",
+      "version": "0.52.60",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.59",
+  "version": "0.52.60",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.60** from `main` (after v0.52.59).

Carries:

- #2042 / #2017 — a stale panel is refused instead of painting audio as a broken image

Held out: P2 #1645 in-flight no PR; P2 #2075 new; hygiene #2003; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.60` tag on the version commit).