### PR TITLE
fix/2114 bad request diagnostics

### DIFF
--- a/src/__tests__/orchestrator/codex-bad-request-diagnostics.test.ts
+++ b/src/__tests__/orchestrator/codex-bad-request-diagnostics.test.ts
@@ -1,0 +1,67 @@
+// #2114 — a provider 400 can reject the awaited `turn/start` request instead of
+// arriving as an app-server `error` notification. That path must still use the
+// scrubbed Codex diagnostic formatter and must not silently turn into the bare
+// `{"detail":"Bad Request"}` panel message.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+type Backend = InstanceType<BackendModule["CodexBackend"]>;
+
+let CodexBackend: BackendModule["CodexBackend"];
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+});
+
+describe("Codex turn/start bad-request diagnostics (#2114)", () => {
+  it("formats a rejected 400 and preserves structured request diagnostics", async () => {
+    const client = {
+      notificationHandler: null as ((message: unknown) => void) | null,
+      exitError: null,
+      exitPromise: new Promise<void>(() => {}),
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "thread-2114" }, model: "gpt-5.6-sol" };
+        if (method === "turn/start") {
+          const error = Object.assign(new Error('{"detail":"Bad Request"}'), {
+            code: -32600,
+            data: {
+              code: "invalid_request_error",
+              type: "invalid_request",
+              request_id: "req_2114",
+            },
+          });
+          throw error;
+        }
+        throw new Error(`unexpected request: ${method}`);
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend: Backend = new CodexBackend({ model: "gpt-5.6-sol" });
+    Object.assign(backend, { client, liveCatalog: [{ id: "gpt-5.6-sol" }] });
+
+    async function* channel() {
+      yield { text: "apply the prompt" };
+    }
+
+    const events: AgentEvent[] = [];
+    for await (const event of backend.run({ channel: channel() })) events.push(event);
+
+    const error = events.find(
+      (event): event is Extract<AgentEvent, { type: "error" }> => event.type === "error",
+    );
+    expect(error?.type).toBe("error");
+    expect(error?.message).toContain("HTTP 400 Bad Request");
+    expect(error?.message).toContain("code=invalid_request_error");
+    expect(error?.message).toContain("request_id=req_2114");
+    expect(error?.message).not.toContain('{"detail":"Bad Request"}');
+    expect(events).toContainEqual({ type: "result", ok: false, subtype: "error", turn: 1 });
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -381,7 +381,16 @@ class AppServerClient {
       const p = this.pending.get(message.id);
       if (!p) return;
       this.pending.delete(message.id);
-      if (message.error) p.reject(new Error(message.error.message ?? `codex app-server ${p.method} failed.`));
+      if (message.error) {
+        // Keep the JSON-RPC error's structured data on the rejected value. A
+        // provider 400 can arrive as a rejected turn/start request rather than
+        // an `error` notification, and its request id/code may only be present
+        // in `error.data` (#2114). The user-facing formatter deliberately
+        // extracts only its safe diagnostic-shaped fields.
+        const error = new Error(message.error.message ?? `codex app-server ${p.method} failed.`);
+        Object.assign(error, message.error);
+        p.reject(error);
+      }
       else p.resolve(message.result ?? {});
       return;
     }
@@ -1887,11 +1896,14 @@ export class CodexBackend implements AgentBackend {
             // Deliberate teardown (interrupt restored/closed the turn): still end
             // with a result so the gate advances, but no user-facing error.
             abortActiveTurn();
-          } else if (tryRetryCodeModeHostSpawn(msgOf(err))) {
-            // retryPending is now true; the dead turn's result is deferred.
           } else {
-            retryPending = false;
-            emitTerminalError(msgOf(err));
+            const message = formatCodexTurnError(err);
+            if (tryRetryCodeModeHostSpawn(message)) {
+              // retryPending is now true; the dead turn's result is deferred.
+            } else {
+              retryPending = false;
+              emitTerminalError(message);
+            }
           }
         });
     };

--- a/src/orchestrator/codex-error.test.ts
+++ b/src/orchestrator/codex-error.test.ts
@@ -54,6 +54,28 @@ describe("formatCodexTurnError (#2112)", () => {
     expect(text).not.toContain("secret prompt");
   });
 
+  it("keeps a numeric 400 marker when a nested provider code wins display precedence (#2114)", () => {
+    const text = formatCodexTurnError({
+      code: 400,
+      message: "Invalid request",
+      data: { code: "invalid_request_error" },
+    });
+
+    expect(text).toContain("HTTP 400 Bad Request");
+    expect(text).toContain("code=invalid_request_error");
+    expect(text).not.toContain("Invalid request");
+  });
+
+  it("does not treat a non-400 transport marker as an HTTP 400", () => {
+    expect(
+      formatCodexTurnError({
+        code: -32600,
+        message: "Invalid request",
+        data: { code: "invalid_request_error" },
+      }),
+    ).toBe("Invalid request");
+  });
+
   it("does not rewrite non-400 provider errors", () => {
     expect(formatCodexTurnError({ message: "provider unavailable", status: 503 })).toBe("provider unavailable");
     expect(formatCodexTurnError({ message: "" })).toBe("");

--- a/src/orchestrator/codex-error.ts
+++ b/src/orchestrator/codex-error.ts
@@ -114,7 +114,13 @@ export function formatCodexTurnError(error: unknown): string {
   ];
   const sources = [root, envelope, ...nestedSources];
   const status = firstNumber(sources, "status", "statusCode", "httpStatus");
-  const rawCode = sources.map((source) => readValue(source, "code", "error_code", "errorCode")).find((value) => value !== undefined);
+  const codeCandidates = sources.map((source) => readValue(source, "code", "error_code", "errorCode"));
+  // A JSON-RPC transport code (for example -32600) can sit on the root error
+  // while the provider's actionable code is nested in `error.data`. Prefer a
+  // non-empty string diagnostic before falling back to a numeric marker.
+  const rawCode =
+    codeCandidates.find((value) => typeof value === "string" && value.trim()) ??
+    codeCandidates.find((value) => typeof value === "number" && Number.isFinite(value));
   const code = safeLabel(typeof rawCode === "string" ? rawCode.trim() : undefined);
   const numericCode =
     typeof rawCode === "number" && Number.isFinite(rawCode)

--- a/src/orchestrator/codex-error.ts
+++ b/src/orchestrator/codex-error.ts
@@ -115,19 +115,22 @@ export function formatCodexTurnError(error: unknown): string {
   const sources = [root, envelope, ...nestedSources];
   const status = firstNumber(sources, "status", "statusCode", "httpStatus");
   const codeCandidates = sources.map((source) => readValue(source, "code", "error_code", "errorCode"));
-  // A JSON-RPC transport code (for example -32600) can sit on the root error
-  // while the provider's actionable code is nested in `error.data`. Prefer a
-  // non-empty string diagnostic before falling back to a numeric marker.
-  const rawCode =
-    codeCandidates.find((value) => typeof value === "string" && value.trim()) ??
-    codeCandidates.find((value) => typeof value === "number" && Number.isFinite(value));
-  const code = safeLabel(typeof rawCode === "string" ? rawCode.trim() : undefined);
-  const numericCode =
-    typeof rawCode === "number" && Number.isFinite(rawCode)
-      ? rawCode
-      : typeof rawCode === "string" && /^\d{3}$/.test(rawCode.trim())
-        ? Number(rawCode.trim())
-        : undefined;
+  // Keep the two code roles independent: a provider's string code wins the
+  // displayed `code=...` field, while numeric transport/RPC markers still
+  // participate in HTTP-status classification. An exact numeric 400 wins over
+  // another numeric marker (for example JSON-RPC -32600).
+  const providerCode = codeCandidates.find(
+    (value): value is string => typeof value === "string" && Boolean(value.trim()),
+  );
+  const numericCodes = codeCandidates
+    .map((value) => {
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+      if (typeof value === "string" && /^\d{3}$/.test(value.trim())) return Number(value.trim());
+      return undefined;
+    })
+    .filter((value): value is number => value !== undefined);
+  const numericCode = numericCodes.find((value) => value === 400) ?? numericCodes[0];
+  const code = safeLabel(providerCode?.trim());
   const type = safeLabel(firstString(sources, "type", "error_type", "errorType"));
   const requestId = safeLabel(firstString(sources, "request_id", "requestId"));
   const is400 =


### PR DESCRIPTION
Fixes #2114. Makes rejected turn/start 400s actionable with bounded scrubbed diagnostics, preserves JSON-RPC data, and keeps provider-code precedence separate from numeric transport classification. Automatic retry/compaction is intentionally not added. Independently reviewed SHIP. Validation: 83 Codex-focused tests, typecheck, and diff check. 
