### PR TITLE
fix(panel-consumer): preserve workflow_list readiness refusal

### DIFF
--- a/src/__tests__/services/pre-executor-refusal-retry.test.ts
+++ b/src/__tests__/services/pre-executor-refusal-retry.test.ts
@@ -143,14 +143,20 @@ describe("isPreExecutorRefusal — only the panel's own claim (#1529)", () => {
 //    never reads it, and both are single lines in large files.
 
 describe("the channel is actually connected (#1529)", () => {
-  it("the bridge attaches a validated refusal to the rejected error", async () => {
+  it("the bridge preserves refusal attachment and workflow-list readiness handling", async () => {
     const { readFileSync } = await import("node:fs");
     const src = readFileSync(new URL("../../services/ui-bridge.ts", import.meta.url), "utf-8");
     const at = src.indexOf('new Error(String(msg.error ?? "panel reported an error"))');
     expect(at, "the reply-to-error conversion must still be recognisable").toBeGreaterThan(-1);
-    const block = src.slice(at, at + 700);
+    const block = src.slice(at, at + 1200);
     expect(block).toMatch(/readPanelRefusal\(/);
-    expect(block).toMatch(/refusal \? attachPanelRefusal\(err, refusal\) : err/);
+    expect(block).toMatch(/let rejected = refusal \? attachPanelRefusal\(err, refusal\) : err;/);
+    expect(block).toMatch(
+      /p\.cmd === "workflow_list" && hasOwnField\(msg, "workflow_list_readiness"\)[\s\S]+?readWorkflowListReadiness\(/,
+    );
+    expect(block).toMatch(
+      /if \(workflowListReadiness\) \{[\s\S]+?attachWorkflowListReadiness\(rejected, workflowListReadiness\);[\s\S]+?p\.reject\(rejected\);/,
+    );
   });
 
   it("the retry gate keys on the FIELD, and lets a MUTATION through on it", async () => {

--- a/src/__tests__/services/workflow-list-readiness.test.ts
+++ b/src/__tests__/services/workflow-list-readiness.test.ts
@@ -18,6 +18,7 @@ import {
   workflowListReadinessOf,
   type WorkflowListReadinessRefusal,
 } from "../../services/panel-workflow-readiness.js";
+import { isPreExecutorRefusal } from "../../services/panel-refusal.js";
 import { waitFor } from "../helpers/wait-for.js";
 
 const BEFORE = "4808c797-417c-4c33-8ab0-99cf2f6ba648";
@@ -29,6 +30,13 @@ const READINESS_REFUSAL: WorkflowListReadinessRefusal = {
   ready: false,
   applied: false,
   stage: "pre-probe",
+  retryable: true,
+};
+
+const PRE_EXECUTOR_REFUSAL = {
+  code: "backend-reconnecting",
+  applied: false,
+  stage: "pre-executor",
   retryable: true,
 };
 
@@ -54,7 +62,7 @@ describe("Panel workflow_list readiness reaches the rebind consumer (#1785)", ()
   let port: number;
   let socket: WebSocket;
   let fence: string;
-  let replyMode: "readiness" | "success";
+  let replyMode: "readiness" | "both" | "success";
   let received: Array<Record<string, unknown>>;
 
   beforeEach(async () => {
@@ -91,19 +99,18 @@ describe("Panel workflow_list readiness reaches the rebind consumer (#1785)", ()
         socket.send(JSON.stringify({ rid: message.rid, ok: true, result: { cmd: message.cmd } }));
         return;
       }
-      if (replyMode === "readiness") {
+      if (replyMode === "readiness" || replyMode === "both") {
         // Model a real re-hello/fence change racing the refusal. The changed
         // fence is deliberately not accompanied by a successful list proof.
         fence = READY;
         sendHello();
-        socket.send(
-          JSON.stringify({
-            rid: message.rid,
-            ok: false,
-            error: "workflow_list readiness is still settling",
-            workflow_list_readiness: READINESS_REFUSAL,
-          }),
-        );
+        socket.send(JSON.stringify({
+          rid: message.rid,
+          ok: false,
+          error: "workflow_list readiness is still settling",
+          workflow_list_readiness: READINESS_REFUSAL,
+          ...(replyMode === "both" ? { refusal: PRE_EXECUTOR_REFUSAL } : {}),
+        }));
       } else {
         socket.send(
           JSON.stringify({ rid: message.rid, ok: true, result: settled(READY) }),
@@ -146,6 +153,16 @@ describe("Panel workflow_list readiness reaches the rebind consumer (#1785)", ()
       .then(() => null, (err: unknown) => err);
 
     expect(error).toBeInstanceOf(Error);
+    expect(workflowListReadinessOf(error)).toEqual(READINESS_REFUSAL);
+  });
+
+  it("preserves the existing refusal attachment alongside readiness", async () => {
+    replyMode = "both";
+    const error = await bridge
+      .send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 3000 })
+      .then(() => null, (err: unknown) => err);
+
+    expect(isPreExecutorRefusal(error)?.code).toBe("backend-reconnecting");
     expect(workflowListReadinessOf(error)).toEqual(READINESS_REFUSAL);
   });
 

--- a/src/__tests__/services/workflow-list-readiness.test.ts
+++ b/src/__tests__/services/workflow-list-readiness.test.ts
@@ -1,0 +1,177 @@
+// #1785 — the Panel's workflow_list reconnect-readiness refusal is an explicit
+// pre-probe answer. A concurrent re-hello may change the bridge's fence, but
+// that change is not a successful workflow_list proof and must not make
+// panel_set_workflow_target report bound.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import {
+  workflowListReadinessOf,
+  type WorkflowListReadinessRefusal,
+} from "../../services/panel-workflow-readiness.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const BEFORE = "4808c797-417c-4c33-8ab0-99cf2f6ba648";
+const READY = "caf45251-53ad-431b-afdd-02239fdb7119";
+const TAB = "wf:route1:workflows/a.json";
+
+const READINESS_REFUSAL: WorkflowListReadinessRefusal = {
+  code: "reconnect-not-ready",
+  ready: false,
+  applied: false,
+  stage: "pre-probe",
+  retryable: true,
+};
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = address && typeof address === "object" ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+describe("Panel workflow_list readiness reaches the rebind consumer (#1785)", () => {
+  let bridge: UiBridge;
+  let port: number;
+  let socket: WebSocket;
+  let fence: string;
+  let replyMode: "readiness" | "success";
+  let received: Array<Record<string, unknown>>;
+
+  beforeEach(async () => {
+    fence = BEFORE;
+    replyMode = "readiness";
+    received = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver(
+      () => fence,
+      (_tabId, uuid) => {
+        fence = uuid;
+        return true;
+      },
+    );
+    socket = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    sendHello();
+    await waitFor(() => expect(bridge.tabs().map((tab) => tab.tab_id)).toContain(TAB));
+    socket.on("message", (raw) => {
+      const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+      if (typeof message.rid !== "string" || typeof message.cmd !== "string") return;
+      received.push(message);
+      if (message.cmd !== "workflow_list") {
+        socket.send(JSON.stringify({ rid: message.rid, ok: true, result: { cmd: message.cmd } }));
+        return;
+      }
+      if (replyMode === "readiness") {
+        // Model a real re-hello/fence change racing the refusal. The changed
+        // fence is deliberately not accompanied by a successful list proof.
+        fence = READY;
+        sendHello();
+        socket.send(
+          JSON.stringify({
+            rid: message.rid,
+            ok: false,
+            error: "workflow_list readiness is still settling",
+            workflow_list_readiness: READINESS_REFUSAL,
+          }),
+        );
+      } else {
+        socket.send(
+          JSON.stringify({ rid: message.rid, ok: true, result: settled(READY) }),
+        );
+      }
+    });
+  });
+
+  afterEach(async () => {
+    try {
+      socket?.close();
+    } catch {
+      // already closed
+    }
+    await bridge?.stop();
+  });
+
+  function sendHello(): void {
+    socket.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: TAB,
+        title: TAB,
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+      }),
+    );
+  }
+
+  async function setCurrentTarget(): Promise<ToolResult> {
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const definition = buildPanelToolDefs().find((def) => def.name === "panel_set_workflow_target");
+    if (!definition) throw new Error("panel_set_workflow_target is not registered");
+    return definition.handler({ mode: "current" } as never, ctx);
+  }
+
+  it("preserves the typed refusal on the bridge Error", async () => {
+    const error = await bridge
+      .send({ cmd: "workflow_list" }, { tabId: TAB, timeoutMs: 3000 })
+      .then(() => null, (err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(workflowListReadinessOf(error)).toEqual(READINESS_REFUSAL);
+  });
+
+  it("does not turn readiness refusal plus concurrent re-hello into bound", async () => {
+    const result = await setCurrentTarget();
+    const text = result.content.map((block) => ("text" in block ? block.text : "")).join(" ");
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("reconnect-not-ready");
+    expect(text).toContain("did NOT restore this session's graph binding");
+    expect(text).not.toContain('"graph_binding": "bound"');
+    expect(text).not.toContain("Graph tools should work now");
+    expect(fence).toBe(READY);
+    expect(received.map((message) => message.cmd)).toEqual(["workflow_list"]);
+  });
+
+  it("keeps successful healing after an actual ready, corroborated workflow_list", async () => {
+    replyMode = "success";
+    const result = await setCurrentTarget();
+    const text = result.content.map((block) => ("text" in block ? block.text : "")).join(" ");
+    const document = JSON.parse(text) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(document.graph_binding).toBe("bound");
+    expect(document.graph_binding_status).toBe("refreshed");
+    expect(fence).toBe(READY);
+    expect(received.map((message) => message.cmd)).toEqual(["workflow_list"]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -64,6 +64,11 @@ import {
 } from "../services/manifest-partial.js";
 import { searchPanelNodes } from "../services/manager-node-search.js";
 import { isPanelAnsweredError } from "../services/panel-answered.js";
+import {
+  readWorkflowListReadiness,
+  workflowListReadinessOf,
+  type WorkflowListReadinessRefusal,
+} from "../services/panel-workflow-readiness.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
@@ -3497,6 +3502,34 @@ function carryPanelAnsweredMark(err: unknown, res: ToolResult): ToolResult {
     configurable: true,
   });
   return res;
+}
+
+/** #1785 — preserve the Panel's typed workflow-list readiness refusal across the
+ * bridge-to-ToolResult conversion. The refusal is an explicit answer, not a
+ * silent read failure, and its distinction controls whether a concurrent
+ * re-hello may be treated as successful healing. */
+const WORKFLOW_LIST_READINESS_RESULT = Symbol("panel.workflowListReadinessResult");
+
+function carryWorkflowListReadinessMark(err: unknown, res: ToolResult): ToolResult {
+  if (res?.isError !== true) return res;
+  const refusal = workflowListReadinessOf(err);
+  if (!refusal) return res;
+  Object.defineProperty(res, WORKFLOW_LIST_READINESS_RESULT, {
+    value: refusal,
+    enumerable: false,
+    configurable: true,
+  });
+  return res;
+}
+
+function workflowListReadinessResultOf(
+  res: ToolResult,
+): WorkflowListReadinessRefusal | null {
+  if (res?.isError !== true) return null;
+  const refusal = (res as Record<symbol, unknown>)[WORKFLOW_LIST_READINESS_RESULT];
+  return refusal && typeof refusal === "object"
+    ? readWorkflowListReadiness(refusal)
+    : null;
 }
 
 /** True only for a ToolResult `ctx.call` produced from an error the BRIDGE minted
@@ -8359,6 +8392,16 @@ export type WorkflowFenceRebind =
     }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
   | { status: "unreadable"; before: FenceRead; detail: string }
+  /** #1785 — the Panel answered that workflow_list itself was not ready. This
+   * is stronger than an unreadable transport failure and weaker than a
+   * successful readiness/list proof: a concurrent re-hello may not turn it
+   * into `healed_by_panel`. */
+  | {
+      status: "readiness_refused";
+      before: FenceRead;
+      detail: string;
+      readiness: WorkflowListReadinessRefusal;
+    }
   /** The panel answered, but no usable identity could be adopted from it. TWO
    *  different facts with different remedies, so they are discriminated rather
    *  than bucketed: `no_uuid` = this panel build exposes no workflow identity at
@@ -8964,6 +9007,17 @@ async function rebindWorkflowFence(
       const res = await ctx.call({ cmd: "workflow_list" }, 6000);
       syncFenceToCurrentTab();
       if (res?.isError) {
+        const readiness = workflowListReadinessResultOf(res);
+        if (readiness) {
+          return {
+            done: {
+              status: "readiness_refused",
+              before,
+              detail: toolResultText(res),
+              readiness,
+            },
+          };
+        }
         return { done: await unreadableOrHealed(ctx, before, toolResultText(res)) };
       }
       parsed = parseToolResultJson(res);
@@ -9486,6 +9540,18 @@ function describeFenceRebind(
           `\n\nWHAT TO DO: call this again — a second attempt is safe and settles it. If it ` +
           `keeps throwing: ${RELOAD_TAB_REMEDY}` +
           `\n\nUNDERLYING CAUSE: ${r.detail}`,
+      };
+    case "readiness_refused":
+      return {
+        binding: "not_recovered",
+        note:
+          ` The panel ANSWERED the workflow_list probe with its typed reconnect-readiness ` +
+          `refusal (${r.readiness.code}): the probe was not run, changed no workflow target, ` +
+          `and the live workflow identity was not ready within the panel's bounded window. ` +
+          `A concurrent re-hello or fence change is not a successful workflow_list proof, so ` +
+          `this call did NOT restore graph binding. Retry after the panel reports readiness, or ` +
+          `use panel_open_workflow(<path>) to explicitly re-establish the tab.` +
+          `\n\nUNDERLYING CAUSE (quoted verbatim): ${r.detail}`,
       };
     case "unreadable":
       // ALWAYS not_recovered, with or without a prior fence (codex gate). The read
@@ -12933,7 +12999,10 @@ export function makePanelToolCtx(
     const res = await callOnce(cmd, timeoutMs, onDispatchedRid, (err) => {
       failure = err;
     });
-    return carryMidCommandDisconnectMark(failure, carryPanelAnsweredMark(failure, res));
+    return carryWorkflowListReadinessMark(
+      failure,
+      carryMidCommandDisconnectMark(failure, carryPanelAnsweredMark(failure, res)),
+    );
   };
   // Human-in-the-loop confirmation for a DESTRUCTIVE op: render a yes/no card in
   // the panel and block on the user's pick. Returns false on decline, timeout, or

--- a/src/services/panel-workflow-readiness.ts
+++ b/src/services/panel-workflow-readiness.ts
@@ -1,0 +1,86 @@
+/**
+ * The Panel's typed `workflow_list` reconnect-readiness refusal (#1785).
+ *
+ * This is deliberately separate from the graph-mutation refusal. `workflow_list`
+ * is a read-only probe, and the Panel's claim is that the probe itself did not
+ * run because the live workflow identity was not ready yet.
+ */
+
+export interface WorkflowListReadinessRefusal {
+  code: "reconnect-not-ready";
+  ready: false;
+  applied: false;
+  stage: "pre-probe";
+  retryable: true;
+}
+
+export const PANEL_WORKFLOW_LIST_READINESS_PROP = "cmcpWorkflowListReadiness";
+
+const OWN = Object.prototype.hasOwnProperty;
+
+function hasOwn(target: unknown, key: string): boolean {
+  return !!target && typeof target === "object" && OWN.call(target, key);
+}
+
+/** Read only a complete, known Panel readiness refusal and rebuild its shape. */
+export function readWorkflowListReadiness(
+  value: unknown,
+): WorkflowListReadinessRefusal | null {
+  if (!value || typeof value !== "object") return null;
+  const refusal = value as Record<string, unknown>;
+  for (const key of ["code", "ready", "applied", "stage", "retryable"]) {
+    if (!hasOwn(refusal, key)) return null;
+  }
+  if (
+    refusal.code !== "reconnect-not-ready" ||
+    refusal.ready !== false ||
+    refusal.applied !== false ||
+    refusal.stage !== "pre-probe" ||
+    refusal.retryable !== true
+  ) {
+    return null;
+  }
+  return {
+    code: "reconnect-not-ready",
+    ready: false,
+    applied: false,
+    stage: "pre-probe",
+    retryable: true,
+  };
+}
+
+/** Attach the validated Panel claim to the Error rejected by the bridge. */
+export function attachWorkflowListReadiness<E extends Error>(
+  err: E,
+  refusal: WorkflowListReadinessRefusal,
+): E {
+  try {
+    Object.defineProperty(err, PANEL_WORKFLOW_LIST_READINESS_PROP, {
+      value: refusal,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  } catch {
+    // Decorating an already-failed command must never replace its error.
+  }
+  return err;
+}
+
+/** Read the bridge-owned readiness claim from an Error. */
+export function workflowListReadinessOf(
+  err: unknown,
+): WorkflowListReadinessRefusal | null {
+  if (!err || typeof err !== "object" || !hasOwn(err, PANEL_WORKFLOW_LIST_READINESS_PROP)) {
+    return null;
+  }
+  return readWorkflowListReadiness(
+    (err as Record<string, unknown>)[PANEL_WORKFLOW_LIST_READINESS_PROP],
+  );
+}
+
+/** Preserve the claim if the bridge substitutes a friendlier Error. */
+export function inheritWorkflowListReadiness<E extends Error>(from: unknown, to: E): E {
+  const refusal = workflowListReadinessOf(from);
+  return refusal ? attachWorkflowListReadiness(to, refusal) : to;
+}

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -21,6 +21,11 @@ import { resolveLocale, trFor, type Locale } from "../i18n/index.js";
 import { logger } from "../utils/logger.js";
 import { attachPanelAnswered, inheritPanelAnswered } from "./panel-answered.js";
 import { attachPanelRefusal, hasOwnField, readPanelRefusal } from "./panel-refusal.js";
+import {
+  attachWorkflowListReadiness,
+  inheritWorkflowListReadiness,
+  readWorkflowListReadiness,
+} from "./panel-workflow-readiness.js";
 import { midCommandDisconnectMessage } from "./mid-command-remedy.js";
 import {
   describePanelUpdateRecovery,
@@ -3231,7 +3236,17 @@ export class UiBridge {
           const refusal = hasOwnField(msg, "refusal")
             ? readPanelRefusal((msg as { refusal?: unknown }).refusal)
             : null;
-          p.reject(refusal ? attachPanelRefusal(err, refusal) : err);
+          const workflowListReadiness =
+            p.cmd === "workflow_list" && hasOwnField(msg, "workflow_list_readiness")
+              ? readWorkflowListReadiness(
+                  (msg as { workflow_list_readiness?: unknown }).workflow_list_readiness,
+                )
+              : null;
+          let rejected = refusal ? attachPanelRefusal(err, refusal) : err;
+          if (workflowListReadiness) {
+            rejected = attachWorkflowListReadiness(rejected, workflowListReadiness);
+          }
+          p.reject(rejected);
         }
         return;
       }
@@ -5671,7 +5686,8 @@ export class UiBridge {
       // label a talking panel silent and send its user to hard-refresh a healthy
       // tab. PROPAGATED from the source error, never re-derived from the
       // replacement's wording.
-      ctx.reject(friendly ? inheritPanelAnswered(err, friendly) : err);
+      const mapped = friendly ? inheritPanelAnswered(err, friendly) : err;
+      ctx.reject(inheritWorkflowListReadiness(err, mapped));
     };
     const timer = setTimeout(() => {
       this.pending.delete(rid);


### PR DESCRIPTION
## Summary

- Preserve the Panel's typed workflow_list_readiness refusal through ui-bridge and make it available to the panel-tools consumer.
- Prevent rebindWorkflowFence/panel_set_workflow_target from treating that refusal plus a concurrent re-hello/fence change as healed or graph_binding bound.
- Keep existing bound/refreshed healing only for an actual successful, corroborated workflow_list proof.
- Update the legacy refusal source-wiring assertion to pin both refusal attachment and typed readiness handling.

## Verification

- Focused bridge/refusal/readiness suite: 2 files, 21 tests passed.
- Broader bridge/rebind suite: 7 files, 720 tests passed.
- Full Vitest run: 12,178 passed, 4 skipped; 3 pre-existing failures remain in src/__tests__/orchestrator/node-id-union-message.test.ts and reproduce in isolation. Those failures are unrelated to this PR's files.
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Tracking

- Related to artokun/comfyui-mcp-panel#1785
- Companion to artokun/comfyui-mcp-panel#1792; Panel-side merge/release remains out of scope.