### PR TITLE
fix(2161): keep panel orchestrator launch persistent

### DIFF
--- a/src/__tests__/services/npx-restart-scope.test.ts
+++ b/src/__tests__/services/npx-restart-scope.test.ts
@@ -77,6 +77,12 @@ describe("#1471 the note names the restart that works", () => {
     expect(note).toMatch(/comfyui-mcp@latest/);
   });
 
+  it("offers a pinned global install to escape @latest churn", () => {
+    expect(note).toContain("npm i -g comfyui-mcp@0.51.16");
+    expect(note).toContain("comfyui-mcp connect");
+    expect(note).toMatch(/escape @latest re-resolution churn/i);
+  });
+
   it("names the check, and refuses to over-read its result", () => {
     // The check is real evidence but NOT a diagnosis: an unchanged version cannot
     // distinguish "the restart never reached this process" from "npx relaunched and

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -77,6 +77,25 @@ describe("panel launcher install", () => {
     expect(existsSync(`${paths.lock}.reclaim`)).toBe(false);
   });
 
+  it("releases the install lock before starting a fallback broker", async () => {
+    const { home, source } = fixture();
+    let lockHeldAtSpawn = false;
+    const paths = panelLauncherPaths(home);
+    await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("no systemd user session");
+      }) as never,
+      spawnImpl: (() => {
+        lockHeldAtSpawn = existsSync(paths.lock);
+        return { unref() {} };
+      }) as never,
+    });
+    expect(lockHeldAtSpawn).toBe(false);
+  });
+
   it("falls back to a Startup autostart when the scheduled task is DENIED", async () => {
     // The failure this covers is not hypothetical: on a machine whose policy or
     // task-store ACL refuses task creation to the user, `schtasks /Create` fails
@@ -754,6 +773,7 @@ describe("panel launcher broker", () => {
     await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
     const children: Array<EventEmitter & { pid?: number; unref: () => void }> = [];
     const spawns: Array<{ file: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+    let launcherLockHeldAtSpawn = false;
     let now = Date.now();
     const server = await startPanelLauncherBroker(home, {
       probeImpl: async () => false,
@@ -761,6 +781,7 @@ describe("panel launcher broker", () => {
       recoveryDelayMs: 10,
       recoveryMaxAttempts: 2,
       spawnImpl: ((file: string, args: readonly string[], options: Record<string, unknown>) => {
+        launcherLockHeldAtSpawn = existsSync(panelLauncherPaths(home).lock);
         const child = Object.assign(new EventEmitter(), { pid: 100 + children.length, unref() {} });
         children.push(child);
         spawns.push({ file, args, options });
@@ -776,6 +797,7 @@ describe("panel launcher broker", () => {
       });
       expect(start.status).toBe(200);
       expect(spawns).toHaveLength(1);
+      expect(launcherLockHeldAtSpawn).toBe(true);
       const command = persistentCommandForPlatform(process.platform);
       expect(spawns[0]).toMatchObject({
         file: command.executable,

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -180,7 +180,12 @@ describe("panel launcher install", () => {
     expect(readFileSync(paths.windowsStartup, "utf8")).toContain(paths.windowsScript);
     // …and the broker starts NOW, or the install "succeeds" while leaving the
     // panel with nothing to talk to until the next logon.
-    expect(spawned).toEqual([[paths.broker, "run", expect.stringMatching(/^--broker-id=/)]]);
+    expect(spawned).toEqual([[
+      paths.broker,
+      "run",
+      expect.stringMatching(/^--broker-id=/),
+      expect.stringMatching(/^--install-id=/),
+    ]]);
     // The install must not throw: everything the launcher needs now exists.
     expect(readPanelLauncherConfig(home)?.token.length).toBeGreaterThanOrEqual(32);
   });
@@ -305,7 +310,12 @@ describe("panel launcher install", () => {
     });
     expect(existsSync(paths.windowsStartup)).toBe(false);
     expect(spawned, "install threw before starting a broker").toEqual([
-      [paths.broker, "run", expect.stringMatching(/^--broker-id=/)],
+      [
+        paths.broker,
+        "run",
+        expect.stringMatching(/^--broker-id=/),
+        expect.stringMatching(/^--install-id=/),
+      ],
     ]);
   });
 
@@ -391,7 +401,12 @@ describe("panel launcher install", () => {
       await new Promise<void>((r) => server.close(() => r()));
     }
     expect(spawned).toEqual([
-      [panelLauncherPaths(home).broker, "run", expect.stringMatching(/^--broker-id=/)],
+      [
+        panelLauncherPaths(home).broker,
+        "run",
+        expect.stringMatching(/^--broker-id=/),
+        expect.stringMatching(/^--install-id=/),
+      ],
     ]);
   });
 
@@ -456,7 +471,12 @@ describe("panel launcher install", () => {
       }) as never,
     });
     expect(spawned).toEqual([
-      [panelLauncherPaths(home).broker, "run", expect.stringMatching(/^--broker-id=/)],
+      [
+        panelLauncherPaths(home).broker,
+        "run",
+        expect.stringMatching(/^--broker-id=/),
+        expect.stringMatching(/^--install-id=/),
+      ],
     ]);
   });
 
@@ -515,7 +535,12 @@ describe("panel launcher install", () => {
     // The task IS registered — no duplicate autostart.
     expect(existsSync(paths.windowsStartup)).toBe(false);
     // …but this session still needs a broker, since /Run did not give it one.
-    expect(spawned).toEqual([[paths.broker, "run", expect.stringMatching(/^--broker-id=/)]]);
+    expect(spawned).toEqual([[
+      paths.broker,
+      "run",
+      expect.stringMatching(/^--broker-id=/),
+      expect.stringMatching(/^--install-id=/),
+    ]]);
   });
 
   it("uninstall removes the Startup fallback, not just the task", async () => {

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -1,10 +1,12 @@
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   installPanelLauncher,
+  persistentCommandForPlatform,
   panelLauncherPaths,
   readPanelLauncherConfig,
   startPanelLauncherBroker,
@@ -506,6 +508,100 @@ describe("panel launcher broker", () => {
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
+  });
+
+  it("launches headlessly and bounds recovery after child exits", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
+    const children: Array<EventEmitter & { pid?: number; unref: () => void }> = [];
+    const spawns: Array<{ file: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+    const server = await startPanelLauncherBroker(home, {
+      probeImpl: async () => false,
+      recoveryDelayMs: 10,
+      recoveryMaxAttempts: 2,
+      spawnImpl: ((file: string, args: readonly string[], options: Record<string, unknown>) => {
+        const child = Object.assign(new EventEmitter(), { pid: 100 + children.length, unref() {} });
+        children.push(child);
+        spawns.push({ file, args, options });
+        return child;
+      }) as never,
+    });
+    try {
+      const config = readPanelLauncherConfig(home)!;
+      const base = `http://127.0.0.1:${config.port}`;
+      const start = await fetch(`${base}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(start.status).toBe(200);
+      expect(spawns).toHaveLength(1);
+      const command = persistentCommandForPlatform(process.platform);
+      expect(spawns[0]).toMatchObject({
+        file: command.executable,
+        args: command.args,
+        options: { detached: true, stdio: "ignore", windowsHide: process.platform === "win32" },
+      });
+
+      // A clean exit is the self-update handoff. The broker waits, probes for
+      // the replacement, then starts one only when the bridge is still absent.
+      children[0].emit("exit", 0);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(spawns).toHaveLength(2);
+
+      children[1].emit("exit", 1);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(spawns).toHaveLength(3);
+
+      // A repeatedly broken install cannot become a hot spawn loop.
+      children[2].emit("exit", 1);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(spawns).toHaveLength(3);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("does not duplicate the replacement during a clean self-update handoff", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
+    let running = false;
+    const children: Array<EventEmitter & { pid?: number; unref: () => void }> = [];
+    const server = await startPanelLauncherBroker(home, {
+      probeImpl: async () => running,
+      recoveryDelayMs: 10,
+      spawnImpl: (() => {
+        const child = Object.assign(new EventEmitter(), { pid: 200 + children.length, unref() {} });
+        children.push(child);
+        return child;
+      }) as never,
+    });
+    try {
+      const config = readPanelLauncherConfig(home)!;
+      await fetch(`http://127.0.0.1:${config.port}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(children).toHaveLength(1);
+      children[0].emit("exit", 0);
+      running = true; // the self-restarter's replacement won the bridge first
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(children).toHaveLength(1);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe("persistent broker command", () => {
+  it("uses a hidden cmd child on Windows and npx directly on Linux", () => {
+    expect(persistentCommandForPlatform("win32", { ComSpec: "cmd.exe" })).toEqual({
+      executable: "cmd.exe",
+      args: ["/d", "/c", "npx.cmd -y comfyui-mcp@latest connect"],
+    });
+    expect(persistentCommandForPlatform("linux")).toEqual({
+      executable: "npx",
+      args: ["-y", "comfyui-mcp@latest", "connect"],
+    });
   });
 });
 

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -117,7 +117,7 @@ describe("panel launcher install", () => {
     expect(readFileSync(paths.windowsStartup, "utf8")).toContain(paths.windowsScript);
     // …and the broker starts NOW, or the install "succeeds" while leaving the
     // panel with nothing to talk to until the next logon.
-    expect(spawned).toEqual([[paths.broker, "run"]]);
+    expect(spawned).toEqual([[paths.broker, "run", expect.stringMatching(/^--broker-id=/)]]);
     // The install must not throw: everything the launcher needs now exists.
     expect(readPanelLauncherConfig(home)?.token.length).toBeGreaterThanOrEqual(32);
   });
@@ -241,7 +241,9 @@ describe("panel launcher install", () => {
       }) as never,
     });
     expect(existsSync(paths.windowsStartup)).toBe(false);
-    expect(spawned, "install threw before starting a broker").toEqual([[paths.broker, "run"]]);
+    expect(spawned, "install threw before starting a broker").toEqual([
+      [paths.broker, "run", expect.stringMatching(/^--broker-id=/)],
+    ]);
   });
 
   it("the PORT is the evidence — a live broker with no pid recorded still counts", async () => {
@@ -325,7 +327,9 @@ describe("panel launcher install", () => {
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }
-    expect(spawned).toEqual([[panelLauncherPaths(home).broker, "run"]]);
+    expect(spawned).toEqual([
+      [panelLauncherPaths(home).broker, "run", expect.stringMatching(/^--broker-id=/)],
+    ]);
   });
 
   it("a /Create failure with the task ALREADY registered adds no second autostart", async () => {
@@ -388,7 +392,9 @@ describe("panel launcher install", () => {
         return { unref() {} };
       }) as never,
     });
-    expect(spawned).toEqual([[panelLauncherPaths(home).broker, "run"]]);
+    expect(spawned).toEqual([
+      [panelLauncherPaths(home).broker, "run", expect.stringMatching(/^--broker-id=/)],
+    ]);
   });
 
   it("puts the Startup entry under %APPDATA%, not a manufactured profile path", async () => {
@@ -446,7 +452,7 @@ describe("panel launcher install", () => {
     // The task IS registered — no duplicate autostart.
     expect(existsSync(paths.windowsStartup)).toBe(false);
     // …but this session still needs a broker, since /Run did not give it one.
-    expect(spawned).toEqual([[paths.broker, "run"]]);
+    expect(spawned).toEqual([[paths.broker, "run", expect.stringMatching(/^--broker-id=/)]]);
   });
 
   it("uninstall removes the Startup fallback, not just the task", async () => {
@@ -465,6 +471,157 @@ describe("panel launcher install", () => {
     // Removing only the task would leave exactly the accounts that needed the
     // fallback with a launcher that survives every uninstall.
     expect(existsSync(paths.windowsStartup)).toBe(false);
+  });
+
+  it("stops a running Windows Startup fallback broker during uninstall", async () => {
+    const { home, source } = fixture();
+    const calls: Array<{ file: string; args: readonly string[] }> = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("denied");
+      }) as never,
+      spawnImpl: (() => ({ pid: 4321, unref() {} })) as never,
+    });
+    const config = readPanelLauncherConfig(home)!;
+    uninstallPanelLauncher({
+      home,
+      platform: "win32",
+      exec: ((_file: string, args: readonly string[]) => {
+        calls.push({ file: _file, args });
+      }) as never,
+      processIdentityImpl: () => ({
+        commandLine: `"${paths.broker}" run --broker-id=${config.broker_id}`,
+      }),
+    });
+    expect(calls).toContainEqual({ file: "taskkill.exe", args: ["/PID", "4321", "/F"] });
+    expect(existsSync(paths.windowsStartup)).toBe(false);
+  });
+
+  it("stops a running Linux XDG fallback broker during uninstall", async () => {
+    const { home, source } = fixture();
+    const killed: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("no systemd user session");
+      }) as never,
+      spawnImpl: (() => ({ pid: 4322, unref() {} })) as never,
+    });
+    const config = readPanelLauncherConfig(home)!;
+    uninstallPanelLauncher({
+      home,
+      platform: "linux",
+      exec: (() => undefined) as never,
+      killImpl: ((pid: number, signal?: NodeJS.Signals | number) => {
+        killed.push({ pid, signal });
+      }) as typeof process.kill,
+      processIdentityImpl: () => ({
+        commandLine: `${paths.broker} run --broker-id=${config.broker_id}`,
+      }),
+    });
+    expect(killed).toEqual([{ pid: 4322, signal: "SIGTERM" }]);
+    expect(existsSync(paths.linuxAutostart)).toBe(false);
+  });
+
+  it("fails closed when the recorded PID identity cannot be read", async () => {
+    const { home, source } = fixture();
+    const calls: string[] = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: (() => { throw new Error("denied"); }) as never,
+      spawnImpl: (() => ({ pid: 4331, unref() {} })) as never,
+    });
+    uninstallPanelLauncher({
+      home,
+      platform: "win32",
+      exec: ((file: string) => { calls.push(file); }) as never,
+      processIdentityImpl: () => null,
+    });
+    expect(calls).not.toContain("taskkill.exe");
+    expect(existsSync(paths.config)).toBe(false);
+  });
+
+  it("does not kill a non-owned process that reuses the recorded PID", async () => {
+    const { home, source } = fixture();
+    const killed: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+    const paths = await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => { throw new Error("no systemd user session"); }) as never,
+      spawnImpl: (() => ({ pid: 4332, unref() {} })) as never,
+    });
+    const config = readPanelLauncherConfig(home)!;
+    uninstallPanelLauncher({
+      home,
+      platform: "linux",
+      exec: (() => undefined) as never,
+      killImpl: ((pid: number, signal?: NodeJS.Signals | number) => {
+        killed.push({ pid, signal });
+      }) as typeof process.kill,
+      processIdentityImpl: () => ({
+        commandLine: `${paths.broker} run --broker-id=not-${config.broker_id}`,
+      }),
+    });
+    expect(killed).toEqual([]);
+  });
+
+  it("disables recovery after uninstall when no broker PID is available", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("no systemd user session");
+      }) as never,
+      spawnImpl: (() => ({ unref() {} })) as never,
+    });
+    const children: Array<EventEmitter & { unref: () => void }> = [];
+    let spawns = 0;
+    const server = await startPanelLauncherBroker(home, {
+      probeImpl: async () => false,
+      recoveryDelayMs: 10,
+      spawnImpl: (() => {
+        spawns += 1;
+        const child = Object.assign(new EventEmitter(), { unref() {} });
+        children.push(child);
+        return child;
+      }) as never,
+    });
+    const config = readPanelLauncherConfig(home)!;
+    const base = `http://127.0.0.1:${config.port}`;
+    try {
+      await fetch(`${base}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(spawns).toBe(1);
+      children[0]!.emit("exit", 1);
+
+      // The uninstall removes the config before the delayed recovery can run.
+      // With no PID to kill, the broker may remain until its process exits, but
+      // it must be disabled and must not launch another orchestrator.
+      uninstallPanelLauncher({ home, platform: "linux", exec: (() => undefined) as never });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(spawns).toBe(1);
+
+      const disabled = await fetch(`${base}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(disabled.status).toBe(200);
+      expect(await disabled.json()).toMatchObject({ disabled: true, started: false });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("writes a Linux user service and falls back to XDG autostart", async () => {
@@ -505,6 +662,70 @@ describe("panel launcher broker", () => {
       const body = await accepted.json() as Record<string, unknown>;
       expect(body).toMatchObject({ ok: true, protocol: 1 });
       expect(body).not.toHaveProperty("token");
+      expect(readPanelLauncherConfig(home)?.broker_id).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("does not republish launcher.json when uninstall races broker startup", async () => {
+    const { home, source } = fixture();
+    const paths = await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    await expect(
+      startPanelLauncherBroker(home, {
+        beforeConfigWrite: () => uninstallPanelLauncher({
+          home,
+          platform: "linux",
+          exec: (() => undefined) as never,
+        }),
+      }),
+    ).rejects.toThrow("uninstalled while the broker was starting");
+    expect(existsSync(paths.config)).toBe(false);
+    expect(existsSync(paths.teardown)).toBe(true);
+  });
+
+  it("does not spawn from an in-flight probe after uninstall", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: (() => undefined) as never,
+    });
+    let releaseProbe!: (running: boolean) => void;
+    let probeStarted!: () => void;
+    const probeReady = new Promise<void>((resolve) => { probeStarted = resolve; });
+    const probeResult = new Promise<boolean>((resolve) => { releaseProbe = resolve; });
+    let spawns = 0;
+    const server = await startPanelLauncherBroker(home, {
+      probeImpl: async () => {
+        probeStarted();
+        return probeResult;
+      },
+      spawnImpl: (() => {
+        spawns += 1;
+        return { unref() {} };
+      }) as never,
+    });
+    try {
+      const config = readPanelLauncherConfig(home)!;
+      const request = fetch(`http://127.0.0.1:${config.port}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      await probeReady;
+      uninstallPanelLauncher({ home, platform: "linux", exec: (() => undefined) as never });
+      releaseProbe(false);
+      const response = await request;
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ disabled: true, started: false });
+      expect(spawns).toBe(0);
+      expect(existsSync(panelLauncherPaths(home).config)).toBe(false);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
@@ -515,8 +736,10 @@ describe("panel launcher broker", () => {
     await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
     const children: Array<EventEmitter & { pid?: number; unref: () => void }> = [];
     const spawns: Array<{ file: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+    let now = Date.now();
     const server = await startPanelLauncherBroker(home, {
       probeImpl: async () => false,
+      now: () => now,
       recoveryDelayMs: 10,
       recoveryMaxAttempts: 2,
       spawnImpl: ((file: string, args: readonly string[], options: Record<string, unknown>) => {
@@ -545,16 +768,39 @@ describe("panel launcher broker", () => {
       // A clean exit is the self-update handoff. The broker waits, probes for
       // the replacement, then starts one only when the bridge is still absent.
       children[0].emit("exit", 0);
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(spawns).toHaveLength(2);
 
       children[1].emit("exit", 1);
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(spawns).toHaveLength(3);
 
       // A repeatedly broken install cannot become a hot spawn loop.
       children[2].emit("exit", 1);
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(spawns).toHaveLength(3);
+
+      // Even after the ordinary 90-second launch cooldown, a panel request
+      // must honor the same bounded recovery budget as the timer supervisor.
+      now += 90_001;
+      const exhausted = await fetch(`${base}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(exhausted.status).toBe(200);
+      expect(await exhausted.json()).toMatchObject({
+        started: false,
+        recovery_exhausted: true,
+      });
+      const stillExhausted = await fetch(`${base}/v1/ensure-running`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      expect(stillExhausted.status).toBe(200);
+      expect(await stillExhausted.json()).toMatchObject({
+        started: false,
+        recovery_exhausted: true,
+      });
       expect(spawns).toHaveLength(3);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -584,7 +830,7 @@ describe("panel launcher broker", () => {
       expect(children).toHaveLength(1);
       children[0].emit("exit", 0);
       running = true; // the self-restarter's replacement won the bridge first
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(children).toHaveLength(1);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -206,7 +206,13 @@ describe("panel launcher install", () => {
     const server = createServer((req, res) => {
       const ok = req.headers.authorization === `Bearer ${cfg.token}`;
       res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: false }));
+      res.end(JSON.stringify({
+        ok,
+        protocol: 1,
+        broker_id: cfg.broker_id,
+        install_id: cfg.install_id,
+        orchestrator_running: false,
+      }));
     });
     await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
     const port = (server.address() as { port: number }).port;
@@ -258,7 +264,13 @@ describe("panel launcher install", () => {
     const server = createServer((req, res) => {
       const ok = req.headers.authorization === `Bearer ${cfg.token}`;
       res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: false }));
+      res.end(JSON.stringify({
+        ok,
+        protocol: 1,
+        broker_id: cfg.broker_id,
+        install_id: cfg.install_id,
+        orchestrator_running: false,
+      }));
     });
     await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
     const port = (server.address() as { port: number }).port;
@@ -337,7 +349,13 @@ describe("panel launcher install", () => {
     const server = createServer((req, res) => {
       const ok = req.headers.authorization === `Bearer ${cfg.token}`;
       res.writeHead(ok ? 200 : 401, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok, protocol: 1, orchestrator_running: true }));
+      res.end(JSON.stringify({
+        ok,
+        protocol: 1,
+        broker_id: cfg.broker_id,
+        install_id: cfg.install_id,
+        orchestrator_running: true,
+      }));
     });
     await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
     const port = (server.address() as { port: number }).port;

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -96,6 +96,35 @@ describe("panel launcher install", () => {
     expect(lockHeldAtSpawn).toBe(false);
   });
 
+  it("does not let an old fallback overwrite a later reinstall", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({
+      home,
+      platform: "linux",
+      nodePath: "old-node",
+      brokerSource: source,
+      exec: (() => {
+        throw new Error("no systemd user session");
+      }) as never,
+      spawnImpl: (() => {
+        // This synchronous seam models the config state after a reinstall
+        // between the old fallback's spawn and its delayed PID publication.
+        const current = readPanelLauncherConfig(home)!;
+        writeFileSync(
+          panelLauncherPaths(home).config,
+          JSON.stringify({
+            ...current,
+            install_id: "new-install-generation-000000000000000000000000000000",
+            broker_executable: "new-node",
+          }),
+          "utf8",
+        );
+        return { pid: 9911, unref() {} };
+      }) as never,
+    });
+    expect(readPanelLauncherConfig(home)?.broker_executable).toBe("new-node");
+  });
+
   it("falls back to a Startup autostart when the scheduled task is DENIED", async () => {
     // The failure this covers is not hypothetical: on a machine whose policy or
     // task-store ACL refuses task creation to the user, `schtasks /Create` fails

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -494,6 +494,7 @@ describe("panel launcher install", () => {
       }) as never,
       processIdentityImpl: () => ({
         commandLine: `"${paths.broker}" run --broker-id=${config.broker_id}`,
+        executable: config.broker_executable!,
       }),
     });
     expect(calls).toContainEqual({ file: "taskkill.exe", args: ["/PID", "4321", "/F"] });
@@ -522,6 +523,7 @@ describe("panel launcher install", () => {
       }) as typeof process.kill,
       processIdentityImpl: () => ({
         commandLine: `${paths.broker} run --broker-id=${config.broker_id}`,
+        executable: config.broker_executable!,
       }),
     });
     expect(killed).toEqual([{ pid: 4322, signal: "SIGTERM" }]);
@@ -568,6 +570,7 @@ describe("panel launcher install", () => {
       }) as typeof process.kill,
       processIdentityImpl: () => ({
         commandLine: `${paths.broker} run --broker-id=not-${config.broker_id}`,
+        executable: config.broker_executable!,
       }),
     });
     expect(killed).toEqual([]);

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -271,10 +271,11 @@ describe("panel launcher install", () => {
 
     try {
       spawned.length = 0;
-      await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: denied, spawnImpl: record });
+      await installPanelLauncher({ home, platform: "win32", nodePath: "new-node", brokerSource: source, exec: denied, spawnImpl: record });
       expect(spawned, "second install spawned a rival broker").toEqual([]);
       // …and the install must not have erased the pid for the NEXT one either.
       expect(readPanelLauncherConfig(home)?.pid).toBe(process.pid);
+      expect(readPanelLauncherConfig(home)?.broker_executable).toBe(cfg.broker_executable);
       spawned.length = 0;
       await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec: denied, spawnImpl: record });
       expect(spawned, "third install spawned a rival broker").toEqual([]);
@@ -732,6 +733,19 @@ describe("panel launcher install", () => {
 });
 
 describe("panel launcher broker", () => {
+  it("requires command-line identity for an installed broker", async () => {
+    const { home, source } = fixture();
+    await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
+    const config = readPanelLauncherConfig(home)!;
+    await expect(startPanelLauncherBroker(home, {
+      enforceCommandIdentity: true,
+      expectedBrokerId: config.broker_id,
+    })).rejects.toThrow("install generation is missing");
+    await expect(startPanelLauncherBroker(home, {
+      enforceCommandIdentity: true,
+    })).rejects.toThrow("broker identity is missing");
+  });
+
   it("binds loopback and rejects requests without the private bearer token", async () => {
     const { home, source } = fixture();
     await installPanelLauncher({

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -96,6 +96,40 @@ describe("panel launcher install", () => {
     expect(lockHeldAtSpawn).toBe(false);
   });
 
+  it("releases the install lock before starting a registered Linux service", async () => {
+    const { home, source } = fixture();
+    const paths = panelLauncherPaths(home);
+    let lockHeldAtStart: boolean | undefined;
+    const calls: Array<readonly string[]> = [];
+    await installPanelLauncher({
+      home,
+      platform: "linux",
+      brokerSource: source,
+      exec: ((_file: string, args: readonly string[]) => {
+        calls.push(args);
+        if (args.includes("start")) lockHeldAtStart = existsSync(paths.lock);
+      }) as never,
+    });
+    expect(lockHeldAtStart).toBe(false);
+    expect(calls).toContainEqual(["--user", "enable", "comfyui-mcp-launcher.service"]);
+    expect(calls).toContainEqual(["--user", "start", "comfyui-mcp-launcher.service"]);
+  });
+
+  it("releases the install lock before running a registered Windows task", async () => {
+    const { home, source } = fixture();
+    const paths = panelLauncherPaths(home);
+    let lockHeldAtRun: boolean | undefined;
+    await installPanelLauncher({
+      home,
+      platform: "win32",
+      brokerSource: source,
+      exec: ((_file: string, args: readonly string[]) => {
+        if (args.includes("/Run")) lockHeldAtRun = existsSync(paths.lock);
+      }) as never,
+    });
+    expect(lockHeldAtRun).toBe(false);
+  });
+
   it("does not let an old fallback overwrite a later reinstall", async () => {
     const { home, source } = fixture();
     await installPanelLauncher({

--- a/src/__tests__/services/panel-launcher.test.ts
+++ b/src/__tests__/services/panel-launcher.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -60,6 +60,21 @@ describe("panel launcher install", () => {
     const first = readPanelLauncherConfig(home)?.token;
     await installPanelLauncher({ home, platform: "win32", brokerSource: source, exec });
     expect(readPanelLauncherConfig(home)?.token).toBe(first);
+  });
+
+  it("recovers a crashed stale-lock reclaimer", async () => {
+    const { home, source } = fixture();
+    const paths = panelLauncherPaths(home);
+    mkdirSync(paths.root, { recursive: true });
+    writeFileSync(paths.lock, JSON.stringify({ pid: 2147483647, token: "crashed-owner" }), "utf8");
+    writeFileSync(
+      `${paths.lock}.reclaim`,
+      JSON.stringify({ pid: 2147483647, token: "crashed-reclaimer" }),
+      "utf8",
+    );
+    await installPanelLauncher({ home, platform: "linux", brokerSource: source, exec: (() => undefined) as never });
+    expect(readPanelLauncherConfig(home)).not.toBeNull();
+    expect(existsSync(`${paths.lock}.reclaim`)).toBe(false);
   });
 
   it("falls back to a Startup autostart when the scheduled task is DENIED", async () => {

--- a/src/services/npx-restart-scope.ts
+++ b/src/services/npx-restart-scope.ts
@@ -19,6 +19,8 @@
  * actionable and is not.
  */
 
+const PACKAGE_NAME = "comfyui-mcp";
+
 /**
  * The npx-mode note. `latest` is the version the registry advertises.
  *
@@ -40,9 +42,11 @@ export function npxUpdateNote(latest: string): string {
     `If currentVersion is unchanged the new build is NOT running, but that alone ` +
     `does not say why — a restart that never reached this process, a deliberate ` +
     `version pin, and npx's execution cache serving an older copy all look identical ` +
-    `from here. If you did restart this process and meant to be on the latest, ` +
-    `relaunch once with an explicit comfyui-mcp@latest: that overrides both a pin ` +
-    `and a cached copy, which is what makes it the check worth running (note that ` +
-    `npm cache clean does NOT clear npx's execution cache — a different cache).`
+      `from here. If you did restart this process and meant to be on the latest, ` +
+      `relaunch once with an explicit comfyui-mcp@latest: that overrides both a pin ` +
+      `and a cached copy, which is what makes it the check worth running (note that ` +
+      `npm cache clean does NOT clear npx's execution cache — a different cache).` +
+      ` To escape @latest re-resolution churn, pin a global install instead: ` +
+      `npm i -g ${PACKAGE_NAME}@${latest}, then run ${PACKAGE_NAME} connect.`
   );
 }

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -45,6 +45,8 @@ export type PanelLauncherConfig = {
   host: "127.0.0.1";
   port: number;
   token: string;
+  /** Changes when a new install supersedes an unfinished fallback launch. */
+  install_id?: string;
   /** Random command-line marker proving that a recorded pid is our broker. */
   broker_id?: string;
   /** Executable recorded when the autostart command was installed. */
@@ -114,6 +116,8 @@ function isConfig(value: unknown): value is PanelLauncherConfig {
     Number(v.port) <= 65535 &&
     typeof v.token === "string" &&
     v.token.length >= 32 &&
+    (v.install_id === undefined ||
+      (typeof v.install_id === "string" && /^[A-Za-z0-9_-]{32,}$/.test(v.install_id))) &&
     (v.pid === undefined ||
       (Number.isInteger(v.pid) && Number(v.pid) > 0 && Number(v.pid) <= 0x7fffffff)) &&
     (v.broker_id === undefined ||
@@ -222,6 +226,12 @@ export async function installPanelLauncher(
 
     const previous = readPanelLauncherConfig(home);
     const token = previous?.token ?? randomBytes(32).toString("base64url");
+    // Preserve the generation of a live broker so reinstall does not disable
+    // the process that already owns the answering port. A port-0/unfinished
+    // install gets a new generation, which invalidates its delayed fallback.
+    const installId = previous?.port && previous.install_id
+      ? previous.install_id
+      : randomBytes(24).toString("base64url");
     const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
     const brokerExecutable = nodePath;
     let needsFallbackBroker = false;
@@ -247,12 +257,20 @@ export async function installPanelLauncher(
     // on a second install — this function's own config write used to drop the
     // pid — so a duplicate broker was spawned beside a live one (merge-gate P1).
     // The port is what the query actually uses; the pid was never evidence.
-    if (existsSync(paths.teardown) || readPanelLauncherConfig(home)?.token !== token) return;
+    if (
+      existsSync(paths.teardown) ||
+      readPanelLauncherConfig(home)?.token !== token ||
+      readPanelLauncherConfig(home)?.install_id !== installId
+    ) return;
     if (previous?.port) {
       const live = (await queryPanelLauncher(home)) as { running?: boolean };
       if (live.running) return; // a real broker answered — leave it alone
     }
-    if (existsSync(paths.teardown) || readPanelLauncherConfig(home)?.token !== token) return;
+    if (
+      existsSync(paths.teardown) ||
+      readPanelLauncherConfig(home)?.token !== token ||
+      readPanelLauncherConfig(home)?.install_id !== installId
+    ) return;
     const child = spawnBroker(nodePath, brokerRunArgs(paths.broker, brokerId), {
       detached: true,
       stdio: "ignore",
@@ -270,7 +288,7 @@ export async function installPanelLauncher(
       };
       if (child.pid) next.pid = child.pid;
       else delete next.pid;
-      writeOwnedPanelLauncherConfig(next, home, token);
+      writeOwnedPanelLauncherConfig(next, home, { token, installId });
     }
     child.unref?.();
   };
@@ -285,6 +303,7 @@ export async function installPanelLauncher(
         host: "127.0.0.1",
         port: previous?.port ?? 0,
         token,
+        install_id: installId,
         broker_id: brokerId,
         broker_executable: brokerExecutable,
         // The running broker's pid is the broker's to publish, not this install's
@@ -694,7 +713,7 @@ function readLauncherLockOwner(path: string): LauncherLockOwner | null {
   }
 }
 
-function launcherLockOwnerIsDead(path: string): boolean {
+function launcherLockOwnerIsDead(path: string, identityCache?: Map<number, string | null>): boolean {
   const owner = readLauncherLockOwner(path);
   if (!owner) return false;
   try {
@@ -706,7 +725,14 @@ function launcherLockOwnerIsDead(path: string): boolean {
   // may have recycled that number. If the platform cannot expose a start
   // identity, fail closed and leave the lock for manual recovery.
   if (!owner.started_at) return false;
-  const current = launcherProcessStartIdentity(owner.pid, process.platform);
+  if (owner.pid === process.pid && currentLauncherProcessStartIdentity() === owner.started_at) return false;
+  let current: string | null;
+  if (identityCache?.has(owner.pid)) {
+    current = identityCache.get(owner.pid) ?? null;
+  } else {
+    current = launcherProcessStartIdentity(owner.pid, process.platform);
+    identityCache?.set(owner.pid, current);
+  }
   return current !== null && current !== owner.started_at;
 }
 
@@ -744,6 +770,7 @@ function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | P
   const reclaimPath = `${paths.lock}.reclaim`;
   mkdirSync(paths.root, { recursive: true });
   const startedAt = currentLauncherProcessStartIdentity();
+  const ownerIdentityCache = new Map<number, string | null>();
   for (let attempt = 0; attempt < 200; attempt += 1) {
     const lockToken = randomBytes(16).toString("hex");
     const owner = { pid: process.pid, token: lockToken, ...(startedAt ? { started_at: startedAt } : {}) };
@@ -752,7 +779,7 @@ function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | P
     let reclaimToken: string | undefined;
     fd = tryCreateOwnedLauncherLock(paths.lock, owner) ?? undefined;
     if (fd === undefined) {
-      if (!launcherLockOwnerIsDead(paths.lock)) continue;
+      if (!launcherLockOwnerIsDead(paths.lock, ownerIdentityCache)) continue;
       try {
         reclaimToken = randomBytes(16).toString("hex");
         reclaimFd = tryCreateOwnedLauncherLock(reclaimPath, {
@@ -761,13 +788,13 @@ function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | P
           ...(startedAt ? { started_at: startedAt } : {}),
         }) ?? undefined;
         if (reclaimFd === undefined) {
-          if (launcherLockOwnerIsDead(reclaimPath)) rmSync(reclaimPath, { force: true });
+          if (launcherLockOwnerIsDead(reclaimPath, ownerIdentityCache)) rmSync(reclaimPath, { force: true });
         }
         if (reclaimFd === undefined) continue;
         // The auxiliary lock is itself a crash-recoverable owner lock. A
         // process which dies between acquiring it and releasing it must not
         // strand every later stale-main-lock recovery forever.
-        const stillDead = launcherLockOwnerIsDead(paths.lock);
+        const stillDead = launcherLockOwnerIsDead(paths.lock, ownerIdentityCache);
         if (stillDead) {
           rmSync(paths.lock, { force: true });
           fd = tryCreateOwnedLauncherLock(paths.lock, owner) ?? undefined;
@@ -835,14 +862,15 @@ function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | P
 function writeOwnedPanelLauncherConfig(
   config: PanelLauncherConfig,
   home: string,
-  ownerToken: string,
+  ownership: { token: string; installId?: string },
 ): boolean {
   return withPanelLauncherLock(home, () => {
     const paths = panelLauncherPaths(home);
     // The tombstone is written before uninstall removes the config. A broker
     // which is still publishing after that point must not recreate launcher.json.
     if (existsSync(paths.teardown)) return false;
-    if (readPanelLauncherConfig(home)?.token !== ownerToken) return false;
+    const current = readPanelLauncherConfig(home);
+    if (current?.token !== ownership.token || current.install_id !== ownership.installId) return false;
     writePanelLauncherConfig(config, home);
     return true;
   }) ?? false;
@@ -1199,7 +1227,8 @@ export async function startPanelLauncherBroker(
   const runtimeConfig = { ...current, broker_id: brokerId };
   const brokerConfigStillOwned = () =>
     !existsSync(panelLauncherPaths(home).teardown) &&
-    readPanelLauncherConfig(home)?.token === current.token;
+    readPanelLauncherConfig(home)?.token === current.token &&
+    readPanelLauncherConfig(home)?.install_id === current.install_id;
   let launch: TerminalLaunch | null = null;
   let lastLaunchAt = 0;
   let recoveryTimer: NodeJS.Timeout | null = null;
@@ -1372,7 +1401,7 @@ export async function startPanelLauncherBroker(
   const published = writeOwnedPanelLauncherConfig(
     { ...runtimeConfig, port: address.port, pid: process.pid, updated_at: new Date().toISOString() },
     home,
-    current.token,
+    { token: current.token, installId: current.install_id },
   );
   if (!published) {
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -612,36 +612,72 @@ function stopOwnedPanelLauncherBroker(
 
 function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
   const paths = panelLauncherPaths(home);
+  const reclaimPath = `${paths.lock}.reclaim`;
   mkdirSync(paths.root, { recursive: true });
   for (let attempt = 0; attempt < 200; attempt += 1) {
-    let fd: number;
     const lockToken = randomBytes(16).toString("hex");
+    let fd: number | undefined;
+    let reclaimFd: number | undefined;
     try {
       fd = openSync(paths.lock, "wx", 0o600);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      let deadOwner = false;
       try {
         const owner = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
-        const pid = owner.pid;
         if (
-          Number.isInteger(pid) &&
-          Number(pid) > 0 &&
-          Number(pid) <= 0x7fffffff
+          Number.isInteger(owner.pid) &&
+          Number(owner.pid) > 0 &&
+          Number(owner.pid) <= 0x7fffffff
         ) {
           try {
-            process.kill(Number(pid), 0);
+            process.kill(Number(owner.pid), 0);
           } catch (probeError) {
-            if ((probeError as NodeJS.ErrnoException).code === "ESRCH") {
-              rmSync(paths.lock, { force: true });
-            }
+            deadOwner = (probeError as NodeJS.ErrnoException).code === "ESRCH";
           }
         }
       } catch {
-        // The other process may be in the middle of publishing its owner.
-        // Never remove an unreadable lock: failing closed is safer than
-        // overlapping a paused owner.
+        // The other process may be publishing its owner. Fail closed.
       }
-      continue;
+      if (!deadOwner) continue;
+      try {
+        reclaimFd = openSync(reclaimPath, "wx", 0o600);
+        let stillDead = false;
+        try {
+          const current = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
+          if (
+            Number.isInteger(current.pid) &&
+            Number(current.pid) > 0 &&
+            Number(current.pid) <= 0x7fffffff
+          ) {
+            try {
+              process.kill(Number(current.pid), 0);
+            } catch (probeError) {
+              stillDead = (probeError as NodeJS.ErrnoException).code === "ESRCH";
+            }
+          }
+        } catch {
+          // An incomplete or replaced lock is never reclaimed.
+        }
+        if (stillDead) {
+          rmSync(paths.lock, { force: true });
+          try {
+            fd = openSync(paths.lock, "wx", 0o600);
+          } catch {
+            fd = undefined;
+          }
+        }
+      } catch {
+        // Another reclaimer owns the auxiliary lock, or the lock changed.
+      }
+      if (fd === undefined) {
+        if (reclaimFd !== undefined) {
+          closeSync(reclaimFd);
+          reclaimFd = undefined;
+          rmSync(reclaimPath, { force: true });
+        }
+        continue;
+      }
     }
     writeFileSync(paths.lock, JSON.stringify({ pid: process.pid, token: lockToken }), {
       encoding: "utf8",
@@ -657,6 +693,10 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
       } catch {
         // The lock was already removed or became unreadable; do not remove a
         // replacement lock owned by another process.
+      }
+      if (reclaimFd !== undefined) {
+        closeSync(reclaimFd);
+        rmSync(reclaimPath, { force: true });
       }
     }
   }

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -451,17 +451,31 @@ export async function installPanelLauncher(
       }
     }
     if (taskRegistered) {
-      try {
-        run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
-        return { paths, startFallback: null }; // the task is registered AND running it worked
-      } catch {
-        // Registered but not startable right now (non-interactive session). The
-        // autostart is in place for the next logon, so do NOT add a second one —
-        // just get a broker up for THIS session.
-      }
+      return {
+        paths,
+        startFallback: null,
+        // The task may need the launcher lock when its broker starts and
+        // publishes its runtime state. Starting it while install still owns
+        // that lock made the broker exit after its bounded reacquire timeout.
+        startAfterInstall: async () => {
+          if (
+            existsSync(paths.teardown) ||
+            readPanelLauncherConfig(home)?.token !== token ||
+            readPanelLauncherConfig(home)?.install_id !== installId
+          ) return;
+          try {
+            run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
+          } catch {
+            // Registered but not startable right now (non-interactive session).
+            // The autostart is in place for the next logon, so do NOT add a
+            // second one — just get a broker up for THIS session.
+            await startBrokerIfIdle();
+          }
+        },
+      }; // the task is registered AND will be started after the lock is released
     }
     needsFallbackBroker = true;
-    return { paths, startFallback: startBrokerIfIdle };
+    return { paths, startFallback: startBrokerIfIdle, startAfterInstall: null };
   }
 
   if (platform === "darwin") {
@@ -484,8 +498,20 @@ export async function installPanelLauncher(
     } catch {
       // It is normal for the label not to be loaded on first install.
     }
-    run("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 0}`, paths.macPlist], { stdio: "ignore" });
-    return { paths, startFallback: null };
+    return {
+      paths,
+      startFallback: null,
+      // Keep launchctl outside the installer lock. The launched broker must be
+      // able to reacquire that lock before it publishes its runtime config.
+      startAfterInstall: () => {
+        if (
+          existsSync(paths.teardown) ||
+          readPanelLauncherConfig(home)?.token !== token ||
+          readPanelLauncherConfig(home)?.install_id !== installId
+        ) return;
+        run("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 0}`, paths.macPlist], { stdio: "ignore" });
+      },
+    };
   }
 
   mkdirSync(dirname(paths.linuxService), { recursive: true });
@@ -496,12 +522,7 @@ export async function installPanelLauncher(
       `[Install]\nWantedBy=default.target\n`,
     "utf8",
   );
-  try {
-    run("systemctl", ["--user", "daemon-reload"], { stdio: "ignore" });
-    run("systemctl", ["--user", "enable", "--now", "comfyui-mcp-launcher.service"], {
-      stdio: "ignore",
-    });
-  } catch {
+  const writeLinuxAutostart = (): void => {
     mkdirSync(dirname(paths.linuxAutostart), { recursive: true });
     writeFileSync(
       paths.linuxAutostart,
@@ -509,13 +530,54 @@ export async function installPanelLauncher(
         `Exec="${nodePath}" "${paths.broker}" run --broker-id=${brokerId} --install-id=${installId}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
+  };
+  try {
+    run("systemctl", ["--user", "daemon-reload"], { stdio: "ignore" });
+    run("systemctl", ["--user", "enable", "comfyui-mcp-launcher.service"], {
+      stdio: "ignore",
+    });
+  } catch {
+    writeLinuxAutostart();
     needsFallbackBroker = true;
   }
-    return { paths, startFallback: needsFallbackBroker ? startBrokerIfIdle : null };
+  return {
+    paths,
+    startFallback: needsFallbackBroker ? startBrokerIfIdle : null,
+    // `enable --now` used to start the broker while the installer still held
+    // the shared lock. Register under the lock, then start after it is released.
+    startAfterInstall: needsFallbackBroker
+      ? null
+      : async () => {
+          if (
+            existsSync(paths.teardown) ||
+            readPanelLauncherConfig(home)?.token !== token ||
+            readPanelLauncherConfig(home)?.install_id !== installId
+          ) return;
+          try {
+            run("systemctl", ["--user", "start", "comfyui-mcp-launcher.service"], { stdio: "ignore" });
+          } catch {
+            // A registered service that cannot start now still needs a
+            // per-user fallback and a broker for this session. Reacquire the
+            // lock only for the fallback artifact write; the broker itself is
+            // launched after that lock is released.
+            await withPanelLauncherLock(home, () => {
+              if (
+                existsSync(paths.teardown) ||
+                readPanelLauncherConfig(home)?.token !== token ||
+                readPanelLauncherConfig(home)?.install_id !== installId
+              ) return false;
+              writeLinuxAutostart();
+              return true;
+            });
+            await startBrokerIfIdle();
+          }
+        },
+  };
   });
   if (locked === null) {
     throw new Error("Could not acquire the panel launcher lock for install");
   }
+  if (locked.startAfterInstall) await locked.startAfterInstall();
   if (locked.startFallback) await locked.startFallback();
   return locked.paths;
 }

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -30,6 +30,12 @@ export const DEFAULT_PANEL_BRIDGE_PORT = 9199;
 /** Pre-#2030 default. Logitech G HUB (`lghub_agent`) occupies 9180 on many desktops. */
 export const LEGACY_PANEL_BRIDGE_PORT = 9180;
 
+/** The broker must not hand the orchestrator the broker's own login terminal. */
+export const ORCHESTRATOR_RECOVERY_DELAY_MS = 15_000;
+/** A broken install must not turn the login broker into an unbounded spawn loop. */
+export const ORCHESTRATOR_RECOVERY_MAX_ATTEMPTS = 3;
+export const ORCHESTRATOR_RECOVERY_WINDOW_MS = 5 * 60_000;
+
 export type PanelLauncherConfig = {
   protocol: 1;
   host: "127.0.0.1";
@@ -588,9 +594,52 @@ export async function probeAnyPanelOrchestrator(timeoutMs = 1200): Promise<boole
   return probePanelOrchestrator(LEGACY_PANEL_BRIDGE_PORT, timeoutMs);
 }
 
-export type TerminalLaunch = { process?: ChildProcess; pid?: number; platform: NodeJS.Platform };
+export type TerminalLaunch = {
+  process?: ChildProcess;
+  pid?: number;
+  platform: NodeJS.Platform;
+  interactive?: boolean;
+};
 
 export type TerminalCommand = { executable: string; args: string[] };
+
+/**
+ * Command used by the installed broker. Unlike terminalCommandForPlatform(),
+ * this is deliberately a headless child: the broker is the persistent login
+ * companion, so the orchestrator must not inherit a disposable terminal or its
+ * console-death semantics. `cmd /c` is used on Windows because npx is a .cmd
+ * shim and the scheduled-task/Startup environment does not guarantee a shell.
+ */
+export function persistentCommandForPlatform(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): TerminalCommand {
+  if (platform === "win32") {
+    return {
+      executable: env.ComSpec || "cmd.exe",
+      args: ["/d", "/c", "npx.cmd -y comfyui-mcp@latest connect"],
+    };
+  }
+  return {
+    executable: "npx",
+    args: ["-y", "comfyui-mcp@latest", "connect"],
+  };
+}
+
+export function launchPersistentMcp(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  spawnImpl: typeof spawn = spawn,
+): TerminalLaunch {
+  const command = persistentCommandForPlatform(platform, env);
+  const child = spawnImpl(command.executable, command.args, {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: platform === "win32",
+  });
+  child.unref?.();
+  return { process: child, pid: child.pid, platform, interactive: false };
+}
 
 export function terminalCommandForPlatform(
   platform: NodeJS.Platform = process.platform,
@@ -633,11 +682,11 @@ export function launchMcpTerminal(platform: NodeJS.Platform = process.platform):
     windowsHide: false,
   });
   child.unref();
-  return { process: child, pid: child.pid, platform };
+  return { process: child, pid: child.pid, platform, interactive: true };
 }
 
 function minimizeOwnedTerminal(launch: TerminalLaunch | null): boolean {
-  if (!launch?.pid || launch.platform !== "win32") return false;
+  if (!launch?.pid || launch.interactive !== true || launch.platform !== "win32") return false;
   try {
     const script =
       `$p=Get-Process -Id ${launch.pid} -ErrorAction SilentlyContinue;` +
@@ -663,24 +712,103 @@ function jsonResponse(res: import("node:http").ServerResponse, status: number, b
   res.end(data);
 }
 
-export async function startPanelLauncherBroker(home: string = homedir()): Promise<Server> {
+export type PanelLauncherBrokerOptions = {
+  /** Test seams; the installed broker calls this with no options. */
+  spawnImpl?: typeof spawn;
+  probeImpl?: () => Promise<boolean>;
+  now?: () => number;
+  recoveryDelayMs?: number;
+  recoveryMaxAttempts?: number;
+};
+
+export async function startPanelLauncherBroker(
+  home: string = homedir(),
+  options: PanelLauncherBrokerOptions = {},
+): Promise<Server> {
   const current = readPanelLauncherConfig(home);
+  const spawnBroker = options.spawnImpl ?? spawn;
+  const probe = options.probeImpl ?? (() => probeAnyPanelOrchestrator());
+  const now = options.now ?? (() => Date.now());
+  const recoveryDelayMs = options.recoveryDelayMs ?? ORCHESTRATOR_RECOVERY_DELAY_MS;
+  const recoveryMaxAttempts = options.recoveryMaxAttempts ?? ORCHESTRATOR_RECOVERY_MAX_ATTEMPTS;
   if (!current) throw new Error("Panel launcher is not installed or its config is invalid");
   let launch: TerminalLaunch | null = null;
   let lastLaunchAt = 0;
+  let recoveryTimer: NodeJS.Timeout | null = null;
+  let recoveryWindowStarted = 0;
+  let recoveryAttempts = 0;
   let starting: Promise<{ already_running: boolean; started: boolean }> | null = null;
-  const ensureRunning = () => {
+
+  const resetRecoveryBudget = () => {
+    recoveryWindowStarted = 0;
+    recoveryAttempts = 0;
+  };
+
+  const scheduleRecovery = (exitCode: number | null) => {
+    if (recoveryTimer) return;
+    const currentTime = now();
+    if (!recoveryWindowStarted || currentTime - recoveryWindowStarted >= ORCHESTRATOR_RECOVERY_WINDOW_MS) {
+      recoveryWindowStarted = currentTime;
+      recoveryAttempts = 0;
+    }
+    if (recoveryAttempts >= recoveryMaxAttempts) return;
+    // A clean exit is the normal self-update handoff. Give the replacement npx
+    // process time to resolve/install and bind before deciding it needs help.
+    const delay = exitCode === 0 ? recoveryDelayMs : Math.min(recoveryDelayMs, 5_000);
+    recoveryTimer = setTimeout(() => {
+      recoveryTimer = null;
+      if (recoveryAttempts >= recoveryMaxAttempts) return;
+      recoveryAttempts += 1;
+      // The failed child is no longer the launch in progress. This retry is
+      // explicitly allowed through the ordinary launch cooldown.
+      lastLaunchAt = 0;
+      void ensureRunning(true).catch(() => {
+        // The next panel request can retry after the normal cooldown. A broker
+        // must never become an unbounded error/spawn loop on a broken install.
+      });
+    }, delay);
+    recoveryTimer.unref?.();
+  };
+
+  const watchLaunch = (started: TerminalLaunch) => {
+    const child = started.process;
+    if (!child) return;
+    const onExit = (exitCode: number | null) => {
+      if (launch?.process !== child) return;
+      launch = null;
+      scheduleRecovery(exitCode);
+    };
+    child.once("exit", onExit);
+    child.once("error", () => onExit(null));
+  };
+
+  const ensureRunning = (fromRecovery = false) => {
     if (!starting) {
-      starting = probeAnyPanelOrchestrator().then((running) => {
+      starting = probe().then((running) => {
         if (running) {
           lastLaunchAt = 0;
+          if (recoveryTimer) {
+            clearTimeout(recoveryTimer);
+            recoveryTimer = null;
+          }
+          resetRecoveryBudget();
           return { already_running: true, started: false };
         }
-        if (lastLaunchAt && Date.now() - lastLaunchAt < 90_000) {
+        if (!fromRecovery && lastLaunchAt && now() - lastLaunchAt < 90_000) {
           return { already_running: false, started: false, start_in_progress: true };
         }
-        launch = launchMcpTerminal();
-        lastLaunchAt = Date.now();
+        lastLaunchAt = now();
+        try {
+          const started = launchPersistentMcp(process.platform, process.env, spawnBroker);
+          launch = started;
+          watchLaunch(started);
+        } catch (error) {
+          // Treat a spawn refusal like an immediate child failure: surface the
+          // current request's error, but let the bounded supervisor make a few
+          // delayed recovery attempts instead of hot-looping on every panel poll.
+          scheduleRecovery(null);
+          throw error;
+        }
         return { already_running: false, started: true };
       }).finally(() => {
         starting = null;

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -224,6 +224,7 @@ export async function installPanelLauncher(
     const token = previous?.token ?? randomBytes(32).toString("base64url");
     const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
     const brokerExecutable = nodePath;
+    let needsFallbackBroker = false;
 
   /**
    * Start the broker unless the previous one is still alive.
@@ -246,10 +247,12 @@ export async function installPanelLauncher(
     // on a second install — this function's own config write used to drop the
     // pid — so a duplicate broker was spawned beside a live one (merge-gate P1).
     // The port is what the query actually uses; the pid was never evidence.
+    if (existsSync(paths.teardown) || readPanelLauncherConfig(home)?.token !== token) return;
     if (previous?.port) {
       const live = (await queryPanelLauncher(home)) as { running?: boolean };
       if (live.running) return; // a real broker answered — leave it alone
     }
+    if (existsSync(paths.teardown) || readPanelLauncherConfig(home)?.token !== token) return;
     const child = spawnBroker(nodePath, brokerRunArgs(paths.broker, brokerId), {
       detached: true,
       stdio: "ignore",
@@ -267,11 +270,7 @@ export async function installPanelLauncher(
       };
       if (child.pid) next.pid = child.pid;
       else delete next.pid;
-      // The install holds the shared lock for the entire mutation sequence,
-      // including platform registration below; do not attempt to reacquire it.
-      if (!existsSync(paths.teardown) && readPanelLauncherConfig(home)?.token === token) {
-        writePanelLauncherConfig(next, home);
-      }
+      writeOwnedPanelLauncherConfig(next, home, token);
     }
     child.unref?.();
   };
@@ -421,15 +420,15 @@ export async function installPanelLauncher(
     if (taskRegistered) {
       try {
         run("schtasks.exe", ["/Run", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
-        return paths; // the task is registered AND running it worked
+        return { paths, startFallback: null }; // the task is registered AND running it worked
       } catch {
         // Registered but not startable right now (non-interactive session). The
         // autostart is in place for the next logon, so do NOT add a second one —
         // just get a broker up for THIS session.
       }
     }
-    await startBrokerIfIdle();
-    return paths;
+    needsFallbackBroker = true;
+    return { paths, startFallback: startBrokerIfIdle };
   }
 
   if (platform === "darwin") {
@@ -453,7 +452,7 @@ export async function installPanelLauncher(
       // It is normal for the label not to be loaded on first install.
     }
     run("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 0}`, paths.macPlist], { stdio: "ignore" });
-    return paths;
+    return { paths, startFallback: null };
   }
 
   mkdirSync(dirname(paths.linuxService), { recursive: true });
@@ -477,14 +476,15 @@ export async function installPanelLauncher(
         `Exec="${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
-    await startBrokerIfIdle();
+    needsFallbackBroker = true;
   }
-    return paths;
+    return { paths, startFallback: needsFallbackBroker ? startBrokerIfIdle : null };
   });
   if (locked === null) {
     throw new Error("Could not acquire the panel launcher lock for install");
   }
-  return locked;
+  if (locked.startFallback) await locked.startFallback();
+  return locked.paths;
 }
 
 export type UninstallLauncherOptions = Pick<
@@ -1293,24 +1293,31 @@ export async function startPanelLauncherBroker(
         if (!fromRecovery && lastLaunchAt && now() - lastLaunchAt < 90_000) {
           return { already_running: false, started: false, start_in_progress: true };
         }
-        // Keep this as the last synchronous ownership check before spawn. Once
-        // this JS turn calls spawn, uninstall cannot interleave within it.
-        if (!brokerConfigStillOwned()) {
-          return { already_running: false, started: false, disabled: true };
+        // Serialize the final ownership check with spawn. Uninstall cannot
+        // remove the tombstone/config between this check and the OS process
+        // creation, including when a test seam or platform shim re-enters JS.
+        const launched = withPanelLauncherLock(home, () => {
+          if (!brokerConfigStillOwned()) {
+            return { already_running: false, started: false, disabled: true };
+          }
+          lastLaunchAt = now();
+          try {
+            const started = launchPersistentMcp(process.platform, process.env, spawnBroker);
+            launch = started;
+            watchLaunch(started);
+          } catch (error) {
+            // Treat a spawn refusal like an immediate child failure: surface the
+            // current request's error, but let the bounded supervisor make a few
+            // delayed recovery attempts instead of hot-looping on every panel poll.
+            scheduleRecovery(null);
+            throw error;
+          }
+          return { already_running: false, started: true };
+        });
+        if (launched === null) {
+          return { already_running: false, started: false, start_in_progress: true };
         }
-        lastLaunchAt = now();
-        try {
-          const started = launchPersistentMcp(process.platform, process.env, spawnBroker);
-          launch = started;
-          watchLaunch(started);
-        } catch (error) {
-          // Treat a spawn refusal like an immediate child failure: surface the
-          // current request's error, but let the bounded supervisor make a few
-          // delayed recovery attempts instead of hot-looping on every panel poll.
-          scheduleRecovery(null);
-          throw error;
-        }
-        return { already_running: false, started: true };
+        return launched;
       };
       const pending = brokerConfigStillOwned()
         ? probe().then(afterProbe)

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -11,6 +11,7 @@ import {
   closeSync,
   copyFileSync,
   existsSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -214,13 +215,15 @@ export async function installPanelLauncher(
   const run = options.exec ?? execFileSync;
   const spawnBroker = options.spawnImpl ?? spawn;
   const paths = panelLauncherPaths(home, roamingAppData(options));
-  mkdirSync(paths.launcherDir, { recursive: true });
-  copyFileSync(source, paths.broker);
 
-  const previous = readPanelLauncherConfig(home);
-  const token = previous?.token ?? randomBytes(32).toString("base64url");
-  const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
-  const brokerExecutable = nodePath;
+  const locked = await withPanelLauncherLock(home, async () => {
+    mkdirSync(paths.launcherDir, { recursive: true });
+    copyFileSync(source, paths.broker);
+
+    const previous = readPanelLauncherConfig(home);
+    const token = previous?.token ?? randomBytes(32).toString("base64url");
+    const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
+    const brokerExecutable = nodePath;
 
   /**
    * Start the broker unless the previous one is still alive.
@@ -264,11 +267,15 @@ export async function installPanelLauncher(
       };
       if (child.pid) next.pid = child.pid;
       else delete next.pid;
-      writeOwnedPanelLauncherConfig(next, home, token);
+      // The install holds the shared lock for the entire mutation sequence,
+      // including platform registration below; do not attempt to reacquire it.
+      if (!existsSync(paths.teardown) && readPanelLauncherConfig(home)?.token === token) {
+        writePanelLauncherConfig(next, home);
+      }
     }
     child.unref?.();
   };
-  const initialPublished = withPanelLauncherLock(home, () => {
+  const initialPublished = (() => {
     // Reinstall is the explicit operation that adopts this launcher root again.
     // Remove the old uninstall tombstone while holding the same lock used by
     // uninstall, so initial config publication cannot cross that teardown.
@@ -292,7 +299,7 @@ export async function installPanelLauncher(
       home,
     );
     return true;
-  });
+  })();
   if (initialPublished === null) {
     throw new Error("Could not acquire the panel launcher lock for install");
   }
@@ -472,7 +479,12 @@ export async function installPanelLauncher(
     );
     await startBrokerIfIdle();
   }
-  return paths;
+    return paths;
+  });
+  if (locked === null) {
+    throw new Error("Could not acquire the panel launcher lock for install");
+  }
+  return locked;
 }
 
 export type UninstallLauncherOptions = Pick<
@@ -617,97 +629,148 @@ function stopOwnedPanelLauncherBroker(
   }
 }
 
-function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
+type LauncherLockOwner = { pid: number; token: string; started_at?: string };
+
+function launcherProcessStartIdentity(pid: number, platform: NodeJS.Platform): string | null {
+  try {
+    if (platform === "linux") {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const endOfCommand = stat.lastIndexOf(")");
+      const fields = stat.slice(endOfCommand + 2).trim().split(/\s+/);
+      const startTicks = fields[19]; // field 22, after the command and state fields
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+      return startTicks && bootId ? `${bootId}:${startTicks}` : null;
+    }
+    if (platform === "win32") {
+      const script =
+        `$p=Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\";` +
+        `if($p){$p.CreationDate.ToUniversalTime().ToString(\"o\")}`;
+      return String(
+        execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+          encoding: "utf8",
+          timeout: 2_000,
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "ignore"],
+        }),
+      ).trim() || null;
+    }
+    return String(
+      execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+        encoding: "utf8",
+        timeout: 2_000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    ).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+let cachedLauncherProcessStartIdentity: string | null | undefined;
+
+function currentLauncherProcessStartIdentity(): string | null {
+  if (cachedLauncherProcessStartIdentity === undefined) {
+    cachedLauncherProcessStartIdentity = launcherProcessStartIdentity(process.pid, process.platform);
+  }
+  return cachedLauncherProcessStartIdentity;
+}
+
+function readLauncherLockOwner(path: string): LauncherLockOwner | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    if (
+      !Number.isInteger(parsed.pid) ||
+      Number(parsed.pid) <= 0 ||
+      Number(parsed.pid) > 0x7fffffff ||
+      typeof parsed.token !== "string"
+    ) return null;
+    return {
+      pid: Number(parsed.pid),
+      token: parsed.token,
+      ...(typeof parsed.started_at === "string" ? { started_at: parsed.started_at } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function launcherLockOwnerIsDead(path: string): boolean {
+  const owner = readLauncherLockOwner(path);
+  if (!owner) return false;
+  try {
+    process.kill(owner.pid, 0);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ESRCH";
+  }
+  // A live PID is not enough: the original process may have died and the OS
+  // may have recycled that number. If the platform cannot expose a start
+  // identity, fail closed and leave the lock for manual recovery.
+  if (!owner.started_at) return false;
+  const current = launcherProcessStartIdentity(owner.pid, process.platform);
+  return current !== null && current !== owner.started_at;
+}
+
+/**
+ * Publish a complete owner record before making the lock name visible. A
+ * process crash cannot leave an ownerless main/reclaim lock between exclusive
+ * create and metadata publication: the completed temp file is linked into the
+ * well-known name atomically, then held open until release.
+ */
+function tryCreateOwnedLauncherLock(path: string, owner: LauncherLockOwner): number | null {
+  const tempPath = `${path}.${owner.token}.tmp`;
+  let linked = false;
+  try {
+    writeFileSync(tempPath, JSON.stringify(owner), { encoding: "utf8", mode: 0o600 });
+    try {
+      linkSync(tempPath, path);
+      linked = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
+      throw error;
+    }
+    return openSync(path, "r");
+  } catch (error) {
+    if (linked) rmSync(path, { force: true });
+    throw error;
+  } finally {
+    rmSync(tempPath, { force: true });
+  }
+}
+
+function withPanelLauncherLock<T>(home: string, fn: () => T): T | null;
+function withPanelLauncherLock<T>(home: string, fn: () => Promise<T>): Promise<T> | null;
+function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | Promise<T> | null {
   const paths = panelLauncherPaths(home);
   const reclaimPath = `${paths.lock}.reclaim`;
   mkdirSync(paths.root, { recursive: true });
+  const startedAt = currentLauncherProcessStartIdentity();
   for (let attempt = 0; attempt < 200; attempt += 1) {
     const lockToken = randomBytes(16).toString("hex");
+    const owner = { pid: process.pid, token: lockToken, ...(startedAt ? { started_at: startedAt } : {}) };
     let fd: number | undefined;
     let reclaimFd: number | undefined;
     let reclaimToken: string | undefined;
-    try {
-      fd = openSync(paths.lock, "wx", 0o600);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      let deadOwner = false;
-      try {
-        const owner = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
-        if (
-          Number.isInteger(owner.pid) &&
-          Number(owner.pid) > 0 &&
-          Number(owner.pid) <= 0x7fffffff
-        ) {
-          try {
-            process.kill(Number(owner.pid), 0);
-          } catch (probeError) {
-            deadOwner = (probeError as NodeJS.ErrnoException).code === "ESRCH";
-          }
-        }
-      } catch {
-        // The other process may be publishing its owner. Fail closed.
-      }
-      if (!deadOwner) continue;
+    fd = tryCreateOwnedLauncherLock(paths.lock, owner) ?? undefined;
+    if (fd === undefined) {
+      if (!launcherLockOwnerIsDead(paths.lock)) continue;
       try {
         reclaimToken = randomBytes(16).toString("hex");
-        try {
-          reclaimFd = openSync(reclaimPath, "wx", 0o600);
-        } catch (reclaimError) {
-          if ((reclaimError as NodeJS.ErrnoException).code !== "EEXIST") throw reclaimError;
-          let reclaimOwnerDead = false;
-          try {
-            const reclaimOwner = JSON.parse(readFileSync(reclaimPath, "utf8")) as {
-              pid?: unknown;
-            };
-            if (
-              Number.isInteger(reclaimOwner.pid) &&
-              Number(reclaimOwner.pid) > 0 &&
-              Number(reclaimOwner.pid) <= 0x7fffffff
-            ) {
-              try {
-                process.kill(Number(reclaimOwner.pid), 0);
-              } catch (probeError) {
-                reclaimOwnerDead = (probeError as NodeJS.ErrnoException).code === "ESRCH";
-              }
-            }
-          } catch {
-            // An incomplete reclaim lock is never reclaimed.
-          }
-          if (reclaimOwnerDead) rmSync(reclaimPath, { force: true });
+        reclaimFd = tryCreateOwnedLauncherLock(reclaimPath, {
+          pid: process.pid,
+          token: reclaimToken,
+          ...(startedAt ? { started_at: startedAt } : {}),
+        }) ?? undefined;
+        if (reclaimFd === undefined) {
+          if (launcherLockOwnerIsDead(reclaimPath)) rmSync(reclaimPath, { force: true });
         }
         if (reclaimFd === undefined) continue;
         // The auxiliary lock is itself a crash-recoverable owner lock. A
         // process which dies between acquiring it and releasing it must not
         // strand every later stale-main-lock recovery forever.
-        writeFileSync(
-          reclaimPath,
-          JSON.stringify({ pid: process.pid, token: reclaimToken }),
-          { encoding: "utf8", mode: 0o600 },
-        );
-        let stillDead = false;
-        try {
-          const current = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
-          if (
-            Number.isInteger(current.pid) &&
-            Number(current.pid) > 0 &&
-            Number(current.pid) <= 0x7fffffff
-          ) {
-            try {
-              process.kill(Number(current.pid), 0);
-            } catch (probeError) {
-              stillDead = (probeError as NodeJS.ErrnoException).code === "ESRCH";
-            }
-          }
-        } catch {
-          // An incomplete or replaced lock is never reclaimed.
-        }
+        const stillDead = launcherLockOwnerIsDead(paths.lock);
         if (stillDead) {
           rmSync(paths.lock, { force: true });
-          try {
-            fd = openSync(paths.lock, "wx", 0o600);
-          } catch {
-            fd = undefined;
-          }
+          fd = tryCreateOwnedLauncherLock(paths.lock, owner) ?? undefined;
         }
       } catch {
         // Another live reclaimer owns the auxiliary lock, or the lock changed.
@@ -728,14 +791,12 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
         continue;
       }
     }
-    writeFileSync(paths.lock, JSON.stringify({ pid: process.pid, token: lockToken }), {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    try {
-      return fn();
-    } finally {
-      closeSync(fd);
+    const lockFd = fd;
+    let released = false;
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      closeSync(lockFd);
       try {
         const owner = JSON.parse(readFileSync(paths.lock, "utf8")) as { token?: unknown };
         if (owner.token === lockToken) rmSync(paths.lock, { force: true });
@@ -755,6 +816,17 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
           // remove a replacement owned by another reclaimer.
         }
       }
+    };
+    try {
+      const result = fn();
+      if (result && typeof (result as unknown as { then?: unknown }).then === "function") {
+        return Promise.resolve(result as T | PromiseLike<T>).finally(release);
+      }
+      release();
+      return result as T;
+    } catch (error) {
+      release();
+      throw error;
     }
   }
   return null;

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -12,6 +12,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -41,6 +42,10 @@ export type PanelLauncherConfig = {
   host: "127.0.0.1";
   port: number;
   token: string;
+  /** Random command-line marker proving that a recorded pid is our broker. */
+  broker_id?: string;
+  /** Executable recorded when the autostart command was installed. */
+  broker_executable?: string;
   pid?: number;
   updated_at: string;
 };
@@ -49,6 +54,8 @@ export type LauncherPaths = {
   root: string;
   launcherDir: string;
   config: string;
+  /** Persistent uninstall tombstone; prevents an old broker from republishing config. */
+  teardown: string;
   broker: string;
   windowsScript: string;
   /** Windows fallback autostart, for accounts that may not create scheduled
@@ -72,6 +79,7 @@ export function panelLauncherPaths(
     root,
     launcherDir,
     config: join(root, "launcher.json"),
+    teardown: join(root, "launcher.uninstalled"),
     broker: join(launcherDir, "broker.mjs"),
     windowsScript: join(launcherDir, "start-launcher.cmd"),
     windowsStartup: join(
@@ -100,6 +108,8 @@ function isConfig(value: unknown): value is PanelLauncherConfig {
     Number(v.port) <= 65535 &&
     typeof v.token === "string" &&
     v.token.length >= 32 &&
+    (v.broker_id === undefined ||
+      (typeof v.broker_id === "string" && /^[A-Za-z0-9_-]{32,}$/.test(v.broker_id))) &&
     typeof v.updated_at === "string"
   );
 }
@@ -192,10 +202,16 @@ export async function installPanelLauncher(
   const run = options.exec ?? execFileSync;
   const spawnBroker = options.spawnImpl ?? spawn;
   const paths = panelLauncherPaths(home, roamingAppData(options));
+  // Reinstall is the explicit operation that adopts this launcher root again.
+  // Remove the old uninstall tombstone before publishing the new ownership.
+  rmSync(paths.teardown, { force: true });
   mkdirSync(paths.launcherDir, { recursive: true });
   copyFileSync(source, paths.broker);
 
   const previous = readPanelLauncherConfig(home);
+  const token = previous?.token ?? randomBytes(32).toString("base64url");
+  const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
+  const brokerExecutable = nodePath;
 
   /**
    * Start the broker unless the previous one is still alive.
@@ -222,10 +238,25 @@ export async function installPanelLauncher(
       const live = (await queryPanelLauncher(home)) as { running?: boolean };
       if (live.running) return; // a real broker answered — leave it alone
     }
-    const child = spawnBroker(nodePath, [paths.broker, "run"], {
+    const child = spawnBroker(nodePath, brokerRunArgs(paths.broker, brokerId), {
       detached: true,
       stdio: "ignore",
     });
+    const current = readPanelLauncherConfig(home);
+    if (current?.token === token) {
+      // Only persist a PID that this fallback launch actually owns. Keeping a
+      // previous PID when a spawn implementation cannot report one would make
+      // uninstall capable of targeting an unrelated recycled process.
+      const next = {
+        ...current,
+        broker_id: brokerId,
+        broker_executable: brokerExecutable,
+        updated_at: new Date().toISOString(),
+      };
+      if (child.pid) next.pid = child.pid;
+      else delete next.pid;
+      writeOwnedPanelLauncherConfig(next, home, token);
+    }
     child.unref?.();
   };
   writePanelLauncherConfig(
@@ -233,7 +264,9 @@ export async function installPanelLauncher(
       protocol: PANEL_LAUNCHER_PROTOCOL,
       host: "127.0.0.1",
       port: previous?.port ?? 0,
-      token: previous?.token ?? randomBytes(32).toString("base64url"),
+      token,
+      broker_id: brokerId,
+      broker_executable: brokerExecutable,
       // The running broker's pid is the broker's to publish, not this install's
       // to erase. Dropping it made the config say "no broker has ever run here"
       // to every subsequent install (merge-gate P1) — the port and token were
@@ -248,7 +281,7 @@ export async function installPanelLauncher(
   if (platform === "win32") {
     writeFileSync(
       paths.windowsScript,
-      `@echo off\r\n"${nodePath}" "${paths.broker}" run\r\n`,
+      `@echo off\r\n"${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\r\n`,
       "utf8",
     );
     // A scheduled task is the preferred registration, but it is NOT available to
@@ -378,10 +411,10 @@ export async function installPanelLauncher(
     writeFileSync(
       paths.macPlist,
       `<?xml version="1.0" encoding="UTF-8"?>\n` +
-        `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n` +
-        `<plist version="1.0"><dict>\n` +
-        `<key>Label</key><string>${PANEL_LAUNCHER_LABEL}</string>\n` +
-        `<key>ProgramArguments</key><array><string>${xml(nodePath)}</string><string>${xml(paths.broker)}</string><string>run</string></array>\n` +
+      `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n` +
+      `<plist version="1.0"><dict>\n` +
+      `<key>Label</key><string>${PANEL_LAUNCHER_LABEL}</string>\n` +
+      `<key>ProgramArguments</key><array><string>${xml(nodePath)}</string><string>${xml(paths.broker)}</string><string>run</string><string>--broker-id=${xml(brokerId)}</string></array>\n` +
         `<key>RunAtLoad</key><true/><key>KeepAlive</key><true/>\n` +
         `<key>StandardOutPath</key><string>${xml(join(paths.launcherDir, "launcher.log"))}</string>\n` +
         `<key>StandardErrorPath</key><string>${xml(join(paths.launcherDir, "launcher-error.log"))}</string>\n` +
@@ -401,7 +434,7 @@ export async function installPanelLauncher(
   writeFileSync(
     paths.linuxService,
     `[Unit]\nDescription=ComfyUI MCP panel launcher\n\n` +
-      `[Service]\nExecStart="${nodePath}" "${paths.broker}" run\nRestart=on-failure\n\n` +
+      `[Service]\nExecStart="${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\nRestart=on-failure\n\n` +
       `[Install]\nWantedBy=default.target\n`,
     "utf8",
   );
@@ -415,7 +448,7 @@ export async function installPanelLauncher(
     writeFileSync(
       paths.linuxAutostart,
       `[Desktop Entry]\nType=Application\nName=ComfyUI MCP Launcher\n` +
-        `Exec="${nodePath}" "${paths.broker}" run\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
+        `Exec="${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
     await startBrokerIfIdle();
@@ -426,15 +459,174 @@ export async function installPanelLauncher(
 export type UninstallLauncherOptions = Pick<
   InstallLauncherOptions,
   "home" | "platform" | "exec" | "appData"
->;
+> & {
+  /** Test seam for the owned fallback-broker stop. */
+  killImpl?: typeof process.kill;
+  /** Test seam; production reads the target process command line from the OS. */
+  processIdentityImpl?: (pid: number, platform: NodeJS.Platform, run: typeof execFileSync) =>
+    PanelLauncherProcessIdentity | null;
+};
+
+export type PanelLauncherProcessIdentity = {
+  commandLine: string;
+  executable?: string;
+};
+
+function readPanelLauncherProcessIdentity(
+  pid: number,
+  platform: NodeJS.Platform,
+  run: typeof execFileSync,
+): PanelLauncherProcessIdentity | null {
+  try {
+    if (platform === "linux") {
+      const argv = readFileSync(`/proc/${pid}/cmdline`, "utf8")
+        .split("\0")
+        .filter(Boolean);
+      if (argv.length === 0) return null;
+      return {
+        commandLine: argv.join(" "),
+        executable: readlinkSync(`/proc/${pid}/exe`),
+      };
+    }
+    if (platform === "win32") {
+      const script =
+        `$p=Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}';` +
+        `if($p){$p|Select-Object -First 1 ExecutablePath,CommandLine|ConvertTo-Json -Compress}`;
+      const raw = run(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", script],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      );
+      const parsed = JSON.parse(String(raw)) as { CommandLine?: unknown; ExecutablePath?: unknown };
+      if (typeof parsed.CommandLine !== "string" || parsed.CommandLine.length === 0) return null;
+      return {
+        commandLine: parsed.CommandLine,
+        ...(typeof parsed.ExecutablePath === "string" ? { executable: parsed.ExecutablePath } : {}),
+      };
+    }
+    const raw = run(
+      "ps",
+      ["-p", String(pid), "-o", "command="],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const commandLine = String(raw).trim();
+    if (!commandLine) return null;
+    let executable: string | undefined;
+    try {
+      executable = String(
+        run("ps", ["-p", String(pid), "-o", "comm="], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }),
+      ).trim() || undefined;
+    } catch {
+      // The command line is still useful; an unavailable executable field is
+      // handled as a fail-closed limitation by the caller.
+    }
+    return { commandLine, ...(executable ? { executable } : {}) };
+  } catch {
+    // If the platform/permissions do not expose identity, safe cleanup is to
+    // leave the process alone. PID equality is never sufficient evidence.
+    return null;
+  }
+}
+
+function processIdentityOwnsBroker(
+  identity: PanelLauncherProcessIdentity | null,
+  brokerPath: string,
+  brokerId: string | undefined,
+  brokerExecutable: string | undefined,
+): boolean {
+  if (!identity || !brokerId || !identity.commandLine) return false;
+  const normalize = (value: string) => value.replaceAll("\\", "/").toLowerCase();
+  const commandLine = normalize(identity.commandLine);
+  const expectedPath = normalize(brokerPath);
+  // The path and random per-install marker must both be present in the OS
+  // observation. A recycled PID or unrelated process cannot satisfy this by
+  // merely reusing the numeric pid. If the OS returns a shortened/opaque
+  // command line, this deliberately fails closed.
+  if (!commandLine.includes(expectedPath) ||
+    !commandLine.includes(`--broker-id=${brokerId.toLowerCase()}`) ||
+    !/(^|[\s"'])run([\s"']|$)/i.test(identity.commandLine)) {
+    return false;
+  }
+  if (identity.executable && brokerExecutable) {
+    const normalizedBase = (value: string) => basename(value.replaceAll("\\", "/")).toLowerCase();
+    if (normalizedBase(identity.executable) !== normalizedBase(brokerExecutable)) return false;
+  }
+  return true;
+}
+
+function stopOwnedPanelLauncherBroker(
+  platform: NodeJS.Platform,
+  run: typeof execFileSync,
+  killImpl: typeof process.kill,
+  pid: number | undefined,
+  brokerPath: string,
+  brokerId: string | undefined,
+  brokerExecutable: string | undefined,
+  processIdentityImpl: UninstallLauncherOptions["processIdentityImpl"],
+): void {
+  // Never let an in-process test broker (or a future embedded caller) kill its
+  // own process. The installed login broker always has a distinct PID.
+  if (!pid || pid === process.pid) return;
+  const identity = (processIdentityImpl ?? readPanelLauncherProcessIdentity)(pid, platform, run);
+  if (!processIdentityOwnsBroker(identity, brokerPath, brokerId, brokerExecutable)) return;
+  try {
+    if (platform === "win32") {
+      // Stop only the owned broker. Its orchestrator child is independent and
+      // may be serving an already-connected panel; what uninstall must prevent
+      // is the broker's recovery loop bringing that child back.
+      run("taskkill.exe", ["/PID", String(pid), "/F"], { stdio: "ignore" });
+    } else {
+      killImpl(pid, "SIGTERM");
+    }
+  } catch {
+    // The service/task may already have stopped it, or the PID may have exited
+    // between reading the owned config and issuing the stop.
+  }
+}
+
+function writeOwnedPanelLauncherConfig(
+  config: PanelLauncherConfig,
+  home: string,
+  ownerToken: string,
+): boolean {
+  const paths = panelLauncherPaths(home);
+  // The tombstone is written before uninstall removes the config. A broker
+  // which is still publishing after that point must not recreate launcher.json.
+  if (existsSync(paths.teardown)) return false;
+  if (readPanelLauncherConfig(home)?.token !== ownerToken) return false;
+  writePanelLauncherConfig(config, home);
+  return true;
+}
+
+function markPanelLauncherTornDown(home: string): void {
+  const paths = panelLauncherPaths(home);
+  mkdirSync(paths.root, { recursive: true });
+  writeFileSync(paths.teardown, `${new Date().toISOString()}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function brokerRunArgs(broker: string, brokerId: string): string[] {
+  return [broker, "run", `--broker-id=${brokerId}`];
+}
 
 export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): void {
   const home = options.home ?? homedir();
   const platform = options.platform ?? process.platform;
   const run = options.exec ?? execFileSync;
+  const killImpl = options.killImpl ?? process.kill.bind(process);
+  const ownedConfig = readPanelLauncherConfig(home);
+  const ownedBrokerPid = ownedConfig?.pid;
   // Same resolution as install, or uninstall deletes a path the install never
   // wrote and leaves the real autostart in place.
   const paths = panelLauncherPaths(home, roamingAppData(options));
+  // This must precede service-manager teardown and config deletion. A broker
+  // with an in-flight probe can otherwise publish/spawn while uninstall runs.
+  markPanelLauncherTornDown(home);
   if (platform === "win32") {
     try {
       run("schtasks.exe", ["/End", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
@@ -469,7 +661,22 @@ export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): 
     rmSync(paths.linuxService, { force: true });
     rmSync(paths.linuxAutostart, { force: true });
   }
+  // Service-manager teardown does not cover the direct broker started by a
+  // Windows Startup/XDG fallback. Stop the broker after disabling every future
+  // autostart, or its exit watcher can relaunch the orchestrator during remove.
   rmSync(paths.config, { force: true });
+  // Remove ownership first so a recovery callback racing uninstall observes a
+  // disabled install before we stop the recorded fallback process.
+  stopOwnedPanelLauncherBroker(
+    platform,
+    run,
+    killImpl,
+    ownedBrokerPid,
+    paths.broker,
+    ownedConfig?.broker_id,
+    ownedConfig?.broker_executable,
+    options.processIdentityImpl,
+  );
   rmSync(paths.launcherDir, { force: true, recursive: true });
 }
 
@@ -719,6 +926,8 @@ export type PanelLauncherBrokerOptions = {
   now?: () => number;
   recoveryDelayMs?: number;
   recoveryMaxAttempts?: number;
+  /** Deterministic seam for uninstall racing the initial config publication. */
+  beforeConfigWrite?: () => void;
 };
 
 export async function startPanelLauncherBroker(
@@ -732,31 +941,55 @@ export async function startPanelLauncherBroker(
   const recoveryDelayMs = options.recoveryDelayMs ?? ORCHESTRATOR_RECOVERY_DELAY_MS;
   const recoveryMaxAttempts = options.recoveryMaxAttempts ?? ORCHESTRATOR_RECOVERY_MAX_ATTEMPTS;
   if (!current) throw new Error("Panel launcher is not installed or its config is invalid");
+  // Older installs may not have a marker yet. Persist one as part of this
+  // broker's runtime publication so future uninstall can fail closed.
+  const brokerId = current.broker_id ?? randomBytes(24).toString("base64url");
+  const runtimeConfig = { ...current, broker_id: brokerId };
+  const brokerConfigStillOwned = () =>
+    !existsSync(panelLauncherPaths(home).teardown) &&
+    readPanelLauncherConfig(home)?.token === current.token;
   let launch: TerminalLaunch | null = null;
   let lastLaunchAt = 0;
   let recoveryTimer: NodeJS.Timeout | null = null;
-  let recoveryWindowStarted = 0;
+  let recoveryWindowStarted: number | null = null;
   let recoveryAttempts = 0;
-  let starting: Promise<{ already_running: boolean; started: boolean }> | null = null;
+  let starting: Promise<{
+    already_running: boolean;
+    started: boolean;
+    recovery_exhausted?: boolean;
+    start_in_progress?: boolean;
+    disabled?: boolean;
+  }> | null = null;
 
   const resetRecoveryBudget = () => {
-    recoveryWindowStarted = 0;
+    recoveryWindowStarted = null;
     recoveryAttempts = 0;
   };
 
+  const recoveryExhausted = (): boolean => {
+    if (recoveryWindowStarted === null) return false;
+    if (now() - recoveryWindowStarted >= ORCHESTRATOR_RECOVERY_WINDOW_MS) {
+      resetRecoveryBudget();
+      return false;
+    }
+    return recoveryAttempts >= recoveryMaxAttempts;
+  };
+
   const scheduleRecovery = (exitCode: number | null) => {
+    if (!brokerConfigStillOwned()) return;
     if (recoveryTimer) return;
     const currentTime = now();
-    if (!recoveryWindowStarted || currentTime - recoveryWindowStarted >= ORCHESTRATOR_RECOVERY_WINDOW_MS) {
+    if (recoveryWindowStarted === null || currentTime - recoveryWindowStarted >= ORCHESTRATOR_RECOVERY_WINDOW_MS) {
       recoveryWindowStarted = currentTime;
       recoveryAttempts = 0;
     }
-    if (recoveryAttempts >= recoveryMaxAttempts) return;
+    if (recoveryExhausted()) return;
     // A clean exit is the normal self-update handoff. Give the replacement npx
     // process time to resolve/install and bind before deciding it needs help.
     const delay = exitCode === 0 ? recoveryDelayMs : Math.min(recoveryDelayMs, 5_000);
     recoveryTimer = setTimeout(() => {
       recoveryTimer = null;
+      if (!brokerConfigStillOwned()) return;
       if (recoveryAttempts >= recoveryMaxAttempts) return;
       recoveryAttempts += 1;
       // The failed child is no longer the launch in progress. This retry is
@@ -784,7 +1017,12 @@ export async function startPanelLauncherBroker(
 
   const ensureRunning = (fromRecovery = false) => {
     if (!starting) {
-      starting = probe().then((running) => {
+      const afterProbe = (running: boolean) => {
+        // The probe is asynchronous. Uninstall may have removed ownership while
+        // it was in flight; no result from that probe may publish or launch.
+        if (!brokerConfigStillOwned()) {
+          return { already_running: false, started: false, disabled: true };
+        }
         if (running) {
           lastLaunchAt = 0;
           if (recoveryTimer) {
@@ -794,8 +1032,19 @@ export async function startPanelLauncherBroker(
           resetRecoveryBudget();
           return { already_running: true, started: false };
         }
+        // Panel polls are also recovery requests. Once the bounded supervisor
+        // has used its budget, do not let a request after the normal launch
+        // cooldown turn the same broken install into an unbounded spawn loop.
+        if (!fromRecovery && recoveryExhausted()) {
+          return { already_running: false, started: false, recovery_exhausted: true };
+        }
         if (!fromRecovery && lastLaunchAt && now() - lastLaunchAt < 90_000) {
           return { already_running: false, started: false, start_in_progress: true };
+        }
+        // Keep this as the last synchronous ownership check before spawn. Once
+        // this JS turn calls spawn, uninstall cannot interleave within it.
+        if (!brokerConfigStillOwned()) {
+          return { already_running: false, started: false, disabled: true };
         }
         lastLaunchAt = now();
         try {
@@ -810,7 +1059,11 @@ export async function startPanelLauncherBroker(
           throw error;
         }
         return { already_running: false, started: true };
-      }).finally(() => {
+      };
+      const pending = brokerConfigStillOwned()
+        ? probe().then(afterProbe)
+        : Promise.resolve({ already_running: false, started: false, disabled: true });
+      starting = pending.finally(() => {
         starting = null;
       });
     }
@@ -852,10 +1105,20 @@ export async function startPanelLauncherBroker(
   });
   const address = server.address();
   if (!address || typeof address === "string") throw new Error("Launcher failed to bind loopback");
-  writePanelLauncherConfig(
-    { ...current, port: address.port, pid: process.pid, updated_at: new Date().toISOString() },
+  options.beforeConfigWrite?.();
+  if (!brokerConfigStillOwned()) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("Panel launcher was uninstalled while the broker was starting");
+  }
+  const published = writeOwnedPanelLauncherConfig(
+    { ...runtimeConfig, port: address.port, pid: process.pid, updated_at: new Date().toISOString() },
     home,
+    current.token,
   );
+  if (!published) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("Panel launcher ownership changed before broker publication");
+  }
   return server;
 }
 

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -274,7 +274,7 @@ export async function installPanelLauncher(
       readPanelLauncherConfig(home)?.token !== token ||
       readPanelLauncherConfig(home)?.install_id !== installId
     ) return;
-    const child = spawnBroker(nodePath, brokerRunArgs(paths.broker, brokerId), {
+    const child = spawnBroker(nodePath, brokerRunArgs(paths.broker, brokerId, installId), {
       detached: true,
       stdio: "ignore",
     });
@@ -328,7 +328,7 @@ export async function installPanelLauncher(
   if (platform === "win32") {
     writeFileSync(
       paths.windowsScript,
-      `@echo off\r\n"${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\r\n`,
+      `@echo off\r\n"${nodePath}" "${paths.broker}" run --broker-id=${brokerId} --install-id=${installId}\r\n`,
       "utf8",
     );
     // A scheduled task is the preferred registration, but it is NOT available to
@@ -461,7 +461,7 @@ export async function installPanelLauncher(
       `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n` +
       `<plist version="1.0"><dict>\n` +
       `<key>Label</key><string>${PANEL_LAUNCHER_LABEL}</string>\n` +
-      `<key>ProgramArguments</key><array><string>${xml(nodePath)}</string><string>${xml(paths.broker)}</string><string>run</string><string>--broker-id=${xml(brokerId)}</string></array>\n` +
+      `<key>ProgramArguments</key><array><string>${xml(nodePath)}</string><string>${xml(paths.broker)}</string><string>run</string><string>--broker-id=${xml(brokerId)}</string><string>--install-id=${xml(installId)}</string></array>\n` +
         `<key>RunAtLoad</key><true/><key>KeepAlive</key><true/>\n` +
         `<key>StandardOutPath</key><string>${xml(join(paths.launcherDir, "launcher.log"))}</string>\n` +
         `<key>StandardErrorPath</key><string>${xml(join(paths.launcherDir, "launcher-error.log"))}</string>\n` +
@@ -481,7 +481,7 @@ export async function installPanelLauncher(
   writeFileSync(
     paths.linuxService,
     `[Unit]\nDescription=ComfyUI MCP panel launcher\n\n` +
-      `[Service]\nExecStart="${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\nRestart=on-failure\n\n` +
+      `[Service]\nExecStart="${nodePath}" "${paths.broker}" run --broker-id=${brokerId} --install-id=${installId}\nRestart=on-failure\n\n` +
       `[Install]\nWantedBy=default.target\n`,
     "utf8",
   );
@@ -495,7 +495,7 @@ export async function installPanelLauncher(
     writeFileSync(
       paths.linuxAutostart,
       `[Desktop Entry]\nType=Application\nName=ComfyUI MCP Launcher\n` +
-        `Exec="${nodePath}" "${paths.broker}" run --broker-id=${brokerId}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
+        `Exec="${nodePath}" "${paths.broker}" run --broker-id=${brokerId} --install-id=${installId}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n`,
       "utf8",
     );
     needsFallbackBroker = true;
@@ -894,8 +894,8 @@ function markPanelLauncherTornDown(home: string): void {
   });
 }
 
-function brokerRunArgs(broker: string, brokerId: string): string[] {
-  return [broker, "run", `--broker-id=${brokerId}`];
+function brokerRunArgs(broker: string, brokerId: string, installId?: string): string[] {
+  return [broker, "run", `--broker-id=${brokerId}`, ...(installId ? [`--install-id=${installId}`] : [])];
 }
 
 export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): void {
@@ -1217,6 +1217,9 @@ export type PanelLauncherBrokerOptions = {
   recoveryMaxAttempts?: number;
   /** Deterministic seam for uninstall racing the initial config publication. */
   beforeConfigWrite?: () => void;
+  /** Identity supplied by the installed command line; absent for in-process tests/legacy launchers. */
+  expectedBrokerId?: string;
+  expectedInstallId?: string;
 };
 
 export async function startPanelLauncherBroker(
@@ -1233,6 +1236,12 @@ export async function startPanelLauncherBroker(
   // Older installs may not have a marker yet. Persist one as part of this
   // broker's runtime publication so future uninstall can fail closed.
   const brokerId = current.broker_id ?? randomBytes(24).toString("base64url");
+  if (options.expectedBrokerId !== undefined && brokerId !== options.expectedBrokerId) {
+    throw new Error("Panel launcher broker identity changed before startup");
+  }
+  if (options.expectedInstallId !== undefined && current.install_id !== options.expectedInstallId) {
+    throw new Error("Panel launcher install generation changed before startup");
+  }
   const runtimeConfig = { ...current, broker_id: brokerId };
   const brokerConfigStillOwned = () => {
     if (existsSync(panelLauncherPaths(home).teardown)) return false;
@@ -1473,7 +1482,12 @@ export async function queryPanelLauncher(home: string = homedir()): Promise<Reco
 // is imported by index.ts and therefore does not enter this branch.
 const invokedPath = process.argv[1] ? basename(process.argv[1]) : "";
 if (invokedPath === "broker.mjs" && process.argv[2] === "run") {
-  startPanelLauncherBroker().catch((error) => {
+  const brokerArg = process.argv.slice(3).find((arg) => arg.startsWith("--broker-id="));
+  const installArg = process.argv.slice(3).find((arg) => arg.startsWith("--install-id="));
+  startPanelLauncherBroker(undefined, {
+    expectedBrokerId: brokerArg?.slice("--broker-id=".length),
+    expectedInstallId: installArg?.slice("--install-id=".length),
+  }).catch((error) => {
     process.stderr.write(`ComfyUI MCP launcher failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   });

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -271,8 +271,14 @@ export async function installPanelLauncher(
       readPanelLauncherConfig(home)?.install_id !== installId
     ) return;
     if (previous?.port) {
-      const live = (await queryPanelLauncher(home)) as { running?: boolean };
-      if (live.running) return; // a real broker answered — leave it alone
+      const live = (await queryPanelLauncher(home)) as {
+        running?: boolean;
+        broker_id?: unknown;
+        install_id?: unknown;
+      };
+      if (live.running && live.broker_id === brokerId && live.install_id === installId) {
+        return; // the answering broker owns this exact generation
+      }
     }
     if (
       existsSync(paths.teardown) ||
@@ -878,12 +884,13 @@ function writeOwnedPanelLauncherConfig(
     // which is still publishing after that point must not recreate launcher.json.
     if (existsSync(paths.teardown)) return false;
     const current = readPanelLauncherConfig(home);
-    const sameGeneration = current?.install_id === ownership.installId;
+    const sameGeneration = ownership.installId !== undefined
+      ? current?.install_id === ownership.installId
+      : ownership.brokerId === undefined && current?.install_id === undefined;
     const legacyRuntimeMigration =
       ownership.installId === undefined &&
       ownership.brokerId !== undefined &&
-      current?.install_id !== undefined &&
-      current.broker_id === ownership.brokerId;
+      current?.broker_id === ownership.brokerId;
     if (current?.token !== ownership.token || (!sameGeneration && !legacyRuntimeMigration)) return false;
     writePanelLauncherConfig(config, home);
     return true;
@@ -1400,9 +1407,13 @@ export async function startPanelLauncherBroker(
       return;
     }
     if (req.method === "GET" && req.url === "/v1/status") {
+      const latest = readPanelLauncherConfig(home);
+      const effectiveInstallId = brokerConfigStillOwned() ? latest?.install_id : current.install_id;
       jsonResponse(res, 200, {
         ok: true,
         protocol: PANEL_LAUNCHER_PROTOCOL,
+        broker_id: brokerId,
+        ...(effectiveInstallId ? { install_id: effectiveInstallId } : {}),
         orchestrator_running: await probeAnyPanelOrchestrator(),
       });
       return;

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -236,7 +236,12 @@ export async function installPanelLauncher(
       ? previous.install_id
       : randomBytes(24).toString("base64url");
     const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
-    const brokerExecutable = nodePath;
+    // Keep the executable evidence paired with a live recorded PID. The
+    // service scripts may adopt the new node path for a future restart, but
+    // uninstall must still identify the currently answering old broker.
+    const brokerExecutable = previousLive.running && previous?.broker_executable
+      ? previous.broker_executable
+      : nodePath;
     let needsFallbackBroker = false;
 
   /**
@@ -1220,6 +1225,8 @@ export type PanelLauncherBrokerOptions = {
   /** Identity supplied by the installed command line; absent for in-process tests/legacy launchers. */
   expectedBrokerId?: string;
   expectedInstallId?: string;
+  /** The installed broker entrypoint requires its command-line identity. */
+  enforceCommandIdentity?: boolean;
 };
 
 export async function startPanelLauncherBroker(
@@ -1236,8 +1243,14 @@ export async function startPanelLauncherBroker(
   // Older installs may not have a marker yet. Persist one as part of this
   // broker's runtime publication so future uninstall can fail closed.
   const brokerId = current.broker_id ?? randomBytes(24).toString("base64url");
+  if (options.enforceCommandIdentity && !options.expectedBrokerId) {
+    throw new Error("Panel launcher broker identity is missing from startup command");
+  }
   if (options.expectedBrokerId !== undefined && brokerId !== options.expectedBrokerId) {
     throw new Error("Panel launcher broker identity changed before startup");
+  }
+  if (options.enforceCommandIdentity && current.install_id !== undefined && !options.expectedInstallId) {
+    throw new Error("Panel launcher install generation is missing from startup command");
   }
   if (options.expectedInstallId !== undefined && current.install_id !== options.expectedInstallId) {
     throw new Error("Panel launcher install generation changed before startup");
@@ -1423,6 +1436,7 @@ export async function startPanelLauncherBroker(
     {
       ...(readPanelLauncherConfig(home) ?? runtimeConfig),
       broker_id: brokerId,
+      broker_executable: process.execPath,
       port: address.port,
       pid: process.pid,
       updated_at: new Date().toISOString(),
@@ -1487,6 +1501,7 @@ if (invokedPath === "broker.mjs" && process.argv[2] === "run") {
   startPanelLauncherBroker(undefined, {
     expectedBrokerId: brokerArg?.slice("--broker-id=".length),
     expectedInstallId: installArg?.slice("--install-id=".length),
+    enforceCommandIdentity: true,
   }).catch((error) => {
     process.stderr.write(`ComfyUI MCP launcher failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -226,12 +226,13 @@ export async function installPanelLauncher(
 
     const previous = readPanelLauncherConfig(home);
     const token = previous?.token ?? randomBytes(32).toString("base64url");
-    // Preserve the generation of a live broker so reinstall does not disable
-    // the process that already owns the answering port. A port-0/unfinished
-    // install gets a new generation, which invalidates its delayed fallback.
-    const installId = previous?.port && previous.install_id
-      ? previous.install_id
-      : randomBytes(24).toString("base64url");
+    const previousLive = previous?.port
+      ? (await queryPanelLauncher(home) as { running?: boolean })
+      : { running: false };
+    // Preserve the generation only for a broker that positively answers the
+    // recorded port. A stale nonzero port and a port-0/unfinished install get a
+    // new generation, invalidating any delayed fallback from that install.
+    const installId = previousLive.running ? previous?.install_id : randomBytes(24).toString("base64url");
     const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
     const brokerExecutable = nodePath;
     let needsFallbackBroker = false;
@@ -303,7 +304,7 @@ export async function installPanelLauncher(
         host: "127.0.0.1",
         port: previous?.port ?? 0,
         token,
-        install_id: installId,
+        ...(installId ? { install_id: installId } : {}),
         broker_id: brokerId,
         broker_executable: brokerExecutable,
         // The running broker's pid is the broker's to publish, not this install's

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -16,7 +16,6 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
@@ -39,7 +38,6 @@ export const ORCHESTRATOR_RECOVERY_DELAY_MS = 15_000;
 /** A broken install must not turn the login broker into an unbounded spawn loop. */
 export const ORCHESTRATOR_RECOVERY_MAX_ATTEMPTS = 3;
 export const ORCHESTRATOR_RECOVERY_WINDOW_MS = 5 * 60_000;
-const PANEL_LAUNCHER_LOCK_STALE_MS = 5 * 60_000;
 
 export type PanelLauncherConfig = {
   protocol: 1;
@@ -548,22 +546,38 @@ function processIdentityOwnsBroker(
   platform: NodeJS.Platform,
 ): boolean {
   if (!identity || !brokerId || !brokerExecutable || !identity.commandLine || !identity.executable) return false;
-  const normalize = (value: string) => {
+  const normalizePath = (value: string) => {
     const path = value.replaceAll("\\", "/");
     return platform === "win32" ? path.toLowerCase() : path;
   };
-  const commandLine = normalize(identity.commandLine);
-  const expectedPath = normalize(brokerPath);
+  const hasToken = (commandLine: string, token: string, caseInsensitive: boolean): boolean => {
+    const normalizedLine = commandLine.replaceAll("\\", "/");
+    const haystack = caseInsensitive ? normalizedLine.toLowerCase() : normalizedLine;
+    const needle = caseInsensitive ? token.toLowerCase() : token;
+    let offset = 0;
+    while (true) {
+      const index = haystack.indexOf(needle, offset);
+      if (index < 0) return false;
+      const before = index === 0 ? "" : haystack[index - 1];
+      const afterIndex = index + needle.length;
+      const after = afterIndex >= haystack.length ? "" : haystack[afterIndex];
+      if ((before === "" || /[\s"']/.test(before)) && (after === "" || /[\s"']/.test(after))) {
+        return true;
+      }
+      offset = afterIndex;
+    }
+  };
+  const commandLine = identity.commandLine;
   // The path and random per-install marker must both be present in the OS
   // observation. A recycled PID or unrelated process cannot satisfy this by
   // merely reusing the numeric pid. If the OS returns a shortened/opaque
   // command line, this deliberately fails closed.
-  if (!commandLine.includes(expectedPath) ||
-    !commandLine.includes(`--broker-id=${normalize(brokerId)}`) ||
-    !/(^|[\s"'])run([\s"']|$)/i.test(identity.commandLine)) {
+  if (!hasToken(commandLine, normalizePath(brokerPath), platform === "win32") ||
+    !hasToken(commandLine, `--broker-id=${brokerId}`, false) ||
+    !hasToken(commandLine, "run", true)) {
     return false;
   }
-  return normalize(identity.executable) === normalize(brokerExecutable);
+  return normalizePath(identity.executable) === normalizePath(brokerExecutable);
 }
 
 function stopOwnedPanelLauncherBroker(
@@ -601,24 +615,49 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
   mkdirSync(paths.root, { recursive: true });
   for (let attempt = 0; attempt < 200; attempt += 1) {
     let fd: number;
+    const lockToken = randomBytes(16).toString("hex");
     try {
       fd = openSync(paths.lock, "wx", 0o600);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       try {
-        if (Date.now() - statSync(paths.lock).mtimeMs > PANEL_LAUNCHER_LOCK_STALE_MS) {
-          rmSync(paths.lock, { force: true });
+        const owner = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
+        const pid = owner.pid;
+        if (
+          Number.isInteger(pid) &&
+          Number(pid) > 0 &&
+          Number(pid) <= 0x7fffffff
+        ) {
+          try {
+            process.kill(Number(pid), 0);
+          } catch (probeError) {
+            if ((probeError as NodeJS.ErrnoException).code === "ESRCH") {
+              rmSync(paths.lock, { force: true });
+            }
+          }
         }
       } catch {
-        // The other process may be in the middle of releasing the lock.
+        // The other process may be in the middle of publishing its owner.
+        // Never remove an unreadable lock: failing closed is safer than
+        // overlapping a paused owner.
       }
       continue;
     }
+    writeFileSync(paths.lock, JSON.stringify({ pid: process.pid, token: lockToken }), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
     try {
       return fn();
     } finally {
       closeSync(fd);
-      rmSync(paths.lock, { force: true });
+      try {
+        const owner = JSON.parse(readFileSync(paths.lock, "utf8")) as { token?: unknown };
+        if (owner.token === lockToken) rmSync(paths.lock, { force: true });
+      } catch {
+        // The lock was already removed or became unreadable; do not remove a
+        // replacement lock owned by another process.
+      }
     }
   }
   return null;

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -214,9 +214,6 @@ export async function installPanelLauncher(
   const run = options.exec ?? execFileSync;
   const spawnBroker = options.spawnImpl ?? spawn;
   const paths = panelLauncherPaths(home, roamingAppData(options));
-  // Reinstall is the explicit operation that adopts this launcher root again.
-  // Remove the old uninstall tombstone before publishing the new ownership.
-  rmSync(paths.teardown, { force: true });
   mkdirSync(paths.launcherDir, { recursive: true });
   copyFileSync(source, paths.broker);
 
@@ -271,24 +268,34 @@ export async function installPanelLauncher(
     }
     child.unref?.();
   };
-  writePanelLauncherConfig(
-    {
-      protocol: PANEL_LAUNCHER_PROTOCOL,
-      host: "127.0.0.1",
-      port: previous?.port ?? 0,
-      token,
-      broker_id: brokerId,
-      broker_executable: brokerExecutable,
-      // The running broker's pid is the broker's to publish, not this install's
-      // to erase. Dropping it made the config say "no broker has ever run here"
-      // to every subsequent install (merge-gate P1) — the port and token were
-      // carried over but the pid was not, which is an incoherent record of the
-      // same broker.
-      ...(previous?.pid ? { pid: previous.pid } : {}),
-      updated_at: new Date().toISOString(),
-    },
-    home,
-  );
+  const initialPublished = withPanelLauncherLock(home, () => {
+    // Reinstall is the explicit operation that adopts this launcher root again.
+    // Remove the old uninstall tombstone while holding the same lock used by
+    // uninstall, so initial config publication cannot cross that teardown.
+    rmSync(paths.teardown, { force: true });
+    writePanelLauncherConfig(
+      {
+        protocol: PANEL_LAUNCHER_PROTOCOL,
+        host: "127.0.0.1",
+        port: previous?.port ?? 0,
+        token,
+        broker_id: brokerId,
+        broker_executable: brokerExecutable,
+        // The running broker's pid is the broker's to publish, not this install's
+        // to erase. Dropping it made the config say "no broker has ever run here"
+        // to every subsequent install (merge-gate P1) — the port and token were
+        // carried over but the pid was not, which is an incoherent record of the
+        // same broker.
+        ...(previous?.pid ? { pid: previous.pid } : {}),
+        updated_at: new Date().toISOString(),
+      },
+      home,
+    );
+    return true;
+  });
+  if (initialPublished === null) {
+    throw new Error("Could not acquire the panel launcher lock for install");
+  }
 
   if (platform === "win32") {
     writeFileSync(
@@ -618,6 +625,7 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
     const lockToken = randomBytes(16).toString("hex");
     let fd: number | undefined;
     let reclaimFd: number | undefined;
+    let reclaimToken: string | undefined;
     try {
       fd = openSync(paths.lock, "wx", 0o600);
     } catch (error) {
@@ -641,7 +649,41 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
       }
       if (!deadOwner) continue;
       try {
-        reclaimFd = openSync(reclaimPath, "wx", 0o600);
+        reclaimToken = randomBytes(16).toString("hex");
+        try {
+          reclaimFd = openSync(reclaimPath, "wx", 0o600);
+        } catch (reclaimError) {
+          if ((reclaimError as NodeJS.ErrnoException).code !== "EEXIST") throw reclaimError;
+          let reclaimOwnerDead = false;
+          try {
+            const reclaimOwner = JSON.parse(readFileSync(reclaimPath, "utf8")) as {
+              pid?: unknown;
+            };
+            if (
+              Number.isInteger(reclaimOwner.pid) &&
+              Number(reclaimOwner.pid) > 0 &&
+              Number(reclaimOwner.pid) <= 0x7fffffff
+            ) {
+              try {
+                process.kill(Number(reclaimOwner.pid), 0);
+              } catch (probeError) {
+                reclaimOwnerDead = (probeError as NodeJS.ErrnoException).code === "ESRCH";
+              }
+            }
+          } catch {
+            // An incomplete reclaim lock is never reclaimed.
+          }
+          if (reclaimOwnerDead) rmSync(reclaimPath, { force: true });
+        }
+        if (reclaimFd === undefined) continue;
+        // The auxiliary lock is itself a crash-recoverable owner lock. A
+        // process which dies between acquiring it and releasing it must not
+        // strand every later stale-main-lock recovery forever.
+        writeFileSync(
+          reclaimPath,
+          JSON.stringify({ pid: process.pid, token: reclaimToken }),
+          { encoding: "utf8", mode: 0o600 },
+        );
         let stillDead = false;
         try {
           const current = JSON.parse(readFileSync(paths.lock, "utf8")) as { pid?: unknown };
@@ -668,13 +710,20 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
           }
         }
       } catch {
-        // Another reclaimer owns the auxiliary lock, or the lock changed.
+        // Another live reclaimer owns the auxiliary lock, or the lock changed.
       }
       if (fd === undefined) {
         if (reclaimFd !== undefined) {
           closeSync(reclaimFd);
           reclaimFd = undefined;
-          rmSync(reclaimPath, { force: true });
+          try {
+            const owner = JSON.parse(readFileSync(reclaimPath, "utf8")) as {
+              token?: unknown;
+            };
+            if (owner.token === reclaimToken) rmSync(reclaimPath, { force: true });
+          } catch {
+            // The reclaim lock was already removed or became unreadable.
+          }
         }
         continue;
       }
@@ -696,7 +745,15 @@ function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
       }
       if (reclaimFd !== undefined) {
         closeSync(reclaimFd);
-        rmSync(reclaimPath, { force: true });
+        try {
+          const owner = JSON.parse(readFileSync(reclaimPath, "utf8")) as {
+            token?: unknown;
+          };
+          if (owner.token === reclaimToken) rmSync(reclaimPath, { force: true });
+        } catch {
+          // The reclaim lock was already removed or became unreadable; do not
+          // remove a replacement owned by another reclaimer.
+        }
       }
     }
   }

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -232,7 +232,9 @@ export async function installPanelLauncher(
     // Preserve the generation only for a broker that positively answers the
     // recorded port. A stale nonzero port and a port-0/unfinished install get a
     // new generation, invalidating any delayed fallback from that install.
-    const installId = previousLive.running ? previous?.install_id : randomBytes(24).toString("base64url");
+    const installId = previousLive.running && previous?.install_id
+      ? previous.install_id
+      : randomBytes(24).toString("base64url");
     const brokerId = previous?.broker_id ?? randomBytes(24).toString("base64url");
     const brokerExecutable = nodePath;
     let needsFallbackBroker = false;
@@ -863,7 +865,7 @@ function withPanelLauncherLock<T>(home: string, fn: () => T | Promise<T>): T | P
 function writeOwnedPanelLauncherConfig(
   config: PanelLauncherConfig,
   home: string,
-  ownership: { token: string; installId?: string },
+  ownership: { token: string; installId?: string; brokerId?: string },
 ): boolean {
   return withPanelLauncherLock(home, () => {
     const paths = panelLauncherPaths(home);
@@ -871,7 +873,13 @@ function writeOwnedPanelLauncherConfig(
     // which is still publishing after that point must not recreate launcher.json.
     if (existsSync(paths.teardown)) return false;
     const current = readPanelLauncherConfig(home);
-    if (current?.token !== ownership.token || current.install_id !== ownership.installId) return false;
+    const sameGeneration = current?.install_id === ownership.installId;
+    const legacyRuntimeMigration =
+      ownership.installId === undefined &&
+      ownership.brokerId !== undefined &&
+      current?.install_id !== undefined &&
+      current.broker_id === ownership.brokerId;
+    if (current?.token !== ownership.token || (!sameGeneration && !legacyRuntimeMigration)) return false;
     writePanelLauncherConfig(config, home);
     return true;
   }) ?? false;
@@ -1226,10 +1234,13 @@ export async function startPanelLauncherBroker(
   // broker's runtime publication so future uninstall can fail closed.
   const brokerId = current.broker_id ?? randomBytes(24).toString("base64url");
   const runtimeConfig = { ...current, broker_id: brokerId };
-  const brokerConfigStillOwned = () =>
-    !existsSync(panelLauncherPaths(home).teardown) &&
-    readPanelLauncherConfig(home)?.token === current.token &&
-    readPanelLauncherConfig(home)?.install_id === current.install_id;
+  const brokerConfigStillOwned = () => {
+    if (existsSync(panelLauncherPaths(home).teardown)) return false;
+    const latest = readPanelLauncherConfig(home);
+    if (latest?.token !== current.token) return false;
+    return latest.install_id === current.install_id ||
+      (current.install_id === undefined && latest.install_id !== undefined && latest.broker_id === brokerId);
+  };
   let launch: TerminalLaunch | null = null;
   let lastLaunchAt = 0;
   let recoveryTimer: NodeJS.Timeout | null = null;
@@ -1400,9 +1411,15 @@ export async function startPanelLauncherBroker(
     throw new Error("Panel launcher was uninstalled while the broker was starting");
   }
   const published = writeOwnedPanelLauncherConfig(
-    { ...runtimeConfig, port: address.port, pid: process.pid, updated_at: new Date().toISOString() },
+    {
+      ...(readPanelLauncherConfig(home) ?? runtimeConfig),
+      broker_id: brokerId,
+      port: address.port,
+      pid: process.pid,
+      updated_at: new Date().toISOString(),
+    },
     home,
-    { token: current.token, installId: current.install_id },
+    { token: current.token, installId: current.install_id, brokerId },
   );
   if (!published) {
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/src/services/panel-launcher.ts
+++ b/src/services/panel-launcher.ts
@@ -8,12 +8,15 @@
  */
 import {
   chmodSync,
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   readlinkSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
@@ -36,6 +39,7 @@ export const ORCHESTRATOR_RECOVERY_DELAY_MS = 15_000;
 /** A broken install must not turn the login broker into an unbounded spawn loop. */
 export const ORCHESTRATOR_RECOVERY_MAX_ATTEMPTS = 3;
 export const ORCHESTRATOR_RECOVERY_WINDOW_MS = 5 * 60_000;
+const PANEL_LAUNCHER_LOCK_STALE_MS = 5 * 60_000;
 
 export type PanelLauncherConfig = {
   protocol: 1;
@@ -54,6 +58,8 @@ export type LauncherPaths = {
   root: string;
   launcherDir: string;
   config: string;
+  /** Cross-process lock for config publication and uninstall teardown. */
+  lock: string;
   /** Persistent uninstall tombstone; prevents an old broker from republishing config. */
   teardown: string;
   broker: string;
@@ -79,6 +85,7 @@ export function panelLauncherPaths(
     root,
     launcherDir,
     config: join(root, "launcher.json"),
+    lock: join(root, "launcher.lock"),
     teardown: join(root, "launcher.uninstalled"),
     broker: join(launcherDir, "broker.mjs"),
     windowsScript: join(launcherDir, "start-launcher.cmd"),
@@ -108,8 +115,15 @@ function isConfig(value: unknown): value is PanelLauncherConfig {
     Number(v.port) <= 65535 &&
     typeof v.token === "string" &&
     v.token.length >= 32 &&
+    (v.pid === undefined ||
+      (Number.isInteger(v.pid) && Number(v.pid) > 0 && Number(v.pid) <= 0x7fffffff)) &&
     (v.broker_id === undefined ||
       (typeof v.broker_id === "string" && /^[A-Za-z0-9_-]{32,}$/.test(v.broker_id))) &&
+    (v.broker_executable === undefined ||
+      (typeof v.broker_executable === "string" &&
+        v.broker_executable.length > 0 &&
+        v.broker_executable.length <= 4096 &&
+        !/[\u0000\r\n]/.test(v.broker_executable))) &&
     typeof v.updated_at === "string"
   );
 }
@@ -469,7 +483,7 @@ export type UninstallLauncherOptions = Pick<
 
 export type PanelLauncherProcessIdentity = {
   commandLine: string;
-  executable?: string;
+  executable: string;
 };
 
 function readPanelLauncherProcessIdentity(
@@ -498,10 +512,15 @@ function readPanelLauncherProcessIdentity(
         { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
       );
       const parsed = JSON.parse(String(raw)) as { CommandLine?: unknown; ExecutablePath?: unknown };
-      if (typeof parsed.CommandLine !== "string" || parsed.CommandLine.length === 0) return null;
+      if (
+        typeof parsed.CommandLine !== "string" ||
+        parsed.CommandLine.length === 0 ||
+        typeof parsed.ExecutablePath !== "string" ||
+        parsed.ExecutablePath.length === 0
+      ) return null;
       return {
         commandLine: parsed.CommandLine,
-        ...(typeof parsed.ExecutablePath === "string" ? { executable: parsed.ExecutablePath } : {}),
+        executable: parsed.ExecutablePath,
       };
     }
     const raw = run(
@@ -511,19 +530,9 @@ function readPanelLauncherProcessIdentity(
     );
     const commandLine = String(raw).trim();
     if (!commandLine) return null;
-    let executable: string | undefined;
-    try {
-      executable = String(
-        run("ps", ["-p", String(pid), "-o", "comm="], {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-        }),
-      ).trim() || undefined;
-    } catch {
-      // The command line is still useful; an unavailable executable field is
-      // handled as a fail-closed limitation by the caller.
-    }
-    return { commandLine, ...(executable ? { executable } : {}) };
+    const executable = commandLine.match(/^\s*(?:"([^"]+)"|(\S+))/)?.[1] ??
+      commandLine.match(/^\s*(?:"([^"]+)"|(\S+))/)?.[2];
+    return executable ? { commandLine, executable } : null;
   } catch {
     // If the platform/permissions do not expose identity, safe cleanup is to
     // leave the process alone. PID equality is never sufficient evidence.
@@ -536,9 +545,13 @@ function processIdentityOwnsBroker(
   brokerPath: string,
   brokerId: string | undefined,
   brokerExecutable: string | undefined,
+  platform: NodeJS.Platform,
 ): boolean {
-  if (!identity || !brokerId || !identity.commandLine) return false;
-  const normalize = (value: string) => value.replaceAll("\\", "/").toLowerCase();
+  if (!identity || !brokerId || !brokerExecutable || !identity.commandLine || !identity.executable) return false;
+  const normalize = (value: string) => {
+    const path = value.replaceAll("\\", "/");
+    return platform === "win32" ? path.toLowerCase() : path;
+  };
   const commandLine = normalize(identity.commandLine);
   const expectedPath = normalize(brokerPath);
   // The path and random per-install marker must both be present in the OS
@@ -546,15 +559,11 @@ function processIdentityOwnsBroker(
   // merely reusing the numeric pid. If the OS returns a shortened/opaque
   // command line, this deliberately fails closed.
   if (!commandLine.includes(expectedPath) ||
-    !commandLine.includes(`--broker-id=${brokerId.toLowerCase()}`) ||
+    !commandLine.includes(`--broker-id=${normalize(brokerId)}`) ||
     !/(^|[\s"'])run([\s"']|$)/i.test(identity.commandLine)) {
     return false;
   }
-  if (identity.executable && brokerExecutable) {
-    const normalizedBase = (value: string) => basename(value.replaceAll("\\", "/")).toLowerCase();
-    if (normalizedBase(identity.executable) !== normalizedBase(brokerExecutable)) return false;
-  }
-  return true;
+  return normalize(identity.executable) === normalize(brokerExecutable);
 }
 
 function stopOwnedPanelLauncherBroker(
@@ -571,7 +580,7 @@ function stopOwnedPanelLauncherBroker(
   // own process. The installed login broker always has a distinct PID.
   if (!pid || pid === process.pid) return;
   const identity = (processIdentityImpl ?? readPanelLauncherProcessIdentity)(pid, platform, run);
-  if (!processIdentityOwnsBroker(identity, brokerPath, brokerId, brokerExecutable)) return;
+  if (!processIdentityOwnsBroker(identity, brokerPath, brokerId, brokerExecutable, platform)) return;
   try {
     if (platform === "win32") {
       // Stop only the owned broker. Its orchestrator child is independent and
@@ -587,18 +596,48 @@ function stopOwnedPanelLauncherBroker(
   }
 }
 
+function withPanelLauncherLock<T>(home: string, fn: () => T): T | null {
+  const paths = panelLauncherPaths(home);
+  mkdirSync(paths.root, { recursive: true });
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    let fd: number;
+    try {
+      fd = openSync(paths.lock, "wx", 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(paths.lock).mtimeMs > PANEL_LAUNCHER_LOCK_STALE_MS) {
+          rmSync(paths.lock, { force: true });
+        }
+      } catch {
+        // The other process may be in the middle of releasing the lock.
+      }
+      continue;
+    }
+    try {
+      return fn();
+    } finally {
+      closeSync(fd);
+      rmSync(paths.lock, { force: true });
+    }
+  }
+  return null;
+}
+
 function writeOwnedPanelLauncherConfig(
   config: PanelLauncherConfig,
   home: string,
   ownerToken: string,
 ): boolean {
-  const paths = panelLauncherPaths(home);
-  // The tombstone is written before uninstall removes the config. A broker
-  // which is still publishing after that point must not recreate launcher.json.
-  if (existsSync(paths.teardown)) return false;
-  if (readPanelLauncherConfig(home)?.token !== ownerToken) return false;
-  writePanelLauncherConfig(config, home);
-  return true;
+  return withPanelLauncherLock(home, () => {
+    const paths = panelLauncherPaths(home);
+    // The tombstone is written before uninstall removes the config. A broker
+    // which is still publishing after that point must not recreate launcher.json.
+    if (existsSync(paths.teardown)) return false;
+    if (readPanelLauncherConfig(home)?.token !== ownerToken) return false;
+    writePanelLauncherConfig(config, home);
+    return true;
+  }) ?? false;
 }
 
 function markPanelLauncherTornDown(home: string): void {
@@ -616,18 +655,19 @@ function brokerRunArgs(broker: string, brokerId: string): string[] {
 
 export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): void {
   const home = options.home ?? homedir();
-  const platform = options.platform ?? process.platform;
-  const run = options.exec ?? execFileSync;
-  const killImpl = options.killImpl ?? process.kill.bind(process);
-  const ownedConfig = readPanelLauncherConfig(home);
-  const ownedBrokerPid = ownedConfig?.pid;
-  // Same resolution as install, or uninstall deletes a path the install never
-  // wrote and leaves the real autostart in place.
-  const paths = panelLauncherPaths(home, roamingAppData(options));
-  // This must precede service-manager teardown and config deletion. A broker
-  // with an in-flight probe can otherwise publish/spawn while uninstall runs.
-  markPanelLauncherTornDown(home);
-  if (platform === "win32") {
+  const completed = withPanelLauncherLock(home, () => {
+    const platform = options.platform ?? process.platform;
+    const run = options.exec ?? execFileSync;
+    const killImpl = options.killImpl ?? process.kill.bind(process);
+    const ownedConfig = readPanelLauncherConfig(home);
+    const ownedBrokerPid = ownedConfig?.pid;
+    // Same resolution as install, or uninstall deletes a path the install never
+    // wrote and leaves the real autostart in place.
+    const paths = panelLauncherPaths(home, roamingAppData(options));
+    // This must precede service-manager teardown and config deletion. A broker
+    // with an in-flight probe cannot publish while this lock is held.
+    markPanelLauncherTornDown(home);
+    if (platform === "win32") {
     try {
       run("schtasks.exe", ["/End", "/TN", PANEL_LAUNCHER_TASK], { stdio: "ignore" });
     } catch {
@@ -642,14 +682,14 @@ export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): 
     // create the task actually has. Removing only the task would leave those
     // users with a launcher that keeps coming back after every uninstall.
     rmSync(paths.windowsStartup, { force: true });
-  } else if (platform === "darwin") {
+    } else if (platform === "darwin") {
     try {
       run("launchctl", ["bootout", `gui/${process.getuid?.() ?? 0}`, paths.macPlist], { stdio: "ignore" });
     } catch {
       // Already absent.
     }
     rmSync(paths.macPlist, { force: true });
-  } else {
+    } else {
     try {
       run("systemctl", ["--user", "disable", "--now", "comfyui-mcp-launcher.service"], {
         stdio: "ignore",
@@ -661,23 +701,27 @@ export function uninstallPanelLauncher(options: UninstallLauncherOptions = {}): 
     rmSync(paths.linuxService, { force: true });
     rmSync(paths.linuxAutostart, { force: true });
   }
-  // Service-manager teardown does not cover the direct broker started by a
-  // Windows Startup/XDG fallback. Stop the broker after disabling every future
-  // autostart, or its exit watcher can relaunch the orchestrator during remove.
-  rmSync(paths.config, { force: true });
-  // Remove ownership first so a recovery callback racing uninstall observes a
-  // disabled install before we stop the recorded fallback process.
-  stopOwnedPanelLauncherBroker(
-    platform,
-    run,
-    killImpl,
-    ownedBrokerPid,
-    paths.broker,
-    ownedConfig?.broker_id,
-    ownedConfig?.broker_executable,
-    options.processIdentityImpl,
-  );
-  rmSync(paths.launcherDir, { force: true, recursive: true });
+    // Service-manager teardown does not cover the direct broker started by a
+    // Windows Startup/XDG fallback. Stop the broker after disabling every future
+    // autostart, or its exit watcher can relaunch the orchestrator during remove.
+    rmSync(paths.config, { force: true });
+    // Remove ownership first so a recovery callback racing uninstall observes a
+    // disabled install before we stop the recorded fallback process.
+    stopOwnedPanelLauncherBroker(
+      platform,
+      run,
+      killImpl,
+      ownedBrokerPid,
+      paths.broker,
+      ownedConfig?.broker_id,
+      ownedConfig?.broker_executable,
+      options.processIdentityImpl,
+    );
+    rmSync(paths.launcherDir, { force: true, recursive: true });
+  });
+  if (completed === null) {
+    throw new Error("Could not acquire the panel launcher lock for uninstall");
+  }
 }
 
 function safeTokenEqual(expected: string, actual: string): boolean {


### PR DESCRIPTION
## Summary\n\n- launch the panel orchestrator from the installed broker as a detached, stdio-isolated child instead of a disposable native terminal\n- preserve platform-specific launch shape (cmd /c on Windows, direct 
px on POSIX) and observe child exit\n- wait for the normal self-update replacement, then perform bounded recovery (maximum three attempts per five-minute window)\n- recommend a pinned global install in the npx update note to avoid @latest re-resolution churn\n\nCloses #2161\n\n## Validation\n\n- 
pm.cmd run lint\n- 
pm.cmd run build\n- focused Vitest: 56 passed\n- full Vitest: 12,138 passed, 4 skipped; 3 pre-existing failures in src/__tests__/orchestrator/node-id-union-message.test.ts\n- remaining 
pm test checks: i18n, docs links/locale/MDX, blog, stale, and structure all pass\n\nExact implementation commit: 89c8152.