### PR TITLE
fix: allow local input video filenames with repeated periods

### DIFF
--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -86,6 +86,20 @@ describe("status branches after a ComfyUI API call are reachable (#385)", () => 
     expect((err as { code?: string }).code).toBe("VIEW_ERROR");
   });
 
+  it("includes a scrubbed /view rejection reason for a 400", async () => {
+    answer(400, '{"error":"filename rejected: repeated periods"}', "application/json");
+    const err = await fetchImage("clip....mp4", "input").then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect((err as { code?: string }).code).toBe("VIEW_ERROR");
+    expect((err as Error).message).toContain("filename rejected: repeated periods");
+    expect((err as { details?: { reason?: string } }).details?.reason).toContain(
+      "filename rejected: repeated periods",
+    );
+  });
+
   it("getSetting treats a 404 as unset rather than throwing", async () => {
     // Documented behaviour that could never happen: "some builds 404 the per-id
     // route, so empty / null / 404 are treated uniformly as unset".

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -16,12 +16,19 @@ const readdirMock = vi.fn();
 const readFileMock = vi.fn();
 const realpathMock = vi.fn();
 const statMock = vi.fn();
+const resolveInputDirMock = vi.fn();
+const resolveOutputDirMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
   readFile: (...a: unknown[]) => readFileMock(...a),
   copyFile: vi.fn(),
   readdir: (...a: unknown[]) => readdirMock(...a),
   realpath: (...a: unknown[]) => realpathMock(...a),
   stat: (...a: unknown[]) => statMock(...a),
+}));
+
+vi.mock("../../services/output-dir.js", () => ({
+  resolveInputDir: (...a: unknown[]) => resolveInputDirMock(...a),
+  resolveOutputDir: (...a: unknown[]) => resolveOutputDirMock(...a),
 }));
 
 const fetchImageMock = vi.fn();
@@ -41,6 +48,8 @@ beforeEach(() => {
   mockConfig.remote = false;
   readdirMock.mockReset();
   getHistoryMock.mockReset().mockResolvedValue({});
+  resolveInputDirMock.mockReset().mockResolvedValue(resolve("/comfy", "input"));
+  resolveOutputDirMock.mockReset().mockResolvedValue(resolve("/comfy", "output"));
 });
 
 beforeEach(() => {

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -35,6 +35,7 @@ const fetchImageMock = vi.fn();
 const uploadImageHttpMock = vi.fn();
 const getHistoryMock = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({
+  MAX_VIEW_RESPONSE_BYTES: 32 * 1024 * 1024,
   fetchImage: (...a: unknown[]) => fetchImageMock(...a),
   uploadImageHttp: (...a: unknown[]) => uploadImageHttpMock(...a),
   getHistory: (...a: unknown[]) => getHistoryMock(...a),

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -14,12 +14,14 @@ vi.mock("../../config.js", () => ({
 
 const readdirMock = vi.fn();
 const readFileMock = vi.fn();
+const openMock = vi.fn();
 const realpathMock = vi.fn();
 const statMock = vi.fn();
 const resolveInputDirMock = vi.fn();
 const resolveOutputDirMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
   readFile: (...a: unknown[]) => readFileMock(...a),
+  open: (...a: unknown[]) => openMock(...a),
   copyFile: vi.fn(),
   readdir: (...a: unknown[]) => readdirMock(...a),
   realpath: (...a: unknown[]) => realpathMock(...a),
@@ -49,6 +51,21 @@ beforeEach(() => {
   mockConfig.remote = false;
   readdirMock.mockReset();
   getHistoryMock.mockReset().mockResolvedValue({});
+  const bytes = Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+    0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+    0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+  ]);
+  let position = 0;
+  openMock.mockReset().mockResolvedValue({
+    read: async (buffer: Buffer, offset: number, length: number) => {
+      const slice = bytes.subarray(position, position + length);
+      slice.copy(buffer, offset);
+      position += slice.length;
+      return { bytesRead: slice.length, buffer };
+    },
+    close: async () => undefined,
+  });
   resolveInputDirMock.mockReset().mockResolvedValue(resolve("/comfy", "input"));
   resolveOutputDirMock.mockReset().mockResolvedValue(resolve("/comfy", "output"));
 });
@@ -118,7 +135,7 @@ describe("getOutputImage — local fallback for ComfyUI's 400 rejection (#2194)"
     });
     expect(realpathMock).toHaveBeenCalledWith(root);
     expect(realpathMock).toHaveBeenCalledWith(localPath);
-    expect(readFileMock).toHaveBeenCalledWith(localPath);
+    expect(openMock).toHaveBeenCalledWith(localPath, "r");
   });
 
   it.each([

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { resolve } from "node:path";
 
 const mockConfig = vi.hoisted(() => ({
   comfyuiPath: "/comfy" as string | undefined,
@@ -7,15 +8,20 @@ const mockConfig = vi.hoisted(() => ({
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
+  isCloudMode: () => false,
   isRemoteMode: () => mockConfig.remote,
 }));
 
 const readdirMock = vi.fn();
+const readFileMock = vi.fn();
+const realpathMock = vi.fn();
+const statMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
-  readFile: vi.fn(),
+  readFile: (...a: unknown[]) => readFileMock(...a),
   copyFile: vi.fn(),
   readdir: (...a: unknown[]) => readdirMock(...a),
-  stat: vi.fn(),
+  realpath: (...a: unknown[]) => realpathMock(...a),
+  stat: (...a: unknown[]) => statMock(...a),
 }));
 
 const fetchImageMock = vi.fn();
@@ -68,6 +74,67 @@ describe("getOutputImage — happy path (legitimate ComfyUI references)", () => 
     await expect(
       getOutputImage("a.png", "temp", ""),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("getOutputImage — local fallback for ComfyUI's 400 rejection (#2194)", () => {
+  const filename = "dreamina-2026-08-12-1653-Locked-off camera, static 16_9 frame.smo....mp4";
+  const mp4 = Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+    0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+    0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+  ]);
+
+  function view400(): ComfyUIError {
+    return new ComfyUIError(
+      `ComfyUI /view returned 400 for "${filename}" (input).`,
+      "VIEW_ERROR",
+      { status: 400, filename, type: "input", subfolder: "" },
+    );
+  }
+
+  it("reads a valid repeated-period input video from the local ComfyUI directory", async () => {
+    const root = resolve("/comfy", "input");
+    const localPath = resolve(root, filename);
+    fetchImageMock.mockRejectedValue(view400());
+    realpathMock.mockImplementation(async (path: string) => path);
+    statMock.mockResolvedValue({ isFile: () => true });
+    readFileMock.mockResolvedValue(mp4);
+
+    await expect(getOutputImage(filename, "input", "", { allowMedia: true })).resolves.toMatchObject({
+      base64: mp4.toString("base64"),
+      mimeType: "video/mp4",
+      filename,
+    });
+    expect(realpathMock).toHaveBeenCalledWith(root);
+    expect(realpathMock).toHaveBeenCalledWith(localPath);
+    expect(readFileMock).toHaveBeenCalledWith(localPath);
+  });
+
+  it.each([
+    ["a filename traversal", "../outside.mp4", ""],
+    ["a subfolder traversal", "safe.mp4", "../outside"],
+  ])("rejects %s before the local fallback can read it", async (_label, name, subfolder) => {
+    fetchImageMock.mockRejectedValue(view400());
+
+    await expect(getOutputImage(name, "input", subfolder, { allowMedia: true })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    expect(realpathMock).not.toHaveBeenCalled();
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the 400 when canonical containment detects an escaping symlink", async () => {
+    const error = view400();
+    const root = resolve("/comfy", "input");
+    fetchImageMock.mockRejectedValue(error);
+    realpathMock.mockImplementation(async (path: string) =>
+      path === root ? root : resolve("/outside", filename),
+    );
+    statMock.mockResolvedValue({ isFile: () => true });
+
+    await expect(getOutputImage(filename, "input", "", { allowMedia: true })).rejects.toBe(error);
+    expect(readFileMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -326,6 +326,13 @@ describe("parseInputDirFromArgv", () => {
     expect(parseInputDirFromArgv(["main.py", `--input-directory=${abs}`])).toBe(abs);
   });
 
+  it("resolves a relative --input-directory against the server cwd", () => {
+    const serverCwd = resolve("/srv/live-comfyui");
+    expect(
+      parseInputDirFromArgv(["main.py", "--input-directory", "custom-input"], serverCwd),
+    ).toBe(join(serverCwd, "custom-input"));
+  });
+
   it("derives <base>/input from --base-directory", () => {
     const base = resolve("/srv/comfy-base");
     expect(parseInputDirFromArgv(["main.py", "--base-directory", base])).toBe(
@@ -802,6 +809,17 @@ describe("resolveInputDir", () => {
     expect(got).toBe(redirected);
     expect(got).not.toBe(resolve("/comfy", "input"));
     expect(isAbsolute(got)).toBe(true);
+  });
+
+  it("resolves a relative redirected dir against the live server cwd", async () => {
+    const serverCwd = resolve("/srv/live-comfyui");
+    getSystemStats.mockResolvedValue({
+      system: {
+        argv: ["python", "main.py", "--input-directory", "custom-input"],
+        cwd: serverCwd,
+      },
+    });
+    expect(await resolveInputDir()).toBe(join(serverCwd, "custom-input"));
   });
 
   it("falls back to <COMFYUI_PATH>/input when argv has no override", async () => {

--- a/src/__tests__/tools/get-image-local-fallback.test.ts
+++ b/src/__tests__/tools/get-image-local-fallback.test.ts
@@ -156,6 +156,27 @@ describe("get_image — canonical local input fallback (#2194)", () => {
     );
   });
 
+  it("refuses an oversized local fallback before loading or saving it", async () => {
+    mocks.stat.mockResolvedValue({
+      isFile: () => true,
+      size: 32 * 1024 * 1024 + 1,
+    });
+
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename,
+      type: "input",
+      save_dir: resolve("test-fixtures", "saved-images"),
+    });
+
+    expect(out.isError).toBe(true);
+    expect(out.content.map((block) => block.text ?? "").join(" ")).toContain("VIEW_ERROR");
+    expect(mocks.realpath).toHaveBeenCalled();
+    expect(mocks.stat).toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
   it("rejects traversal through the actual get_image handler before fallback I/O", async () => {
     const out = await getHandler("get_image")({
       action: "get",

--- a/src/__tests__/tools/get-image-local-fallback.test.ts
+++ b/src/__tests__/tools/get-image-local-fallback.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { join, resolve } from "node:path";
+import { ComfyUIError } from "../../utils/errors.js";
+
+const mocks = vi.hoisted(() => ({
+  config: {
+    comfyuiPath: "",
+    comfyuiBasePath: "",
+    comfyuiSsl: false,
+  },
+  fetchImage: vi.fn(),
+  getSystemStats: vi.fn(),
+  comfyApiFetch: vi.fn(),
+  liveRoot: vi.fn(),
+  readFile: vi.fn(),
+  realpath: vi.fn(),
+  stat: vi.fn(),
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    config: mocks.config,
+    isCloudMode: () => false,
+    isRemoteMode: () => false,
+  };
+});
+
+vi.mock("../../comfyui/client.js", async () => {
+  const actual = await vi.importActual<typeof import("../../comfyui/client.js")>("../../comfyui/client.js");
+  return {
+    ...actual,
+    fetchImage: (...args: unknown[]) => mocks.fetchImage(...args),
+    getSystemStats: (...args: unknown[]) => mocks.getSystemStats(...args),
+    comfyApiFetch: (...args: unknown[]) => mocks.comfyApiFetch(...args),
+  };
+});
+
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/workspace-env.js")>("../../services/workspace-env.js");
+  return {
+    ...actual,
+    resolveLiveComfyUIBase: (...args: unknown[]) => mocks.liveRoot(...args),
+  };
+});
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    readFile: (...args: unknown[]) => mocks.readFile(...args),
+    realpath: (...args: unknown[]) => mocks.realpath(...args),
+    stat: (...args: unknown[]) => mocks.stat(...args),
+    mkdir: (...args: unknown[]) => mocks.mkdir(...args),
+    writeFile: (...args: unknown[]) => mocks.writeFile(...args),
+  };
+});
+
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolResult = {
+  isError?: boolean;
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+};
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (toolName: string, _description: string, _schema: unknown, toolHandler: ToolHandler) => {
+      if (toolName === name) handler = toolHandler;
+    },
+  };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+const filename = "dreamina-2026-08-12-1653-Locked-off camera, static 16_9 frame.smo....mp4";
+const mp4 = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+  0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+]);
+
+function view400(): ComfyUIError {
+  return new ComfyUIError(
+    `ComfyUI /view returned 400 for "${filename}" (input).`,
+    "VIEW_ERROR",
+    { status: 400, filename, type: "input", subfolder: "" },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.config.comfyuiPath = resolve("test-fixtures", "configured-comfyui");
+  mocks.getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
+  mocks.comfyApiFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+  mocks.liveRoot.mockResolvedValue(undefined);
+  mocks.fetchImage.mockRejectedValue(view400());
+  mocks.readFile.mockResolvedValue(mp4);
+  mocks.realpath.mockImplementation(async (path: string) => path);
+  mocks.stat.mockResolvedValue({ isFile: () => true });
+  mocks.mkdir.mockResolvedValue(undefined);
+  mocks.writeFile.mockResolvedValue(undefined);
+});
+
+describe("get_image — canonical local input fallback (#2194)", () => {
+  it("reads a repeated-period video from the connected custom --input-directory", async () => {
+    const customInput = resolve("test-fixtures", "connected-comfyui", "custom-input");
+    const staleConfigured = resolve(mocks.config.comfyuiPath, "input", filename);
+    const localPath = join(customInput, filename);
+    mocks.getSystemStats.mockResolvedValue({
+      system: { argv: ["python", "main.py", "--input-directory", customInput] },
+    });
+
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename,
+      type: "input",
+      save_dir: resolve("test-fixtures", "saved-images"),
+    });
+
+    expect(out.isError).toBeUndefined();
+    expect(mocks.getSystemStats).toHaveBeenCalled();
+    expect(mocks.fetchImage).toHaveBeenCalledWith(filename, "input", "");
+    expect(mocks.readFile).toHaveBeenCalledWith(localPath);
+    expect(mocks.readFile).not.toHaveBeenCalledWith(staleConfigured);
+    expect(mocks.writeFile).toHaveBeenCalledWith(
+      join(resolve("test-fixtures", "saved-images"), filename),
+      mp4,
+    );
+    expect(out.content.map((block) => block.text ?? "").join(" ")).toContain("Saved to:");
+  });
+
+  it("uses the connected live install input directory when no input flag is present", async () => {
+    const liveBase = resolve("test-fixtures", "connected-live-comfyui");
+    const localPath = join(liveBase, "input", filename);
+    mocks.liveRoot.mockResolvedValue(liveBase);
+
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename,
+      type: "input",
+      save_dir: resolve("test-fixtures", "saved-images"),
+    });
+
+    expect(out.isError).toBeUndefined();
+    expect(mocks.liveRoot).toHaveBeenCalled();
+    expect(mocks.readFile).toHaveBeenCalledWith(localPath);
+    expect(mocks.readFile).not.toHaveBeenCalledWith(
+      join(resolve(mocks.config.comfyuiPath), "input", filename),
+    );
+  });
+
+  it("rejects traversal through the actual get_image handler before fallback I/O", async () => {
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename: "../outside.mp4",
+      type: "input",
+    });
+
+    expect(out.isError).toBe(true);
+    expect(out.content.map((block) => block.text ?? "").join(" ")).toContain("VALIDATION_ERROR");
+    expect(mocks.fetchImage).not.toHaveBeenCalled();
+    expect(mocks.realpath).not.toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/tools/get-image-local-fallback.test.ts
+++ b/src/__tests__/tools/get-image-local-fallback.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   readFile: vi.fn(),
   realpath: vi.fn(),
   stat: vi.fn(),
+  open: vi.fn(),
   mkdir: vi.fn(),
   writeFile: vi.fn(),
 }));
@@ -54,6 +55,7 @@ vi.mock("node:fs/promises", async () => {
     readFile: (...args: unknown[]) => mocks.readFile(...args),
     realpath: (...args: unknown[]) => mocks.realpath(...args),
     stat: (...args: unknown[]) => mocks.stat(...args),
+    open: (...args: unknown[]) => mocks.open(...args),
     mkdir: (...args: unknown[]) => mocks.mkdir(...args),
     writeFile: (...args: unknown[]) => mocks.writeFile(...args),
   };
@@ -94,6 +96,19 @@ function view400(): ComfyUIError {
   );
 }
 
+function fileHandleFor(bytes: Buffer) {
+  let position = 0;
+  return {
+    read: vi.fn(async (buffer: Buffer, offset: number, length: number) => {
+      const slice = bytes.subarray(position, position + length);
+      slice.copy(buffer, offset);
+      position += slice.length;
+      return { bytesRead: slice.length, buffer };
+    }),
+    close: vi.fn(async () => undefined),
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.config.comfyuiPath = resolve("test-fixtures", "configured-comfyui");
@@ -104,17 +119,22 @@ beforeEach(() => {
   mocks.readFile.mockResolvedValue(mp4);
   mocks.realpath.mockImplementation(async (path: string) => path);
   mocks.stat.mockResolvedValue({ isFile: () => true });
+  mocks.open.mockResolvedValue(fileHandleFor(mp4));
   mocks.mkdir.mockResolvedValue(undefined);
   mocks.writeFile.mockResolvedValue(undefined);
 });
 
 describe("get_image — canonical local input fallback (#2194)", () => {
-  it("reads a repeated-period video from the connected custom --input-directory", async () => {
-    const customInput = resolve("test-fixtures", "connected-comfyui", "custom-input");
+  it("resolves a relative --input-directory against the live cwd, not stale config", async () => {
+    const serverCwd = resolve("test-fixtures", "connected-comfyui");
+    const customInput = join(serverCwd, "custom-input");
     const staleConfigured = resolve(mocks.config.comfyuiPath, "input", filename);
     const localPath = join(customInput, filename);
     mocks.getSystemStats.mockResolvedValue({
-      system: { argv: ["python", "main.py", "--input-directory", customInput] },
+      system: {
+        argv: ["python", "main.py", "--input-directory", "custom-input"],
+        cwd: serverCwd,
+      },
     });
 
     const out = await getHandler("get_image")({
@@ -127,8 +147,8 @@ describe("get_image — canonical local input fallback (#2194)", () => {
     expect(out.isError).toBeUndefined();
     expect(mocks.getSystemStats).toHaveBeenCalled();
     expect(mocks.fetchImage).toHaveBeenCalledWith(filename, "input", "");
-    expect(mocks.readFile).toHaveBeenCalledWith(localPath);
-    expect(mocks.readFile).not.toHaveBeenCalledWith(staleConfigured);
+    expect(mocks.open).toHaveBeenCalledWith(localPath, "r");
+    expect(mocks.open).not.toHaveBeenCalledWith(staleConfigured, "r");
     expect(mocks.writeFile).toHaveBeenCalledWith(
       join(resolve("test-fixtures", "saved-images"), filename),
       mp4,
@@ -150,17 +170,27 @@ describe("get_image — canonical local input fallback (#2194)", () => {
 
     expect(out.isError).toBeUndefined();
     expect(mocks.liveRoot).toHaveBeenCalled();
-    expect(mocks.readFile).toHaveBeenCalledWith(localPath);
-    expect(mocks.readFile).not.toHaveBeenCalledWith(
+    expect(mocks.open).toHaveBeenCalledWith(localPath, "r");
+    expect(mocks.open).not.toHaveBeenCalledWith(
       join(resolve(mocks.config.comfyuiPath), "input", filename),
+      "r",
     );
   });
 
   it("refuses an oversized local fallback before loading or saving it", async () => {
+    const localPath = join(resolve(mocks.config.comfyuiPath), "input", filename);
+    const grownHandle = {
+      read: vi.fn(async (_buffer: Buffer, _offset: number, length: number) => ({
+        bytesRead: length,
+      })),
+      close: vi.fn(async () => undefined),
+    };
     mocks.stat.mockResolvedValue({
       isFile: () => true,
-      size: 32 * 1024 * 1024 + 1,
+      // The file is at the limit when checked, then grows while it is read.
+      size: 32 * 1024 * 1024,
     });
+    mocks.open.mockResolvedValue(grownHandle);
 
     const out = await getHandler("get_image")({
       action: "get",
@@ -173,6 +203,9 @@ describe("get_image — canonical local input fallback (#2194)", () => {
     expect(out.content.map((block) => block.text ?? "").join(" ")).toContain("VIEW_ERROR");
     expect(mocks.realpath).toHaveBeenCalled();
     expect(mocks.stat).toHaveBeenCalled();
+    expect(mocks.open).toHaveBeenCalledWith(localPath, "r");
+    expect(grownHandle.read).toHaveBeenCalled();
+    expect(grownHandle.close).toHaveBeenCalled();
     expect(mocks.readFile).not.toHaveBeenCalled();
     expect(mocks.writeFile).not.toHaveBeenCalled();
   });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1392,15 +1392,30 @@ export async function fetchImage(
     const responder = answeredByPanelOrigin
       ? `The connected panel's ComfyUI at ${answeredByPanelOrigin}`
       : "ComfyUI";
+    let rejectionReason = "";
+    if (res.status === 400) {
+      try {
+        const body = await readViewResponseBounded(res, filename, responseReadTimeoutMs);
+        rejectionReason = bodyPrefixOf(body.toString("utf8"));
+      } catch {
+        // The status is still actionable when a diagnostic body cannot be read.
+      }
+    }
     throw new ComfyUIError(
       `${responder} /view returned ${res.status} for "${filename}" (${where}). ` +
         (res.status === 404
           ? `No such file in the ComfyUI ${type} directory` +
             (subfolder ? ` under subfolder "${subfolder}"` : "") +
             `. Check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`
-          : `The ComfyUI server rejected the request.`),
+          : `The ComfyUI server rejected the request${rejectionReason ? `: ${rejectionReason}` : "."}`),
       res.status === 404 ? "IMAGE_NOT_FOUND" : "VIEW_ERROR",
-      { status: res.status, filename, type, subfolder },
+      {
+        status: res.status,
+        filename,
+        type,
+        subfolder,
+        ...(rejectionReason ? { reason: rejectionReason } : {}),
+      },
     );
   }
   const contentType = res.headers.get("content-type") ?? "image/png";

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1,4 +1,4 @@
-import { readFile, copyFile, readdir, realpath, stat } from "node:fs/promises";
+import { readFile, copyFile, open, readdir, realpath, stat } from "node:fs/promises";
 import { join, basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
 import { config, isCloudMode, isRemoteMode } from "../config.js";
 import {
@@ -571,6 +571,28 @@ function localViewMimeType(filename: string): string {
   );
 }
 
+/** Read at most the shared /view limit, including when the file grows after stat(). */
+async function readLocalViewFileBounded(path: string): Promise<Buffer | undefined> {
+  const handle = await open(path, "r");
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      // Read one byte beyond the limit so growth after the initial stat is
+      // refused rather than silently truncated into a valid-looking payload.
+      const capacity = Math.min(64 * 1024, MAX_VIEW_RESPONSE_BYTES - total + 1);
+      const chunk = Buffer.allocUnsafe(capacity);
+      const { bytesRead } = await handle.read(chunk, 0, capacity, null);
+      if (bytesRead === 0) return Buffer.concat(chunks, total);
+      total += bytesRead;
+      if (total > MAX_VIEW_RESPONSE_BYTES) return undefined;
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
 /**
  * Recover a local file when ComfyUI rejects an otherwise valid /view reference
  * with HTTP 400. Some ComfyUI builds reject basenames containing repeated
@@ -610,7 +632,8 @@ async function readLocalViewFallback(
     if (!isStrictlyInside(realRoot, realCandidate)) return undefined;
     const candidateStat = await stat(realCandidate);
     if (!candidateStat.isFile() || candidateStat.size > MAX_VIEW_RESPONSE_BYTES) return undefined;
-    const data = await readFile(realCandidate);
+    const data = await readLocalViewFileBounded(realCandidate);
+    if (!data) return undefined;
     return { base64: data.toString("base64"), mimeType: localViewMimeType(filename) };
   } catch {
     // Preserve the original /view 400 when the local path cannot be resolved

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1,7 +1,12 @@
 import { readFile, copyFile, readdir, realpath, stat } from "node:fs/promises";
 import { join, basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
 import { config, isCloudMode, isRemoteMode } from "../config.js";
-import { getHistory, getObjectInfo, resetObjectInfoCache } from "../comfyui/client.js";
+import {
+  getHistory,
+  getObjectInfo,
+  resetObjectInfoCache,
+  MAX_VIEW_RESPONSE_BYTES,
+} from "../comfyui/client.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import { ValidationError, ModelError, ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -603,7 +608,8 @@ async function readLocalViewFallback(
       realpath(candidate),
     ]);
     if (!isStrictlyInside(realRoot, realCandidate)) return undefined;
-    if (!(await stat(realCandidate)).isFile()) return undefined;
+    const candidateStat = await stat(realCandidate);
+    if (!candidateStat.isFile() || candidateStat.size > MAX_VIEW_RESPONSE_BYTES) return undefined;
     const data = await readFile(realCandidate);
     return { base64: data.toString("base64"), mimeType: localViewMimeType(filename) };
   } catch {

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1,6 +1,6 @@
-import { readFile, copyFile, readdir, stat } from "node:fs/promises";
-import { join, basename, extname, relative, sep } from "node:path";
-import { config, isRemoteMode } from "../config.js";
+import { readFile, copyFile, readdir, realpath, stat } from "node:fs/promises";
+import { join, basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { config, isCloudMode, isRemoteMode } from "../config.js";
 import { getHistory, getObjectInfo, resetObjectInfoCache } from "../comfyui/client.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import { ValidationError, ModelError, ComfyUIError } from "../utils/errors.js";
@@ -544,6 +544,73 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
   }
 }
 
+/** Strict lexical containment for the local fallback below. */
+function isStrictlyInside(root: string, candidate: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate));
+  return (
+    rel !== "" &&
+    rel !== ".." &&
+    !rel.startsWith(`..${sep}`) &&
+    !rel.startsWith("../") &&
+    !isAbsolute(rel)
+  );
+}
+
+function localViewMimeType(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return (
+    IMAGE_MIME[ext] ??
+    VIDEO_MIME[ext] ??
+    AUDIO_MIME[ext] ??
+    (ext === ".json" ? "application/json" : "application/octet-stream")
+  );
+}
+
+/**
+ * Recover a local file when ComfyUI rejects an otherwise valid /view reference
+ * with HTTP 400. Some ComfyUI builds reject basenames containing repeated
+ * periods even though the loader can read the file from disk. This is only a
+ * local, 400-specific fallback; remote and cloud targets must never read this
+ * process's filesystem.
+ */
+async function readLocalViewFallback(
+  filename: string,
+  type: "output" | "input" | "temp",
+  subfolder: string,
+): Promise<{ base64: string; mimeType: string } | undefined> {
+  if (isRemoteMode() || isCloudMode() || !config.comfyuiPath) return undefined;
+
+  const root = resolve(config.comfyuiPath, type);
+  const candidate = resolve(root, subfolder, filename);
+  if (!isStrictlyInside(root, candidate)) return undefined;
+
+  try {
+    // Check the canonical paths too: an input-side symlink must not turn this
+    // compatibility path into an arbitrary local file read.
+    const [realRoot, realCandidate] = await Promise.all([
+      realpath(root),
+      realpath(candidate),
+    ]);
+    if (!isStrictlyInside(realRoot, realCandidate)) return undefined;
+    if (!(await stat(realCandidate)).isFile()) return undefined;
+    const data = await readFile(realCandidate);
+    return { base64: data.toString("base64"), mimeType: localViewMimeType(filename) };
+  } catch {
+    // Preserve the original /view 400 when the local path cannot be resolved
+    // or read; the fallback must not hide the server's actionable error.
+    return undefined;
+  }
+}
+
+function isViewBadRequest(error: unknown): error is ComfyUIError {
+  if (!(error instanceof ComfyUIError) || error.code !== "VIEW_ERROR") return false;
+  return (
+    typeof error.details === "object" &&
+    error.details !== null &&
+    (error.details as { status?: unknown }).status === 400
+  );
+}
+
 /**
  * Media formats get_image can save, identified by magic-byte sniff (#663).
  * Format — not just family — so a cross-format mislabel (MP3 bytes declared
@@ -765,7 +832,15 @@ export async function getOutputImage(
   }: { allowMedia?: boolean; allowJson?: boolean } = {},
 ): Promise<{ base64: string; mimeType: string; filename: string }> {
   assertSafeViewRef(filename, subfolder);
-  const result = await fetchImage(filename, type, subfolder);
+  let result: { base64: string; mimeType: string };
+  try {
+    result = await fetchImage(filename, type, subfolder);
+  } catch (error) {
+    if (!isViewBadRequest(error)) throw error;
+    const local = await readLocalViewFallback(filename, type, subfolder);
+    if (!local) throw error;
+    result = local;
+  }
 
   // Guard against non-image /view payloads. ComfyUI (or a reverse proxy in
   // front of it) can answer /view with a 200 whose body is actually a JSON or

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -578,13 +578,24 @@ async function readLocalViewFallback(
   type: "output" | "input" | "temp",
   subfolder: string,
 ): Promise<{ base64: string; mimeType: string } | undefined> {
-  if (isRemoteMode() || isCloudMode() || !config.comfyuiPath) return undefined;
-
-  const root = resolve(config.comfyuiPath, type);
-  const candidate = resolve(root, subfolder, filename);
-  if (!isStrictlyInside(root, candidate)) return undefined;
+  if (isRemoteMode() || isCloudMode()) return undefined;
 
   try {
+    // Use the same live/argv-aware roots as local filesystem tools. In
+    // particular, input may be redirected with --input-directory and the
+    // configured COMFYUI_PATH may belong to a different installed copy.
+    const root =
+      type === "input"
+        ? await resolveInputDir()
+        : type === "output"
+          ? await resolveOutputDir()
+          : config.comfyuiPath
+            ? resolve(config.comfyuiPath, "temp")
+            : undefined;
+    if (!root) return undefined;
+    const candidate = resolve(root, subfolder, filename);
+    if (!isStrictlyInside(root, candidate)) return undefined;
+
     // Check the canonical paths too: an input-side symlink must not turn this
     // compatibility path into an arbitrary local file read.
     const [realRoot, realCandidate] = await Promise.all([

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1222,7 +1222,10 @@ export function localOutputDirFallback(): string {
  * --input-directory wins; otherwise --base-directory implies <base>/input.
  * Returns undefined when neither flag is present.
  */
-export function parseInputDirFromArgv(argv: string[] | undefined): string | undefined {
+export function parseInputDirFromArgv(
+  argv: string[] | undefined,
+  serverCwd?: string,
+): string | undefined {
   if (!argv || argv.length === 0) return undefined;
 
   let inputDir: string | undefined;
@@ -1232,8 +1235,12 @@ export function parseInputDirFromArgv(argv: string[] | undefined): string | unde
     baseDir = flagValue(argv, i, "--base-directory") ?? baseDir;
   }
 
-  const resolvedBase = baseDir ? resolveDir(baseDir) : undefined;
-  if (inputDir) return resolveDir(inputDir, resolvedBase);
+  // ComfyUI resolves these command-line paths with os.path.abspath(), which
+  // anchors relative values at the SERVER process cwd, not COMFYUI_PATH or
+  // the MCP process cwd. Without an absolute server cwd, fail closed rather
+  // than silently selecting a different local install.
+  if (inputDir) return resolveServerLaunchPath(inputDir, serverCwd);
+  const resolvedBase = baseDir ? resolveServerLaunchPath(baseDir, serverCwd) : undefined;
   if (resolvedBase) return join(resolvedBase, "input");
   return undefined;
 }
@@ -1291,7 +1298,8 @@ async function liveIoDirFallback(kind: "input" | "output"): Promise<string | und
 export async function resolveInputDir(): Promise<string> {
   try {
     const stats = await getSystemStats();
-    const fromArgv = parseInputDirFromArgv(stats.system?.argv);
+    const serverCwd = (stats.system as { cwd?: string } | undefined)?.cwd;
+    const fromArgv = parseInputDirFromArgv(stats.system?.argv, serverCwd);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI input directory from launch argv", {
         inputDir: fromArgv,


### PR DESCRIPTION
## Summary
- fall back to the local ComfyUI media directory when /view rejects a local reference with HTTP 400
- keep lexical and canonical containment checks plus existing traversal validation
- include a bounded, scrubbed /view rejection reason for 400 responses

## Tests
- npm.cmd exec vitest run src/__tests__/services/image-management-traversal.test.ts src/__tests__/tools/get-image-binary-safe.test.ts src/__tests__/services/list-output-images.test.ts src/__tests__/comfyui/unreachable-status-branches.test.ts
- npm.cmd run lint
- git diff --check

Fixes #2194