### PR TITLE
fix(orchestrator): recover Codex active-writer resumes (#2232)

### DIFF
--- a/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
+++ b/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
@@ -1,9 +1,10 @@
 // #277 — PanelAgent self-heals a missing resume target. Current Codex reports a
 // pruned/missing resume session as EITHER "No conversation found with session
-// ID: <id>" OR "no rollout found for thread id <uuid>". Both must clear the dead
-// resume target, start a FRESH session, and replay the queued message — instead
-// of retrying the same dead resume until the give-up threshold self-exits the
-// orchestrator.
+// ID: <id>" OR "no rollout found for thread id <uuid>", while Codex can report
+// "already has an active writer" when another client owns the resumed thread.
+// All must clear the unavailable resume target, start a FRESH session, and replay
+// the queued message — instead of retrying the same resume until the give-up
+// threshold self-exits the orchestrator.
 
 import { describe, expect, it, beforeAll } from "vitest";
 import type {
@@ -12,7 +13,10 @@ import type {
   BackendStartOptions,
   ModelChoice,
 } from "../../orchestrator/agent-backend.js";
-import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import {
+  CLAUDE_CAPABILITIES,
+  CODEX_CAPABILITIES,
+} from "../../orchestrator/agent-backend.js";
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
 
@@ -25,15 +29,19 @@ beforeAll(async () => {
  *  throws the error on EVERY run (even fresh) — to prove a fresh-start failure
  *  still counts toward the rapid-restart give-up bound. */
 class ResumeMissBackend implements AgentBackend {
-  readonly id = "claude" as const;
-  readonly capabilities = CLAUDE_CAPABILITIES;
+  readonly id: "claude" | "codex";
+  readonly capabilities: typeof CLAUDE_CAPABILITIES | typeof CODEX_CAPABILITIES;
   runCount = 0;
   resumes: Array<string | undefined> = [];
   turnTexts: string[] = [];
   constructor(
     private readonly errorText: string,
     private readonly alwaysThrow = false,
-  ) {}
+    backend: "claude" | "codex" = "claude",
+  ) {
+    this.id = backend;
+    this.capabilities = backend === "codex" ? CODEX_CAPABILITIES : CLAUDE_CAPABILITIES;
+  }
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     this.runCount += 1;
@@ -56,14 +64,17 @@ class ResumeMissBackend implements AgentBackend {
 }
 
 function makeManager(backend: AgentBackend) {
-  return new PanelAgentManager({
+  const fatals: string[] = [];
+  const manager = new PanelAgentManager({
     mcpServers: {},
     systemAppend: "",
     model: "claude-test",
     onSay: () => {},
     onTurn: () => {},
     makeBackend: () => backend,
+    onAgentFatal: (_tab, reason) => fatals.push(reason),
   } as never);
+  return { manager, fatals };
 }
 
 async function waitFor(cond: () => boolean, timeoutMs = 4000): Promise<void> {
@@ -81,7 +92,7 @@ describe("resume-miss self-heal (#277)", () => {
   ]) {
     it(`clears the dead resume + replays the queued message: "${errorText.slice(0, 24)}…"`, async () => {
       const backend = new ResumeMissBackend(errorText);
-      const manager = makeManager(backend);
+      const { manager } = makeManager(backend);
       const tab = "tab-resume-miss";
       // Seed a resume target so the FIRST run resumes (and fails).
       manager.setResume(tab, "dead-sess");
@@ -96,12 +107,35 @@ describe("resume-miss self-heal (#277)", () => {
     });
   }
 
+  it("Codex active-writer resume conflict drops the resume and starts fresh without a fatal exit", async () => {
+    const backend = new ResumeMissBackend(
+      "stream error: thread dead-sess already has an active writer",
+      false,
+      "codex",
+    );
+    const { manager, fatals } = makeManager(backend);
+    const tab = "tab-codex-active-writer";
+
+    manager.setResume(tab, "dead-sess");
+    manager.send(tab, "retry after conflict");
+
+    await waitFor(() => backend.turnTexts.includes("retry after conflict"));
+    expect(backend.id).toBe("codex");
+    expect(backend.resumes[0]).toBe("dead-sess");
+    expect(backend.resumes[1]).toBeUndefined();
+    expect(backend.runCount).toBeLessThanOrEqual(3);
+    expect(manager.hasLiveAgent(tab)).toBe(true);
+    expect(fatals).toHaveLength(0);
+
+    await manager.stopAll();
+  });
+
   it("a FRESH start that keeps emitting the rollout error still hits the give-up bound (#278)", async () => {
     // No resume seeded → every run is a fresh start that throws the same text.
     // resumeMiss must NOT be set for a fresh start, so the rapid-restart counter
     // is NOT reset and the loop terminates (gives up) instead of spinning forever.
     const backend = new ResumeMissBackend("no rollout found for thread id deadbeef", true);
-    const manager = makeManager(backend);
+    const { manager } = makeManager(backend);
     const tab = "tab-fresh-fail";
     manager.send(tab, "hello");
     // The agent should GIVE UP (drop itself from the live map) within the bound.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1867,23 +1867,29 @@ export class PanelAgent {
         if (this.closed) break;
         const emsg = msgOf(err);
         logger.error(`[panel-agent ${this.short()}] stream error: ${emsg}`);
-        // A resume whose target session no longer exists — e.g. the orchestrator was
-        // relaunched from a different cwd, or the session transcript was pruned —
-        // fails with "No conversation found with session ID: <id>". Current Codex
-        // can instead report "no rollout found for thread id <uuid>" for the same
-        // pruned/missing-target condition (#277). Retrying the SAME resume just
-        // loops until the give-up threshold trips and self-exits the whole
-        // orchestrator (a live bridge left serving a permanently-dead agent). Drop
-        // the dead resume target so the NEXT iteration starts a FRESH session and
-        // self-heals; queued messages (this.queue) survive and replay.
+        // A resume whose target session is unavailable — e.g. the orchestrator was
+        // relaunched from a different cwd, the session transcript was pruned, or
+        // another Codex client currently owns its writer — fails with "No
+        // conversation found with session ID: <id>", "no rollout found for
+        // thread id <uuid>", or "already has an active writer". Retrying the
+        // SAME resume just loops until the give-up threshold trips and self-exits
+        // the whole orchestrator (a live bridge left serving a permanently-dead
+        // agent). Drop the unavailable resume target so the NEXT iteration starts
+        // a FRESH session and self-heals; queued messages (this.queue) survive and
+        // replay.
         // GUARD (#278): only treat this as a recoverable resume-MISS when this
         // start actually RESUMED something. A FRESH start (no resume) that emits
         // the same text is a real, non-recoverable failure and MUST count toward
         // the rapid-restart give-up bound below — otherwise resumeMiss would reset
         // the counter forever and spin an infinite restart loop.
-        if (resume && /(?:No conversation found with session ID|no rollout found for thread id)/i.test(emsg)) {
+        if (
+          resume &&
+          /(?:No conversation found with session ID|no rollout found for thread id|already has an active writer)/i.test(
+            emsg,
+          )
+        ) {
           logger.warn(
-            `[panel-agent ${this.short()}] resume target is gone — starting a fresh session`,
+            `[panel-agent ${this.short()}] resume target is unavailable — starting a fresh session`,
           );
           this.sessionId = null;
           resumeSessionId = undefined;


### PR DESCRIPTION
## Summary

- Treat Codex `thread/resume` errors containing `already has an active writer` as an unavailable resume target.
- Preserve the existing `resume &&` guard, clear the stale resume, start a fresh thread, and replay queued panel mail without invoking the fatal/self-exit path.
- Add a production-path PanelAgentManager regression using Codex capabilities that asserts the resumed attempt, fresh retry, queued-message delivery, live agent, and zero fatal callbacks.

Fixes #2232

## Verification

- `npm.cmd exec -- vitest run src/__tests__/orchestrator/resume-miss-selfheal.test.ts --reporter=dot` — PASS (4/4).
- Adjacent orchestrator tests — PASS (10/10 across 3 files).
- `npm.cmd run lint` — PASS.
- `npm.cmd run build` — PASS.
- i18n/docs/blog checks — PASS.
- Full Vitest practical gate — 657 files passed, 12,124 tests passed, 4 skipped; 3 pre-existing failures remain in untouched `src/__tests__/orchestrator/node-id-union-message.test.ts`. No changed-file failures.

Not merged.