### PR TITLE
fix(2100): surface failed Manager model tasks

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -205,6 +205,8 @@ function stubFetch(opts: {
   queueOpStatus?: number;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
   registryDetails?: unknown;
+  /** Body for v4 per-task queue history lookups. */
+  managerTaskHistory?: unknown | ((uiId: string) => unknown);
 } = {}) {
   const calls: Call[] = [];
   let statusIdx = 0;
@@ -231,6 +233,14 @@ function stubFetch(opts: {
         const s = statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
         statusIdx++;
         return jsonResponse(s);
+      }
+      if (parsed.pathname === "/v2/manager/queue/history") {
+        const uiId = parsed.searchParams.get("ui_id") ?? "";
+        const h =
+          typeof opts.managerTaskHistory === "function"
+            ? opts.managerTaskHistory(uiId)
+            : opts.managerTaskHistory;
+        return h === undefined ? new Response("", { status: 200 }) : jsonResponse(h);
       }
       // queue ops + start return empty bodies
       if (path.includes("/queue/")) {
@@ -2762,6 +2772,106 @@ describe("node-management service", () => {
       const { params } = taskOf(calls, "install-model");
       expect(params.name).toBe("m.safetensors");
       expect(params.save_path).toBe("default");
+    });
+
+    it.each(["failed", "error"] as const)(
+      "surfaces a v4 per-task install-model %s after queue drain",
+      async (statusStr) => {
+        const secret = "0123456789abcdef0123456789abcdef";
+        const huge =
+          `HTTP 429 Too Many Requests: <html>slow down</html> failed fetching ` +
+          `https://civitai.com/api/download/models/123?token=${secret}&page=2 ` +
+          "x".repeat(1200);
+        const { calls } = stubFetch({
+          managerTaskHistory: (uiId) => ({
+            history: {
+              ui_id: uiId,
+              kind: "install-model",
+              result: huge,
+              status: { status_str: statusStr },
+            },
+          }),
+        });
+
+        const err = await installModelViaManager({
+          name: "bad.safetensors",
+          url: `https://civitai.com/api/download/models/123?token=${secret}`,
+          filename: "bad.safetensors",
+          type: "checkpoints",
+        }).catch((e) => e as Error);
+
+        expect(err).toBeInstanceOf(NodeManagementError);
+        const msg = err.message;
+        expect(msg).toContain(`server-side model download task as ${statusStr}`);
+        expect(msg).toMatch(/HTTP 429 Too Many Requests/);
+        expect(msg).toMatch(/<html>slow down<\/html>/);
+        expect(msg).toContain("token=");
+        expect(msg).toContain("page=2");
+        expect(msg).not.toContain(secret);
+        expect(msg).toMatch(/truncated/);
+        expect(msg.length).toBeLessThan(1200);
+
+        const { body } = taskOf(calls, "install-model");
+        const historyCalls = calls.filter(
+          (c) => new URL(c.url).pathname === "/v2/manager/queue/history",
+        );
+        expect(historyCalls).toHaveLength(1);
+        expect(new URL(historyCalls[0].url).searchParams.get("ui_id")).toBe(body.ui_id);
+
+        const details = JSON.stringify((err as NodeManagementError).details);
+        expect(details).toContain(String(body.ui_id));
+        expect(details).toContain(statusStr);
+        expect(details).toContain("HTTP 429 Too Many Requests");
+        expect(details).not.toContain(secret);
+        expect(details).toMatch(/truncated/);
+        expect(details.length).toBeLessThan(1200);
+      },
+    );
+
+    it("preserves the handoff result when v4 history records success", async () => {
+      const { calls } = stubFetch({
+        managerTaskHistory: (uiId) => ({
+          history: {
+            ui_id: uiId,
+            kind: "install-model",
+            result: "success",
+            status: { status_str: "success" },
+          },
+        }),
+      });
+
+      const res = await installModelViaManager({
+        name: "ok.safetensors",
+        url: "https://example.com/ok.safetensors",
+        filename: "ok.safetensors",
+        type: "checkpoints",
+      });
+
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Dispatched model/);
+      expect(res.message).toMatch(/success is NOT guaranteed/);
+      expect(
+        calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/history"),
+      ).toBe(true);
+    });
+
+    it("preserves the handoff result when history is unavailable or unknown", async () => {
+      const { calls } = stubFetch({
+        managerTaskHistory: { history: {} },
+      });
+
+      const res = await installModelViaManager({
+        name: "unknown.safetensors",
+        url: "https://example.com/unknown.safetensors",
+        filename: "unknown.safetensors",
+        type: "checkpoints",
+      });
+
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Dispatched model/);
+      expect(
+        calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/history"),
+      ).toBe(true);
     });
   });
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -831,6 +831,27 @@ function managerBodyExcerpt(details: unknown): string {
   return ` ComfyUI-Manager said: ${clipped}`;
 }
 
+/** A bounded, credential-stripped per-task result from Manager queue history. */
+function managerTaskResultExcerpt(result: unknown): string {
+  const raw = typeof result === "string" ? result.replace(/\s+/g, " ").trim() : "";
+  if (!raw) return "";
+  const body = redactCredentialsForDisplay(raw);
+  const MAX = 600;
+  return body.length > MAX ? `${body.slice(0, MAX)}… (truncated)` : body;
+}
+
+function safeManagerTaskDetails(
+  record: ManagerTaskHistoryEntry,
+  result: string,
+): ManagerTaskHistoryEntry {
+  return {
+    uiId: record.uiId,
+    kind: record.kind,
+    statusStr: record.statusStr,
+    ...(result ? { result } : {}),
+  };
+}
+
 /** Wrap a legacy-Manager failure with the upgrade guidance (keeps details). */
 function annotateLegacyError(
   err: unknown,
@@ -5320,15 +5341,32 @@ export async function installModelViaManager(
   // retry/drain, AND the landing watcher (the file lands on the server the task
   // was dispatched to, so that is the only server worth polling).
   const base = managerBaseUrl();
-  const status = await queueManagerTask("install-model", taskParams, base);
-  // NOTE: the Manager queue reports the task "done" once it DRAINS, even when
-  // the underlying OperationResult failed (e.g. a 404 download, or Manager's
-  // security gate rejecting a network fetch) — and with an aria2 sidecar
-  // (COMFYUI_MANAGER_ARIA2_SERVER) it drains at HANDOFF, while the host is
-  // still streaming gigabytes. The v2 queue/status endpoint only exposes
-  // aggregate counts (no per-task result), so a clean drain here does NOT
-  // prove the file landed — phrase the result as "dispatched", not
-  // "installed", and leave final verification to a list on the pod.
+  const queued = await queueManagerTaskTracked("install-model", taskParams, base);
+  const status = queued.status;
+  let taskRecord: ManagerTaskHistoryEntry | null | undefined;
+  try {
+    taskRecord = await fetchManagerTaskHistoryEntry(queued.uiId, base);
+  } catch {
+    taskRecord = undefined;
+  }
+  const taskStatus = taskRecord?.statusStr?.trim().toLowerCase();
+  if (taskRecord && (taskStatus === "failed" || taskStatus === "error")) {
+    const excerpt = managerTaskResultExcerpt(taskRecord?.result);
+    throw new NodeManagementError(
+      `ComfyUI-Manager recorded the server-side model download task as ${taskStatus}. ` +
+        `The queue drained, but that only proves the task finished running; it does not prove ` +
+        `the model file landed or is valid.` +
+        (excerpt ? ` Manager result: ${excerpt}` : ""),
+      { queueStatus: status, managerTask: safeManagerTaskDetails(taskRecord, excerpt), uiId: queued.uiId },
+    );
+  }
+  // NOTE: the Manager queue reports the task "done" once it DRAINS, and with
+  // an aria2 sidecar (COMFYUI_MANAGER_ARIA2_SERVER) it drains at HANDOFF,
+  // while the host is still streaming gigabytes. On v4, queue/history can tell
+  // us that OUR task already failed; older or unreadable history cannot. A
+  // clean drain (or unknown history) still does NOT prove the file landed —
+  // phrase the result as "dispatched", not "installed", and leave final
+  // verification to a list on the pod.
   //
   // DEPLOYMENT: remote model install requires the pod's ComfyUI-Manager to be
   // in network_mode=personal_cloud (or loopback) with permissive security; a
@@ -5343,8 +5381,8 @@ export async function installModelViaManager(
       `${params.type} on the connected ComfyUI via ComfyUI-Manager. The queue ` +
       `drained, but that only means the download was HANDED OFF (with an aria2 ` +
       `sidecar the host keeps streaming after the queue drains), and Manager ` +
-      `reports tasks "done" even on failure with no per-task result — so ` +
-      `success is NOT guaranteed. The file appears in the server's ` +
+      `history did not prove the file landed — so success is ` +
+      `NOT guaranteed. The file appears in the server's ` +
       `/models/<category> listing only once the download COMPLETES (in-progress ` +
       `files are hidden), and Manager may store it under its own type dir ` +
       `(e.g. unet/, clip/) which ComfyUI aliases to diffusion_models/` +


### PR DESCRIPTION
## Summary\n- correlate v4 install-model queue drains with the exact task history record\n- surface structured Manager failed/error results instead of committing a misleading done download\n- preserve accepted/handoff semantics for success, unknown history, and non-v4 Manager paths\n- redact and bound echoed Manager error details\n\nCloses #2100\n\n## Validation\n- npx vitest run src/__tests__/services/node-management.test.ts\n- npx vitest run src/__tests__/services/node-management.test.ts src/__tests__/services/manager-dialect-cache.test.ts src/__tests__/services/manager-install-model-cause.test.ts src/__tests__/services/manager-dispatch-visibility.test.ts\n- npm.cmd run lint\n\nRemote Manager bytes remain unverified; this patch only turns an observed per-task failure into a failed download and keeps accepted/listed distinct from valid model content.