### PR TITLE
fix(panel): retry idempotent reads after transport send errors

### DIFF
--- a/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
+++ b/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
@@ -29,11 +29,17 @@
 // These tests drive the REAL server over a real socket. A fake would only prove
 // the shape I already believe.
 import { afterEach, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "../../orchestrator/panel-mcp-http.js";
 import type { UiBridge } from "../../services/ui-bridge.js";
 
 const TAB = "tmp:1524";
+
+const TRANSIENT_ORCHESTRATOR_SEND_ERROR =
+  "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
+  "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator::codex";
 
 /** A bridge that is never actually reached — these tests stop at the transport. */
 const bridge = {
@@ -171,5 +177,67 @@ describe("a stale panel MCP session is reported as a SESSION problem (#1524)", (
       method: "notifications/initialized",
     });
     expect(r.status, "a live session must not be told it is gone").not.toBe(404);
+  });
+});
+
+describe("idempotent panel reads retry a transient orchestrator send error (#2233)", () => {
+  it("retries panel_query_graph and panel_graph_outline once through the real HTTP MCP path", async () => {
+    const attempts = new Map<string, number>();
+    const readBridge = {
+      ...bridge,
+      send: async (cmd: { cmd: string }) => {
+        const attempt = (attempts.get(cmd.cmd) ?? 0) + 1;
+        attempts.set(cmd.cmd, attempt);
+        if (attempt === 1) throw new Error(TRANSIENT_ORCHESTRATOR_SEND_ERROR);
+        return cmd.cmd === "graph_query"
+          ? { text: "1 KSampler", nodes: [{ id: 1, type: "KSampler" }], node_count: 1 }
+          : { outline: "1 KSampler", node_count: 1, group_count: 0 };
+      },
+    } as unknown as UiBridge;
+    const s = await startPanelMcpHttpServer(readBridge, 0);
+    let client: Client | undefined;
+    try {
+      client = new Client({ name: "test-2233", version: "1" });
+      await client.connect(new StreamableHTTPClientTransport(new URL(s.urlFor(TAB))));
+
+      const query = await client.callTool({ name: "panel_query_graph", arguments: {} });
+      const outline = await client.callTool({ name: "panel_graph_outline", arguments: {} });
+
+      expect(query.isError).not.toBe(true);
+      expect(outline.isError).not.toBe(true);
+      expect(attempts.get("graph_query")).toBe(2);
+      expect(attempts.get("graph_outline")).toBe(2);
+    } finally {
+      await client?.close();
+      await s.stop();
+    }
+  });
+
+  it("does not retry a mutation on the same transport error", async () => {
+    let attempts = 0;
+    const mutationBridge = {
+      ...bridge,
+      send: async () => {
+        attempts += 1;
+        throw new Error(TRANSIENT_ORCHESTRATOR_SEND_ERROR);
+      },
+    } as unknown as UiBridge;
+    const s = await startPanelMcpHttpServer(mutationBridge, 0);
+    let client: Client | undefined;
+    try {
+      client = new Client({ name: "test-2233-mutation", version: "1" });
+      await client.connect(new StreamableHTTPClientTransport(new URL(s.urlFor(TAB))));
+
+      const result = await client.callTool({
+        name: "panel_set_widget",
+        arguments: { node_id: 1, widget: "steps", value: 20 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(attempts).toBe(1);
+    } finally {
+      await client?.close();
+      await s.stop();
+    }
   });
 });

--- a/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
+++ b/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
@@ -29,8 +29,6 @@
 // These tests drive the REAL server over a real socket. A fake would only prove
 // the shape I already believe.
 import { afterEach, describe, expect, it } from "vitest";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "../../orchestrator/panel-mcp-http.js";
 import type { UiBridge } from "../../services/ui-bridge.js";
@@ -40,6 +38,79 @@ const TAB = "tmp:1524";
 const TRANSIENT_ORCHESTRATOR_SEND_ERROR =
   "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
   "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator::codex";
+
+const RAW_MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+};
+
+interface RawMcpPayload {
+  result?: { isError?: boolean };
+  error?: unknown;
+}
+
+function parseRawMcpPayload(body: string): RawMcpPayload {
+  const trimmed = body.trim();
+  const json = trimmed.startsWith("{")
+    ? trimmed
+    : trimmed
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("data:"))
+        ?.slice("data:".length)
+        .trim();
+  if (!json) throw new Error(`MCP response was not JSON or SSE: ${body}`);
+  return JSON.parse(json) as RawMcpPayload;
+}
+
+async function openRawMcpSession(s: PanelMcpHttpServer, clientName: string): Promise<string> {
+  const init = await fetch(s.urlFor(TAB), {
+    method: "POST",
+    headers: RAW_MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: clientName, version: "1" },
+      },
+    }),
+  });
+  expect(init.status).toBe(200);
+  const sessionId = init.headers.get("mcp-session-id");
+  expect(sessionId).toBeTruthy();
+  await init.text();
+
+  const initialized = await fetch(s.urlFor(TAB), {
+    method: "POST",
+    headers: { ...RAW_MCP_HEADERS, "mcp-session-id": sessionId! },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  expect([200, 202]).toContain(initialized.status);
+  await initialized.text();
+  return sessionId!;
+}
+
+async function rawMcpToolCall(
+  s: PanelMcpHttpServer,
+  sessionId: string,
+  id: number,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ status: number; payload: RawMcpPayload }> {
+  const response = await fetch(s.urlFor(TAB), {
+    method: "POST",
+    headers: { ...RAW_MCP_HEADERS, "mcp-session-id": sessionId },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+  return { status: response.status, payload: parseRawMcpPayload(await response.text()) };
+}
 
 /** A bridge that is never actually reached — these tests stop at the transport. */
 const bridge = {
@@ -181,7 +252,7 @@ describe("a stale panel MCP session is reported as a SESSION problem (#1524)", (
 });
 
 describe("idempotent panel reads retry a transient orchestrator send error (#2233)", () => {
-  it("retries panel_query_graph and panel_graph_outline once through the real HTTP MCP path", async () => {
+  it("retries panel_query_graph and panel_graph_outline once through the raw HTTP MCP handoff", async () => {
     const attempts = new Map<string, number>();
     const readBridge = {
       ...bridge,
@@ -195,25 +266,25 @@ describe("idempotent panel reads retry a transient orchestrator send error (#223
       },
     } as unknown as UiBridge;
     const s = await startPanelMcpHttpServer(readBridge, 0);
-    let client: Client | undefined;
     try {
-      client = new Client({ name: "test-2233", version: "1" });
-      await client.connect(new StreamableHTTPClientTransport(new URL(s.urlFor(TAB))));
+      const sessionId = await openRawMcpSession(s, "test-2233");
+      const query = await rawMcpToolCall(s, sessionId, 2, "panel_query_graph", {});
+      const outline = await rawMcpToolCall(s, sessionId, 3, "panel_graph_outline", {});
 
-      const query = await client.callTool({ name: "panel_query_graph", arguments: {} });
-      const outline = await client.callTool({ name: "panel_graph_outline", arguments: {} });
-
-      expect(query.isError).not.toBe(true);
-      expect(outline.isError).not.toBe(true);
+      expect(query.status).toBe(200);
+      expect(query.payload.error).toBeUndefined();
+      expect(query.payload.result?.isError).not.toBe(true);
+      expect(outline.status).toBe(200);
+      expect(outline.payload.error).toBeUndefined();
+      expect(outline.payload.result?.isError).not.toBe(true);
       expect(attempts.get("graph_query")).toBe(2);
       expect(attempts.get("graph_outline")).toBe(2);
     } finally {
-      await client?.close();
       await s.stop();
     }
   });
 
-  it("does not retry a mutation on the same transport error", async () => {
+  it("does not retry set_todo on the same transport error", async () => {
     let attempts = 0;
     const mutationBridge = {
       ...bridge,
@@ -223,20 +294,45 @@ describe("idempotent panel reads retry a transient orchestrator send error (#223
       },
     } as unknown as UiBridge;
     const s = await startPanelMcpHttpServer(mutationBridge, 0);
-    let client: Client | undefined;
     try {
-      client = new Client({ name: "test-2233-mutation", version: "1" });
-      await client.connect(new StreamableHTTPClientTransport(new URL(s.urlFor(TAB))));
-
-      const result = await client.callTool({
-        name: "panel_set_widget",
-        arguments: { node_id: 1, widget: "steps", value: 20 },
+      const sessionId = await openRawMcpSession(s, "test-2233-set-todo");
+      const result = await rawMcpToolCall(s, sessionId, 2, "panel_set_todo", {
+        items: [{ text: "read", status: "active" }],
       });
 
-      expect(result.isError).toBe(true);
+      expect(result.status).toBe(200);
+      expect(result.payload.result?.isError).toBe(true);
       expect(attempts).toBe(1);
     } finally {
-      await client?.close();
+      await s.stop();
+    }
+  });
+
+  it("does not retry redirected set_todo on the same transport error", async () => {
+    let attempts = 0;
+    const mutationBridge = {
+      ...bridge,
+      isHeadless: (tabId: string) => tabId === TAB,
+      tabs: () => [
+        { tab_id: TAB, title: "headless", connected_at: 0 },
+        { tab_id: "desktop-2233", title: "desktop", connected_at: 0 },
+      ],
+      send: async () => {
+        attempts += 1;
+        throw new Error(TRANSIENT_ORCHESTRATOR_SEND_ERROR);
+      },
+    } as unknown as UiBridge;
+    const s = await startPanelMcpHttpServer(mutationBridge, 0);
+    try {
+      const sessionId = await openRawMcpSession(s, "test-2233-set-todo-redirect");
+      const result = await rawMcpToolCall(s, sessionId, 2, "panel_set_todo", {
+        items: [{ text: "read", status: "active" }],
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.payload.result?.isError).toBe(true);
+      expect(attempts).toBe(1);
+    } finally {
       await s.stop();
     }
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1558,9 +1558,13 @@ function isTransientReconnectError(err: unknown): boolean {
   // next single-origin message can.
   if (isRoutingAmbiguity(err)) return false;
   const msg = err instanceof Error ? err.message : String(err ?? "");
+  // #2233 — the Codex/rmcp loopback client wraps a transient pre-response
+  // orchestrator HTTP failure as `Transport send error: WorkerTransport…` instead
+  // of preserving the lower-level socket phrase. This remains retryable only for
+  // commands admitted by RETRY_SAFE_CMDS at the caller below.
   return /no connected tab|genuinely gone|is not open|Failed to fetch|Panel not reachable|ECONNRESET|socket hang up|premature close|other side closed|ECONNABORTED|EPIPE/i.test(
     msg,
-  );
+  ) || /Transport send error:\s*WorkerTransport\b/i.test(msg);
 }
 
 /**

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1233,6 +1233,8 @@ export const __panelToolsTestHooks = {
   },
   isRetrySafeCmd,
   isTransientReconnectError,
+  isWorkerTransportSendError,
+  isWorkerTransportRetrySafeCmd,
   // CivitAI sample-image gating (#623): the predicate that decides which results'
   // pixels may be shown to the agent, and the bounded thumbnail fetcher.
   civitaiSampleEligible,
@@ -1433,11 +1435,23 @@ const RETRY_SAFE_CMDS = new Set<string>([
   "refresh_nodes",
 ]);
 
+// #2233 — this is deliberately narrower than RETRY_SAFE_CMDS. That existing
+// set also contains idempotent UI-state writes such as set_todo, which may keep
+// their established retry behavior for the panel's own reconnect errors but
+// must not inherit retries for a new outer HTTP transport failure. Only the two
+// affected live-canvas reads may retry this wrapper error.
+const WORKER_TRANSPORT_RETRY_SAFE_CMDS = new Set<string>(["graph_query", "graph_outline"]);
+
 /** A command whose result is unchanged by being re-issued after a reconnect —
  *  so it is safe to transparently retry once when the transport dropped. */
 function isRetrySafeCmd(cmd: Record<string, unknown>): boolean {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   return RETRY_SAFE_CMDS.has(name);
+}
+
+function isWorkerTransportRetrySafeCmd(cmd: Record<string, unknown>): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  return WORKER_TRANSPORT_RETRY_SAFE_CMDS.has(name);
 }
 
 // Graph-EDIT mutations that CHANGE the user's canvas (undoable edits). These are
@@ -1558,13 +1572,19 @@ function isTransientReconnectError(err: unknown): boolean {
   // next single-origin message can.
   if (isRoutingAmbiguity(err)) return false;
   const msg = err instanceof Error ? err.message : String(err ?? "");
-  // #2233 — the Codex/rmcp loopback client wraps a transient pre-response
-  // orchestrator HTTP failure as `Transport send error: WorkerTransport…` instead
-  // of preserving the lower-level socket phrase. This remains retryable only for
-  // commands admitted by RETRY_SAFE_CMDS at the caller below.
   return /no connected tab|genuinely gone|is not open|Failed to fetch|Panel not reachable|ECONNRESET|socket hang up|premature close|other side closed|ECONNABORTED|EPIPE/i.test(
     msg,
-  ) || /Transport send error:\s*WorkerTransport\b/i.test(msg);
+  );
+}
+
+/** #2233 — the Codex/rmcp loopback client wraps a transient pre-response
+ * orchestrator HTTP failure as `Transport send error: WorkerTransport…` instead
+ * of preserving the lower-level socket phrase. Its retry gate is intentionally
+ * separate from isTransientReconnectError so existing allowlisted UI writes do
+ * not inherit this new retry class. */
+function isWorkerTransportSendError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /Transport send error:\s*WorkerTransport\b/i.test(msg);
 }
 
 /**
@@ -11990,9 +12010,14 @@ export function makePanelToolCtx(
       // arrival; an older panel sends no field, `preExecutorRefusal` is null, and
       // this branch simply never fires.
       const preExecutorRefusal = isPreExecutorRefusal(err);
+      const workerTransportRetry =
+        isWorkerTransportSendError(err) && isWorkerTransportRetrySafeCmd(cmd);
       if (
         preExecutorRefusal ||
-        (isRetrySafeCmd(cmd) && (isTransientReconnectError(err) || isWorkflowSwitchGuardRefusal(err)))
+        (isRetrySafeCmd(cmd) &&
+          (isTransientReconnectError(err) ||
+            isWorkflowSwitchGuardRefusal(err) ||
+            workerTransportRetry))
       ) {
         // panel#1097 — declared out here so the refusal branch below can see it,
         // and REASSIGNED after ensureReachable so it names the tab the command is
@@ -13629,7 +13654,11 @@ async function dispatchToTab(
   try {
     return ok(await ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs }));
   } catch (err) {
-    if (isRetrySafeCmd(cmd) && isTransientReconnectError(err)) {
+    if (
+      isRetrySafeCmd(cmd) &&
+      (isTransientReconnectError(err) ||
+        (isWorkerTransportSendError(err) && isWorkerTransportRetrySafeCmd(cmd)))
+    ) {
       try {
         await sleep(retrySettleMs());
         const fresh = reResolve?.() ?? tabId;


### PR DESCRIPTION
Fixes #2233\n\n## Summary\n- classify the Codex/rmcp loopback Transport send error: WorkerTransport... wrapper as transient at the shared panel call boundary\n- retain the existing one-retry bound and RETRY_SAFE_CMDS gate, so panel reads may retry but mutations do not\n- add real Streamable HTTP MCP production-path coverage for panel_query_graph, panel_graph_outline, and a mutation refusal\n\n## Verification\n- 
pm.cmd exec vitest run src/__tests__/orchestrator/panel-mcp-stale-session.test.ts\n- focused orchestrator suite: 490 tests passed\n- 
pm.cmd run build\n- 
pm.cmd test: 658 files passed, 12,128 tests passed, 4 skipped; i18n/docs/blog checks passed\n\nThe native etter-sqlite3 binding was rebuilt locally after the initial dependency install used --ignore-scripts; no source or lockfile changes resulted. Not merged.