### PR TITLE
fix(panel): complete large panel_get_errors audits

### DIFF
--- a/src/__tests__/orchestrator/get-errors-call-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-call-budget.test.ts
@@ -23,6 +23,13 @@ const EXECUTION_NODES = [
   { id: 73, type: "ImpactSwitch", widget: "select", value: "prompt_a" },
 ] as const;
 
+const FIFTY_NODE_WORKFLOW = Array.from({ length: 50 }, (_, i) => ({
+  id: i + 1,
+  type: "Loader",
+  widget: "asset",
+  value: `asset-${i + 1}.safetensors`,
+}));
+
 function budgetExhaustedReply(opts?: { extraUnchecked?: number }): Record<string, unknown> {
   const extra = opts?.extraUnchecked ?? 35;
   const extras = Array.from({ length: extra }, (_, i) => ({
@@ -165,6 +172,66 @@ describe("panel_get_errors leftover call-budget audit (#1973)", () => {
     }
     expect(payload.errored_count).toBe(0);
     expect(payload.unavailable_widget_values).toBeUndefined();
+  });
+
+  it("pages a 50-node detail audit so graph_query's character cap cannot strand leftovers (#2199)", async () => {
+    const panel = {
+      viewing: { kind: "root", workflow: "fifty.json", workflow_uuid: "workflow-50" },
+      node_count: FIFTY_NODE_WORKFLOW.length,
+      errored_count: 0,
+      nodes: [],
+      unchecked_nodes: FIFTY_NODE_WORKFLOW.map((n) => ({
+        id: n.id,
+        type: n.type,
+        reason: BUDGET_REASON,
+      })),
+      unchecked_budget_exhausted: true,
+      last_execution_error: null,
+      node_errors: null,
+      note: CLEAN_NOTE,
+    };
+    const pages: number[][] = [];
+    const { payload, cmds } = await runGetErrors((cmd) => {
+      if (cmd.cmd === "graph_get_errors") return panel;
+      if (cmd.cmd === "graph_query") {
+        const ids = (cmd.ids as unknown[]).map(Number);
+        pages.push(ids);
+        const rows = FIFTY_NODE_WORKFLOW.filter((n) => ids.includes(n.id));
+        // Model graph_query's max_chars truncation if the completion regresses
+        // to one oversized detail request. The fixed-size pages below fit.
+        if (ids.length > 10) {
+          const shown = rows.slice(0, 10);
+          return {
+            matched: rows.length,
+            shown: shown.length,
+            truncated: true,
+            truncated_by: "max_chars",
+            text: detailText(shown),
+          };
+        }
+        return {
+          matched: rows.length,
+          shown: rows.length,
+          truncated: false,
+          truncated_by: null,
+          text: detailText(rows),
+        };
+      }
+      if (cmd.cmd === "graph_get_object_info") {
+        return { ok: true, object_info: objectInfoFor(FIFTY_NODE_WORKFLOW) };
+      }
+      return { ok: false };
+    });
+
+    expect(cmds.filter((c) => c === "graph_get_object_info")).toHaveLength(1);
+    expect(pages).toHaveLength(5);
+    expect(pages.every((ids) => ids.length <= 10)).toBe(true);
+    expect(new Set(pages.flat())).toEqual(new Set(FIFTY_NODE_WORKFLOW.map((n) => n.id)));
+    expect(payload.audit_complete).toBe(true);
+    expect(payload.node_count).toBe(50);
+    expect(payload.checked_count).toBe(50);
+    expect(payload.unchecked_count).toBe(0);
+    expect(payload.unchecked_nodes).toBeUndefined();
   });
 
   it("keeps the completion pass on the live route after a primary reconnect rebind", async () => {

--- a/src/__tests__/orchestrator/get-errors-call-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-call-budget.test.ts
@@ -7,7 +7,7 @@
 // the real panel_get_errors def: a stubbed panel returns the reporter's shape,
 // and the assertions read the payload the caller actually gets.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildPanelToolDefs, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
 
 type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string }> };
@@ -25,7 +25,7 @@ const EXECUTION_NODES = [
 
 const FIFTY_NODE_WORKFLOW = Array.from({ length: 50 }, (_, i) => ({
   id: i + 1,
-  type: "Loader",
+  type: `Loader${i + 1}`,
   widget: "asset",
   value: `asset-${i + 1}.safetensors`,
 }));
@@ -80,38 +80,76 @@ function detailText(
     .join("\n");
 }
 
+function fiftyNodeBudgetReply(): Record<string, unknown> {
+  return {
+    viewing: { kind: "root", workflow: "fifty.json", workflow_uuid: "workflow-50" },
+    node_count: FIFTY_NODE_WORKFLOW.length,
+    errored_count: 0,
+    nodes: [],
+    unchecked_nodes: FIFTY_NODE_WORKFLOW.map((n) => ({
+      id: n.id,
+      type: n.type,
+      reason: BUDGET_REASON,
+    })),
+    unchecked_budget_exhausted: true,
+    last_execution_error: null,
+    node_errors: null,
+    note: CLEAN_NOTE,
+  };
+}
+
 async function runGetErrors(
   replies: (cmd: Record<string, unknown>) => Record<string, unknown>,
-  opts: { rebindAfterPrimary?: string } = {},
-): Promise<{ payload: Record<string, unknown>; cmds: string[]; keys: string[] }> {
+  opts: {
+    rebindAfterPrimary?: string;
+    onDispatched?: (
+      cmd: Record<string, unknown>,
+      reply: Record<string, unknown>,
+    ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  } = {},
+): Promise<{
+  payload: Record<string, unknown>;
+  cmds: string[];
+  calls: Record<string, unknown>[];
+  keys: string[];
+}> {
   const def = buildPanelToolDefs().find((d) => d.name === "panel_get_errors");
   if (!def) throw new Error("panel_get_errors is not registered");
   const cmds: string[] = [];
+  const calls: Record<string, unknown>[] = [];
   let primaryViewing: unknown;
+  let graphLane = Promise.resolve();
+  const dispatch = async (cmd: Record<string, unknown>) => {
+    cmds.push(String(cmd.cmd));
+    calls.push(cmd);
+    let reply = replies(cmd);
+    if (opts.onDispatched) reply = await opts.onDispatched(cmd, reply);
+    if (cmd.cmd === "graph_get_errors" && reply.viewing != null) primaryViewing = reply.viewing;
+    // Current graph_query replies always carry viewing. Keep older fixture
+    // bodies compact while supplying the same root identity to the real
+    // completion path; mismatch tests provide an explicit different one.
+    const withViewing =
+      cmd.cmd === "graph_query" && !Object.hasOwn(reply, "viewing")
+        ? { viewing: primaryViewing ?? { kind: "root", workflow_uuid: "workflow-a" }, ...reply }
+        : reply;
+    if (cmd.cmd === "graph_get_errors" && opts.rebindAfterPrimary) {
+      ctx.tabId = opts.rebindAfterPrimary;
+    }
+    return { content: [{ type: "text" as const, text: JSON.stringify(withViewing, null, 2) }] };
+  };
   const ctx = {
-      call: async (cmd: Record<string, unknown>) => {
-        cmds.push(String(cmd.cmd));
-        const reply = replies(cmd);
-        if (cmd.cmd === "graph_get_errors" && reply.viewing != null) primaryViewing = reply.viewing;
-        // Current graph_query replies always carry viewing. Keep older fixture
-        // bodies compact while supplying the same root identity to the real
-        // completion path; mismatch tests provide an explicit different one.
-        const withViewing =
-          cmd.cmd === "graph_query" && !Object.hasOwn(reply, "viewing")
-            ? { viewing: primaryViewing ?? { kind: "root", workflow_uuid: "workflow-a" }, ...reply }
-            : reply;
-        if (cmd.cmd === "graph_get_errors" && opts.rebindAfterPrimary) {
-          ctx.tabId = opts.rebindAfterPrimary;
-        }
-        return { content: [{ type: "text" as const, text: JSON.stringify(withViewing, null, 2) }] };
-      },
-      tabId: "test-tab",
-    } as unknown as PanelToolCtx;
+    call: (cmd: Record<string, unknown>) => {
+      const next = graphLane.then(() => dispatch(cmd), () => dispatch(cmd));
+      graphLane = next.then(() => undefined, () => undefined);
+      return next;
+    },
+    tabId: "test-tab",
+  } as unknown as PanelToolCtx;
   const res = (await def.handler({}, ctx)) as ToolResult;
   const text = res.content.find((c) => c.type === "text")?.text;
   if (typeof text !== "string") throw new Error("panel_get_errors returned no text");
   const payload = JSON.parse(text) as Record<string, unknown>;
-  return { payload, cmds, keys: Object.keys(payload) };
+  return { payload, cmds, calls, keys: Object.keys(payload) };
 }
 
 describe("panel_get_errors leftover call-budget audit (#1973)", () => {
@@ -175,23 +213,9 @@ describe("panel_get_errors leftover call-budget audit (#1973)", () => {
   });
 
   it("pages a 50-node detail audit so graph_query's character cap cannot strand leftovers (#2199)", async () => {
-    const panel = {
-      viewing: { kind: "root", workflow: "fifty.json", workflow_uuid: "workflow-50" },
-      node_count: FIFTY_NODE_WORKFLOW.length,
-      errored_count: 0,
-      nodes: [],
-      unchecked_nodes: FIFTY_NODE_WORKFLOW.map((n) => ({
-        id: n.id,
-        type: n.type,
-        reason: BUDGET_REASON,
-      })),
-      unchecked_budget_exhausted: true,
-      last_execution_error: null,
-      node_errors: null,
-      note: CLEAN_NOTE,
-    };
+    const panel = fiftyNodeBudgetReply();
     const pages: number[][] = [];
-    const { payload, cmds } = await runGetErrors((cmd) => {
+    const { payload, calls } = await runGetErrors((cmd) => {
       if (cmd.cmd === "graph_get_errors") return panel;
       if (cmd.cmd === "graph_query") {
         const ids = (cmd.ids as unknown[]).map(Number);
@@ -223,15 +247,80 @@ describe("panel_get_errors leftover call-budget audit (#1973)", () => {
       return { ok: false };
     });
 
-    expect(cmds.filter((c) => c === "graph_get_object_info")).toHaveLength(1);
-    expect(pages).toHaveLength(5);
-    expect(pages.every((ids) => ids.length <= 10)).toBe(true);
-    expect(new Set(pages.flat())).toEqual(new Set(FIFTY_NODE_WORKFLOW.map((n) => n.id)));
+    expect(calls.map((call) => call.cmd)).toEqual([
+      "graph_get_errors",
+      "graph_get_object_info",
+      "graph_query",
+      "graph_query",
+      "graph_query",
+      "graph_query",
+      "graph_query",
+    ]);
+    expect(pages).toEqual([
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+      [21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+      [31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+      [41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
+    ]);
     expect(payload.audit_complete).toBe(true);
     expect(payload.node_count).toBe(50);
     expect(payload.checked_count).toBe(50);
     expect(payload.unchecked_count).toBe(0);
     expect(payload.unchecked_nodes).toBeUndefined();
+    expect(payload.errored_count).toBe(0);
+    expect(payload.unavailable_widget_values).toBeUndefined();
+    expect(payload.note).toBe(CLEAN_NOTE);
+  });
+
+  it("stops serialized completion at the aggregate deadline instead of queueing later pages (#2199)", async () => {
+    const panel = fiftyNodeBudgetReply();
+    let now = 1_000_000;
+    const start = now;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const { payload, calls } = await runGetErrors(
+        (cmd) => {
+          if (cmd.cmd === "graph_get_errors") return panel;
+          if (cmd.cmd === "graph_query") {
+            const ids = (cmd.ids as unknown[]).map(Number);
+            return {
+              matched: ids.length,
+              shown: ids.length,
+              truncated: false,
+              truncated_by: null,
+              text: detailText(FIFTY_NODE_WORKFLOW.filter((n) => ids.includes(n.id))),
+            };
+          }
+          if (cmd.cmd === "graph_get_object_info") {
+            return { ok: true, object_info: objectInfoFor(FIFTY_NODE_WORKFLOW) };
+          }
+          return { ok: false };
+        },
+        {
+          onDispatched: (cmd, reply) => {
+            if (cmd.cmd !== "graph_get_errors") now += 4_000;
+            return reply;
+          },
+        },
+      );
+
+      expect(calls.map((call) => call.cmd)).toEqual([
+        "graph_get_errors",
+        "graph_get_object_info",
+        "graph_query",
+      ]);
+      expect((calls[2].ids as unknown[]).map(Number)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      ]);
+      expect(now).toBe(start + 8_000);
+      expect(payload.audit_complete).toBe(false);
+      expect(payload.node_count).toBe(50);
+      expect(payload.checked_count).toBe(10);
+      expect(payload.unchecked_count).toBe(40);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("keeps the completion pass on the live route after a primary reconnect rebind", async () => {
@@ -692,6 +781,14 @@ describe("get_errors completion follow-ups run on the elective budget (#1973/#58
           const body =
             cmd.cmd === "graph_get_errors"
               ? budgetExhaustedReply({ extraUnchecked: 0 })
+              : cmd.cmd === "graph_query"
+                ? {
+                    matched: EXECUTION_NODES.length,
+                    shown: EXECUTION_NODES.length,
+                    text: detailText(EXECUTION_NODES),
+                  }
+                : cmd.cmd === "graph_get_object_info"
+                  ? { ok: true, object_info: objectInfoFor(EXECUTION_NODES) }
               : { ok: false };
           return { content: [{ type: "text" as const, text: JSON.stringify(body) }] };
         },
@@ -718,9 +815,12 @@ describe("get_errors completion follow-ups run on the elective budget (#1973/#58
     ).toBeLessThan(primary!);
     expect(objectInfo!).toBeLessThan(primary!);
 
-    // Worst case is the primary budget plus ONE follow-up budget: the two
-    // follow-ups are issued concurrently, so they overlap rather than sum.
-    expect(primary! + Math.max(query!, objectInfo!)).toBeLessThanOrEqual(40_000);
+    // The follow-up wave has one aggregate 8 s budget. Each individual dispatch
+    // is capped by the remaining time, so serialized pages cannot sum their
+    // per-call timeout into a longer handler wait.
+    expect(query!).toBeLessThanOrEqual(8_000);
+    expect(objectInfo!).toBeLessThanOrEqual(8_000);
+    expect(primary! + Math.max(query!, objectInfo!)).toBeLessThanOrEqual(38_000);
   });
 });
 

--- a/src/orchestrator/get-errors-audit.ts
+++ b/src/orchestrator/get-errors-audit.ts
@@ -62,8 +62,8 @@ const FILE_LIKE = /\.[A-Za-z0-9_]{2,12}$/;
  * `graph_query` has no cursor/offset. Explicit-ID pages are therefore the only
  * pagination available to this completion pass, and keeping each detail page
  * small leaves room under its 60,000-character ceiling for ordinary workflows.
- * Pages are issued concurrently under the existing single elective timeout; the
- * graph-query ceiling also bounds the pass at 200 leftover ids.
+ * Pages are issued in graph order under one aggregate deadline; the graph-query
+ * ceiling also bounds the pass at 200 leftover ids.
  */
 const GET_ERRORS_QUERY_PAGE_SIZE = 10;
 
@@ -104,6 +104,8 @@ type FollowUpRead = {
   payload: Record<string, unknown> | null;
   stayedOnPrimaryTab: boolean;
 };
+
+const GET_ERRORS_DEADLINE = Symbol("get-errors-completion-deadline");
 
 export function parseToolResultJson(res: GetErrorsToolResult): Record<string, unknown> | null {
   if (!res || res.isError) return null;
@@ -495,11 +497,29 @@ async function followUpJson(
   ctx: GetErrorsCallCtx,
   cmd: Record<string, unknown>,
   timeoutMs: number,
+  deadlineAt: number,
   primaryTabId?: string,
 ): Promise<FollowUpRead> {
   const tabBefore = ctx.tabId;
+  const remaining = Math.min(timeoutMs, deadlineAt - Date.now());
+  if (!(remaining > 0)) {
+    return {
+      payload: null,
+      stayedOnPrimaryTab: primaryTabId == null || tabBefore === primaryTabId,
+    };
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const res = await ctx.call(cmd, timeoutMs);
+    const timeout = new Promise<typeof GET_ERRORS_DEADLINE>((resolve) => {
+      timer = setTimeout(() => resolve(GET_ERRORS_DEADLINE), remaining);
+    });
+    const res = await Promise.race([ctx.call(cmd, remaining), timeout]);
+    if (res === GET_ERRORS_DEADLINE) {
+      return {
+        payload: null,
+        stayedOnPrimaryTab: primaryTabId == null || tabBefore === primaryTabId,
+      };
+    }
     const tabAfter = ctx.tabId;
     return {
       payload: parseToolResultJson(res),
@@ -511,6 +531,8 @@ async function followUpJson(
       payload: null,
       stayedOnPrimaryTab: primaryTabId == null || tabBefore === primaryTabId,
     };
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -593,12 +615,23 @@ export async function completeGetErrorsAudit(
     // graph_query has no cursor/offset, and a single detail reply can be cut by
     // max_chars even when its limit is high. Page by explicit ids so every normal
     // 50-node workflow gets a complete detail read within one bounded follow-up
-    // wave. A truncated page stays wholly unchecked below; it must never silently
+    // pass. A truncated page stays wholly unchecked below; it must never silently
     // retire only the rows that happened to fit in the reply.
+    const deadlineAt = Date.now() + Math.max(0, timeoutMs);
     const queryIds = leftoverIds.slice(0, LIMIT_CEILING);
-    const queryReadsPromise = Promise.all(
-      chunks(queryIds, GET_ERRORS_QUERY_PAGE_SIZE).map((ids) =>
-        followUpJson(
+    const infoRead = await followUpJson(
+      ctx,
+      { cmd: "graph_get_object_info" },
+      timeoutMs,
+      deadlineAt,
+      primaryTabId,
+    );
+    const infoReply = infoRead.payload;
+    const objectInfo = infoReply ? objectInfoFromReply(infoReply) : null;
+    const queryReads: Array<{ ids: unknown[]; read: FollowUpRead }> = [];
+    if (objectInfo && infoRead.stayedOnPrimaryTab) {
+      for (const ids of chunks(queryIds, GET_ERRORS_QUERY_PAGE_SIZE)) {
+        const read = await followUpJson(
           ctx,
           {
             cmd: "graph_query",
@@ -608,33 +641,25 @@ export async function completeGetErrorsAudit(
             max_chars: MAX_CHARS_CEILING,
           },
           timeoutMs,
+          deadlineAt,
           primaryTabId,
-        ),
-      ),
-    );
-    const [queryReads, infoRead] = await Promise.all([
-      queryReadsPromise,
-      followUpJson(ctx, { cmd: "graph_get_object_info" }, timeoutMs, primaryTabId),
-    ]);
-    const infoReply = infoRead.payload;
-    const objectInfo = infoReply ? objectInfoFromReply(infoReply) : null;
+        );
+        queryReads.push({ ids, read });
+        if (Date.now() >= deadlineAt) break;
+      }
+    }
     const incompletePageIds = new Set(
       leftoverIds.slice(LIMIT_CEILING).map((id) => String(id)),
     );
-    const nodes = queryReads.flatMap((queryRead, pageIndex) => {
-      const query = queryRead.payload;
-      if (queryReplyWasTruncated(query)) {
-        for (const id of queryIds.slice(
-          pageIndex * GET_ERRORS_QUERY_PAGE_SIZE,
-          (pageIndex + 1) * GET_ERRORS_QUERY_PAGE_SIZE,
-        )) incompletePageIds.add(String(id));
+    const nodes = queryReads.flatMap(({ ids, read }) => {
+      if (queryReplyWasTruncated(read.payload)) {
+        for (const id of ids) incompletePageIds.add(String(id));
       }
-      return query ? parseQueryNodes(query) : [];
+      return read.payload ? parseQueryNodes(read.payload) : [];
     });
     const sameGraph =
       queryReads.every(
-        (queryRead) =>
-          queryRead.stayedOnPrimaryTab && sameViewingIdentity(payload, queryRead.payload),
+        ({ read }) => read.stayedOnPrimaryTab && sameViewingIdentity(payload, read.payload),
       ) &&
       infoRead.stayedOnPrimaryTab &&
       queryReads.length > 0;

--- a/src/orchestrator/get-errors-audit.ts
+++ b/src/orchestrator/get-errors-audit.ts
@@ -8,8 +8,8 @@
  * sampler / decoder / assembler / SaveVideo still in `unchecked_nodes`, plus
  * the clean-scan note. The orchestrator already waits 30 s for that reply, so
  * after a budget-exhausted payload it finishes the leftover nodes from ONE
- * batched `graph_get_object_info` plus a targeted `graph_query` — not another
- * per-class round trip. If that completion cannot run, the reply still leads
+ * batched `graph_get_object_info` plus bounded explicit-ID `graph_query` pages —
+ * not another per-class round trip. If that completion cannot run, the reply still leads
  * with `audit_complete: false` and checked/unchecked counts rather than a
  * primary clean 0.
  *
@@ -57,6 +57,15 @@ export type GetErrorsCallCtx = Pick<PanelToolCtx, "call" | "tabId">;
 const RETRYABLE_UNCHECKED_RE =
   /ran out of its shared server-call budget|lookup cap was reached/i;
 const FILE_LIKE = /\.[A-Za-z0-9_]{2,12}$/;
+
+/**
+ * `graph_query` has no cursor/offset. Explicit-ID pages are therefore the only
+ * pagination available to this completion pass, and keeping each detail page
+ * small leaves room under its 60,000-character ceiling for ordinary workflows.
+ * Pages are issued concurrently under the existing single elective timeout; the
+ * graph-query ceiling also bounds the pass at 200 leftover ids.
+ */
+const GET_ERRORS_QUERY_PAGE_SIZE = 10;
 
 /**
  * ComfyUI's own upload-input flags, from `UploadType` in
@@ -120,6 +129,12 @@ function asUncheckedList(payload: Record<string, unknown>): UncheckedEntry[] {
 /** An abstention a second batched read has a chance of retiring. */
 function isRetryableUnchecked(entry: UncheckedEntry): boolean {
   return typeof entry?.reason === "string" && RETRYABLE_UNCHECKED_RE.test(entry.reason);
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < values.length; i += size) out.push(values.slice(i, i + size));
+  return out;
 }
 
 /** Distinct node ids the scan abstained on — same counting rule as the panel. */
@@ -508,6 +523,16 @@ function viewingIdentity(payload: Record<string, unknown> | null): ViewingIdenti
   return Object.keys(identity).length > 0 ? identity : null;
 }
 
+function queryReplyWasTruncated(payload: Record<string, unknown> | null): boolean {
+  if (!payload) return true;
+  if (payload.truncated === true) return true;
+  return (
+    typeof payload.matched === "number" &&
+    typeof payload.shown === "number" &&
+    payload.shown < payload.matched
+  );
+}
+
 /**
  * A follow-up may only retire leftovers when it identifies the same live graph
  * as the primary read. Compare every stable identity field both replies expose;
@@ -538,7 +563,7 @@ function sameViewingIdentity(
 
 /**
  * After a budget-exhausted graph_get_errors, finish leftover combo checks from
- * one batched object_info + a targeted graph_query, then present completeness
+ * one batched object_info + bounded targeted graph_query pages, then present completeness
  * honestly. Never throws: a failed follow-up still returns the incomplete audit.
  *
  * A payload the panel already finished still goes through presentGetErrorsAudit.
@@ -565,36 +590,63 @@ export async function completeGetErrorsAudit(
   ];
 
   if (leftoverIds.length > 0) {
-    const [queryRead, infoRead] = await Promise.all([
-      followUpJson(
-        ctx,
-        {
-          cmd: "graph_query",
-          ids: leftoverIds,
-          fields: "detail",
-          limit: LIMIT_CEILING,
-          max_chars: MAX_CHARS_CEILING,
-        },
-        timeoutMs,
-        primaryTabId,
+    // graph_query has no cursor/offset, and a single detail reply can be cut by
+    // max_chars even when its limit is high. Page by explicit ids so every normal
+    // 50-node workflow gets a complete detail read within one bounded follow-up
+    // wave. A truncated page stays wholly unchecked below; it must never silently
+    // retire only the rows that happened to fit in the reply.
+    const queryIds = leftoverIds.slice(0, LIMIT_CEILING);
+    const queryReadsPromise = Promise.all(
+      chunks(queryIds, GET_ERRORS_QUERY_PAGE_SIZE).map((ids) =>
+        followUpJson(
+          ctx,
+          {
+            cmd: "graph_query",
+            ids,
+            fields: "detail",
+            limit: Math.min(LIMIT_CEILING, ids.length),
+            max_chars: MAX_CHARS_CEILING,
+          },
+          timeoutMs,
+          primaryTabId,
+        ),
       ),
+    );
+    const [queryReads, infoRead] = await Promise.all([
+      queryReadsPromise,
       followUpJson(ctx, { cmd: "graph_get_object_info" }, timeoutMs, primaryTabId),
     ]);
-    const query = queryRead.payload;
     const infoReply = infoRead.payload;
     const objectInfo = infoReply ? objectInfoFromReply(infoReply) : null;
-    const nodes = query ? parseQueryNodes(query) : [];
+    const incompletePageIds = new Set(
+      leftoverIds.slice(LIMIT_CEILING).map((id) => String(id)),
+    );
+    const nodes = queryReads.flatMap((queryRead, pageIndex) => {
+      const query = queryRead.payload;
+      if (queryReplyWasTruncated(query)) {
+        for (const id of queryIds.slice(
+          pageIndex * GET_ERRORS_QUERY_PAGE_SIZE,
+          (pageIndex + 1) * GET_ERRORS_QUERY_PAGE_SIZE,
+        )) incompletePageIds.add(String(id));
+      }
+      return query ? parseQueryNodes(query) : [];
+    });
     const sameGraph =
-      queryRead.stayedOnPrimaryTab &&
+      queryReads.every(
+        (queryRead) =>
+          queryRead.stayedOnPrimaryTab && sameViewingIdentity(payload, queryRead.payload),
+      ) &&
       infoRead.stayedOnPrimaryTab &&
-      sameViewingIdentity(payload, query);
+      queryReads.length > 0;
     if (sameGraph && objectInfo && nodes.length > 0) {
-      const judged = judgeLeftoverCombos(leftover, nodes, objectInfo);
+      const judgeable = leftover.filter((entry) => !incompletePageIds.has(String(entry.id)));
+      const judged = judgeLeftoverCombos(judgeable, nodes, objectInfo);
       // Non-retryable abstentions (the probe cap, a failed lookup, an unenumerable
       // path the panel already disclosed) stay; retryable leftovers are replaced by
       // whatever this pass still could not judge.
       const nextUnchecked = [
         ...asUncheckedList(payload).filter((e) => !isRetryableUnchecked(e)),
+        ...leftover.filter((entry) => incompletePageIds.has(String(entry.id))),
         ...judged.stillUnchecked,
       ];
       payload.unchecked_nodes = nextUnchecked;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -17054,8 +17054,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       // panel gives the live combo scan only the 4 s STEP cap, so a ~77-node graph
       // returns unchecked_budget_exhausted with the sampler / decoder / SaveVideo
       // still unjudged. After the panel returns we finish those leftover nodes from
-      // one batched graph_get_object_info (not another per-class wait) and never
-      // lead with errored_count:0 while the audit is incomplete.
+      // one batched graph_get_object_info plus bounded explicit-ID graph_query pages
+      // (not another per-class wait) and never lead with errored_count:0 while the
+      // audit is incomplete.
       //
       // COMPLETENESS IS JUDGED FROM THE ABSTENTION LIST, NOT THE BUDGET FLAG. The
       // panel abstains for five reasons and only two raise unchecked_budget_exhausted;


### PR DESCRIPTION
Fixes #2199. Pages leftover graph_query detail reads into bounded explicit-ID batches under the existing elective timeout, preserving truncated pages as unchecked and completing ordinary 50-node audits. Validation: npm.cmd exec vitest run src/__tests__/orchestrator/get-errors-ack-budget.test.ts src/__tests__/orchestrator/get-errors-call-budget.test.ts src/__tests__/orchestrator/get-errors-concurrent-reads.test.ts (3 files, 43 tests); npm.cmd run build; npm.cmd run lint; git diff --check.