### PR TITLE
fix: relay get_image through authenticated panel transport

### DIFF
--- a/src/__tests__/comfyui/child-panel-origin-drift.test.ts
+++ b/src/__tests__/comfyui/child-panel-origin-drift.test.ts
@@ -141,7 +141,7 @@ describe("#1415 WIRING: the orchestrator publishes on its existing poll tick", (
     );
   });
 
-  it("publishes the BRIDGE's server-observed origins, inside pollDownloads", () => {
+  it("publishes the BRIDGE's diagnostic server-observed origins, inside pollDownloads", () => {
     const open = src.indexOf("const pollDownloads = () => {");
     // pollDownloads' body ends exactly where the timer that drives it is created.
     const close = src.indexOf("const downloadTimer = setInterval(pollDownloads, 700);");
@@ -149,7 +149,7 @@ describe("#1415 WIRING: the orchestrator publishes on its existing poll tick", (
     expect(close).toBeGreaterThan(open);
     const body = src.slice(open, close);
     expect(body).toMatch(
-      /publishConnectedPanelOrigins\(\s*progressDir,\s*bridge\.connectedSafePanelOrigins\(\)\s*\)/,
+      /publishConnectedPanelOrigins\(\s*progressDir,\s*bridge\.connectedServerOrigins\(\)\s*\)/,
     );
     // …and nowhere else, so this test is asking about the only call site.
     expect(src.split("publishConnectedPanelOrigins(").length - 1).toBe(1);

--- a/src/__tests__/comfyui/child-panel-origin-drift.test.ts
+++ b/src/__tests__/comfyui/child-panel-origin-drift.test.ts
@@ -149,7 +149,7 @@ describe("#1415 WIRING: the orchestrator publishes on its existing poll tick", (
     expect(close).toBeGreaterThan(open);
     const body = src.slice(open, close);
     expect(body).toMatch(
-      /publishConnectedPanelOrigins\(\s*progressDir,\s*bridge\.connectedServerOrigins\(\)\s*\)/,
+      /publishConnectedPanelOrigins\(\s*progressDir,\s*bridge\.connectedSafePanelOrigins\(\)\s*\)/,
     );
     // …and nowhere else, so this test is asking about the only call site.
     expect(src.split("publishConnectedPanelOrigins(").length - 1).toBe(1);

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "/comfyapi" },
+  getComfyUIApiHost: () => "127.0.0.1:8000",
+  getComfyUIBasePath: () => "/comfyapi",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8000/comfyapi",
+  getComfyUIAuthHeaders: () => ({ Authorization: "Bearer headless-token" }),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { fetchImage, MAX_VIEW_RESPONSE_BYTES, resetClient } from "../../comfyui/client.js";
+import { setConnectedPanelOrigins } from "../../comfyui/fetch.js";
+
+const HEADLESS = "http://127.0.0.1:8000";
+const PANEL = "http://localhost:8188";
+
+function transportFailure(): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+  });
+}
+
+function imageResponse(status = 200): Response {
+  return new Response(Uint8Array.from([1, 2, 3]), {
+    status,
+    headers: { "content-type": "image/jpeg" },
+  });
+}
+
+type FetchCall = { input: RequestInfo | URL; init?: RequestInit };
+
+let calls: FetchCall[];
+
+beforeEach(() => {
+  calls = [];
+  resetClient();
+  setConnectedPanelOrigins(() => []);
+});
+
+afterEach(() => {
+  setConnectedPanelOrigins(null);
+  vi.unstubAllGlobals();
+});
+
+describe("fetchImage connected-panel fallback (#2149)", () => {
+  it("retries an unreachable headless target at the one different panel origin", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        const url = String(input);
+        if (url.startsWith(HEADLESS)) throw transportFailure();
+        return imageResponse();
+      }),
+    );
+
+    await expect(fetchImage("render.png", "output", "shots")).resolves.toEqual({
+      base64: "AQID",
+      mimeType: "image/jpeg",
+    });
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
+    expect(String(calls[1].input)).toContain(`${PANEL}/comfyapi/view?`);
+    expect(new Headers(calls[0].init?.headers).get("authorization")).toBe("Bearer headless-token");
+    expect(calls[1].init?.headers).toBeUndefined();
+  });
+
+  it("does not guess when multiple different panel origins are connected", async () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188", "http://localhost:8189"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        throw transportFailure();
+      }),
+    );
+
+    const err = await fetchImage("render.png").catch((error: unknown) => error as Error);
+    expect(err.message).toContain("I did NOT retry against a connected panel");
+    expect(err.message).toContain("127.0.0.1:8188");
+    expect(err.message).toContain("localhost:8189");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not retry a loopback alias of the failed target", async () => {
+    setConnectedPanelOrigins(() => ["http://localhost:8000"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        throw transportFailure();
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toThrow(/fetch failed/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("keeps a panel response's HTTP error classified as an image error", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        if (calls.length === 1) throw transportFailure();
+        return imageResponse(404);
+      }),
+    );
+
+    const err = await fetchImage("missing.png").catch(
+      (error: unknown) => error as { code?: string; message: string },
+    );
+    expect(err.code).toBe("IMAGE_NOT_FOUND");
+    expect(err.message).toContain(`at ${PANEL}`);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not retry a timeout as if it were a dead target", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    const timeout = new Error("request timed out");
+    timeout.name = "TimeoutError";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        throw timeout;
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toThrow(/No reply from ComfyUI within 120s/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it.each([
+    "http://evil.example:8188",
+    "ws://localhost:8188",
+    "http://localhost:8188/comfyapi",
+    "http://localhost:8188?token=leak",
+    "http://user:pass@localhost:8188",
+  ])("rejects unsafe panel origin %s without contacting it", async (unsafeOrigin) => {
+    setConnectedPanelOrigins(() => [PANEL, unsafeOrigin]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        throw transportFailure();
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toThrow(/malformed, unsupported, remote, or otherwise unsafe/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not follow a cross-origin redirect from the panel", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        if (calls.length === 1) throw transportFailure();
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://evil.example/collect" },
+        });
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toMatchObject({ code: "VIEW_REDIRECT_UNSAFE" });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].init?.redirect).toBe("manual");
+    expect(calls[1].init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("uses manual redirects for the configured target too", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://evil.example/collect" },
+        });
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toMatchObject({ code: "VIEW_REDIRECT_UNSAFE" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init?.redirect).toBe("manual");
+  });
+
+  it("refuses a response whose final URL is a different origin", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        if (calls.length === 1) throw transportFailure();
+        const response = imageResponse();
+        Object.defineProperty(response, "url", { value: "http://evil.example:8188/view" });
+        return response;
+      }),
+    );
+
+    await expect(fetchImage("render.png")).rejects.toMatchObject({ code: "VIEW_RESPONSE_ORIGIN" });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("refuses an oversized streamed response before buffering it", async () => {
+    setConnectedPanelOrigins(() => [PANEL]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        if (calls.length === 1) throw transportFailure();
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(MAX_VIEW_RESPONSE_BYTES + 1));
+            controller.close();
+          },
+        });
+        return new Response(body, { headers: { "content-type": "image/png" } });
+      }),
+    );
+
+    await expect(fetchImage("huge.png")).rejects.toMatchObject({ code: "VIEW_TOO_LARGE" });
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -1,8 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 vi.mock("../../config.js", () => ({
   config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "/comfyapi" },
   getComfyUIApiHost: () => "127.0.0.1:8000",
@@ -19,7 +15,6 @@ import {
   setConnectedPanelFallbackOrigins,
   setConnectedPanelOrigins,
 } from "../../comfyui/fetch.js";
-import { PANEL_IMAGE_RELAY_REQUEST_PREFIX, PANEL_IMAGE_RELAY_RESPONSE_PREFIX } from "../../services/panel-image-relay.js";
 
 const HEADLESS = "http://127.0.0.1:8000";
 const PANEL = "http://localhost:8188";
@@ -261,11 +256,10 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
   });
 
-  it("uses the authenticated relay in production and never reconstructs a panel URL", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-client-"));
-    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  it("does not fall back to the unsafe progress-dir file channel", async () => {
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = "a".repeat(64);
+    process.env.COMFYUI_MCP_PROGRESS_DIR = "C:/path-that-must-not-be-read";
     setConnectedPanelFallbackOrigins(null);
     vi.stubGlobal(
       "fetch",
@@ -275,31 +269,8 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
       }),
     );
 
-    const pending = fetchImage("render.png", "output", "shots");
-    let requestName = "";
-    for (let i = 0; i < 100 && !requestName; i += 1) {
-      requestName = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
-      if (!requestName) await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    expect(requestName).not.toBe("");
-    const body = JSON.parse(readFileSync(join(dir, requestName), "utf8")) as Record<string, unknown>;
-    expect(body).toMatchObject({ filename: "render.png", subfolder: "shots", type: "output" });
-    expect(String(body.capability)).toMatch(/^[a-f0-9]{64}$/);
-    expect(body).not.toHaveProperty("requester");
-    expect(body).not.toHaveProperty("url");
-    const id = String(body.requestId);
-    writeFileSync(join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${id}.json`), JSON.stringify({
-      version: 1,
-      requestId: id,
-      ok: true,
-      base64: "AQID",
-      mimeType: "image/png",
-      bytes: 3,
-      updated: Date.now(),
-    }));
-    await expect(pending).resolves.toEqual({ base64: "AQID", mimeType: "image/png" });
+    await expect(fetchImage("render.png", "output", "shots")).rejects.toThrow(/fetch failed/);
     expect(calls).toHaveLength(1);
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
-    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "/comfyapi" },
@@ -16,6 +19,7 @@ import {
   setConnectedPanelFallbackOrigins,
   setConnectedPanelOrigins,
 } from "../../comfyui/fetch.js";
+import { PANEL_IMAGE_RELAY_REQUEST_PREFIX, PANEL_IMAGE_RELAY_RESPONSE_PREFIX } from "../../services/panel-image-relay.js";
 
 const HEADLESS = "http://127.0.0.1:8000";
 const PANEL = "http://localhost:8188";
@@ -46,6 +50,8 @@ beforeEach(() => {
 afterEach(() => {
   setConnectedPanelFallbackOrigins(null);
   setConnectedPanelOrigins(null);
+  delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  delete process.env.COMFYUI_MCP_TAB;
   vi.unstubAllGlobals();
 });
 
@@ -252,5 +258,44 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     await expect(fetchImage("forged.png")).rejects.toThrow(/fetch failed/);
     expect(calls).toHaveLength(1);
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
+  });
+
+  it("uses the authenticated relay in production and never reconstructs a panel URL", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-client-"));
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    setConnectedPanelFallbackOrigins(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        throw transportFailure();
+      }),
+    );
+
+    const pending = fetchImage("render.png", "output", "shots");
+    let requestName = "";
+    for (let i = 0; i < 100 && !requestName; i += 1) {
+      requestName = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!requestName) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(requestName).not.toBe("");
+    const body = JSON.parse(readFileSync(join(dir, requestName), "utf8")) as Record<string, unknown>;
+    expect(body).toMatchObject({ filename: "render.png", subfolder: "shots", type: "output", requester: "orchestrator::claude" });
+    expect(body).not.toHaveProperty("url");
+    const id = String(body.requestId);
+    writeFileSync(join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${id}.json`), JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: true,
+      base64: "AQID",
+      mimeType: "image/png",
+      bytes: 3,
+      updated: Date.now(),
+    }));
+    await expect(pending).resolves.toEqual({ base64: "AQID", mimeType: "image/png" });
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -11,7 +11,11 @@ vi.mock("../../config.js", () => ({
 }));
 
 import { fetchImage, MAX_VIEW_RESPONSE_BYTES, resetClient } from "../../comfyui/client.js";
-import { setConnectedPanelOrigins } from "../../comfyui/fetch.js";
+import {
+  connectedPanelFallbackOriginsNow,
+  setConnectedPanelFallbackOrigins,
+  setConnectedPanelOrigins,
+} from "../../comfyui/fetch.js";
 
 const HEADLESS = "http://127.0.0.1:8000";
 const PANEL = "http://localhost:8188";
@@ -36,17 +40,18 @@ let calls: FetchCall[];
 beforeEach(() => {
   calls = [];
   resetClient();
-  setConnectedPanelOrigins(() => []);
+  setConnectedPanelFallbackOrigins(() => []);
 });
 
 afterEach(() => {
+  setConnectedPanelFallbackOrigins(null);
   setConnectedPanelOrigins(null);
   vi.unstubAllGlobals();
 });
 
 describe("fetchImage connected-panel fallback (#2149)", () => {
   it("retries an unreachable headless target at the one different panel origin", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -69,7 +74,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("does not guess when multiple different panel origins are connected", async () => {
-    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188", "http://localhost:8189"]);
+    setConnectedPanelFallbackOrigins(() => ["http://127.0.0.1:8188", "http://localhost:8189"]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -86,7 +91,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("does not retry a loopback alias of the failed target", async () => {
-    setConnectedPanelOrigins(() => ["http://localhost:8000"]);
+    setConnectedPanelFallbackOrigins(() => ["http://localhost:8000"]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -100,7 +105,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("keeps a panel response's HTTP error classified as an image error", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -119,7 +124,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("does not retry a timeout as if it were a dead target", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     const timeout = new Error("request timed out");
     timeout.name = "TimeoutError";
     vi.stubGlobal(
@@ -141,7 +146,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     "http://localhost:8188?token=leak",
     "http://user:pass@localhost:8188",
   ])("rejects unsafe panel origin %s without contacting it", async (unsafeOrigin) => {
-    setConnectedPanelOrigins(() => [PANEL, unsafeOrigin]);
+    setConnectedPanelFallbackOrigins(() => [PANEL, unsafeOrigin]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -155,7 +160,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("does not follow a cross-origin redirect from the panel", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -175,7 +180,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("uses manual redirects for the configured target too", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -193,7 +198,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("refuses a response whose final URL is a different origin", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -210,7 +215,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
   });
 
   it("refuses an oversized streamed response before buffering it", async () => {
-    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(() => [PANEL]);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -228,5 +233,24 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
 
     await expect(fetchImage("huge.png")).rejects.toMatchObject({ code: "VIEW_TOO_LARGE" });
     expect(calls).toHaveLength(2);
+  });
+
+  it("does not promote diagnostic origins into direct fallback targets", async () => {
+    // This models the forged Origin + hello pair from a local non-browser socket.
+    // The diagnostic source may report it, but it is not an authorization source.
+    setConnectedPanelOrigins(() => [PANEL]);
+    setConnectedPanelFallbackOrigins(null);
+    expect(connectedPanelFallbackOriginsNow()).toEqual([]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push({ input });
+        throw transportFailure();
+      }),
+    );
+
+    await expect(fetchImage("forged.png")).rejects.toThrow(/fetch failed/);
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
   });
 });

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -52,6 +52,7 @@ afterEach(() => {
   setConnectedPanelOrigins(null);
   delete process.env.COMFYUI_MCP_PROGRESS_DIR;
   delete process.env.COMFYUI_MCP_TAB;
+  delete process.env.COMFYUI_MCP_RELAY_SECRET;
   vi.unstubAllGlobals();
 });
 
@@ -264,6 +265,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-client-"));
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = "a".repeat(64);
     setConnectedPanelFallbackOrigins(null);
     vi.stubGlobal(
       "fetch",
@@ -281,7 +283,9 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     }
     expect(requestName).not.toBe("");
     const body = JSON.parse(readFileSync(join(dir, requestName), "utf8")) as Record<string, unknown>;
-    expect(body).toMatchObject({ filename: "render.png", subfolder: "shots", type: "output", requester: "orchestrator::claude" });
+    expect(body).toMatchObject({ filename: "render.png", subfolder: "shots", type: "output" });
+    expect(String(body.capability)).toMatch(/^[a-f0-9]{64}$/);
+    expect(body).not.toHaveProperty("requester");
     expect(body).not.toHaveProperty("url");
     const id = String(body.requestId);
     writeFileSync(join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${id}.json`), JSON.stringify({

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -7,8 +7,10 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
   it("uses the pinned shared-scope resolver, not panelTabOf on shared agent keys", () => {
     expect(SOURCE).toContain("const scopeToRealTab = (tabId: string): string | undefined =>");
     expect(SOURCE).toContain("isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId)");
-    expect(SOURCE).toContain("resolvePanelAgentKey: panelImageRelayAgentKeyFor");
+    expect(SOURCE).toContain("resolvePanelAgent: panelImageRelayAgentFor");
     expect(SOURCE).toContain("resolvePanelTab: scopeToRealTab");
     expect(SOURCE).toContain("COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor");
+    expect(SOURCE).toContain("COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint");
+    expect(SOURCE).not.toContain("processPanelImageRequests({");
   });
 });

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SOURCE = readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+
+describe("panel image relay orchestrator wiring (#2149)", () => {
+  it("uses the pinned shared-scope resolver, not panelTabOf on shared agent keys", () => {
+    expect(SOURCE).toContain("const scopeToRealTab = (tabId: string): string | undefined =>");
+    expect(SOURCE).toContain("isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId)");
+    expect(SOURCE).toContain("resolvePanelTab: scopeToRealTab");
+  });
+});

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -7,6 +7,8 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
   it("uses the pinned shared-scope resolver, not panelTabOf on shared agent keys", () => {
     expect(SOURCE).toContain("const scopeToRealTab = (tabId: string): string | undefined =>");
     expect(SOURCE).toContain("isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId)");
+    expect(SOURCE).toContain("resolvePanelAgentKey: panelImageRelayAgentKeyFor");
     expect(SOURCE).toContain("resolvePanelTab: scopeToRealTab");
+    expect(SOURCE).toContain("COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor");
   });
 });

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -12,12 +12,14 @@ import {
   PANEL_IMAGE_RELAY_REQUEST_PREFIX,
   PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
   PANEL_IMAGE_RELAY_STALE_MS,
+  makePanelImageRelayCapability,
   processPanelImageRequests,
   requestPanelImage,
   type PanelImageRelayRequest,
 } from "../../services/panel-image-relay.js";
 
 const dirs: string[] = [];
+const SECRET = "a".repeat(64);
 
 function tempChannel(): string {
   const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-"));
@@ -27,19 +29,22 @@ function tempChannel(): string {
 
 function request(id: string, patch: Partial<PanelImageRelayRequest> = {}): PanelImageRelayRequest {
   const createdAt = Date.now();
+  const { capability: patchedCapability, ...restPatch } = patch;
   const value = {
     version: 1,
     requestId: id,
-    requester: "orchestrator::claude",
     filename: "render.png",
     subfolder: "shots",
     type: "output",
     createdAt,
     deadlineAt: createdAt + 8_000,
-    ...patch,
+    ...restPatch,
   };
   if (!("deadlineAt" in patch)) value.deadlineAt = value.createdAt + 8_000;
-  return value;
+  return {
+    ...value,
+    capability: patchedCapability ?? makePanelImageRelayCapability(SECRET, value),
+  };
 }
 
 function requestFile(dir: string, id: string): string {
@@ -58,6 +63,7 @@ afterEach(() => {
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   delete process.env.COMFYUI_MCP_PROGRESS_DIR;
   delete process.env.COMFYUI_MCP_TAB;
+  delete process.env.COMFYUI_MCP_RELAY_SECRET;
   vi.restoreAllMocks();
 });
 
@@ -66,6 +72,7 @@ describe("panel image relay child channel", () => {
     const dir = tempChannel();
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     const pending = requestPanelImage("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
@@ -75,11 +82,11 @@ describe("panel image relay child channel", () => {
     expect(file).not.toBe("");
     const requestBody = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
     expect(Object.keys(requestBody).sort()).toEqual([
+      "capability",
       "createdAt",
       "deadlineAt",
       "filename",
       "requestId",
-      "requester",
       "subfolder",
       "type",
       "version",
@@ -107,7 +114,17 @@ describe("panel image relay child channel", () => {
     const dir = tempChannel();
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     await expect(requestPanelImage(filename, type as "output", subfolder)).rejects.toMatchObject({ code: "UNSAFE_REFERENCE" });
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("does not authorize the relay from COMFYUI_MCP_TAB alone", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::victim";
+    delete process.env.COMFYUI_MCP_RELAY_SECRET;
+    await expect(requestPanelImage("render.png", "output", "shots")).resolves.toBeUndefined();
     expect(readdirSync(dir)).toEqual([]);
   });
 
@@ -115,6 +132,7 @@ describe("panel image relay child channel", () => {
     const dir = tempChannel();
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     const pending = requestPanelImage("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
@@ -135,10 +153,49 @@ describe("panel image relay child channel", () => {
     await expect(pending).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
   });
 
+  it("moves a symlinked response into private staging without opening its target", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    const pending = requestPanelImage("render.png", "output", "shots");
+    let file = "";
+    for (let i = 0; i < 100 && !file; i += 1) {
+      file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!file) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const body = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
+    const id = String(body.requestId);
+    const target = join(dir, "response-target.json");
+    writeFileSync(target, JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: true,
+      base64: "AQID",
+      mimeType: "image/png",
+      bytes: 3,
+      updated: Date.now(),
+    }));
+    let symlinkSupported = true;
+    try {
+      symlinkSync(target, responseFile(dir, id), "file");
+    } catch {
+      symlinkSupported = false;
+      writeFileSync(responseFile(dir, id), readFileSync(target));
+    }
+    if (symlinkSupported) {
+      await expect(pending).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+      expect(readFileSync(target, "utf8")).toContain('"ok":true');
+    } else {
+      await expect(pending).resolves.toMatchObject({ base64: "AQID" });
+    }
+  });
+
   it("does not accept a response discovered after the single end-to-end deadline", async () => {
     const dir = tempChannel();
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     const pending = requestPanelImage("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
@@ -154,6 +211,29 @@ describe("panel image relay child channel", () => {
       base64: "AQID",
       mimeType: "image/png",
       bytes: 3,
+      updated: Number(body.deadlineAt) + 1,
+    }));
+    await expect(pending).rejects.toMatchObject({ code: "STALE_REPLY" });
+  });
+
+  it("validates failure freshness before preserving the panel failure code", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    const pending = requestPanelImage("render.png", "output", "shots");
+    let file = "";
+    for (let i = 0; i < 100 && !file; i += 1) {
+      file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!file) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const body = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
+    const id = String(body.requestId);
+    writeFileSync(responseFile(dir, id), JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: false,
+      error: "HTTP_404",
       updated: Number(body.deadlineAt) + 1,
     }));
     await expect(pending).rejects.toMatchObject({ code: "STALE_REPLY" });
@@ -175,6 +255,10 @@ describe("panel image relay orchestrator poll", () => {
     });
     await processPanelImageRequests({
       dir,
+      resolvePanelAgentKey: (value) => {
+        expect(value.capability).toBe(makePanelImageRelayCapability(SECRET, value));
+        return "orchestrator::claude";
+      },
       resolvePanelTab: (agentKey) => {
         expect(agentKey).toBe("orchestrator::claude");
         // This is the production scopeToRealTab result for the shared key:
@@ -196,6 +280,7 @@ describe("panel image relay orchestrator poll", () => {
       const send = vi.fn();
       await processPanelImageRequests({
         dir,
+        resolvePanelAgentKey: () => "orchestrator::claude",
         resolvePanelTab: () => failure === "NO_LIVE_PANEL" ? undefined : "panel-tab",
         bridge: {
           canReach: () => false,
@@ -222,6 +307,7 @@ describe("panel image relay orchestrator poll", () => {
       writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
       await processPanelImageRequests({
         dir,
+        resolvePanelAgentKey: () => "orchestrator::claude",
         resolvePanelTab: () => "panel-tab",
         bridge: { canReach: () => true, send: async () => testCase.reply },
       });
@@ -238,10 +324,28 @@ describe("panel image relay orchestrator poll", () => {
     const forgedId = "forged-url-1234567";
     writeFileSync(requestFile(dir, forgedId), JSON.stringify({ ...request(forgedId), url: "http://127.0.0.1:9/secret" }));
     const send = vi.fn();
-    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    await processPanelImageRequests({ dir, resolvePanelAgentKey: () => "orchestrator::claude", resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
     expect(readResponse(dir, staleId)).toMatchObject({ ok: false, error: "TIMEOUT" });
     expect(readResponse(dir, forgedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not accept a file-supplied requester or an unknown capability", async () => {
+    const dir = tempChannel();
+    const forgedId = "forged-requester-123456";
+    writeFileSync(requestFile(dir, forgedId), JSON.stringify({ ...request(forgedId), requester: "orchestrator::victim" }));
+    const unknownId = "unknown-capability-123456";
+    writeFileSync(requestFile(dir, unknownId), JSON.stringify(request(unknownId, { capability: "b".repeat(64) })));
+    const send = vi.fn();
+    await processPanelImageRequests({
+      dir,
+      resolvePanelAgentKey: (value) => value.capability === makePanelImageRelayCapability(SECRET, value) ? "orchestrator::claude" : undefined,
+      resolvePanelTab: () => "victim-panel",
+      bridge: { canReach: () => true, send },
+    });
+    expect(send).not.toHaveBeenCalled();
+    expect(readResponse(dir, forgedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
+    expect(readResponse(dir, unknownId)).toMatchObject({ ok: false, error: "NO_LIVE_PANEL" });
   });
 
   it("carries one deadline through the bridge and refuses a late panel result", async () => {
@@ -255,6 +359,7 @@ describe("panel image relay orchestrator poll", () => {
     let timeoutMs = 0;
     await processPanelImageRequests({
       dir,
+      resolvePanelAgentKey: () => "orchestrator::claude",
       resolvePanelTab: () => "panel-tab",
       bridge: {
         canReach: () => true,
@@ -281,6 +386,7 @@ describe("panel image relay orchestrator poll", () => {
     let sends = 0;
     await processPanelImageRequests({
       dir,
+      resolvePanelAgentKey: () => "orchestrator::claude",
       resolvePanelTab: () => "panel-tab",
       bridge: {
         canReach: () => true,
@@ -313,7 +419,7 @@ describe("panel image relay orchestrator poll", () => {
     const id = "response-cap-request-123456";
     writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
     const send = vi.fn();
-    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    await processPanelImageRequests({ dir, resolvePanelAgentKey: () => "orchestrator::claude", resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
     expect(send).not.toHaveBeenCalled();
     expect(readdirSync(dir)).toContain(`control-image-request-${id}.json`);
   });
@@ -337,7 +443,7 @@ describe("panel image relay orchestrator poll", () => {
     }
 
     const send = vi.fn();
-    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    await processPanelImageRequests({ dir, resolvePanelAgentKey: () => "orchestrator::claude", resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
     expect(send).not.toHaveBeenCalled();
     expect(readResponse(dir, oversizedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
     if (symlinksSupported) expect(readdirSync(dir)).not.toContain(`control-image-response-${symlinkId}.json`);
@@ -352,7 +458,7 @@ describe("panel image relay orchestrator poll", () => {
     const old = (Date.now() - PANEL_IMAGE_RELAY_STALE_MS - 1) / 1000;
     utimesSync(stale, old, old);
     truncateSync(oversized, 48 * 1024 * 1024 + 1);
-    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => false, send: vi.fn() } });
+    await processPanelImageRequests({ dir, resolvePanelAgentKey: () => "orchestrator::claude", resolvePanelTab: () => "panel-tab", bridge: { canReach: () => false, send: vi.fn() } });
     expect(readdirSync(dir)).not.toContain(stale.split("\\").at(-1));
     expect(readdirSync(dir)).not.toContain(oversized.split("\\").at(-1));
   });

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
 import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,12 +10,16 @@ import {
   PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES,
   PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES,
   PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK,
+  PANEL_IMAGE_RELAY_HTTP_PATH,
   PANEL_IMAGE_RELAY_REQUEST_PREFIX,
   PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
   PANEL_IMAGE_RELAY_STALE_MS,
   makePanelImageRelayCapability,
   processPanelImageRequests,
+  requestPanelImageFromFileChannel,
   requestPanelImage,
+  startPanelImageRelayServer,
+  verifyPanelImageRelayCapability,
   type PanelImageRelayRequest,
 } from "../../services/panel-image-relay.js";
 
@@ -64,6 +69,7 @@ afterEach(() => {
   delete process.env.COMFYUI_MCP_PROGRESS_DIR;
   delete process.env.COMFYUI_MCP_TAB;
   delete process.env.COMFYUI_MCP_RELAY_SECRET;
+  delete process.env.COMFYUI_MCP_RELAY_URL;
   vi.restoreAllMocks();
 });
 
@@ -73,7 +79,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    const pending = requestPanelImage("render.png", "output", "shots");
+    const pending = requestPanelImageFromFileChannel("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
       file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
@@ -115,7 +121,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    await expect(requestPanelImage(filename, type as "output", subfolder)).rejects.toMatchObject({ code: "UNSAFE_REFERENCE" });
+    await expect(requestPanelImageFromFileChannel(filename, type as "output", subfolder)).rejects.toMatchObject({ code: "UNSAFE_REFERENCE" });
     expect(readdirSync(dir)).toEqual([]);
   });
 
@@ -124,7 +130,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::victim";
     delete process.env.COMFYUI_MCP_RELAY_SECRET;
-    await expect(requestPanelImage("render.png", "output", "shots")).resolves.toBeUndefined();
+    await expect(requestPanelImageFromFileChannel("render.png", "output", "shots")).resolves.toBeUndefined();
     expect(readdirSync(dir)).toEqual([]);
   });
 
@@ -133,7 +139,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    const pending = requestPanelImage("render.png", "output", "shots");
+    const pending = requestPanelImageFromFileChannel("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
       file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
@@ -158,7 +164,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    const pending = requestPanelImage("render.png", "output", "shots");
+    const pending = requestPanelImageFromFileChannel("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
       file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
@@ -196,7 +202,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    const pending = requestPanelImage("render.png", "output", "shots");
+    const pending = requestPanelImageFromFileChannel("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
       file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
@@ -221,7 +227,7 @@ describe("panel image relay child channel", () => {
     process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
     process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
-    const pending = requestPanelImage("render.png", "output", "shots");
+    const pending = requestPanelImageFromFileChannel("render.png", "output", "shots");
     let file = "";
     for (let i = 0; i < 100 && !file; i += 1) {
       file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
@@ -461,5 +467,166 @@ describe("panel image relay orchestrator poll", () => {
     await processPanelImageRequests({ dir, resolvePanelAgentKey: () => "orchestrator::claude", resolvePanelTab: () => "panel-tab", bridge: { canReach: () => false, send: vi.fn() } });
     expect(readdirSync(dir)).not.toContain(stale.split("\\").at(-1));
     expect(readdirSync(dir)).not.toContain(oversized.split("\\").at(-1));
+  });
+});
+
+describe("authenticated loopback panel image relay", () => {
+  it("uses only the explicit IPv4 loopback endpoint and reaches the pinned shared panel", async () => {
+    const send = vi.fn(async (command: unknown, options: unknown) => {
+      expect(command).toEqual({ cmd: "fetch_image", filename: "render.png", subfolder: "shots", type: "output" });
+      expect(options).toMatchObject({ tabId: "pinned-live-panel" });
+      return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
+    });
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: (agentKey) => agentKey === "orchestrator::claude" ? "pinned-live-panel" : undefined,
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      expect(new URL(server.endpointUrl).hostname).toBe("127.0.0.1");
+      expect(new URL(server.endpointUrl).pathname).toBe(PANEL_IMAGE_RELAY_HTTP_PATH);
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      process.env.COMFYUI_MCP_PROGRESS_DIR = join(tmpdir(), "this-file-channel-must-not-be-read");
+      await expect(requestPanelImage("render.png", "output", "shots")).resolves.toEqual({
+        base64: "AQID",
+        mimeType: "image/png",
+        bytes: 3,
+      });
+      expect(send).toHaveBeenCalledOnce();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects forged HMACs before resolving or dispatching a panel tab", async () => {
+    const send = vi.fn();
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "victim-panel",
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      const forged = request("forged-hmac-123456789", { capability: "b".repeat(64) });
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(forged),
+      });
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({ ok: false, error: "UNAUTHORIZED" });
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("binds the child result to the request id and response MAC", async () => {
+    const fake = createServer((_req, res) => {
+      const body = JSON.stringify({
+        version: 1,
+        requestId: "different-request-123456",
+        ok: true,
+        base64: "AQID",
+        mimeType: "image/png",
+        bytes: 3,
+        updated: Date.now(),
+        responseMac: "a".repeat(64),
+      });
+      res.writeHead(200, { "content-type": "application/json", "content-length": String(Buffer.byteLength(body)) });
+      res.end(body);
+    });
+    await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", resolve));
+    const address = fake.address();
+    if (!address || typeof address === "string") throw new Error("fake relay did not bind");
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${address.port}${PANEL_IMAGE_RELAY_HTTP_PATH}`;
+      await expect(requestPanelImage("render.png", "output", "shots")).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+    } finally {
+      await new Promise<void>((resolve) => fake.close(() => resolve()));
+    }
+  });
+
+  it("rejects a response with the right request id but a forged response MAC", async () => {
+    const fake = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const input = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { requestId: string };
+        const body = JSON.stringify({
+          version: 1,
+          requestId: input.requestId,
+          ok: true,
+          base64: "AQID",
+          mimeType: "image/png",
+          bytes: 3,
+          updated: Date.now(),
+          responseMac: "b".repeat(64),
+        });
+        res.writeHead(200, { "content-type": "application/json", "content-length": String(Buffer.byteLength(body)) });
+        res.end(body);
+      });
+    });
+    await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", resolve));
+    const address = fake.address();
+    if (!address || typeof address === "string") throw new Error("fake relay did not bind");
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${address.port}${PANEL_IMAGE_RELAY_HTTP_PATH}`;
+      await expect(requestPanelImage("render.png", "output", "shots")).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+    } finally {
+      await new Promise<void>((resolve) => fake.close(() => resolve()));
+    }
+  });
+
+  it("enforces the single request deadline around bridge.send", async () => {
+    let timeoutMs = 0;
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async (_command, options) => {
+          timeoutMs = options.timeoutMs;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
+        },
+      },
+    });
+    try {
+      const createdAt = Date.now();
+      const short = request("short-deadline-123456", { createdAt, deadlineAt: createdAt + 30 });
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(short),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "TIMEOUT", requestId: short.requestId });
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThanOrEqual(30);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects oversized HTTP requests and overloads without unbounded work", async () => {
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: () => ({ agentKey: "orchestrator::claude", secret: SECRET }),
+      resolvePanelTab: () => "panel-tab",
+      bridge: { canReach: () => true, send: vi.fn() },
+    });
+    try {
+      const oversized = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": String(20 * 1024) },
+        body: "x".repeat(20 * 1024),
+      });
+      expect(oversized.status).toBe(413);
+      expect(await oversized.json()).toMatchObject({ error: "REQUEST_TOO_LARGE" });
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   PANEL_IMAGE_RELAY_MAX_BYTES,
+  PANEL_IMAGE_RELAY_MAX_CONCURRENT,
+  PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS,
+  PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES,
+  PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES,
+  PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK,
   PANEL_IMAGE_RELAY_REQUEST_PREFIX,
   PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
   PANEL_IMAGE_RELAY_STALE_MS,
@@ -21,16 +26,20 @@ function tempChannel(): string {
 }
 
 function request(id: string, patch: Partial<PanelImageRelayRequest> = {}): PanelImageRelayRequest {
-  return {
+  const createdAt = Date.now();
+  const value = {
     version: 1,
     requestId: id,
     requester: "orchestrator::claude",
     filename: "render.png",
     subfolder: "shots",
     type: "output",
-    createdAt: Date.now(),
+    createdAt,
+    deadlineAt: createdAt + 8_000,
     ...patch,
   };
+  if (!("deadlineAt" in patch)) value.deadlineAt = value.createdAt + 8_000;
+  return value;
 }
 
 function requestFile(dir: string, id: string): string {
@@ -67,6 +76,7 @@ describe("panel image relay child channel", () => {
     const requestBody = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
     expect(Object.keys(requestBody).sort()).toEqual([
       "createdAt",
+      "deadlineAt",
       "filename",
       "requestId",
       "requester",
@@ -124,6 +134,30 @@ describe("panel image relay child channel", () => {
     }));
     await expect(pending).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
   });
+
+  it("does not accept a response discovered after the single end-to-end deadline", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    const pending = requestPanelImage("render.png", "output", "shots");
+    let file = "";
+    for (let i = 0; i < 100 && !file; i += 1) {
+      file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!file) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const body = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
+    const id = String(body.requestId);
+    writeFileSync(responseFile(dir, id), JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: true,
+      base64: "AQID",
+      mimeType: "image/png",
+      bytes: 3,
+      updated: Number(body.deadlineAt) + 1,
+    }));
+    await expect(pending).rejects.toMatchObject({ code: "STALE_REPLY" });
+  });
 });
 
 describe("panel image relay orchestrator poll", () => {
@@ -134,7 +168,9 @@ describe("panel image relay orchestrator poll", () => {
     const send = vi.fn(async (command: unknown, options: unknown) => {
       expect(command).toEqual({ cmd: "fetch_image", filename: "render.png", subfolder: "shots", type: "output" });
       expect(command).not.toHaveProperty("url");
-      expect(options).toEqual({ tabId: "pinned-live-panel", timeoutMs: 8_000 });
+      expect(options).toMatchObject({ tabId: "pinned-live-panel" });
+      expect((options as { timeoutMs: number }).timeoutMs).toBeGreaterThan(0);
+      expect((options as { timeoutMs: number }).timeoutMs).toBeLessThanOrEqual(8_000);
       return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
     });
     await processPanelImageRequests({
@@ -203,9 +239,108 @@ describe("panel image relay orchestrator poll", () => {
     writeFileSync(requestFile(dir, forgedId), JSON.stringify({ ...request(forgedId), url: "http://127.0.0.1:9/secret" }));
     const send = vi.fn();
     await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
-    expect(readResponse(dir, staleId)).toMatchObject({ ok: false, error: "STALE_REQUEST" });
+    expect(readResponse(dir, staleId)).toMatchObject({ ok: false, error: "TIMEOUT" });
     expect(readResponse(dir, forgedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("carries one deadline through the bridge and refuses a late panel result", async () => {
+    const dir = tempChannel();
+    const id = "deadline-race-123456";
+    const createdAt = Date.now();
+    writeFileSync(requestFile(dir, id), JSON.stringify(request(id, {
+      createdAt,
+      deadlineAt: createdAt + 50,
+    })));
+    let timeoutMs = 0;
+    await processPanelImageRequests({
+      dir,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async (_command, options) => {
+          timeoutMs = options.timeoutMs;
+          await new Promise((resolve) => setTimeout(resolve, 75));
+          return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
+        },
+      },
+    });
+    expect(timeoutMs).toBeGreaterThan(0);
+    expect(timeoutMs).toBeLessThanOrEqual(50);
+    expect(readResponse(dir, id)).toMatchObject({ ok: false, error: "TIMEOUT" });
+  });
+
+  it("bounds per-tick concurrency and fails closed when the request backlog is full", async () => {
+    const dir = tempChannel();
+    const ids = Array.from({ length: PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS + 8 }, (_, index) =>
+      `flood-${index}-1234567890`,
+    );
+    for (const id of ids) writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
+    let active = 0;
+    let maxActive = 0;
+    let sends = 0;
+    await processPanelImageRequests({
+      dir,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async () => {
+          active += 1;
+          sends += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          active -= 1;
+          return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
+        },
+      },
+    });
+    expect(maxActive).toBeLessThanOrEqual(PANEL_IMAGE_RELAY_MAX_CONCURRENT);
+    expect(sends).toBe(PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK);
+    const remainingRequests = readdirSync(dir).filter((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX));
+    expect(remainingRequests.length).toBe(PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS - PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK);
+    const backlogFailures = ids.filter((id) => {
+      try { return readResponse(dir, id).error === "BACKLOG_FULL"; } catch { return false; }
+    });
+    expect(backlogFailures.length).toBe(ids.length - PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS);
+  });
+
+  it("does not dispatch more panel fetches while bounded response slots are occupied", async () => {
+    const dir = tempChannel();
+    for (let index = 0; index < PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES; index += 1) {
+      const id = `held-response-${index}-123456`;
+      writeFileSync(responseFile(dir, id), JSON.stringify({ version: 1, requestId: id, ok: false, error: "PANEL_FETCH_FAILED", updated: Date.now() }));
+    }
+    const id = "response-cap-request-123456";
+    writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
+    const send = vi.fn();
+    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    expect(send).not.toHaveBeenCalled();
+    expect(readdirSync(dir)).toContain(`control-image-request-${id}.json`);
+  });
+
+  it("rejects oversized and symlinked request files before bridge dispatch", async () => {
+    const dir = tempChannel();
+    const oversizedId = "oversized-request-123456";
+    const oversizedPath = requestFile(dir, oversizedId);
+    writeFileSync(oversizedPath, "{}");
+    truncateSync(oversizedPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES + 1);
+
+    const targetPath = join(dir, "ordinary-target.json");
+    writeFileSync(targetPath, JSON.stringify(request("symlink-request-123456")));
+    const symlinkId = "symlink-request-123456";
+    const symlinkPath = requestFile(dir, symlinkId);
+    let symlinksSupported = true;
+    try {
+      symlinkSync(targetPath, symlinkPath, "file");
+    } catch {
+      symlinksSupported = false;
+    }
+
+    const send = vi.fn();
+    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    expect(send).not.toHaveBeenCalled();
+    expect(readResponse(dir, oversizedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
+    if (symlinksSupported) expect(readdirSync(dir)).not.toContain(`control-image-response-${symlinkId}.json`);
   });
 
   it("reaps stale and oversized response files without reading them", async () => {

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PANEL_IMAGE_RELAY_MAX_BYTES,
+  PANEL_IMAGE_RELAY_REQUEST_PREFIX,
+  PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
+  PANEL_IMAGE_RELAY_STALE_MS,
+  processPanelImageRequests,
+  requestPanelImage,
+  type PanelImageRelayRequest,
+} from "../../services/panel-image-relay.js";
+
+const dirs: string[] = [];
+
+function tempChannel(): string {
+  const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-"));
+  dirs.push(dir);
+  return dir;
+}
+
+function request(id: string, patch: Partial<PanelImageRelayRequest> = {}): PanelImageRelayRequest {
+  return {
+    version: 1,
+    requestId: id,
+    requester: "orchestrator::claude",
+    filename: "render.png",
+    subfolder: "shots",
+    type: "output",
+    createdAt: Date.now(),
+    ...patch,
+  };
+}
+
+function requestFile(dir: string, id: string): string {
+  return join(dir, `${PANEL_IMAGE_RELAY_REQUEST_PREFIX}${id}.json`);
+}
+
+function responseFile(dir: string, id: string): string {
+  return join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${id}.json`);
+}
+
+function readResponse(dir: string, id: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(responseFile(dir, id), "utf8")) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+  delete process.env.COMFYUI_MCP_TAB;
+  vi.restoreAllMocks();
+});
+
+describe("panel image relay child channel", () => {
+  it("writes only a bounded reference and accepts the exact panel result contract", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    const pending = requestPanelImage("render.png", "output", "shots");
+    let file = "";
+    for (let i = 0; i < 100 && !file; i += 1) {
+      file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!file) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(file).not.toBe("");
+    const requestBody = JSON.parse(readFileSync(join(dir, file), "utf8")) as Record<string, unknown>;
+    expect(Object.keys(requestBody).sort()).toEqual([
+      "createdAt",
+      "filename",
+      "requestId",
+      "requester",
+      "subfolder",
+      "type",
+      "version",
+    ]);
+    expect(requestBody).not.toHaveProperty("url");
+    const id = String(requestBody.requestId);
+    writeFileSync(responseFile(dir, id), JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: true,
+      base64: "AQID",
+      mimeType: "image/png",
+      bytes: 3,
+      updated: Date.now(),
+    }));
+    await expect(pending).resolves.toEqual({ base64: "AQID", mimeType: "image/png", bytes: 3 });
+  });
+
+  it.each([
+    ["../escape.png", "", "output"],
+    ["render.png", "shots\\nested", "output"],
+    ["render.png", "shots/../nested", "output"],
+    ["render.png", "shots", "other"],
+  ])("rejects unsafe reference %s / %s / %s before writing", async (filename, subfolder, type) => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    await expect(requestPanelImage(filename, type as "output", subfolder)).rejects.toMatchObject({ code: "UNSAFE_REFERENCE" });
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("rejects a malformed response instead of accepting a URL-shaped field", async () => {
+    const dir = tempChannel();
+    process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+    process.env.COMFYUI_MCP_TAB = "orchestrator::claude";
+    const pending = requestPanelImage("render.png", "output", "shots");
+    let file = "";
+    for (let i = 0; i < 100 && !file; i += 1) {
+      file = readdirSync(dir).find((name) => name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX)) ?? "";
+      if (!file) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const id = file.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -5);
+    writeFileSync(responseFile(dir, id), JSON.stringify({
+      version: 1,
+      requestId: id,
+      ok: true,
+      url: "http://127.0.0.1:9/secret",
+      base64: "AQID",
+      mimeType: "image/png",
+      bytes: 3,
+      updated: Date.now(),
+    }));
+    await expect(pending).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+  });
+});
+
+describe("panel image relay orchestrator poll", () => {
+  it("resolves a shared agent key to its pinned live panel and sends only the reference command", async () => {
+    const dir = tempChannel();
+    const id = "request-1234567890";
+    writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
+    const send = vi.fn(async (command: unknown, options: unknown) => {
+      expect(command).toEqual({ cmd: "fetch_image", filename: "render.png", subfolder: "shots", type: "output" });
+      expect(command).not.toHaveProperty("url");
+      expect(options).toEqual({ tabId: "pinned-live-panel", timeoutMs: 8_000 });
+      return { ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 };
+    });
+    await processPanelImageRequests({
+      dir,
+      resolvePanelTab: (agentKey) => {
+        expect(agentKey).toBe("orchestrator::claude");
+        // This is the production scopeToRealTab result for the shared key:
+        // bridge.resolveSharedTabId("orchestrator::claude").
+        return "pinned-live-panel";
+      },
+      bridge: { canReach: () => true, send },
+    });
+    expect(send).toHaveBeenCalledOnce();
+    expect(readResponse(dir, id)).toMatchObject({ ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 });
+    expect(readdirSync(dir).some((name) => name === requestFile(dir, id))).toBe(false);
+  });
+
+  it("fails closed for missing or ambiguous live panel routing", async () => {
+    for (const failure of ["NO_LIVE_PANEL", "AMBIGUOUS_REQUESTER"] as const) {
+      const dir = tempChannel();
+      const id = `request-${failure.toLowerCase()}-123456`;
+      writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
+      const send = vi.fn();
+      await processPanelImageRequests({
+        dir,
+        resolvePanelTab: () => failure === "NO_LIVE_PANEL" ? undefined : "panel-tab",
+        bridge: {
+          canReach: () => false,
+          resolveFailure: () => (failure === "AMBIGUOUS_REQUESTER" ? "ambiguous" : "unresolved"),
+          send,
+        },
+      });
+      expect(send).not.toHaveBeenCalled();
+      expect(readResponse(dir, id)).toMatchObject({ ok: false, error: failure });
+      rmSync(dir, { recursive: true, force: true });
+      dirs.splice(dirs.indexOf(dir), 1);
+    }
+  });
+
+  it("rejects malformed, oversized, and HTTP-error panel replies", async () => {
+    const cases = [
+      { reply: { ok: true, base64: "not-base64", mimeType: "image/png", bytes: 3 }, error: "MALFORMED_REPLY" },
+      { reply: { ok: true, base64: "AQID", mimeType: "image/png", bytes: PANEL_IMAGE_RELAY_MAX_BYTES + 1 }, error: "MALFORMED_REPLY" },
+      { reply: { ok: false, error: "HTTP_404" }, error: "PANEL_FETCH_FAILED" },
+    ];
+    for (const [index, testCase] of cases.entries()) {
+      const dir = tempChannel();
+      const id = `reply-case-${index}-123456789`;
+      writeFileSync(requestFile(dir, id), JSON.stringify(request(id)));
+      await processPanelImageRequests({
+        dir,
+        resolvePanelTab: () => "panel-tab",
+        bridge: { canReach: () => true, send: async () => testCase.reply },
+      });
+      expect(readResponse(dir, id), `case ${index}`).toMatchObject({ ok: false, error: testCase.error });
+      rmSync(dir, { recursive: true, force: true });
+      dirs.splice(dirs.indexOf(dir), 1);
+    }
+  });
+
+  it("rejects stale requests and requests containing a URL", async () => {
+    const dir = tempChannel();
+    const staleId = "stale-request-123456";
+    writeFileSync(requestFile(dir, staleId), JSON.stringify(request(staleId, { createdAt: Date.now() - PANEL_IMAGE_RELAY_STALE_MS - 1 })));
+    const forgedId = "forged-url-1234567";
+    writeFileSync(requestFile(dir, forgedId), JSON.stringify({ ...request(forgedId), url: "http://127.0.0.1:9/secret" }));
+    const send = vi.fn();
+    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => true, send } });
+    expect(readResponse(dir, staleId)).toMatchObject({ ok: false, error: "STALE_REQUEST" });
+    expect(readResponse(dir, forgedId)).toMatchObject({ ok: false, error: "MALFORMED_REQUEST" });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("reaps stale and oversized response files without reading them", async () => {
+    const dir = tempChannel();
+    const stale = join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}stale-response-123456.json`);
+    const oversized = join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}oversized-response-123456.json`);
+    writeFileSync(stale, "{}");
+    writeFileSync(oversized, "");
+    const old = (Date.now() - PANEL_IMAGE_RELAY_STALE_MS - 1) / 1000;
+    utimesSync(stale, old, old);
+    truncateSync(oversized, 48 * 1024 * 1024 + 1);
+    await processPanelImageRequests({ dir, resolvePanelTab: () => "panel-tab", bridge: { canReach: () => false, send: vi.fn() } });
+    expect(readdirSync(dir)).not.toContain(stale.split("\\").at(-1));
+    expect(readdirSync(dir)).not.toContain(oversized.split("\\").at(-1));
+  });
+});

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHmac } from "node:crypto";
 import { createServer } from "node:http";
 import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -11,6 +12,7 @@ import {
   PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES,
   PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK,
   PANEL_IMAGE_RELAY_HTTP_PATH,
+  PANEL_IMAGE_RELAY_TIMEOUT_MS,
   PANEL_IMAGE_RELAY_REQUEST_PREFIX,
   PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
   PANEL_IMAGE_RELAY_STALE_MS,
@@ -575,6 +577,40 @@ describe("authenticated loopback panel image relay", () => {
       process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
       process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${address.port}${PANEL_IMAGE_RELAY_HTTP_PATH}`;
       await expect(requestPanelImage("render.png", "output", "shots")).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+    } finally {
+      await new Promise<void>((resolve) => fake.close(() => resolve()));
+    }
+  });
+
+  it("classifies an authenticated server TIMEOUT before deadline freshness", async () => {
+    const fake = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const input = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { requestId: string };
+        const updated = Date.now() + PANEL_IMAGE_RELAY_TIMEOUT_MS * 2;
+        const unsigned = {
+          version: 1,
+          requestId: input.requestId,
+          ok: false,
+          error: "TIMEOUT",
+          updated,
+        } as const;
+        const responseMac = createHmac("sha256", SECRET)
+          .update(JSON.stringify([unsigned.version, unsigned.requestId, false, unsigned.error, unsigned.updated]))
+          .digest("hex");
+        const body = JSON.stringify({ ...unsigned, responseMac });
+        res.writeHead(200, { "content-type": "application/json", "content-length": String(Buffer.byteLength(body)) });
+        res.end(body);
+      });
+    });
+    await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", resolve));
+    const address = fake.address();
+    if (!address || typeof address === "string") throw new Error("fake relay did not bind");
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${address.port}${PANEL_IMAGE_RELAY_HTTP_PATH}`;
+      await expect(requestPanelImage("render.png", "output", "shots")).rejects.toMatchObject({ code: "TIMEOUT" });
     } finally {
       await new Promise<void>((resolve) => fake.close(() => resolve()));
     }

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -79,7 +79,7 @@ describe("panel-origin channel", () => {
         origins: [1, null, "", "http://a:1"],
         updated: Date.now(),
         pid: process.pid,
-        trustedLocalPanelOrigins: true,
+        diagnosticPanelOrigins: true,
       }),
     );
     expect(readPublishedPanelOrigins()).toEqual([]);
@@ -171,7 +171,7 @@ describe("panel-origin channel — staleness", () => {
   it("accepts a live, fresh record", () => {
     // The direction that must keep working: everything above rejects, so a test
     // that only asserted rejection could pass with the reader hard-wired to [].
-    writeRecord({ origins, updated: Date.now(), pid: process.pid, trustedLocalPanelOrigins: true });
+    writeRecord({ origins, updated: Date.now(), pid: process.pid, diagnosticPanelOrigins: true });
     expect(readPublishedPanelOrigins()).toEqual(origins);
   });
 
@@ -181,14 +181,14 @@ describe("panel-origin channel — staleness", () => {
       origins,
       updated: now - PANEL_ORIGINS_MAX_AGE_MS + 1_000,
       pid: process.pid,
-      trustedLocalPanelOrigins: true,
+      diagnosticPanelOrigins: true,
     });
     expect(readPublishedPanelOrigins(now)).toEqual(origins);
     writeRecord({
       origins,
       updated: now - PANEL_ORIGINS_MAX_AGE_MS - 1_000,
       pid: process.pid,
-      trustedLocalPanelOrigins: true,
+      diagnosticPanelOrigins: true,
     });
     expect(readPublishedPanelOrigins(now)).toEqual([]);
   });
@@ -201,7 +201,7 @@ describe("panel-origin channel — staleness", () => {
     expect(readPublishedPanelOrigins()).toEqual(origins);
     const raw = JSON.parse(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8"));
     expect(raw.pid).toBe(process.pid);
-    expect(raw.trustedLocalPanelOrigins).toBe(true);
+    expect(raw.diagnosticPanelOrigins).toBe(true);
   });
 });
 
@@ -358,7 +358,7 @@ describe("panel-origin channel — bounded read (review, finding 3)", () => {
         origins: ["http://127.0.0.1:8188"],
         updated: Date.now(),
         pid: process.pid,
-        trustedLocalPanelOrigins: true,
+        diagnosticPanelOrigins: true,
       }),
     );
     expect(readPublishedPanelOrigins()).toEqual(["http://127.0.0.1:8188"]);

--- a/src/__tests__/services/panel-origin-channel.test.ts
+++ b/src/__tests__/services/panel-origin-channel.test.ts
@@ -75,9 +75,14 @@ describe("panel-origin channel", () => {
     // this would pass while proving nothing about the string filter.
     writeFileSync(
       join(dir, PANEL_ORIGINS_FILE),
-      JSON.stringify({ origins: [1, null, "", "http://a:1"], updated: Date.now(), pid: process.pid }),
+      JSON.stringify({
+        origins: [1, null, "", "http://a:1"],
+        updated: Date.now(),
+        pid: process.pid,
+        trustedLocalPanelOrigins: true,
+      }),
     );
-    expect(readPublishedPanelOrigins()).toEqual(["http://a:1"]);
+    expect(readPublishedPanelOrigins()).toEqual([]);
   });
 
   it("survives an unwritable directory instead of throwing into the poll tick", () => {
@@ -166,15 +171,25 @@ describe("panel-origin channel — staleness", () => {
   it("accepts a live, fresh record", () => {
     // The direction that must keep working: everything above rejects, so a test
     // that only asserted rejection could pass with the reader hard-wired to [].
-    writeRecord({ origins, updated: Date.now(), pid: process.pid });
+    writeRecord({ origins, updated: Date.now(), pid: process.pid, trustedLocalPanelOrigins: true });
     expect(readPublishedPanelOrigins()).toEqual(origins);
   });
 
   it("accepts a record right up to the age limit, and not past it", () => {
     const now = Date.now();
-    writeRecord({ origins, updated: now - PANEL_ORIGINS_MAX_AGE_MS + 1_000, pid: process.pid });
+    writeRecord({
+      origins,
+      updated: now - PANEL_ORIGINS_MAX_AGE_MS + 1_000,
+      pid: process.pid,
+      trustedLocalPanelOrigins: true,
+    });
     expect(readPublishedPanelOrigins(now)).toEqual(origins);
-    writeRecord({ origins, updated: now - PANEL_ORIGINS_MAX_AGE_MS - 1_000, pid: process.pid });
+    writeRecord({
+      origins,
+      updated: now - PANEL_ORIGINS_MAX_AGE_MS - 1_000,
+      pid: process.pid,
+      trustedLocalPanelOrigins: true,
+    });
     expect(readPublishedPanelOrigins(now)).toEqual([]);
   });
 
@@ -186,6 +201,7 @@ describe("panel-origin channel — staleness", () => {
     expect(readPublishedPanelOrigins()).toEqual(origins);
     const raw = JSON.parse(readFileSync(join(dir, PANEL_ORIGINS_FILE), "utf-8"));
     expect(raw.pid).toBe(process.pid);
+    expect(raw.trustedLocalPanelOrigins).toBe(true);
   });
 });
 
@@ -338,7 +354,12 @@ describe("panel-origin channel — bounded read (review, finding 3)", () => {
   it("still reads a normal-sized record", () => {
     writeFileSync(
       join(dir, PANEL_ORIGINS_FILE),
-      JSON.stringify({ origins: ["http://127.0.0.1:8188"], updated: Date.now(), pid: process.pid }),
+      JSON.stringify({
+        origins: ["http://127.0.0.1:8188"],
+        updated: Date.now(),
+        pid: process.pid,
+        trustedLocalPanelOrigins: true,
+      }),
     );
     expect(readPublishedPanelOrigins()).toEqual(["http://127.0.0.1:8188"]);
   });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5425,11 +5425,22 @@ describe("UiBridge (late MUTATION outcome — #694)", () => {
 // callback the orchestrator installs, and this is what it asks for.
 describe("UiBridge.connectedServerOrigins (#952)", () => {
   /** A panel socket carrying a SERVER-OBSERVED handshake Origin, like a browser. */
-  function connectWithOrigin(tabId: string, origin?: string): Promise<WebSocket> {
+  function connectWithOrigin(
+    tabId: string,
+    origin?: string,
+    claimedOrigin: string | undefined = origin,
+  ): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
       const sock = new WebSocket(`ws://127.0.0.1:${port}`, origin ? { origin } : {});
       sock.on("open", () => {
-        sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title: tabId }));
+        sock.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: tabId,
+            title: tabId,
+            ...(claimedOrigin ? { comfyui_url: claimedOrigin } : {}),
+          }),
+        );
         resolve(sock);
       });
       sock.on("error", reject);
@@ -5475,6 +5486,22 @@ describe("UiBridge.connectedServerOrigins (#952)", () => {
 
   it("is empty with nothing connected, and never throws", () => {
     expect(bridge.connectedServerOrigins()).toEqual([]);
+  });
+
+  it("only exposes a corroborated local loopback panel to direct MCP fallback", async () => {
+    const local = await connectWithOrigin("safe-local", "http://127.0.0.1:8188");
+    const remote = await connectWithOrigin("unsafe-remote", "http://192.168.1.50:8188");
+    const mismatch = await connectWithOrigin(
+      "unsafe-claim",
+      "http://127.0.0.1:8189",
+      "http://127.0.0.1:8188",
+    );
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(3));
+
+    expect(bridge.connectedSafePanelOrigins()).toEqual(["http://127.0.0.1:8188"]);
+    local.close();
+    remote.close();
+    mismatch.close();
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3661,12 +3661,18 @@ describe("tabServerOrigin (server-observed handshake Origin — #509 spoof gate)
     s.close();
   });
 
-  it("normalizes to scheme://host:port — any path is stripped (Origin carries none)", async () => {
-    // Even if a client sends a path-bearing value, the stored origin is authority-only, so
-    // a path-mounted boot base is fail-closed (never falsely matched) downstream.
-    const s = await connectWithOrigin("tab-origin-3", "http://127.0.0.1:8188/comfy");
+  it.each([
+    "http://127.0.0.1:8188/comfy",
+    "http://127.0.0.1:8188/",
+    "http://127.0.0.1:8188?token=secret",
+    "http://user:pass@127.0.0.1:8188",
+    "ws://127.0.0.1:8188",
+  ])("rejects a non-origin handshake value %s", async (origin) => {
+    // A tokenless local client can write the HTTP header, so syntax normalization
+    // must not turn a path/query/userinfo/unsupported scheme into origin data.
+    const s = await connectWithOrigin("tab-origin-3", origin);
     await waitFor(() => expect(bridge.canReach("tab-origin-3")).toBe(true));
-    expect(bridge.tabServerOrigin("tab-origin-3")).toBe("http://127.0.0.1:8188");
+    expect(bridge.tabServerOrigin("tab-origin-3")).toBeUndefined();
     s.close();
   });
 });
@@ -5488,20 +5494,16 @@ describe("UiBridge.connectedServerOrigins (#952)", () => {
     expect(bridge.connectedServerOrigins()).toEqual([]);
   });
 
-  it("only exposes a corroborated local loopback panel to direct MCP fallback", async () => {
-    const local = await connectWithOrigin("safe-local", "http://127.0.0.1:8188");
-    const remote = await connectWithOrigin("unsafe-remote", "http://192.168.1.50:8188");
-    const mismatch = await connectWithOrigin(
-      "unsafe-claim",
-      "http://127.0.0.1:8189",
-      "http://127.0.0.1:8188",
-    );
-    await waitFor(() => expect(bridge.tabs()).toHaveLength(3));
+  it("keeps a forged tokenless local handshake origin diagnostic-only", async () => {
+    const forged = await connectWithOrigin("forged-local", "http://127.0.0.1:8188");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
 
-    expect(bridge.connectedSafePanelOrigins()).toEqual(["http://127.0.0.1:8188"]);
-    local.close();
-    remote.close();
-    mismatch.close();
+    // The observed header and matching hello claim are both forgeable by this
+    // non-browser WebSocket client. It may remain diagnostic data, but no
+    // UiBridge API exposes it as a direct MCP fallback authorization.
+    expect(bridge.connectedServerOrigins()).toEqual(["http://127.0.0.1:8188"]);
+    expect("connectedSafePanelOrigins" in bridge).toBe(false);
+    forged.close();
   });
 });
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -16,7 +16,7 @@ import {
 } from "../utils/errors.js";
 import {
   comfyuiFetch,
-  connectedPanelOriginsNow,
+  connectedPanelFallbackOriginsNow,
   comfyHttpTimeoutSeconds,
   isComfyTransportFailure,
   isTimeoutAbort,
@@ -1322,7 +1322,7 @@ export async function fetchImage(
   } catch (primaryError) {
     if (!isComfyTransportFailure(primaryError)) throw primaryError;
 
-    const choice = choosePanelFallbackOrigin(configuredTarget, connectedPanelOriginsNow());
+    const choice = choosePanelFallbackOrigin(configuredTarget, connectedPanelFallbackOriginsNow());
     const declined = describeDeclinedPanelFallback(choice);
     if (choice.kind !== "use") {
       if (declined) {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -12,8 +12,21 @@ import {
   ComfyUIError,
   ConnectionError,
   WorkflowExecutionError,
+  describeFetchFailure,
 } from "../utils/errors.js";
-import { comfyuiFetch, isTimeoutAbort, raceAbort } from "./fetch.js";
+import {
+  comfyuiFetch,
+  connectedPanelOriginsNow,
+  comfyHttpTimeoutSeconds,
+  isComfyTransportFailure,
+  isTimeoutAbort,
+  raceAbort,
+} from "./fetch.js";
+import {
+  choosePanelFallbackOrigin,
+  describeDeclinedPanelFallback,
+  httpOriginOf,
+} from "../services/panel-fallback-target.js";
 import {
   bodyPrefixOf,
   classifyNonJson,
@@ -1166,6 +1179,121 @@ export async function getHistory(
   return readComfyJson<Record<string, HistoryEntry>>(res, { url: path });
 }
 
+/** A /view response is saved and may later be previewed, so bound the first read too. */
+export const MAX_VIEW_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+function validateViewResponseOrigin(res: Response, expectedOrigin: string, label: string): void {
+  if (res.url) {
+    const actualOrigin = httpOriginOf(res.url);
+    if (actualOrigin !== expectedOrigin) {
+      throw new ComfyUIError(
+        `ComfyUI /view response from ${label} changed origin unexpectedly; the response was refused.`,
+        "VIEW_RESPONSE_ORIGIN",
+        { expectedOrigin, actualOrigin: actualOrigin ?? "invalid" },
+      );
+    }
+  }
+  if (res.status >= 300 && res.status < 400) {
+    // The caller must not follow a redirect from a panel-origin fallback. A
+    // same-origin redirect is refused too: without a validated final URL it
+    // would be easy to reintroduce cross-origin leakage in a later edit.
+    throw new ComfyUIError(
+      `ComfyUI /view returned an unsafe redirect from ${label}; the response was refused.`,
+      "VIEW_REDIRECT_UNSAFE",
+      { status: res.status },
+    );
+  }
+}
+
+function viewTooLarge(filename: string): ComfyUIError {
+  return new ComfyUIError(
+    `ComfyUI /view response for "${filename}" exceeds the ${MAX_VIEW_RESPONSE_BYTES / 1024 ** 2} MB safety limit.`,
+    "VIEW_TOO_LARGE",
+    { filename, maxBytes: MAX_VIEW_RESPONSE_BYTES },
+  );
+}
+
+function readChunkWithAbort(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal,
+): Promise<Awaited<ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>>> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason ?? new Error("The response read timed out"));
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      void reader.cancel(signal.reason).catch(() => undefined);
+      reject(signal.reason ?? new Error("The response read timed out"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    reader.read().then(
+      (result) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(result);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+async function readViewResponseBounded(
+  res: Response,
+  filename: string,
+  timeoutMs: number,
+): Promise<Buffer> {
+  const declared = Number(res.headers.get("content-length") ?? "");
+  if (Number.isFinite(declared) && declared > MAX_VIEW_RESPONSE_BYTES) {
+    throw viewTooLarge(filename);
+  }
+  if (!res.body) return Buffer.alloc(0);
+
+  const reader = res.body.getReader();
+  const signal = AbortSignal.timeout(timeoutMs);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await readChunkWithAbort(reader, signal);
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_VIEW_RESPONSE_BYTES) {
+        try {
+          await reader.cancel("ComfyUI /view response exceeded the safety limit");
+        } catch {
+          // The size refusal is the useful error even if the producer is already gone.
+        }
+        throw viewTooLarge(filename);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (signal.aborted) {
+      throw new ComfyUIError(
+        `ComfyUI /view did not finish sending "${filename}" within ${timeoutMs / 1000}s; the response was aborted.`,
+        "VIEW_READ_TIMEOUT",
+        { filename, timeout_ms: timeoutMs },
+      );
+    }
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
 /**
  * Fetch an image from ComfyUI's /view endpoint as a base64 string.
  * Works over HTTP — no local filesystem access needed.
@@ -1178,11 +1306,64 @@ export async function fetchImage(
   if (isCloudMode()) return cloudClient.fetchImage(filename, type, subfolder);
   const client = getClient();
   const params = new URLSearchParams({ filename, type, subfolder });
-  const res = await comfyApiFetch(`/view?${params.toString()}`);
+  const viewRoute = `/view?${params.toString()}`;
+  const configuredTarget = `${getComfyUIBaseUrl().replace(/\/+$/, "")}${viewRoute}`;
+  const configuredOrigin = httpOriginOf(configuredTarget);
+  const fallbackPath = `${getComfyUIBasePath().replace(/\/+$/, "")}${viewRoute}`;
+  let res: Response;
+  let answeredByPanelOrigin: string | undefined;
+  let responseReadTimeoutMs = Math.round(comfyHttpTimeoutSeconds() * 1000);
+  try {
+    res = await comfyApiFetch(viewRoute, { redirect: "manual" });
+    if (configuredOrigin === undefined) {
+      throw new ComfyUIError("The configured ComfyUI target is not a valid HTTP(S) origin.", "VIEW_ERROR");
+    }
+    validateViewResponseOrigin(res, configuredOrigin, "the configured ComfyUI target");
+  } catch (primaryError) {
+    if (!isComfyTransportFailure(primaryError)) throw primaryError;
+
+    const choice = choosePanelFallbackOrigin(configuredTarget, connectedPanelOriginsNow());
+    const declined = describeDeclinedPanelFallback(choice);
+    if (choice.kind !== "use") {
+      if (declined) {
+        const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+        throw new Error(`${primary}${declined}`, { cause: primaryError });
+      }
+      throw primaryError;
+    }
+
+    const fallbackUrl = `${choice.origin}${fallbackPath}`;
+    try {
+      // The configured auth headers are for the headless target, not an origin
+      // selected from a browser handshake. Never send them to the fallback.
+      // A browser-only/tunnel origin can be unreachable from this process; do
+      // not add the full headless timeout on top of the failed primary request.
+      res = await fetch(fallbackUrl, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(8_000),
+      });
+      responseReadTimeoutMs = 8_000;
+    } catch (fallbackError) {
+      const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+      const secondary = describeFetchFailure(fallbackError).message;
+      throw new Error(
+        `${primary} I then tried the ComfyUI a connected sidebar panel is on ` +
+          `(${fallbackUrl}), and that failed too: ${secondary}. The browser can reach ` +
+          `that origin — this process cannot — so something between them (a tunnel, a ` +
+          `container boundary, or a server bound to one interface) is in the way.`,
+        { cause: fallbackError },
+      );
+    }
+    validateViewResponseOrigin(res, choice.origin, "the connected panel's ComfyUI");
+    answeredByPanelOrigin = choice.origin;
+  }
   if (!res.ok) {
     const where = subfolder ? `${type}/${subfolder}` : type;
+    const responder = answeredByPanelOrigin
+      ? `The connected panel's ComfyUI at ${answeredByPanelOrigin}`
+      : "ComfyUI";
     throw new ComfyUIError(
-      `ComfyUI /view returned ${res.status} for "${filename}" (${where}). ` +
+      `${responder} /view returned ${res.status} for "${filename}" (${where}). ` +
         (res.status === 404
           ? `No such file in the ComfyUI ${type} directory` +
             (subfolder ? ` under subfolder "${subfolder}"` : "") +
@@ -1194,8 +1375,8 @@ export async function fetchImage(
   }
   const contentType = res.headers.get("content-type") ?? "image/png";
   const mimeType = contentType.split(";")[0].trim();
-  const arrayBuffer = await res.arrayBuffer();
-  const base64 = Buffer.from(arrayBuffer).toString("base64");
+  const bytes = await readViewResponseBounded(res, filename, responseReadTimeoutMs);
+  const base64 = bytes.toString("base64");
   return { base64, mimeType };
 }
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -28,6 +28,11 @@ import {
   httpOriginOf,
 } from "../services/panel-fallback-target.js";
 import {
+  PANEL_IMAGE_RELAY_MAX_BYTES,
+  PanelImageRelayError,
+  requestPanelImage,
+} from "../services/panel-image-relay.js";
+import {
   bodyPrefixOf,
   classifyNonJson,
   describeStatus,
@@ -1180,7 +1185,7 @@ export async function getHistory(
 }
 
 /** A /view response is saved and may later be previewed, so bound the first read too. */
-export const MAX_VIEW_RESPONSE_BYTES = 32 * 1024 * 1024;
+export const MAX_VIEW_RESPONSE_BYTES = PANEL_IMAGE_RELAY_MAX_BYTES;
 
 function validateViewResponseOrigin(res: Response, expectedOrigin: string, label: string): void {
   if (res.url) {
@@ -1325,6 +1330,23 @@ export async function fetchImage(
     const choice = choosePanelFallbackOrigin(configuredTarget, connectedPanelFallbackOriginsNow());
     const declined = describeDeclinedPanelFallback(choice);
     if (choice.kind !== "use") {
+      // Production children have no bridge object. They use the bounded
+      // reference-only relay instead: the orchestrator resolves the requester
+      // and asks the authenticated panel to fetch same-origin /view. The old
+      // direct-origin seam remains injectable for focused fallback mechanics
+      // tests, but it is never installed by production.
+      try {
+        const relayed = await requestPanelImage(filename, type, subfolder);
+        if (relayed) return { base64: relayed.base64, mimeType: relayed.mimeType };
+      } catch (relayError) {
+        if (relayError instanceof PanelImageRelayError && !relayError.unavailable) {
+          const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+          throw new Error(
+            `${primary} The connected panel image relay failed safely (${relayError.code}).`,
+            { cause: relayError },
+          );
+        }
+      }
       if (declined) {
         const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
         throw new Error(`${primary}${declined}`, { cause: primaryError });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1331,8 +1331,8 @@ export async function fetchImage(
     const declined = describeDeclinedPanelFallback(choice);
     if (choice.kind !== "use") {
       // Production children have no bridge object. They use the bounded
-      // reference-only relay instead: the orchestrator resolves the requester
-      // and asks the authenticated panel to fetch same-origin /view. The old
+      // reference-only relay instead: the orchestrator resolves the child
+      // capability and asks the authenticated panel to fetch same-origin /view. The old
       // direct-origin seam remains injectable for focused fallback mechanics
       // tests, but it is never installed by production.
       try {

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -28,12 +28,24 @@ function methodOf(input: string | URL | Request, init: RequestInit): string {
  * MCP server, tests, any process with no bridge) simply means the comparison is
  * skipped — never that there is no drift.
  *
- * Origins here must be the SERVER-OBSERVED handshake Origin (UiBridge's
- * `tabServerOrigin`), not the client-supplied `hello.comfyui_url`: the browser
- * sets the former and blocks page JS from forging it, so it is the trustworthy
- * answer to "which ComfyUI is this tab actually on".
+ * Origins here are diagnostic data. They must be the SERVER-OBSERVED handshake
+ * Origin (UiBridge's `tabServerOrigin`), not the client-supplied
+ * `hello.comfyui_url`, because the latter is page-controlled. This source is
+ * deliberately separate from the direct /view fallback authorization below:
+ * a tokenless local WebSocket client can forge HTTP headers, so neither this
+ * source nor the published channel is permission to contact an origin.
  */
 let connectedPanelOrigins: (() => string[]) | null = null;
+
+/**
+ * Direct /view fallback authorization. This is intentionally a separate,
+ * fail-closed seam from the diagnostic origin source and the published channel.
+ * Production installs no source: a tokenless loopback WebSocket has no
+ * browser-only provenance that could authorize MCP to make a new HTTP request.
+ * Keep this injectable only for an explicitly authenticated integration in the
+ * future and for focused tests of the already-hardened fallback mechanics.
+ */
+let connectedPanelFallbackOrigins: (() => string[]) | null = null;
 
 /**
  * #1415 — WHERE THESE CALLS ACTUALLY RUN.
@@ -59,10 +71,24 @@ export function setConnectedPanelOrigins(fn: (() => string[]) | null): void {
   connectedPanelOrigins = fn;
 }
 
+/** Install the direct-fallback source. Null is the production-safe default. */
+export function setConnectedPanelFallbackOrigins(fn: (() => string[]) | null): void {
+  connectedPanelFallbackOrigins = fn;
+}
+
 /** Read the current panel origins without allowing a stale channel read to abort a request. */
 export function connectedPanelOriginsNow(): string[] {
   try {
     return panelOrigins();
+  } catch {
+    return [];
+  }
+}
+
+/** Read direct-fallback candidates. Never falls back to diagnostic/channel data. */
+export function connectedPanelFallbackOriginsNow(): string[] {
+  try {
+    return connectedPanelFallbackOrigins ? connectedPanelFallbackOrigins() : [];
   } catch {
     return [];
   }

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -59,6 +59,28 @@ export function setConnectedPanelOrigins(fn: (() => string[]) | null): void {
   connectedPanelOrigins = fn;
 }
 
+/** Read the current panel origins without allowing a stale channel read to abort a request. */
+export function connectedPanelOriginsNow(): string[] {
+  try {
+    return panelOrigins();
+  } catch {
+    return [];
+  }
+}
+
+/** True when the request failed at the network layer, rather than returning an HTTP status. */
+export function isComfyTransportFailure(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current instanceof Error && !seen.has(current)) {
+    if (isTimeoutAbort(current)) return false;
+    if (isBareFetchFailure(current)) return true;
+    seen.add(current);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 /** Origin (scheme://host:port) of a request target, or undefined if unparsable. */
 function originOf(target: string): string | undefined {
   try {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -103,6 +103,7 @@ import {
   setConnectedPanelOrigins,
 } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
+import { processPanelImageRequests } from "../services/panel-image-relay.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
 import { completionDisagreesWithRecord, failureDisagreesWithRecord } from "./download-done-guard.js";
@@ -5879,7 +5880,20 @@ export async function runPanelOrchestrator(): Promise<void> {
   } catch {
     // no saved state
   }
+  // #2149 — image requests from spawned MCP children are reference-only. The
+  // poll worker below resolves the child agent key to a panel tab and uses the
+  // authenticated bridge command; it never reads or accepts a URL from disk.
+  const panelImageRelayInFlight = new Set<string>();
   const pollDownloads = () => {
+    void processPanelImageRequests({
+      dir: progressDir,
+      bridge,
+      resolvePanelTab: scopeToRealTab,
+      inFlight: panelImageRelayInFlight,
+    }).catch(() => {
+      // A failed poll is fail-closed for this request; the child times out or
+      // receives a bounded safe error, and the next tick can process new work.
+    });
     // #1415 — the OTHER half of the #952 drift comparison installed above. That
     // source only serves THIS process, and the tools that fail with `fetch
     // failed` run in the spawned comfyui children, which have no bridge. Publish

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -98,7 +98,10 @@ import {
 } from "./turn-origins.js";
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
-import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
+import {
+  setConnectedPanelFallbackOrigins,
+  setConnectedPanelOrigins,
+} from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
@@ -3007,12 +3010,14 @@ export async function runPanelOrchestrator(): Promise<void> {
   // `null` (ambiguous origin) makes the bridge refuse loudly; no entry lets
   // the bridge fall back to active-tab resolution (idle-time probes).
   bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker: turnOrigins, scopeAgentKeyOf }));
-  // #2149 — the direct /view fallback is narrower than the diagnostic origin
-  // list: only a server-proven local panel whose hello claim matches its
-  // observed origin and whose origin is loopback may be contacted by MCP.
-  // Remote/tunnel/LAN origins remain diagnostic-only and never become SSRF
-  // targets for a headless tool.
-  setConnectedPanelOrigins(() => bridge.connectedSafePanelOrigins());
+  // #2149 — observed tokenless WebSocket origins are diagnostic only. A local
+  // non-browser client can forge both the Origin header and hello claim, so
+  // there is no browser-proven authorization for MCP to make a new /view
+  // request. Keep diagnostics live, but leave the direct-fallback source at
+  // its fail-closed production default until an authenticated panel signal
+  // exists.
+  setConnectedPanelOrigins(() => bridge.connectedServerOrigins());
+  setConnectedPanelFallbackOrigins(null);
   // #884 P1 (confirming gate 2) — EXPLICIT recovery from a DEAD or AMBIGUOUS
   // pin, and from those only. The bridge's refusal names
   // panel_set_workflow_target as the way out; this is the ONLY path that
@@ -5883,7 +5888,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // connect/disconnect events) so a tab that goes away blanks it within 700ms —
     // the child must never quote a panel that has since disconnected. Writes only
     // when the set changed.
-    publishConnectedPanelOrigins(progressDir, bridge.connectedSafePanelOrigins());
+    publishConnectedPanelOrigins(progressDir, bridge.connectedServerOrigins());
     // #1400 — the same level-triggered discipline for the frontend-virtual
     // registry: republish the CURRENT map, scoped to origins a connected tab
     // actually fronts, so a disconnected tab's entry drops out of the channel

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -103,7 +103,11 @@ import {
   setConnectedPanelOrigins,
 } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
-import { processPanelImageRequests } from "../services/panel-image-relay.js";
+import {
+  processPanelImageRequests,
+  verifyPanelImageRelayCapability,
+  type PanelImageRelayRequest,
+} from "../services/panel-image-relay.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
 import { completionDisagreesWithRecord, failureDisagreesWithRecord } from "./download-done-guard.js";
@@ -1657,6 +1661,23 @@ export async function runPanelOrchestrator(): Promise<void> {
   const agentKeyFor = (panelTabId: string): string =>
     SHARED_SESSION_SCOPE + AGENT_KEY_SEP + backendForTab(panelTabId);
   const sharedKeyFor = (backend: string): string => SHARED_SESSION_SCOPE + AGENT_KEY_SEP + backend;
+  // #2149 — a child may write to the shared progress directory, so its tab
+  // identity must never come from request JSON. Capabilities are minted here,
+  // injected into the child environment, and resolved only by this process.
+  const panelImageRelaySecrets = new Map<string, string>();
+  const panelImageRelaySecretFor = (agentKey: string): string => {
+    const existing = [...panelImageRelaySecrets.entries()].find(([, key]) => key === agentKey)?.[0];
+    if (existing) return existing;
+    const secret = randomBytes(32).toString("hex");
+    panelImageRelaySecrets.set(secret, agentKey);
+    return secret;
+  };
+  const panelImageRelayAgentKeyFor = (request: PanelImageRelayRequest): string | undefined => {
+    for (const [secret, agentKey] of panelImageRelaySecrets) {
+      if (verifyPanelImageRelayCapability(secret, request)) return agentKey;
+    }
+    return undefined;
+  };
   // The scope/backend halves of a composite key. Neither half contains "::", so
   // split on the LAST separator.
   const panelTabOf = (key: string): string => {
@@ -2106,6 +2127,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // downloads resolved to nobody and the owning conversation stalled).
         // `tabId` here IS the agent key (the scope address the lane binds).
         COMFYUI_MCP_TAB: tabId,
+        COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(tabId),
         // …and the same key addresses this agent's published identity.
         ...agentIdentityEnv(tabId),
       }),
@@ -2422,6 +2444,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // child stamps its own COMFYUI_MCP_TAB into each progress row, and the
         // settle path resolves an agent-key-shaped stamp directly.
         ...(agentKey ? { COMFYUI_MCP_TAB: agentKey } : {}),
+        ...(agentKey ? { COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(agentKey) } : {}),
         // Which LLM is driving this agent, for report_issue's stamp (see
         // agentIdentityEnv). Same key, same reason it is keyed by agent.
         ...agentIdentityEnv(agentKey),
@@ -5881,13 +5904,15 @@ export async function runPanelOrchestrator(): Promise<void> {
     // no saved state
   }
   // #2149 — image requests from spawned MCP children are reference-only. The
-  // poll worker below resolves the child agent key to a panel tab and uses the
-  // authenticated bridge command; it never reads or accepts a URL from disk.
+  // poll worker below resolves an in-memory child capability to an agent key,
+  // then to a panel tab, and uses the authenticated bridge command; it never
+  // reads or accepts a URL or tab identity from disk.
   const panelImageRelayInFlight = new Set<string>();
   const pollDownloads = () => {
     void processPanelImageRequests({
       dir: progressDir,
       bridge,
+      resolvePanelAgentKey: panelImageRelayAgentKeyFor,
       resolvePanelTab: scopeToRealTab,
       inFlight: panelImageRelayInFlight,
     }).catch(() => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3007,12 +3007,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // `null` (ambiguous origin) makes the bridge refuse loudly; no entry lets
   // the bridge fall back to active-tab resolution (idle-time probes).
   bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker: turnOrigins, scopeAgentKeyOf }));
-  // #952 — let a headless `fetch failed` say whether the connected panel is on a
-  // DIFFERENT ComfyUI than COMFYUI_URL. The reporter's readonly tools failed
-  // while every panel tool worked, and nothing in the error connected the two.
-  // SERVER-OBSERVED origins only (tabServerOrigin): the browser sets the
-  // handshake Origin and page JS cannot forge it, unlike hello.comfyui_url.
-  setConnectedPanelOrigins(() => bridge.connectedServerOrigins());
+  // #2149 — the direct /view fallback is narrower than the diagnostic origin
+  // list: only a server-proven local panel whose hello claim matches its
+  // observed origin and whose origin is loopback may be contacted by MCP.
+  // Remote/tunnel/LAN origins remain diagnostic-only and never become SSRF
+  // targets for a headless tool.
+  setConnectedPanelOrigins(() => bridge.connectedSafePanelOrigins());
   // #884 P1 (confirming gate 2) — EXPLICIT recovery from a DEAD or AMBIGUOUS
   // pin, and from those only. The bridge's refusal names
   // panel_set_workflow_target as the way out; this is the ONLY path that
@@ -5883,7 +5883,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // connect/disconnect events) so a tab that goes away blanks it within 700ms —
     // the child must never quote a panel that has since disconnected. Writes only
     // when the set changed.
-    publishConnectedPanelOrigins(progressDir, bridge.connectedServerOrigins());
+    publishConnectedPanelOrigins(progressDir, bridge.connectedSafePanelOrigins());
     // #1400 — the same level-triggered discipline for the frontend-virtual
     // registry: republish the CURRENT map, scoped to origins a connected tab
     // actually fronts, so a disconnected tab's entry drops out of the channel

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -104,8 +104,10 @@ import {
 } from "../comfyui/fetch.js";
 import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.js";
 import {
-  processPanelImageRequests,
+  startPanelImageRelayServer,
   verifyPanelImageRelayCapability,
+  type PanelImageRelayResolvedAgent,
+  type PanelImageRelayServer,
   type PanelImageRelayRequest,
 } from "../services/panel-image-relay.js";
 import { logger } from "../utils/logger.js";
@@ -1672,9 +1674,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     panelImageRelaySecrets.set(secret, agentKey);
     return secret;
   };
-  const panelImageRelayAgentKeyFor = (request: PanelImageRelayRequest): string | undefined => {
+  const panelImageRelayAgentFor = (request: PanelImageRelayRequest): PanelImageRelayResolvedAgent | undefined => {
     for (const [secret, agentKey] of panelImageRelaySecrets) {
-      if (verifyPanelImageRelayCapability(secret, request)) return agentKey;
+      if (verifyPanelImageRelayCapability(secret, request)) return { agentKey, secret };
     }
     return undefined;
   };
@@ -1688,6 +1690,26 @@ export async function runPanelOrchestrator(): Promise<void> {
     const i = key.lastIndexOf(AGENT_KEY_SEP);
     return i >= 0 ? key.slice(i + AGENT_KEY_SEP.length) : defaultBackend;
   };
+  // #2149 — shared agent keys are not panel tab ids. Resolve through the
+  // bridge's pinned shared-tab mapping before dispatching fetch_image.
+  const scopeToRealTab = (tabId: string): string | undefined =>
+    isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
+  let panelImageRelayServer: PanelImageRelayServer | undefined;
+  let panelImageRelayEndpoint: string | undefined;
+  try {
+    panelImageRelayServer = await startPanelImageRelayServer({
+      bridge,
+      resolvePanelAgent: panelImageRelayAgentFor,
+      resolvePanelTab: scopeToRealTab,
+    });
+    panelImageRelayEndpoint = panelImageRelayServer.endpointUrl;
+  } catch (error) {
+    // No filesystem fallback exists. A failed bind leaves get_image on its
+    // normal headless error path rather than exposing an unsafe channel.
+    logger.warn(
+      `[panel-orchestrator] authenticated panel image relay unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   // #884 — PER-CONVERSATION TURN ORIGINS: the issue-time workflow stamp
   // (#570's rule at conversation level — a scope mutation carries the uuid its
   // turn was ISSUED for, never re-resolved at dispatch; codex round 1, P0),
@@ -2128,6 +2150,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // `tabId` here IS the agent key (the scope address the lane binds).
         COMFYUI_MCP_TAB: tabId,
         COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(tabId),
+        ...(panelImageRelayEndpoint ? { COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint } : {}),
         // …and the same key addresses this agent's published identity.
         ...agentIdentityEnv(tabId),
       }),
@@ -2445,6 +2468,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // settle path resolves an agent-key-shaped stamp directly.
         ...(agentKey ? { COMFYUI_MCP_TAB: agentKey } : {}),
         ...(agentKey ? { COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(agentKey) } : {}),
+        ...(agentKey && panelImageRelayEndpoint ? { COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint } : {}),
         // Which LLM is driving this agent, for report_issue's stamp (see
         // agentIdentityEnv). Same key, same reason it is keyed by agent.
         ...agentIdentityEnv(agentKey),
@@ -3027,8 +3051,6 @@ export async function runPanelOrchestrator(): Promise<void> {
   // current workflow: re-resolving at dispatch would let a mutation conceived
   // on workflow A silently land on workflow B after a mid-turn switch (codex
   // round 1, P0). A real-tab caller keeps the per-tab stamp.
-  const scopeToRealTab = (tabId: string): string | undefined =>
-    isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
   // #884 P0 (confirming gate) — while a conversation's turn is in flight, its
   // scope-addressed tool calls are PINNED to the tab the turn was issued from;
   // `null` (ambiguous origin) makes the bridge refuse loudly; no entry lets
@@ -5903,22 +5925,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   } catch {
     // no saved state
   }
-  // #2149 — image requests from spawned MCP children are reference-only. The
-  // poll worker below resolves an in-memory child capability to an agent key,
-  // then to a panel tab, and uses the authenticated bridge command; it never
-  // reads or accepts a URL or tab identity from disk.
-  const panelImageRelayInFlight = new Set<string>();
   const pollDownloads = () => {
-    void processPanelImageRequests({
-      dir: progressDir,
-      bridge,
-      resolvePanelAgentKey: panelImageRelayAgentKeyFor,
-      resolvePanelTab: scopeToRealTab,
-      inFlight: panelImageRelayInFlight,
-    }).catch(() => {
-      // A failed poll is fail-closed for this request; the child times out or
-      // receives a bounded safe error, and the next tick can process new work.
-    });
     // #1415 — the OTHER half of the #952 drift comparison installed above. That
     // source only serves THIS process, and the tools that fail with `fetch
     // failed` run in the spawned comfyui children, which have no bridge. Publish
@@ -6725,6 +6732,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // Tear down the loopback panel HTTP MCP (codex/gemini mode only).
     if (panelMcpHttp) await panelMcpHttp.stop().catch(() => {});
     if (panelConsoleHttp) await panelConsoleHttp.stop().catch(() => {});
+    if (panelImageRelayServer) await panelImageRelayServer.close().catch(() => {});
     secureBridge?.stop();
     await bridge.stop();
     // Only remove the lockfile if it still names us — avoid clobbering a fresh

--- a/src/services/panel-fallback-target.ts
+++ b/src/services/panel-fallback-target.ts
@@ -1,0 +1,119 @@
+// Choosing a validated local CONNECTED-PANEL origin to retry a failed headless
+// read against (#2149).
+//
+// The browser handshake is useful provenance, but a server-observed origin can
+// still be a remote/tunnel/LAN page. This module is deliberately stricter than
+// canonicalOrigin: only an HTTP(S) origin with no credentials, path, query, or
+// fragment, and only loopback hosts, is eligible for direct MCP contact.
+
+import { canonicalOrigin } from "../utils/origin.js";
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+export type PanelFallbackChoice =
+  | { kind: "none" }
+  | { kind: "same"; origin: string }
+  | { kind: "ambiguous"; origins: string[] }
+  | { kind: "use"; origin: string }
+  | { kind: "invalid"; count: number };
+
+/** Parse an HTTP(S) URL and return its origin, rejecting credentials and fragments. */
+export function httpOriginOf(raw: unknown, allowPath = true, allowQuery = true): string | undefined {
+  if (typeof raw !== "string" || raw.trim() === "") return undefined;
+  try {
+    const parsed = new URL(raw.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    if (parsed.username || parsed.password || (!allowQuery && (parsed.hash || parsed.search))) return undefined;
+    if (!allowPath && parsed.pathname !== "/") return undefined;
+    return parsed.origin === "null" ? undefined : parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize a candidate panel origin, with no path/query/userinfo allowed. */
+export function normalizePanelOrigin(raw: unknown): string | undefined {
+  return httpOriginOf(raw, false, false);
+}
+
+/** Only loopback origins are safe for direct MCP contact in this fallback. */
+export function isLoopbackPanelOrigin(origin: string): boolean {
+  try {
+    const host = new URL(origin).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return LOOPBACK_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}
+
+/** The MCP target and fallback candidate must both be local loopback origins. */
+export function isSafePanelOriginForMcp(failedTarget: string, candidate: string): boolean {
+  const targetOrigin = httpOriginOf(failedTarget);
+  const candidateOrigin = normalizePanelOrigin(candidate);
+  return (
+    targetOrigin !== undefined &&
+    candidateOrigin !== undefined &&
+    isLoopbackPanelOrigin(targetOrigin) &&
+    isLoopbackPanelOrigin(candidateOrigin)
+  );
+}
+
+/** Choose exactly one validated local panel origin different from the failed target. */
+export function choosePanelFallbackOrigin(
+  failedTarget: string,
+  origins: readonly string[],
+): PanelFallbackChoice {
+  const targetOrigin = httpOriginOf(failedTarget);
+  if (targetOrigin === undefined || !isLoopbackPanelOrigin(targetOrigin)) return { kind: "none" };
+
+  const byCanonical = new Map<string, string>();
+  let invalidCount = 0;
+  for (const raw of origins) {
+    const origin = normalizePanelOrigin(raw);
+    if (origin === undefined || !isSafePanelOriginForMcp(failedTarget, origin)) {
+      invalidCount++;
+      continue;
+    }
+    const canon = canonicalOrigin(origin);
+    if (canon === undefined) {
+      invalidCount++;
+      continue;
+    }
+    if (!byCanonical.has(canon)) byCanonical.set(canon, origin);
+  }
+  // A valid origin must never survive beside malformed, unsupported, or remote
+  // input. That would turn a mixed trust set into a silently selected target.
+  if (invalidCount > 0) return { kind: "invalid", count: invalidCount };
+  if (byCanonical.size === 0) return { kind: "none" };
+
+  const targetCanonical = canonicalOrigin(targetOrigin);
+  if (targetCanonical === undefined) return { kind: "none" };
+  const different: string[] = [];
+  let same: string | undefined;
+  for (const [canon, origin] of byCanonical) {
+    if (canon === targetCanonical) same = origin;
+    else different.push(origin);
+  }
+  if (different.length === 0) return same ? { kind: "same", origin: same } : { kind: "none" };
+  if (different.length > 1) return { kind: "ambiguous", origins: different };
+  return { kind: "use", origin: different[0] };
+}
+
+/** Explain why a panel set was not retried. */
+export function describeDeclinedPanelFallback(choice: PanelFallbackChoice): string {
+  if (choice.kind === "ambiguous") {
+    return (
+      ` I did NOT retry against a connected panel: ${choice.origins.length} different local ` +
+      `ComfyUI origins are connected (${choice.origins.join(", ")}), and choosing one of ` +
+      `them would risk answering from a server you did not mean. Point COMFYUI_URL at the one you want.`
+    );
+  }
+  if (choice.kind === "invalid") {
+    return (
+      ` I did NOT retry against a connected panel: ${choice.count} connected origin` +
+      `${choice.count === 1 ? " was" : "s were"} malformed, unsupported, remote, or otherwise ` +
+      `unsafe for direct MCP contact.`
+    );
+  }
+  return "";
+}

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -388,13 +388,13 @@ function validateResponse(value: unknown, requestId: string): PanelImageRelayRes
   throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
 }
 
-function failureResponse(requestId: string, error: string): PanelImageRelayResponseFailure {
+function failureResponse(requestId: string, error: string, updated = Date.now()): PanelImageRelayResponseFailure {
   return {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId,
     ok: false,
     error,
-    updated: Date.now(),
+    updated,
   };
 }
 
@@ -681,7 +681,11 @@ export async function startPanelImageRelayServer(
         const age = now - request.createdAt;
         let response: PanelImageRelayResponse;
         if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS || now >= requestDeadline(request)) {
-          response = failureResponse(request.requestId, now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST");
+          response = failureResponse(
+            request.requestId,
+            now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST",
+            now >= requestDeadline(request) ? requestDeadline(request) : now,
+          );
         } else {
           const panelTab = options.resolvePanelTab(auth.agentKey);
           if (!panelTab || !options.bridge.canReach(panelTab)) {
@@ -692,7 +696,7 @@ export async function startPanelImageRelayServer(
           } else {
             const remainingMs = requestDeadline(request) - Date.now();
             if (remainingMs <= 0) {
-              response = failureResponse(request.requestId, "TIMEOUT");
+              response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
             } else {
               try {
                 const reply = await withinDeadline(
@@ -707,7 +711,7 @@ export async function startPanelImageRelayServer(
                   ? validateImagePayload({ base64: replyRecord.base64, mimeType: replyRecord.mimeType, bytes: replyRecord.bytes })
                   : undefined;
                 if (Date.now() >= requestDeadline(request)) {
-                  response = failureResponse(request.requestId, "TIMEOUT");
+                  response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
                 } else if (replyRecord?.ok === false && hasOnlyKeys(replyRecord, ["ok", "error"]) && isSafeText(replyRecord.error, 160)) {
                   response = failureResponse(request.requestId, "PANEL_FETCH_FAILED");
                 } else if (!replyRecord || replyRecord.ok !== true || !payload || !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])) {
@@ -716,7 +720,12 @@ export async function startPanelImageRelayServer(
                   response = { version: PANEL_IMAGE_RELAY_VERSION, requestId: request.requestId, ok: true, ...payload, updated: Date.now() };
                 }
               } catch (error) {
-                response = failureResponse(request.requestId, error instanceof PanelImageRelayError && error.code === "TIMEOUT" ? "TIMEOUT" : "PANEL_FETCH_FAILED");
+                const timedOut = error instanceof PanelImageRelayError && error.code === "TIMEOUT";
+                response = failureResponse(
+                  request.requestId,
+                  timedOut ? "TIMEOUT" : "PANEL_FETCH_FAILED",
+                  timedOut ? requestDeadline(request) : Date.now(),
+                );
               }
             }
           }
@@ -819,11 +828,13 @@ export async function requestPanelImage(
   }
   const response = validateTransportResponse(decoded, request.requestId, secret);
   const responseAge = Date.now() - response.updated;
+  const authenticatedTimeout = response.ok === false && response.error === "TIMEOUT";
   if (
-    response.updated < request.createdAt ||
-    response.updated > request.deadlineAt ||
-    responseAge < -5_000 ||
-    responseAge > PANEL_IMAGE_RELAY_STALE_MS
+    !authenticatedTimeout &&
+    (response.updated < request.createdAt ||
+      response.updated > request.deadlineAt ||
+      responseAge < -5_000 ||
+      responseAge > PANEL_IMAGE_RELAY_STALE_MS)
   ) {
     throw new PanelImageRelayError("The panel returned a stale image relay reply.", "STALE_REPLY");
   }

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -1,0 +1,490 @@
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+
+/**
+ * The only production path for a /view retry when the configured headless
+ * ComfyUI target is unreachable. The child writes a reference-only request;
+ * the orchestrator resolves the requester to a live panel and performs the
+ * authenticated bridge command. No URL, origin, or server claim crosses this
+ * channel.
+ */
+export const PANEL_IMAGE_RELAY_VERSION = 1;
+export const PANEL_IMAGE_RELAY_MAX_BYTES = 32 * 1024 * 1024;
+export const PANEL_IMAGE_RELAY_TIMEOUT_MS = 8_000;
+export const PANEL_IMAGE_RELAY_STALE_MS = 15_000;
+export const PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES = 16 * 1024;
+export const PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES = 48 * 1024 * 1024;
+
+export const PANEL_IMAGE_RELAY_REQUEST_PREFIX = "control-image-request-";
+export const PANEL_IMAGE_RELAY_RESPONSE_PREFIX = "control-image-response-";
+const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
+const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
+const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
+
+export type PanelImageType = "output" | "input" | "temp";
+
+export interface PanelImageRelayRequest {
+  version: typeof PANEL_IMAGE_RELAY_VERSION;
+  requestId: string;
+  requester: string;
+  filename: string;
+  subfolder: string;
+  type: PanelImageType;
+  createdAt: number;
+}
+
+export interface PanelImageRelaySuccess {
+  base64: string;
+  mimeType: string;
+  bytes: number;
+}
+
+interface PanelImageRelayResponseFailure {
+  version: typeof PANEL_IMAGE_RELAY_VERSION;
+  requestId: string;
+  ok: false;
+  error: string;
+  updated: number;
+}
+
+interface PanelImageRelayResponseSuccess extends PanelImageRelaySuccess {
+  version: typeof PANEL_IMAGE_RELAY_VERSION;
+  requestId: string;
+  ok: true;
+  updated: number;
+}
+
+type PanelImageRelayResponse =
+  | PanelImageRelayResponseSuccess
+  | PanelImageRelayResponseFailure;
+
+export interface PanelImageRelayBridge {
+  canReach(tabId: string): boolean;
+  resolveFailure?: (tabId: string) => "ambiguous" | "unresolved" | undefined;
+  send(
+    command: { cmd: "fetch_image"; filename: string; subfolder: string; type: PanelImageType },
+    options: { tabId: string; timeoutMs: number },
+  ): Promise<unknown>;
+}
+
+export class PanelImageRelayError extends Error {
+  readonly code: string;
+  readonly unavailable: boolean;
+
+  constructor(message: string, code: string, unavailable = false) {
+    super(message);
+    this.name = "PanelImageRelayError";
+    this.code = code;
+    this.unavailable = unavailable;
+  }
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function hasOnlyKeys(value: object, keys: readonly string[]): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isSafeText(value: unknown, max: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= max &&
+    ![...value].some((char) => {
+      const code = char.charCodeAt(0);
+      return code < 0x20 || code === 0x7f;
+    })
+  );
+}
+
+/** Strict wire-level validation. Keep this stricter than the legacy tool path. */
+export function isSafePanelImageRef(
+  filename: unknown,
+  subfolder: unknown,
+  type: unknown,
+): filename is string {
+  if (!isSafeText(filename, 4096) || !isSafeText(subfolder, 4096) && subfolder !== "") return false;
+  if (typeof type !== "string" || !IMAGE_TYPES.has(type as PanelImageType)) return false;
+  if (
+    filename === "." ||
+    filename === ".." ||
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    filename.includes(":") ||
+    filename.includes("?") ||
+    filename.includes("#")
+  ) return false;
+  if (subfolder === "") return true;
+  if (
+    subfolder.startsWith("/") ||
+    subfolder.startsWith("\\") ||
+    /^[A-Za-z]:/.test(subfolder) ||
+    subfolder.includes("\\") ||
+    subfolder.includes("?") ||
+    subfolder.includes("#")
+  ) return false;
+  const segments = subfolder.split("/");
+  return segments.every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+function isSafeRequester(value: unknown): value is string {
+  return isSafeText(value, 1024) && value.trim() === value;
+}
+
+function isSafeRelayId(value: unknown): value is string {
+  return typeof value === "string" && RELAY_ID_RE.test(value);
+}
+
+function requestPath(dir: string, requestId: string): string {
+  return join(dir, `${PANEL_IMAGE_RELAY_REQUEST_PREFIX}${requestId}.json`);
+}
+
+function responsePath(dir: string, requestId: string): string {
+  return join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${requestId}.json`);
+}
+
+function readBoundedJson(path: string, maxBytes: number): unknown {
+  const size = statSync(path).size;
+  if (size > maxBytes) throw new Error("file exceeds the relay safety limit");
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+function writeJsonAtomically(path: string, value: unknown, maxBytes: number): void {
+  const data = Buffer.from(JSON.stringify(value), "utf8");
+  if (data.byteLength > maxBytes) throw new Error("relay response exceeds the safety limit");
+  const temp = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  try {
+    writeFileSync(temp, data, { flag: "wx", mode: 0o600 });
+    renameSync(temp, path);
+  } finally {
+    try {
+      rmSync(temp, { force: true });
+    } catch {
+      // best effort cleanup
+    }
+  }
+}
+
+function canonicalBase64(value: unknown): value is string {
+  if (typeof value !== "string" || value.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    return false;
+  }
+  return Buffer.from(value, "base64").toString("base64") === value;
+}
+
+function validateImagePayload(
+  value: unknown,
+): PanelImageRelaySuccess | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    !hasOwn(record, "base64") ||
+    !hasOwn(record, "mimeType") ||
+    !hasOwn(record, "bytes") ||
+    !hasOnlyKeys(record, ["base64", "mimeType", "bytes"])
+  ) return undefined;
+  if (!canonicalBase64(record.base64) || !isSafeText(record.mimeType, 128) || !MIME_RE.test(record.mimeType)) return undefined;
+  const bytes = record.bytes;
+  if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes < 0 || bytes > PANEL_IMAGE_RELAY_MAX_BYTES) return undefined;
+  const actualBytes = Buffer.byteLength(record.base64, "base64");
+  if (actualBytes !== bytes) return undefined;
+  return { base64: record.base64, mimeType: record.mimeType, bytes };
+}
+
+function validateRequest(value: unknown, requestId: string): PanelImageRelayRequest | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    !hasOnlyKeys(record, ["version", "requestId", "requester", "filename", "subfolder", "type", "createdAt"]) ||
+    record.version !== PANEL_IMAGE_RELAY_VERSION ||
+    record.requestId !== requestId ||
+    !isSafeRequester(record.requester) ||
+    !isSafePanelImageRef(record.filename, record.subfolder, record.type) ||
+    !Number.isSafeInteger(record.createdAt)
+  ) return undefined;
+  return record as unknown as PanelImageRelayRequest;
+}
+
+function validateResponse(value: unknown, requestId: string): PanelImageRelayResponse {
+  if (!value || typeof value !== "object") throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== PANEL_IMAGE_RELAY_VERSION ||
+    record.requestId !== requestId ||
+    !hasOwn(record, "ok") ||
+    !Number.isSafeInteger(record.updated)
+  ) throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+  const updated = record.updated;
+  if (typeof updated !== "number") throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+  if (record.ok === true) {
+    const payload = validateImagePayload({
+      base64: record.base64,
+      mimeType: record.mimeType,
+      bytes: record.bytes,
+    });
+    if (
+      !payload ||
+      !hasOwn(record, "updated") ||
+      !hasOnlyKeys(record, ["version", "requestId", "ok", "base64", "mimeType", "bytes", "updated"])
+    ) throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+    return { ...payload, version: PANEL_IMAGE_RELAY_VERSION, requestId, ok: true, updated };
+  }
+  if (
+    record.ok === false &&
+    typeof record.error === "string" &&
+    record.error.length <= 160 &&
+    isSafeText(record.error, 160) &&
+    hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated"])
+  ) {
+    return record as unknown as PanelImageRelayResponseFailure;
+  }
+  throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+}
+
+function failureResponse(requestId: string, error: string): PanelImageRelayResponseFailure {
+  return {
+    version: PANEL_IMAGE_RELAY_VERSION,
+    requestId,
+    ok: false,
+    error,
+    updated: Date.now(),
+  };
+}
+
+function responseFailureMessage(response: PanelImageRelayResponseFailure): never {
+  throw new PanelImageRelayError("The connected panel could not fetch that image.", "PANEL_FETCH_FAILED");
+}
+
+function channelDir(): string {
+  return process.env.COMFYUI_MCP_PROGRESS_DIR?.trim() ?? "";
+}
+
+/** Child-side request writer and bounded response waiter. */
+export async function requestPanelImage(
+  filename: string,
+  type: PanelImageType,
+  subfolder: string,
+): Promise<PanelImageRelaySuccess | undefined> {
+  const dir = channelDir();
+  const requester = process.env.COMFYUI_MCP_TAB;
+  if (!dir || !isSafeRequester(requester)) return undefined;
+  if (!isSafePanelImageRef(filename, subfolder, type)) {
+    throw new PanelImageRelayError("The image reference is unsafe and was refused.", "UNSAFE_REFERENCE");
+  }
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return undefined;
+
+  const requestId = `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`;
+  const request: PanelImageRelayRequest = {
+    version: PANEL_IMAGE_RELAY_VERSION,
+    requestId,
+    requester,
+    filename,
+    subfolder,
+    type,
+    createdAt: Date.now(),
+  };
+  const requestFile = requestPath(dir, requestId);
+  const responseFile = responsePath(dir, requestId);
+  try {
+    writeJsonAtomically(requestFile, request, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES);
+  } catch {
+    throw new PanelImageRelayError("The connected panel relay is unavailable.", "REQUEST_WRITE_FAILED", true);
+  }
+
+  const deadline = Date.now() + PANEL_IMAGE_RELAY_TIMEOUT_MS;
+  try {
+    while (Date.now() < deadline) {
+      if (existsSync(responseFile)) {
+        let response: PanelImageRelayResponse;
+        try {
+          response = validateResponse(
+            readBoundedJson(responseFile, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES),
+            requestId,
+          );
+        } catch (error) {
+          try { unlinkSync(responseFile); } catch { /* best effort */ }
+          if (error instanceof PanelImageRelayError) throw error;
+          throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+        }
+        try { unlinkSync(responseFile); } catch { /* best effort */ }
+        if (response.ok === false) responseFailureMessage(response);
+        if (
+          response.updated < request.createdAt ||
+          response.updated > Date.now() + 5_000 ||
+          Date.now() - response.updated > PANEL_IMAGE_RELAY_STALE_MS
+        ) {
+          throw new PanelImageRelayError("The panel returned a stale image relay reply.", "STALE_REPLY");
+        }
+        return { base64: response.base64, mimeType: response.mimeType, bytes: response.bytes };
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+    throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
+  } finally {
+    try { unlinkSync(requestFile); } catch { /* orchestrator may already have consumed it */ }
+  }
+}
+
+function requestFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((name) => {
+      if (!name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX) || !name.endsWith(".json")) return false;
+      const id = name.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -".json".length);
+      return isSafeRelayId(id);
+    });
+  } catch {
+    return [];
+  }
+}
+
+function reapStaleResponseFiles(dir: string, now: number): void {
+  try {
+    for (const name of readdirSync(dir)) {
+      if (!name.startsWith(PANEL_IMAGE_RELAY_RESPONSE_PREFIX) || !name.endsWith(".json")) continue;
+      const id = name.slice(PANEL_IMAGE_RELAY_RESPONSE_PREFIX.length, -".json".length);
+      if (!isSafeRelayId(id)) continue;
+      const path = join(dir, name);
+      try {
+        const stat = statSync(path);
+        if (stat.size > PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES || now - stat.mtimeMs > PANEL_IMAGE_RELAY_STALE_MS) {
+          unlinkSync(path);
+        }
+      } catch {
+        // A child may be atomically replacing or consuming the response.
+      }
+    }
+  } catch {
+    // The channel may disappear during orchestrator shutdown.
+  }
+}
+
+async function processOneRequest(
+  dir: string,
+  file: string,
+  bridge: PanelImageRelayBridge,
+  resolvePanelTab: (agentKey: string) => string | undefined,
+): Promise<void> {
+  const requestId = file.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -".json".length);
+  const fullPath = join(dir, file);
+  let request: PanelImageRelayRequest | undefined;
+  try {
+    request = validateRequest(readBoundedJson(fullPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES), requestId);
+  } catch {
+    request = undefined;
+  }
+  if (!request) {
+    try {
+      writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, "MALFORMED_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
+    } catch { /* child will time out safely */ }
+    try { unlinkSync(fullPath); } catch { /* best effort */ }
+    return;
+  }
+  const age = Date.now() - request.createdAt;
+  if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS) {
+    try {
+      writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, "STALE_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
+    } catch { /* best effort */ }
+    try { unlinkSync(fullPath); } catch { /* best effort */ }
+    return;
+  }
+
+  let response: PanelImageRelayResponse;
+  const panelTab = resolvePanelTab(request.requester);
+  if (!panelTab || !bridge.canReach(panelTab)) {
+    const failure = bridge.resolveFailure?.(panelTab ?? request.requester);
+    response = failureResponse(
+      requestId,
+      failure === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
+    );
+  } else {
+    try {
+      const reply = await bridge.send(
+        { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
+        { tabId: panelTab, timeoutMs: PANEL_IMAGE_RELAY_TIMEOUT_MS },
+      );
+      const payload =
+        reply && typeof reply === "object"
+          ? validateImagePayload({
+              base64: (reply as Record<string, unknown>).base64,
+              mimeType: (reply as Record<string, unknown>).mimeType,
+              bytes: (reply as Record<string, unknown>).bytes,
+            })
+          : undefined;
+      const replyRecord = reply && typeof reply === "object" ? reply as Record<string, unknown> : undefined;
+      if (
+        replyRecord?.ok === false &&
+        hasOnlyKeys(replyRecord, ["ok", "error"]) &&
+        isSafeText(replyRecord.error, 160)
+      ) {
+        response = failureResponse(requestId, "PANEL_FETCH_FAILED");
+      } else if (
+        !replyRecord ||
+        replyRecord.ok !== true ||
+        !payload ||
+        !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])
+      ) {
+        response = failureResponse(requestId, "MALFORMED_REPLY");
+      } else {
+        response = {
+          version: PANEL_IMAGE_RELAY_VERSION,
+          requestId,
+          ok: true,
+          ...payload,
+          updated: Date.now(),
+        };
+      }
+    } catch {
+      response = failureResponse(requestId, "PANEL_FETCH_FAILED");
+    }
+  }
+  try {
+    writeJsonAtomically(responsePath(dir, requestId), response, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
+  } catch {
+    // A bounded response that cannot be written is a failed relay; never retry
+    // the request with a different target or fall back to a child-supplied URL.
+  }
+  try { unlinkSync(fullPath); } catch { /* best effort */ }
+}
+
+export interface ProcessPanelImageRequestsOptions {
+  dir: string;
+  bridge: PanelImageRelayBridge;
+  /** Resolve both shared agent keys and real-tab agent keys to a live panel tab. */
+  resolvePanelTab: (agentKey: string) => string | undefined;
+  inFlight?: Set<string>;
+}
+
+/** Orchestrator-side poll worker. Requests are consumed exactly once. */
+export async function processPanelImageRequests({
+  dir,
+  bridge,
+  resolvePanelTab,
+  inFlight = new Set<string>(),
+}: ProcessPanelImageRequestsOptions): Promise<void> {
+  if (!dir || !existsSync(dir)) return;
+  reapStaleResponseFiles(dir, Date.now());
+  const work = requestFiles(dir)
+    .filter((file) => !inFlight.has(file))
+    .map(async (file) => {
+      inFlight.add(file);
+      try {
+        await processOneRequest(dir, file, bridge, resolvePanelTab);
+      } finally {
+        inFlight.delete(file);
+      }
+    });
+  await Promise.all(work);
+}

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -1,13 +1,11 @@
 import {
-  existsSync,
-  readFileSync,
-  readdirSync,
   renameSync,
   rmSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { constants } from "node:fs";
+import { lstat, open, opendir, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 
@@ -24,6 +22,11 @@ export const PANEL_IMAGE_RELAY_TIMEOUT_MS = 8_000;
 export const PANEL_IMAGE_RELAY_STALE_MS = 15_000;
 export const PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES = 16 * 1024;
 export const PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES = 48 * 1024 * 1024;
+export const PANEL_IMAGE_RELAY_MAX_CONCURRENT = 4;
+export const PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK = 4;
+export const PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK = 128;
+export const PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS = 16;
+export const PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES = 4;
 
 export const PANEL_IMAGE_RELAY_REQUEST_PREFIX = "control-image-request-";
 export const PANEL_IMAGE_RELAY_RESPONSE_PREFIX = "control-image-response-";
@@ -41,6 +44,7 @@ export interface PanelImageRelayRequest {
   subfolder: string;
   type: PanelImageType;
   createdAt: number;
+  deadlineAt: number;
 }
 
 export interface PanelImageRelaySuccess {
@@ -156,10 +160,32 @@ function responsePath(dir: string, requestId: string): string {
   return join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${requestId}.json`);
 }
 
-function readBoundedJson(path: string, maxBytes: number): unknown {
-  const size = statSync(path).size;
-  if (size > maxBytes) throw new Error("file exceeds the relay safety limit");
-  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+const noFollowFlag = (constants as unknown as Record<string, unknown>).O_NOFOLLOW;
+const safeReadFlags = constants.O_RDONLY | (typeof noFollowFlag === "number" ? noFollowFlag : 0);
+
+/** Read one bounded regular file through one descriptor; never stat then reopen. */
+async function readBoundedJson(path: string, maxBytes: number): Promise<unknown> {
+  const linkStat = await lstat(path);
+  if (!linkStat.isFile()) throw new Error("relay input is not a regular file");
+  const handle = await open(path, safeReadFlags);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > maxBytes) throw new Error("file exceeds the relay safety limit");
+    const data = Buffer.alloc(stat.size);
+    let offset = 0;
+    while (offset < data.byteLength) {
+      const { bytesRead } = await handle.read(data, offset, data.byteLength - offset, null);
+      if (bytesRead === 0) throw new Error("relay input ended before its declared size");
+      offset += bytesRead;
+    }
+    const finalStat = await handle.stat();
+    if (!finalStat.isFile() || finalStat.size !== stat.size) {
+      throw new Error("relay input changed while it was being read");
+    }
+    return JSON.parse(data.toString("utf8")) as unknown;
+  } finally {
+    await handle.close();
+  }
 }
 
 function writeJsonAtomically(path: string, value: unknown, maxBytes: number): void {
@@ -207,13 +233,20 @@ function validateImagePayload(
 function validateRequest(value: unknown, requestId: string): PanelImageRelayRequest | undefined {
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
+  const createdAt = record.createdAt;
+  const deadlineAt = record.deadlineAt;
   if (
-    !hasOnlyKeys(record, ["version", "requestId", "requester", "filename", "subfolder", "type", "createdAt"]) ||
+    !hasOnlyKeys(record, ["version", "requestId", "requester", "filename", "subfolder", "type", "createdAt", "deadlineAt"]) ||
     record.version !== PANEL_IMAGE_RELAY_VERSION ||
     record.requestId !== requestId ||
     !isSafeRequester(record.requester) ||
     !isSafePanelImageRef(record.filename, record.subfolder, record.type) ||
-    !Number.isSafeInteger(record.createdAt)
+    typeof createdAt !== "number" ||
+    typeof deadlineAt !== "number" ||
+    !Number.isSafeInteger(createdAt) ||
+    !Number.isSafeInteger(deadlineAt) ||
+    deadlineAt < createdAt ||
+    deadlineAt - createdAt > PANEL_IMAGE_RELAY_TIMEOUT_MS
   ) return undefined;
   return record as unknown as PanelImageRelayRequest;
 }
@@ -284,9 +317,16 @@ export async function requestPanelImage(
   if (!isSafePanelImageRef(filename, subfolder, type)) {
     throw new PanelImageRelayError("The image reference is unsafe and was refused.", "UNSAFE_REFERENCE");
   }
-  if (!existsSync(dir) || !statSync(dir).isDirectory()) return undefined;
+  let dirStat;
+  try {
+    dirStat = await lstat(dir);
+  } catch {
+    return undefined;
+  }
+  if (!dirStat.isDirectory()) return undefined;
 
   const requestId = `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`;
+  const createdAt = Date.now();
   const request: PanelImageRelayRequest = {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId,
@@ -294,7 +334,8 @@ export async function requestPanelImage(
     filename,
     subfolder,
     type,
-    createdAt: Date.now(),
+    createdAt,
+    deadlineAt: createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS,
   };
   const requestFile = requestPath(dir, requestId);
   const responseFile = responsePath(dir, requestId);
@@ -304,14 +345,32 @@ export async function requestPanelImage(
     throw new PanelImageRelayError("The connected panel relay is unavailable.", "REQUEST_WRITE_FAILED", true);
   }
 
-  const deadline = Date.now() + PANEL_IMAGE_RELAY_TIMEOUT_MS;
+  const deadline = request.deadlineAt;
   try {
     while (Date.now() < deadline) {
-      if (existsSync(responseFile)) {
+      let responsePresent = false;
+      try {
+        const responseStat = await lstat(responseFile);
+        if (!responseStat.isFile()) {
+          try { await unlink(responseFile); } catch { /* best effort */ }
+          throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+        }
+        responsePresent = true;
+      } catch (error) {
+        if (error instanceof PanelImageRelayError) throw error;
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+        }
+      }
+      if (responsePresent) {
+        if (Date.now() >= deadline) {
+          try { await unlink(responseFile); } catch { /* best effort */ }
+          throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
+        }
         let response: PanelImageRelayResponse;
         try {
           response = validateResponse(
-            readBoundedJson(responseFile, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES),
+            await readBoundedJson(responseFile, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES),
             requestId,
           );
         } catch (error) {
@@ -320,10 +379,13 @@ export async function requestPanelImage(
           throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
         }
         try { unlinkSync(responseFile); } catch { /* best effort */ }
+        if (Date.now() >= deadline) {
+          throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
+        }
         if (response.ok === false) responseFailureMessage(response);
         if (
           response.updated < request.createdAt ||
-          response.updated > Date.now() + 5_000 ||
+          response.updated > request.deadlineAt ||
           Date.now() - response.updated > PANEL_IMAGE_RELAY_STALE_MS
         ) {
           throw new PanelImageRelayError("The panel returned a stale image relay reply.", "STALE_REPLY");
@@ -338,36 +400,42 @@ export async function requestPanelImage(
   }
 }
 
-function requestFiles(dir: string): string[] {
+async function matchingFiles(dir: string, prefix: string, limit: number): Promise<string[]> {
+  let handle;
   try {
-    return readdirSync(dir).filter((name) => {
-      if (!name.startsWith(PANEL_IMAGE_RELAY_REQUEST_PREFIX) || !name.endsWith(".json")) return false;
-      const id = name.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -".json".length);
-      return isSafeRelayId(id);
-    });
+    handle = await opendir(dir);
   } catch {
     return [];
   }
+  const files: string[] = [];
+  let scanned = 0;
+  try {
+    while (scanned < PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK && files.length < limit) {
+      const entry = await handle.read();
+      if (!entry) break;
+      scanned += 1;
+      if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith(".json")) continue;
+      const id = entry.name.slice(prefix.length, -".json".length);
+      if (isSafeRelayId(id)) files.push(entry.name);
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+  return files;
 }
 
-function reapStaleResponseFiles(dir: string, now: number): void {
-  try {
-    for (const name of readdirSync(dir)) {
-      if (!name.startsWith(PANEL_IMAGE_RELAY_RESPONSE_PREFIX) || !name.endsWith(".json")) continue;
-      const id = name.slice(PANEL_IMAGE_RELAY_RESPONSE_PREFIX.length, -".json".length);
-      if (!isSafeRelayId(id)) continue;
-      const path = join(dir, name);
-      try {
-        const stat = statSync(path);
-        if (stat.size > PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES || now - stat.mtimeMs > PANEL_IMAGE_RELAY_STALE_MS) {
-          unlinkSync(path);
-        }
-      } catch {
-        // A child may be atomically replacing or consuming the response.
+async function reapStaleResponseFiles(dir: string, now: number): Promise<void> {
+  const files = await matchingFiles(dir, PANEL_IMAGE_RELAY_RESPONSE_PREFIX, PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK);
+  for (const name of files) {
+    const path = join(dir, name);
+    try {
+      const stat = await lstat(path);
+      if (!stat.isFile() || stat.size > PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES || now - stat.mtimeMs > PANEL_IMAGE_RELAY_STALE_MS) {
+        await unlink(path);
       }
+    } catch {
+      // A child may be atomically replacing or consuming the response.
     }
-  } catch {
-    // The channel may disappear during orchestrator shutdown.
   }
 }
 
@@ -381,7 +449,7 @@ async function processOneRequest(
   const fullPath = join(dir, file);
   let request: PanelImageRelayRequest | undefined;
   try {
-    request = validateRequest(readBoundedJson(fullPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES), requestId);
+    request = validateRequest(await readBoundedJson(fullPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES), requestId);
   } catch {
     request = undefined;
   }
@@ -392,10 +460,11 @@ async function processOneRequest(
     try { unlinkSync(fullPath); } catch { /* best effort */ }
     return;
   }
-  const age = Date.now() - request.createdAt;
-  if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS) {
+  const now = Date.now();
+  const age = now - request.createdAt;
+  if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS || now >= request.deadlineAt) {
     try {
-      writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, "STALE_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
+      writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, now >= request.deadlineAt ? "TIMEOUT" : "STALE_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
     } catch { /* best effort */ }
     try { unlinkSync(fullPath); } catch { /* best effort */ }
     return;
@@ -410,44 +479,51 @@ async function processOneRequest(
       failure === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
     );
   } else {
-    try {
-      const reply = await bridge.send(
-        { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
-        { tabId: panelTab, timeoutMs: PANEL_IMAGE_RELAY_TIMEOUT_MS },
-      );
-      const payload =
-        reply && typeof reply === "object"
-          ? validateImagePayload({
-              base64: (reply as Record<string, unknown>).base64,
-              mimeType: (reply as Record<string, unknown>).mimeType,
-              bytes: (reply as Record<string, unknown>).bytes,
-            })
-          : undefined;
-      const replyRecord = reply && typeof reply === "object" ? reply as Record<string, unknown> : undefined;
-      if (
-        replyRecord?.ok === false &&
-        hasOnlyKeys(replyRecord, ["ok", "error"]) &&
-        isSafeText(replyRecord.error, 160)
-      ) {
-        response = failureResponse(requestId, "PANEL_FETCH_FAILED");
-      } else if (
-        !replyRecord ||
-        replyRecord.ok !== true ||
-        !payload ||
-        !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])
-      ) {
-        response = failureResponse(requestId, "MALFORMED_REPLY");
+    const remainingMs = request.deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      response = failureResponse(requestId, "TIMEOUT");
       } else {
-        response = {
-          version: PANEL_IMAGE_RELAY_VERSION,
-          requestId,
-          ok: true,
-          ...payload,
-          updated: Date.now(),
-        };
-      }
-    } catch {
-      response = failureResponse(requestId, "PANEL_FETCH_FAILED");
+        try {
+          const reply = await bridge.send(
+            { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
+            { tabId: panelTab, timeoutMs: Math.min(PANEL_IMAGE_RELAY_TIMEOUT_MS, remainingMs) },
+          );
+          const payload =
+            reply && typeof reply === "object"
+              ? validateImagePayload({
+                  base64: (reply as Record<string, unknown>).base64,
+                  mimeType: (reply as Record<string, unknown>).mimeType,
+                  bytes: (reply as Record<string, unknown>).bytes,
+                })
+              : undefined;
+          const replyRecord = reply && typeof reply === "object" ? reply as Record<string, unknown> : undefined;
+          if (Date.now() >= request.deadlineAt) {
+            response = failureResponse(requestId, "TIMEOUT");
+          } else if (
+            replyRecord?.ok === false &&
+            hasOnlyKeys(replyRecord, ["ok", "error"]) &&
+            isSafeText(replyRecord.error, 160)
+          ) {
+            response = failureResponse(requestId, "PANEL_FETCH_FAILED");
+          } else if (
+            !replyRecord ||
+            replyRecord.ok !== true ||
+            !payload ||
+            !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])
+          ) {
+            response = failureResponse(requestId, "MALFORMED_REPLY");
+          } else {
+            response = {
+              version: PANEL_IMAGE_RELAY_VERSION,
+              requestId,
+              ok: true,
+              ...payload,
+              updated: Date.now(),
+            };
+          }
+        } catch {
+          response = failureResponse(requestId, Date.now() >= request.deadlineAt ? "TIMEOUT" : "PANEL_FETCH_FAILED");
+        }
     }
   }
   try {
@@ -467,6 +543,20 @@ export interface ProcessPanelImageRequestsOptions {
   inFlight?: Set<string>;
 }
 
+function rejectQueuedRequest(dir: string, file: string): void {
+  const requestId = file.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -".json".length);
+  try {
+    writeJsonAtomically(
+      responsePath(dir, requestId),
+      failureResponse(requestId, "BACKLOG_FULL"),
+      PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES,
+    );
+  } catch {
+    // The child will time out safely if the bounded failure cannot be published.
+  }
+  try { unlinkSync(join(dir, file)); } catch { /* best effort */ }
+}
+
 /** Orchestrator-side poll worker. Requests are consumed exactly once. */
 export async function processPanelImageRequests({
   dir,
@@ -474,11 +564,36 @@ export async function processPanelImageRequests({
   resolvePanelTab,
   inFlight = new Set<string>(),
 }: ProcessPanelImageRequestsOptions): Promise<void> {
-  if (!dir || !existsSync(dir)) return;
-  reapStaleResponseFiles(dir, Date.now());
-  const work = requestFiles(dir)
-    .filter((file) => !inFlight.has(file))
-    .map(async (file) => {
+  if (!dir) return;
+  let dirStat;
+  try {
+    dirStat = await lstat(dir);
+  } catch {
+    return;
+  }
+  if (!dirStat.isDirectory()) return;
+  await reapStaleResponseFiles(dir, Date.now());
+  const pendingResponseCount = (
+    await matchingFiles(dir, PANEL_IMAGE_RELAY_RESPONSE_PREFIX, PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES + 1)
+  ).length;
+  const responseCapacity = Math.max(0, PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES - pendingResponseCount);
+
+  const candidates = await matchingFiles(
+    dir,
+    PANEL_IMAGE_RELAY_REQUEST_PREFIX,
+    PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK,
+  );
+  const pending = candidates.filter((file) => !inFlight.has(file));
+  const pendingCapacity = Math.max(0, PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS - inFlight.size);
+  for (const file of pending.slice(pendingCapacity)) rejectQueuedRequest(dir, file);
+
+  const available = Math.min(
+    PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK,
+    PANEL_IMAGE_RELAY_MAX_CONCURRENT - inFlight.size,
+    pendingCapacity,
+    responseCapacity,
+  );
+  const work = pending.slice(0, Math.max(0, available)).map(async (file) => {
       inFlight.add(file);
       try {
         await processOneRequest(dir, file, bridge, resolvePanelTab);

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -5,16 +5,17 @@ import {
   writeFileSync,
 } from "node:fs";
 import { constants } from "node:fs";
-import { lstat, open, opendir, unlink } from "node:fs/promises";
-import { randomBytes } from "node:crypto";
+import { lstat, mkdtemp, open, opendir, rename, rmdir, unlink } from "node:fs/promises";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 /**
  * The only production path for a /view retry when the configured headless
  * ComfyUI target is unreachable. The child writes a reference-only request;
- * the orchestrator resolves the requester to a live panel and performs the
- * authenticated bridge command. No URL, origin, or server claim crosses this
- * channel.
+ * the orchestrator resolves an in-memory capability to a live panel and
+ * performs the authenticated bridge command. No URL, origin, or file-supplied
+ * tab identity crosses this channel.
  */
 export const PANEL_IMAGE_RELAY_VERSION = 1;
 export const PANEL_IMAGE_RELAY_MAX_BYTES = 32 * 1024 * 1024;
@@ -31,6 +32,8 @@ export const PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES = 4;
 export const PANEL_IMAGE_RELAY_REQUEST_PREFIX = "control-image-request-";
 export const PANEL_IMAGE_RELAY_RESPONSE_PREFIX = "control-image-response-";
 const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
+const RELAY_CAPABILITY_RE = /^[a-f0-9]{64}$/;
+const RELAY_SECRET_RE = /^[a-f0-9]{64}$/;
 const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
 const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
 
@@ -39,13 +42,18 @@ export type PanelImageType = "output" | "input" | "temp";
 export interface PanelImageRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
   requestId: string;
-  requester: string;
+  capability: string;
   filename: string;
   subfolder: string;
   type: PanelImageType;
   createdAt: number;
   deadlineAt: number;
 }
+
+export type PanelImageRelayAuthInput = Pick<
+  PanelImageRelayRequest,
+  "requestId" | "filename" | "subfolder" | "type" | "createdAt" | "deadlineAt"
+>;
 
 export interface PanelImageRelaySuccess {
   base64: string;
@@ -144,8 +152,39 @@ export function isSafePanelImageRef(
   return segments.every((segment) => segment !== "" && segment !== "." && segment !== "..");
 }
 
-function isSafeRequester(value: unknown): value is string {
-  return isSafeText(value, 1024) && value.trim() === value;
+function isSafeRelayCapability(value: unknown): value is string {
+  return typeof value === "string" && RELAY_CAPABILITY_RE.test(value);
+}
+
+function isSafeRelaySecret(value: unknown): value is string {
+  return typeof value === "string" && RELAY_SECRET_RE.test(value);
+}
+
+function relayAuthPayload(input: PanelImageRelayAuthInput): string {
+  return JSON.stringify([
+    input.requestId,
+    input.filename,
+    input.subfolder,
+    input.type,
+    input.createdAt,
+    input.deadlineAt,
+  ]);
+}
+
+export function makePanelImageRelayCapability(
+  secret: string,
+  input: PanelImageRelayAuthInput,
+): string {
+  return createHmac("sha256", secret).update(relayAuthPayload(input)).digest("hex");
+}
+
+export function verifyPanelImageRelayCapability(
+  secret: string,
+  request: PanelImageRelayRequest,
+): boolean {
+  if (!isSafeRelaySecret(secret) || !isSafeRelayCapability(request.capability)) return false;
+  const expected = makePanelImageRelayCapability(secret, request);
+  return timingSafeEqual(Buffer.from(request.capability, "hex"), Buffer.from(expected, "hex"));
 }
 
 function isSafeRelayId(value: unknown): value is string {
@@ -161,16 +200,26 @@ function responsePath(dir: string, requestId: string): string {
 }
 
 const noFollowFlag = (constants as unknown as Record<string, unknown>).O_NOFOLLOW;
-const safeReadFlags = constants.O_RDONLY | (typeof noFollowFlag === "number" ? noFollowFlag : 0);
+const nonBlockingFlag = (constants as unknown as Record<string, unknown>).O_NONBLOCK;
+const safeReadFlags =
+  constants.O_RDONLY |
+  (typeof noFollowFlag === "number" ? noFollowFlag : 0) |
+  (typeof nonBlockingFlag === "number" ? nonBlockingFlag : 0);
+
+function sameFileIdentity(left: { dev: number; ino: number }, right: { dev: number; ino: number }): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
 
 /** Read one bounded regular file through one descriptor; never stat then reopen. */
 async function readBoundedJson(path: string, maxBytes: number): Promise<unknown> {
   const linkStat = await lstat(path);
-  if (!linkStat.isFile()) throw new Error("relay input is not a regular file");
+  if (!linkStat.isFile() || linkStat.isSymbolicLink()) throw new Error("relay input is not a regular file");
   const handle = await open(path, safeReadFlags);
   try {
     const stat = await handle.stat();
-    if (!stat.isFile() || stat.size > maxBytes) throw new Error("file exceeds the relay safety limit");
+    if (!stat.isFile() || !sameFileIdentity(linkStat, stat) || stat.size > maxBytes) {
+      throw new Error("relay input is not the handed-off regular file");
+    }
     const data = Buffer.alloc(stat.size);
     let offset = 0;
     while (offset < data.byteLength) {
@@ -185,6 +234,51 @@ async function readBoundedJson(path: string, maxBytes: number): Promise<unknown>
     return JSON.parse(data.toString("utf8")) as unknown;
   } finally {
     await handle.close();
+  }
+}
+
+async function createPrivateStagingDir(): Promise<string | undefined> {
+  try {
+    return await mkdtemp(join(tmpdir(), "comfyui-mcp-image-relay-"));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Move the untrusted directory entry without opening or following it. */
+async function handoffRequest(dir: string, file: string, stagingDir: string): Promise<string | undefined> {
+  const source = join(dir, file);
+  const destination = join(stagingDir, file);
+  try {
+    await rename(source, destination);
+    return destination;
+  } catch {
+    return undefined;
+  }
+}
+
+async function handoffResponse(dir: string, requestId: string, stagingDir: string): Promise<string | undefined> {
+  const file = `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${requestId}.json`;
+  const source = join(dir, file);
+  const destination = join(stagingDir, file);
+  try {
+    await rename(source, destination);
+    return destination;
+  } catch {
+    return undefined;
+  }
+}
+
+async function removeStagedEntry(path: string): Promise<void> {
+  try {
+    const stat = await lstat(path);
+    if (stat.isDirectory() && !stat.isSymbolicLink()) {
+      await rmdir(path).catch(() => undefined);
+    } else {
+      await unlink(path).catch(() => undefined);
+    }
+  } catch {
+    // The entry may already have been removed during shutdown or cleanup.
   }
 }
 
@@ -233,13 +327,14 @@ function validateImagePayload(
 function validateRequest(value: unknown, requestId: string): PanelImageRelayRequest | undefined {
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
+  const capability = record.capability;
   const createdAt = record.createdAt;
   const deadlineAt = record.deadlineAt;
   if (
-    !hasOnlyKeys(record, ["version", "requestId", "requester", "filename", "subfolder", "type", "createdAt", "deadlineAt"]) ||
+    !hasOnlyKeys(record, ["version", "requestId", "capability", "filename", "subfolder", "type", "createdAt", "deadlineAt"]) ||
     record.version !== PANEL_IMAGE_RELAY_VERSION ||
     record.requestId !== requestId ||
-    !isSafeRequester(record.requester) ||
+    !isSafeRelayCapability(capability) ||
     !isSafePanelImageRef(record.filename, record.subfolder, record.type) ||
     typeof createdAt !== "number" ||
     typeof deadlineAt !== "number" ||
@@ -312,8 +407,8 @@ export async function requestPanelImage(
   subfolder: string,
 ): Promise<PanelImageRelaySuccess | undefined> {
   const dir = channelDir();
-  const requester = process.env.COMFYUI_MCP_TAB;
-  if (!dir || !isSafeRequester(requester)) return undefined;
+  const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
+  if (!dir || !isSafeRelaySecret(secret)) return undefined;
   if (!isSafePanelImageRef(filename, subfolder, type)) {
     throw new PanelImageRelayError("The image reference is unsafe and was refused.", "UNSAFE_REFERENCE");
   }
@@ -330,66 +425,60 @@ export async function requestPanelImage(
   const request: PanelImageRelayRequest = {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId,
-    requester,
+    capability: "",
     filename,
     subfolder,
     type,
     createdAt,
     deadlineAt: createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS,
   };
+  request.capability = makePanelImageRelayCapability(secret, request);
   const requestFile = requestPath(dir, requestId);
-  const responseFile = responsePath(dir, requestId);
+  const responseStagingDir = await createPrivateStagingDir();
+  if (!responseStagingDir) {
+    throw new PanelImageRelayError("The connected panel relay is unavailable.", "REQUEST_WRITE_FAILED", true);
+  }
   try {
     writeJsonAtomically(requestFile, request, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES);
   } catch {
+    await removeStagedEntry(responseStagingDir);
     throw new PanelImageRelayError("The connected panel relay is unavailable.", "REQUEST_WRITE_FAILED", true);
   }
 
   const deadline = request.deadlineAt;
   try {
     while (Date.now() < deadline) {
-      let responsePresent = false;
-      try {
-        const responseStat = await lstat(responseFile);
-        if (!responseStat.isFile()) {
-          try { await unlink(responseFile); } catch { /* best effort */ }
-          throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
-        }
-        responsePresent = true;
-      } catch (error) {
-        if (error instanceof PanelImageRelayError) throw error;
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
-        }
-      }
-      if (responsePresent) {
+      const stagedResponsePath = await handoffResponse(dir, requestId, responseStagingDir);
+      if (stagedResponsePath) {
         if (Date.now() >= deadline) {
-          try { await unlink(responseFile); } catch { /* best effort */ }
+          await removeStagedEntry(stagedResponsePath);
           throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
         }
         let response: PanelImageRelayResponse;
         try {
           response = validateResponse(
-            await readBoundedJson(responseFile, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES),
+            await readBoundedJson(stagedResponsePath, PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES),
             requestId,
           );
         } catch (error) {
-          try { unlinkSync(responseFile); } catch { /* best effort */ }
+          await removeStagedEntry(stagedResponsePath);
           if (error instanceof PanelImageRelayError) throw error;
           throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
         }
-        try { unlinkSync(responseFile); } catch { /* best effort */ }
+        await removeStagedEntry(stagedResponsePath);
         if (Date.now() >= deadline) {
           throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
         }
-        if (response.ok === false) responseFailureMessage(response);
+        const responseAge = Date.now() - response.updated;
         if (
           response.updated < request.createdAt ||
           response.updated > request.deadlineAt ||
-          Date.now() - response.updated > PANEL_IMAGE_RELAY_STALE_MS
+          responseAge < -5_000 ||
+          responseAge > PANEL_IMAGE_RELAY_STALE_MS
         ) {
           throw new PanelImageRelayError("The panel returned a stale image relay reply.", "STALE_REPLY");
         }
+        if (response.ok === false) responseFailureMessage(response);
         return { base64: response.base64, mimeType: response.mimeType, bytes: response.bytes };
       }
       await new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -397,6 +486,7 @@ export async function requestPanelImage(
     throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
   } finally {
     try { unlinkSync(requestFile); } catch { /* orchestrator may already have consumed it */ }
+    await removeStagedEntry(responseStagingDir);
   }
 }
 
@@ -443,13 +533,16 @@ async function processOneRequest(
   dir: string,
   file: string,
   bridge: PanelImageRelayBridge,
+  stagingDir: string,
+  resolvePanelAgentKey: (request: PanelImageRelayRequest) => string | undefined,
   resolvePanelTab: (agentKey: string) => string | undefined,
 ): Promise<void> {
   const requestId = file.slice(PANEL_IMAGE_RELAY_REQUEST_PREFIX.length, -".json".length);
-  const fullPath = join(dir, file);
+  const stagedPath = await handoffRequest(dir, file, stagingDir);
+  if (!stagedPath) return;
   let request: PanelImageRelayRequest | undefined;
   try {
-    request = validateRequest(await readBoundedJson(fullPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES), requestId);
+    request = validateRequest(await readBoundedJson(stagedPath, PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES), requestId);
   } catch {
     request = undefined;
   }
@@ -457,7 +550,7 @@ async function processOneRequest(
     try {
       writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, "MALFORMED_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
     } catch { /* child will time out safely */ }
-    try { unlinkSync(fullPath); } catch { /* best effort */ }
+    await removeStagedEntry(stagedPath);
     return;
   }
   const now = Date.now();
@@ -466,14 +559,15 @@ async function processOneRequest(
     try {
       writeJsonAtomically(responsePath(dir, requestId), failureResponse(requestId, now >= request.deadlineAt ? "TIMEOUT" : "STALE_REQUEST"), PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES);
     } catch { /* best effort */ }
-    try { unlinkSync(fullPath); } catch { /* best effort */ }
+    await removeStagedEntry(stagedPath);
     return;
   }
 
   let response: PanelImageRelayResponse;
-  const panelTab = resolvePanelTab(request.requester);
+  const agentKey = resolvePanelAgentKey(request);
+  const panelTab = agentKey ? resolvePanelTab(agentKey) : undefined;
   if (!panelTab || !bridge.canReach(panelTab)) {
-    const failure = bridge.resolveFailure?.(panelTab ?? request.requester);
+    const failure = agentKey ? bridge.resolveFailure?.(agentKey) : undefined;
     response = failureResponse(
       requestId,
       failure === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
@@ -532,12 +626,14 @@ async function processOneRequest(
     // A bounded response that cannot be written is a failed relay; never retry
     // the request with a different target or fall back to a child-supplied URL.
   }
-  try { unlinkSync(fullPath); } catch { /* best effort */ }
+  await removeStagedEntry(stagedPath);
 }
 
 export interface ProcessPanelImageRequestsOptions {
   dir: string;
   bridge: PanelImageRelayBridge;
+  /** Verify the request MAC and resolve it to the owning agent key. */
+  resolvePanelAgentKey: (request: PanelImageRelayRequest) => string | undefined;
   /** Resolve both shared agent keys and real-tab agent keys to a live panel tab. */
   resolvePanelTab: (agentKey: string) => string | undefined;
   inFlight?: Set<string>;
@@ -561,6 +657,7 @@ function rejectQueuedRequest(dir: string, file: string): void {
 export async function processPanelImageRequests({
   dir,
   bridge,
+  resolvePanelAgentKey,
   resolvePanelTab,
   inFlight = new Set<string>(),
 }: ProcessPanelImageRequestsOptions): Promise<void> {
@@ -593,13 +690,20 @@ export async function processPanelImageRequests({
     pendingCapacity,
     responseCapacity,
   );
-  const work = pending.slice(0, Math.max(0, available)).map(async (file) => {
-      inFlight.add(file);
-      try {
-        await processOneRequest(dir, file, bridge, resolvePanelTab);
-      } finally {
-        inFlight.delete(file);
-      }
-    });
-  await Promise.all(work);
+  if (available <= 0) return;
+  const stagingDir = await createPrivateStagingDir();
+  if (!stagingDir) return;
+  try {
+    const work = pending.slice(0, available).map(async (file) => {
+        inFlight.add(file);
+        try {
+          await processOneRequest(dir, file, bridge, stagingDir, resolvePanelAgentKey, resolvePanelTab);
+        } finally {
+          inFlight.delete(file);
+        }
+      });
+    await Promise.all(work);
+  } finally {
+    await removeStagedEntry(stagingDir);
+  }
 }

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -7,6 +7,7 @@ import {
 import { constants } from "node:fs";
 import { lstat, mkdtemp, open, opendir, rename, rmdir, unlink } from "node:fs/promises";
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,6 +29,9 @@ export const PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK = 4;
 export const PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK = 128;
 export const PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS = 16;
 export const PANEL_IMAGE_RELAY_MAX_PENDING_RESPONSES = 4;
+export const PANEL_IMAGE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_image_relay";
+export const PANEL_IMAGE_RELAY_MAX_HTTP_REQUEST_BYTES = 16 * 1024;
+export const PANEL_IMAGE_RELAY_MAX_HTTP_RESPONSE_BYTES = 48 * 1024 * 1024;
 
 export const PANEL_IMAGE_RELAY_REQUEST_PREFIX = "control-image-request-";
 export const PANEL_IMAGE_RELAY_RESPONSE_PREFIX = "control-image-response-";
@@ -79,6 +83,8 @@ interface PanelImageRelayResponseSuccess extends PanelImageRelaySuccess {
 type PanelImageRelayResponse =
   | PanelImageRelayResponseSuccess
   | PanelImageRelayResponseFailure;
+
+type PanelImageRelayTransportResponse = PanelImageRelayResponse & { responseMac: string };
 
 export interface PanelImageRelayBridge {
   canReach(tabId: string): boolean;
@@ -393,20 +399,445 @@ function failureResponse(requestId: string, error: string): PanelImageRelayRespo
 }
 
 function responseFailureMessage(response: PanelImageRelayResponseFailure): never {
-  throw new PanelImageRelayError("The connected panel could not fetch that image.", "PANEL_FETCH_FAILED");
+  const known = new Set([
+    "AMBIGUOUS_REQUESTER",
+    "BACKLOG_FULL",
+    "MALFORMED_REPLY",
+    "NO_LIVE_PANEL",
+    "PANEL_FETCH_FAILED",
+    "STALE_REQUEST",
+    "TIMEOUT",
+  ]);
+  const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
+  throw new PanelImageRelayError(
+    code === "PANEL_FETCH_FAILED"
+      ? "The connected panel could not fetch that image."
+      : `The connected panel image relay failed (${code}).`,
+    code,
+  );
 }
 
-function channelDir(): string {
-  return process.env.COMFYUI_MCP_PROGRESS_DIR?.trim() ?? "";
+function responseMacPayload(response: PanelImageRelayResponse): string {
+  return response.ok
+    ? JSON.stringify([
+        response.version,
+        response.requestId,
+        true,
+        response.base64,
+        response.mimeType,
+        response.bytes,
+        response.updated,
+      ])
+    : JSON.stringify([response.version, response.requestId, false, response.error, response.updated]);
 }
 
-/** Child-side request writer and bounded response waiter. */
+function addResponseMac(secret: string, response: PanelImageRelayResponse): PanelImageRelayTransportResponse {
+  return {
+    ...response,
+    responseMac: createHmac("sha256", secret).update(responseMacPayload(response)).digest("hex"),
+  };
+}
+
+function validateTransportResponse(
+  value: unknown,
+  requestId: string,
+  secret: string,
+): PanelImageRelayResponse {
+  if (!value || typeof value !== "object") {
+    throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+  }
+  const record = value as Record<string, unknown>;
+  const responseMac = record.responseMac;
+  if (!isSafeRelayCapability(responseMac) || !hasOwn(record, "responseMac")) {
+    throw new PanelImageRelayError("The panel returned an unauthenticated image relay reply.", "MALFORMED_REPLY");
+  }
+  const { responseMac: ignored, ...unsigned } = record;
+  const response = validateResponse(unsigned, requestId);
+  const expected = createHmac("sha256", secret).update(responseMacPayload(response)).digest("hex");
+  if (!timingSafeEqual(Buffer.from(responseMac, "hex"), Buffer.from(expected, "hex"))) {
+    throw new PanelImageRelayError("The panel returned an unauthenticated image relay reply.", "MALFORMED_REPLY");
+  }
+  return response;
+}
+
+function relayEndpoint(): URL | undefined {
+  const raw = process.env.COMFYUI_MCP_RELAY_URL?.trim();
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    if (
+      url.protocol !== "http:" ||
+      url.hostname !== "127.0.0.1" ||
+      !url.port ||
+      Number(url.port) < 1 ||
+      Number(url.port) > 65535 ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      url.pathname !== PANEL_IMAGE_RELAY_HTTP_PATH
+    ) return undefined;
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readHttpResponseBounded(response: Response, maxBytes: number): Promise<unknown> {
+  const declared = response.headers.get("content-length");
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > maxBytes) {
+      throw new PanelImageRelayError("The panel relay response exceeded its safety limit.", "RESPONSE_TOO_LARGE");
+    }
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > maxBytes) {
+      throw new PanelImageRelayError("The panel relay response exceeded its safety limit.", "RESPONSE_TOO_LARGE");
+    }
+    return JSON.parse(text) as unknown;
+  }
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new PanelImageRelayError("The panel relay response exceeded its safety limit.", "RESPONSE_TOO_LARGE");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return JSON.parse(Buffer.concat(chunks, total).toString("utf8")) as unknown;
+}
+
+function requestDeadline(request: PanelImageRelayRequest): number {
+  return Math.min(request.deadlineAt, request.createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS);
+}
+
+function errorCodeFromHttpBody(value: unknown, status: number): string {
+  if (value && typeof value === "object" && typeof (value as Record<string, unknown>).error === "string") {
+    const error = (value as Record<string, unknown>).error as string;
+    if (/^[A-Z_]{3,40}$/.test(error)) return error;
+  }
+  if (status === 400) return "MALFORMED_REQUEST";
+  if (status === 401) return "UNAUTHORIZED";
+  if (status === 429) return "BACKLOG_FULL";
+  return "RELAY_UNAVAILABLE";
+}
+
+function readRequestBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
+  const declared = req.headers["content-length"];
+  if (declared !== undefined) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > maxBytes) {
+      return Promise.reject(new PanelImageRelayError("The relay request exceeded its safety limit.", "REQUEST_TOO_LARGE"));
+    }
+  }
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const finish = (error: Error | undefined, value?: Buffer) => {
+      if (settled) return;
+      settled = true;
+      req.removeListener("data", onData);
+      req.removeListener("end", onEnd);
+      req.removeListener("error", onError);
+      req.removeListener("aborted", onAborted);
+      req.setTimeout(0);
+      if (error) reject(error);
+      else resolve(value ?? Buffer.alloc(0));
+    };
+    const onData = (chunk: Buffer | string) => {
+      const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += data.byteLength;
+      if (total > maxBytes) {
+        req.destroy();
+        finish(new PanelImageRelayError("The relay request exceeded its safety limit.", "REQUEST_TOO_LARGE"));
+        return;
+      }
+      chunks.push(data);
+    };
+    const onEnd = () => finish(undefined, Buffer.concat(chunks, total));
+    const onError = () => finish(new PanelImageRelayError("The relay request was interrupted.", "RELAY_UNAVAILABLE", true));
+    const onAborted = () => finish(new PanelImageRelayError("The relay request was interrupted.", "RELAY_UNAVAILABLE", true));
+    req.on("data", onData);
+    req.once("end", onEnd);
+    req.once("error", onError);
+    req.once("aborted", onAborted);
+    req.setTimeout(PANEL_IMAGE_RELAY_TIMEOUT_MS + 1_000, () => {
+      req.destroy();
+      finish(new PanelImageRelayError("The relay request timed out.", "TIMEOUT"));
+    });
+  });
+}
+
+function writeHttpJson(res: ServerResponse, status: number, value: unknown): void {
+  const body = Buffer.from(JSON.stringify(value), "utf8");
+  if (body.byteLength > PANEL_IMAGE_RELAY_MAX_HTTP_RESPONSE_BYTES) {
+    res.writeHead(500, { "content-type": "application/json", "content-length": "0" });
+    res.end();
+    return;
+  }
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": String(body.byteLength),
+    connection: "close",
+  });
+  res.end(body);
+}
+
+async function withinDeadline<T>(promise: Promise<T>, deadlineAt: number): Promise<T> {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) throw new PanelImageRelayError("The panel image relay timed out.", "TIMEOUT");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new PanelImageRelayError("The panel image relay timed out.", "TIMEOUT")), remaining);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface PanelImageRelayResolvedAgent {
+  agentKey: string;
+  secret: string;
+}
+
+export interface PanelImageRelayServerOptions {
+  bridge: PanelImageRelayBridge;
+  resolvePanelAgent: (request: PanelImageRelayRequest) => PanelImageRelayResolvedAgent | undefined;
+  resolvePanelTab: (agentKey: string) => string | undefined;
+}
+
+export interface PanelImageRelayServer {
+  endpointUrl: string;
+  close(): Promise<void>;
+}
+
+/**
+ * The production child/orchestrator channel. It binds only to IPv4 loopback,
+ * authenticates the reference before resolving an agent, and never reads the
+ * shared progress directory. The file poller below is retained solely for
+ * legacy/unit coverage and is not wired into the orchestrator.
+ */
+export async function startPanelImageRelayServer(
+  options: PanelImageRelayServerOptions,
+): Promise<PanelImageRelayServer> {
+  let active = 0;
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      if (req.method !== "POST" || req.url !== PANEL_IMAGE_RELAY_HTTP_PATH) {
+        writeHttpJson(res, 404, { ok: false, error: "NOT_FOUND" });
+        return;
+      }
+      if (active >= PANEL_IMAGE_RELAY_MAX_CONCURRENT) {
+        writeHttpJson(res, 429, { ok: false, error: "BACKLOG_FULL" });
+        return;
+      }
+      active += 1;
+      try {
+        let body: Buffer;
+        try {
+          body = await readRequestBody(req, PANEL_IMAGE_RELAY_MAX_HTTP_REQUEST_BYTES);
+        } catch (error) {
+          const status = error instanceof PanelImageRelayError && error.code === "REQUEST_TOO_LARGE" ? 413 : 408;
+          writeHttpJson(res, status, { ok: false, error: error instanceof PanelImageRelayError ? error.code : "MALFORMED_REQUEST" });
+          return;
+        }
+        let raw: unknown;
+        try {
+          raw = JSON.parse(body.toString("utf8")) as unknown;
+        } catch {
+          writeHttpJson(res, 400, { ok: false, error: "MALFORMED_REQUEST" });
+          return;
+        }
+        const rawRecord = raw && typeof raw === "object" ? raw as Record<string, unknown> : undefined;
+        const requestId = rawRecord?.requestId;
+        const request = isSafeRelayId(requestId) ? validateRequest(raw, requestId) : undefined;
+        if (!request) {
+          writeHttpJson(res, 400, { ok: false, error: "MALFORMED_REQUEST" });
+          return;
+        }
+        const auth = options.resolvePanelAgent(request);
+        if (!auth || !isSafeRelaySecret(auth.secret)) {
+          writeHttpJson(res, 401, { ok: false, error: "UNAUTHORIZED" });
+          return;
+        }
+        const now = Date.now();
+        const age = now - request.createdAt;
+        let response: PanelImageRelayResponse;
+        if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS || now >= requestDeadline(request)) {
+          response = failureResponse(request.requestId, now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST");
+        } else {
+          const panelTab = options.resolvePanelTab(auth.agentKey);
+          if (!panelTab || !options.bridge.canReach(panelTab)) {
+            response = failureResponse(
+              request.requestId,
+              options.bridge.resolveFailure?.(auth.agentKey) === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
+            );
+          } else {
+            const remainingMs = requestDeadline(request) - Date.now();
+            if (remainingMs <= 0) {
+              response = failureResponse(request.requestId, "TIMEOUT");
+            } else {
+              try {
+                const reply = await withinDeadline(
+                  options.bridge.send(
+                    { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
+                    { tabId: panelTab, timeoutMs: Math.min(PANEL_IMAGE_RELAY_TIMEOUT_MS, remainingMs) },
+                  ),
+                  requestDeadline(request),
+                );
+                const replyRecord = reply && typeof reply === "object" ? reply as Record<string, unknown> : undefined;
+                const payload = replyRecord
+                  ? validateImagePayload({ base64: replyRecord.base64, mimeType: replyRecord.mimeType, bytes: replyRecord.bytes })
+                  : undefined;
+                if (Date.now() >= requestDeadline(request)) {
+                  response = failureResponse(request.requestId, "TIMEOUT");
+                } else if (replyRecord?.ok === false && hasOnlyKeys(replyRecord, ["ok", "error"]) && isSafeText(replyRecord.error, 160)) {
+                  response = failureResponse(request.requestId, "PANEL_FETCH_FAILED");
+                } else if (!replyRecord || replyRecord.ok !== true || !payload || !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])) {
+                  response = failureResponse(request.requestId, "MALFORMED_REPLY");
+                } else {
+                  response = { version: PANEL_IMAGE_RELAY_VERSION, requestId: request.requestId, ok: true, ...payload, updated: Date.now() };
+                }
+              } catch (error) {
+                response = failureResponse(request.requestId, error instanceof PanelImageRelayError && error.code === "TIMEOUT" ? "TIMEOUT" : "PANEL_FETCH_FAILED");
+              }
+            }
+          }
+        }
+        writeHttpJson(res, 200, addResponseMac(auth.secret, response));
+      } catch {
+        if (!res.headersSent) writeHttpJson(res, 503, { ok: false, error: "RELAY_UNAVAILABLE" });
+      } finally {
+        active -= 1;
+      }
+    })();
+  });
+  server.headersTimeout = 2_000;
+  server.requestTimeout = PANEL_IMAGE_RELAY_TIMEOUT_MS + 1_000;
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.removeListener("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: "127.0.0.1", port: 0 });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string" || address.address !== "127.0.0.1" || !address.port) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("panel image relay did not bind to IPv4 loopback");
+  }
+  return {
+    endpointUrl: `http://127.0.0.1:${address.port}${PANEL_IMAGE_RELAY_HTTP_PATH}`,
+    close: () => new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeIdleConnections?.();
+    }),
+  };
+}
+
+/** Child-side production request over the authenticated loopback HTTP channel. */
 export async function requestPanelImage(
   filename: string,
   type: PanelImageType,
   subfolder: string,
 ): Promise<PanelImageRelaySuccess | undefined> {
-  const dir = channelDir();
+  if (!isSafePanelImageRef(filename, subfolder, type)) {
+    throw new PanelImageRelayError("The image reference is unsafe and was refused.", "UNSAFE_REFERENCE");
+  }
+  const endpoint = relayEndpoint();
+  const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
+  if (!endpoint || !isSafeRelaySecret(secret)) return undefined;
+  const createdAt = Date.now();
+  const request: PanelImageRelayRequest = {
+    version: PANEL_IMAGE_RELAY_VERSION,
+    requestId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`,
+    capability: "",
+    filename,
+    subfolder,
+    type,
+    createdAt,
+    deadlineAt: createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS,
+  };
+  request.capability = makePanelImageRelayCapability(secret, request);
+  const body = Buffer.from(JSON.stringify(request), "utf8");
+  if (body.byteLength > PANEL_IMAGE_RELAY_MAX_HTTP_REQUEST_BYTES) {
+    throw new PanelImageRelayError("The relay request exceeded its safety limit.", "REQUEST_TOO_LARGE");
+  }
+  let httpResponse: Response;
+  try {
+    httpResponse = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(body.byteLength) },
+      body,
+      redirect: "error",
+      signal: AbortSignal.timeout(PANEL_IMAGE_RELAY_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof PanelImageRelayError) throw error;
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new PanelImageRelayError("The connected panel image relay timed out.", "TIMEOUT");
+    }
+    throw new PanelImageRelayError("The connected panel relay is unavailable.", "RELAY_UNAVAILABLE", true);
+  }
+  let decoded: unknown;
+  try {
+    decoded = await readHttpResponseBounded(httpResponse, PANEL_IMAGE_RELAY_MAX_HTTP_RESPONSE_BYTES);
+  } catch (error) {
+    if (error instanceof PanelImageRelayError) throw error;
+    throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
+  }
+  if (!httpResponse.ok) {
+    const code = errorCodeFromHttpBody(decoded, httpResponse.status);
+    throw new PanelImageRelayError(
+      code === "RELAY_UNAVAILABLE" ? "The connected panel relay is unavailable." : `The connected panel image relay failed (${code}).`,
+      code,
+      httpResponse.status >= 500,
+    );
+  }
+  const response = validateTransportResponse(decoded, request.requestId, secret);
+  const responseAge = Date.now() - response.updated;
+  if (
+    response.updated < request.createdAt ||
+    response.updated > request.deadlineAt ||
+    responseAge < -5_000 ||
+    responseAge > PANEL_IMAGE_RELAY_STALE_MS
+  ) {
+    throw new PanelImageRelayError("The panel returned a stale image relay reply.", "STALE_REPLY");
+  }
+  if (response.ok === false) responseFailureMessage(response);
+  return { base64: response.base64, mimeType: response.mimeType, bytes: response.bytes };
+}
+
+/** Legacy file-channel request writer, retained for focused/unit coverage only. */
+export async function requestPanelImageFromFileChannel(
+  filename: string,
+  type: PanelImageType,
+  subfolder: string,
+): Promise<PanelImageRelaySuccess | undefined> {
+  const dir = process.env.COMFYUI_MCP_PROGRESS_DIR?.trim() ?? "";
   const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
   if (!dir || !isSafeRelaySecret(secret)) return undefined;
   if (!isSafePanelImageRef(filename, subfolder, type)) {

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -4,7 +4,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { constants } from "node:fs";
 import { lstat, mkdtemp, open, opendir, rename, rmdir, unlink } from "node:fs/promises";
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
@@ -205,13 +204,6 @@ function responsePath(dir: string, requestId: string): string {
   return join(dir, `${PANEL_IMAGE_RELAY_RESPONSE_PREFIX}${requestId}.json`);
 }
 
-const noFollowFlag = (constants as unknown as Record<string, unknown>).O_NOFOLLOW;
-const nonBlockingFlag = (constants as unknown as Record<string, unknown>).O_NONBLOCK;
-const safeReadFlags =
-  constants.O_RDONLY |
-  (typeof noFollowFlag === "number" ? noFollowFlag : 0) |
-  (typeof nonBlockingFlag === "number" ? nonBlockingFlag : 0);
-
 function sameFileIdentity(left: { dev: number; ino: number }, right: { dev: number; ino: number }): boolean {
   return left.dev === right.dev && left.ino === right.ino;
 }
@@ -220,7 +212,7 @@ function sameFileIdentity(left: { dev: number; ino: number }, right: { dev: numb
 async function readBoundedJson(path: string, maxBytes: number): Promise<unknown> {
   const linkStat = await lstat(path);
   if (!linkStat.isFile() || linkStat.isSymbolicLink()) throw new Error("relay input is not a regular file");
-  const handle = await open(path, safeReadFlags);
+  const handle = await open(path, "r");
   try {
     const stat = await handle.stat();
     if (!stat.isFile() || !sameFileIdentity(linkStat, stat) || stat.size > maxBytes) {

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -321,9 +321,9 @@ export function publishConnectedPanelOrigins(
     origins: published,
     updated: now,
     pid: process.pid,
-    // The child may use this channel for direct HTTP contact, so an old or
-    // hand-written broad diagnostic record must never become a trust source.
-    trustedLocalPanelOrigins: true,
+    // This channel is diagnostic-only. Its records must never become an
+    // authorization source for a new outbound request.
+    diagnosticPanelOrigins: true,
   });
   // The atomic write lives in writeChannelPayload (shared with the sibling
   // frontend-virtual-types channel, #1400); a false return means the PRIOR
@@ -362,12 +362,12 @@ export function readPublishedPanelOrigins(now: number = Date.now()): string[] {
       origins?: unknown;
       updated?: unknown;
       pid?: unknown;
-      trustedLocalPanelOrigins?: unknown;
+      diagnosticPanelOrigins?: unknown;
     };
     if (!Array.isArray(raw?.origins)) return [];
     // Old records carried every server-observed origin, including relay/tunnel
     // targets. They are diagnostic data, not permission to make a new request.
-    if (raw.trustedLocalPanelOrigins !== true) return [];
+    if (raw.diagnosticPanelOrigins !== true) return [];
     // A record whose publisher is gone describes panels that are gone with it.
     // Both checks, for the reasons in the header: liveness catches the death,
     // freshness catches a reused pid.

--- a/src/services/panel-origin-channel.ts
+++ b/src/services/panel-origin-channel.ts
@@ -321,6 +321,9 @@ export function publishConnectedPanelOrigins(
     origins: published,
     updated: now,
     pid: process.pid,
+    // The child may use this channel for direct HTTP contact, so an old or
+    // hand-written broad diagnostic record must never become a trust source.
+    trustedLocalPanelOrigins: true,
   });
   // The atomic write lives in writeChannelPayload (shared with the sibling
   // frontend-virtual-types channel, #1400); a false return means the PRIOR
@@ -359,8 +362,12 @@ export function readPublishedPanelOrigins(now: number = Date.now()): string[] {
       origins?: unknown;
       updated?: unknown;
       pid?: unknown;
+      trustedLocalPanelOrigins?: unknown;
     };
     if (!Array.isArray(raw?.origins)) return [];
+    // Old records carried every server-observed origin, including relay/tunnel
+    // targets. They are diagnostic data, not permission to make a new request.
+    if (raw.trustedLocalPanelOrigins !== true) return [];
     // A record whose publisher is gone describes panels that are gone with it.
     // Both checks, for the reasons in the header: liveness catches the death,
     // freshness catches a reused pid.
@@ -375,7 +382,12 @@ export function readPublishedPanelOrigins(now: number = Date.now()): string[] {
     // `updated > now` (a clock step, or a future-dated write) is NOT freshness
     // evidence — without this it would read as maximally fresh, forever.
     if (updated > now || now - updated > PANEL_ORIGINS_MAX_AGE_MS) return [];
-    return raw.origins.filter((o): o is string => typeof o === "string" && o !== "");
+    // Preserve malformed strings for panel-fallback-target.ts to reject as a
+    // mixed set. Filtering one invalid entry here would silently select the
+    // remaining valid origin, which is exactly the fail-open bug this channel
+    // boundary is meant to prevent.
+    if (!raw.origins.every((o): o is string => typeof o === "string" && o !== "")) return [];
+    return raw.origins;
   } catch {
     return [];
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -34,6 +34,12 @@ import {
   QUEUE_BUSY_READ_TOOLS,
   panelToolForGraphCmd,
 } from "./panel-graph-cmd-tools.js";
+import {
+  httpOriginOf,
+  isLoopbackPanelOrigin,
+  normalizePanelOrigin,
+} from "./panel-fallback-target.js";
+import { canonicalOrigin } from "../utils/origin.js";
 
 export const DEFAULT_BRIDGE_PORT = 9101;
 
@@ -3969,6 +3975,34 @@ export class UiBridge {
     for (const conn of this.conns.values()) {
       const origin = conn.serverOrigin;
       if (typeof origin === "string" && origin !== "" && !out.includes(origin)) out.push(origin);
+    }
+    return out;
+  }
+
+  /**
+   * Origins eligible for a direct MCP fallback request (#2149).
+   *
+   * `connectedServerOrigins()` is intentionally broader because it powers
+   * diagnostics. Direct contact needs a stronger boundary: the socket must be
+   * server-proven local, the panel's claimed URL must corroborate the observed
+   * handshake origin, and the resulting origin must be a loopback HTTP(S)
+   * origin. Relay/tunnel/LAN/remote origins are never exported here.
+   */
+  connectedSafePanelOrigins(): string[] {
+    const out: string[] = [];
+    for (const conn of this.conns.values()) {
+      if (conn.local !== true) continue;
+      const observed = normalizePanelOrigin(conn.serverOrigin);
+      const claimed = httpOriginOf(conn.originUrl, true, false);
+      if (
+        observed === undefined ||
+        claimed === undefined ||
+        canonicalOrigin(observed) !== canonicalOrigin(claimed) ||
+        !isLoopbackPanelOrigin(observed)
+      ) {
+        continue;
+      }
+      if (!out.includes(observed)) out.push(observed);
     }
     return out;
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -34,12 +34,6 @@ import {
   QUEUE_BUSY_READ_TOOLS,
   panelToolForGraphCmd,
 } from "./panel-graph-cmd-tools.js";
-import {
-  httpOriginOf,
-  isLoopbackPanelOrigin,
-  normalizePanelOrigin,
-} from "./panel-fallback-target.js";
-import { canonicalOrigin } from "../utils/origin.js";
 
 export const DEFAULT_BRIDGE_PORT = 9101;
 
@@ -263,25 +257,17 @@ interface Conn {
    *  gate — checked BEFORE the version gate — wins. So a wrongly-inherited entry costs at
    *  most one honest round-trip, never a fabricated success. */
   provenSupportedCmds: Set<string>;
-  /** The ComfyUI origin this tab's browser was served from (`comfyui_url` =
-   *  window.location in its `hello`), if sent. Lets a tool bind an HTTP probe to the
-   *  EXACT instance THIS tab fronts — not the process-global target, which a
-   *  different instance's hello may have retargeted (#509). */
+  /** The ComfyUI origin this tab claims in `hello` (`comfyui_url`), if sent.
+   *  This is page/client-controlled metadata and is never an authorization signal. */
   originUrl?: string;
-  /** SERVER-OBSERVED: the browser `Origin` header from THIS socket's WebSocket upgrade
-   *  handshake (scheme://host:port of the page the panel runs in). Unlike `originUrl`
-   *  (client-supplied `hello.comfyui_url`, spoofable by page JS), the browser sets Origin
-   *  and forbids page scripts from overriding it — so it is the TRUSTED proof of which
-   *  ComfyUI a real browser tab actually fronts. Undefined when the handshake carried no
-   *  Origin (a non-browser / relay client). Used to gate the reboot self-probe (#509): a
-   *  socket can CLAIM any comfyui_url, but only a page genuinely SERVED FROM the boot
-   *  origin gets a matching handshake Origin, so we never certify a same-instance cycle
-   *  from a spoofed origin. */
+  /** SERVER-OBSERVED, syntactically validated metadata from THIS socket's WebSocket
+   *  upgrade (scheme://host:port). It is distinct from `originUrl`, but HTTP headers
+   *  are forgeable by a non-browser client on a tokenless listener, so this is not
+   *  authentication and must not authorize outbound requests. */
   serverOrigin?: string;
-  /** SERVER-TRUSTED: the socket arrived on the token-less loopback primary listener
-   *  (a browser on the orchestrator's OWN host). False for relay/tunnel/LAN/pairing
-   *  connections, whose advertised loopback origin is NOT the orchestrator's host
-   *  and must not be directly health-probed (#509). */
+  /** The socket arrived on the token-less loopback primary listener. This is a
+   *  transport/bind fact, not browser provenance; a local non-browser client can
+   *  still connect and forge request headers. */
   local: boolean;
   /** The panel language THIS tab resolved for itself (`locale` in its `hello`), already
    *  narrowed to a locale we ship. Undefined when the panel sent none (an older build) or
@@ -1536,17 +1522,32 @@ function expectedNodeTypeFenceRefusal(tabId: string): Error {
   );
 }
 
-/** Normalize a WebSocket handshake `Origin` header into a canonical scheme://host:port
- *  string, or undefined when it is absent, the opaque literal `"null"` (a sandboxed /
- *  file:// / data: origin, which proves nothing), or unparseable. The browser sets this
- *  header on the upgrade and forbids page JS from overriding it, so a value here is
- *  server-trusted provenance of the page the socket runs in. Host case is lowercased and
- *  the default port made explicit so it compares cleanly against a probe base. */
+/** Normalize a syntactically valid HTTP(S) WebSocket handshake `Origin` into a
+ *  canonical scheme://host:port string. This is metadata for diagnostics and
+ *  workflow identity, not authentication: an arbitrary client can write the
+ *  header when the listener is tokenless. Reject paths, queries, userinfo,
+ *  unsupported schemes, and other values rather than stripping them into a
+ *  value that looks trustworthy. */
 function normalizeHandshakeOrigin(raw: string | string[] | undefined): string | undefined {
+  if (Array.isArray(raw) && raw.length !== 1) return undefined;
   const val = Array.isArray(raw) ? raw[0] : raw;
   if (typeof val !== "string" || val === "" || val.toLowerCase() === "null") return undefined;
   try {
     const u = new URL(val);
+    if (
+      (u.protocol !== "http:" && u.protocol !== "https:") ||
+      u.username !== "" ||
+      u.password !== "" ||
+      u.pathname !== "/" ||
+      u.search !== "" ||
+      u.hash !== ""
+    ) {
+      return undefined;
+    }
+    // Origin serializes as scheme://host with no trailing slash. Requiring the
+    // exact serialization prevents a client from smuggling a path-like spelling
+    // that this boundary would otherwise normalize away.
+    if (val !== `${u.protocol}//${u.host}`) return undefined;
     const port = u.port || (u.protocol === "https:" ? "443" : "80");
     return `${u.protocol}//${u.hostname.toLowerCase()}:${port}`;
   } catch {
@@ -2617,9 +2618,9 @@ export class UiBridge {
       // relay-client.ts / the relay README for why that's believed low-risk).
       this.missedPongs.set(sock, 0);
       sock.on("pong", () => this.missedPongs.set(sock, 0));
-      // SERVER-OBSERVED handshake Origin (the browser sets it and forbids page JS from
-      // overriding it) — the trusted proof of which page this socket runs in, distinct
-      // from the spoofable hello.comfyui_url (#509 self-probe gate).
+      // SERVER-OBSERVED handshake Origin, kept as syntactically validated metadata.
+      // On this tokenless local listener a non-browser client can forge the header,
+      // so it is never an authorization signal for outbound MCP requests.
       const handshakeOrigin = normalizeHandshakeOrigin(req?.headers?.origin);
       // Trusted-local ONLY when the primary listener is a token-less loopback bind
       // (no LAN bind, no tunnel/secure token in front) — see handleConnection's doc.
@@ -2701,20 +2702,15 @@ export class UiBridge {
   }
 
   /**
-   * @param local SERVER-TRUSTED provenance: true only when the socket arrived on
-   *   the token-less loopback primary listener, i.e. a browser genuinely on the
-   *   orchestrator's own host. A token-gated/tunnel-fronted primary, a relay shim,
-   *   and any LAN/pairing listener are all `false` — a browser reaching those can
-   *   sit on a DIFFERENT machine yet advertise its OWN 127.0.0.1 ComfyUI, which
-   *   must never be treated as the orchestrator's local host (#509).
+   * @param local True only when the socket arrived on the token-less loopback
+   *   primary listener. This is a bind/transport fact, not browser provenance:
+   *   an arbitrary local client can still connect and forge HTTP headers.
+   *   Token-gated/tunnel-fronted, relay, and LAN/pairing connections are `false`.
    * @param serverOrigin The origin (scheme://host:port) this connection's workflow
-   *   identity is scoped to, and which the reboot self-probe trusts to know which page
-   *   it fronts. NEVER client-supplied. Normally SERVER-OBSERVED, captured from the
-   *   WebSocket upgrade's `Origin` header. A relay socket has no upgrade to observe, so
-   *   `attachRelayConnection` passes the one the orchestrator DERIVES from its own
-   *   COMFYUI_URL (#1077) — the panel page is served by that ComfyUI, so it is the same
-   *   origin a browser would send. Undefined only when neither is available, which
-   *   leaves the connection unable to adopt a workflow fence.
+   *   identity is scoped to. Normally it is captured from the WebSocket upgrade's
+   *   syntactically validated `Origin` header; a relay socket has no upgrade, so
+   *   `attachRelayConnection` supplies an orchestrator-derived value. Neither path
+   *   is an authorization signal for outbound requests.
    */
   private handleConnection(sock: BridgeSocket, local = false, serverOrigin?: string): void {
     // Track from ACCEPT, not from hello: an anonymous socket is still a socket,
@@ -3928,13 +3924,11 @@ export class UiBridge {
     }
   }
 
-  /** SERVER-OBSERVED origin (scheme://host:port) of the given tab's WebSocket handshake —
-   *  the page the browser was actually serving when it opened this socket. Unlike
-   *  {@link tabOrigin} (client-supplied `hello.comfyui_url`, spoofable), the browser sets
-   *  the handshake `Origin` and blocks page JS from forging it, so this is the TRUSTED
-   *  proof of which ComfyUI a real tab fronts — the origin the reboot self-probe binds to
-   *  (#509). Undefined when the handshake carried no usable Origin. Resolves migration
-   *  aliases like tabOrigin; never throws. */
+  /** SERVER-OBSERVED, syntactically validated origin (scheme://host:port) of the given
+   *  tab's WebSocket handshake. Unlike {@link tabOrigin}, it is independent of the
+   *  hello claim, but it is not authentication on a tokenless listener: a local
+   *  non-browser client can forge the HTTP header. Undefined when unusable. Resolves
+   *  migration aliases like tabOrigin; never throws. */
   tabServerOrigin(tabId: string): string | undefined {
     try {
       return this.resolveTarget(tabId).serverOrigin;
@@ -3975,34 +3969,6 @@ export class UiBridge {
     for (const conn of this.conns.values()) {
       const origin = conn.serverOrigin;
       if (typeof origin === "string" && origin !== "" && !out.includes(origin)) out.push(origin);
-    }
-    return out;
-  }
-
-  /**
-   * Origins eligible for a direct MCP fallback request (#2149).
-   *
-   * `connectedServerOrigins()` is intentionally broader because it powers
-   * diagnostics. Direct contact needs a stronger boundary: the socket must be
-   * server-proven local, the panel's claimed URL must corroborate the observed
-   * handshake origin, and the resulting origin must be a loopback HTTP(S)
-   * origin. Relay/tunnel/LAN/remote origins are never exported here.
-   */
-  connectedSafePanelOrigins(): string[] {
-    const out: string[] = [];
-    for (const conn of this.conns.values()) {
-      if (conn.local !== true) continue;
-      const observed = normalizePanelOrigin(conn.serverOrigin);
-      const claimed = httpOriginOf(conn.originUrl, true, false);
-      if (
-        observed === undefined ||
-        claimed === undefined ||
-        canonicalOrigin(observed) !== canonicalOrigin(claimed) ||
-        !isLoopbackPanelOrigin(observed)
-      ) {
-        continue;
-      }
-      if (!out.includes(observed)) out.push(observed);
     }
     return out;
   }
@@ -4056,11 +4022,11 @@ export class UiBridge {
     }
   }
 
-  /** SERVER-TRUSTED: true only when this tab's socket arrived on the token-less
-   *  loopback primary listener (a browser on the orchestrator's OWN host), so its
-   *  advertised loopback ComfyUI origin really is the orchestrator's local host and
-   *  may be directly health-probed (#509). Relay/tunnel/LAN/pairing tabs → false.
-   *  Resolves migration aliases like tabOrigin; unknown → false. */
+  /** True when this tab's socket arrived on the token-less loopback primary
+   *  listener. This reports local transport placement only; it is not browser
+   *  provenance and must not authorize a new outbound request. Relay/tunnel/
+   *  LAN/pairing tabs → false. Resolves migration aliases like tabOrigin;
+   *  unknown → false. */
   tabIsLocal(tabId: string): boolean {
     try {
       return this.resolveTarget(tabId).local === true;


### PR DESCRIPTION
Closes #2149.\n\nWhen the configured headless ComfyUI target is unreachable, retry get_image through the connected Panel's authenticated browser fetch. The production child/orchestrator channel is a bounded HMAC-authenticated loopback HTTP relay bound to 127.0.0.1; it carries only validated image references, resolves the agent from in-memory capabilities, preserves shared-scope tab routing, and enforces deadlines, concurrency, response MACs, redirects, MIME, and 32 MiB limits. The old filesystem relay remains test-only and is not production-wired.\n\nPanel support is in the paired Panel PR and must be released with it.\n\nValidation: focused relay/UI tests, build, lint, no-emit typecheck, and independent SHIP review passed.
