### PR TITLE
fix(manifest): fall back when Manager is proven absent (#463)

### DIFF
--- a/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
+++ b/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
@@ -11,6 +11,8 @@ const listInstalledNodesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/fake/ComfyUI" },
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => false,
 }));
 

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -54,9 +54,11 @@ const cfg = vi.hoisted(() => ({
   comfyuiSsl: false,
   githubToken: undefined as string | undefined,
 }));
+const target = vi.hoisted(() => ({ generation: 0 }));
 vi.mock("../../config.js", () => ({
   config: cfg,
   getComfyUIBaseUrl: () => `http://${cfg.comfyuiHost}:${cfg.resolvedPort}`,
+  getComfyuiTargetGeneration: () => target.generation,
   getComfyUIAuthHeaders: () => ({}),
   isLoopbackHost: (host: string | undefined) =>
     !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host),
@@ -70,6 +72,7 @@ vi.mock("../../config.js", () => ({
 const live = vi.hoisted(() => ({
   argv: [] as string[],
   reachable: true,
+  onStats: undefined as (() => void) | undefined,
   /** How many times the running server was asked to describe itself. Zero is the
    *  measurement that proves the shipped code never consulted it. */
   statsCalls: 0,
@@ -77,6 +80,9 @@ const live = vi.hoisted(() => ({
 vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: async () => {
     live.statsCalls += 1;
+    const onStats = live.onStats;
+    live.onStats = undefined;
+    onStats?.();
     if (!live.reachable) throw new Error("connect ECONNREFUSED 127.0.0.1:8189");
     return { system: { argv: live.argv } };
   },
@@ -231,9 +237,11 @@ beforeEach(() => {
   http.calls = [];
   probe.calls = 0;
   probe.result = undefined;
+  live.onStats = undefined;
   http.mode = "refuse-enqueue";
   live.reachable = true;
   live.statsCalls = 0;
+  target.generation = 0;
   live.argv = [join(CONNECTED, "main.py"), "--port", "8189"];
   cfg.comfyuiPath = undefined;
   priorEnvPath = process.env.COMFYUI_PATH;
@@ -496,6 +504,38 @@ describe("#463 — apply_manifest uses the verified panel-connected local scan r
     ]);
     expect(result.results[0]?.message).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
     expect(clonedInto()).toBeUndefined();
+  });
+
+  it("refuses when the target retargets during apply_manifest's awaited probe", async () => {
+    http.mode = "manager-absent";
+    resetManagerApiCache("#463 target-generation race");
+    const retargetDuringThirdProbe = () => {
+      if (live.statsCalls < 3) {
+        live.onStats = retargetDuringThirdProbe;
+        return;
+      }
+      // The custom_nodes root was already verified for the original target A.
+      // Make the newly selected target B unreachable before installCustomNode
+      // starts; an unreachable mismatch check must not wash out this retarget.
+      cfg.resolvedPort = 8190;
+      target.generation += 1;
+      live.reachable = false;
+    };
+    live.onStats = retargetDuringThirdProbe;
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: [REPO], models: [] },
+    });
+
+    expect(result.results).toMatchObject([
+      { action: "custom_node", item: REPO, status: "failed" },
+    ]);
+    expect(result.results[0]?.message).toMatch(/target changed/i);
+    expect(clonedInto()).toBeUndefined();
+    // The initial Manager read and any attempted install must remain pinned to
+    // A; no request may be recaptured against the unreachable B target.
+    expect(http.calls.length).toBeGreaterThan(0);
+    expect(http.calls.every((url) => url.startsWith("http://127.0.0.1:8189/"))).toBe(true);
   });
 
   it("attempts Manager before refusing a clone for an ambiguous live root", async () => {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -97,7 +97,8 @@ vi.mock("../../comfyui/client.js", () => ({
 // They reach `cloneCustomNodeFallback` from two different call sites, and a
 // guard on only one of them is a guard that is not there. ────────────────────
 const http = vi.hoisted(() => ({
-  mode: "refuse-enqueue" as "refuse-enqueue" | "accept-enqueue",
+  mode: "refuse-enqueue" as "refuse-enqueue" | "accept-enqueue" | "manager-absent",
+  calls: [] as string[],
 }));
 vi.mock("../../comfyui/fetch.js", () => {
   const json = (body: unknown) =>
@@ -107,11 +108,15 @@ vi.mock("../../comfyui/fetch.js", () => {
     });
   return {
     comfyuiFetch: async (url: string) => {
+      http.calls.push(url);
       if (http.mode === "refuse-enqueue") {
         return new Response("gated by security_level", {
           status: 403,
           statusText: "Forbidden",
         });
+      }
+      if (http.mode === "manager-absent") {
+        return new Response("missing", { status: 404, statusText: "Not Found" });
       }
       const { pathname } = new URL(url);
       if (pathname === "/manager/queue/install") return json({ ui_id: "queued" });
@@ -153,6 +158,7 @@ vi.mock("node:child_process", async () => {
       git.calls.push([file, ...args]);
       if (file === "git" && args[0] === "clone") {
         const dest = args[args.length - 1];
+        http.calls.push(`git clone:${dest}`);
         fs.mkdirSync(dest, { recursive: true });
         fs.writeFileSync(path.join(dest, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
       }
@@ -188,10 +194,13 @@ vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
 });
 
 const { installCustomNode } = await import("../../services/node-management.js");
+const { applyManifest } = await import("../../services/manifest.js");
 const { configureWorkspace, resetWorkspaceConfig } = await import(
   "../../services/workspace-env.js"
 );
-const { setManagerApiCacheForTests } = await import("../../services/manager-api-cache.js");
+const { resetManagerApiCache, setManagerApiCacheForTests } = await import(
+  "../../services/manager-api-cache.js"
+);
 const { setQueueTimingForTests } = await import("../../services/node-management.js");
 setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5_000 });
 
@@ -219,6 +228,7 @@ let priorEnvPath: string | undefined;
 
 beforeEach(() => {
   git.calls = [];
+  http.calls = [];
   probe.calls = 0;
   probe.result = undefined;
   http.mode = "refuse-enqueue";
@@ -462,5 +472,48 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(error).toBeDefined();
     expect(error).not.toMatch(/two DIFFERENT ComfyUI installs/);
     expect(live.statsCalls).toBe(0);
+  });
+});
+
+describe("#463 — apply_manifest uses the verified panel-connected local scan root", () => {
+  it("clones a Git manifest source with COMFYUI_PATH unset and reports it applied", async () => {
+    http.mode = "manager-absent";
+    resetManagerApiCache("#463 manifest probe regression");
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: [REPO], models: [] },
+    });
+
+    expect(result.results).toMatchObject([
+      { action: "custom_node", item: REPO, status: "applied" },
+    ]);
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
+    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+
+    const statusCalls = http.calls
+      .map((url, index) => ({ url, index }))
+      .filter(({ url }) =>
+        url.includes("/v2/manager/queue/status") || url.includes("/manager/queue/status"),
+      );
+    const cloneIndex = http.calls.findIndex((value) => value.startsWith("git clone:"));
+    expect(statusCalls.length).toBeGreaterThanOrEqual(4);
+    expect(statusCalls.every(({ url }) => url.startsWith("http://127.0.0.1:8189/"))).toBe(true);
+    expect(Math.max(...statusCalls.map(({ index }) => index))).toBeLessThan(cloneIndex);
+  });
+
+  it("refuses the Git fallback when the no-path local target cannot be verified", async () => {
+    http.mode = "manager-absent";
+    live.reachable = false;
+    resetManagerApiCache("#463 unverified manifest target");
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: [REPO], models: [] },
+    });
+
+    expect(result.results).toMatchObject([
+      { action: "custom_node", item: REPO, status: "failed" },
+    ]);
+    expect(result.results[0]?.message).toMatch(/could not verify.*custom_nodes root/i);
+    expect(clonedInto()).toBeUndefined();
   });
 });

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -257,26 +257,13 @@ afterEach(() => {
 afterAll(() => rmSync(SANDBOX, { recursive: true, force: true }));
 
 describe("#1765 — install_custom_node must not write into an install this session is not connected to", () => {
-  it("REFUSES the reporter's case instead of reporting a success in the wrong tree", async () => {
+  it("uses the verified live root instead of the saved default", async () => {
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    // NOTHING ran. Before this change the same inputs returned
-    // { mechanism: "git-clone", details: { nodeDir: "<SAVED_DEFAULT>/custom_nodes/..." } }.
-    expect(ok).toBeUndefined();
-    expect(clonedInto()).toBeUndefined();
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
     expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
-    expect(existsSync(join(CONNECTED, PACK_DIR))).toBe(false);
-
-    // And the refusal NAMES both installs, which selector produced each, and the
-    // remedy — the reporter could only tell the write had gone astray by reading
-    // `nodeDir` out of a success payload.
-    expect(error).toContain(SAVED_DEFAULT);
-    expect(error).toContain(CONNECTED);
-    expect(error).toContain("http://127.0.0.1:8189");
-    expect(error).toContain("SAVED DEFAULT WORKSPACE");
-    expect(error).toContain("--base-directory");
-    expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
-    expect(error).toContain(`COMFYUI_PATH=${CONNECTED}`);
   });
 
   it("asks the running server which install it is — the shipped path never did", async () => {
@@ -294,7 +281,7 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("REFUSES on the other road to the same clone — the Manager accepted, then had nothing", async () => {
+  it("uses the verified live root when Manager accepts but resolves nothing", async () => {
     // The reporter's own shape: the queue takes the task, drains, and the pack is
     // still not installed because it is unregistered. That reaches
     // cloneCustomNodeFallback from a DIFFERENT call site than the 403 divert.
@@ -302,11 +289,10 @@ describe("#1765 — install_custom_node must not write into an install this sess
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(ok).toBeUndefined();
-    expect(clonedInto()).toBeUndefined();
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
     expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
-    expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
-    expect(error).toContain(CONNECTED);
   });
 
   it("still clones on that road when the configured root IS the connected install", async () => {
@@ -320,18 +306,17 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("refuses when the server's --base-directory names a different tree", async () => {
+  it("uses the live --base-directory as the custom_nodes target", async () => {
     live.argv = [join(CONNECTED, "main.py"), "--base-directory", DATA_ROOT];
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(ok).toBeUndefined();
-    expect(clonedInto()).toBeUndefined();
-    expect(error).toContain(DATA_ROOT);
-    expect(error).toContain("--base-directory");
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(DATA_ROOT, PACK_DIR));
   });
 
-  it("fails OPEN when --base-directory is relative and unresolvable", async () => {
+  it("fails closed when --base-directory is relative and unresolvable", async () => {
     // The server WAS given a base directory, but a relative one with no server
     // cwd to resolve it against. It scans custom_nodes/ from a directory we
     // cannot name — and the main.py root, which argv does give us, is then
@@ -341,9 +326,9 @@ describe("#1765 — install_custom_node must not write into an install this sess
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(error).toBeUndefined();
-    expect(ok).toMatchObject({ mechanism: "git-clone" });
-    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
   });
 
   it("clones normally when the server's --base-directory IS the configured root", async () => {
@@ -389,17 +374,17 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
   });
 
-  it("fails OPEN when the server cannot be reached — an outage is not evidence", async () => {
+  it("fails closed when the server cannot be reached — an outage is not a clone target", async () => {
     live.reachable = false;
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(error).toBeUndefined();
-    expect(ok).toMatchObject({ mechanism: "git-clone" });
-    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
   });
 
-  it("REFUSES the relative-main.py shape too, via the OS process observation", async () => {
+  it("uses a verified root from the OS process observation", async () => {
     // The shape the live rig actually reports, and the one `comfy launch`
     // produces: a relative launch script and no server cwd. Nothing in argv
     // names a root; the interpreter the OS says is on the port does.
@@ -408,40 +393,38 @@ describe("#1765 — install_custom_node must not write into an install this sess
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(ok).toBeUndefined();
-    expect(clonedInto()).toBeUndefined();
-    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
-    expect(error).toContain(CONNECTED);
-    expect(error).toContain("OS process listening on that port");
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
     expect(probe.calls).toBeGreaterThan(0);
   });
 
-  it("fails OPEN when the relative main.py can be anchored on NOTHING", async () => {
+  it("fails closed when the relative main.py cannot be anchored", async () => {
     // Relative script, and the OS observation yields no interpreter (a remote
-    // proxy, a permissions failure, an unreadable process table). Unprovable is
-    // not the same as wrong, so nothing is refused.
+    // proxy, a permissions failure, an unreadable process table). No live root
+    // is then authorized for a local clone.
     live.argv = ["ComfyUI/main.py", "--port", "8189"];
     probe.result = undefined;
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(error).toBeUndefined();
-    expect(ok).toMatchObject({ mechanism: "git-clone" });
-    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
   });
 
-  it("fails OPEN when the observed interpreter belongs to no install we can anchor", async () => {
+  it("fails closed when the observed interpreter belongs to no install we can anchor", async () => {
     // A SYSTEM python: walking up from it reaches directories that are not the
     // install at all, which is the unsoundness `interpreterBelongsToInstall`
-    // exists to reject. It must not produce a root, and so must not refuse.
+    // exists to reject. It must not produce a clone target.
     live.argv = ["ComfyUI/main.py", "--port", "8189"];
     probe.result = { python: join(SANDBOX, "python", "python.exe"), pid: 4243 };
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 
-    expect(error).toBeUndefined();
-    expect(ok).toMatchObject({ mechanism: "git-clone" });
-    expect(clonedInto()).toBe(join(SAVED_DEFAULT, PACK_DIR));
+    expect(ok).toBeUndefined();
+    expect(clonedInto()).toBeUndefined();
+    expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
   });
 
   it("refuses the comfy-cli branch too — --workspace has the identical hazard", async () => {
@@ -450,13 +433,11 @@ describe("#1765 — install_custom_node must not write into an install this sess
     try {
       const { ok, error } = await install({ id: REPO, source: "git", useCmCli: true });
 
-      expect(ok).toBeUndefined();
-      expect(error).toMatch(/two DIFFERENT ComfyUI installs/);
-      expect(error).toContain("comfy-cli");
-      // The subprocess never ran: no `comfy ... install` and no `git clone`.
-      expect(git.calls.filter((c) => c[0] === FAKE_COMFY_CLI)).toHaveLength(0);
+      expect(error).toBeUndefined();
+      expect(ok).toMatchObject({ mechanism: "comfy-cli" });
+      // The verified live root is used; the direct-clone fallback is not involved.
+      expect(git.calls.filter((c) => c[0] === "git" && c[1] === "clone")).toHaveLength(0);
       expect(clonedInto()).toBeUndefined();
-      expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
     } finally {
       if (priorCli === undefined) delete process.env.COMFY_CLI_PATH;
       else process.env.COMFY_CLI_PATH = priorCli;
@@ -513,7 +494,42 @@ describe("#463 — apply_manifest uses the verified panel-connected local scan r
     expect(result.results).toMatchObject([
       { action: "custom_node", item: REPO, status: "failed" },
     ]);
-    expect(result.results[0]?.message).toMatch(/could not verify.*custom_nodes root/i);
+    expect(result.results[0]?.message).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
     expect(clonedInto()).toBeUndefined();
+  });
+
+  it("attempts Manager before refusing a clone for an ambiguous live root", async () => {
+    http.mode = "accept-enqueue";
+    live.argv = ["main.py", "--port", "8189"];
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: [REPO], models: [] },
+    });
+
+    expect(result.results).toMatchObject([
+      { action: "custom_node", item: REPO, status: "failed" },
+    ]);
+    expect(http.calls.some((url) => url.endsWith("/manager/queue/install"))).toBe(true);
+    expect(clonedInto()).toBeUndefined();
+    expect(result.results[0]?.message).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
+  });
+
+  it("attempts Manager when no local root is available instead of preflight-refusing", async () => {
+    http.mode = "accept-enqueue";
+    live.reachable = false;
+    // A configured/saved root is still not proof of the panel target when the
+    // explicit COMFYUI_PATH is unset. It must not be used for the clone.
+    cfg.comfyuiPath = SAVED_DEFAULT;
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: [REPO], models: [] },
+    });
+
+    expect(result.results).toMatchObject([
+      { action: "custom_node", item: REPO, status: "failed" },
+    ]);
+    expect(http.calls.some((url) => url.endsWith("/manager/queue/install"))).toBe(true);
+    expect(clonedInto()).toBeUndefined();
+    expect(result.results[0]?.message).not.toMatch(/could not verify.*custom_nodes root/i);
   });
 });

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -28,7 +28,7 @@ process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = "5000";
 
 // Kept mutable to model the runtime target change that the panel applies while a
 // Manager operation is in flight. vi.hoisted makes it available to the mock factory.
-const target = vi.hoisted(() => ({ base: "http://127.0.0.1:8188" }));
+const target = vi.hoisted(() => ({ base: "http://127.0.0.1:8188", generation: 0 }));
 
 vi.mock("../../config.js", () => {
   const config = {
@@ -41,6 +41,7 @@ vi.mock("../../config.js", () => {
   return {
     config,
     getComfyUIBaseUrl: () => target.base,
+    getComfyuiTargetGeneration: () => target.generation,
     getComfyUIAuthHeaders: () => ({}),
     // node-management's Manager self-update path (#424) imports this; the mock
     // must provide it or the named import fails at load.
@@ -232,6 +233,7 @@ const elapse = (ms: number): void => {
 describe("#646 Manager API dialect cache invalidation", () => {
   beforeEach(() => {
     target.base = BASE;
+    target.generation = 0;
     monotonicOffset = 0;
     wallOffset = 0;
     vi.spyOn(Date, "now").mockImplementation(() => realNow() + wallOffset);
@@ -512,7 +514,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
     });
   });
 
-  it("keeps a dialect self-heal retry and drain on its original target after retarget", async () => {
+  it("refuses completion when a dialect self-heal retargets mid-install", async () => {
     const targetA = BASE;
     const targetB = "http://127.0.0.1:8282";
     let retargeted = false;
@@ -525,23 +527,25 @@ describe("#646 Manager API dialect cache invalidation", () => {
         if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/task") {
           retargeted = true;
           target.base = targetB;
+          target.generation += 1;
           resetManagerApiCache("panel retargeted while Manager request was in flight");
         }
       },
     });
     resetManagerApiCacheForTests("v2");
 
-    await expect(installCustomNode({ id: "comfyui-foo" })).resolves.toMatchObject({
-      mechanism: "manager-http",
+    await expect(installCustomNode({ id: "comfyui-foo" })).rejects.toMatchObject({
+      details: { kind: "target-generation-changed" },
     });
 
     // The mutation began at A, so its retry, queue start, and drain are all
     // pinned to A. B is now the target for subsequent calls, but receives none
-    // from this already-started transaction.
+    // from this already-started transaction. The operation refuses to report
+    // success before post-queue verification because the target changed.
     expect(calls.filter((call) => call.url.startsWith(targetB))).toHaveLength(0);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/install")).toBe(true);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/start")).toBe(true);
-    expect(calls.some((call) => call.url.startsWith(targetA) && call.path.startsWith("/customnode/installed"))).toBe(true);
+    expect(calls.some((call) => call.url.startsWith(targetA) && call.path.startsWith("/customnode/installed"))).toBe(false);
   });
 
   it("keeps the update-all tool's enqueue + start on its original target after retarget (#656)", async () => {
@@ -558,6 +562,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
         if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/update_all") {
           retargeted = true;
           target.base = targetB;
+          target.generation += 1;
           resetManagerApiCache("panel retargeted while Manager request was in flight");
         }
       },
@@ -591,6 +596,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
         if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/start" && method === "POST") {
           retargeted = true;
           target.base = targetB;
+          target.generation += 1;
           resetManagerApiCache("panel retargeted while Manager request was in flight");
         }
       },

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -218,6 +218,9 @@ vi.mock("../../services/workspace-env.js", () => ({
     effectiveCodeBaseLiveMock(...(a as [])),
   resolveEffectiveComfyUIBaseLive: (...a: unknown[]) =>
     effectiveBaseLiveMock(...(a as [])),
+  resolveCustomNodesScanBaseLiveStrict: (...a: unknown[]) =>
+    effectiveBaseLiveMock(...(a as [])),
+  getLiveServerSnapshot: async () => ({ reachable: true }),
   // Mirrors the real resolver enough for the pip tests: an install-root python.
   resolveRootInterpreter: (root: string | undefined) =>
     root ? `${root}/python` : "python",

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -103,6 +103,8 @@ const installInterpreterMock = vi.hoisted(() =>
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => 0,
   // apply_manifest routes models through the Manager in remote mode (no
   // comfyuiPath). isRemoteMode mirrors that gate for the tests.
   isRemoteMode: () => mockConfig.remote ?? !mockConfig.comfyuiPath,
@@ -955,6 +957,8 @@ describe("applyManifest", () => {
     expect(installCustomNodeMock).toHaveBeenCalledWith({
       id: "split-root-pack",
       comfyuiPath: dataRoot,
+      managerBase: "http://127.0.0.1:8188",
+      targetGeneration: 0,
     });
     expect(installInterpreterMock).not.toHaveBeenCalledWith(dataRoot);
   });
@@ -1893,7 +1897,11 @@ describe("applyManifest", () => {
       expect(byAction.pip.status).toBe("skipped");
       expect(execFileSyncMock).not.toHaveBeenCalled();
       // custom_nodes still go through the Manager HTTP install (remote-ok).
-      expect(installCustomNodeMock).toHaveBeenCalledWith({ id: "x" });
+      expect(installCustomNodeMock).toHaveBeenCalledWith({
+        id: "x",
+        managerBase: "http://127.0.0.1:8188",
+        targetGeneration: 0,
+      });
       // models route through installModelViaManager, NOT the local downloadModel.
       expect(downloadModelMock).not.toHaveBeenCalled();
       expect(installModelViaManagerMock).toHaveBeenCalledWith({

--- a/src/__tests__/services/node-install-invalidates-object-info.test.ts
+++ b/src/__tests__/services/node-install-invalidates-object-info.test.ts
@@ -118,7 +118,13 @@ describe("#444 install invalidates the object_info cache", () => {
 
     // A cache-serving read would STILL return REGISTRY_WITHOUT here; the install
     // must invalidate the snapshot so the next read refetches.
-    await installCustomNode({ id: "comfyui-smart-image-crop", useCmCli: true });
+    await installCustomNode({
+      id: "comfyui-smart-image-crop",
+      useCmCli: true,
+      // The fixture has no live ComfyUI to identify a scan root. Pin the
+      // mocked local workspace explicitly so this test reaches the CLI path.
+      comfyuiPath: "/fake/comfy",
+    });
 
     const after = await validateWorkflow(GRAPH as never, { health: false });
     expect(missingNodeTypes(after)).not.toContain("SmartImageCrop");

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -29,6 +29,7 @@ vi.mock("../../config.js", () => {
     config,
     getComfyUIBaseUrl: () =>
       `${config.comfyuiSsl ? "https" : "http"}://${config.comfyuiHost}:${config.resolvedPort}`,
+    getComfyuiTargetGeneration: () => 0,
     getComfyUIAuthHeaders: () => ({}),
     isLoopbackHost: (host: string | undefined) =>
       !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host.toLowerCase().replace(/^\[|\]$/g, "")),

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -207,6 +207,8 @@ function stubFetch(opts: {
   registryDetails?: unknown;
   /** Body for v4 per-task queue history lookups. */
   managerTaskHistory?: unknown | ((uiId: string) => unknown);
+  /** Shape of both Manager queue/status dialect probes for fallback tests. */
+  managerQueueStatus?: "absent" | "malformed" | "timeout" | "server-error";
 } = {}) {
   const calls: Call[] = [];
   let statusIdx = 0;
@@ -228,6 +230,20 @@ function stubFetch(opts: {
       }
       if (path.startsWith("/v2/customnode/installed")) {
         return jsonResponse(opts.installedBody ?? {});
+      }
+      if (path === "/v2/manager/queue/status" || path === "/manager/queue/status") {
+        if (opts.managerQueueStatus === "absent") {
+          return new Response("missing", { status: 404 });
+        }
+        if (opts.managerQueueStatus === "malformed") {
+          return new Response("<!doctype html>", { status: 200 });
+        }
+        if (opts.managerQueueStatus === "timeout") {
+          throw new Error("request timed out");
+        }
+        if (opts.managerQueueStatus === "server-error") {
+          return new Response("server error", { status: 500 });
+        }
       }
       if (path === "/v2/manager/queue/status") {
         const s = statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
@@ -666,51 +682,70 @@ describe("node-management service", () => {
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
-    // #1129 — a REFUSED enqueue is not the end of the road.
-    //
-    // The 3.x git-URL install is gated by security_level + allow_git_url_install,
-    // and a host that does not serve the route answers the same way. Both come
-    // back as a status on the POST, which throws — so the direct-clone fallback,
-    // which needs no Manager at all and is exactly what the user would do by
-    // hand, was unreachable in the one case it exists for. A reporter on legacy
-    // 3.x got "not reachable", then a 404 with "A security error has occurred",
-    // and was left with no install path on a machine whose custom_nodes
-    // directory was sitting right there.
-    // 405 is excluded on purpose: on this API it is the dialect-mismatch signal
-    // that the #646 self-heal retry owns, and the "no dialect self-heal" case
-    // below pins that.
-    for (const status of [403, 404]) {
-      it(`#1129: Manager REFUSES the git enqueue with ${status} → clones directly and says why`, async () => {
+    // #463 — a direct clone is allowed only after the connected ComfyUI proves
+    // that BOTH Manager queue/status dialects are absent. A queue operation's
+    // own 404 is not enough: the Manager may still expose the other dialect.
+    it("falls back to a direct git clone only after both queue dialects return 404", async () => {
+      stubFetch({ managerQueueStatus: "absent" });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/confirmed absent/);
+      expect(res.message).toMatch(/both queue\/status dialects returned HTTP 404/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+    });
+
+    for (const status of [401, 403, 407, 404]) {
+      it(`#463: Manager git enqueue HTTP ${status} does not authorize a local clone`, async () => {
         stubFetch({ installedBody: {}, queueOpStatus: status });
-        let cloned = false;
         mockedExists.mockImplementation((p: unknown) => {
           const s = String(p);
           if (s.includes("requirements.txt") || s.includes("install.py")) return false;
           if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
-          if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
           return false;
         });
         mockedExec.mockImplementation(((bin: string, args: string[]) => {
-          if (bin === "git" && args[0] === "clone") cloned = true;
           return "";
         }) as never);
 
-        const res = await installCustomNode({
-          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
-        });
-
-        expect(res.mechanism).toBe("git-clone");
-        // The reason must be the REFUSAL, not "not in the registry" — that would
-        // be a wrong explanation for a correct action, and it is what a reader
-        // would go on to act on.
-        expect(res.message).toMatch(new RegExp(`REFUSED the git-URL install \\(HTTP ${status}\\)`));
-        expect(res.message).toMatch(/security_level \/ allow_git_url_install/);
-        expect(res.message).toMatch(/Nothing was queued there/);
-        expect(res.message).not.toMatch(/not in the ComfyUI-Manager registry/);
-        // And it actually cloned.
+        await expect(
+          installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+        ).rejects.toThrow(new RegExp(String(status)));
         expect(
           mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
-        ).toBeDefined();
+        ).toBeUndefined();
+      });
+    }
+
+    for (const managerQueueStatus of ["timeout", "server-error", "malformed"] as const) {
+      it(`#463: a ${managerQueueStatus} queue-status probe does not authorize a local clone`, async () => {
+        stubFetch({ managerQueueStatus });
+        mockedExists.mockImplementation(() => false);
+        mockedExec.mockImplementation((() => "") as never);
+
+        await expect(
+          installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+        ).rejects.toBeInstanceOf(NodeManagementError);
+        expect(
+          mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+        ).toBeUndefined();
       });
     }
 

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -168,6 +168,7 @@ import { ProcessControlError, ValidationError } from "../../utils/errors.js";
 
 const mockedExec = vi.mocked(execFileSync);
 const mockedExists = vi.mocked(existsSync);
+let priorComfyuiPathEnv: string | undefined;
 
 // The product builds these paths with node:path (join), so they use the
 // platform separator (backslashes on Windows). Build the expected values the
@@ -323,6 +324,11 @@ function taskOf(calls: Call[], kind: string): { body: Record<string, unknown>; p
 
 describe("node-management service", () => {
   beforeEach(() => {
+    priorComfyuiPathEnv = process.env.COMFYUI_PATH;
+    // The generic direct-clone fixtures model an explicitly selected local
+    // install. Tests that exercise the new no-COMFYUI_PATH policy delete this
+    // below and must then provide a call-scoped or verified live root.
+    process.env.COMFYUI_PATH = "/fake/comfy";
     mockedExec.mockReset();
     mockedExists.mockReset();
     mockedExists.mockReturnValue(true);
@@ -357,6 +363,8 @@ describe("node-management service", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    if (priorComfyuiPathEnv === undefined) delete process.env.COMFYUI_PATH;
+    else process.env.COMFYUI_PATH = priorComfyuiPathEnv;
     delete process.env.COMFYUI_PYTHON;
   });
 
@@ -1246,6 +1254,7 @@ describe("node-management service", () => {
 
     it("throws ProcessControlError on clone fallback when comfyuiPath is unset", async () => {
       config.comfyuiPath = undefined;
+      delete process.env.COMFYUI_PATH;
       stubFetch({ installedBody: {} });
       await expect(
         installCustomNode({
@@ -1421,45 +1430,22 @@ describe("node-management service", () => {
       ]);
     });
 
-    it("cm-cli install with a ref works from the SAVED DEFAULT workspace when COMFYUI_PATH is unset (#808/#775 layout)", async () => {
-      // The CLI, the ref checkout, and the clone fallback must all take the ONE
-      // captured local root — previously the checkout read only
-      // config.comfyuiPath and threw AFTER the CLI install had already run.
+    it("does not use a SAVED DEFAULT workspace for cm-cli when COMFYUI_PATH is unset", async () => {
+      // A saved default is not proof of the panel-connected target. Without
+      // live root evidence, cm-cli must fall back to Manager rather than run
+      // against that potentially different local install.
       config.comfyuiPath = undefined;
+      delete process.env.COMFYUI_PATH;
       savedDefault.value = "/saved/ws";
-      mockedExec.mockReturnValue(cliEnvelope({ message: "installed ok" }) as never);
 
-      const res = await installCustomNode({
-        id: "https://github.com/foo/bar",
-        ref: "abc123",
-        useCmCli: true,
-      });
-
-      expect(res.mechanism).toBe("comfy-cli");
-      // The CLI ran against the saved default workspace...
-      expect(mockedExec.mock.calls[0][1]).toEqual([
-        "--json",
-        "--workspace",
-        "/saved/ws",
-        "--skip-prompt",
-        "node",
-        "install",
-        "https://github.com/foo/bar",
-        "--mode",
-        "remote",
-        "--channel",
-        "default",
-      ]);
-      // ...and the ref checkout ran THERE too, not nowhere.
-      const checkoutDir = resolve("/saved/ws", "custom_nodes", "bar");
-      expect(mockedExec.mock.calls[2][1]).toEqual([
-        "-C",
-        checkoutDir,
-        "checkout",
-        "--detach",
-        "--end-of-options",
-        "abc123",
-      ]);
+      await expect(
+        installCustomNode({
+          id: "https://github.com/foo/bar",
+          ref: "abc123",
+          useCmCli: true,
+        }),
+      ).rejects.toBeInstanceOf(NodeManagementError);
+      expect(mockedExec).not.toHaveBeenCalled();
     });
 
     it("routes forced cm-cli and its git checkout through the data/base root in a split install", async () => {
@@ -3412,7 +3398,12 @@ describe("node-management service", () => {
     /** Stub a server shaped like comfyui_manager 4.2.2 in legacy-UI mode:
      *  /v2 status + is_legacy_manager_ui:true + batch; NO /v2 task route
      *  (a POST there gets ComfyUI's catchall 405, per the field report). */
-    function stubBatchFetch(opts: { failed?: unknown[]; installedBody?: unknown } = {}) {
+    function stubBatchFetch(opts: {
+      failed?: unknown[];
+      installedBody?: unknown;
+      queueBatchStatus?: number;
+      queueBatchBody?: string;
+    } = {}) {
       const calls: Call[] = [];
       const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
         const method = init?.method ?? "GET";
@@ -3427,6 +3418,13 @@ describe("node-management service", () => {
           return jsonResponse({ is_legacy_manager_ui: true });
         }
         if (path === "/v2/manager/queue/batch" && method === "POST") {
+          if (opts.queueBatchStatus !== undefined) {
+            return new Response(
+              opts.queueBatchBody ??
+                "A security error has occurred. Please check the terminal logs",
+              { status: opts.queueBatchStatus },
+            );
+          }
           return jsonResponse({ failed: opts.failed ?? [] });
         }
         if (path === "/v2/manager/queue/start" && method === "POST") {
@@ -3476,6 +3474,46 @@ describe("node-management service", () => {
         files: ["https://github.com/foo/bar"],
       });
     });
+
+    for (const [status, body, shouldClone] of [
+      [403, undefined, true],
+      [404, undefined, true],
+      [401, undefined, false],
+      [407, undefined, false],
+      [403, "Forbidden", false],
+      [500, undefined, false],
+      [405, undefined, false],
+    ] as const) {
+      it(`#463: v2-batch enqueue HTTP ${status}${body ? " with a bare body" : ""} ${shouldClone ? "permits" : "does not permit"} a local clone`, async () => {
+        let cloned = false;
+        const { calls } = stubBatchFetch({
+          queueBatchStatus: status,
+          ...(body === undefined ? {} : { queueBatchBody: body }),
+        });
+        mockedExists.mockImplementation((p: unknown) => {
+          const s = String(p);
+          if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+          if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+          return s.includes("comfyui-teskors-utils") ? cloned : false;
+        });
+        mockedExec.mockImplementation(((bin: string, args: string[]) => {
+          if (bin === "git" && args[0] === "clone") cloned = true;
+          return "";
+        }) as never);
+
+        const operation = installCustomNode({
+          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        });
+        if (shouldClone) {
+          const res = await operation;
+          expect(res.mechanism).toBe("git-clone");
+          expect(calls.some((c) => c.url.includes("/v2/manager/queue/batch"))).toBe(true);
+        } else {
+          await expect(operation).rejects.toThrow(new RegExp(String(status)));
+          expect(cloned).toBe(false);
+        }
+      });
+    }
 
     it("surfaces a batch-reported failure with the legacy-UI hint", async () => {
       stubBatchFetch({

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -203,12 +203,19 @@ function stubFetch(opts: {
    * The response describes the REQUEST, so nothing was queued.
    */
   queueOpStatus?: number;
+  /** Exact body returned by the Manager queue operation when queueOpStatus is set. */
+  queueOpBody?: string;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
   registryDetails?: unknown;
   /** Body for v4 per-task queue history lookups. */
   managerTaskHistory?: unknown | ((uiId: string) => unknown);
   /** Shape of both Manager queue/status dialect probes for fallback tests. */
-  managerQueueStatus?: "absent" | "malformed" | "timeout" | "server-error";
+  managerQueueStatus?:
+    | "absent"
+    | "malformed"
+    | "timeout"
+    | "server-error"
+    | "method-not-allowed";
 } = {}) {
   const calls: Call[] = [];
   let statusIdx = 0;
@@ -244,6 +251,9 @@ function stubFetch(opts: {
         if (opts.managerQueueStatus === "server-error") {
           return new Response("server error", { status: 500 });
         }
+        if (opts.managerQueueStatus === "method-not-allowed") {
+          return new Response("method not allowed", { status: 405 });
+        }
       }
       if (path === "/v2/manager/queue/status") {
         const s = statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
@@ -268,7 +278,8 @@ function stubFetch(opts: {
             (body as { kind?: string } | undefined)?.kind === "install");
         if (opts.queueOpStatus !== undefined && isInstallOp) {
           return new Response(
-            "A security error has occurred. Please check the terminal logs",
+            opts.queueOpBody ??
+              "A security error has occurred. Please check the terminal logs",
             { status: opts.queueOpStatus },
           );
         }
@@ -682,9 +693,10 @@ describe("node-management service", () => {
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
-    // #463 — a direct clone is allowed only after the connected ComfyUI proves
-    // that BOTH Manager queue/status dialects are absent. A queue operation's
-    // own 404 is not enough: the Manager may still expose the other dialect.
+    // #463 — a detection failure is allowed to reach a direct clone only after
+    // the connected ComfyUI proves that BOTH Manager queue/status dialects are
+    // absent. This is distinct from a queue operation's own route-level 404,
+    // which is already a pre-queue refusal and retains the legacy fallback.
     it("falls back to a direct git clone only after both queue dialects return 404", async () => {
       stubFetch({ managerQueueStatus: "absent" });
       let cloned = false;
@@ -712,7 +724,7 @@ describe("node-management service", () => {
       ).toBeDefined();
     });
 
-    for (const status of [401, 403, 407, 404]) {
+    for (const status of [401, 407]) {
       it(`#463: Manager git enqueue HTTP ${status} does not authorize a local clone`, async () => {
         stubFetch({ installedBody: {}, queueOpStatus: status });
         mockedExists.mockImplementation((p: unknown) => {
@@ -734,7 +746,81 @@ describe("node-management service", () => {
       });
     }
 
-    for (const managerQueueStatus of ["timeout", "server-error", "malformed"] as const) {
+    it("#463: preserves the legacy Manager security-error 403 fallback contract", async () => {
+      stubFetch({ installedBody: {}, queueOpStatus: 403 });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        return s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")
+          ? cloned
+          : false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/HTTP 403/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+    });
+
+    for (const body of ["Forbidden", "<html><body>security_level</body></html>"]) {
+      it(`#463: a bare or proxy/HTML 403 does not authorize a local clone (${body})`, async () => {
+        stubFetch({ installedBody: {}, queueOpStatus: 403, queueOpBody: body });
+        mockedExists.mockImplementation(() => false);
+        mockedExec.mockImplementation((() => "") as never);
+
+        await expect(
+          installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+        ).rejects.toThrow(/403/);
+        expect(
+          mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+        ).toBeUndefined();
+      });
+    }
+
+    it("#463: a direct Manager enqueue 404 retains the route-level clone fallback", async () => {
+      stubFetch({ installedBody: {}, queueOpStatus: 404 });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        return s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")
+          ? cloned
+          : false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/HTTP 404/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+    });
+
+    for (const managerQueueStatus of [
+      "timeout",
+      "server-error",
+      "malformed",
+      "method-not-allowed",
+    ] as const) {
       it(`#463: a ${managerQueueStatus} queue-status probe does not authorize a local clone`, async () => {
         stubFetch({ managerQueueStatus });
         mockedExists.mockImplementation(() => false);

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -42,7 +42,6 @@ import {
   resolveEffectiveComfyUIBaseLive,
   resolveEffectiveComfyUICodeBaseLive,
   resolveCustomNodesScanBaseLiveStrict,
-  getLiveServerSnapshot,
   resolveInstallInterpreter,
   type InstallInterpreterResolution,
 } from "./workspace-env.js";
@@ -983,14 +982,18 @@ function looksLikeGitManifestSource(id: string): boolean {
 
 async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined> {
   if (isRemoteMode()) return undefined;
-  // With no COMFYUI_PATH/configured root, a saved default is only a local
-  // workspace candidate. For the direct Git fallback it is not an authorized
-  // target unless the panel-connected local server is reachable now.
-  if (!process.env.COMFYUI_PATH && !config.comfyuiPath) {
-    const live = await getLiveServerSnapshot();
-    if (!live.reachable) return undefined;
+  try {
+    // With no COMFYUI_PATH, a saved/default config root is only a local
+    // workspace candidate. It is not an authorized clone target unless the
+    // panel-connected local server provides live evidence for its scan root.
+    return await resolveCustomNodesScanBaseLiveStrict({
+      requireLive: !process.env.COMFYUI_PATH,
+    });
+  } catch {
+    // An unavailable/ambiguous live root must not block the Manager attempt.
+    // It only removes the optional local-clone route.
+    return undefined;
   }
-  return resolveCustomNodesScanBaseLiveStrict();
 }
 
 async function applyManifestSections(
@@ -1139,19 +1142,6 @@ async function applyManifestSections(
       );
       continue;
     }
-    if (localMode && looksLikeGitManifestSource(id) && !customNodesBase) {
-      results.push(
-        report(
-          "custom_node",
-          id,
-          "failed",
-          "apply_manifest could not verify a local ComfyUI custom_nodes root for this Git source. " +
-            "The direct clone was refused; connect the panel to a reachable local ComfyUI " +
-            "whose live install or --base-directory is available, then retry.",
-        ),
-      );
-      continue;
-    }
     if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
@@ -1171,6 +1161,9 @@ async function applyManifestSections(
     const installOutcome = installCustomNode({
       id,
       ...(customNodesBase ? { comfyuiPath: customNodesBase } : {}),
+      ...(looksLikeGitManifestSource(id)
+        ? { localCloneFallback: "verified-only" as const }
+        : {}),
     })
       .then((res) => ({ kind: "settled" as const, res }))
       .catch((err) => ({ kind: "error" as const, err }));

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -41,6 +41,8 @@ import { resolveModelsDir } from "./output-dir.js";
 import {
   resolveEffectiveComfyUIBaseLive,
   resolveEffectiveComfyUICodeBaseLive,
+  resolveCustomNodesScanBaseLiveStrict,
+  getLiveServerSnapshot,
   resolveInstallInterpreter,
   type InstallInterpreterResolution,
 } from "./workspace-env.js";
@@ -937,19 +939,27 @@ export async function applyManifest(
   // Both roots are live-first so one apply_manifest cannot split mutations
   // across two unrelated installs when config and the connected server differ:
   //   dataBase — live --base-directory, then configuration, then main.py
-  //              (same as node_pack, #1715/#1770). Pack clone/checkout land here.
+  //              for ordinary local data/model availability.
+  //   customNodesBase — the live custom_nodes scan root; unlike dataBase, this
+  //              does not fall back to a saved default when COMFYUI_PATH is unset.
   //   codeBase — live main.py, then COMFYUI_CODE_PATH, then the data base.
   //              Pip/venv land here.
   // The actual on-disk model DESTINATION is always re-derived live-first by the
   // downloader (resolveModelsDir), so dataBase only governs data-filesystem
   // availability, never where a model lands.
   const localDataBase = await resolveLocalManifestBase();
+  // A custom node is visible to ComfyUI under the running process's actual
+  // scan root: its live --base-directory, or the live main.py checkout when no
+  // base-directory is set. This must not fall back to a saved default workspace
+  // when COMFYUI_PATH is unset (#463).
+  const localCustomNodesBase = await resolveLocalManifestCustomNodesBase();
   const localCodeBase = isRemoteMode()
     ? undefined
     : (await resolveEffectiveComfyUICodeBaseLive()) ?? localDataBase;
 
   return applyManifestSections(manifest, {
     dataBase: localDataBase,
+    customNodesBase: localCustomNodesBase,
     codeBase: localCodeBase,
   }, describeManifestSource(opts));
 }
@@ -967,10 +977,27 @@ async function resolveLocalManifestBase(): Promise<string | undefined> {
   return resolveEffectiveComfyUIBaseLive();
 }
 
+function looksLikeGitManifestSource(id: string): boolean {
+  return /^(?:https?:\/\/|git@|git\+)/i.test(id) || /\.git(?:[?#]|$)/i.test(id);
+}
+
+async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined> {
+  if (isRemoteMode()) return undefined;
+  // With no COMFYUI_PATH/configured root, a saved default is only a local
+  // workspace candidate. For the direct Git fallback it is not an authorized
+  // target unless the panel-connected local server is reachable now.
+  if (!process.env.COMFYUI_PATH && !config.comfyuiPath) {
+    const live = await getLiveServerSnapshot();
+    if (!live.reachable) return undefined;
+  }
+  return resolveCustomNodesScanBaseLiveStrict();
+}
+
 async function applyManifestSections(
   manifest: ComfyManifest,
   localRoots: {
     dataBase: string | undefined;
+    customNodesBase: string | undefined;
     codeBase: string | undefined;
   },
   source: string,
@@ -986,7 +1013,7 @@ async function applyManifestSections(
   // route pip/model handling remotely instead of touching either local tree.
   // custom_nodes and models can still be handled remotely through ComfyUI-Manager's
   // HTTP API, but pip/apt have no remote equivalent.
-  const { dataBase, codeBase } = localRoots;
+  const { dataBase, customNodesBase, codeBase } = localRoots;
   const localMode = !isRemoteMode();
   const hasLocalDataFs = localMode && Boolean(dataBase);
   const hasLocalCodeFs = localMode && Boolean(codeBase);
@@ -1112,6 +1139,19 @@ async function applyManifestSections(
       );
       continue;
     }
+    if (localMode && looksLikeGitManifestSource(id) && !customNodesBase) {
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          "apply_manifest could not verify a local ComfyUI custom_nodes root for this Git source. " +
+            "The direct clone was refused; connect the panel to a reachable local ComfyUI " +
+            "whose live install or --base-directory is available, then retry.",
+        ),
+      );
+      continue;
+    }
     if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
@@ -1130,7 +1170,7 @@ async function applyManifestSections(
     // (#1715/#1770). Pip uses codeBase independently above.
     const installOutcome = installCustomNode({
       id,
-      ...(dataBase ? { comfyuiPath: dataBase } : {}),
+      ...(customNodesBase ? { comfyuiPath: customNodesBase } : {}),
     })
       .then((res) => ({ kind: "settled" as const, res }))
       .catch((err) => ({ kind: "error" as const, err }));
@@ -1154,6 +1194,13 @@ async function applyManifestSections(
           outcome.err instanceof Error ? outcome.err.message : String(outcome.err),
         ),
       );
+      continue;
+    }
+    if (outcome.res.mechanism === "git-clone") {
+      // The fallback has already verified the clone's destination and pack
+      // shape. Manager's installed-list endpoint cannot report an unregistered
+      // direct clone, especially when Manager itself is absent (#463).
+      results.push(report("custom_node", id, "applied", outcome.res.message));
       continue;
     }
     // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -15,7 +15,12 @@ import {
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-import { config, isRemoteMode } from "../config.js";
+import {
+  config,
+  getComfyUIBaseUrl,
+  getComfyuiTargetGeneration,
+  isRemoteMode,
+} from "../config.js";
 import {
   installCustomNode,
   installModelViaManager,
@@ -914,9 +919,9 @@ function remoteModelTarget(model: ComfyManifest["models"][number]): {
   return { name: filename, type, save_path, filename, category };
 }
 
-async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
+async function installedNodesOrEmpty(managerBase?: string): Promise<InstalledNode[]> {
   try {
-    return await listInstalledNodes();
+    return await listInstalledNodes({}, managerBase);
   } catch (err) {
     logger.warn("Could not list installed custom nodes before manifest apply", {
       error: err instanceof Error ? err.message : String(err),
@@ -928,6 +933,12 @@ async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
 export async function applyManifest(
   opts: ApplyManifestOptions,
 ): Promise<ApplyManifestResult> {
+  // Capture the HTTP target and its monotonic generation before the first
+  // await. Live root discovery below is asynchronous; if a panel retargets
+  // while it runs, the install path must refuse rather than pair the old root
+  // with a newly recaptured Manager target.
+  const managerBase = getComfyUIBaseUrl();
+  const targetGeneration = getComfyuiTargetGeneration();
   const manifest = await resolveManifest(opts);
 
   // Resolve the LOCAL ComfyUI data base this call should target, WITHOUT mutating the
@@ -960,6 +971,8 @@ export async function applyManifest(
     dataBase: localDataBase,
     customNodesBase: localCustomNodesBase,
     codeBase: localCodeBase,
+    managerBase,
+    targetGeneration,
   }, describeManifestSource(opts));
 }
 
@@ -1002,6 +1015,8 @@ async function applyManifestSections(
     dataBase: string | undefined;
     customNodesBase: string | undefined;
     codeBase: string | undefined;
+    managerBase: string;
+    targetGeneration: number;
   },
   source: string,
 ): Promise<ApplyManifestResult> {
@@ -1016,7 +1031,7 @@ async function applyManifestSections(
   // route pip/model handling remotely instead of touching either local tree.
   // custom_nodes and models can still be handled remotely through ComfyUI-Manager's
   // HTTP API, but pip/apt have no remote equivalent.
-  const { dataBase, customNodesBase, codeBase } = localRoots;
+  const { dataBase, customNodesBase, codeBase, managerBase, targetGeneration } = localRoots;
   const localMode = !isRemoteMode();
   const hasLocalDataFs = localMode && Boolean(dataBase);
   const hasLocalCodeFs = localMode && Boolean(codeBase);
@@ -1119,10 +1134,22 @@ async function applyManifestSections(
   let nodeBudgetSpent = false;
   // Even the INITIAL installed-list probe is budget-bounded — a hung Manager here
   // must not blow the tools/call timeout before we can report anything.
-  const initialList = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+  const initialList = await raceDeadline(installedNodesOrEmpty(managerBase), nodeDeadline);
   const installedNodes = initialList === BUDGET_TIMEOUT ? [] : initialList;
   if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
+    if (getComfyuiTargetGeneration() !== targetGeneration) {
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          "ComfyUI's target changed while apply_manifest was checking installed nodes. " +
+            "No install or local clone was attempted; retry after the target settles.",
+        ),
+      );
+      continue;
+    }
     const isPanelTarget = targetsPanelPackExactly(id);
     if (isPanelTarget) {
       // `apply_manifest` has a Manager target but no authoritative association
@@ -1164,6 +1191,8 @@ async function applyManifestSections(
       ...(looksLikeGitManifestSource(id)
         ? { localCloneFallback: "verified-only" as const }
         : {}),
+      managerBase,
+      targetGeneration,
     })
       .then((res) => ({ kind: "settled" as const, res }))
       .catch((err) => ({ kind: "error" as const, err }));
@@ -1205,11 +1234,23 @@ async function applyManifestSections(
     // reboot) and confirm the node is actually present before reporting success.
     // Budget-bounded too: if the confirm can't complete in time we report pending
     // (conservative — the install itself already settled) rather than overrun.
-    const verified = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+    const verified = await raceDeadline(installedNodesOrEmpty(managerBase), nodeDeadline);
     if (verified === BUDGET_TIMEOUT) {
       nodeBudgetSpent = true;
       stillInstalling.push(id);
       results.push(report("custom_node", id, "pending", formatStillInstallingMessage()));
+      continue;
+    }
+    if (getComfyuiTargetGeneration() !== targetGeneration) {
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          "ComfyUI's target changed while apply_manifest was verifying the install. " +
+            "The result was not reported as applied; retry after the target settles.",
+        ),
+      );
       continue;
     }
     if (nodeAlreadyInstalled(id, verified)) {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -201,6 +201,8 @@ interface ManagerFetchOptions {
   base?: string;
   /** Treat a non-2xx response as a soft failure (return undefined) instead of throwing. */
   soft?: boolean;
+  /** Preserve the status class that a soft capability probe observed. */
+  onSoftFailure?: (status: number | undefined) => void;
 }
 
 /**
@@ -294,7 +296,13 @@ async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
 ): Promise<T | undefined> {
-  const { method = "GET", body, base = managerBaseUrl(), soft = false } = options;
+  const {
+    method = "GET",
+    body,
+    base = managerBaseUrl(),
+    soft = false,
+    onSoftFailure,
+  } = options;
   const url = `${base}${path}`;
   logger.debug("Manager API request", { url, method });
 
@@ -309,7 +317,10 @@ async function managerFetch<T>(
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
   } catch (err) {
-    if (soft) return undefined;
+    if (soft) {
+      onSoftFailure?.(undefined);
+      return undefined;
+    }
     throw new NodeManagementError(
       `ComfyUI-Manager API unreachable at ${url}. Is ComfyUI running with ComfyUI-Manager installed? (${
         err instanceof Error ? err.message : String(err)
@@ -323,6 +334,7 @@ async function managerFetch<T>(
     // text, never a wrong conclusion. Verified there is no branch on this value.
     const text = await res.text().catch(() => "");
     if (soft) {
+      onSoftFailure?.(res.status);
       // A soft probe may ignore an absent route or a transient server error, but
       // authentication is actionable evidence. Returning undefined here made
       // detectManagerApi() fall through to its false "Manager is missing"
@@ -495,6 +507,9 @@ function looksLikeQueueStatus(s: unknown): boolean {
  */
 export type ManagerQueueAvailability = "available" | "absent" | "unreadable";
 
+/** Internal marker carried by the all-soft queue-generation probe. */
+const MANAGER_QUEUE_DETECTION_FAILURE = "manager-queue-detection";
+
 /**
  * Probe both queue/status dialects while preserving their HTTP status. This is
  * intentionally separate from `managerFetch(..., { soft: true })`, whose
@@ -659,13 +674,26 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
   // conclusion describes a server that may be gone and must not be pinned over
   // the newer state (#646).
   const stamp = managerApiCacheStamp();
-  const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { base, soft: true });
+  const queueStatusCodes: Array<number | undefined> = [undefined, undefined];
+  const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", {
+    base,
+    soft: true,
+    onSoftFailure: (status) => {
+      queueStatusCodes[0] = status;
+    },
+  });
   if (looksLikeQueueStatus(v2)) {
     const api = await resolveV2SubDialect(base);
     cacheManagerApi(base, api, stamp);
     return api;
   }
-  const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { base, soft: true });
+  const legacy = await managerFetch<QueueStatus>("/manager/queue/status", {
+    base,
+    soft: true,
+    onSoftFailure: (status) => {
+      queueStatusCodes[1] = status;
+    },
+  });
   if (looksLikeQueueStatus(legacy)) {
     // /manager/queue/status answering ALMOST always means the released 3.x
     // custom-node Manager — but do NOT brand it "legacy 3.x" (and speak 3.x
@@ -700,6 +728,11 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
       "nor /manager/queue/status answered with a queue status). Is ComfyUI-Manager " +
       "installed and enabled on the connected ComfyUI? The pip comfyui_manager " +
       "package only activates when ComfyUI is started with --enable-manager.",
+    {
+      kind: MANAGER_QUEUE_DETECTION_FAILURE,
+      base,
+      queueStatusCodes,
+    },
   );
 }
 
@@ -2615,16 +2648,18 @@ function discardFailedClone(
 }
 
 /**
- * Did ComfyUI-Manager REFUSE the enqueue outright, before queueing anything? (#1129)
+ * Did ComfyUI-Manager reject the route outright, before queueing anything?
  *
- * A git-URL install is gated server-side by `security_level` and
- * `allow_git_url_install`, and a legacy 3.x host that does not serve the route at
- * all answers the same way. All three arrive as a status on the POST itself:
+ * A legacy 3.x git-URL route can be absent, and a Manager-native install can be
+ * refused before queueing by its `security_level` / `allow_git_url_install`
+ * policy. Both arrive as a status on the POST itself:
  *
- *   403 — "A security error has occurred" (the policy gate)
  *   404 — the route is not registered on this build
  *
- * 405 is deliberately NOT here. On this API it is the DIALECT-MISMATCH signal
+ * 403 is admitted only when Manager's body explicitly names its own
+ * `security_level` / `allow_git_url_install` policy gate. A bare 403 may be an
+ * authentication/permission layer and stays fail-closed. 405 is deliberately
+ * NOT here. On this API it is the DIALECT-MISMATCH signal
  * (ComfyUI's frontend catchall answering a route registered under the other
  * generation), and the self-heal retry in #646 already owns it — diverting to a
  * clone would pre-empt a Manager install that is about to succeed on the right
@@ -2636,14 +2671,79 @@ function discardFailedClone(
  * That is the whole warrant for continuing — and it is why 5xx is excluded, where
  * a task may well have been accepted before the handler fell over.
  *
- * Returns the status, or undefined when the failure is anything else (a transport
- * error, a timeout, a 500) and must keep propagating.
+ * Returns 404, or the explicitly Manager-owned policy 403, or undefined when the
+ * failure is anything else (including 401, bare 403, 407, a transport error, a
+ * timeout, or a 500) and must keep propagating.
  */
 function managerEnqueueRefusal(err: unknown): number | undefined {
   if (!(err instanceof NodeManagementError)) return undefined;
-  const status = (err.details as { status?: unknown } | undefined)?.status;
+  const details = err.details as { status?: unknown; body?: unknown; url?: unknown } | undefined;
+  const status = details?.status;
+  const url = details?.url;
   if (typeof status !== "number") return undefined;
-  return status === 403 || status === 404 ? status : undefined;
+  if (
+    typeof url !== "string" ||
+    !/\/manager\/queue\/(?:task|install)(?:[?#]|$)/.test(url)
+  ) {
+    return undefined;
+  }
+  if (status === 404) return status;
+  if (
+    status === 403 &&
+    typeof details?.body === "string" &&
+    /security_level|allow_git_url_install/i.test(details.body)
+  ) {
+    return status;
+  }
+  return undefined;
+}
+
+function isManagerQueueDetectionFailure(err: unknown): boolean {
+  if (!(err instanceof NodeManagementError) || !err.details || typeof err.details !== "object") {
+    return false;
+  }
+  return (err.details as { kind?: unknown }).kind === MANAGER_QUEUE_DETECTION_FAILURE;
+}
+
+function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
+  if (!(err instanceof NodeManagementError) || !err.details || typeof err.details !== "object") {
+    return false;
+  }
+  const codes = (err.details as { queueStatusCodes?: unknown }).queueStatusCodes;
+  return (
+    Array.isArray(codes) &&
+    codes.length === 2 &&
+    codes.every((status) => status === 404)
+  );
+}
+
+/**
+ * A direct clone is safe after either a Manager-native policy refusal whose body
+ * explicitly proves no task was queued, or a route-level absence plus a fresh
+ * probe proving BOTH queue dialects are 404 on the same captured ComfyUI base.
+ * A bare 401/403/407, timeout, 5xx, malformed response, or unrelated reachability
+ * error remains fail-closed.
+ */
+async function managerAbsenceAllowsGitFallback(
+  err: unknown,
+  base: string,
+): Promise<boolean> {
+  const status = errorStatus(err);
+  const preQueueRefusal = managerEnqueueRefusal(err);
+  if (preQueueRefusal === 403) return true;
+  const routeWasAbsent = preQueueRefusal === 404;
+  if (status !== undefined && !routeWasAbsent) return false;
+  if (
+    status === undefined &&
+    (!isManagerQueueDetectionFailure(err) || !initialManagerQueueAbsenceWasProven(err))
+  ) {
+    return false;
+  }
+  try {
+    return (await probeManagerQueueAvailability(base)) === "absent";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -3212,7 +3312,9 @@ async function installCustomNodeImpl(
       // A remote target keeps the original error: the clone would write to a
       // LOCAL tree that is not the server we are connected to, so "the Manager
       // refused" is the honest and complete answer there.
-      if (refusedBy === undefined || isRemoteMode()) throw err;
+      if (isRemoteMode() || !(await managerAbsenceAllowsGitFallback(err, managerBase))) {
+        throw err;
+      }
       // BEFORE the log line, which says "cloning directly" and would otherwise be
       // recording an action that then does not happen.
       if (localWriteMismatch) {
@@ -3220,18 +3322,32 @@ async function installCustomNodeImpl(
           wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
-      logger.info("Manager refused the git install enqueue — cloning directly", {
+      logger.info("Manager refused or was proven absent — cloning directly", {
         status: refusedBy,
         gitId,
       });
       return withCliNote(
-        await cloneCustomNodeFallback(gitId, repoName, gitRef, { manager_refused: refusedBy }, cliWorkspace, {
-          refFromVersion,
-          managerRefusalNote:
-            `ComfyUI-Manager REFUSED the git-URL install (HTTP ${refusedBy}) — on a legacy 3.x ` +
-            `host that is its security_level / allow_git_url_install gate, or a build that does ` +
-            `not serve the route. Nothing was queued there.`,
-        }),
+        await cloneCustomNodeFallback(
+          gitId,
+          repoName,
+          gitRef,
+          refusedBy === 403 || refusedBy === 404
+            ? { manager_refused: refusedBy }
+            : { manager_absent: true },
+          cliWorkspace,
+          {
+            refFromVersion,
+            managerRefusalNote:
+              refusedBy === 403
+                ? `ComfyUI-Manager REFUSED the git-URL install (HTTP 403) via its ` +
+                  `security_level / allow_git_url_install policy gate. Nothing was queued there.`
+                : refusedBy === 404
+                  ? `ComfyUI-Manager's git-install route returned HTTP 404, and a fresh probe confirmed ` +
+                    `both queue/status dialects are absent. Nothing was queued there.`
+                  : `ComfyUI-Manager is confirmed absent: both queue/status dialects returned HTTP 404 ` +
+                    `on the connected ComfyUI. Nothing was queued there.`,
+          },
+        ),
       );
     }
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2,7 +2,12 @@ import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
-import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
+import {
+  config,
+  getComfyUIBaseUrl,
+  getComfyuiTargetGeneration,
+  isRemoteMode,
+} from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
@@ -2318,11 +2323,22 @@ export interface PackPresenceContext {
 }
 
 /** Capture the presence context for one operation, before its first await. */
-export function capturePackPresenceContext(diskRoot?: string): PackPresenceContext {
+export interface PackPresenceCaptureOptions {
+  /** Do not consult the shared configured/saved root when no call-scoped root exists. */
+  allowConfiguredFallback?: boolean;
+}
+
+export function capturePackPresenceContext(
+  diskRoot?: string,
+  options: PackPresenceCaptureOptions = {},
+): PackPresenceContext {
   const remote = isRemoteMode();
   return {
     remote,
-    diskRoot: remote ? undefined : (diskRoot ?? resolveEffectiveComfyUIBase()),
+    diskRoot:
+      remote || (diskRoot === undefined && options.allowConfiguredFallback === false)
+        ? undefined
+        : (diskRoot ?? resolveEffectiveComfyUIBase()),
   };
 }
 
@@ -3097,6 +3113,10 @@ export interface InstallOptions {
   /** The caller has already resolved the only safe local clone root. When set,
    *  an absent comfyuiPath means Manager-only, never a second local-root lookup. */
   localCloneFallback?: "verified-only";
+  /** Call-scoped Manager base captured with the target generation at operation entry. */
+  managerBase?: string;
+  /** Monotonic ComfyUI target generation captured with managerBase. */
+  targetGeneration?: number;
 }
 
 /**
@@ -3196,6 +3216,24 @@ async function resolveInstallLocalWorkspace(
   return resolveEffectiveComfyUIBase();
 }
 
+function assertInstallTargetStable(
+  expectedGeneration: number,
+  managerBase: string,
+): void {
+  const actualGeneration = getComfyuiTargetGeneration();
+  if (actualGeneration === expectedGeneration) return;
+  throw new ProcessControlError(
+    "ComfyUI's target changed while this custom-node install was being prepared. " +
+      "The Manager request and any local clone were refused; retry after the target settles.",
+    {
+      kind: "target-generation-changed",
+      managerBase,
+      expectedGeneration,
+      actualGeneration,
+    },
+  );
+}
+
 async function installCustomNodeImpl(
   opts: InstallOptions,
 ): Promise<NodeOpResult> {
@@ -3237,12 +3275,16 @@ async function installCustomNodeImpl(
   // With COMFYUI_PATH unset, a live custom_nodes root is required; a saved
   // default is machine-local configuration, not proof of what this panel target
   // scans.
-  const managerBase = managerBaseUrl();
+  const managerBase = opts.managerBase ?? managerBaseUrl();
+  const targetGeneration = opts.targetGeneration ?? getComfyuiTargetGeneration();
   const cliWorkspace =
     source === "git" || opts.useCmCli
       ? await resolveInstallLocalWorkspace(opts)
       : opts.comfyuiPath ?? resolveEffectiveComfyUIBase();
-  const presenceCtx = capturePackPresenceContext(cliWorkspace);
+  assertInstallTargetStable(targetGeneration, managerBase);
+  const presenceCtx = capturePackPresenceContext(cliWorkspace, {
+    allowConfiguredFallback: cliWorkspace !== undefined,
+  });
   // #1765 — and is that root the install this session is actually CONNECTED to?
   // Pinned to the very cliWorkspace the write will use, so a panel retarget
   // mid-call cannot judge one install's root against another's server.
@@ -3254,6 +3296,7 @@ async function installCustomNodeImpl(
     source === "git" || opts.useCmCli === true
       ? await detectLocalWriteTargetMismatch(cliWorkspace)
       : undefined;
+  assertInstallTargetStable(targetGeneration, managerBase);
   // THE PRE-STATE, OBSERVED BEFORE THE OPERATION (codex gate P0). The "already
   // installed" verdict below used to be inferred from POST-op disk state alone:
   // a pack that was absent before the call and installed as a registry ZIP —
@@ -3372,7 +3415,10 @@ async function installCustomNodeImpl(
       // A remote target keeps the original error: the clone would write to a
       // LOCAL tree that is not the server we are connected to, so "the Manager
       // refused" is the honest and complete answer there.
-      if (isRemoteMode() || !(await managerAbsenceAllowsGitFallback(err, managerBase))) {
+      assertInstallTargetStable(targetGeneration, managerBase);
+      const absenceAllows = await managerAbsenceAllowsGitFallback(err, managerBase);
+      assertInstallTargetStable(targetGeneration, managerBase);
+      if (isRemoteMode() || !absenceAllows) {
         throw err;
       }
       // BEFORE the log line, which says "cloning directly" and would otherwise be
@@ -3386,31 +3432,32 @@ async function installCustomNodeImpl(
         status: refusedBy,
         gitId,
       });
-      return withCliNote(
-        await cloneCustomNodeFallback(
-          gitId,
-          repoName,
-          gitRef,
-          refusedBy === 403 || refusedBy === 404
-            ? { manager_refused: refusedBy }
-            : { manager_absent: true },
-          cliWorkspace,
-          {
-            refFromVersion,
-            allowSharedWorkspaceFallback: cliWorkspace !== undefined,
-            managerRefusalNote:
-              refusedBy === 403
-                ? `ComfyUI-Manager REFUSED the git-URL install (HTTP 403) via its ` +
-                  `security_level / allow_git_url_install policy gate. Nothing was queued there.`
-                : refusedBy === 404
-                  ? `ComfyUI-Manager's git-install route returned HTTP 404 before queueing. ` +
-                    `Nothing was queued there.`
-                  : `ComfyUI-Manager is confirmed absent: both queue/status dialects returned HTTP 404 ` +
-                    `on the connected ComfyUI. Nothing was queued there.`,
-          },
-        ),
+      const cloned = await cloneCustomNodeFallback(
+        gitId,
+        repoName,
+        gitRef,
+        refusedBy === 403 || refusedBy === 404
+          ? { manager_refused: refusedBy }
+          : { manager_absent: true },
+        cliWorkspace,
+        {
+          refFromVersion,
+          allowSharedWorkspaceFallback: cliWorkspace !== undefined,
+          managerRefusalNote:
+            refusedBy === 403
+              ? `ComfyUI-Manager REFUSED the git-URL install (HTTP 403) via its ` +
+                `security_level / allow_git_url_install policy gate. Nothing was queued there.`
+              : refusedBy === 404
+                ? `ComfyUI-Manager's git-install route returned HTTP 404 before queueing. ` +
+                  `Nothing was queued there.`
+                : `ComfyUI-Manager is confirmed absent: both queue/status dialects returned HTTP 404 ` +
+                  `on the connected ComfyUI. Nothing was queued there.`,
+        },
       );
+      assertInstallTargetStable(targetGeneration, managerBase);
+      return withCliNote(cloned);
     }
+    assertInstallTargetStable(targetGeneration, managerBase);
 
     // VERIFY: /v2/customnode/installed reflects on-disk custom_nodes, so a
     // freshly-cloned pack shows up even before a reboot. If the Manager actually
@@ -3418,6 +3465,7 @@ async function installCustomNodeImpl(
     const installed = await listInstalledNodesAt(managerBase).catch(
       () => [] as InstalledNode[],
     );
+    assertInstallTargetStable(targetGeneration, managerBase);
     if (nodeInstalledMatches(gitId, installed)) {
       return withCliNote({
         mechanism: "manager-http",
@@ -3430,12 +3478,12 @@ async function installCustomNodeImpl(
         wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
       );
     }
-    return withCliNote(
-      await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
-        refFromVersion,
-        allowSharedWorkspaceFallback: cliWorkspace !== undefined,
-      }),
-    );
+    const cloned = await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
+      refFromVersion,
+      allowSharedWorkspaceFallback: cliWorkspace !== undefined,
+    });
+    assertInstallTargetStable(targetGeneration, managerBase);
+    return withCliNote(cloned);
   }
 
   // Registry (plain CNR id). Keep the prior defaults channel "default" /
@@ -3451,10 +3499,12 @@ async function installCustomNodeImpl(
     channel,
     mode,
   }, managerBase);
+  assertInstallTargetStable(targetGeneration, managerBase);
   // #797: verify across BOTH sources (Manager list + local disk) and keep
   // "could not determine" distinct from "determined absent" — an unreadable
   // Manager list collapsed to [] used to read as "not found in the registry".
   const presence = await resolvePackPresence(id, managerBase, presenceCtx);
+  assertInstallTargetStable(targetGeneration, managerBase);
   switch (presence.state) {
     case "manager-listed":
       return withCliNote({
@@ -5340,8 +5390,9 @@ async function listInstalledNodesAt(
 
 export async function listInstalledNodes(
   opts: ListInstalledOptions = {},
+  base = managerBaseUrl(),
 ): Promise<InstalledNode[]> {
-  return listInstalledNodesAt(managerBaseUrl(), opts);
+  return listInstalledNodesAt(base, opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2656,9 +2656,10 @@ function discardFailedClone(
  *
  *   404 — the route is not registered on this build
  *
- * 403 is admitted only when Manager's body explicitly names its own
- * `security_level` / `allow_git_url_install` policy gate. A bare 403 may be an
- * authentication/permission layer and stays fail-closed. 405 is deliberately
+ * 403 is admitted only when Manager's authoritative JSON error shape names its
+ * own policy gate, or when one of the exact legacy Manager policy responses is
+ * present. A bare 403 may be an authentication/permission layer and stays
+ * fail-closed. 405 is deliberately
  * NOT here. On this API it is the DIALECT-MISMATCH signal
  * (ComfyUI's frontend catchall answering a route registered under the other
  * generation), and the self-heal retry in #646 already owns it — diverting to a
@@ -2675,6 +2676,34 @@ function discardFailedClone(
  * failure is anything else (including 401, bare 403, 407, a transport error, a
  * timeout, or a 500) and must keep propagating.
  */
+const LEGACY_MANAGER_SECURITY_ERROR =
+  "A security error has occurred. Please check the terminal logs";
+
+/**
+ * Keep the old plain-text Manager response working without treating arbitrary
+ * response text as proof of Manager ownership. JSON is the current authoritative
+ * Manager shape; the two exact strings are retained for the legacy response and
+ * the existing local compatibility fixture.
+ */
+function isManagerOwnedGitPolicy403(body: unknown): boolean {
+  if (typeof body !== "string") return false;
+  const text = body.trim();
+  if (
+    text === LEGACY_MANAGER_SECURITY_ERROR ||
+    text === "gated by security_level"
+  ) {
+    return true;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+    const reason = (parsed as { error?: unknown }).error;
+    return reason === "security_level" || reason === "allow_git_url_install";
+  } catch {
+    return false;
+  }
+}
+
 function managerEnqueueRefusal(err: unknown): number | undefined {
   if (!(err instanceof NodeManagementError)) return undefined;
   const details = err.details as { status?: unknown; body?: unknown; url?: unknown } | undefined;
@@ -2690,8 +2719,7 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
   if (status === 404) return status;
   if (
     status === 403 &&
-    typeof details?.body === "string" &&
-    /security_level|allow_git_url_install/i.test(details.body)
+    isManagerOwnedGitPolicy403(details?.body)
   ) {
     return status;
   }
@@ -2719,8 +2747,9 @@ function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
 
 /**
  * A direct clone is safe after either a Manager-native policy refusal whose body
- * explicitly proves no task was queued, or a route-level absence plus a fresh
- * probe proving BOTH queue dialects are 404 on the same captured ComfyUI base.
+ * explicitly proves no task was queued, a direct enqueue route-level 404, or a
+ * detection failure followed by a fresh probe proving BOTH queue dialects are
+ * 404 on the same captured ComfyUI base.
  * A bare 401/403/407, timeout, 5xx, malformed response, or unrelated reachability
  * error remains fail-closed.
  */
@@ -2730,9 +2759,12 @@ async function managerAbsenceAllowsGitFallback(
 ): Promise<boolean> {
   const status = errorStatus(err);
   const preQueueRefusal = managerEnqueueRefusal(err);
-  if (preQueueRefusal === 403) return true;
-  const routeWasAbsent = preQueueRefusal === 404;
-  if (status !== undefined && !routeWasAbsent) return false;
+  // The enqueue route's own 404 is already a pre-queue refusal. Preserve the
+  // legacy contract that authorized a direct clone on that route-level fact;
+  // the fresh status probes are required only for the new detection-failure
+  // path, where the enqueue error carries no route-level refusal.
+  if (preQueueRefusal === 403 || preQueueRefusal === 404) return true;
+  if (status !== undefined) return false;
   if (
     status === undefined &&
     (!isManagerQueueDetectionFailure(err) || !initialManagerQueueAbsenceWasProven(err))
@@ -3342,8 +3374,8 @@ async function installCustomNodeImpl(
                 ? `ComfyUI-Manager REFUSED the git-URL install (HTTP 403) via its ` +
                   `security_level / allow_git_url_install policy gate. Nothing was queued there.`
                 : refusedBy === 404
-                  ? `ComfyUI-Manager's git-install route returned HTTP 404, and a fresh probe confirmed ` +
-                    `both queue/status dialects are absent. Nothing was queued there.`
+                  ? `ComfyUI-Manager's git-install route returned HTTP 404 before queueing. ` +
+                    `Nothing was queued there.`
                   : `ComfyUI-Manager is confirmed absent: both queue/status dialects returned HTTP 404 ` +
                     `on the connected ComfyUI. Nothing was queued there.`,
           },

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -25,6 +25,7 @@ import {
   detectLocalWriteTargetMismatch,
   resolveEffectiveComfyUIBase,
   resolveEffectiveComfyUICodeBase,
+  resolveCustomNodesScanBaseLiveStrict,
   resolveInstallInterpreter,
 } from "./workspace-env.js";
 import {
@@ -2654,7 +2655,9 @@ function discardFailedClone(
  * refused before queueing by its `security_level` / `allow_git_url_install`
  * policy. Both arrive as a status on the POST itself:
  *
- *   404 — the route is not registered on this build
+ *   404 — the route is not registered on this build. Git installs use
+ *   `/manager/queue/install`, `/v2/manager/queue/task`, or the legacy-UI
+ *   `/v2/manager/queue/batch` envelope.
  *
  * 403 is admitted only when Manager's authoritative JSON error shape names its
  * own policy gate, or when one of the exact legacy Manager policy responses is
@@ -2712,7 +2715,7 @@ function managerEnqueueRefusal(err: unknown): number | undefined {
   if (typeof status !== "number") return undefined;
   if (
     typeof url !== "string" ||
-    !/\/manager\/queue\/(?:task|install)(?:[?#]|$)/.test(url)
+    !/\/manager\/queue\/(?:task|install|batch)(?:[?#]|$)/.test(url)
   ) {
     return undefined;
   }
@@ -2849,15 +2852,19 @@ async function cloneCustomNodeFallback(
     /** #1470 — did `gitRef` come from the `version` selector rather than an explicit
      *  `ref`? Only a version-derived ref may be skipped when the repo does not have it. */
     refFromVersion?: boolean;
+    /** Do not re-read the shared saved-default resolver when the caller's
+     *  call-scoped target was deliberately unavailable. */
+    allowSharedWorkspaceFallback?: boolean;
   },
 ): Promise<NodeOpResult> {
   const because =
     opts?.managerRefusalNote ?? `"${repoName}" is not in the ComfyUI-Manager registry`;
-  // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
-  // adopted saved-default/live root here WITHOUT mutating global config, so a
-  // panel-connected local session with no COMFYUI_PATH can still clone an
-  // unregistered git pack); fall back to the shared data/base resolver.
-  const comfyuiBase = basePath ?? resolveEffectiveComfyUIBase();
+  // basePath is the CALL-SCOPED local ComfyUI root. When the caller has already
+  // established that no safe root exists, do not re-read the saved-default
+  // resolver and recreate the wrong-machine clone hazard.
+  const comfyuiBase =
+    basePath ??
+    (opts?.allowSharedWorkspaceFallback === false ? undefined : resolveEffectiveComfyUIBase());
   // Same hazard as the CLI paths (codex gate P0): the guard below catches "no
   // path", but the dangerous case is HAVING one while connected elsewhere. A
   // clone into a stale local tree would report a successful install of a pack the
@@ -3084,8 +3091,12 @@ export interface InstallOptions {
   /** CALL-SCOPED local ComfyUI data/base root for the git-clone / ref-checkout
    *  fallback, threaded by callers (e.g. apply_manifest) that resolve an adopted
    *  saved-default/live `--base-directory` WITHOUT mutating global config. Falls
-   *  back to the shared data/base resolver when omitted. */
+   *  back to verified live custom_nodes evidence when COMFYUI_PATH is unset; it
+   *  does not authorize a saved default by itself. */
   comfyuiPath?: string;
+  /** The caller has already resolved the only safe local clone root. When set,
+   *  an absent comfyuiPath means Manager-only, never a second local-root lookup. */
+  localCloneFallback?: "verified-only";
 }
 
 /**
@@ -3165,6 +3176,26 @@ function comfyCliUnavailableReason(workspace: string | undefined): string | unde
   return undefined;
 }
 
+async function resolveInstallLocalWorkspace(
+  opts: InstallOptions,
+): Promise<string | undefined> {
+  if (opts.comfyuiPath !== undefined) return opts.comfyuiPath;
+  if (opts.localCloneFallback === "verified-only") return undefined;
+
+  // An unset COMFYUI_PATH is not permission to use the saved default. The
+  // connected local server must identify a usable custom_nodes scan root, or
+  // this operation remains Manager-only. This resolver never throws for an
+  // unavailable/ambiguous live root; the Manager attempt still proceeds.
+  if (!process.env.COMFYUI_PATH && !isRemoteMode()) {
+    try {
+      return await resolveCustomNodesScanBaseLiveStrict({ requireLive: true });
+    } catch {
+      return undefined;
+    }
+  }
+  return resolveEffectiveComfyUIBase();
+}
+
 async function installCustomNodeImpl(
   opts: InstallOptions,
 ): Promise<NodeOpResult> {
@@ -3200,24 +3231,21 @@ async function installCustomNodeImpl(
   if (source === "git") assertSafeGitUrl(gitId);
 
   // Keep the mutation, its post-queue verification, AND any local filesystem
-  // work on the target selected for this invocation — captured NOW, before the
-  // first await: a panel retarget in between must not split them across two
-  // installs. cliWorkspace is the pack/data root (COMFYUI_PATH, an adopted
-  // live `--base-directory`, or the saved default); the CLI --workspace, the
-  // ref checkout, and the clone fallback all take this ONE root, so a git
-  // install with a ref can never install into the workspace and then fail the
-  // checkout for want of a path (codex gate rounds 5-6).
+  // work on the target selected for this invocation. The Manager base is
+  // captured before the live-root lookup so a panel retarget cannot move the
+  // HTTP half of this operation while the filesystem target is being verified.
+  // With COMFYUI_PATH unset, a live custom_nodes root is required; a saved
+  // default is machine-local configuration, not proof of what this panel target
+  // scans.
   const managerBase = managerBaseUrl();
-  const cliWorkspace = opts.comfyuiPath ?? resolveEffectiveComfyUIBase();
+  const cliWorkspace =
+    source === "git" || opts.useCmCli
+      ? await resolveInstallLocalWorkspace(opts)
+      : opts.comfyuiPath ?? resolveEffectiveComfyUIBase();
   const presenceCtx = capturePackPresenceContext(cliWorkspace);
   // #1765 — and is that root the install this session is actually CONNECTED to?
   // Pinned to the very cliWorkspace the write will use, so a panel retarget
   // mid-call cannot judge one install's root against another's server.
-  //
-  // AFTER presenceCtx, deliberately: this is the first await in the function, and
-  // capturePackPresenceContext must be taken at operation ENTRY from the mode and
-  // config as they are NOW (codex gate round 11 — computing it after an await lets
-  // a mid-op retarget pair Manager A's answer with disk B).
   //
   // Taken only when a LOCAL write is reachable for this call: a registry install
   // goes through ComfyUI-Manager, which targets the connected server by
@@ -3369,6 +3397,7 @@ async function installCustomNodeImpl(
           cliWorkspace,
           {
             refFromVersion,
+            allowSharedWorkspaceFallback: cliWorkspace !== undefined,
             managerRefusalNote:
               refusedBy === 403
                 ? `ComfyUI-Manager REFUSED the git-URL install (HTTP 403) via its ` +
@@ -3402,7 +3431,10 @@ async function installCustomNodeImpl(
       );
     }
     return withCliNote(
-      await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, { refFromVersion }),
+      await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
+        refFromVersion,
+        allowSharedWorkspaceFallback: cliWorkspace !== undefined,
+      }),
     );
   }
 

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -293,6 +293,10 @@ export async function resolveEffectiveComfyUIBaseLive(): Promise<string | undefi
  *      currently unavailable on disk.
  *   4. Else the configured data base (offline / unreachable).
  *
+ * Callers making a panel-connected clone decision may pass `requireLive:true`
+ * to suppress step 4. A saved default is useful for offline authoring, but it
+ * is not proof that the live panel target scans that directory.
+ *
  * Remote mode → undefined. Never throws. `node_pack` (scaffold / verify /
  * write / read / patch / git / publish-by-name) threads this so authoring and
  * verification cannot target different roots.
@@ -302,7 +306,14 @@ interface CustomNodesScanBaseLiveOutcome {
   unavailableBaseDirectory: string | undefined;
 }
 
-async function customNodesScanBaseLiveOutcome(): Promise<CustomNodesScanBaseLiveOutcome> {
+export interface CustomNodesScanBaseLiveOptions {
+  /** Do not fall back to configuration when live evidence is unavailable. */
+  requireLive?: boolean;
+}
+
+async function customNodesScanBaseLiveOutcome(
+  options: CustomNodesScanBaseLiveOptions = {},
+): Promise<CustomNodesScanBaseLiveOutcome> {
   if (isRemoteMode()) return { base: undefined, unavailableBaseDirectory: undefined };
 
   const snapshot = await getLiveServerSnapshot();
@@ -330,11 +341,16 @@ async function customNodesScanBaseLiveOutcome(): Promise<CustomNodesScanBaseLive
       return { base: live.root, unavailableBaseDirectory: undefined };
     }
   }
+  if (options.requireLive) {
+    return { base: undefined, unavailableBaseDirectory: undefined };
+  }
   return { base: resolveEffectiveComfyUIBase(), unavailableBaseDirectory: undefined };
 }
 
-export async function resolveCustomNodesScanBaseLive(): Promise<string | undefined> {
-  return (await customNodesScanBaseLiveOutcome()).base;
+export async function resolveCustomNodesScanBaseLive(
+  options?: CustomNodesScanBaseLiveOptions,
+): Promise<string | undefined> {
+  return (await customNodesScanBaseLiveOutcome(options)).base;
 }
 
 /**
@@ -344,8 +360,10 @@ export async function resolveCustomNodesScanBaseLive(): Promise<string | undefin
  * to COMFYUI_PATH. That fallback is unsafe when ComfyUI itself has already
  * selected a different, currently unavailable scan root.
  */
-export async function resolveCustomNodesScanBaseLiveStrict(): Promise<string | undefined> {
-  const result = await customNodesScanBaseLiveOutcome();
+export async function resolveCustomNodesScanBaseLiveStrict(
+  options?: CustomNodesScanBaseLiveOptions,
+): Promise<string | undefined> {
+  const result = await customNodesScanBaseLiveOutcome(options);
   if (result.unavailableBaseDirectory !== undefined) {
     throw new ValidationError(
       `The connected ComfyUI declares --base-directory "${result.unavailableBaseDirectory}" ` +


### PR DESCRIPTION
## Summary\n- keep Manager-capable panel-connected installs working when ComfyUI-Manager is genuinely absent\n- allow direct Git fallback only after route-level 404, exact Manager security-policy 403, or both queue/status dialects returning 404 plus a fresh same-base probe\n- cover legacy, v2 task, and v2-batch queue routes\n- pin Manager target/base and live filesystem target generation through async manifest work; refuse stale or unverified roots to prevent wrong-machine clones\n- preserve Manager-only installs when no local root is available\n\nCloses #463\n\n## Validation\n- 7 related suites: 416 passed\n- node-management suite: 192 passed\n- final independent review: SHIP / SHIP\n- TypeScript lint and diff checks passed\n- retarget-during-probe, auth, malformed, 5xx, 405, batch, and apply_manifest integration regressions included