### PR TITLE
fix(panel): extend add-node refresh ACK budget (#2242)

### DIFF
--- a/src/__tests__/orchestrator/add-node-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/add-node-ack-timeout.test.ts
@@ -1,0 +1,41 @@
+// #2242 — panel_add_node must leave enough time for a slow full /object_info refresh
+// to compose its reply. If the relay expires first, the mutation may still be applied
+// by the panel and a later caller retry can create a duplicate node.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/2242.json";
+
+describe("panel_add_node ACK budget (#2242)", () => {
+  it("forwards the bounded 90s refresh budget to graph_add_node", async () => {
+    const seen: Array<{ cmd: string; timeoutMs: number | undefined }> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        seen.push({ cmd: String(cmd.cmd), timeoutMs: opts?.timeoutMs });
+        return { node_id: 42, class_type: cmd.class_type };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => TAB,
+      tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((entry) => entry.name === "panel_add_node");
+    if (!def) throw new Error("panel_add_node is not registered");
+
+    const result = await def.handler({ class_type: "RemoteStacker" }, ctx);
+
+    expect(result.isError).not.toBe(true);
+    expect(seen).toEqual([{ cmd: "graph_add_node", timeoutMs: 90_000 }]);
+  });
+});

--- a/src/__tests__/orchestrator/get-errors-ack-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-ack-budget.test.ts
@@ -26,7 +26,7 @@
 // The margin has to come from the ORCHESTRATOR. The panel's 18 s bound must stay where it
 // is: it is what keeps a current panel safe in front of an older orchestrator still using
 // the 20 s default. So `graph_get_errors` joins the #599 refresh-ack cohort — the same
-// bounded 30 s budget `graph_set_widget`, `graph_add_node`, `graph_remove_widget`,
+// bounded 90 s budget `graph_set_widget`, `graph_add_node`, `graph_remove_widget`,
 // `graph_get_object_info` and `refresh_nodes` already forward for the same reason.
 //
 // The property under test is the CALL SITE. A shared constant that nothing passes still
@@ -43,7 +43,7 @@ const PANEL_TOOLS_TS = fileURLToPath(new URL("../../orchestrator/panel-tools.ts"
 /** The #599 bounded refresh-ack budget (OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS). Duplicated as
  *  a literal on purpose: if the constant moves, these tests force the relationship to the
  *  panel's own budget to be re-examined rather than silently re-broken. */
-const REFRESH_ACK_MS = 30_000;
+const REFRESH_ACK_MS = 90_000;
 
 /** GET_ERRORS_TOTAL_BUDGET_MS in the PANEL repo (web/js/lib/get-errors-budget.js) — the
  *  wall clock one graph_get_errors call may spend on elective server waits alone, before
@@ -101,7 +101,7 @@ describe("panel_get_errors ack budget (#1493)", () => {
   it("stays BOUNDED, so a genuinely frozen tab still fails", async () => {
     const { timeoutMs } = await forwardedAckMs("panel_get_errors");
     expect(Number.isFinite(timeoutMs!)).toBe(true);
-    expect(timeoutMs!).toBeLessThanOrEqual(60_000);
+    expect(timeoutMs!).toBeLessThanOrEqual(90_000);
   });
 
   it("uses the SAME bound as the #599 siblings, so the cohort cannot drift apart", async () => {

--- a/src/__tests__/orchestrator/get-errors-call-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-call-budget.test.ts
@@ -759,8 +759,8 @@ describe("the clean note may survive only where the PANEL would have called it c
 });
 
 // #1973 — the completion follow-ups are ELECTIVE and run with the panel's reply
-// already in hand, so they must NOT get the same 30 s budget as the primary read.
-// Handing them the ack timeout makes the handler's worst case 30 s + 30 s and puts
+// already in hand, so they must NOT get the same 90 s budget as the primary read.
+// Handing them the ack timeout makes the handler's worst case 90 s + 90 s and puts
 // a reply we already hold behind an optional improvement — which is #589 (an agent
 // left with NO error surface) re-introduced from the orchestrator side, on the one
 // tool a user staring at red nodes has nothing else to fall back on.
@@ -808,7 +808,7 @@ describe("get_errors completion follow-ups run on the elective budget (#1973/#58
     expect(query, "graph_query follow-up did not run").toBeTypeOf("number");
     expect(objectInfo, "graph_get_object_info follow-up did not run").toBeTypeOf("number");
 
-    expect(primary, "the primary read keeps the #1493 refresh-ack budget").toBe(30_000);
+    expect(primary, "the primary read keeps the #1493 refresh-ack budget").toBe(90_000);
     expect(
       query!,
       "an elective follow-up must not be able to double the handler's worst case",
@@ -820,7 +820,7 @@ describe("get_errors completion follow-ups run on the elective budget (#1973/#58
     // per-call timeout into a longer handler wait.
     expect(query!).toBeLessThanOrEqual(8_000);
     expect(objectInfo!).toBeLessThanOrEqual(8_000);
-    expect(primary! + Math.max(query!, objectInfo!)).toBeLessThanOrEqual(38_000);
+    expect(primary! + Math.max(query!, objectInfo!)).toBeLessThanOrEqual(98_000);
   });
 });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -227,9 +227,9 @@ describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
   // replying; on a large install that can outlast the bridge's 6000 ms default
   // ack, returning a FALSE "tab did not reply" timeout. The tools must forward a
   // larger BOUNDED ack budget so a slow-but-valid refresh isn't a false timeout.
-  const REFRESH_ACK_MS = 30_000;
+  const REFRESH_ACK_MS = 90_000;
 
-  it("panel_set_widget forwards graph_set_widget with the 30s refresh ack timeout, not the 6s default", async () => {
+  it("panel_set_widget forwards graph_set_widget with the 90s refresh ack timeout, not the 6s default", async () => {
     const { ctx, calls, timeouts } = makeFakeCtx();
     await defByName("panel_set_widget").handler(
       { node_id: 39, widget: "image", value: "staged_00001_.png" },
@@ -239,7 +239,7 @@ describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
     expect(timeouts[0]).toBe(REFRESH_ACK_MS);
   });
 
-  it("panel_add_node forwards graph_add_node with the 30s refresh ack timeout", async () => {
+  it("panel_add_node forwards graph_add_node with the 90s refresh ack timeout", async () => {
     const { ctx, calls, timeouts } = makeFakeCtx();
     await defByName("panel_add_node").handler(
       { class_type: "LoadImage", pos: [0, 0] },
@@ -251,7 +251,7 @@ describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
 
   it("keeps the ack bounded (never Infinity) so a genuinely dead tab still fails", () => {
     expect(Number.isFinite(REFRESH_ACK_MS)).toBe(true);
-    expect(REFRESH_ACK_MS).toBeLessThanOrEqual(60_000);
+    expect(REFRESH_ACK_MS).toBeLessThanOrEqual(90_000);
   });
 });
 
@@ -739,9 +739,9 @@ describe("panel-tools: panel_refresh_nodes (#608 — force a combo/object_info r
     await defByName("panel_refresh_nodes").handler({}, ctx);
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({ cmd: "refresh_nodes" });
-    // Same 30s budget as the refresh-before-validate writes — this command's whole
+    // Same 90s budget as the refresh-before-validate writes — this command's whole
     // purpose is to await a fresh /object_info fetch.
-    expect(timeouts[0]).toBe(30_000);
+    expect(timeouts[0]).toBe(90_000);
   });
 
   it("takes no arguments (empty schema)", () => {
@@ -7593,7 +7593,7 @@ describe("#767 panel_add_node warns against parallel bursts", () => {
   // Parallel adds each carry a fresh /object_info payload, and the coalescer
   // registers those SERIALLY (deliberately — joining an older in-flight refresh
   // once dropped a just-installed node's defs, #289 P2). So N concurrent adds
-  // become N sequential refresh cycles; on a large install that outruns the 30s
+  // become N sequential refresh cycles; on a large install that outruns the 90s
   // per-command deadline and the later adds time out WHILE STILL QUEUED, then
   // apply when their turn comes. The reporter found "ghost" nodes matching calls
   // they had been told failed.
@@ -7605,7 +7605,7 @@ describe("#767 panel_add_node warns against parallel bursts", () => {
     const d = defByName("panel_add_node");
     expect(d.description).toMatch(/ONE AT A TIME/);
     expect(d.description).toMatch(/register SERIALLY|SERIALLY/);
-    expect(d.description).toMatch(/30s per-command deadline/);
+    expect(d.description).toMatch(/90s per-command deadline/);
   });
 
   it("names the consequence that makes it worth heeding", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1282,13 +1282,19 @@ function sleep(ms: number): Promise<void> {
 // in progress. Give these a larger BOUNDED ack budget so a slow-but-valid refresh
 // is not mistaken for a dead tab — still capped (never Infinity) so a genuinely
 // frozen/backgrounded tab fails in bounded time instead of hanging forever.
-const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
+// #2242 — a full /object_info refresh can legitimately outlive the old 30 s relay
+// window. The panel may have already delivered graph_add_node and continue applying
+// it after that window, so a later caller-supplied add can create a duplicate. Keep
+// the timeout finite, but leave enough room for the panel's bounded refresh/add path
+// to compose and acknowledge one mutation before the bridge declares the outcome
+// unknown.
+const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 90_000;
 
 /** #1973 — the budget for get_errors' ELECTIVE completion follow-ups, deliberately a
  *  fraction of the ack timeout above and NOT the same number.
  *
  *  By the time those follow-ups run, the panel's reply is already in hand. Spending
- *  the full 30 s ack budget on them would make the handler's worst case 30 s + 30 s
+ *  the full 90 s ack budget on them would make the handler's worst case 90 s + 90 s
  *  and put a reply we ALREADY HAVE behind an elective completeness improvement — for
  *  a tool whose entire reason for existing is that an agent staring at red nodes has
  *  no other error surface. #589 is precisely that failure, and the shared panel-side
@@ -1301,7 +1307,7 @@ const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
 const GET_ERRORS_COMPLETION_BUDGET_MS = 8_000;
 
 // #1639 — while a ComfyUI prompt is running the frontend main thread often
-// cannot service graph_* at all. Waiting out the 20/30 s ack bound only
+// cannot service graph_* at all. Waiting out the 20/90 s ack bound only
 // surfaces "tab may be backgrounded or frozen" with an unknown mutation
 // outcome. Fail closed BEFORE dispatch for canvas-touching graph commands so
 // the agent gets an explicit QUEUE BUSY instead. `graph_run` is excluded:
@@ -1341,7 +1347,7 @@ const GET_ERRORS_COMPLETION_BUDGET_MS = 8_000;
 // trade #357 and #589 were both regressions of, in a file whose read-timeout policy
 // is "reads get MORE patience, not less, because a false timeout costs an agent its
 // only look at a broken graph". #589 is precisely this: panel_get_errors was given a
-// 30 s budget because the panel's own bound is 18 s. A cap here would re-break it.
+// 90 s budget because the panel's own bound is 18 s. A cap here would re-break it.
 function queueBusySnapshotNote(): string {
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return "";
@@ -15369,7 +15375,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_add_node",
-      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values. Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' — the supported way to ANNOTATE a workflow with on-canvas instructions (add the node, then put the text in its 'text' widget via panel_set_widget) — plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry, so they legitimately bypass the backend class_type check. ComfyUI-LoRA-Manager's 'Lora Loader (LoraManager)' (and other AUTOCOMPLETE_TEXT_* nodes) cannot be added: the pack is healthy, but the add-node guard cannot see its Vue autocomplete widget. Use 'LoRA Text Loader (LoraManager)' — same outputs, lora_syntax is a STRING — or core LoraLoader; reload/retry will not clear it. A 'no installed node outputs' refusal for a custom link type (SEEDVR2_DIT, SEEDVR2_VAE, DICT, …) after sibling producer nodes were just added (ConvertAny2Dict on the canvas while DictGetNode is refused) is the guard looking at a single-class /object_info, not the live graph; retry/refresh will not clear it — copy the node from another workflow (panel_copy_nodes / panel_paste_nodes) or reload the tab. ADD NODES ONE AT A TIME, not as a parallel batch: each add carries a fresh /object_info payload and those register SERIALLY, so N concurrent adds become N sequential refresh cycles. On a large install that outruns the 30s per-command deadline and the later adds time out WHILE STILL QUEUED — they then apply when their turn arrives, leaving nodes you were told had failed (panel#767). Sequential adds each get the refresh to themselves and stay well inside the deadline.",
+      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values. Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' — the supported way to ANNOTATE a workflow with on-canvas instructions (add the node, then put the text in its 'text' widget via panel_set_widget) — plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry, so they legitimately bypass the backend class_type check. ComfyUI-LoRA-Manager's 'Lora Loader (LoraManager)' (and other AUTOCOMPLETE_TEXT_* nodes) cannot be added: the pack is healthy, but the add-node guard cannot see its Vue autocomplete widget. Use 'LoRA Text Loader (LoraManager)' — same outputs, lora_syntax is a STRING — or core LoraLoader; reload/retry will not clear it. A 'no installed node outputs' refusal for a custom link type (SEEDVR2_DIT, SEEDVR2_VAE, DICT, …) after sibling producer nodes were just added (ConvertAny2Dict on the canvas while DictGetNode is refused) is the guard looking at a single-class /object_info, not the live graph; retry/refresh will not clear it — copy the node from another workflow (panel_copy_nodes / panel_paste_nodes) or reload the tab. ADD NODES ONE AT A TIME, not as a parallel batch: each add carries a fresh /object_info payload and those register SERIALLY, so N concurrent adds become N sequential refresh cycles. On a large install that outruns the 90s per-command deadline and the later adds time out WHILE STILL QUEUED — they then apply when their turn arrives, leaving nodes you were told had failed (panel#767). Sequential adds each get the refresh to themselves and stay well inside the deadline.",
       {
         class_type: z.string().describe("Exact ComfyUI node class_type to create."),
         pos: xy()
@@ -15435,9 +15441,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // handling. `joinMs` never cancels work already in flight; the panel coalescer says
         // so outright ("The run keeps going, registers whatever it fetched"), and its own
         // worked example is a join ending at 20,000 ms plus a run adding ~13,000 ms —
-        // ~33 s against a 30 s relay window, every per-step bound respected. On a large
+        // ~33 s against a 90 s relay window, every per-step bound respected. On a large
         // install the refresh legitimately outlives this ack and then COMPLETES, which is
-        // exactly what the reporter saw: the automatic refresh "failed" at 30 s and an
+        // exactly what the reporter saw: the automatic refresh "failed" at 90 s and an
         // explicit panel_refresh_nodes moments later succeeded immediately.
         //
         // Decided on the BRIDGE-OWNED tag (#1468), never on message text: two codex rounds
@@ -15518,7 +15524,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and did ` +
                 `NOT answer within its window, and the add was then retried ONCE anyway — a refresh ` +
                 `that outruns its ack is NOT cancelled: it keeps running and registers what it ` +
-                `fetched. On a large install it can take ~33s against a 30s window. The retry still ` +
+                `fetched. On a large install it can take ~33s against a 90s window. The retry still ` +
                 `refuses, which means that registration had not landed YET — not that the schema is ` +
                 `stuck. Neither attempt added anything. RETRY the add in a few seconds; that is the ` +
                 `action that clears this. Only if it keeps refusing is the page's registry actually ` +
@@ -17192,7 +17198,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       // default — so the orchestrator widens its own wait to the same bounded budget its
       // refresh-before-validate siblings already use. This read is idempotent, so waiting longer
       // costs a slow reply and never a double-applied write; it stays BOUNDED (never Infinity), so
-      // a genuinely frozen tab still fails, just at 30 s instead of 20 s.
+      // a genuinely frozen tab still fails, just at 90 s instead of 20 s.
       //
       // #1973 — even a reply that BEATS that bound can still be a false-clean 0: the
       // panel gives the live combo scan only the 4 s STEP cap, so a ~77-node graph


### PR DESCRIPTION
Extends the bounded object-info refresh ACK budget from 30s to 90s for panel mutations and refreshes, preventing a slow delivered graph_add_node from being reported timed out before it applies and later duplicated by a retry. Updates shared budget documentation/tests and adds a direct panel_add_node forwarding regression. Fixes #2242. Validation: focused Vitest 443 passed; npm run lint passed; npm run build passed; broad npm test reached 12,133 passed with 3 pre-existing node-id-union-message failures and 4 skipped.