### PR TITLE
fix(2209): mode:"current" reconciles the routed tab's stale advertisement so its own prescribed recovery works

### DIFF
--- a/src/__tests__/services/stamp-target-reconcile.test.ts
+++ b/src/__tests__/services/stamp-target-reconcile.test.ts
@@ -1,0 +1,309 @@
+// #2209 — the recovery the agreement gate's own refusal prescribes now CLEARS it.
+//
+// Reported shape: after a workflow-tab switch, `panel_graph_outline` refused on a
+// workflow-instance mismatch; `panel_set_workflow_target({mode:"current"})` answered that
+// mode current was applied but that it had NOT restored the graph binding, "because it
+// compared the live canvas rather than the routed tab handshake identity"; the next graph
+// read refused identically; and retrying that identical read once succeeded.
+//
+// That disclosure is #1494's, and it was accurate — the two sides compare different facts:
+//
+//   the dispatch-time agreement gate (ui-bridge send / stampTargetVerdict)
+//        session stamp  vs  the identity the ROUTED TAB last advertised
+//   the rebind recovery (rebindWorkflowFence)
+//        session stamp  vs  the LIVE canvas read back with workflow_list
+//
+// When the ADVERTISEMENT is the stale side the rebind has nothing to move (the fence
+// already names the live canvas) and the gate goes on refusing every graph command, reads
+// included. The only thing that ever cleared it was the panel noticing its own drift and
+// re-advertising — which is what the reporter's "retry the identical read once" was
+// waiting for, and which the panel only attempts MISMATCH_REHELLO_MAX_PER_IDENTITY (3)
+// times per identity before the session is wedged for good.
+//
+// So mode:"current" now performs that same write itself, from the observation it already
+// made. These tests measure the EFFECT — the advertisement the gate reads, and whether a
+// previously-refused `graph_add_node` reaches the socket — not the reply's claims about
+// itself. The refresh validator below mirrors the orchestrator's real one
+// (orchestrator/index.ts `setTabWorkflowUuidResolver`) gate for gate, including the
+// conversation-stamp write that must NOT happen on this path.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import { isScopeAddress } from "../../services/session-scope.js";
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/** What the session is fenced to, and what the live canvas keeps reporting. */
+const LIVE = "4808c797-417c-4c33-8ab0-99cf2f6ba648";
+/** The stale value the routed tab's last handshake left behind. */
+const STALE = "caf45251-53ad-431b-afdd-02239fdb7119";
+/** A third instance — never this session's stamp, so never reconcilable onto it. */
+const OTHER = "9f0e6d21-7c4a-4b7e-9a11-5d2c3f8e4b60";
+const TAB = "wf:route1:workflows/a.json";
+const SCOPE = "orchestrator::claude";
+/** A browser panel always presents one; the relay path is the case that has none. */
+const ORIGIN = "http://127.0.0.1:8188";
+
+/** The orchestrator's key normalisation (index.ts `panelTabOf`), mirrored so the test's
+ *  map is keyed exactly the way production keys it. */
+const AGENT_KEY_SEP = "::";
+function panelTabOf(key: string): string {
+  const i = key.lastIndexOf(AGENT_KEY_SEP);
+  return i >= 0 ? key.slice(0, i) : key;
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** A self-corroborating workflow_list reply — the active record also appears in the
+ *  open-workflow list flagged active, which is what corroboration requires. */
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+describe("a stale routed-tab advertisement is RECONCILED by mode:\"current\" (#2209)", () => {
+  let bridge: UiBridge;
+  let port: number;
+
+  /** The two answers the bug is about: the per-tab advertised identity
+   *  (tabCommandWorkflowUuid) and the conversation's issue-time stamp
+   *  (turnOrigins.stampOf). */
+  const advertised = new Map<string, string>();
+  const carried = new Set<string>();
+  let sessionStamp: string | undefined;
+  /** What the fake panel says the LIVE canvas is when workflow_list is read. */
+  let liveCanvas: string;
+  let received: Array<Record<string, unknown>>;
+  /** Every (tabId, uuid) the refresh validator was asked to adopt. */
+  let adoptions: Array<{ tabId: string; uuid: string }>;
+
+  beforeEach(async () => {
+    advertised.clear();
+    carried.clear();
+    sessionStamp = undefined;
+    liveCanvas = LIVE;
+    received = [];
+    adoptions = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver(
+      (id) => (isScopeAddress(id) ? sessionStamp : advertised.get(panelTabOf(id))),
+      // The orchestrator's validator, gate for gate (index.ts). The conversation-stamp
+      // write at the end is deliberately kept: it is what makes an adoption addressed to
+      // a SCOPE address move the session, so a reconciliation that quietly addressed the
+      // caller instead of the routed tab would show up as a moved `sessionStamp`.
+      (id, uuid) => {
+        adoptions.push({ tabId: id, uuid });
+        if (!bridge.canReach(id)) return { ok: false, reason: `the routed tab ${id} is gone` };
+        const panelTab = isScopeAddress(id) ? bridge.resolveSharedTabId(id) : panelTabOf(id);
+        if (!panelTab) return { ok: false, reason: `${id} does not name a panel tab` };
+        const identity = workflowIdentityParts({
+          workflowUuid: uuid,
+          origin: bridge.tabServerOrigin(id),
+        });
+        if (!identity) {
+          return { ok: false, reason: `there is no server-observed Origin for ${id}` };
+        }
+        advertised.set(panelTab, identity.uuid);
+        carried.delete(panelTab);
+        if (isScopeAddress(id)) sessionStamp = identity.uuid;
+        return true;
+      },
+    );
+    bridge.setCarriedTabStampPredicate((id) => !isScopeAddress(id) && carried.has(panelTabOf(id)));
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  /** `null` means send NO Origin header — `undefined` would take the default. */
+  function connectPanel(tabId: string, origin: string | null = ORIGIN): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`, origin ? { origin } : {});
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: tabId,
+            title: tabId,
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+          }),
+        );
+        resolve(sock);
+      });
+      sock.on("error", reject);
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString());
+        if (!msg.rid || !msg.cmd) return;
+        received.push(msg);
+        const result = msg.cmd === "workflow_list" ? settled(liveCanvas) : { cmd: msg.cmd };
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result }));
+      });
+    });
+  }
+
+  /** The reported state: the session's stamp names the live canvas, the routed tab's last
+   *  advertisement does not. */
+  async function inTheReportedState(origin: string | null = ORIGIN): Promise<WebSocket> {
+    advertised.set(TAB, STALE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel(TAB, origin);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    received.length = 0;
+    return sock;
+  }
+
+  async function setWorkflowTargetCurrent(): Promise<ToolResult> {
+    const ctx = makePanelToolCtx(bridge, SCOPE, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+    if (!def) throw new Error("panel_set_workflow_target is not registered");
+    return def.handler({ mode: "current" } as never, ctx);
+  }
+
+  it("THE REPORTED FLOW: the refusal, the recovery, and the SAME read going through", async () => {
+    const sock = await inTheReportedState();
+
+    // Step 3 of the report — refused pre-dispatch, nothing reaches the socket.
+    const before = await bridge.send({ cmd: "graph_add_node" }, { tabId: SCOPE }).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(before?.message).toContain(`issued for workflow instance ${LIVE}`);
+    expect(before?.message).toContain(`different active workflow (${STALE})`);
+    expect(received.map((f) => f.cmd)).toEqual([]);
+
+    // Step 4 — the recovery the refusal itself names.
+    const res = await setWorkflowTargetCurrent();
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+    expect(received.map((f) => f.cmd)).toContain("workflow_list");
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain('"graph_binding": "bound"');
+    expect(text).toContain('"graph_binding_status": "reconciled"');
+    expect(text).toContain(STALE); // it NAMES the stale value it replaced
+    expect(text).not.toContain("did NOT restore this session's graph binding");
+
+    // THE EFFECT, not the claim: the value the gate reads has moved…
+    expect(advertised.get(TAB)).toBe(LIVE);
+    // …the adoption was addressed to the ROUTED TAB, so no conversation stamp moved…
+    expect(adoptions).toEqual([{ tabId: TAB, uuid: LIVE }]);
+    expect(sessionStamp).toBe(LIVE);
+    // …and step 5, the read that kept refusing, now reaches the panel.
+    received.length = 0;
+    await expect(bridge.send({ cmd: "graph_add_node" }, { tabId: SCOPE })).resolves.toBeTruthy();
+    expect(received.map((f) => f.cmd)).toEqual(["graph_add_node"]);
+    sock.close();
+  });
+
+  it("the gate's own capability verdict stops refusing — the probe the reply reports from", async () => {
+    const sock = await inTheReportedState();
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({
+      known: true,
+      canMutate: false,
+      because: "target_disagreement",
+    });
+    await setWorkflowTargetCurrent();
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({ known: true, canMutate: true });
+    sock.close();
+  });
+
+  it("REFUSES to write anything but the identity the session already holds", async () => {
+    // The safety argument, driven directly: an observation that is not this session's own
+    // stamp can never be adopted here, so this path cannot re-point a session at another
+    // canvas however it is called.
+    const sock = await inTheReportedState();
+    expect(bridge.reconcileStampTarget(SCOPE, OTHER)).toEqual({
+      ok: false,
+      why: "stamp_moved",
+      landedOn: STALE,
+      reason: LIVE,
+    });
+    expect(advertised.get(TAB)).toBe(STALE);
+    expect(adoptions).toEqual([]);
+    sock.close();
+  });
+
+  it("does nothing when the two AGREE, and nothing on a CARRIED pair", async () => {
+    // `carried` is an EQUAL pair whose provenance is doubted (#1656) and it has its own
+    // non-writing remedy (corroborateTabStamp). Reconciling has no business firing on it.
+    advertised.set(TAB, LIVE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel(TAB);
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    expect(bridge.reconcileStampTarget(SCOPE, LIVE)).toEqual({ ok: false, why: "no_disagreement" });
+    carried.add(TAB);
+    expect(bridge.reconcileStampTarget(SCOPE, LIVE)).toEqual({ ok: false, why: "no_disagreement" });
+    expect(adoptions).toEqual([]);
+    sock.close();
+  });
+
+  it("a REFUSED reconciliation keeps the honest failure and says why", async () => {
+    // The production case with no server-observed Origin (a relay connection): the
+    // validator can never adopt, so the reply must go on reporting a wedged session
+    // rather than claiming the repair it attempted.
+    const sock = await inTheReportedState(null);
+    const res = await setWorkflowTargetCurrent();
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+    expect(res.isError).toBe(true);
+    expect(text).toContain("did NOT restore this session's graph binding");
+    expect(text).toContain("was ATTEMPTED and did not go through");
+    expect(text).toContain("no server-observed Origin");
+    expect(text).not.toContain('"graph_binding": "bound"');
+    // Nothing moved: the gate still refuses, exactly as it did before the call.
+    expect(advertised.get(TAB)).toBe(STALE);
+    expect(bridge.tabGraphMutationCapability(SCOPE)).toEqual({
+      known: true,
+      canMutate: false,
+      because: "target_disagreement",
+    });
+    sock.close();
+  });
+
+  it("a READ-ONLY mismatch diagnosis reconciles NOTHING (#1646 stays intact)", async () => {
+    // The refused mutation's own diagnosis probes with `adopt:false`. A diagnosis that
+    // repaired its own subject would be the #1646 corruption in a friendlier costume, so
+    // the advertisement must survive it untouched — and the diagnosis must point at the
+    // call that IS allowed to write.
+    const sock = await inTheReportedState();
+    const ctx = makePanelToolCtx(bridge, SCOPE, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+    if (!def) throw new Error("panel_add_node is not registered");
+    const res: ToolResult = await def.handler({ node_type: "KSampler" } as never, ctx);
+    const text = res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+    expect(res.isError).toBe(true);
+    expect(received.map((f) => f.cmd)).toContain("workflow_list");
+    expect(advertised.get(TAB)).toBe(STALE);
+    expect(adoptions).toEqual([]);
+    expect(text).toContain('panel_set_workflow_target({mode:"current"})');
+    expect(text).toContain("RECONCILES");
+    expect(received.map((f) => f.cmd)).not.toContain("graph_add_node");
+    sock.close();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7820,9 +7820,17 @@ async function clearFenceOnIdentityProvenOpen(
   let repaired = false;
   try {
     const rebind = await rebindWorkflowFence(ctx);
-    repaired = rebind.status === "refreshed" || rebind.status === "already_current";
+    // #2209 — `reconciled` belongs with these: the fence names the live canvas AND the
+    // routed tab's advertisement now agrees with it, so graph commands dispatch. Leaving
+    // it out would report a CLEARED fence as "not cleared (reconciled)".
+    repaired =
+      rebind.status === "refreshed" ||
+      rebind.status === "already_current" ||
+      rebind.status === "reconciled";
     note =
-      rebind.status === "refreshed" || rebind.status === "already_current"
+      rebind.status === "refreshed" ||
+      rebind.status === "already_current" ||
+      rebind.status === "reconciled"
         ? `\n\nFENCE: CLEARED. This reply published no workflow_uuid, so the fence was re-derived ` +
           `from the panel's own fence-EXEMPT workflow_list read instead — the active identity is ` +
           `${rebind.uuid}, and graph commands from this session are stamped with it again. You do ` +
@@ -8063,6 +8071,33 @@ function corroborateTabStamp(ctx: PanelToolCtx, workflowUuid: string): boolean {
   }
 }
 
+/** #2209 — reconcile the ROUTED TAB's stale advertisement onto an identity the panel
+ *  just reported for it, so the recovery the agreement gate's own refusal prescribes can
+ *  clear it. The bridge owns every gate (see `reconcileStampTarget`); this is only the
+ *  accessor, and it never throws — a repair that cannot be attempted must leave the
+ *  outcome it was trying to improve exactly as it was. */
+function reconcileStampTarget(
+  ctx: PanelToolCtx,
+  workflowUuid: string,
+):
+  | { ok: true; routedTabId: string; replaced: string }
+  | { ok: false; why: string; landedOn?: string; reason?: string } {
+  const fn = (ctx.bridge as unknown as { reconcileStampTarget?: unknown }).reconcileStampTarget;
+  if (typeof fn !== "function") return { ok: false, why: "unavailable" };
+  try {
+    return (
+      fn as (
+        t: string,
+        u: string,
+      ) =>
+        | { ok: true; routedTabId: string; replaced: string }
+        | { ok: false; why: string; landedOn?: string; reason?: string }
+    ).call(ctx.bridge, ctx.tabId, workflowUuid);
+  } catch (err) {
+    return { ok: false, why: "threw", reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
   const uuid = responseWorkflowUuid(value);
   const refresh = (ctx.bridge as unknown as { refreshWorkflowUuid?: unknown }).refreshWorkflowUuid;
@@ -8196,8 +8231,37 @@ export type WorkflowFenceRebind =
    *  from the fence and deliberately did NOT adopt it: a mismatch diagnosis
    *  must never re-point mutation routing on its own authority. */
   | { status: "diverged"; uuid: string; before: FenceRead; active?: Record<string, unknown> }
-  /** Read the live identity; the stamp already named it. Nothing to repair. */
-  | { status: "already_current"; uuid: string; before: FenceRead; active?: Record<string, unknown> }
+  /** Read the live identity; the stamp already named it. Nothing to repair.
+   *
+   *  #2209 — `targetDisagreement` is set when there WAS something to repair on the
+   *  other axis and the repair did not happen: the routed tab was still advertising a
+   *  different identity (the comparison the dispatch-time gate refuses on), and
+   *  reconciling that advertisement was attempted and did not go through. Kept on THIS
+   *  status rather than given its own, because the fence outcome it names is unchanged —
+   *  the session's stamp already matched the live canvas — and a caller must not read a
+   *  failed second repair as a failed first one. */
+  | {
+      status: "already_current";
+      uuid: string;
+      before: FenceRead;
+      active?: Record<string, unknown>;
+      targetDisagreement?: { landedOn?: string; why: string; reason?: string };
+    }
+  /** #2209 — the stamp already named the live canvas AND the routed tab's stale
+   *  advertisement, the value the dispatch-time agreement gate was refusing on, has been
+   *  reconciled onto that same identity. Its own status because something WAS written and
+   *  a refusal WAS cleared: `already_current` means "nothing needed doing", which is the
+   *  claim #1494 exists to stop this path making while graph commands were refused. */
+  | {
+      status: "reconciled";
+      uuid: string;
+      before: FenceRead;
+      active?: Record<string, unknown>;
+      /** The stale identity the routed tab had been advertising until this call. */
+      replaced: string;
+      /** The canonical id of the tab whose advertisement was reconciled. */
+      routedTabId: string;
+    }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
   | { status: "unreadable"; before: FenceRead; detail: string }
   /** The panel answered, but no usable identity could be adopted from it. TWO
@@ -8919,6 +8983,55 @@ async function rebindWorkflowFence(
     // off parsed prose, and the result is ignored: this is corroboration, and a diagnostic
     // must never replace the outcome it is describing.
     corroborateTabStamp(ctx, uuid);
+    // #2209 — AND THE OTHER AXIS, which #1494 could only report.
+    //
+    // Reaching here with the agreement gate still refusing means the ROUTED TAB is
+    // advertising a different identity than the one the panel just told us is live on it.
+    // That advertisement is the value the gate compares against, so every graph command —
+    // reads included — is refused before dispatch, and this call, the recovery the
+    // refusal itself prescribes, had nothing to offer: the fence it CAN move already
+    // named the right canvas. Only the panel's own drift re-hello ever cleared it, and
+    // that repair is capped at three attempts per identity, after which the session is
+    // wedged.
+    //
+    // So reconcile the stale advertisement onto the identity the panel reported a moment
+    // ago — the same write its drift re-hello performs, from an observation already in
+    // hand. The bridge holds every gate: only a genuine `disagrees`, only when the
+    // observation still EQUALS this session's own stamp (so no session can be re-pointed
+    // by it), and only through the orchestrator's validator addressed to the routed tab.
+    //
+    // A READ-ONLY probe never comes here (`adopt:false` is the mismatch diagnosis, and a
+    // diagnosis that repairs its own subject is the #1646 corruption in a friendlier
+    // costume) — reconciling is a deliberate rebind's business.
+    if (opts?.adopt !== false) {
+      const rec = reconcileStampTarget(ctx, uuid);
+      if (rec.ok) {
+        return {
+          status: "reconciled",
+          uuid,
+          before,
+          active,
+          replaced: rec.replaced,
+          routedTabId: rec.routedTabId,
+        };
+      }
+      // `no_disagreement` is the healthy case and says nothing worth reporting. Anything
+      // else is an attempted repair that did not happen, and the reply must not go on
+      // implying the comparison was never made.
+      if (rec.why !== "no_disagreement") {
+        return {
+          status: "already_current",
+          uuid,
+          before,
+          active,
+          targetDisagreement: {
+            why: rec.why,
+            ...(rec.landedOn ? { landedOn: rec.landedOn } : {}),
+            ...(rec.reason ? { reason: rec.reason } : {}),
+          },
+        };
+      }
+    }
     return { status: "already_current", uuid, before, active };
   }
   // #1646 — a READ-ONLY probe never moves the fence: the live canvas naming a
@@ -8972,6 +9085,7 @@ function liveActiveFromProbe(probe: WorkflowFenceRebind): Record<string, unknown
   if (
     probe.status === "diverged" ||
     probe.status === "already_current" ||
+    probe.status === "reconciled" ||
     probe.status === "refreshed"
   ) {
     return probe.active;
@@ -9106,11 +9220,13 @@ function describeFenceRebind(
     : mutationsRefused && refusalCause === "target_disagreement"
     ? `\n\nBUT THIS DID NOT CLEAR THE REFUSAL, and saying otherwise is the bug this ` +
       `wording exists to stop (#1494). Graph commands are refused BEFORE they are ` +
-      `dispatched, by a comparison this call does not perform: the session's stamp against ` +
-      `the identity the ROUTED TAB last advertised in its handshake. This call compared the ` +
-      `stamp against the LIVE canvas instead, and those are different facts — the live ` +
-      `canvas agreeing is exactly why nothing above says "rebound". Graph READS are refused ` +
-      `by the same gate, so this is not a reads-only session.` +
+      `dispatched, by a comparison that is NOT the one this call's rebind reports on: the ` +
+      `session's stamp against the identity the ROUTED TAB last advertised in its ` +
+      `handshake, rather than against the LIVE canvas. Those are different facts, and the ` +
+      `live canvas agreeing is why nothing above says "rebound". Reconciling that stale ` +
+      `advertisement IS attempted here (#2209) and it did not go through on this call — ` +
+      `the line above says what was found. Graph READS are refused by the same gate, so ` +
+      `this is not a reads-only session.` +
       `\n\nWHAT TO DO: re-open the workflow you mean with panel_open_workflow(<path>) — an ` +
       `open proves an identity for the tab under its current id, which is what the gate is ` +
       `missing; for a never-saved canvas use its routing_key from panel_list_workflows. The ` +
@@ -9162,12 +9278,45 @@ function describeFenceRebind(
           `next graph command fails closed with a fresh instance mismatch — safe, and cleared by ` +
           `calling this again.)${mutationCaveat}${unknownCaveat}`,
       };
+    case "reconciled":
+      // #2209 — BOTH halves of what happened, and neither one overstated. The fence did
+      // not move (it already named the live canvas), and the routed tab's stale
+      // advertisement — the value the dispatch-time gate was refusing every graph command
+      // against, reads included — did. Reported through `okBinding` like the others: the
+      // capability probe is re-read after this rebind, so if anything ELSE still refuses
+      // writes on this tab the caveat below states it instead.
+      return {
+        binding: okBinding,
+        note:
+          ` The graph command fence already named the canvas the panel reported as active a ` +
+          `moment ago (workflow instance ${r.uuid}) — but the ROUTED TAB was still ` +
+          `advertising ${r.replaced}, and THAT is the comparison the pre-dispatch agreement ` +
+          `gate refuses on, so graph commands were being rejected before they were sent. ` +
+          `That advertisement has been RECONCILED onto the identity the panel just reported ` +
+          `for this tab, which is the same write the panel's own drift re-hello performs. ` +
+          `Nothing was re-targeted: this session stays fenced to the instance it already ` +
+          `held, and the only value that changed is the stale advertisement.` +
+          ` (If the user switched tabs again in that instant, the next graph command fails ` +
+          `closed with a fresh instance mismatch — safe, and cleared by calling this ` +
+          `again.)${mutationCaveat}${unknownCaveat}`,
+      };
     case "already_current":
       return {
         binding: okBinding,
         note:
           ` The graph command fence already named the canvas the panel reported as active a ` +
           `moment ago (workflow instance ${r.uuid}), so nothing needed rebinding.` +
+          // #2209 — an attempted repair that did not happen is REPORTED. Without this the
+          // reply reads as a settled session while the agreement gate goes on refusing
+          // every graph command, which is the #1494 false-negative in a new place.
+          (r.targetDisagreement
+            ? ` The ROUTED TAB is nevertheless still advertising ` +
+              `${r.targetDisagreement.landedOn ?? "a different identity"}, which is what the ` +
+              `pre-dispatch agreement gate compares against — reconciling it onto the live ` +
+              `identity was ATTEMPTED and did not go through (${r.targetDisagreement.why}` +
+              `${r.targetDisagreement.reason ? `: ${r.targetDisagreement.reason}` : ""}), so ` +
+              `graph commands stay refused and this call did not fix that.`
+            : "") +
           // The SAME post-probe window as `refreshed` (codex gate). This branch used
           // to jump straight to "the mismatch is coming from the panel" and send the
           // caller to a browser reload — but a switch after workflow_list replied
@@ -12269,12 +12418,14 @@ export function makePanelToolCtx(
                   `(${stamped}), and the refusal above is not about the live canvas — it is ` +
                   `the pre-dispatch check on the identity the ROUTED TAB last advertised, ` +
                   `which is the stale side here. So a bare retry is compared against that ` +
-                  `same unchanged value and is refused the same way; ` +
-                  `panel_set_workflow_target({mode:"current"}) reports "already current" for ` +
-                  `the same reason and does not clear it either. Nothing was applied. WHAT TO ` +
-                  `DO: re-open the workflow you mean with panel_open_workflow(<path>) — that ` +
-                  `proves an identity for the tab under its CURRENT id, which is what is ` +
-                  `missing; for a never-saved canvas use its routing_key from ` +
+                  `same unchanged value and is refused the same way. Nothing was applied. ` +
+                  `WHAT TO DO: call panel_set_workflow_target({mode:"current"}) — it ` +
+                  `RECONCILES that stale advertisement onto the identity the panel reports ` +
+                  `as live (#2209), which is exactly this state, and its reply says whether ` +
+                  `it went through; then re-issue this call. If it reports that the ` +
+                  `reconciliation did NOT go through, re-open the workflow you mean with ` +
+                  `panel_open_workflow(<path>) instead — that proves an identity for the tab ` +
+                  `under its CURRENT id; for a never-saved canvas use its routing_key from ` +
                   `panel_list_workflows. The panel also re-advertises on its own once it ` +
                   `notices the drift, so a retry may start working shortly — that is the ` +
                   `panel repairing it, not this call.`
@@ -18077,7 +18228,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   ? `The graph command fence WAS refreshed onto this tab's live canvas (workflow instance ${fenceRebind.uuid}), which is correct for it either way.`
                   : fenceRebind.status === "already_current"
                     ? `The graph command fence already named this tab's live canvas, so it needed no change.`
-                    : `The graph command fence was NOT established on this tab (${fenceRebind.status}) — so graph tools may also fail here with a workflow-instance mismatch, independently of the pin below.`;
+                    : // #2209 — a RECONCILED target is an established fence, not a missing one.
+                      // Falling through to the "NOT established" arm would report the repair as
+                      // the failure it just cleared.
+                      fenceRebind.status === "reconciled"
+                      ? `The graph command fence already named this tab's live canvas, and the routed tab's stale advertisement (${fenceRebind.replaced}) was reconciled onto it, so graph commands are no longer refused before dispatch.`
+                      : `The graph command fence was NOT established on this tab (${fenceRebind.status}) — so graph tools may also fail here with a workflow-instance mismatch, independently of the pin below.`;
               return fail(
                 `panel_set_workflow_target({mode:"current"}) did NOT take effect on the tab this ` +
                   `session is now bound to.\n\nWHAT HAPPENED: the panel dropped mid-call, so this ` +

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -5782,6 +5782,82 @@ export class UiBridge {
   }
 
   /**
+   * #2209 — RECONCILE the routed tab's stale advertisement with an identity the panel
+   * has just reported for that same tab, so the recovery the gate's own refusal
+   * prescribes can actually clear it.
+   *
+   * #1494 made the disagreement VISIBLE: `panel_set_workflow_target({mode:"current"})`
+   * stopped claiming `bound` while the gate refused, because the two sides compare
+   * different facts — the gate compares the session's stamp against the identity the
+   * ROUTED TAB last advertised, the rebind compares it against the LIVE canvas. When the
+   * advertisement is the stale side the rebind short-circuits (`already_current`) and
+   * repairs nothing, so the only thing that ever cleared it was the panel noticing its
+   * own drift and re-advertising — capped at MISMATCH_REHELLO_MAX_PER_IDENTITY (3), after
+   * which the session is wedged for good. The reporter's workaround was to issue the
+   * identical read twice and let the race settle it.
+   *
+   * This writes the advertisement the panel's own drift re-hello would write, from an
+   * observation already in hand. THREE gates, and the middle one is the safety argument:
+   *
+   *  - only the `disagrees` arm. `carried` is an equal pair whose PROVENANCE is doubted,
+   *    and it has its own non-writing remedy ({@link corroborateTabStamp}); the
+   *    non-refusing kinds have nothing to reconcile.
+   *  - the observation must EQUAL what the session already holds. So this can never
+   *    re-point a session at another canvas: the value written is the one the session is
+   *    already fenced to, and the only thing that changes is the routed tab's stale
+   *    advertisement. Re-read HERE rather than trusted from the caller — the session's
+   *    stamp can move between the caller's read and this write, and a stamp that moved
+   *    makes the observation stale rather than reconcilable.
+   *  - the write goes through the orchestrator's validator ({@link refreshWorkflowUuid}),
+   *    addressed to the ROUTED tab's canonical id — the exact key the gate reads — so the
+   *    uuid is re-checked for shape and origin binding and is never adopted off parsed
+   *    prose, and a tab id that is not a scope address cannot touch any conversation's
+   *    issue-time stamp.
+   *
+   * Being wrong is bounded: the panel authorizes a fenced command IFF the stamp equals
+   * its LIVE active workflow, so a reconciliation the canvas has already moved past is
+   * refused by the panel itself — exactly as it is for any session whose stamp equals the
+   * last identity the panel reported. It cannot land a command on the wrong canvas.
+   */
+  reconcileStampTarget(
+    tabId: string,
+    observedWorkflowUuid: string,
+  ):
+    | { ok: true; routedTabId: string; replaced: string }
+    | {
+        ok: false;
+        why: "unroutable" | "no_disagreement" | "stamp_moved" | "refused";
+        /** The stale identity the routed tab is advertising — present only on the arms
+         *  that FOUND a disagreement and could not reconcile it. */
+        landedOn?: string;
+        reason?: string;
+      } {
+    let routedTabId: string;
+    try {
+      routedTabId = this.resolveTarget(tabId).tabId;
+    } catch {
+      return { ok: false, why: "unroutable" };
+    }
+    const verdict = this.stampTargetVerdict(tabId, routedTabId);
+    if (!verdict.refuses || verdict.kind !== "disagrees") {
+      return { ok: false, why: "no_disagreement" };
+    }
+    if (verdict.issuedFor !== observedWorkflowUuid) {
+      return {
+        ok: false,
+        why: "stamp_moved",
+        landedOn: verdict.landedOn,
+        reason: verdict.issuedFor,
+      };
+    }
+    if (!this.refreshWorkflowUuid(routedTabId, observedWorkflowUuid)) {
+      const reason = this.lastFenceRefusal(routedTabId);
+      return { ok: false, why: "refused", landedOn: verdict.landedOn, ...(reason ? { reason } : {}) };
+    }
+    return { ok: true, routedTabId, replaced: verdict.landedOn };
+  }
+
+  /**
    * #1077 — WHY the last adoption for this tab was refused, if it was.
    *
    * The validator has three independent gates (the tab is unreachable, it does


### PR DESCRIPTION
Fixes #2209.

## What was broken

After a workflow-tab switch the reporter got a `graph_outline` refusal on a
workflow-instance mismatch, called the recovery that refusal itself prescribes —
`panel_set_workflow_target({mode:"current"})` — and was told the target was applied but
that the graph binding was **not** restored, "because it compared the live canvas rather
than the routed tab handshake identity". The next read refused identically. Retrying the
identical read once succeeded.

That disclosure is #1494's, and it was accurate. The two sides compare different facts:

| | compares |
|---|---|
| the dispatch-time agreement gate (`send()` / `stampTargetVerdict`) | session stamp **vs the identity the ROUTED TAB last advertised** |
| the rebind recovery (`rebindWorkflowFence`) | session stamp **vs the LIVE canvas** read back with `workflow_list` |

When the *advertisement* is the stale side, the rebind has nothing to move — the fence
already names the live canvas, so it short-circuits to `already_current` — while the gate
goes on refusing every graph command, reads included. #1494 made that honest; it did not
make it recoverable. The only thing that ever cleared it was the panel noticing its own
drift and re-advertising, which is what the reporter's "retry once" was waiting on, and
which the panel attempts at most `MISMATCH_REHELLO_MAX_PER_IDENTITY` (3) times per
identity before the session is wedged for the rest of its life.

## What changed

`mode:"current"` now performs that same write itself, from the observation it already
made. New `UiBridge.reconcileStampTarget(tabId, observedUuid)`, called from
`rebindWorkflowFence`'s `already_current` branch, with three gates:

- **only the `disagrees` arm.** `carried` is an *equal* pair whose provenance is doubted
  and it keeps its own non-writing remedy (`corroborateTabStamp`, #1656).
- **the observation must EQUAL what the session already holds**, re-read at write time.
  This is the safety property: the value written is the one the session is *already*
  fenced to, so this path can never re-point a session at another canvas. A stamp that
  moved between the read and the write makes the observation stale, not reconcilable.
- **the write goes through the orchestrator's validator**, addressed to the routed tab's
  **canonical id** — the exact key the gate reads (`panelTabOf(conn.tabId)` on both
  sides) — so shape and origin binding are re-checked, nothing is adopted off parsed
  prose, and because that id is not a scope address it cannot touch any conversation's
  issue-time stamp.

Read-only probes (`adopt:false`, the mismatch diagnosis) reconcile nothing: a diagnosis
that repairs its own subject is #1646 in a friendlier costume.

New `reconciled` rebind status rather than reusing `already_current`, because something
WAS written and a refusal WAS cleared — and `already_current` now carries
`targetDisagreement` when the repair was attempted and did **not** go through, so a
failed second repair is never rendered as a settled session.

## Please look hard at

1. **The safety argument.** Is "the observation equals the session's own stamp" enough to
   make this unable to retarget anything? My claim: the only value that changes is the
   routed tab's advertisement, moved to a value the panel reported as live on that same
   tab a moment ago — the identical write its own drift re-hello performs. And being wrong
   is bounded: the panel authorizes a fenced command IFF the stamp equals its LIVE active
   workflow (the tab provably advertises both write fences by the time this arm is
   reached), so a reconciliation the canvas has moved past is refused *by the panel*,
   exactly as for any session whose stamp equals the last identity the panel reported. It
   cannot land a command on the wrong canvas.
2. **The write address.** `refreshWorkflowUuid(routedTabId, …)` not `(tabId, …)`. Mutant
   M3 below covers it, but it is the line where a wrong-key write would be silent.
3. **Stale prose.** The #1330/#1494 mismatch diagnosis used to tell callers that
   `mode:"current"` "reports already current for the same reason and does not clear it
   either". That sentence is now false, so it is rewritten to point at the call that does
   clear it *and* at `panel_open_workflow` for the case where the reconciliation is
   refused. Same for the `target_disagreement` caveat, which claimed the call "does not
   perform" the comparison.

## Evidence

New `src/__tests__/services/stamp-target-reconcile.test.ts` — real `UiBridge` over a real
socket, real tool handlers, and a refresh validator that mirrors the orchestrator's
(`orchestrator/index.ts`) gate for gate, **including the conversation-stamp write that
must not happen here**. It measures effects, not claims: the map the gate reads, whether a
previously-refused `graph_add_node` reaches the socket, and which tab id the adoption was
addressed to.

Mutation results (each mutant caught by the *right* test; the others stayed green, so no
mutant is caught by a shared cause):

| mutant | test that failed |
|---|---|
| M1 reconciliation removed entirely | reported flow / capability verdict / refused-says-why |
| M2 equality guard removed | "REFUSES to write anything but the identity the session already holds" |
| M3 write addressed to the caller, not the routed tab | reported flow (adoptions + session stamp) |
| M4 `adopt:false` guard removed | "a READ-ONLY mismatch diagnosis reconciles NOTHING" |
| M5 `carried` arm allowed through | "does nothing when the two AGREE, and nothing on a CARRIED pair" |

The #1494 suite (`stamp-target-disagreement-recovery.test.ts`) is unchanged and green: it
wires **no** refresh validator, so nothing can be written there and it now stands as the
control that a session which cannot be repaired still gets the honest failure.

- `npx vitest run` — 653 files, 12047 passed, 4 skipped.
- `tsc --noEmit` clean; `check:vocabulary` and `check:unknown-collapse` clean.

## Not done

- **No browser verification.** Nothing here is panel-visible: the change is entirely
  orchestrator-side (bridge gate + MCP tool reply text). The panel repo is untouched.
- The refusal wording at the bridge gate is byte-identical; the gate itself does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
