### PR TITLE
fix: verify untracked registry installs from disk

### DIFF
--- a/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
+++ b/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   scanBase: undefined as string | undefined,
   afterDispatch: undefined as (() => void) | undefined,
   queueStatus: { pending_count: 0, is_processing: false } as Record<string, unknown>,
+  queueTopLevel: {} as Record<string, unknown>,
   calls: [] as string[],
 }));
 
@@ -69,7 +70,7 @@ function bridge() {
         };
       }
       if (cmd.cmd === "nodes_queue_status") {
-        return { status: state.queueStatus };
+        return { status: state.queueStatus, ...state.queueTopLevel };
       }
       return { ok: true };
     },
@@ -101,6 +102,7 @@ beforeEach(() => {
   state.scanBase = undefined;
   state.afterDispatch = undefined;
   state.queueStatus = { pending_count: 0, is_processing: false };
+  state.queueTopLevel = {};
   state.calls = [];
 });
 
@@ -289,6 +291,31 @@ describe("panel_install_node registry verification (#2180)", () => {
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
+    }
+  });
+
+  it("blocks promotion when failure metadata is on the queue envelope beside nested status", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-mixed-failure-"));
+    try {
+      mkdirSync(join(root, "custom_nodes"), { recursive: true });
+      state.scanBase = root;
+      state.queueStatus = { pending_count: 0, is_processing: false };
+      state.queueTopLevel = { recent_failures: [{ id: "comfyui-reactor" }] };
+      state.afterDispatch = () => {
+        const pack = join(root, "custom_nodes", "comfyui-reactor");
+        mkdirSync(pack, { recursive: true });
+        writeFileSync(join(pack, ".tracking"), "{}\n");
+        writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      };
+
+      const result = await install("comfyui-reactor");
+
+      expect(state.calls).toEqual(["nodes_install", "nodes_queue_status"]);
+      expect(result.installed).toBe(false);
+      expect(result.verified).toBe(false);
+      expect(result.verification_evidence).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
+++ b/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
@@ -243,4 +243,52 @@ describe("panel_install_node registry verification (#2180)", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("keeps installed:false and blocks disk promotion for every explicit queue failure shape", async () => {
+    const failureShapes: Array<{ name: string; fields: Record<string, unknown> }> = [
+      { name: "failed flag", fields: { failed: true } },
+      { name: "failed array", fields: { failed: [{ id: "comfyui-reactor" }] } },
+      { name: "error flag", fields: { error: true } },
+      { name: "failure flag", fields: { failure: true } },
+      { name: "failures array", fields: { failures: [{ message: "install failed" }] } },
+      { name: "recent failures array", fields: { recent_failures: [{ id: "comfyui-reactor" }] } },
+      { name: "errors array", fields: { errors: [{ message: "install failed" }] } },
+      { name: "failed_count", fields: { failed_count: 1 } },
+      { name: "failure_count", fields: { failure_count: 1 } },
+      { name: "error_count", fields: { error_count: 1 } },
+      { name: "fail_count", fields: { fail_count: 1 } },
+      { name: "failure_reporting", fields: { failure_reporting: "failed" } },
+      { name: "status failed", fields: { status: "failed" } },
+      { name: "status failure", fields: { status: "failure" } },
+      { name: "status error", fields: { status: "error" } },
+    ];
+
+    for (const shape of failureShapes) {
+      const root = mkdtempSync(join(tmpdir(), "cmcp-2180-failure-"));
+      try {
+        mkdirSync(join(root, "custom_nodes"), { recursive: true });
+        state.scanBase = root;
+        state.queueStatus = {
+          pending_count: 0,
+          is_processing: false,
+          ...shape.fields,
+        };
+        state.afterDispatch = () => {
+          const pack = join(root, "custom_nodes", "comfyui-reactor");
+          mkdirSync(pack, { recursive: true });
+          writeFileSync(join(pack, ".tracking"), "{}\n");
+          writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+        };
+
+        const result = await install("comfyui-reactor");
+
+        expect(result.installed, shape.name).toBe(false);
+        expect(result.verified, shape.name).toBe(false);
+        expect(result.verification_evidence, shape.name).toBeUndefined();
+        expect(state.calls).toContain("nodes_queue_status");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
+++ b/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
@@ -1,7 +1,7 @@
 // #2180 — Panel 0.15.71 can report a registry install as unverified when the
 // zip landed in custom_nodes but Manager did not add it to its installed list.
 // The MCP fallback is allowed only with same-target local, readable pack evidence.
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   remote: false,
   scanBase: undefined as string | undefined,
+  afterDispatch: undefined as (() => void) | undefined,
+  queueStatus: { pending_count: 0, is_processing: false } as Record<string, unknown>,
+  calls: [] as string[],
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -52,7 +55,9 @@ function installDef() {
 function bridge() {
   return {
     send: async (cmd: Record<string, unknown>) => {
+      state.calls.push(String(cmd.cmd));
       if (cmd.cmd === "nodes_install") {
+        state.afterDispatch?.();
         return {
           queued: true,
           installed: false,
@@ -64,7 +69,7 @@ function bridge() {
         };
       }
       if (cmd.cmd === "nodes_queue_status") {
-        return { status: { pending_count: 0, is_processing: true } };
+        return { status: state.queueStatus };
       }
       return { ok: true };
     },
@@ -94,24 +99,33 @@ async function install(id: string): Promise<Record<string, unknown>> {
 beforeEach(() => {
   state.remote = false;
   state.scanBase = undefined;
+  state.afterDispatch = undefined;
+  state.queueStatus = { pending_count: 0, is_processing: false };
+  state.calls = [];
 });
 
 describe("panel_install_node registry verification (#2180)", () => {
   it("accepts a readable pack on the live target and reports restart_required", async () => {
     const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
     try {
-      const pack = join(root, "custom_nodes", "comfyui-reactor");
-      mkdirSync(pack, { recursive: true });
-      writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      mkdirSync(join(root, "custom_nodes"), { recursive: true });
       state.scanBase = root;
+      state.afterDispatch = () => {
+        const pack = join(root, "custom_nodes", "comfyui-reactor");
+        mkdirSync(pack, { recursive: true });
+        writeFileSync(join(pack, ".tracking"), "{}\n");
+        writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      };
 
       const result = await install("comfyui-reactor");
 
+      expect(state.calls).toEqual(["nodes_install", "nodes_queue_status"]);
       expect(result.installed).toBe(true);
       expect(result.verified).toBe(true);
       expect(result.restart_required).toBe(true);
-      expect(result.verification_evidence).toBe("on-disk");
-      expect(String(result.note)).toMatch(/readable custom-node pack/i);
+      expect(result.verification_evidence).toBe("new-on-disk-registry-pack");
+      expect(String(result.note)).toMatch(/pre-install snapshot/i);
+      expect(String(result.note)).toMatch(/version or channel/i);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -157,6 +171,74 @@ describe("panel_install_node registry verification (#2180)", () => {
       expect(result.installed).toBe(false);
       expect(result.verified).toBe(false);
       expect(result.restart_required).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not promote an old, arbitrary same-name, disabled, or symlink directory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
+    const external = mkdtempSync(join(tmpdir(), "cmcp-2180-link-"));
+    try {
+      state.scanBase = root;
+      const oldPack = join(root, "custom_nodes", "comfyui-reactor");
+      mkdirSync(oldPack, { recursive: true });
+      writeFileSync(join(oldPack, ".tracking"), "{}\n");
+      writeFileSync(join(oldPack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      expect((await install("comfyui-reactor")).installed).toBe(false);
+
+      rmSync(oldPack, { recursive: true, force: true });
+      state.afterDispatch = () => {
+        const arbitrary = join(root, "custom_nodes", "comfyui-reactor");
+        mkdirSync(arbitrary, { recursive: true });
+        writeFileSync(join(arbitrary, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      };
+      expect((await install("comfyui-reactor")).installed).toBe(false);
+
+      rmSync(join(root, "custom_nodes", "comfyui-reactor"), { recursive: true, force: true });
+      state.afterDispatch = () => {
+        const disabled = join(root, "custom_nodes", "comfyui-reactor.disabled");
+        mkdirSync(disabled, { recursive: true });
+        writeFileSync(join(disabled, ".tracking"), "{}\n");
+        writeFileSync(join(disabled, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      };
+      expect((await install("comfyui-reactor")).installed).toBe(false);
+
+      rmSync(join(root, "custom_nodes", "comfyui-reactor.disabled"), { recursive: true, force: true });
+      state.afterDispatch = undefined;
+      mkdirSync(external, { recursive: true });
+      try {
+        symlinkSync(external, join(root, "custom_nodes", "comfyui-reactor"), "junction");
+      } catch {
+        // Directory junction creation can be denied on Windows CI; the other
+        // three cases remain fully exercised on that host.
+        return;
+      }
+      expect((await install("comfyui-reactor")).installed).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps installed:false while the settled queue is still processing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
+    try {
+      mkdirSync(join(root, "custom_nodes"), { recursive: true });
+      state.scanBase = root;
+      state.queueStatus = { pending_count: 1, is_processing: true };
+      state.afterDispatch = () => {
+        const pack = join(root, "custom_nodes", "comfyui-reactor");
+        mkdirSync(pack, { recursive: true });
+        writeFileSync(join(pack, ".tracking"), "{}\n");
+        writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      };
+
+      const result = await install("comfyui-reactor");
+
+      expect(state.calls).toEqual(["nodes_install", "nodes_queue_status"]);
+      expect(result.installed).toBe(false);
+      expect(result.verified).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
+++ b/src/__tests__/orchestrator/install-registry-disk-verification.test.ts
@@ -1,0 +1,164 @@
+// #2180 — Panel 0.15.71 can report a registry install as unverified when the
+// zip landed in custom_nodes but Manager did not add it to its installed list.
+// The MCP fallback is allowed only with same-target local, readable pack evidence.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  remote: false,
+  scanBase: undefined as string | undefined,
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    isRemoteMode: () => state.remote,
+    getBootLocalComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  };
+});
+
+vi.mock("../../services/workspace-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/workspace-env.js")>();
+  return {
+    ...actual,
+    resolveCustomNodesScanBaseLive: async () => state.scanBase,
+  };
+});
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+
+function installDef() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
+  if (!def) throw new Error("panel_install_node is not registered");
+  return def;
+}
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "nodes_install") {
+        return {
+          queued: true,
+          installed: false,
+          verified: false,
+          pending: false,
+          id: "comfyui-reactor",
+          dialect: "v4",
+          note: "The installed list did not contain the target.",
+        };
+      }
+      if (cmd.cmd === "nodes_queue_status") {
+        return { status: { pending_count: 0, is_processing: true } };
+      }
+      return { ok: true };
+    },
+    tabIncarnation: () => "inc-A",
+    tabIsLocal: () => true,
+    tabServerOrigin: () => "http://127.0.0.1:8188",
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function install(id: string): Promise<Record<string, unknown>> {
+  const ctx = makePanelToolCtx(bridge(), TAB, new WorkflowTargetStore());
+  const result: ToolResult = await installDef().handler({ id } as never, ctx);
+  const text = result.content.find((content) => content.type === "text");
+  if (!text || text.type !== "text") throw new Error("install result had no text payload");
+  return JSON.parse(text.text) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  state.remote = false;
+  state.scanBase = undefined;
+});
+
+describe("panel_install_node registry verification (#2180)", () => {
+  it("accepts a readable pack on the live target and reports restart_required", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
+    try {
+      const pack = join(root, "custom_nodes", "comfyui-reactor");
+      mkdirSync(pack, { recursive: true });
+      writeFileSync(join(pack, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      state.scanBase = root;
+
+      const result = await install("comfyui-reactor");
+
+      expect(result.installed).toBe(true);
+      expect(result.verified).toBe(true);
+      expect(result.restart_required).toBe(true);
+      expect(result.verification_evidence).toBe("on-disk");
+      expect(String(result.note)).toMatch(/readable custom-node pack/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the panel failure when the matching directory is absent or the panel is remote", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
+    try {
+      const unrelated = join(root, "custom_nodes", "another-pack");
+      mkdirSync(unrelated, { recursive: true });
+      writeFileSync(join(unrelated, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      state.scanBase = root;
+
+      const absent = await install("comfyui-reactor");
+      expect(absent.installed).toBe(false);
+      expect(absent.verified).toBe(false);
+      expect(absent.restart_required).toBeUndefined();
+
+      const matching = join(root, "custom_nodes", "comfyui-reactor");
+      mkdirSync(matching, { recursive: true });
+      writeFileSync(join(matching, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      state.remote = true;
+
+      const remote = await install("comfyui-reactor");
+      expect(remote.installed).toBe(false);
+      expect(remote.verified).toBe(false);
+      expect(remote.restart_required).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not promote an install-marker-only directory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-2180-"));
+    try {
+      const pack = join(root, "custom_nodes", "comfyui-reactor");
+      mkdirSync(pack, { recursive: true });
+      writeFileSync(join(pack, ".tracking"), "{}\n");
+      state.scanBase = root;
+
+      const result = await install("comfyui-reactor");
+
+      expect(result.installed).toBe(false);
+      expect(result.verified).toBe(false);
+      expect(result.restart_required).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4234,10 +4234,15 @@ async function captureRegistryInstallSnapshot(
 }
 
 function queueStatusRecord(reply: Record<string, unknown> | null): Record<string, unknown> | null {
-  const status = reply?.status ?? reply;
-  return status && typeof status === "object" && !Array.isArray(status)
-    ? (status as Record<string, unknown>)
-    : null;
+  if (!reply) return null;
+  const nested = reply.status;
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    // Manager responses can put queue counters under `status` while leaving
+    // failure metadata (for example recent_failures) on the outer envelope.
+    // Flatten both records so the settlement gate cannot discard that evidence.
+    return { ...reply, ...(nested as Record<string, unknown>) };
+  }
+  return reply;
 }
 
 function explicitQueueFailure(value: unknown): boolean {
@@ -4279,8 +4284,14 @@ function queueReportsFailure(status: Record<string, unknown>): boolean {
   return state === "failed" || state === "failure" || state === "error";
 }
 
-function queueSettledForDiskCorroboration(status: Record<string, unknown> | null): boolean {
-  if (!status || queueReportsFailure(status) || status.is_processing !== false) return false;
+function queueSettledForDiskCorroboration(
+  status: Record<string, unknown> | null,
+  outerReply?: Record<string, unknown> | null,
+): boolean {
+  if (!status || queueReportsFailure(status) || (outerReply && queueReportsFailure(outerReply))) {
+    return false;
+  }
+  if (status.is_processing !== false) return false;
   for (const key of ["pending_count", "in_progress_count"]) {
     if (typeof status[key] === "number" && status[key] !== 0) return false;
   }
@@ -4428,7 +4439,7 @@ async function settleDroppedEnqueue(
   if (!queueNeverSawATask(queueReply)) {
     return {
       result: res,
-      mayCorroborateDisk: queueSettledForDiskCorroboration(status),
+      mayCorroborateDisk: queueSettledForDiskCorroboration(status, queueReply),
     };
   }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -53,7 +53,11 @@ import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
-import { nodesInstallCommandArgs } from "../services/node-management.js";
+import {
+  findPackOnDisk,
+  looksLikeAPack,
+  nodesInstallCommandArgs,
+} from "../services/node-management.js";
 import { sanitizePanelUpdateNodeResult } from "../services/manager-update-error.js";
 import {
   formatQueueStatusPartialNote,
@@ -351,7 +355,10 @@ import { describeUnappliedFilters } from "./civitai-filter-guard.js";
 import { recordTodo, normalizeTodoItems, TODO_STATUS_INPUTS } from "./todo-state.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
-import { resolveEffectiveComfyUIBase } from "../services/workspace-env.js";
+import {
+  resolveCustomNodesScanBaseLive,
+  resolveEffectiveComfyUIBase,
+} from "../services/workspace-env.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { RunCompletions } from "./run-completion-journal.js";
@@ -4115,6 +4122,100 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
 function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined {
   const b = ctx.bridge as { tabIncarnation?: (t: string) => string | undefined };
   return typeof b?.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
+}
+
+/**
+ * #2180 — Panel v0.15.71 verifies Manager installs from the Manager's installed
+ * list. A registry zip can land in custom_nodes without being in that list, so
+ * the panel truthfully answers installed:false even though ComfyUI will load it
+ * after a restart.
+ *
+ * This is deliberately a narrow, local-only corroboration. The panel binding is
+ * proven against the boot ComfyUI before dispatch, the live scan root is resolved
+ * from that local ComfyUI (not the saved workspace), and the matched directory is
+ * both readable and pack-shaped. A path that cannot be read, a remote panel, an
+ * ambiguous target, or a non-registry spelling leaves the panel's failure intact.
+ */
+async function corroborateUntrackedRegistryInstall(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+  args: Record<string, unknown>,
+  dispatch: { tab: string; incarnation: string | undefined },
+  panelBaseBeforeDispatch: string | null,
+): Promise<ToolResult> {
+  if (res.isError) return res;
+  const parsed = parseToolResultJson(res);
+  if (
+    !parsed ||
+    parsed.installed !== false ||
+    parsed.verified !== false ||
+    !claimsQueued(parsed)
+  ) {
+    return res;
+  }
+
+  // Only a registry id has an identity that can be checked safely here. A URL,
+  // owner/repo shorthand, or a caller-supplied repository may land under a
+  // renamed checkout; guessing its directory would turn unrelated disk state
+  // into a success claim.
+  const id = typeof args.id === "string" ? args.id.trim() : "";
+  if (!id || /[/\\\x00-\x1F\x7F]/.test(id) || /^[a-z][a-z0-9+.-]*:\/\//i.test(id)) return res;
+
+  // The follow-up must still be attributable to the panel that received the
+  // install. This mirrors settleDroppedEnqueue's takeover guard.
+  if (ctx.tabId !== dispatch.tab || dispatch.incarnation === undefined) return res;
+  if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
+  if (!panelBaseBeforeDispatch || !sameHttpBase(getComfyUIBaseUrl(), panelBaseBeforeDispatch)) {
+    return res;
+  }
+
+  let scanBase: string | undefined;
+  try {
+    scanBase = await resolveCustomNodesScanBaseLive({ requireLive: true });
+  } catch {
+    return res;
+  }
+  if (!scanBase) return res;
+
+  const disk = findPackOnDisk(id, scanBase);
+  if (disk.state !== "found") return res;
+
+  // looksLikeAPack intentionally treats an unreadable directory as
+  // inconclusive for existing install workflows. Re-read the matched directory
+  // here so an EACCES/race cannot become positive verification.
+  let readable = false;
+  try {
+    readable = readdirSync(disk.dir).length > 0 && looksLikeAPack(disk.dir);
+  } catch {
+    return res;
+  }
+  if (!readable) return res;
+
+  const { installed: _installed, verified: _verified, pending: _pending, note, ...rest } = parsed;
+  const upgraded = {
+    ...rest,
+    installed: true,
+    verified: true,
+    restart_required: true,
+    verification_evidence: "on-disk",
+    note: [
+      typeof note === "string" ? note : undefined,
+      `The panel could not verify registry id "${id}", but a readable custom-node pack is present at ${disk.dir}.`,
+      "Restart ComfyUI before relying on newly installed nodes; restart_required is true because the running node registry was not verified.",
+    ]
+      .filter(Boolean)
+      .join(" "),
+  };
+  return {
+    ...res,
+    content: [
+      { type: "text", text: JSON.stringify(upgraded, null, 2) },
+      ...res.content.slice(1),
+    ],
+    ...(res.structuredContent
+      ? { structuredContent: { ...res.structuredContent, ...upgraded } }
+      : {}),
+  };
 }
 
 async function settleDroppedEnqueue(
@@ -18672,6 +18773,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // #1129 — the panel identity is captured BEFORE dispatch, because a
         // takeover during the install is exactly what the follow-up read must not
         // be attributed to.
+        // #2180 — the local disk corroboration below uses the same server-authorized
+        // binding, captured before dispatch, so a reconnect cannot retarget it.
+        const panelBaseBeforeDispatch = captureRebootHealthBase(ctx);
         const dispatch = {
           tab: ctx.tabId,
           incarnation: panelIncarnation(ctx, ctx.tabId),
@@ -18686,7 +18790,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // and silently does nothing. Git notes describe v4 bare-name resolution, but
         // v4 Git requests now fail before this point and legacy 3.x receives files:[url]
         // directly; appending that v4 note to a legacy success would be false.
-        const settled = await settleDroppedEnqueue(ctx, res, dispatch);
+        const corroborated = await corroborateUntrackedRegistryInstall(
+          ctx,
+          res,
+          args,
+          dispatch,
+          panelBaseBeforeDispatch,
+        );
+        const settled = await settleDroppedEnqueue(ctx, corroborated, dispatch);
         if (note && !cmdArgs.repository) {
           const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -32,7 +32,7 @@ import {
   toolAllowed,
 } from "../tools/tool-surface-filter.js";
 import { logger as toolPolicyLogger } from "../utils/logger.js";
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
 import {
   forwardedByReferenceNote,
@@ -55,7 +55,6 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import {
   findPackOnDisk,
-  looksLikeAPack,
   nodesInstallCommandArgs,
 } from "../services/node-management.js";
 import { sanitizePanelUpdateNodeResult } from "../services/manager-update-error.js";
@@ -4124,84 +4123,232 @@ function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined 
   return typeof b?.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
 }
 
+type RegistryInstallSnapshot = {
+  id: string;
+  scanBase: string;
+  before: ReturnType<typeof findPackOnDisk>;
+};
+
+type QueueSettlement = {
+  result: ToolResult;
+  /** True only after the queued response has gone through a same-panel queue read. */
+  mayCorroborateDisk: boolean;
+};
+
+function registryInstallId(args: Record<string, unknown>): string | null {
+  // The normalized command is the authority here. In particular, a repository
+  // URL that arrived in `id` has already been rerouted to `repository` and must
+  // not enter this local registry-only fallback.
+  if (args.repository !== undefined || typeof args.id !== "string") return null;
+  const id = args.id.trim();
+  if (!id || /[/\\\x00-\x1F\x7F]/.test(id) || /^[a-z][a-z0-9+.-]*:\/\//i.test(id)) {
+    return null;
+  }
+  return id;
+}
+
+/** A path comparison that does not let case or slash spelling retarget evidence on Windows. */
+function sameFilesystemPath(a: string, b: string): boolean {
+  try {
+    const normalize = (value: string) => resolve(value).replace(/[\\/]+$/, "");
+    const left = normalize(a);
+    const right = normalize(b);
+    return process.platform === "win32"
+      ? left.toLowerCase() === right.toLowerCase()
+      : left === right;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * #2180 — Panel v0.15.71 verifies Manager installs from the Manager's installed
- * list. A registry zip can land in custom_nodes without being in that list, so
- * the panel truthfully answers installed:false even though ComfyUI will load it
- * after a restart.
+ * Strict post-install evidence for the registry-only fallback.
  *
- * This is deliberately a narrow, local-only corroboration. The panel binding is
- * proven against the boot ComfyUI before dispatch, the live scan root is resolved
- * from that local ComfyUI (not the saved workspace), and the matched directory is
- * both readable and pack-shaped. A path that cannot be read, a remote panel, an
- * ambiguous target, or a non-registry spelling leaves the panel's failure intact.
+ * `findPackOnDisk` is intentionally broader because other node-management
+ * operations must recognize renamed and disabled packs. This fallback needs a
+ * narrower answer: the exact, newly-created, enabled directory, with Manager's
+ * tracking marker and readable Python/package metadata. A symlink, marker-only
+ * husk, arbitrary same-name folder, or any read error is inconclusive.
+ */
+function inspectNewRegistryPack(
+  id: string,
+  scanBase: string,
+): { state: "found"; dir: string } | { state: "not-found"; scanned: string } | { state: "unreadable"; reason: string } {
+  const customNodes = join(scanBase, "custom_nodes");
+  try {
+    const entries = readdirSync(customNodes, { withFileTypes: true });
+    const wanted = id.toLowerCase();
+    const entry = entries.find((candidate) => candidate.name.toLowerCase() === wanted);
+    if (!entry || entry.isSymbolicLink() || !entry.isDirectory()) {
+      return { state: "not-found", scanned: customNodes };
+    }
+
+    const dir = join(customNodes, entry.name);
+    const lstat = lstatSync(dir);
+    if (!lstat.isDirectory() || lstat.isSymbolicLink()) {
+      return { state: "not-found", scanned: customNodes };
+    }
+    // Reject junctions and other directory indirections too. The panel's local
+    // proof must describe the directory Manager just populated, not another tree.
+    if (!sameFilesystemPath(realpathSync(dir), dir)) {
+      return { state: "not-found", scanned: customNodes };
+    }
+
+    const files = readdirSync(dir, { withFileTypes: true });
+    const tracking = files.find((file) => file.name === ".tracking" && file.isFile());
+    const code = files.find(
+      (file) =>
+        file.isFile() &&
+        (file.name.toLowerCase() === "__init__.py" ||
+          file.name.toLowerCase() === "pyproject.toml" ||
+          file.name.toLowerCase().endsWith(".py")),
+    );
+    if (!tracking || !code) return { state: "not-found", scanned: customNodes };
+
+    // Reading both the Manager marker and the loadable file makes an access
+    // failure a refusal, never a truthy `looksLikeAPack` fallback.
+    readFileSync(join(dir, tracking.name));
+    readFileSync(join(dir, code.name));
+    return { state: "found", dir };
+  } catch (err) {
+    return {
+      state: "unreadable",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function captureRegistryInstallSnapshot(
+  args: Record<string, unknown>,
+  panelBaseBeforeDispatch: string | null,
+): Promise<RegistryInstallSnapshot | null> {
+  const id = registryInstallId(args);
+  if (!id || !panelBaseBeforeDispatch) return null;
+  try {
+    const scanBase = await resolveCustomNodesScanBaseLive({ requireLive: true });
+    if (!scanBase) return null;
+    return { id, scanBase, before: findPackOnDisk(id, scanBase) };
+  } catch {
+    return null;
+  }
+}
+
+function queueStatusRecord(reply: Record<string, unknown> | null): Record<string, unknown> | null {
+  const status = reply?.status ?? reply;
+  return status && typeof status === "object" && !Array.isArray(status)
+    ? (status as Record<string, unknown>)
+    : null;
+}
+
+function queueReportsFailure(status: Record<string, unknown>): boolean {
+  for (const key of ["failed", "error", "failure"]) {
+    if (status[key] === true) return true;
+  }
+  for (const key of ["failed_count", "failure_count"]) {
+    if (typeof status[key] === "number" && status[key] > 0) return true;
+  }
+  for (const key of ["failures", "recent_failures", "errors"]) {
+    const value = status[key];
+    if (Array.isArray(value) && value.length > 0) return true;
+    if (typeof value === "string" && value.trim() !== "") return true;
+    if (value && typeof value === "object" && !Array.isArray(value)) return true;
+  }
+  return status.status === "failed" || status.status === "error";
+}
+
+function queueSettledForDiskCorroboration(status: Record<string, unknown> | null): boolean {
+  if (!status || queueReportsFailure(status) || status.is_processing !== false) return false;
+  for (const key of ["pending_count", "in_progress_count"]) {
+    if (typeof status[key] === "number" && status[key] !== 0) return false;
+  }
+  // A legacy zero-total idle snapshot is the known dropped-enqueue signature;
+  // settleDroppedEnqueue turns that into a warning and blocks this path. A v4
+  // idle snapshot has no total_count, so the strict disk delta remains the
+  // available post-install evidence.
+  if (status.total_count === 0) return false;
+  if (
+    typeof status.total_count === "number" &&
+    (typeof status.done_count !== "number" || status.done_count <= 0)
+  ) {
+    return false;
+  }
+  return typeof status.pending_count === "number" ||
+    (typeof status.total_count === "number" && status.total_count > 0) ||
+    (typeof status.done_count === "number" && status.done_count > 0);
+}
+
+/**
+ * #2180 — Panel 0.15.71 can report a registry install as unverified when a
+ * registry zip lands in custom_nodes without entering the installed list.
+ *
+ * The fallback is deliberately narrower than the normal node-management disk
+ * scan: it can only corroborate a registry id whose target was absent in a
+ * pre-dispatch snapshot, after the queued response has passed queue settlement,
+ * and only when a strict new-pack read succeeds on the same live target.
  */
 async function corroborateUntrackedRegistryInstall(
   ctx: PanelToolCtx,
   res: ToolResult,
-  args: Record<string, unknown>,
+  snapshot: RegistryInstallSnapshot | null,
   dispatch: { tab: string; incarnation: string | undefined },
   panelBaseBeforeDispatch: string | null,
+  mayCorroborateDisk: boolean,
 ): Promise<ToolResult> {
-  if (res.isError) return res;
+  if (!mayCorroborateDisk || res.isError || !snapshot || snapshot.before.state !== "not-found") {
+    return res;
+  }
   const parsed = parseToolResultJson(res);
   if (
     !parsed ||
     parsed.installed !== false ||
     parsed.verified !== false ||
-    !claimsQueued(parsed)
+    !claimsQueued(parsed) ||
+    parsed.failed === true ||
+    parsed.error === true
   ) {
     return res;
   }
 
-  // Only a registry id has an identity that can be checked safely here. A URL,
-  // owner/repo shorthand, or a caller-supplied repository may land under a
-  // renamed checkout; guessing its directory would turn unrelated disk state
-  // into a success claim.
-  const id = typeof args.id === "string" ? args.id.trim() : "";
-  if (!id || /[/\\\x00-\x1F\x7F]/.test(id) || /^[a-z][a-z0-9+.-]*:\/\//i.test(id)) return res;
+  // Require the panel response to echo the same registry identity. A fresh
+  // directory with only a caller-supplied same-name id is not proof that the
+  // Manager installed that id.
+  if (
+    typeof parsed.id !== "string" ||
+    parsed.id.trim().toLowerCase() !== snapshot.id.toLowerCase()
+  ) {
+    return res;
+  }
 
-  // The follow-up must still be attributable to the panel that received the
-  // install. This mirrors settleDroppedEnqueue's takeover guard.
+  // The follow-up must still be attributable to the panel and server that were
+  // captured before dispatch. This mirrors settleDroppedEnqueue's takeover guard
+  // and keeps local disk evidence inside the requireLive/security scope.
   if (ctx.tabId !== dispatch.tab || dispatch.incarnation === undefined) return res;
   if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
   if (!panelBaseBeforeDispatch || !sameHttpBase(getComfyUIBaseUrl(), panelBaseBeforeDispatch)) {
     return res;
   }
 
-  let scanBase: string | undefined;
+  let liveScanBase: string | undefined;
   try {
-    scanBase = await resolveCustomNodesScanBaseLive({ requireLive: true });
+    liveScanBase = await resolveCustomNodesScanBaseLive({ requireLive: true });
   } catch {
     return res;
   }
-  if (!scanBase) return res;
+  if (!liveScanBase || !sameFilesystemPath(liveScanBase, snapshot.scanBase)) return res;
 
-  const disk = findPackOnDisk(id, scanBase);
+  const disk = inspectNewRegistryPack(snapshot.id, snapshot.scanBase);
   if (disk.state !== "found") return res;
 
-  // looksLikeAPack intentionally treats an unreadable directory as
-  // inconclusive for existing install workflows. Re-read the matched directory
-  // here so an EACCES/race cannot become positive verification.
-  let readable = false;
-  try {
-    readable = readdirSync(disk.dir).length > 0 && looksLikeAPack(disk.dir);
-  } catch {
-    return res;
-  }
-  if (!readable) return res;
-
-  const { installed: _installed, verified: _verified, pending: _pending, note, ...rest } = parsed;
   const upgraded = {
-    ...rest,
+    ...parsed,
     installed: true,
     verified: true,
     restart_required: true,
-    verification_evidence: "on-disk",
+    verification_evidence: "new-on-disk-registry-pack",
     note: [
-      typeof note === "string" ? note : undefined,
-      `The panel could not verify registry id "${id}", but a readable custom-node pack is present at ${disk.dir}.`,
-      "Restart ComfyUI before relying on newly installed nodes; restart_required is true because the running node registry was not verified.",
+      typeof parsed.note === "string" ? parsed.note : undefined,
+      `The pre-install snapshot found no matching pack, and after queue settlement a readable enabled registry pack with Manager tracking metadata appeared at ${disk.dir}.`,
+      "The disk evidence does not establish the requested version or channel; those response fields were preserved unchanged. Restart ComfyUI before relying on the new nodes.",
     ]
       .filter(Boolean)
       .join(" "),
@@ -4222,9 +4369,11 @@ async function settleDroppedEnqueue(
   ctx: PanelToolCtx,
   res: ToolResult,
   dispatch: { tab: string; incarnation: string | undefined },
-): Promise<ToolResult> {
-  if (res.isError) return res;
-  if (!claimsQueued(parseToolResultJson(res))) return res;
+): Promise<QueueSettlement> {
+  if (res.isError) return { result: res, mayCorroborateDisk: false };
+  if (!claimsQueued(parseToolResultJson(res))) {
+    return { result: res, mayCorroborateDisk: false };
+  }
 
   // The queue is only evidence about the panel the install was DISPATCHED to
   // (codex P1 — and the same guard #1468 needed, which I did not carry across).
@@ -4238,7 +4387,7 @@ async function settleDroppedEnqueue(
   // draws exactly this distinction and exposes `tabIncarnation` for it (#486), so
   // both are captured: the key AND the incarnation currently holding it.
   const queue = await ctx.call({ cmd: "nodes_queue_status" }, 15000);
-  if (ctx.tabId !== dispatch.tab) return res;
+  if (ctx.tabId !== dispatch.tab) return { result: res, mayCorroborateDisk: false };
   // Both captured BEFORE the install was dispatched, not here — a takeover that
   // happens DURING the install is already baked in by the time this function
   // runs, so comparing two post-install readings would always agree and the guard
@@ -4246,9 +4395,19 @@ async function settleDroppedEnqueue(
   // UNKNOWN is not "unchanged": a bridge that cannot report an incarnation cannot
   // rule out a same-key takeover, so it does not get to make a claim about which
   // panel answered.
-  if (dispatch.incarnation === undefined) return res;
-  if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) return res;
-  if (queue.isError || !queueNeverSawATask(parseToolResultJson(queue))) return res;
+  if (dispatch.incarnation === undefined) return { result: res, mayCorroborateDisk: false };
+  if (panelIncarnation(ctx, ctx.tabId) !== dispatch.incarnation) {
+    return { result: res, mayCorroborateDisk: false };
+  }
+  if (queue.isError) return { result: res, mayCorroborateDisk: false };
+  const queueReply = parseToolResultJson(queue);
+  const status = queueStatusRecord(queueReply);
+  if (!queueNeverSawATask(queueReply)) {
+    return {
+      result: res,
+      mayCorroborateDisk: queueSettledForDiskCorroboration(status),
+    };
+  }
 
   // NO PROVENANCE CLAIM AT ALL — deliberately, after five review rounds.
   //
@@ -4263,9 +4422,10 @@ async function settleDroppedEnqueue(
   // saying, needs no provenance, and cannot be wrong. The cause belongs to
   // whoever can see the install — so the message asks for the ONE check that
   // settles it and stops there. Less useful in the common case; never false.
-  return appendNote(
-    res,
-    `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but a ` +
+  return {
+    result: appendNote(
+      res,
+      `WARNING — THE QUEUE DOES NOT HAVE THIS TASK. The Manager accepted the install above, but a ` +
       `read taken immediately afterwards, on that same panel, reports an IDLE queue holding no ` +
       `tasks at all (total_count, done, in_progress all 0). "queued" is its acknowledgement, not ` +
       `a receipt.\n\n` +
@@ -4278,7 +4438,9 @@ async function settleDroppedEnqueue(
       `pack really landed instead of trusting the queue, and can clone a repository URL directly ` +
       `when the Manager will not take it. This tool cannot clone for you — it drives whatever ` +
       `ComfyUI the panel is bound to, which need not be this machine.`,
-  );
+    ),
+    mayCorroborateDisk: false,
+  };
 }
 
 /**
@@ -18780,24 +18942,30 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           tab: ctx.tabId,
           incarnation: panelIncarnation(ctx, ctx.tabId),
         };
+        // #2180 — this snapshot must happen BEFORE Manager dispatch. A post-only
+        // scan cannot distinguish a newly landed registry zip from an old pack,
+        // a concurrent writer, or a directory that merely shares the id.
+        const registrySnapshot = await captureRegistryInstallSnapshot(
+          cmdArgs,
+          panelBaseBeforeDispatch,
+        );
         const res = await ctx.call(
           { cmd: "nodes_install", ...cmdArgs },
           30000,
         );
-        // #1129 — settle BEFORE any supplemental note is appended. The note is glued on
-        // after the JSON body, which makes the payload unparseable as JSON, so a probe
-        // running afterwards reads `null`, concludes the panel never claimed a queue,
-        // and silently does nothing. Git notes describe v4 bare-name resolution, but
-        // v4 Git requests now fail before this point and legacy 3.x receives files:[url]
-        // directly; appending that v4 note to a legacy success would be false.
+        // #1129 / #2180 — settle EVERY queued/pending response before any disk
+        // corroboration. An early rewrite would bypass the queue read and could
+        // turn a still-running or failed request into installed:true.
+        const settlement = await settleDroppedEnqueue(ctx, res, dispatch);
         const corroborated = await corroborateUntrackedRegistryInstall(
           ctx,
-          res,
-          args,
+          settlement.result,
+          registrySnapshot,
           dispatch,
           panelBaseBeforeDispatch,
+          settlement.mayCorroborateDisk,
         );
-        const settled = await settleDroppedEnqueue(ctx, corroborated, dispatch);
+        const settled = corroborated;
         if (note && !cmdArgs.repository) {
           const text = settled.content.find((c) => c.type === "text");
           if (text && text.type === "text") {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4240,20 +4240,43 @@ function queueStatusRecord(reply: Record<string, unknown> | null): Record<string
     : null;
 }
 
+function explicitQueueFailure(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === "number") return Number.isFinite(value) && value > 0;
+  if (typeof value === "string") return value.trim() !== "";
+  if (Array.isArray(value)) return value.length > 0;
+  return value !== null && typeof value === "object";
+}
+
 function queueReportsFailure(status: Record<string, unknown>): boolean {
-  for (const key of ["failed", "error", "failure"]) {
-    if (status[key] === true) return true;
+  // These are the protocol's explicit failure payloads. Empty lists/strings and
+  // false flags are not failures; every non-empty/error-shaped value is.
+  for (const key of [
+    "failed",
+    "error",
+    "failure",
+    "failures",
+    "recent_failures",
+    "errors",
+  ]) {
+    if (explicitQueueFailure(status[key])) return true;
   }
-  for (const key of ["failed_count", "failure_count"]) {
+  for (const key of [
+    "failed_count",
+    "failure_count",
+    "error_count",
+    "fail_count",
+  ]) {
     if (typeof status[key] === "number" && status[key] > 0) return true;
   }
-  for (const key of ["failures", "recent_failures", "errors"]) {
-    const value = status[key];
-    if (Array.isArray(value) && value.length > 0) return true;
-    if (typeof value === "string" && value.trim() !== "") return true;
-    if (value && typeof value === "object" && !Array.isArray(value)) return true;
+  if (typeof status.failure_reporting === "string") {
+    const reporting = status.failure_reporting.trim().toLowerCase();
+    if (reporting === "failed" || reporting === "failure" || reporting === "error") {
+      return true;
+    }
   }
-  return status.status === "failed" || status.status === "error";
+  const state = typeof status.status === "string" ? status.status.toLowerCase() : "";
+  return state === "failed" || state === "failure" || state === "error";
 }
 
 function queueSettledForDiskCorroboration(status: Record<string, unknown> | null): boolean {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2591,7 +2591,7 @@ function isLoadablePackFileName(name: string): boolean {
  * `custom_nodes/`): fall through to the two files every loadable pack has.
  * Unreadable is not a finding either way.
  */
-export function looksLikeAPack(dir: string): boolean {
+function looksLikeAPack(dir: string): boolean {
   try {
     const names = readdirSync(dir).map((entry) =>
       readdirEntryName(entry as string | { name: string }),

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2591,7 +2591,7 @@ function isLoadablePackFileName(name: string): boolean {
  * `custom_nodes/`): fall through to the two files every loadable pack has.
  * Unreadable is not a finding either way.
  */
-function looksLikeAPack(dir: string): boolean {
+export function looksLikeAPack(dir: string): boolean {
   try {
     const names = readdirSync(dir).map((entry) =>
       readdirEntryName(entry as string | { name: string }),


### PR DESCRIPTION
## Summary\n- verify registry installs using strict pre/post live-disk evidence\n- preserve queue settlement and fail closed on nested or envelope-level failure metadata\n- report restart_required only for a newly landed valid pack\n\nIssue: #2180\n\nValidation: 124 focused tests, build, no-emit typecheck, vocabulary check, and diff check passed. Full suite not run.