### PR TITLE
fix(panel): prevent staged Manager sync false-success

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -742,6 +742,7 @@ describe("runPanelAction", () => {
     expect(r.message).toMatch(/STAGED, not failed/);
     expect(r.message).toMatch(/RESTART ComfyUI/);
     expect(r.restartRequired).toBe(true);
+    expect(r.staged).toBe(true);
     // The misreport that cost the reporter four attempts and a reinstall path.
     expect(r.message).not.toMatch(/did NOT apply/);
     expect(r.message).not.toMatch(/silent no-op/);

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -438,6 +438,7 @@ function makeDeps(opts: {
   installedVersion?: string;
   pin?: PanelPinState;
   dirs?: string[];
+  managerReserved?: boolean;
   /** Mutate the live files map to simulate what the Manager actually did. */
   onUpdate?: (files: Record<string, string>) => void;
   updateDetails?: unknown;
@@ -445,6 +446,11 @@ function makeDeps(opts: {
   const files: Record<string, string> = {};
   if (opts.installedVersion !== undefined) {
     files[join(PANEL_DIR, "pyproject.toml")] = pyproject(opts.installedVersion);
+  }
+  if (opts.managerReserved) {
+    files[
+      join(COMFY, "user", "__manager", "startup-scripts", "install-scripts.txt")
+    ] = `['${PANEL_REGISTRY_ID}', '#LAZY-CNR-SWITCH-SCRIPT', 'https://x/y.zip']\n`;
   }
   const dirs = opts.dirs ?? (opts.installedVersion !== undefined ? ["comfyui-mcp-panel"] : []);
   const h: Harness = { updates: 0, installs: 0, deps: undefined as never };
@@ -618,6 +624,40 @@ describe("performPanelSync", () => {
     await expect(performPanelSync({ deps: h.deps, ...RUN })).rejects.toThrow(
       /Could not verify|NOT reporting/i,
     );
+  });
+
+  it("does not call a staged legacy-Manager update a completed sync (#639)", async () => {
+    // Current recurrence: panel 0.15.57 is behind the 0.15.58 floor, while
+    // legacy Manager reports success and leaves its startup reservation. The
+    // panel is still 0.15.57 on disk until ComfyUI restarts.
+    const h = makeDeps({
+      installedVersion: "0.15.57",
+      managerReserved: true,
+      updateDetails: {
+        total_count: 0,
+        done_count: 2,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+      onUpdate: () => {
+        /* Manager staged the update; nothing moves until restart. */
+      },
+    });
+    const r = await performPanelSync({
+      deps: h.deps,
+      requiredVersion: "0.15.58",
+      orchestratorVersion: ORCH,
+    });
+
+    expect(h.updates).toBe(1);
+    expect(r.synced).toBe(false);
+    expect(r.staged).toBe(true);
+    expect(r.verifiedVersion).toBeUndefined();
+    expect(r.previousVersion).toBe("0.15.57");
+    expect(r.requiredPanelVersion).toBe("0.15.58");
+    expect(r.restartRequired).toBe(true);
+    expect(r.message).toMatch(/STAGED|RESTART ComfyUI/i);
   });
 
   it("reports stillBehind honestly when the sync landed but did not close the gap", async () => {

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2152,6 +2152,8 @@ export interface PanelActionResult {
   action: "install" | "update" | "reinstall";
   result: NodeOpResult;
   restartRequired: boolean;
+  /** True when ComfyUI-Manager reserved the update for the next startup. */
+  staged?: boolean;
   message: string;
   /** update only — installed version read from disk BEFORE the op (if known). */
   previousVersion?: string;
@@ -6151,6 +6153,7 @@ async function runPanelActionCore(
           action: "update",
           result: { ...result, message },
           restartRequired: true,
+          staged: true,
           message,
           previousVersion,
           installedVersion: post.version,

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -798,6 +798,8 @@ export interface PanelSyncResult {
    * intended one. Only ever set when `synced` is true.
    */
   verifiedVersion?: string;
+  /** True when Manager staged the update for the next ComfyUI startup. */
+  staged?: boolean;
   /** Highest panel version this orchestrator build needs. */
   requiredPanelVersion: string;
   /**
@@ -887,9 +889,10 @@ export async function reassessPanelAfterSyncFailure(
  *    mutation. In particular `pinned-warn` returns the warning and stops; this
  *    is a policy refusal, not an error.
  *  - `sync` delegates to `runPanelAction`, which THROWS unless the pack provably
- *    moved on disk (#639) and no shadow copy is serving (#641). That throw
- *    propagates: a verification failure is an explicit failure, never a
- *    downgraded "sync completed with warnings".
+ *    moved on disk (#639) and no shadow copy is serving (#641), or Manager
+ *    explicitly staged the update for the next startup (#1133). A staged
+ *    update is returned as pending, not as `synced: true`, because its bytes
+ *    have not moved on disk yet.
  *  - On success the installed version is RE-READ from disk and reported. If the
  *    re-read cannot confirm a version, we throw rather than claim a version we
  *    did not observe.
@@ -986,6 +989,25 @@ export async function performPanelSync(
           `".comfyui-agent-panel.bak-*". NOT reporting a completed sync — re-run ` +
           `${describeInstallPanelAction("status", "a re-check on the ComfyUI host")} once custom_nodes is readable.`,
       );
+    }
+
+    // #639 recurrence: a Manager-success response can be a legitimate staged
+    // update (#1133), leaving the old version on disk until the next startup.
+    // That is safe to report as pending — and must retain restartRequired — but
+    // it is not a completed sync and must not publish the unchanged version as
+    // `verifiedVersion`. The installer marks this path explicitly so a same-
+    // version nightly git movement cannot be confused with staging.
+    if (result.staged) {
+      assertPinnedTarget(pinnedDeps, "sync", "before reporting a staged update");
+      return {
+        synced: false,
+        staged: true,
+        decision: "sync",
+        previousVersion: result.previousVersion ?? before.installedVersion,
+        requiredPanelVersion: assessment.requiredPanelVersion,
+        restartRequired: true,
+        message: result.message,
+      };
     }
 
     // Tri-state: `null` when the landed version can't be compared at all.


### PR DESCRIPTION
Fixes #639\n\nThe legacy ComfyUI-Manager 3.x reservation path is a pending startup update, not a completed sync. Mark that installer result explicitly and keep performPanelSync from returning synced:true or verifiedVersion until the on-disk panel changes.\n\nRegression coverage exercises panel 0.15.57 behind required 0.15.58, Manager's stale total_count:0/done_count:2 response, unchanged disk version, and the startup reservation.\n\nValidation:\n- focused regression: 1 passed\n- panel service suite: 24 files, 915 passed\n- npm run lint\n- npm run build\n- git diff --check