### PR TITLE
fix: anchor embedded Windows ComfyUI restart

### DIFF
--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -485,7 +485,10 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
   winIt(
     "#2252: refuses the same shape when the observed main.py is not a regular file",
     async () => {
-      mockResolveBase.mockReturnValue(undefined);
+      // Keep a separate, valid canonical install available. Without the hard
+      // refusal in resolveLaunchCommand, this fixture would incorrectly pass by
+      // relaunching that install after the observed embedded layout failed.
+      mockResolveBase.mockReturnValue(BASE);
       mockLiveRootFromArgv.mockReturnValue(undefined);
       mockGetSystemStats.mockResolvedValue({
         system: { argv: ["main.py", "--port", "8188"] },
@@ -493,13 +496,15 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
       mockExistsSync.mockImplementation((p: string) => {
         const s = String(p);
         return (
+          s === ABS_MAIN ||
+          s === ABS_PYTHON ||
           s === EMBEDDED_ROOT ||
           s === EMBEDDED_PYTHON_DIR ||
           s === EMBEDDED_MAIN ||
           s === EMBEDDED_PYTHON
         );
       });
-      mockFindComfyuiPython.mockReturnValue("python");
+      mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
       mockIsFile.mockImplementation((p: string) => String(p) !== EMBEDDED_MAIN);
       __processControlTestHooks.setLiveCwdResolver(() => undefined);
       mockResolveLiveServerRoot.mockReturnValue({

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -119,6 +119,17 @@ vi.mock("node:fs", () => ({
     if (!mockExistsSync(String(p))) throw new Error("ENOENT");
     return { isFile: () => mockIsFile(String(p)) };
   }),
+  // #2252's exact embedded layout rejects symlinked roots/files rather than
+  // turning a lexical observation into a relaunch target.
+  lstatSync: vi.fn((p: string) => {
+    const s = String(p);
+    if (!mockExistsSync(s)) throw new Error("ENOENT");
+    return {
+      isFile: () => s !== EMBEDDED_ROOT && mockIsFile(s),
+      isDirectory: () => s === EMBEDDED_ROOT || s === join(EMBEDDED_ROOT, "python"),
+      isSymbolicLink: () => false,
+    };
+  }),
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -169,6 +180,13 @@ import {
 const BASE = resolve("ComfyUI_portable", "ComfyUI");
 const ABS_MAIN = join(BASE, "main.py");
 const ABS_PYTHON = join(BASE, "python_embeded", "python.exe");
+// #2252: the standalone embedded-python layout is different from the classic
+// portable bundle: the interpreter is directly under `<root>\python` and the
+// server's bare `main.py` is directly under that same root.
+const EMBEDDED_ROOT = resolve("ComfyUI_embedded");
+const EMBEDDED_MAIN = join(EMBEDDED_ROOT, "main.py");
+const EMBEDDED_PYTHON_DIR = join(EMBEDDED_ROOT, "python");
+const EMBEDDED_PYTHON = join(EMBEDDED_ROOT, "python", "python.exe");
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -248,6 +266,8 @@ afterEach(() => {
 });
 
 describe("restart_comfyui — live-first script resolution (#476, #426)", () => {
+  const winIt = process.platform === "win32" ? it : it.skip;
+
   it("RESTARTS a reachable install, anchoring a relative argv[0] to the canonical absolute base (not refusing on a stale/relative COMFYUI_PATH)", async () => {
     mockLivePortThenFree();
     const children: FakeChild[] = [];
@@ -406,6 +426,107 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
 
     killSpy.mockRestore();
   });
+
+  winIt(
+    "#2252: anchors bare main.py from an observed <root>\\python\\python.exe",
+    async () => {
+      // The old path resolved the live root but then asked the general layout
+      // resolver for a python candidate. That resolver intentionally does not
+      // guess this embedded layout, so the script stayed relative and preflight
+      // refused before stopping anything. The narrow repair may use this pair
+      // only because the interpreter came from the PID-correlated command line.
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: ["main.py", "--port", "8188"] },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const s = String(p);
+        return (
+          s === EMBEDDED_ROOT ||
+          s === EMBEDDED_PYTHON_DIR ||
+          s === EMBEDDED_MAIN ||
+          s === EMBEDDED_PYTHON
+        );
+      });
+      mockFindComfyuiPython.mockReturnValue("python");
+      __processControlTestHooks.setLiveCwdResolver(() => undefined);
+      mockResolveLiveServerRoot.mockReturnValue({
+        source: "observed-process",
+        anchorDir: EMBEDDED_ROOT,
+        observedPid: 4321,
+      });
+      __processControlTestHooks.setProcessIdentityResolver(() => ({
+        startedAt: "stable-stamp",
+        commandLine: `"${EMBEDDED_PYTHON}" main.py --port 8188`,
+        argv: [EMBEDDED_PYTHON, "main.py", "--port", "8188"],
+        argvFidelity: "exact",
+      }));
+      mockLivePortThenFree();
+      mockSpawn.mockImplementation(() => new FakeChild());
+      vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true }) as Response));
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).not.toMatch(/refusing to restart/i);
+      expect(result.stopped).toBe(true);
+      expect(result.started).toBe(true);
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      const [exe, args, opts] = mockSpawn.mock.calls[0];
+      expect(exe).toBe(EMBEDDED_PYTHON);
+      expect(args[0]).toBe(EMBEDDED_MAIN);
+      expect((opts as { cwd?: string }).cwd).toBe(EMBEDDED_ROOT);
+
+      killSpy.mockRestore();
+    },
+  );
+
+  winIt(
+    "#2252: refuses the same shape when the observed main.py is not a regular file",
+    async () => {
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: ["main.py", "--port", "8188"] },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const s = String(p);
+        return (
+          s === EMBEDDED_ROOT ||
+          s === EMBEDDED_PYTHON_DIR ||
+          s === EMBEDDED_MAIN ||
+          s === EMBEDDED_PYTHON
+        );
+      });
+      mockFindComfyuiPython.mockReturnValue("python");
+      mockIsFile.mockImplementation((p: string) => String(p) !== EMBEDDED_MAIN);
+      __processControlTestHooks.setLiveCwdResolver(() => undefined);
+      mockResolveLiveServerRoot.mockReturnValue({
+        source: "observed-process",
+        anchorDir: EMBEDDED_ROOT,
+        observedPid: 4321,
+      });
+      __processControlTestHooks.setProcessIdentityResolver(() => ({
+        startedAt: "stable-stamp",
+        commandLine: `"${EMBEDDED_PYTHON}" main.py --port 8188`,
+        argv: [EMBEDDED_PYTHON, "main.py", "--port", "8188"],
+        argvFidelity: "exact",
+      }));
+      mockLivePortThenFree();
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).toMatch(/refusing to restart/i);
+      expect(result.stopped).toBe(false);
+      expect(result.started).toBe(false);
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(killSpy).not.toHaveBeenCalled();
+
+      killSpy.mockRestore();
+    },
+  );
 
   it("WINDOWS: a PID MISMATCH discards the observed anchor and keeps the refusal (#535)", async () => {
     // The safety property. The observation is anchored on "whatever is listening on

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -64,10 +64,18 @@ const mockSpawn = vi.hoisted(() => vi.fn());
 const mockGetSystemStats = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
 const mockIsFile = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockIsDirectory = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockIsSymlink = vi.hoisted(() => vi.fn((_p: string) => false));
 const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
 const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
 const mockLiveRootFromArgv = vi.hoisted(() =>
   vi.fn<[string[], string?], string | undefined>(),
+);
+const mockResolveLiveRoot = vi.hoisted(() =>
+  vi.fn<
+    [],
+    { source: "unresolved" | "observed-process"; anchorDir?: string; observedPid?: number }
+  >(),
 );
 
 vi.mock("../../config.js", () => ({
@@ -86,6 +94,14 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
+  lstatSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return {
+      isDirectory: () => mockIsDirectory(String(p)),
+      isFile: () => mockIsFile(String(p)),
+      isSymbolicLink: () => mockIsSymlink(String(p)),
+    };
+  }),
   readlinkSync: vi.fn(() => {
     throw new Error("no /proc in test");
   }),
@@ -120,6 +136,7 @@ vi.mock("../../services/env-capabilities.js", () => ({
 vi.mock("../../services/workspace-env.js", () => ({
   resolveEffectiveComfyUIBase: mockResolveBase,
   liveRootFromArgv: mockLiveRootFromArgv,
+  resolveLiveServerRoot: mockResolveLiveRoot,
   markLocalComfyUILaunched: vi.fn(),
   resetLocalComfyUILaunchState: vi.fn(),
 }));
@@ -184,6 +201,9 @@ beforeEach(() => {
   mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
   mockLiveRootFromArgv.mockReturnValue(undefined);
   mockResolveBase.mockReturnValue(BASE);
+  mockResolveLiveRoot.mockReturnValue({ source: "unresolved" });
+  mockIsDirectory.mockImplementation((_p: string) => true);
+  mockIsSymlink.mockImplementation((_p: string) => false);
   mockExistsSync.mockImplementation((p: string) => {
     const s = String(p);
     return s === ABS_MAIN || s === ABS_PYTHON;
@@ -789,6 +809,134 @@ describe("restart_comfyui (action:\"stop\") — has_restart_info means a relaunc
     expect(stopped.message).not.toMatch(/will NOT be able/i);
 
     killSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2252 — Windows embedded-python portable layout
+// ---------------------------------------------------------------------------
+
+describe("restart_comfyui — anchors the observed embedded-python root (#2252)", () => {
+  const runOnWindows = it.skipIf(process.platform !== "win32");
+
+  runOnWindows("uses the corroborated <root>\\python\\python.exe with <root>\\main.py", async () => {
+    const root = "C:\\ComfyUI-portable";
+    const pythonDir = join(root, "python");
+    const python = join(root, "python", "python.exe");
+    const main = join(root, "main.py");
+    const argv = ["main.py", "--port", "8188"];
+
+    mockGetSystemStats.mockResolvedValue({ system: { argv } });
+    mockLivePortThenFree();
+    mockFindComfyuiPython.mockReturnValue("C:\\stale\\python.exe");
+    mockResolveBase.mockReturnValue(undefined);
+    mockResolveLiveRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: root,
+      observedPid: 4321,
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const value = String(p);
+      return value === root || value === pythonDir || value === python || value === main;
+    });
+    mockIsDirectory.mockImplementation(
+      (p: string) => String(p) === root || String(p) === `${root}\\python`,
+    );
+    mockIsFile.mockImplementation((p: string) => String(p) === python || String(p) === main);
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `"${python}" main.py --port 8188`,
+      argv: [python, ...argv],
+      argvFidelity: "exact",
+    }));
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true }) as Response));
+
+    await restartComfyUI();
+
+    const [exe, args, options] = mockSpawn.mock.calls[0] as [
+      string,
+      string[],
+      { cwd?: string },
+    ];
+    expect(exe).toBe(python);
+    expect(args).toEqual([main, "--port", "8188"]);
+    expect(options.cwd).toBe(root);
+  });
+
+  runOnWindows("keeps the refusal when the exact embedded layout is symlinked", async () => {
+    const root = "C:\\ComfyUI-portable";
+    const pythonDir = join(root, "python");
+    const python = join(root, "python", "python.exe");
+    const main = join(root, "main.py");
+    mockGetSystemStats.mockResolvedValue({ system: { argv: ["main.py", "--port", "8188"] } });
+    mockLivePortThenFree();
+    mockFindComfyuiPython.mockReturnValue(undefined);
+    mockResolveBase.mockReturnValue(undefined);
+    mockResolveLiveRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: root,
+      observedPid: 4321,
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const value = String(p);
+      return value === root || value === pythonDir || value === python || value === main;
+    });
+    mockIsDirectory.mockImplementation(
+      (p: string) => String(p) === root || String(p) === `${root}\\python`,
+    );
+    mockIsFile.mockImplementation((p: string) => String(p) === python || String(p) === main);
+    mockIsSymlink.mockImplementation((p: string) => String(p) === main);
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `"${python}" main.py --port 8188`,
+      argv: [python, "main.py", "--port", "8188"],
+      argvFidelity: "exact",
+    }));
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/main\.py|launch command/i);
+    expect(killWasIssued()).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  runOnWindows("does not broaden the repair to a different relative script path", async () => {
+    const root = "C:\\ComfyUI-portable";
+    const pythonDir = join(root, "python");
+    const python = join(root, "python", "python.exe");
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["ComfyUI\\main.py", "--port", "8188"] },
+    });
+    mockLivePortThenFree();
+    mockFindComfyuiPython.mockReturnValue(undefined);
+    mockResolveBase.mockReturnValue(undefined);
+    mockResolveLiveRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: root,
+      observedPid: 4321,
+    });
+    mockExistsSync.mockImplementation(
+      (p: string) =>
+        String(p) === root || String(p) === pythonDir || String(p) === python,
+    );
+    mockIsDirectory.mockImplementation(
+      (p: string) => String(p) === root || String(p) === `${root}\\python`,
+    );
+    mockIsFile.mockImplementation((p: string) => String(p) === python);
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `"${python}" ComfyUI\\main.py --port 8188`,
+      argv: [python, "ComfyUI\\main.py", "--port", "8188"],
+      argvFidelity: "exact",
+    }));
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/main\.py|launch command/i);
+    expect(killWasIssued()).toBe(false);
   });
 });
 

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -871,8 +871,10 @@ describe("restart_comfyui — anchors the observed embedded-python root (#2252)"
     const main = join(root, "main.py");
     mockGetSystemStats.mockResolvedValue({ system: { argv: ["main.py", "--port", "8188"] } });
     mockLivePortThenFree();
-    mockFindComfyuiPython.mockReturnValue(undefined);
-    mockResolveBase.mockReturnValue(undefined);
+    // A valid alternate canonical install proves that an invalid observed
+    // embedded layout cannot fall through to the generic anchor.
+    mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
+    mockResolveBase.mockReturnValue(BASE);
     mockResolveLiveRoot.mockReturnValue({
       source: "observed-process",
       anchorDir: root,
@@ -880,7 +882,15 @@ describe("restart_comfyui — anchors the observed embedded-python root (#2252)"
     });
     mockExistsSync.mockImplementation((p: string) => {
       const value = String(p);
-      return value === root || value === pythonDir || value === python || value === main;
+      return (
+        value === BASE ||
+        value === ABS_MAIN ||
+        value === ABS_PYTHON ||
+        value === root ||
+        value === pythonDir ||
+        value === python ||
+        value === main
+      );
     });
     mockIsDirectory.mockImplementation(
       (p: string) => String(p) === root || String(p) === `${root}\\python`,

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -2130,6 +2130,30 @@ describe("resolveLiveServerRoot (#369)", () => {
     }
   });
 
+  it("anchors the Windows embedded layout: <root>\\python\\python.exe + <root>\\main.py", async () => {
+    const dir = await tmpDir();
+    try {
+      const root = join(dir, "ComfyUI");
+      const python = join(root, "python", "python.exe");
+      await mkdir(dirname(python), { recursive: true });
+      await writeFile(python, "", "utf-8");
+      await writeFile(join(root, "main.py"), "", "utf-8");
+
+      const res = resolveLiveServerRoot(["main.py", "--listen"], undefined, {
+        observedPython: python,
+        observedPid: 2252,
+      });
+
+      expect(res.source).toBe("observed-process");
+      expect(res.root).toBe(root);
+      expect(res.anchorDir).toBe(root);
+      expect(res.observedPython).toBe(python);
+      expect(res.observedPid).toBe(2252);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("stays UNRESOLVED when nothing observes the process — never a layout guess", () => {
     h.mockLiveInterpreter.mockReturnValue(undefined);
     const res = resolveLiveServerRoot([join("ComfyUI", "main.py")]);

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -8,6 +8,7 @@ import {
 import { randomUUID } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readdirSync,
@@ -1496,6 +1497,48 @@ function resolveScriptAnchor(argv: string[]): string | undefined {
 }
 
 /**
+ * Resolve the one embedded-python layout that process-control can prove without
+ * turning the general interpreter resolver into a layout guess:
+ *
+ *   <root>\python\python.exe  <root>\main.py
+ *
+ * `python` is the interpreter observed in the already-correlated process command
+ * line, and `root` is the live process anchor recovered by resolveLiveServerRoot.
+ * Keep this deliberately narrower than findComfyuiPython: this is only a relaunch
+ * repair for a process we are about to stop, not authority for arbitrary local
+ * filesystem writes. The caller still validates the script and interpreter as
+ * regular files before adopting the pair.
+ */
+function observedEmbeddedMainAnchor(
+  observedPython: string | undefined,
+  liveRoot: string | undefined,
+  scriptToken: string,
+): { python: string; script: string } | null | undefined {
+  if (!IS_WIN || !observedPython || !liveRoot) return undefined;
+  if (!isAbsolute(observedPython) || !isAbsolute(liveRoot)) return undefined;
+
+  // Only the bare script form is eligible. A different relative path may name a
+  // launcher/symlink or depend on the cwd in a way this narrow repair cannot prove.
+  if (scriptToken.trim().toLowerCase() !== "main.py") return undefined;
+
+  const python = join(liveRoot, "python", "python.exe");
+  const script = join(liveRoot, "main.py");
+  if (!sameInterpreterPath(observedPython, python)) return undefined;
+  // An exact observed layout must not fall through to findComfyuiPython when its
+  // own files are missing, directories, or links. That would replace a narrow
+  // refusal with an unverified layout guess.
+  if (
+    !isNonSymlinkDirectory(liveRoot) ||
+    !isNonSymlinkDirectory(join(liveRoot, "python")) ||
+    !isNonSymlinkRegularFile(python) ||
+    !isNonSymlinkRegularFile(script)
+  ) {
+    return null;
+  }
+  return { python, script };
+}
+
+/**
  * The live process's own working directory — the most authoritative anchor for a
  * RELATIVE launch script. A ComfyUI launched as `python main.py …` has argv[0] =
  * `main.py` with no path root, an unset/stale COMFYUI_PATH gives no canonical base,
@@ -2074,16 +2117,23 @@ function resolveLaunchCommand(
     let liveCwdPython: string | undefined;
     if (!scriptIsAbsolute && info.liveCwd && relSegments.length > 0) {
       const candidateScript = join(info.liveCwd, ...relSegments);
-      const candidatePython = findComfyuiPython(info.liveCwd, argv);
+      const embeddedAnchor = observedEmbeddedMainAnchor(
+        info.observedInterpreter,
+        info.liveCwd,
+        firstUnquoted,
+      );
+      const candidatePython =
+        embeddedAnchor?.python ??
+        (embeddedAnchor === undefined ? findComfyuiPython(info.liveCwd, argv) : undefined);
       const pythonIsAbsolute =
         !!candidatePython &&
         (isAbsolute(candidatePython) || /^[a-zA-Z]:[\\/]/.test(candidatePython));
       if (
-        isRegularFile(candidateScript) &&
+        isRegularFile(embeddedAnchor?.script ?? candidateScript) &&
         pythonIsAbsolute &&
         isRegularFile(candidatePython)
       ) {
-        liveCwdScript = candidateScript;
+        liveCwdScript = embeddedAnchor?.script ?? candidateScript;
         liveCwdPython = candidatePython;
       }
     }
@@ -2193,6 +2243,32 @@ function isRegularFile(p: string | undefined): boolean {
   if (!p) return false;
   try {
     return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The exact embedded-portable repair is deliberately stricter than the existing
+ * generic live-cwd path: a symlinked executable or entrypoint would make the
+ * lexical `<root>` anchor mean something different from the process identity we
+ * observed, so it must retain the refusal.
+ */
+function isNonSymlinkRegularFile(p: string | undefined): boolean {
+  if (!p) return false;
+  try {
+    const st = lstatSync(p);
+    return st.isFile() && !st.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isNonSymlinkDirectory(p: string | undefined): boolean {
+  if (!p) return false;
+  try {
+    const st = lstatSync(p);
+    return st.isDirectory() && !st.isSymbolicLink();
   } catch {
     return false;
   }
@@ -5458,7 +5534,7 @@ export const __processControlTestHooks = {
    *  recycled-PID scenarios on any host, including where the native read is
    *  deliberately skipped. */
   setProcessIdentityResolver(
-    fn: ((pid: number) => { startedAt?: string } | undefined) | null,
+    fn: ((pid: number) => ProcessIdentity | undefined) | null,
   ): void {
     processIdentityOverride = fn;
   },

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -2122,9 +2122,14 @@ function resolveLaunchCommand(
         info.liveCwd,
         firstUnquoted,
       );
+      // `null` means the observed process proved the exact embedded layout but
+      // its root/interpreter/script failed validation. Do not let that explicit
+      // refusal fall through to the broader canonical anchor below: it could
+      // relaunch a different install after stopping the observed process.
+      if (embeddedAnchor === null) return null;
       const candidatePython =
         embeddedAnchor?.python ??
-        (embeddedAnchor === undefined ? findComfyuiPython(info.liveCwd, argv) : undefined);
+        findComfyuiPython(info.liveCwd, argv);
       const pythonIsAbsolute =
         !!candidatePython &&
         (isAbsolute(candidatePython) || /^[a-zA-Z]:[\\/]/.test(candidatePython));


### PR DESCRIPTION
Fixes #2252

## Summary
- Anchor the narrow Windows embedded-python layout only after the live process passes PID/creation-time and command-line identity checks.
- Resolve the exact `<root>\python\python.exe` + `<root>\main.py` pair from the observed live root.
- Treat an invalid exact embedded observation as a hard refusal, preventing canonical-anchor or generic fallback after the observed process is stopped.
- Keep refusal coverage for non-regular/symlinked embedded paths, with a valid alternate canonical install proving the fallback bypass is blocked.

## Validation
- `npm.cmd exec -- vitest run src/__tests__/services/restart-live-first.test.ts src/__tests__/services/restart-relaunch-lifecycle.test.ts src/__tests__/services/workspace-env.test.ts --reporter=dot` — 3 files, 220 tests passed.
- `npm.cmd run lint` passed.
- `npm.cmd run build` passed.
- `git diff --check` passed.