### PR TITLE
chore(release): v0.52.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.78] - 2026-08-23
+
+### MCP
+
+#### Fixed
+- pin manifest install target generation and Manager-only fallback (#463)
+- close manager-only manifest clone gap
+- gate manager queue clone fallback
+- fall back when Manager is proven absent
+
+
 ## [0.52.77] - 2026-08-23
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.77",
+  "version": "0.52.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.77",
+      "version": "0.52.78",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.77",
+  "version": "0.52.78",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary\n- release comfyui-mcp v0.52.78\n- include the #463 apply_manifest Manager-only fallback and target-pinning fix\n\n## Validation\n- release metadata and changelog updated\n- PR #2153 CI passed on macOS, Ubuntu, Windows, smoke, and packs\n\nAfter merge, tag the merge commit as v0.52.78.