### PR TITLE
fix: recover Desktop restart from verified ancestry

### DIFF
--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -960,12 +960,19 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
    * Desktop-flavoured `--extra-model-paths-config`, which is what identifies it
    * (captured from the #814 report's own recovery command line).
    */
-  // Keep the production-level recovery fixture in the path dialect of the host
-  // running the test. The recovery path must not accidentally pass because a
-  // POSIX runner accepted Windows separators (or because its process-list parser
-  // happened to parse a Windows CSV row).
   const TEST_IS_WIN = process.platform === "win32";
-  const DESKTOP_ARGV = TEST_IS_WIN
+  // Existing lifecycle fixtures intentionally retain their Windows-shaped
+  // command. The listener-unavailable recovery case gets its own portable
+  // fixture because it exercises platform-specific process readers.
+  const DESKTOP_ARGV = [
+    "ComfyUI\\main.py",
+    "--enable-manager",
+    "--extra-model-paths-config",
+    "C:\\Users\\u\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
+    "--port",
+    "8188",
+  ];
+  const RECOVERY_DESKTOP_ARGV = TEST_IS_WIN
     ? [
         "ComfyUI\\main.py",
         "--enable-manager",
@@ -991,9 +998,15 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   const DESKTOP_ROOT_PID = 18752;
   const DESKTOP_PYTHON_PID = 26628;
   const DESKTOP_SERVER_PID = 27264;
-  const DESKTOP_SERVER_OS_ARGV = [
-    "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
-    ...DESKTOP_ARGV,
+  const RECOVERY_SERVER_VENV_PYTHON = TEST_IS_WIN
+    ? "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe"
+    : "/Users/u/ComfyUI/.venv/bin/python";
+  const RECOVERY_SERVER_BASE_PYTHON = TEST_IS_WIN
+    ? "C:\\Users\\u\\python_embeded\\python.exe"
+    : "/usr/bin/python3";
+  const RECOVERY_DESKTOP_SERVER_OS_ARGV = [
+    RECOVERY_SERVER_VENV_PYTHON,
+    ...RECOVERY_DESKTOP_ARGV,
   ];
 
   function desktopListenerFailure(
@@ -1002,7 +1015,7 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     options: { serverArgv?: string[]; processListError?: boolean } = {},
   ): void {
     mockGetSystemStats.mockResolvedValue({
-      system: { argv: options.serverArgv ?? DESKTOP_ARGV },
+      system: { argv: options.serverArgv ?? RECOVERY_DESKTOP_ARGV },
     });
     mockExecSync.mockImplementation((cmd: string) => {
       const c = String(cmd);
@@ -1026,14 +1039,11 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   }
 
   function verifiedDesktopTree(
-    serverArgv = DESKTOP_SERVER_OS_ARGV,
+    serverArgv = RECOVERY_DESKTOP_SERVER_OS_ARGV,
   ): Record<number, ProcessIdentity> {
     const desktopExe = TEST_IS_WIN
       ? "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"
       : "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop";
-    const pythonExe = TEST_IS_WIN
-      ? "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe"
-      : "/Users/u/ComfyUI/.venv/bin/python";
     return {
       [DESKTOP_ROOT_PID]: {
         executablePath: desktopExe,
@@ -1044,15 +1054,15 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
         parentPid: 1,
       },
       [DESKTOP_PYTHON_PID]: {
-        executablePath: pythonExe,
-        commandLine: `"${pythonExe}" -m desktop_server`,
-        argv: [pythonExe, "-m", "desktop_server"],
+        executablePath: RECOVERY_SERVER_BASE_PYTHON,
+        commandLine: `"${RECOVERY_SERVER_VENV_PYTHON}" -m desktop_server`,
+        argv: [RECOVERY_SERVER_VENV_PYTHON, "-m", "desktop_server"],
         argvFidelity: "exact",
         startedAt: "2000",
         parentPid: DESKTOP_ROOT_PID,
       },
       [DESKTOP_SERVER_PID]: {
-        executablePath: pythonExe,
+        executablePath: RECOVERY_SERVER_BASE_PYTHON,
         commandLine: `"${serverArgv[0]}" ${serverArgv.slice(1).join(" ")}`,
         argv: [...serverArgv],
         argvFidelity: "exact",
@@ -1083,7 +1093,7 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   });
 
   it("refuses a Desktop descendant whose OS command has an extra or mismatched argument", async () => {
-    const wrongArgv = [...DESKTOP_SERVER_OS_ARGV, "--wrong-command"];
+    const wrongArgv = [...RECOVERY_DESKTOP_SERVER_OS_ARGV, "--wrong-command"];
     desktopListenerFailure(verifiedDesktopTree(wrongArgv));
     healthyFetch();
 
@@ -1098,12 +1108,12 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     const helperArgv = [
       TEST_IS_WIN ? "tools\\main.py" : "tools/main.py",
       "--extra-model-paths-config",
-      DESKTOP_ARGV[3]!,
+      RECOVERY_DESKTOP_ARGV[3]!,
       "--port",
       "8188",
       "--helper-mode",
     ];
-    desktopListenerFailure(verifiedDesktopTree([DESKTOP_SERVER_OS_ARGV[0]!, ...helperArgv]), [
+    desktopListenerFailure(verifiedDesktopTree([RECOVERY_DESKTOP_SERVER_OS_ARGV[0]!, ...helperArgv]), [
       DESKTOP_PYTHON_PID,
       DESKTOP_SERVER_PID,
     ], { serverArgv: helperArgv });
@@ -1224,8 +1234,8 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     identities[DESKTOP_SERVER_PID] = {
       ...identities[DESKTOP_SERVER_PID],
       executablePath: serverExecutable,
-      commandLine: `"${serverExecutable}" ${DESKTOP_ARGV.join(" ")}`,
-      argv: [serverExecutable, ...DESKTOP_ARGV],
+      commandLine: `"${serverExecutable}" ${RECOVERY_DESKTOP_ARGV.join(" ")}`,
+      argv: [serverExecutable, ...RECOVERY_DESKTOP_ARGV],
     };
     identities[DESKTOP_ROOT_PID] = {
       ...identities[DESKTOP_ROOT_PID],
@@ -1244,7 +1254,7 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   });
 
   it("uses exact platform-aware argument matching for the process-table script token", async () => {
-    const observed = [...DESKTOP_SERVER_OS_ARGV];
+    const observed = [...RECOVERY_DESKTOP_SERVER_OS_ARGV];
     observed[1] = TEST_IS_WIN
       ? "C:\\Users\\u\\ComfyUI\\main.py"
       : "/Users/u/ComfyUI/main.py";

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -33,7 +33,7 @@ import {
   compareStartTimes,
   unclassifiedSupervision,
 } from "../../services/listener-ownership.js";
-import { tokenizeCommandLine } from "../../services/live-interpreter.js";
+import { tokenizeCommandLine, type ProcessIdentity } from "../../services/live-interpreter.js";
 
 /** `lsof -V` STATING that nothing is listening (see restart-live-first.test.ts). */
 function noListener(): Error {
@@ -973,6 +973,196 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     mockGetSystemStats.mockResolvedValue({ system: { argv: DESKTOP_ARGV } });
     mockLivePortThenFree();
   }
+
+  const DESKTOP_ROOT_PID = 18752;
+  const DESKTOP_PYTHON_PID = 26628;
+  const DESKTOP_SERVER_PID = 27264;
+  const DESKTOP_SERVER_OS_ARGV = [
+    "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
+    ...DESKTOP_ARGV,
+  ];
+
+  function desktopListenerFailure(
+    identities: Record<number, ProcessIdentity | undefined>,
+    pythonPids = [DESKTOP_PYTHON_PID, DESKTOP_SERVER_PID],
+  ): void {
+    mockGetSystemStats.mockResolvedValue({ system: { argv: DESKTOP_ARGV } });
+    mockExecSync.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (/netstat|lsof/i.test(c)) throw new Error("listener unavailable");
+      if (/tasklist.*Comfy(?:UI| Desktop)\.exe|pgrep -f/i.test(c)) {
+        return '"Comfy Desktop.exe","18752","Console","1","206,248 K"';
+      }
+      if (/tasklist.*python|pgrep -x/i.test(c)) {
+        return /tasklist/i.test(c)
+          ? pythonPids.map((pid) => `"python.exe","${pid}","Console","1","20,000 K"`).join("\n")
+          : `${pythonPids.join("\n")}\n`;
+      }
+      return "";
+    });
+    __processControlTestHooks.setProcessIdentityResolver((pid) => identities[pid]);
+    __processControlTestHooks.setParentPidResolver((pid) => identities[pid]?.parentPid);
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+  }
+
+  function verifiedDesktopTree(
+    serverArgv = DESKTOP_SERVER_OS_ARGV,
+  ): Record<number, ProcessIdentity> {
+    return {
+      [DESKTOP_ROOT_PID]: {
+        executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+        commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
+        argv: ["C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"],
+        argvFidelity: "exact",
+        startedAt: "1000",
+        parentPid: 1,
+      },
+      [DESKTOP_PYTHON_PID]: {
+        executablePath: "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
+        commandLine: '"C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe" -m desktop_server',
+        argv: [
+          "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
+          "-m",
+          "desktop_server",
+        ],
+        argvFidelity: "exact",
+        startedAt: "2000",
+        parentPid: DESKTOP_ROOT_PID,
+      },
+      [DESKTOP_SERVER_PID]: {
+        executablePath: "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
+        commandLine: `"${serverArgv[0]}" ${serverArgv.slice(1).join(" ")}`,
+        argv: [...serverArgv],
+        argvFidelity: "exact",
+        startedAt: "3000",
+        parentPid: DESKTOP_PYTHON_PID,
+      },
+    };
+  }
+
+  function healthyFetch(): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ system: {} }), { status: 200 })),
+    );
+  }
+
+  it("recovers a Desktop backend from its verified Python ancestry when the listener lookup fails (#2265)", async () => {
+    desktopListenerFailure(verifiedDesktopTree());
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.message).not.toMatch(/could not be identified/i);
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(globalThis.fetch).toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("refuses a Desktop descendant whose OS command has an extra or mismatched argument", async () => {
+    const wrongArgv = [...DESKTOP_SERVER_OS_ARGV, "--wrong-command"];
+    desktopListenerFailure(verifiedDesktopTree(wrongArgv));
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("refuses a matching Python command when its ancestry does not reach the Desktop PID", async () => {
+    const identities = verifiedDesktopTree();
+    identities[DESKTOP_PYTHON_PID] = {
+      ...identities[DESKTOP_PYTHON_PID],
+      parentPid: 31000,
+    };
+    identities[31000] = {
+      executablePath: "C:\\Tools\\launcher.exe",
+      commandLine: '"C:\\Tools\\launcher.exe"',
+      argv: ["C:\\Tools\\launcher.exe"],
+      argvFidelity: "exact",
+      startedAt: "500",
+      parentPid: 1,
+    };
+    desktopListenerFailure(identities);
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("refuses a server Python process separated from Desktop by an unrelated wrapper", async () => {
+    const identities = verifiedDesktopTree();
+    identities[DESKTOP_SERVER_PID] = {
+      ...identities[DESKTOP_SERVER_PID],
+      parentPid: 31000,
+    };
+    identities[31000] = {
+      executablePath: "C:\\Tools\\launcher.exe",
+      commandLine: '"C:\\Tools\\launcher.exe"',
+      argv: ["C:\\Tools\\launcher.exe"],
+      argvFidelity: "exact",
+      startedAt: "2500",
+      parentPid: DESKTOP_ROOT_PID,
+    };
+    desktopListenerFailure(identities);
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("refuses a Python candidate whose executable path is not OS-verifiable", async () => {
+    const identities = verifiedDesktopTree();
+    identities[DESKTOP_SERVER_PID] = {
+      ...identities[DESKTOP_SERVER_PID],
+      executablePath: "python.exe",
+    };
+    desktopListenerFailure(identities);
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("refuses when the ancestry evidence is unavailable or ambiguous", async () => {
+    const unavailable = verifiedDesktopTree();
+    delete unavailable[DESKTOP_PYTHON_PID];
+    desktopListenerFailure(unavailable);
+    healthyFetch();
+
+    const unavailableResult = await restartComfyUI();
+    expect(unavailableResult.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    __processControlTestHooks.reset();
+    const ambiguous = verifiedDesktopTree();
+    const secondServerPid = 27265;
+    ambiguous[secondServerPid] = {
+      ...ambiguous[DESKTOP_SERVER_PID],
+      startedAt: "3001",
+      parentPid: DESKTOP_PYTHON_PID,
+    };
+    desktopListenerFailure(ambiguous, [DESKTOP_PYTHON_PID, DESKTOP_SERVER_PID, secondServerPid]);
+    healthyFetch();
+
+    const ambiguousResult = await restartComfyUI();
+    expect(ambiguousResult.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
 
   it("REFUSES before any reboot when the Desktop supervisor has gone", async () => {
     // #814 exactly: two backends off one install, the shell that spawned the bound

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -960,14 +960,28 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
    * Desktop-flavoured `--extra-model-paths-config`, which is what identifies it
    * (captured from the #814 report's own recovery command line).
    */
-  const DESKTOP_ARGV = [
-    "ComfyUI\\main.py",
-    "--enable-manager",
-    "--extra-model-paths-config",
-    "C:\\Users\\u\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
-    "--port",
-    "8188",
-  ];
+  // Keep the production-level recovery fixture in the path dialect of the host
+  // running the test. The recovery path must not accidentally pass because a
+  // POSIX runner accepted Windows separators (or because its process-list parser
+  // happened to parse a Windows CSV row).
+  const TEST_IS_WIN = process.platform === "win32";
+  const DESKTOP_ARGV = TEST_IS_WIN
+    ? [
+        "ComfyUI\\main.py",
+        "--enable-manager",
+        "--extra-model-paths-config",
+        "C:\\Users\\u\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
+        "--port",
+        "8188",
+      ]
+    : [
+        "ComfyUI/main.py",
+        "--enable-manager",
+        "--extra-model-paths-config",
+        "/Users/u/Library/Application Support/Comfy Desktop/shared_model_paths.yaml",
+        "--port",
+        "8188",
+      ];
 
   function desktopServer(): void {
     mockGetSystemStats.mockResolvedValue({ system: { argv: DESKTOP_ARGV } });
@@ -985,15 +999,21 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   function desktopListenerFailure(
     identities: Record<number, ProcessIdentity | undefined>,
     pythonPids = [DESKTOP_PYTHON_PID, DESKTOP_SERVER_PID],
+    options: { serverArgv?: string[]; processListError?: boolean } = {},
   ): void {
-    mockGetSystemStats.mockResolvedValue({ system: { argv: DESKTOP_ARGV } });
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: options.serverArgv ?? DESKTOP_ARGV },
+    });
     mockExecSync.mockImplementation((cmd: string) => {
       const c = String(cmd);
       if (/netstat|lsof/i.test(c)) throw new Error("listener unavailable");
       if (/tasklist.*Comfy(?:UI| Desktop)\.exe|pgrep -f/i.test(c)) {
-        return '"Comfy Desktop.exe","18752","Console","1","206,248 K"';
+        return TEST_IS_WIN ? '"Comfy Desktop.exe","18752","Console","1","206,248 K"' : "18752\n";
       }
       if (/tasklist.*python|pgrep -x/i.test(c)) {
+        if (options.processListError && /pythonw|python3/i.test(c)) {
+          throw new Error("python process query unavailable");
+        }
         return /tasklist/i.test(c)
           ? pythonPids.map((pid) => `"python.exe","${pid}","Console","1","20,000 K"`).join("\n")
           : `${pythonPids.join("\n")}\n`;
@@ -1008,29 +1028,31 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   function verifiedDesktopTree(
     serverArgv = DESKTOP_SERVER_OS_ARGV,
   ): Record<number, ProcessIdentity> {
+    const desktopExe = TEST_IS_WIN
+      ? "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"
+      : "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop";
+    const pythonExe = TEST_IS_WIN
+      ? "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe"
+      : "/Users/u/ComfyUI/.venv/bin/python";
     return {
       [DESKTOP_ROOT_PID]: {
-        executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
-        commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
-        argv: ["C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"],
+        executablePath: desktopExe,
+        commandLine: `"${desktopExe}"`,
+        argv: [desktopExe],
         argvFidelity: "exact",
         startedAt: "1000",
         parentPid: 1,
       },
       [DESKTOP_PYTHON_PID]: {
-        executablePath: "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
-        commandLine: '"C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe" -m desktop_server',
-        argv: [
-          "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
-          "-m",
-          "desktop_server",
-        ],
+        executablePath: pythonExe,
+        commandLine: `"${pythonExe}" -m desktop_server`,
+        argv: [pythonExe, "-m", "desktop_server"],
         argvFidelity: "exact",
         startedAt: "2000",
         parentPid: DESKTOP_ROOT_PID,
       },
       [DESKTOP_SERVER_PID]: {
-        executablePath: "C:\\Users\\u\\ComfyUI\\.venv\\Scripts\\python.exe",
+        executablePath: pythonExe,
         commandLine: `"${serverArgv[0]}" ${serverArgv.slice(1).join(" ")}`,
         argv: [...serverArgv],
         argvFidelity: "exact",
@@ -1063,6 +1085,28 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
   it("refuses a Desktop descendant whose OS command has an extra or mismatched argument", async () => {
     const wrongArgv = [...DESKTOP_SERVER_OS_ARGV, "--wrong-command"];
     desktopListenerFailure(verifiedDesktopTree(wrongArgv));
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("does not let an unrelated helper with Desktop markers satisfy the H3 authority shape", async () => {
+    const helperArgv = [
+      TEST_IS_WIN ? "tools\\main.py" : "tools/main.py",
+      "--extra-model-paths-config",
+      DESKTOP_ARGV[3]!,
+      "--port",
+      "8188",
+      "--helper-mode",
+    ];
+    desktopListenerFailure(verifiedDesktopTree([DESKTOP_SERVER_OS_ARGV[0]!, ...helperArgv]), [
+      DESKTOP_PYTHON_PID,
+      DESKTOP_SERVER_PID,
+    ], { serverArgv: helperArgv });
     healthyFetch();
 
     const result = await restartComfyUI();
@@ -1133,6 +1177,89 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
 
     expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
     expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it.each(["startedAt", "executablePath", "commandLine", "argv"] as const)(
+    "refuses a listener-failure candidate when %s evidence is missing",
+    async (missing) => {
+      const identities = verifiedDesktopTree();
+      const server = identities[DESKTOP_SERVER_PID]!;
+      if (missing === "startedAt") delete server.startedAt;
+      if (missing === "executablePath") delete server.executablePath;
+      if (missing === "commandLine") delete server.commandLine;
+      if (missing === "argv") delete server.argv;
+      desktopListenerFailure(identities);
+      healthyFetch();
+
+      const result = await restartComfyUI();
+
+      expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(killWasIssued()).toBe(false);
+    },
+  );
+
+  it("refuses an otherwise valid candidate when a process-list query is unavailable", async () => {
+    desktopListenerFailure(verifiedDesktopTree(), [DESKTOP_PYTHON_PID, DESKTOP_SERVER_PID], {
+      processListError: true,
+    });
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("rejects absolute Python and Desktop paths that only have a trusted-looking basename", async () => {
+    const identities = verifiedDesktopTree();
+    const serverExecutable = TEST_IS_WIN
+      ? "C:\\attacker\\venv\\Scripts\\python.exe"
+      : "/tmp/attacker/venv/bin/python";
+    const desktopExecutable = TEST_IS_WIN
+      ? "C:\\attacker\\Comfy Desktop\\Comfy Desktop.exe"
+      : "/tmp/Comfy Desktop.app/Contents/MacOS/Comfy Desktop";
+    identities[DESKTOP_SERVER_PID] = {
+      ...identities[DESKTOP_SERVER_PID],
+      executablePath: serverExecutable,
+      commandLine: `"${serverExecutable}" ${DESKTOP_ARGV.join(" ")}`,
+      argv: [serverExecutable, ...DESKTOP_ARGV],
+    };
+    identities[DESKTOP_ROOT_PID] = {
+      ...identities[DESKTOP_ROOT_PID],
+      executablePath: desktopExecutable,
+      commandLine: `"${desktopExecutable}"`,
+      argv: [desktopExecutable],
+    };
+    desktopListenerFailure(identities);
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("uses exact platform-aware argument matching for the process-table script token", async () => {
+    const observed = [...DESKTOP_SERVER_OS_ARGV];
+    observed[1] = TEST_IS_WIN
+      ? "C:\\Users\\u\\ComfyUI\\main.py"
+      : "/Users/u/ComfyUI/main.py";
+    desktopListenerFailure(verifiedDesktopTree(observed), [DESKTOP_PYTHON_PID, DESKTOP_SERVER_PID]);
+    healthyFetch();
+
+    const result = await restartComfyUI();
+
+    if (TEST_IS_WIN) {
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(result.message).not.toMatch(/refusing to restart/i);
+    } else {
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(result.message).toMatch(/could not be mapped|could not be identified|reachable/i);
+    }
     expect(killWasIssued()).toBe(false);
   });
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -829,38 +829,59 @@ function hasExactProcessIdentity(identity: ProcessIdentity | undefined): identit
 }
 
 /**
- * The executable path is useful only when it agrees with the OS command's first
- * token. A basename or absolute-path shape alone is not authentication: an
- * unrelated `python.exe`/`Comfy Desktop.exe` can live at either.
+ * The process reader exposes two different Python paths on Windows/Linux for a
+ * venv: `executablePath` is the base interpreter image, while argv[0] is the venv
+ * interpreter that owns the server's site-packages. Either path alone is not
+ * enough; the pair must have the shape the reader documents, and the server's
+ * exact H3 command must tie the venv path to the ComfyUI install.
  */
+function isPythonInterpreterPath(path: string | undefined): path is string {
+  if (!isVerifiedExecutablePath(path)) return false;
+  const basename = path.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+  return /^python(?:w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(basename);
+}
+
 function isAuthenticatedPython(
   identity: ProcessIdentity,
   serverArgv?: string[],
 ): boolean {
   const executable = identity.executablePath;
-  if (!hasExactProcessIdentity(identity) || !executable || !isVerifiedExecutablePath(executable)) {
+  const argv0 = identity.argv?.[0];
+  if (
+    !hasExactProcessIdentity(identity) ||
+    !isPythonInterpreterPath(executable) ||
+    !isPythonInterpreterPath(argv0)
+  ) {
     return false;
   }
-  if (!identity.argv?.[0] || !sameRecoveryPath(executable, identity.argv[0])) return false;
-  const basename = executable.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
-  if (!/^python(?:w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(basename)) return false;
+
+  // A normal process has the same path in both fields. A venv process is the
+  // documented exception: the kernel image resolves to base Python, while
+  // argv[0] remains the venv trampoline. Do not accept arbitrary two-Python
+  // paths; only that one-way base -> venv relationship is reader-proven.
+  const samePath = sameRecoveryPath(executable, argv0);
+  if (!samePath && !(isVenvInterpreterPath(argv0) && !isVenvInterpreterPath(executable))) {
+    return false;
+  }
   if (!serverArgv) return true;
 
   // A recovered Desktop server must use a venv interpreter under the same
   // ComfyUI install named by its H3 script. This rejects an arbitrary absolute
   // `C:\\attacker\\venv\\Scripts\\python.exe` even when its basename is valid.
+  if (!isVenvInterpreterPath(argv0)) return false;
   const script = normalizeRecoveryPath(serverArgv[0] ?? "");
-  const pythonPath = normalizeRecoveryPath(executable);
+  const pythonPath = normalizeRecoveryPath(argv0);
   const comfySegment = IS_WIN ? "comfyui" : "ComfyUI";
   const scriptSegments = script.split("/").filter(Boolean);
   const pythonSegments = pythonPath.split("/").filter(Boolean);
   const scriptRootIndex = scriptSegments.lastIndexOf(comfySegment);
   const pythonRootIndex = pythonSegments.lastIndexOf(comfySegment);
   if (scriptRootIndex < 0 || pythonRootIndex < 0) return false;
-  if (!isVenvInterpreterPath(executable)) return false;
   if (isAbsoluteRecoveryPath(serverArgv[0] ?? "")) {
-    const expectedRoot = scriptSegments.slice(0, scriptRootIndex + 1).join("/");
-    if (!pythonPath.startsWith(`${expectedRoot}/`)) return false;
+    const expectedRoot = scriptSegments.slice(0, scriptRootIndex + 1);
+    if (!expectedRoot.every((segment, index) => pythonSegments[index] === segment)) {
+      return false;
+    }
   }
   return true;
 }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -496,6 +496,38 @@ function findDesktopAppPids(): number[] {
   return pids;
 }
 
+/**
+ * Find Python processes that may be the Desktop server when the port-owner
+ * lookup is unavailable. This is only a candidate list: every candidate is
+ * re-read through the process identity reader and must still pass the exact
+ * command and authenticated-ancestry checks below.
+ */
+function findPythonProcessPids(): number[] {
+  const pids = new Set<number>();
+  const names = IS_WIN ? ["python.exe", "pythonw.exe"] : ["python", "python3", "pythonw"];
+  for (const name of names) {
+    try {
+      const out = IS_WIN
+        ? execSync(`tasklist /FI "IMAGENAME eq ${name}" /FO CSV /NH`, {
+            encoding: "utf-8",
+            timeout: 5000,
+          })
+        : execSync(`pgrep -x "${name}"`, {
+            encoding: "utf-8",
+            timeout: 5000,
+          });
+      for (const line of String(out).split(/\r?\n/)) {
+        const match = IS_WIN ? line.match(/^"[^"]+","(\d+)"/) : line.match(/^\s*(\d+)\s*$/);
+        const pid = match ? Number.parseInt(match[1], 10) : NaN;
+        if (Number.isInteger(pid) && pid > 0) pids.add(pid);
+      }
+    } catch {
+      // A missing process-list query is unknown evidence, not an empty tree.
+    }
+  }
+  return [...pids];
+}
+
 function killProcessTree(pid: number): void {
   try {
     if (IS_WIN) {
@@ -652,6 +684,100 @@ function isDesktopApp(argv: string[]): boolean {
     joined.includes("comfy desktop") ||
     joined.includes("@comfyorgcomfyui-electron")
   );
+}
+
+/**
+ * Is this the narrow server command shape that can be recovered from Desktop?
+ * The Desktop markers alone are not enough: an arbitrary Python helper launched
+ * from the Desktop install must not become a restart target.
+ */
+function isDesktopServerArgv(argv: string[]): boolean {
+  const script = argv[0]?.trim().replace(/^['"]+|['"]+$/g, "") ?? "";
+  const basename = script.split(/[\\/]/).pop()?.toLowerCase();
+  return basename === "main.py" && isDesktopApp(argv);
+}
+
+function normalizedWindowsToken(token: string): string {
+  return token.trim().replace(/^['"]+|['"]+$/g, "").replace(/\\/g, "/").toLowerCase();
+}
+
+/**
+ * Match the server's argv to an OS process command without the permissive
+ * substring semantics used for ordinary corroboration. The OS argv is exact on
+ * Windows; requiring equal lengths rejects an injected extra command or flag.
+ * A relative server script may correspond to the absolute script the process
+ * table reports, but every other token must agree exactly.
+ */
+function exactDesktopServerCommand(
+  identity: ProcessIdentity,
+  serverArgv: string[],
+): boolean {
+  if (
+    identity.argvFidelity !== "exact" ||
+    !identity.commandLine ||
+    !identity.argv ||
+    identity.argv.length < 2
+  ) {
+    return false;
+  }
+  const observed = identity.argv.slice(1);
+  if (observed.length !== serverArgv.length) return false;
+  return observed.every((token, index) => {
+    const actual = normalizedWindowsToken(token);
+    const expected = normalizedWindowsToken(serverArgv[index] ?? "");
+    if (actual === expected) return true;
+    // Only the script token may be relative in sys.argv. The process table's
+    // absolute spelling still has to end at that exact script name.
+    if (index !== 0 || expected.includes("/") || /^[a-z]:/.test(expected)) return false;
+    return actual.endsWith(`/${expected}`);
+  });
+}
+
+function isVerifiedExecutablePath(path: string | undefined): path is string {
+  return Boolean(path && /^(?:[a-z]:[\\/]|\\\\|\/)/i.test(path));
+}
+
+function isAuthenticatedPython(identity: ProcessIdentity): boolean {
+  const executable = identity.executablePath;
+  if (!executable) return false;
+  // A bare image name is only a claim. The recovery path needs the OS-reported
+  // executable location so an unrelated launcher cannot masquerade as the
+  // Python process that Desktop owns.
+  if (!isVerifiedExecutablePath(executable)) return false;
+  const basename = executable.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+  return /^python(?:w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(basename);
+}
+
+function directDesktopPythonAncestry(
+  pid: number,
+  knownPids: ReadonlySet<number>,
+  readParent: (pid: number) => number | undefined,
+  readIdentity: (pid: number) => ProcessIdentity | undefined,
+): { desktopPid: number; desktopIdentity: ProcessIdentity } | "unavailable" | undefined {
+  // The issue's accepted shape is specifically Desktop.exe -> python.exe ->
+  // server python.exe. Do not walk through an arbitrary wrapper and turn a
+  // merely shared Desktop ancestor into restart authority.
+  const pythonPid = readParent(pid);
+  if (pythonPid == null) return "unavailable";
+  if (pythonPid <= 1 || pythonPid === pid) return undefined;
+  const python = readIdentity(pythonPid);
+  if (!python || !python.startedAt) return "unavailable";
+  if (!isAuthenticatedPython(python)) return undefined;
+
+  const desktopPid = readParent(pythonPid);
+  if (desktopPid == null) return "unavailable";
+  if (desktopPid <= 1 || desktopPid === pythonPid) return undefined;
+  if (!knownPids.has(desktopPid)) return undefined;
+  const desktop = readIdentity(desktopPid);
+  if (
+    !desktop ||
+    !desktop.startedAt ||
+    !isVerifiedExecutablePath(desktop.executablePath)
+  ) {
+    return "unavailable";
+  }
+  if (!isDesktopSupervisorProcess(desktop)) return undefined;
+  return { desktopPid, desktopIdentity: desktop };
 }
 
 /**
@@ -2963,6 +3089,101 @@ async function reconfirmAnsweringServer(
   return ownerNow === pid ? "confirmed" : "changed";
 }
 
+/**
+ * Recover a Desktop backend when the listener cannot be mapped to a PID.
+ *
+ * This is deliberately narrower than the old "find a Desktop process by name"
+ * fallback. The server has to have supplied a Desktop-shaped `sys.argv`; the OS
+ * process table has to expose one exact, spawn-faithful Python command with the
+ * same arguments; its direct parent has to be Python and that process's direct
+ * parent has to be a name-discovered Desktop PID; and the normal supervision
+ * classifier must authenticate every causality link. Missing or ambiguous evidence
+ * returns undefined so the caller keeps its existing refusal.
+ */
+function recoverDesktopProcessFromAncestry(
+  port: number,
+  serverArgv: string[],
+): ProcessInfo | undefined {
+  if (!isDesktopServerArgv(serverArgv)) return undefined;
+
+  const desktopPids = new Set(findDesktopAppPids());
+  if (desktopPids.size === 0) return undefined;
+
+  const identities = new Map<number, ProcessIdentity | undefined>();
+  const readIdentity = (pid: number): ProcessIdentity | undefined => {
+    if (!identities.has(pid)) identities.set(pid, resolveProcessIdentity(pid));
+    return identities.get(pid);
+  };
+  const readParent = (pid: number): number | undefined => {
+    // The normal reader and the test seam both represent the same OS fact. Use
+    // the seam when installed, otherwise retain the identity snapshot in the
+    // cache so one recovery decision does not mix process generations.
+    if (parentPidResolverOverride) return readParentPid(pid);
+    return readIdentity(pid)?.parentPid;
+  };
+
+  const matches: Array<{
+    pid: number;
+    identity: ProcessIdentity;
+    desktopPid: number;
+    desktopIdentity: ProcessIdentity;
+  }> = [];
+  let evidenceUnavailable = false;
+  for (const pid of findPythonProcessPids()) {
+    const identity = readIdentity(pid);
+    if (!identity) {
+      evidenceUnavailable = true;
+      continue;
+    }
+    if (!identity.startedAt) continue;
+    if (!isAuthenticatedPython(identity)) continue;
+    if (!exactDesktopServerCommand(identity, serverArgv)) continue;
+    const ancestry = directDesktopPythonAncestry(
+      pid,
+      desktopPids,
+      readParent,
+      readIdentity,
+    );
+    if (ancestry === "unavailable") {
+      evidenceUnavailable = true;
+      continue;
+    }
+    if (!ancestry) continue;
+
+    const { verdict } = classifyDesktopSupervision({
+      pid,
+      readParentPid: readParent,
+      readIdentity,
+      processExists,
+      isSupervisorProcess: isDesktopSupervisorProcess,
+    });
+    if (verdict === "supervised") {
+      matches.push({ pid, identity, ...ancestry });
+    } else if (verdict === "unconfirmed") {
+      evidenceUnavailable = true;
+    }
+  }
+
+  // Two identical H3 launches under Desktop are not distinguishable once the
+  // port table is unavailable. Choosing one would turn ambiguity into authority.
+  if (evidenceUnavailable || matches.length !== 1) return undefined;
+  const match = matches[0];
+  if (!match) return undefined;
+
+  return {
+    pid: match.pid,
+    port,
+    argv: [...serverArgv],
+    osArgv: match.identity.argv,
+    osArgvExact: match.identity.argvFidelity === "exact",
+    osCommandLine: match.identity.commandLine,
+    observedInterpreter: observedInterpreterFromIdentity(match.identity),
+    isDesktopApp: true,
+    desktopExePath: match.desktopIdentity.executablePath,
+    startedAt: match.identity.startedAt,
+  };
+}
+
 async function gatherProcessInfo(): Promise<ProcessInfo> {
   const port = config.resolvedPort;
 
@@ -3122,6 +3343,16 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     throw err;
   }
   if (!pid) {
+    // A broken Windows listener can leave the server alive and still answering
+    // through an already-established panel connection, while every port-owner
+    // lookup returns unknown. Bind that server through the authenticated
+    // Desktop→Python ancestry instead of treating a Desktop name scan as proof.
+    // The recovery helper returns nothing unless the command and ancestry are
+    // independently verified, so the ordinary fail-closed error remains intact.
+    if (argv.length > 0) {
+      const recovered = recoverDesktopProcessFromAncestry(port, argv);
+      if (recovered) return recovered;
+    }
     // Liveness is the reachable SERVER, not only a local PID scan. If
     // /system_stats just answered (argv populated) yet we still can't map the
     // listening socket to a PID, say so precisely instead of claiming the

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -460,8 +460,24 @@ export { parseListenerPidFromNetstat, findPidByPort };
  * "ComfyUI.app"). The Python backend is a child of the Electron app, so we
  * need to kill the parent to fully stop the Desktop app.
  */
-function findDesktopAppPids(): number[] {
+interface ProcessListProbe {
+  pids: number[];
+  complete: boolean;
+}
+
+function isExpectedPgrepNoMatch(error: unknown): boolean {
+  return (
+    !IS_WIN &&
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: unknown }).status === 1
+  );
+}
+
+function findDesktopAppPidsWithStatus(): ProcessListProbe {
   const pids: number[] = [];
+  let complete = true;
   if (IS_WIN) {
     for (const exe of ["ComfyUI.exe", "Comfy Desktop.exe"]) {
       try {
@@ -476,7 +492,7 @@ function findDesktopAppPids(): number[] {
           if (match) pids.push(parseInt(match[1], 10));
         }
       } catch {
-        // No processes with this image name
+        complete = false;
       }
     }
   } else {
@@ -489,11 +505,15 @@ function findDesktopAppPids(): number[] {
         const pid = parseInt(line, 10);
         if (!isNaN(pid) && pid > 0) pids.push(pid);
       }
-    } catch {
-      // No Desktop app processes found
+    } catch (error) {
+      if (!isExpectedPgrepNoMatch(error)) complete = false;
     }
   }
-  return pids;
+  return { pids, complete };
+}
+
+function findDesktopAppPids(): number[] {
+  return findDesktopAppPidsWithStatus().pids;
 }
 
 /**
@@ -502,8 +522,9 @@ function findDesktopAppPids(): number[] {
  * re-read through the process identity reader and must still pass the exact
  * command and authenticated-ancestry checks below.
  */
-function findPythonProcessPids(): number[] {
+function findPythonProcessPids(): ProcessListProbe {
   const pids = new Set<number>();
+  let complete = true;
   const names = IS_WIN ? ["python.exe", "pythonw.exe"] : ["python", "python3", "pythonw"];
   for (const name of names) {
     try {
@@ -521,11 +542,11 @@ function findPythonProcessPids(): number[] {
         const pid = match ? Number.parseInt(match[1], 10) : NaN;
         if (Number.isInteger(pid) && pid > 0) pids.add(pid);
       }
-    } catch {
-      // A missing process-list query is unknown evidence, not an empty tree.
+    } catch (error) {
+      if (!isExpectedPgrepNoMatch(error)) complete = false;
     }
   }
-  return [...pids];
+  return { pids: [...pids], complete };
 }
 
 function killProcessTree(pid: number): void {
@@ -687,26 +708,74 @@ function isDesktopApp(argv: string[]): boolean {
 }
 
 /**
- * Is this the narrow server command shape that can be recovered from Desktop?
- * The Desktop markers alone are not enough: an arbitrary Python helper launched
- * from the Desktop install must not become a restart target.
+ * Return a path without command-line quoting and with the host's path rules
+ * applied. POSIX paths are intentionally not case-folded: unlike Windows,
+ * `/ComfyUI/main.py` and `/comfyui/main.py` are different paths.
  */
-function isDesktopServerArgv(argv: string[]): boolean {
-  const script = argv[0]?.trim().replace(/^['"]+|['"]+$/g, "") ?? "";
-  const basename = script.split(/[\\/]/).pop()?.toLowerCase();
-  return basename === "main.py" && isDesktopApp(argv);
+function normalizeRecoveryPath(path: string): string {
+  const unquoted = path.trim().replace(/^['"]+|['"]+$/g, "");
+  if (!IS_WIN) return unquoted;
+  return unquoted.replace(/\\/g, "/").toLowerCase();
 }
 
-function normalizedWindowsToken(token: string): string {
-  return token.trim().replace(/^['"]+|['"]+$/g, "").replace(/\\/g, "/").toLowerCase();
+function isAbsoluteRecoveryPath(path: string): boolean {
+  return IS_WIN
+    ? /^[a-z]:[\\/]/i.test(path) || /^\\\\/.test(path)
+    : path.startsWith("/");
+}
+
+function isComfyUIServerScript(path: string): boolean {
+  const normalized = normalizeRecoveryPath(path);
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.pop() !== "main.py") return false;
+  // Desktop's H3 launch names the ComfyUI install explicitly. A broad
+  // "Desktop" marker elsewhere in argv must not make an arbitrary helper.py
+  // authoritative.
+  return segments.some((segment) => segment === (IS_WIN ? "comfyui" : "ComfyUI"));
+}
+
+function isDesktopConfigPath(path: string): boolean {
+  const normalized = normalizeRecoveryPath(path);
+  if (!isAbsoluteRecoveryPath(path)) return false;
+  const segments = normalized.split("/").filter(Boolean);
+  return segments.some((segment) => segment === (IS_WIN ? "comfy desktop" : "Comfy Desktop"));
+}
+
+/**
+ * Is this the exact H3 server command Desktop uses for its backend?
+ *
+ * The old check only looked for `main.py` plus any Desktop-looking token. That
+ * allowed an unrelated helper launched from the Desktop install to become a
+ * restart target. Keep the accepted shape deliberately narrow: script, Manager
+ * flag, one absolute Desktop model-paths config, and the requested port, in that
+ * order and with no extra arguments.
+ */
+function isDesktopServerArgv(argv: string[], port: number): boolean {
+  if (argv.length !== 6) return false;
+  const [script, managerFlag, configFlag, configPath, portFlag, reportedPort] = argv;
+  return Boolean(
+    script &&
+      managerFlag === "--enable-manager" &&
+      configFlag === "--extra-model-paths-config" &&
+      configPath &&
+      isComfyUIServerScript(script) &&
+      isDesktopConfigPath(configPath) &&
+      portFlag === "--port" &&
+      reportedPort === String(port),
+  );
+}
+
+function normalizeRecoveryToken(token: string): string {
+  const unquoted = token.trim().replace(/^['"]+|['"]+$/g, "");
+  return IS_WIN ? unquoted.replace(/\\/g, "/").toLowerCase() : unquoted;
 }
 
 /**
  * Match the server's argv to an OS process command without the permissive
- * substring semantics used for ordinary corroboration. The OS argv is exact on
- * Windows; requiring equal lengths rejects an injected extra command or flag.
- * A relative server script may correspond to the absolute script the process
- * table reports, but every other token must agree exactly.
+ * substring semantics used for ordinary corroboration. Requiring equal lengths
+ * rejects an injected extra command or flag. Windows permits the process table to
+ * report an absolute spelling for Desktop's relative `ComfyUI\\main.py`; POSIX
+ * does not get that suffix fallback because its path and case rules are exact.
  */
 function exactDesktopServerCommand(
   identity: ProcessIdentity,
@@ -723,29 +792,125 @@ function exactDesktopServerCommand(
   const observed = identity.argv.slice(1);
   if (observed.length !== serverArgv.length) return false;
   return observed.every((token, index) => {
-    const actual = normalizedWindowsToken(token);
-    const expected = normalizedWindowsToken(serverArgv[index] ?? "");
+    const actual = normalizeRecoveryToken(token);
+    const expected = normalizeRecoveryToken(serverArgv[index] ?? "");
     if (actual === expected) return true;
-    // Only the script token may be relative in sys.argv. The process table's
-    // absolute spelling still has to end at that exact script name.
-    if (index !== 0 || expected.includes("/") || /^[a-z]:/.test(expected)) return false;
+    // Only Windows may reconcile Desktop's relative sys.argv[0] with the
+    // absolute script path exposed by the process table.
+    const expectedRaw = (serverArgv[index] ?? "").trim().replace(/^['"]+|['"]+$/g, "");
+    if (
+      !IS_WIN ||
+      index !== 0 ||
+      /^[a-z]:[\\/]/i.test(expectedRaw) ||
+      /^\\\\/.test(expectedRaw)
+    ) {
+      return false;
+    }
     return actual.endsWith(`/${expected}`);
   });
 }
 
 function isVerifiedExecutablePath(path: string | undefined): path is string {
-  return Boolean(path && /^(?:[a-z]:[\\/]|\\\\|\/)/i.test(path));
+  return Boolean(path && isAbsoluteRecoveryPath(path));
 }
 
-function isAuthenticatedPython(identity: ProcessIdentity): boolean {
+function sameRecoveryPath(a: string, b: string): boolean {
+  return normalizeRecoveryPath(a) === normalizeRecoveryPath(b);
+}
+
+function hasExactProcessIdentity(identity: ProcessIdentity | undefined): identity is ProcessIdentity {
+  return Boolean(
+    identity?.startedAt &&
+      identity.executablePath &&
+      identity.commandLine &&
+      identity.argvFidelity === "exact" &&
+      identity.argv?.length,
+  );
+}
+
+/**
+ * The executable path is useful only when it agrees with the OS command's first
+ * token. A basename or absolute-path shape alone is not authentication: an
+ * unrelated `python.exe`/`Comfy Desktop.exe` can live at either.
+ */
+function isAuthenticatedPython(
+  identity: ProcessIdentity,
+  serverArgv?: string[],
+): boolean {
   const executable = identity.executablePath;
-  if (!executable) return false;
-  // A bare image name is only a claim. The recovery path needs the OS-reported
-  // executable location so an unrelated launcher cannot masquerade as the
-  // Python process that Desktop owns.
-  if (!isVerifiedExecutablePath(executable)) return false;
+  if (!hasExactProcessIdentity(identity) || !executable || !isVerifiedExecutablePath(executable)) {
+    return false;
+  }
+  if (!identity.argv?.[0] || !sameRecoveryPath(executable, identity.argv[0])) return false;
   const basename = executable.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
-  return /^python(?:w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(basename);
+  if (!/^python(?:w)?(?:\d+(?:\.\d+)*)?(?:\.exe)?$/.test(basename)) return false;
+  if (!serverArgv) return true;
+
+  // A recovered Desktop server must use a venv interpreter under the same
+  // ComfyUI install named by its H3 script. This rejects an arbitrary absolute
+  // `C:\\attacker\\venv\\Scripts\\python.exe` even when its basename is valid.
+  const script = normalizeRecoveryPath(serverArgv[0] ?? "");
+  const pythonPath = normalizeRecoveryPath(executable);
+  const comfySegment = IS_WIN ? "comfyui" : "ComfyUI";
+  const scriptSegments = script.split("/").filter(Boolean);
+  const pythonSegments = pythonPath.split("/").filter(Boolean);
+  const scriptRootIndex = scriptSegments.lastIndexOf(comfySegment);
+  const pythonRootIndex = pythonSegments.lastIndexOf(comfySegment);
+  if (scriptRootIndex < 0 || pythonRootIndex < 0) return false;
+  if (!isVenvInterpreterPath(executable)) return false;
+  if (isAbsoluteRecoveryPath(serverArgv[0] ?? "")) {
+    const expectedRoot = scriptSegments.slice(0, scriptRootIndex + 1).join("/");
+    if (!pythonPath.startsWith(`${expectedRoot}/`)) return false;
+  }
+  return true;
+}
+
+function expectedDesktopExecutablePaths(): string[] {
+  if (IS_WIN) {
+    const localAppData = process.env.LOCALAPPDATA;
+    const userProfile = process.env.USERPROFILE;
+    return [
+      "C:/Program Files/Comfy Desktop/Comfy Desktop.exe",
+      "C:/Program Files/ComfyUI/ComfyUI.exe",
+      ...(localAppData
+        ? [
+            `${localAppData}/Programs/Comfy Desktop/Comfy Desktop.exe`,
+            `${localAppData}/Programs/@comfyorgcomfyui-electron/ComfyUI.exe`,
+            `${localAppData}/Programs/ComfyUI/ComfyUI.exe`,
+          ]
+        : []),
+      ...(userProfile ? [`${userProfile}/Programs/ComfyUI/ComfyUI.exe`] : []),
+    ];
+  }
+  const home = homedir();
+  return [
+    "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop",
+    "/Applications/Comfy Desktop.app/Contents/MacOS/ComfyUI",
+    "/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop",
+    "/Applications/ComfyUI.app/Contents/MacOS/ComfyUI",
+    `${home}/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop`,
+    `${home}/Applications/Comfy Desktop.app/Contents/MacOS/ComfyUI`,
+    `${home}/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop`,
+    `${home}/Applications/ComfyUI.app/Contents/MacOS/ComfyUI`,
+  ];
+}
+
+function isExpectedDesktopExecutablePath(path: string): boolean {
+  const normalized = normalizeRecoveryPath(path);
+  return expectedDesktopExecutablePaths().some((candidate) =>
+    sameRecoveryPath(normalized, candidate),
+  );
+}
+
+function isAuthenticatedDesktopSupervisor(identity: ProcessIdentity): boolean {
+  return Boolean(
+    hasExactProcessIdentity(identity) &&
+      identity.executablePath &&
+      identity.argv?.[0] &&
+      isExpectedDesktopExecutablePath(identity.executablePath) &&
+      sameRecoveryPath(identity.executablePath, identity.argv[0]) &&
+      isDesktopSupervisorProcess(identity),
+  );
 }
 
 function directDesktopPythonAncestry(
@@ -761,8 +926,7 @@ function directDesktopPythonAncestry(
   if (pythonPid == null) return "unavailable";
   if (pythonPid <= 1 || pythonPid === pid) return undefined;
   const python = readIdentity(pythonPid);
-  if (!python || !python.startedAt) return "unavailable";
-  if (!isAuthenticatedPython(python)) return undefined;
+  if (!python || !isAuthenticatedPython(python)) return "unavailable";
 
   const desktopPid = readParent(pythonPid);
   if (desktopPid == null) return "unavailable";
@@ -771,12 +935,12 @@ function directDesktopPythonAncestry(
   const desktop = readIdentity(desktopPid);
   if (
     !desktop ||
-    !desktop.startedAt ||
+    !hasExactProcessIdentity(desktop) ||
     !isVerifiedExecutablePath(desktop.executablePath)
   ) {
     return "unavailable";
   }
-  if (!isDesktopSupervisorProcess(desktop)) return undefined;
+  if (!isAuthenticatedDesktopSupervisor(desktop)) return undefined;
   return { desktopPid, desktopIdentity: desktop };
 }
 
@@ -3104,10 +3268,15 @@ function recoverDesktopProcessFromAncestry(
   port: number,
   serverArgv: string[],
 ): ProcessInfo | undefined {
-  if (!isDesktopServerArgv(serverArgv)) return undefined;
+  if (!isDesktopServerArgv(serverArgv, port)) return undefined;
 
-  const desktopPids = new Set(findDesktopAppPids());
+  const desktopProbe = findDesktopAppPidsWithStatus();
+  if (!desktopProbe.complete) return undefined;
+  const desktopPids = new Set(desktopProbe.pids);
   if (desktopPids.size === 0) return undefined;
+
+  const pythonProbe = findPythonProcessPids();
+  if (!pythonProbe.complete) return undefined;
 
   const identities = new Map<number, ProcessIdentity | undefined>();
   const readIdentity = (pid: number): ProcessIdentity | undefined => {
@@ -3129,15 +3298,20 @@ function recoverDesktopProcessFromAncestry(
     desktopIdentity: ProcessIdentity;
   }> = [];
   let evidenceUnavailable = false;
-  for (const pid of findPythonProcessPids()) {
+  for (const pid of pythonProbe.pids) {
     const identity = readIdentity(pid);
-    if (!identity) {
+    if (!hasExactProcessIdentity(identity)) {
       evidenceUnavailable = true;
       continue;
     }
-    if (!identity.startedAt) continue;
-    if (!isAuthenticatedPython(identity)) continue;
+    // Fully observed non-matching Python processes are ordinary background
+    // processes and can be ignored. Once the exact H3 command matches, however,
+    // an untrusted executable path is an ambiguous target and must fail closed.
     if (!exactDesktopServerCommand(identity, serverArgv)) continue;
+    if (!isAuthenticatedPython(identity, serverArgv)) {
+      evidenceUnavailable = true;
+      continue;
+    }
     const ancestry = directDesktopPythonAncestry(
       pid,
       desktopPids,


### PR DESCRIPTION
## Summary

Fixes #2265.

When the listener-owner probe is unavailable, restart authorization now accepts only a uniquely verified direct `Comfy Desktop.exe -> python.exe -> server python.exe` chain whose server process has an exact command matching the live ComfyUI `sys.argv`. The OS-reported executable paths, process start times, parent links, and Desktop supervision are required; missing, mismatched, unrelated, ambiguous, or non-exact evidence preserves the existing refusal.

The `restart_comfyui` and `panel_restart_comfyui` callers continue through the existing Manager-reboot authorization path; no unrelated restart behavior is changed.

## Validation

- `npm.cmd exec vitest run src/__tests__/services/restart-relaunch-lifecycle.test.ts --reporter=dot` — 70 passed
- `npm.cmd run lint` — passed (`tsc --noEmit`)