### PR TITLE
fix(2082): verify staged loader references

### DIFF
--- a/src/__tests__/comfyui/cloud-client.test.ts
+++ b/src/__tests__/comfyui/cloud-client.test.ts
@@ -160,6 +160,12 @@ describe("cloud-client", () => {
     expect((form.get("image") as File).name).toBe("clip.mp4");
   });
 
+  it("can request a unique name instead of overwriting an existing input", async () => {
+    await uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4", false);
+    const form = calls.at(-1)?.init?.body as FormData;
+    expect(form.get("overwrite")).toBe("false");
+  });
+
   it("uploadImageHttp refuses a traversal before anything is sent", async () => {
     await expect(uploadImageHttp("../escape.png", Buffer.from("x"))).rejects.toThrow(
       /walks outside/,

--- a/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
+++ b/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
@@ -79,6 +79,12 @@ describe("#946: uploadImageHttp sends the subfolder as its own field", () => {
     expect((sentForm().get("image") as File).name).toBe("clip.mp4");
   });
 
+  it("can request a unique name instead of overwriting an existing input", async () => {
+    fetchApi.mockResolvedValue(okJson({ name: "clip_1.mp4", subfolder: "", type: "input" }));
+    await uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4", false);
+    expect(sentForm().get("overwrite")).toBe("false");
+  });
+
   it("refuses a traversal before anything is sent", async () => {
     await expect(uploadImageHttp("../escape.png", Buffer.from("x"))).rejects.toThrow(
       /walks outside/,

--- a/src/__tests__/services/media-upload.test.ts
+++ b/src/__tests__/services/media-upload.test.ts
@@ -34,9 +34,13 @@ vi.mock("node:fs/promises", () => ({
 
 const uploadImageHttpMock = vi.fn();
 const fetchImageMock = vi.fn();
+const getObjectInfoMock = vi.fn();
+const resetObjectInfoCacheMock = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({
   uploadImageHttp: (...a: unknown[]) => uploadImageHttpMock(...a),
   fetchImage: (...a: unknown[]) => fetchImageMock(...a),
+  getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+  resetObjectInfoCache: (...a: unknown[]) => resetObjectInfoCacheMock(...a),
 }));
 
 import { config } from "../../config.js";
@@ -56,6 +60,7 @@ beforeEach(() => {
   (config as { comfyuiPath?: string }).comfyuiPath = "/comfy";
   readFileMock.mockResolvedValue(Buffer.from("data"));
   uploadImageHttpMock.mockResolvedValue({ name: "x" });
+  getObjectInfoMock.mockResolvedValue({});
   copyFileMock.mockResolvedValue(undefined);
 });
 
@@ -223,7 +228,87 @@ describe("stageOutputAsInput (output → input via server API)", () => {
       subfolder: "",
       type: "input",
       kind: "image",
+      loaderSelectable: "unverified",
     });
+  });
+
+  it("verifies a nested stage reference against the fresh loader combo", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "example.png",
+      subfolder: "stage",
+      type: "input",
+    });
+    getObjectInfoMock.mockResolvedValueOnce({
+      LoadImage: {
+        input: { required: { image: ["COMBO", { options: ["stage/example.png"] }] } },
+      },
+    });
+
+    const r = await stageOutputAsInput({
+      filename: "source.png",
+      asFilename: "stage/example.png",
+    });
+
+    expect(uploadImageHttpMock).toHaveBeenCalledTimes(1);
+    expect(r).toMatchObject({
+      filename: "example.png",
+      subfolder: "stage",
+      loaderSelectable: "verified",
+    });
+    expect(resetObjectInfoCacheMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a root filename when the host omits nested paths from LoadImage", async () => {
+    uploadImageHttpMock
+      .mockResolvedValueOnce({ name: "example.png", subfolder: "stage", type: "input" })
+      .mockResolvedValueOnce({ name: "example_1.png", subfolder: "", type: "input" });
+    getObjectInfoMock
+      .mockResolvedValueOnce({
+        LoadImage: {
+          input: { required: { image: ["COMBO", { options: ["other.png"] }] } },
+        },
+      })
+      .mockResolvedValueOnce({
+        LoadImage: {
+          input: { required: { image: ["COMBO", { options: ["example_1.png"] }] } },
+        },
+      });
+
+    const r = await stageOutputAsInput({
+      filename: "source.png",
+      asFilename: "stage/example.png",
+    });
+
+    expect(uploadImageHttpMock).toHaveBeenCalledTimes(2);
+    expect(uploadImageHttpMock.mock.calls[1]).toEqual([
+      "example.png",
+      expect.any(Buffer),
+      "image/png",
+      false,
+    ]);
+    expect(r).toMatchObject({
+      filename: "example_1.png",
+      subfolder: "",
+      loaderSelectable: "root-fallback",
+      requestedFilename: "stage/example.png",
+    });
+  });
+
+  it("does not claim loader selectability when /object_info is unavailable", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "example.png",
+      subfolder: "stage",
+      type: "input",
+    });
+    getObjectInfoMock.mockRejectedValueOnce(new Error("server unavailable"));
+
+    const r = await stageOutputAsInput({
+      filename: "source.png",
+      asFilename: "stage/example.png",
+    });
+
+    expect(r.loaderSelectable).toBe("unverified");
+    expect(uploadImageHttpMock).toHaveBeenCalledTimes(1);
   });
 
   it("infers video and uploads with the video mime", async () => {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1207,8 +1207,9 @@ export async function uploadImageHttp(
   filename: string,
   data: Buffer,
   mimeType = "image/png",
+  overwrite = true,
 ): Promise<{ name: string; subfolder: string; type: string }> {
-  if (isCloudMode()) return cloudClient.uploadImageHttp(filename, data, mimeType);
+  if (isCloudMode()) return cloudClient.uploadImageHttp(filename, data, mimeType, overwrite);
   const client = getClient();
   // #946 — a `filename` carrying a path ("assets/clip.mp4") is a SUBFOLDER
   // request, and ComfyUI's /upload/image takes that as its own form field, not
@@ -1222,7 +1223,7 @@ export async function uploadImageHttp(
   const blob = new Blob([data], { type: mimeType });
   formData.append("image", blob, name);
   formData.append("type", "input");
-  formData.append("overwrite", "true");
+  formData.append("overwrite", String(overwrite));
   if (subfolder) formData.append("subfolder", subfolder);
   const res = await comfyApiFetch("/upload/image", {
     method: "POST",

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -362,6 +362,7 @@ export async function uploadImageHttp(
   filename: string,
   data: Buffer,
   mimeType = "image/png",
+  overwrite = true,
 ): Promise<{ name: string; subfolder: string; type: string }> {
   // #946 — same split as client.ts's uploadImageHttp: a `filename` carrying a
   // path ("assets/clip.mp4") is a subfolder request, and the API takes that as
@@ -372,7 +373,7 @@ export async function uploadImageHttp(
   const blob = new Blob([data], { type: mimeType });
   formData.append("image", blob, name);
   formData.append("type", "input");
-  formData.append("overwrite", "true");
+  formData.append("overwrite", String(overwrite));
   if (subfolder) formData.append("subfolder", subfolder);
   // multipart sets its own Content-Type; skip the JSON header.
   const res = await cloudFetch("/upload/image", {

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1,7 +1,8 @@
 import { readFile, copyFile, readdir, stat } from "node:fs/promises";
 import { join, basename, extname, relative, sep } from "node:path";
 import { config, isRemoteMode } from "../config.js";
-import { getHistory } from "../comfyui/client.js";
+import { getHistory, getObjectInfo, resetObjectInfoCache } from "../comfyui/client.js";
+import type { ObjectInfo } from "../comfyui/types.js";
 import { ValidationError, ModelError, ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { resolveOutputDir, resolveInputDir } from "./output-dir.js";
@@ -1084,6 +1085,89 @@ export const uploadAudioLocal = (sourcePath: string, filename?: string) =>
 
 export type MediaKind = "image" | "video" | "audio";
 
+export type StageLoaderSelectability = "verified" | "root-fallback" | "unverified";
+
+const STAGE_LOADER_INPUTS: Readonly<Record<MediaKind, ReadonlyMap<string, ReadonlySet<string>>>> = {
+  image: new Map([
+    ["LoadImage", new Set(["image"])],
+    ["LoadImageMask", new Set(["image"])],
+    ["LoadImageOutput", new Set(["image"])],
+  ]),
+  video: new Map([
+    ["VHS_LoadVideo", new Set(["video"])],
+    ["VHS_LoadVideoPath", new Set(["video"])],
+    ["VHS_LoadVideoFFmpeg", new Set(["video"])],
+    ["VHS_LoadVideoFFmpegPath", new Set(["video"])],
+  ]),
+  audio: new Map([
+    ["LoadAudio", new Set(["audio"])],
+    ["VHS_LoadAudio", new Set(["audio"])],
+    ["VHS_LoadAudioUpload", new Set(["audio"])],
+  ]),
+};
+
+/** Read every ComfyUI combo shape that can enumerate loader filenames. */
+function comboOptions(spec: unknown): string[] | null {
+  if (!Array.isArray(spec)) return null;
+  if (Array.isArray(spec[0])) {
+    return spec[0].filter((value): value is string => typeof value === "string");
+  }
+  const options = (spec[1] as { options?: unknown } | undefined)?.options;
+  if (!Array.isArray(options)) return null;
+  return options
+    .map((value) =>
+      value && typeof value === "object" && !Array.isArray(value) && "key" in value
+        ? (value as { key?: unknown }).key
+        : value,
+    )
+    .filter((value): value is string => typeof value === "string");
+}
+
+/**
+ * Verify the exact input reference against ComfyUI's fresh loader choices.
+ * `null` means the server did not expose a usable loader list, so callers must
+ * not turn an unverified upload into a claim that a widget can select it.
+ */
+function loaderReferenceIsSelectable(
+  objectInfo: ObjectInfo,
+  kind: MediaKind,
+  reference: string,
+): boolean | null {
+  let sawEnumerableList = false;
+  for (const [classType, inputNames] of STAGE_LOADER_INPUTS[kind]) {
+    const def = objectInfo?.[classType];
+    if (!def || typeof def !== "object") continue;
+    for (const inputName of inputNames) {
+      const spec = def.input?.required?.[inputName] ?? def.input?.optional?.[inputName];
+      if (!spec) continue;
+      const options = comboOptions(spec);
+      if (options) sawEnumerableList = true;
+      if (options?.includes(reference)) return true;
+    }
+  }
+  return sawEnumerableList ? false : null;
+}
+
+async function verifyLoaderReference(
+  kind: MediaKind,
+  reference: string,
+): Promise<boolean | null> {
+  try {
+    // The upload changes the server-side file list, not the node definitions.
+    // Invalidate the shared snapshot so this check cannot certify against the
+    // pre-stage /object_info response (#2082).
+    resetObjectInfoCache();
+    return loaderReferenceIsSelectable(await getObjectInfo(), kind, reference);
+  } catch (err) {
+    logger.warn("Could not verify staged input against /object_info", {
+      kind,
+      reference,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
 const MIME_BY_KIND: Record<MediaKind, Record<string, string>> = {
   image: IMAGE_MIME,
   video: VIDEO_MIME,
@@ -1137,6 +1221,10 @@ export interface StagedInput {
   type: string;
   /** Detected/forced media kind. */
   kind: MediaKind;
+  /** Whether a fresh loader option list verified the returned reference. */
+  loaderSelectable: StageLoaderSelectability;
+  /** The requested nested reference, when a host required the root fallback. */
+  requestedFilename?: string;
 }
 
 /**
@@ -1175,11 +1263,51 @@ export async function stageOutputAsInput(
     targetName,
   });
 
+  const referenceOf = (result: { name: string; subfolder?: string }) =>
+    result.subfolder ? `${result.subfolder}/${result.name}` : result.name;
   const result = await uploadImageHttp(targetName, data, mimeType);
+  const stagedReference = referenceOf(result);
+  const nestedTarget = targetName.includes("/") || targetName.includes("\\");
+  const nestedSelectable = await verifyLoaderReference(kind, stagedReference);
+
+  if (nestedTarget && nestedSelectable === false) {
+    // Some ComfyUI builds store a nested upload correctly but do not expose
+    // nested input paths in the loader combo. Re-register the same bytes at the
+    // root so the returned value is actually selectable, rather than claiming
+    // that the nested path works because /upload/image returned 200.
+    const rootName = basename(targetName);
+    // Never replace an unrelated root file when the host requires this
+    // compatibility fallback. ComfyUI will choose a unique name when the
+    // requested root name already exists, and the returned name is verified
+    // below before being reported as selectable.
+    const rootResult = await uploadImageHttp(rootName, data, mimeType, false);
+    const rootReference = referenceOf(rootResult);
+    const rootSelectable = await verifyLoaderReference(kind, rootReference);
+    if (rootSelectable === true) {
+      return {
+        filename: rootResult.name,
+        subfolder: rootResult.subfolder ?? "",
+        type: rootResult.type,
+        kind,
+        loaderSelectable: "root-fallback",
+        requestedFilename: stagedReference,
+      };
+    }
+    return {
+      filename: rootResult.name,
+      subfolder: rootResult.subfolder ?? "",
+      type: rootResult.type,
+      kind,
+      loaderSelectable: "unverified",
+      requestedFilename: stagedReference,
+    };
+  }
+
   return {
     filename: result.name,
-    subfolder: result.subfolder,
+    subfolder: result.subfolder ?? "",
     type: result.type,
     kind,
+    loaderSelectable: nestedSelectable === true ? "verified" : "unverified",
   };
 }

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -995,6 +995,21 @@ export function registerImageManagementTools(server: McpServer): void {
             const stagedRef = staged.subfolder
               ? `${staged.subfolder}/${staged.filename}`
               : staged.filename;
+            const loaderInstruction =
+              staged.loaderSelectable === "unverified"
+                ? `The staged reference is "${stagedRef}" for ${loaderHint}.`
+                : `Use "${stagedRef}" as ${loaderHint}.`;
+            const selectabilityNote =
+              staged.loaderSelectable === "verified"
+                ? `The fresh /object_info loader list verifies that "${stagedRef}" is selectable.`
+                : staged.loaderSelectable === "root-fallback"
+                  ? `This ComfyUI stored the requested nested path "${staged.requestedFilename}" ` +
+                    `but did not enumerate it in its loader list, so the same bytes were also ` +
+                    `registered at the root as "${stagedRef}". The fresh /object_info loader ` +
+                    `list verifies the root reference; use that one.`
+                  : `The upload succeeded, but a fresh /object_info response did not prove that ` +
+                    `"${stagedRef}" is present in a loader list. Do not assume the widget can ` +
+                    `select it; inspect the loader or retry after panel_refresh_nodes.`;
             return {
               content: [
                 {
@@ -1004,7 +1019,8 @@ export function registerImageManagementTools(server: McpServer): void {
                     `Input filename: ${stagedRef}\n` +
                     `subfolder: ${staged.subfolder || "(none)"}\n` +
                     `type: ${staged.type}\n\n` +
-                    `Use "${stagedRef}" as ${loaderHint}.\n\n` +
+                    `${loaderInstruction}\n\n` +
+                    `${selectabilityNote}\n\n` +
                     `NOTE: the open ComfyUI tab's loader dropdown was populated at page-load, ` +
                     `so this just-registered input is not in it yet — call panel_refresh_nodes ` +
                     `first (it re-pulls /object_info so the new file becomes selectable), THEN ` +


### PR DESCRIPTION
Fixes #2082\n\n- Refresh /object_info after staging and report whether the exact loader reference is verified.\n- Fall back to a root input reference when nested paths are omitted, using overwrite=false so existing root files are never replaced.\n- Keep the tool response fail-closed when loader selectability cannot be proven.\n\nValidation: focused media/upload/client tests 45 passed; build passed; i18n/docs/blog checks passed. Full Vitest baseline: 11,778 passed, 4 skipped, 3 unrelated failures in node-id-union-message.test.ts.