### PR TITLE
fix(workflow): refuse empty UI-to-API conversion

### DIFF
--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -121,6 +121,7 @@ describe('get_workflow (action:"get") — JSON before conversion warnings (#494)
       workflow: {},
       warnings: [],
       missingNodeTypes: [],
+      potentiallyExecutableNodeCount: 1,
     });
 
     const result = await getHandler("get_workflow")({

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -50,7 +50,7 @@ import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
 
 type ToolHandler = (
   args: Record<string, unknown>,
-) => Promise<{ content: Array<{ type: string; text: string }> }>;
+) => Promise<{ isError?: boolean; content: Array<{ type: string; text: string }> }>;
 function getHandler(name: string): ToolHandler {
   let handler: ToolHandler | undefined;
   const server = {
@@ -101,5 +101,37 @@ describe('get_workflow (action:"get") — JSON before conversion warnings (#494)
     });
     expect(content).toHaveLength(1);
     expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
+  });
+
+  it("refuses a non-empty UI graph that converts to an empty API graph (#2125)", async () => {
+    const uiWorkflow = {
+      // The reported workflow had 164 nodes, including UUID-backed subgraphs
+      // and bypassed pipeline branches. Keep that cardinality here so the
+      // production guard cannot regress to treating a large source graph as an
+      // empty/absent input.
+      nodes: Array.from({ length: 164 }, (_, index) => ({
+        id: index + 1,
+        type: index % 2 === 0 ? `subgraph-${index}` : "Fast Groups Bypasser (rgthree)",
+        mode: index % 2 === 0 ? 4 : 0,
+      })),
+      links: [],
+    };
+    fetchApiMock.mockResolvedValue({ ok: true, status: 200, json: async () => uiWorkflow });
+    convertUiToApiMock.mockReturnValue({
+      workflow: {},
+      warnings: [],
+      missingNodeTypes: [],
+    });
+
+    const result = await getHandler("get_workflow")({
+      action: "get",
+      filename: "WAN 2.2 Smooth Workflow v6.0.json",
+      format: "api",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("produced no executable API nodes");
+    expect(result.content[0].text).toContain("Request format");
+    expect(result.content[0].text).not.toBe("{}");
   });
 });

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -103,7 +103,7 @@ describe('get_workflow (action:"get") — JSON before conversion warnings (#494)
     expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
   });
 
-  it("refuses a non-empty UI graph that converts to an empty API graph (#2125)", async () => {
+  it("accepts a non-empty UI graph when the converter identifies only frontend-only content", async () => {
     const uiWorkflow = {
       // The reported workflow had 164 nodes, including UUID-backed subgraphs
       // and bypassed pipeline branches. Keep that cardinality here so the
@@ -121,7 +121,7 @@ describe('get_workflow (action:"get") — JSON before conversion warnings (#494)
       workflow: {},
       warnings: [],
       missingNodeTypes: [],
-      potentiallyExecutableNodeCount: 1,
+      potentiallyExecutableNodeCount: 0,
     });
 
     const result = await getHandler("get_workflow")({
@@ -130,9 +130,7 @@ describe('get_workflow (action:"get") — JSON before conversion warnings (#494)
       format: "api",
     });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("produced no executable API nodes");
-    expect(result.content[0].text).toContain("Request format");
-    expect(result.content[0].text).not.toBe("{}");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual({});
   });
 });

--- a/src/__tests__/tools/workflow-library-conversion.test.ts
+++ b/src/__tests__/tools/workflow-library-conversion.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   fetchApi: vi.fn(),
   getObjectInfo: vi.fn(),
   backfillObjectInfo: vi.fn(),
+  queryApiGraph: vi.fn(),
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -15,7 +16,7 @@ vi.mock("../../comfyui/client.js", () => ({
 vi.mock("node:fs/promises", () => ({ readFile: vi.fn() }));
 vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
 vi.mock("../../services/graph-query.js", () => ({
-  queryApiGraph: vi.fn(),
+  queryApiGraph: (...args: unknown[]) => mocks.queryApiGraph(...args),
   LIMIT_CEILING: 200,
   MAX_CHARS_CEILING: 60000,
   MAX_CHARS_FLOOR: 500,
@@ -35,6 +36,13 @@ vi.mock("../../tools/prompt-director.js", () => ({ promptDirectorInspectAction: 
 vi.mock("../../tools/workflow-lock.js", () => ({
   lockWorkflowAction: vi.fn(),
   verifyWorkflowLockAction: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+vi.mock("../../services/frontend-virtual-types.js", () => ({
+  frontendVirtualTypesFor: () =>
+    new Set(["Fast Groups Bypasser (rgthree)", "Fast Groups Muter (rgthree)"]),
 }));
 
 // Deliberately do not mock workflow-converter.js: these are production-path
@@ -134,6 +142,51 @@ function lostExecutableGraph(): Record<string, unknown> {
   };
 }
 
+const EXECUTABLE_OBJECT_INFO = {
+  SourceNode: { input: { required: {} }, output: ["IMAGE"] },
+  SinkNode: { input: { required: { image: ["IMAGE"] } }, output: [] },
+};
+
+/** An active UUID component whose legacy object links survive flattening. */
+function executableUuidLegacyGraph(): Record<string, unknown> {
+  const component = uiNode(5, UUID_COMPONENT);
+  component.outputs = [{ name: "IMAGE", type: "IMAGE", links: [800] }];
+  const outerSink = uiNode(20, "SinkNode");
+  outerSink.inputs = [{ name: "image", type: "IMAGE", link: 800 }];
+
+  const source = uiNode(1, "SourceNode");
+  source.outputs = [{ name: "IMAGE", type: "IMAGE", links: [701, 702] }];
+  const innerSink = uiNode(2, "SinkNode");
+  innerSink.inputs = [{ name: "image", type: "IMAGE", link: 701 }];
+
+  return {
+    nodes: [component, outerSink],
+    links: [[800, 5, 0, 20, 0, "IMAGE"]],
+    definitions: {
+      subgraphs: [
+        {
+          id: UUID_COMPONENT,
+          name: "active UUID component",
+          inputNode: { id: -10 },
+          outputNode: { id: -20 },
+          inputs: [],
+          outputs: [{ id: "out", name: "IMAGE", type: "IMAGE", linkIds: [702] }],
+          nodes: [source, innerSink],
+          links: [
+            { id: 701, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0, type: "IMAGE" },
+            { id: 702, origin_id: 1, origin_slot: 0, target_id: -20, target_slot: 0, type: "IMAGE" },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function imageLink(node: { inputs: Record<string, unknown> }): unknown {
+  const value = node.inputs.image;
+  return Array.isArray(value) ? value[0] : undefined;
+}
+
 function setLibraryResponse(body: unknown): void {
   mocks.fetchApi.mockResolvedValue({
     ok: true,
@@ -149,6 +202,7 @@ beforeEach(() => {
   mocks.backfillObjectInfo.mockReset();
   mocks.getObjectInfo.mockResolvedValue({});
   mocks.backfillObjectInfo.mockImplementation(async (bulk: unknown) => bulk);
+  mocks.queryApiGraph.mockReturnValue({ text: "No executable API nodes" });
 });
 
 describe("workflow-library UI→API conversion seam (#2125)", () => {
@@ -182,6 +236,80 @@ describe("workflow-library UI→API conversion seam (#2125)", () => {
       expect(result.isError).toBeUndefined();
       expect(JSON.parse(result.content[0].text)).toEqual({});
     }
+  });
+
+  it("accepts panel-proven Fast Groups Bypasser/Muter-only graphs as valid empty UI conversions", async () => {
+    const source = {
+      nodes: [
+        uiNode(1, "Fast Groups Bypasser (rgthree)"),
+        uiNode(2, "Fast Groups Muter (rgthree)"),
+      ],
+      links: [],
+    };
+    const before = structuredClone(source);
+    setLibraryResponse(source);
+
+    const result = await getHandler()({ action: "get", filename: "toggles.json", format: "api" });
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual({});
+    expect(source).toEqual(before);
+  });
+
+  it("does not let a virtual proof override a node type registered by object_info", async () => {
+    const source = {
+      nodes: [uiNode(1, "Fast Groups Bypasser (rgthree)"), uiNode(2, "Note")],
+      links: [],
+    };
+    mocks.getObjectInfo.mockResolvedValue({
+      "Fast Groups Bypasser (rgthree)": { input: { required: {} }, output: [] },
+    });
+    setLibraryResponse(source);
+
+    const result = await getHandler()({ action: "get", filename: "registered.json", format: "api" });
+
+    expect(result.isError).toBeUndefined();
+    const api = JSON.parse(result.content[0].text) as Record<string, { class_type: string }>;
+    expect(Object.values(api)).toEqual([{ class_type: "Fast Groups Bypasser (rgthree)", inputs: {} }]);
+  });
+
+  it("preserves active UUID expansion and legacy links through get without mutating the source", async () => {
+    const source = executableUuidLegacyGraph();
+    const before = structuredClone(source);
+    mocks.getObjectInfo.mockResolvedValue(EXECUTABLE_OBJECT_INFO);
+    setLibraryResponse(source);
+
+    const result = await getHandler()({ action: "get", filename: "uuid.json", format: "api" });
+
+    expect(result.isError).toBeUndefined();
+    const api = JSON.parse(result.content[0].text) as Record<string, {
+      class_type: string;
+      inputs: Record<string, unknown>;
+    }>;
+    const sourceEntry = Object.entries(api).find(([, node]) => node.class_type === "SourceNode");
+    const innerSink = Object.values(api).filter((node) => node.class_type === "SinkNode");
+    expect(sourceEntry).toBeDefined();
+    expect(innerSink).toHaveLength(2);
+    expect(innerSink.some((node) => imageLink(node) === sourceEntry![0])).toBe(true);
+    expect(Object.values(api).some((node) => imageLink(node) === sourceEntry![0])).toBe(true);
+    expect(source).toEqual(before);
+  });
+
+  it("keeps valid empty conversion semantics across strip, query, and analyze", async () => {
+    const source = { nodes: [uiNode(1, "Note")], links: [] };
+
+    const stripped = await getHandler()({ action: "strip", graph: source, format: "api" });
+    expect(stripped.isError).toBeUndefined();
+    expect(stripped.content.at(-1)?.text).toBe("{}");
+
+    const queried = await getHandler()({ action: "query", graph: source, types: ["Note"] });
+    expect(queried.isError).toBeUndefined();
+    expect(queried.content[0].text).toContain("No executable API nodes");
+
+    setLibraryResponse(source);
+    const analyzed = await getHandler()({ action: "analyze", filename: "note.json", view: "health" });
+    expect(analyzed.isError).toBeUndefined();
+    expect(analyzed.content[0].text).toContain("no executable API nodes");
   });
 
   it("refuses genuinely lost executable content and retains converter warnings", async () => {

--- a/src/__tests__/tools/workflow-library-conversion.test.ts
+++ b/src/__tests__/tools/workflow-library-conversion.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchApi: vi.fn(),
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  comfyApiFetch: (...args: unknown[]) => mocks.fetchApi(...args),
+  getObjectInfo: (...args: unknown[]) => mocks.getObjectInfo(...args),
+  backfillObjectInfo: (...args: unknown[]) => mocks.backfillObjectInfo(...args),
+}));
+
+vi.mock("node:fs/promises", () => ({ readFile: vi.fn() }));
+vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
+vi.mock("../../services/graph-query.js", () => ({
+  queryApiGraph: vi.fn(),
+  LIMIT_CEILING: 200,
+  MAX_CHARS_CEILING: 60000,
+  MAX_CHARS_FLOOR: 500,
+}));
+vi.mock("../../services/userdata-library.js", () => ({ listWorkflowLibraryKeys: vi.fn() }));
+vi.mock("../../services/workflow-sections.js", () => ({ detectSections: vi.fn() }));
+vi.mock("../../services/hierarchical-mermaid.js", () => ({
+  generateOverview: vi.fn(),
+  generateSectionDetail: vi.fn(),
+  listSections: vi.fn(),
+  generateSummary: vi.fn(),
+}));
+vi.mock("../../services/mermaid-converter.js", () => ({ convertToMermaid: vi.fn() }));
+vi.mock("../../services/workflow-health.js", () => ({ analyzeGraphHealth: vi.fn() }));
+vi.mock("../../services/image-management.js", () => ({ extractWorkflowFromImage: vi.fn() }));
+vi.mock("../../tools/prompt-director.js", () => ({ promptDirectorInspectAction: vi.fn() }));
+vi.mock("../../tools/workflow-lock.js", () => ({
+  lockWorkflowAction: vi.fn(),
+  verifyWorkflowLockAction: vi.fn(),
+}));
+
+// Deliberately do not mock workflow-converter.js: these are production-path
+// regressions through the real UI→API converter and workflow-library handler.
+import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    tool: (name: string, _description: string, _shape: unknown, candidate: Handler) => {
+      if (name === "get_workflow") handler = candidate;
+    },
+  };
+  registerWorkflowLibraryTools(server as never);
+  if (!handler) throw new Error("get_workflow was not registered");
+  return handler;
+}
+
+function uiNode(id: number, type: string, mode = 0): Record<string, unknown> {
+  return {
+    id,
+    type,
+    mode,
+    pos: [id, 0],
+    inputs: [],
+    outputs: [],
+    widgets_values: [],
+  };
+}
+
+const UUID_COMPONENT = "0f0f0f0f-2125-4b21-8b21-000000000001";
+
+/**
+ * A 164-node UI export with a UUID component, bypassed execution branches,
+ * frontend-only notes, ordinary legacy link tuples, and a subgraph's legacy
+ * object links. Every executable candidate is intentionally absent.
+ */
+function validLargeEmptyGraph(): Record<string, unknown> {
+  const nodes = [uiNode(1, UUID_COMPONENT)];
+  for (let id = 2; id <= 164; id++) {
+    nodes.push(uiNode(id, id % 2 === 0 ? "KSampler" : "Note", id % 2 === 0 ? 4 : 0));
+  }
+  (nodes[1].outputs as Array<Record<string, unknown>>)[0] = {
+    name: "LATENT",
+    type: "LATENT",
+    links: [700],
+  };
+  (nodes[2].inputs as Array<Record<string, unknown>>)[0] = {
+    name: "latent",
+    type: "LATENT",
+    link: 700,
+  };
+
+  return {
+    nodes,
+    links: [[700, 2, 0, 3, 0, "LATENT"]],
+    definitions: {
+      subgraphs: [
+        {
+          id: UUID_COMPONENT,
+          name: "bypassed UUID component",
+          inputNode: { id: -10 },
+          outputNode: { id: -20 },
+          inputs: [],
+          outputs: [],
+          nodes: [
+            uiNode(1, "KSampler", 4),
+            uiNode(2, "Note"),
+          ],
+          // ComfyUI component definitions use object links, unlike the
+          // top-level legacy tuple links.
+          links: [
+            { id: 1, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0, type: "LATENT" },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function lostExecutableGraph(): Record<string, unknown> {
+  const nodes = [uiNode(1, "missing-uuid-node-1")];
+  for (let id = 2; id <= 12; id++) {
+    nodes.push(uiNode(id, `missing-uuid-node-${id}`));
+  }
+  for (let id = 13; id <= 164; id++) {
+    nodes.push(uiNode(id, id % 2 === 0 ? "KSampler" : "Note", id % 2 === 0 ? 4 : 0));
+  }
+  return {
+    nodes,
+    links: [[900, 1, 0, 3, 0, "LATENT"]],
+  };
+}
+
+function setLibraryResponse(body: unknown): void {
+  mocks.fetchApi.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  });
+}
+
+beforeEach(() => {
+  mocks.fetchApi.mockReset();
+  mocks.getObjectInfo.mockReset();
+  mocks.backfillObjectInfo.mockReset();
+  mocks.getObjectInfo.mockResolvedValue({});
+  mocks.backfillObjectInfo.mockImplementation(async (bulk: unknown) => bulk);
+});
+
+describe("workflow-library UI→API conversion seam (#2125)", () => {
+  it("keeps a valid 164-node UUID/bypassed/frontend-only graph empty and immutable", async () => {
+    const source = validLargeEmptyGraph();
+    const before = structuredClone(source);
+    setLibraryResponse(source);
+
+    const result = await getHandler()({
+      action: "get",
+      filename: "WAN 2.2 Smooth Workflow v6.0.json",
+      format: "api",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual({});
+    expect(source).toEqual(before);
+    expect((source.nodes as unknown[]).length).toBe(164);
+  });
+
+  it("preserves literal empty, bypassed executable, and frontend-only UI graphs", async () => {
+    const graphs = [
+      { nodes: [], links: [] },
+      { nodes: [uiNode(1, "KSampler", 4)], links: [] },
+      { nodes: [uiNode(1, "Note")], links: [] },
+    ];
+
+    for (const graph of graphs) {
+      setLibraryResponse(graph);
+      const result = await getHandler()({ action: "get", filename: "empty.json", format: "api" });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text)).toEqual({});
+    }
+  });
+
+  it("refuses genuinely lost executable content and retains converter warnings", async () => {
+    const source = lostExecutableGraph();
+    setLibraryResponse(source);
+    const result = await getHandler()({
+      action: "get",
+      filename: "lost.json",
+      format: "api",
+    });
+
+    expect(result.isError).toBe(true);
+    const error = JSON.parse(result.content[0].text) as { message: string };
+    expect(error.message).toContain("produced no executable API nodes");
+    expect(error.message).toContain("Node 1 (missing-uuid-node-1)");
+    expect(error.message).toContain("Node 9 (missing-uuid-node-9)");
+    expect(error.message).toContain("Conversion diagnostics (12)");
+    expect(error.message).toContain('Request format:"ui"');
+  });
+
+  it("uses the same refusal and diagnostics for strip, query, and analyze", async () => {
+    const source = lostExecutableGraph();
+    const expected = "Node 1 (missing-uuid-node-1)";
+
+    const strip = await getHandler()({ action: "strip", graph: source, format: "api" });
+    expect(strip.isError).toBe(true);
+    expect(strip.content[0].text).toContain(expected);
+
+    const query = await getHandler()({
+      action: "query",
+      graph: source,
+      types: ["missing-uuid-node"],
+    });
+    expect(query.isError).toBe(true);
+    expect(query.content[0].text).toContain(expected);
+
+    setLibraryResponse(source);
+    const analyze = await getHandler()({
+      action: "analyze",
+      filename: "lost.json",
+      view: "health",
+    });
+    expect(analyze.isError).toBe(true);
+    expect(analyze.content[0].text).toContain(expected);
+  });
+
+  it('leaves format:"ui" as the raw source representation', async () => {
+    const source = validLargeEmptyGraph();
+    setLibraryResponse(source);
+    const result = await getHandler()({
+      action: "get",
+      filename: "raw.json",
+      format: "ui",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(source);
+    expect(result.content).toHaveLength(1);
+  });
+});

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -42,6 +42,15 @@ export interface ConversionResult {
   }>;
 }
 
+/**
+ * Runtime facts supplied by a connected frontend. These are deliberately
+ * optional: a headless MCP process without a panel has no proof and must keep
+ * treating unknown node types as potentially executable.
+ */
+export interface UiToApiConversionOptions {
+  frontendVirtualTypes?: ReadonlySet<string>;
+}
+
 interface LinkInfo {
   sourceNodeId: number;
   sourceSlot: number;
@@ -2494,6 +2503,7 @@ export const FRONTEND_ONLY_NODE_TYPES: ReadonlySet<string> = new Set([
 export function convertUiToApi(
   ui: UiWorkflow,
   objectInfo: ObjectInfo,
+  options?: UiToApiConversionOptions,
 ): ConversionResult {
   // Clone (don't mutate the caller's workflow), materialize the node-pack
   // broadcast wiring that isn't in `links` at all (cg-use-everywhere), strip the
@@ -2529,7 +2539,12 @@ export function convertUiToApi(
   }
 
   // Node types that are purely visual/internal and have no API equivalent
-  const SKIP_TYPES = NON_EXECUTING_NODE_TYPES;
+  const provenFrontendOnlyTypes = [...(options?.frontendVirtualTypes ?? [])].filter(
+    (type) =>
+      !WIRING_VIRTUAL_TYPES.has(type) &&
+      !Object.prototype.hasOwnProperty.call(objectInfo, type),
+  );
+  const SKIP_TYPES = new Set([...NON_EXECUTING_NODE_TYPES, ...provenFrontendOnlyTypes]);
 
   // Get/Set node types that need special handling (not in object_info). The SAME
   // set the de-virtualization pre-pass uses — this was a verbatim second copy, and

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -19,6 +19,12 @@ export interface ConversionResult {
   workflow: WorkflowJSON;
   warnings: string[];
   /**
+   * Expanded nodes that the main conversion loop considered executable. A
+   * zero count is meaningful: a UI graph made only of bypassed/muted or
+   * frontend-only nodes legitimately converts to an empty API prompt.
+   */
+  potentiallyExecutableNodeCount: number;
+  /**
    * Nodes DROPPED because their class_type is absent from object_info. Reported
    * structurally so a caller can raise the same authoritative "unknown node type"
    * error the API-format path raises, instead of parsing it back out of the
@@ -2539,6 +2545,18 @@ export function convertUiToApi(
   // written down instead of assumed.
   const GET_SET_TYPES = WIRING_VIRTUAL_TYPES;
 
+  // Keep the production empty-result guard aligned with the exact skip rules
+  // below. Counting after component expansion is important: a UUID-backed
+  // component whose inner graph is entirely bypassed/frontend-only is also a
+  // valid empty executable graph.
+  const potentiallyExecutableNodeCount = expanded.nodes.filter(
+    (node) =>
+      node.mode !== 2 &&
+      node.mode !== 4 &&
+      !SKIP_TYPES.has(node.type) &&
+      !GET_SET_TYPES.has(node.type),
+  ).length;
+
   const nodesById = new Map(expanded.nodes.map((n) => [n.id, n]));
 
   const isGetType = (t: string) => GET_SET_TYPES.has(t) && /get/i.test(t);
@@ -3678,5 +3696,10 @@ export function convertUiToApi(
   // duplicates are pure noise. Distinct nodes/inputs keep their own warnings.
   const dedupedWarnings = [...new Set(warnings)];
 
-  return { workflow, warnings: dedupedWarnings, missingNodeTypes };
+  return {
+    workflow,
+    warnings: dedupedWarnings,
+    missingNodeTypes,
+    potentiallyExecutableNodeCount,
+  };
 }

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { WorkflowJSON } from "../comfyui/types.js";
+import type { UiWorkflow, WorkflowJSON } from "../comfyui/types.js";
 import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
 import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
@@ -13,6 +13,7 @@ import {
   convertApiToUi,
   collectNodeTypes,
 } from "../services/workflow-converter.js";
+import type { ConversionResult } from "../services/workflow-converter.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import {
   queryApiGraph,
@@ -72,6 +73,51 @@ async function loadRawFromSource(
     );
   }
   return await res.json();
+}
+
+/** Keep every saved-workflow UI conversion on the same schema-backed path. */
+async function convertUiWorkflow(raw: UiWorkflow): Promise<ConversionResult> {
+  const bulk = await getObjectInfo();
+  const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
+  return convertUiToApi(raw, objectInfo);
+}
+
+const MAX_CONVERSION_DIAGNOSTICS_CHARS = 12_000;
+
+function formatConversionDiagnostics(warnings: readonly string[]): string {
+  if (warnings.length === 0) return "";
+  const rendered = warnings.map((warning) => `- ${warning}`).join("\n");
+  if (rendered.length <= MAX_CONVERSION_DIAGNOSTICS_CHARS) return rendered;
+  return `${rendered.slice(0, MAX_CONVERSION_DIAGNOSTICS_CHARS)}\n- … conversion diagnostics truncated after ${MAX_CONVERSION_DIAGNOSTICS_CHARS} characters; use action:"strip" for the full bounded report.`;
+}
+
+/**
+ * Fail closed only when the converter saw an executable candidate and lost
+ * all of them. Empty UI graphs and graphs consisting solely of bypassed,
+ * muted, or frontend-only nodes are valid empty executable prompts.
+ */
+function refuseIfExecutableContentWasLost(
+  sourceName: string,
+  raw: UiWorkflow,
+  converted: ConversionResult,
+): void {
+  if (
+    raw.nodes.length === 0 ||
+    Object.keys(converted.workflow).length > 0 ||
+    converted.potentiallyExecutableNodeCount === 0
+  ) {
+    return;
+  }
+
+  const diagnostics = formatConversionDiagnostics(converted.warnings);
+  const diagnosticNote = diagnostics
+    ? ` Conversion diagnostics (${converted.warnings.length}):\n${diagnostics}`
+    : " No conversion diagnostics were emitted; inspect the saved UI graph before retrying.";
+  throw new ValidationError(
+    `Could NOT convert "${sourceName}" from UI to API: the saved graph contains ${
+      raw.nodes.length
+    } node(s), including ${converted.potentiallyExecutableNodeCount} executable candidate(s), but conversion produced no executable API nodes. Refusing to return an empty {} graph because downstream analysis would be misleading.${diagnosticNote} Request format:"ui" to inspect the original graph; action:"strip" uses the same conversion diagnostics.`,
+  );
 }
 
 /**
@@ -581,37 +627,10 @@ async function getWorkflowAction(filename: string, format: "ui" | "api"): Promis
 
         // If API format requested and workflow is in UI format, convert
         if (format === "api" && isUiFormat(raw)) {
-          const bulk = await getObjectInfo();
-          // Backfill node types missing from the bulk /object_info (e.g.
-          // controlnet_aux's DWPreprocessor) so the converter doesn't skip them.
-          const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
-          const converted = convertUiToApi(raw, objectInfo);
+          const converted = await convertUiWorkflow(raw);
           const { workflow, warnings } = converted;
 
-          // A non-empty UI graph must never be reported as a successful empty
-          // API graph. That makes a conversion failure look like a valid
-          // dependency-free workflow to callers such as list_packs
-          // (action:"extract_deps") and is especially misleading for large
-          // graphs whose executable nodes were all skipped by schema, UUID or
-          // bypass handling (#2125). Refuse at this production boundary rather
-          // than broadening the converter's schema guesses or changing its
-          // existing fail-closed node semantics.
-          if (raw.nodes.length > 0 && Object.keys(workflow).length === 0) {
-            const missingTypes = [
-              ...new Set((converted.missingNodeTypes ?? []).map((entry) => entry.classType)),
-            ];
-            const missingNote =
-              missingTypes.length > 0
-                ? ` Missing node type(s): ${missingTypes.slice(0, 8).join(", ")}${
-                    missingTypes.length > 8 ? ", …" : ""
-                  }.`
-                : "";
-            throw new ValidationError(
-              `Could NOT convert "${filename}" from UI to API: the saved graph contains ${
-                raw.nodes.length
-              } node(s), but conversion produced no executable API nodes. Refusing to return an empty {} graph because downstream analysis would be misleading.${missingNote} Request format:"ui" to inspect the original graph and its conversion warnings.`,
-            );
-          }
+          refuseIfExecutableContentWasLost(filename, raw, converted);
 
           // Return the JSON workflow as the primary/first content block so
           // consumers that read the first text result always receive the graph
@@ -655,9 +674,9 @@ async function stripWorkflowAction(
           return { content: [{ type: "text", text: JSON.stringify(raw, null, 2) }] };
         }
 
-        const bulk = await getObjectInfo();
-        const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
-        const { workflow, warnings } = convertUiToApi(raw, objectInfo);
+        const converted = await convertUiWorkflow(raw);
+        const { workflow, warnings } = converted;
+        refuseIfExecutableContentWasLost(filename ?? path ?? "inline workflow", raw, converted);
 
         const hist: Record<string, number> = {};
         for (const node of Object.values(workflow)) {
@@ -702,10 +721,9 @@ async function queryWorkflowAction(
         let api = raw;
         const notes: string[] = [];
         if (isUiFormat(raw)) {
-          const bulk = await getObjectInfo();
-          const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
-          const converted = convertUiToApi(raw, objectInfo);
+          const converted = await convertUiWorkflow(raw);
           api = converted.workflow;
+          refuseIfExecutableContentWasLost(filename ?? path ?? "inline workflow", raw, converted);
           if (converted.warnings.length)
             notes.push(
               `${converted.warnings.length} conversion warning(s) — see get_workflow (action:"strip") for details`,
@@ -858,10 +876,11 @@ async function loadWorkflowApi(filename: string): Promise<{ workflow: WorkflowJS
   }
 
   const raw = await res.json();
-  const objectInfo = await getObjectInfo();
 
   if (isUiFormat(raw)) {
-    return convertUiToApi(raw, objectInfo);
+    const converted = await convertUiWorkflow(raw);
+    refuseIfExecutableContentWasLost(filename, raw, converted);
+    return converted;
   }
 
   // Already API format

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -585,7 +585,33 @@ async function getWorkflowAction(filename: string, format: "ui" | "api"): Promis
           // Backfill node types missing from the bulk /object_info (e.g.
           // controlnet_aux's DWPreprocessor) so the converter doesn't skip them.
           const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
-          const { workflow, warnings } = convertUiToApi(raw, objectInfo);
+          const converted = convertUiToApi(raw, objectInfo);
+          const { workflow, warnings } = converted;
+
+          // A non-empty UI graph must never be reported as a successful empty
+          // API graph. That makes a conversion failure look like a valid
+          // dependency-free workflow to callers such as list_packs
+          // (action:"extract_deps") and is especially misleading for large
+          // graphs whose executable nodes were all skipped by schema, UUID or
+          // bypass handling (#2125). Refuse at this production boundary rather
+          // than broadening the converter's schema guesses or changing its
+          // existing fail-closed node semantics.
+          if (raw.nodes.length > 0 && Object.keys(workflow).length === 0) {
+            const missingTypes = [
+              ...new Set((converted.missingNodeTypes ?? []).map((entry) => entry.classType)),
+            ];
+            const missingNote =
+              missingTypes.length > 0
+                ? ` Missing node type(s): ${missingTypes.slice(0, 8).join(", ")}${
+                    missingTypes.length > 8 ? ", …" : ""
+                  }.`
+                : "";
+            throw new ValidationError(
+              `Could NOT convert "${filename}" from UI to API: the saved graph contains ${
+                raw.nodes.length
+              } node(s), but conversion produced no executable API nodes. Refusing to return an empty {} graph because downstream analysis would be misleading.${missingNote} Request format:"ui" to inspect the original graph and its conversion warnings.`,
+            );
+          }
 
           // Return the JSON workflow as the primary/first content block so
           // consumers that read the first text result always receive the graph

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -6,6 +6,7 @@ import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/cli
 import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { getComfyUIBaseUrl } from "../config.js";
 import {
   isUiFormat,
   isApiFormat,
@@ -14,6 +15,7 @@ import {
   collectNodeTypes,
 } from "../services/workflow-converter.js";
 import type { ConversionResult } from "../services/workflow-converter.js";
+import { frontendVirtualTypesFor } from "../services/frontend-virtual-types.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import {
   queryApiGraph,
@@ -79,7 +81,9 @@ async function loadRawFromSource(
 async function convertUiWorkflow(raw: UiWorkflow): Promise<ConversionResult> {
   const bulk = await getObjectInfo();
   const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
-  return convertUiToApi(raw, objectInfo);
+  return convertUiToApi(raw, objectInfo, {
+    frontendVirtualTypes: frontendVirtualTypesFor(getComfyUIBaseUrl()),
+  });
 }
 
 const MAX_CONVERSION_DIAGNOSTICS_CHARS = 12_000;
@@ -857,7 +861,12 @@ async function saveWorkflowAction(
 }
 
 /** Load and convert a workflow from the library (shared by action:"analyze"). */
-async function loadWorkflowApi(filename: string): Promise<{ workflow: WorkflowJSON; warnings: string[] }> {
+async function loadWorkflowApi(filename: string): Promise<{
+  workflow: WorkflowJSON;
+  warnings: string[];
+  /** Defined only for UI input, where zero means a valid empty conversion. */
+  potentiallyExecutableNodeCount?: number;
+}> {
   const encoded = encodeURIComponent(`workflows/${filename}`);
   const res = await comfyApiFetch(`/api/userdata/${encoded}`);
 
@@ -894,11 +903,10 @@ async function analyzeWorkflowAction(
   section: string | undefined,
 ): Promise<TextResult> {
         logger.info(`Analyzing workflow: ${filename} (view=${view})`);
-        const { workflow, warnings } = await loadWorkflowApi(filename);
-        const objectInfo = await getObjectInfo();
-
+        const { workflow, warnings, potentiallyExecutableNodeCount } = await loadWorkflowApi(filename);
         const nodeCount = Object.keys(workflow).length;
-        if (nodeCount === 0) {
+        const validEmptyUiConversion = nodeCount === 0 && potentiallyExecutableNodeCount === 0;
+        if (nodeCount === 0 && !validEmptyUiConversion) {
           throw new ValidationError("Workflow contains no nodes");
         }
 
@@ -911,6 +919,17 @@ async function analyzeWorkflowAction(
             text: `**Conversion warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join("\n")}`,
           });
         }
+
+        if (validEmptyUiConversion) {
+          content.push({
+            type: "text",
+            text:
+              "Workflow contains no executable API nodes. The saved UI graph is empty or contains only bypassed, muted, or frontend-only nodes.",
+          });
+          return { content };
+        }
+
+        const objectInfo = await getObjectInfo();
 
         if (view === "flat") {
           // Simple mermaid flowchart — good for small workflows


### PR DESCRIPTION
Fixes #2125

Summary:
- Refuse UI-to-API empty results only when the real converter saw executable candidates that were all lost after component expansion.
- Accept valid literal empty, bypassed/muted-only, UUID-component, and panel-proven frontend-only graphs, including Fast Groups Bypasser/Muter, while keeping unknown/unproven active types fail-closed.
- Share the conversion/refusal seam across get, strip, query, and analyze; valid empty UI conversions now have coherent analyze results, while API `{}` still refuses as before.
- Preserve bounded converter warnings in refusal diagnostics without relaxing node schemas; a frontend proof cannot override a type registered in `/object_info`.

Regression coverage:
- Real converter-backed 164-node UUID/bypassed/legacy-link empty graph with source immutability.
- Real converter-backed Fast Groups Bypasser/Muter empty graph through the production workflow-library path.
- Active UUID expansion and legacy object-link preservation with executable nodes, plus source immutability.
- Valid empty get/strip/query/analyze behavior and multi-node loss refusal with retained diagnostics.

Verification:
- Focused regression Vitest: 2 files, 12 tests passed.
- Relevant converter/workflow-library/serializer/validator/runtime Vitest: 19 files, 498 tests passed.
- `npm run lint`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.

No merge or release performed.