### PR TITLE
fix: normalize panel graph query rows for kitchen

### DIFF
--- a/src/__tests__/orchestrator/panel-kitchen.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen.test.ts
@@ -77,6 +77,49 @@ describe("panel_kitchen", () => {
     expect(Array.isArray(body.recommendations)).toBe(true);
   });
 
+  it("assess normalizes text-serialized graph_query rows and skips malformed rows", async () => {
+    resetKitchenHintSession();
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "graph_query") {
+          return {
+            matched: 1,
+            text: [
+              "not-json",
+              JSON.stringify({
+                id: 12,
+                type: "UNETLoader",
+                widgets: { unet_name: "flux1-dev.safetensors", weight_dtype: "default" },
+              }),
+              JSON.stringify(null),
+              JSON.stringify(["not a row"]),
+            ].join("\n"),
+          };
+        }
+        return {};
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+      workflowUuidFor: () => ({ known: false }),
+      refreshWorkflowUuid: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
+
+    const res = await def.handler({ action: "assess" } as never, ctx);
+
+    expect(res.isError).toBeFalsy();
+    const body = JSON.parse(textOf(res));
+    expect(body.loaders).toHaveLength(1);
+    expect(body.loaders[0].node_id).toBe("12");
+    expect(body.loaders[0].unet_name).toEqual({ status: "known", value: "flux1-dev.safetensors" });
+  });
+
   it("apply of an unknown id names the assess ids rather than guessing", async () => {
     const bridge = {
       send: async (cmd: Record<string, unknown>) => {

--- a/src/__tests__/orchestrator/panel-kitchen.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen.test.ts
@@ -67,6 +67,7 @@ async function assessLiveGraph(graphQueryReply: unknown) {
     types: ["UNETLoader"],
     fields: "detail",
     limit: 200,
+    max_chars: 60000,
   });
   return JSON.parse(textOf(res)) as { loaders: Array<Record<string, unknown>> };
 }
@@ -120,6 +121,28 @@ describe("panel_kitchen", () => {
     const body = await assessLiveGraph(graph);
 
     expect(body.loaders).toEqual([]);
+  });
+
+  it("refuses a truncated graph_query instead of assessing a partial graph", async () => {
+    resetKitchenHintSession();
+    const harness = panelKitchenHarness({
+      matched: 2,
+      shown: 1,
+      truncated: true,
+      text: JSON.stringify(unetRow(12)),
+    });
+
+    const res = await harness.def.handler({ action: "assess" } as never, harness.ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/truncated.*detail rows/i);
+    expect(harness.sent).toContainEqual({
+      cmd: "graph_query",
+      types: ["UNETLoader"],
+      fields: "detail",
+      limit: 200,
+      max_chars: 60000,
+    });
   });
 
   it("apply of an unknown id names the assess ids rather than guessing", async () => {

--- a/src/__tests__/orchestrator/panel-kitchen.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen.test.ts
@@ -129,6 +129,7 @@ describe("panel_kitchen", () => {
       matched: 2,
       shown: 1,
       truncated: true,
+      truncated_by: "max_chars",
       text: JSON.stringify(unetRow(12)),
     });
 

--- a/src/__tests__/orchestrator/panel-kitchen.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen.test.ts
@@ -28,6 +28,49 @@ function textOf(res: ToolResult): string {
   return res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
 }
 
+function panelKitchenHarness(graphQueryReply: unknown) {
+  const sent: Array<Record<string, unknown>> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "graph_query") return graphQueryReply;
+      return {};
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: false }),
+    refreshWorkflowUuid: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
+  return { ctx, def, sent };
+}
+
+const unetRow = (id: number) => ({
+  id,
+  type: "UNETLoader",
+  widgets: { unet_name: "flux1-dev.safetensors", weight_dtype: "default" },
+});
+
+async function assessLiveGraph(graphQueryReply: unknown) {
+  resetKitchenHintSession();
+  const harness = panelKitchenHarness(graphQueryReply);
+  const res = await harness.def.handler({ action: "assess" } as never, harness.ctx);
+  expect(res.isError).toBeFalsy();
+  expect(harness.sent).toContainEqual({
+    cmd: "graph_query",
+    types: ["UNETLoader"],
+    fields: "detail",
+    limit: 200,
+  });
+  return JSON.parse(textOf(res)) as { loaders: Array<Record<string, unknown>> };
+}
+
 describe("panel_kitchen", () => {
   it("is on the panel surface with status/assess/apply", () => {
     const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen");
@@ -37,87 +80,46 @@ describe("panel_kitchen", () => {
     expect(def!.description).toMatch(/action:"apply"/);
   });
 
-  it("assess walks the live graph from graph_query, not a saved file", async () => {
-    resetKitchenHintSession();
-    const sent: Array<Record<string, unknown>> = [];
-    const bridge = {
-      send: async (cmd: Record<string, unknown>) => {
-        sent.push(cmd);
-        if (cmd.cmd === "graph_query") {
-          return {
-            nodes: [
-              {
-                id: 12,
-                type: "UNETLoader",
-                widgets: { unet_name: "flux1-dev.safetensors", weight_dtype: "default" },
-              },
-            ],
-          };
-        }
-        return {};
-      },
-      push: () => 1,
-      canReach: () => true,
-      isHeadless: () => false,
-      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
-      resolveActiveTabId: () => TAB,
-      tabCanMutateGraph: () => true,
-      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
-      workflowUuidFor: () => ({ known: false }),
-      refreshWorkflowUuid: () => true,
-    } as unknown as PanelToolCtx["bridge"];
-    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
-    const res = await def.handler({ action: "assess" } as never, ctx);
-    expect(res.isError).toBeFalsy();
-    expect(sent.some((s) => s.cmd === "graph_query")).toBe(true);
-    const body = JSON.parse(textOf(res));
-    expect(body.loaders[0].node_id).toBe("12");
-    expect(body.loaders[0].weight_dtype).toEqual({ status: "known", value: "default" });
-    expect(Array.isArray(body.recommendations)).toBe(true);
+  it("assess walks an object graph response from graph_query, not a saved file", async () => {
+    const body = await assessLiveGraph({ nodes: [unetRow(12)] });
+
+    expect(body.loaders[0]).toMatchObject({
+      node_id: "12",
+      node_type: "UNETLoader",
+      unet_name: { status: "known", value: "flux1-dev.safetensors" },
+      weight_dtype: { status: "known", value: "default" },
+    });
   });
 
   it("assess normalizes text-serialized graph_query rows and skips malformed rows", async () => {
-    resetKitchenHintSession();
-    const bridge = {
-      send: async (cmd: Record<string, unknown>) => {
-        if (cmd.cmd === "graph_query") {
-          return {
-            matched: 1,
-            text: [
-              "not-json",
-              JSON.stringify({
-                id: 12,
-                type: "UNETLoader",
-                widgets: { unet_name: "flux1-dev.safetensors", weight_dtype: "default" },
-              }),
-              JSON.stringify(null),
-              JSON.stringify(["not a row"]),
-            ].join("\n"),
-          };
-        }
-        return {};
-      },
-      push: () => 1,
-      canReach: () => true,
-      isHeadless: () => false,
-      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
-      resolveActiveTabId: () => TAB,
-      tabCanMutateGraph: () => true,
-      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
-      workflowUuidFor: () => ({ known: false }),
-      refreshWorkflowUuid: () => true,
-    } as unknown as PanelToolCtx["bridge"];
-    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
-    const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
+    const body = await assessLiveGraph({
+      matched: 1,
+      text: ["not-json", JSON.stringify(unetRow(12)), JSON.stringify(null), JSON.stringify(["not a row"])].join("\n"),
+    });
 
-    const res = await def.handler({ action: "assess" } as never, ctx);
-
-    expect(res.isError).toBeFalsy();
-    const body = JSON.parse(textOf(res));
     expect(body.loaders).toHaveLength(1);
-    expect(body.loaders[0].node_id).toBe("12");
-    expect(body.loaders[0].unet_name).toEqual({ status: "known", value: "flux1-dev.safetensors" });
+    expect(body.loaders[0]).toMatchObject({
+      node_id: "12",
+      unet_name: { status: "known", value: "flux1-dev.safetensors" },
+    });
+  });
+
+  it("assess keeps supporting an array graph response from graph_query", async () => {
+    const body = await assessLiveGraph([unetRow(13)]);
+
+    expect(body.loaders).toHaveLength(1);
+    expect(body.loaders[0]?.node_id).toBe("13");
+  });
+
+  it.each([
+    ["malformed graph_query text", { matched: 1, shown: 1, text: "{not-json" }],
+    ["an empty text result", { matched: 0, shown: 0, text: "" }],
+    ["an empty object graph", { nodes: [] }],
+    ["an empty array graph", []],
+  ] as const)("assess returns no loaders for %s", async (_shape, graph) => {
+    const body = await assessLiveGraph(graph);
+
+    expect(body.loaders).toEqual([]);
   });
 
   it("apply of an unknown id names the assess ids rather than guessing", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19969,8 +19969,17 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           types: ["UNETLoader"],
           fields: "detail",
           limit: 200,
+          max_chars: 60000,
         });
+        if (query.isError) return query;
         const graph = normalizeGraphQueryResult(query);
+        if (graph.truncated === true) {
+          return fail(
+            `panel_kitchen could not assess the complete live graph: graph_query truncated its ` +
+              `detail rows at the panel's max_chars ceiling. Narrow the live graph with a ` +
+              `more specific workflow or retry after reducing the number of UNETLoaders.`,
+          );
+        }
         const recs = await assessKitchenGraph(status, graph);
         if (args.action === "assess") {
           const hint = kitchenProactiveHint(status, recs);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19974,9 +19974,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         if (query.isError) return query;
         const graph = normalizeGraphQueryResult(query);
         if (graph.truncated === true) {
+          const truncationCause =
+            graph.truncated_by === "limit"
+              ? "the graph_query row limit"
+              : graph.truncated_by === "max_chars"
+                ? "the panel's max_chars ceiling"
+                : "a panel response cap";
           return fail(
             `panel_kitchen could not assess the complete live graph: graph_query truncated its ` +
-              `detail rows at the panel's max_chars ceiling. Narrow the live graph with a ` +
+              `detail rows at ${truncationCause}. Narrow the live graph with a ` +
               `more specific workflow or retry after reducing the number of UNETLoaders.`,
           );
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4194,6 +4194,35 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
   }
 }
 
+/**
+ * Normalize the panel's graph_query detail reply for graph consumers. Newer
+ * panel executors return matching detail rows as JSON Lines in `text` inside a
+ * wrapper object, while older/current executors may return `{ nodes: [...] }`.
+ * A malformed row is only one bad observation; it must not discard the valid
+ * rows that follow it or make panel_kitchen report a transport failure.
+ */
+function normalizeGraphQueryResult(res: ToolResult): Record<string, unknown> {
+  const parsed = parseToolResultJson(res);
+  if (!parsed) return { nodes: [] };
+  if (Array.isArray(parsed.nodes)) return parsed;
+
+  if (typeof parsed.text !== "string") return { nodes: [] };
+  const nodes: Record<string, unknown>[] = [];
+  for (const line of parsed.text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const row = JSON.parse(trimmed) as unknown;
+      if (row && typeof row === "object" && !Array.isArray(row)) {
+        nodes.push(row as Record<string, unknown>);
+      }
+    } catch {
+      // Ignore one malformed JSON row; other graph_query rows remain usable.
+    }
+  }
+  return { nodes };
+}
+
 function toolResultText(res: ToolResult): string {
   return res?.content?.find((c) => c.type === "text")?.text ?? "workflow_open failed";
 }
@@ -19932,7 +19961,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           fields: "detail",
           limit: 200,
         });
-        const graph = parseToolResultJson(query) ?? { nodes: [] };
+        const graph = normalizeGraphQueryResult(query);
         const recs = await assessKitchenGraph(status, graph);
         if (args.action === "assess") {
           const hint = kitchenProactiveHint(status, recs);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4182,16 +4182,22 @@ function annotateQueueStatusWithManifestPartial(res: ToolResult): ToolResult {
 }
 
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
-function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
+function parseToolResultValue(res: ToolResult): unknown {
   if (!res || res.isError) return null;
   const text = res?.content?.find((c) => c.type === "text")?.text;
   if (typeof text !== "string") return null;
   try {
-    const parsed = JSON.parse(text) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+    return JSON.parse(text) as unknown;
   } catch {
     return null;
   }
+}
+
+function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
+  const parsed = parseToolResultValue(res);
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
 }
 
 /**
@@ -4202,13 +4208,16 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
  * rows that follow it or make panel_kitchen report a transport failure.
  */
 function normalizeGraphQueryResult(res: ToolResult): Record<string, unknown> {
-  const parsed = parseToolResultJson(res);
+  const parsed = parseToolResultValue(res);
   if (!parsed) return { nodes: [] };
-  if (Array.isArray(parsed.nodes)) return parsed;
+  if (Array.isArray(parsed)) return { nodes: parsed };
+  if (typeof parsed !== "object") return { nodes: [] };
+  const record = parsed as Record<string, unknown>;
+  if (Array.isArray(record.nodes)) return record;
 
-  if (typeof parsed.text !== "string") return { nodes: [] };
+  if (typeof record.text !== "string") return { nodes: [] };
   const nodes: Record<string, unknown>[] = [];
-  for (const line of parsed.text.split(/\r?\n/)) {
+  for (const line of record.text.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
@@ -4220,7 +4229,7 @@ function normalizeGraphQueryResult(res: ToolResult): Record<string, unknown> {
       // Ignore one malformed JSON row; other graph_query rows remain usable.
     }
   }
-  return { nodes };
+  return { ...record, nodes };
 }
 
 function toolResultText(res: ToolResult): string {


### PR DESCRIPTION
## Summary
- normalize panel graph_query detail JSONL rows before panel_kitchen assessment
- ignore malformed and non-object rows while preserving valid rows
- preserve existing object and array graph response shapes
- add production-seam regression coverage

Closes #2109

## Validation
- focused panel-kitchen and kitchen suites: 39 passed
- npm run lint: passed
- full npm test: 11,836 passed, 4 skipped, 3 pre-existing failures in node-id-union-message.test.ts (#1889)