### PR TITLE
fix(codex): explain bare Bad Request turns

### DIFF
--- a/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
+++ b/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
@@ -218,6 +218,52 @@ describe("CodexBackend interrupt recovery", () => {
     await expect(iterator.next()).resolves.toMatchObject({ done: true });
   });
 
+  it("surfaces the bare app-server Bad Request as an actionable 400 diagnosis (#2112)", async () => {
+    const client = {
+      notificationHandler: null as ((message: unknown) => void) | null,
+      exitError: null,
+      exitPromise: new Promise(() => {}),
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/start") {
+          return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
+        }
+        if (method === "turn/start") return { turn: { id: "turn-1" } };
+        throw new Error(`unexpected request: ${method}`);
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend = new CodexBackend({ model: "gpt-5.6-sol" });
+    Object.assign(backend, { client });
+
+    async function* channel() {
+      yield { text: "continue" };
+    }
+
+    const iterator = backend.run({ channel: channel() });
+    await iterator.next();
+    const errorEvent = iterator.next();
+    for (let attempt = 0; attempt < 10 && !(backend as any).turnId; attempt += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    client.notificationHandler?.({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: false,
+        error: { message: '{"detail":"Bad Request"}' },
+      },
+    });
+
+    await expect(errorEvent).resolves.toMatchObject({
+      value: { type: "error", message: expect.stringContaining("HTTP 400 Bad Request") },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: "result", ok: false, subtype: "error" },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
   it("keeps a responsive client and bounds an unresponsive one", async () => {
     const responsive = {
       request: vi.fn().mockResolvedValue({}),

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -45,6 +45,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
 import { errorText, messageText, promptText } from "./error-text.js";
+import { formatCodexTurnError } from "./codex-error.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -1715,9 +1716,9 @@ export class CodexBackend implements AgentBackend {
           // "Reconnecting... 2/5" as the final failure. `error` is in the turn
           // liveness set, so this already re-armed the watchdog — keep waiting
           // for either a later terminal error or turn/completed.
-          const e = (params.error ?? {}) as { message?: string };
+          const e = params.error ?? {};
           if (params.willRetry === true) break;
-          const message = e.message ?? "Codex error";
+          const message = formatCodexTurnError(e);
           // #1929 / #2045 — a Windows sharing-violation or stale WinGet path on
           // the bundled code-mode host is the same transient /restart recovered.
           if (tryRetryCodeModeHostSpawn(message)) break;

--- a/src/orchestrator/codex-error.test.ts
+++ b/src/orchestrator/codex-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { formatCodexTurnError } from "./codex-error.js";
+
+describe("formatCodexTurnError (#2112)", () => {
+  it("turns the reported JSON-string Bad Request into an actionable unknown-400 diagnosis", () => {
+    const text = formatCodexTurnError({ message: '{"detail":"Bad Request"}' });
+
+    expect(text).toContain("HTTP 400 Bad Request");
+    expect(text).toContain("no error code or request id");
+    expect(text).toContain("oversized context or tool history");
+    expect(text).toContain("Retry once");
+    expect(text).not.toContain('{"detail":"Bad Request"}');
+  });
+
+  it("preserves safe provider diagnostics without dumping arbitrary request data", () => {
+    const text = formatCodexTurnError({
+      status: 400,
+      message: "Bad Request",
+      code: "invalid_request_error",
+      type: "invalid_request",
+      request_id: "req_abc123",
+      input: "secret prompt content that must not reach the panel",
+      data: { raw_body: "do not copy this" },
+    });
+
+    expect(text).toContain("code=invalid_request_error");
+    expect(text).toContain("type=invalid_request");
+    expect(text).toContain("request_id=req_abc123");
+    expect(text).not.toContain("secret prompt");
+    expect(text).not.toContain("do not copy this");
+    expect(text).not.toContain("no error code or request id");
+  });
+
+  it("finds diagnostics nested in the app-server data envelope", () => {
+    const text = formatCodexTurnError({
+      message: "Bad Request",
+      data: { code: "context_length_exceeded", type: "invalid_request_error", request_id: "req_nested" },
+    });
+
+    expect(text).toContain("code=context_length_exceeded");
+    expect(text).toContain("type=invalid_request_error");
+    expect(text).toContain("request_id=req_nested");
+  });
+
+  it("recognizes numeric and nested 400 markers without reflecting a prompt-bearing message", () => {
+    const text = formatCodexTurnError({
+      code: 400,
+      message: "Bad Request: secret prompt content",
+      details: { status: 400, request_id: "req_numeric" },
+    });
+
+    expect(text).toContain("HTTP 400 Bad Request");
+    expect(text).toContain("request_id=req_numeric");
+    expect(text).not.toContain("secret prompt");
+  });
+
+  it("does not rewrite non-400 provider errors", () => {
+    expect(formatCodexTurnError({ message: "provider unavailable", status: 503 })).toBe("provider unavailable");
+    expect(formatCodexTurnError({ message: "" })).toBe("");
+    expect(formatCodexTurnError({})).toBe("Codex error");
+  });
+});

--- a/src/orchestrator/codex-error.ts
+++ b/src/orchestrator/codex-error.ts
@@ -1,0 +1,150 @@
+/**
+ * Turn the app-server's provider error payload into a useful, scrubbed panel
+ * diagnostic (#2112).
+ *
+ * Codex has emitted both a plain `Bad Request` message and a JSON string such
+ * as `{\"detail\":\"Bad Request\"}`. Forwarding either verbatim leaves the
+ * user unable to distinguish an oversized context/tool history from an invalid
+ * request or a transient provider rejection. Keep the extraction deliberately
+ * narrow: provider error objects may contain request content, so only the
+ * documented diagnostic-shaped fields are copied into the user-facing text.
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+function record(value: unknown): UnknownRecord | null {
+  try {
+    return value && typeof value === "object" && !Array.isArray(value) ? (value as UnknownRecord) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readValue(value: unknown, ...keys: string[]): unknown {
+  const obj = record(value);
+  if (!obj) return undefined;
+  for (const key of keys) {
+    try {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) return obj[key];
+    } catch {
+      // A hostile provider-shaped object must never break error reporting.
+    }
+  }
+  return undefined;
+}
+
+function readRawString(value: unknown, ...keys: string[]): string | undefined {
+  const candidate = readValue(value, ...keys);
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function readString(value: unknown, ...keys: string[]): string | undefined {
+  const candidate = readRawString(value, ...keys);
+  return candidate?.trim() || undefined;
+}
+
+function readNumber(value: unknown, ...keys: string[]): number | undefined {
+  const candidate = readValue(value, ...keys);
+  if (typeof candidate === "number" && Number.isFinite(candidate)) return candidate;
+  if (typeof candidate === "string" && /^\d{3}$/.test(candidate.trim())) return Number(candidate.trim());
+  return undefined;
+}
+
+function firstString(sources: readonly unknown[], ...keys: string[]): string | undefined {
+  for (const source of sources) {
+    const value = readString(source, ...keys);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function firstNumber(sources: readonly unknown[], ...keys: string[]): number | undefined {
+  for (const source of sources) {
+    const value = readNumber(source, ...keys);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function safeLabel(value: string | undefined, max = 120): string | undefined {
+  if (!value) return undefined;
+  const oneLine = value.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!oneLine) return undefined;
+  // These fields are identifiers, not prose. Reject anything outside the
+  // provider's ordinary request-id/code alphabet instead of reflecting an
+  // attacker-controlled payload into the panel.
+  if (!/^[A-Za-z0-9._:/-]+$/.test(oneLine)) return undefined;
+  return oneLine.slice(0, max);
+}
+
+function parseMessageEnvelope(message: unknown): UnknownRecord | null {
+  if (typeof message !== "string") return record(message);
+  const trimmed = message.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+  try {
+    return record(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function hasBadRequestMessage(value: unknown): boolean {
+  const message = readString(value, "message", "detail");
+  return typeof message === "string" && /^bad request$/i.test(message);
+}
+
+/**
+ * Format a terminal Codex app-server error.
+ *
+ * Non-400 errors retain their existing message exactly. A generic 400 gets a
+ * bounded explanation and retry/session guidance, while any safe structured
+ * fields are included without dumping the provider payload into the panel.
+ */
+export function formatCodexTurnError(error: unknown): string {
+  const root = record(error);
+  // Keep the old non-400 behavior: an explicitly empty message stays empty,
+  // while an absent message falls back to the generic label.
+  const message = readRawString(error, "message") ?? (typeof error === "string" ? error : undefined);
+  const envelope = parseMessageEnvelope(message) ?? root;
+  const nestedSources = [
+    record(readValue(root, "data")),
+    record(readValue(root, "details")),
+    record(readValue(envelope, "data")),
+    record(readValue(envelope, "details")),
+  ];
+  const sources = [root, envelope, ...nestedSources];
+  const status = firstNumber(sources, "status", "statusCode", "httpStatus");
+  const rawCode = sources.map((source) => readValue(source, "code", "error_code", "errorCode")).find((value) => value !== undefined);
+  const code = safeLabel(typeof rawCode === "string" ? rawCode.trim() : undefined);
+  const numericCode =
+    typeof rawCode === "number" && Number.isFinite(rawCode)
+      ? rawCode
+      : typeof rawCode === "string" && /^\d{3}$/.test(rawCode.trim())
+        ? Number(rawCode.trim())
+        : undefined;
+  const type = safeLabel(firstString(sources, "type", "error_type", "errorType"));
+  const requestId = safeLabel(firstString(sources, "request_id", "requestId"));
+  const is400 =
+    status === 400 ||
+    numericCode === 400 ||
+    (typeof message === "string" && /^bad request(?:\b|:)/i.test(message.trim())) ||
+    hasBadRequestMessage(root) ||
+    hasBadRequestMessage(envelope);
+
+  if (!is400) return message !== undefined ? message : "Codex error";
+
+  const fields = [
+    code && `code=${code}`,
+    type && `type=${type}`,
+    requestId && `request_id=${requestId}`,
+  ].filter(Boolean);
+  const metadata = fields.length ? ` (${fields.join(", ")})` : "";
+  const missing = [!code && "error code", !requestId && "request id"].filter(Boolean).join(" or ");
+  const missingText = missing ? ` The provider returned no ${missing}.` : "";
+  return (
+    `Codex rejected this request with HTTP 400 Bad Request${metadata}.` +
+    `${missingText} Possible causes include an oversized context or tool history, an invalid request ` +
+    `payload, an unsupported model parameter, or a transient provider rejection. Retry once; if it ` +
+    `repeats, start a new session or switch models, and check the orchestrator terminal for the raw diagnostic.`
+  );
+}


### PR DESCRIPTION
Fixes #2112

The Codex app-server can surface a terminal 400 as only `{"detail":"Bad Request"}`. This change formats that path into a bounded, actionable diagnosis, preserves safe upstream code/type/request-id fields, detects numeric and nested 400 markers, and never reflects prompt-bearing 400 text into the panel. Non-400 error messages keep their prior behavior.

Validation:
- `npx.cmd vitest run src/orchestrator/codex-error.test.ts src/__tests__/orchestrator/codex-callback-serialize.test.ts src/__tests__/orchestrator/codex-interrupt-recovery.test.ts` — 3 files, 21 tests passed
- `npm.cmd run lint` — passed
- Independent SHIP review completed