### PR TITLE
fix(panel-run): preserve uncertain queue receipts

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1406,6 +1406,33 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     expect(textOf(res)).toContain(QUEUED_NOTE);
   });
 
+  it("#2143: tickets the Panel's known queued_prompt_ids and preserves retry guidance", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: true,
+            complete: false,
+            partially_queued: true,
+            queued_prompt_ids: ["p-known-1", "p-known-2"],
+            retry_guidance: "Check the queue before retrying the unresolved request.",
+          }),
+        },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ batch_count: 3, to_node_id: 9 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    expect(textOf(res)).toContain("Check the queue before retrying the unresolved request.");
+    for (const id of ["p-known-1", "p-known-2"]) {
+      expect(RunCompletions.ticketFor(id), id).toBeDefined();
+      expect(QueueMonitor.attributeRun(id), id).toBe("mine");
+    }
+  });
+
   it("#949: prompt_id repeated inside prompt_ids opens ONE ticket, not two", async () => {
     const reply: ToolResult = {
       content: [
@@ -1440,6 +1467,16 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     ]);
     expect(acceptedPromptIds({ prompt_ids: "not-an-array" })).toEqual([]);
     expect(acceptedPromptIds(null)).toEqual([]);
+  });
+
+  it("#2143: prompt_id(s) stay first-class alongside queued_prompt_ids", () => {
+    expect(
+      acceptedPromptIds({
+        prompt_id: "p-first",
+        prompt_ids: ["p-first", "p-second"],
+        queued_prompt_ids: ["p-second", "p-known"],
+      }),
+    ).toEqual(["p-first", "p-second", "p-known"]);
   });
 
   it("#704: the ticket records the CONVERSATION that queued the run, not just the routed tab", async () => {
@@ -1481,6 +1518,35 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     expect(text).toContain("UNDETERMINED");
     expect(text).toContain("get_history");
   });
+
+  it("#2143: queued_unknown with no ids is a normal uncertain receipt, not a failure", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued_unknown: true,
+            error: "the frontend queue call did not answer within the run budget",
+            indeterminate_count: 1,
+            retry_guidance: "Check the ComfyUI queue before retrying anything.",
+          }),
+        },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+
+    // A normal Panel timeout receipt must stay non-error so its explicit retry
+    // guidance survives verbatim. The handler performs no second dispatch and
+    // cannot ticket an unidentifiable completion.
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    const text = textOf(res);
+    expect(text).toContain("Check the ComfyUI queue before retrying anything.");
+    expect(text).toContain("[UNCERTAIN]");
+    expect(text).not.toContain(QUEUED_NOTE);
+    expect(text).not.toContain("ComfyUI refused to queue");
+  });
 });
 
 describe("panel-tools: detectRunRejection helper", () => {
@@ -1507,6 +1573,15 @@ describe("panel-tools: detectRunRejection helper", () => {
   it("passes an isError reply through verbatim", () => {
     const err: ToolResult = { content: [{ type: "text", text: "Error: boom" }], isError: true };
     expect(detectRunRejection(err)).toBe(err);
+  });
+
+  it("#2143: keeps the explicit queued_unknown receipt out of refusal handling", () => {
+    const reply = jsonReply({
+      queued_unknown: true,
+      error: "the frontend queue call timed out",
+      retry_guidance: "Check the queue before retrying.",
+    });
+    expect(detectRunRejection(reply)).toBeNull();
   });
 
   // #944 — ComfyUI's PARTIAL-validation path: some outputs fail, at least one
@@ -7165,6 +7240,17 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
     // failure (unchanged), but the text no longer settles the contradiction it
     // has no way to settle.
     expect(runText(res)).toContain("[UNCERTAIN]");
+  });
+
+  it("a reported queued_prompt_ids receipt also vetoes the retry", async () => {
+    const { ctx, runs } = runCtx([
+      { error: RACE, queued_prompt_ids: ["p-known-race"] },
+      { queued: true },
+    ]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
   });
 
   // #944 END-TO-END. The unit tests above cover the decision; this covers the

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6645,11 +6645,6 @@ function formatRunRejection(payload: { error?: unknown; node_errors?: unknown })
  * overrides the flag-based rule and #213 does not regress: that reply had no
  * prompt id. The same asymmetry the retry guard already relies on.
  */
-function acceptedPromptId(parsed: Record<string, unknown> | null): string | null {
-  const pid = parsed?.prompt_id;
-  return typeof pid === "string" && pid.trim() !== "" ? pid.trim() : null;
-}
-
 /**
  * EVERY prompt id a graph_run reply minted, first one first (#949).
  *
@@ -6661,6 +6656,8 @@ function acceptedPromptId(parsed: Record<string, unknown> | null): string | null
  *
  * Deduped and order-preserving: `prompt_id` normally repeats the first entry of
  * `prompt_ids`, and a duplicate would open two tickets for one render.
+ * The Panel's scoped-run uncertainty receipt uses `queued_prompt_ids` for the
+ * subset it did confirm (#2143); those are receipts too and must be ticketed.
  */
 export function acceptedPromptIds(parsed: Record<string, unknown> | null): string[] {
   const out: string[] = [];
@@ -6672,7 +6669,23 @@ export function acceptedPromptIds(parsed: Record<string, unknown> | null): strin
   add(parsed?.prompt_id);
   const many = parsed?.prompt_ids;
   if (Array.isArray(many)) for (const v of many) add(v);
+  const queued = parsed?.queued_prompt_ids;
+  if (Array.isArray(queued)) for (const v of queued) add(v);
   return out;
+}
+
+function acceptedPromptId(parsed: Record<string, unknown> | null): string | null {
+  return acceptedPromptIds(parsed)[0] ?? null;
+}
+
+/**
+ * The Panel's explicit scoped-run uncertainty contract (#2143). This is a
+ * normal, parseable receipt rather than a transport failure: the Panel knows
+ * that one or more requests left the tab but cannot prove whether ComfyUI
+ * accepted them. Do not reinterpret its `error` field as a refusal.
+ */
+function isPanelQueueUncertainty(parsed: Record<string, unknown> | null): boolean {
+  return parsed?.queued_unknown === true;
 }
 
 function detectRunRejection(res: ToolResult): ToolResult | null {
@@ -6682,6 +6695,12 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
 
   const parsed = parseToolResultJson(res);
   if (!parsed) return null; // unparseable non-error reply — don't regress a success
+
+  // #2143 — `queued_unknown` is an explicit Panel receipt, not the ComfyUI
+  // rejection channel. Its `error` field explains the timeout and its
+  // `retry_guidance` tells the caller how to settle it; keep the receipt intact
+  // and never redispatch from here.
+  if (isPanelQueueUncertainty(parsed)) return null;
 
   const topError = parsed.error;
   const nodeErrors = parsed.node_errors;
@@ -6800,7 +6819,7 @@ function isRetryableRunToNodeStampRace(res: ToolResult, rejection: ToolResult): 
   const parsed = parseToolResultJson(res);
   if (!parsed) return false; // unreadable reply — an unknown, not a clean queue
   if (parsed.queued === true) return false; // observed queue evidence vetoes prose
-  if (typeof parsed.prompt_id === "string" && parsed.prompt_id.trim() !== "") return false;
+  if (acceptedPromptIds(parsed).length > 0) return false; // any receipt vetoes retry
   const text = toolResultText(rejection);
   return (
     /workflow graph CHANGED after the run was queued/i.test(text) &&
@@ -13257,6 +13276,27 @@ function queueRunReceiptNote(promptId: string): string {
   );
 }
 
+/**
+ * #2143 — a normal Panel timeout receipt is neither a confirmed queue nor a
+ * refusal. Keep its retry guidance in the original JSON and add only the
+ * local fact that this handler did not dispatch a second run.
+ */
+function panelQueueUncertaintyNote(queuedPromptIds: readonly string[]): string {
+  if (queuedPromptIds.length > 0) {
+    return (
+      `\n\n[UNCERTAIN] The Panel confirmed these prompt id(s) left its queue path: ` +
+      `${queuedPromptIds.join(", ")}. Completion tickets were opened for them. ` +
+      `Any remaining request(s) are still uncertain; follow the Panel's retry_guidance above ` +
+      `before retrying. No second panel_run was dispatched.`
+    );
+  }
+  return (
+    `\n\n[UNCERTAIN] The Panel could not determine whether this run entered ComfyUI's queue. ` +
+    `This is not a confirmed refusal, and no completion ticket can be opened without a prompt id. ` +
+    `Follow the Panel's retry_guidance above before retrying. No second panel_run was dispatched.`
+  );
+}
+
 async function pollLateAskReply(
   bridge: PanelToolCtx["bridge"],
   askId: string,
@@ -16025,7 +16065,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // "does NOT match any run you queued … its origin is UNDETERMINED" — for
         // runs the agent had just queued itself. Ticket all of them.
         const queuedIds = acceptedPromptIds(runReply);
-        const queuedId = queuedIds[0];
+        const panelQueueUncertain = isPanelQueueUncertainty(runReply);
         // #944: a run ComfyUI accepted while dropping some outputs reaches here
         // (a minted prompt id outranks the rejection signals). Say which outputs
         // were dropped, or the caller waits for files that will never be written.
@@ -16047,8 +16087,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `and this dispatch stacked a duplicate.`
             : "";
         // markSelfQueued with NO id still stamps the recent-self-queue timestamp,
-        // so the id-less case must still call it exactly once (#559).
-        if (queuedIds.length === 0) QueueMonitor.markSelfQueued(null);
+        // so both the id-less genuine queue and the Panel's explicit uncertainty
+        // receipt must call it exactly once (#559/#2143). The latter must not be
+        // mistaken for a definite queue, but it is still unsafe to immediately
+        // redispatch a request that the Panel says left its tab.
+        if (queuedIds.length === 0 || panelQueueUncertain) QueueMonitor.markSelfQueued(null);
         for (const id of queuedIds) QueueMonitor.markSelfQueued(id);
         // #468 — open a run ticket so the render's completion can be CORRELATED
         // to this exact call by prompt id. This is what lets the orchestrator
@@ -16071,7 +16114,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // actually be correlated back.
         const ticketedPromptIds: string[] = [];
         const correlatable =
-          queuedIds.length === 0
+          panelQueueUncertain && queuedIds.length === 0
+            ? false
+            : queuedIds.length === 0
             ? RunCompletions.openRun(undefined, ticketOpts)
             : queuedIds.map((id) => {
                 const opened = RunCompletions.openRun(id, ticketOpts);
@@ -16132,7 +16177,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           queuedIds.length === 1
             ? ""
             : ` (this run queued ${queuedIds.length} prompts, so the check is the queue as a whole; get_history settles the outcome of any that are no longer in flight)`;
-        const note = correlatable
+        const note = panelQueueUncertain
+          ? panelQueueUncertaintyNote(ticketedPromptIds)
+          : correlatable
           ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or get_image (action:\"list_outputs\"). Just end your turn now and wait for the result to be delivered to you." +
             `\n[FALLBACK] That notification is journaled and replayed if an agent is not there to take it, and the orchestrator will fill one in from ComfyUI itself — its execution event or its history record — if the panel never reports the finish. But it cannot be GUARANTEED, so do not wait forever on it. If nothing has arrived LONG after this render should have finished (roughly twice the time you expect it to take), make ONE check with ${fallbackCheck} instead of idling indefinitely${fallbackTail}. One check, not a loop — and not before then.`
           : "\n\n[IMPORTANT] The run was queued, but the panel reported NO prompt id for it, so a completion event CANNOT be correlated back to this run — its outcome will be reported to you as UNDETERMINED. Do NOT simply idle and wait indefinitely: end your turn, and if nothing arrives, confirm the outcome with get_history (action:\"list\") before acting on it.";


### PR DESCRIPTION
## Summary
- recognize the Panel's explicit `queued_unknown` receipt as uncertainty, preserving its retry guidance instead of formatting it as a refusal
- ticket all known `queued_prompt_ids` alongside the existing `prompt_id`/`prompt_ids` paths
- keep unknown receipts from opening id-less completion tickets or redispatching; extend the run-to-node retry veto to every recognized receipt shape

## Verification
- `npm.cmd exec vitest run src/__tests__/orchestrator/panel-tools.test.ts --passWithNoTests` (397 passed)
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

Fixes #2143