### PR TITLE
chore: release v0.52.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.97] - 2026-08-24
+
+### MCP
+
+#### Fixed
+- Preserve route-bound Panel run receipts across reconnects, remounts, timeouts, batches, and duplicate delivery (#1728)
+- Prevent health diagnostics from recursively suggesting the environment-install path (#2188)
+
 ## [0.52.96] - 2026-08-24
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.96",
+  "version": "0.52.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.96",
+      "version": "0.52.97",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.96",
+  "version": "0.52.97",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.97.\n\nIncludes merged fixes for Panel run receipt recovery across reconnects, remounts, batches, duplicate delivery, and timeout handoff (#1728), plus non-recursive health/environment diagnostics (#2188).\n\nRelease gates: lint/build passed; Panel-paired CI for the merged code is green. The local full test command was stopped after a long-running pre-existing cancellation fixture; release CI is authoritative.