### PR TITLE
fix(nodes): resolve portable local git fallback root

### DIFF
--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -34,6 +34,11 @@ const hoisted = vi.hoisted(() => ({
 // The live-root routing branch only streams local when the root exists locally.
 vi.mock("node:fs", () => ({
   existsSync: () => hoisted.liveRootExists,
+  // The resolver follows the launch script before checking its regular-file
+  // status. Keep this synthetic absolute path a resolvable regular entry so
+  // the fixture continues to exercise routing, not the real filesystem.
+  realpathSync: (path: string) => path,
+  lstatSync: () => ({}),
   // #2261 — live-root authorization now requires main.py to be a regular file,
   // not merely an existing directory entry. Keep this fixture's root-presence
   // switch authoritative for both checks.

--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -34,6 +34,10 @@ const hoisted = vi.hoisted(() => ({
 // The live-root routing branch only streams local when the root exists locally.
 vi.mock("node:fs", () => ({
   existsSync: () => hoisted.liveRootExists,
+  // #2261 — live-root authorization now requires main.py to be a regular file,
+  // not merely an existing directory entry. Keep this fixture's root-presence
+  // switch authoritative for both checks.
+  statSync: () => ({ isFile: () => hoisted.liveRootExists }),
 }));
 
 // isRemoteMode is the first gate; keep every other real config export.

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -43,6 +43,10 @@ writeFileSync(WORKSPACE_JSON, JSON.stringify({ defaultWorkspace: SAVED_DEFAULT }
 /** A stand-in comfy-cli executable, so the `useCmCli` branch is reachable. */
 const FAKE_COMFY_CLI = join(SANDBOX, "comfy");
 writeFileSync(FAKE_COMFY_CLI, "#!/bin/sh");
+/** A stand-in absolute Python image for the producer-to-clone contract test. */
+const FAKE_PORTABLE_PYTHON = join(SANDBOX, "python_embeded", "python.exe");
+mkdirSync(join(SANDBOX, "python_embeded"), { recursive: true });
+writeFileSync(FAKE_PORTABLE_PYTHON, "");
 
 // ── config: a LOOPBACK target on :8189 (that is LOCAL mode, which is why the
 //    filesystem fallback runs at all), with COMFYUI_PATH unset. ───────────────
@@ -185,6 +189,17 @@ vi.mock("node:child_process", async () => {
 // several installs coexist. Hence this tier, and hence these tests.
 const probe = vi.hoisted(() => ({
   calls: 0,
+  useActualProducer: false,
+  actualPid: 4244,
+  actualIdentity: undefined as
+    | {
+        commandLine?: string;
+        argv?: string[];
+        argvFidelity?: "exact" | "flattened";
+        executablePath?: string;
+        startedAt?: string;
+      }
+    | undefined,
   /** What the OS says is running on the port; undefined = nothing observable. */
   result: undefined as { python?: string; pid: number; launchScript?: string } | undefined,
 }));
@@ -192,8 +207,15 @@ vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
   return {
     ...actual,
-    observeLiveServerProcess: () => {
+    observeLiveServerProcess: (opts: Parameters<typeof actual.observeLiveServerProcess>[0]) => {
       probe.calls += 1;
+      if (probe.useActualProducer) {
+        return actual.observeLiveServerProcess({
+          ...opts,
+          findPid: () => probe.actualPid,
+          readIdentity: () => probe.actualIdentity,
+        });
+      }
       return probe.result;
     },
   };
@@ -236,6 +258,8 @@ beforeEach(() => {
   git.calls = [];
   http.calls = [];
   probe.calls = 0;
+  probe.useActualProducer = false;
+  probe.actualIdentity = undefined;
   probe.result = undefined;
   live.onStats = undefined;
   http.mode = "refuse-enqueue";
@@ -408,12 +432,19 @@ describe("#1765 — install_custom_node must not write into an install this sess
   });
 
   it("uses the correlated absolute launch script for a portable bare-main.py process", async () => {
-    // The portable interpreter is a sibling of the actual ComfyUI checkout, so
-    // the existing interpreter-as-anchor tier intentionally cannot identify this
-    // root. The OS process command line has already correlated the absolute script
-    // with this server; that direct evidence is sufficient for the clone target.
+    // Drive the real OS-process producer, not a hand-authored LiveServerProcess:
+    // the portable interpreter is a sibling of the actual ComfyUI checkout, so
+    // only the producer's correlated absolute launch script can identify this root.
     live.argv = ["main.py", "--port", "8189"];
-    probe.result = { pid: 4244, launchScript: join(CONNECTED, "main.py") };
+    probe.useActualProducer = true;
+    const script = join(CONNECTED, "main.py");
+    probe.actualIdentity = {
+      commandLine: `${FAKE_PORTABLE_PYTHON} -s "${script}" --port 8189`,
+      argv: [FAKE_PORTABLE_PYTHON, "-s", script, "--port", "8189"],
+      argvFidelity: "exact",
+      executablePath: FAKE_PORTABLE_PYTHON,
+      startedAt: "t1",
+    };
 
     const { ok, error } = await install({ id: REPO, source: "git" });
 

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -186,7 +186,7 @@ vi.mock("node:child_process", async () => {
 const probe = vi.hoisted(() => ({
   calls: 0,
   /** What the OS says is running on the port; undefined = nothing observable. */
-  result: undefined as { python: string; pid: number } | undefined,
+  result: undefined as { python?: string; pid: number; launchScript?: string } | undefined,
 }));
 vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
@@ -405,6 +405,21 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(ok).toMatchObject({ mechanism: "git-clone" });
     expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
     expect(probe.calls).toBeGreaterThan(0);
+  });
+
+  it("uses the correlated absolute launch script for a portable bare-main.py process", async () => {
+    // The portable interpreter is a sibling of the actual ComfyUI checkout, so
+    // the existing interpreter-as-anchor tier intentionally cannot identify this
+    // root. The OS process command line has already correlated the absolute script
+    // with this server; that direct evidence is sufficient for the clone target.
+    live.argv = ["main.py", "--port", "8189"];
+    probe.result = { pid: 4244, launchScript: join(CONNECTED, "main.py") };
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
   });
 
   it("fails closed when the relative main.py cannot be anchored", async () => {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -456,15 +456,23 @@ describe("#1765 — install_custom_node must not write into an install this sess
   it("refuses the git fallback when the producer sees a DIRECTORY named main.py", async () => {
     const badRoot = join(SANDBOX, "directory-main");
     const badScript = join(badRoot, "main.py");
+    // Keep the observed interpreter usable and portable-looking. Before the
+    // invalid launch-script veto, this let the resolver authorize this other
+    // regular-main.py tree after rejecting the observed directory.
+    const fallbackRoot = join(SANDBOX, "interpreter-fallback");
+    const fallbackPython = join(fallbackRoot, "python_embeded", "python.exe");
     mkdirSync(badScript, { recursive: true });
+    mkdirSync(join(fallbackRoot, "python_embeded"), { recursive: true });
+    writeFileSync(join(fallbackRoot, "main.py"), "# fallback tree\n");
+    writeFileSync(fallbackPython, "");
     try {
       live.argv = ["main.py", "--port", "8189"];
       probe.useActualProducer = true;
       probe.actualIdentity = {
-        commandLine: `${FAKE_PORTABLE_PYTHON} -s "${badScript}" --port 8189`,
-        argv: [FAKE_PORTABLE_PYTHON, "-s", badScript, "--port", "8189"],
+        commandLine: `${fallbackPython} -s "${badScript}" --port 8189`,
+        argv: [fallbackPython, "-s", badScript, "--port", "8189"],
         argvFidelity: "exact",
-        executablePath: FAKE_PORTABLE_PYTHON,
+        executablePath: fallbackPython,
         startedAt: "t1",
       };
 
@@ -475,6 +483,7 @@ describe("#1765 — install_custom_node must not write into an install this sess
       expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
     } finally {
       rmSync(badRoot, { recursive: true, force: true });
+      rmSync(fallbackRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -453,6 +453,31 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
   });
 
+  it("refuses the git fallback when the producer sees a DIRECTORY named main.py", async () => {
+    const badRoot = join(SANDBOX, "directory-main");
+    const badScript = join(badRoot, "main.py");
+    mkdirSync(badScript, { recursive: true });
+    try {
+      live.argv = ["main.py", "--port", "8189"];
+      probe.useActualProducer = true;
+      probe.actualIdentity = {
+        commandLine: `${FAKE_PORTABLE_PYTHON} -s "${badScript}" --port 8189`,
+        argv: [FAKE_PORTABLE_PYTHON, "-s", badScript, "--port", "8189"],
+        argvFidelity: "exact",
+        executablePath: FAKE_PORTABLE_PYTHON,
+        startedAt: "t1",
+      };
+
+      const { ok, error } = await install({ id: REPO, source: "git" });
+
+      expect(ok).toBeUndefined();
+      expect(clonedInto()).toBeUndefined();
+      expect(error).toMatch(/no ComfyUI path is set|local ComfyUI install/i);
+    } finally {
+      rmSync(badRoot, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when the relative main.py cannot be anchored", async () => {
     // Relative script, and the OS observation yields no interpreter (a remote
     // proxy, a permissions failure, an unreadable process table). No live root

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -371,6 +371,53 @@ describe("observeLiveServerProcess — the OS image survives a relative argv[0] 
     expect(res).toMatchObject({ pid: 5, image: exe, launchScript: script });
   });
 
+  it("uses the positional launch script among multiple main.py-shaped arguments", async () => {
+    const exe = await makeExe("multi-main-python.exe");
+    const actualRoot = join(dir, "actual");
+    const decoyRoot = join(dir, "decoy");
+    await mkdir(actualRoot, { recursive: true });
+    await mkdir(decoyRoot, { recursive: true });
+    const actualScript = join(actualRoot, "main.py");
+    const decoyScript = join(decoyRoot, "main.py");
+    await writeFile(actualScript, "# actual ComfyUI\n", "utf-8");
+    await writeFile(decoyScript, "# option value, not the launch script\n", "utf-8");
+
+    const serverArgv = [
+      "main.py",
+      "--extra-model-paths-config",
+      decoyScript,
+      "--port",
+      "8188",
+    ];
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv,
+      findPid: () => 5,
+      readIdentity: () => ({
+        // The -X value appears before the actual script, and the same decoy
+        // appears later as a script argument. Neither may replace the position
+        // Python actually uses as the launch script.
+        commandLine: `${exe} -X "${decoyScript}" "${actualScript}" --extra-model-paths-config "${decoyScript}" --port 8188`,
+        argv: [
+          exe,
+          "-X",
+          decoyScript,
+          actualScript,
+          "--extra-model-paths-config",
+          decoyScript,
+          "--port",
+          "8188",
+        ],
+        argvFidelity: "exact",
+        executablePath: exe,
+        startedAt: "t1",
+      }),
+    });
+
+    expect(res).toMatchObject({ pid: 5, launchScript: actualScript });
+  });
+
   it("does not expose an ABSOLUTE launch script when process correlation fails", async () => {
     const exe = await makeExe("unrelated-python.exe");
     const script = join(dir, "main.py");

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -391,7 +391,12 @@ describe("observeLiveServerProcess — the OS image survives a relative argv[0] 
       }),
     });
 
-    expect(res).toMatchObject({ pid: 5, image: exe });
+    expect(res).toMatchObject({
+      pid: 5,
+      image: exe,
+      python: exe,
+      launchScriptInvalid: true,
+    });
     expect(res?.launchScript).toBeUndefined();
   });
 

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -371,6 +371,30 @@ describe("observeLiveServerProcess — the OS image survives a relative argv[0] 
     expect(res).toMatchObject({ pid: 5, image: exe, launchScript: script });
   });
 
+  it("does not treat a DIRECTORY named main.py as a launch script", async () => {
+    const exe = await makeExe("directory-main-python.exe");
+    const root = join(dir, "directory-main");
+    const script = join(root, "main.py");
+    await mkdir(script, { recursive: true });
+
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py", "--port", "8188"],
+      findPid: () => 5,
+      readIdentity: () => ({
+        commandLine: `${exe} -s "${script}" --port 8188`,
+        argv: [exe, "-s", script, "--port", "8188"],
+        argvFidelity: "exact",
+        executablePath: exe,
+        startedAt: "t1",
+      }),
+    });
+
+    expect(res).toMatchObject({ pid: 5, image: exe });
+    expect(res?.launchScript).toBeUndefined();
+  });
+
   it("uses the positional launch script among multiple main.py-shaped arguments", async () => {
     const exe = await makeExe("multi-main-python.exe");
     const actualRoot = join(dir, "actual");

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -349,6 +349,48 @@ describe("observeLiveServerProcess — the OS image survives a relative argv[0] 
     expect(observeLiveServerProcess(opts)).toEqual({ pid: 5, image: exe });
   });
 
+  it("reports a correlated ABSOLUTE launch script for a bare server argv", async () => {
+    const exe = await makeExe("portable-python.exe");
+    const root = join(dir, "ComfyUI");
+    await mkdir(root, { recursive: true });
+    const script = join(root, "main.py");
+    await writeFile(script, "# ComfyUI\n", "utf-8");
+
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py", "--port", "8188"],
+      findPid: () => 5,
+      readIdentity: () => ({
+        commandLine: `${exe} -s "${script}" --port 8188`,
+        executablePath: exe,
+        startedAt: "t1",
+      }),
+    });
+
+    expect(res).toMatchObject({ pid: 5, image: exe, launchScript: script });
+  });
+
+  it("does not expose an ABSOLUTE launch script when process correlation fails", async () => {
+    const exe = await makeExe("unrelated-python.exe");
+    const script = join(dir, "main.py");
+    await writeFile(script, "# not the connected server\n", "utf-8");
+
+    const res = observeLiveServerProcess({
+      port: 8188,
+      remote: false,
+      serverArgv: ["main.py", "--port", "8188"],
+      findPid: () => 5,
+      readIdentity: () => ({
+        commandLine: `${exe} -s "${script}" --port 8189`,
+        executablePath: exe,
+        startedAt: "t1",
+      }),
+    });
+
+    expect(res).toBeUndefined();
+  });
+
   it("NORMALIZES the image — Windows records it exactly as the launcher wrote it", async () => {
     // Measured: a process launched as `..\python_embeded\python.exe` reports
     // `…\ComfyUI\..\python_embeded\python.exe` — absolute, but not yet a path an

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, mkdir, symlink } from "node:fs/promises";
 import { tmpdir, platform } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
+import { itWithSymlinks } from "../helpers/platform.js";
 
 const IS_WIN = platform() === "win32";
 /** Create a venv interpreter on disk under `root`, returning its absolute path. */
@@ -1699,6 +1700,27 @@ describe("liveScriptFromArgv agrees with liveRootFromArgv on every argv shape", 
   }
 });
 
+itWithSymlinks("realpath-resolves a symlinked absolute launch script for live authorization", async () => {
+  const dir = await tmpDir();
+  try {
+    const realRoot = join(dir, "real-install");
+    const launcherRoot = join(dir, "launcher");
+    const realScript = join(realRoot, "main.py");
+    const launchScript = join(launcherRoot, "main.py");
+    await mkdir(realRoot, { recursive: true });
+    await mkdir(launcherRoot, { recursive: true });
+    await writeFile(realScript, "# real ComfyUI\n", "utf-8");
+    await symlink(realScript, launchScript, "file");
+
+    expect(liveScriptFromArgv([launchScript])).toBe(realScript);
+    const resolved = resolveLiveServerRoot([launchScript]);
+    expect(resolved.source).toBe("argv");
+    expect(resolved.root).toBe(realRoot);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 describe("resolveRootInterpreter (portable + venv layouts)", () => {
   it("finds the install's own .venv interpreter on disk", async () => {
     const root = await tmpDir();
@@ -2270,6 +2292,28 @@ describe("resolveLiveServerRoot (#369)", () => {
       expect(res.source).toBe("observed-process");
       expect(res.root).toBe(serverRoot);
       expect(res.observedPid).toBe(4242);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  itWithSymlinks("realpath-resolves an observed symlinked launch script before authorizing its root", async () => {
+    const dir = await tmpDir();
+    try {
+      const realRoot = join(dir, "real-install");
+      const launcherRoot = join(dir, "launcher");
+      const realScript = join(realRoot, "main.py");
+      const launchScript = join(launcherRoot, "main.py");
+      await mkdir(realRoot, { recursive: true });
+      await mkdir(launcherRoot, { recursive: true });
+      await writeFile(realScript, "# real ComfyUI\n", "utf-8");
+      await symlink(realScript, launchScript, "file");
+      h.mockLiveProcess.mockReturnValue({ pid: 4243, launchScript });
+
+      const resolved = resolveLiveServerRoot(["main.py"], undefined, {});
+      expect(resolved.source).toBe("observed-process");
+      expect(resolved.root).toBe(realRoot);
+      expect(resolved.observedLaunchScript).toBe(realScript);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -2339,6 +2339,54 @@ describe("resolveLiveServerRoot (#369)", () => {
     }
   });
 
+  it("does not fall back to an interpreter after an invalid observed launch script", async () => {
+    const dir = await tmpDir();
+    try {
+      const root = join(dir, "interpreter-fallback");
+      const python = join(root, "python_embeded", IS_WIN ? "python.exe" : "python3");
+      await mkdir(dirname(python), { recursive: true });
+      await writeFile(join(root, "main.py"), "# fallback tree\n", "utf-8");
+      await writeFile(python, "", "utf-8");
+
+      h.mockLiveProcess.mockReturnValue({
+        pid: 4245,
+        python,
+        launchScriptInvalid: true,
+      });
+
+      const resolved = resolveLiveServerRoot(["main.py"], undefined, {});
+      expect(resolved.source).toBe("unresolved");
+      expect(resolved.root).toBeUndefined();
+      expect(resolved.observedPython).toBe(python);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on an indeterminate observed launch-script path", async () => {
+    const dir = await tmpDir();
+    try {
+      const root = join(dir, "interpreter-fallback");
+      const python = join(root, "python_embeded", IS_WIN ? "python.exe" : "python3");
+      await mkdir(dirname(python), { recursive: true });
+      await writeFile(join(root, "main.py"), "# fallback tree\n", "utf-8");
+      await writeFile(python, "", "utf-8");
+
+      // NUL makes realpathSync throw a non-ENOENT/ENOTDIR argument error. It
+      // must not be converted into a lexical path and then an interpreter root.
+      const indeterminateScript = `${join(dir, "blocked")}\0main.py`;
+      const resolved = resolveLiveServerRoot(
+        ["main.py"],
+        undefined,
+        { observedPython: python, observedLaunchScript: indeterminateScript },
+      );
+      expect(resolved.source).toBe("unresolved");
+      expect(resolved.root).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("anchors a BARE main.py on the OS image when that image is inside the install", async () => {
     const dir = await tmpDir();
     try {

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -2319,6 +2319,26 @@ describe("resolveLiveServerRoot (#369)", () => {
     }
   });
 
+  it("refuses an observed DIRECTORY named main.py before authorizing its parent", async () => {
+    const dir = await tmpDir();
+    try {
+      const root = join(dir, "directory-main");
+      const script = join(root, "main.py");
+      await mkdir(script, { recursive: true });
+      h.mockLiveProcess.mockReturnValue({ pid: 4244, launchScript: script });
+
+      const resolved = resolveLiveServerRoot(["main.py"], undefined, {});
+      expect(resolved.source).toBe("unresolved");
+      expect(resolved.root).toBeUndefined();
+
+      const argvResolved = resolveLiveServerRoot([script]);
+      expect(argvResolved.source).toBe("unresolved");
+      expect(argvResolved.root).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("anchors a BARE main.py on the OS image when that image is inside the install", async () => {
     const dir = await tmpDir();
     try {

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -648,28 +648,36 @@ export function commandLineMatchesArgv(
  * launch evidence, not a portable-bundle layout guess. A flattened macOS `ps`
  * command line is intentionally not strong enough to supply this evidence.
  */
+type LaunchScriptEvidence = {
+  path?: string;
+  /** A correlated script token was present, but it could not be proven usable. */
+  invalid: boolean;
+};
+
 function absoluteLaunchScriptFromIdentity(
   identity: ProcessIdentity | undefined,
   serverArgv: string[] | undefined,
-): string | undefined {
+): LaunchScriptEvidence {
   const serverScript = positionalMainScript(serverArgv);
-  if (!serverScript) return undefined;
-  if (identity?.argvFidelity === "flattened") return undefined;
+  if (!serverScript) return { invalid: false };
+  if (identity?.argvFidelity === "flattened") return { invalid: false };
 
   const processArgv =
     identity?.argv && identity.argv.length > 0
       ? identity.argv
       : tokenizeCommandLine(identity?.commandLine ?? "");
   const processScript = positionalProcessScript(processArgv);
-  if (!processScript || !isAbsolute(processScript)) return undefined;
+  if (!processScript || !isAbsolute(processScript)) return { invalid: false };
 
-  if (!sameLaunchScriptShape(processScript, serverScript)) return undefined;
+  if (!sameLaunchScriptShape(processScript, serverScript)) return { invalid: false };
 
   try {
     const resolved = realpathSync(pathResolve(processScript));
-    return statSync(resolved).isFile() ? resolved : undefined;
+    return statSync(resolved).isFile() ? { path: resolved, invalid: false } : { invalid: true };
   } catch {
-    return undefined;
+    // This was an explicit, correlated launch-script claim. Do not turn an
+    // unreadable/missing/non-file entry into permission to anchor on python.
+    return { invalid: true };
   }
 }
 
@@ -807,6 +815,12 @@ export interface LiveServerProcess {
    * of the ComfyUI directory and the server reports only bare `main.py`.
    */
   launchScript?: string;
+  /**
+   * A correlated launch-script path was present but could not be proven to be
+   * a regular file. This is a veto, not an absence of evidence: callers must
+   * not replace it with an interpreter-based root anchor.
+   */
+  launchScriptInvalid?: boolean;
 }
 
 /**
@@ -868,7 +882,12 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
     rawImage && isAbsolute(rawImage) && existsSync(rawImage)
       ? pathResolve(rawImage)
       : undefined;
-  const launchScript = absoluteLaunchScriptFromIdentity(identity, opts.serverArgv);
+  const launchEvidence = absoluteLaunchScriptFromIdentity(identity, opts.serverArgv);
+  const launchEvidenceFields = launchEvidence.invalid
+    ? { launchScriptInvalid: true as const }
+    : launchEvidence.path
+      ? { launchScript: launchEvidence.path }
+      : {};
 
   // Tier 1 — the process we launched, confirmed by PID *and* start time.
   // The recorded interpreter must be ABSOLUTE: a bare `python` would be
@@ -902,7 +921,7 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
         pid,
         image,
       };
-      return launchScript ? { ...result, launchScript } : result;
+      return { ...result, ...launchEvidenceFields };
     }
     // Same PID, different (or unreadable) start time → this is NOT our process, or
     // we cannot prove it is. Fall through to tier 2 rather than trust the record.
@@ -939,12 +958,12 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
     : identity?.venvPython;
   if (fromEnv && isAbsolute(fromEnv) && existsSync(fromEnv)) {
     const result = { python: fromEnv, source: "process-table" as const, pid, image };
-    return launchScript ? { ...result, launchScript } : result;
+    return { ...result, ...launchEvidenceFields };
   }
 
   if (argv0) {
     const result = { python: argv0, source: "process-table" as const, pid, image };
-    return launchScript ? { ...result, launchScript } : result;
+    return { ...result, ...launchEvidenceFields };
   }
-  return launchScript ? { pid, image, launchScript } : { pid, image };
+  return { pid, image, ...launchEvidenceFields };
 }

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -26,7 +26,7 @@
 // should be added here as tier 0 — it works for remote servers too.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readlinkSync } from "node:fs";
+import { existsSync, readFileSync, readlinkSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve as pathResolve } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
@@ -665,8 +665,12 @@ function absoluteLaunchScriptFromIdentity(
 
   if (!sameLaunchScriptShape(processScript, serverScript)) return undefined;
 
-  const resolved = pathResolve(processScript);
-  return existsSync(resolved) ? resolved : undefined;
+  try {
+    const resolved = realpathSync(pathResolve(processScript));
+    return statSync(resolved).isFile() ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -642,10 +642,11 @@ export function commandLineMatchesArgv(
  * server's own argv only reports a bare/relative `main.py`.
  *
  * The command-line identity has already been correlated with `serverArgv` by
- * `observeLiveServerProcess`. Keep the extra extraction narrow: use the first
- * main.py-shaped process argument and require it to agree with the server's
- * positional script token and exist on disk. This is observed launch evidence,
- * not a portable-bundle layout guess.
+ * `observeLiveServerProcess`. Keep the extra extraction narrow: parse the Python
+ * launch position (skipping Python option values), require that positional script
+ * to agree with the server's script token and exist on disk. This is observed
+ * launch evidence, not a portable-bundle layout guess. A flattened macOS `ps`
+ * command line is intentionally not strong enough to supply this evidence.
  */
 function absoluteLaunchScriptFromIdentity(
   identity: ProcessIdentity | undefined,
@@ -653,33 +654,80 @@ function absoluteLaunchScriptFromIdentity(
 ): string | undefined {
   const serverScript = positionalMainScript(serverArgv);
   if (!serverScript) return undefined;
+  if (identity?.argvFidelity === "flattened") return undefined;
 
   const processArgv =
     identity?.argv && identity.argv.length > 0
       ? identity.argv
       : tokenizeCommandLine(identity?.commandLine ?? "");
-  const processScript = processArgv
-    .map((raw) => raw.trim().replace(/^["']+|["']+$/g, ""))
-    .find((arg) => /(^|[\\/])main\.pyw?$/i.test(arg));
+  const processScript = positionalProcessScript(processArgv);
   if (!processScript || !isAbsolute(processScript)) return undefined;
 
-  const serverParts = serverScript
-    .split(/[\\/]/)
-    .filter((part) => part !== "" && part !== ".");
-  const processParts = processScript.split(/[\\/]/).filter(Boolean);
-  const processSuffix = processParts.slice(-serverParts.length);
-  if (
-    serverParts.length === 0 ||
-    processParts.length < serverParts.length ||
-    serverParts.some(
-      (part, index) => part.toLowerCase() !== processSuffix[index]?.toLowerCase(),
-    )
-  ) {
-    return undefined;
-  }
+  if (!sameLaunchScriptShape(processScript, serverScript)) return undefined;
 
   const resolved = pathResolve(processScript);
   return existsSync(resolved) ? resolved : undefined;
+}
+
+/**
+ * Return the actual Python script position, never a later script-shaped option
+ * value. Unknown options fail closed because their arity is not safe to infer.
+ * `-X` and `-W` are the Python options whose separate value can itself end in
+ * `main.py`; those values must be skipped before looking for the script.
+ */
+function positionalProcessScript(argv: string[]): string | undefined {
+  const noValueOptions = new Set([
+    "-B",
+    "-b",
+    "-d",
+    "-E",
+    "-i",
+    "-I",
+    "-O",
+    "-OO",
+    "-P",
+    "-q",
+    "-s",
+    "-S",
+    "-u",
+    "-v",
+    "-V",
+    "-VV",
+    "--help",
+    "--version",
+  ]);
+  for (let index = 1; index < argv.length; index++) {
+    const arg = argv[index]?.trim().replace(/^["']+|["']+$/g, "");
+    if (!arg) continue;
+    if (arg === "--") {
+      const script = argv[index + 1]?.trim().replace(/^["']+|["']+$/g, "");
+      return script && /(^|[\\/])main\.pyw?$/i.test(script) ? script : undefined;
+    }
+    if (!arg.startsWith("-")) {
+      return /(^|[\\/])main\.pyw?$/i.test(arg) ? arg : undefined;
+    }
+    if (arg === "-c" || arg === "-m" || arg === "--command" || arg === "--module") {
+      return undefined;
+    }
+    if (arg === "-X" || arg === "-W" || arg === "--check-hash-based-pycs") index++;
+    else if (!noValueOptions.has(arg) && !/^-[BbdEiIOPqSsuvV]+$/.test(arg)) return undefined;
+  }
+  return undefined;
+}
+
+/** Compare a process's positional script with the server's `sys.argv[0]`. */
+function sameLaunchScriptShape(processScript: string, serverScript: string): boolean {
+  const clean = (value: string): string[] =>
+    value
+      .split(/[\\/]/)
+      .filter((part) => part !== "" && part !== ".");
+  const processParts = clean(processScript);
+  const serverParts = clean(serverScript);
+  if (serverParts.length === 0 || processParts.length < serverParts.length) return false;
+  const suffix = processParts.slice(-serverParts.length);
+  return serverParts.every(
+    (part, index) => part.toLowerCase() === suffix[index]?.toLowerCase(),
+  );
 }
 
 /** The positional launch script in the server's own argv. */

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -637,6 +637,63 @@ export function commandLineMatchesArgv(
   });
 }
 
+/**
+ * Recover an absolute launch-script path from the OS process record when the
+ * server's own argv only reports a bare/relative `main.py`.
+ *
+ * The command-line identity has already been correlated with `serverArgv` by
+ * `observeLiveServerProcess`. Keep the extra extraction narrow: use the first
+ * main.py-shaped process argument and require it to agree with the server's
+ * positional script token and exist on disk. This is observed launch evidence,
+ * not a portable-bundle layout guess.
+ */
+function absoluteLaunchScriptFromIdentity(
+  identity: ProcessIdentity | undefined,
+  serverArgv: string[] | undefined,
+): string | undefined {
+  const serverScript = positionalMainScript(serverArgv);
+  if (!serverScript) return undefined;
+
+  const processArgv =
+    identity?.argv && identity.argv.length > 0
+      ? identity.argv
+      : tokenizeCommandLine(identity?.commandLine ?? "");
+  const processScript = processArgv
+    .map((raw) => raw.trim().replace(/^["']+|["']+$/g, ""))
+    .find((arg) => /(^|[\\/])main\.pyw?$/i.test(arg));
+  if (!processScript || !isAbsolute(processScript)) return undefined;
+
+  const serverParts = serverScript
+    .split(/[\\/]/)
+    .filter((part) => part !== "" && part !== ".");
+  const processParts = processScript.split(/[\\/]/).filter(Boolean);
+  const processSuffix = processParts.slice(-serverParts.length);
+  if (
+    serverParts.length === 0 ||
+    processParts.length < serverParts.length ||
+    serverParts.some(
+      (part, index) => part.toLowerCase() !== processSuffix[index]?.toLowerCase(),
+    )
+  ) {
+    return undefined;
+  }
+
+  const resolved = pathResolve(processScript);
+  return existsSync(resolved) ? resolved : undefined;
+}
+
+/** The positional launch script in the server's own argv. */
+function positionalMainScript(argv: string[] | undefined): string | undefined {
+  if (!Array.isArray(argv)) return undefined;
+  for (const raw of argv) {
+    if (typeof raw !== "string") continue;
+    const arg = raw.trim().replace(/^["']+|["']+$/g, "");
+    if (arg.startsWith("-")) return undefined;
+    if (/(^|[\\/])main\.pyw?$/i.test(arg)) return arg;
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // The resolver
 // ---------------------------------------------------------------------------
@@ -691,6 +748,13 @@ export interface LiveServerProcess {
    * simply fails it, so this reading can add a resolution but never redirect one.
    */
   image?: string;
+  /**
+   * An absolute `main.py`/`main.pyw` path observed in the correlated process
+   * command line. Unlike `image`, this identifies the script's actual checkout
+   * directly and is useful when a portable bundle's interpreter is a sibling
+   * of the ComfyUI directory and the server reports only bare `main.py`.
+   */
+  launchScript?: string;
 }
 
 /**
@@ -752,6 +816,7 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
     rawImage && isAbsolute(rawImage) && existsSync(rawImage)
       ? pathResolve(rawImage)
       : undefined;
+  const launchScript = absoluteLaunchScriptFromIdentity(identity, opts.serverArgv);
 
   // Tier 1 — the process we launched, confirmed by PID *and* start time.
   // The recorded interpreter must be ABSOLUTE: a bare `python` would be
@@ -779,7 +844,13 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
       launchRecord.startedAt === identity.startedAt &&
       corroborated
     ) {
-      return { python: launchRecord.python, source: "launched-by-us", pid, image };
+      const result = {
+        python: launchRecord.python,
+        source: "launched-by-us" as const,
+        pid,
+        image,
+      };
+      return launchScript ? { ...result, launchScript } : result;
     }
     // Same PID, different (or unreadable) start time → this is NOT our process, or
     // we cannot prove it is. Fall through to tier 2 rather than trust the record.
@@ -815,11 +886,13 @@ export function observeLiveServerProcess(opts: ResolveOptions): LiveServerProces
     ? interpreterFromVenvHints(identity.venvHints, argv0)
     : identity?.venvPython;
   if (fromEnv && isAbsolute(fromEnv) && existsSync(fromEnv)) {
-    return { python: fromEnv, source: "process-table", pid, image };
+    const result = { python: fromEnv, source: "process-table" as const, pid, image };
+    return launchScript ? { ...result, launchScript } : result;
   }
 
   if (argv0) {
-    return { python: argv0, source: "process-table", pid, image };
+    const result = { python: argv0, source: "process-table" as const, pid, image };
+    return launchScript ? { ...result, launchScript } : result;
   }
-  return { pid, image };
+  return launchScript ? { pid, image, launchScript } : { pid, image };
 }

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -991,12 +991,22 @@ export function liveScriptFromArgv(
   const dir = dirname(a);
   if (dir === "." || dir === "") {
     // Bare "main.py" — only resolvable via an absolute cwd.
-    return cwd && isAbsolute(cwd) ? pathResolve(cwd, a) : undefined;
+    return cwd && isAbsolute(cwd) ? realpathIfPresent(pathResolve(cwd, a)) : undefined;
   }
-  if (isAbsolute(dir)) return a;
+  if (isAbsolute(dir)) return realpathIfPresent(a);
   // Relative dir (e.g. "ComfyUI/main.py") — resolve against the server's cwd.
-  if (cwd && isAbsolute(cwd)) return pathResolve(cwd, a);
+  if (cwd && isAbsolute(cwd)) return realpathIfPresent(pathResolve(cwd, a));
   return undefined; // cannot resolve to an absolute dir → UNRESOLVED
+}
+
+/** Resolve a launch script through symlinks when it exists, preserving the
+ * lexical result for the parser's existing missing-path behavior. */
+function realpathIfPresent(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
 }
 
 /**
@@ -1278,7 +1288,9 @@ export function resolveLiveServerRoot(
   },
 ): LiveServerRootResolution {
   const relDir = liveRelDirFromArgv(argv);
-  const fromArgv = liveRootFromArgv(argv, cwd);
+  const lexicalFromArgv = liveRootFromArgv(argv, cwd);
+  const argvScript = liveScriptFromArgv(argv, cwd);
+  const fromArgv = argvScript ? dirname(argvScript) : lexicalFromArgv;
   if (fromArgv) return { root: fromArgv, source: "argv", relDir };
   const remote = opts?.remote ?? isRemoteMode();
   if (remote || relDir === undefined) return { source: "unresolved", relDir };
@@ -1294,21 +1306,28 @@ export function resolveLiveServerRoot(
   }
 
   if (observedLaunchScript) {
-    const root = pathResolve(dirname(observedLaunchScript));
-    if (
-      isAbsolute(observedLaunchScript) &&
-      /(^|[\\/])main\.pyw?$/i.test(observedLaunchScript) &&
-      existsSync(observedLaunchScript) &&
-      hasMainPy(root)
-    ) {
-      return {
-        root,
-        source: "observed-process",
-        relDir,
-        observedPython,
-        observedPid,
-        observedLaunchScript: pathResolve(observedLaunchScript),
-      };
+    let resolvedLaunchScript: string | undefined;
+    try {
+      resolvedLaunchScript = realpathSync(observedLaunchScript);
+    } catch {
+      resolvedLaunchScript = undefined;
+    }
+    if (resolvedLaunchScript) {
+      const root = dirname(resolvedLaunchScript);
+      if (
+        isAbsolute(observedLaunchScript) &&
+        /(^|[\\/])main\.pyw?$/i.test(observedLaunchScript) &&
+        hasMainPy(root)
+      ) {
+        return {
+          root,
+          source: "observed-process",
+          relDir,
+          observedPython,
+          observedPid,
+          observedLaunchScript: resolvedLaunchScript,
+        };
+      }
     }
   }
   if (!observedPython) return { source: "unresolved", relDir };

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1041,6 +1041,8 @@ export interface LiveServerRootResolution {
    *  relatively and names no probeable file (#1374). Reported so a refusal can name
    *  what WAS seen; it is the anchor input, not a runnable interpreter. */
   observedPython?: string;
+  /** The absolute main.py path observed in the correlated process command line. */
+  observedLaunchScript?: string;
   /**
    * The directory `relDir` was resolved AGAINST to produce `root` — i.e. the
    * working directory the running server must have had for its relative
@@ -1204,7 +1206,7 @@ function anchorRelDirOnInterpreter(
  */
 function observeLivePython(
   argv: string[] | undefined,
-): { python: string; pid: number } | undefined {
+): { python?: string; pid: number; launchScript?: string } | undefined {
   let statsHost: string | undefined;
   try {
     statsHost = new URL(getComfyUIBaseUrl()).hostname;
@@ -1222,7 +1224,9 @@ function observeLivePython(
     // The PID travels with the interpreter (#535). A caller that is about to STOP
     // a process must be able to confirm the anchor describes that very process
     // and not some other ComfyUI — an interpreter path alone cannot prove it.
-    return live && binary ? { python: binary, pid: live.pid } : undefined;
+    return live && (binary || live.launchScript)
+      ? { python: binary, pid: live.pid, launchScript: live.launchScript }
+      : undefined;
   } catch {
     return undefined;
   }
@@ -1246,10 +1250,10 @@ function observeLivePython(
  *     COMFYUI_PATH — a DIFFERENT, stale install — and the model landed where the
  *     running server never reads. So we ask the OS instead: `observeLiveServerProcess`
  *     identifies the process listening on our port (correlated against the server's
- *     own argv, so a proxy can't impersonate it) and reports the binary it runs — its
- *     interpreter, or the OS's own image record when the launcher spelled the
- *     interpreter relatively (#1374); the relative `main.py` dir is re-anchored on
- *     that binary's install tree.
+ *     own argv, so a proxy can't impersonate it) and reports its absolute launch
+ *     script when available, otherwise the binary it runs — its interpreter, or the
+ *     OS's own image record when the launcher spelled the interpreter relatively
+ *     (#1374); the relative `main.py` dir is re-anchored on that evidence.
  *
  * Anything else is `unresolved`. There is deliberately NO layout-guess tier: a
  * COMFYUI_PATH that merely looks plausible is what wrote 4.88 GB into the wrong
@@ -1267,6 +1271,8 @@ export function resolveLiveServerRoot(
     observedPython?: string;
     /** PID the caller-supplied observation belongs to (test seam companion). */
     observedPid?: number;
+    /** Absolute launch script from the correlated live process observation. */
+    observedLaunchScript?: string;
     /** Skip the process-table probe entirely (remote server). Defaults to isRemoteMode(). */
     remote?: boolean;
   },
@@ -1279,10 +1285,31 @@ export function resolveLiveServerRoot(
 
   let observedPython = opts?.observedPython;
   let observedPid = opts?.observedPid;
-  if (!observedPython) {
+  let observedLaunchScript = opts?.observedLaunchScript;
+  if (!observedPython && !observedLaunchScript) {
     const observed = observeLivePython(argv);
     observedPython = observed?.python;
     observedPid = observed?.pid;
+    observedLaunchScript = observed?.launchScript;
+  }
+
+  if (observedLaunchScript) {
+    const root = pathResolve(dirname(observedLaunchScript));
+    if (
+      isAbsolute(observedLaunchScript) &&
+      /(^|[\\/])main\.pyw?$/i.test(observedLaunchScript) &&
+      existsSync(observedLaunchScript) &&
+      hasMainPy(root)
+    ) {
+      return {
+        root,
+        source: "observed-process",
+        relDir,
+        observedPython,
+        observedPid,
+        observedLaunchScript: pathResolve(observedLaunchScript),
+      };
+    }
   }
   if (!observedPython) return { source: "unresolved", relDir };
 
@@ -1294,10 +1321,11 @@ export function resolveLiveServerRoot(
       relDir,
       observedPython,
       observedPid,
+      observedLaunchScript,
       anchorDir: anchored.anchorDir,
     };
   }
-  return { source: "unresolved", relDir, observedPython, observedPid };
+  return { source: "unresolved", relDir, observedPython, observedPid, observedLaunchScript };
 }
 
 /**

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -986,27 +986,50 @@ export function liveScriptFromArgv(
   argv: string[] | undefined,
   cwd?: string,
 ): string | undefined {
+  return liveScriptResolutionFromArgv(argv, cwd).path;
+}
+
+type PathResolution = {
+  path?: string;
+  indeterminate: boolean;
+};
+
+function liveScriptResolutionFromArgv(
+  argv: string[] | undefined,
+  cwd?: string,
+): PathResolution {
   const a = scriptTokenFromArgv(argv);
-  if (a === undefined) return undefined;
+  if (a === undefined) return { indeterminate: false };
   const dir = dirname(a);
   if (dir === "." || dir === "") {
     // Bare "main.py" — only resolvable via an absolute cwd.
-    return cwd && isAbsolute(cwd) ? realpathIfPresent(pathResolve(cwd, a)) : undefined;
+    return cwd && isAbsolute(cwd)
+      ? realpathIfPresent(pathResolve(cwd, a))
+      : { indeterminate: false };
   }
   if (isAbsolute(dir)) return realpathIfPresent(a);
   // Relative dir (e.g. "ComfyUI/main.py") — resolve against the server's cwd.
   if (cwd && isAbsolute(cwd)) return realpathIfPresent(pathResolve(cwd, a));
-  return undefined; // cannot resolve to an absolute dir → UNRESOLVED
+  return { indeterminate: false }; // cannot resolve to an absolute dir → UNRESOLVED
 }
 
 /** Resolve a launch script through symlinks when it exists, preserving the
- * lexical result for the parser's existing missing-path behavior. */
-function realpathIfPresent(path: string): string {
+ * lexical result for callers that need to report the exact failed path. Errors
+ * other than a missing path are marked indeterminate; authorization callers
+ * must inspect that flag instead of treating the lexical path as evidence. */
+function realpathIfPresent(path: string): PathResolution {
   try {
-    return realpathSync(path);
-  } catch {
-    return path;
+    return { path: realpathSync(path), indeterminate: false };
+  } catch (error) {
+    if (isMissingPathError(error)) return { path, indeterminate: false };
+    return { path, indeterminate: true };
   }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "ENOENT" || code === "ENOTDIR";
 }
 
 /**
@@ -1216,7 +1239,12 @@ function anchorRelDirOnInterpreter(
  */
 function observeLivePython(
   argv: string[] | undefined,
-): { python?: string; pid: number; launchScript?: string } | undefined {
+): {
+  python?: string;
+  pid: number;
+  launchScript?: string;
+  launchScriptInvalid?: boolean;
+} | undefined {
   let statsHost: string | undefined;
   try {
     statsHost = new URL(getComfyUIBaseUrl()).hostname;
@@ -1234,8 +1262,13 @@ function observeLivePython(
     // The PID travels with the interpreter (#535). A caller that is about to STOP
     // a process must be able to confirm the anchor describes that very process
     // and not some other ComfyUI — an interpreter path alone cannot prove it.
-    return live && (binary || live.launchScript)
-      ? { python: binary, pid: live.pid, launchScript: live.launchScript }
+    return live && (binary || live.launchScript || live.launchScriptInvalid)
+      ? {
+          python: binary,
+          pid: live.pid,
+          launchScript: live.launchScript,
+          launchScriptInvalid: live.launchScriptInvalid,
+        }
       : undefined;
   } catch {
     return undefined;
@@ -1283,19 +1316,27 @@ export function resolveLiveServerRoot(
     observedPid?: number;
     /** Absolute launch script from the correlated live process observation. */
     observedLaunchScript?: string;
+    /** Correlated launch script was present but invalid/non-regular. */
+    observedLaunchScriptInvalid?: boolean;
     /** Skip the process-table probe entirely (remote server). Defaults to isRemoteMode(). */
     remote?: boolean;
   },
 ): LiveServerRootResolution {
   const relDir = liveRelDirFromArgv(argv);
   const lexicalFromArgv = liveRootFromArgv(argv, cwd);
-  const argvScript = liveScriptFromArgv(argv, cwd);
+  const argvScriptResolution = liveScriptResolutionFromArgv(argv, cwd);
+  if (argvScriptResolution.indeterminate) return { source: "unresolved", relDir };
+  const argvScript = argvScriptResolution.path;
   const fromArgv = argvScript ? dirname(argvScript) : lexicalFromArgv;
   // Preserve the historical unresolved/missing-path behavior, but never let an
   // existing directory, FIFO, or dangling symlink named main.py vouch for its
   // parent as a live install.
-  if (argvScript && pathEntryExists(argvScript) && !safeFileExists(argvScript)) {
-    return { source: "unresolved", relDir };
+  if (argvScript) {
+    const entry = pathEntryExists(argvScript);
+    if (entry === "indeterminate") return { source: "unresolved", relDir };
+    if (entry === "present" && regularFileState(argvScript) !== "file") {
+      return { source: "unresolved", relDir };
+    }
   }
   if (fromArgv) return { root: fromArgv, source: "argv", relDir };
   const remote = opts?.remote ?? isRemoteMode();
@@ -1304,26 +1345,33 @@ export function resolveLiveServerRoot(
   let observedPython = opts?.observedPython;
   let observedPid = opts?.observedPid;
   let observedLaunchScript = opts?.observedLaunchScript;
-  if (!observedPython && !observedLaunchScript) {
+  let observedLaunchScriptInvalid = opts?.observedLaunchScriptInvalid;
+  if (!observedPython && !observedLaunchScript && !observedLaunchScriptInvalid) {
     const observed = observeLivePython(argv);
     observedPython = observed?.python;
     observedPid = observed?.pid;
     observedLaunchScript = observed?.launchScript;
+    observedLaunchScriptInvalid = observed?.launchScriptInvalid;
+  }
+
+  // A correlated but unusable launch script is explicit contradictory evidence.
+  // It must not be erased by anchoring the same observation on its interpreter.
+  if (observedLaunchScriptInvalid) {
+    return { source: "unresolved", relDir, observedPython, observedPid };
   }
 
   if (observedLaunchScript) {
-    let resolvedLaunchScript: string | undefined;
-    try {
-      resolvedLaunchScript = realpathSync(observedLaunchScript);
-    } catch {
-      resolvedLaunchScript = undefined;
+    const resolvedLaunchScript = realpathIfPresent(observedLaunchScript);
+    if (!resolvedLaunchScript.path || resolvedLaunchScript.indeterminate) {
+      return { source: "unresolved", relDir, observedPython, observedPid };
     }
-    if (resolvedLaunchScript) {
-      const root = dirname(resolvedLaunchScript);
+    if (resolvedLaunchScript.path) {
+      const resolvedPath = resolvedLaunchScript.path;
+      const root = dirname(resolvedPath);
       if (
         isAbsolute(observedLaunchScript) &&
         /(^|[\\/])main\.pyw?$/i.test(observedLaunchScript) &&
-        safeFileExists(resolvedLaunchScript) &&
+        regularFileState(resolvedPath) === "file" &&
         hasMainPy(root)
       ) {
         return {
@@ -1332,10 +1380,13 @@ export function resolveLiveServerRoot(
           relDir,
           observedPython,
           observedPid,
-          observedLaunchScript: resolvedLaunchScript,
+          observedLaunchScript: resolvedPath,
         };
       }
     }
+    // An explicit observed script that did not authorize its root is not a
+    // reason to fall through to an interpreter anchor from another tree.
+    return { source: "unresolved", relDir, observedPython, observedPid };
   }
   if (!observedPython) return { source: "unresolved", relDir };
 
@@ -1394,23 +1445,31 @@ function hasMainPy(dir: string): boolean {
 
 /** Does the path resolve to a regular file? `statSync` follows symlinks, so a
  * symlink to a directory or a dangling/non-file entry cannot vouch for a root. */
-function safeFileExists(path: string): boolean {
-  if (/^\\\\/.test(path)) return false;
+type RegularFileState = "file" | "not-file" | "indeterminate";
+
+function regularFileState(path: string): RegularFileState {
+  if (/^\\\\/.test(path)) return "indeterminate";
   try {
-    return statSync(path).isFile();
-  } catch {
-    return false;
+    return statSync(path).isFile() ? "file" : "not-file";
+  } catch (error) {
+    return isMissingPathError(error) ? "not-file" : "indeterminate";
   }
 }
 
+function safeFileExists(path: string): boolean {
+  return regularFileState(path) === "file";
+}
+
 /** Does the lexical path itself exist, including a dangling symlink? */
-function pathEntryExists(path: string): boolean {
-  if (/^\\\\/.test(path)) return false;
+type PathEntryState = "present" | "missing" | "indeterminate";
+
+function pathEntryExists(path: string): PathEntryState {
+  if (/^\\\\/.test(path)) return "indeterminate";
   try {
     lstatSync(path);
-    return true;
-  } catch {
-    return false;
+    return "present";
+  } catch (error) {
+    return isMissingPathError(error) ? "missing" : "indeterminate";
   }
 }
 

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve as pathResolve, sep } from "node:path";
@@ -1291,6 +1291,12 @@ export function resolveLiveServerRoot(
   const lexicalFromArgv = liveRootFromArgv(argv, cwd);
   const argvScript = liveScriptFromArgv(argv, cwd);
   const fromArgv = argvScript ? dirname(argvScript) : lexicalFromArgv;
+  // Preserve the historical unresolved/missing-path behavior, but never let an
+  // existing directory, FIFO, or dangling symlink named main.py vouch for its
+  // parent as a live install.
+  if (argvScript && pathEntryExists(argvScript) && !safeFileExists(argvScript)) {
+    return { source: "unresolved", relDir };
+  }
   if (fromArgv) return { root: fromArgv, source: "argv", relDir };
   const remote = opts?.remote ?? isRemoteMode();
   if (remote || relDir === undefined) return { source: "unresolved", relDir };
@@ -1317,6 +1323,7 @@ export function resolveLiveServerRoot(
       if (
         isAbsolute(observedLaunchScript) &&
         /(^|[\\/])main\.pyw?$/i.test(observedLaunchScript) &&
+        safeFileExists(resolvedLaunchScript) &&
         hasMainPy(root)
       ) {
         return {
@@ -1382,7 +1389,29 @@ function safeExists(p: string): boolean {
 
 /** Does this directory hold a ComfyUI entrypoint (`main.py`/`main.pyw`)? */
 function hasMainPy(dir: string): boolean {
-  return safeExists(join(dir, "main.py")) || safeExists(join(dir, "main.pyw"));
+  return safeFileExists(join(dir, "main.py")) || safeFileExists(join(dir, "main.pyw"));
+}
+
+/** Does the path resolve to a regular file? `statSync` follows symlinks, so a
+ * symlink to a directory or a dangling/non-file entry cannot vouch for a root. */
+function safeFileExists(path: string): boolean {
+  if (/^\\\\/.test(path)) return false;
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Does the lexical path itself exist, including a dangling symlink? */
+function pathEntryExists(path: string): boolean {
+  if (/^\\\\/.test(path)) return false;
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #2261

Harden the connected-local git fallback root proof:

- Correlate the actual positional Python launch script and carry an explicit invalid/non-regular veto through the live-interpreter producer, so a usable interpreter cannot authorize a different tree.
- Resolve launch scripts with realpath semantics and require regular files; reject directories, non-files, dangling paths, and non-ENOENT/ENOTDIR filesystem errors before parent authorization.
- Exercise the real producer-to-install_custom_node git fallback with directory-main.py plus usable-interpreter, multi-main, symlink, and indeterminate-I/O regressions.
- Preserve download-manager routing semantics with a filesystem-faithful fixture.

Validation:
- Focused Vitest (5 suites): 233 passed, 2 skipped (Windows symlink privilege).
- npm.cmd run lint and git diff --check pass.
- Full npm.cmd test: 12,191 passed, 6 skipped; 4 pre-existing failures in package-hooks (dist is not built) and node-id-union-message (existing Zod message-format mismatch).
- Hosted CI for this new head is pending.