### PR TITLE
fix(panel): allow git fallback when Manager is absent

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -161,6 +161,7 @@ import {
   syncNodeDependencies,
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
+  probeManagerQueueAvailability,
   NodeManagementError,
 } from "../../services/node-management.js";
 import { ProcessControlError, ValidationError } from "../../utils/errors.js";
@@ -320,6 +321,64 @@ describe("node-management service", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     delete process.env.COMFYUI_PYTHON;
+  });
+
+  describe("probeManagerQueueAvailability (#2096)", () => {
+    function installProbeFetch(
+      responses: Record<string, Response | (() => Response | Promise<Response>)>,
+    ) {
+      const calls: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          const path = new URL(url).pathname;
+          calls.push(path);
+          const response = responses[path];
+          if (!response) throw new Error(`unexpected probe path ${path}`);
+          return typeof response === "function" ? await response() : response;
+        }),
+      );
+      return calls;
+    }
+
+    it("requires both dialect endpoints to return 404 before calling Manager absent", async () => {
+      const calls = installProbeFetch({
+        "/v2/manager/queue/status": new Response("missing", { status: 404 }),
+        "/manager/queue/status": new Response("missing", { status: 404 }),
+      });
+      await expect(probeManagerQueueAvailability("http://same-host:8188")).resolves.toBe("absent");
+      expect(calls).toEqual(["/v2/manager/queue/status", "/manager/queue/status"]);
+    });
+
+    it.each([
+      ["a mixed 404 and 500", {
+        "/v2/manager/queue/status": new Response("missing", { status: 404 }),
+        "/manager/queue/status": new Response("server error", { status: 500 }),
+      }],
+      ["a malformed 2xx and a 404", {
+        "/v2/manager/queue/status": new Response("<!doctype html>", { status: 200 }),
+        "/manager/queue/status": new Response("missing", { status: 404 }),
+      }],
+    ])("keeps %s as unreadable", async (_name, responses) => {
+      installProbeFetch(responses);
+      await expect(probeManagerQueueAvailability("http://same-host:8188")).resolves.toBe("unreadable");
+    });
+
+    it("keeps a timeout as unreadable instead of absence", async () => {
+      installProbeFetch({
+        "/v2/manager/queue/status": () => Promise.reject(new Error("timeout")),
+        "/manager/queue/status": new Response("missing", { status: 404 }),
+      });
+      await expect(probeManagerQueueAvailability("http://same-host:8188")).resolves.toBe("unreadable");
+    });
+
+    it("recognizes a real queue payload as available", async () => {
+      installProbeFetch({
+        "/v2/manager/queue/status": jsonResponse({ pending_count: 0, in_progress_count: 0, is_processing: false }),
+        "/manager/queue/status": new Response("missing", { status: 404 }),
+      });
+      await expect(probeManagerQueueAvailability("http://same-host:8188")).resolves.toBe("available");
+    });
   });
 
   // ---- install -----------------------------------------------------------

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -138,6 +138,8 @@ function makeDeps(opts: {
   noUpstream?: boolean;
   /** Manager API dialect the probe reports ("unproven" -> undefined). Defaults to "legacy". */
   dialect?: "v2" | "v2-batch" | "legacy" | "unproven";
+  /** Result of the two-endpoint queue-availability probe when live counts are unreadable. */
+  managerQueueAvailability?: "available" | "absent" | "unreadable";
   /** Ignored-file collisions the fallback gate reports (default: none). */
   ignoredConflicts?: string[];
   /** When set, the Manager `update` mock throws this — the #771 direct path. */
@@ -218,6 +220,7 @@ function makeDeps(opts: {
       if (seq && i < seq.length) return seq[i];
       return { pending: 0, inProgress: 0, processing: false };
     },
+    probeManagerQueueAvailability: async () => opts.managerQueueAvailability ?? "available",
     gitWorktreeRoot: (dir) => {
       if (opts.gitRootError) throw new Error(opts.gitRootError);
       return opts.gitRoot ?? dir;
@@ -1045,6 +1048,46 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(err).toBeInstanceOf(PanelInstallError);
     expect(String(err?.message ?? err)).not.toMatch(/already at the upstream tip/);
     // The git fallback must NOT fire on a movement state it cannot prove.
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("confirmed Manager absence permits the guarded git fallback", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateThrows: "ComfyUI-Manager queue status returned 404",
+      // The count read is unreadable because Manager is absent; the separate
+      // probe proves that BOTH dialect endpoints returned 404.
+      liveQueue: [undefined, undefined],
+      managerQueueAvailability: "absent",
+      upstreamRev: REV_B,
+      onGitPull: ({ files, revs }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.35");
+        revs[dir] = REV_B;
+        return "Updating aaaaaaaa..bbbbbbbb\nFast-forward";
+      },
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(h.updates).toEqual([{ id: PANEL_REGISTRY_ID }]);
+    expect(h.gitPulls).toEqual([dir]);
+    expect(r.installedVersion).toBe("0.11.35");
+  });
+
+  it("an unreadable Manager probe still refuses the git fallback", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateThrows: "ComfyUI-Manager queue status timed out",
+      liveQueue: [undefined],
+      managerQueueAvailability: "unreadable",
+      upstreamRev: REV_B,
+      onGitPull: () => "Updating aaaaaaaa..bbbbbbbb\nFast-forward",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    expect(String(err?.message ?? err)).toMatch(/could not be read at all/);
     expect(h.gitPulls).toEqual([]);
   });
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -488,6 +488,57 @@ function looksLikeQueueStatus(s: unknown): boolean {
 }
 
 /**
+ * What the two Manager queue/status routes established for ONE connected
+ * ComfyUI. A 404 on only one route is not enough: the other route may be the
+ * dialect this host serves, and a timeout/5xx/HTML response is not evidence
+ * that Manager is absent.
+ */
+export type ManagerQueueAvailability = "available" | "absent" | "unreadable";
+
+/**
+ * Probe both queue/status dialects while preserving their HTTP status. This is
+ * intentionally separate from `managerFetch(..., { soft: true })`, whose
+ * contract is to erase non-authentication failures for ordinary callers.
+ *
+ * `absent` is deliberately narrow: BOTH routes must answer HTTP 404 on the
+ * SAME captured base. Everything else that is not a recognizable queue payload
+ * is `unreadable`, including network errors, 5xx, auth/permission failures,
+ * malformed 2xx bodies, and a mixed 404/non-404 result.
+ */
+export async function probeManagerQueueAvailability(
+  base = managerBaseUrl(),
+): Promise<ManagerQueueAvailability> {
+  const statuses: number[] = [];
+  for (const path of ["/v2/manager/queue/status", "/manager/queue/status"]) {
+    let res: Response;
+    try {
+      res = await comfyuiFetch(`${base}${path}`, { method: "GET" });
+    } catch {
+      return "unreadable";
+    }
+    statuses.push(res.status);
+    if (res.ok) {
+      let raw: string;
+      try {
+        raw = await res.text();
+      } catch {
+        return "unreadable";
+      }
+      if (!raw) continue;
+      try {
+        if (looksLikeQueueStatus(JSON.parse(raw))) return "available";
+      } catch {
+        // A malformed response is not absence; continue so the other dialect
+        // still gets a chance to establish a real queue surface.
+      }
+    }
+  }
+  return statuses.length === 2 && statuses.every((status) => status === 404)
+    ? "absent"
+    : "unreadable";
+}
+
+/**
  * Authoritative Manager MAJOR-version probe (issue #555). The two Manager
  * generations expose their version string on DISJOINT paths and nowhere else:
  *   • v4 (pip comfyui-manager) → GET /v2/manager/version   → text "V4.2.2"

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -38,7 +38,7 @@ import {
 } from "node:fs";
 import { createHash } from "node:crypto";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { config, isLocalMode } from "../config.js";
+import { config, getComfyUIBaseUrl, isLocalMode } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { parsePyproject } from "./node-authoring.js";
 import {
@@ -48,6 +48,8 @@ import {
   nonInteractiveGitEnv,
   type NodeOpResult,
   type ManagerTaskHistoryEntry,
+  type ManagerQueueAvailability,
+  probeManagerQueueAvailability as probeManagerQueueAvailabilityOnHost,
 } from "./node-management.js";
 import { getSystemStats } from "../comfyui/client.js";
 import {
@@ -292,6 +294,17 @@ export interface PanelInstallerDeps {
    * the real fetchManagerQueueCounts; tests stub it.
    */
   fetchLiveQueueCounts?: ((base?: string) => Promise<LiveQueueCounts | undefined>) | undefined;
+  /**
+   * Distinguish a confirmed Manager absence from an unreadable queue. `absent`
+   * is returned only when both queue/status dialects answered HTTP 404 on the
+   * same captured ComfyUI base; timeout, malformed, 5xx, auth, and mixed
+   * responses remain `unreadable` and refuse a direct git mutation.
+   */
+  probeManagerQueueAvailability?:
+    | ((base?: string) => Promise<ManagerQueueAvailability>)
+    | undefined;
+  /** Capture the Manager base before an update call that may throw without a result. */
+  managerBase?: (() => string) | undefined;
   /**
    * #1999 — look up ONE Manager task by the exact `ui_id` it was enqueued
    * under. Manager v4 keeps a per-task record (result + a structured
@@ -602,6 +615,7 @@ export function gitIgnoredPullConflicts(dir: string, upstreamRev: string): strin
 
 export const defaultDeps: PanelInstallerDeps = {
   isLocalMode: () => isLocalMode(),
+  managerBase: () => getComfyUIBaseUrl(),
   // #766/#769 — LIVE-FIRST. The panel is not a file the user reads; it is a web
   // extension the RUNNING ComfyUI serves to the browser tab, so the only
   // custom_nodes that can matter is the one belonging to the server we are
@@ -2275,13 +2289,51 @@ async function readLiveQueueCounts(
   }
 }
 
+/** A queue observation that can safely authorize a direct git fallback. */
+type LiveQueueObservation = LiveQueueCounts | { managerAbsent: true };
+
+/**
+ * A missing queue count is normally an unreadable queue and must refuse. The
+ * one safe exception is a probe that saw HTTP 404 from BOTH Manager dialects on
+ * this same base: there is no Manager queue that could be writing the checkout.
+ * Injected test deps without the probe stay fail-closed; production deps carry
+ * the real probe through the default dependency set.
+ */
+async function readLiveQueueObservation(
+  deps: PanelInstallerDeps,
+  base: string | undefined,
+): Promise<LiveQueueObservation | undefined> {
+  const live = await readLiveQueueCounts(deps, base);
+  if (live) return live;
+  try {
+    let availability: ManagerQueueAvailability;
+    if (deps.probeManagerQueueAvailability) {
+      availability = await deps.probeManagerQueueAvailability(base);
+    } else if (isRealDeps(deps)) {
+      availability = await probeManagerQueueAvailabilityOnHost(base);
+    } else {
+      return undefined;
+    }
+    return availability === "absent" ? { managerAbsent: true } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** True only when the probe SUCCEEDED and every live indicator reports clear. */
-function isLiveQueueIdle(c: LiveQueueCounts | undefined): boolean {
-  return !!c && c.pending === 0 && c.inProgress === 0 && c.processing === false;
+function isLiveQueueIdle(c: LiveQueueObservation | undefined): boolean {
+  return (
+    !!c &&
+    ("managerAbsent" in c ||
+      (c.pending === 0 && c.inProgress === 0 && c.processing === false))
+  );
 }
 
 /** Render a live probe for a message — including the "no answer at all" case. */
-function describeLiveQueue(c: LiveQueueCounts | undefined): string {
+function describeLiveQueue(c: LiveQueueObservation | undefined): string {
+  if (c && "managerAbsent" in c) {
+    return `ComfyUI-Manager is confirmed absent (both queue/status endpoints returned HTTP 404)`;
+  }
   return c
     ? `pending=${c.pending}, in_progress=${c.inProgress}, is_processing=${c.processing}`
     : `the live queue could not be read at all`;
@@ -3049,7 +3101,7 @@ async function updateViaGitCheckoutFallback(opts: {
   // Each pre-merge check refuses BEFORE any mutation, so its own failure is
   // free — the guard cannot itself damage the tree it is protecting.
   {
-    const live = await readLiveQueueCounts(deps, managerBase);
+    const live = await readLiveQueueObservation(deps, managerBase);
     if (!isLiveQueueIdle(live)) {
       throw new PanelInstallError(
         `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
@@ -3256,7 +3308,7 @@ async function updateViaGitCheckoutFallback(opts: {
     );
   }
   {
-    const live = await readLiveQueueCounts(deps, managerBase);
+    const live = await readLiveQueueObservation(deps, managerBase);
     if (!isLiveQueueIdle(live)) {
       throw new PanelInstallError(
         `Could not verify the panel update: the pinned fast-forward ALREADY RAN ` +
@@ -5737,6 +5789,16 @@ async function runPanelActionCore(
     // to propagate when the disk AGREES the pack is absent — then the message
     // is true and there is genuinely nothing to update.
     assertSameTarget("before the ComfyUI-Manager update");
+    // updateCustomNode captures this same base before its first await, but a
+    // Manager-absent failure has no NodeOpResult to carry it back. Capture it
+    // here too so the absence probe cannot silently drift to a different
+    // configured ComfyUI while this operation is in flight.
+    let managerBaseForFailure: string | undefined;
+    try {
+      managerBaseForFailure = deps.managerBase?.();
+    } catch {
+      managerBaseForFailure = undefined;
+    }
     let result: NodeOpResult | undefined;
     let managerFailure: string | undefined;
     try {
@@ -5916,11 +5978,11 @@ async function runPanelActionCore(
           // The Manager errored on its OWN pack list, not on its queue — and
           // an erroring Manager is no less likely to have a task writing to
           // this checkout, so the merge is bracketed here exactly as it is
-          // everywhere else. There is no observed base to pin to on this path
-          // (the call threw before returning one), so the re-probe resolves the
-          // configured Manager; the assertSameTarget checks around the mutation
-          // are what catch a retarget in the meantime.
-          managerBase: undefined,
+          // everywhere else. The base was captured immediately before the
+          // Manager call even though the thrown path has no NodeOpResult to
+          // carry it back; the assertSameTarget checks around the mutation
+          // still catch a local retarget in the meantime.
+          managerBase: managerBaseForFailure,
           // Synthesize the shape the fallback reports around; there is no real
           // Manager result because the Manager call failed.
           result: {


### PR DESCRIPTION
Allow the existing guarded panel git fallback only after a status-preserving probe confirms both Manager queue status dialects return HTTP 404. Preserve refusal for unreadable or ambiguous queue state. Tests: npm.cmd run build; focused Vitest 366 passed. Closes #2096.