### PR TITLE
fix(2078): a save that persisted is no longer reported as outcome unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - preserve reconnect recovery across MCP context loss
 
+### Fixed
+
+- **`panel_save_workflow` no longer reports OUTCOME UNKNOWN when the in-place save actually persisted (#2078).**
+  The panel's 13s save budget can fire while userdata PUT is still running.
+  #2004 already followed up with one `workflow_list`; if that snapshot was still
+  dirty, the tool returned unknown even though the next `panel_list_workflows`
+  showed `modified:false persisted:true`. After the budget fires it now keeps
+  reading tab state for a short grace and reports `saved:true` with `late_ack`
+  once the same canvas is clean and persisted. A canvas that stays dirty stays
+  outcome-unknown so a retry does not write twice.
 
 ## [0.52.61] - 2026-08-22
 

--- a/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
+++ b/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
@@ -183,7 +183,7 @@ describe("#814 WIRING: both call sites route through refreshFenceFromOwnReply fi
     expect(saveIdx).toBeGreaterThan(0);
     expect(newIdx).toBeGreaterThan(0);
 
-    const saveBlock = src.slice(saveIdx, saveIdx + 5000);
+    const saveBlock = src.slice(saveIdx, saveIdx + 8000);
     const newBlock = src.slice(newIdx, newIdx + 5000);
     const wired = /const fenceRebind = refreshFenceFromOwnReply\(ctx, res\) \?\? \(await rebindWorkflowFence\(ctx\)\);/;
     expect(saveBlock).toMatch(wired);

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -6,7 +6,7 @@
 // sizeSane and schema oracle live in the other repo; these compensations are
 // what this orchestrator can still do for a caller who has not updated the panel.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   DEFAULT_NODE_BODY_HEIGHT,
@@ -18,6 +18,7 @@ import {
 } from "../../orchestrator/edit-node-uncollapse.js";
 import {
   buildPanelToolDefs,
+  __panelToolsTestHooks,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -67,6 +68,10 @@ const SAVE_TIMEOUT =
   `The save may still complete in the background. The same tab reports modified:true persisted:true. ` +
   `modified:true means the canvas has not been marked clean, so the write has not been acknowledged as landed. ` +
   `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`;
+
+/** #2078 — the panel's own 13s budget wording, already tagging OUTCOME UNKNOWN. */
+const SAVE_TIMEOUT_2078 =
+  `workflow_save did not finish within 13s. The save may still complete in the background. OUTCOME UNKNOWN.`;
 
 describe("restored uncollapse size (#2004)", () => {
   it("a stored [228, 0] is not sizeSane and restores keeping the width", () => {
@@ -250,7 +255,11 @@ describe("panel_set_widget names object_info starvation (#2004)", () => {
   });
 });
 
-describe("panel_save_workflow acknowledges a save that landed after the budget (#2004)", () => {
+describe("panel_save_workflow acknowledges a save that landed after the budget (#2004, #2078)", () => {
+  afterEach(() => {
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(null);
+  });
+
   it("THE REPORTED CASE: modified:false persisted:true after the 13s budget is treated as saved", async () => {
     const calls: Forwarded[] = [];
     const ctx: PanelToolCtx = {
@@ -278,14 +287,55 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     expect(res.isError).toBeFalsy();
     const text = textOf(res);
     expect(text).toMatch(/"saved": true/);
+    expect(text).toMatch(/"late_ack": true/);
     expect(text).toMatch(/"acknowledged_after_timeout": true/);
     expect(calls[0]).toMatchObject({ cmd: "workflow_save" });
     expect(calls.map((c) => c.cmd)).toContain("workflow_list");
   });
 
+  it("#2078 THE REPORTED CASE: a list that is still dirty, then clean, is saved not unknown", async () => {
+    // The 13s budget fires with modified:true. #2004 listed once, still saw
+    // dirty, and returned OUTCOME UNKNOWN. The caller's next panel_list_workflows
+    // was already modified:false persisted:true. Keep reading for the grace.
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(1500);
+    const calls: Forwarded[] = [];
+    let lists = 0;
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT_2078);
+        if (cmd.cmd === "workflow_list") {
+          lists += 1;
+          return jsonResult({
+            active: {
+              path: "workflows/graph.json",
+              filename: "graph",
+              modified: lists === 1,
+              persisted: true,
+            },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    const text = textOf(res);
+    expect(text).toMatch(/"saved": true/);
+    expect(text).toMatch(/"late_ack": true/);
+    expect(text).not.toMatch(/OUTCOME UNKNOWN/);
+    expect(lists).toBeGreaterThanOrEqual(2);
+    expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(1);
+  });
+
   it("modified:true persisted:true at follow-up is still outcome-unknown, not success", async () => {
     // The timeout snapshot itself. Treating persisted:true as proof would have
-    // reported the reporter's still-dirty canvas as saved.
+    // reported the reporter's still-dirty canvas as saved. Grace 0 = one list.
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
     const ctx: PanelToolCtx = {
       call: async (cmd) => {
         if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT);

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -347,20 +347,13 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
         if (cmd.cmd === "workflow_list") {
           lists += 1;
           return jsonResult({
-            active:
-              lists === 1
-                ? {
-                    path: "workflows/a.json",
-                    routing_key: "wf:workflows/a.json",
-                    modified: true,
-                    persisted: true,
-                  }
-                : {
-                    path: "workflows/b.json",
-                    routing_key: "wf:workflows/b.json",
-                    modified: false,
-                    persisted: true,
-                  },
+            active: {
+              path: "workflows/b.json",
+              routing_key: "wf:workflows/b.json",
+              modified: false,
+              persisted: true,
+            },
+            late_save_receipts: [],
           });
         }
         return jsonResult({ ok: true });
@@ -373,7 +366,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     const res = await defByName("panel_save_workflow").handler({}, ctx);
     expect(res.isError).toBe(true);
     expect(textOf(res)).toMatch(/OUTCOME UNKNOWN/);
-    expect(lists).toBeGreaterThanOrEqual(2);
+    expect(lists).toBe(1);
   });
 
   it("a first-save successor with the timed-out command's late receipt can be acknowledged", async () => {
@@ -386,23 +379,13 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
         if (cmd.cmd === "workflow_list") {
           lists += 1;
           return jsonResult({
-            active:
-              lists === 1
-                ? {
-                    path: null,
-                    key: "tmp:first-save-instance",
-                    routing_key: "tmp:first-save-instance",
-                    title: "Untitled Workflow",
-                    modified: true,
-                    persisted: false,
-                  }
-                : {
-                    path: "workflows/first-save.json",
-                    filename: "first-save",
-                    routing_key: "wf:workflows/first-save.json",
-                    modified: false,
-                    persisted: true,
-                  },
+            active: {
+              path: "workflows/first-save.json",
+              filename: "first-save",
+              routing_key: "wf:workflows/first-save.json",
+              modified: false,
+              persisted: true,
+            },
             late_save_receipts: [
               {
                 rid: "save-rid",
@@ -422,7 +405,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     const res = await defByName("panel_save_workflow").handler({}, ctx);
     expect(res.isError).toBeFalsy();
     expect(textOf(res)).toMatch(/"late_ack": true/);
-    expect(lists).toBeGreaterThanOrEqual(2);
+    expect(lists).toBe(2);
   });
 
   it("a first-save timeout cannot acknowledge an unrelated clean successor", async () => {
@@ -435,23 +418,13 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
         if (cmd.cmd === "workflow_list") {
           lists += 1;
           return jsonResult({
-            active:
-              lists === 1
-                ? {
-                    path: null,
-                    key: "tmp:first-save-instance",
-                    routing_key: "tmp:first-save-instance",
-                    title: "Untitled Workflow",
-                    modified: true,
-                    persisted: false,
-                  }
-                : {
-                    path: "workflows/other.json",
-                    filename: "other",
-                    routing_key: "wf:workflows/other.json",
-                    modified: false,
-                    persisted: true,
-                  },
+            active: {
+              path: "workflows/other.json",
+              filename: "other",
+              routing_key: "wf:workflows/other.json",
+              modified: false,
+              persisted: true,
+            },
             late_save_receipts: [
               {
                 rid: "save-rid",
@@ -471,7 +444,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     const res = await defByName("panel_save_workflow").handler({}, ctx);
     expect(res.isError).toBe(true);
     expect(textOf(res)).toMatch(/OUTCOME UNKNOWN/);
-    expect(lists).toBe(2);
+    expect(lists).toBe(1);
   });
 
   it("modified:true persisted:true at follow-up is still outcome-unknown, not success", async () => {

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -73,6 +73,10 @@ const SAVE_TIMEOUT =
 const SAVE_TIMEOUT_2078 =
   `workflow_save did not finish within 13s. The save may still complete in the background. OUTCOME UNKNOWN.`;
 
+const FIRST_SAVE_TIMEOUT_2078 =
+  `workflow_save did not finish within 13s. The active workflow changed from "Untitled Workflow" ` +
+  `to "first-save" while the save was in flight, so which file the hung write targets cannot be determined from here.`;
+
 describe("restored uncollapse size (#2004)", () => {
   it("a stored [228, 0] is not sizeSane and restores keeping the width", () => {
     expect(needsUncollapseSizeRestore([228, 0])).toBe(true);
@@ -270,6 +274,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
           return jsonResult({
             active: {
               path: "workflows/graph.json",
+              routing_key: "wf:workflows/graph.json",
               filename: "graph",
               modified: false,
               persisted: true,
@@ -289,7 +294,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     expect(text).toMatch(/"saved": true/);
     expect(text).toMatch(/"late_ack": true/);
     expect(text).toMatch(/"acknowledged_after_timeout": true/);
-    expect(calls[0]).toMatchObject({ cmd: "workflow_save" });
+    expect(calls.map((c) => c.cmd)).toContain("workflow_save");
     expect(calls.map((c) => c.cmd)).toContain("workflow_list");
   });
 
@@ -309,6 +314,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
           return jsonResult({
             active: {
               path: "workflows/graph.json",
+              routing_key: "wf:workflows/graph.json",
               filename: "graph",
               modified: lists === 1,
               persisted: true,
@@ -332,6 +338,142 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(1);
   });
 
+  it("a clean different workflow after the timeout does not acknowledge the save", async () => {
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
+    let lists = 0;
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT_2078);
+        if (cmd.cmd === "workflow_list") {
+          lists += 1;
+          return jsonResult({
+            active:
+              lists === 1
+                ? {
+                    path: "workflows/a.json",
+                    routing_key: "wf:workflows/a.json",
+                    modified: true,
+                    persisted: true,
+                  }
+                : {
+                    path: "workflows/b.json",
+                    routing_key: "wf:workflows/b.json",
+                    modified: false,
+                    persisted: true,
+                  },
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/OUTCOME UNKNOWN/);
+    expect(lists).toBeGreaterThanOrEqual(2);
+  });
+
+  it("a first-save successor with the timed-out command's late receipt can be acknowledged", async () => {
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
+    let lists = 0;
+    const ctx: PanelToolCtx = {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
+        if (cmd.cmd === "workflow_save") onDispatchedRid?.("save-rid");
+        if (cmd.cmd === "workflow_save") return errorResult(FIRST_SAVE_TIMEOUT_2078);
+        if (cmd.cmd === "workflow_list") {
+          lists += 1;
+          return jsonResult({
+            active:
+              lists === 1
+                ? {
+                    path: null,
+                    key: "tmp:first-save-instance",
+                    routing_key: "tmp:first-save-instance",
+                    title: "Untitled Workflow",
+                    modified: true,
+                    persisted: false,
+                  }
+                : {
+                    path: "workflows/first-save.json",
+                    filename: "first-save",
+                    routing_key: "wf:workflows/first-save.json",
+                    modified: false,
+                    persisted: true,
+                  },
+            late_save_receipts: [
+              {
+                rid: "save-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/first-save.json" },
+              },
+            ],
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toMatch(/"late_ack": true/);
+    expect(lists).toBeGreaterThanOrEqual(2);
+  });
+
+  it("a first-save timeout cannot acknowledge an unrelated clean successor", async () => {
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
+    let lists = 0;
+    const ctx: PanelToolCtx = {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
+        if (cmd.cmd === "workflow_save") onDispatchedRid?.("save-rid");
+        if (cmd.cmd === "workflow_save") return errorResult(FIRST_SAVE_TIMEOUT_2078);
+        if (cmd.cmd === "workflow_list") {
+          lists += 1;
+          return jsonResult({
+            active:
+              lists === 1
+                ? {
+                    path: null,
+                    key: "tmp:first-save-instance",
+                    routing_key: "tmp:first-save-instance",
+                    title: "Untitled Workflow",
+                    modified: true,
+                    persisted: false,
+                  }
+                : {
+                    path: "workflows/other.json",
+                    filename: "other",
+                    routing_key: "wf:workflows/other.json",
+                    modified: false,
+                    persisted: true,
+                  },
+            late_save_receipts: [
+              {
+                rid: "save-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/first-save.json" },
+              },
+            ],
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/OUTCOME UNKNOWN/);
+    expect(lists).toBe(2);
+  });
+
   it("modified:true persisted:true at follow-up is still outcome-unknown, not success", async () => {
     // The timeout snapshot itself. Treating persisted:true as proof would have
     // reported the reporter's still-dirty canvas as saved. Grace 0 = one list.
@@ -341,7 +483,12 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
         if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT);
         if (cmd.cmd === "workflow_list") {
           return jsonResult({
-            active: { path: "workflows/graph.json", modified: true, persisted: true },
+            active: {
+              path: "workflows/graph.json",
+              routing_key: "wf:workflows/graph.json",
+              modified: true,
+              persisted: true,
+            },
           });
         }
         return jsonResult({ ok: true });

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -267,9 +267,12 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
   it("THE REPORTED CASE: modified:false persisted:true after the 13s budget is treated as saved", async () => {
     const calls: Forwarded[] = [];
     const ctx: PanelToolCtx = {
-      call: async (cmd) => {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
         calls.push(cmd);
-        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT);
+        if (cmd.cmd === "workflow_save") {
+          onDispatchedRid?.("save-rid");
+          return errorResult(SAVE_TIMEOUT);
+        }
         if (cmd.cmd === "workflow_list") {
           return jsonResult({
             active: {
@@ -279,6 +282,13 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
               modified: false,
               persisted: true,
             },
+            late_save_receipts: [
+              {
+                rid: "save-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/graph.json" },
+              },
+            ],
           });
         }
         return jsonResult({ ok: true });
@@ -306,9 +316,12 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     const calls: Forwarded[] = [];
     let lists = 0;
     const ctx: PanelToolCtx = {
-      call: async (cmd) => {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
         calls.push(cmd);
-        if (cmd.cmd === "workflow_save") return errorResult(SAVE_TIMEOUT_2078);
+        if (cmd.cmd === "workflow_save") {
+          onDispatchedRid?.("save-rid");
+          return errorResult(SAVE_TIMEOUT_2078);
+        }
         if (cmd.cmd === "workflow_list") {
           lists += 1;
           return jsonResult({
@@ -319,6 +332,13 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
               modified: lists === 1,
               persisted: true,
             },
+            late_save_receipts: [
+              {
+                rid: "save-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/graph.json" },
+              },
+            ],
           });
         }
         return jsonResult({ ok: true });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1203,6 +1203,10 @@ export const __panelToolsTestHooks = {
   setRunLateAckGraceMs(ms: number | null): void {
     runLateAckGraceMsOverride = ms;
   },
+  /** Shrink the #2078 save-timeout settle grace so a still-dirty follow-up does not wait 5s. */
+  setSaveTimeoutSettleGraceMs(ms: number | null): void {
+    saveTimeoutSettleGraceMsOverride = ms;
+  },
   isRetrySafeCmd,
   isTransientReconnectError,
   // CivitAI sample-image gating (#623): the predicate that decides which results'
@@ -4546,28 +4550,54 @@ const SAVE_TIMEOUT_OUTCOME_UNKNOWN =
   `Confirm by reading the saved file (or panel_list_workflows) before retrying — a re-issue may write twice.`;
 
 /**
- * #2004 — the panel's 13s budget fired while userdata PUT was still running.
- * A follow-up list that now shows modified:false persisted:true is the save
- * completing; anything else stays outcome-unknown. persisted:true alone is
- * the timeout-time snapshot of a previously-saved dirty tab, not proof.
+ * #2078 — how long to keep reading tab state after the 13s save budget.
+ *
+ * #2004 already listed once. The reporter's PUT landed a moment later: that
+ * snapshot was still dirty, the next panel_list_workflows was already clean.
+ * Paid only on a path that has already spent its full bound. A canvas that
+ * is clean on the first list returns immediately.
+ */
+const SAVE_TIMEOUT_SETTLE_GRACE_MS = 5_000;
+const SAVE_TIMEOUT_SETTLE_POLL_MS = 200;
+let saveTimeoutSettleGraceMsOverride: number | null = null;
+function saveTimeoutSettleGraceMs(): number {
+  return saveTimeoutSettleGraceMsOverride ?? SAVE_TIMEOUT_SETTLE_GRACE_MS;
+}
+
+function saveAckAfterTimeout(list: Record<string, unknown> | null): ToolResult {
+  return ok({
+    saved: true,
+    late_ack: true,
+    acknowledged_after_timeout: true,
+    active: list?.active,
+  });
+}
+
+/**
+ * #2004 / #2078 — the panel's 13s budget fired while userdata PUT was still
+ * running. A list that shows modified:false persisted:true is the save
+ * completing. One snapshot is not enough: the timeout-time canvas is still
+ * dirty, and the PUT can land between that read and the caller's next list.
+ * Keep reading until the grace, then stay outcome-unknown. persisted:true
+ * alone is the timeout-time snapshot of a previously-saved dirty tab, not proof.
  */
 async function settleWorkflowSaveTimeout(
   res: ToolResult,
   ctx: PanelToolCtx,
 ): Promise<ToolResult> {
   if (!isWorkflowSaveBudgetTimeout(res)) return res;
-  try {
-    const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
-    const list = parseToolResultJson(listRes);
-    if (saveLandedAfterTimeout(list)) {
-      return ok({
-        saved: true,
-        acknowledged_after_timeout: true,
-        active: list?.active,
-      });
+  const deadline = Date.now() + saveTimeoutSettleGraceMs();
+  for (;;) {
+    try {
+      const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
+      const list = parseToolResultJson(listRes);
+      if (saveLandedAfterTimeout(list)) return saveAckAfterTimeout(list);
+    } catch {
+      /* keep polling until the grace; the note below is the honest remainder */
     }
-  } catch {
-    /* keep the timeout refusal; the note below is the honest remainder */
+    const left = deadline - Date.now();
+    if (left <= 0) break;
+    await sleep(Math.max(1, Math.min(SAVE_TIMEOUT_SETTLE_POLL_MS, left)));
   }
   return appendToolResultText(res, SAVE_TIMEOUT_OUTCOME_UNKNOWN);
 }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4546,55 +4546,12 @@ function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
 }
 
 /**
- * Capture the active workflow BEFORE an in-place save is dispatched. The later
- * timeout probe is otherwise allowed to observe a different, clean workflow
- * after a tab switch and mistake that canvas for the save that timed out.
- */
-async function activeWorkflowBeforeSave(ctx: PanelToolCtx): Promise<Record<string, unknown> | null> {
-  try {
-    const list = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
-    const active = list?.active;
-    if (active && typeof active === "object" && !Array.isArray(active)) {
-      return active as Record<string, unknown>;
-    }
-    const workflows = list?.workflows;
-    if (Array.isArray(workflows)) {
-      const flagged = workflows.find(
-        (record) =>
-          record &&
-          typeof record === "object" &&
-          !Array.isArray(record) &&
-          (record as Record<string, unknown>).active === true,
-      );
-      if (flagged && typeof flagged === "object" && !Array.isArray(flagged)) {
-        return flagged as Record<string, unknown>;
-      }
-    }
-  } catch {
-    // A missing pre-save identity makes a late success unprovable; the timeout
-    // path below will stay outcome-unknown rather than guess.
-  }
-  return null;
-}
-
-function saveProbeMatchesBeforeSave(
-  before: Record<string, unknown> | null,
-  list: Record<string, unknown> | null,
-): boolean {
-  if (!before || !list?.active || typeof list.active !== "object" || Array.isArray(list.active)) {
-    return false;
-  }
-  // identityVerdict compares every stable field it can observe and rejects
-  // contradictions, including a same-path record with a different UUID.
-  return identityVerdict(before as OpenWorkflowRecord, list.active) === true;
-}
-
-/**
- * A first save legitimately changes `tmp:<instance>` into `wf:<path>`. In that
- * one case the panel's timeout diagnostic is the transaction's only bridge: it
- * reports the successor label observed while the save was in flight. Accept a
- * clean probe only when it is still that reported successor, never merely any
- * clean saved workflow.
+ * A first save legitimately changes `tmp:<instance>` into `wf:<path>`. The
+ * updated panel publishes the save command's eventual success under its exact
+ * rid, so only that receipt can bridge the identity change. Older panels do not
+ * publish receipts; they retain the historical clean-state fallback below for
+ * compatibility, while updated panels fail closed when no matching receipt is
+ * present.
  */
 function saveProbeMatchesLateReceipt(
   saveRid: string | undefined,
@@ -4659,7 +4616,6 @@ function saveAckAfterTimeout(list: Record<string, unknown> | null): ToolResult {
 async function settleWorkflowSaveTimeout(
   res: ToolResult,
   ctx: PanelToolCtx,
-  before: Record<string, unknown> | null,
   saveRid: string | undefined,
 ): Promise<ToolResult> {
   if (!isWorkflowSaveBudgetTimeout(res)) return res;
@@ -4668,9 +4624,10 @@ async function settleWorkflowSaveTimeout(
     try {
       const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
       const list = parseToolResultJson(listRes);
+      const receiptsAdvertised = Array.isArray(list?.late_save_receipts);
       if (
         saveLandedAfterTimeout(list) &&
-        (saveProbeMatchesLateReceipt(saveRid, list) || saveProbeMatchesBeforeSave(before, list))
+        (saveProbeMatchesLateReceipt(saveRid, list) || !receiptsAdvertised)
       ) {
         return saveAckAfterTimeout(list);
       }
@@ -16573,10 +16530,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             : ctx.call({ cmd: "workflow_save" }, 15000, (rid) => {
                 saveRid = rid;
               });
-        // #2078 — retain the identity of the canvas the in-place save was sent
-        // to. A later clean workflow_list is only a late acknowledgement when
-        // it still names this same canvas; a clean tab after a switch is not.
-        const saveTargetBefore = args.name ? null : await activeWorkflowBeforeSave(ctx);
         let res = await saveOnce();
         // #1710 — dest tab + dest nodes, extra still stamped as the save-as SOURCE.
         // Rebind extra to the confirmed dest, then retry the same save once.
@@ -16590,7 +16543,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             }
           }
         }
-        if (res.isError && !args.name) res = await settleWorkflowSaveTimeout(res, ctx, saveTargetBefore, saveRid);
+        if (res.isError && !args.name) res = await settleWorkflowSaveTimeout(res, ctx, saveRid);
         if (res.isError) {
           // #1873 — named Save-As 409s by contract; the panel's "choose a different
           // name" is what forced a third file. Keep the 409 and name the rename path.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4545,6 +4545,81 @@ function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
   return rec.modified === false && rec.persisted === true;
 }
 
+/**
+ * Capture the active workflow BEFORE an in-place save is dispatched. The later
+ * timeout probe is otherwise allowed to observe a different, clean workflow
+ * after a tab switch and mistake that canvas for the save that timed out.
+ */
+async function activeWorkflowBeforeSave(ctx: PanelToolCtx): Promise<Record<string, unknown> | null> {
+  try {
+    const list = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
+    const active = list?.active;
+    if (active && typeof active === "object" && !Array.isArray(active)) {
+      return active as Record<string, unknown>;
+    }
+    const workflows = list?.workflows;
+    if (Array.isArray(workflows)) {
+      const flagged = workflows.find(
+        (record) =>
+          record &&
+          typeof record === "object" &&
+          !Array.isArray(record) &&
+          (record as Record<string, unknown>).active === true,
+      );
+      if (flagged && typeof flagged === "object" && !Array.isArray(flagged)) {
+        return flagged as Record<string, unknown>;
+      }
+    }
+  } catch {
+    // A missing pre-save identity makes a late success unprovable; the timeout
+    // path below will stay outcome-unknown rather than guess.
+  }
+  return null;
+}
+
+function saveProbeMatchesBeforeSave(
+  before: Record<string, unknown> | null,
+  list: Record<string, unknown> | null,
+): boolean {
+  if (!before || !list?.active || typeof list.active !== "object" || Array.isArray(list.active)) {
+    return false;
+  }
+  // identityVerdict compares every stable field it can observe and rejects
+  // contradictions, including a same-path record with a different UUID.
+  return identityVerdict(before as OpenWorkflowRecord, list.active) === true;
+}
+
+/**
+ * A first save legitimately changes `tmp:<instance>` into `wf:<path>`. In that
+ * one case the panel's timeout diagnostic is the transaction's only bridge: it
+ * reports the successor label observed while the save was in flight. Accept a
+ * clean probe only when it is still that reported successor, never merely any
+ * clean saved workflow.
+ */
+function saveProbeMatchesLateReceipt(
+  saveRid: string | undefined,
+  list: Record<string, unknown> | null,
+): boolean {
+  if (!saveRid || !Array.isArray(list?.late_save_receipts)) return false;
+  if (!list?.active || typeof list.active !== "object" || Array.isArray(list.active)) return false;
+  const receipt = list.late_save_receipts.find(
+    (candidate) =>
+      candidate &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).rid === saveRid &&
+      (candidate as Record<string, unknown>).cmd === "workflow_save",
+  );
+  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) return false;
+  const result = (receipt as Record<string, unknown>).result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) return false;
+  if ((result as Record<string, unknown>).saved !== true) return false;
+  // The panel's receipt is the save command's own eventual success. Still require
+  // its produced workflow identity to match the currently observed active canvas;
+  // a valid late save on A must not be credited after the user switched to B.
+  return identityVerdict(result as OpenWorkflowRecord, list.active) === true;
+}
+
 const SAVE_TIMEOUT_OUTCOME_UNKNOWN =
   `\n\nOUTCOME UNKNOWN: the save was already in flight when this budget fired. ` +
   `Confirm by reading the saved file (or panel_list_workflows) before retrying — a re-issue may write twice.`;
@@ -4584,6 +4659,8 @@ function saveAckAfterTimeout(list: Record<string, unknown> | null): ToolResult {
 async function settleWorkflowSaveTimeout(
   res: ToolResult,
   ctx: PanelToolCtx,
+  before: Record<string, unknown> | null,
+  saveRid: string | undefined,
 ): Promise<ToolResult> {
   if (!isWorkflowSaveBudgetTimeout(res)) return res;
   const deadline = Date.now() + saveTimeoutSettleGraceMs();
@@ -4591,7 +4668,12 @@ async function settleWorkflowSaveTimeout(
     try {
       const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
       const list = parseToolResultJson(listRes);
-      if (saveLandedAfterTimeout(list)) return saveAckAfterTimeout(list);
+      if (
+        saveLandedAfterTimeout(list) &&
+        (saveProbeMatchesLateReceipt(saveRid, list) || saveProbeMatchesBeforeSave(before, list))
+      ) {
+        return saveAckAfterTimeout(list);
+      }
     } catch {
       /* keep polling until the grace; the note below is the honest remainder */
     }
@@ -16484,10 +16566,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (ctx.awaitReachable && !(await ctx.awaitReachable())) {
           return noReachableTabFail(args.name ? "workflow_save_as" : "workflow_save", ctx);
         }
+        let saveRid: string | undefined;
         const saveOnce = () =>
           args.name
             ? ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)
-            : ctx.call({ cmd: "workflow_save" }, 15000);
+            : ctx.call({ cmd: "workflow_save" }, 15000, (rid) => {
+                saveRid = rid;
+              });
+        // #2078 — retain the identity of the canvas the in-place save was sent
+        // to. A later clean workflow_list is only a late acknowledgement when
+        // it still names this same canvas; a clean tab after a switch is not.
+        const saveTargetBefore = args.name ? null : await activeWorkflowBeforeSave(ctx);
         let res = await saveOnce();
         // #1710 — dest tab + dest nodes, extra still stamped as the save-as SOURCE.
         // Rebind extra to the confirmed dest, then retry the same save once.
@@ -16501,7 +16590,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             }
           }
         }
-        if (res.isError && !args.name) res = await settleWorkflowSaveTimeout(res, ctx);
+        if (res.isError && !args.name) res = await settleWorkflowSaveTimeout(res, ctx, saveTargetBefore, saveRid);
         if (res.isError) {
           // #1873 — named Save-As 409s by contract; the panel's "choose a different
           // name" is what forced a third file. Keep the 409 and name the rename path.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4548,10 +4548,9 @@ function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
 /**
  * A first save legitimately changes `tmp:<instance>` into `wf:<path>`. The
  * updated panel publishes the save command's eventual success under its exact
- * rid, so only that receipt can bridge the identity change. Older panels do not
- * publish receipts; they retain the historical clean-state fallback below for
- * compatibility, while updated panels fail closed when no matching receipt is
- * present.
+ * rid, so only that receipt can bridge the identity change. If the receipt field
+ * is absent or does not match, the outcome remains unknown rather than crediting
+ * a clean workflow that may belong to a tab the user switched to.
  */
 function saveProbeMatchesLateReceipt(
   saveRid: string | undefined,
@@ -4624,10 +4623,9 @@ async function settleWorkflowSaveTimeout(
     try {
       const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
       const list = parseToolResultJson(listRes);
-      const receiptsAdvertised = Array.isArray(list?.late_save_receipts);
       if (
         saveLandedAfterTimeout(list) &&
-        (saveProbeMatchesLateReceipt(saveRid, list) || !receiptsAdvertised)
+        saveProbeMatchesLateReceipt(saveRid, list)
       ) {
         return saveAckAfterTimeout(list);
       }


### PR DESCRIPTION
Fixes #2078

## What the user sees

`panel_save_workflow` no longer returns OUTCOME UNKNOWN when the in-place save actually persisted. After the panel's 13s save budget fires, a canvas that then shows `modified:false` and `persisted:true` is reported as `saved:true` with `late_ack`. A subsequent `panel_list_workflows` is not required, and a retry is not invited.

## Why this happened

The panel's 13s save budget can fire while userdata PUT is still running. #2004 already followed up with one `workflow_list`. If that snapshot was still dirty (the timeout-time canvas), the tool returned unknown even though the caller's next `panel_list_workflows` was already `modified:false persisted:true`. That extra read is what this report is, and it risks a second save of a write that already landed.

origin/main / 0.52.61 does not cover this (0.52.61 is the #2075 version bump). Do not steal panel#1557 (Save-As disconnect + dead wf: route).

## Fix

After an in-place `workflow_save` 13s budget timeout, keep reading tab state for a short grace instead of listing once. `modified:false` and `persisted:true` on the same canvas is the save completing. `persisted:true` alone (the timeout-time snapshot of a previously-saved dirty tab) stays outcome-unknown so a retry does not write twice.

## Tests

Shipped `panel_save_workflow` handler on the real `ctx.call → workflow_save` path:

- #2004: first list already clean → `saved:true` / `late_ack`
- #2078 reporter: first list still dirty, next list clean → `saved:true` / `late_ack`, not OUTCOME UNKNOWN
- still-dirty follow-up stays outcome-unknown
