### PR TITLE
fix(panel): classify nodes_search as safe read

### DIFF
--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import {
   buildPanelToolDefs,
   makePanelToolCtx,
+  RETRY_TOKEN_CMDS,
   RETRY_TOKEN_CMD_BY_TOOL,
   type PanelToolCtx,
   type ToolResult,
@@ -150,6 +151,32 @@ describe("#694 retry token on OUTCOME-UNKNOWN mutating failures", () => {
     const res = await ctx.call({ cmd: "graph_query" });
     expect(res.isError).toBe(true);
     expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("#2145 nodes_search retries only reconnect drops and never mints a mutation token", async () => {
+    let attempts = 0;
+    const bridge = {
+      send: async (
+        _cmd: Record<string, unknown>,
+        opts?: { onDispatchedRid?: (rid: string) => void },
+      ) => {
+        attempts++;
+        opts?.onDispatchedRid?.(DISPATCHED_RID);
+        throw replyTimeout("nodes_search");
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "tab-1", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await ctx.call({ cmd: "nodes_search", query: "kjnodes" });
+
+    expect(attempts).toBe(1);
+    expect(textOf(res)).not.toMatch(/MUTATES|double-apply|retry_of/i);
+    expect(RETRY_TOKEN_CMDS.has("nodes_search")).toBe(false);
+    expect(Object.values(RETRY_TOKEN_CMD_BY_TOOL)).not.toContain("nodes_search");
   });
 
   it("(e) READS never mint a token — mid-command drop phrasing on graph_outline", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2162,12 +2162,14 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
   // A bridge that DROPS the first send (the tab was replaced under a new id during a
   // reboot/free_vram/reconnect), then serves the reconnected tab on the retry.
   function droppingBridge() {
+    const attempted: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
     const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
     let live = new Set(["old-tab"]);
     let dropsLeft = 1;
     const bridge = {
       send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
         const id = opts?.tabId;
+        attempted.push({ cmd, tabId: id });
         if (dropsLeft > 0) {
           dropsLeft--;
           live = new Set(["new-tab"]); // the tab reconnected under a fresh id
@@ -2185,7 +2187,7 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
         throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
       },
     } as unknown as PanelToolCtx["bridge"];
-    return { bridge, sent };
+    return { bridge, attempted, sent };
   }
 
   it("idempotent read (graph_get_errors) rebinds and succeeds after a mid-command drop (#310)", async () => {
@@ -2231,6 +2233,28 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
     const res = await defByName("panel_list_nodes").handler({}, ctx);
     expect(res.isError).toBeFalsy();
     expect(sent.at(-1)?.tabId).toBe("new-tab");
+  });
+
+  it("panel_search_nodes retries nodes_search once after a reconnect drop (#2145)", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, attempted } = droppingBridge();
+    const ctx = makePanelToolCtx(bridge, "old-tab", store);
+    const res = await defByName("panel_search_nodes").handler(
+      { query: "kjnodes", limit: 5 },
+      ctx,
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe("new-tab");
+    expect(attempted).toHaveLength(2);
+    expect(attempted[0]).toMatchObject({
+      tabId: "old-tab",
+      cmd: { cmd: "nodes_search", query: "kjnodes", limit: 5 },
+    });
+    expect(attempted[1]).toMatchObject({
+      tabId: "new-tab",
+      cmd: { cmd: "nodes_search", query: "kjnodes", limit: 5 },
+    });
   });
 
   it("MUTATING edit (graph_add_node) is NOT retried — no double-apply — and errors clearly", async () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -892,6 +892,38 @@ describe("UiBridge (multi-tab)", () => {
     a2.close();
   });
 
+  it("resumes nodes_search as a read with a fresh dispatch RID (#2145)", async () => {
+    const a1 = await connectPanel("tab-2145");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    const frames: Array<Record<string, unknown>> = [];
+    a1.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.cmd === "nodes_search") frames.push(msg);
+    });
+
+    const promise = bridge.send(
+      { cmd: "nodes_search", query: "kjnodes", limit: 5 },
+      { tabId: "tab-2145", timeoutMs: 5000 },
+    );
+    await waitFor(() => expect(frames).toHaveLength(1));
+    a1.close();
+
+    const a2 = await connectPanel("tab-2145");
+    a2.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.cmd === "nodes_search") {
+        frames.push(msg);
+        a2.send(JSON.stringify({ rid: msg.rid, ok: true, result: { packs: [] } }));
+      }
+    });
+    await expect(promise).resolves.toMatchObject({ packs: [] });
+    expect(frames).toHaveLength(2);
+    expect(frames[1]?.rid).toEqual(expect.any(String));
+    expect(frames[1]?.rid).not.toBe(frames[0]?.rid);
+    expect(frames[1]).toMatchObject({ cmd: "nodes_search", query: "kjnodes", limit: 5 });
+    a2.close();
+  });
+
   it("does NOT extend the caller's deadline when a read resumes (#450)", async () => {
     const a1 = await connectPanel("tab-aaaa-1111");
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
@@ -3673,6 +3705,21 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     // slow /object_info fetch on a large install isn't cut off at the tight 6s.
     expect(BRIDGE_READONLY_CMDS.has("refresh_nodes")).toBe(true);
     expect(defaultBridgeTimeoutMs("refresh_nodes")).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+  });
+
+  it("classifies nodes_search as a READ without a mutation warning (#2145)", async () => {
+    expect(BRIDGE_READONLY_CMDS.has("nodes_search")).toBe(true);
+    const sock = await connectPanel("tab-2145-timeout");
+    const err = await bridge
+      .send(
+        { cmd: "nodes_search", query: "kjnodes" },
+        { tabId: "tab-2145-timeout", timeoutMs: 40 },
+      )
+      .then(() => null)
+      .catch((value: unknown) => value as Error);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toMatch(/MUTATES|double-apply/i);
+    sock.close();
   });
 
   it("graph_query is tolerant and STRICTLY longer than the old flat 6s default (#357)", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1406,6 +1406,7 @@ const RETRY_SAFE_CMDS = new Set<string>([
   "graph_query",
   "get_todo",
   "workflow_list",
+  "nodes_search",
   "nodes_list",
   "nodes_queue_status",
   "node_queue_status",

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1110,6 +1110,8 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_prompt_director_audit",
   "graph_query",
   "civitai_results",
+  // #2145: Manager search reads registry data only; it does not touch the canvas.
+  "nodes_search",
   "get_todo",
   // #608: a forced /object_info re-register + combo refresh. It has NO effect on
   // graph content — it only re-registers node defs and rebuilds combo option lists


### PR DESCRIPTION
Fixes #2145. Summary: classify nodes_search as a bridge read and orchestrator reconnect-retry-safe command; keep it out of mutation receipt/retry-token ledgers; preserve the existing reply-timeout no-auto-retry boundary. Tests: focused Vitest suite, npm.cmd run lint, npm.cmd run build, git diff --check.