### PR TITLE
release: v0.52.61 — a verified widget write is no longer reported as a degraded schema probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.61] - 2026-08-22
+
 ### Fixed
 
 - **`panel_set_widget` no longer paints a verified write as a degraded schema probe (#2075).**
@@ -16,6 +18,12 @@ All notable changes to this project are documented here. This project adheres to
   silence is known; adding a node records a live map and unlatches that skip, so
   the next write re-probes. A verified last-observed success against an unchanged
   backend is now returned as a clean write.
+
+### MCP
+
+#### Fixed
+- a verified widget write is no longer reported as a degraded schema probe (#2077)
+
 
 ## [0.52.60] - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.60",
+  "version": "0.52.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.60",
+      "version": "0.52.61",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.60",
+  "version": "0.52.61",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.61** from `main` (after v0.52.60).

Carries:

- #2077 / #2075 — a verified widget write is no longer reported as a degraded schema probe

Held out: P2 #1645 in-flight no PR; P2 #2078 new; panel#1557 recurrence; hygiene #2003; parked panel#1572.

Do **not** squash-merge. Merge-commit (keeps the `v0.52.61` tag on the version commit).