### PR TITLE
fix(panel): apply canonical download cache dir on reload

### DIFF
--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { MANAGED_SECRET_KEYS_ENV, resetEnvFileProvenanceForTests } from "../../env-file.js";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import {
+  MANAGED_SECRET_KEYS_ENV,
+  loadEnvFileIntoProcess,
+  resetEnvFileProvenanceForTests,
+} from "../../env-file.js";
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -125,6 +129,40 @@ describe("panel-secrets (canonical .env store)", () => {
     } finally {
       if (previous === undefined) delete process.env.COMFYUI_CODE_PATH;
       else process.env.COMFYUI_CODE_PATH = previous;
+    }
+  });
+
+  it("forwards a cache path added to the canonical env into the panel-spawned child", () => {
+    const previous = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    try {
+      delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      writeFileSync(envPath, "COMFYUI_DOWNLOAD_CACHE_DIR=E:\\comfy-cache\\models\n");
+
+      const env = buildComfyuiMcpEnv({
+        COMFYUI_URL: "http://127.0.0.1:8188",
+        COMFYUI_MCP_PROGRESS_DIR: "/tmp/p",
+      });
+
+      expect(env.COMFYUI_DOWNLOAD_CACHE_DIR).toBe("E:\\comfy-cache\\models");
+      expect(env.COMFYUI_MCP_ENV_FILE).toBe(envPath);
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = previous;
+    }
+  });
+
+  it("uses a rotated canonical cache path instead of the value loaded at orchestrator boot", () => {
+    const previous = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    try {
+      writeFileSync(envPath, "COMFYUI_DOWNLOAD_CACHE_DIR=E:\\old-cache\n");
+      expect(loadEnvFileIntoProcess()).toContain("COMFYUI_DOWNLOAD_CACHE_DIR");
+
+      writeFileSync(envPath, "COMFYUI_DOWNLOAD_CACHE_DIR=E:\\new-cache\n");
+
+      expect(buildComfyuiMcpEnv({}).COMFYUI_DOWNLOAD_CACHE_DIR).toBe("E:\\new-cache");
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = previous;
     }
   });
 

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -151,6 +151,22 @@ export function resetEnvFileProvenanceForTests(): void {
   fileDerivedKeys.clear();
 }
 
+function freshValueFromParsed(key: string, parsed: Record<string, string> | null): string | undefined {
+  const envValue = process.env[key];
+  if (typeof envValue === "string" && envValue.trim() && !fileDerivedKeys.has(key)) {
+    return envValue;
+  }
+  if (parsed) {
+    const fileValue = parsed[key];
+    if (typeof fileValue === "string" && fileValue.trim()) return fileValue;
+    // A readable file without the key means a file-derived boot value is stale,
+    // not that the old value should be resurrected.
+    if (fileDerivedKeys.has(key)) return undefined;
+  }
+  if (typeof envValue === "string" && envValue.trim()) return envValue;
+  return undefined;
+}
+
 /**
  * Resolve a credential NOW, in precedence order:
  *   1. a REAL environment variable (shell / spawn env) — the escape hatch wins;
@@ -179,18 +195,18 @@ export function freshSecretValue(...keys: string[]): string | undefined {
   // variable still outranks the file.
   const parsed = parseEnvFile();
   for (const k of keys) {
-    const envValue = process.env[k];
-    if (typeof envValue === "string" && envValue.trim() && !fileDerivedKeys.has(k)) return envValue;
-    if (parsed) {
-      const fileValue = parsed[k];
-      if (typeof fileValue === "string" && fileValue.trim()) return fileValue;
-      // The file is readable and does not carry this alias, so a value seeded
-      // from the file at boot is stale — it must not resurrect the credential.
-      if (fileDerivedKeys.has(k)) continue;
-    }
-    if (typeof envValue === "string" && envValue.trim()) return envValue;
+    const value = freshValueFromParsed(k, parsed);
+    if (value !== undefined) return value;
   }
   return undefined;
+}
+
+/** Resolve one non-aliased environment value at access time. The same
+ * real-environment vs canonical-file precedence applies to configuration values
+ * that are not credentials, while a file-derived boot value is still superseded
+ * by a later readable file change. Never logs the value. */
+export function freshEnvValue(key: string): string | undefined {
+  return freshValueFromParsed(key, parseEnvFile());
 }
 
 /** Whether a credential resolves to SOMETHING right now — presence only, so
@@ -215,22 +231,8 @@ export function freshSecretValues(keys: readonly string[]): Record<string, strin
   const parsed = parseEnvFile();
   const out: Record<string, string> = {};
   for (const k of keys) {
-    const envValue = process.env[k];
-    if (typeof envValue === "string" && envValue.trim() && !fileDerivedKeys.has(k)) {
-      out[k] = envValue;
-      continue;
-    }
-    if (parsed) {
-      const fileValue = parsed[k];
-      if (typeof fileValue === "string" && fileValue.trim()) {
-        out[k] = fileValue;
-        continue;
-      }
-      // Readable file without the key: it is genuinely unset, so a stale
-      // boot-seeded value must not resurrect it.
-      if (fileDerivedKeys.has(k)) continue;
-    }
-    if (typeof envValue === "string" && envValue.trim()) out[k] = envValue;
+    const value = freshValueFromParsed(k, parsed);
+    if (value !== undefined) out[k] = value;
   }
   return out;
 }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -39,6 +39,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
   comfyuiEnvFilePath,
+  freshEnvValue,
   freshSecretValue,
   freshSecretValues,
   isShellProvided,
@@ -2262,6 +2263,13 @@ export function removeAgentSecret(key: string): SecretRemoveOutcome {
  */
 export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string, string> {
   const secrets = loadComfyuiSecretEnv();
+  // The orchestrator constructs the child env instead of inheriting it. Read
+  // this non-secret configuration value from the same canonical env file as the
+  // rest of the process, so a path added after the orchestrator booted reaches a
+  // panel_reload respawn even when it was never present in the parent's env.
+  // download-cache.ts remains authoritative for path normalization and its
+  // existing volume/containment checks; this forwards the raw configured value.
+  const downloadCacheDir = freshEnvValue("COMFYUI_DOWNLOAD_CACHE_DIR");
   // Which of the injected credentials does the canonical FILE own? Those must be
   // marked so the child treats its inherited copy as file-derived and a later
   // rotate/revoke supersedes it (codex gate, round 1, finding 1). Only a
@@ -2288,6 +2296,9 @@ export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string,
     // writer and reader the same file by construction. Not a secret: a path.
     ...(process.env.COMFYUI_MCP_ENV_FILE
       ? { COMFYUI_MCP_ENV_FILE: process.env.COMFYUI_MCP_ENV_FILE }
+      : {}),
+    ...(downloadCacheDir !== undefined
+      ? { COMFYUI_DOWNLOAD_CACHE_DIR: downloadCacheDir }
       : {}),
     // #873 — THE OPERATOR'S TOOL-SURFACE POLICY, forwarded HERE because this is the one
     // function BOTH comfyui spawn lanes share.


### PR DESCRIPTION
Fixes #2255\n\nThe panel-spawned comfyui MCP child gets an explicitly constructed environment. buildComfyuiMcpEnv now resolves COMFYUI_DOWNLOAD_CACHE_DIR from the canonical env file at spawn time, preserving real-environment precedence and file-derived rotation/revoke semantics. Only this non-secret key is forwarded; download-cache.ts remains authoritative for normalization, volume checks, and containment behavior.\n\nRegression coverage exercises the production spawn-env boundary for a cache path added after boot and a rotated canonical path.\n\nVerified:\n- 243 relevant test files: 6092 passed, 4 skipped\n- Focused env-file/panel-secrets: 48 passed\n- npm run lint (tsc --noEmit)\n- git diff --check\n\nHead: 036aa03