### PR TITLE
fix(2215): mode:"imported" is a staleness window, not an import-success filter

### DIFF
--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -103,7 +103,7 @@ Install, repair, enable/disable and remove ComfyUI custom node packs on this Com
   action:"install" — git ref (commit SHA, branch, or tag) to pin when installing a git URL. Overrides any ref parsed from the URL and any `version` value. Ignored for registry-id installs.
 </ParamField>
 <ParamField path="mode" type="enum">
-  Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default 'remote'); 'remote' fetches the live node list, 'local'/'cache' use bundled/cached data. For action:"list": 'default' lists all installed packs, 'imported' lists only those successfully imported this session. Passing a value from the wrong group is refused, naming the ones the action accepts.
+  Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default 'remote'); 'remote' fetches the live node list, 'local'/'cache' use bundled/cached data. For action:"list": 'default' lists the installed packs as they are on disk NOW; 'imported' returns that SAME custom_nodes/ scan frozen at ComfyUI startup, so the only difference is packs installed or removed since the server booted. 'imported' is NOT an import-success filter: it includes DISABLED packs and cannot tell you whether the Python of a pack actually loaded — for that use node_pack action:"verify", which checks the node class_types of the pack against /object_info on the running server. Passing a value from the wrong group is refused, naming the ones the action accepts.
   Options: `remote`, `local`, `cache`, `default`, `imported`.
 </ParamField>
 <ParamField path="channel" type="string">

--- a/src/__tests__/tools/node-management.test.ts
+++ b/src/__tests__/tools/node-management.test.ts
@@ -523,3 +523,104 @@ describe("the retired custom-node lifecycle names", () => {
     );
   });
 });
+
+/**
+ * #2215 — mode:"imported" is a STALENESS window, not an import-success filter.
+ *
+ * ComfyUI-Manager answers /customnode/installed?mode=imported from
+ * `startup_time_installed_node_packs`, a module-scope freeze of the very same
+ * `core.get_installed_node_packs()` filesystem scan mode:"default" runs live —
+ * disabled packs and all. Our schema said it "lists only those successfully
+ * imported this session", which no version of the Manager has ever done, so the
+ * reporter read an unfiltered 98-pack list as a confident yes.
+ *
+ * These pin the DISCLOSURE, not a filter. The distinction is the whole fix: an
+ * ENABLED pack that fails on a torch/CUDA mismatch is the case that matters and
+ * it survives any filter we could write here, because the scan never opens the
+ * Python. So the disabled-pack assertion below is deliberate — it exists to make
+ * a future 'helpful' filter argue with a test instead of shipping a prettier
+ * wrong answer.
+ */
+describe("install_custom_node action:\"list\" discloses what mode:\"imported\" cannot answer (#2215)", () => {
+  const PACKS = [
+    { module: "was-node-suite-comfyui", version: "1.0", enabled: true },
+    { module: "ComfyUI-Impact-Pack.disabled", version: "8.2", enabled: false },
+  ];
+
+  it('mode:"imported" carries the disclosure, and still carries the list', async () => {
+    mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
+    const out = text(await handler()({ action: "list", mode: "imported" }));
+
+    // The note names what the mode is NOT ...
+    expect(out).toContain('mode:"imported" is NOT an import-success list');
+    expect(out).toContain("frozen at server startup");
+    // ... why the reporter saw two identical lists ...
+    expect(out).toContain("installed or removed since the server booted");
+    // ... and the tool that DOES answer the question, by name and arguments,
+    // because an undiscoverable remedy is why /object_info was hand-grepped.
+    expect(out).toContain('node_pack {action:"verify"');
+    expect(out).toContain("/object_info");
+
+    // The disclosure is APPENDED. A note that replaced the payload would trade
+    // one silent failure for another.
+    expect(out).toContain("1. was-node-suite-comfyui");
+    expect(out).toContain("2. ComfyUI-Impact-Pack.disabled");
+  });
+
+  it('does not filter the disabled packs out of mode:"imported"', async () => {
+    mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
+    const out = text(await handler()({ action: "list", mode: "imported" }));
+    // Present, and reported as disabled — the honest shape. Dropping it would
+    // read as "everything left imported fine", which is the bug in a costume.
+    expect(out).toContain("ComfyUI-Impact-Pack.disabled");
+    expect(out).toContain("version: 8.2 | disabled");
+    expect(mocks.listInstalledNodes).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "imported" }),
+    );
+  });
+
+  // The controls. A note that fires unconditionally discloses nothing: it would
+  // survive every mutation of the `mode === "imported"` guard.
+  it('mode:"default" and an omitted mode say nothing about imports', async () => {
+    for (const args of [
+      { action: "list", mode: "default" },
+      { action: "list" },
+    ]) {
+      mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
+      const out = text(await handler()(args));
+      expect(out, JSON.stringify(args)).not.toContain("import-success");
+      expect(out, JSON.stringify(args)).not.toContain("node_pack");
+      expect(out, JSON.stringify(args)).toContain("1. was-node-suite-comfyui");
+    }
+  });
+
+  // cm-cli `show installed` has no mode parameter, so useCmCli does not degrade
+  // `mode` — it drops it. Reporting the live on-disk list under a mode that was
+  // never sent is the same misreport wearing a second costume.
+  it("discloses that useCmCli dropped `mode` entirely", async () => {
+    mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
+    const out = text(
+      await handler()({ action: "list", mode: "default", useCmCli: true }),
+    );
+    expect(out).toContain("`mode` was NOT applied");
+    expect(out).toContain("cm-cli show installed");
+  });
+
+  it("says nothing about `mode` when none was asked for", async () => {
+    mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
+    const out = text(await handler()({ action: "list", useCmCli: true }));
+    expect(out).not.toContain("was NOT applied");
+  });
+
+  // The schema is the other half. The result note only reaches a caller who
+  // already ran the tool; the description is what stops the call being made on a
+  // false premise in the first place.
+  it("the `mode` description no longer promises an import-success filter", () => {
+    const desc = (registered()[0].shape.mode as z.ZodTypeAny).description ?? "";
+    expect(desc).not.toContain("successfully imported this session");
+    expect(desc).toContain("NOT an import-success filter");
+    expect(desc).toContain("frozen at ComfyUI startup");
+    expect(desc).toContain("DISABLED packs");
+    expect(desc).toContain('node_pack action:"verify"');
+  });
+});

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -162,7 +162,8 @@ function preferLocalComfyCli(explicit: boolean | undefined): boolean {
  *
  * - install/update/reinstall/fix took `mode: "remote"|"local"|"cache"` — the
  *   ComfyUI-Manager DATA SOURCE.
- * - list took `mode: "default"|"imported"` — WHICH installed packs to report.
+ * - list took `mode: "default"|"imported"` — WHICH installed packs to report: the
+ *   live custom_nodes/ scan, or that same scan frozen at server startup.
  *
  * A flat schema has one `mode`, so the enum is the union and the handler
  * refuses a value the chosen action cannot honour, naming the ones it can. That
@@ -185,7 +186,7 @@ const modeSchema = z
   .enum([...MANAGER_MODES, ...LIST_MODES])
   .optional()
   .describe(
-    'Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default \'remote\'); \'remote\' fetches the live node list, \'local\'/\'cache\' use bundled/cached data. For action:"list": \'default\' lists all installed packs, \'imported\' lists only those successfully imported this session. Passing a value from the wrong group is refused, naming the ones the action accepts.',
+    'Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default \'remote\'); \'remote\' fetches the live node list, \'local\'/\'cache\' use bundled/cached data. For action:"list": \'default\' lists the installed packs as they are on disk NOW; \'imported\' returns that SAME custom_nodes/ scan frozen at ComfyUI startup, so the only difference is packs installed or removed since the server booted. \'imported\' is NOT an import-success filter: it includes DISABLED packs and cannot tell you whether the Python of a pack actually loaded — for that use node_pack action:"verify", which checks the node class_types of the pack against /object_info on the running server. Passing a value from the wrong group is refused, naming the ones the action accepts.',
   );
 
 const useCmCliSchema = z
@@ -199,6 +200,47 @@ const channelSchema = z
   .string()
   .optional()
   .describe("ComfyUI-Manager channel name (default 'default').");
+
+/**
+ * #2215: mode:"imported" reads as an import-success filter and is not one.
+ *
+ * ComfyUI-Manager (3.41, 4.2.x; both the `glob` and `legacy` server modules)
+ * answers /customnode/installed?mode=imported out of a module-scope binding:
+ *
+ *     # freeze imported version
+ *     startup_time_installed_node_packs = core.get_installed_node_packs()
+ *
+ * "imported" there means the MANAGER MODULE was imported — i.e. server startup.
+ * It is the identical get_installed_node_packs() filesystem scan of custom_nodes/
+ * that mode:"default" runs live, and that scan deliberately keeps disabled packs
+ * (`is_disabled = not y.endswith('.disabled')`, stored with enabled: False). So
+ * the ONLY difference between the two modes is staleness, and on a server nobody
+ * has installed into since boot the two lists are byte-identical — disabled
+ * entries and all.
+ *
+ * Reported as a broken filter because our own description promised one. The
+ * filter is not repairable here: an ENABLED pack that dies on a torch/CUDA
+ * mismatch is exactly the case the reporter cares about, and it sits in the scan
+ * either way, because the scan never opens the Python. Dropping the disabled
+ * entries would return a MORE plausible list that is just as unable to answer the
+ * question — so disclose instead, and name the tool that can.
+ */
+const IMPORTED_MODE_DISCLOSURE =
+  'NOTE — mode:"imported" is NOT an import-success list. ComfyUI-Manager answers it with ' +
+  'the same custom_nodes/ scan as mode:"default", frozen at server startup; disabled packs ' +
+  'are included, and nothing here reflects whether the Python of a pack imported cleanly. ' +
+  'The only difference from mode:"default" is packs installed or removed since the server ' +
+  'booted. To find out whether a pack actually loaded, use node_pack {action:"verify", ' +
+  'name:"<pack>", restart:false} — it checks the node class_types of that pack against ' +
+  '/object_info on the running server.';
+
+/** cm-cli `show installed` takes no mode parameter, so useCmCli drops `mode`
+ *  entirely rather than degrading it. Silently returning the live on-disk list
+ *  under a mode that was never sent is the same misreport in a second costume. */
+const CM_CLI_MODE_DROPPED =
+  'NOTE — `mode` was NOT applied: useCmCli:true reads `cm-cli show installed`, which has ' +
+  'no mode parameter, so this is the current on-disk pack list regardless of the mode ' +
+  'requested.';
 
 function formatInstalledNodes(nodes: InstalledNode[]): string {
   if (nodes.length === 0) return "No custom nodes installed.";
@@ -512,13 +554,20 @@ export function registerNodeManagementTools(server: McpServer): void {
             );
           }
           case "list": {
+            const mode = listMode();
             const nodes = await listInstalledNodes({
-              mode: listMode(),
+              mode,
               useCmCli: args.useCmCli,
             });
-            return {
-              content: [{ type: "text" as const, text: formatInstalledNodes(nodes) }],
-            };
+            // The disclosure rides on the RESULT, not only on the schema: the
+            // caller who has already been misled is the one reading this text.
+            // See IMPORTED_MODE_DISCLOSURE.
+            const notes = [
+              mode === "imported" ? IMPORTED_MODE_DISCLOSURE : undefined,
+              mode !== undefined && args.useCmCli ? CM_CLI_MODE_DROPPED : undefined,
+            ].filter((n): n is string => n !== undefined);
+            const text = [formatInstalledNodes(nodes), ...notes].join("\n\n");
+            return { content: [{ type: "text" as const, text }] };
           }
           case "sync_deps":
             return json(await syncNodeDependencies());


### PR DESCRIPTION
## What was actually wrong

Not the filter. The description.

`install_custom_node action:"list" mode:"imported"` returned a list identical to `mode:"default"` — 98 entries, `.disabled` packs included — because that is what ComfyUI-Manager returns. Both the `glob` and `legacy` server modules, in 3.41 and 4.2.x alike, answer `/customnode/installed?mode=imported` out of a module-scope freeze:

```python
# freeze imported version
startup_time_installed_node_packs = core.get_installed_node_packs()

@routes.get("/v2/customnode/installed")
async def installed_list(request):
    mode = request.query.get('mode', 'default')
    if mode == 'imported':
        res = startup_time_installed_node_packs
    else:
        res = core.get_installed_node_packs()
```

`imported` in that upstream comment means *the Manager module was imported* — server startup. It is the identical `get_installed_node_packs()` **filesystem scan of `custom_nodes/`** that `mode:"default"` runs live, and that scan deliberately keeps disabled packs:

```python
is_disabled = not y.endswith('.disabled')
res[info[0]] = { ..., 'enabled': is_disabled }
```

So the only difference between the two modes is **staleness** — packs installed or removed since boot. On a server nobody has installed into since boot the two lists are byte-identical, disabled entries and all. The reporter's 98-vs-98 observation is the endpoint working as designed.

Our schema promised something the server has never had: *"lists only those successfully imported this session"*. That sentence is the defect — it is what turns an unfiltered list into a confident yes for packs that may have failed to import.

## Why this does not filter

The reporter offered two options; I took the fail-loud one deliberately, and that is the load-bearing judgement in this PR — **please push on it if you disagree.**

The reported use case is "did pack X import on my torch/CUDA combination". An **enabled** pack that dies on exactly that mismatch is the case that matters, and it stays in the scan either way, because the scan never opens the Python — it reads directory names. Dropping the disabled entries would return a *shorter, more plausible* list that is just as unable to answer the question, which is strictly worse than one that says what it cannot do.

Genuinely answering it means cross-checking every pack against `/object_info` — a new mechanism, and a feature under the freeze. It also **already exists**: `node_pack {action:"verify", name, restart:false}` checks a pack's node class_types against the running server's `/object_info` (`src/services/node-verify.ts`), which is precisely the reporter's hand-rolled workaround. It was never missing, only undiscoverable. So the fix names it.

## The change

- The `mode` description states what `imported` IS (the startup snapshot), that it includes disabled packs, and that it cannot report import success.
- The **result** carries that disclosure whenever `mode:"imported"` is asked for. The schema is read once by the model; the result is read on every call, and the caller who has already been misled is the one reading the output.
- `useCmCli:true` now says so when it drops `mode` entirely — `cm-cli show installed` has no mode parameter, so returning the live on-disk list under a mode that was never sent is the same misreport in a second costume. This was a second silent no-op sitting next to the reported one.
- Docs regenerated via `npm run docs:gen` (one line in `docs/tools/custom-nodes.mdx`; the other 15 files it rewrote were line-ending-only and are restored).

## Where to look hardest

1. **The scope call above.** Disclose-don't-filter is a judgement, not a fact.
2. **`mode !== undefined && args.useCmCli`** — the cm-cli note fires only when a mode was actually requested and dropped. Mutant M4 (firing on `args.useCmCli` alone) is killed by a control test, but that guard is the fiddliest line here.
3. **The disclosure is appended, never substituted.** M7 pins it; a note that ate the payload would trade one silent failure for another.

## Verification

`npx vitest run src/__tests__/tools/node-management.test.ts` → **46 passed**. Full suite: 12061 passed, 1 failed — `late-mutation-e2e.test.ts`, the known 60 ms wall-clock flake; **passes in isolation** (5/5) and that file never imports node-management.

Green tests prove a mechanism, not that production reaches it, so: `registerNodeManagementTools` is wired at `src/tools/index.ts:76` under the `custom-nodes` group, and `install_custom_node` is in the live `TOOL_NAMES` ledger.

**Mutation testing — every clause deleted, each killed by a NAMED test:**

| # | mutation | result |
|---|---|---|
| M1 | drop the imported disclosure from the result | KILLED — *carries the disclosure, and still carries the list* |
| M2 | fire the disclosure unconditionally (guard removed) | KILLED ×2 — *reports an empty install honestly*, *default and omitted mode say nothing about imports* |
| M3 | drop the cm-cli mode-dropped note | KILLED — *discloses that useCmCli dropped `mode` entirely* |
| M4 | fire the cm-cli note whenever useCmCli is set | KILLED — *says nothing about `mode` when none was asked for* |
| M5 | restore the old import-success promise in the schema | KILLED — *the `mode` description no longer promises an import-success filter* |
| M6 | filter the disabled packs out of the imported list | KILLED ×2 — *does not filter the disabled packs out*, *still carries the list* |
| M7 | replace the payload with the note instead of appending | KILLED ×3 |

M5 first came back ANCHOR-MISS: my anchor used a bare `'imported'` where the TypeScript source has escaped `\'imported\'`, so the mutation never applied. A mutation that never applied reads exactly like a surviving one, so it was re-run against the correct bytes before being counted.

Gates: `check:vocabulary` OK (1810 files), `i18n:check` OK, `check:docs-links` / `check:docs-locale` / `check:docs-mdx` OK, `tsc --noEmit` clean.

**Not run:** Playwright. This diff touches no panel code — the `via-panel` label only records how the report was filed — so there is nothing browser-visible to gate.

Fixes #2215
