### PR TITLE
fix: parse dictionary-shaped comfy-kitchen backend logs

### DIFF
--- a/src/__tests__/services/kitchen.test.ts
+++ b/src/__tests__/services/kitchen.test.ts
@@ -107,6 +107,21 @@ describe("parseKitchenLog", () => {
     expect(parsed.backends.eager).toEqual({ available: false, raw });
   });
 
+  it.each([
+    ["a nested available property", "{'nested': {'available': True}}"],
+    ["trailing garbage", "{'available': True} garbage"],
+  ])("rejects %s as a backend dictionary", (_caseName, raw) => {
+    const parsed = parseKitchenLog(`Found comfy_kitchen backend eager: ${raw}`);
+
+    expect(parsed.backends.eager).toEqual({ available: false, raw });
+  });
+
+  it("preserves the legacy cached availability status", () => {
+    const parsed = parseKitchenLog("Found comfy_kitchen backend eager: available (cached)");
+
+    expect(parsed.backends.eager).toEqual({ available: true, raw: "available (cached)" });
+  });
+
   it("does not treat a missing attention line as a no", () => {
     const parsed = parseKitchenLog("comfy-kitchen version: 0.2.10");
     expect(parsed.ckAttentionLog.status).toBe("unknown");

--- a/src/__tests__/services/kitchen.test.ts
+++ b/src/__tests__/services/kitchen.test.ts
@@ -116,6 +116,17 @@ describe("parseKitchenLog", () => {
     expect(parsed.backends.eager).toEqual({ available: false, raw });
   });
 
+  it.each([
+    ["a double comma", "{'available': True,,}"],
+    ["an initial empty member", "{,'available': True}"],
+    ["an empty key", "{'available': True, :}"],
+    ["an empty value", "{'available': True, 'x':}"],
+  ])("rejects %s as a malformed dictionary", (_caseName, raw) => {
+    const parsed = parseKitchenLog(`Found comfy_kitchen backend eager: ${raw}`);
+
+    expect(parsed.backends.eager).toEqual({ available: false, raw });
+  });
+
   it("preserves the legacy cached availability status", () => {
     const parsed = parseKitchenLog("Found comfy_kitchen backend eager: available (cached)");
 

--- a/src/__tests__/services/kitchen.test.ts
+++ b/src/__tests__/services/kitchen.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const comfyClientMocks = vi.hoisted(() => ({
+  getLogs: vi.fn(),
+  getSystemStats: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => comfyClientMocks);
 import {
   KITCHEN_PROBE_SOURCE,
   applyKitchenRecommendation,
@@ -63,6 +70,7 @@ const UNET_API = {
 
 afterEach(() => {
   resetKitchenHintSession();
+  comfyClientMocks.getLogs.mockReset();
 });
 
 describe("parseKitchenLog", () => {
@@ -87,6 +95,16 @@ describe("parseKitchenLog", () => {
       available: false,
       raw: "{'available': False, 'disabled': True, 'reason': 'not supported'}",
     });
+  });
+
+  it.each([
+    ["an unavailable key", "{'unavailable': true}"],
+    ["a trueish value", "{'available': trueish}"],
+    ["a nested-looking reason", "{reason: available: True}"],
+  ])("does not infer availability from %s", (_caseName, raw) => {
+    const parsed = parseKitchenLog(`Found comfy_kitchen backend eager: ${raw}`);
+
+    expect(parsed.backends.eager).toEqual({ available: false, raw });
   });
 
   it("does not treat a missing attention line as a no", () => {
@@ -349,6 +367,24 @@ describe("applyKitchenRecommendation", () => {
 });
 
 describe("gatherKitchenStatus", () => {
+  it("uses the default log fetch before merging backend availability", async () => {
+    comfyClientMocks.getLogs.mockResolvedValueOnce(DICTIONARY_LOG.split("\n"));
+    const remote = await gatherKitchenStatus({
+      location: "REMOTE",
+      stats: {
+        system: {
+          argv: [],
+          comfy_package_versions: [{ name: "comfy-kitchen", installed: "0.2.31" }],
+        },
+        devices: [],
+      },
+    });
+
+    expect(comfyClientMocks.getLogs).toHaveBeenCalledWith({ maxLines: 2000 });
+    expect(remote.backends.eager.available).toEqual(known(true));
+    expect(remote.backends.triton.available).toEqual(known(false));
+  });
+
   it("carries dictionary-shaped backend availability through status aggregation", async () => {
     const remote = await gatherKitchenStatus({
       location: "REMOTE",

--- a/src/__tests__/services/kitchen.test.ts
+++ b/src/__tests__/services/kitchen.test.ts
@@ -34,6 +34,12 @@ const LOG = [
   "Using Comfy Kitchen attention",
 ].join("\n");
 
+const DICTIONARY_LOG = [
+  "comfy-kitchen version: 0.2.31",
+  "Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'reason': None}",
+  "Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'reason': 'not supported'}",
+].join("\n");
+
 function status(over: Partial<KitchenStatus> = {}): KitchenStatus {
   const base = mergeKitchenStatus({
     location: "LOCAL",
@@ -68,6 +74,19 @@ describe("parseKitchenLog", () => {
     expect(parsed.ckAttentionLog).toEqual(known(true));
     expect(parsed.tritonEnabledLog).toEqual(known(true));
     expect(parsed.tritonVersion).toEqual(known("3.7.0"));
+  });
+
+  it("reads availability from dictionary-shaped backend startup lines", () => {
+    const parsed = parseKitchenLog(DICTIONARY_LOG);
+
+    expect(parsed.backends.eager).toEqual({
+      available: true,
+      raw: "{'available': True, 'disabled': False, 'reason': None}",
+    });
+    expect(parsed.backends.triton).toEqual({
+      available: false,
+      raw: "{'available': False, 'disabled': True, 'reason': 'not supported'}",
+    });
   });
 
   it("does not treat a missing attention line as a no", () => {
@@ -330,6 +349,23 @@ describe("applyKitchenRecommendation", () => {
 });
 
 describe("gatherKitchenStatus", () => {
+  it("carries dictionary-shaped backend availability through status aggregation", async () => {
+    const remote = await gatherKitchenStatus({
+      location: "REMOTE",
+      logText: DICTIONARY_LOG,
+      stats: {
+        system: {
+          argv: [],
+          comfy_package_versions: [{ name: "comfy-kitchen", installed: "0.2.31" }],
+        },
+        devices: [],
+      },
+    });
+
+    expect(remote.backends.eager.available).toEqual(known(true));
+    expect(remote.backends.triton.available).toEqual(known(false));
+  });
+
   it("merges log + stats + probe and reports present without guessing on a remote host", async () => {
     const remote = await gatherKitchenStatus({
       location: "REMOTE",

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -233,10 +233,12 @@ export function parseKitchenLog(text: string): KitchenLogParse {
     const name = m[1]!.toLowerCase();
     if ((KITCHEN_BACKENDS as readonly string[]).includes(name)) {
       const raw = m[2]!.trim();
-      const field = /['"]?available['"]?\s*:\s*(true|false)/i.exec(raw);
+      const field = /(?:\{|,)\s*(?:"available"|'available'|available)\s*:\s*(true|false)(?=\s*(?:,|}))/i.exec(
+        raw,
+      );
       const available = field
         ? field[1]!.toLowerCase() === "true"
-        : /^(available|enabled|ok|loaded|true|ready)/i.test(raw);
+        : /^(?:available|enabled|ok|loaded|true|ready)$/i.test(raw);
       backends[name as KitchenBackendName] = { available, raw };
     }
   }

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -225,6 +225,93 @@ export function logTextFromPayload(data: unknown): string {
   }
 }
 
+function matchingClose(open: string, close: string): boolean {
+  return (open === "{" && close === "}") || (open === "[" && close === "]") || (open === "(" && close === ")");
+}
+
+function splitTopLevelDictionary(raw: string): string[] | undefined {
+  const text = raw.trim();
+  if (text.length < 2 || text[0] !== "{" || text[text.length - 1] !== "}") return undefined;
+
+  const members: string[] = [];
+  const stack: string[] = [];
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let start = 1;
+
+  for (let i = 1; i < text.length - 1; i++) {
+    const ch = text[i]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+    } else if (ch === "{" || ch === "[" || ch === "(") {
+      stack.push(ch);
+    } else if (ch === "}" || ch === "]" || ch === ")") {
+      const open = stack.pop();
+      if (!open || !matchingClose(open, ch)) return undefined;
+    } else if (ch === "," && stack.length === 0) {
+      const member = text.slice(start, i).trim();
+      if (member) members.push(member);
+      start = i + 1;
+    }
+  }
+
+  if (quote || stack.length > 0) return undefined;
+  const last = text.slice(start, -1).trim();
+  if (last) members.push(last);
+  return members;
+}
+
+function topLevelColon(member: string): number {
+  const stack: string[] = [];
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  for (let i = 0; i < member.length; i++) {
+    const ch = member[i]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+    } else if (ch === "{" || ch === "[" || ch === "(") {
+      stack.push(ch);
+    } else if (ch === "}" || ch === "]" || ch === ")") {
+      const open = stack.pop();
+      if (!open || !matchingClose(open, ch)) return -1;
+    } else if (ch === ":" && stack.length === 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function parseKitchenDictionaryAvailable(raw: string): boolean | undefined {
+  const members = splitTopLevelDictionary(raw);
+  if (!members) return undefined;
+
+  let available: boolean | undefined;
+  for (const member of members) {
+    const colon = topLevelColon(member);
+    if (colon < 0) return undefined;
+    const key = member.slice(0, colon).trim();
+    if (!/^(?:"available"|'available'|available)$/i.test(key)) continue;
+
+    const value = member.slice(colon + 1).trim();
+    if (!/^true$/i.test(value) && !/^false$/i.test(value)) return undefined;
+    if (available !== undefined) return undefined;
+    available = /^true$/i.test(value);
+  }
+  return available;
+}
+
 export function parseKitchenLog(text: string): KitchenLogParse {
   const versionMatch = text.match(/comfy-kitchen version:\s*(\S+)/i);
   const backends: KitchenLogParse["backends"] = {};
@@ -233,12 +320,10 @@ export function parseKitchenLog(text: string): KitchenLogParse {
     const name = m[1]!.toLowerCase();
     if ((KITCHEN_BACKENDS as readonly string[]).includes(name)) {
       const raw = m[2]!.trim();
-      const field = /(?:\{|,)\s*(?:"available"|'available'|available)\s*:\s*(true|false)(?=\s*(?:,|}))/i.exec(
-        raw,
-      );
-      const available = field
-        ? field[1]!.toLowerCase() === "true"
-        : /^(?:available|enabled|ok|loaded|true|ready)$/i.test(raw);
+      const dictionaryAvailable = parseKitchenDictionaryAvailable(raw);
+      // Older logs used "available (cached)" rather than a bare status.
+      const available =
+        dictionaryAvailable ?? /^(?:available|enabled|ok|loaded|true|ready)(?:\s+\(cached\))?$/i.test(raw);
       backends[name as KitchenBackendName] = { available, raw };
     }
   }

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -228,12 +228,15 @@ export function logTextFromPayload(data: unknown): string {
 export function parseKitchenLog(text: string): KitchenLogParse {
   const versionMatch = text.match(/comfy-kitchen version:\s*(\S+)/i);
   const backends: KitchenLogParse["backends"] = {};
-  const backendRe = /Found comfy_kitchen backend\s+(\w+)\s*:\s*(\S+)/gi;
+  const backendRe = /Found comfy_kitchen backend\s+(\w+)\s*:\s*([^\r\n]+)/gi;
   for (const m of text.matchAll(backendRe)) {
     const name = m[1]!.toLowerCase();
     if ((KITCHEN_BACKENDS as readonly string[]).includes(name)) {
-      const raw = m[2]!;
-      const available = /^(available|enabled|ok|loaded|true|ready)/i.test(raw);
+      const raw = m[2]!.trim();
+      const field = /['"]?available['"]?\s*:\s*(true|false)/i.exec(raw);
+      const available = field
+        ? field[1]!.toLowerCase() === "true"
+        : /^(available|enabled|ok|loaded|true|ready)/i.test(raw);
       backends[name as KitchenBackendName] = { available, raw };
     }
   }

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -256,7 +256,8 @@ function splitTopLevelDictionary(raw: string): string[] | undefined {
       if (!open || !matchingClose(open, ch)) return undefined;
     } else if (ch === "," && stack.length === 0) {
       const member = text.slice(start, i).trim();
-      if (member) members.push(member);
+      if (!member) return undefined;
+      members.push(member);
       start = i + 1;
     }
   }
@@ -302,9 +303,10 @@ function parseKitchenDictionaryAvailable(raw: string): boolean | undefined {
     const colon = topLevelColon(member);
     if (colon < 0) return undefined;
     const key = member.slice(0, colon).trim();
+    const value = member.slice(colon + 1).trim();
+    if (!key || !value) return undefined;
     if (!/^(?:"available"|'available'|available)$/i.test(key)) continue;
 
-    const value = member.slice(colon + 1).trim();
     if (!/^true$/i.test(value) && !/^false$/i.test(value)) return undefined;
     if (available !== undefined) return undefined;
     available = /^true$/i.test(value);


### PR DESCRIPTION
Fixes #2117

The parser previously captured only the first { from Python-dict backend lines, turning eager available into false. It now captures the full line and reads an explicit available true/false field while preserving legacy text handling.

Verification: npx.cmd vitest run src/__tests__/services/kitchen.test.ts src/__tests__/tools/kitchen.test.ts src/__tests__/orchestrator/panel-kitchen.test.ts --reporter=dot (3 files, 48 tests passed); npm.cmd run lint (tsc --noEmit); git diff --check.