### PR TITLE
fix(panel-run): reconcile late scoped prompt receipts (#1728)

### DIFF
--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -56,17 +56,26 @@ afterEach(() => {
 describe("panel_run late prompt reconciliation (#1728)", () => {
   it("turns an id-less queued_unknown receipt into one ticket without redispatch", async () => {
     let calls = 0;
+    let receiptTaken = false;
     const bridge = {
       send: async () => ({}),
       canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        runRid === "run-rid-1728"
+          ? { runRid, tabId: "panel-1728", promptIds: ["prompt-1728"], lateByMs: 25 }
+          : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (runRid !== "run-rid-1728" || receiptTaken) return undefined;
+        receiptTaken = true;
+        return { runRid, tabId: "panel-1728", promptIds: ["prompt-1728"], lateByMs: 25 };
+      },
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "panel-1728");
-    ctx.call = async () => {
+    ctx.call = async (_cmd, _timeout, observeRid) => {
       calls++;
+      observeRid?.("run-rid-1728");
       // This is the late watchdog observation: the Panel has already answered
       // queued_unknown, but a new prompt is now visible after this dispatch.
-      qm.state.runningPromptId = "prompt-1728";
-      qm.state.queueRemaining = 1;
       return {
         content: [
           {
@@ -89,8 +98,31 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     expect(res.isError).toBeFalsy();
     expect(text).toMatch(/"prompt_id"\s*:\s*"prompt-1728"/);
     expect(text).toContain("[RECOVERED]");
-    expect(text).toContain("opening its completion ticket");
+    expect(text).toContain("completion ticket");
     expect(RunCompletions.ticketFor("prompt-1728")?.promptId).toBe("prompt-1728");
+    expect(receiptTaken).toBe(true);
+
+    // The real journal path now correlates the later bridge executed frame to
+    // the ticket, and its pending coalescer keeps duplicate frames to one entry.
+    const ticket = RunCompletions.ticketFor("prompt-1728");
+    const first = RunCompletions.record(
+      "panel-1728",
+      { kind: "executed", prompt_id: "prompt-1728", images: [{ filename: "out.png" }] },
+      ticket?.conversation === undefined ? undefined : { conversation: ticket.conversation },
+    );
+    const second = RunCompletions.record(
+      "panel-1728",
+      { kind: "executed", prompt_id: "prompt-1728", images: [{ filename: "out.png" }] },
+      ticket?.conversation === undefined ? undefined : { conversation: ticket.conversation },
+    );
+    expect(first.correlation.status).toBe("matched");
+    expect(second.correlation.status).toBe("matched");
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
   });
 
   it("does not infer a full-graph queued_unknown result from a queue observation", async () => {

--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -1,0 +1,121 @@
+// panel#1728 — a normal Panel queued_unknown reply can arrive before the
+// scoped /prompt request has exposed its prompt id. The MCP consumer must use
+// the existing bounded queue receipt path, then open the ordinary journal ticket.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+
+type QueueMonitorPrivate = {
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+
+const qm = QueueMonitor as unknown as QueueMonitorPrivate;
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function textOf(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((content) => content.type === "text")?.text ?? "";
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  RunCompletions.reset();
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+});
+
+describe("panel_run late prompt reconciliation (#1728)", () => {
+  it("turns an id-less queued_unknown receipt into one ticket without redispatch", async () => {
+    let calls = 0;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-1728");
+    ctx.call = async () => {
+      calls++;
+      // This is the late watchdog observation: the Panel has already answered
+      // queued_unknown, but a new prompt is now visible after this dispatch.
+      qm.state.runningPromptId = "prompt-1728";
+      qm.state.queueRemaining = 1;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              queued_unknown: true,
+              indeterminate_count: 1,
+              inFlight: 1,
+              error: "scoped dispatch budget expired before prompt_id arrived",
+            }),
+          },
+        ],
+      };
+    };
+
+    const res = await panelRun().handler({ to_node_id: 38 }, ctx);
+    const text = textOf(res);
+
+    expect(calls).toBe(1);
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/"prompt_id"\s*:\s*"prompt-1728"/);
+    expect(text).toContain("[RECOVERED]");
+    expect(text).toContain("opening its completion ticket");
+    expect(RunCompletions.ticketFor("prompt-1728")?.promptId).toBe("prompt-1728");
+  });
+
+  it("does not infer a full-graph queued_unknown result from a queue observation", async () => {
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-1728-full");
+    ctx.call = async () => {
+      qm.state.runningPromptId = "prompt-full-foreign";
+      qm.state.queueRemaining = 1;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ queued_unknown: true, indeterminate_count: 1 }),
+          },
+        ],
+      };
+    };
+
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toContain("no completion ticket can be opened");
+    expect(RunCompletions.ticketFor("prompt-full-foreign")).toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -158,6 +158,135 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     expect(RunCompletions.ticketFor("prompt-full-foreign")).toBeUndefined();
   });
 
+  it("does not reopen a normal-reply ticket when its exact receipt arrives later", async () => {
+    let handoff: ((receipt: { runRid: string; tabId: string; promptIds: string[] }) => void) | null = null;
+    let receipt: { runRid: string; tabId: string; promptIds: string[] } | undefined;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        receipt && receipt.runRid === runRid ? { ...receipt, lateByMs: 250 } : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (!receipt || receipt.runRid !== runRid) return undefined;
+        const taken = { ...receipt, lateByMs: 250 };
+        receipt = undefined;
+        return taken;
+      },
+      registerLateRunReceiptHandoff: (_rid: string, _tabId: string, onReceipt: typeof handoff) => {
+        handoff = onReceipt;
+        return () => {
+          handoff = null;
+        };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-normal-late-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      observeRid?.("run-rid-normal-late-1728");
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ queued: true, prompt_id: "prompt-normal-late-1728" }) },
+        ],
+      };
+    };
+
+    await panelRun().handler({ to_node_id: 38 }, ctx);
+    const ticketBeforeReceipt = RunCompletions.ticketFor("prompt-normal-late-1728");
+    expect(ticketBeforeReceipt?.reused).toBeUndefined();
+    const seqBeforeReceipt = ticketBeforeReceipt?.seq;
+
+    receipt = {
+      runRid: "run-rid-normal-late-1728",
+      tabId: "panel-normal-late-1728",
+      promptIds: ["prompt-normal-late-1728"],
+    };
+    handoff?.(receipt);
+
+    const ticketAfterReceipt = RunCompletions.ticketFor("prompt-normal-late-1728");
+    expect(ticketAfterReceipt?.seq).toBe(seqBeforeReceipt);
+    expect(ticketAfterReceipt?.reused).toBeUndefined();
+    RunCompletions.record(
+      "panel-normal-late-1728",
+      { kind: "executed", prompt_id: "prompt-normal-late-1728" },
+      undefined,
+    );
+    RunCompletions.record(
+      "panel-normal-late-1728",
+      { kind: "executed", prompt_id: "prompt-normal-late-1728" },
+      undefined,
+    );
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-normal-late-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
+  });
+
+  it("does not reopen a QueueMonitor fallback ticket when its exact receipt arrives later", async () => {
+    let handoff: ((receipt: { runRid: string; tabId: string; promptIds: string[] }) => void) | null = null;
+    let receipt: { runRid: string; tabId: string; promptIds: string[] } | undefined;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        receipt && receipt.runRid === runRid ? { ...receipt, lateByMs: 250 } : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (!receipt || receipt.runRid !== runRid) return undefined;
+        const taken = { ...receipt, lateByMs: 250 };
+        receipt = undefined;
+        return taken;
+      },
+      registerLateRunReceiptHandoff: (_rid: string, _tabId: string, onReceipt: typeof handoff) => {
+        handoff = onReceipt;
+        return () => {
+          handoff = null;
+        };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-queue-fallback-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      observeRid?.("run-rid-queue-fallback-1728");
+      qm.state.runningPromptId = "prompt-queue-fallback-1728";
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ queued_unknown: true, indeterminate_count: 1, inFlight: 1 }) },
+        ],
+      };
+    };
+
+    await panelRun().handler({ to_node_id: 38 }, ctx);
+    const ticketBeforeReceipt = RunCompletions.ticketFor("prompt-queue-fallback-1728");
+    expect(ticketBeforeReceipt?.reused).toBeUndefined();
+    const seqBeforeReceipt = ticketBeforeReceipt?.seq;
+
+    receipt = {
+      runRid: "run-rid-queue-fallback-1728",
+      tabId: "panel-queue-fallback-1728",
+      promptIds: ["prompt-queue-fallback-1728"],
+    };
+    handoff?.(receipt);
+
+    const ticketAfterReceipt = RunCompletions.ticketFor("prompt-queue-fallback-1728");
+    expect(ticketAfterReceipt?.seq).toBe(seqBeforeReceipt);
+    expect(ticketAfterReceipt?.reused).toBeUndefined();
+    RunCompletions.record(
+      "panel-queue-fallback-1728",
+      { kind: "executed", prompt_id: "prompt-queue-fallback-1728" },
+      undefined,
+    );
+    RunCompletions.record(
+      "panel-queue-fallback-1728",
+      { kind: "executed", prompt_id: "prompt-queue-fallback-1728" },
+      undefined,
+    );
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-queue-fallback-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
+  });
+
   it("waits for the complete exact batch before falling back to the first queue prompt", async () => {
     let calls = 0;
     let receiptReads = 0;
@@ -349,6 +478,64 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     );
     const frames: unknown[] = [];
     RunCompletions.deliverPending("panel-timeout-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
+  });
+
+  it("registers a transport handoff when ctx.call throws before returning", async () => {
+    let handoff: ((receipt: { runRid: string; tabId: string; promptIds: string[] }) => void) | null = null;
+    let receipt: { runRid: string; tabId: string; promptIds: string[] } | undefined;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        receipt && receipt.runRid === runRid ? { ...receipt, lateByMs: 250 } : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (!receipt || receipt.runRid !== runRid) return undefined;
+        const taken = { ...receipt, lateByMs: 250 };
+        receipt = undefined;
+        return taken;
+      },
+      registerLateRunReceiptHandoff: (_rid: string, _tabId: string, onReceipt: typeof handoff) => {
+        handoff = onReceipt;
+        return () => {
+          handoff = null;
+        };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-disconnect-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      observeRid?.("run-rid-disconnect-1728");
+      throw new Error("bridge socket closed after dispatch");
+    };
+
+    const res = await panelRun().handler({ to_node_id: 38 }, ctx);
+    expect(res.isError).toBe(true);
+    expect(handoff).toBeTypeOf("function");
+
+    receipt = {
+      runRid: "run-rid-disconnect-1728",
+      tabId: "panel-disconnect-1728",
+      promptIds: ["prompt-after-disconnect-1728"],
+    };
+    handoff?.(receipt);
+    expect(RunCompletions.ticketFor("prompt-after-disconnect-1728")?.promptId).toBe(
+      "prompt-after-disconnect-1728",
+    );
+    RunCompletions.record(
+      "panel-disconnect-1728",
+      { kind: "executed", prompt_id: "prompt-after-disconnect-1728" },
+      undefined,
+    );
+    RunCompletions.record(
+      "panel-disconnect-1728",
+      { kind: "executed", prompt_id: "prompt-after-disconnect-1728" },
+      undefined,
+    );
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-disconnect-1728", (payload) => {
       frames.push(payload);
       return true;
     });

--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -3,7 +3,12 @@
 // the existing bounded queue receipt path, then open the ordinary journal ticket.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 
@@ -33,6 +38,7 @@ function textOf(res: { content?: Array<{ type: string; text?: string }> }): stri
 }
 
 beforeEach(() => {
+  __panelToolsTestHooks.setRunLateAckGraceMs(450);
   RunCompletions.reset();
   qm.selfQueuedIds.clear();
   qm.lastSelfQueueTs = null;
@@ -45,6 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  __panelToolsTestHooks.setRunLateAckGraceMs(null);
   RunCompletions.reset();
   qm.selfQueuedIds.clear();
   qm.lastSelfQueueTs = null;
@@ -149,5 +156,122 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     expect(res.isError).toBeFalsy();
     expect(textOf(res)).toContain("no completion ticket can be opened");
     expect(RunCompletions.ticketFor("prompt-full-foreign")).toBeUndefined();
+  });
+
+  it("waits for the complete exact batch before falling back to the first queue prompt", async () => {
+    let calls = 0;
+    let receiptReads = 0;
+    let receiptTaken = false;
+    const allPromptIds = ["batch-prompt-1", "batch-prompt-2", "batch-prompt-3"];
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) => {
+        if (runRid !== "run-rid-batch-1728") return undefined;
+        receiptReads += 1;
+        const promptIds = receiptReads < 2 ? allPromptIds.slice(0, 1) : allPromptIds;
+        return { runRid, tabId: "panel-batch-1728", promptIds, lateByMs: 30 };
+      },
+      takeLateRunReceipt: (runRid: string) => {
+        if (runRid !== "run-rid-batch-1728" || receiptTaken) return undefined;
+        receiptTaken = true;
+        return { runRid, tabId: "panel-batch-1728", promptIds: allPromptIds, lateByMs: 30 };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-batch-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      calls += 1;
+      observeRid?.("run-rid-batch-1728");
+      qm.state.runningPromptId = allPromptIds[0];
+      qm.state.queueRemaining = 2;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              queued_unknown: true,
+              indeterminate_count: 3,
+              inFlight: 3,
+            }),
+          },
+        ],
+      };
+    };
+
+    const res = await panelRun().handler({ batch_count: 3, to_node_id: 38 }, ctx);
+
+    expect(calls).toBe(1);
+    expect(receiptReads).toBeGreaterThanOrEqual(2);
+    expect(receiptTaken).toBe(true);
+    expect(textOf(res)).toContain('"prompt_ids"');
+    for (const promptId of allPromptIds) {
+      expect(RunCompletions.ticketFor(promptId)?.promptId).toBe(promptId);
+      const ticket = RunCompletions.ticketFor(promptId);
+      RunCompletions.record("panel-batch-1728", { kind: "executed", prompt_id: promptId }, undefined);
+      RunCompletions.record("panel-batch-1728", { kind: "executed", prompt_id: promptId }, undefined);
+      expect(ticket).toBeDefined();
+    }
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-batch-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(3);
+  });
+
+  it("opens the exact ticket when a receipt arrives after the reconcile grace", async () => {
+    __panelToolsTestHooks.setRunLateAckGraceMs(25);
+    let calls = 0;
+    let handoff: ((receipt: { runRid: string; tabId: string; promptIds: string[] }) => void) | null = null;
+    let receipt: { runRid: string; tabId: string; promptIds: string[] } | undefined;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        receipt && receipt.runRid === runRid ? { ...receipt, lateByMs: 100 } : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (!receipt || receipt.runRid !== runRid) return undefined;
+        const taken = { ...receipt, lateByMs: 100 };
+        receipt = undefined;
+        return taken;
+      },
+      registerLateRunReceiptHandoff: (_rid: string, _tabId: string, onReceipt: typeof handoff) => {
+        handoff = onReceipt;
+        return () => {
+          handoff = null;
+        };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-late-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      calls += 1;
+      observeRid?.("run-rid-late-1728");
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ queued_unknown: true, indeterminate_count: 1, inFlight: 1 }),
+          },
+        ],
+      };
+    };
+
+    const res = await panelRun().handler({ to_node_id: 38 }, ctx);
+    expect(calls).toBe(1);
+    expect(RunCompletions.ticketFor("prompt-after-grace")).toBeUndefined();
+    receipt = { runRid: "run-rid-late-1728", tabId: "panel-late-1728", promptIds: ["prompt-after-grace"] };
+    handoff?.(receipt);
+
+    const ticket = RunCompletions.ticketFor("prompt-after-grace");
+    expect(ticket?.promptId).toBe("prompt-after-grace");
+    RunCompletions.record("panel-late-1728", { kind: "executed", prompt_id: "prompt-after-grace" }, undefined);
+    RunCompletions.record("panel-late-1728", { kind: "executed", prompt_id: "prompt-after-grace" }, undefined);
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-late-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
+    expect(res.isError).toBeFalsy();
   });
 });

--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -169,7 +169,16 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
       peekLateRunReceipt: (runRid: string) => {
         if (runRid !== "run-rid-batch-1728") return undefined;
         receiptReads += 1;
-        const promptIds = receiptReads < 2 ? allPromptIds.slice(0, 1) : allPromptIds;
+        // QueueMonitor sees the first prompt before the exact receipt frames
+        // finish arriving. The reconcile must keep the weaker observation as a
+        // candidate while merging the later exact batch, rather than returning
+        // the first id and stranding the rest in the bridge TTL map.
+        const promptIds =
+          receiptReads < 2
+            ? []
+            : receiptReads < 3
+              ? allPromptIds.slice(0, 1)
+              : allPromptIds;
         return { runRid, tabId: "panel-batch-1728", promptIds, lateByMs: 30 };
       },
       takeLateRunReceipt: (runRid: string) => {
@@ -201,9 +210,10 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     const res = await panelRun().handler({ batch_count: 3, to_node_id: 38 }, ctx);
 
     expect(calls).toBe(1);
-    expect(receiptReads).toBeGreaterThanOrEqual(2);
+    expect(receiptReads).toBeGreaterThanOrEqual(3);
     expect(receiptTaken).toBe(true);
     expect(textOf(res)).toContain('"prompt_ids"');
+    expect(textOf(res)).toContain("exact captured prompt");
     for (const promptId of allPromptIds) {
       expect(RunCompletions.ticketFor(promptId)?.promptId).toBe(promptId);
       const ticket = RunCompletions.ticketFor(promptId);
@@ -273,5 +283,75 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     });
     expect(frames).toHaveLength(1);
     expect(res.isError).toBeFalsy();
+  });
+
+  it("registers a timeout handoff before returning so a beyond-grace receipt still tickets", async () => {
+    __panelToolsTestHooks.setRunLateAckGraceMs(25);
+    let handoff: ((receipt: { runRid: string; tabId: string; promptIds: string[] }) => void) | null = null;
+    let receipt: { runRid: string; tabId: string; promptIds: string[] } | undefined;
+    const bridge = {
+      send: async () => ({}),
+      canReach: () => true,
+      peekLateRunReceipt: (runRid: string) =>
+        receipt && receipt.runRid === runRid ? { ...receipt, lateByMs: 250 } : undefined,
+      takeLateRunReceipt: (runRid: string) => {
+        if (!receipt || receipt.runRid !== runRid) return undefined;
+        const taken = { ...receipt, lateByMs: 250 };
+        receipt = undefined;
+        return taken;
+      },
+      registerLateRunReceiptHandoff: (_rid: string, _tabId: string, onReceipt: typeof handoff) => {
+        handoff = onReceipt;
+        return () => {
+          handoff = null;
+        };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "panel-timeout-1728");
+    ctx.call = async (_cmd, _timeout, observeRid) => {
+      observeRid?.("run-rid-timeout-1728");
+      const result = {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Error: Panel tab panel-timeout-1728 did not reply to \"graph_run\" within 20 ms",
+          },
+        ],
+      };
+      return __panelToolsTestHooks.markRunReplyTimeout(result);
+    };
+
+    const res = await panelRun().handler({ to_node_id: 38 }, ctx);
+    expect(res.isError).toBe(true);
+    expect(handoff).toBeTypeOf("function", "the timeout must install the bounded late owner before returning");
+    expect(RunCompletions.ticketFor("prompt-after-timeout-1728")).toBeUndefined();
+
+    receipt = {
+      runRid: "run-rid-timeout-1728",
+      tabId: "panel-timeout-1728",
+      promptIds: ["prompt-after-timeout-1728"],
+    };
+    handoff?.(receipt);
+
+    expect(RunCompletions.ticketFor("prompt-after-timeout-1728")?.promptId).toBe(
+      "prompt-after-timeout-1728",
+    );
+    RunCompletions.record(
+      "panel-timeout-1728",
+      { kind: "executed", prompt_id: "prompt-after-timeout-1728" },
+      undefined,
+    );
+    RunCompletions.record(
+      "panel-timeout-1728",
+      { kind: "executed", prompt_id: "prompt-after-timeout-1728" },
+      undefined,
+    );
+    const frames: unknown[] = [];
+    RunCompletions.deliverPending("panel-timeout-1728", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
   });
 });

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -282,7 +282,7 @@ describe("WIRING: panel_run stamps the dispatch time before dispatching (#1327)"
     const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
 
     const stamp = src.indexOf("let runDispatchedAt = Date.now();");
-    const call = src.indexOf("let res = await ctx.call(runCmd", stamp);
+    const call = src.indexOf("res = await ctx.call(runCmd", stamp);
     expect(stamp).toBeGreaterThan(-1);
     expect(call).toBeGreaterThan(stamp); // stamped first
     expect(src).toContain("dispatchedAt: runDispatchedAt,");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -29,6 +29,7 @@ import {
   makeScopeTargetResolver,
 } from "../../orchestrator/turn-origins.js";
 import { buildPanelToolDefs, makePanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
   __resetPanelBaseCache,
@@ -5593,6 +5594,101 @@ describe("#1728: late panel run receipts", () => {
     );
     await waitFor(() => expect(seen).toEqual([["prompt-after-grace-1728"]]));
     expect(bridge.peekLateRunReceipt("run-rid-1728-handoff")).toBeUndefined();
+    dispose();
+    sock.close();
+  });
+
+  it("does not reopen a ticket or emit a second completion for a duplicate receipt", async () => {
+    RunCompletions.reset();
+    const sock = await connectPanel("tab-1728-duplicate");
+    let callbacks = 0;
+    let opened = 0;
+    const frames: unknown[] = [];
+    const dispose = bridge.registerLateRunReceiptHandoff(
+      "run-rid-1728-duplicate",
+      "tab-1728-duplicate",
+      (receipt) => {
+        callbacks += 1;
+        const taken = bridge.takeLateRunReceipt(receipt.runRid);
+        for (const promptId of taken?.promptIds ?? []) {
+          if (
+            RunCompletions.openRun(promptId, {
+              tabId: "tab-1728-duplicate",
+              dispatchedAt: Date.now(),
+            })
+          ) {
+            opened += 1;
+          }
+        }
+      },
+      1000,
+    );
+    const frame = JSON.stringify({
+      type: "run_receipt",
+      run_rid: "run-rid-1728-duplicate",
+      prompt_id: "prompt-1728-duplicate",
+    });
+    sock.send(frame);
+    sock.send(frame);
+
+    await waitFor(() => expect(callbacks).toBe(1));
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(callbacks).toBe(1);
+    expect(opened).toBe(1, "the duplicate must not reopen the existing journal ticket");
+
+    RunCompletions.record(
+      "tab-1728-duplicate",
+      { kind: "executed", prompt_id: "prompt-1728-duplicate" },
+      undefined,
+    );
+    RunCompletions.record(
+      "tab-1728-duplicate",
+      { kind: "executed", prompt_id: "prompt-1728-duplicate" },
+      undefined,
+    );
+    RunCompletions.deliverPending("tab-1728-duplicate", (payload) => {
+      frames.push(payload);
+      return true;
+    });
+    expect(frames).toHaveLength(1);
+    expect(bridge.peekLateRunReceipt("run-rid-1728-duplicate")).toBeUndefined();
+
+    dispose();
+    sock.close();
+    RunCompletions.reset();
+  });
+
+  it("retries an undelivered receipt identity, but suppresses it after handoff succeeds", async () => {
+    const sock = await connectPanel("tab-1728-duplicate-retry");
+    let callbacks = 0;
+    let opened = 0;
+    const dispose = bridge.registerLateRunReceiptHandoff(
+      "run-rid-1728-duplicate-retry",
+      "tab-1728-duplicate-retry",
+      (receipt) => {
+        callbacks += 1;
+        if (callbacks === 1) throw new Error("temporary handoff failure");
+        const taken = bridge.takeLateRunReceipt(receipt.runRid);
+        for (const promptId of taken?.promptIds ?? []) {
+          if (RunCompletions.openRun(promptId, { tabId: "tab-1728-duplicate-retry", dispatchedAt: Date.now() })) {
+            opened += 1;
+          }
+        }
+      },
+      1000,
+    );
+    const frame = JSON.stringify({
+      type: "run_receipt",
+      run_rid: "run-rid-1728-duplicate-retry",
+      prompt_id: "prompt-1728-duplicate-retry",
+    });
+    sock.send(frame);
+    sock.send(frame);
+
+    await waitFor(() => expect(callbacks).toBe(2));
+    expect(opened).toBe(1);
+    expect(bridge.peekLateRunReceipt("run-rid-1728-duplicate-retry")).toBeUndefined();
+
     dispose();
     sock.close();
   });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5541,6 +5541,38 @@ describe("UiBridge.connectedServerOrigins (#952)", () => {
   });
 });
 
+describe("#1728: late panel run receipts", () => {
+  it("retains a rid-correlated receipt without forwarding it as an agent event", async () => {
+    const events: unknown[] = [];
+    const sock = await connectPanel("tab-1728-receipt");
+    bridge.onPanelMessage = (event) => events.push(event);
+
+    sock.send(
+      JSON.stringify({
+        type: "run_receipt",
+        run_rid: "run-rid-1728",
+        prompt_id: "prompt-1728",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(bridge.peekLateRunReceipt("run-rid-1728")).toMatchObject({
+        runRid: "run-rid-1728",
+        tabId: "tab-1728-receipt",
+        promptIds: ["prompt-1728"],
+      }),
+    );
+    expect(events.some((event) => (event as { type?: string }).type === "run_receipt")).toBe(false);
+
+    expect(bridge.takeLateRunReceipt("run-rid-1728")).toMatchObject({
+      runRid: "run-rid-1728",
+      promptIds: ["prompt-1728"],
+    });
+    expect(bridge.peekLateRunReceipt("run-rid-1728")).toBeUndefined();
+    sock.close();
+  });
+});
+
 // #875 — the liveness signal the self-restarter's tunnel gate depends on.
 //
 // isHeadless() is STICKY on purpose (a tab that ever connected headless stays so

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5571,6 +5571,31 @@ describe("#1728: late panel run receipts", () => {
     expect(bridge.peekLateRunReceipt("run-rid-1728")).toBeUndefined();
     sock.close();
   });
+
+  it("notifies the bounded exact handoff for a receipt that arrives after the normal grace", async () => {
+    const sock = await connectPanel("tab-1728-handoff");
+    const seen: string[][] = [];
+    const dispose = bridge.registerLateRunReceiptHandoff(
+      "run-rid-1728-handoff",
+      "tab-1728-handoff",
+      (receipt) => {
+        seen.push([...receipt.promptIds]);
+        bridge.takeLateRunReceipt(receipt.runRid);
+      },
+      1000,
+    );
+    sock.send(
+      JSON.stringify({
+        type: "run_receipt",
+        run_rid: "run-rid-1728-handoff",
+        prompt_id: "prompt-after-grace-1728",
+      }),
+    );
+    await waitFor(() => expect(seen).toEqual([["prompt-after-grace-1728"]]));
+    expect(bridge.peekLateRunReceipt("run-rid-1728-handoff")).toBeUndefined();
+    dispose();
+    sock.close();
+  });
 });
 
 // #875 — the liveness signal the self-restarter's tunnel gate depends on.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1218,6 +1218,15 @@ export const __panelToolsTestHooks = {
   setRunLateAckGraceMs(ms: number | null): void {
     runLateAckGraceMsOverride = ms;
   },
+  /** Mark a synthetic graph_run result as the bridge's authoritative reply timeout. */
+  markRunReplyTimeout(res: ToolResult): ToolResult {
+    Object.defineProperty(res, REPLY_TIMEOUT_RESULT, {
+      value: true,
+      enumerable: false,
+      configurable: true,
+    });
+    return res;
+  },
   /** Shrink the #2078 save-timeout settle grace so a still-dirty follow-up does not wait 5s. */
   setSaveTimeoutSettleGraceMs(ms: number | null): void {
     saveTimeoutSettleGraceMsOverride = ms;
@@ -13602,8 +13611,15 @@ async function reconcileLateRunAck(
   const parsed = parseToolResultJson(res);
   // An exact Panel receipt is safe even when a queued_unknown reply already
   // carried some ids: the bridge event is the producer's own prompt capture,
-  // not a queue guess. The old queue path remains id-less-only below.
-  const receiptEligible = allowPanelQueueUnknown && isPanelQueueUncertainty(parsed);
+  // not a queue guess. Timeout and mid-command disconnect results also need
+  // this exact path: their later receipt is the only authoritative handoff
+  // available after the transport failed. The old queue path remains
+  // id-less-only below.
+  const receiptEligible =
+    Boolean(rid) &&
+    ((allowPanelQueueUnknown && isPanelQueueUncertainty(parsed)) ||
+      isReplyTimeoutResult(res) ||
+      isMidCommandDisconnectResult(res));
   const queueEligible = isUnackedGraphRunResult(res, allowPanelQueueUnknown);
   if (!receiptEligible && !queueEligible) return null;
   const fromQueue = (): {
@@ -16377,6 +16393,51 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const observeRunRid = (rid: string): void => {
           runRid = rid;
         };
+        const makeRunTicketOpts = () => ({
+          // #884 — the REAL routed tab, captured at dispatch (see runTicketTab):
+          // the panel's `executed` event arrives under that id.
+          tabId: runTicketTab,
+          // #704 — …and WHOSE run it is. Unlike the tab, this owner cannot drift
+          // while a late receipt is being delivered.
+          ...(runTicketConversation !== undefined ? { conversation: runTicketConversation } : {}),
+          ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
+          // #1327 — lets the journal claim a completion that beat its own ticket.
+          dispatchedAt: runDispatchedAt,
+        });
+        let lateReceiptHandoffInstalled = false;
+        const installLateReceiptHandoff = (): void => {
+          const handoffRid = runRid;
+          if (
+            lateReceiptHandoffInstalled ||
+            !handoffRid ||
+            typeof ctx.bridge.registerLateRunReceiptHandoff !== "function"
+          ) {
+            return;
+          }
+          const ticketOpts = makeRunTicketOpts();
+          try {
+            ctx.bridge.registerLateRunReceiptHandoff(handoffRid, runTicketTab, (receipt) => {
+              if (receipt.runRid !== handoffRid || receipt.tabId !== runTicketTab) return;
+              const taken =
+                typeof ctx.bridge.takeLateRunReceipt === "function"
+                  ? ctx.bridge.takeLateRunReceipt(handoffRid)
+                  : undefined;
+              const promptIds = taken?.promptIds ?? receipt.promptIds;
+              const opened: string[] = [];
+              for (const rawId of promptIds) {
+                const id = typeof rawId === "string" ? rawId.trim() : "";
+                if (!id) continue;
+                QueueMonitor.markSelfQueued(id);
+                if (RunCompletions.openRun(id, ticketOpts)) opened.push(id);
+              }
+              if (opened.length) ctx.onRunTicketOpened?.(opened);
+            });
+            lateReceiptHandoffInstalled = true;
+          } catch {
+            // The receipt map remains available to the normal bounded drain;
+            // a handoff installation failure must never redispatch the run.
+          }
+        };
         let lateAckNote = "";
         let res = await ctx.call(runCmd, 20000, observeRunRid);
         // #1175 — fold a late acknowledgement into `res` BEFORE anything reads it,
@@ -16470,6 +16531,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             await reconcileRun();
             rejection = detectRunRejection(res);
           } catch (err) {
+            // A retry timeout/transport failure still has a concrete rid when the
+            // bridge accepted the dispatch. Register the bounded exact handoff
+            // before returning so a later Panel receipt can open its ticket.
+            installLateReceiptHandoff();
             // A bridge/late-receipt failure after ctx.call already returned must not
             // erase the retry's own result (notably its retry_of token). Preserve it
             // verbatim and stop: no further dispatch is justified by a failed local
@@ -16511,6 +16576,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
         if (rejection) {
+          // Timeout and transport failures can return before the ordinary ticket
+          // phase. Keep this exact rid owner alive before exposing the error.
+          installLateReceiptHandoff();
           // Disclose the re-issue on the failure path too: the caller must know a SECOND
           // dispatch went out. The disclosure states only what is CERTIFIED — that the
           // FIRST dispatch queued nothing — and leaves the second attempt's outcome to be
@@ -16613,49 +16681,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // to this exact call by prompt id. This is what lets the orchestrator
         // journal an undelivered completion and replay it into the right run
         // instead of losing it while the agent works through a goal.
-        const ticketOpts = {
-          // #884 — the REAL routed tab, captured at dispatch (see runTicketTab):
-          // the panel's `executed` event arrives under that id.
-          tabId: runTicketTab,
-          // #704 — …and WHOSE run it is. The tab is where the completion is
-          // expected FROM; this is the conversation that gets to call it its own,
-          // which is what still holds after the panel reconnects under a new id.
-          ...(runTicketConversation !== undefined ? { conversation: runTicketConversation } : {}),
-          ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
-          // #1327 — lets the journal claim a completion that beat its own ticket.
-          dispatchedAt: runDispatchedAt,
-        };
+        const ticketOpts = makeRunTicketOpts();
         // #1728 — keep an exact, rid-scoped owner alive after the bounded
         // reconcile. A receipt can be delayed by a closed/reconnecting Panel
         // route and arrive after this handler has already returned its
         // queued_unknown recovery. The owner opens only exact prompt tickets;
         // RunCompletions.openRun remains the idempotency fence.
-        if (
-          runRid &&
-          typeof ctx.bridge.registerLateRunReceiptHandoff === "function"
-        ) {
-          try {
-            ctx.bridge.registerLateRunReceiptHandoff(runRid, runTicketTab, (receipt) => {
-              if (receipt.runRid !== runRid || receipt.tabId !== runTicketTab) return;
-              const taken =
-                typeof ctx.bridge.takeLateRunReceipt === "function"
-                  ? ctx.bridge.takeLateRunReceipt(runRid)
-                  : undefined;
-              const promptIds = taken?.promptIds ?? receipt.promptIds;
-              const opened: string[] = [];
-              for (const rawId of promptIds) {
-                const id = typeof rawId === "string" ? rawId.trim() : "";
-                if (!id) continue;
-                QueueMonitor.markSelfQueued(id);
-                if (RunCompletions.openRun(id, ticketOpts)) opened.push(id);
-              }
-              if (opened.length) ctx.onRunTicketOpened?.(opened);
-            });
-          } catch {
-            // The receipt map remains available to the normal bounded drain;
-            // a handoff installation failure must never redispatch the run.
-          }
-        }
+        installLateReceiptHandoff();
         // Every id gets its own ticket. `correlatable` stays the promise the
         // anti-poll note is allowed to make — true only if at least one run can
         // actually be correlated back.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16578,6 +16578,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               for (const rawId of promptIds) {
                 const id = typeof rawId === "string" ? rawId.trim() : "";
                 if (!id) continue;
+                // The normal reply/queue fallback owns the same stable prompt
+                // identity when it wins the race. A late receipt is only a
+                // transport retry of that identity; reopening the journal
+                // ticket would mark it reused and disable exact correlation.
+                // A settled ticket is equally authoritative: late
+                // at-least-once receipt frames must be a no-op.
+                if (RunCompletions.hasTicket(id)) continue;
                 QueueMonitor.markSelfQueued(id);
                 if (RunCompletions.openRun(id, ticketOpts)) opened.push(id);
               }
@@ -16590,7 +16597,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         };
         let lateAckNote = "";
-        let res = await ctx.call(runCmd, 20000, observeRunRid);
+        let res: ToolResult;
+        try {
+          res = await ctx.call(runCmd, 20000, observeRunRid);
+        } catch (err) {
+          // A transport implementation may throw instead of returning the
+          // canonical error result. The dispatch rid is still authoritative:
+          // install the bounded owner before exposing the unknown outcome so a
+          // later exact Panel receipt can open its ticket without redispatch.
+          installLateReceiptHandoff();
+          return fail(
+            `panel_run dispatch failed before a reply could be read — its outcome is UNKNOWN ` +
+              `and it may have queued a render. Do NOT re-run blindly: check the queue ` +
+              `(action:"list") or get_history before deciding. (${err instanceof Error ? err.message : String(err)})`,
+          );
+        }
         // #1175 — fold a late acknowledgement into `res` BEFORE anything reads it,
         // so a recovered run takes the identical path an on-time one takes: the same
         // rejection detection, the same prompt-id ticketing, the same anti-poll
@@ -16833,12 +16854,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // journal an undelivered completion and replay it into the right run
         // instead of losing it while the agent works through a goal.
         const ticketOpts = makeRunTicketOpts();
-        // #1728 — keep an exact, rid-scoped owner alive after the bounded
-        // reconcile. A receipt can be delayed by a closed/reconnecting Panel
-        // route and arrive after this handler has already returned its
-        // queued_unknown recovery. The owner opens only exact prompt tickets;
-        // RunCompletions.openRun remains the idempotency fence.
-        installLateReceiptHandoff();
         // Every id gets its own ticket. `correlatable` stays the promise the
         // anti-poll note is allowed to make — true only if at least one run can
         // actually be correlated back.
@@ -16857,6 +16872,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // returns. Promote that in-memory arm immediately after its journal
         // ticket opens, so a completion burst cannot evict this owed run.
         if (ticketedPromptIds.length) ctx.onRunTicketOpened?.(ticketedPromptIds);
+        // #1728 — install the exact rid-scoped owner AFTER the normal reply or
+        // QueueMonitor fallback has opened its tickets. If a receipt was already
+        // buffered, registration drains it immediately; the handoff's ticket
+        // identity fence then makes that delivery a no-op instead of reopening
+        // the ticket as a reused run.
+        installLateReceiptHandoff();
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         //

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3386,9 +3386,18 @@ function isMidCommandDisconnectResult(res: ToolResult): boolean {
   );
 }
 
-/** A `graph_run` we wrote and then lost the reply for — timeout or disconnect. */
-function isUnackedGraphRunResult(res: ToolResult): boolean {
-  return isReplyTimeoutResult(res) || isMidCommandDisconnectResult(res);
+/** A `graph_run` whose queue receipt still needs reconciliation. */
+function isUnackedGraphRunResult(res: ToolResult, allowPanelQueueUnknown = false): boolean {
+  if (isReplyTimeoutResult(res) || isMidCommandDisconnectResult(res)) return true;
+  // #1728 — Panel can answer normally with queued_unknown while its scoped
+  // dispatch still has an in-flight /prompt request. Only enter the existing
+  // queue grace when NO prompt id was returned; a partial receipt already has
+  // tickets for its known ids and must not be guessed into a different id. The
+  // caller gates this new inference to panel_run's scoped form; full-graph
+  // uncertainty keeps its existing retry guidance.
+  if (!allowPanelQueueUnknown) return false;
+  const parsed = parseToolResultJson(res);
+  return isPanelQueueUncertainty(parsed) && acceptedPromptIds(parsed).length === 0;
 }
 
 /**
@@ -13522,7 +13531,7 @@ function runLateAckGraceMs(): number {
 /**
  * Wait, bounded, for evidence that a `graph_run` we stopped waiting for still
  * queued — and hand back the reply it would have produced on time (#1175,
- * panel#1524).
+ * panel#1524, panel#1728).
  *
  * Two receipts, in this order:
  *
@@ -13536,7 +13545,8 @@ function runLateAckGraceMs(): number {
  *
  * Returns null when there is nothing to reconcile. The negatives are deliberate:
  *
- *  - NOT an unacked post-write (timeout or disconnect) ⇒ nothing to wait for.
+ *  - NOT an unacked post-write (timeout or disconnect), or the Panel's explicit
+ *    id-less queued_unknown receipt (#1728) ⇒ nothing to wait for.
  *    Gated on the bridge's own typed marks, never on message text: an acked
  *    panel error can quote our timeout/OUTCOME UNKNOWN sentence verbatim
  *    (#1468 round 2), and the difference is whether the tab answered, which
@@ -13568,12 +13578,23 @@ async function reconcileLateRunAck(
   res: ToolResult,
   rid: string | undefined,
   preRunningPromptId?: string | null,
-): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" } | null> {
-  if (!isUnackedGraphRunResult(res)) return null;
-  const fromQueue = (): { result: unknown; lateByMs: number; via: "queue" } | null => {
+  allowPanelQueueUnknown = false,
+): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" | "queue-uncertain" } | null> {
+  if (!isUnackedGraphRunResult(res, allowPanelQueueUnknown)) return null;
+  const fromQueue = (): {
+    result: unknown;
+    lateByMs: number;
+    via: "queue" | "queue-uncertain";
+  } | null => {
     const promptId = promptAppearedAfterDispatch(preRunningPromptId);
     if (!promptId) return null;
-    return { result: { queued: true, prompt_id: promptId }, lateByMs: 0, via: "queue" };
+    return {
+      result: { queued: true, prompt_id: promptId },
+      lateByMs: 0,
+      via: isPanelQueueUncertainty(parseToolResultJson(res))
+        ? "queue-uncertain"
+        : "queue",
+    };
   };
   const bridge = ctx.bridge;
   const canPeek =
@@ -13628,6 +13649,18 @@ function queueRunReceiptNote(promptId: string): string {
     `prompt when this command was dispatched. Treating that as this run's receipt (queued:true). ` +
     `Nothing was dispatched a second time. Do NOT re-run: a second panel_run would bill/queue ` +
     `another render behind the one already running.`
+  );
+}
+
+/** #1728 — the Panel answered with queued_unknown, then its late prompt became
+ * visible to the watchdog. That is a bounded receipt, not a second dispatch. */
+function panelQueueUncertainReceiptNote(promptId: string): string {
+  return (
+    `\n\n[RECOVERED] The Panel returned queued_unknown before its scoped dispatch ` +
+    `reported a prompt id, but ComfyUI's queue now contains prompt ${promptId} — which was not ` +
+    `running when this command was dispatched. Treating that observation as this run's receipt ` +
+    `(queued:true) and opening its completion ticket. Nothing was dispatched a second time. ` +
+    `Do NOT re-run: a second panel_run could queue a duplicate render.`
   );
 }
 
@@ -16268,17 +16301,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // guidance. Rebuilding the reply here (rather than describing it) is what
         // makes that possible — `ok()` is exactly what ctx.call would have produced.
         const reconcileRun = async (): Promise<void> => {
-          const recovered = await reconcileLateRunAck(ctx, res, runRid, pre.runningPromptId);
+          const recovered = await reconcileLateRunAck(
+            ctx,
+            res,
+            runRid,
+            pre.runningPromptId,
+            typeof args.to_node_id === "number",
+          );
           if (!recovered) return;
           res = ok(recovered.result);
+          const promptId =
+            typeof (recovered.result as { prompt_id?: unknown }).prompt_id === "string"
+              ? (recovered.result as { prompt_id: string }).prompt_id
+              : "?";
           lateAckNote =
-            recovered.via === "queue"
-              ? queueRunReceiptNote(
-                  typeof (recovered.result as { prompt_id?: unknown }).prompt_id === "string"
-                    ? (recovered.result as { prompt_id: string }).prompt_id
-                    : "?",
-                )
-              : lateRunAckNote(recovered.lateByMs);
+            recovered.via === "queue-uncertain"
+              ? panelQueueUncertainReceiptNote(promptId)
+              : recovered.via === "queue"
+                ? queueRunReceiptNote(promptId)
+                : lateRunAckNote(recovered.lateByMs);
         };
         await reconcileRun();
         // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -13597,6 +13597,7 @@ async function reconcileLateRunAck(
   preRunningPromptId?: string | null,
   allowPanelQueueUnknown = false,
   expectedTabId?: string,
+  expectedPromptCount = 1,
 ): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" | "queue-uncertain" | "receipt" } | null> {
   const parsed = parseToolResultJson(res);
   // An exact Panel receipt is safe even when a queued_unknown reply already
@@ -13635,14 +13636,25 @@ async function reconcileLateRunAck(
   if (!canPeek && !canPeekReceipt) return queueEligible ? fromQueue() : null;
   const startedAt = Date.now();
   const deadline = startedAt + runLateAckGraceMs();
+  const expectedReceipts = Math.max(1, Math.min(64, Math.floor(expectedPromptCount)));
+  const waitForBatchReceipts = receiptEligible && canPeekReceipt && expectedReceipts > 1;
+  let queueCandidate: { result: unknown; via: "queue" | "queue-uncertain" } | null = null;
+  let exactReceiptPromptIds: string[] = [];
   for (;;) {
     if (receiptEligible && canPeekReceipt) {
       const seenReceipt = bridge.peekLateRunReceipt(rid!);
       if (seenReceipt && (!expectedTabId || seenReceipt.tabId === expectedTabId)) {
-        const takenReceipt = bridge.takeLateRunReceipt(rid!);
-        const result = takenReceipt ? latePanelReceiptResult(parsed, takenReceipt.promptIds) : null;
-        if (takenReceipt && result) {
-          return { result, lateByMs: takenReceipt.lateByMs, via: "receipt" };
+        for (const id of seenReceipt.promptIds) {
+          if (typeof id === "string" && id.trim() !== "" && !exactReceiptPromptIds.includes(id.trim())) {
+            exactReceiptPromptIds.push(id.trim());
+          }
+        }
+        if (exactReceiptPromptIds.length >= expectedReceipts) {
+          const takenReceipt = bridge.takeLateRunReceipt(rid!);
+          const result = takenReceipt ? latePanelReceiptResult(parsed, takenReceipt.promptIds) : null;
+          if (takenReceipt && result) {
+            return { result, lateByMs: takenReceipt.lateByMs, via: "receipt" };
+          }
         }
       }
     }
@@ -13657,10 +13669,32 @@ async function reconcileLateRunAck(
     }
     if (queueEligible) {
       const queued = fromQueue();
-      if (queued) return { ...queued, lateByMs: Date.now() - startedAt };
+      if (queued) {
+        if (!waitForBatchReceipts) return { ...queued, lateByMs: Date.now() - startedAt };
+        queueCandidate = queued;
+      }
     }
     const left = deadline - Date.now();
-    if (left <= 0) return null;
+    if (left <= 0) {
+      // Exact ids outrank the weaker QueueMonitor observation even when a
+      // partial batch is all that arrived before the bounded grace expired.
+      // Leave later frames to the post-reconcile handoff and let the ticket
+      // phase drain any ids that arrived between this read and ticketing.
+      if (receiptEligible && canPeekReceipt && exactReceiptPromptIds.length) {
+        const takenReceipt = bridge.takeLateRunReceipt(rid!);
+        const result = takenReceipt
+          ? latePanelReceiptResult(parsed, takenReceipt.promptIds)
+          : latePanelReceiptResult(parsed, exactReceiptPromptIds);
+        if (result) {
+          return {
+            result,
+            lateByMs: takenReceipt?.lateByMs ?? Date.now() - startedAt,
+            via: "receipt",
+          };
+        }
+      }
+      return queueCandidate ? { ...queueCandidate, lateByMs: Date.now() - startedAt } : null;
+    }
     await sleep(Math.max(1, Math.min(RUN_LATE_ACK_POLL_MS, left)));
   }
 }
@@ -16358,6 +16392,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             pre.runningPromptId,
             typeof args.to_node_id === "number",
             runTicketTab,
+            typeof args.batch_count === "number"
+              ? Math.max(1, Math.min(64, Math.floor(args.batch_count)))
+              : 1,
           );
           if (!recovered) return;
           res = ok(recovered.result);
@@ -16588,6 +16625,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // #1327 — lets the journal claim a completion that beat its own ticket.
           dispatchedAt: runDispatchedAt,
         };
+        // #1728 — keep an exact, rid-scoped owner alive after the bounded
+        // reconcile. A receipt can be delayed by a closed/reconnecting Panel
+        // route and arrive after this handler has already returned its
+        // queued_unknown recovery. The owner opens only exact prompt tickets;
+        // RunCompletions.openRun remains the idempotency fence.
+        if (
+          runRid &&
+          typeof ctx.bridge.registerLateRunReceiptHandoff === "function"
+        ) {
+          try {
+            ctx.bridge.registerLateRunReceiptHandoff(runRid, runTicketTab, (receipt) => {
+              if (receipt.runRid !== runRid || receipt.tabId !== runTicketTab) return;
+              const taken =
+                typeof ctx.bridge.takeLateRunReceipt === "function"
+                  ? ctx.bridge.takeLateRunReceipt(runRid)
+                  : undefined;
+              const promptIds = taken?.promptIds ?? receipt.promptIds;
+              const opened: string[] = [];
+              for (const rawId of promptIds) {
+                const id = typeof rawId === "string" ? rawId.trim() : "";
+                if (!id) continue;
+                QueueMonitor.markSelfQueued(id);
+                if (RunCompletions.openRun(id, ticketOpts)) opened.push(id);
+              }
+              if (opened.length) ctx.onRunTicketOpened?.(opened);
+            });
+          } catch {
+            // The receipt map remains available to the normal bounded drain;
+            // a handoff installation failure must never redispatch the run.
+          }
+        }
         // Every id gets its own ticket. `correlatable` stays the promise the
         // anti-poll note is allowed to make — true only if at least one run can
         // actually be correlated back.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -13573,14 +13573,38 @@ function promptAppearedAfterDispatch(preRunningPromptId: string | null | undefin
   return now;
 }
 
+/** Turn exact Panel-captured ids into the same receipt shape as an on-time reply. */
+function latePanelReceiptResult(
+  parsed: Record<string, unknown> | null,
+  latePromptIds: string[],
+): Record<string, unknown> | null {
+  const ids = [...acceptedPromptIds(parsed)];
+  for (const id of latePromptIds) {
+    if (typeof id === "string" && id.trim() !== "" && !ids.includes(id.trim())) ids.push(id.trim());
+  }
+  if (!ids.length) return null;
+  return {
+    queued: true,
+    prompt_id: ids[0],
+    ...(ids.length > 1 ? { prompt_ids: ids } : {}),
+  };
+}
+
 async function reconcileLateRunAck(
   ctx: PanelToolCtx,
   res: ToolResult,
   rid: string | undefined,
   preRunningPromptId?: string | null,
   allowPanelQueueUnknown = false,
-): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" | "queue-uncertain" } | null> {
-  if (!isUnackedGraphRunResult(res, allowPanelQueueUnknown)) return null;
+  expectedTabId?: string,
+): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" | "queue-uncertain" | "receipt" } | null> {
+  const parsed = parseToolResultJson(res);
+  // An exact Panel receipt is safe even when a queued_unknown reply already
+  // carried some ids: the bridge event is the producer's own prompt capture,
+  // not a queue guess. The old queue path remains id-less-only below.
+  const receiptEligible = allowPanelQueueUnknown && isPanelQueueUncertainty(parsed);
+  const queueEligible = isUnackedGraphRunResult(res, allowPanelQueueUnknown);
+  if (!receiptEligible && !queueEligible) return null;
   const fromQueue = (): {
     result: unknown;
     lateByMs: number;
@@ -13601,24 +13625,40 @@ async function reconcileLateRunAck(
     Boolean(rid) &&
     typeof bridge?.peekLateMutation === "function" &&
     typeof bridge?.takeLateMutation === "function";
+  const canPeekReceipt =
+    Boolean(rid) &&
+    typeof bridge?.peekLateRunReceipt === "function" &&
+    typeof bridge?.takeLateRunReceipt === "function";
   // Stubbed bridges in unit tests have no late-mutation map. One-shot the queue
   // (no grace wait) so a timeout whose prompt did not change still returns in
   // the same tick it always has.
-  if (!canPeek) return fromQueue();
+  if (!canPeek && !canPeekReceipt) return queueEligible ? fromQueue() : null;
   const startedAt = Date.now();
   const deadline = startedAt + runLateAckGraceMs();
   for (;;) {
-    const seen = bridge.peekLateMutation(rid!);
+    if (receiptEligible && canPeekReceipt) {
+      const seenReceipt = bridge.peekLateRunReceipt(rid!);
+      if (seenReceipt && (!expectedTabId || seenReceipt.tabId === expectedTabId)) {
+        const takenReceipt = bridge.takeLateRunReceipt(rid!);
+        const result = takenReceipt ? latePanelReceiptResult(parsed, takenReceipt.promptIds) : null;
+        if (takenReceipt && result) {
+          return { result, lateByMs: takenReceipt.lateByMs, via: "receipt" };
+        }
+      }
+    }
+    const seen = canPeek ? bridge.peekLateMutation(rid!) : undefined;
     if (seen) {
-      if (seen.cmd !== "graph_run" || !("result" in seen)) return fromQueue();
+      if (seen.cmd !== "graph_run" || !("result" in seen)) return queueEligible ? fromQueue() : null;
       // Only now is it certain this entry will be USED, so draining it costs the
       // caller nothing: they are about to be handed its contents.
       const taken = bridge.takeLateMutation(rid!);
-      if (!taken || !("result" in taken)) return fromQueue();
+      if (!taken || !("result" in taken)) return queueEligible ? fromQueue() : null;
       return { result: taken.result, lateByMs: taken.lateByMs, via: "ack" };
     }
-    const queued = fromQueue();
-    if (queued) return { ...queued, lateByMs: Date.now() - startedAt };
+    if (queueEligible) {
+      const queued = fromQueue();
+      if (queued) return { ...queued, lateByMs: Date.now() - startedAt };
+    }
     const left = deadline - Date.now();
     if (left <= 0) return null;
     await sleep(Math.max(1, Math.min(RUN_LATE_ACK_POLL_MS, left)));
@@ -13661,6 +13701,16 @@ function panelQueueUncertainReceiptNote(promptId: string): string {
     `running when this command was dispatched. Treating that observation as this run's receipt ` +
     `(queued:true) and opening its completion ticket. Nothing was dispatched a second time. ` +
     `Do NOT re-run: a second panel_run could queue a duplicate render.`
+  );
+}
+
+/** #1728 — exact prompt id sent by the Panel after its graph_run reply window. */
+function panelLateReceiptNote(promptId: string): string {
+  return (
+    `\n\n[RECOVERED] The Panel reported prompt ${promptId} after the scoped dispatch ` +
+    `reply window closed. This is the Panel's exact captured prompt id, so its ` +
+    `completion ticket is now open. Nothing was dispatched a second time; do NOT re-run ` +
+    `panel_run or you may queue a duplicate render.`
   );
 }
 
@@ -16307,6 +16357,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             runRid,
             pre.runningPromptId,
             typeof args.to_node_id === "number",
+            runTicketTab,
           );
           if (!recovered) return;
           res = ok(recovered.result);
@@ -16315,7 +16366,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               ? (recovered.result as { prompt_id: string }).prompt_id
               : "?";
           lateAckNote =
-            recovered.via === "queue-uncertain"
+            recovered.via === "receipt"
+              ? panelLateReceiptNote(promptId)
+              : recovered.via === "queue-uncertain"
               ? panelQueueUncertainReceiptNote(promptId)
               : recovered.via === "queue"
                 ? queueRunReceiptNote(promptId)
@@ -16466,7 +16519,31 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // ever ticketed, so completions 2..N came back as
         // "does NOT match any run you queued … its origin is UNDETERMINED" — for
         // runs the agent had just queued itself. Ticket all of them.
-        const queuedIds = acceptedPromptIds(runReply);
+        // The Panel sends exact receipts for every captured batch prompt. A
+        // normal reply can race those frames and expose only its first id, so
+        // consume any still-buffered, route-matching receipt before opening
+        // tickets; otherwise a second exact id could be discarded as merely
+        // redundant.
+        let lateReceiptPromptIds: string[] = [];
+        if (
+          runRid &&
+          typeof ctx.bridge.peekLateRunReceipt === "function" &&
+          typeof ctx.bridge.takeLateRunReceipt === "function"
+        ) {
+          try {
+            const pendingReceipt = ctx.bridge.peekLateRunReceipt(runRid);
+            if (pendingReceipt && pendingReceipt.tabId === runTicketTab) {
+              const takenReceipt = ctx.bridge.takeLateRunReceipt(runRid);
+              lateReceiptPromptIds = takenReceipt?.promptIds ?? [];
+            }
+          } catch {}
+        }
+        const queuedIds = [...acceptedPromptIds(runReply)];
+        for (const id of lateReceiptPromptIds) {
+          if (typeof id === "string" && id.trim() !== "" && !queuedIds.includes(id.trim())) {
+            queuedIds.push(id.trim());
+          }
+        }
         const panelQueueUncertain = isPanelQueueUncertainty(runReply);
         // #944: a run ComfyUI accepted while dropping some outputs reaches here
         // (a minted prompt id outranks the rejection signals). Say which outputs

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1444,6 +1444,10 @@ export class RunCompletionJournalImpl {
   }
 
   /** Test/diagnostic helpers. */
+  /** Whether this prompt identity still has an open or terminal ticket. */
+  hasTicket(promptId: string): boolean {
+    return this.tickets.has(promptId);
+  }
   ticketFor(promptId: string): RunTicket | undefined {
     return this.tickets.get(promptId);
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1726,6 +1726,14 @@ export type LateMutation = {
   result?: unknown;
 };
 
+/** A prompt id captured by the Panel after the graph_run reply window (#1728). */
+export type LateRunReceipt = {
+  runRid: string;
+  tabId: string;
+  promptIds: string[];
+  lateByMs: number;
+};
+
 /**
  * Size ceiling on a RETAINED reply payload (#1175).
  *
@@ -2147,6 +2155,8 @@ export class UiBridge {
     string,
     { ok: true; cmd: string; tabId: string; ts: number; lateByMs: number; result?: unknown }
   >();
+  /** Exact prompt receipts sent by the Panel after its graph_run command returned. */
+  private lateRunReceipts = new Map<string, { tabId: string; promptIds: string[]; ts: number }>();
   /**
    * TTL for both maps above.
    *
@@ -3286,6 +3296,13 @@ export class UiBridge {
           msg.title = this.conns.get(effectiveTab)?.title;
           if (msg.type === "user_message") this.setLastActiveTab(effectiveTab);
         }
+        // #1728 — this is a control receipt, not an agent-facing completion.
+        // Retain it by the original graph_run rid so panel_run can open the
+        // server ticket even when the normal command reply was already returned.
+        if (msg.type === "run_receipt") {
+          this.recordLateRunReceipt(msg, effectiveTab);
+          return;
+        }
         this.deliverPanelEvent(msg as PanelEvent);
       }
     });
@@ -4209,6 +4226,51 @@ export class UiBridge {
     };
   }
 
+  /** Record one exact prompt id from the Panel's late graph_run capture. */
+  private recordLateRunReceipt(msg: Record<string, unknown>, tabId: string | null): void {
+    const runRid = typeof msg.run_rid === "string" ? msg.run_rid.trim() : "";
+    const promptId = typeof msg.prompt_id === "string" ? msg.prompt_id.trim() : "";
+    if (!runRid || !promptId || !tabId) return;
+    this.pruneLateMutations();
+    const prior = this.lateRunReceipts.get(runRid);
+    if (prior && prior.tabId !== tabId) return;
+    const promptIds = prior?.promptIds ?? [];
+    if (!promptIds.includes(promptId)) {
+      // A Panel batch is bounded by the same map cardinality as other late
+      // receipts; never let a forged control frame create an unbounded list.
+      if (promptIds.length >= UiBridge.MAX_LATE_MUTATIONS) return;
+      promptIds.push(promptId);
+    }
+    this.lateRunReceipts.set(runRid, { tabId, promptIds, ts: prior?.ts ?? Date.now() });
+  }
+
+  /** Drain a Panel late prompt receipt once, after panel_run consumes it. */
+  takeLateRunReceipt(runRid: string): LateRunReceipt | undefined {
+    this.pruneLateMutations();
+    const hit = this.lateRunReceipts.get(runRid);
+    if (!hit) return undefined;
+    this.lateRunReceipts.delete(runRid);
+    return {
+      runRid,
+      tabId: hit.tabId,
+      promptIds: [...hit.promptIds],
+      lateByMs: Math.max(0, Date.now() - hit.ts),
+    };
+  }
+
+  /** Peek without draining so panel_run only consumes a receipt it can use. */
+  peekLateRunReceipt(runRid: string): LateRunReceipt | undefined {
+    this.pruneLateMutations();
+    const hit = this.lateRunReceipts.get(runRid);
+    if (!hit) return undefined;
+    return {
+      runRid,
+      tabId: hit.tabId,
+      promptIds: [...hit.promptIds],
+      lateByMs: Math.max(0, Date.now() - hit.ts),
+    };
+  }
+
   /** TTL + cardinality bound for both #694 maps. */
   private pruneLateMutations(): void {
     const now = Date.now();
@@ -4218,11 +4280,14 @@ export class UiBridge {
     for (const [rid, e] of this.lateMutations) {
       if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.lateMutations.delete(rid);
     }
+    for (const [rid, e] of this.lateRunReceipts) {
+      if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.lateRunReceipts.delete(rid);
+    }
     // Map iteration is insertion-ordered, so dropping from the front drops the
     // oldest. Quiet, unlike the ask-mapping overflow: losing one of 256 late
     // completions costs the caller a notice they can still get by looking, where
     // losing an ask mapping loses a user's answer outright.
-    for (const map of [this.timedOutMutations, this.lateMutations]) {
+    for (const map of [this.timedOutMutations, this.lateMutations, this.lateRunReceipts]) {
       while (map.size > UiBridge.MAX_LATE_MUTATIONS) {
         const oldest = map.keys().next();
         if (oldest.done) break;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1734,6 +1734,8 @@ export type LateRunReceipt = {
   lateByMs: number;
 };
 
+export type LateRunReceiptHandoff = (receipt: LateRunReceipt) => void;
+
 /**
  * Size ceiling on a RETAINED reply payload (#1175).
  *
@@ -2157,6 +2159,11 @@ export class UiBridge {
   >();
   /** Exact prompt receipts sent by the Panel after its graph_run command returned. */
   private lateRunReceipts = new Map<string, { tabId: string; promptIds: string[]; ts: number }>();
+  /** Bounded post-reconcile owners for exact receipts that arrive after panel_run returned. */
+  private lateRunReceiptHandoffs = new Map<
+    string,
+    { tabId: string; expiresAt: number; onReceipt: LateRunReceiptHandoff }
+  >();
   /**
    * TTL for both maps above.
    *
@@ -2168,6 +2175,8 @@ export class UiBridge {
    * what the timeout disclosure told them to do in the first place.
    */
   private static readonly LATE_MUTATION_TTL_MS = 10 * 60 * 1000;
+  /** A ticket handoff outlives the normal reconcile grace, but never indefinitely. */
+  private static readonly LATE_RUN_RECEIPT_HANDOFF_TTL_MS = 60 * 1000;
   /** Hard cardinality bound, so a pathological tab timing out in a loop cannot
    *  grow either map without limit even inside the TTL. */
   private static readonly MAX_LATE_MUTATIONS = 256;
@@ -4242,6 +4251,52 @@ export class UiBridge {
       promptIds.push(promptId);
     }
     this.lateRunReceipts.set(runRid, { tabId, promptIds, ts: prior?.ts ?? Date.now() });
+    const handoff = this.lateRunReceiptHandoffs.get(runRid);
+    if (handoff && handoff.expiresAt > Date.now() && handoff.tabId === tabId) {
+      const receipt = this.peekLateRunReceipt(runRid);
+      if (receipt) {
+        try {
+          handoff.onReceipt(receipt);
+        } catch {
+          // A receipt must remain buffered if its late consumer is transiently
+          // unavailable; the owner can still drain it explicitly.
+        }
+      }
+    }
+  }
+
+  /**
+   * Keep an exact run receipt actionable after panel_run's bounded reconcile
+   * window. Registration also drains an already-buffered receipt, which closes
+   * the race between the normal ticket pass and this late owner.
+   */
+  registerLateRunReceiptHandoff(
+    runRid: string,
+    tabId: string,
+    onReceipt: LateRunReceiptHandoff,
+    ttlMs = UiBridge.LATE_RUN_RECEIPT_HANDOFF_TTL_MS,
+  ): () => void {
+    const rid = typeof runRid === "string" ? runRid.trim() : "";
+    const tab = typeof tabId === "string" ? tabId.trim() : "";
+    if (!rid || !tab || typeof onReceipt !== "function") return () => {};
+    this.pruneLateMutations();
+    const entry = {
+      tabId: tab,
+      expiresAt: Date.now() + Math.max(1, ttlMs),
+      onReceipt,
+    };
+    this.lateRunReceiptHandoffs.set(rid, entry);
+    const current = this.peekLateRunReceipt(rid);
+    if (current && current.tabId === tab) {
+      try {
+        onReceipt(current);
+      } catch {
+        // Keep the map entry for a later frame/explicit drain.
+      }
+    }
+    return () => {
+      if (this.lateRunReceiptHandoffs.get(rid) === entry) this.lateRunReceiptHandoffs.delete(rid);
+    };
   }
 
   /** Drain a Panel late prompt receipt once, after panel_run consumes it. */
@@ -4283,11 +4338,14 @@ export class UiBridge {
     for (const [rid, e] of this.lateRunReceipts) {
       if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.lateRunReceipts.delete(rid);
     }
+    for (const [rid, e] of this.lateRunReceiptHandoffs) {
+      if (e.expiresAt <= now) this.lateRunReceiptHandoffs.delete(rid);
+    }
     // Map iteration is insertion-ordered, so dropping from the front drops the
     // oldest. Quiet, unlike the ask-mapping overflow: losing one of 256 late
     // completions costs the caller a notice they can still get by looking, where
     // losing an ask mapping loses a user's answer outright.
-    for (const map of [this.timedOutMutations, this.lateMutations, this.lateRunReceipts]) {
+    for (const map of [this.timedOutMutations, this.lateMutations, this.lateRunReceipts, this.lateRunReceiptHandoffs]) {
       while (map.size > UiBridge.MAX_LATE_MUTATIONS) {
         const oldest = map.keys().next();
         if (oldest.done) break;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2162,7 +2162,15 @@ export class UiBridge {
   /** Bounded post-reconcile owners for exact receipts that arrive after panel_run returned. */
   private lateRunReceiptHandoffs = new Map<
     string,
-    { tabId: string; expiresAt: number; onReceipt: LateRunReceiptHandoff }
+    {
+      tabId: string;
+      expiresAt: number;
+      onReceipt: LateRunReceiptHandoff;
+      // Panel receipts are at-least-once across reconnect/retry. Keep the
+      // prompt identities already handed to the owner so a duplicate cannot
+      // reopen an existing RunCompletions ticket.
+      deliveredPromptIds: Set<string>;
+    }
   >();
   /**
    * TTL for both maps above.
@@ -4243,20 +4251,41 @@ export class UiBridge {
     this.pruneLateMutations();
     const prior = this.lateRunReceipts.get(runRid);
     if (prior && prior.tabId !== tabId) return;
+    const handoff = this.lateRunReceiptHandoffs.get(runRid);
     const promptIds = prior?.promptIds ?? [];
-    if (!promptIds.includes(promptId)) {
+    const isNewPromptId = !promptIds.includes(promptId);
+    if (
+      handoff &&
+      handoff.expiresAt > Date.now() &&
+      handoff.tabId === tabId &&
+      handoff.deliveredPromptIds.has(promptId)
+    ) {
+      // The owner already consumed this stable prompt identity. Do not even
+      // re-buffer the at-least-once duplicate behind the TTL map.
+      return;
+    }
+    if (isNewPromptId) {
       // A Panel batch is bounded by the same map cardinality as other late
       // receipts; never let a forged control frame create an unbounded list.
       if (promptIds.length >= UiBridge.MAX_LATE_MUTATIONS) return;
       promptIds.push(promptId);
     }
     this.lateRunReceipts.set(runRid, { tabId, promptIds, ts: prior?.ts ?? Date.now() });
-    const handoff = this.lateRunReceiptHandoffs.get(runRid);
-    if (handoff && handoff.expiresAt > Date.now() && handoff.tabId === tabId) {
+    if (
+      handoff &&
+      handoff.expiresAt > Date.now() &&
+      handoff.tabId === tabId &&
+      !handoff.deliveredPromptIds.has(promptId)
+    ) {
       const receipt = this.peekLateRunReceipt(runRid);
       if (receipt) {
         try {
           handoff.onReceipt(receipt);
+          for (const deliveredId of receipt.promptIds) {
+            if (typeof deliveredId === "string" && deliveredId.trim() !== "") {
+              handoff.deliveredPromptIds.add(deliveredId.trim());
+            }
+          }
         } catch {
           // A receipt must remain buffered if its late consumer is transiently
           // unavailable; the owner can still drain it explicitly.
@@ -4284,12 +4313,18 @@ export class UiBridge {
       tabId: tab,
       expiresAt: Date.now() + Math.max(1, ttlMs),
       onReceipt,
+      deliveredPromptIds: new Set<string>(),
     };
     this.lateRunReceiptHandoffs.set(rid, entry);
     const current = this.peekLateRunReceipt(rid);
     if (current && current.tabId === tab) {
       try {
         onReceipt(current);
+        for (const promptId of current.promptIds) {
+          if (typeof promptId === "string" && promptId.trim() !== "") {
+            entry.deliveredPromptIds.add(promptId.trim());
+          }
+        }
       } catch {
         // Keep the map entry for a later frame/explicit drain.
       }


### PR DESCRIPTION
Companion to artokun/comfyui-mcp-panel#1748.\n\nWhen a scoped panel_run returns the Panel's id-less queued_unknown receipt, use the existing bounded queue reconciliation to recover a prompt that appears after dispatch, then open the normal completion journal ticket. The inference is gated to scoped runs with no known prompt IDs; full-graph uncertainty and partial receipts are unchanged. No redispatch, timeout-fence, or idempotency behavior changes.\n\nVerification: npm.cmd run lint; npm.cmd exec -- vitest run src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts src/__tests__/orchestrator/run-late-ack-reconcile.test.ts. Full suite has 5 pre-existing failures in package-hooks dist allowlist, late-mutation-e2e timing, and node-id-union-message expectations.