### PR TITLE
fix: enable disabled ComfyUI-Manager locally

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -99,6 +99,8 @@ const fsCtl = vi.hoisted(() => ({
   removed: [] as string[],
   /** Make removal fail, so the leftover has to be disclosed rather than swallowed. */
   rmThrows: false,
+  /** Simulate a local .disabled rename without touching the fake filesystem. */
+  renameSync: undefined as ((from: string, to: string) => void) | undefined,
 }));
 vi.mock("node:fs", async (importOriginal) => {
   const real = await importOriginal<typeof import("node:fs")>();
@@ -111,6 +113,10 @@ vi.mock("node:fs", async (importOriginal) => {
       fsCtl.removed.push(String(path));
       if (fsCtl.rmThrows) throw new Error("EPERM: removal refused");
       return (real.rmSync as (p: unknown, o?: unknown) => unknown)(path, options);
+    }),
+    renameSync: vi.fn((from: unknown, to: unknown) => {
+      if (fsCtl.renameSync) return fsCtl.renameSync(String(from), String(to));
+      return (real.renameSync as (a: unknown, b: unknown) => unknown)(from, to);
     }),
     readdirSync: vi.fn((path: unknown, options?: unknown) =>
       fsCtl.readdirSync
@@ -338,6 +344,7 @@ describe("node-management service", () => {
     fsCtl.readdirSync = undefined;
     fsCtl.removed = [];
     fsCtl.rmThrows = false;
+    fsCtl.renameSync = undefined;
     fsCtl.readFileSync = undefined;
     savedDefault.value = undefined;
     config.comfyuiPath = "/fake/comfy";
@@ -2398,6 +2405,86 @@ describe("node-management service", () => {
       const res = await enableCustomNode({ id: "my-pack" });
       expect(taskOf(calls, "enable").params).toMatchObject({ cnr_id: "my-pack" });
       expect(res.message).toMatch(/Enabled "my-pack"/);
+    });
+
+    it("#2247 enables Manager via comfy-cli before its disabled HTTP precheck", async () => {
+      let enabled = false;
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt(enabled ? "ComfyUI-Manager" : "ComfyUI-Manager.disabled")]
+          : [];
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (args.includes("enable")) enabled = true;
+        return cliEnvelope({ message: "enabled" });
+      }) as never);
+      const fetchMock = vi.fn(async () => {
+        throw new Error("Manager HTTP must not be consulted before local enable");
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await enableCustomNode({ id: "ComfyUI-Manager", useCmCli: true });
+
+      expect(res.mechanism).toBe("comfy-cli");
+      expect(res.message).toMatch(/verified on disk/);
+      expect(mockedExec.mock.calls.some(([, args]) => (args as string[]).includes("enable"))).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("#2247 falls back to a validated filesystem rename when Manager and comfy-cli are unavailable", async () => {
+      let enabled = false;
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt(enabled ? "ComfyUI-Manager" : "ComfyUI-Manager.disabled")]
+          : [];
+      fsCtl.renameSync = (from, to) => {
+        expect(from).toContain("ComfyUI-Manager.disabled");
+        expect(to).toContain("ComfyUI-Manager");
+        enabled = true;
+      };
+      mockedExists.mockImplementation((p: unknown) => {
+        const normalized = String(p).replace(/\\/g, "/").toLowerCase();
+        return !normalized.includes("/.venv/") && !/(^|\/)comfy(?:\.exe|\.cmd|\.bat)?$/.test(normalized);
+      });
+      const { calls } = stubFetch({ installedBody: {}, managerQueueStatus: "absent" });
+
+      const res = await enableCustomNode({ id: "ComfyUI-Manager", useCmCli: true });
+
+      expect(res.mechanism).toBe("filesystem");
+      expect(res.message).toMatch(/verified on disk/);
+      expect(calls.some((c) => c.url.includes("/queue/task"))).toBe(false);
+      expect(mockedExec).not.toHaveBeenCalled();
+    });
+
+    it("#2247 refuses traversal-shaped local enable ids before CLI or filesystem mutation", async () => {
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt("ComfyUI-Manager.disabled")]
+          : [];
+      const err = await enableCustomNode({
+        id: "../ComfyUI-Manager",
+        useCmCli: true,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect(String(err)).toMatch(/path separators/);
+      expect(mockedExec).not.toHaveBeenCalled();
+      expect(fsCtl.renameSync).toBeUndefined();
+    });
+
+    it("#2247 refuses an active/.disabled duplicate instead of choosing a directory", async () => {
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt("ComfyUI-Manager"), dirEnt("ComfyUI-Manager.disabled")]
+          : [];
+
+      const err = await enableCustomNode({ id: "ComfyUI-Manager", useCmCli: true }).catch(
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/both .*ComfyUI-Manager.*ComfyUI-Manager\.disabled/);
+      expect(mockedExec).not.toHaveBeenCalled();
+      expect(fsCtl.renameSync).toBeUndefined();
     });
 
     it("uninstall refuses a pack that resolves nowhere — NOTHING is queued", async () => {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -309,10 +309,18 @@ function jsonResponse(obj: unknown): Response {
 }
 
 /** A minimal fs.Dirent stand-in for the #797 on-disk presence scan fixtures. */
-function dirEnt(name: string) {
+function dirEnt(name: string, symbolicLink = false) {
   return {
     name,
-    isDirectory: () => true,
+    isDirectory: () => !symbolicLink,
+    isSymbolicLink: () => symbolicLink,
+  };
+}
+
+function fileEnt(name: string) {
+  return {
+    name,
+    isDirectory: () => false,
     isSymbolicLink: () => false,
   };
 }
@@ -2485,6 +2493,120 @@ describe("node-management service", () => {
       expect(String(err)).toMatch(/both .*ComfyUI-Manager.*ComfyUI-Manager\.disabled/);
       expect(mockedExec).not.toHaveBeenCalled();
       expect(fsCtl.renameSync).toBeUndefined();
+    });
+
+    it("#2247 does not recover an arbitrary disabled pack when Manager is unreadable", async () => {
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt("Some-Pack.disabled")]
+          : [];
+      const { calls } = stubFetch({ installedBody: {}, managerQueueStatus: "absent" });
+
+      const err = await enableCustomNode({ id: "some-pack", useCmCli: true }).catch(
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/only the validated ComfyUI-Manager identity/);
+      expect(mockedExec).not.toHaveBeenCalled();
+      expect(fsCtl.renameSync).toBeUndefined();
+      expect(calls.some((c) => c.url.includes("/queue/task"))).toBe(false);
+    });
+
+    it("#2247 useCmCli:false never local-renames Manager when its HTTP API is unavailable", async () => {
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt("ComfyUI-Manager.disabled")]
+          : [];
+      fsCtl.renameSync = () => {
+        throw new Error("useCmCli:false must not reach the filesystem rename");
+      };
+      const { calls } = stubFetch({ installedBody: {}, managerQueueStatus: "absent" });
+
+      const err = await enableCustomNode({
+        id: "ComfyUI-Manager",
+        useCmCli: false,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/installed-pack list could not be read|NOTHING was queued/);
+      expect(calls.some((c) => c.url.includes("/queue/task"))).toBe(false);
+    });
+
+    it("#2247 treats an active destination symlink as a collision", async () => {
+      fsCtl.readdirSync = (p) =>
+        p.replace(/\\/g, "/").endsWith("/custom_nodes")
+          ? [dirEnt("ComfyUI-Manager.disabled"), dirEnt("ComfyUI-Manager", true)]
+          : [];
+
+      const err = await enableCustomNode({
+        id: "ComfyUI-Manager",
+        useCmCli: true,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/active destination.*symlink/);
+      expect(mockedExec).not.toHaveBeenCalled();
+      expect(fsCtl.renameSync).toBeUndefined();
+    });
+
+    it("#2247 revalidates source and destination immediately before renaming", async () => {
+      let customNodesScans = 0;
+      fsCtl.readdirSync = (p) => {
+        if (!p.replace(/\\/g, "/").endsWith("/custom_nodes")) return [];
+        customNodesScans++;
+        return customNodesScans < 3
+          ? [dirEnt("ComfyUI-Manager.disabled")]
+          : [dirEnt("ComfyUI-Manager")];
+      };
+      fsCtl.renameSync = () => {
+        throw new Error("rename must not run after the target changed");
+      };
+      mockedExists.mockImplementation((p: unknown) => {
+        const normalized = String(p).replace(/\\/g, "/").toLowerCase();
+        return !normalized.includes("/.venv/") && !/(^|\/)comfy(?:\.exe|\.cmd|\.bat)?$/.test(normalized);
+      });
+      stubFetch({ installedBody: {}, managerQueueStatus: "absent" });
+
+      const err = await enableCustomNode({ id: "ComfyUI-Manager", useCmCli: true }).catch(
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/source or destination changed/);
+      expect(customNodesScans).toBeGreaterThanOrEqual(3);
+    });
+
+    it("#2247 rolls back the rename when local post-state verification fails", async () => {
+      let customNodesScans = 0;
+      let renameCalls = 0;
+      fsCtl.readdirSync = (p) => {
+        if (!p.replace(/\\/g, "/").endsWith("/custom_nodes")) return [];
+        customNodesScans++;
+        if (customNodesScans === 5) return [fileEnt("ComfyUI-Manager")];
+        if (customNodesScans >= 8) return [dirEnt("ComfyUI-Manager.disabled")];
+        return customNodesScans < 4
+          ? [dirEnt("ComfyUI-Manager.disabled")]
+          : [dirEnt("ComfyUI-Manager")];
+      };
+      fsCtl.renameSync = () => {
+        renameCalls++;
+      };
+      mockedExists.mockImplementation((p: unknown) => {
+        const normalized = String(p).replace(/\\/g, "/").toLowerCase();
+        return !normalized.includes("/.venv/") && !/(^|\/)comfy(?:\.exe|\.cmd|\.bat)?$/.test(normalized);
+      });
+      stubFetch({ installedBody: {}, managerQueueStatus: "absent" });
+
+      const err = await enableCustomNode({ id: "ComfyUI-Manager", useCmCli: true }).catch(
+        (e: unknown) => e,
+      );
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(String(err)).toMatch(/could NOT be verified/);
+      expect(String(err)).toMatch(/rolled back/);
+      expect(renameCalls).toBe(2);
+      expect(customNodesScans).toBeGreaterThanOrEqual(8);
     });
 
     it("uninstall refuses a pack that resolves nowhere — NOTHING is queued", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import {
   config,
@@ -152,7 +152,7 @@ export interface InstalledNode {
 
 export interface NodeOpResult {
   /** Which mechanism handled the request. */
-  mechanism: "manager-http" | "comfy-cli" | "git-clone";
+  mechanism: "manager-http" | "comfy-cli" | "filesystem" | "git-clone";
   /** Human-readable summary. */
   message: string;
   /** Raw queue status (HTTP path) or subprocess output (cm-cli path). */
@@ -2303,7 +2303,13 @@ function findInstalledNode(
 /** Directory names a pack could plausibly be installed under for `id`. */
 function packDirNameCandidates(id: string): Set<string> {
   const wanted = id.trim().toLowerCase();
-  const names = new Set<string>([wanted, basename(wanted)]);
+  // A path-shaped enable/disable id must never be reduced to its basename:
+  // doing that would let `../pack` vouch for `custom_nodes/pack` and could
+  // hand an untrusted id to a local mutation path. Git URLs are the one
+  // deliberate exception because their checkout directory is derived from
+  // the URL after it has already passed git-URL validation.
+  const names = new Set<string>();
+  if (!/[/\\]/.test(wanted)) names.add(wanted);
   if (looksLikeGitUrl(id)) {
     names.add(gitCheckoutDir(parseGitUrl(id).baseUrl).toLowerCase());
   }
@@ -2364,6 +2370,183 @@ export function findPackOnDisk(id: string, comfyuiBase: string): DiskPackPresenc
     }
   }
   return { state: "not-found", scanned: customNodes };
+}
+
+interface DisabledPackOnDisk {
+  disabledDir: string;
+  enabledDir: string;
+  /** The directory name passed to comfy-cli, never the caller's raw id. */
+  cliId: string;
+}
+
+/**
+ * Validate the id before it can participate in a local filesystem mutation or
+ * become a comfy-cli argument. Installed-pack ids are single directory names;
+ * URLs, separators, option-like names, and control characters are not valid
+ * targets for this recovery path.
+ */
+function assertSafeLocalPackId(id: string): string {
+  const trimmed = id.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed !== id ||
+    trimmed === "." ||
+    trimmed === ".." ||
+    trimmed.startsWith("-") ||
+    /[/\\]/.test(trimmed) ||
+    /[\x00-\x1F\x7F]/.test(trimmed)
+  ) {
+    throw new ValidationError(
+      `Refusing to enable local custom node "${id}": expected a single installed ` +
+        `pack id without path separators, control characters, or a leading '-'.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Find a real directory named `<pack>.disabled` under the selected
+ * custom_nodes root. This intentionally does not follow symlink entries and
+ * refuses duplicate active/disabled identities; otherwise a rename could
+ * enable a different pack than the caller named or make ComfyUI load an
+ * arbitrary external tree after restart.
+ */
+function findDisabledPackOnDisk(
+  id: string,
+  comfyuiBase: string,
+): DisabledPackOnDisk | undefined {
+  const customNodes = join(comfyuiBase, "custom_nodes");
+  let entries: import("node:fs").Dirent[];
+  try {
+    if (!existsSync(customNodes)) return undefined;
+    entries = readdirSync(customNodes, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const wanted = new Set([id.toLowerCase()]);
+  let disabled: DisabledPackOnDisk | undefined;
+  let activeDir: string | undefined;
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith(".")) continue;
+    const lower = name.toLowerCase();
+    const isDisabled = lower.endsWith(".disabled");
+    const canonical = isDisabled ? name.slice(0, -".disabled".length) : name;
+    const canonicalLower = canonical.toLowerCase();
+    if (!wanted.has(canonicalLower)) continue;
+
+    if (entry.isSymbolicLink()) {
+      if (isDisabled) {
+        throw new NodeManagementError(
+          `Refusing to enable "${id}": ${join(customNodes, name)} is a symlink; ` +
+            `the local recovery path only renames a real custom-node directory.`,
+        );
+      }
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+
+    const dir = join(customNodes, name);
+    if (isDisabled) {
+      if (disabled) {
+        throw new NodeManagementError(
+          `Refusing to enable "${id}": multiple matching .disabled directories ` +
+            `exist under ${customNodes}.`,
+        );
+      }
+      disabled = {
+        disabledDir: dir,
+        enabledDir: join(customNodes, canonical),
+        cliId: canonical,
+      };
+    } else {
+      activeDir = dir;
+    }
+  }
+
+  if (disabled && activeDir) {
+    throw new NodeManagementError(
+      `Refusing to enable "${id}": both ${activeDir} and ${disabled.disabledDir} ` +
+        `exist. Remove the duplicate before retrying.`,
+    );
+  }
+  return disabled;
+}
+
+function verifyLocalEnable(
+  id: string,
+  comfyuiBase: string,
+  enabledDir: string,
+): void {
+  const disabled = findDisabledPackOnDisk(id, comfyuiBase);
+  if (disabled) {
+    throw new NodeManagementError(
+      `The local enable of "${id}" did NOT take effect: ${disabled.disabledDir} ` +
+        `is still disabled.`,
+    );
+  }
+  const after = findPackOnDisk(id, comfyuiBase);
+  if (
+    after.state !== "found" ||
+    resolve(after.dir) !== resolve(enabledDir) ||
+    basename(after.dir).toLowerCase().endsWith(".disabled")
+  ) {
+    throw new NodeManagementError(
+      `The local enable of "${id}" could NOT be verified under ${join(comfyuiBase, "custom_nodes")}.`,
+    );
+  }
+}
+
+function enablePackFromDisk(
+  id: string,
+  comfyuiBase: string,
+  disabled: DisabledPackOnDisk,
+): NodeOpResult {
+  try {
+    renameSync(disabled.disabledDir, disabled.enabledDir);
+  } catch (err) {
+    throw new NodeManagementError(
+      `Could not enable "${id}" by renaming ${disabled.disabledDir}: ` +
+        `${err instanceof Error ? err.message : String(err)}. NOTHING was changed by this tool.`,
+    );
+  }
+  verifyLocalEnable(id, comfyuiBase, disabled.enabledDir);
+  return {
+    mechanism: "filesystem",
+    message:
+      `Enabled "${id}" by renaming its validated local directory to ` +
+      `${disabled.enabledDir} (verified on disk). A ComfyUI restart is required ` +
+      `for the change to take effect.`,
+    details: { from: disabled.disabledDir, to: disabled.enabledDir },
+  };
+}
+
+function enablePackViaComfyCliFromDisk(
+  id: string,
+  comfyuiBase: string,
+  disabled: DisabledPackOnDisk,
+): NodeOpResult {
+  const out = runCmCli(["enable", disabled.cliId], comfyuiBase);
+  try {
+    verifyLocalEnable(id, comfyuiBase, disabled.enabledDir);
+  } catch (err) {
+    if (err instanceof NodeManagementError) {
+      return {
+        mechanism: "comfy-cli",
+        message: err.message + " comfy-cli reported success, but the local post-state disagrees.",
+        details: out.trim(),
+      };
+    }
+    throw err;
+  }
+  return {
+    mechanism: "comfy-cli",
+    message:
+      `Enabled "${id}" via official comfy-cli (verified on disk at ` +
+      `${disabled.enabledDir}). A ComfyUI restart is required for the change to take effect.`,
+    details: out.trim(),
+  };
 }
 
 export type PackPresence =
@@ -4385,6 +4568,16 @@ async function setCustomNodeEnabled(
   const cliWorkspace = resolveEffectiveComfyUIBase();
   const presenceCtx = capturePackPresenceContext(cliWorkspace);
 
+  // A disabled Manager cannot answer its own installed-list or queue routes.
+  // For local enable, only permit the recovery path for a validated real
+  // `<pack>.disabled` child of this operation's captured custom_nodes root.
+  // Remote sessions never inspect or mutate local disk.
+  const localPackId = !presenceCtx.remote ? assertSafeLocalPackId(id) : id;
+  const disabledOnDisk =
+    enable && !presenceCtx.remote && presenceCtx.diskRoot
+      ? findDisabledPackOnDisk(localPackId, presenceCtx.diskRoot)
+      : undefined;
+
   // CLI availability probe FIRST (#808 fallback discipline), but NO subprocess
   // runs yet: the presence pre-check below comes before either mechanism,
   // because a CLI run of an already-satisfied/no-such-pack request reports a
@@ -4401,6 +4594,18 @@ async function setCustomNodeEnabled(
       `NOTHING was run through comfy-cli — ComfyUI-Manager was used for what follows instead.`;
   }
 
+  // Honor an explicitly requested usable comfy-cli BEFORE the Manager list
+  // precheck. This is the only safe early escape: the directory was found by
+  // enumerating the captured custom_nodes root, its name is validated, and the
+  // CLI is given the canonical directory name rather than the raw caller id.
+  if (enable && useCli && disabledOnDisk && presenceCtx.diskRoot) {
+    return enablePackViaComfyCliFromDisk(
+      localPackId,
+      presenceCtx.diskRoot,
+      disabledOnDisk,
+    );
+  }
+
   // Pre-op validation: a disable/enable for an id Manager never heard of is a
   // silent no-op (queue or CLI alike), and the LEGACY dialects key the body on
   // the pack's REAL installed version (node-bisect's controller does the same
@@ -4409,6 +4614,7 @@ async function setCustomNodeEnabled(
   const presence = await resolvePackPresence(id, base, presenceCtx);
   if (
     presence.state === "on-disk" &&
+    !(enable && disabledOnDisk) &&
     // A READABLE list that doesn't track the pack: refuse — neither mechanism
     // can verify the op through it. An UNREADABLE list with the pack on disk
     // only blocks the HTTP path; comfy-cli works on the local install directly,
@@ -4429,6 +4635,19 @@ async function setCustomNodeEnabled(
           `Manager can ${op} it could NOT be determined and NOTHING was queued. Check ` +
           `that ComfyUI-Manager is reachable, then retry.`,
     );
+  }
+
+  // Manager-unreadable or Manager-untracked local disabled packs can still be
+  // enabled safely without queueing blind: the source and destination are
+  // validated siblings under the captured custom_nodes root, and the rename is
+  // followed by an exact on-disk postcondition check.
+  if (
+    enable &&
+    disabledOnDisk &&
+    presenceCtx.diskRoot &&
+    (presence.state === "on-disk" || presence.state === "unverifiable")
+  ) {
+    return enablePackFromDisk(localPackId, presenceCtx.diskRoot, disabledOnDisk);
   }
   if (presence.state === "absent") {
     throw new NodeManagementError(
@@ -5443,6 +5662,7 @@ async function listInstalledNodesAt(
         (v) => v !== null && typeof v === "object" && !Array.isArray(v),
       );
   }
+
   if (!readable) {
     throw new NodeManagementError(
       `ComfyUI-Manager's installed-pack list returned an unreadable payload ` +

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2434,7 +2434,12 @@ function findDisabledPackOnDisk(
     const isDisabled = lower.endsWith(".disabled");
     const canonical = isDisabled ? name.slice(0, -".disabled".length) : name;
     const canonicalLower = canonical.toLowerCase();
-    if (!wanted.has(canonicalLower)) continue;
+    if (
+      !wanted.has(canonicalLower) &&
+      !(isManagerSelfTarget(id) && isManagerSelfTarget(canonical))
+    ) {
+      continue;
+    }
 
     if (entry.isSymbolicLink()) {
       if (isDisabled) {
@@ -2443,12 +2448,19 @@ function findDisabledPackOnDisk(
             `the local recovery path only renames a real custom-node directory.`,
         );
       }
-      continue;
+      throw new NodeManagementError(
+        `Refusing to enable "${id}": the active destination ${join(customNodes, name)} ` +
+          `is a symlink. Remove the collision before retrying.`,
+      );
     }
-    if (!entry.isDirectory()) continue;
 
     const dir = join(customNodes, name);
     if (isDisabled) {
+      if (!entry.isDirectory()) {
+        throw new NodeManagementError(
+          `Refusing to enable "${id}": ${dir} is not a real directory.`,
+        );
+      }
       if (disabled) {
         throw new NodeManagementError(
           `Refusing to enable "${id}": multiple matching .disabled directories ` +
@@ -2461,6 +2473,9 @@ function findDisabledPackOnDisk(
         cliId: canonical,
       };
     } else {
+      // Any existing active-name entry is a collision, including a file. A
+      // POSIX rename could otherwise replace it, and a symlink could redirect
+      // what ComfyUI loads after restart.
       activeDir = dir;
     }
   }
@@ -2498,27 +2513,94 @@ function verifyLocalEnable(
   }
 }
 
+function revalidateLocalEnableTarget(
+  id: string,
+  comfyuiBase: string,
+  expected: DisabledPackOnDisk,
+): DisabledPackOnDisk {
+  const current = findDisabledPackOnDisk(id, comfyuiBase);
+  if (
+    !current ||
+    resolve(current.disabledDir) !== resolve(expected.disabledDir) ||
+    resolve(current.enabledDir) !== resolve(expected.enabledDir)
+  ) {
+    throw new NodeManagementError(
+      `Refusing to enable "${id}": the validated source or destination changed ` +
+        `before the local rename. NOTHING was changed by this tool.`,
+    );
+  }
+  return current;
+}
+
+/** Return undefined on a verified rollback, otherwise a safe refusal reason. */
+function rollbackLocalEnable(
+  id: string,
+  comfyuiBase: string,
+  disabled: DisabledPackOnDisk,
+): string | undefined {
+  try {
+    // Do not move a destination that appeared or changed while verification
+    // was running. A rollback is only safe when the original source is absent
+    // and the exact destination is still the directory we created.
+    if (findDisabledPackOnDisk(id, comfyuiBase)) {
+      return "the original .disabled source is still present or a collision appeared";
+    }
+    const active = findPackOnDisk(id, comfyuiBase);
+    if (
+      active.state !== "found" ||
+      resolve(active.dir) !== resolve(disabled.enabledDir) ||
+      basename(active.dir).toLowerCase().endsWith(".disabled")
+    ) {
+      return "the destination no longer matches the directory this call renamed";
+    }
+    renameSync(disabled.enabledDir, disabled.disabledDir);
+    const restored = findDisabledPackOnDisk(id, comfyuiBase);
+    if (
+      !restored ||
+      resolve(restored.disabledDir) !== resolve(disabled.disabledDir) ||
+      resolve(restored.enabledDir) !== resolve(disabled.enabledDir)
+    ) {
+      return "the rollback rename landed but its .disabled post-state could not be verified";
+    }
+    return undefined;
+  } catch (err) {
+    return `rollback failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
 function enablePackFromDisk(
   id: string,
   comfyuiBase: string,
   disabled: DisabledPackOnDisk,
 ): NodeOpResult {
+  const target = revalidateLocalEnableTarget(id, comfyuiBase, disabled);
   try {
-    renameSync(disabled.disabledDir, disabled.enabledDir);
+    renameSync(target.disabledDir, target.enabledDir);
   } catch (err) {
     throw new NodeManagementError(
-      `Could not enable "${id}" by renaming ${disabled.disabledDir}: ` +
+      `Could not enable "${id}" by renaming ${target.disabledDir}: ` +
         `${err instanceof Error ? err.message : String(err)}. NOTHING was changed by this tool.`,
     );
   }
-  verifyLocalEnable(id, comfyuiBase, disabled.enabledDir);
+  try {
+    verifyLocalEnable(id, comfyuiBase, target.enabledDir);
+  } catch (err) {
+    const rollbackError = rollbackLocalEnable(id, comfyuiBase, target);
+    const verification = err instanceof Error ? err.message : String(err);
+    throw new NodeManagementError(
+      `The local enable of "${id}" could NOT be verified: ${verification}. ` +
+        (rollbackError === undefined
+          ? "The rename was rolled back."
+          : `The rename could NOT be rolled back safely: ${rollbackError}.`),
+    );
+  }
   return {
     mechanism: "filesystem",
     message:
       `Enabled "${id}" by renaming its validated local directory to ` +
-      `${disabled.enabledDir} (verified on disk). A ComfyUI restart is required ` +
+      `${target.enabledDir} (verified on disk). A ComfyUI restart is required ` +
       `for the change to take effect.`,
-    details: { from: disabled.disabledDir, to: disabled.enabledDir },
+    details: { from: target.disabledDir, to: target.enabledDir },
   };
 }
 
@@ -4573,9 +4655,17 @@ async function setCustomNodeEnabled(
   // `<pack>.disabled` child of this operation's captured custom_nodes root.
   // Remote sessions never inspect or mutate local disk.
   const localPackId = !presenceCtx.remote ? assertSafeLocalPackId(id) : id;
+  const localRecoveryAllowed =
+    !presenceCtx.remote && opts.useCmCli !== false && isManagerSelfTarget(localPackId);
   const disabledOnDisk =
-    enable && !presenceCtx.remote && presenceCtx.diskRoot
+    enable && !presenceCtx.remote && opts.useCmCli !== false && presenceCtx.diskRoot
       ? findDisabledPackOnDisk(localPackId, presenceCtx.diskRoot)
+      : undefined;
+  const managerDisabledOnDisk =
+    localRecoveryAllowed &&
+    disabledOnDisk &&
+    isManagerSelfTarget(disabledOnDisk.cliId)
+      ? disabledOnDisk
       : undefined;
 
   // CLI availability probe FIRST (#808 fallback discipline), but NO subprocess
@@ -4598,11 +4688,11 @@ async function setCustomNodeEnabled(
   // precheck. This is the only safe early escape: the directory was found by
   // enumerating the captured custom_nodes root, its name is validated, and the
   // CLI is given the canonical directory name rather than the raw caller id.
-  if (enable && useCli && disabledOnDisk && presenceCtx.diskRoot) {
+  if (enable && useCli && managerDisabledOnDisk && presenceCtx.diskRoot) {
     return enablePackViaComfyCliFromDisk(
       localPackId,
       presenceCtx.diskRoot,
-      disabledOnDisk,
+      managerDisabledOnDisk,
     );
   }
 
@@ -4613,8 +4703,20 @@ async function setCustomNodeEnabled(
   // list read up front.
   const presence = await resolvePackPresence(id, base, presenceCtx);
   if (
+    enable &&
+    disabledOnDisk &&
+    !managerDisabledOnDisk &&
+    (presence.state === "on-disk" || presence.state === "unverifiable")
+  ) {
+    throw new NodeManagementError(
+      `Refusing local recovery for "${id}": only the validated ` +
+        `ComfyUI-Manager identity may be enabled from a .disabled directory ` +
+        `without a readable Manager installed-pack list. NOTHING was changed.`,
+    );
+  }
+  if (
     presence.state === "on-disk" &&
-    !(enable && disabledOnDisk) &&
+    !(enable && managerDisabledOnDisk) &&
     // A READABLE list that doesn't track the pack: refuse — neither mechanism
     // can verify the op through it. An UNREADABLE list with the pack on disk
     // only blocks the HTTP path; comfy-cli works on the local install directly,
@@ -4643,11 +4745,11 @@ async function setCustomNodeEnabled(
   // followed by an exact on-disk postcondition check.
   if (
     enable &&
-    disabledOnDisk &&
+    managerDisabledOnDisk &&
     presenceCtx.diskRoot &&
     (presence.state === "on-disk" || presence.state === "unverifiable")
   ) {
-    return enablePackFromDisk(localPackId, presenceCtx.diskRoot, disabledOnDisk);
+    return enablePackFromDisk(localPackId, presenceCtx.diskRoot, managerDisabledOnDisk);
   }
   if (presence.state === "absent") {
     throw new NodeManagementError(


### PR DESCRIPTION
Fixes #2247\n\nWhen ComfyUI-Manager is itself renamed to custom_nodes/ComfyUI-Manager.disabled, its installed-pack and queue endpoints are unavailable. This patch allows a validated local .disabled pack to be enabled before the Manager HTTP precheck when comfy-cli is explicitly usable, and uses a validated filesystem rename fallback when Manager and comfy-cli are unavailable. Both paths verify the local post-state. Traversal-shaped IDs, symlink entries, duplicate active/.disabled directories, and failed post-verification refuse safely.\n\nTests: npm.cmd exec vitest -- run src/__tests__/services/node-management.test.ts --pool=threads --maxWorkers=1 (201 passed)\nGates: npm.cmd run lint; npm.cmd run build; git diff --check