### PR TITLE
fix(panel#1557): preserve reconnect recovery across MCP context loss

### DIFF
--- a/src/__tests__/orchestrator/codex-reconnect-rebind.test.ts
+++ b/src/__tests__/orchestrator/codex-reconnect-rebind.test.ts
@@ -41,8 +41,10 @@ import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import { waitFor } from "../helpers/wait-for.js";
 
 const SCOPE_KEY = `${SHARED_SESSION_SCOPE}::codex`;
+const CHATGPT_SCOPE = `${SHARED_SESSION_SCOPE}::chatgpt`;
 const LIVE = "wf:tab-live:workflows/a.json";
 const GONE = "wf:tab-gone:workflows/a.json";
+const UNTITLED = "tmp:untitled-chatgpt";
 const PATH = "workflows/a.json";
 const UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 
@@ -93,30 +95,34 @@ function connectPanel(port: number, tabId: string, title: string): Promise<WebSo
   });
 }
 
-function autoReply(sock: WebSocket): void {
+function autoReply(sock: WebSocket, opts?: { untitled?: boolean }): void {
   sock.on("message", (buf) => {
     const msg = JSON.parse(buf.toString());
     if (!msg.rid || !msg.cmd) return;
     if (msg.cmd === "workflow_list") {
+      const active = opts?.untitled
+        ? {
+            path: null,
+            filename: null,
+            title: "Unsaved Workflow",
+            key: UNTITLED,
+            routing_key: UNTITLED,
+            workflow_uuid: UUID,
+            active: true,
+          }
+        : {
+            path: PATH,
+            routing_key: `wf:${PATH}`,
+            workflow_uuid: UUID,
+            active: true,
+          };
       sock.send(
         JSON.stringify({
           rid: msg.rid,
           ok: true,
           result: {
-            active: {
-              path: PATH,
-              routing_key: `wf:${PATH}`,
-              workflow_uuid: UUID,
-              active: true,
-            },
-            workflows: [
-              {
-                path: PATH,
-                routing_key: `wf:${PATH}`,
-                workflow_uuid: UUID,
-                active: true,
-              },
-            ],
+            active,
+            workflows: [{ ...active, persisted: !opts?.untitled, modified: false }],
             active_confirmed: true,
           },
         }),
@@ -171,13 +177,14 @@ describe("panel#1557 Codex reconnect: mode:current binds the live canvas", () =>
     await bridge.stop();
   });
 
-  function tools() {
+  function tools(scopeKey = SCOPE_KEY) {
     const defs = buildPanelToolDefs();
-    const ctx = makePanelToolCtx(bridge, SCOPE_KEY, new WorkflowTargetStore());
+    const ctx = makePanelToolCtx(bridge, scopeKey, new WorkflowTargetStore());
     return {
       ctx,
       setTarget: defs.find((d) => d.name === "panel_set_workflow_target")!,
       outline: defs.find((d) => d.name === "panel_graph_outline")!,
+      list: defs.find((d) => d.name === "panel_list_workflows")!,
     };
   }
 
@@ -256,6 +263,80 @@ describe("panel#1557 Codex reconnect: mode:current binds the live canvas", () =>
     // conversation's backend or writing a turn pin onto it.
     expect(tracker.pinOf(SCOPE_KEY)).toBeUndefined();
     expect(tabBackends.get(LIVE)).toBe("claude");
+    sock.close();
+  });
+
+  // Recurrence (reopened 2026-08-22): during panel_save_workflow Save-As the
+  // tab disconnected mid-command. mode:"current" cleared the stale binding
+  // (DEFER), but the next workflow_list still targeted the dead
+  // wf:<id>:workflows/... pin while the catalog showed one connected
+  // untitled tab on the ChatGPT conversation.
+  it("after a Save-As disconnect DEFER, workflow_list binds the untitled canvas that reconnects (ChatGPT)", async () => {
+    tracker.repinTo(CHATGPT_SCOPE, GONE);
+    const { ctx, setTarget, list } = tools(CHATGPT_SCOPE);
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    expect(bindRes.isError, textOf(bindRes as ToolResult)).toBeFalsy();
+    expect(JSON.parse(textOf(bindRes as ToolResult))).toMatchObject({ deferred: true });
+
+    const sock = await connectPanel(port, UNTITLED, "Unsaved Workflow");
+    autoReply(sock, { untitled: true });
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(UNTITLED, "claude");
+
+    const listRes = await list.handler({}, ctx);
+    const listText = textOf(listRes as ToolResult);
+    expect(listRes.isError, listText).toBeFalsy();
+    expect(listText).not.toMatch(GONE);
+    expect(listText).not.toMatch(/no connected tab with id/);
+    expect(tracker.resolvedPinOf(CHATGPT_SCOPE)).toBe(UNTITLED);
+    expect(tabBackends.get(UNTITLED)).toBe("chatgpt");
+    expect(bridge.canReach(CHATGPT_SCOPE)).toBe(true);
+    sock.close();
+  });
+
+  it("a dead ChatGPT pin plus one untitled canvas is adopted by mode:current even when hello joined the default backend", async () => {
+    const sock = await connectPanel(port, UNTITLED, "Unsaved Workflow");
+    autoReply(sock, { untitled: true });
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(UNTITLED, "claude");
+    tracker.repinTo(CHATGPT_SCOPE, GONE);
+    expect(bridge.canReach(CHATGPT_SCOPE)).toBe(false);
+
+    const { ctx, setTarget, list } = tools(CHATGPT_SCOPE);
+    const bindRes = await setTarget.handler({ mode: "current" }, ctx);
+    const bindText = textOf(bindRes as ToolResult);
+    expect(bindRes.isError, bindText).toBeFalsy();
+    expect(bindText).not.toMatch(/did NOT restore this session's graph binding/);
+    expect(bindText).not.toMatch(/no connected tab belongs to this conversation's backend/);
+    expect(tracker.resolvedPinOf(CHATGPT_SCOPE)).toBe(UNTITLED);
+    expect(tabBackends.get(UNTITLED)).toBe("chatgpt");
+
+    const listRes = await list.handler({}, ctx);
+    expect(listRes.isError, textOf(listRes as ToolResult)).toBeFalsy();
+    sock.close();
+  });
+
+  it("a later workflow_list on a NEW ctx still binds the untitled canvas after this conversation's DEFER", async () => {
+    // A ChatGPT/Codex HTTP MCP drop between the DEFER and the recovery list
+    // mints a fresh ctx. The dead pin is still on the tracker; the catalog
+    // already shows the untitled tab. Consent must survive the new ctx.
+    tracker.repinTo(CHATGPT_SCOPE, GONE);
+    const first = tools(CHATGPT_SCOPE);
+    const bindRes = await first.setTarget.handler({ mode: "current" }, first.ctx);
+    expect(JSON.parse(textOf(bindRes as ToolResult))).toMatchObject({ deferred: true });
+
+    const sock = await connectPanel(port, UNTITLED, "Unsaved Workflow");
+    autoReply(sock, { untitled: true });
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(UNTITLED, "claude");
+
+    const second = tools(CHATGPT_SCOPE);
+    const listRes = await second.list.handler({}, second.ctx);
+    const listText = textOf(listRes as ToolResult);
+    expect(listRes.isError, listText).toBeFalsy();
+    expect(listText).not.toMatch(GONE);
+    expect(listText).not.toMatch(/no connected tab with id/);
+    expect(tracker.resolvedPinOf(CHATGPT_SCOPE)).toBe(UNTITLED);
     sock.close();
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10488,6 +10488,8 @@ export interface PanelToolCtx {
    * graph call's `ensureReachable` consumes this as the same explicit consent,
    * so a tab that reconnects a moment later is bound instead of staying fenced
    * to the previous (dead) workflow instance.
+   *
+   * Same-session only. The durable copy is `bridge.armScopeRecoveryConsent`.
    */
   pendingScopeRecoveryConsent?: boolean;
   /**
@@ -10625,11 +10627,20 @@ export function makePanelToolCtx(
     // here is the same recovery, just delayed until a canvas tab exists; it is
     // not a silent re-target.
     if (isScopeAddress(ctx.tabId)) {
-      if (ctx.pendingScopeRecoveryConsent) {
+      const deferredConsent =
+        ctx.pendingScopeRecoveryConsent === true ||
+        (typeof bridge.hasScopeRecoveryConsent === "function" &&
+          bridge.hasScopeRecoveryConsent(ctx.tabId));
+      if (deferredConsent) {
         try {
           const out = rebindToActiveTab({ scopeRecoveryConsent: true });
-          if (out.rebound) ctx.pendingScopeRecoveryConsent = false;
-          else if ((interactiveTabIds() ?? []).length > 0) ctx.pendingScopeRecoveryConsent = false;
+          if (out.rebound) {
+            ctx.pendingScopeRecoveryConsent = false;
+            bridge.clearScopeRecoveryConsent?.(ctx.tabId);
+          } else if ((interactiveTabIds() ?? []).length > 0) {
+            ctx.pendingScopeRecoveryConsent = false;
+            bridge.clearScopeRecoveryConsent?.(ctx.tabId);
+          }
         } catch {
           // still nothing bindable — keep the consent for the next attempt
         }
@@ -16671,9 +16682,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           } finally {
             if (recoveringScope) ctx.bridge.endScopeRecovery?.(before);
           }
-          // panel#1557 — the consent survives a zero-tab DEFER so a graph call
-          // after the canvas reconnects can finish the recovery.
-          if (deferredBind && recoveringScope) ctx.pendingScopeRecoveryConsent = true;
+          // panel#1557 — the consent survives a zero-tab DEFER so a later graph
+          // call (possibly on a fresh HTTP MCP ctx) can finish the recovery.
+          if (deferredBind && recoveringScope) {
+            ctx.pendingScopeRecoveryConsent = true;
+            ctx.bridge.armScopeRecoveryConsent?.(before);
+          }
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
           if (!deferredBind && ctx.tabId !== before) {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1921,6 +1921,12 @@ export class UiBridge {
     string,
     { count: number; done: Promise<void>; finish: () => void }
   >();
+  /**
+   * panel#1557 — deferred mode:"current" consent, keyed by scope address.
+   * Lives here rather than on the tool ctx so an HTTP MCP session drop cannot
+   * drop it while the dead turn pin is still on the tracker.
+   */
+  private pendingScopeRecoveryConsent = new Set<string>();
   /** #884 — orchestrator-injected: normalize a hello's raw `backend` value the
    *  same way the orchestrator does (unknown/absent → the default backend), so
    *  the backend-qualified scope-buffer replay matches the conversation the
@@ -3799,6 +3805,19 @@ export class UiBridge {
     if (rec.count > 0) return;
     rec.finish();
     this.scopeRecovery.delete(scopeId);
+  }
+
+  /** panel#1557 — keep a deferred mode:"current" recovery across MCP sessions. */
+  armScopeRecoveryConsent(scopeId: string): void {
+    this.pendingScopeRecoveryConsent.add(scopeId);
+  }
+
+  hasScopeRecoveryConsent(scopeId: string): boolean {
+    return this.pendingScopeRecoveryConsent.has(scopeId);
+  }
+
+  clearScopeRecoveryConsent(scopeId: string): void {
+    this.pendingScopeRecoveryConsent.delete(scopeId);
   }
 
   /**


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1557

## Summary
- Preserve deferred mode:"current" recovery consent in UiBridge, keyed by scope.
- Consume and clear that durable consent when a connected canvas tab becomes available.
- Cover Save-As disconnects, untitled canvas adoption, default-backend hello, and a fresh MCP context.

## Validation
- npm.cmd exec -- vitest run src/__tests__/orchestrator/codex-reconnect-rebind.test.ts --reporter=dot
- 10 related orchestrator suites: 141 tests passed
- npm.cmd run build
- independent Codex gate: SHIP