### PR TITLE
fix(manifest): resolve local model route consistently (#2089)

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1359,6 +1359,7 @@ describe("applyManifest", () => {
     mockConfig.comfyuiPath = undefined;
     mockConfig.remote = false; // local loopback target, just no COMFYUI_PATH
     savedWorkspaceMock.mockReturnValue("/saved/ComfyUI");
+    shouldDispatchToManagerMock.mockResolvedValueOnce(false);
     existsSyncMock.mockImplementation((p: unknown) => {
       const s = String(p);
       return (
@@ -1391,6 +1392,7 @@ describe("applyManifest", () => {
     mockConfig.remote = false; // local loopback target reached over the panel session
     savedWorkspaceMock.mockReturnValue(undefined);
     liveComfyBaseMock.mockResolvedValue("/live/ComfyUI");
+    shouldDispatchToManagerMock.mockResolvedValueOnce(false);
     existsSyncMock.mockImplementation((p: unknown) => {
       const s = String(p);
       return (
@@ -1412,6 +1414,112 @@ describe("applyManifest", () => {
     expect(downloadModelMock).toHaveBeenCalled();
     // Call-scoped: the adopted live path must NOT persist process-wide.
     expect(mockConfig.comfyuiPath).toBeUndefined();
+  });
+
+  it("uses the live models resolver when the generic data root is unavailable (#2089)", async () => {
+    // A server may expose a usable models root through --models-directory (or the
+    // live download resolver) without yielding a generic dataBase for custom_nodes.
+    // The old manifest gate skipped the model before resolveLocalModelPath could
+    // use that authoritative route.
+    mockConfig.comfyuiPath = undefined;
+    mockConfig.remote = false;
+    savedWorkspaceMock.mockReturnValue(undefined);
+    liveComfyBaseMock.mockResolvedValue(undefined);
+    effectiveBaseLiveMock.mockResolvedValue(undefined);
+    modelsDirMock.mockResolvedValue("/live/ComfyUI/models");
+    shouldDispatchToManagerMock.mockResolvedValueOnce(false);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 1, failed: 0, skipped: 0 });
+    expect(downloadModelMock).toHaveBeenCalled();
+    expect(installModelViaManagerMock).not.toHaveBeenCalled();
+    // The route was captured before local target resolution and threaded through
+    // startDownloadJob; it must not re-read mutable connection state mid-call.
+    expect(shouldDispatchToManagerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses Manager when a local reconnect has no resolvable models root (#2089)", async () => {
+    mockConfig.comfyuiPath = undefined;
+    mockConfig.remote = false;
+    savedWorkspaceMock.mockReturnValue(undefined);
+    liveComfyBaseMock.mockResolvedValue(undefined);
+    effectiveBaseLiveMock.mockResolvedValue(undefined);
+    modelsDirMock.mockRejectedValueOnce(
+      new Error("The connected ComfyUI models directory could not be resolved"),
+    );
+    shouldDispatchToManagerMock.mockResolvedValueOnce(true);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+    expect(result.results[0]?.message).toMatch(/ACCEPTED.*NOT verified/i);
+    const managerRouteCall = downloadModelMock.mock.calls[0] as unknown[] | undefined;
+    expect(managerRouteCall?.[1]).toBe("loras");
+    expect(managerRouteCall?.[2]).toBe("m.safetensors");
+    expect(managerRouteCall?.[4]).toBe(true);
+  });
+
+  it("does not let a configured data root suppress Manager routing for an unresolvable model root (#2089)", async () => {
+    // COMFYUI_PATH can still resolve custom-node/pip operations while the live
+    // server's explicit --models-directory is relative and lacks cwd. The model
+    // route must follow download_model's Manager decision, not the data root.
+    mockConfig.comfyuiPath = COMFY;
+    mockConfig.remote = false;
+    modelsDirMock.mockRejectedValueOnce(
+      new Error("relative --models-directory has no reported working directory"),
+    );
+    shouldDispatchToManagerMock.mockResolvedValueOnce(true);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+    const managerRouteCall = downloadModelMock.mock.calls[0] as unknown[] | undefined;
+    expect(managerRouteCall?.[4]).toBe(true);
+    expect(result.results[0]?.message).toMatch(/ACCEPTED.*NOT verified/i);
+  });
+
+  it("reports the local path-resolution reason when neither local models nor Manager is available (#2089)", async () => {
+    mockConfig.comfyuiPath = undefined;
+    mockConfig.remote = false;
+    savedWorkspaceMock.mockReturnValue(undefined);
+    liveComfyBaseMock.mockResolvedValue(undefined);
+    effectiveBaseLiveMock.mockResolvedValue(undefined);
+    modelsDirMock.mockRejectedValueOnce(
+      new Error("relative --models-directory has no reported working directory"),
+    );
+    shouldDispatchToManagerMock.mockResolvedValueOnce(false);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 0, failed: 0, skipped: 1 });
+    expect(result.results[0]?.message).toMatch(/could not resolve a local models directory/i);
+    expect(result.results[0]?.message).toMatch(/relative --models-directory/i);
+    expect(result.results[0]?.message).not.toMatch(/no local filesystem and no ComfyUI-Manager HTTP API/i);
   });
 
   it("reports a custom_node as PENDING (not failed) when the Manager queue is still installing at the budget (#489)", async () => {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -396,6 +396,10 @@ export async function startDownloadJob(
   /** Post-download work (sidecars, type checks). Its lines land on `job.notes`
    *  so they reach the user even when the download outlives the tool call. */
   onComplete?: (path: string) => Promise<string[]>,
+  /** Optional call-scoped route decision supplied by apply_manifest. When present,
+   *  it must drive both the identity key and the writer, just like the decision
+   *  computed here for ordinary download_model calls. */
+  dispatchToManagerOverride?: boolean,
 ): Promise<Entry> {
   // Identity depends on mode. LOCAL: resolve the canonical on-disk destination
   // with the SAME resolver the write uses (throws on an invalid filename/subfolder
@@ -414,7 +418,8 @@ export async function startDownloadJob(
   // so a reconnect/reachability flip between two evaluations would split the job —
   // Manager-key + local-writer (or a duplicate job) for one request (#420 codex
   // round 1). One decision keys the identity AND drives the writer.
-  const dispatchToManager = await shouldDispatchDownloadToManager();
+  const dispatchToManager =
+    dispatchToManagerOverride ?? (await shouldDispatchDownloadToManager());
 
   // DEDUP INDEX (route-independent) vs WRITER ROUTE (the single decision above) are
   // deliberately separated (#420 codex round 2). The in-flight lookup/registration

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -33,6 +33,7 @@ import {
   resolveExistingModelFile,
   managerModelDestination,
   MODEL_SUBDIRS,
+  shouldDispatchDownloadToManager,
   type ModelType,
 } from "./model-resolver.js";
 import { startDownloadJob, describePlacement, type DownloadJob } from "./download-jobs.js";
@@ -663,6 +664,39 @@ function defaultFilenameForUrl(url: string): string {
   return basename(new URL(url).pathname) || "model.safetensors";
 }
 
+/** Resolve a manifest destination without needing a local models root. */
+function manifestModelTarget(model: ComfyManifest["models"][number]): {
+  targetSubfolder: string;
+  filename: string;
+} {
+  if (model.local_path) {
+    if (isAbsolute(model.local_path)) {
+      throw new ValidationError(
+        `Model local_path must be relative to models/: ${model.local_path}`,
+      );
+    }
+    const segments = model.local_path.split(/[/\\]+/).filter(Boolean);
+    if (segments.length === 0 || segments.includes("..")) {
+      throw new ValidationError(
+        `Model local_path escapes the models directory: ${model.local_path}`,
+      );
+    }
+    if (segments.length < 2) {
+      throw new ValidationError(
+        `Model local_path must include a category subfolder (e.g. 'checkpoints/foo.safetensors'): ${model.local_path}`,
+      );
+    }
+    return {
+      targetSubfolder: segments.slice(0, -1).join("/"),
+      filename: segments[segments.length - 1],
+    };
+  }
+  return {
+    targetSubfolder: model.model_type ?? "checkpoints",
+    filename: model.filename ?? defaultFilenameForUrl(model.url),
+  };
+}
+
 async function resolveLocalModelPath(
   model: ComfyManifest["models"][number],
 ): Promise<{ targetSubfolder: string; filename: string; targetPath: string }> {
@@ -870,38 +904,12 @@ function remoteModelTarget(model: ComfyManifest["models"][number]): {
   /** OUR canonical category folder — for the panel download-tray watcher. */
   category: string;
 } {
-  if (model.local_path) {
-    if (isAbsolute(model.local_path)) {
-      throw new ValidationError(
-        `Model local_path must be relative to models/: ${model.local_path}`,
-      );
-    }
-    const segments = model.local_path.split(/[/\\]+/).filter(Boolean);
-    if (segments.length === 0 || segments.includes("..")) {
-      throw new ValidationError(
-        `Model local_path escapes the models directory: ${model.local_path}`,
-      );
-    }
-    const filename = segments[segments.length - 1];
-    const dirSegments = segments.slice(0, -1);
-    if (dirSegments.length === 0) {
-      throw new ValidationError(
-        `Model local_path must include a category subfolder (e.g. 'checkpoints/foo.safetensors'): ${model.local_path}`,
-      );
-    }
-    // Map our category folder to a Manager-valid { type, save_path }. Nested
-    // paths are handed to Manager verbatim; top-level categories resolve via the
-    // type-map ("default") or fall back to the folder name.
-    const { type, save_path } = managerModelDestination(
-      dirSegments[0],
-      dirSegments.length > 1 ? dirSegments.join("/") : undefined,
-    );
-    return { name: filename, type, save_path, filename, category: dirSegments[0] };
-  }
-
-  const category: ModelType = model.model_type ?? "checkpoints";
-  const filename = model.filename ?? defaultFilenameForUrl(model.url);
-  const { type, save_path } = managerModelDestination(category);
+  const { targetSubfolder, filename } = manifestModelTarget(model);
+  const category = targetSubfolder.split("/")[0] as ModelType;
+  const { type, save_path } = managerModelDestination(
+    category,
+    targetSubfolder === category ? undefined : targetSubfolder,
+  );
   return { name: filename, type, save_path, filename, category };
 }
 
@@ -982,6 +990,40 @@ async function applyManifestSections(
   const localMode = !isRemoteMode();
   const hasLocalDataFs = localMode && Boolean(dataBase);
   const hasLocalCodeFs = localMode && Boolean(codeBase);
+
+  // The data root answers where custom_nodes and the ordinary models/ tree live,
+  // but it is not the complete answer for model downloads. A connected local
+  // ComfyUI may name its models directory independently with --models-directory,
+  // or the live download resolver may derive it from the serving install while the
+  // generic data-root resolver cannot. Reuse the same live-first route predicate
+  // the download_model path uses before resolving a local target (#2089). Keep
+  // this separate from dataBase: using the models directory as the custom-node
+  // root would target a different filesystem contract.
+  let hasLocalModelFs = hasLocalDataFs;
+  let localModelResolutionError: string | undefined;
+  // Any local session can be Manager-routed: an explicit --models-directory may
+  // be unresolvable even while COMFYUI_PATH exists, and reconnects can change the
+  // answer between calls. Capture the route BEFORE attempting local model
+  // resolution: a retarget in between must not leave a stale local preflight
+  // deciding the model branch. The override is threaded to startDownloadJob below
+  // so its identity key and writer use this same call-scoped decision.
+  let dispatchModelsToManager = isRemoteMode();
+  const routeOverrideNeeded = localMode && manifest.models.length > 0;
+  if (routeOverrideNeeded) {
+    try {
+      dispatchModelsToManager = await shouldDispatchDownloadToManager();
+    } catch (err) {
+      localModelResolutionError ??= err instanceof Error ? err.message : String(err);
+    }
+    if (!dispatchModelsToManager) {
+      try {
+        await resolveModelsDir();
+        hasLocalModelFs = true;
+      } catch (err) {
+        localModelResolutionError ??= err instanceof Error ? err.message : String(err);
+      }
+    }
+  }
 
   for (const pkg of manifest.apt) {
     results.push(
@@ -1165,22 +1207,24 @@ async function applyManifestSections(
   for (const model of manifest.models) {
     const item = model.local_path ?? model.filename ?? model.url;
     try {
-      if (!hasLocalDataFs) {
+      if (!hasLocalModelFs && !dispatchModelsToManager && !isRemoteMode()) {
+        results.push(
+          report(
+            "model",
+            item,
+            "skipped",
+            "Model install could not resolve a local models directory for the connected ComfyUI, and no Manager route was available. " +
+              (localModelResolutionError ??
+                "Set COMFYUI_PATH, save a default workspace, or connect to a ComfyUI whose models directory can be detected."),
+          ),
+        );
+        continue;
+      }
+      if (isRemoteMode()) {
         // REMOTE: no local filesystem to scan/write. Route the download to the
         // ComfyUI host via ComfyUI-Manager's install-model task (server-side
         // fetch, returns at handoff). Cloud mode has no Manager, so report it as
-        // unsupported.
-        if (!isRemoteMode()) {
-          results.push(
-            report(
-              "model",
-              item,
-              "skipped",
-              "Model install is not supported against this ComfyUI (no local filesystem and no ComfyUI-Manager HTTP API); install it on the ComfyUI host.",
-            ),
-          );
-          continue;
-        }
+        // unsupported before this branch.
         const { name, type, save_path, filename, category } = remoteModelTarget(model);
         const res = await installModelViaManager({
           name,
@@ -1205,6 +1249,24 @@ async function applyManifestSections(
               "list_local_models before relying on it.",
           ),
         );
+        continue;
+      }
+      if (dispatchModelsToManager) {
+        // A local target can still be Manager-routed when the live server is
+        // reachable but its models directory cannot be safely resolved. Use the
+        // background job path so the accepted-vs-landed verdict and progress
+        // polling match download_model. `manifestModelTarget` supplies the
+        // Manager identity without touching a local root.
+        const { targetSubfolder, filename } = manifestModelTarget(model);
+        const { job, settled } = await startDownloadJob(
+          model.url,
+          targetSubfolder,
+          filename,
+          undefined,
+          undefined,
+          true,
+        );
+        enqueued.push({ item, job, settled });
         continue;
       }
       const target = await resolveLocalModelPath(model);
@@ -1353,6 +1415,9 @@ async function applyManifestSections(
         model.url,
         target.targetSubfolder,
         target.filename,
+        undefined,
+        undefined,
+        routeOverrideNeeded ? dispatchModelsToManager : undefined,
       );
       enqueued.push({ item, job, settled, staleOutsideLiveRoots });
     } catch (err) {


### PR DESCRIPTION
## Summary\n- use the same live Manager-vs-local model route decision as download_model before manifest model resolution\n- support connected local sessions whose models root is discoverable independently of the generic data root\n- route unresolved local model targets through the background Manager job and preserve actionable resolution diagnostics\n- add regression coverage for live roots, reconnect fallback, configured-root masking, and no-route diagnostics\n\n## Verification\n- 
pm.cmd run build\n- 
pm.cmd exec vitest -- run src/__tests__/services/manifest.test.ts src/__tests__/services/download-jobs.test.ts --reporter=dot (157 passed)\n- independent Codex gate: SHIP (r3)