### PR TITLE
fix(1539): align panel install contract with Manager v4

### DIFF
--- a/src/__tests__/orchestrator/install-node-ambiguous-name.test.ts
+++ b/src/__tests__/orchestrator/install-node-ambiguous-name.test.ts
@@ -468,13 +468,15 @@ describe("the ambiguous from-source install is refused, not picked (#1616)", () 
     expect(out.sent?.channel).toBe("default");
   });
 
-  it("the tool's DESCRIPTION says the refusal exists, before any call is made", () => {
+  it("the tool's DESCRIPTION states the supported v4 contract, before any call is made", () => {
     const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/REFUSES instead of picking/i);
-    expect(text).toMatch(/111 bare names/);
-    expect(text).toMatch(/28 are ambiguous inside ONE channel/i);
-    // And the 3.x false positive is disclosed where a caller reads before calling.
-    expect(text).toMatch(/Manager 3\.x/);
+    expect(text).toMatch(/panel runtime refuses Git URLs before Manager v4 queueing/i);
+    expect(text).toMatch(/ignores the supplied repository/i);
+    expect(text).toMatch(/resolves by bare name/i);
+    expect(text).toMatch(/id from panel_search_nodes/i);
+    expect(text).toMatch(/install_custom_node\(source:'git'\)/i);
+    expect(text).toMatch(/legacy Manager 3\.x direct-URL routing/i);
+    expect(text).not.toMatch(/REFUSES instead of picking/i);
   });
 });
 

--- a/src/__tests__/orchestrator/install-node-git-expectation.test.ts
+++ b/src/__tests__/orchestrator/install-node-git-expectation.test.ts
@@ -99,7 +99,9 @@ async function dispatchInstall(
     send: async (cmd: Record<string, unknown>) => {
       if (cmd.cmd === "nodes_install") {
         sent = cmd;
-        return { queued: true, pending: true, id: "comfyui-anima-ipadapter", dialect: "v2" };
+        // This MCP-only fixture represents the legacy direct-URL relay. The
+        // panel's real v4 refusal is covered by browser_tests in the paired repo.
+        return { queued: true, pending: true, id: "comfyui-anima-ipadapter", dialect: "legacy" };
       }
       // Leave the #1129 dropped-enqueue probe inconclusive so it appends nothing.
       return { status: { in_progress_count: 0, is_processing: true } };
@@ -122,10 +124,10 @@ async function dispatchInstall(
   return { sent, text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" ") };
 }
 
-describe("the git-URL install asks a channel that can list the pack (#1539)", () => {
-  it("THE REPORT'S OWN INPUT: a bare repository URL no longer asks the 'dev' channel", () => {
-    // The whole bug in one assertion. `dev` lists 1210 packs and shares 3 with the
-    // 5887-pack default list; the reporter's pack is in default, not dev.
+describe("legacy direct-URL normalization remains intact (#1539)", () => {
+  it("normalizes the reporter's URL for the legacy direct-URL route", () => {
+    // Manager v4 refuses arbitrary Git URLs before queueing. These fields remain
+    // normalized because legacy Manager 3.x carries the URL directly.
     const out = nodesInstallCommandArgs({ repository: REPORTED_URL });
     expect(out.repository).toBe(REPORTED_URL);
     expect(out.version).toBe("nightly");
@@ -133,10 +135,10 @@ describe("the git-URL install asks a channel that can list the pack (#1539)", ()
     expect(out.channel).not.toBe("dev");
   });
 
-  it("a URL arriving as `id` takes the same channel — both spellings reach the same route", () => {
-    // #789 reroutes a URL-shaped `id` onto the from-source path. If only the
-    // `repository` spelling were fixed, the identical request would still fail when
-    // written the other way, which is how a half-fix survives review.
+  it("a URL arriving as `id` takes the same legacy route", () => {
+    // #789 reroutes a URL-shaped `id` onto the direct-URL path. If only the
+    // `repository` spelling were normalized, the identical legacy request would
+    // still fail when written the other way.
     const out = nodesInstallCommandArgs({ id: REPORTED_URL });
     expect(out.id).toBeUndefined();
     expect(out.repository).toBe(REPORTED_URL);
@@ -194,7 +196,7 @@ describe("the git-URL install asks a channel that can list the pack (#1539)", ()
   });
 });
 
-describe("EVERY spelling the panel routes as git gets the channel (#1539 gate round 3)", () => {
+describe("legacy direct-URL normalization covers every git spelling (#1539)", () => {
   // The hole the gate found, and it swallowed the reporter's own pack. The orchestrator
   // decided "is this a git install?" with a NARROWER predicate than the panel's:
   //
@@ -415,15 +417,15 @@ describe("the FIRST attempt's wrong-author risk is disclosed too (#1539 gate rou
     expect(note).toMatch(/need not be the ComfyUI this panel drives/i);
   });
 
-  it("REACHES THE CALLER — asserted on the tool's returned text, not the args", async () => {
+  it("does not append the v4-only warning to a legacy-shaped response", async () => {
     const cmd = await dispatchInstall({ repository: COLLIDING });
     expect(cmd.sent.channel).toBe("default");
-    expect(cmd.text).toMatch(/NOT NECESSARILY THE URL YOU PASSED/i);
-    expect(cmd.text).toMatch(/BlenderNeko\/ComfyUI_TiledKSampler you passed/);
+    expect(cmd.text).not.toMatch(/NOT NECESSARILY THE URL YOU PASSED/i);
+    expect(cmd.text).not.toMatch(/BlenderNeko\/ComfyUI_TiledKSampler you passed/);
   });
 });
 
-describe("panel_install_node actually DISPATCHES the channel (#1539 wiring)", () => {
+describe("panel_install_node preserves legacy direct-URL dispatch normalization (#1539)", () => {
   it("sends channel 'default' to the panel for the reporter's request", async () => {
     const { sent } = await dispatchInstall({ repository: REPORTED_URL });
     expect(sent.cmd).toBe("nodes_install");
@@ -436,127 +438,65 @@ describe("panel_install_node actually DISPATCHES the channel (#1539 wiring)", ()
     expect(sent.channel).toBe("dev");
   });
 
-  it("the channel disclosure REACHES THE CALLER, not just the args object", async () => {
-    // A note computed and never appended is the #1129 failure again — that probe
-    // shipped once and never ran. This asserts on the tool's returned TEXT.
+  it("does not append the v4-only channel disclosure to a legacy-shaped response", async () => {
     const { sent, text } = await dispatchInstall({ repository: REPORTED_URL });
     expect(sent.channel).toBe("default");
-    expect(text).toMatch(/asked ComfyUI-Manager's "default" channel/i);
-    expect(text).toMatch(/rules the pack out of "default" ONLY/);
+    expect(text).not.toMatch(/asked ComfyUI-Manager's "default" channel/i);
+    expect(text).not.toMatch(/rules the pack out of "default" ONLY/);
   });
 });
 
-describe("panel_install_node describes what was measured (#1539)", () => {
-  // A REVERSION FENCE, and nothing more: every asserted string lives in the definition
-  // under test, so a wrong claim written consistently in both places would pass. The
-  // truth of these claims rests on the run recorded at the top of this file.
-
-  it("names the version measured and the mechanism that actually decides the outcome", () => {
+describe("panel_install_node advertises the supported contract (#1539)", () => {
+  it("directs callers to registry ids and explains the v4 Git-URL refusal", () => {
     const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/V4\.2\.2/, "so a later Manager can be re-checked, not assumed");
-    expect(text).toMatch(/IS NOT THE URL THAT GETS CLONED/i);
-    expect(text).toMatch(/bare repo name/i);
-    expect(text).toMatch(/whether the repo is listed in the channel this call asks for/i);
+    expect(text).toMatch(/Registry ids are supported/i);
+    expect(text).toMatch(/id from panel_search_nodes/i);
+    expect(text).toMatch(/panel runtime refuses Git URLs before Manager v4 queueing/i);
+    expect(text).toMatch(/ignores the supplied repository/i);
+    expect(text).toMatch(/resolves by bare name/i);
+    expect(text).toMatch(/not a successful v4 from-source install/i);
+    expect(text).toMatch(/install_custom_node\(source:'git'\)/i);
+    expect(text).toMatch(/same ComfyUI/i);
+    expect(text).toMatch(/ComfyUI host/i);
   });
 
-  it("quotes the error with the channel as a VARIABLE, not hard-coded to dev", () => {
-    // The old text quoted `[ManagerChannel.dev, ManagerDatabaseSource.cache]` literally.
-    // After this change the tool no longer asks for dev, so that quote would send a
-    // reader looking for a string their own call can no longer produce.
+  it("does not retain the old v4 from-source promise or channel retry advice", () => {
     const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/ManagerChannel\.<channel>/);
-    expect(text).not.toMatch(/\[ManagerChannel\.dev, ManagerDatabaseSource\.cache\]/);
+    expect(text).not.toMatch(/auto-routed to a from-source/i);
+    expect(text).not.toMatch(/what gets cloned/i);
+    expect(text).not.toMatch(/retry.*channel/i);
+    expect(text).not.toMatch(/success can also be the wrong repo/i);
+    expect(text).toMatch(/legacy Manager 3\.x direct-URL routing/i);
+    expect(text).toMatch(/does not bypass the v4 Git-URL refusal/i);
   });
 
-  it("owns the part that was ours instead of calling the whole thing upstream", () => {
-    const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/WHAT WAS OURS/);
-    expect(text).toMatch(/used to ask the 'dev' channel/i);
-    // The retracted claim must be gone, not merely softened: it was measured false
-    // against the reporter's own pack, which IS listed.
-    expect(text).not.toMatch(/UPSTREAM limitation/i);
-    expect(text).not.toMatch(/DOES NOT INSTALL A REPO THE MANAGER'S REGISTRY DOES NOT LIST/i);
-    expect(text).not.toMatch(/being listed is necessary/i);
-  });
-
-  it("does NOT let the fix read as a guarantee", () => {
-    // The failure mode of a fix like this is a description that now over-promises in
-    // the opposite direction. Both limits that were measured have to survive.
-    const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/STILL NOT GUARANTEED/);
-    expect(text).toMatch(/`mode` is inert/i);
-    expect(text).toMatch(/not measured/i);
-  });
-
-  it("attributes the pip fallback to PACKAGING, not to the channel config (gate round 2)", () => {
-    // The shipped caveat said the bundled-snapshot fallback hits "a host configured to a
-    // non-default channel URL". Measured false: `is_manager_pip_package()` is just "not
-    // inside a custom_nodes tree", so it fires on every pip/Desktop install whatever the
-    // config — and a stock host's one startup-written cache is for a DIFFERENT URL than
-    // the name 'default' resolves to. Blaming the configuration would send a reader to
-    // check a setting that is not the cause.
-    const text = installNodeDef().description ?? "";
-    expect(text).not.toMatch(/host configured to a non-default channel URL/i);
-    expect(text).toMatch(/not inside a custom_nodes tree/i);
-    expect(text).toMatch(/cloned into custom_nodes fetches/i);
-    // And it must not claim the pip host is fixed — there it is a no-op, not a win.
-    expect(text).toMatch(/both land on that same file/i);
-  });
-
-  it("does NOT turn a one-channel miss into a verdict about the pack (review P1)", () => {
-    // The shipped sentence said "the pack is absent from every channel this Manager can
-    // read". A `default` miss establishes nothing about `dev` — the same class of
-    // over-claim this PR retracted, handing out harmful recovery advice.
-    const text = installNodeDef().description ?? "";
-    expect(text).not.toMatch(/absent from every channel this Manager can read/i);
-    expect(text).toMatch(/A NOT-FOUND RULES OUT ONE CHANNEL, NOT THE PACK/);
-    expect(text).toMatch(/absent from the channel THIS CALL ASKED and nothing more/i);
-    expect(text).toMatch(/will NOT retry another channel for you/i);
-    expect(text).toMatch(/could install a repo you never named/i);
-  });
-
-  it("warns that a SUCCESS can be the wrong author, not just a retry (gate round 2)", () => {
-    // The blurb framed the 35 colliding names purely as a reason not to auto-retry. The
-    // same resolution makes the FIRST attempt substitutable, and that one reports
-    // success — so a caller who never reads the retry paragraph is the one at risk.
-    const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/A SUCCESS CAN ALSO BE THE WRONG REPO/);
-    expect(text).toMatch(/THAT author's repository installs and the call still reports success/i);
-    expect(text).toMatch(/names the owner you passed/i);
-  });
-
-  it("keeps the local-only precondition on the tool that CAN clone", () => {
-    const text = installNodeDef().description ?? "";
-    expect(text).toMatch(/install_custom_node/);
-    expect(text).toMatch(/LOCAL ComfyUI/);
-    expect(text).toMatch(/not necessarily the one the panel drives/i);
-  });
-
-  it("the LATER recovery advice still agrees with the caveat above it", () => {
-    // Review precedent from the first pass: a contradiction a few sentences on talks a
-    // user into a retry loop that cannot succeed. The advice now names the real reason
-    // a retry is futile — absence from every readable channel — rather than "unlisted".
-    const text = installNodeDef().description ?? "";
-    const retryAdvice = text.slice(text.indexOf("a pack you installed that is absent"));
-    expect(retryAdvice).toMatch(/resolves against ONE channel.s list/i);
-    // Names the action that CAN change the outcome (a different channel) before the
-    // one that gives up. The old wording said "clone it yourself instead of retrying",
-    // which skipped straight past the retry that actually works.
-    expect(retryAdvice).toMatch(/change the `channel` first/i);
-    expect(retryAdvice).toMatch(/once the plausible channels are ruled out/i);
-  });
-
-  it("the repository and channel PARAMS carry it too", () => {
-    // A caller reading the schema may never see the tool blurb.
+  it("repeats the same contract in the repository and channel schema", () => {
     const def = installNodeDef() as unknown as {
       schema?: Record<string, { description?: string; _def?: { description?: string } }>;
     };
-    const descOf = (k: string): string => {
-      const f = def.schema?.[k];
-      return f?.description ?? f?._def?.description ?? "";
+    const descOf = (key: string): string => {
+      const field = def.schema?.[key];
+      return field?.description ?? field?._def?.description ?? "";
     };
-    expect(descOf("repository")).toMatch(/recorded but never cloned/i);
-    expect(descOf("repository")).toMatch(/'default' channel unless you pass `channel`/i);
-    expect(descOf("channel")).toMatch(/WHICH node list/i);
+    const repository = descOf("repository");
+    const channel = descOf("channel");
+    const version = descOf("version");
+    const id = descOf("id");
+
+    expect(id).toMatch(/Registry id returned by panel_search_nodes/i);
+    expect(id).not.toMatch(/author\/repo/i);
+
+    expect(repository).toMatch(/legacy Manager 3\.x direct-URL routing/i);
+    expect(repository).toMatch(/panel runtime refuses arbitrary Git URLs before Manager v4 queueing/i);
+    expect(repository).toMatch(/ignores the supplied repository/i);
+    expect(repository).toMatch(/id from panel_search_nodes/i);
+    expect(repository).toMatch(/install_custom_node\(source:'git'\)/i);
+    expect(repository).toMatch(/same ComfyUI/i);
+    expect(repository).toMatch(/ComfyUI host/i);
+
+    expect(channel).toMatch(/supported registry-id install/i);
+    expect(channel).toMatch(/does not bypass Manager v4.*refusal.*Git URLs/i);
+    expect(channel).not.toMatch(/which node list/i);
+    expect(version).not.toMatch(/nightly.*repository/i);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -17750,26 +17750,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_install_node",
-      "Install a custom-node pack into the user's ComfyUI via the BUILT-IN Manager (queues the install). Pass `id` (registry id like 'comfyui-kjnodes' or 'author/repo') from panel_search_nodes, or `repository` (git URL) to request a nightly/from-source install — see the v4 limit below before relying on it. A search result whose `id` IS a git URL (legacy/repository-style entries) is auto-routed to a from-source 'nightly' install — 'latest' cannot resolve for those. " +
-        "⚠️ ON MANAGER v4, `repository` IS NOT THE URL THAT GETS CLONED (#1539). Read out of ComfyUI-Manager V4.2.2's own source and confirmed on a live V4.2.2: a 'nightly' install resolves the pack by its BARE REPO NAME against the CHANNEL's custom-node-list, then clones the URL recorded in THAT entry; the `repository` you pass is stored in the task params and never read. So what decides success is whether the repo is listed in the channel this call asks for — and a miss does NOT simply stop: on 'nightly' v4 falls back to the COMFY REGISTRY entry whose id is that same bare name and clones whatever repository it is registered to, so an unlisted name can still install someone else's code. Only when the registry lacks the id too do you get \"Node '<name>@nightly' not found in [ManagerChannel.<channel>, ManagerDatabaseSource.<mode>]\", naming that channel. " +
-        "RESOLVING BY NAME MEANS A SUCCESS CAN ALSO BE THE WRONG REPO, and for the names where that is MEASURED rather than hypothetical this tool now REFUSES instead of picking (#1616). 111 bare names resolve to different repositories depending on the channel — 60 of them disagree between 'default' and 'dev', and 28 are ambiguous inside ONE channel (two entries under one name collapse onto a single key and the survivor is upstream list order). If you pass a git URL whose bare name is one of those and you name no `channel`, the call is refused before dispatch and both candidate repositories are named for you. Naming a `channel` dispatches instead, with the concrete collision quoted — but read what it quotes before trusting it: for the 28 intra-channel names that argument selects NOTHING (both entries are in the one list, and v4 keeps whichever its order keeps), and no `channel` value can separate them. The bypass exists because Manager 3.x carries the URL in `files` and clones it as passed, which this check cannot distinguish since the panel picks the dialect after the request leaves the orchestrator; on v4, install_custom_node (source:'git') is what clones the URL you typed. Outside that measured set the hazard stands: if the channel lists your pack's name under someone else, THAT author's repository installs and the call still reports success — the queued reply names the owner you passed, so confirm with panel_list_nodes that it is what landed. " +
-        "WHAT WAS OURS: this call used to ask the 'dev' channel, a ~1200-pack side list sharing 3 entries with the ~5900-pack 'default' list — so it could miss a pack panel_search_nodes had just returned to you (that search reads a channel-INDEPENDENT map, measured). It now asks 'default', the channel the registry-id path already used; pass `channel` to override. " +
-        "STILL NOT GUARANTEED, and do not read the fix as one: it depends on HOW Manager was installed. A Manager cloned into custom_nodes fetches the channel's real list, where 'default' carries ~5900 packs — there this works. A PIP/Desktop Manager (`is_manager_pip_package()` is just 'not inside a custom_nodes tree') never fetches: it reads a per-channel-URL cache or, failing that, the ~3600-pack snapshot bundled in the package, so `mode` is inert and packs added since that snapshot resolve on NEITHER channel. Measured: the only cache a stock host writes at startup is for a DIFFERENT URL than the name 'default' resolves to, so a pip host serves the bundled list. The fix is an improvement there only in the sense of doing no harm — old 'dev' and new 'default' both land on that same file. Whether a listed repo then always installs was not measured either. " +
-        "A NOT-FOUND RULES OUT ONE CHANNEL, NOT THE PACK. The channels are near-disjoint (default ~5900 packs, dev ~1200, sharing 3), so a miss says the pack is absent from the channel THIS CALL ASKED and nothing more — try an explicit `channel` (e.g. 'dev') before concluding it does not exist. This tool will NOT retry another channel for you: v4 resolves by BARE REPO NAME and clones the URL in the channel's entry rather than the one you passed, and 60 names sit in 'default' and 'dev' under DIFFERENT repositories, so a silent retry could install a repo you never named. (That is also why you should confirm with panel_list_nodes that what landed is the repo you meant.) Once the channels that could plausibly carry it are ruled out, clone it into custom_nodes yourself and restart, or use install_custom_node (source:'git'), which needs a LOCAL ComfyUI because it clones onto THIS machine's filesystem — not necessarily the one the panel drives. On Manager 3.x we send a DIFFERENT request shape that carries the URL directly (that much is our own code); whether 3.x then installs an unlisted repo was NOT measured here, so treat 'it worked before on 3.x' as unverified rather than as a regression on our side. " +
-        "A ComfyUI restart (panel_restart_comfyui) is usually required afterward to load the nodes — poll panel_node_queue_status first. Prefer this over the headless install_custom_node tool. " +
-        "⚠️ QUEUE-DONE IS NOT INSTALLED: Manager marks a task 'done' (queue drained) even when the git clone produced NOTHING — an empty dir, a transient git failure, or a repo not in its registry. So after the queue is idle you MUST VERIFY with panel_list_nodes that each pack actually appears before you restart or report success; a pack you installed that is absent from that list did NOT install (retry it, or install it from its git `repository` URL — but see the v4 note above: on Manager v4 that retry resolves against ONE channel's list, so re-running the identical call fails identically every time — change the `channel` first, and clone it yourself only once the plausible channels are ruled out). " +
-        "Install packs ONE AT A TIME and confirm each populated before the next — batching several installs then restarting is exactly how you end up with empty dirs and a broken restart.",
+      "Install a custom-node pack into the user's ComfyUI through the BUILT-IN Manager. Registry ids are supported: pass an id from panel_search_nodes (or another known registry id), then poll panel_node_queue_status and verify with panel_list_nodes before restarting. The panel runtime refuses Git URLs before Manager v4 queueing because v4 ignores the supplied repository and resolves by bare name, so a URL is not a successful v4 from-source install. Use an id from panel_search_nodes; use install_custom_node(source:'git') only when its local target is the same ComfyUI as this panel. If the panel drives another machine, install the repository on the ComfyUI host instead. The repository input remains normalized for legacy Manager 3.x direct-URL routing, but that compatibility path is not a v4 guarantee. The channel input can select a Manager channel for a supported registry-id install; it does not bypass the v4 Git-URL refusal. Install packs one at a time and confirm each is present before restarting.",
       {
-        id: z.string().optional().describe("Registry id or 'author/repo'."),
+        id: z.string().optional().describe("Registry id returned by panel_search_nodes."),
         repository: z
           .string()
           .optional()
           .describe(
-            "Git URL, to REQUEST a nightly/from-source install. On Manager v4 this URL is recorded but never cloned: the pack is resolved by its bare repo name against the CHANNEL's node list and the URL in that entry is what gets cloned, so an install only proceeds for a repo the asked-for channel lists (#1539, measured on V4.2.2). This call asks the 'default' channel unless you pass `channel`.",
+            "Git URL for legacy Manager 3.x direct-URL routing only. The panel runtime refuses arbitrary Git URLs before Manager v4 queueing because v4 ignores the supplied repository and resolves by bare name; this is not a successful v4 from-source install. Use an id from panel_search_nodes, or install_custom_node(source:'git') only when the local target is the same ComfyUI; otherwise install on the ComfyUI host.",
           ),
-        version: z.string().optional().describe("Specific version; default 'latest' (or 'nightly' with repository)."),
-        channel: z.string().optional().describe("Manager channel (default 'default'). On a git-URL install this picks WHICH node list the repo is looked up in — pass 'dev' only for a pack that genuinely lives on that channel (#1539)."),
-        mode: z.enum(["remote", "local", "cache"]).optional().describe("DB source (default 'remote'). Inert on a pip Manager v4, which reads its cached/bundled list either way."),
+        version: z.string().optional().describe("Specific registry version; default 'latest'."),
+        channel: z.string().optional().describe("Optional Manager channel for a supported registry-id install. It does not bypass Manager v4's refusal of arbitrary Git URLs."),
+        mode: z.enum(["remote", "local", "cache"]).optional().describe("DB source (default 'remote')."),
       },
       async (args: A, ctx) => {
         // The panel pack is installable like any other, and this path has NO
@@ -17777,6 +17769,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // spellings (registry id and git URL) — see panel-pin-guard.
         assertPanelNotTargetedUnverifiable("panel_install_node", args.id);
         assertPanelNotTargetedUnverifiable("panel_install_node", args.repository);
+        // The panel owns dialect detection and enforces the v4 Git-URL refusal;
+        // these normalized fields remain here so legacy Manager 3.x can receive
+        // its direct `files:[url]` request shape.
         // #789 — a search result whose `id` is a repository URL (the Manager's
         // legacy/repository-style entries) cannot install as id+"latest": the
         // Manager resolves that as a registry version and rejects it ("not
@@ -17795,14 +17790,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           { cmd: "nodes_install", ...cmdArgs },
           30000,
         );
-        // #1129 — settle BEFORE the note is appended. The note is glued on after
-        // the JSON body, which makes the payload unparseable as JSON, so a probe
-        // running afterwards reads `null`, concludes the panel never claimed a
-        // queue, and silently does nothing. Found by printing the real reply
-        // rather than by reasoning about it: the first version of this shipped
-        // the check and the check never ran.
+        // #1129 — settle BEFORE any supplemental note is appended. The note is glued on
+        // after the JSON body, which makes the payload unparseable as JSON, so a probe
+        // running afterwards reads `null`, concludes the panel never claimed a queue,
+        // and silently does nothing. Git notes describe v4 bare-name resolution, but
+        // v4 Git requests now fail before this point and legacy 3.x receives files:[url]
+        // directly; appending that v4 note to a legacy success would be false.
         const settled = await settleDroppedEnqueue(ctx, res, dispatch);
-        if (note) {
+        if (note && !cmdArgs.repository) {
           const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {
             text.text += `\n\nNOTE: ${note}`;


### PR DESCRIPTION
## Summary\n- Stop advertising arbitrary Git URLs as supported Manager v4 panel installs.\n- Document the pre-queue v4 refusal and the local-only scope of install_custom_node(source:'git').\n- Preserve legacy Manager 3.x direct-URL normalization and update focused contract tests.\n\nManager v4 ignores the supplied repository URL and resolves by bare name; the paired panel PR enforces the no-mutation refusal.\n\nIssue: #1539\nPaired panel PR: https://github.com/artokun/comfyui-mcp-panel/pull/1686\n\n## Validation\n- npx.cmd vitest run src/__tests__/orchestrator/install-node-git-expectation.test.ts src/__tests__/orchestrator/install-node-ambiguous-name.test.ts (86 passed)\n- npm.cmd run lint\n- git diff --check\n\nCo-authored-by: Codex <codex@openai.com>