### PR TITLE
fix(2221): bound inline image payloads and make a 413 recoverable on the openai-compatible lane

### DIFF
--- a/src/__tests__/orchestrator/ollama-image-payload-budget.test.ts
+++ b/src/__tests__/orchestrator/ollama-image-payload-budget.test.ts
@@ -1,0 +1,273 @@
+// #2221 — the openai-compatible lane shipped inline images unbounded, and the
+// recovery that should have caught the resulting 413 was unreachable from the
+// state that produced it.
+//
+// Two halves, pinned separately here because either one alone leaves the bug:
+//
+//   • The BOUND. `fetchImageB64` caps a single ref at 12 MB of RAW bytes; the
+//     wire carries base64 (4/3 larger), a turn may attach 4 refs, and
+//     `this.history` is built once per session and never trimmed — so every
+//     image any turn ever attached rides every later request. Nothing summed
+//     that.
+//   • The RECOVERY. The 4xx strip-and-retry is gated on `unprovenMedia`, which
+//     is false for a turn that attaches nothing. The reported turn was plain
+//     text, so the strip never armed and the error rethrew — and since history
+//     is stable, every retry rebuilt the identical oversized payload. The
+//     session could not be talked out of it.
+//
+// The reproduction below is the reported shape exactly: an image lands on one
+// turn, and a later PLAIN-TEXT turn is refused for size.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OllamaBackend, type McpToolClient } from "../../orchestrator/ollama-backend.js";
+import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
+
+type OpenAiMsg = {
+  role: string;
+  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+};
+
+let openaiChatRequests: Array<{ messages: OpenAiMsg[] }> = [];
+/** Statuses to answer the next chat requests with, consumed one per request.
+ *  An entry of 0 (or an exhausted queue) means "respond normally". */
+let chatStatusQueue: number[] = [];
+/** Raw bytes /view hands back for every image ref. */
+let viewImageRawBytes = 4;
+
+function sseOk(): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        enc.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "ok" }, finish_reason: "stop" }] })}\n`),
+      );
+      controller.enqueue(enc.encode("data: [DONE]\n"));
+      controller.close();
+    },
+  });
+}
+
+const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input);
+  if (url.includes("/view?")) {
+    return new Response(new Uint8Array(viewImageRawBytes).fill(0x41), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  }
+  if (url.endsWith("/models")) {
+    // `prepare()` reachability probe — without it every run() throws before a
+    // single chat request is made.
+    return new Response(JSON.stringify({ data: [{ id: "xiaomi/mimo-v2.5" }] }), { status: 200 });
+  }
+  if (url.endsWith("/chat/completions")) {
+    openaiChatRequests.push(JSON.parse(String(init?.body)));
+    const status = chatStatusQueue.shift() ?? 0;
+    if (status) {
+      return new Response(
+        JSON.stringify({ error: { message: "Downloaded image content cannot exceed 30MB", code: status } }),
+        { status },
+      );
+    }
+    return new Response(sseOk(), { status: 200 });
+  }
+  return new Response("not found", { status: 404 });
+});
+
+function fakeComfyClient(): McpToolClient {
+  return {
+    listTools: async () => ({
+      tools: [
+        { name: "list_tools", description: "Catalog.", inputSchema: { type: "object", properties: {} } },
+        { name: "describe_tool", description: "Describe.", inputSchema: { type: "object", properties: {} } },
+        { name: "call_tool", description: "Run.", inputSchema: { type: "object", properties: {} } },
+      ],
+    }),
+    callTool: (async () => ({ content: [{ type: "text", text: "ok" }] })) as unknown as McpToolClient["callTool"],
+    close: async () => {},
+  };
+}
+
+function backend() {
+  return new OllamaBackend({
+    api: "openai",
+    host: "http://127.0.0.1:9999/v1",
+    apiKey: "sk-test",
+    model: "xiaomi/mimo-v2.5",
+    comfyuiUrl: "http://127.0.0.1:8188",
+    connectToolClients: async () => ({ comfyui: fakeComfyClient() }),
+  });
+}
+
+async function* turnsOf(...turns: NeutralTurn[]): AsyncGenerator<NeutralTurn> {
+  for (const t of turns) yield t;
+}
+
+async function collect(b: OllamaBackend, channel: AsyncIterable<NeutralTurn>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const ev of b.run({ channel })) events.push(ev);
+  return events;
+}
+
+const imageTurn = (text: string, filename: string): NeutralTurn => ({
+  text,
+  images: [{ filename, type: "input" }],
+});
+
+/** Every image_url data URL on the request, in order. */
+function imagePartsOf(req: { messages: OpenAiMsg[] }): string[] {
+  return req.messages.flatMap((m) =>
+    Array.isArray(m.content)
+      ? m.content.filter((p) => p.type === "image_url").map((p) => p.image_url?.url ?? "")
+      : [],
+  );
+}
+
+function assistantTexts(events: AgentEvent[]): string[] {
+  return events.filter((e) => e.type === "assistant").map((e) => (e as { text: string }).text);
+}
+
+beforeEach(() => {
+  openaiChatRequests = [];
+  chatStatusQueue = [];
+  viewImageRawBytes = 4;
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("#2221 — inline image payload is bounded before the request is sent", () => {
+  it("sums images across the WHOLE history and drops the oldest to fit the budget", async () => {
+    // 3000 raw bytes encodes to exactly 4000 base64 bytes. Two of them (8000)
+    // overrun a 5000-byte budget; one does not — so the trim must remove
+    // precisely the older message's image and keep the newer one.
+    viewImageRawBytes = 3000;
+    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", "5000");
+
+    const events = await collect(
+      backend(),
+      turnsOf(imageTurn("first frame?", "a.png"), imageTurn("and the last frame?", "b.png")),
+    );
+
+    // Turn 1 was under budget on its own and went out untouched.
+    expect(imagePartsOf(openaiChatRequests[0])).toHaveLength(1);
+    // Turn 2 would have carried BOTH (this is the accumulation that made the
+    // payload grow without limit); it carries only the newest.
+    expect(imagePartsOf(openaiChatRequests[1])).toHaveLength(1);
+    // Exactly one request per turn — the bound is applied a priori, not by
+    // spending a round-trip on a rejection first.
+    expect(openaiChatRequests).toHaveLength(2);
+
+    // The model is told, and told the TRUE version: it did see that image, it
+    // just no longer has it. Claiming a non-delivery for media it described a
+    // turn ago would put it at odds with its own transcript.
+    const trimmedMsg = openaiChatRequests[1].messages.find(
+      (m) => typeof m.content === "string" && m.content.includes("first frame?"),
+    );
+    expect(String(trimmedMsg?.content)).toContain("You DID receive them earlier");
+    // The budget is named in units that survive a sub-megabyte override — a
+    // note claiming an "0 MB image limit" would be worse than no number.
+    expect(String(trimmedMsg?.content)).toContain("image limit (5000 bytes)");
+
+    // And so is the user — a silently dropped attachment is the failure mode
+    // this whole file exists to avoid.
+    expect(assistantTexts(events).some((t) => t.includes("dropped the oldest 1 image(s)"))).toBe(true);
+  });
+
+  it("CONTROL: an ordinary image turn under the default budget is untouched", async () => {
+    // No env override: the real 30 MB default. A normal attachment must not be
+    // trimmed, or the fix would silently un-ship inline vision.
+    viewImageRawBytes = 3000;
+    const events = await collect(backend(), turnsOf(imageTurn("what is this?", "a.png")));
+    expect(imagePartsOf(openaiChatRequests[0])).toHaveLength(1);
+    expect(assistantTexts(events).some((t) => t.includes("dropped"))).toBe(false);
+  });
+
+  it("ignores a non-numeric budget override rather than dropping every image", async () => {
+    // `=30MB` parses to NaN. Obeying it would compare against NaN, which is
+    // false for `<=`, and strip every image on every request forever.
+    viewImageRawBytes = 3000;
+    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", "30MB");
+    await collect(backend(), turnsOf(imageTurn("what is this?", "a.png")));
+    expect(imagePartsOf(openaiChatRequests[0])).toHaveLength(1);
+  });
+});
+
+describe("#2221 — a 413 on inherited images is recoverable, not terminal", () => {
+  it("REPRODUCTION: a plain-text turn refused for size strips history and retries once", async () => {
+    // The reported sequence. Turn 1 delivers an image successfully. Turn 2 is
+    // ordinary text — `turnSentImages` is false — and the endpoint answers the
+    // accumulated payload with 413. Before the fix this rethrew: the strip was
+    // gated on media THIS turn attached, so it never armed, and the next
+    // attempt rebuilt the same bytes. Every later turn in the session died the
+    // same way.
+    chatStatusQueue = [0, 413]; // turn 1 lands; turn 2's first request is refused
+    const events = await collect(
+      backend(),
+      turnsOf(imageTurn("look at this frame", "a.png"), { text: "this workflow appears to have firstframe last frame" }),
+    );
+
+    // turn 1 → 1 request; turn 2 → the refused one plus ONE retry.
+    expect(openaiChatRequests).toHaveLength(3);
+    expect(imagePartsOf(openaiChatRequests[1])).toHaveLength(1); // the payload that 413'd
+    expect(imagePartsOf(openaiChatRequests[2])).toHaveLength(0); // the retry is clean
+
+    // The turn COMPLETES. This is the whole point: the session is no longer
+    // bricked by bytes it accumulated.
+    const result = events.filter((e) => e.type === "result").at(-1) as { ok: boolean };
+    expect(result.ok).toBe(true);
+
+    // The user is told the real cause, and told that retrying is not the
+    // remedy — the one thing the generic "turn failed … try again" got wrong.
+    const texts = assistantTexts(events);
+    expect(texts.some((t) => t.includes("too large for the endpoint (http 413)"))).toBe(true);
+    expect(texts.some((t) => t.includes("will fail the same way"))).toBe(true);
+    // It must NOT be reported as a vision-capability problem: the model can see
+    // fine, and "switch to a vision-capable model" would send the user to
+    // change a setting that changes nothing.
+    expect(texts.some((t) => t.includes("vision-capable model"))).toBe(false);
+
+    // The model is told the honest version too: it DID get that image.
+    const stripped = openaiChatRequests[2].messages.find(
+      (m) => typeof m.content === "string" && m.content.includes("look at this frame"),
+    );
+    expect(String(stripped?.content)).toContain("You DID receive them earlier");
+  });
+
+  it("a 413 with NO media in history is not retried, and names size as the cause", async () => {
+    // Nothing to strip: a conversation that is merely long. Retrying would
+    // spend a request to fail identically, so the turn ends — but it must not
+    // end as an anonymous failure, because the panel's fallback advice for a
+    // dead turn is "try again".
+    chatStatusQueue = [413];
+    const events = await collect(backend(), turnsOf({ text: "hello" }));
+
+    expect(openaiChatRequests).toHaveLength(1); // refused, no retry
+    const result = events.find((e) => e.type === "result") as { ok: boolean };
+    expect(result.ok).toBe(false);
+
+    const texts = assistantTexts(events);
+    expect(texts.some((t) => t.includes("too large for this endpoint to accept (http 413)"))).toBe(true);
+    expect(texts.some((t) => t.includes("Retrying the same message will not help"))).toBe(true);
+    // The provider's own sentence is the most useful one available — keep it.
+    expect(texts.some((t) => t.includes("Downloaded image content cannot exceed 30MB"))).toBe(true);
+  });
+
+  it("a 5xx is NOT treated as an oversized payload (no strip, no size claim)", async () => {
+    // 413 is the only status that licenses blaming size. A 502 is the endpoint
+    // failing, and stripping the user's image on one would destroy context for
+    // a reason that was never observed.
+    chatStatusQueue = [0, 502];
+    const events = await collect(
+      backend(),
+      turnsOf(imageTurn("look at this frame", "a.png"), { text: "and now?" }),
+    );
+    expect(openaiChatRequests).toHaveLength(2); // no retry
+    expect(assistantTexts(events).some((t) => t.includes("too large"))).toBe(false);
+    // history keeps the image: the second request still carried it
+    expect(imagePartsOf(openaiChatRequests[1])).toHaveLength(1);
+  });
+});

--- a/src/__tests__/orchestrator/ollama-image-payload-budget.test.ts
+++ b/src/__tests__/orchestrator/ollama-image-payload-budget.test.ts
@@ -18,7 +18,7 @@
 // The reproduction below is the reported shape exactly: an image lands on one
 // turn, and a later PLAIN-TEXT turn is refused for size.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { OllamaBackend, type McpToolClient } from "../../orchestrator/ollama-backend.js";
+import { OllamaBackend, imagePayloadBudgetBytes, type McpToolClient } from "../../orchestrator/ollama-backend.js";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 
 type OpenAiMsg = {
@@ -186,13 +186,42 @@ describe("#2221 — inline image payload is bounded before the request is sent",
     expect(assistantTexts(events).some((t) => t.includes("dropped"))).toBe(false);
   });
 
-  it("ignores a non-numeric budget override rather than dropping every image", async () => {
-    // `=30MB` parses to NaN. Obeying it would compare against NaN, which is
-    // false for `<=`, and strip every image on every request forever.
+  // Every unusable override falls back to the default instead of being obeyed.
+  // The failure directions differ and both are silent, which is why each value
+  // is exercised rather than assumed to follow from its neighbour:
+  //   NaN   — `bytesBefore <= NaN` is false, so the trim fires on EVERY request
+  //           and strips every image forever. Inline vision just stops working.
+  //   0/-1  — a budget nothing can fit under: same total loss, by arithmetic
+  //           rather than by NaN.
+  //   ∞     — the opposite failure, and the one this whole fix exists to close:
+  //           an unbounded payload is how #2221 happened.
+  it.each([
+    ["30MB", "a unit suffix that parses to NaN"],
+    ["0", "a zero budget nothing could fit under"],
+    ["-1", "a negative budget"],
+    ["Infinity", "an unbounded budget — the pre-fix behaviour"],
+  ])("ignores the unusable override %j (%s) and keeps the default", async (value) => {
     viewImageRawBytes = 3000;
-    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", "30MB");
-    await collect(backend(), turnsOf(imageTurn("what is this?", "a.png")));
+    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", value);
+    const events = await collect(backend(), turnsOf(imageTurn("what is this?", "a.png")));
     expect(imagePartsOf(openaiChatRequests[0])).toHaveLength(1);
+    expect(assistantTexts(events).some((t) => t.includes("dropped"))).toBe(false);
+  });
+
+  // The wired assertions above cannot separate `Infinity` from the 30 MB
+  // default — both leave a small image alone, and telling them apart on the
+  // wire would need a >30 MB fixture. The parse is pinned directly instead.
+  // The 5000-byte case in the first test is what proves this value is the one
+  // the trim actually reads, so this is not a helper tested in isolation.
+  it("resolves the budget: usable overrides win, unusable ones fall back", () => {
+    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", "");
+    expect(imagePayloadBudgetBytes()).toBe(30 * 1024 * 1024);
+    vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", "5000");
+    expect(imagePayloadBudgetBytes()).toBe(5000);
+    for (const bad of ["30MB", "0", "-1", "Infinity"]) {
+      vi.stubEnv("COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES", bad);
+      expect(imagePayloadBudgetBytes()).toBe(30 * 1024 * 1024);
+    }
   });
 });
 

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -263,6 +263,54 @@ const DEFAULT_MODEL = "artokun/gemma4-comfyui-mcp:e4b";
 const MAX_TOOL_ROUNDS = 32;
 
 /**
+ * Ceiling on the inline image bytes ONE request may carry, summed across the
+ * WHOLE history (#2221).
+ *
+ * The bound that already existed is per-IMAGE and pre-encoding: fetchImageB64
+ * refuses a single ref over 12 MB of raw bytes. Neither half of that reaches the
+ * number a provider actually measures.
+ *
+ *   • Per-image is not per-request. A turn attaches up to 4 refs, and — the part
+ *     that made #2221 permanent — `this.history` is built ONCE per session and
+ *     never trimmed, so every image any turn ever attached is re-serialized onto
+ *     every later request. The total only grows.
+ *   • Raw bytes are not wire bytes. Both dialects ship base64, which is 4/3 the
+ *     size, so 12 MB of PNG leaves here as ~16 MB.
+ *
+ * So the existing cap permits ~64 MB on the first turn alone and is unbounded
+ * over a session. OpenRouter answers that with `http 413 {"error":{"message":
+ * "Downloaded image content cannot exceed 30MB"}}`, and because history is
+ * stable the next attempt rebuilds the identical payload — the session is
+ * bricked, which is exactly what #2221 reported (three identical failures in
+ * ~30s on a plain-text message that attached nothing).
+ *
+ * 30 MB is OpenRouter's documented ceiling and the default here. It is measured
+ * on the BASE64 length rather than the decoded bytes deliberately: base64 is the
+ * larger of the two, so a history under this budget is under the limit on either
+ * reading. Other openai-compatible endpoints differ, hence the override.
+ *
+ * This is a ceiling, not a target — a single-image turn is nowhere near it, so
+ * the trim only ever fires on a history that would otherwise be refused.
+ */
+const DEFAULT_IMAGE_PAYLOAD_BUDGET_BYTES = 30 * 1024 * 1024;
+
+/** The per-request image budget in base64 bytes, honouring the env override.
+ *  A non-numeric or non-positive override is ignored rather than obeyed: a
+ *  typo'd `COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES=30MB` parsing to NaN must not
+ *  silently drop every image on every request. */
+function imagePayloadBudgetBytes(): number {
+  const raw = Number(process.env.COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_IMAGE_PAYLOAD_BUDGET_BYTES;
+}
+
+/** Render a byte budget for the note the MODEL reads. Sub-megabyte budgets stay
+ *  in bytes: `Math.round(5000 / 1MB)` is 0, and a note claiming an "0 MB image
+ *  limit" is worse than no number at all. */
+function formatByteBudget(bytes: number): string {
+  return bytes >= 1024 * 1024 ? `${Math.round(bytes / (1024 * 1024))} MB` : `${bytes} bytes`;
+}
+
+/**
  * The Ollama system prompt REPLACES the frontier panel prompt: that one is
  * thousands of tokens and instructs the agent to call dozens of tools BY NAME
  * (panel_query_graph, list_packs, …) that don't exist on this backend's 6-tool
@@ -1249,6 +1297,63 @@ export class OllamaBackend implements AgentBackend {
   }
 
   /**
+   * Bring the request's inline image bytes under the budget BEFORE sending, by
+   * dropping whole messages' images OLDEST-FIRST (#2221).
+   *
+   * Oldest-first is the direction that keeps the turn answerable: the image the
+   * user is asking about right now is the newest one, and a session dies of the
+   * images it accumulated, not the one it just took.
+   *
+   * Every drop is written into the message it came from, and the wording turns
+   * on `mediaDelivered` for the same reason stripImagesFromHistory does — a
+   * model told "you did not see this" about a picture it demonstrably described
+   * three turns ago will contradict its own transcript. Silence is not an option
+   * either: an image removed with no note leaves the model answering from a text
+   * reference to a file it can no longer see, as if it could.
+   *
+   * Audio is deliberately NOT trimmed here. It rides a different content part on
+   * the OpenAI wire, the reported limit is an IMAGE limit, and clips are small
+   * next to full-resolution frames — dropping one to fit an image budget would
+   * cost the user a sense for no measured gain.
+   *
+   * Returns what was removed so the caller can tell the user; `undeliveredImages`
+   * counts images that never survived a request, i.e. the ones whose loss the
+   * user has to hear about as "I did not see it" rather than "I forgot it".
+   */
+  private trimImagePayloadToBudget(): {
+    droppedImages: number;
+    undeliveredImages: number;
+    budget: number;
+    bytesBefore: number;
+  } {
+    const budget = imagePayloadBudgetBytes();
+    // base64 length IS the byte count on the wire (one ASCII char per byte).
+    const sizeOf = (m: ChatMessage) => (m.images ?? []).reduce((n, b64) => n + b64.length, 0);
+    let bytesBefore = 0;
+    for (const m of this.history) bytesBefore += sizeOf(m);
+    if (bytesBefore <= budget) return { droppedImages: 0, undeliveredImages: 0, budget, bytesBefore };
+
+    let remaining = bytesBefore;
+    let droppedImages = 0;
+    let undeliveredImages = 0;
+    for (const m of this.history) {
+      if (remaining <= budget) break;
+      const count = m.images?.length ?? 0;
+      if (!count) continue;
+      const delivered = m.mediaDelivered === true;
+      remaining -= sizeOf(m);
+      droppedImages += count;
+      if (!delivered) undeliveredImages += count;
+      delete m.images;
+      delete m.imageMimes;
+      m.content += delivered
+        ? `\n[note: the ${count} image(s) attached to this message were removed from your context to keep the request under the endpoint's image limit (${formatByteBudget(budget)}). You DID receive them earlier in this conversation - nothing was lost, but you can no longer see them.]`
+        : `\n[note: the ${count} image(s) attached to this message were removed BEFORE the request was sent - together with the rest of this conversation they exceeded the endpoint's image limit (${formatByteBudget(budget)}). You did NOT receive them: you did not see any image. Say so plainly rather than describing or guessing at the contents.]`;
+    }
+    return { droppedImages, undeliveredImages, budget, bytesBefore };
+  }
+
+  /**
    * Drop audio the ACTIVE model must not be handed (#1972).
    *
    * The attach-time allowlist only governs the turn the audio arrives on. Ollama
@@ -1465,6 +1570,27 @@ export class OllamaBackend implements AgentBackend {
       const notice = audioUserNotice(audioOutcomes, audioConfidence, this.model);
       if (notice) yield { type: "assistant", text: notice };
     }
+    // #2221 — bound the inline image bytes BEFORE the first request, not after a
+    // provider refuses them. Here rather than at attach time because the payload
+    // that goes over the limit is the accumulated HISTORY, which a turn that
+    // attaches nothing still re-sends in full.
+    //
+    // Before the turnSentImages capture below, so that capture describes what
+    // this request will ACTUALLY carry: an image trimmed away here was never
+    // sent, and counting it as "this turn attached an image" would arm the
+    // rejection path to apologise for media the endpoint never saw.
+    const trimmed = this.trimImagePayloadToBudget();
+    if (trimmed.droppedImages) {
+      logger.warn(
+        `[ollama-backend] inline images (${trimmed.bytesBefore} b64 bytes) exceeded the ${trimmed.budget}-byte request budget — dropped ${trimmed.droppedImages} oldest-first`,
+      );
+      yield {
+        type: "assistant",
+        text: trimmed.undeliveredImages
+          ? `📦 This conversation's images add up to more than the endpoint accepts in one request, so I dropped the oldest ${trimmed.droppedImages} image(s) to get under the limit — ${trimmed.undeliveredImages} of those I never got to see at all. Re-attach just the one you want me to look at, or start a fresh chat to clear what has built up.`
+          : `📦 This conversation's images add up to more than the endpoint accepts in one request, so I dropped the oldest ${trimmed.droppedImages} image(s) from my context to get under the limit. I saw them at the time and nothing you sent was lost, but I can't look at them again — re-attach one if you need me to.`,
+      };
+    }
     // What THIS turn attached, captured now: stripImagesFromHistory deletes the
     // fields, and the correction below must describe the sense the USER just
     // sent — not whatever happens to be left in the retained history.
@@ -1594,10 +1720,38 @@ export class OllamaBackend implements AgentBackend {
           // A NEW file is always judged on its own: an earlier clip landing is
           // not evidence about a different one (codec, length).
           const unprovenMedia = (turnSentImages || turnSentAudio) && !turnMediaAccepted;
-          if (!abort.signal.aborted && requestWasRejected && !attachmentsStripped && unprovenMedia) {
+          // #2221 — the ONE rejection that `unprovenMedia` must not gate.
+          //
+          // Everything above reasons about whether the MODEL can perceive what we
+          // sent, and for that question media the endpoint already accepted is
+          // rightly off the table. A 413 is not that question. It is the
+          // TRANSPORT saying the request is too big, and the bytes making it too
+          // big are exactly the ones history has been accumulating since the
+          // session started — media that IS proven-delivered, and that
+          // `unprovenMedia` therefore refuses to touch.
+          //
+          // That refusal is what made #2221 terminal rather than merely annoying:
+          // the user sent plain text, so `turnSentImages` was false, so the strip
+          // never armed, so the error rethrew — and because `this.history` is
+          // built once per session and never trimmed, the next attempt
+          // reassembled byte-for-byte the same oversized payload. Three
+          // identical 413s in 30 seconds, and every later turn in that session
+          // too. The recovery existed the whole time and was unreachable from
+          // the state that needed it.
+          //
+          // Still 4xx-only and still one-shot, and still conditioned on there
+          // BEING media to remove: a 413 on a conversation that is merely long
+          // is a real failure with no attachment to blame, and stripping nothing
+          // then retrying would just spend a second request to fail identically.
+          const oversizedPayload = status === 413;
+          const historyCarriesMedia = this.history.some((m) => m.images?.length || m.audios?.length);
+          const recoverable = unprovenMedia || (oversizedPayload && historyCarriesMedia);
+          if (!abort.signal.aborted && requestWasRejected && !attachmentsStripped && recoverable) {
             attachmentsStripped = true;
             logger.warn(
-              `[ollama-backend] media input rejected (${msgOf(err).slice(0, 200)}) — retrying without attachments`,
+              oversizedPayload
+                ? `[ollama-backend] request too large for the endpoint (${msgOf(err).slice(0, 200)}) — retrying without inline attachments`
+                : `[ollama-backend] media input rejected (${msgOf(err).slice(0, 200)}) — retrying without attachments`,
             );
             this.stripImagesFromHistory();
             // #790 — the correction for an attachment we had already told the
@@ -1617,10 +1771,24 @@ export class OllamaBackend implements AgentBackend {
             // and only an older turn's media was carried along, saying "I
             // couldn't hear your audio" would be about a file they did not
             // just send.
+            //
+            // A 413 takes its own wording, and the distinction is the whole
+            // point of #2221's third ask. "rejected image input … switch to a
+            // vision-capable model" would be a wrong diagnosis here — the model
+            // may see perfectly well; the request was simply too big — and it
+            // would send the user to change a setting that changes nothing.
+            // Size is also the one cause where "try again" is actively false, so
+            // the text says so rather than leaving the panel's generic retry
+            // advice as the only thing the user is told.
             yield {
               type: "assistant",
-              text:
-                turnSentAudio && turnSentImages
+              text: oversizedPayload
+                ? `📦 That request was too large for the endpoint (http 413) — this conversation's inline attachments pushed it over the provider's size limit. I dropped them and answered without them, so ${
+                    turnSentImages || turnSentAudio
+                      ? "I did NOT see what you just attached"
+                      : "I can no longer look at the earlier attachments (I did receive them at the time — nothing you sent was lost)"
+                  }. Sending the same message again will fail the same way; re-attach a single smaller image, or start a fresh chat to clear what has built up.`
+                : turnSentAudio && turnSentImages
                   ? `📎🔇 ${this.model} rejected the request carrying the attachments, so I'm continuing without them — I did NOT see the image and did NOT hear the audio, and the endpoint didn't say which one it objected to. Describe the image in words, and switch to a model that reports audio support (\`ollama pull gemma4:e4b\`) if you need me to listen.`
                   : turnSentAudio
                     ? `🔇 ${this.model} rejected the request carrying the audio attachment, so I'm continuing without it — I did NOT hear it and won't describe it. Switch to an audio-capable model (\`ollama pull gemma4:e4b\`), or ask me to run a ComfyUI audio-analysis node over the file instead.`
@@ -1761,9 +1929,19 @@ export class OllamaBackend implements AgentBackend {
         // panel silent (the turn just ends), which reads as a wedge.
         logger.warn(`[ollama-backend] turn failed: ${msgOf(err)}`);
         yield { type: "error", message: `ollama backend: ${msgOf(err)}` };
+        // #2221 — a 413 that got this far is one the strip could not rescue
+        // (nothing left to remove, or it had already fired once this turn). It
+        // still must not be handed to the user as an anonymous failure: the
+        // panel's fallback advice for a dead turn is "try again", and size is
+        // precisely the cause for which that is guaranteed wrong. Name it, and
+        // keep the raw body — the provider's own text ("Downloaded image content
+        // cannot exceed 30MB") is the most useful sentence available.
+        const tooLarge = (err as { httpStatus?: number } | null)?.httpStatus === 413;
         yield {
           type: "assistant",
-          text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+          text: tooLarge
+            ? `📦 The request was too large for this endpoint to accept (http 413), so the turn could not run. Retrying the same message will not help — the payload is rebuilt identically each time. Start a fresh chat to clear what this conversation has accumulated, or re-send with a smaller attachment.\n\nEndpoint said: ${msgOf(err).slice(0, 400)}`
+            : `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
         };
       }
       if (!resultEmitted) {

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -1316,10 +1316,15 @@ export class OllamaBackend implements AgentBackend {
    * either: an image removed with no note leaves the model answering from a text
    * reference to a file it can no longer see, as if it could.
    *
-   * Audio is deliberately NOT trimmed here. It rides a different content part on
-   * the OpenAI wire, the reported limit is an IMAGE limit, and clips are small
-   * next to full-resolution frames — dropping one to fit an image budget would
-   * cost the user a sense for no measured gain.
+   * Audio is deliberately neither trimmed NOR counted here, and the second half
+   * of that is the part worth knowing. On the OpenAI wire audio is a separate
+   * content part and the reported limit is an IMAGE limit, so leaving it out of
+   * the sum is right. On the NATIVE wire it is not: `toOllamaMessages` merges
+   * `audios` into `images[]`, so audio bytes do travel in the image slot and
+   * this budget does not see them. That is a knowingly incomplete accounting
+   * rather than an oversight — Ollama is local, no size limit was ever reported
+   * against it, and clips are small next to full-resolution frames. What this
+   * budget promises is a bound on IMAGE bytes, not on the whole request.
    *
    * Returns what was removed so the caller can tell the user; `undeliveredImages`
    * counts images that never survived a request, i.e. the ones whose loss the

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -295,10 +295,15 @@ const MAX_TOOL_ROUNDS = 32;
 const DEFAULT_IMAGE_PAYLOAD_BUDGET_BYTES = 30 * 1024 * 1024;
 
 /** The per-request image budget in base64 bytes, honouring the env override.
- *  A non-numeric or non-positive override is ignored rather than obeyed: a
- *  typo'd `COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES=30MB` parsing to NaN must not
- *  silently drop every image on every request. */
-function imagePayloadBudgetBytes(): number {
+ *  An unusable override is ignored rather than obeyed, and the ways it can be
+ *  unusable fail in opposite directions — all of them silently:
+ *    • NaN (`=30MB`): `total <= NaN` is false, so the trim fires on every
+ *      request and strips every image forever. Inline vision just stops.
+ *    • 0 or negative: the same total loss by arithmetic instead of by NaN.
+ *    • Infinity: no bound at all — the pre-fix behaviour this exists to close.
+ *  Exported for the unit test: `Infinity` and 30 MB are indistinguishable at
+ *  the wire level without a >30 MB fixture, so that clause is pinned there. */
+export function imagePayloadBudgetBytes(): number {
   const raw = Number(process.env.COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_IMAGE_PAYLOAD_BUDGET_BYTES;
 }


### PR DESCRIPTION
## What broke

On the openai-compatible lane pointed at OpenRouter, a plain-text turn died with
`http 413 "Downloaded image content cannot exceed 30MB"` — three times in ~30
seconds — for a user who had attached nothing. Retrying could not work.

Two independent defects produced that, and either one alone leaves the bug.

### 1. The bound that existed measured the wrong thing, twice

`fetchImageB64` refuses a single ref over **12 MB of raw bytes**. Neither half of
that is the number a provider measures:

- **per-image is not per-request** — a turn attaches up to 4 refs;
- **raw is not wire** — both dialects ship base64, which is 4/3 larger.

So one turn could legitimately ship ~64 MB. Worse, `this.history` is built **once
per session** (`ollama-backend.ts:1186`) and never trimmed, so every image any
turn ever attached is re-serialized onto every later request. Nothing anywhere
summed the total.

### 2. The recovery existed and was unreachable from the state that needed it

The 4xx strip-and-retry has been there since #790. It is gated on `unprovenMedia`
= *this turn attached media that has not yet come back from a successful
request*. That gate is correct for the question it was written for — "can the
MODEL perceive what we just sent" — and media the endpoint already accepted is
rightly off the table.

A 413 is not that question. It is the **transport** refusing the size, and the
bytes making it too big are exactly the proven-delivered ones `unprovenMedia`
declines to touch. The reported turn was plain text, so `turnSentImages` was
false, so the strip never armed, so the error rethrew — and because history is
stable, the next attempt rebuilt the identical payload. **Every** subsequent turn
in that session died the same way. The session could not be talked out of it.

## The fix

- **`trimImagePayloadToBudget()`** sums base64 image bytes across the whole
  history before the first request of a turn and drops whole messages' images
  **oldest-first** until they fit. Default **30 MB**, overridable with
  `COMFYUI_MCP_OLLAMA_MAX_IMAGE_BYTES`.
- **A 413 with media in history now licenses the strip on its own.** Still
  4xx-only, still one-shot, still conditioned on there *being* media to remove.
- **A 413 is named as a 413** on both the recovered and the unrecoverable path,
  and both say retrying will not help — issue item 3. This is the one cause for
  which the panel's generic "try again" is guaranteed wrong, and the reason this
  took a log dive to find.

Measured on **base64** length rather than decoded bytes deliberately: base64 is
the larger of the two, so a history under the budget is under the limit on either
reading of "30MB".

## Where to look hardest

- **`recoverable = unprovenMedia || (oversizedPayload && historyCarriesMedia)`**
  is the load-bearing line. The `historyCarriesMedia` clause is what stops a 413
  on a merely-long conversation from spending a second request to fail
  identically; the `status === 413` clause is what stops a plain 400 from
  blaming size.
- **The honest-note direction.** `stripImagesFromHistory` and the new trim both
  branch on `mediaDelivered`, because telling a model "you did not see this"
  about an image it described two turns ago puts it at odds with its own
  transcript — and the opposite error (dropping an image with no note) leaves it
  answering from a text reference to a file it can no longer see. Both directions
  are asserted.
- **The 413 wording deliberately does not reuse "switch to a vision-capable
  model."** The model may see perfectly well; that advice would send the user to
  change a setting that changes nothing. Asserted negatively.
- **The budget applies to the native Ollama lane too**, since it operates on
  `this.history` before dialect selection. It is a ceiling far above normal use —
  the CONTROL test pins that an ordinary image turn is untouched.

## Evidence

Mutation matrix — each clause deleted in turn, the named test that died:

| mutation | test killed |
|---|---|
| trim made a no-op | `sums images across the WHOLE history…` |
| `recoverable` → `unprovenMedia` (pre-fix) | `REPRODUCTION: a plain-text turn refused for size…` |
| drop `historyCarriesMedia` | `a 413 with NO media in history is not retried…` |
| drop outer-catch 413 naming | `a 413 with NO media in history is not retried…` |
| 413 reuses the vision-rejection wording | `REPRODUCTION: …` |
| env guard removed entirely | 4 tests |
| drop `raw > 0` | 3 tests |
| drop `Number.isFinite` | `resolves the budget…` |

Controls survived every mutation. The reproduction drives the real `backend.run()`
entry point in the reported shape (image lands on turn 1; a later **plain-text**
turn is refused for size), so this is reachability, not a helper in isolation.

`tsc --noEmit` clean, `npm run build` clean, full suite green.

## Deliberately not done

- **No downscale / re-encode.** The reporter flagged the resampling policy as a
  maintainer call and they are right — it needs an image codec on the orchestrator
  path and a per-provider quality policy. Dropping oldest-first is the freeze-safe
  half that un-bricks the session; re-encoding can land on top without changing
  this contract.
- **Per-provider limit table** (issue item 2) reduced to one env knob. A provider
  registry is a feature; the knob is not.
- **`ChatGptOAuthBackend` shares the shape and is NOT fixed here.** It has a fully
  independent `runCodexTurn` with its own `turnHistory`, its own image assembly
  and its own strip-and-retry, against ChatGPT's `/responses` endpoint. Same
  unbounded accumulation, different provider and different limits, and no report
  against it. Generalizing the helper across both history types blind, under the
  freeze, on a lane I cannot exercise, is worse than saying so — filing separately.
- **No browser verification.** Nothing here renders in the panel; the change is
  orchestrator-side. The user-visible strings travel as ordinary `assistant`
  events.

Refs #2221
