### PR TITLE
fix(panel): fence DaSiWa widget writes

### DIFF
--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -29,7 +29,7 @@ import { WebSocket } from "ws";
 /** Panel version the mock advertises (#1384). Kept in step with the product's own derived
  *  fence minimum by src/__tests__/scripts/knowledge-parity-mock-version.test.ts — a raised
  *  floor fails that test instead of silently refusing every graph write in the smoke. */
-const MOCK_PANEL_VERSION = "0.15.11";
+const MOCK_PANEL_VERSION = "0.15.58";
 /** A well-formed workflow uuid, so the per-command stamp fence has something to fence on. */
 // MOCK_WORKFLOW_UUID is imported above — it belongs with the executors that answer with it.
 
@@ -121,6 +121,7 @@ function runScenario(task) {
           panel_version: MOCK_PANEL_VERSION,
           enforces_workflow_stamp: true,
           enforces_workflow_stamp_at_write: true,
+          enforces_expected_node_type_at_write: true,
           workflow_uuid: MOCK_WORKFLOW_UUID,
         }),
       );

--- a/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
+++ b/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
@@ -155,7 +155,7 @@ const UNAVAILABLE_REFUSAL =
 
 describe("#2000 frontend-only type refused for an unavailable /object_info", () => {
   it("THE REPORTED CASE: names the fact that /object_info never lists this type, and says not to reinstall", async () => {
-    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.20");
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.60");
     expect(r.isError).toBe(true);
     // The panel's own refusal is KEPT — the note is appended, never a replacement.
     expect(r.text).toContain("object_info is unavailable");
@@ -188,11 +188,11 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
 
   it("THE REPORTER'S OWN VERSION is ABOVE the floor — so the note must not depend on skew", async () => {
     // Measured, and it is the reason this note is not gated on the version floor at
-    // all: the reporter ran panel 0.15.20 while the floor is lower, because the floor
+    // all: the reporter ran panel 0.15.60 while the floor is lower, because the floor
     // tracks BRIDGE CAPABILITY requirements, not "the version with the latest fixes".
     // Gating on it would have made this hint fire for almost nobody — and it is also
     // why #1828's skew note could never have fired for this reporter.
-    const REPORTER_VERSION = "0.15.20";
+    const REPORTER_VERSION = "0.15.60";
     expect(compareSemver(REPORTER_VERSION, requiredPanelVersion())).toBeGreaterThan(0);
     const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, REPORTER_VERSION);
     expect(r.text).toContain("FRONTEND-ONLY");
@@ -207,7 +207,7 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
     const r = await addNode(
       "KSampler",
       UNAVAILABLE_REFUSAL.replace("MarkdownNote", "KSampler"),
-      "0.15.20",
+      "0.15.60",
     );
     expect(r.isError).toBe(true);
     expect(r.text).toContain("object_info is unavailable");

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -501,6 +501,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
         }
         return identity;
       },
+      tabExpectedNodeTypeFenceCapability: () => true,
       call: async (cmd: Record<string, unknown>) => {
         cmds.push(String(cmd.cmd));
         calls.push(cmd);

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -465,6 +465,71 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
   });
 });
 
+describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
+  const SET_OK = {
+    set: { node_id: 2571, widget: "stack_data", previous: "old", value: "NEW" },
+  };
+
+  async function run(queryReply: unknown): Promise<{ res: ToolResult; cmds: string[] }> {
+    const cmds: string[] = [];
+    const res = (await defByName("panel_set_widget").handler(
+      { node_id: 2571, widget: "stack_data", value: "NEW" },
+      {
+        call: async (cmd: Record<string, unknown>) => {
+          cmds.push(String(cmd.cmd));
+          if (cmd.cmd === "graph_query") {
+            if (typeof queryReply === "object" && queryReply !== null && "isError" in queryReply) {
+              return queryReply;
+            }
+            return { content: [{ type: "text" as const, text: JSON.stringify(queryReply, null, 2) }] };
+          }
+          return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
+        },
+      } as unknown as PanelToolCtx,
+    )) as ToolResult;
+    return { res, cmds };
+  }
+
+  it("refuses stack_data on DaSiWa_LTX2LoraLoader before graph_set_widget", async () => {
+    const { res, cmds } = await run({ text: '#2571 DaSiWa_LTX2LoraLoader "Lora HIGH" · stack_data=old' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/cannot set "stack_data" on DaSiWa_LTX2LoraLoader/);
+    expect(res.content[0].text).toMatch(/custom multi-row widget/);
+    expect(res.content[0].text).toMatch(/false success/);
+    expect(res.content[0].text).toMatch(/Edit the stack rows in the node UI/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("reads structured node identity and still refuses the unsafe write", async () => {
+    const { res, cmds } = await run({ nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("DaSiWa_LTX2LoraLoader");
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("does not block stack_data on another node type", async () => {
+    const { res, cmds } = await run({ text: '#3 OtherLoraLoader "other" · stack_data=old' });
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("fails open when the identity probe is unavailable", async () => {
+    const { res, cmds } = await run({
+      isError: true,
+      content: [{ type: "text", text: "Error: no connected tab" }],
+    });
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("documents the refusal on the tool itself", () => {
+    const description = defByName("panel_set_widget").description;
+    expect(description).toContain("DaSiWa_LTX2LoraLoader");
+    expect(description).toContain("stack_data");
+  });
+});
+
 describe("panel-tools: panel_add_node frontend-only virtual types (#741)", () => {
   // #741: Note/MarkdownNote/Reroute/PrimitiveNode are frontend-only virtual types —
   // they exist only in LiteGraph, never in the backend /object_info. The MCP side

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -470,22 +470,70 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     set: { node_id: 2571, widget: "stack_data", previous: "old", value: "NEW" },
   };
 
-  async function run(queryReply: unknown): Promise<{ res: ToolResult; cmds: string[] }> {
+  type RunOptions = {
+    tabChange?: boolean;
+    sessionChange?: boolean;
+    identityUnavailable?: boolean;
+    identityUnavailableAfterProbe?: boolean;
+    probeThrows?: boolean;
+  };
+
+  async function run(
+    queryReply: unknown,
+    args: Record<string, unknown> = { node_id: 2571, widget: "stack_data", value: "NEW" },
+    options: RunOptions = {},
+  ): Promise<{ res: ToolResult; cmds: string[] }> {
     const cmds: string[] = [];
-    const res = (await defByName("panel_set_widget").handler(
-      { node_id: 2571, widget: "stack_data", value: "NEW" },
-      {
-        call: async (cmd: Record<string, unknown>) => {
-          cmds.push(String(cmd.cmd));
-          if (cmd.cmd === "graph_query") {
-            if (typeof queryReply === "object" && queryReply !== null && "isError" in queryReply) {
-              return queryReply;
-            }
-            return { content: [{ type: "text" as const, text: JSON.stringify(queryReply, null, 2) }] };
+    let identity: { generation: number; tabSessionId: string } | undefined = {
+      generation: 1,
+      tabSessionId: "browser-tab-a",
+    };
+    let probeComplete = false;
+    const ctx = {
+      tabId: "test-tab",
+      panelConnectionIdentity: () => {
+        if (options.identityUnavailable || (probeComplete && options.identityUnavailableAfterProbe)) {
+          return undefined;
+        }
+        return identity;
+      },
+      call: async (cmd: Record<string, unknown>) => {
+        cmds.push(String(cmd.cmd));
+        if (cmd.cmd === "graph_query") {
+          if (options.probeThrows) throw new Error("probe unavailable");
+          if (options.tabChange) ctx.tabId = "other-tab";
+          if (options.sessionChange) {
+            identity = { generation: 2, tabSessionId: "browser-tab-b" };
           }
-          return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
-        },
-      } as unknown as PanelToolCtx,
+          probeComplete = true;
+          if (typeof queryReply === "object" && queryReply !== null && "isError" in queryReply) {
+            return queryReply as ToolResult;
+          }
+          return { content: [{ type: "text" as const, text: JSON.stringify(queryReply, null, 2) }] };
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  set: {
+                    ...SET_OK.set,
+                    node_id: args.node_id,
+                    widget: args.widget,
+                  },
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      },
+    } as unknown as PanelToolCtx;
+    const res = (await defByName("panel_set_widget").handler(
+      args,
+      ctx,
     )) as ToolResult;
     return { res, cmds };
   }
@@ -507,20 +555,109 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     expect(cmds).toEqual(["graph_query"]);
   });
 
-  it("does not block stack_data on another node type", async () => {
-    const { res, cmds } = await run({ text: '#3 OtherLoraLoader "other" · stack_data=old' });
+  it("does not block stack_data on another node type after exact identity", async () => {
+    const { res, cmds } = await run(
+      { text: '#3 OtherLoraLoader "other" · stack_data=old' },
+      { node_id: 3, widget: "stack_data", value: "NEW" },
+    );
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
     expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
-  it("fails open when the identity probe is unavailable", async () => {
-    const { res, cmds } = await run({
-      isError: true,
-      content: [{ type: "text", text: "Error: no connected tab" }],
-    });
+  it("refuses when graph_query returns an error", async () => {
+    const { res, cmds } = await run(
+      { isError: true, content: [{ type: "text", text: "Error: no connected tab" }] },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/No graph_set_widget was dispatched/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses before probing when the bound panel identity is unavailable", async () => {
+    const { res, cmds } = await run(
+      { nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] },
+      undefined,
+      { identityUnavailable: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/identity was unavailable/);
+    expect(cmds).toEqual([]);
+  });
+
+  it("refuses when graph_query throws before identity can be verified", async () => {
+    const { res, cmds } = await run(
+      { text: '#2571 DaSiWa_LTX2LoraLoader "Lora HIGH" · stack_data=old' },
+      undefined,
+      { probeThrows: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/probe failed/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses a wrong-id row instead of trusting its type", async () => {
+    const { res, cmds } = await run({ text: '#3 DaSiWa_LTX2LoraLoader "other" · stack_data=old' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/different node_id/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses a truncated identity response", async () => {
+    const { res, cmds } = await run({ truncated: true, nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/malformed, truncated/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses a malformed identity response", async () => {
+    const { res, cmds } = await run({ text: "not a node row" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/malformed, truncated/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses if the panel identity disappears after probing", async () => {
+    const { res, cmds } = await run(
+      { nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] },
+      undefined,
+      { identityUnavailableAfterProbe: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/became unavailable/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses when the panel-tab connection changes during the probe", async () => {
+    const { res, cmds } = await run(
+      { nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] },
+      undefined,
+      { sessionChange: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/connection changed/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses when the panel tab changes during the probe", async () => {
+    const { res, cmds } = await run(
+      { nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] },
+      undefined,
+      { tabChange: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/different panel tab/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("keeps a different widget writable on the exact DaSiWa node", async () => {
+    const { res, cmds } = await run(
+      { nodes: [{ id: 2571, type: "DaSiWa_LTX2LoraLoader" }] },
+      { node_id: 2571, widget: "strength_model", value: 0.5 },
+    );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(JSON.parse(res.content[0].text!).set.widget).toBe("strength_model");
+    expect(cmds).toEqual(["graph_set_widget"]);
   });
 
   it("documents the refusal on the tool itself", () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -484,8 +484,9 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     queryReply: unknown,
     args: Record<string, unknown> = { node_id: 2571, widget: "stack_data", value: "NEW" },
     options: RunOptions = {},
-  ): Promise<{ res: ToolResult; cmds: string[] }> {
+  ): Promise<{ res: ToolResult; cmds: string[]; calls: Record<string, unknown>[] }> {
     const cmds: string[] = [];
+    const calls: Record<string, unknown>[] = [];
     let identity: { generation: number; tabSessionId: string } | undefined = {
       generation: 1,
       tabSessionId: "browser-tab-a",
@@ -502,6 +503,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
       },
       call: async (cmd: Record<string, unknown>) => {
         cmds.push(String(cmd.cmd));
+        calls.push(cmd);
         if (cmd.cmd === "graph_query") {
           queryCount++;
           if (options.probeThrows) throw new Error("probe unavailable");
@@ -544,7 +546,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
       args,
       ctx,
     )) as ToolResult;
-    return { res, cmds };
+    return { res, cmds, calls };
   }
 
   it("refuses stack_data on DaSiWa_LTX2LoraLoader before graph_set_widget", async () => {
@@ -568,7 +570,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
   });
 
   it("does not block stack_data on another node type after exact identity", async () => {
-    const { res, cmds } = await run(
+    const { res, cmds, calls } = await run(
       {
         text:
           '1 match(es) of 1 in scope (viewing: 3 nodes)\n#3 OtherLoraLoader "other" · stack_data=old\n' +
@@ -579,6 +581,10 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
     expect(cmds).toEqual(["graph_query", "graph_query", "graph_set_widget"]);
+    expect(calls[2]).toMatchObject({
+      cmd: "graph_set_widget",
+      expected_node_type: "OtherLoraLoader",
+    });
   });
 
   it("refuses when graph_query returns an error", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -476,6 +476,8 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     identityUnavailable?: boolean;
     identityUnavailableAfterProbe?: boolean;
     probeThrows?: boolean;
+    finalTabChange?: boolean;
+    finalQueryReply?: unknown;
   };
 
   async function run(
@@ -489,6 +491,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
       tabSessionId: "browser-tab-a",
     };
     let probeComplete = false;
+    let queryCount = 0;
     const ctx = {
       tabId: "test-tab",
       panelConnectionIdentity: () => {
@@ -500,16 +503,22 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
       call: async (cmd: Record<string, unknown>) => {
         cmds.push(String(cmd.cmd));
         if (cmd.cmd === "graph_query") {
+          queryCount++;
           if (options.probeThrows) throw new Error("probe unavailable");
-          if (options.tabChange) ctx.tabId = "other-tab";
+          if (options.tabChange || (options.finalTabChange && queryCount === 2)) {
+            ctx.tabId = "other-tab";
+          }
           if (options.sessionChange) {
             identity = { generation: 2, tabSessionId: "browser-tab-b" };
           }
           probeComplete = true;
-          if (typeof queryReply === "object" && queryReply !== null && "isError" in queryReply) {
-            return queryReply as ToolResult;
+          const reply = queryCount === 2 && options.finalQueryReply !== undefined
+            ? options.finalQueryReply
+            : queryReply;
+          if (typeof reply === "object" && reply !== null && "isError" in reply) {
+            return reply as ToolResult;
           }
-          return { content: [{ type: "text" as const, text: JSON.stringify(queryReply, null, 2) }] };
+          return { content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }] };
         }
         return {
           content: [
@@ -539,7 +548,10 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
   }
 
   it("refuses stack_data on DaSiWa_LTX2LoraLoader before graph_set_widget", async () => {
-    const { res, cmds } = await run({ text: '#2571 DaSiWa_LTX2LoraLoader "Lora HIGH" · stack_data=old' });
+    const { res, cmds } = await run({
+      text:
+        '1 match(es) of 1 in scope (viewing: 3 nodes)\n#2571 DaSiWa_LTX2LoraLoader "Lora HIGH" · stack_data=old',
+    });
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/cannot set "stack_data" on DaSiWa_LTX2LoraLoader/);
     expect(res.content[0].text).toMatch(/custom multi-row widget/);
@@ -557,12 +569,16 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
 
   it("does not block stack_data on another node type after exact identity", async () => {
     const { res, cmds } = await run(
-      { text: '#3 OtherLoraLoader "other" · stack_data=old' },
+      {
+        text:
+          '1 match(es) of 1 in scope (viewing: 3 nodes)\n#3 OtherLoraLoader "other" · stack_data=old\n' +
+          '(1 widget value(s) clipped to 60 chars by `fields`:"compact" — read fuller values with `fields`:"detail", which caps values at 2048 chars.)',
+      },
       { node_id: 3, widget: "stack_data", value: "NEW" },
     );
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_query", "graph_set_widget"]);
   });
 
   it("refuses when graph_query returns an error", async () => {
@@ -648,6 +664,28 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/different panel tab/);
     expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("refuses if the final fence sees the node become DaSiWa", async () => {
+    const { res, cmds } = await run(
+      { text: '1 match(es) of 1 in scope (viewing: 3 nodes)\n#3 OtherLoraLoader · stack_data=old' },
+      { node_id: 3, widget: "stack_data", value: "NEW" },
+      { finalQueryReply: { nodes: [{ id: 3, type: "DaSiWa_LTX2LoraLoader" }] } },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/cannot set "stack_data"/);
+    expect(cmds).toEqual(["graph_query", "graph_query"]);
+  });
+
+  it("refuses if the panel tab changes during the final fence", async () => {
+    const { res, cmds } = await run(
+      { text: '1 match(es) of 1 in scope (viewing: 3 nodes)\n#3 OtherLoraLoader · stack_data=old' },
+      { node_id: 3, widget: "stack_data", value: "NEW" },
+      { finalTabChange: true },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/final fence.*different panel tab/);
+    expect(cmds).toEqual(["graph_query", "graph_query"]);
   });
 
   it("keeps a different widget writable on the exact DaSiWa node", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -72,6 +72,7 @@ function bridge(opts: {
   scopeLost?: boolean;
   promotedDetail?: Record<string, unknown>;
   stackDataIdentity?: Record<string, unknown>;
+  stackDataInnerIdentity?: Record<string, unknown> | null;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -111,6 +112,9 @@ function bridge(opts: {
       if (cmd.cmd === "graph_query") {
         graphQueries += 1;
         if (opts.stackDataIdentity && graphQueries <= 2) return opts.stackDataIdentity;
+        if (opts.stackDataIdentity && graphQueries === 3) {
+          return opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] };
+        }
         return (
           opts.promotedDetail ?? {
             nodes: [
@@ -280,12 +284,41 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_query",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
     expect(calls[2]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(calls[5]).not.toHaveProperty("expected_node_type");
+    expect(calls[6]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
     expect(text).toMatch(/inner widget this promotion lists/);
+  });
+
+  it("refuses a promoted inner retry when the post-enter identity is stale", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "stack_data", value: "NEW" },
+      {
+        stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+        stackDataInnerIdentity: { nodes: [{ id: 99, type: "OtherLoraLoader" }] },
+        subgraph: {
+          subgraph_of: { node_id: 78, title: "OtherLoraLoader" },
+          node_count: 1,
+          nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_query",
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_query",
+      "graph_exit_subgraph",
+    ]);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(text).toMatch(/post-enter identity probe did not verify/);
   });
 
   it("reports ambiguous promoted name/label candidates without a second write (#2015)", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -37,6 +37,10 @@ const CONTRADICTORY =
   `Cannot set widget on subgraph node 78: "width" is not a promoted widget on this subgraph ` +
   `(promoted: width, height, seed, control_after_generate, steps, cfg, sampler_name, scheduler, denoise, batch_size).`;
 
+const STACK_DATA_CONTRADICTORY =
+  `Cannot set widget on subgraph node 78: "stack_data" is not a promoted widget on this subgraph ` +
+  `(promoted: stack_data).`;
+
 const AMBIGUOUS =
   `promoted widget "text" is ambiguous - 2 promoted inputs match; refusing to guess.`;
 
@@ -67,9 +71,11 @@ function bridge(opts: {
   ambiguous?: boolean;
   scopeLost?: boolean;
   promotedDetail?: Record<string, unknown>;
+  stackDataIdentity?: Record<string, unknown>;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
+  let graphQueries = 0;
   const b = {
     send: async (cmd: Record<string, unknown>) => {
       calls.push({ ...cmd });
@@ -77,6 +83,7 @@ function bridge(opts: {
         writes += 1;
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
+        if (writes === 1 && opts.stackDataIdentity) throw new Error(STACK_DATA_CONTRADICTORY);
         const which =
           writes === 1
             ? (opts.firstWrite ?? "contradict")
@@ -102,6 +109,8 @@ function bridge(opts: {
         return { scope: "root" };
       }
       if (cmd.cmd === "graph_query") {
+        graphQueries += 1;
+        if (opts.stackDataIdentity && graphQueries <= 2) return opts.stackDataIdentity;
         return (
           opts.promotedDetail ?? {
             nodes: [
@@ -124,6 +133,8 @@ function bridge(opts: {
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
+    tabConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
+    tabExpectedNodeTypeFenceCapability: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];
   return { b, calls };
@@ -249,6 +260,34 @@ describe("resolveInnerPromotedTarget", () => {
 });
 
 describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
+  it("does not carry the outer node-type fence into a promoted inner retry (#2107)", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "stack_data", value: "NEW" },
+      {
+        stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+        subgraph: {
+          subgraph_of: { node_id: 78, title: "OtherLoraLoader" },
+          node_count: 1,
+          nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_query",
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_set_widget",
+      "graph_exit_subgraph",
+    ]);
+    expect(calls[2]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[5]).not.toHaveProperty("expected_node_type");
+    expect(text).toMatch(/inner widget this promotion lists/);
+  });
+
   it("reports ambiguous promoted name/label candidates without a second write (#2015)", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 190, widget: "text", value: "hello" },

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -321,6 +321,35 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(text).toMatch(/post-enter identity probe did not verify/);
   });
 
+  it("refuses a promoted inner DaSiWa stack write without a second mutation", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "stack_data", value: "NEW" },
+      {
+        stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+        stackDataInnerIdentity: { nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader" }] },
+        subgraph: {
+          subgraph_of: { node_id: 78, title: "OtherLoraLoader" },
+          node_count: 1,
+          nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader", widgets: { stack_data: "old" } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_query",
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_query",
+      "graph_exit_subgraph",
+    ]);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(text).toMatch(/promoted inner node 76 was identified as DaSiWa_LTX2LoraLoader/);
+    expect(text).toMatch(/No inner graph_set_widget was dispatched/);
+  });
+
   it("reports ambiguous promoted name/label candidates without a second write (#2015)", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 190, widget: "text", value: "hello" },

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3017,6 +3017,64 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     old.close();
   });
 
+  it("rechecks expected_node_type capability after a graph-lane wait and reconnect", async () => {
+    const modern = await connectPanel("tmp:queued-node-type", "queued");
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:queued-node-type")).toBe(true),
+    );
+    const frames: Array<Record<string, unknown>> = [];
+    modern.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.rid && msg.cmd) frames.push(msg);
+    });
+    const predecessor = bridge.send({ cmd: "graph_outline" } as never, {
+      tabId: "tmp:queued-node-type",
+    });
+    await waitFor(() => expect(frames.some((frame) => frame.cmd === "graph_outline")).toBe(true));
+    const fenced = bridge.send(
+      {
+        cmd: "graph_set_widget",
+        node_id: 7,
+        widget: "stack_data",
+        value: "NEW",
+        expected_node_type: "OtherLoraLoader",
+      },
+      { tabId: "tmp:queued-node-type" },
+    );
+
+    // A stale reconnect lands on the same socket while the fenced write is
+    // waiting behind the predecessor. The initial gate saw the modern hello;
+    // the launch gate must inspect this downgraded hello before sending.
+    modern.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "tmp:queued-node-type",
+        title: "old queued panel",
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(bridge.tabExpectedNodeTypeFenceCapability("tmp:queued-node-type")).toBe(false),
+    );
+    const first = frames.find((frame) => frame.cmd === "graph_outline");
+    const firstRid = first?.rid;
+    expect(firstRid).toBeTruthy();
+    if (!firstRid) throw new Error("graph_outline was not dispatched");
+    modern.send(JSON.stringify({ rid: firstRid, ok: true, result: {} }));
+    await predecessor;
+
+    const caught = await fenced.then(
+      () => null,
+      (err) => err,
+    );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/atomic expected-node-type write fence/);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    modern.close();
+  });
+
   it("ALLOWS active-workflow mutations (graph AND workflow_*) for a panel that DOES enforce the stamp (#570 P0c)", async () => {
     const modern = await connectPanel("tmp:modern", "M"); // connectPanel advertises enforcement + has a resolver stamp
     autoReply(modern, "modern");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -161,6 +161,7 @@ function connectPanel(
             title,
             enforces_workflow_stamp: true,
             enforces_workflow_stamp_at_write: true,
+            enforces_expected_node_type_at_write: true,
             // The panel's sessionStorage-backed browser-tab identity: unique per
             // browser tab, stable across a reload (#486/#709).
             ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
@@ -2970,10 +2971,57 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     old.close();
   });
 
+  it("FAILS CLOSED when expected_node_type reaches a panel without #2107's write fence", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:old-node-type-fence",
+            title: "old node-type fence",
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+            // Deliberately omit enforces_expected_node_type_at_write: this is
+            // the pre-#2107 panel shape, and it must not silently ignore the
+            // optional expected_node_type field.
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-node-type-fence")).toBe(true),
+    );
+    expect(bridge.tabExpectedNodeTypeFenceCapability("tmp:old-node-type-fence")).toBe(false);
+    const caught = await bridge
+      .send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 7,
+          widget: "stack_data",
+          value: "NEW",
+          expected_node_type: "OtherLoraLoader",
+        },
+        { tabId: "tmp:old-node-type-fence" },
+      )
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/atomic expected-node-type write fence.*0\.15\.58/i);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    old.close();
+  });
+
   it("ALLOWS active-workflow mutations (graph AND workflow_*) for a panel that DOES enforce the stamp (#570 P0c)", async () => {
     const modern = await connectPanel("tmp:modern", "M"); // connectPanel advertises enforcement + has a resolver stamp
     autoReply(modern, "modern");
     await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:modern")).toBe(true));
+    expect(bridge.tabExpectedNodeTypeFenceCapability("tmp:modern")).toBe(true);
     // A graph mutator AND each workflow mutator all dispatch (enforcement + trusted stamp present).
     for (const cmd of [
       { cmd: "graph_add_node", node: "x" },

--- a/src/__tests__/tools/panel-status-latest.test.ts
+++ b/src/__tests__/tools/panel-status-latest.test.ts
@@ -44,9 +44,9 @@ import { requiredPanelVersion } from "../../services/panel-sync.js";
 import { compareSemver } from "../../services/self-update.js";
 import { panelAction } from "../../tools/install-panel.js";
 
-/** The machine state in the issue: 0.15.16 on disk against a 0.15.11 floor. */
-const INSTALLED = "0.15.16";
-const LATEST = "0.15.32";
+/** A panel above the 0.15.58 capability floor, with a newer published release. */
+const INSTALLED = "0.15.60";
+const LATEST = "0.15.76";
 
 function status(over: Partial<PanelStatus> = {}): PanelStatus {
   return {
@@ -135,7 +135,7 @@ describe("#1983 — the status tool REACHES the latest-version probe", () => {
 
 describe("#1983 — floor and latest are two answers, never one", () => {
   it("the fixture is still above the floor (input precondition, not an expectation)", () => {
-    // If the derived floor ever rises past 0.15.16 these fixtures stop testing
+    // If the derived floor ever rises past 0.15.60 these fixtures stop testing
     // the reported state. Fail here with a clear reason rather than three tests
     // failing obscurely.
     expect(compareSemver(INSTALLED, requiredPanelVersion())).toBeGreaterThanOrEqual(0);
@@ -147,7 +147,7 @@ describe("#1983 — floor and latest are two answers, never one", () => {
 
     const sync = await statusCall();
 
-    // The floor answer is UNCHANGED — 0.15.16 is not too old to work.
+    // The floor answer is UNCHANGED — 0.15.60 is not too old to work.
     expect(sync.behind).toBe(false);
     expect(sync.decision).toBe("meets-floor");
     // The latest answer is the one that was missing.
@@ -411,7 +411,7 @@ describe("#1983 — boundaries of the ahead-of-published comparison", () => {
   });
 
   it("a higher patch with a prerelease tag IS ahead", async () => {
-    mocks.panelStatus.mockResolvedValue(status({ installedVersion: "0.15.33-rc1" }));
+    mocks.panelStatus.mockResolvedValue(status({ installedVersion: "0.15.77-rc1" }));
     stubFetch(() => new Response(pyproject(LATEST), { status: 200 }));
 
     const sync = await statusCall();
@@ -484,7 +484,7 @@ describe("#1995 gate P1 — every remedy names an action that can succeed from t
     expect(sync.summary).toMatch(SYNC_VERB);
     // And it must not claim a version gap it has no installed version for.
     expect(sync.summary).not.toMatch(/a NEWER panel is published/);
-    expect(sync.summary).toMatch(/newest published panel is 0\.15\.32/);
+    expect(sync.summary).toMatch(/newest published panel is 0\.15\.76/);
   });
 
   it("ABSENT + pinned → clear the pin, never update", async () => {
@@ -493,7 +493,7 @@ describe("#1995 gate P1 — every remedy names an action that can succeed from t
         installed: false,
         installedVersion: undefined,
         absenceProven: true,
-        pin: { pinned: true, source: "settings", version: "0.15.20" },
+        pin: { pinned: true, source: "settings", version: INSTALLED },
       }),
     );
     stubFetch(() => new Response(pyproject(LATEST), { status: 200 }));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -15107,7 +15107,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   node_id: nodeId,
                   widget,
                   value,
-                  ...(expectedNodeType ? { expected_node_type: expectedNodeType } : {}),
+                  // The final identity probe authenticates the ORIGINAL target.
+                  // A promoted-widget recovery can deliberately re-enter a
+                  // different inner node; carrying the outer type into that
+                  // write would make the Panel's direct-target fence reject a
+                  // valid inner mutation. The inner route has its own panel
+                  // target/workflow guards, so omit this outer-only fence there.
+                  ...(expectedNodeType && String(nodeId) === String(args.node_id)
+                    ? { expected_node_type: expectedNodeType }
+                    : {}),
                 },
                 OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
               ),

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -15098,7 +15098,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // to the raw success reply so a later appendToolResultText disclosure
         // (which makes the text no longer parse as JSON) cannot dodge it.
         const echoFull = args.echo === "full";
-        const write = async (nodeId: unknown, widget: string): Promise<ToolResult> =>
+        const write = async (
+          nodeId: unknown,
+          widget: string,
+          targetExpectedNodeType: string | undefined = expectedNodeType,
+        ): Promise<ToolResult> =>
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
               await ctx.call(
@@ -15107,14 +15111,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   node_id: nodeId,
                   widget,
                   value,
-                  // The final identity probe authenticates the ORIGINAL target.
-                  // A promoted-widget recovery can deliberately re-enter a
-                  // different inner node; carrying the outer type into that
-                  // write would make the Panel's direct-target fence reject a
-                  // valid inner mutation. The inner route has its own panel
-                  // target/workflow guards, so omit this outer-only fence there.
-                  ...(expectedNodeType && String(nodeId) === String(args.node_id)
-                    ? { expected_node_type: expectedNodeType }
+                  // The caller supplies the type proven for THIS addressed node.
+                  // The outer final fence is used for direct/re-mapped writes;
+                  // promoted recovery re-probes its inner node after entering
+                  // and supplies that node's own type.
+                  ...(targetExpectedNodeType
+                    ? { expected_node_type: targetExpectedNodeType }
                     : {}),
                 },
                 OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
@@ -15270,7 +15272,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
-        const written = await write(inner.innerNodeId, inner.widget);
+        let innerExpectedNodeType: string | undefined;
+        if (expectedNodeType !== undefined) {
+          // The inner mapping was discovered before an awaited enter. Re-query
+          // the addressed inner node after entering so the stack_data write gets
+          // its OWN live type fence; carrying the outer wrapper's type would
+          // reject a valid inner node, while omitting a fence would let a same-
+          // type replacement mutate a detached object and report false success.
+          const innerProbe = await ctx.call(
+            { cmd: "graph_query", ids: [inner.innerNodeId], fields: "compact", limit: 1 },
+            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+          );
+          const innerIdentity = innerProbe.isError
+            ? null
+            : parseVerifiedQueriedNodeIdentity(parseToolResultJson(innerProbe));
+          const expectedInnerId = canonicalQueriedNodeId(inner.innerNodeId);
+          if (!innerIdentity || !expectedInnerId || innerIdentity.id !== expectedInnerId) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n(The panel listed "${refusal.widget}" as promoted and mapped it to inner node ` +
+                `${inner.innerNodeId}, but the post-enter identity probe did not verify that ` +
+                `exact live node${innerProbe.isError ? `: ${textOfToolResult(innerProbe)}` : "."} ` +
+                `The write was not retried.${
+                  exited.isError
+                    ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}`
+                    : ""
+                })`,
+            );
+          }
+          innerExpectedNodeType = innerIdentity.type;
+        }
+
+        const written = await write(inner.innerNodeId, inner.widget, innerExpectedNodeType);
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
         if (!written.isError) {
           const via =

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5402,9 +5402,32 @@ function parseVerifiedQueriedNodeIdentity(
 
   if (typeof payload.text !== "string") return null;
   const rows: QueriedNodeIdentity[] = [];
-  for (const line of payload.text.split("\n")) {
+  const lines = payload.text.split(/\r?\n/);
+  for (const [index, line] of lines.entries()) {
     const trimmed = line.trim();
     if (!trimmed) continue;
+
+    // The live compact projection always prefixes its rows with this bounded summary.
+    // Keep the grammar narrow so arbitrary prose cannot make an unverified row usable,
+    // while accepting the documented header that older tests and panels may omit.
+    if (
+      index === 0 &&
+      /^\d+ match\(es\) of \d+ in scope \(viewing: \d+ nodes\)(?: · traversal depth≤-?\d+)?$/.test(
+        trimmed,
+      )
+    ) {
+      continue;
+    }
+    // A compact row may be followed by one of the panel's bounded clipping notes or
+    // truncation remedies. They do not identify nodes and are ignored only after a row
+    // has been authenticated below.
+    if (
+      rows.length > 0 &&
+      (/^\(\d+ widget value\(s\) clipped to \d+ chars/.test(trimmed) ||
+        /^… truncated at \d+ of \d+/.test(trimmed))
+    ) {
+      continue;
+    }
 
     if (trimmed.startsWith("#")) {
       const compact = trimmed.match(/^#(\S+)\s+(\S+)(?:\s|$)/);
@@ -5496,6 +5519,13 @@ function isUsablePanelConnectionIdentity(
   );
 }
 
+function samePanelConnectionIdentity(
+  left: { generation: number; tabSessionId: string },
+  right: { generation: number; tabSessionId: string },
+): boolean {
+  return left.generation === right.generation && left.tabSessionId === right.tabSessionId;
+}
+
 /** Refuse the DaSiWa stack widget whose custom UI deterministically overwrites a
  *  graph_set_widget write after acknowledging it. This gate fails closed unless
  *  the probe proves the requested node and remains bound to the same panel tab. */
@@ -5541,10 +5571,7 @@ async function refuseDaSiWaStackWrite(
   if (!isUsablePanelConnectionIdentity(identityAfter)) {
     return daSiWaIdentityRefusal("the panel-tab identity became unavailable after the probe");
   }
-  if (
-    identityAfter.tabSessionId !== identityBefore.tabSessionId ||
-    identityAfter.generation !== identityBefore.generation
-  ) {
+  if (!samePanelConnectionIdentity(identityBefore, identityAfter)) {
     return daSiWaIdentityRefusal("the panel-tab connection changed during the probe");
   }
   if (probe.isError) {
@@ -5563,6 +5590,70 @@ async function refuseDaSiWaStackWrite(
   }
   if (identity.type !== DASIWA_LTX2_LORA_LOADER) return null;
   return daSiWaStackRefusal(identity.type);
+}
+
+/** Recheck the target immediately before a stack_data mutation. The first probe
+ *  prevents the known refusal from dispatching; this final fence catches a tab
+ *  reconnect or node replacement observed between that probe and graph_set_widget. */
+async function verifyDaSiWaStackWriteFence(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+): Promise<ToolResult | null> {
+  const tabBefore = ctx.tabId;
+  let identityBefore: { generation: number; tabSessionId: string } | undefined;
+  try {
+    identityBefore = ctx.panelConnectionIdentity?.();
+  } catch {
+    return daSiWaIdentityRefusal("the bound browser-tab identity was unreadable before dispatch");
+  }
+  if (!isUsablePanelConnectionIdentity(identityBefore)) {
+    return daSiWaIdentityRefusal("the bound browser-tab identity was unavailable before dispatch");
+  }
+
+  let probe: ToolResult;
+  try {
+    probe = await ctx.call({
+      cmd: "graph_query",
+      ids: [nodeId],
+      fields: "compact",
+      limit: 1,
+    });
+  } catch {
+    return daSiWaIdentityRefusal("the final graph_query fence failed before dispatch");
+  }
+  if (ctx.tabId !== tabBefore) {
+    return daSiWaIdentityRefusal("the final fence was answered by a different panel tab");
+  }
+
+  let identityAfter: { generation: number; tabSessionId: string } | undefined;
+  try {
+    identityAfter = ctx.panelConnectionIdentity?.();
+  } catch {
+    return daSiWaIdentityRefusal("the panel-tab identity became unreadable before dispatch");
+  }
+  if (!isUsablePanelConnectionIdentity(identityAfter)) {
+    return daSiWaIdentityRefusal("the panel-tab identity became unavailable before dispatch");
+  }
+  if (!samePanelConnectionIdentity(identityBefore, identityAfter)) {
+    return daSiWaIdentityRefusal("the panel-tab connection changed before dispatch");
+  }
+  if (probe.isError) {
+    return daSiWaIdentityRefusal("the final graph_query fence returned an error");
+  }
+
+  const identity = parseVerifiedQueriedNodeIdentity(parseToolResultJson(probe));
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!identity || !requestedId) {
+    return daSiWaIdentityRefusal(
+      "the final graph_query fence was malformed, truncated, or did not contain exactly one verifiable row",
+    );
+  }
+  if (identity.id !== requestedId) {
+    return daSiWaIdentityRefusal("the final graph_query fence identified a different node_id");
+  }
+  return identity.type === DASIWA_LTX2_LORA_LOADER
+    ? daSiWaStackRefusal(identity.type)
+    : null;
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -14963,6 +15054,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           args.widget as string,
         );
         if (daSiWaBlocked) return daSiWaBlocked;
+        if (args.widget === DASIWA_STACK_WIDGET) {
+          const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
+          if (daSiWaFence) return daSiWaFence;
+        }
         // #599: the frontend runs refresh-before-validate here (pulls a fresh
         // /object_info so a just-staged/-downloaded/-installed value is accepted on
         // a single revalidation, #338/#458) — that authoritative fetch can outlast

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5536,6 +5536,16 @@ async function refuseDaSiWaStackWrite(
 ): Promise<ToolResult | null> {
   if (widget !== DASIWA_STACK_WIDGET) return null;
 
+  try {
+    if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
+      return daSiWaIdentityRefusal(
+        "the bound panel does not advertise the atomic expected-node-type write fence; update the panel and hard-refresh",
+      );
+    }
+  } catch {
+    return daSiWaIdentityRefusal("the panel expected-node-type write fence could not be verified");
+  }
+
   const tabBefore = ctx.tabId;
   let identityBefore: { generation: number; tabSessionId: string } | undefined;
   try {
@@ -5599,6 +5609,16 @@ async function verifyDaSiWaStackWriteFence(
   ctx: PanelToolCtx,
   nodeId: unknown,
 ): Promise<ToolResult | { expectedNodeType: string } | null> {
+  try {
+    if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
+      return daSiWaIdentityRefusal(
+        "the bound panel does not advertise the atomic expected-node-type write fence; update the panel and hard-refresh",
+      );
+    }
+  } catch {
+    return daSiWaIdentityRefusal("the panel expected-node-type write fence could not be verified");
+  }
+
   const tabBefore = ctx.tabId;
   let identityBefore: { generation: number; tabSessionId: string } | undefined;
   try {
@@ -11035,6 +11055,10 @@ export interface PanelToolCtx {
    * Optional only for lightweight legacy test contexts.
    */
   tabCanMutateGraph?: () => boolean;
+  /** Whether the currently bound panel enforces graph_set_widget's optional
+   * expected_node_type at the synchronous mutation boundary. Real contexts
+   * provide this; omitted/false is a fail-closed answer for #2107. */
+  tabExpectedNodeTypeFenceCapability?: () => boolean;
   /**
    * The same question TRI-STATE, for code that must REPORT the answer rather than
    * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
@@ -12432,6 +12456,8 @@ export function makePanelToolCtx(
   ctx.panelConnectionIdentity = panelConnectionIdentity;
   ctx.awaitPostRestartReachable = awaitPostRestartReachable;
   ctx.tabCanMutateGraph = () => bridge.tabCanMutateGraph(ctx.tabId);
+  ctx.tabExpectedNodeTypeFenceCapability = () =>
+    bridge.tabExpectedNodeTypeFenceCapability(ctx.tabId);
   ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5598,7 +5598,7 @@ async function refuseDaSiWaStackWrite(
 async function verifyDaSiWaStackWriteFence(
   ctx: PanelToolCtx,
   nodeId: unknown,
-): Promise<ToolResult | null> {
+): Promise<ToolResult | { expectedNodeType: string } | null> {
   const tabBefore = ctx.tabId;
   let identityBefore: { generation: number; tabSessionId: string } | undefined;
   try {
@@ -5653,7 +5653,7 @@ async function verifyDaSiWaStackWriteFence(
   }
   return identity.type === DASIWA_LTX2_LORA_LOADER
     ? daSiWaStackRefusal(identity.type)
-    : null;
+    : { expectedNodeType: identity.type };
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -15054,9 +15054,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           args.widget as string,
         );
         if (daSiWaBlocked) return daSiWaBlocked;
+        let expectedNodeType: string | undefined;
         if (args.widget === DASIWA_STACK_WIDGET) {
           const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
-          if (daSiWaFence) return daSiWaFence;
+          if (daSiWaFence && "content" in daSiWaFence) return daSiWaFence;
+          expectedNodeType = daSiWaFence?.expectedNodeType;
         }
         // #599: the frontend runs refresh-before-validate here (pulls a fresh
         // /object_info so a just-staged/-downloaded/-installed value is accepted on
@@ -15074,7 +15076,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
               await ctx.call(
-                { cmd: "graph_set_widget", node_id: nodeId, widget, value },
+                {
+                  cmd: "graph_set_widget",
+                  node_id: nodeId,
+                  widget,
+                  value,
+                  ...(expectedNodeType ? { expected_node_type: expectedNodeType } : {}),
+                },
                 OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
               ),
               echoFull,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5311,6 +5311,9 @@ const ANIMA_REGIONAL_WIRED_PROMPT_INPUT: Record<string, string> = {
   negative_prompt: "negative_prompt_in",
 };
 
+const DASIWA_STACK_WIDGET = "stack_data";
+const DASIWA_LTX2_LORA_LOADER = "DaSiWa_LTX2LoraLoader";
+
 function isAnimaRegionalPromptWidget(widget: string): boolean {
   return ANIMA_REGIONAL_PROMPT_WIDGETS.has(widget);
 }
@@ -5380,6 +5383,37 @@ async function refuseAnimaRegionalPromptWrite(
   const type = parseQueriedNodeType(parseToolResultJson(probe));
   if (!type || !ANIMA_REGIONAL_CANVAS_TYPES.has(type)) return null;
   return animaRegionalPromptRefusal(type, widget);
+}
+
+function daSiWaStackRefusal(type: string): ToolResult {
+  return fail(
+    `panel_set_widget cannot set "${DASIWA_STACK_WIDGET}" on ${type}. ` +
+      `The node's custom multi-row widget owns the LoRA stack in its internal JS state and ` +
+      `re-serializes that state over widget.value, so the normal graph_set_widget success ` +
+      `echo would be a false success. Edit the stack rows in the node UI instead; do not retry ` +
+      `panel_set_widget for this widget.`,
+  );
+}
+
+/** Refuse the DaSiWa stack widget whose custom UI deterministically overwrites a
+ *  graph_set_widget write after acknowledging it. Probe only this widget and fail
+ *  open when the read cannot identify the node, matching the LC123 refusal policy. */
+async function refuseDaSiWaStackWrite(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<ToolResult | null> {
+  if (widget !== DASIWA_STACK_WIDGET) return null;
+  const probe = await ctx.call({
+    cmd: "graph_query",
+    ids: [nodeId],
+    fields: "compact",
+    limit: 1,
+  });
+  if (probe.isError) return null;
+  const type = parseQueriedNodeType(parseToolResultJson(probe));
+  if (type !== DASIWA_LTX2_LORA_LOADER) return null;
+  return daSiWaStackRefusal(type);
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -14734,7 +14768,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_widget",
-      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value (a string longer than 1000 chars is echoed as {chars, sha256, preview} so batched calls stay inside the outer tool-result budget — pass `echo: \"full\"` for the verbatim string). Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted). For AnimaRegionalCanvasInline / Krea2RegionalCanvasInline (LC123), quality/scene/red/green/blue/negative prompt writes are refused: the custom textarea and node.properties.animaPrompts overwrite widget.value on APPLY. Drive quality/scene/negative via a PrimitiveStringMultiline wired into quality_prompt_in / scene_prompt_in / negative_prompt_in; red/green/blue have no socket.",
+      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value (a string longer than 1000 chars is echoed as {chars, sha256, preview} so batched calls stay inside the outer tool-result budget — pass `echo: \"full\"` for the verbatim string). Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted). For AnimaRegionalCanvasInline / Krea2RegionalCanvasInline (LC123), quality/scene/red/green/blue/negative prompt writes are refused: the custom textarea and node.properties.animaPrompts overwrite widget.value on APPLY. Drive quality/scene/negative via a PrimitiveStringMultiline wired into quality_prompt_in / scene_prompt_in / negative_prompt_in; red/green/blue have no socket. DaSiWa_LTX2LoraLoader's `stack_data` write is also refused: its custom multi-row widget reserializes its own JS state over `widget.value`, so the echoed write would be a false success; edit the stack rows in the node UI instead.",
       {
         node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
@@ -14774,6 +14808,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           args.widget as string,
         );
         if (blocked) return blocked;
+        const daSiWaBlocked = await refuseDaSiWaStackWrite(
+          ctx,
+          args.node_id,
+          args.widget as string,
+        );
+        if (daSiWaBlocked) return daSiWaBlocked;
         // #599: the frontend runs refresh-before-validate here (pulls a fresh
         // /object_info so a just-staged/-downloaded/-installed value is accepted on
         // a single revalidation, #338/#458) — that authoritative fetch can outlast

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5351,6 +5351,87 @@ function parseQueriedNodeType(payload: Record<string, unknown> | null): string |
   return null;
 }
 
+type QueriedNodeIdentity = { id: string; type: string };
+
+function canonicalQueriedNodeId(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? String(value) : null;
+  }
+  if (typeof value !== "string" || !NODE_ID_PATTERN.test(value)) return null;
+  const normalized = normalizeNodeId(value);
+  return typeof normalized === "number" && !Number.isSafeInteger(normalized)
+    ? null
+    : String(normalized);
+}
+
+function parseQueriedNodeIdentityRow(row: unknown): QueriedNodeIdentity | null {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const record = row as Record<string, unknown>;
+  const id = canonicalQueriedNodeId(record.id);
+  if (!id) return null;
+
+  const type = record.type;
+  const classType = record.class_type;
+  if (type !== undefined && typeof type !== "string") return null;
+  if (classType !== undefined && typeof classType !== "string") return null;
+  if (typeof type === "string" && typeof classType === "string" && type !== classType) {
+    return null;
+  }
+  const resolvedType = typeof type === "string" ? type : classType;
+  return resolvedType ? { id, type: resolvedType } : null;
+}
+
+/** Strict identity parser for the DaSiWa refusal gate. Unlike the older type-only
+ * parser above, this accepts exactly one non-truncated row and authenticates its id. */
+function parseVerifiedQueriedNodeIdentity(
+  payload: Record<string, unknown> | null,
+): QueriedNodeIdentity | null {
+  if (!payload) return null;
+  if (
+    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
+    payload.truncated !== false
+  ) {
+    return null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
+    return Array.isArray(payload.nodes) && payload.nodes.length === 1
+      ? parseQueriedNodeIdentityRow(payload.nodes[0])
+      : null;
+  }
+
+  if (typeof payload.text !== "string") return null;
+  const rows: QueriedNodeIdentity[] = [];
+  for (const line of payload.text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.startsWith("#")) {
+      const compact = trimmed.match(/^#(\S+)\s+(\S+)(?:\s|$)/);
+      if (!compact) return null;
+      const id = canonicalQueriedNodeId(compact[1]);
+      if (!id) return null;
+      rows.push({ id, type: compact[2] });
+      continue;
+    }
+
+    if (trimmed.startsWith("{")) {
+      let row: unknown;
+      try {
+        row = JSON.parse(trimmed);
+      } catch {
+        return null;
+      }
+      const parsed = parseQueriedNodeIdentityRow(row);
+      if (!parsed) return null;
+      rows.push(parsed);
+      continue;
+    }
+    return null;
+  }
+  return rows.length === 1 ? rows[0] : null;
+}
+
 function animaRegionalPromptRefusal(type: string, widget: string): ToolResult {
   const wired = ANIMA_REGIONAL_WIRED_PROMPT_INPUT[widget];
   const route = wired
@@ -5395,25 +5476,93 @@ function daSiWaStackRefusal(type: string): ToolResult {
   );
 }
 
+function daSiWaIdentityRefusal(reason: string): ToolResult {
+  return fail(
+    `panel_set_widget refused "${DASIWA_STACK_WIDGET}" because the panel probe could not ` +
+      `prove the requested node is the intended ${DASIWA_LTX2_LORA_LOADER} (${reason}). ` +
+      `No graph_set_widget was dispatched. Edit the stack rows in the node UI instead; ` +
+      `do not retry this write until the node identity can be read exactly.`,
+  );
+}
+
+function isUsablePanelConnectionIdentity(
+  identity: { generation: number; tabSessionId: string } | undefined,
+): identity is { generation: number; tabSessionId: string } {
+  return (
+    !!identity &&
+    Number.isSafeInteger(identity.generation) &&
+    typeof identity.tabSessionId === "string" &&
+    identity.tabSessionId.length > 0
+  );
+}
+
 /** Refuse the DaSiWa stack widget whose custom UI deterministically overwrites a
- *  graph_set_widget write after acknowledging it. Probe only this widget and fail
- *  open when the read cannot identify the node, matching the LC123 refusal policy. */
+ *  graph_set_widget write after acknowledging it. This gate fails closed unless
+ *  the probe proves the requested node and remains bound to the same panel tab. */
 async function refuseDaSiWaStackWrite(
   ctx: PanelToolCtx,
   nodeId: unknown,
   widget: string,
 ): Promise<ToolResult | null> {
   if (widget !== DASIWA_STACK_WIDGET) return null;
-  const probe = await ctx.call({
-    cmd: "graph_query",
-    ids: [nodeId],
-    fields: "compact",
-    limit: 1,
-  });
-  if (probe.isError) return null;
-  const type = parseQueriedNodeType(parseToolResultJson(probe));
-  if (type !== DASIWA_LTX2_LORA_LOADER) return null;
-  return daSiWaStackRefusal(type);
+
+  const tabBefore = ctx.tabId;
+  let identityBefore: { generation: number; tabSessionId: string } | undefined;
+  try {
+    identityBefore = ctx.panelConnectionIdentity?.();
+  } catch {
+    return daSiWaIdentityRefusal("the bound browser-tab identity was unreadable");
+  }
+  if (!isUsablePanelConnectionIdentity(identityBefore)) {
+    return daSiWaIdentityRefusal("the bound browser-tab identity was unavailable");
+  }
+
+  let probe: ToolResult;
+  try {
+    probe = await ctx.call({
+      cmd: "graph_query",
+      ids: [nodeId],
+      fields: "compact",
+      limit: 1,
+    });
+  } catch {
+    return daSiWaIdentityRefusal("the graph_query probe failed before identity could be verified");
+  }
+
+  if (ctx.tabId !== tabBefore) {
+    return daSiWaIdentityRefusal("the probe was answered by a different panel tab");
+  }
+  let identityAfter: { generation: number; tabSessionId: string } | undefined;
+  try {
+    identityAfter = ctx.panelConnectionIdentity?.();
+  } catch {
+    return daSiWaIdentityRefusal("the panel-tab identity became unreadable after the probe");
+  }
+  if (!isUsablePanelConnectionIdentity(identityAfter)) {
+    return daSiWaIdentityRefusal("the panel-tab identity became unavailable after the probe");
+  }
+  if (
+    identityAfter.tabSessionId !== identityBefore.tabSessionId ||
+    identityAfter.generation !== identityBefore.generation
+  ) {
+    return daSiWaIdentityRefusal("the panel-tab connection changed during the probe");
+  }
+  if (probe.isError) {
+    return daSiWaIdentityRefusal("the graph_query probe returned an error");
+  }
+
+  const identity = parseVerifiedQueriedNodeIdentity(parseToolResultJson(probe));
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!identity || !requestedId) {
+    return daSiWaIdentityRefusal(
+      "the graph_query reply was malformed, truncated, or did not contain exactly one verifiable row",
+    );
+  }
+  if (identity.id !== requestedId) {
+    return daSiWaIdentityRefusal("the graph_query row identified a different node_id");
+  }
+  if (identity.type !== DASIWA_LTX2_LORA_LOADER) return null;
+  return daSiWaStackRefusal(identity.type);
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -15301,6 +15301,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 })`,
             );
           }
+          if (innerIdentity.type === DASIWA_LTX2_LORA_LOADER) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n(The promoted inner node ${inner.innerNodeId} was identified as ` +
+                `${DASIWA_LTX2_LORA_LOADER}; ${textOfToolResult(daSiWaStackRefusal(innerIdentity.type))} ` +
+                `No inner graph_set_widget was dispatched.${
+                  exited.isError
+                    ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}`
+                    : ""
+                })`,
+            );
+          }
           innerExpectedNodeType = innerIdentity.type;
         }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -211,6 +211,11 @@ interface Conn {
    * its required fresh-backend query yields to the browser, allowing a workflow
    * switch before it writes. Re-read per hello and fail closed if absent. */
   enforcesWorkflowStampAtWrite: boolean;
+  /** True only when THIS hello advertises that the panel validates an optional
+   * expected_node_type at the synchronous graph_set_widget write boundary.
+   * Re-read per hello and fail closed when absent: an older panel would silently
+   * ignore the field and leave the node-replacement fence unenforced. */
+  enforcesExpectedNodeTypeAtWrite: boolean;
   /** True when THIS hello advertises that the panel understands `agent_note` — a frame
    *  delivered to the AGENT ONLY and never rendered as a chat bubble.
    *
@@ -350,6 +355,9 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   // handshake capabilities, not commands, hence this table.
   enforces_workflow_stamp: "0.11.30",
   enforces_workflow_stamp_at_write: "0.11.35",
+  // #2107 — graph_set_widget's optional expected_node_type fence shipped with
+  // the panel-side write-boundary check.
+  enforces_expected_node_type_at_write: "0.15.58",
 };
 
 /**
@@ -2919,6 +2927,8 @@ export class UiBridge {
             (msg as { enforces_workflow_stamp?: unknown }).enforces_workflow_stamp === true,
           enforcesWorkflowStampAtWrite:
             (msg as { enforces_workflow_stamp_at_write?: unknown }).enforces_workflow_stamp_at_write === true,
+          enforcesExpectedNodeTypeAtWrite:
+            (msg as { enforces_expected_node_type_at_write?: unknown }).enforces_expected_node_type_at_write === true,
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
@@ -3469,6 +3479,16 @@ export class UiBridge {
     // state to a human should use tabGraphMutationCapability instead — see below.
     const r = this.tabGraphMutationCapability(tabId);
     return r.known ? r.canMutate : false;
+  }
+
+  /** Whether THIS connected panel enforces graph_set_widget's optional
+   * expected-node-type fence at the actual mutation boundary (#2107). */
+  tabExpectedNodeTypeFenceCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).enforcesExpectedNodeTypeAtWrite === true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -4922,6 +4942,25 @@ export class UiBridge {
       panelVersionProvesUnsupported(cmd.cmd, conn.panelVersion)
     ) {
       return Promise.reject(buildPanelTooOldError(cmd.cmd, connPanelVersionReading(conn)));
+    }
+    // #2107 — an expected_node_type is meaningful only when the receiving panel
+    // checks it immediately before mutating. An old panel silently ignoring this
+    // optional field would reopen the node-replacement race, so never dispatch it
+    // without the matching hello capability.
+    if (
+      cmd.cmd === "graph_set_widget" &&
+      Object.prototype.hasOwnProperty.call(cmd, "expected_node_type") &&
+      !conn.enforcesExpectedNodeTypeAtWrite
+    ) {
+      const refusal = markDispatched(
+        new Error(
+          `graph_set_widget was refused before dispatch because panel tab ${conn.tabId} ` +
+            `does not advertise the atomic expected-node-type write fence. Update the ` +
+            `panel to 0.15.58+ and hard-refresh the browser tab.`,
+        ),
+        false,
+      );
+      return Promise.reject(markCapabilityRefusal(refusal));
     }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1520,6 +1520,14 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
+function expectedNodeTypeFenceRefusal(tabId: string): Error {
+  return new Error(
+    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
+      `does not advertise the atomic expected-node-type write fence. Update the ` +
+      `panel to 0.15.58+ and hard-refresh the browser tab.`,
+  );
+}
+
 /** Normalize a WebSocket handshake `Origin` header into a canonical scheme://host:port
  *  string, or undefined when it is absent, the opaque literal `"null"` (a sandboxed /
  *  file:// / data: origin, which proves nothing), or unparseable. The browser sets this
@@ -4953,11 +4961,7 @@ export class UiBridge {
       !conn.enforcesExpectedNodeTypeAtWrite
     ) {
       const refusal = markDispatched(
-        new Error(
-          `graph_set_widget was refused before dispatch because panel tab ${conn.tabId} ` +
-            `does not advertise the atomic expected-node-type write fence. Update the ` +
-            `panel to 0.15.58+ and hard-refresh the browser tab.`,
-        ),
+        expectedNodeTypeFenceRefusal(conn.tabId),
         false,
       );
       return Promise.reject(markCapabilityRefusal(refusal));
@@ -5346,6 +5350,19 @@ export class UiBridge {
       } catch (err) {
         return Promise.reject(
           markDispatched(err instanceof Error ? err : new Error(String(err)), false),
+        );
+      }
+      // The graph lane may have waited behind another command. Re-read the
+      // capability on the connection that will actually receive the frame;
+      // a reconnect during that wait must not turn the optional fence into a
+      // silently ignored field on an older panel.
+      if (
+        cmd.cmd === "graph_set_widget" &&
+        Object.prototype.hasOwnProperty.call(cmd, "expected_node_type") &&
+        !live.enforcesExpectedNodeTypeAtWrite
+      ) {
+        return Promise.reject(
+          markCapabilityRefusal(markDispatched(expectedNodeTypeFenceRefusal(live.tabId), false)),
         );
       }
       if (live.sock.readyState !== WebSocket.OPEN) {


### PR DESCRIPTION
Addresses #2107.

Adds fail-closed DaSiWa stack_data identity/type fencing, capability negotiation with Panel, promoted-inner re-probing, and refusal for promoted inner DaSiWa nodes. Includes MCP bridge/panel-tools/promoted-widget regression coverage.

Validation: 633 focused tests passed; lint passed.