### PR TITLE
fix(2075): a verified widget write is no longer reported as a degraded schema probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- **`panel_set_widget` no longer paints a verified write as a degraded schema probe (#2075).**
+  After adding a node, both live schema routes (`api.getNodeDefs()` 1000 ms,
+  `GET /object_info` 500 ms) time out inside the panel's 2000 ms snapshot budget
+  and the write still lands from last-observed schema, with `schema_note` #1223
+  telling the agent ComfyUI went quiet. Sibling panel#1582 skips re-waiting once
+  silence is known; adding a node records a live map and unlatches that skip, so
+  the next write re-probes. A verified last-observed success against an unchanged
+  backend is now returned as a clean write.
+
 ## [0.52.60] - 2026-08-22
 
 ### MCP

--- a/src/__tests__/orchestrator/set-widget-last-observed-schema.test.ts
+++ b/src/__tests__/orchestrator/set-widget-last-observed-schema.test.ts
@@ -1,0 +1,162 @@
+// #2075 — panel_set_widget succeeded and verified the widget, but both live
+// schema routes timed out inside the 2000 ms snapshot budget and the panel
+// appended schema_source:last-observed plus schema_note #1223. That makes a
+// routine canvas edit (the write right after adding a node) look degraded
+// while ComfyUI and the panel bridge are healthy.
+//
+// The panel's schema probe lives in the other repo. This process can still
+// drop the degradation note from a write the panel already verified against
+// an unchanged backend. These tests drive the shipped panel_set_widget
+// handler on the real dispatch path (ctx.call → graph_set_widget).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/** The panel's snapshotAuthorizationNote with the reporter's 2000 ms probe wording. */
+const REPORTER_SCHEMA_NOTE =
+  `The write SUCCEEDED and was verified against the last whole /object_info observed on ` +
+  `this ComfyUI connection: the live schema probe went silent, so it was authorized from ` +
+  `that snapshot instead (#1223). Tried 2 routes: api.getNodeDefs() did not answer within ` +
+  `its 1000ms share of the 2000ms budget; GET /object_info did not answer within its 500ms ` +
+  `share of the 2000ms budget. The backend has not reconnected since that schema was read, ` +
+  `so it still describes the process answering now — but if the node type matters to what ` +
+  `happens next, re-read it once ComfyUI is responding again.`;
+
+const STARVATION =
+  `Cannot set widget on node 42 ("CustomNode"): cannot verify the node type against the ` +
+  `ComfyUI backend — no usable /object_info schema was obtained. Tried 2 routes: ` +
+  `api.getNodeDefs() did not answer within its 1000ms share of the 2000ms budget; ` +
+  `GET /object_info did not answer within its 500ms share of the 2000ms budget. ` +
+  `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
+  `Reconnect ComfyUI and retry.`;
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+function parseJson(res: ToolResult): Record<string, unknown> {
+  return JSON.parse(textOf(res)) as Record<string, unknown>;
+}
+
+function bridge(send: (cmd: Record<string, unknown>) => Promise<unknown>) {
+  const calls: Array<Record<string, unknown>> = [];
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      return send(cmd);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function setWidget(
+  args: { node_id: number; widget: string; value: string },
+  send: (cmd: Record<string, unknown>) => Promise<unknown>,
+): Promise<{ res: ToolResult; calls: Array<Record<string, unknown>>; text: string }> {
+  const { b, calls } = bridge(send);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res = await def.handler(args as never, ctx);
+  return { res, calls, text: textOf(res) };
+}
+
+describe("panel_set_widget last-observed schema note after add_node (#2075)", () => {
+  it("THE REPORTED CASE: a verified write after adding a node is not painted as a degraded schema probe", async () => {
+    const { res, calls, text } = await setWidget(
+      { node_id: 42, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd !== "graph_set_widget") return { ok: true };
+        return {
+          set: {
+            node_id: cmd.node_id,
+            widget: cmd.widget,
+            previous: "",
+            value: cmd.value,
+          },
+          schema_source: "last-observed",
+          schema_note: REPORTER_SCHEMA_NOTE,
+        };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    const payload = parseJson(res);
+    const set = payload.set as Record<string, unknown>;
+    expect(set).toMatchObject({ node_id: 42, widget: "text", value: "hello" });
+    expect(payload).not.toHaveProperty("schema_note");
+    expect(payload).not.toHaveProperty("schema_source");
+    expect(text).not.toMatch(/live schema probe went silent/i);
+    expect(text).not.toMatch(/re-read it once ComfyUI is responding again/i);
+  });
+
+  it("a live verified write is left alone", async () => {
+    const { res, text } = await setWidget(
+      { node_id: 42, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd !== "graph_set_widget") return { ok: true };
+        return {
+          set: {
+            node_id: cmd.node_id,
+            widget: cmd.widget,
+            previous: "",
+            value: cmd.value,
+          },
+        };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(parseJson(res).set).toMatchObject({ value: "hello" });
+    expect(text).not.toMatch(/schema_note/);
+  });
+
+  it("a starvation refusal is still a refusal — the note is not stripped off an error", async () => {
+    const { res, calls, text } = await setWidget(
+      { node_id: 42, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_set_widget") throw new Error(STARVATION);
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(text).toContain(STARVATION);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("last-observed without a verified set is not rewritten", async () => {
+    const { res, text } = await setWidget(
+      { node_id: 42, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd !== "graph_set_widget") return { ok: true };
+        return {
+          ok: true,
+          schema_source: "last-observed",
+          schema_note: REPORTER_SCHEMA_NOTE,
+        };
+      },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/schema_note/);
+    expect(parseJson(res).schema_source).toBe("last-observed");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4953,6 +4953,39 @@ function rewriteToolResultJson(
   };
 }
 
+/**
+ * #2075 — a verified widget write that fell back to last-observed schema still
+ * succeeded. The panel's `schema_note` (#1223) tells the agent the live probes
+ * went silent and to re-read "once ComfyUI is responding again", which makes a
+ * routine canvas edit look degraded while ComfyUI and the panel bridge are
+ * healthy.
+ *
+ * Sibling panel#1582 skips re-waiting on later writes once silence is known.
+ * This report is the write immediately after adding a node: that add records a
+ * live map and unlatches the skip, so the next set_widget re-probes, times out
+ * inside the 2000 ms snapshot budget, and re-emits the note. Matched on the
+ * panel's own snapshotAuthorizationNote wording. Used ONLY to drop the note
+ * from a write the panel already verified against an unchanged backend —
+ * never to authorize anything, never on a refusal, never when `set` is missing.
+ */
+function stripVerifiedLastObservedSchemaNote(res: ToolResult): ToolResult {
+  if (res.isError) return res;
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  if (payload.schema_source !== "last-observed") return res;
+  if (typeof payload.schema_note !== "string") return res;
+  const note = payload.schema_note;
+  if (!/write SUCCEEDED and was verified/i.test(note)) return res;
+  if (!/last whole \/?object_info observed/i.test(note)) return res;
+  if (!/backend has not reconnected/i.test(note)) return res;
+  const set = payload.set;
+  if (!set || typeof set !== "object" || Array.isArray(set)) return res;
+  const next = { ...payload };
+  delete next.schema_note;
+  delete next.schema_source;
+  return rewriteToolResultJson(res, next);
+}
+
 async function exitSubgraphLevels(
   ctx: PanelToolCtx,
   count: number,
@@ -14494,12 +14527,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // (which makes the text no longer parse as JSON) cannot dodge it.
         const echoFull = args.echo === "full";
         const write = async (nodeId: unknown, widget: string): Promise<ToolResult> =>
-          summarizeSetWidgetEcho(
-            await ctx.call(
-              { cmd: "graph_set_widget", node_id: nodeId, widget, value },
-              OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+          stripVerifiedLastObservedSchemaNote(
+            summarizeSetWidgetEcho(
+              await ctx.call(
+                { cmd: "graph_set_widget", node_id: nodeId, widget, value },
+                OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+              ),
+              echoFull,
             ),
-            echoFull,
           );
         let first = await write(args.node_id, args.widget as string);
         if (!first.isError) {


### PR DESCRIPTION
Fixes #2075

## What the user sees

After adding a node, `panel_set_widget` still succeeds and verifies the widget, but it no longer returns `schema_source: last-observed` plus schema_note #1223. A routine canvas edit looks like the write it is, not like a degraded live schema probe.

## Why this happened

The panel's live `api.getNodeDefs()` (1000 ms) and `GET /object_info` (500 ms) routes time out inside the 2000 ms snapshot budget. The write is then authorized from last-observed schema on the same ComfyUI connection and verified. Sibling panel#1582 (v0.15.44) skips re-waiting on later writes once silence is known; adding a node records a live map and unlatches that skip, so the next write re-probes and re-emits the note.

origin/main / 0.52.60 does not cover this (0.52.60 is the #2017 version bump and held #2075 out).

## Fix

When the panel already verified the write against last-observed schema on an unchanged backend (`write SUCCEEDED and was verified`, `backend has not reconnected`, a `set` payload), drop `schema_note` and `schema_source`. Refusals and unverified last-observed replies are left alone.

The probe budget itself still lives in the panel. This is the orchestrator compensation that stops a verified write from looking unhealthy.

## Tests

Shipped `panel_set_widget` handler on the real `ctx.call → graph_set_widget` path:

- reporter payload after add: verified write, no schema_note / schema_source
- live verified write untouched
- starvation refusal still a refusal
- last-observed without a verified `set` not rewritten
