### PR TITLE
fix: persist connect orchestrator logs (#2198)

### DIFF
--- a/src/__tests__/services/orchestrator-log.test.ts
+++ b/src/__tests__/services/orchestrator-log.test.ts
@@ -90,10 +90,21 @@ describe("persistent orchestrator logger", () => {
     expect(() => logger.warn("stderr remains available")).not.toThrow();
   });
 
-  it("is wired before the orchestrator branch can fail during startup", () => {
+  it("keeps policy validation first and logs connect failures before orchestration", () => {
     const boot = readFileSync(new URL("../../boot.ts", import.meta.url), "utf8");
-    expect(boot).toContain("if (cli.panelOrchestrator)");
-    expect(boot).toContain("const logPath = orchestratorLogPath();");
+    const policy = boot.indexOf("resolveToolSurfacePolicy();");
+    const orchestrator = boot.indexOf("if (cli.panelOrchestrator)");
+    const logging = boot.indexOf("const logPath = orchestratorLogPath();", orchestrator);
+    const http = boot.indexOf('if (cli.transport === "http")', orchestrator);
+    const urlValidation = boot.indexOf("const urlError = validateConnectUrl(cli.comfyuiUrl);", logging);
+    const dynamicImport = boot.indexOf('await import("./orchestrator/index.js")', logging);
+
+    expect(policy).toBeGreaterThan(-1);
+    expect(orchestrator).toBeGreaterThan(policy);
+    expect(logging).toBeGreaterThan(orchestrator);
+    expect(orchestrator).toBeLessThan(http);
+    expect(urlValidation).toBeGreaterThan(logging);
+    expect(dynamicImport).toBeGreaterThan(logging);
     expect(boot).toContain("configurePersistentLogFile(logPath)");
   });
 });

--- a/src/__tests__/services/orchestrator-log.test.ts
+++ b/src/__tests__/services/orchestrator-log.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closePersistentLogFile,
+  configurePersistentLogFile,
+  logger,
+  MAX_PERSISTENT_LOG_BYTES,
+} from "../../utils/logger.js";
+import { orchestratorLogPath } from "../../services/orchestrator-log.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-orchestrator-log-"));
+});
+
+afterEach(() => {
+  closePersistentLogFile();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("orchestratorLogPath", () => {
+  it("uses the shared data-dir override and stable connect log name", () => {
+    expect(orchestratorLogPath({ dataDir: root })).toBe(
+      join(root, "launch-logs", "connect-orchestrator.log"),
+    );
+  });
+
+  it("falls back to the supplied home when no data-dir override exists", () => {
+    const home = join(root, "home");
+    expect(orchestratorLogPath({ home, dataDir: "" })).toBe(
+      join(home, ".comfyui-mcp", "launch-logs", "connect-orchestrator.log"),
+    );
+  });
+});
+
+describe("persistent orchestrator logger", () => {
+  it("mirrors startup and exit records to disk without changing the stderr contract", () => {
+    const path = orchestratorLogPath({ dataDir: root });
+    expect(configurePersistentLogFile(path)).toBe(true);
+
+    const originalStderrWrite = process.stderr.write;
+    let stderr = "";
+    process.stderr.write = ((chunk: unknown) => {
+      stderr += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      logger.info("orchestrator startup");
+      logger.error("orchestrator exit", { code: 1 });
+    } finally {
+      process.stderr.write = originalStderrWrite;
+    }
+
+    const log = readFileSync(path, "utf8");
+    expect(stderr).toContain("orchestrator startup");
+    expect(stderr).toContain("orchestrator exit");
+    expect(log).toContain("orchestrator startup");
+    expect(log).toContain("orchestrator exit");
+    expect(log).toContain('"code":1');
+  });
+
+  it("bounds a noisy history and keeps the newest diagnostic record", () => {
+    const path = orchestratorLogPath({ dataDir: root });
+    expect(configurePersistentLogFile(path)).toBe(true);
+
+    const originalStderrWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      logger.info("x".repeat(MAX_PERSISTENT_LOG_BYTES + 128));
+      logger.info("newest diagnostic record");
+    } finally {
+      process.stderr.write = originalStderrWrite;
+    }
+
+    const log = readFileSync(path, "utf8");
+    expect(Buffer.byteLength(log, "utf8")).toBeLessThanOrEqual(MAX_PERSISTENT_LOG_BYTES);
+    expect(log).toContain("persistent log truncated");
+    expect(log).toContain("newest diagnostic record");
+  });
+
+  it("fails open when the persistent path is unusable", () => {
+    const blocker = join(root, "file");
+    writeFileSync(blocker, "not a directory", "utf8");
+
+    expect(configurePersistentLogFile(join(blocker, "nested", "orchestrator.log"))).toBe(false);
+    expect(() => logger.warn("stderr remains available")).not.toThrow();
+  });
+
+  it("is wired before the orchestrator branch can fail during startup", () => {
+    const boot = readFileSync(new URL("../../boot.ts", import.meta.url), "utf8");
+    expect(boot).toContain("if (cli.panelOrchestrator)");
+    expect(boot).toContain("const logPath = orchestratorLogPath();");
+    expect(boot).toContain("configurePersistentLogFile(logPath)");
+  });
+});

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -503,19 +503,6 @@ async function main() {
     }
   }
 
-  // The panel orchestrator is commonly launched from a disposable terminal (and
-  // the panel broker intentionally detaches that terminal). Mirror its existing
-  // stderr logger to a bounded file before policy validation or dynamic imports,
-  // so startup failures and every later exit path leave evidence on disk.
-  if (cli.panelOrchestrator) {
-    const logPath = orchestratorLogPath();
-    if (configurePersistentLogFile(logPath)) {
-      logger.info(`[panel-orchestrator] persistent log enabled at ${logPath}`);
-    } else {
-      logger.warn(`[panel-orchestrator] could not open persistent log at ${logPath}`);
-    }
-  }
-
   // #873 — VALIDATE THE OPERATOR'S TOOL POLICY BEFORE ANY SERVER STARTS, of any kind.
   //
   // resolveToolSurfacePolicy() throws on a misconfiguration (an unknown preset, a variable
@@ -538,6 +525,17 @@ async function main() {
   // Standalone background orchestrator: owns the UI bridge and drives the panel
   // with autonomous Agent SDK sessions. Not an MCP server — it never returns.
   if (cli.panelOrchestrator) {
+    // The panel orchestrator is commonly launched from a disposable terminal (and
+    // the panel broker intentionally detaches that terminal). Mirror its existing
+    // stderr logger to a bounded file before URL validation or dynamic imports, so
+    // every connect-mode lifecycle and exit path leaves evidence on disk.
+    const logPath = orchestratorLogPath();
+    if (configurePersistentLogFile(logPath)) {
+      logger.info(`[panel-orchestrator] persistent log enabled at ${logPath}`);
+    } else {
+      logger.warn(`[panel-orchestrator] could not open persistent log at ${logPath}`);
+    }
+
     // `connect <comfyui-url>`: drive a (possibly REMOTE) ComfyUI from an agent on
     // THIS machine. Export the URL as COMFYUI_URL so the orchestrator and the
     // comfyui MCP it spawns target that server — the same remote-URL mechanism the

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -10,7 +10,7 @@ import {
 import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { tryInstallRetiredNameRedirect } from "./tools/retired-redirect.js";
-import { logger } from "./utils/logger.js";
+import { configurePersistentLogFile, logger } from "./utils/logger.js";
 import { readPackageVersion } from "./utils/package-version.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
@@ -28,6 +28,7 @@ import {
 } from "./services/advertised-origin.js";
 import { banner, labelRows, numberedSteps } from "./i18n/terminal-layout.js";
 import { STDIO_HANDSHAKE_INSTRUCTIONS } from "./handshake-instructions.js";
+import { orchestratorLogPath } from "./services/orchestrator-log.js";
 
 /** A RunPod proxy can only reach a listener exposed beyond loopback. */
 function advertisedOriginForBind(host: string, port: number): string | undefined {
@@ -499,6 +500,19 @@ async function main() {
         })}\n`,
       );
       process.exit(1);
+    }
+  }
+
+  // The panel orchestrator is commonly launched from a disposable terminal (and
+  // the panel broker intentionally detaches that terminal). Mirror its existing
+  // stderr logger to a bounded file before policy validation or dynamic imports,
+  // so startup failures and every later exit path leave evidence on disk.
+  if (cli.panelOrchestrator) {
+    const logPath = orchestratorLogPath();
+    if (configurePersistentLogFile(logPath)) {
+      logger.info(`[panel-orchestrator] persistent log enabled at ${logPath}`);
+    } else {
+      logger.warn(`[panel-orchestrator] could not open persistent log at ${logPath}`);
     }
   }
 

--- a/src/services/orchestrator-log.ts
+++ b/src/services/orchestrator-log.ts
@@ -1,0 +1,19 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * One bounded history for both `connect` and `--panel-orchestrator`.
+ * They enter the same long-lived runtime; keeping one stable path means a
+ * panel-launched terminal and a manually launched connect process are equally
+ * diagnosable without making the broker guess where the child will write.
+ */
+export function orchestratorLogPath(
+  options: { home?: string; dataDir?: string } = {},
+): string {
+  const configuredDataDir =
+    options.dataDir === undefined
+      ? process.env.COMFYUI_MCP_DATA_DIR?.trim()
+      : options.dataDir.trim();
+  const dataDir = configuredDataDir || join(options.home ?? homedir(), ".comfyui-mcp");
+  return join(dataDir, "launch-logs", "connect-orchestrator.log");
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,11 +1,125 @@
-// Logs to stderr only — critical for MCP stdio transport
+import {
+  chmodSync,
+  closeSync,
+  fstatSync,
+  ftruncateSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  writeSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+// Logs to stderr by default — critical for MCP stdio transport. The
+// orchestrator may additionally opt into a bounded file sink before it starts;
+// the ordinary MCP server never does, so its wire transport stays untouched.
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
 type LogLevel = keyof typeof LOG_LEVELS;
+
+/** Keep one diagnostic file from growing forever across a long-lived install. */
+export const MAX_PERSISTENT_LOG_BYTES = 2 * 1024 * 1024;
+const TRUNCATION_MARKER = "\n[comfyui-mcp] persistent log truncated; keeping the newest records\n";
+
+type PersistentFileSink = { fd: number; bytes: number };
+let persistentFileSink: PersistentFileSink | undefined;
 
 const currentLevel: LogLevel = (process.env.LOG_LEVEL as LogLevel) || "info";
 
 function shouldLog(level: LogLevel): boolean {
   return LOG_LEVELS[level] >= LOG_LEVELS[currentLevel];
+}
+
+function retainNewestBytes(fd: number, size: number, reserveBytes = 0): number {
+  const marker = Buffer.from(TRUNCATION_MARKER, "utf8");
+  const keep = Math.max(0, MAX_PERSISTENT_LOG_BYTES - marker.length - reserveBytes);
+  const tailLength = Math.min(size, keep);
+  const tail = Buffer.alloc(tailLength);
+  if (tailLength > 0) readSync(fd, tail, 0, tailLength, size - tailLength);
+  ftruncateSync(fd, 0);
+  writeSync(fd, marker, 0, marker.length, 0);
+  if (tailLength > 0) writeSync(fd, tail, 0, tailLength, marker.length);
+  return marker.length + tailLength;
+}
+
+/**
+ * Open a best-effort persistent mirror for a long-lived process.
+ *
+ * The sink is deliberately explicit rather than env-enabled: a normal MCP
+ * stdio process must never write an unexpected file, while the panel
+ * orchestrator has a user-visible need for evidence after its terminal dies.
+ * Writes are synchronous because the orchestrator has several hard
+ * `process.exit()` paths; an async stream could lose the last fatal line.
+ */
+export function configurePersistentLogFile(path: string): boolean {
+  closePersistentLogFile();
+  let fd: number | undefined;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    // Create first when needed, then reopen read/write. Windows does not allow
+    // ftruncate on an append-mode descriptor, and bounded rotation needs both
+    // operations on the same file.
+    try {
+      fd = openSync(path, "r+", 0o600);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      fd = openSync(path, "w+", 0o600);
+    }
+    try {
+      // chmod is a no-op on platforms whose ACLs own the mode, and best-effort
+      // there. On POSIX this keeps diagnostic contents owner-readable only.
+      chmodSync(path, 0o600);
+    } catch {
+      /* best-effort permissions */
+    }
+    const size = fstatSync(fd).size;
+    const bytes = size > MAX_PERSISTENT_LOG_BYTES ? retainNewestBytes(fd, size) : size;
+    persistentFileSink = { fd, bytes };
+    return true;
+  } catch {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    return false;
+  }
+}
+
+export function closePersistentLogFile(): void {
+  const sink = persistentFileSink;
+  persistentFileSink = undefined;
+  if (!sink) return;
+  try {
+    closeSync(sink.fd);
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function appendPersistentLog(line: string): void {
+  const sink = persistentFileSink;
+  if (!sink) return;
+  try {
+    const marker = Buffer.from(TRUNCATION_MARKER, "utf8");
+    let bytes = Buffer.from(`${line}\n`, "utf8");
+    if (bytes.length + marker.length >= MAX_PERSISTENT_LOG_BYTES) {
+      const keep = Math.max(0, MAX_PERSISTENT_LOG_BYTES - marker.length);
+      bytes = bytes.subarray(bytes.length - keep);
+      ftruncateSync(sink.fd, 0);
+      writeSync(sink.fd, marker, 0, marker.length, 0);
+      sink.bytes = marker.length;
+    } else if (sink.bytes + bytes.length > MAX_PERSISTENT_LOG_BYTES) {
+      sink.bytes = retainNewestBytes(sink.fd, sink.bytes, bytes.length);
+    }
+    writeSync(sink.fd, bytes, 0, bytes.length, sink.bytes);
+    sink.bytes += bytes.length;
+  } catch {
+    // Diagnostics must never become the reason the orchestrator fails to start
+    // or finish shutting down. Keep stderr logging alive if the file vanishes.
+    closePersistentLogFile();
+  }
 }
 
 function log(level: LogLevel, message: string, data?: unknown): void {
@@ -14,6 +128,7 @@ function log(level: LogLevel, message: string, data?: unknown): void {
   const line = data
     ? `[${ts}] [${level.toUpperCase()}] ${message} ${JSON.stringify(data)}`
     : `[${ts}] [${level.toUpperCase()}] ${message}`;
+  appendPersistentLog(line);
   process.stderr.write(line + "\n");
 }
 


### PR DESCRIPTION
Fixes #2198

## Summary
- enable the existing stderr logger to mirror panel-orchestrator/connect records to ~/.comfyui-mcp/launch-logs/connect-orchestrator.log
- bound the persistent sink at 2 MiB, keep newest records, use owner-readable permissions, and fail open if disk logging is unavailable
- wire logging before orchestrator policy validation/dynamic import so startup and exit failures leave evidence

## Validation
- focused Vitest: 86 passed across orchestrator-log, CLI, launch-log-capture, panel-launcher, and startup-deadline suites
- npm run build
- npm run lint (tsc --noEmit)
- git diff --check
- built entrypoint probe: connect invalid URL exited 1 and created the persistent log

Commit: 4609ac9
No merge performed.