### PR TITLE
fix: reconcile panel workflow load fetch failures (#2106)

### DIFF
--- a/src/__tests__/orchestrator/load-claims-instance.test.ts
+++ b/src/__tests__/orchestrator/load-claims-instance.test.ts
@@ -123,13 +123,12 @@ describe("a load discloses the fence it just invalidated (#1478)", () => {
     expect(out.stamp).not.toBe(OTHER_UUID);
   });
 
-  it("costs no extra round trip", async () => {
-    // The earlier version called the re-derivation, which on a panel that cannot
-    // corroborate spends up to four 6-second probes plus recheck sleeps — to reach an
-    // answer it must not use. Only the load itself goes out now.
+  it("takes one bounded preflight snapshot before the load", async () => {
+    // The snapshot distinguishes a post-error state transition from a graph that
+    // was already identical before this RID was dispatched.
     await load();
 
-    expect(sent).toEqual(["graph_load"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load"]);
   });
 
   it("a reply that did NOT replace the graph gets no stale-fence claim (codex r2)", async () => {

--- a/src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts
@@ -36,8 +36,10 @@ function bridgeFor(options: {
   nodeCount?: number;
   workflowUuid?: string;
   nodeTypeMismatch?: boolean;
+  preExistingSame?: boolean;
 } = {}) {
   const sent: string[] = [];
+  let serializeCalls = 0;
   const bridge = {
     send: async (
       cmd: Record<string, unknown>,
@@ -49,9 +51,14 @@ function bridgeFor(options: {
         throw new Error(options.graphLoadError ?? "Failed to fetch");
       }
       if (cmd.cmd === "graph_serialize") {
+        serializeCalls += 1;
         const nodeCount = options.nodeCount ?? UI_GRAPH.nodes.length;
         const nodes = UI_GRAPH.nodes.slice(0, nodeCount).map((node, index) =>
-          options.nodeTypeMismatch && index === 0 ? { ...node, type: "DifferentNode" } : node,
+          serializeCalls > 1 && options.nodeTypeMismatch && index === 0
+            ? { ...node, type: "DifferentNode" }
+            : serializeCalls === 1 && index === 0 && !options.preExistingSame
+              ? { ...node, type: "OldNode" }
+              : node,
         );
         return { workflow: { ...UI_GRAPH, nodes }, node_count: nodeCount };
       }
@@ -100,7 +107,7 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
       workflow_uuid: WORKFLOW_UUID,
       response_error: "Failed to fetch",
     });
-    expect(sent).toEqual(["graph_load", "graph_serialize", "workflow_list"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load", "graph_serialize", "workflow_list"]);
   });
 
   it("keeps an outcome-unknown error when the live node count does not prove the load", async () => {
@@ -111,7 +118,7 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
     expect(text).toContain("Failed to fetch");
     expect(text).toContain("OUTCOME UNKNOWN");
     expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
-    expect(sent).toEqual(["graph_load", "graph_serialize"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load", "graph_serialize"]);
   });
 
   it("keeps an outcome-unknown error when the active workflow UUID changed", async () => {
@@ -121,7 +128,7 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
     expect(result.isError).toBe(true);
     expect(text).toContain("OUTCOME UNKNOWN");
     expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
-    expect(sent).toEqual(["graph_load", "graph_serialize", "workflow_list"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load", "graph_serialize", "workflow_list"]);
   });
 
   it("does not recover an old graph with the same UUID and node count", async () => {
@@ -131,7 +138,17 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
     expect(result.isError).toBe(true);
     expect(text).toContain("OUTCOME UNKNOWN");
     expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
-    expect(sent).toEqual(["graph_load", "graph_serialize"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load", "graph_serialize"]);
+  });
+
+  it("keeps an identical pre-existing graph outcome-unknown because causality is unproven", async () => {
+    const { result, sent } = await load({ preExistingSame: true });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("OUTCOME UNKNOWN");
+    expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
+    expect(sent).toEqual(["graph_serialize", "graph_load"]);
   });
 
   it("does not reconcile or soften a genuine executor failure", async () => {
@@ -141,7 +158,7 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
     expect(result.isError).toBe(true);
     expect(text).toContain("Unknown node type: MissingNode");
     expect(text).not.toContain("OUTCOME UNKNOWN");
-    expect(sent).toEqual(["graph_load"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load"]);
   });
 
   it("does not call a mutation outcome-unknown when fetch failed before dispatch", async () => {
@@ -151,6 +168,6 @@ describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
     expect(result.isError).toBe(true);
     expect(text).toBe("Error: Failed to fetch");
     expect(text).not.toContain("OUTCOME UNKNOWN");
-    expect(sent).toEqual(["graph_load"]);
+    expect(sent).toEqual(["graph_serialize", "graph_load"]);
   });
 });

--- a/src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts
@@ -1,0 +1,156 @@
+// #2106 — the panel can apply graph_load and lose the fetch carrying its reply.
+// Exercise the real makePanelToolCtx + panel_load_workflow boundary so the test covers
+// dispatch observation, transport classification, and the post-failure probes together.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const WORKFLOW_UUID = "99999999-8888-4777-a666-555555555555";
+const OTHER_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const DISPATCHED_RID = "22222222-3333-4444-8555-666666666666";
+
+const UI_GRAPH = {
+  last_node_id: 16,
+  nodes: Array.from({ length: 16 }, (_, index) => ({ id: index + 1, type: "KSampler" })),
+  links: [],
+};
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((part) => (part as { text?: string }).text ?? "").join(" ");
+
+function loadTool() {
+  const tool = buildPanelToolDefs().find((def) => def.name === "panel_load_workflow");
+  if (!tool) throw new Error("panel_load_workflow is not registered");
+  return tool;
+}
+
+function bridgeFor(options: {
+  dispatch?: boolean;
+  graphLoadError?: string;
+  nodeCount?: number;
+  workflowUuid?: string;
+  nodeTypeMismatch?: boolean;
+} = {}) {
+  const sent: string[] = [];
+  const bridge = {
+    send: async (
+      cmd: Record<string, unknown>,
+      opts?: { onDispatchedRid?: (rid: string) => void },
+    ) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd === "graph_load") {
+        if (options.dispatch !== false) opts?.onDispatchedRid?.(DISPATCHED_RID);
+        throw new Error(options.graphLoadError ?? "Failed to fetch");
+      }
+      if (cmd.cmd === "graph_serialize") {
+        const nodeCount = options.nodeCount ?? UI_GRAPH.nodes.length;
+        const nodes = UI_GRAPH.nodes.slice(0, nodeCount).map((node, index) =>
+          options.nodeTypeMismatch && index === 0 ? { ...node, type: "DifferentNode" } : node,
+        );
+        return { workflow: { ...UI_GRAPH, nodes }, node_count: nodeCount };
+      }
+      if (cmd.cmd === "workflow_list") {
+        const workflowUuid = options.workflowUuid ?? WORKFLOW_UUID;
+        const key = `tmp:${workflowUuid}`;
+        return {
+          active: { workflow_uuid: workflowUuid, key },
+          active_confirmed: true,
+          workflows: [{ workflow_uuid: workflowUuid, key, active: true }],
+        };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "workflow", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    workflowUuidFor: () => ({ known: true, uuid: WORKFLOW_UUID }),
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent };
+}
+
+async function load(
+  options: Parameters<typeof bridgeFor>[0] = {},
+): Promise<{ result: ToolResult; sent: string[] }> {
+  const { bridge, sent } = bridgeFor(options);
+  const result = await loadTool().handler({ graph: UI_GRAPH }, makePanelToolCtx(bridge, TAB));
+  return { result: result as ToolResult, sent };
+}
+
+describe("panel_load_workflow post-dispatch fetch failure (#2106)", () => {
+  it("acknowledges a UI graph proven by the same UUID and node count", async () => {
+    const { result, sent } = await load();
+    const payload = JSON.parse(textOf(result)) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(payload).toMatchObject({
+      loaded: true,
+      reconciled: true,
+      acknowledged_after_error: true,
+      format: "ui",
+      node_count: 16,
+      workflow_uuid: WORKFLOW_UUID,
+      response_error: "Failed to fetch",
+    });
+    expect(sent).toEqual(["graph_load", "graph_serialize", "workflow_list"]);
+  });
+
+  it("keeps an outcome-unknown error when the live node count does not prove the load", async () => {
+    const { result, sent } = await load({ nodeCount: 15 });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Failed to fetch");
+    expect(text).toContain("OUTCOME UNKNOWN");
+    expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
+    expect(sent).toEqual(["graph_load", "graph_serialize"]);
+  });
+
+  it("keeps an outcome-unknown error when the active workflow UUID changed", async () => {
+    const { result, sent } = await load({ workflowUuid: OTHER_UUID });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("OUTCOME UNKNOWN");
+    expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
+    expect(sent).toEqual(["graph_load", "graph_serialize", "workflow_list"]);
+  });
+
+  it("does not recover an old graph with the same UUID and node count", async () => {
+    const { result, sent } = await load({ nodeTypeMismatch: true });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("OUTCOME UNKNOWN");
+    expect(text).toContain(`retry_of:"${DISPATCHED_RID}"`);
+    expect(sent).toEqual(["graph_load", "graph_serialize"]);
+  });
+
+  it("does not reconcile or soften a genuine executor failure", async () => {
+    const { result, sent } = await load({ graphLoadError: "Unknown node type: MissingNode" });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Unknown node type: MissingNode");
+    expect(text).not.toContain("OUTCOME UNKNOWN");
+    expect(sent).toEqual(["graph_load"]);
+  });
+
+  it("does not call a mutation outcome-unknown when fetch failed before dispatch", async () => {
+    const { result, sent } = await load({ dispatch: false });
+    const text = textOf(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toBe("Error: Failed to fetch");
+    expect(text).not.toContain("OUTCOME UNKNOWN");
+    expect(sent).toEqual(["graph_load"]);
+  });
+});

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -76,6 +76,12 @@ function makeCtx(opts?: { panelOrigin?: string }): { ctx: PanelToolCtx; calls: F
   return { ctx, calls };
 }
 
+function graphLoadCall(calls: Forwarded[]): Forwarded {
+  const call = calls.find((entry) => entry.cmd === "graph_load");
+  if (!call) throw new Error("graph_load was not dispatched");
+  return call;
+}
+
 function loadWorkflow() {
   const def = buildPanelToolDefs().find((d) => d.name === "panel_load_workflow");
   if (!def) throw new Error("panel_load_workflow not found");
@@ -127,8 +133,8 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     // workflow_list while proving nothing about what this test guards, which is that the
     // graph is not loaded twice.
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0]).toMatchObject({ cmd: "graph_load" });
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls)).toMatchObject({ cmd: "graph_load" });
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
   });
 
   it("fails LOUDLY (no graph_load) when the userdata library 404s the name", async () => {
@@ -178,7 +184,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
       expect(res.isError).toBeUndefined();
       expect(fetchApi).toHaveBeenCalled(); // authoritative source was consulted first
       expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-      expect(calls[0].graph).toMatchObject(runtime); // NOT the stale default-dir file
+      expect(graphLoadCall(calls).graph).toMatchObject(runtime); // NOT the stale default-dir file
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -503,7 +509,7 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
 
       if (sep === "\\") {
         expect(res.isError).toBeUndefined();
-        expect(calls[0].graph).toMatchObject(staged);
+        expect(graphLoadCall(calls).graph).toMatchObject(staged);
       } else {
         expect(res.isError).toBe(true);
         expect(calls).toHaveLength(0);
@@ -529,7 +535,7 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
       const res = await loadWorkflow().handler({ path: "recipes/foo.json" }, ctx);
 
       expect(res.isError).toBeUndefined();
-      expect(calls[0].graph).toMatchObject(staged);
+      expect(graphLoadCall(calls).graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -553,7 +559,7 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
 
       expect(res.isError).toBeUndefined();
       expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-      expect(calls[0].graph).toMatchObject(staged);
+      expect(graphLoadCall(calls).graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -661,7 +667,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBeUndefined();
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     // It fetched the SERVER's key, not a locally reconstructed path.
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
   });
@@ -681,7 +687,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBeUndefined();
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
   });
 
@@ -726,7 +732,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: `workflows/workflows/${nfd}` }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     expect(fetchApi).toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/workflows/${nfc}`)}`,
     );
@@ -768,7 +774,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: `recipes/${nfd}` }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     expect(fetchApi).toHaveBeenCalledWith(WORKFLOW_LIBRARY_LISTING_ROUTE);
     expect(fetchApi).toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/recipes/${nfc}`)}`,
@@ -829,7 +835,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: "WORKFLOWS/foo.json" }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls[0].graph).toMatchObject(nested); // the NESTED file, not the root one
+      expect(graphLoadCall(calls).graph).toMatchObject(nested); // the NESTED file, not the root one
     expect(fetchApi).not.toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent("workflows/foo.json")}`,
     );
@@ -848,7 +854,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     const keys = fetchApi.mock.calls
       .map((c: unknown[]) => String(c[0]))
       .filter((u: string) => u.startsWith("/api/userdata/"))
@@ -870,7 +876,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
 
     expect(res.isError).toBeUndefined();
-    expect(calls[0].graph).toMatchObject(literal);
+    expect(graphLoadCall(calls).graph).toMatchObject(literal);
     expect(fetchApi).not.toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent("workflows/recipes/foo.json")}`,
     );
@@ -982,7 +988,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBeUndefined();
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
     expect(fetchApi).not.toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/${upper}`)}`,
     );
@@ -1084,7 +1090,7 @@ describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-
       `/api/userdata/${encodeURIComponent("workflows/workflows/Daily Anime Portrait - Fast Preview.json")}`,
     );
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
   });
 
   it("a bare name (no prefix) still resolves to the same single-prefixed key", async () => {
@@ -1117,7 +1123,7 @@ describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-
 
       expect(res.isError).toBeUndefined();
       expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-      expect(calls[0].graph).toMatchObject(staged);
+    expect(graphLoadCall(calls).graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1226,7 +1232,7 @@ describe("panel_load_workflow after a confirmed restart (#1845)", () => {
     expect(res.isError).toBeUndefined();
     expect(fetchApi).toHaveBeenCalledTimes(2);
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
   });
 
   it("reads the library through the connected panel origin when the headless target is refused", async () => {
@@ -1249,7 +1255,7 @@ describe("panel_load_workflow after a confirmed restart (#1845)", () => {
       `http://localhost:8188/api/userdata/${encodeURIComponent("workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json")}`,
     );
     expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-    expect(calls[0].graph).toMatchObject(graph);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
   });
 
   it("loads from the trusted workspace when COMFYUI_PATH env is unset", async () => {
@@ -1278,7 +1284,7 @@ describe("panel_load_workflow after a confirmed restart (#1845)", () => {
 
       expect(res.isError).toBeUndefined();
       expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
-      expect(calls[0].graph).toMatchObject(staged);
+    expect(graphLoadCall(calls).graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7947,6 +7947,144 @@ NOTE: an API-format load CAN re-mint the canvas workflow instance. If your next 
   );
 }
 
+/**
+ * #2106 — a panel can apply a UI graph and then lose the fetch carrying the reply.
+ *
+ * Reconcile only the narrow, post-dispatch transport failure reported by the issue. A
+ * dispatched request id is required: without it, "Failed to fetch" may be a pre-write
+ * refusal and there is no mutation to reconcile. The live graph must also have the exact
+ * requested node count and still belong to the workflow instance that was active before
+ * the load. Anything less remains outcome-unknown, so a real load failure is never turned
+ * into a success by a coincidental canvas shape.
+ */
+function isBarePanelFetchFailure(res: ToolResult): boolean {
+  return res.isError === true && /^(?:Error:\s*)?Failed to fetch$/i.test(textOfToolResult(res));
+}
+
+function uiWorkflowNodeCount(value: unknown): number | undefined {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { nodes?: unknown }).nodes)) {
+    return undefined;
+  }
+  return (value as { nodes: unknown[] }).nodes.length;
+}
+
+/** Stable identity for the nodes in a UI graph; layout/widget state is checked by
+ * the normal load path, while this proof prevents an old same-sized graph from
+ * being mistaken for the requested one. */
+function uiWorkflowNodeSignature(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { nodes?: unknown }).nodes)) {
+    return undefined;
+  }
+  const nodes = (value as { nodes: unknown[] }).nodes;
+  const signature: string[] = [];
+  for (const raw of nodes) {
+    if (!raw || typeof raw !== "object") return undefined;
+    const node = raw as { id?: unknown; type?: unknown };
+    if ((typeof node.id !== "number" && typeof node.id !== "string") || typeof node.type !== "string") {
+      return undefined;
+    }
+    signature.push(`${String(node.id)}\u0000${node.type}`);
+  }
+  return signature.sort().join("\u0001");
+}
+
+function uiWorkflowLinkSignature(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { links?: unknown }).links)) {
+    return undefined;
+  }
+  return (value as { links: unknown[] }).links
+    .map((link) => JSON.stringify(link))
+    .sort()
+    .join("\u0001");
+}
+
+function loadOutcomeUnknown(res: ToolResult, dispatchedRid: string | undefined): ToolResult {
+  if (!dispatchedRid) return res;
+  return appendToolResultText(
+    res,
+    `\n\nOUTCOME UNKNOWN: panel_load_workflow was dispatched, but the panel reply failed with ` +
+      `"Failed to fetch" and the live canvas did not prove the requested UI graph on the ` +
+      `same workflow instance. Do not retry blindly. To retry this exact mutation, re-issue ` +
+      `identical args plus retry_of:"${dispatchedRid}"; otherwise call normally.`,
+  );
+}
+
+async function reconcileFailedPanelLoad(
+  res: ToolResult,
+  ctx: PanelToolCtx,
+  data: unknown,
+  tabAtDispatch: string,
+  fenceBefore: FenceRead,
+  dispatchedRid: string | undefined,
+): Promise<ToolResult> {
+  if (!isBarePanelFetchFailure(res) || !dispatchedRid) return res;
+
+  const expectedNodeCount = uiWorkflowNodeCount(data);
+  const expectedNodeSignature = uiWorkflowNodeSignature(data);
+  const expectedLinkSignature = uiWorkflowLinkSignature(data);
+  if (
+    expectedNodeCount === undefined ||
+    expectedNodeSignature === undefined ||
+    fenceBefore.known !== true ||
+    typeof fenceBefore.uuid !== "string" ||
+    ctx.tabId !== tabAtDispatch
+  ) {
+    return loadOutcomeUnknown(res, dispatchedRid);
+  }
+
+  try {
+    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+    if (ctx.tabId !== tabAtDispatch || serialized.isError) {
+      return loadOutcomeUnknown(res, dispatchedRid);
+    }
+    const serializedPayload = parseToolResultJson(serialized);
+    const liveWorkflow = serializedPayload?.workflow;
+    const liveNodeCount =
+      typeof serializedPayload?.node_count === "number" &&
+      Number.isInteger(serializedPayload.node_count) &&
+      serializedPayload.node_count >= 0
+        ? serializedPayload.node_count
+        : uiWorkflowNodeCount(liveWorkflow);
+    if (liveNodeCount !== expectedNodeCount) {
+      return loadOutcomeUnknown(res, dispatchedRid);
+    }
+    if (
+      uiWorkflowNodeSignature(liveWorkflow) !== expectedNodeSignature ||
+      (expectedLinkSignature !== undefined && uiWorkflowLinkSignature(liveWorkflow) !== expectedLinkSignature)
+    ) {
+      return loadOutcomeUnknown(res, dispatchedRid);
+    }
+
+    const listed = await ctx.call({ cmd: "workflow_list" }, 6000);
+    if (ctx.tabId !== tabAtDispatch || listed.isError) {
+      return loadOutcomeUnknown(res, dispatchedRid);
+    }
+    const listedPayload = parseToolResultJson(listed);
+    if (!listedPayload) return loadOutcomeUnknown(res, dispatchedRid);
+    const corroborated = corroborateActiveForFence(listedPayload);
+    if (!corroborated.ok) return loadOutcomeUnknown(res, dispatchedRid);
+    const liveUuid = responseWorkflowUuid(corroborated.active);
+    if (!liveUuid || liveUuid !== fenceBefore.uuid) {
+      return loadOutcomeUnknown(res, dispatchedRid);
+    }
+
+    return ok({
+      loaded: true,
+      reconciled: true,
+      acknowledged_after_error: true,
+      format: "ui",
+      node_count: liveNodeCount,
+      workflow_uuid: liveUuid,
+      response_error: "Failed to fetch",
+      note:
+        "The panel applied the requested UI graph, but its reply failed after dispatch. " +
+        "The same workflow instance now contains the expected node count; do not retry.",
+    });
+  } catch {
+    return loadOutcomeUnknown(res, dispatchedRid);
+  }
+}
+
 async function rebindWorkflowFence(
   ctx: PanelToolCtx,
   opts?: { adopt?: boolean },
@@ -14503,8 +14641,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             throw new Error("Provide one of `pack` (a bundled pack name), `path` (a workflow .json on disk), or `graph` (a UI workflow).");
           }
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
-          const loaded = await ctx.call({ cmd: "graph_load", graph: data }, 30000);
-          if (loaded.isError) return loaded;
+          const tabAtDispatch = ctx.tabId;
+          const fenceBefore = currentWorkflowFence(ctx);
+          let dispatchedRid: string | undefined;
+          const loaded = await ctx.call(
+            { cmd: "graph_load", graph: data },
+            30000,
+            (rid) => {
+              dispatchedRid = rid;
+            },
+          );
+          if (loaded.isError) {
+            return reconcileFailedPanelLoad(
+              loaded,
+              ctx,
+              data,
+              tabAtDispatch,
+              fenceBefore,
+              dispatchedRid,
+            );
+          }
           // Keyed on the reply SAYING the graph was replaced, not merely on the call not
           // erroring (codex r2). A non-error envelope that reports `loaded:false` did not
           // replace anything, and telling that caller their fence is stale would be a

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7983,6 +7983,7 @@ async function reconcileFailedPanelLoad(
   res: ToolResult,
   ctx: PanelToolCtx,
   data: unknown,
+  graphBefore: unknown,
   tabAtDispatch: string,
   fenceBefore: FenceRead,
   dispatchedRid: string | undefined,
@@ -7992,10 +7993,17 @@ async function reconcileFailedPanelLoad(
   const expectedNodeCount = uiWorkflowNodeCount(data);
   if (
     expectedNodeCount === undefined ||
+    graphBefore == null ||
     fenceBefore.known !== true ||
     typeof fenceBefore.uuid !== "string" ||
     ctx.tabId !== tabAtDispatch
   ) {
+    return loadOutcomeUnknown(res, dispatchedRid);
+  }
+  // A matching post-failure graph is only a causal proof when the pre-dispatch
+  // graph was different. If the requested graph was already present, the reads
+  // cannot tell whether this RID changed anything, so keep the retry token.
+  if (openLiveMatchesDestContent(graphBefore, data)) {
     return loadOutcomeUnknown(res, dispatchedRid);
   }
 
@@ -14612,6 +14620,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
           const tabAtDispatch = ctx.tabId;
           const fenceBefore = currentWorkflowFence(ctx);
+          let graphBefore: unknown;
+          if (uiWorkflowNodeCount(data) !== undefined) {
+            try {
+              const before = await ctx.call({ cmd: "graph_serialize" }, 8000);
+              if (!before.isError) graphBefore = parseToolResultJson(before)?.workflow;
+            } catch {
+              // Without a pre-dispatch snapshot, a later matching graph cannot
+              // prove that this request caused the transition.
+            }
+          }
           let dispatchedRid: string | undefined;
           const loaded = await ctx.call(
             { cmd: "graph_load", graph: data },
@@ -14625,6 +14643,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               loaded,
               ctx,
               data,
+              graphBefore,
               tabAtDispatch,
               fenceBefore,
               dispatchedRid,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7953,9 +7953,9 @@ NOTE: an API-format load CAN re-mint the canvas workflow instance. If your next 
  * Reconcile only the narrow, post-dispatch transport failure reported by the issue. A
  * dispatched request id is required: without it, "Failed to fetch" may be a pre-write
  * refusal and there is no mutation to reconcile. The live graph must also have the exact
- * requested node count and still belong to the workflow instance that was active before
- * the load. Anything less remains outcome-unknown, so a real load failure is never turned
- * into a success by a coincidental canvas shape.
+ * requested content and still belong to the workflow instance that was active before the
+ * load. Anything less remains outcome-unknown, so a real load failure is never turned into
+ * a success by a coincidental canvas shape.
  */
 function isBarePanelFetchFailure(res: ToolResult): boolean {
   return res.isError === true && /^(?:Error:\s*)?Failed to fetch$/i.test(textOfToolResult(res));
@@ -7966,36 +7966,6 @@ function uiWorkflowNodeCount(value: unknown): number | undefined {
     return undefined;
   }
   return (value as { nodes: unknown[] }).nodes.length;
-}
-
-/** Stable identity for the nodes in a UI graph; layout/widget state is checked by
- * the normal load path, while this proof prevents an old same-sized graph from
- * being mistaken for the requested one. */
-function uiWorkflowNodeSignature(value: unknown): string | undefined {
-  if (!value || typeof value !== "object" || !Array.isArray((value as { nodes?: unknown }).nodes)) {
-    return undefined;
-  }
-  const nodes = (value as { nodes: unknown[] }).nodes;
-  const signature: string[] = [];
-  for (const raw of nodes) {
-    if (!raw || typeof raw !== "object") return undefined;
-    const node = raw as { id?: unknown; type?: unknown };
-    if ((typeof node.id !== "number" && typeof node.id !== "string") || typeof node.type !== "string") {
-      return undefined;
-    }
-    signature.push(`${String(node.id)}\u0000${node.type}`);
-  }
-  return signature.sort().join("\u0001");
-}
-
-function uiWorkflowLinkSignature(value: unknown): string | undefined {
-  if (!value || typeof value !== "object" || !Array.isArray((value as { links?: unknown }).links)) {
-    return undefined;
-  }
-  return (value as { links: unknown[] }).links
-    .map((link) => JSON.stringify(link))
-    .sort()
-    .join("\u0001");
 }
 
 function loadOutcomeUnknown(res: ToolResult, dispatchedRid: string | undefined): ToolResult {
@@ -8020,11 +7990,8 @@ async function reconcileFailedPanelLoad(
   if (!isBarePanelFetchFailure(res) || !dispatchedRid) return res;
 
   const expectedNodeCount = uiWorkflowNodeCount(data);
-  const expectedNodeSignature = uiWorkflowNodeSignature(data);
-  const expectedLinkSignature = uiWorkflowLinkSignature(data);
   if (
     expectedNodeCount === undefined ||
-    expectedNodeSignature === undefined ||
     fenceBefore.known !== true ||
     typeof fenceBefore.uuid !== "string" ||
     ctx.tabId !== tabAtDispatch
@@ -8048,10 +8015,12 @@ async function reconcileFailedPanelLoad(
     if (liveNodeCount !== expectedNodeCount) {
       return loadOutcomeUnknown(res, dispatchedRid);
     }
-    if (
-      uiWorkflowNodeSignature(liveWorkflow) !== expectedNodeSignature ||
-      (expectedLinkSignature !== undefined && uiWorkflowLinkSignature(liveWorkflow) !== expectedLinkSignature)
-    ) {
+    // Count alone is not proof: an old same-sized graph on the same workflow
+    // instance would otherwise be reported as the requested load. Reuse the
+    // existing fail-closed content matcher, which checks node identities/types,
+    // link topology, non-empty widget values, and nested subgraph content while
+    // tolerating frontend schema/presentation normalization.
+    if (!openLiveMatchesDestContent(liveWorkflow, data)) {
       return loadOutcomeUnknown(res, dispatchedRid);
     }
 
@@ -8078,7 +8047,7 @@ async function reconcileFailedPanelLoad(
       response_error: "Failed to fetch",
       note:
         "The panel applied the requested UI graph, but its reply failed after dispatch. " +
-        "The same workflow instance now contains the expected node count; do not retry.",
+        "The same workflow instance now contains the expected graph; do not retry.",
     });
   } catch {
     return loadOutcomeUnknown(res, dispatchedRid);


### PR DESCRIPTION
## Summary\n- capture the dispatched graph_load RID when the panel returns a bare Failed to fetch\n- capture the pre-dispatch UI graph and reconcile only after an observed state transition to matching graph content on the same corroborated workflow UUID\n- otherwise preserve outcome-unknown semantics and provide the exact etry_of token\n\n## Validation\n- 
pm.cmd exec vitest run src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts src/__tests__/orchestrator/panel-retry-identity.test.ts --no-file-parallelism\n- 43 tests passed\n- 
pm.cmd run lint\n- git diff --check\n\nCloses #2106