### PR TITLE
fix(codex): recover stale panel MCP transport

### DIFF
--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -45,6 +45,9 @@ const MCP_SERVERS = {
   comfyui: { transport: "stdio" as const, command: "node", args: ["mcp.js"] },
   panel: { transport: "http" as const, url: "http://127.0.0.1:9198/tab" },
 };
+const WORKER_TRANSPORT_FAILURE =
+  "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
+  "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator%3A%3Acodex";
 
 const noticesOf = (events: AgentEvent[]) =>
   events.filter(
@@ -74,7 +77,8 @@ interface Drive {
   reloadCalls: number;
   polls: number;
   pollParams: unknown[];
-  endTurn(): Promise<void>;
+  turnStarts: number;
+  endTurn(kind?: "completed" | "worker-transport"): Promise<void>;
   finish(): Promise<void>;
 }
 
@@ -102,6 +106,7 @@ function startDrive(opts: {
       if (method === "model/list") return { data: [{ id: "gpt-5.6-sol", hidden: false }] };
       if (method === "turn/start") {
         starts += 1;
+        drive.turnStarts = starts;
         waitingForTurn = true;
         for (const w of turnWaiters.splice(0)) w();
         return { turn: { id: `turn-${starts}` } };
@@ -158,7 +163,8 @@ function startDrive(opts: {
     reloadCalls: 0,
     polls: 0,
     pollParams: [],
-    async endTurn() {
+    turnStarts: 0,
+    async endTurn(kind = "completed") {
       await waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
       idle = false;
       turns.push({ text: "continue" });
@@ -170,10 +176,22 @@ function startDrive(opts: {
       await waitUntil(() => waitingForTurn && starts > 0);
       waitingForTurn = false;
       const turnId = `turn-${starts}`;
-      client.notificationHandler?.({
-        method: "turn/completed",
-        params: { threadId: "thread-1", turn: { id: turnId, status: "completed" } },
-      });
+      if (kind === "worker-transport") {
+        client.notificationHandler?.({
+          method: "error",
+          params: {
+            threadId: "thread-1",
+            turnId,
+            error: { message: WORKER_TRANSPORT_FAILURE },
+            willRetry: false,
+          },
+        });
+      } else {
+        client.notificationHandler?.({
+          method: "turn/completed",
+          params: { threadId: "thread-1", turn: { id: turnId, status: "completed" } },
+        });
+      }
       // The MCP watch runs AFTER the turn result, before the run loop waits
       // for the next channel item. Idle is the barrier that it finished.
       await waitFor(() => expect(idle).toBe(true));
@@ -188,6 +206,32 @@ function startDrive(opts: {
 }
 
 describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
+  it("a WorkerTransport send failure forces one panel reload without retrying the turn (#1777)", async () => {
+    // Codex can report the HTTP send failure while its status inventory still
+    // says `panel` is connected. The observed error is the recovery trigger;
+    // the reload is control-plane only and must not re-run panel_run.
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("worker-transport");
+
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.turnStarts).toBe(1);
+    const failure = drive.events.find(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failure?.outcomeUnknown).toBe(true);
+    expect(failure?.message).toMatch(/did not retry/i);
+    expect(failure?.message).toMatch(/outcome as UNKNOWN/i);
+    expect(noticesOf(drive.events)).toHaveLength(0);
+
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.turnStarts).toBe(2);
+    expect(noticesOf(drive.events)).toHaveLength(1);
+    expect(noticesOf(drive.events)[0].message).toMatch(/reconnect brought it back/);
+  });
+
   it("a drop the reload fixes is narrated once, as fixed, on the next turn", async () => {
     // Reload is queued for the NEXT turn. Same-turn is silent; the following
     // poll is the verdict, and that is the only line the user gets.

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -75,25 +75,31 @@ async function waitUntil(pred: () => boolean, timeoutMs = 500): Promise<void> {
 interface Drive {
   events: AgentEvent[];
   reloadCalls: number;
+  interruptCalls: number;
   polls: number;
   pollParams: unknown[];
   turnStarts: number;
-  endTurn(kind?: "completed" | "worker-transport"): Promise<void>;
+  endTurn(kind?: "completed" | "worker-transport" | "worker-transport-retry"): Promise<void>;
+  releaseInterrupt(): void;
+  waitForIdle(): Promise<void>;
   finish(): Promise<void>;
 }
 
 function startDrive(opts: {
   listings: Listing[];
   reloadThrows?: boolean;
+  holdInterrupt?: boolean;
   requiredMcpTools?: Readonly<Record<string, readonly string[]>>;
 }): Drive {
   const listings = [...opts.listings];
   const events: AgentEvent[] = [];
   let polls = 0;
   let reloadCalls = 0;
+  let interruptCalls = 0;
   let starts = 0;
   const turnWaiters: Array<() => void> = [];
   let waitingForTurn = false;
+  let releaseInterrupt: (() => void) | null = null;
 
   const client = {
     notificationHandler: null as ((msg: unknown) => void) | null,
@@ -124,6 +130,16 @@ function startDrive(opts: {
         reloadCalls += 1;
         drive.reloadCalls = reloadCalls;
         if (opts.reloadThrows) throw new Error("unknown method config/mcpServer/reload");
+        return {};
+      }
+      if (method === "turn/interrupt") {
+        interruptCalls += 1;
+        drive.interruptCalls = interruptCalls;
+        if (opts.holdInterrupt) {
+          await new Promise<void>((resolve) => {
+            releaseInterrupt = resolve;
+          });
+        }
         return {};
       }
       throw new Error(`unexpected request: ${method}`);
@@ -161,6 +177,7 @@ function startDrive(opts: {
   const drive: Drive = {
     events,
     reloadCalls: 0,
+    interruptCalls: 0,
     polls: 0,
     pollParams: [],
     turnStarts: 0,
@@ -176,16 +193,26 @@ function startDrive(opts: {
       await waitUntil(() => waitingForTurn && starts > 0);
       waitingForTurn = false;
       const turnId = `turn-${starts}`;
-      if (kind === "worker-transport") {
+      if (kind === "worker-transport" || kind === "worker-transport-retry") {
         client.notificationHandler?.({
           method: "error",
           params: {
             threadId: "thread-1",
             turnId,
             error: { message: WORKER_TRANSPORT_FAILURE },
-            willRetry: false,
+            willRetry: kind === "worker-transport-retry",
           },
         });
+        if (kind === "worker-transport-retry") {
+          // Codex may still complete/retry the original turn after a
+          // willRetry:true notification. The backend must fence this late
+          // completion before it emits the local terminal error.
+          client.notificationHandler?.({
+            method: "turn/completed",
+            params: { threadId: "thread-1", turn: { id: turnId, status: "completed" } },
+          });
+          return;
+        }
       } else {
         client.notificationHandler?.({
           method: "turn/completed",
@@ -194,6 +221,13 @@ function startDrive(opts: {
       }
       // The MCP watch runs AFTER the turn result, before the run loop waits
       // for the next channel item. Idle is the barrier that it finished.
+      await waitFor(() => expect(idle).toBe(true));
+    },
+    releaseInterrupt() {
+      releaseInterrupt?.();
+      releaseInterrupt = null;
+    },
+    async waitForIdle() {
       await waitFor(() => expect(idle).toBe(true));
     },
     async finish() {
@@ -228,6 +262,37 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     await drive.finish();
     expect(drive.reloadCalls).toBe(1);
     expect(drive.turnStarts).toBe(2);
+    expect(noticesOf(drive.events)).toHaveLength(1);
+    expect(noticesOf(drive.events)[0].message).toMatch(/reconnect brought it back/);
+  });
+
+  it("fences a willRetry WorkerTransport turn before local recovery (#1777)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP], holdInterrupt: true });
+    await drive.endTurn("worker-transport-retry");
+
+    await waitUntil(() => drive.interruptCalls === 1);
+    expect(drive.turnStarts).toBe(1);
+    expect(drive.events.filter((e) => e.type === "error")).toHaveLength(0);
+
+    // The app-server's late completion was delivered above, but the fenced
+    // turn must remain open locally until turn/interrupt is accepted.
+    drive.releaseInterrupt();
+    await drive.waitForIdle();
+
+    const failure = drive.events.find(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failure?.outcomeUnknown).toBe(true);
+    expect(failure?.message).toMatch(/active app-server turn was interrupted/i);
+    expect(failure?.message).toMatch(/did not retry/i);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.interruptCalls).toBe(1);
+
+    await drive.endTurn();
+    await drive.finish();
+    expect(drive.turnStarts).toBe(2);
+    expect(drive.reloadCalls).toBe(1);
     expect(noticesOf(drive.events)).toHaveLength(1);
     expect(noticesOf(drive.events)[0].message).toMatch(/reconnect brought it back/);
   });

--- a/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
+++ b/src/__tests__/orchestrator/panel-mcp-stale-session.test.ts
@@ -308,6 +308,28 @@ describe("idempotent panel reads retry a transient orchestrator send error (#223
     }
   });
 
+  it("does not retry panel_run after the HTTP handoff reports a WorkerTransport failure", async () => {
+    let graphRunAttempts = 0;
+    const mutationBridge = {
+      ...bridge,
+      send: async (cmd: { cmd: string }) => {
+        if (cmd.cmd === "graph_run") graphRunAttempts += 1;
+        throw new Error(TRANSIENT_ORCHESTRATOR_SEND_ERROR);
+      },
+    } as unknown as UiBridge;
+    const s = await startPanelMcpHttpServer(mutationBridge, 0);
+    try {
+      const sessionId = await openRawMcpSession(s, "test-1777-panel-run");
+      const result = await rawMcpToolCall(s, sessionId, 2, "panel_run", { allow_duplicate: true });
+
+      expect(result.status).toBe(200);
+      expect(result.payload.result?.isError).toBe(true);
+      expect(graphRunAttempts).toBe(1);
+    } finally {
+      await s.stop();
+    }
+  });
+
   it("does not retry redirected set_todo on the same transport error", async () => {
     let attempts = 0;
     const mutationBridge = {

--- a/src/__tests__/orchestrator/session-notice-render.test.ts
+++ b/src/__tests__/orchestrator/session-notice-render.test.ts
@@ -61,6 +61,25 @@ function noticeThenTurnErrorBackend(): AgentBackend {
   };
 }
 
+function outcomeUnknownBackend(): AgentBackend {
+  return {
+    id: "codex" as AgentBackend["id"],
+    capabilities: CAPS,
+    async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+      yield { type: "session", sessionId: "s-unknown" };
+      for await (const _turn of opts.channel) {
+        void _turn;
+        yield { type: "error", outcomeUnknown: true, message: "MCP reconnect is pending; inspect before retrying." };
+        yield { type: "result", ok: false, subtype: "error_during_execution", turn: 1 };
+      }
+    },
+    async interrupt() {},
+    async listModels() {
+      return [];
+    },
+  };
+}
+
 const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
 
 describe("a session notice renders on its own terms (#1524)", () => {
@@ -83,6 +102,23 @@ describe("a session notice renders on its own terms (#1524)", () => {
     // that re-runs nothing.
     expect(line).not.toMatch(/turn failed/);
     expect(line).not.toMatch(/Nothing was lost/);
+  });
+
+  it("shows an outcome-unknown transport error without generic retry framing (#1777)", async () => {
+    const said: string[] = [];
+    const agent = new PanelAgent(
+      "tab-unknown",
+      { mcpServers: undefined, systemAppend: "", model: "codex-test-1", onSay: (_t, m) => said.push(m) } as never,
+      outcomeUnknownBackend(),
+    );
+    void agent.start();
+    agent.send("queue a render");
+    await settle();
+    await agent.stop().catch(() => {});
+
+    const line = said.find((m) => m.includes("MCP reconnect is pending"));
+    expect(line).toBe("⚠️ MCP reconnect is pending; inspect before retrying.");
+    expect(line).not.toMatch(/turn failed|Nothing was lost/i);
   });
 
   it("does not spend the turn's one error line", async () => {

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -159,6 +159,10 @@ export type AgentEvent = (
        *  once-per-turn error slot, or a session notice would silence the first
        *  REAL turn error that follows it. */
       sessionNotice?: boolean;
+      /** The provider/transport did not establish a mutation outcome. Renderers
+       *  must show the backend's self-contained recovery guidance rather than
+       *  adding the generic "Nothing was lost — try again" prompt. */
+      outcomeUnknown?: boolean;
     }
 ) & {
   /** Backend-minted TURN MARKER (#728): a monotonically increasing id (1 = the

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -1614,6 +1614,14 @@ export class CodexBackend implements AgentBackend {
       return activeTurnId === null || msgTurnId === null || msgTurnId === activeTurnId;
     };
 
+    // A WorkerTransport error can arrive with willRetry:true, which means the
+    // app-server still owns the turn and may emit a retry/completion after the
+    // notification. Local recovery must fence that turn before exposing a
+    // terminal outcome to PanelAgent; otherwise a new turn could start while
+    // the original panel mutation is still being retried.
+    let mcpTransportFencePending = false;
+    let turnFenced = false;
+
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A
     // long tool call streams item/* and turn/* notifications that carry no
@@ -1642,7 +1650,7 @@ export class CodexBackend implements AgentBackend {
     const TURN_LIVENESS = (m: string) =>
       m.startsWith("item/") || m.startsWith("turn/") || m === "error" || MODEL_TURN_EVENTS.has(m);
     const bumpTurnActivity = (msg: RpcMessage): void => {
-      if (!belongsToTurn(msg) || !TURN_LIVENESS(msg.method ?? "")) return;
+      if (turnFenced || !belongsToTurn(msg) || !TURN_LIVENESS(msg.method ?? "")) return;
       try {
         onActivity?.();
       } catch {
@@ -1696,7 +1704,7 @@ export class CodexBackend implements AgentBackend {
     let hostRecycleInFlight = false;
     const watchExit = (watched: AppServerClient) => {
       void watched.exitPromise.then(() => {
-        if (done) return;
+        if (done || turnFenced) return;
         if (watched !== liveClient) return;
         // Closing the old app-server is the point of a stale-host recycle;
         // its exit must not finish the replacement turn (#2045).
@@ -1705,6 +1713,69 @@ export class CodexBackend implements AgentBackend {
           watched.exitError ? msgOf(watched.exitError) : "codex app-server connection closed.",
         );
       });
+    };
+
+    const closeFencedClient = async (fencedClient: AppServerClient): Promise<void> => {
+      if (this.client === fencedClient) {
+        this.client = null;
+        this.threadId = null;
+        this.turnId = null;
+      }
+      await this.beginClientClose(fencedClient, "panel MCP transport recovery fence teardown failed");
+    };
+
+    const finishMcpTransportFailure = (message: string, willRetry: boolean): void => {
+      if (mcpTransportFencePending || finishedResult) return;
+      mcpTransportFencePending = true;
+
+      // willRetry:false is already terminal at the app-server boundary. Keep
+      // the existing bounded recovery path and its single local error/result.
+      if (!willRetry) {
+        emitTerminalError(panelMcpTransportFailureNotice(message), { outcomeUnknown: true });
+        return;
+      }
+
+      // willRetry:true is different: Codex may still retry the failed MCP call.
+      // Fence notification handling immediately, then wait for the app-server
+      // to accept turn/interrupt before emitting the local terminal error. If
+      // the interrupt cannot be confirmed, close the client so the old turn
+      // cannot continue while reload/reconnect/new-turn processing starts.
+      turnFenced = true;
+      const fencedClient = liveClient;
+      const fencedTurnId = activeTurnId ?? this.turnId;
+      void (async () => {
+        let interruptError: unknown;
+        if (fencedTurnId) {
+          let timer: NodeJS.Timeout | undefined;
+          try {
+            await Promise.race([
+              fencedClient.request("turn/interrupt", { threadId, turnId: fencedTurnId }),
+              new Promise<never>((_, reject) => {
+                timer = setTimeout(
+                  () => reject(new Error(`turn/interrupt timed out after ${CODEX_INTERRUPT_TIMEOUT_MS}ms`)),
+                  CODEX_INTERRUPT_TIMEOUT_MS,
+                );
+              }),
+            ]);
+          } catch (err) {
+            interruptError = err;
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+        } else {
+          interruptError = new Error("the active Codex turn had no interruptible turn id");
+        }
+
+        if (interruptError) {
+          logger.warn(`[codex-backend] panel MCP transport fence failed: ${msgOf(interruptError)}`);
+          await closeFencedClient(fencedClient);
+        }
+        if (finishedResult) return;
+        const fenceNote = interruptError
+          ? " The active app-server turn could not be interrupted; its connection was closed before recovery."
+          : " The active app-server turn was interrupted before recovery.";
+        emitTerminalError(panelMcpTransportFailureNotice(message) + fenceNote, { outcomeUnknown: true });
+      })();
     };
 
     const tryRetryCodeModeHostSpawn = (message: string): boolean => {
@@ -1800,6 +1871,7 @@ export class CodexBackend implements AgentBackend {
       // (double-completing PanelAgent's gate) or enqueue deltas into a closing
       // iterator. This is the "exactly one result" invariant (P0-B).
       if (finishedResult) return;
+      if (turnFenced) return;
       // The previous turn died on a retryable host-spawn; wait for the replacement
       // turn/start rather than treating its turn/completed as ours (#1929).
       if (retryPending) return;
@@ -1896,7 +1968,7 @@ export class CodexBackend implements AgentBackend {
           // panel transport failure for the turn-boundary reload, and make the
           // outcome/reconnect boundary explicit to the caller.
           if (this.noteMcpTransportFailure(message)) {
-            emitTerminalError(panelMcpTransportFailureNotice(message), { outcomeUnknown: true });
+            finishMcpTransportFailure(message, params.willRetry === true);
             break;
           }
           if (params.willRetry === true) break;
@@ -2068,6 +2140,10 @@ export class CodexBackend implements AgentBackend {
             // Deliberate teardown (interrupt restored/closed the turn): still end
             // with a result so the gate advances, but no user-facing error.
             abortActiveTurn();
+          } else if (turnFenced) {
+            // The fenced MCP recovery owns terminalization. A late
+            // turn/start rejection must not race it with a generic error.
+            return;
           } else {
             const message = formatCodexTurnError(err);
             if (tryRetryCodeModeHostSpawn(message)) {

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -72,6 +72,33 @@ function msgOf(err: unknown): string {
   return errorText(err);
 }
 
+/**
+ * Codex wraps a failed request to the orchestrator-hosted HTTP MCP in its
+ * WorkerTransport error. This is narrower than matching every HTTP/provider
+ * error: the Codex lane has one HTTP MCP (`panel`) and the stdio `comfyui`
+ * server cannot produce this transport shape.
+ */
+export function isCodexPanelMcpTransportFailure(message: string): boolean {
+  return (
+    /Transport send error:\s*WorkerTransport\b/i.test(message) &&
+    /HTTP request failed sending request to\s+https?:\/\//i.test(message)
+  );
+}
+
+/** Keep a WorkerTransport failure self-contained: PanelAgent's generic turn
+ * failure text says "Nothing was lost — try again", which is unsafe when a
+ * mutation's dispatch/outcome was not established at this boundary. */
+function panelMcpTransportFailureNotice(message: string): string {
+  return (
+    `The local panel MCP connection failed before a tool result was returned. ` +
+    `The orchestrator did not retry the request. For a render or other mutation, ` +
+    `treat the first attempt's outcome as UNKNOWN until you inspect queue ` +
+    `(action:"list") or get_history; do not re-run panel_run blindly. The panel MCP ` +
+    `connection is being reloaded for the next turn. If it remains unavailable, ` +
+    `reconnect the orchestrator (Disconnect → Connect) before retrying. (${message})`
+  );
+}
+
 const configuredInterruptTimeoutMs = Number(process.env.COMFYUI_MCP_CODEX_INTERRUPT_TIMEOUT_MS);
 const CODEX_INTERRUPT_TIMEOUT_MS =
   Number.isFinite(configuredInterruptTimeoutMs) && configuredInterruptTimeoutMs > 0
@@ -964,6 +991,10 @@ export class CodexBackend implements AgentBackend {
   private mcpReloadPending = new Set<string>();
   /** Partial-catalog episodes cannot be closed by a connected row alone. */
   private mcpCatalogRecovery = new Set<string>();
+  /** A WorkerTransport send failure is stronger evidence than a cached
+   * `runtimeStatus: connected` row, but it still opens only one recovery episode.
+   * The control-plane reload below never replays the failed tool call. */
+  private mcpTransportRecovery = new Set<string>();
   /** The model requested for new turns (mutable for a future live setModel). */
   private model: string | undefined;
   /** The Codex reasoning effort for new turns, already mapped to a valid Codex
@@ -1232,6 +1263,7 @@ export class CodexBackend implements AgentBackend {
     this.mcpDown.clear();
     this.mcpReloadPending.clear();
     this.mcpCatalogRecovery.clear();
+    this.mcpTransportRecovery.clear();
     await this.prepare();
     const client = this.client;
     if (!client) throw new Error("codex app-server not initialized");
@@ -1347,9 +1379,17 @@ export class CodexBackend implements AgentBackend {
   private async checkMcpServers(client: AppServerClient): Promise<AgentEvent[]> {
     const names = Object.keys(this.deps.mcpServers ?? {});
     if (names.length === 0) return [];
+    // A WorkerTransport failure can leave Codex's status inventory cached as
+    // connected. Preserve the observation as a bounded, panel-only recovery
+    // episode so a status poll cannot erase the evidence before reload.
+    const transportRecovery = new Set(
+      [...this.mcpTransportRecovery].filter(
+        (name) => !this.mcpDown.has(name) && !this.mcpReloadPending.has(name),
+      ),
+    );
     const polled = await this.pollMcpStatus(client);
-    if (!polled) return [];
-    const { reported, listed } = polled;
+    if (!polled && transportRecovery.size === 0) return [];
+    const { reported, listed } = polled ?? { reported: [], listed: [] };
     const events: AgentEvent[] = [];
     const health = inspectMcpServers(names, reported);
     const catalogGaps = missingRequiredMcpTools(listed, this.deps.requiredMcpTools);
@@ -1361,6 +1401,9 @@ export class CodexBackend implements AgentBackend {
     const degradedByName = new Map(health.degraded.map((d) => [d.name, d]));
     for (const gap of catalogGaps) {
       if (!degradedByName.has(gap.name)) degradedByName.set(gap.name, { name: gap.name, status: "partial" });
+    }
+    for (const name of transportRecovery) {
+      if (!degradedByName.has(name)) degradedByName.set(name, { name, status: "transport-error" });
     }
     const degraded: DegradedMcpServer[] = [...degradedByName.values()];
     const catalogGapNames = new Set(catalogGaps.map((gap) => gap.name));
@@ -1404,10 +1447,13 @@ export class CodexBackend implements AgentBackend {
       (d) =>
         !pendingVerdict.includes(d.name) &&
         this.mcpDown.get(d.name) !== true &&
-        (reconnectableMcpStatus(d.status) || catalogGapNames.has(d.name)),
+        (reconnectableMcpStatus(d.status) || catalogGapNames.has(d.name) || transportRecovery.has(d.name)),
     );
     if (triable.length > 0) {
-      for (const d of triable) this.mcpDown.set(d.name, true);
+      for (const d of triable) {
+        this.mcpDown.set(d.name, true);
+        this.mcpTransportRecovery.delete(d.name);
+      }
       try {
         await client.request("config/mcpServer/reload", {});
         for (const d of triable) this.mcpReloadPending.add(d.name);
@@ -1448,6 +1494,18 @@ export class CodexBackend implements AgentBackend {
       });
     }
     return events;
+  }
+
+  /** Record the specific HTTP MCP failure observed by the Codex app-server.
+   * Do not open a second episode while an existing status/reload episode is
+   * still unresolved; the next turn's status poll is its verdict. */
+  private noteMcpTransportFailure(message: string): boolean {
+    const panel = this.deps.mcpServers?.panel;
+    if (panel?.transport !== "http" || !isCodexPanelMcpTransportFailure(message)) return false;
+    if (!this.mcpDown.has("panel") && !this.mcpReloadPending.has("panel")) {
+      this.mcpTransportRecovery.add("panel");
+    }
+    return true;
   }
 
   private reportDegradedMcp(degraded: readonly DegradedMcpServer[], when: string): void {
@@ -1522,11 +1580,11 @@ export class CodexBackend implements AgentBackend {
     // already emitted (so the error notification, the exit watcher, and the
     // turn/start rejection can all call it without double-finishing) (P0-B).
     let finishedResult = false;
-    const emitTerminalError = (message: string) => {
+    const emitTerminalError = (message: string, flags?: { outcomeUnknown?: boolean }) => {
       if (finishedResult) return;
       finishedResult = true;
       closeStream();
-      push({ type: "error", message });
+      push({ type: "error", message, ...flags });
       push({ type: "result", ok: false, subtype: "error" });
       finish();
     };
@@ -1831,8 +1889,17 @@ export class CodexBackend implements AgentBackend {
           // liveness set, so this already re-armed the watchdog — keep waiting
           // for either a later terminal error or turn/completed.
           const e = params.error ?? {};
-          if (params.willRetry === true) break;
           const message = formatCodexTurnError(e);
+          // The app-server's normal willRetry path is useful for provider
+          // failures, but it is unsafe to allow a WorkerTransport MCP error to
+          // silently replay a panel mutation. Stop this turn, remember the
+          // panel transport failure for the turn-boundary reload, and make the
+          // outcome/reconnect boundary explicit to the caller.
+          if (this.noteMcpTransportFailure(message)) {
+            emitTerminalError(panelMcpTransportFailureNotice(message), { outcomeUnknown: true });
+            break;
+          }
+          if (params.willRetry === true) break;
           // #1929 / #2045 — a Windows sharing-violation or stale WinGet path on
           // the bundled code-mode host is the same transient /restart recovered.
           if (tryRetryCodeModeHostSpawn(message)) break;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2282,7 +2282,7 @@ export class PanelAgent {
           // DONE) and would invite a destructive duplicate retry.
           this.deps.onSay(
             this.tabId,
-            ev.unverifiedCompletion
+            ev.unverifiedCompletion || ev.outcomeUnknown
               ? `⚠️ ${detail}`
               : `⚠️ The ${this.model} turn failed: ${detail}\n\nNothing was lost — try again, switch models from the composer picker, or check the terminal running the orchestrator for more detail.`,
           );


### PR DESCRIPTION
## Summary

- Treat the observed Codex WorkerTransport HTTP-send failure for the orchestrator-hosted panel MCP as one bounded down episode even when mcpServerStatus/list still reports the cached row as connected.
- Queue the existing config/mcpServer/reload control-plane recovery at the turn boundary; never re-issue 	urn/start, panel_run, or another render mutation.
- Surface an actionable outcome-unknown message so the Panel does not append the generic Nothing was lost — try again guidance.
- Preserve the existing Panel bridge distinction between pre-write dispatched:false and post-write outcome-unknown failures.

Refs artokun/comfyui-mcp-panel#1777

## Validation

- PASS: 
pm.cmd exec vitest run src/__tests__/orchestrator/codex-mcp-reconnect.test.ts src/__tests__/orchestrator/panel-mcp-stale-session.test.ts src/__tests__/orchestrator/session-notice-render.test.ts — 3 files, 27 tests.
- PASS: 
pm.cmd run build (	sc).
- INTERRUPTED: 
pm.cmd test was started but intentionally stopped at the requested checkpoint before its final result; it is not claimed green.
- PASS: git diff --check before commit.

Independent review requested before merge. Do not merge this PR as part of the issue work.