### PR TITLE
fix(panel): preserve animated media payloads

### DIFF
--- a/src/__tests__/orchestrator/panel-show-media-animated.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-animated.test.ts
@@ -27,13 +27,15 @@ function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
   return { ctx, calls };
 }
 
-async function showMedia(path: string): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+async function showMedia(items: Array<Record<string, unknown>>): Promise<{ res: ToolResult; calls: Forwarded[] }> {
   const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
   if (!def) throw new Error("panel_show_media not found");
   const { ctx, calls } = makeCtx();
-  const res = (await def.handler({ items: [{ source: { path } }] }, ctx)) as ToolResult;
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
   return { res, calls };
 }
+
+const textOf = (res: ToolResult): string => res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
 
 const cases = [
   [".gif", "image/gif", Buffer.from("GIF89a\x00animated-frame-data", "binary")],
@@ -56,7 +58,7 @@ describe("#2248 animated image delivery", () => {
     const path = join(root, `animated${ext}`);
     writeFileSync(path, bytes);
 
-    const { res, calls } = await showMedia(path);
+    const { res, calls } = await showMedia([{ source: { path } }]);
     expect(res.isError).toBeFalsy();
 
     const command = calls.find((call) => call.cmd === "show_media");
@@ -64,6 +66,20 @@ describe("#2248 animated image delivery", () => {
     const item = (command!.items as Array<Record<string, unknown>>)[0];
     expect(item.kind).toBe("image");
     expect(item.dataUrl).toBe(`data:${mime};base64,${bytes.toString("base64")}`);
+  });
+
+  it("reports frame uncertainty for inline bytes, not a filename-only viewRef", async () => {
+    const inlinePath = join(root, "inline.gif");
+    writeFileSync(inlinePath, Buffer.from("GIF89a\x00animated-frame-data", "binary"));
+    const inline = await showMedia([{ source: { path: inlinePath } }]);
+    expect(textOf(inline.res)).toContain("Animated GIF/APNG/WebP bytes were dispatched");
+
+    const reference = await showMedia([{ source: { filename: "remote.gif", type: "output" } }]);
+    const command = reference.calls.find((call) => call.cmd === "show_media");
+    const item = (command!.items as Array<Record<string, unknown>>)[0];
+    expect(item.kind).toBe("viewRef");
+    expect(item.dataUrl).toBeUndefined();
+    expect(textOf(reference.res)).not.toContain("Animated GIF/APNG/WebP bytes were dispatched");
   });
 
   it.each([".gif", ".apng", ".webp"])("classifies %s view references as images", (ext) => {

--- a/src/__tests__/orchestrator/panel-show-media-animated.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-animated.test.ts
@@ -1,0 +1,77 @@
+// #2248 — animated media must leave this repository with its original bytes.
+// The mobile/remote renderer is not part of comfyui-mcp, so this suite pins the
+// producer-side guarantee: GIF/APNG/WebP are accepted as images, their MIME is
+// correct, and no thumbnail/bitmap conversion drops animation frames.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildPanelToolDefs, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import { paintedShowMediaKind } from "../../services/ui-bridge.js";
+
+type Forwarded = Record<string, unknown>;
+
+function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    bridge: { isHeadless: () => false } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(path: string): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx();
+  const res = (await def.handler({ items: [{ source: { path } }] }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+const cases = [
+  [".gif", "image/gif", Buffer.from("GIF89a\x00animated-frame-data", "binary")],
+  [".apng", "image/apng", Buffer.from("\x89PNG\r\n\x1a\n\x00APNG\x00animated-frame-data", "binary")],
+  [".webp", "image/webp", Buffer.from("RIFF\x00\x00\x00\x00WEBPanimated-frame-data", "binary")],
+] as const;
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-showmedia-animated-"));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("#2248 animated image delivery", () => {
+  it.each(cases)("preserves the original %s bytes and MIME", async (ext, mime, bytes) => {
+    const path = join(root, `animated${ext}`);
+    writeFileSync(path, bytes);
+
+    const { res, calls } = await showMedia(path);
+    expect(res.isError).toBeFalsy();
+
+    const command = calls.find((call) => call.cmd === "show_media");
+    expect(command).toBeTruthy();
+    const item = (command!.items as Array<Record<string, unknown>>)[0];
+    expect(item.kind).toBe("image");
+    expect(item.dataUrl).toBe(`data:${mime};base64,${bytes.toString("base64")}`);
+  });
+
+  it.each([".gif", ".apng", ".webp"])("classifies %s view references as images", (ext) => {
+    expect(
+      paintedShowMediaKind({
+        kind: "viewRef",
+        viewRef: { filename: `animated${ext}`, type: "output" },
+      }),
+    ).toBe("image");
+  });
+});

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -127,9 +127,9 @@ describe("#2010 an unaccounted reply no longer answers with the client's claim",
 
   it("calls out unobserved animation for GIF/APNG/WebP items", () => {
     const animated = [
-      { filename: "clip.gif", kind: "image" },
-      { filename: "clip.apng", kind: "image" },
-      { filename: "clip.webp", kind: "image" },
+      { filename: "clip.gif", kind: "image", inline: true },
+      { filename: "clip.apng", kind: "image", inline: true },
+      { filename: "clip.webp", kind: "image", inline: true },
     ];
     expect(unaccountedShowMediaNote(animated, readShowMediaAck(MOBILE_REPLY, animated.length))).toMatch(
       /GIF\/APNG\/WebP bytes were dispatched.*frames advanced beyond the first frame/,

--- a/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts
@@ -125,6 +125,17 @@ describe("#2010 an unaccounted reply no longer answers with the client's claim",
     expect(d.presented_confirmed).not.toBe(0);
   });
 
+  it("calls out unobserved animation for GIF/APNG/WebP items", () => {
+    const animated = [
+      { filename: "clip.gif", kind: "image" },
+      { filename: "clip.apng", kind: "image" },
+      { filename: "clip.webp", kind: "image" },
+    ];
+    expect(unaccountedShowMediaNote(animated, readShowMediaAck(MOBILE_REPLY, animated.length))).toMatch(
+      /GIF\/APNG\/WebP bytes were dispatched.*frames advanced beyond the first frame/,
+    );
+  });
+
   it("the client's own words are preserved verbatim under client_reply", () => {
     // Kills: dropping client_reply. Deleting what the client said would be its
     // own dishonesty; it is demoted, not discarded.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -21249,7 +21249,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           caption?: string;
         }>;
 
-        const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+        // APNG is an image container just like GIF/WebP. Keep the original
+        // bytes in the data URL: the downstream client decides whether it can
+        // advance the animation, while this producer must not flatten it.
+        const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".apng", ".webp"]);
         // #811 — this used to be just {.mp4, .webm}, narrower than what this
         // codebase ALREADY treats as video elsewhere: get_image's
         // action:"list_outputs" documents ".mp4/.webm/.mov/.mkv/.m4v/.avi", and

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -21628,6 +21628,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             // "viewRef" for a ComfyUI reference whose media kind only the
             // client's own classifier decides.
             kind: typeof r.kind === "string" ? r.kind : "(unknown)",
+            // The animated-media diagnostic may only claim bytes were
+            // dispatched when this exact item carried the data URL. A
+            // filename-only viewRef is not proof that this process sent bytes.
+            inline: typeof r.dataUrl === "string",
           })) satisfies DispatchedMediaItem[],
         );
         // Why an item the caller passed as a PATH came back described as a

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -998,6 +998,12 @@ export function unaccountedShowMediaNote(
     .map((d) => `  - ${d.filename} (dispatched as ${d.kind})`)
     .join("\n");
   const more = dispatched.length > 8 ? `\n  - …and ${dispatched.length - 8} more` : "";
+  const animatedImages = dispatched.filter((d) => /\.(?:gif|apng|webp)$/i.test(d.filename));
+  const animationCaveat =
+    animatedImages.length > 0
+      ? ` Animated GIF/APNG/WebP bytes were dispatched, but this reply does not say whether ` +
+        `their frames advanced beyond the first frame.`
+      : "";
 
   let what: string;
   if (verdict.reason === "mailboxed") {
@@ -1038,7 +1044,7 @@ export function unaccountedShowMediaNote(
       `The client acknowledged the command but did not report what it rendered — its reply carries no ` +
       `per-item accounting (\`count\`/\`painted\`/\`unrenderable\`), so it did not read the items. ` +
       `The mobile / remote client answers \`{"shown": true}\` to any show_media without looking at them, ` +
-      `and it has no audio player at all.`;
+      `and it has no audio player at all.${animationCaveat}`;
   }
 
   return (

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -860,6 +860,9 @@ export type DispatchedMediaItem = {
    *  re-derived here: a guess about the media kind is the thing this module is
    *  refusing to make. */
   kind: string;
+  /** True only when the outbound item carried a data URL with the source
+   *  bytes. Omitted/false means the item was sent as a reference. */
+  inline?: boolean;
 };
 
 /** Why a `show_media` reply did or did not establish that its items were
@@ -998,7 +1001,9 @@ export function unaccountedShowMediaNote(
     .map((d) => `  - ${d.filename} (dispatched as ${d.kind})`)
     .join("\n");
   const more = dispatched.length > 8 ? `\n  - …and ${dispatched.length - 8} more` : "";
-  const animatedImages = dispatched.filter((d) => /\.(?:gif|apng|webp)$/i.test(d.filename));
+  const animatedImages = dispatched.filter(
+    (d) => d.inline === true && /\.(?:gif|apng|webp)$/i.test(d.filename),
+  );
   const animationCaveat =
     animatedImages.length > 0
       ? ` Animated GIF/APNG/WebP bytes were dispatched, but this reply does not say whether ` +

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -571,7 +571,7 @@ const SHOW_MEDIA_AUDIO_PAINT_EXTS = new Set([
   ".aac",
 ]);
 const SHOW_MEDIA_VIDEO_PAINT_EXTS = new Set([".mp4", ".webm", ".mov", ".mkv", ".m4v", ".avi"]);
-const SHOW_MEDIA_IMAGE_PAINT_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+const SHOW_MEDIA_IMAGE_PAINT_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".apng", ".webp"]);
 
 function showMediaFilenameExt(filename: string): string {
   const stem = filename.split("#")[0]!.split("?")[0]!;


### PR DESCRIPTION
## Summary

- accept `.apng` as an image in `panel_show_media` and the bridge filename classifier
- preserve GIF/APNG/WebP source bytes and MIME in the outbound data URL
- make unaccounted mobile/remote replies disclose that animated frame advancement is not observed
- add focused regression coverage for outbound bytes, MIME, view-ref classification, and accounting disclosure

Closes #2248

## Validation

- `npm.cmd exec vitest run src/__tests__/orchestrator/panel-show-media-animated.test.ts src/__tests__/orchestrator/panel-show-media-unaccounted-ack.test.ts src/__tests__/orchestrator/panel-show-media-view-probe.test.ts src/__tests__/orchestrator/panel-show-media-client-kind.test.ts` — 4 files, 100 tests passed
- `npm.cmd run lint` — passed
- `npm.cmd run build` — passed
- `git diff --check` — passed

The full Vitest run also exposed three pre-existing failures in `src/__tests__/orchestrator/node-id-union-message.test.ts` and then entered an unrelated long-running cancellation test path; no failure occurred in the touched media suites.

## Scope limitation

The mobile/remote renderer and its `{shown:true}` response implementation are not present in this repository. This PR does not claim to make that client animate frames or fabricate per-item `count`/`painted`/`unrenderable` results. It ensures this repository does not reject APNG or flatten animated bytes, and it reports the renderer limitation honestly when the client supplies no accounting.