### PR TITLE
fix(manager): surface auth-gated probes

### DIFF
--- a/src/__tests__/services/manager-403-reason.test.ts
+++ b/src/__tests__/services/manager-403-reason.test.ts
@@ -6,7 +6,10 @@
 
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { explainManagerForbidden } from "../../services/node-management.js";
+import {
+  explainManagerAuthenticationRequired,
+  explainManagerForbidden,
+} from "../../services/node-management.js";
 
 const j = (o: unknown) => JSON.stringify(o);
 
@@ -73,5 +76,23 @@ describe("#1089 Manager 403 names its own reason", () => {
     // …and the raw body is still carried in details, so nothing is LOST by
     // summarising it in the message.
     expect(window).toMatch(/body: text/);
+  });
+});
+
+describe("#2085 an auth gate is not a missing Manager", () => {
+  it("explains 401 as the ComfyUI/proxy authentication layer", () => {
+    const t = explainManagerAuthenticationRequired(401);
+    expect(t).toMatch(/HTTP 401/);
+    expect(t).toMatch(/authentication failure/i);
+    expect(t).toMatch(/not evidence that ComfyUI-Manager is missing/i);
+    expect(t).toMatch(/COMFYUI_AUTH_TOKEN/);
+    expect(t).toMatch(/browser cookies/i);
+  });
+
+  it("identifies 407 as proxy authentication and ignores unrelated statuses", () => {
+    expect(explainManagerAuthenticationRequired(407)).toMatch(/proxy authentication layer/i);
+    for (const status of [200, 400, 403, 404, 500]) {
+      expect(explainManagerAuthenticationRequired(status)).toBe("");
+    }
   });
 });

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -87,6 +87,7 @@ const {
   reinstallCustomNode,
   updateCustomNode,
   queueUpdateAllCustomNodes,
+  detectManagerApi,
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
   fetchManagerTaskHistoryEntry,
@@ -249,6 +250,20 @@ describe("#646 Manager API dialect cache invalidation", () => {
   afterAll(() => {
     if (PRIOR_TTL_ENV === undefined) delete process.env.COMFYUI_MCP_MANAGER_API_TTL_MS;
     else process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = PRIOR_TTL_ENV;
+  });
+
+  it("does not translate an authenticated-proxy 401 into 'Manager is missing' (#2085)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401, statusText: "Unauthorized" })),
+    );
+
+    const error = (await detectManagerApi(BASE).catch((e: unknown) => e)) as Error;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatch(/HTTP 401/);
+    expect(error.message).toMatch(/authentication failure/i);
+    expect(error.message).toMatch(/not evidence that ComfyUI-Manager is missing/i);
+    expect(error.message).not.toMatch(/queue API is not reachable.*installed and enabled/i);
   });
 
   it("re-detects after a restart at the SAME url (explicit invalidation)", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -270,6 +270,26 @@ export function explainManagerForbidden(status: number, body: string): string {
   return "";
 }
 
+/**
+ * A Manager capability probe can be answered by the authentication layer in
+ * front of ComfyUI. Treating a 401/407 as an absent Manager loses the one fact
+ * the caller can act on, especially when the browser is authenticated but the
+ * MCP process is not carrying that browser session.
+ */
+export function explainManagerAuthenticationRequired(status: number): string {
+  if (status !== 401 && status !== 407) return "";
+  const gate = status === 407 ? "proxy authentication layer" : "ComfyUI or an authentication proxy";
+  const credentialHint =
+    "Configure the gateway credentials for this MCP process (COMFYUI_AUTH_TOKEN / " +
+    "COMFYUI_AUTH_HEADER, or the CF-Access client-id/client-secret pair); browser cookies " +
+    "and panel login sessions are not forwarded automatically.";
+  return (
+    ` — the ${gate} rejected the Manager probe with HTTP ${status}. This is an ` +
+    "authentication failure, not evidence that ComfyUI-Manager is missing. " +
+    credentialHint
+  );
+}
+
 async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
@@ -298,14 +318,28 @@ async function managerFetch<T>(
   }
 
   if (!res.ok) {
-    if (soft) return undefined;
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the
     // text, never a wrong conclusion. Verified there is no branch on this value.
     const text = await res.text().catch(() => "");
+    if (soft) {
+      // A soft probe may ignore an absent route or a transient server error, but
+      // authentication is actionable evidence. Returning undefined here made
+      // detectManagerApi() fall through to its false "Manager is missing"
+      // conclusion when an authenticated reverse proxy answered 401 (#2085).
+      const auth = explainManagerAuthenticationRequired(res.status);
+      if (auth) {
+        throw new NodeManagementError(
+          `ComfyUI-Manager probe at ${url} was rejected` + auth + managerBodyClause(text),
+          { url, status: res.status, body: text },
+        );
+      }
+      return undefined;
+    }
     throw new NodeManagementError(
       `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}` +
         explainManagerForbidden(res.status, text) +
+        explainManagerAuthenticationRequired(res.status) +
         // #1397 — SHOW THE BODY. It was already being captured into `details` below
         // and only surfaced for 403, so a task-queue failure reported a bare status
         // line while the serialized exception naming the cause sat one layer down.


### PR DESCRIPTION
Closes #2085. Soft Manager capability probes now preserve actionable HTTP 401/407 authentication evidence instead of misdiagnosing an authenticated reverse proxy as a missing Manager. Adds bounded guidance for MCP-side auth configuration and regression coverage for 401/407 plus the probe wiring. Tests: build; Manager/node-management suites 167/167; focused auth/dialect suites 32/32; vocabulary check.