### PR TITLE
fix: remove circular health connection advice

### DIFF
--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -192,6 +192,24 @@ describe("#2188: health connection advice does not call health again", () => {
     expect(text).toContain("COMFYUI_AUTH_*");
     expect(text).not.toContain('get_system_stats (action:"health")');
   });
+
+  it("keeps Panel-origin and transport evidence in nested environment advice", async () => {
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188"),
+    );
+    const text = await comfyuiFetch(
+      "http://127.0.0.1:8188/system_stats",
+      {},
+      "install_comfyui_environment",
+    ).catch((err) => (err instanceof Error ? err.message : String(err)));
+    expect(text).toContain("http://192.168.1.50:8188");
+    expect(text).toContain("a DIFFERENT address");
+    expect(text).toContain("ECONNREFUSED");
+    expect(text).toContain("COMFYUI_AUTH_*");
+    expect(text).not.toContain('install_comfyui (action:"environment")');
+    expect(text).not.toContain('get_system_stats (action:"health")');
+  });
 });
 
 // #952 follow-on — naming the drift instead of asking the reader to check for it.

--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -149,6 +149,51 @@ describe("comfyuiFetch names the target it could not reach", () => {
   });
 });
 
+describe("#2188: health connection advice does not call health again", () => {
+  afterEach(() => setConnectedPanelOrigins(null));
+
+  async function healthFailureText(target: string): Promise<string> {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188"),
+    );
+    try {
+      await comfyuiFetch(target, {}, "get_system_stats_health");
+      throw new Error("expected comfyuiFetch to throw");
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  it("uses the independent environment readiness probe for a dead target", async () => {
+    const target = "http://127.0.0.1:8188/system_stats";
+    const text = await healthFailureText(target);
+    expect(text).toContain("ECONNREFUSED");
+    expect(text).toContain(target);
+    expect(text).toContain('install_comfyui (action:"environment")');
+    expect(text).toContain("independent readiness probe");
+    expect(text).not.toContain('get_system_stats (action:"health")');
+  });
+
+  it("keeps the panel DIFFERENT diagnosis while removing the health loop", async () => {
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
+    const text = await healthFailureText("http://127.0.0.1:8188/system_stats");
+    expect(text).toContain("a DIFFERENT address");
+    expect(text).toContain('install_comfyui (action:"environment")');
+    expect(text).toContain("COMFYUI_URL");
+    expect(text).not.toContain('get_system_stats (action:"health")');
+  });
+
+  it("keeps the SAME-origin route diagnosis while removing the health loop", async () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const text = await healthFailureText("http://127.0.0.1:8188/system_stats");
+    expect(text).toContain("NOT a wrong-address problem");
+    expect(text).toContain("route or firewall");
+    expect(text).toContain('install_comfyui (action:"environment")');
+    expect(text).toContain("COMFYUI_AUTH_*");
+    expect(text).not.toContain('get_system_stats (action:"health")');
+  });
+});
+
 // #952 follow-on — naming the drift instead of asking the reader to check for it.
 //
 // The shipped message said a connected panel "does not imply this address is

--- a/src/__tests__/services/health-check.test.ts
+++ b/src/__tests__/services/health-check.test.ts
@@ -90,6 +90,7 @@ describe("runHealthCheck", () => {
     await expect(
       runHealthCheck({ modelCategories: ["checkpoints"] }),
     ).rejects.toThrow(/ComfyUI unreachable/);
+    expect(getSystemStats).toHaveBeenCalledWith({ diagnosticContext: "health" });
   });
 });
 

--- a/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
+++ b/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
@@ -56,6 +56,12 @@ function statsOk(): Response {
   );
 }
 
+function undiciFailure(code: string, detail: string): Error {
+  const cause = new Error(detail);
+  (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
 /** Route /system_stats to JSON while healthy; everything else is the post-crash 502. */
 function serve(mode: { healthy: boolean }): void {
   global.fetch = vi.fn(async (input: RequestInfo | URL) => {
@@ -126,5 +132,21 @@ describe("post-CUDA-crash empty 502 is an outage, not a base-URL misconfig (#167
       expect(text).toContain("/system_stats");
       expect(text).toContain("not newly misconfigured");
     }
+  });
+
+  it('get_system_stats (action:"health") preserves transport details without a circular retry', async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED remote.example:8188"),
+    ) as unknown as typeof fetch;
+
+    const out = await getHandler("get_system_stats", registerSystemStatsTools)({ action: "health" });
+    expect(out.isError).toBe(true);
+    const payload = JSON.parse(out.content[0].text) as { error: string; message: string };
+    expect(payload.error).toBe("CONNECTION_ERROR");
+    expect(payload.message).toContain("ECONNREFUSED");
+    expect(payload.message).toContain("http://remote.example:8188/system_stats");
+    expect(payload.message).toContain('install_comfyui (action:"environment")');
+    expect(payload.message).toContain("independent readiness probe");
+    expect(payload.message).not.toContain('get_system_stats (action:"health")');
   });
 });

--- a/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
+++ b/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
@@ -23,6 +23,7 @@ import { resetClient } from "../../comfyui/client.js";
 import { resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
 import { registerDiagnosticsTools } from "../../tools/diagnostics.js";
 import { registerSystemStatsTools } from "../../tools/system-stats.js";
+import { getEnvironmentAction } from "../../tools/workspace-env.js";
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
@@ -148,5 +149,28 @@ describe("post-CUDA-crash empty 502 is an outage, not a base-URL misconfig (#167
     expect(payload.message).toContain('install_comfyui (action:"environment")');
     expect(payload.message).toContain("independent readiness probe");
     expect(payload.message).not.toContain('get_system_stats (action:"health")');
+  });
+
+  it('health failure -> environment probe keeps nested error text non-recursive (#2188)', async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED remote.example:8188"),
+    ) as unknown as typeof fetch;
+
+    const health = await getHandler("get_system_stats", registerSystemStatsTools)({ action: "health" });
+    const healthPayload = JSON.parse(health.content[0].text) as { message: string };
+    expect(healthPayload.message).toContain('install_comfyui (action:"environment")');
+
+    const environment = await getEnvironmentAction();
+    expect(environment.isError).not.toBe(true);
+    const environmentPayload = JSON.parse(environment.content[0].text) as {
+      running_instance: { reachable: boolean; error?: string };
+    };
+    const nested = environmentPayload.running_instance.error ?? "";
+    expect(environmentPayload.running_instance.reachable).toBe(false);
+    expect(nested).toContain("ECONNREFUSED");
+    expect(nested).toContain("http://remote.example:8188/system_stats");
+    expect(nested).toContain("COMFYUI_AUTH_*");
+    expect(nested).not.toContain('install_comfyui (action:"environment")');
+    expect(nested).not.toContain('get_system_stats (action:"health")');
   });
 });

--- a/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
+++ b/src/__tests__/tools/post-crash-502-not-misconfig.test.ts
@@ -19,6 +19,15 @@ vi.mock("../../config.js", () => ({
   isRemoteMode: () => true,
 }));
 
+// getEnvironmentAction reaches the live-interpreter seam while building its
+// running-instance report. Keep this production-path regression independent of
+// the machine running the test; the network behavior remains real and is driven
+// by the fetch stub below.
+vi.mock("../../services/live-interpreter.js", async () => ({
+  ...(await vi.importActual("../../services/live-interpreter.js")),
+  resolveLiveInterpreter: () => undefined,
+}));
+
 import { resetClient } from "../../comfyui/client.js";
 import { resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
 import { registerDiagnosticsTools } from "../../tools/diagnostics.js";

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -220,7 +220,7 @@ function looksLikeSystemStats(body: unknown): boolean {
  *  call_tool timeout test can shrink only THIS deadline. */
 export const SYSTEM_STATS_TIMEOUT_MS = 15_000;
 
-export async function getSystemStats(): Promise<SystemStats> {
+export async function getSystemStats(options: { diagnosticContext?: "health" } = {}): Promise<SystemStats> {
   if (isCloudMode()) return cloudClient.getSystemStats();
   requireLocalMode("getSystemStats");
   // Fetched directly (not via the client library) so a non-JSON answer can be
@@ -242,6 +242,8 @@ export async function getSystemStats(): Promise<SystemStats> {
         expectShape: looksLikeSystemStats,
         shapeHint:
           "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
+        diagnosticContext:
+          options.diagnosticContext === "health" ? "get_system_stats_health" : undefined,
       }),
     );
     // Shape-valid /system_stats is the in-session proof that this base URL is a

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -220,7 +220,9 @@ function looksLikeSystemStats(body: unknown): boolean {
  *  call_tool timeout test can shrink only THIS deadline. */
 export const SYSTEM_STATS_TIMEOUT_MS = 15_000;
 
-export async function getSystemStats(options: { diagnosticContext?: "health" } = {}): Promise<SystemStats> {
+export async function getSystemStats(
+  options: { diagnosticContext?: "health" | "environment" } = {},
+): Promise<SystemStats> {
   if (isCloudMode()) return cloudClient.getSystemStats();
   requireLocalMode("getSystemStats");
   // Fetched directly (not via the client library) so a non-JSON answer can be
@@ -243,7 +245,11 @@ export async function getSystemStats(options: { diagnosticContext?: "health" } =
         shapeHint:
           "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
         diagnosticContext:
-          options.diagnosticContext === "health" ? "get_system_stats_health" : undefined,
+          options.diagnosticContext === "health"
+            ? "get_system_stats_health"
+            : options.diagnosticContext === "environment"
+              ? "install_comfyui_environment"
+              : undefined,
       }),
     );
     // Shape-valid /system_stats is the in-session proof that this base URL is a

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -156,7 +156,9 @@ export type TargetDriftVerdict = "different" | "same" | "unknown";
 
 /** A caller-specific diagnostic context. Keep this narrow so generic ComfyUI
  * failures retain their existing next-step advice. */
-export type ComfyFetchDiagnosticContext = "get_system_stats_health";
+export type ComfyFetchDiagnosticContext =
+  | "get_system_stats_health"
+  | "install_comfyui_environment";
 
 function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; text: string } {
   const origins = (() => {
@@ -213,11 +215,12 @@ function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; tex
  * The health check is therefore RE-AIMED rather than dropped — see the note at
  * the SAME branch for why suppressing it would have been an overclaim.
  *
- * `install_comfyui (action:"environment")` survives in both branches and is NOT
- * described as failing: its `/system_stats` read sits inside a try (see
- * services/workspace-env.ts getEnvironment), so it still reports the resolved
- * target on an unreachable server. Claiming otherwise would be the same
- * overclaim pointed the other way.
+ * The generic and direct-health paths keep `install_comfyui (action:"environment")`
+ * explicit and do NOT describe it as failing: its `/system_stats` read sits
+ * inside a try (see services/workspace-env.ts getEnvironment), so it still
+ * reports the resolved target on an unreachable server. The environment probe
+ * itself uses the separate context below, where naming that action again would
+ * recurse through its stored `running_instance.error`.
  *
  * `budget` is the timeout path's extra option. It stays offered even on a SAME
  * verdict: a connected browser proves something answers that origin, never that
@@ -230,6 +233,29 @@ function nextStepsFor(
   budget: boolean,
   context?: ComfyFetchDiagnosticContext,
 ): string {
+  if (context === "install_comfyui_environment") {
+    if (verdict === "same") {
+      const want = originOf(target) ?? target;
+      return (
+        ` The connected panel is already on ${want}, so the browser can reach this ` +
+        `origin while this process cannot. Check the route or firewall between them, ` +
+        `the server's bound interface, and any COMFYUI_AUTH_* credentials required ` +
+        `from this process.`
+      );
+    }
+    if (verdict === "different") {
+      return (
+        ` Check COMFYUI_URL and point it at the intended server. If this target is ` +
+        `the intended one, check its route or firewall and any COMFYUI_AUTH_* ` +
+        `credentials required from this process.`
+      );
+    }
+    return (
+      ` Check COMFYUI_URL from this process, the route or firewall, and any ` +
+      `COMFYUI_AUTH_* credentials required by the target. The transport details ` +
+      `above are the available readiness evidence.`
+    );
+  }
   if (context === "get_system_stats_health") {
     const environment = 'install_comfyui (action:"environment")';
     const independentProbe =

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -154,6 +154,10 @@ export function describeTargetDrift(target: string): string {
  */
 export type TargetDriftVerdict = "different" | "same" | "unknown";
 
+/** A caller-specific diagnostic context. Keep this narrow so generic ComfyUI
+ * failures retain their existing next-step advice. */
+export type ComfyFetchDiagnosticContext = "get_system_stats_health";
+
 function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; text: string } {
   const origins = (() => {
     try {
@@ -224,7 +228,39 @@ function nextStepsFor(
   verdict: TargetDriftVerdict,
   target: string,
   budget: boolean,
+  context?: ComfyFetchDiagnosticContext,
 ): string {
+  if (context === "get_system_stats_health") {
+    const environment = 'install_comfyui (action:"environment")';
+    const independentProbe =
+      ` Run ${environment} as an independent readiness probe from this MCP process; ` +
+      `inspect its running_instance.reachable and running_instance.error instead of ` +
+      `repeating this failing request.`;
+    if (verdict === "same") {
+      const want = originOf(target) ?? target;
+      return (
+        independentProbe +
+        ` The connected panel is already on ${want}, so if the probe is unreachable, ` +
+        `fix the route or firewall between this process and that origin. If it is ` +
+        `reachable, keep the transport and any COMFYUI_AUTH_* details above in view; ` +
+        `the browser session may have different access.`
+      );
+    }
+    if (verdict === "different") {
+      return (
+        independentProbe +
+        ` The panel is on a different origin, so point COMFYUI_URL at the server you ` +
+        `meant; if the probe still cannot reach that target, check its route/firewall ` +
+        `and any required COMFYUI_AUTH_* credentials.`
+      );
+    }
+    return (
+      independentProbe +
+      ` If the probe is unreachable, check COMFYUI_URL, the route/firewall, and any ` +
+      `required COMFYUI_AUTH_* credentials; if it is reachable, retry the health ` +
+      `check once while keeping the transport details above.`
+    );
+  }
   if (verdict !== "same") {
     return budget
       ? ` Confirm it is up with get_system_stats (action:"health"), and raise ` +
@@ -327,7 +363,12 @@ export function deliveryDoubt(code: string | undefined, method: string): string 
   );
 }
 
-function describeComfyFetchFailure(err: unknown, target: string, method: string): Error {
+function describeComfyFetchFailure(
+  err: unknown,
+  target: string,
+  method: string,
+  context?: ComfyFetchDiagnosticContext,
+): Error {
   const { message, code } = describeFetchFailure(err);
   // ONE classification, used for both the sentence and the tail it governs
   // (#1896) — two calls would read the channel twice and could, across a
@@ -340,7 +381,7 @@ function describeComfyFetchFailure(err: unknown, target: string, method: string)
       `That is the headless ComfyUI target (COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable, ` +
       `because the panel talks to whichever ComfyUI its browser tab is on.` +
       drift.text +
-      nextStepsFor(drift.verdict, target, false),
+      nextStepsFor(drift.verdict, target, false, context),
     { cause: err },
   );
   if (code) (wrapped as { code?: string }).code = code;
@@ -502,6 +543,7 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
 export async function comfyuiFetch(
   input: string | URL | Request,
   init: RequestInit = {},
+  context?: ComfyFetchDiagnosticContext,
 ): Promise<Response> {
   const auth = getComfyUIAuthHeaders();
   // A CEILING, not a policy. Callers that know their own budget pass a signal
@@ -530,6 +572,6 @@ export async function comfyuiFetch(
     // its own message, or anything else already says what happened, and
     // replacing that text would be a downgrade.
     if (!isBareFetchFailure(err)) throw err;
-    throw describeComfyFetchFailure(err, targetOf(input), methodOf(input, init));
+    throw describeComfyFetchFailure(err, targetOf(input), methodOf(input, init), context);
   }
 }

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -20,7 +20,11 @@
 
 import { ComfyUIError } from "../utils/errors.js";
 import { config, getComfyUIAuthHeaders, getComfyUIBaseUrl } from "../config.js";
-import { comfyuiFetch, targetOf } from "./fetch.js";
+import {
+  comfyuiFetch,
+  targetOf,
+  type ComfyFetchDiagnosticContext,
+} from "./fetch.js";
 
 /** What answered instead of the ComfyUI JSON API. */
 export type NonJsonKind =
@@ -1289,9 +1293,10 @@ export async function fetchComfyJson<T = unknown>(
     init?: RequestInit;
     expectShape?: (v: unknown) => boolean;
     shapeHint?: string;
+    diagnosticContext?: ComfyFetchDiagnosticContext;
   } = {},
 ): Promise<T> {
-  const res = await comfyuiFetch(url, opts.init ?? {});
+  const res = await comfyuiFetch(url, opts.init ?? {}, opts.diagnosticContext);
   return readComfyJson<T>(res, {
     url,
     expectShape: opts.expectShape,

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -67,7 +67,7 @@ export async function runHealthCheck(
   const lines: string[] = ["## Health Check\n"];
 
   try {
-    const stats = (await getSystemStats()) as unknown as Record<string, any>;
+    const stats = (await getSystemStats({ diagnosticContext: "health" })) as unknown as Record<string, any>;
     const sys = stats.system ?? {};
     const dev = stats.devices?.[0] ?? {};
     const vramTotalGB = dev.vram_total

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1886,7 +1886,7 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   let statsArgv: string[] | undefined;
   let statsCwd: string | undefined;
   try {
-    const stats = await getSystemStats();
+    const stats = await getSystemStats({ diagnosticContext: "environment" });
     running.reachable = true;
     running.os = stats.system.os;
     running.python_version = stats.system.python_version;


### PR DESCRIPTION
Closes #2188

## Summary
- Thread a narrow health-call diagnostic context through health check, client JSON fetch, and transport classification.
- Replace the self-referential health retry with install_comfyui (action:"environment") as an independent readiness probe.
- Preserve transport codes, target URLs, Panel same/different-origin diagnostics, and COMFYUI_AUTH_* guidance.

## Verification
- Base: 7ae6703725ee78fbb5f433cc5dfa3a6cf7516ff1 (origin/main, v0.52.96)
- npm.cmd run lint
- npm.cmd run build
- Focused Vitest: 10 files, 147 tests passed