### PR TITLE
Fix EZi proxy restart ownership (#2118)

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-ezi-wrapper.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-ezi-wrapper.test.ts
@@ -1,0 +1,117 @@
+// #2118 — an EZi/CEI helper serves the panel on one local port while the
+// immutable ComfyUI boot endpoint and Manager live on another. The panel restart
+// must use the verified backend proof, not the helper listener's process identity.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  target: { value: "http://127.0.0.1:50404" },
+  boot: { value: "http://127.0.0.1:8188" },
+  generation: { value: 7 },
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  getQueue: vi.fn(),
+  getSystemStats: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    config: { ...actual.config, comfyuiRestartCommand: undefined },
+    getComfyUIBaseUrl: () => hoisted.target.value,
+    getBootLocalComfyUIBaseUrl: () => hoisted.boot.value,
+    getComfyuiTargetGeneration: () => hoisted.generation.value,
+    isRemoteMode: () => false,
+    isCloudMode: () => false,
+  };
+});
+
+const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const PROXY = hoisted.target.value;
+const BACKEND = hoisted.boot.value;
+const ARGV = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+
+const parse = (res: ToolResult): Record<string, unknown> =>
+  JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+function restartHandler() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def.handler;
+}
+
+function makeCtx(sends: Array<Record<string, unknown>>): PanelToolCtx {
+  return {
+    call: async () => {
+      throw new Error("ctx.call must not be used by the restart handler");
+    },
+    confirm: async () => "yes" as const,
+    ensureReachable: () => {},
+    bridge: {
+      send: async (cmd: Record<string, unknown>) => {
+        sends.push(cmd);
+        return cmd.cmd === "comfy_reboot" ? { rebooting: true } : {};
+      },
+      tabIsLocal: () => true,
+      tabServerOrigin: () => PROXY,
+      tabOrigin: () => PROXY,
+      canReach: () => true,
+      tabSockId: () => "sock-2118",
+    } as unknown as PanelToolCtx["bridge"],
+    tabId: "tab-2118",
+    panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "session-2118" }),
+    awaitPostRestartReachable: async () => true,
+    tabCanMutateGraph: () => true,
+  } as unknown as PanelToolCtx;
+}
+
+beforeEach(() => {
+  __panelToolsTestHooks.setVerifiedProxyRestartTarget(async () => ({
+    proxyBase: PROXY,
+    backendBase: BACKEND,
+    generation: hoisted.generation.value,
+    argv: [...ARGV],
+  }));
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+    throw new Error("the verified proxy path must not run local process preflight");
+  });
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 60,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+  let probes = 0;
+  __panelToolsTestHooks.setHealthProbe(async (base) => {
+    expect(base).toBe(BACKEND);
+    return probes++ === 0 ? "down" : "healthy";
+  });
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setVerifiedProxyRestartTarget(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+});
+
+describe("panel_restart_comfyui with an EZi/CEI proxy (#2118)", () => {
+  it("accepts the tab binding, skips proxy process ownership, and dispatches the panel reboot", async () => {
+    const sends: Array<Record<string, unknown>> = [];
+    const out = parse(await restartHandler()({}, makeCtx(sends)));
+
+    expect(out.rebooting).toBe(true);
+    expect(out.refused).toBeUndefined();
+    expect(sends.filter((cmd) => cmd.cmd === "comfy_reboot")).toHaveLength(1);
+    expect(out.server_ready).toBe(true);
+  });
+});

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -77,6 +77,14 @@ describe("commandLineMatchesArgv — correlate the process against the server's 
     expect(commandLineMatchesArgv(proxyCmd, COMFY_ARGV)).toBe(false);
   });
 
+  it("reproduces EZi/CEI ownership refusal for the helper wrapper (#2118)", () => {
+    const eziWrapperCmd =
+      'C:\\ComfyUI\\.venv\\Scripts\\python.exe -c "import runpy; runpy.run_path(\'C:\\ComfyUI\\main.py\')" ' +
+      "--port 50404";
+    const backendArgv = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+    expect(commandLineMatchesArgv(eziWrapperCmd, backendArgv)).toBe(false);
+  });
+
   it("does NOT match a DIFFERENT ComfyUI instance launched with other arguments", () => {
     const otherCmd = "C:\\Other\\.venv\\Scripts\\python.exe -s ComfyUI\\main.py --listen 0.0.0.0";
     expect(commandLineMatchesArgv(otherCmd, COMFY_ARGV)).toBe(false);

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -20,6 +20,7 @@ const hoisted = vi.hoisted(() => ({
   remoteMode: { value: true },
   platform: { value: "win32" as NodeJS.Platform },
   base: { value: "http://alpha.example:8188" },
+  bootBase: { value: null as string | null },
   generation: { value: 0 },
   fetchMock: vi.fn(),
   resetClient: vi.fn(),
@@ -38,6 +39,7 @@ const retargetTo = (url: string): void => {
 vi.mock("../../config.js", () => ({
   config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
   getComfyUIBaseUrl: () => hoisted.base.value,
+  getBootLocalComfyUIBaseUrl: () => hoisted.bootBase.value,
   getComfyuiTargetGeneration: () => hoisted.generation.value,
   isRemoteMode: () => hoisted.remoteMode.value,
 }));
@@ -95,6 +97,7 @@ const hostsHit = (pathSuffix: string): string[] =>
 beforeEach(() => {
   hoisted.remoteMode.value = true;
   hoisted.base.value = "http://alpha.example:8188";
+  hoisted.bootBase.value = null;
   hoisted.generation.value = 0;
   hoisted.fetchMock.mockReset();
   hoisted.resetClient.mockClear();
@@ -107,6 +110,57 @@ beforeEach(() => {
 });
 
 describe("restart anchors to the instance it read", () => {
+  it("routes a verified EZi proxy to the immutable backend Manager without inspecting or killing the proxy", async () => {
+    hoisted.remoteMode.value = false;
+    hoisted.base.value = "http://127.0.0.1:50404";
+    hoisted.bootBase.value = "http://127.0.0.1:8188";
+    const argv = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv } });
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 200,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = new URL(url).pathname;
+      if (path.includes("/reboot")) return new Response("ok", { status: 200 });
+      return new Response(JSON.stringify({ system: { argv } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.message).not.toMatch(/Nothing was stopped/i);
+    expect(calls().filter(([url]) => new URL(url).pathname.includes("/reboot")).map(([url]) => new URL(url).host))
+      .toEqual(["127.0.0.1:8188"]);
+    expect(calls().map(([url]) => new URL(url).host)).not.toContain("127.0.0.1:50404");
+    expect(hoisted.execSync).not.toHaveBeenCalled();
+    expect(hoisted.spawn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the refusal path when the proxy and boot endpoint do not corroborate the same explicit port", async () => {
+    hoisted.remoteMode.value = false;
+    hoisted.base.value = "http://127.0.0.1:50404";
+    hoisted.bootBase.value = "http://127.0.0.1:8188";
+    hoisted.getSystemStats.mockResolvedValue({
+      system: { argv: ["C:\\ComfyUI\\main.py", "--port", "50404"] },
+    });
+    hoisted.fetchMock.mockImplementation(async () =>
+      new Response(
+        JSON.stringify({ system: { argv: ["C:\\ComfyUI\\main.py", "--port", "50404"] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const res = await restartComfyUI();
+
+    expect(calls().filter(([url]) => new URL(url).pathname.includes("/reboot"))).toHaveLength(0);
+    expect(res.stopped).toBe(false);
+    expect(res.startup).toBe("not-attempted");
+  });
+
   it("REFUSES without dispatching when the target moves between the argv read and the reboot", async () => {
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../services/instance-witness.js", () => ({
 
 import {
   restartComfyUI,
+  resolveVerifiedProxyRestartTarget,
   startComfyUI,
   __processControlTestHooks,
 } from "../../services/process-control.js";
@@ -138,6 +139,64 @@ describe("restart anchors to the instance it read", () => {
     expect(calls().map(([url]) => new URL(url).host)).not.toContain("127.0.0.1:50404");
     expect(hoisted.execSync).not.toHaveBeenCalled();
     expect(hoisted.spawn).not.toHaveBeenCalled();
+  });
+
+  it("does not let a localhost backend satisfy the EZi proxy proof on the restart path", async () => {
+    hoisted.remoteMode.value = false;
+    hoisted.base.value = "http://127.0.0.1:50404";
+    hoisted.bootBase.value = "http://localhost:8188";
+    const argv = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv } });
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 200,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = new URL(url).pathname;
+      if (path.includes("/reboot")) return new Response("ok", { status: 200 });
+      return new Response(JSON.stringify({ system: { argv } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(calls().filter(([url]) => new URL(url).pathname.includes("/reboot"))).toHaveLength(0);
+    expect(res.stopped).toBe(false);
+    expect(res.startup).toBe("not-attempted");
+    expect(hoisted.spawn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a localhost backend", "http://127.0.0.1:50404", "http://localhost:8188"],
+    ["a non-IP DNS backend", "http://127.0.0.1:50404", "http://example.com:8188"],
+    [
+      "a backend URL with loopback-looking userinfo",
+      "http://127.0.0.1:50404",
+      "http://localhost:8188@evil.example:8189",
+    ],
+    [
+      "a proxy URL with loopback-looking userinfo",
+      "http://127.0.0.1:50404@evil.example:50405",
+      "http://127.0.0.1:8188",
+    ],
+  ])("rejects %s before making identity probes", async (_label, proxyBase, backendBase) => {
+    hoisted.base.value = proxyBase;
+    hoisted.bootBase.value = backendBase;
+    const argv = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv } });
+    hoisted.fetchMock.mockImplementation(async () =>
+      new Response(JSON.stringify({ system: { argv } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(resolveVerifiedProxyRestartTarget()).resolves.toBeUndefined();
+    expect(hoisted.getSystemStats).not.toHaveBeenCalled();
+    expect(hoisted.fetchMock).not.toHaveBeenCalled();
   });
 
   it("keeps the refusal path when the proxy and boot endpoint do not corroborate the same explicit port", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -374,6 +374,8 @@ import {
   restartComfyUI,
   preflightLocalRestart,
   readServingArgv,
+  resolveVerifiedProxyRestartTarget,
+  type VerifiedProxyRestartTarget,
   describeArgvDrift,
   recordRestartDispatch,
   clearRestartDispatch,
@@ -1113,6 +1115,12 @@ export const __panelToolsTestHooks = {
       | null,
   ): void {
     localRestartPreflightOverride = fn;
+  },
+  /** Inject the narrow EZi/CEI proxy proof; null restores the live resolver. */
+  setVerifiedProxyRestartTarget(
+    fn: (() => Promise<VerifiedProxyRestartTarget | undefined>) | null,
+  ): void {
+    verifiedProxyRestartTargetOverride = fn;
   },
   /** Inject a fast #742 decline-probe recheck window so decline-path tests
    *  don't wait the real ~6s. null restores the DECLINE_PROBE_* constants. */
@@ -2964,6 +2972,26 @@ let localRestartPreflightOverride:
       selfRelaunch?: boolean;
     }>)
   | null = null;
+
+let verifiedProxyRestartTargetOverride:
+  | (() => Promise<VerifiedProxyRestartTarget | undefined>)
+  | null = null;
+
+function panelVerifiedProxyRestartTarget(): Promise<VerifiedProxyRestartTarget | undefined> {
+  return (verifiedProxyRestartTargetOverride ?? resolveVerifiedProxyRestartTarget)();
+}
+
+function proxyTargetBindsPanel(
+  ctx: PanelToolCtx,
+  target: VerifiedProxyRestartTarget | undefined,
+): target is VerifiedProxyRestartTarget {
+  return (
+    target != null &&
+    sameHttpBase(getComfyUIBaseUrl(), target.proxyBase) &&
+    ctx.bridge?.tabIsLocal?.(ctx.tabId) === true &&
+    sameHttpBase(ctx.bridge?.tabServerOrigin?.(ctx.tabId), target.proxyBase)
+  );
+}
 
 /** Test injection for the #742 decline-probe recheck window, so tests don't
  *  wait the real ~6s. null → the DECLINE_PROBE_* constants. */
@@ -18557,6 +18585,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               " To restart the server without a panel confirmation card, use restart_comfyui.",
           );
         }
+        // #2118: keep the proxy proof alive across the confirmation/preflight
+        // awaits. The proxy is never treated as a ComfyUI process; it only lets
+        // the tab-scoped Manager request be observed against the immutable backend.
+        let proxyRestartTarget: VerifiedProxyRestartTarget | undefined;
         // #1819: resolve instance identity BEFORE the confirmation card. Asking the
         // user to confirm a restart, then refusing because we cannot tell which
         // ComfyUI this tab fronts, is two contradictory outcomes (timeout vs refuse)
@@ -18572,11 +18604,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             identityHealthBase != null &&
             sameHttpBase(getComfyUIBaseUrl(), identityHealthBase);
           if (!identityBound) {
+            const candidate = await panelVerifiedProxyRestartTarget();
+            if (proxyTargetBindsPanel(ctx, candidate)) {
+              proxyRestartTarget = candidate;
+            }
             const tabStillHere =
               typeof ctx.bridge?.canReach === "function"
                 ? ctx.bridge.canReach(ctx.tabId) === true
                 : true;
-            if (tabStillHere) {
+            if (tabStillHere && proxyRestartTarget == null) {
               return restartRefusedPreservingBinding(
                 ctx,
                 unboundLocalRestartRefusalNote(ctx, identityHealthBase, identityBinding.blocker),
@@ -19208,8 +19244,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // "idle" and a restart aborts whatever is running.
         const configuredRestartCommand = config.comfyuiRestartCommand;
         if (configuredRestartCommand && !isRemoteMode() && !isCloudMode()) {
-          const commandHealthBase = captureRebootHealthBase(ctx);
-          if (commandHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), commandHealthBase)) {
+          if (proxyRestartTarget != null) {
+            const refreshedProxy = await panelVerifiedProxyRestartTarget();
+            proxyRestartTarget = proxyTargetBindsPanel(ctx, refreshedProxy)
+              ? refreshedProxy
+              : undefined;
+          }
+          const commandHealthBase =
+            proxyRestartTarget?.backendBase ?? captureRebootHealthBase(ctx);
+          const commandBound =
+            proxyRestartTarget != null ||
+            (commandHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), commandHealthBase));
+          if (commandHealthBase != null && commandBound) {
             if (force !== true) {
               let busyCount: number | null = null;
               try {
@@ -19248,7 +19294,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             // Re-heal and re-verify at the point of action, exactly as the
             // dispatch path below does.
             ctx.ensureReachable?.();
-            const postCheckHealthBase = captureRebootHealthBase(ctx);
+            if (proxyRestartTarget != null) {
+              const postProxy = await panelVerifiedProxyRestartTarget();
+              proxyRestartTarget = proxyTargetBindsPanel(ctx, postProxy)
+                ? postProxy
+                : undefined;
+            }
+            const postCheckHealthBase =
+              proxyRestartTarget?.backendBase ?? captureRebootHealthBase(ctx);
             if (
               postCheckHealthBase == null ||
               !sameHttpBase(commandHealthBase, postCheckHealthBase)
@@ -19333,11 +19386,22 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // can be proven. They keep restart_comfyui, and the note says so. Weighed
         // against #814 — where exactly such a user's server was stopped and never came
         // back — declining is the recoverable side.
+        // Re-resolve after the confirmation await. A proxy proof is an endpoint
+        // identity claim, not a durable permission; a retarget or tab rebind makes
+        // it unusable and returns to the existing refusal path.
+        if (proxyRestartTarget != null) {
+          const refreshedProxy = await panelVerifiedProxyRestartTarget();
+          proxyRestartTarget = proxyTargetBindsPanel(ctx, refreshedProxy)
+            ? refreshedProxy
+            : undefined;
+        }
         const preflightBinding = resolveRebootHealthBinding(ctx);
-        const preflightHealthBase = preflightBinding.base;
+        const preflightHealthBase =
+          proxyRestartTarget?.backendBase ?? preflightBinding.base;
         const preflightBound =
-          preflightHealthBase != null &&
-          sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase);
+          proxyRestartTarget != null ||
+          (preflightHealthBase != null &&
+            sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase));
         // #848: what the instance was OBSERVED running with, taken from the preflight
         // that already had to resolve it. Nothing new is probed before the dispatch —
         // the no-await invariant between the binding capture and the reboot stands.
@@ -19374,7 +19438,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // EVERY retarget — any mutation, including a round trip back to the
           // same base, is caught.
           const preflightTargetGeneration = getComfyuiTargetGeneration();
-          const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
+          const preflight = proxyRestartTarget
+            ? { ok: true, observedArgv: proxyRestartTarget.argv }
+            : await (localRestartPreflightOverride ?? preflightLocalRestart)();
           // #848: keep the observed launch arguments. Recorded here and spent ONLY on
           // the success path far below, where the reboot has been proven to have
           // cycled THIS instance — it never influences any decision above.
@@ -19393,13 +19459,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // re-capture BEFORE trusting the result either way. The guarantee
           // that must hold: a stop/reboot is only ever sent when the preflight
           // validated THE instance the dispatch will cycle.
+          if (proxyRestartTarget) {
+            // The proxy branch performs no local stop/preflight. Its direct
+            // backend proof is rechecked immediately before dispatch below.
+            preflightArgvGeneration = proxyRestartTarget.generation;
+          }
           ctx.ensureReachable?.();
           const postPreflightHealthBase = captureRebootHealthBase(ctx);
           const tabFrontsSameInstance =
-            postPreflightHealthBase != null &&
-            sameHttpBase(preflightHealthBase, postPreflightHealthBase);
+            proxyRestartTarget != null ||
+            (postPreflightHealthBase != null &&
+              sameHttpBase(preflightHealthBase, postPreflightHealthBase));
           const configStable =
-            getComfyuiTargetGeneration() === preflightTargetGeneration;
+            proxyRestartTarget != null
+              ? getComfyuiTargetGeneration() === proxyRestartTarget.generation
+              : getComfyuiTargetGeneration() === preflightTargetGeneration;
           if (!configStable && tabFrontsSameInstance) {
             // r10: the target config moved MID-CHECK, so the preflight result
             // — pass OR fail — cannot vouch for the tab-fronted instance (a
@@ -19478,7 +19552,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // this SAME browser tab; a different tab can reuse the same saved-workflow
         // routing id while the original is still reconnecting.
         const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
-        const healthBase = captureRebootHealthBase(ctx);
+        if (proxyRestartTarget != null) {
+          const dispatchProxy = await panelVerifiedProxyRestartTarget();
+          proxyRestartTarget = proxyTargetBindsPanel(ctx, dispatchProxy)
+            ? dispatchProxy
+            : undefined;
+          if (proxyRestartTarget) {
+            preflightArgv = [...proxyRestartTarget.argv];
+            preflightArgvGeneration = proxyRestartTarget.generation;
+          }
+        }
+        const healthBase =
+          proxyRestartTarget?.backendBase ?? captureRebootHealthBase(ctx);
         // THE BINDING RULE APPLIES AT THE DISPATCH POINT, NOT ONLY BEFORE THE AWAIT.
         //
         // The check above happens before the preflight; a tab or connection rebind
@@ -19492,7 +19577,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // Same rule, same exclusions: only a LOCAL target we cannot tie to the
         // instance this server accounts for is refused.
         const dispatchBound =
-          healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase);
+          proxyRestartTarget != null ||
+          (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase));
         if (!dispatchBound && !isRemoteMode() && !isCloudMode()) {
           return restartRefusedPreservingBinding(
             ctx,
@@ -19698,6 +19784,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             // server replaced at the same URL between the reboot and here. That gap is real
             // and tracked in #871; this gate narrows the window, it does not close it.
             healthBase != null &&
+            proxyRestartTarget == null &&
             sameHttpBase(getComfyUIBaseUrl(), healthBase)
           ) {
             return runHeadlessManagedRestart({

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -17,6 +17,7 @@ import {
   unlinkSync,
   writeSync,
 } from "node:fs";
+import { isIP } from "node:net";
 import { homedir, platform } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
@@ -1178,6 +1179,24 @@ export interface VerifiedProxyRestartTarget {
 }
 
 /**
+ * The proxy proof must identify concrete listeners, not names whose resolution
+ * can change between the proof and the reboot. Keep this narrower than the
+ * general local-VRAM locality rule, which intentionally treats `localhost` as
+ * local for non-destructive provider handling.
+ */
+function isConcreteLoopbackHttpBase(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return isIP(hostname) > 0 && (hostname === "127.0.0.1" || hostname === "::1");
+}
+
+/**
  * Resolve the narrow EZi/CEI shape without ever claiming the helper listener is
  * ComfyUI. A proxy is eligible only when:
  *
@@ -1204,7 +1223,9 @@ export async function resolveVerifiedProxyRestartTarget(): Promise<VerifiedProxy
   const proxyBase = getComfyUIBaseUrl().replace(/\/+$/, "");
   const backendBase = bootBaseGetter()?.replace(/\/+$/, "") ?? "";
   if (!proxyBase || !backendBase || proxyBase === backendBase) return undefined;
-  if (!isLoopbackServerUrl(proxyBase) || !isLoopbackServerUrl(backendBase)) return undefined;
+  if (!isConcreteLoopbackHttpBase(proxyBase) || !isConcreteLoopbackHttpBase(backendBase)) {
+    return undefined;
+  }
 
   let proxyUrl: URL;
   let backendUrl: URL;
@@ -1214,9 +1235,6 @@ export async function resolveVerifiedProxyRestartTarget(): Promise<VerifiedProxy
   } catch {
     return undefined;
   }
-  // Match the panel binding gate's fail-closed treatment of DNS-ambiguous
-  // `localhost`: the proxy exception is for a concrete local listener only.
-  if (proxyUrl.hostname.toLowerCase() === "localhost") return undefined;
   if (proxyUrl.protocol !== backendUrl.protocol || proxyUrl.port === backendUrl.port) return undefined;
   const backendPort = Number(backendUrl.port || (backendUrl.protocol === "https:" ? 443 : 80));
   if (!Number.isInteger(backendPort) || backendPort < 1 || backendPort > 65535) return undefined;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -23,6 +23,7 @@ import { promisify } from "node:util";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
 import {
   config,
+  getBootLocalComfyUIBaseUrl,
   getComfyUIBaseUrl,
   getComfyuiTargetGeneration,
   isRemoteMode,
@@ -1114,6 +1115,121 @@ export async function readServingArgv(
       /* a timer we cannot clear is a leak at worst; it is unref'd and self-resolves */
     }
   }
+}
+
+/**
+ * Read `/system_stats.argv` from an explicitly anchored base. This is used only
+ * for the local-proxy restart proof: the mutable client target may be the panel
+ * helper, while the server-authorized boot base is the ComfyUI API we are willing
+ * to reboot. Keeping this separate from `readServingArgv` prevents an accidental
+ * re-read through the proxy from becoming the backend identity proof.
+ */
+async function readServingArgvAtBase(
+  base: string,
+  timeoutMs = 3000,
+): Promise<string[] | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  try {
+    const res = await comfyuiFetch(`${base.replace(/\/+$/, "")}/system_stats`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as {
+      system?: { argv?: unknown };
+    };
+    const argv = body?.system?.argv;
+    return Array.isArray(argv) && argv.every((arg) => typeof arg === "string") && argv.length > 0
+      ? [...argv]
+      : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function explicitPortFromArgv(argv: string[] | undefined): number | undefined {
+  if (!argv) return undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]?.trim();
+    const raw = token === "--port" ? argv[i + 1] : token?.startsWith("--port=") ? token.slice(7) : undefined;
+    if (raw == null || !/^\d{1,5}$/.test(raw)) continue;
+    const port = Number(raw);
+    if (port >= 1 && port <= 65535) return port;
+  }
+  return undefined;
+}
+
+function sameArgv(a: string[] | undefined, b: string[] | undefined): boolean {
+  return a != null && b != null && a.length === b.length && a.every((arg, i) => arg === b[i]);
+}
+
+export interface VerifiedProxyRestartTarget {
+  /** The mutable target currently fronted by the panel/helper. */
+  proxyBase: string;
+  /** The immutable, server-authorized local boot endpoint. */
+  backendBase: string;
+  /** Target generation at which both identity reads were made. */
+  generation: number;
+  /** ComfyUI's own argv, observed identically through both endpoints. */
+  argv: string[];
+}
+
+/**
+ * Resolve the narrow EZi/CEI shape without ever claiming the helper listener is
+ * ComfyUI. A proxy is eligible only when:
+ *
+ *  - the mutable target and immutable boot target are both loopback endpoints on
+ *    different ports;
+ *  - `/system_stats.argv` is non-empty and byte-for-byte identical through the
+ *    proxy and the boot endpoint; and
+ *  - that argv explicitly names the immutable endpoint's port.
+ *
+ * The generation/base checks fence the two awaited reads against a retarget. If
+ * any proof is missing, callers retain the ordinary refusal/ownership path.
+ */
+export async function resolveVerifiedProxyRestartTarget(): Promise<VerifiedProxyRestartTarget | undefined> {
+  // Some process-control unit fixtures intentionally provide only the config
+  // surface they exercise. Missing boot provenance means no proxy exception.
+  let bootBaseGetter: (() => string | null) | undefined;
+  try {
+    bootBaseGetter = getBootLocalComfyUIBaseUrl;
+  } catch {
+    // A partial test module mock may omit this optional seam.
+    return undefined;
+  }
+  if (typeof bootBaseGetter !== "function") return undefined;
+  const proxyBase = getComfyUIBaseUrl().replace(/\/+$/, "");
+  const backendBase = bootBaseGetter()?.replace(/\/+$/, "") ?? "";
+  if (!proxyBase || !backendBase || proxyBase === backendBase) return undefined;
+  if (!isLoopbackServerUrl(proxyBase) || !isLoopbackServerUrl(backendBase)) return undefined;
+
+  let proxyUrl: URL;
+  let backendUrl: URL;
+  try {
+    proxyUrl = new URL(proxyBase);
+    backendUrl = new URL(backendBase);
+  } catch {
+    return undefined;
+  }
+  // Match the panel binding gate's fail-closed treatment of DNS-ambiguous
+  // `localhost`: the proxy exception is for a concrete local listener only.
+  if (proxyUrl.hostname.toLowerCase() === "localhost") return undefined;
+  if (proxyUrl.protocol !== backendUrl.protocol || proxyUrl.port === backendUrl.port) return undefined;
+  const backendPort = Number(backendUrl.port || (backendUrl.protocol === "https:" ? 443 : 80));
+  if (!Number.isInteger(backendPort) || backendPort < 1 || backendPort > 65535) return undefined;
+
+  const generation = getComfyuiTargetGeneration();
+  const proxyArgv = await readServingArgv();
+  const backendArgv = await readServingArgvAtBase(backendBase);
+  if (!sameArgv(proxyArgv, backendArgv) || explicitPortFromArgv(backendArgv) !== backendPort) return undefined;
+  if (!backendArgv) return undefined;
+  if (getComfyuiTargetGeneration() !== generation || getComfyUIBaseUrl().replace(/\/+$/, "") !== proxyBase) {
+    return undefined;
+  }
+  return { proxyBase, backendBase, generation, argv: backendArgv };
 }
 
 /**
@@ -4024,6 +4140,10 @@ async function restartViaManagerReboot(context: {
    * `lastProcessInfo` so startComfyUI can rebuild that command.
    */
   selfRelaunch?: boolean;
+  /** Explicit backend endpoint for a verified local proxy (issue #2118). */
+  targetBase?: string;
+  /** Mutable target to fence while dispatching to `targetBase`. */
+  targetFenceBase?: string;
 }): Promise<RestartResult> {
   logger.info(`Restarting ${context.label} ComfyUI via ComfyUI-Manager reboot...`);
 
@@ -4045,10 +4165,11 @@ async function restartViaManagerReboot(context: {
   // the caller's read and this handshake is not seen. The caller's own identify
   // fences bound its reading to a live instance at the time it was taken; this
   // fences everything from here on.
-  const anchoredBase = getComfyUIBaseUrl();
+  const anchoredBase = context.targetBase ?? getComfyUIBaseUrl();
+  const targetFenceBase = context.targetFenceBase ?? anchoredBase;
   const witness = await acquireInstanceWitness(anchoredBase);
   try {
-    return await restartViaManagerRebootDispatch(context, anchoredBase, witness);
+    return await restartViaManagerRebootDispatch(context, anchoredBase, targetFenceBase, witness);
   } finally {
     witness?.close();
   }
@@ -4061,8 +4182,11 @@ async function restartViaManagerRebootDispatch(
     isDesktop?: boolean;
     supervisionNote?: string;
     selfRelaunch?: boolean;
+    targetBase?: string;
+    targetFenceBase?: string;
   },
   anchoredBase: string,
+  targetFenceBase: string,
   witness: InstanceWitness | undefined,
 ): Promise<RestartResult> {
   // #848: capture what it is running BEFORE the reboot, so the report afterwards can
@@ -4090,7 +4214,9 @@ async function restartViaManagerRebootDispatch(
   // reported the health of a third (codex gate P0/P1).
   const priorArgv = context.prior?.argv.length
     ? context.prior.argv
-    : await readServingArgv();
+    : context.targetBase
+      ? await readServingArgvAtBase(anchoredBase)
+      : await readServingArgv();
   const argvGeneration = context.prior?.argv.length
     ? context.prior.generation
     : selfReadGeneration;
@@ -4121,7 +4247,7 @@ async function restartViaManagerRebootDispatch(
   // equal but means the two readings may not describe the same server, so that
   // comparison declines while this dispatch correctly proceeds — the reboot goes
   // to the URL we read either way.
-  if (getComfyUIBaseUrl() !== anchoredBase) {
+  if (getComfyUIBaseUrl().replace(/\/+$/, "") !== targetFenceBase.replace(/\/+$/, "")) {
     return {
       stopped: false,
       started: false,
@@ -4337,7 +4463,9 @@ async function restartViaManagerRebootDispatch(
   //   - witness closed BEFORE the dispatch → the instance whose argv we read was
   //     gone before the reboot went out; the reboot reached a successor and the
   //     two readings may describe different lineages — decline.
-  const afterArgv = await readServingArgv();
+  const afterArgv = context.targetBase
+    ? await readServingArgvAtBase(anchoredBase)
+    : await readServingArgv();
   const targetStable = getComfyuiTargetGeneration() === argvGeneration;
   const witnessClosedAt = witness?.closedAt();
   const identityContinuous =
@@ -4694,6 +4822,20 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // process info, so it also works when the server is too wedged to answer.
   if (config.comfyuiRestartCommand) {
     return restartViaConfiguredCommand(config.comfyuiRestartCommand);
+  }
+  // EZi/CEI can serve the panel through a local helper port while the real
+  // ComfyUI child remains on the immutable boot port (#2118). The helper is
+  // deliberately NOT treated as an owned ComfyUI listener: when both endpoints
+  // corroborate the same explicit backend argv, use Manager against that backend
+  // and keep the ordinary process-ownership refusal for every other shape.
+  const verifiedProxy = await resolveVerifiedProxyRestartTarget();
+  if (verifiedProxy) {
+    return restartViaManagerReboot({
+      label: "EZi/CEI-proxied",
+      prior: { argv: verifiedProxy.argv, generation: verifiedProxy.generation },
+      targetBase: verifiedProxy.backendBase,
+      targetFenceBase: verifiedProxy.proxyBase,
+    });
   }
   logger.info("Restarting ComfyUI...");
 


### PR DESCRIPTION
Fixes #2118

When a local EZi/CEI helper exposes the panel on a different port, require identical non-empty /system_stats argv through the proxy and immutable boot endpoint, including an explicit boot-port argument. Route verified cases through the backend Manager reboot and backend readiness probe; never claim or kill the helper listener. Recheck target generation and panel binding across confirmation/preflight/dispatch awaits. Keep the existing strict process argv ownership refusal for unverified cases.

Tests: focused panel restart suites, process-control restart identity/target-anchor suites, live-interpreter, build, lint, and diff checks.