### PR TITLE
test: cover authenticated list_packs templates

### DIFF
--- a/src/__tests__/tools/html-instead-of-json.test.ts
+++ b/src/__tests__/tools/html-instead-of-json.test.ts
@@ -65,6 +65,7 @@ function htmlResponse(status = 200): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  authHeaders.value = {};
 });
 
 describe('list_packs action:"list_templates" on an HTML-answering remote (#828)', () => {
@@ -88,6 +89,39 @@ describe('list_packs action:"list_templates" on an HTML-answering remote (#828)'
     // The old message guessed at an outdated server; the body says otherwise.
     expect(text).not.toMatch(/recent enough to expose workflow templates/);
     expect(text).toContain("502");
+  });
+
+  it("keeps an empty 401 as an auth failure instead of a JSON parse error", async () => {
+    global.fetch = vi.fn(
+      async () => new Response(null, { status: 401, headers: { "content-type": "application/json" } }),
+    ) as unknown as typeof fetch;
+    const out = await getHandler("list_packs")({ action: "list_templates" });
+    const text = out.content[0].text;
+
+    expect(out.isError).toBe(true);
+    expect(text).toContain("401");
+    expect(text).toContain("EMPTY body");
+    expect(text).toContain("Whichever layer rejected the request");
+    expect(text).not.toContain("Unexpected end of JSON input");
+    expect(text).not.toContain("No custom-node-contributed workflow template named");
+  });
+
+  it("identifies a non-JSON 401 sign-in page without claiming the template is missing", async () => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          '<!doctype html><html><head><title>Sign in</title></head><body><form action="/login"><input type="password"></form></body></html>',
+          { status: 401, headers: { "content-type": "text/html" } },
+        ),
+    ) as unknown as typeof fetch;
+    const out = await getHandler("list_packs")({ action: "list_templates" });
+    const text = out.content[0].text;
+
+    expect(out.isError).toBe(true);
+    expect(text).toContain("401");
+    expect(text).toContain("SIGN-IN PAGE");
+    expect(text).toContain("COMFYUI_AUTH_TOKEN / COMFYUI_AUTH_HEADER");
+    expect(text).not.toContain("No custom-node-contributed workflow template named");
   });
 
   it("shows the JSON error body so the caller can tell ComfyUI from a gateway", async () => {

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -27,6 +27,11 @@ const mocks = vi.hoisted(() => ({
   checkWorkflowRuntime: vi.fn(),
 }));
 
+const comfyui = vi.hoisted(() => ({
+  baseUrl: "http://comfy.test:8188",
+  authHeaders: {} as Record<string, string>,
+}));
+
 vi.mock("../../services/workflow-deps.js", () => ({
   extractWorkflowDependencies: (...args: unknown[]) => mocks.extractWorkflowDependencies(...args),
   installWorkflowDependencies: (...args: unknown[]) => mocks.installWorkflowDependencies(...args),
@@ -46,8 +51,8 @@ vi.mock("../../services/api-nodes.js", async (importOriginal) => {
 });
 
 vi.mock("../../config.js", () => ({
-  getComfyUIBaseUrl: () => "http://comfy.test:8188",
-  getComfyUIAuthHeaders: () => ({}),
+  getComfyUIBaseUrl: () => comfyui.baseUrl,
+  getComfyUIAuthHeaders: () => comfyui.authHeaders,
 }));
 
 import { registerSkillsAccessTools, enumeratePacks } from "../../tools/skills-access.js";
@@ -102,6 +107,8 @@ const savedFetch = global.fetch;
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
+  comfyui.baseUrl = "http://comfy.test:8188";
+  comfyui.authHeaders = {};
   // Every action that touches the network gets a healthy default so a test
   // about SOMETHING ELSE never accidentally exercises an error path.
   global.fetch = vi.fn(
@@ -272,6 +279,21 @@ describe("actions call the same services with the same arguments", () => {
     const parsed = JSON.parse(text(res));
     expect(parsed.source_count).toBe(1);
     expect(parsed.template_count).toBe(1);
+  });
+
+  it('action:"list_templates" uses the shared auth and proxy-prefix path', async () => {
+    comfyui.baseUrl = "https://remote.example/comfyapi";
+    comfyui.authHeaders = { "X-Proxy-Token": "Token proxy-secret" };
+
+    const res = await handler()({ action: "list_templates" });
+    expect(res.isError).toBeUndefined();
+
+    const fetchMock = global.fetch as unknown as {
+      mock: { calls: Array<[string, RequestInit?]> };
+    };
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://remote.example/comfyapi/api/workflow_templates");
+    expect(new Headers(init?.headers).get("X-Proxy-Token")).toBe("Token proxy-secret");
   });
 
   it('action:"check_runtime" classifies the given graph and adds the guidance line', async () => {


### PR DESCRIPTION
## Summary\n- cover authenticated proxy headers and prefixed remote base paths for list_packs action:list_templates\n- cover empty and non-JSON 401 responses without misclassifying them as missing templates\n\nIssue: #2151\n\nValidation: focused tests, build, lint, no-emit typecheck, vocabulary check, and diff check passed. Full suite was not completed due prolonged fixture activity.