### PR TITLE
fix(panel): recover widget schema after combo refresh timeout

### DIFF
--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -6,12 +6,16 @@
 // and panel_set_widget all fail because /object_info did not answer inside the
 // panel's fixed 10s/5s shares. The canvas is readable; schema-guarded edits are
 // not. refresh_nodes also CLEARS the last-known schema, so calling it as the
-// recovery makes the next widget write worse.
+// recovery makes the next widget write worse — except for #2202's stale-combo
+// timeout, where the panel has already retired that snapshot and a refresh is
+// the safe way to restore it for later unrelated writes.
 //
 // These drive the real tool defs. The panel's 5s/10s shares live in the other
 // repo; this process can still (1) retry a before-create/before-write refusal
 // without dispatching refresh_nodes, (2) stop advertising mutations_ready:true
-// once that refusal has been observed, (3) say not to refresh_nodes.
+// once that refusal has been observed, and (3) reserve refresh_nodes for the
+// acknowledged #2202 stale-combo timeout where the panel has already retired
+// its schema snapshot.
 
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -45,6 +49,16 @@ const SET_WIDGET_STARVATION =
   `GET /object_info did not answer within its 5000ms share of the 20000ms budget. ` +
   `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
   `Reconnect ComfyUI and retry.`;
+
+const STALE_COMBO_REFRESH_TIMEOUT =
+  `panel_set_widget refused "image" on node 12 (LoadImage): the value is not in this ` +
+  `combo's current option list, and the authoritative refresh that would have re-read ` +
+  `the list — a node-def refresh started by another tool call — was still running ` +
+  `when this command's time budget ran out waiting for it, so the revalidation did NOT ` +
+  `complete. That refresh is still running and is registering exactly the list this ` +
+  `write needs, so RETRY in a few seconds. This refusal cannot tell a genuinely-invalid ` +
+  `value from one the refresh would have accepted. NOTHING WAS WRITTEN. Call ` +
+  `panel_refresh_nodes if retrying keeps failing.`;
 
 const STALE_SCHEMA =
   `"LoadImage" required input "image" was added or retyped since this page loaded its node ` +
@@ -223,6 +237,56 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
     expect(calls.filter((c) => c === "graph_set_widget")).toHaveLength(2);
     expect(text).toMatch(/already retried ONCE/);
     expect(text).toMatch(/Do NOT call panel_refresh_nodes/);
+  });
+
+  it("#2202 restores schema after a stale-combo refresh timeout before an unrelated write", async () => {
+    let writes = 0;
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        if (writes === 1) throw new Error(STALE_COMBO_REFRESH_TIMEOUT);
+        return { ok: true, node_id: 20, widget: "text", previous: "", value: "hello" };
+      }
+      if (cmd.cmd === "refresh_nodes") return { refreshed: true };
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const setWidget = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!setWidget) throw new Error("panel_set_widget is not registered");
+
+    const combo = await setWidget.handler(
+      { node_id: 12, widget: "image", value: "new.png" } as never,
+      ctx,
+    );
+    expect(combo.isError).toBe(true);
+    expect(textOf(combo)).toMatch(/#2202 recovery/);
+
+    const unrelated = await setWidget.handler(
+      { node_id: 20, widget: "text", value: "hello" } as never,
+      ctx,
+    );
+    expect(unrelated.isError).toBeFalsy();
+    expect(calls).toEqual(["graph_set_widget", "refresh_nodes", "graph_set_widget"]);
+  });
+
+  it("does not refresh for an ordinary combo-value refusal", async () => {
+    const ordinaryRefusal =
+      `panel_set_widget refused "image" on node 12 (LoadImage): after refreshing combo ` +
+      `options: "new.png" is not a valid option`;
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_set_widget") throw new Error(ordinaryRefusal);
+      return { refreshed: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const setWidget = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!setWidget) throw new Error("panel_set_widget is not registered");
+
+    const refused = await setWidget.handler(
+      { node_id: 12, widget: "image", value: "new.png" } as never,
+      ctx,
+    );
+    expect(refused.isError).toBe(true);
+    expect(calls).toEqual(["graph_set_widget"]);
   });
 
   it("records a starvation refusal so the next outline does not advertise readiness", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5049,6 +5049,24 @@ function isObjectInfoBudgetRefusal(res: ToolResult): boolean {
 }
 
 /**
+ * #2202 — the panel's stale-combo recovery can time out after it has retired the
+ * usable whole-schema snapshot. That refusal is safe to repair here: the panel
+ * explicitly says the write was not attempted, and `refresh_nodes` is
+ * non-destructive. Keep this narrower than the generic combo/value refusals — a
+ * value that was actually checked must not trigger an unsolicited refresh.
+ */
+function isStaleComboRefreshTimeoutRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  const text = textOfToolResult(res);
+  return (
+    /panel_set_widget refused/i.test(text) &&
+    /authoritative refresh[\s\S]{0,600}(?:still running|never started)/i.test(text) &&
+    /revalidation did NOT complete/i.test(text) &&
+    /NOTHING WAS WRITTEN/i.test(text)
+  );
+}
+
+/**
  * Per-tab: the last schema-guarded panel mutation we observed could not obtain
  * /object_info. Socket-up is not the same fact — that is why panel_graph_outline
  * reported mutations_ready:true while panel_add_node(LoadImage) then refused.
@@ -15990,6 +16008,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (isObjectInfoStarvationRefusal(first)) {
           markPanelSchemaBlocked(panelSchemaKey(ctx));
           return appendToolResultText(first, objectInfoStarvationNote());
+        }
+
+        // #2202 — stale-combo recovery may have retired the panel's last usable
+        // whole-schema snapshot before its bounded refresh wait abandoned. The
+        // panel refused before writing, so dispatching its idempotent,
+        // non-destructive refresh is safe and repairs the state for the next
+        // unrelated widget write. Do not do this for an ordinary invalid-combo
+        // refusal, and do not retry the rejected value: it was never validated
+        // against the refreshed option list.
+        if (isStaleComboRefreshTimeoutRefusal(first)) {
+          const schemaKey = panelSchemaKey(ctx);
+          markPanelSchemaBlocked(schemaKey);
+          const refreshed = await ctx.call(
+            { cmd: "refresh_nodes" },
+            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+          );
+          const refreshPayload = parseToolResultJson(refreshed);
+          const refreshReportedFailure =
+            refreshPayload?.refreshed === false || isObjectInfoBudgetRefusal(refreshed);
+          if (!refreshed.isError && refreshPayload?.refreshed === true) {
+            markPanelSchemaReady(schemaKey);
+          }
+          if (isReplyTimeoutResult(refreshed)) {
+            return appendToolResultText(
+              first,
+              `\n\n(#2202 recovery: the combo refresh timeout was a before-write refusal, ` +
+                `so the requested value was not written. panel_refresh_nodes was ` +
+                `dispatched automatically but did NOT answer within its window; the ` +
+                `refresh is not cancelled and may still register the schema. Retry ` +
+                `the intended widget write after it settles.)`,
+            );
+          }
+          if (refreshed.isError || refreshReportedFailure) {
+            return appendToolResultText(
+              first,
+              `\n\n(#2202 recovery: the combo refresh timeout was a before-write refusal, ` +
+                `so the requested value was not written. panel_refresh_nodes was ` +
+                `dispatched automatically but did not establish a fresh schema; ` +
+                `retry the intended widget write after the refresh issue is resolved. ` +
+                `${textOfToolResult(refreshed)})`,
+            );
+          }
+          return appendToolResultText(
+            first,
+            `\n\n(#2202 recovery: the combo refresh timeout was a before-write refusal, ` +
+              `so the requested value was not written. panel_refresh_nodes was ` +
+              `dispatched automatically and completed; retry the intended widget ` +
+              `write. This refresh is non-destructive.)`,
+          );
         }
 
         // #2015 — a panel pre-executor can reject an inner node because the


### PR DESCRIPTION
## Summary

Fixes #2202.

- Detect only the panel's acknowledged stale-combo refresh-abandoned refusal (the panel says revalidation did not complete and nothing was written).
- Dispatch one idempotent `refresh_nodes` recovery without retrying the rejected combo value, so the next unrelated widget write can use a restored schema.
- Keep schema readiness blocked unless the recovery returns authoritative `refreshed: true`; transport timeout and refresh failure remain fail-closed.
- Add production-handler regressions for the sequential combo-timeout/unrelated-write path and for ordinary combo refusals.

## Validation

- `npm.cmd exec vitest run src/__tests__/orchestrator/object-info-budget-mutations.test.ts` — 17 passed.
- Related orchestrator suites (`object-info-starvation`, `set-widget-last-observed-schema`, `panel-tools`) — 422 passed.
- `npm.cmd run lint` — passed (`tsc --noEmit`).
- Full Vitest was attempted; it exposed four unrelated baseline failures (`node-id-union-message.test.ts` 3, `package-hooks.test.ts` 1 — the latter reports missing generated `dist`) and then hung in existing cancellation/watchdog tests, so it was stopped. No touched-file failures were observed.