### PR TITLE
fix(2084): validate RunPod readiness JSON

### DIFF
--- a/src/__tests__/tools/runpod.test.ts
+++ b/src/__tests__/tools/runpod.test.ts
@@ -133,8 +133,13 @@ beforeEach(() => {
   watcherState.watched = null;
   mockBaseUrl = "http://127.0.0.1:8188";
   setComfyuiTargetMock.mockReturnValue(true);
-  // default probe: ComfyUI answers
-  global.fetch = vi.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
+  // default probe: ComfyUI answers with a JSON object
+  global.fetch = vi.fn(async () =>
+    new Response(JSON.stringify({ system: {} }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  ) as unknown as typeof fetch;
 });
 
 describe("runpod registration", () => {
@@ -439,6 +444,19 @@ describe("runpod actions call the same services with the same arguments", () => 
     expect(setComfyuiTargetMock).not.toHaveBeenCalled();
   });
 
+  it('action:"connect" rejects an HTTP-200 nginx startup page', async () => {
+    getPodMock.mockResolvedValue(runningPod());
+    global.fetch = vi.fn(async () =>
+      new Response("<!doctype html><title>ComfyUI is starting</title>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    ) as unknown as typeof fetch;
+    const t = text(await runpod()({ action: "connect", pod_id: "pod123" }));
+    expect(t).toContain("response was not valid JSON");
+    expect(setComfyuiTargetMock).not.toHaveBeenCalled();
+  });
+
   it('action:"deploy_link" returns the referral deploy link', async () => {
     const t = text(await runpod()({ action: "deploy_link" }));
     expect(t).toContain("console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b");
@@ -510,6 +528,20 @@ describe("runpod_watch actions call the same services with the same arguments", 
     global.fetch = vi.fn(async () => ({ ok: false, status: 502 })) as unknown as typeof fetch;
     const t = text(await runpodWatch()({ action: "troubleshoot", pod_id: "pod123" }));
     expect(t).toContain("did not answer");
+  });
+
+  it('action:"troubleshoot" rejects an HTTP-200 nginx startup page', async () => {
+    getPodMock.mockResolvedValue(runningPod());
+    global.fetch = vi.fn(async () =>
+      new Response("<!doctype html><title>ComfyUI is starting</title>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    ) as unknown as typeof fetch;
+    const t = text(await runpodWatch()({ action: "troubleshoot", pod_id: "pod123" }));
+    expect(t).toContain("did not answer");
+    expect(t).not.toContain("The pod is healthy");
+    expect(t).toContain("response was not valid JSON");
   });
 
   it('action:"troubleshoot" reports healthy when ComfyUI answers', async () => {

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -92,7 +92,15 @@ async function probe(url: string, timeoutMs = 8000): Promise<{ ok: boolean; stat
   const t = setTimeout(() => ctl.abort(), timeoutMs);
   try {
     const res = await fetch(url, { signal: ctl.signal });
-    return { ok: res.ok, status: res.status };
+    if (!res.ok) return { ok: false, status: res.status };
+    try {
+      const body: unknown = await res.json();
+      return body !== null && typeof body === "object" && !Array.isArray(body)
+        ? { ok: true, status: res.status }
+        : { ok: false, status: res.status, error: "response was not a JSON object" };
+    } catch {
+      return { ok: false, status: res.status, error: "response was not valid JSON" };
+    }
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   } finally {
@@ -437,14 +445,14 @@ export function registerRunpodTools(server: McpServer): void {
             const url = runpodProxyUrl(pod.id);
             const probeRes = await probe(`${url}/system_stats`);
             if (!probeRes.ok) {
-              return { content: [{ type: "text", text: `Pod \`${pod.id}\` exposes ComfyUI but it isn't answering yet at ${url} (${probeRes.status ?? probeRes.error}). It may still be booting — wait ~30s, or run runpod_watch action:"troubleshoot".` }] };
+              return { content: [{ type: "text", text: `Pod \`${pod.id}\` exposes ComfyUI but it isn't answering yet at ${url} (${probeRes.error ?? probeRes.status}). It may still be booting — wait ~30s, or run runpod_watch action:"troubleshoot".` }] };
             }
             // Readiness needs MORE than /system_stats (#269): a ComfyUI whose core is
             // up but whose queue/prompt endpoint is broken would answer /system_stats
             // yet fail every render. Verify /queue answers too before declaring ready.
             const queueProbe = await probe(`${url}/queue`);
             if (!queueProbe.ok) {
-              return { content: [{ type: "text", text: `Pod \`${pod.id}\` answers /system_stats but its queue endpoint isn't ready at ${url} (${queueProbe.status ?? queueProbe.error}) — ComfyUI may still be initializing. Wait ~30s, or run runpod_watch action:"troubleshoot".` }] };
+              return { content: [{ type: "text", text: `Pod \`${pod.id}\` answers /system_stats but its queue endpoint isn't ready at ${url} (${queueProbe.error ?? queueProbe.status}) — ComfyUI may still be initializing. Wait ~30s, or run runpod_watch action:"troubleshoot".` }] };
             }
             const applied = setComfyuiTarget(url);
             if (!applied) return { content: [{ type: "text", text: `Resolved ${url} but could not retarget (unexpected URL parse failure).` }] };
@@ -615,7 +623,7 @@ export function registerRunpodTools(server: McpServer): void {
             if (p.ok) {
               lines.push(`✅ ComfyUI is answering at ${url}. The pod is healthy — connect with runpod action:"connect".`);
             } else {
-              lines.push(`❌ Port ${RUNPOD_COMFYUI_PORT} is exposed but ComfyUI did not answer at ${url}/system_stats (${p.status ?? p.error}). Likely still starting, or ComfyUI crashed on boot. → Wait ~30s and re-check; if it persists, view the pod's logs in the console (a missing model/custom node can abort ComfyUI on startup).`);
+              lines.push(`❌ Port ${RUNPOD_COMFYUI_PORT} is exposed but ComfyUI did not answer at ${url}/system_stats (${p.error ?? p.status}). Likely still starting, or ComfyUI crashed on boot. → Wait ~30s and re-check; if it persists, view the pod's logs in the console (a missing model/custom node can abort ComfyUI on startup).`);
             }
             return { content: [{ type: "text", text: lines.join("\n") }] };
           }


### PR DESCRIPTION
Fixes #2084\n\n- Require RunPod /system_stats and /queue probes to return a non-null JSON object, rejecting HTTP-200 nginx startup HTML and scalar placeholders.\n- Surface the probe diagnostic in connect/troubleshoot responses and never retarget on a false-ready response.\n- Add HTTP-200 HTML regressions for both connect and troubleshoot.\n\nValidation: independent Codex gate SHIP; RunPod/client tests 98 passed; build passed; vocabulary check passed.