### PR TITLE
fix(restart): anchor portable relative main.py (#2260)

### DIFF
--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -187,6 +187,13 @@ const EMBEDDED_ROOT = resolve("ComfyUI_embedded");
 const EMBEDDED_MAIN = join(EMBEDDED_ROOT, "main.py");
 const EMBEDDED_PYTHON_DIR = join(EMBEDDED_ROOT, "python");
 const EMBEDDED_PYTHON = join(EMBEDDED_ROOT, "python", "python.exe");
+// #2260: the stock Windows portable bundle keeps its embedded interpreter beside
+// the inner ComfyUI checkout. The launcher may `cd ComfyUI` before invoking bare
+// `main.py`, so the server cwd is the only direct anchor for that script.
+const PORTABLE_BUNDLE_ROOT = resolve("ComfyUI_windows_portable");
+const PORTABLE_SERVER_ROOT = join(PORTABLE_BUNDLE_ROOT, "ComfyUI");
+const PORTABLE_MAIN = join(PORTABLE_SERVER_ROOT, "main.py");
+const PORTABLE_PYTHON = join(PORTABLE_BUNDLE_ROOT, "python_embeded", "python.exe");
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -477,6 +484,94 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
       expect(exe).toBe(EMBEDDED_PYTHON);
       expect(args[0]).toBe(EMBEDDED_MAIN);
       expect((opts as { cwd?: string }).cwd).toBe(EMBEDDED_ROOT);
+
+      killSpy.mockRestore();
+    },
+  );
+
+  winIt(
+    "#2260: anchors bare main.py from the stock portable server cwd",
+    async () => {
+      // The stock bundle is <bundle>\\python_embeded\\python.exe plus
+      // <bundle>\\ComfyUI\\main.py. Its launcher can enter the inner checkout
+      // before invoking bare main.py, which the shared live-root resolver
+      // deliberately cannot infer from the sibling interpreter alone.
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        system: {
+          argv: ["main.py", "--port", "8188"],
+          cwd: PORTABLE_SERVER_ROOT,
+        },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const value = String(p);
+        return value === PORTABLE_MAIN || value === PORTABLE_PYTHON;
+      });
+      mockFindComfyuiPython.mockReturnValue(PORTABLE_PYTHON);
+      __processControlTestHooks.setLiveCwdResolver(() => undefined);
+      mockResolveLiveServerRoot.mockReturnValue({ source: "unresolved" });
+      __processControlTestHooks.setProcessIdentityResolver(() => ({
+        startedAt: "stable-stamp",
+        commandLine: `"${PORTABLE_PYTHON}" main.py --port 8188`,
+        argv: [PORTABLE_PYTHON, "main.py", "--port", "8188"],
+        argvFidelity: "exact",
+      }));
+      mockLivePortThenFree();
+      mockSpawn.mockImplementation(() => new FakeChild());
+      vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true }) as Response));
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).not.toMatch(/refusing to restart/i);
+      expect(result.stopped).toBe(true);
+      expect(result.started).toBe(true);
+      expect(mockFindComfyuiPython).toHaveBeenCalledWith(
+        PORTABLE_SERVER_ROOT,
+        ["main.py", "--port", "8188"],
+      );
+      const [exe, args, opts] = mockSpawn.mock.calls[0];
+      expect(exe).toBe(PORTABLE_PYTHON);
+      expect(args[0]).toBe(PORTABLE_MAIN);
+      expect((opts as { cwd?: string }).cwd).toBe(PORTABLE_SERVER_ROOT);
+
+      killSpy.mockRestore();
+    },
+  );
+
+  winIt(
+    "#2260: keeps refusing the sibling-interpreter layout without an absolute reported cwd",
+    async () => {
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        // A relative cwd is no safer than no cwd after the old process is
+        // stopped: it would be interpreted relative to the MCP process.
+        system: { argv: ["main.py", "--port", "8188"], cwd: "ComfyUI" },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const value = String(p);
+        return value === PORTABLE_MAIN || value === PORTABLE_PYTHON;
+      });
+      mockFindComfyuiPython.mockReturnValue(PORTABLE_PYTHON);
+      mockResolveLiveServerRoot.mockReturnValue({ source: "unresolved" });
+      __processControlTestHooks.setProcessIdentityResolver(() => ({
+        startedAt: "stable-stamp",
+        commandLine: `"${PORTABLE_PYTHON}" main.py --port 8188`,
+        argv: [PORTABLE_PYTHON, "main.py", "--port", "8188"],
+        argvFidelity: "exact",
+      }));
+      mockLivePortThenFree();
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).toMatch(/refusing to restart/i);
+      expect(result.stopped).toBe(false);
+      expect(result.started).toBe(false);
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(killSpy).not.toHaveBeenCalled();
 
       killSpy.mockRestore();
     },

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -157,10 +157,12 @@ interface ProcessInfo {
   desktopExePath?: string;
   /**
    * The live ComfyUI process's working directory, captured at gather-time while
-   * the process is still ALIVE (a known-good moment). Used to resolve a RELATIVE
-   * launch script (`python main.py`) to an absolute path so relaunch works
-   * regardless of the orchestrator's own cwd — and, crucially, still resolves
-   * after the stop kills the pid (when `/proc/<pid>/cwd` is gone) (#535).
+   * the process is still ALIVE (a known-good moment). This may come from the
+   * server's own `/system_stats` report, `/proc/<pid>/cwd`, or the bounded
+   * process-observation fallback. Used to resolve a RELATIVE launch script
+   * (`python main.py`) to an absolute path so relaunch works regardless of the
+   * orchestrator's own cwd — and, crucially, still resolves after the stop kills
+   * the pid (when `/proc/<pid>/cwd` is gone) (#535/#2260).
    */
   liveCwd?: string;
   /**
@@ -1859,6 +1861,20 @@ function resolveLiveProcessCwd(pid: number): string | undefined {
 }
 
 /**
+ * `/system_stats` reports the server's actual working directory on recent
+ * ComfyUI builds. Accept only an absolute path: a relative value would be
+ * relative to this MCP process after the old server is stopped, which is the
+ * exact ambiguity the restart preflight refuses to guess through (#2260).
+ * Windows drive and UNC paths are recognized even when a cross-platform test
+ * harness is exercising the parser on a POSIX host.
+ */
+function reportedServerCwd(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const cwd = raw.trim();
+  return cwd && isAbsolutePath(cwd) ? cwd : undefined;
+}
+
+/**
  * The live process's working directory, reconstructed from the OS process
  * observation rather than from procfs (#535) — the Windows path, where
  * `/proc/<pid>/cwd` does not exist.
@@ -3006,6 +3022,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   };
 
   let argv: string[] = [];
+  let serverCwd: string | undefined;
   let pid: number | null = null;
   let ownerStartedAt: string | undefined;
   let bracketed = false;
@@ -3026,8 +3043,10 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
       try {
         const stats = await getSystemStats();
         argv = stats.system.argv ?? [];
+        serverCwd = reportedServerCwd(stats.system.cwd);
       } catch {
         argv = [];
+        serverCwd = undefined;
         logger.warn("Could not fetch system_stats — will rely on PID detection");
       }
       const after = observeOwner();
@@ -3156,7 +3175,9 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // interpreter lives in.
   const liveCwd = desktop
     ? undefined
-    : (resolveLiveProcessCwd(pid) ?? observedLiveCwd(pid, argv, ownerStartedAt));
+    : (resolveLiveProcessCwd(pid) ??
+      serverCwd ??
+      observedLiveCwd(pid, argv, ownerStartedAt));
   // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
   // is guaranteed alive, so a relaunch can reproduce the launcher environment the
   // server was actually started with instead of substituting the orchestrator's.


### PR DESCRIPTION
Fixes #2260.\n\nSummary:\n- capture an absolute /system_stats cwd while the live process is bracketed\n- use it as the existing live-cwd restart anchor for stock Windows portable main.py launches\n- reject relative cwd values and retain existing refusal/symlink protections\n- add stock portable-layout success and refusal regression coverage\n\nValidation:\n- npm.cmd exec -- vitest run src/__tests__/services/restart-live-first.test.ts --reporter=dot\n- relevant services/orchestrator suite: 249 files, 5818 passed, 4 skipped\n- npm.cmd run lint\n- npm.cmd run build\n- git diff --check