### PR TITLE
fix: respect pinned npx runtime versions

### DIFF
--- a/src/__tests__/services/self-restart.test.ts
+++ b/src/__tests__/services/self-restart.test.ts
@@ -3,10 +3,14 @@
 // timers, registry, or process spawns).
 
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SelfRestarter, type SelfRestartDeps } from "../../services/self-restart.js";
+import {
+  defaultSpawnReplacement,
+  SelfRestarter,
+  type SelfRestartDeps,
+} from "../../services/self-restart.js";
 import { releaseOwnedPanelLock } from "../../services/panel-pin-guard.js";
 import type { InstallInfo, SelfUpdateResult } from "../../services/self-update.js";
 
@@ -25,6 +29,8 @@ function makeHarness(opts: {
   latest?: string;
   updateResult?: SelfUpdateResult;
   env?: NodeJS.ProcessEnv;
+  packageDir?: string;
+  argv?: readonly string[];
   uptimeMs?: number;
   spawnOk?: boolean;
   mtime?: number;
@@ -40,9 +46,10 @@ function makeHarness(opts: {
   const mode = opts.mode ?? "linked";
   const deps: Partial<SelfRestartDeps> = {
     env: () => opts.env ?? {},
+    argv: () => opts.argv ?? process.argv,
     detectInstall: () => ({
       mode,
-      packageDir: "/pkg",
+      packageDir: opts.packageDir ?? "/pkg",
       currentVersion: opts.currentVersion ?? "1.0.0",
       isDevLink: mode === "linked",
     }),
@@ -179,7 +186,7 @@ describe("SelfRestarter — published installs", () => {
       mode: "npx",
       currentVersion: "1.0.0",
       latest: "1.2.0",
-      env: { npm_config_package: "comfyui-mcp" },
+      argv: ["npx.cmd", "-y", "comfyui-mcp", "connect"],
     });
     h.restarter.start();
     await h.restarter.updateTick();
@@ -188,22 +195,35 @@ describe("SelfRestarter — published installs", () => {
     expect(h.spawns[0]?.npxVersion).toBe("1.2.0");
   });
 
-  it("npx: an exact launch pin does not update or tear down the healthy runtime", async () => {
-    const h = makeHarness({
-      mode: "npx",
-      currentVersion: "0.52.66",
-      latest: "0.52.67",
-      env: { npm_config_package: "comfyui-mcp@0.52.66" },
-    });
-    h.restarter.start();
-    await h.restarter.updateTick();
-    await Promise.resolve();
+  it("npx: positional exact pin from the execution cache keeps the healthy runtime", async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), "cmcp-npx-pin-"));
+    const packageDir = join(cacheRoot, "node_modules", "comfyui-mcp");
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(cacheRoot, "package.json"),
+      JSON.stringify({ _npx: { packages: ["comfyui-mcp@0.52.66"] } }),
+    );
+    try {
+      const h = makeHarness({
+        mode: "npx",
+        packageDir,
+        currentVersion: "0.52.66",
+        latest: "0.52.67",
+        env: {},
+        argv: ["C:\\npx.cmd", "-y", "comfyui-mcp", "connect"],
+      });
+      h.restarter.start();
+      await h.restarter.updateTick();
+      await Promise.resolve();
 
-    // The dangerous regression was not merely selecting the wrong child: the
-    // parent was torn down after spawning it. A pin must leave every handoff
-    // step untouched, so a stalled replacement cannot take down the service.
-    expect(h.calls).toEqual([]);
-    expect(h.spawns).toEqual([]);
+      // npm's positional npx child has no package spec in env or argv. The
+      // cache manifest is the production provenance that distinguishes this
+      // exact pin from the bare command above.
+      expect(h.calls).toEqual([]);
+      expect(h.spawns).toEqual([]);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
   });
 
   it("npx: @latest remains unpinned and keeps the spawn-first handoff", async () => {
@@ -225,6 +245,26 @@ describe("SelfRestarter — published installs", () => {
     h.restarter.start();
     await h.restarter.updateTick();
     expect(h.calls).toEqual([]);
+  });
+
+  it("production npx replacement passes the positional package version", () => {
+    let captured:
+      | { command: string; args: readonly string[]; options: { detached?: boolean; shell?: boolean } }
+      | undefined;
+    const ok = defaultSpawnReplacement({
+      npxVersion: "0.52.67",
+      env: { PATH: "/usr/bin" },
+      spawn: (command, args, options) => {
+        captured = { command, args, options };
+        return { pid: 4321, unref() {} };
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(captured?.command).toBe(process.platform === "win32" ? "npx.cmd" : "npx");
+    expect(captured?.args.slice(0, 2)).toEqual(["-y", "comfyui-mcp@0.52.67"]);
+    expect(captured?.args.slice(2)).toEqual(process.argv.slice(2));
+    expect(captured?.options.detached).toBe(true);
   });
 });
 

--- a/src/__tests__/services/self-restart.test.ts
+++ b/src/__tests__/services/self-restart.test.ts
@@ -175,12 +175,49 @@ describe("SelfRestarter — published installs", () => {
   });
 
   it("npx: respawns pinned to the newer version", async () => {
-    const h = makeHarness({ mode: "npx", currentVersion: "1.0.0", latest: "1.2.0" });
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "1.0.0",
+      latest: "1.2.0",
+      env: { npm_config_package: "comfyui-mcp" },
+    });
     h.restarter.start();
     await h.restarter.updateTick();
     await Promise.resolve();
     expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
     expect(h.spawns[0]?.npxVersion).toBe("1.2.0");
+  });
+
+  it("npx: an exact launch pin does not update or tear down the healthy runtime", async () => {
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "0.52.66",
+      latest: "0.52.67",
+      env: { npm_config_package: "comfyui-mcp@0.52.66" },
+    });
+    h.restarter.start();
+    await h.restarter.updateTick();
+    await Promise.resolve();
+
+    // The dangerous regression was not merely selecting the wrong child: the
+    // parent was torn down after spawning it. A pin must leave every handoff
+    // step untouched, so a stalled replacement cannot take down the service.
+    expect(h.calls).toEqual([]);
+    expect(h.spawns).toEqual([]);
+  });
+
+  it("npx: @latest remains unpinned and keeps the spawn-first handoff", async () => {
+    const h = makeHarness({
+      mode: "npx",
+      currentVersion: "0.52.66",
+      latest: "0.52.67",
+      env: { npm_config_package: "comfyui-mcp@latest" },
+    });
+    h.restarter.start();
+    await h.restarter.updateTick();
+    await Promise.resolve();
+    expect(h.calls).toEqual(["spawn", "releasePanelLock", "teardown", "exit"]);
+    expect(h.spawns[0]?.npxVersion).toBe("0.52.67");
   });
 
   it("npx: same version → no restart", async () => {

--- a/src/services/self-restart.ts
+++ b/src/services/self-restart.ts
@@ -37,7 +37,8 @@
 //   COMFYUI_MCP_UPDATE_CHECK_MS        registry re-check period (default 1h)
 
 import { spawn } from "node:child_process";
-import { statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 import {
   PACKAGE_NAME,
   checkAndSelfUpdate,
@@ -77,17 +78,7 @@ function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
   return key === undefined ? undefined : env[key];
 }
 
-/**
- * Return the exact version requested by the npx invocation, if one is known.
- *
- * `npm_config_package` is set by npm for both `comfyui-mcp` and
- * `comfyui-mcp@0.52.66`. The package directory alone cannot carry this
- * distinction because npx stores both forms under the same disposable cache
- * layout. Treat only an exact semver as a pin: a bare package, `@latest`, and
- * ranges/tags retain the existing auto-update behavior.
- */
-export function npxVersionPin(env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const raw = envValue(env, NPX_PACKAGE_SPEC_ENV)?.trim();
+function exactVersionFromSpec(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
   const prefix = `${PACKAGE_NAME}@`;
   if (!raw.toLowerCase().startsWith(prefix)) return undefined;
@@ -95,8 +86,69 @@ export function npxVersionPin(env: NodeJS.ProcessEnv = process.env): string | un
   return EXACT_VERSION_SPEC.test(requested) ? requested : undefined;
 }
 
+/** Read the launch spec npm records beside an npx execution cache. */
+function npxCachePackageSpec(packageDir: string | undefined): string | undefined {
+  if (!packageDir) return undefined;
+  try {
+    // npx's package root is `_npx/<hash>`, two levels above the resolved
+    // package (`_npx/<hash>/node_modules/comfyui-mcp`). Its `_npx.packages`
+    // entry preserves an exact positional spec even though the child process
+    // itself receives only the resolved package's argv.
+    const cacheRoot = resolve(packageDir, "..", "..");
+    const metadata = JSON.parse(
+      readFileSync(join(cacheRoot, "package.json"), "utf8"),
+    ) as { _npx?: { packages?: unknown } };
+    const packages = metadata._npx?.packages;
+    if (!Array.isArray(packages)) return undefined;
+    return packages.find(
+      (candidate): candidate is string =>
+        typeof candidate === "string" && candidate.toLowerCase().startsWith(`${PACKAGE_NAME}@`),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse a raw npx command line when one is available to the caller. */
+function npxArgvPackageSpec(argv: readonly string[]): string | undefined {
+  const npxIndex = argv.findIndex((arg) => /(?:^|[\\/])npx(?:\.cmd)?$/i.test(arg));
+  if (npxIndex < 0) return undefined;
+  for (const arg of argv.slice(npxIndex + 1)) {
+    if (arg === "--" || arg === "-y" || arg === "--yes") continue;
+    if (arg.startsWith("-")) continue;
+    if (arg.toLowerCase().startsWith(`${PACKAGE_NAME}@`)) return arg;
+    if (arg.toLowerCase() === PACKAGE_NAME) return undefined;
+    break;
+  }
+  return undefined;
+}
+
+/**
+ * Return the exact version requested by the npx invocation, if one is known.
+ *
+ * Positional npx launches do not pass their package spec in the child
+ * environment or argv. npm does preserve it in the npx cache-root manifest;
+ * that is the production source of truth. Environment/raw-command fallbacks
+ * keep this helper useful for alternate npm runners and direct tests. Treat
+ * only an exact semver as a pin: a bare package, `@latest`, and ranges/tags
+ * retain the existing auto-update behavior.
+ */
+export function npxVersionPin(
+  env: NodeJS.ProcessEnv = process.env,
+  packageDir?: string,
+  argv: readonly string[] = process.argv,
+): string | undefined {
+  return (
+    exactVersionFromSpec(envValue(env, NPX_PACKAGE_SPEC_ENV)?.trim()) ??
+    exactVersionFromSpec(npxArgvPackageSpec(argv)) ??
+    exactVersionFromSpec(npxCachePackageSpec(packageDir))
+  );
+}
+
 export interface SelfRestartDeps {
   env: () => NodeJS.ProcessEnv;
+  /** Raw process argv, injectable for launch-shape tests. */
+  argv?: () => readonly string[];
   detectInstall: () => InstallInfo;
   /** self-update.ts policy engine (updates global/local installs on disk). */
   checkAndSelfUpdate: typeof checkAndSelfUpdate;
@@ -285,7 +337,10 @@ export class SelfRestarter {
   constructor(deps: Partial<SelfRestartDeps> = {}) {
     this.deps = { ...defaultSelfRestartDeps, ...deps };
     this.info = this.deps.detectInstall();
-    this.npxPin = this.info.mode === "npx" ? npxVersionPin(this.deps.env()) : undefined;
+    this.npxPin =
+      this.info.mode === "npx"
+        ? npxVersionPin(this.deps.env(), this.info.packageDir, this.deps.argv?.() ?? process.argv)
+        : undefined;
   }
 
   /** Wire the periodic checks. No-op when the master switch is off. */

--- a/src/services/self-restart.ts
+++ b/src/services/self-restart.ts
@@ -8,8 +8,9 @@
 //
 //   - PUBLISHED installs (global / local / npx): periodically re-check the npm
 //     registry. global/local self-update on disk (self-update.ts) and then
-//     restart into the new code; npx respawns pinned to the new version (npx
-//     fetches it on launch).
+//     restart into the new code; an UNPINNED npx launch respawns pinned to the
+//     new version (npx fetches it on launch). An exact npx version pin is a
+//     stability boundary and is never replaced by this process.
 //   - DEV installs (npm link / checkout): NEVER touch the disk — instead watch
 //     the running entry script's mtime and restart when a rebuild lands, so
 //     `npm run build` is all a developer needs.
@@ -64,6 +65,35 @@ const IDLE_POLL_MS = 5_000;
 /** Defense-in-depth against restart churn: never restart a process younger
  *  than this (change-driven triggers make a true loop impossible anyway). */
 const MIN_UPTIME_MS = 2 * 60 * 1000;
+
+/** npm's exec runner passes the package spec that selected this process. */
+const NPX_PACKAGE_SPEC_ENV = "npm_config_package";
+/** An exact version is a pin; tags and ranges retain the normal update policy. */
+const EXACT_VERSION_SPEC =
+  /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name);
+  return key === undefined ? undefined : env[key];
+}
+
+/**
+ * Return the exact version requested by the npx invocation, if one is known.
+ *
+ * `npm_config_package` is set by npm for both `comfyui-mcp` and
+ * `comfyui-mcp@0.52.66`. The package directory alone cannot carry this
+ * distinction because npx stores both forms under the same disposable cache
+ * layout. Treat only an exact semver as a pin: a bare package, `@latest`, and
+ * ranges/tags retain the existing auto-update behavior.
+ */
+export function npxVersionPin(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const raw = envValue(env, NPX_PACKAGE_SPEC_ENV)?.trim();
+  if (!raw) return undefined;
+  const prefix = `${PACKAGE_NAME}@`;
+  if (!raw.toLowerCase().startsWith(prefix)) return undefined;
+  const requested = raw.slice(prefix.length).trim();
+  return EXACT_VERSION_SPEC.test(requested) ? requested : undefined;
+}
 
 export interface SelfRestartDeps {
   env: () => NodeJS.ProcessEnv;
@@ -246,6 +276,8 @@ export class SelfRestarter {
   private restarting = false;
   /** Versions already announced when restart is disabled — once each. */
   private announced = new Set<string>();
+  /** Exact npx launch pins are intentional and must not trigger a replacement. */
+  private readonly npxPin: string | undefined;
   /** apply_updates_now: one tick (and its armed restart) may ignore the gate. */
   private forceApply = false;
   stopped = false;
@@ -253,6 +285,7 @@ export class SelfRestarter {
   constructor(deps: Partial<SelfRestartDeps> = {}) {
     this.deps = { ...defaultSelfRestartDeps, ...deps };
     this.info = this.deps.detectInstall();
+    this.npxPin = this.info.mode === "npx" ? npxVersionPin(this.deps.env()) : undefined;
   }
 
   /** Wire the periodic checks. No-op when the master switch is off. */
@@ -266,6 +299,11 @@ export class SelfRestarter {
     if (gen > 0) {
       logger.info(
         `[self-restart] running v${this.info.currentVersion ?? "?"} after self-restart (gen ${gen}, ${this.info.mode})`,
+      );
+    }
+    if (this.npxPin) {
+      logger.info(
+        `[self-restart] npx launch is pinned to ${this.npxPin} — automatic version replacement is disabled`,
       );
     }
 
@@ -353,7 +391,11 @@ export class SelfRestarter {
         return;
       }
       if (this.info.mode === "npx") {
-        // npx can't be updated on disk — respawn pinned to the new version.
+        // npx can't be updated on disk — an unpinned launch respawns pinned to
+        // the new version. An exact package spec is an explicit stability
+        // boundary; never turn `@0.52.66` into `@0.52.67` from inside the
+        // healthy process.
+        if (this.npxPin) return;
         const latest = await this.deps.latestVersion();
         const current = this.info.currentVersion;
         if (!latest || !current || !isNewer(latest, current)) {


### PR DESCRIPTION
## Summary\n- detect exact pinned versions from positional npx _npx.packages metadata\n- prevent pinned runtimes from resolving latest and arming replacement\n- preserve bare/@latest auto-update and spawn-first handoff\n\nIssue: artokun/comfyui-mcp-panel#1675\n\nValidation: 21 focused self-restart tests, build, lint, vocabulary, diff check, and independent review passed.