### PR TITLE
fix(2217): an unrecognized key with no near-miss names the keys that ARE accepted

### DIFF
--- a/src/__tests__/orchestrator/unrecognized-keys.test.ts
+++ b/src/__tests__/orchestrator/unrecognized-keys.test.ts
@@ -349,3 +349,153 @@ describe("#1969 review — the live surface, not a hand-built shape", () => {
     expect(text).toMatch(/Unrecognized key 'groupid'/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2217 — the arm where NOTHING pairs. #1969's suggester is live and correct:
+// `panel_restart_comfyui {forced:true}` is told 'force', because `forced` is an
+// edit-1 neighbour. `reason` is not near `force`, and `panel_restart_comfyui`
+// has no required keys, so every rule declines and the caller was told what is
+// wrong and nothing about what is right.
+//
+// The served JSON schema already carries `properties`, so this is not
+// information the client lacks — it is information the client did not JOIN,
+// which is the same gap #1969 was opened to close. The two suites below are
+// therefore the point: the reported call gains the list, and every call that
+// already had an answer must NOT gain it.
+// ---------------------------------------------------------------------------
+describe("#2217 a key with no near-miss names the keys that ARE accepted", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "unrecognized-keys-2217", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "unrecognized-keys-2217-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const errorText = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const r = await client.callTool({ name, arguments: args });
+    expect(r.isError, `${name} was expected to reject ${JSON.stringify(args)}`).toBe(true);
+    return (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+  };
+
+  /** The accepted keys as the CLIENT sees them — the served schema, not the
+   *  zod source. If those two ever diverge, the message names the wrong list. */
+  const servedKeys = async (name: string): Promise<string[]> => {
+    const tools = await client.listTools();
+    const schema = tools.tools.find((t) => t.name === name)?.inputSchema;
+    return Object.keys((schema?.properties ?? {}) as Record<string, unknown>);
+  };
+
+  it("REPRODUCTION: panel_restart_comfyui {reason} now names 'force'", async () => {
+    const text = await errorText("panel_restart_comfyui", { reason: "Load custom-node fix" });
+    expect(text).toContain("Unrecognized key 'reason' — accepted keys: 'force'");
+    // Still a refusal, and still no invented target: the tool does not accept
+    // a `reason`, and forwarding one is parked with #1968's `title`.
+    expect(text).toMatch(/Input validation error/);
+    expect(text).not.toMatch(/did you mean/);
+  });
+
+  it("CONTROL: the near-miss 'forced' keeps #1969's answer and does NOT gain the list", async () => {
+    const text = await errorText("panel_restart_comfyui", { forced: true });
+    expect(text).toMatch(/Unrecognized key 'forced' — did you mean 'force'\?/);
+    expect(text).not.toMatch(/accepted keys/);
+  });
+
+  it("CONTROL: the canonical key still reaches the handler", async () => {
+    const r = await client.callTool({ name: "panel_restart_comfyui", arguments: { force: true } });
+    const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(text).not.toMatch(/Input validation error|Unrecognized key/);
+  });
+
+  it("a tool that takes NO arguments says so instead of an empty list", async () => {
+    // Dies if panel_free_vram ever gains a key — at which point this pins the
+    // wrong tool, not the wrong behaviour.
+    expect(await servedKeys("panel_free_vram")).toEqual([]);
+    const text = await errorText("panel_free_vram", { reason: "cleanup" });
+    expect(text).toContain("Unrecognized key 'reason' — this tool takes no arguments");
+    expect(text).not.toMatch(/accepted keys/);
+  });
+
+  it("the WIDEST live shape is listed in full — no elision", async () => {
+    const keys = await servedKeys("panel_query_graph");
+    expect(keys.length).toBeGreaterThan(10);
+    const text = await errorText("panel_query_graph", { node_type: "KSampler" });
+    expect(text).toContain("Unrecognized key 'node_type' — accepted keys:");
+    // Every key the client was served is named. A cap would hide the one the
+    // caller wanted; measured, the full clause is 152 characters.
+    for (const k of keys) expect(text).toContain(`'${k}'`);
+    expect(text).not.toMatch(/…|\.\.\./);
+  });
+
+  it("a rule-3 tool keeps 'required key … is missing' and does NOT also get the list", async () => {
+    // The join was already made for this caller; 14 more names would bury it.
+    const text = await errorText("panel_remove_node", { dry_run: true });
+    expect(text).toMatch(/Unrecognized key 'dry_run' — required key 'node_id' is missing/);
+    expect(text).not.toMatch(/accepted keys/);
+  });
+
+  it("the ambiguous panel_connect {id} names BOTH endpoints without guessing one", async () => {
+    // #1969 refuses to pick between from_node_id and to_node_id. Listing the
+    // accepted keys hands the caller both candidates, which is the honest
+    // answer — and it is still not a "did you mean".
+    const text = await errorText("panel_connect", { id: 5 });
+    expect(text).toContain("Unrecognized key 'id' — accepted keys:");
+    expect(text).toContain("'from_node_id'");
+    expect(text).toContain("'to_node_id'");
+    expect(text).not.toMatch(/did you mean/);
+  });
+
+  it("two stray keys get ONE trailing clause, not one list each", async () => {
+    const text = await errorText("panel_restart_comfyui", { reason: "a", why: "b" });
+    expect(text).toContain(
+      "Unrecognized key 'reason'; Unrecognized key 'why'; accepted keys: 'force'",
+    );
+    expect(text.match(/accepted keys/g)).toHaveLength(1);
+  });
+});
+
+describe("#2217 the sentence, at the formatter", () => {
+  it("emits the reported string exactly", () => {
+    expect(formatUnrecognizedKeyMessage(["reason"], ["force"], [], { reason: "x" })).toBe(
+      "Unrecognized key 'reason' — accepted keys: 'force'",
+    );
+  });
+
+  it("an empty shape cannot produce a dangling 'accepted keys:'", () => {
+    expect(formatUnrecognizedKeyMessage(["reason"], [], [], { reason: "x" })).toBe(
+      "Unrecognized key 'reason' — this tool takes no arguments",
+    );
+  });
+
+  it("a paired key and an unpaired one keep their own answers, list stated once", () => {
+    const shape = { group_id: z.number(), pos: z.array(z.number()) };
+    const msg = formatUnrecognizedKeyMessage(["group", "reason"], Object.keys(shape), [], {
+      group: 2,
+      reason: "x",
+    });
+    expect(msg).toBe(
+      "Unrecognized key 'group' — did you mean 'group_id'?; Unrecognized key 'reason'; " +
+        "accepted keys: 'group_id', 'pos'",
+    );
+  });
+
+  it("the list is stated in the schema's own order", () => {
+    expect(formatUnrecognizedKeyMessage(["zzz"], ["b", "a", "c"], [], { zzz: 1 })).toBe(
+      "Unrecognized key 'zzz' — accepted keys: 'b', 'a', 'c'",
+    );
+  });
+
+  it("still never throws on a hostile input", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    expect(() => formatUnrecognizedKeyMessage(["reason"], ["force"], [], proxy)).not.toThrow();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14302,7 +14302,7 @@ export interface PanelToolDef {
  *
  * `.strict()` turns that into a validation error the caller can see and correct,
  * which is the whole value for an LLM caller: a loud, specific failure ("Unrecognized
- * key: X") is something a model can read and fix on the next attempt; a silent no-op
+ * key 'X'") is something a model can read and fix on the next attempt; a silent no-op
  * is not distinguishable from "it worked but had no effect".
  *
  * #1969 — the refusal used to name the unknown key AND, separately, the missing
@@ -14312,6 +14312,11 @@ export interface PanelToolDef {
  * intended key in the same sentence ("did you mean 'group_id'?") so a small
  * model can recover without aliases (#1968) and without failed-then-corrected
  * training pairs.
+ *
+ * #2217 — and when nothing pairs (`panel_restart_comfyui {reason}`: not a
+ * near-miss of `force`, and no required key to join), the same sentence states
+ * the keys that ARE accepted rather than stopping at the name. Same principle,
+ * the arm where the suggester has nothing to say.
  *
  * BOTH transports' registration functions accept this directly in place of the raw
  * shape (verified against each SDK's actual runtime behavior, not assumed from the

--- a/src/orchestrator/unrecognized-keys.ts
+++ b/src/orchestrator/unrecognized-keys.ts
@@ -234,6 +234,29 @@ function quoteKey(k: string): string {
   return `'${k.replace(/'/g, "\\'")}'`;
 }
 
+/**
+ * #2217 — what a caller is told when NOTHING pairs.
+ *
+ * `panel_restart_comfyui {reason}` had no near-miss (`reason` is neither an
+ * affix nor an edit-neighbour of `force`) and no missing required key, so every
+ * rule declined and the caller was told what is wrong and nothing about what is
+ * right. The served JSON schema already lists `properties`, so this adds no
+ * information the caller lacks — it JOINs it into the refusal, which is what
+ * #1969 exists to do for the models that will not join it themselves.
+ *
+ * Stated in FULL, no cap: measured across the 96 live panel tools the widest
+ * shape is 14 keys (`panel_edit_node`) and the longest clause is 173
+ * characters, so eliding entries would risk hiding the very key the caller
+ * wanted to save a line that is already short.
+ */
+function acceptedKeysClause(knownKeys: readonly string[]): string {
+  // 15 of the 96 panel tools take no arguments at all (`panel_free_vram`,
+  // `panel_list_workflows`, …). "accepted keys:" followed by nothing would be
+  // a worse answer than the bare name it replaces.
+  if (!knownKeys.length) return "this tool takes no arguments";
+  return `accepted keys: ${knownKeys.map(quoteKey).join(", ")}`;
+}
+
 /** The sentence a caller reads. Never throws — a formatter that throws turns
  *  a clean validation refusal into a 500. */
 export function formatUnrecognizedKeyMessage(
@@ -246,18 +269,24 @@ export function formatUnrecognizedKeyMessage(
   try {
     const unique = [...new Set(keys)];
     const paired = pairUnrecognizedKeys(unique, knownKeys, requiredKeys, input, fits);
-    return unique
-      .map((k) => {
-        const suggestion = paired.get(k);
-        if (!suggestion) return `Unrecognized key ${quoteKey(k)}`;
-        // An unconfident pairing still carries both halves of the join in one
-        // sentence — which is the whole ask — but states the schema fact it
-        // actually knows instead of guessing at intent.
-        return suggestion.confident
-          ? `Unrecognized key ${quoteKey(k)} — did you mean ${quoteKey(suggestion.key)}?`
-          : `Unrecognized key ${quoteKey(k)} — required key ${quoteKey(suggestion.key)} is missing`;
-      })
-      .join("; ");
+    const messages = unique.map((k) => {
+      const suggestion = paired.get(k);
+      if (!suggestion) return `Unrecognized key ${quoteKey(k)}`;
+      // An unconfident pairing still carries both halves of the join in one
+      // sentence — which is the whole ask — but states the schema fact it
+      // actually knows instead of guessing at intent.
+      return suggestion.confident
+        ? `Unrecognized key ${quoteKey(k)} — did you mean ${quoteKey(suggestion.key)}?`
+        : `Unrecognized key ${quoteKey(k)} — required key ${quoteKey(suggestion.key)} is missing`;
+    });
+    // Only where nothing at all was said: a pairing — confident or not — has
+    // already named the one key that matters, and the list would bury it.
+    if (unique.every((k) => paired.has(k))) return messages.join("; ");
+    // The list is a property of the TOOL, not of any one stray key, so it is
+    // stated once. With a single message it reads as that key's remedy; with
+    // several it is its own trailing clause rather than one key's footnote.
+    const clause = acceptedKeysClause(knownKeys);
+    return messages.length === 1 ? `${messages[0]} — ${clause}` : `${messages.join("; ")}; ${clause}`;
   } catch {
     const listed = keys.map((k) => quoteKey(k)).join(", ");
     return `Unrecognized key${keys.length > 1 ? "s" : ""} ${listed}`;


### PR DESCRIPTION
Fixes #2217.

## What was wrong

#1969's suggester is live and correct — the control in the report proves it:

```
panel_restart_comfyui {forced: true}   -> Unrecognized key 'forced' — did you mean 'force'?
panel_restart_comfyui {force: true}    -> passes validation, reaches the handler
panel_restart_comfyui {reason: "..."}  -> Unrecognized key 'reason'
```

`reason` is not near `force` (`isAffixMatch` false, `editDistance` over the
threshold) and `panel_restart_comfyui` has no required keys, so rule 3 cannot
fire either. Every rule declines, `suggestKnownKey` returns `undefined`,
`formatUnrecognizedKeyMessage` falls through to the bare name, and the caller
is told what is wrong and nothing about what is right.

The served JSON schema already carries `properties`, so this is not
information the client lacks — it is information the client did not JOIN.
That is the same gap #1969 exists to close for models that will not join it
themselves.

## What this changes

One branch in `formatUnrecognizedKeyMessage`'s no-pairing arm.
`unrecognizedKeysError` already closes over `knownKeys`, so it costs nothing on
the success path.

```
Unrecognized key 'reason' — accepted keys: 'force'
Unrecognized key 'reason' — this tool takes no arguments          (0-key tools)
Unrecognized key 'reason'; Unrecognized key 'why'; accepted keys: 'force'
```

## The three shapes, decided by measurement not by guess

Measured over the 96 tools `buildPanelToolDefs()` registers:

| | |
|---|---|
| widest shape | `panel_edit_node`, 14 keys |
| longest clause | 173 characters |
| key-count distribution | 0:15, 1:19, 2:17, 3:15, 4:13, 5:4, 6:6, 7:2, 8:1, 10+:4 |

- **No cap.** The issue floated one for wide schemas. At 173 characters worst
  case, eliding entries would risk hiding the very key the caller wanted to
  save a line that is already short. If the surface ever grows a 40-key tool
  this is the decision to revisit — the measurement is in the code comment so
  it can be re-run.
- **15 tools take no arguments at all.** `accepted keys:` followed by nothing
  is a worse answer than the bare name it replaces, so those say
  `this tool takes no arguments`.
- **The arm fires only where nothing at all was said** (the issue's second
  point). A confident `did you mean 'force'?` and rule 3's
  `required key 'node_id' is missing` have already named the one key that
  matters; appending 14 more names buries it.

The list is a property of the TOOL, not of any one stray key, so it is stated
once — as that key's remedy with a single message, as a trailing clause with
several.

## Where the load-bearing claims are (please attack these)

1. **`unique.every((k) => paired.has(k))` is the gate.** If it is wrong in the
   permissive direction, every already-answered refusal grows a key list and
   #1969's whole point (say the ONE key, not the schema) is undone. Pinned by
   two negative tests over the real surface — `{forced:true}` and
   `panel_remove_node {dry_run:true}` — each asserting `not.toMatch(/accepted keys/)`.
2. **The unpaired-but-ambiguous case.** `panel_connect {id:5}` deliberately
   refuses to pick between `from_node_id` and `to_node_id`. It now gets the
   full list, which names both. I claim that is honest rather than a
   regression of #1969's refusal — it is still not a `did you mean`, and the
   existing #1969 assertions (`not.toMatch(/did you mean 'to_node_id'/)`)
   still hold. Worth a second opinion.
3. **The single-vs-multiple join.** `messages.length === 1` picks ` — ` over
   `; `. Two code paths for one clause; the alternative was one path and a
   message that reads `Unrecognized key 'reason'; accepted keys: 'force'` for
   the reported case.
4. **The widest-shape test reads its expectation off the SERVED schema**, not
   off the zod source, so a message that names a different list than the one
   the client was handed fails. The 0-key test asserts `servedKeys` is empty
   first, so it dies as "wrong tool pinned" rather than silently passing if
   `panel_free_vram` ever gains a key.

## Verification

- `src/__tests__/orchestrator/unrecognized-keys.test.ts` — 40 tests green
  (26 pre-existing + 14 new), through a real `McpServer` + `Client` over
  `InMemoryTransport` registered by `registerPanelTools`, asserting the string
  the SDK renderer hands the caller.
- Mutation-tested clause by clause (results in a comment below): deleting the
  fix, widening the gate, dropping the 0-key guard, forcing the `; ` join, and
  capping the list each kill a named test, and the #1969 suite survives all of
  them.
- Not panel-visible: nothing in `comfyui-mcp-panel` renders this string — it
  is an MCP protocol-boundary validation message. No Playwright run.
