### PR TITLE
fix(panel): share widget schema refresh recovery

### DIFF
--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -5,17 +5,18 @@
 // mutations_ready=true, then panel_add_node("LoadImage"), panel_refresh_nodes,
 // and panel_set_widget all fail because /object_info did not answer inside the
 // panel's fixed 10s/5s shares. The canvas is readable; schema-guarded edits are
-// not. refresh_nodes also CLEARS the last-known schema, so calling it as the
-// recovery makes the next widget write worse — except for #2202's stale-combo
-// timeout, where the panel has already retired that snapshot and a refresh is
-// the safe way to restore it for later unrelated writes.
+// not. panel_add_node still avoids refresh_nodes after a generic budget miss,
+// while #2274 gives panel_set_widget a stricter shared refresh path: it retries
+// only after an authoritative refreshed:true result and otherwise remains refused.
+// #2202's stale-combo timeout continues to use its narrower refresh recovery.
 //
 // These drive the real tool defs. The panel's 5s/10s shares live in the other
-// repo; this process can still (1) retry a before-create/before-write refusal
-// without dispatching refresh_nodes, (2) stop advertising mutations_ready:true
-// once that refusal has been observed, and (3) reserve refresh_nodes for the
-// acknowledged #2202 stale-combo timeout where the panel has already retired
-// its schema snapshot.
+// repo; this process can still (1) retry a before-create refusal without
+// dispatching refresh_nodes, (2) share one bounded authoritative refresh for
+// panel_set_widget's #2274 recovery, (3) stop advertising mutations_ready:true
+// once a schema refusal has been observed, and (4) reserve refresh_nodes for the
+// acknowledged #2202 stale-combo timeout where the panel has already
+// retired its schema snapshot.
 
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -203,13 +204,14 @@ describe("panel_add_node retries a schema-budget refusal without refresh_nodes (
   });
 });
 
-describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
+describe("panel_set_widget shares schema refresh recovery (#2007, #2274)", () => {
   it("THE REPORTED CASE: share-timeout write then succeeds on the retry", async () => {
     let writes = 0;
     const { res, calls, text } = await callTool(
       "panel_set_widget",
       { node_id: 12, widget: "text", value: "hello" },
       async (cmd) => {
+        if (cmd.cmd === "refresh_nodes") return { refreshed: true };
         if (cmd.cmd !== "graph_set_widget") return { ok: true };
         writes += 1;
         if (writes === 1) throw new Error(SET_WIDGET_BUDGET);
@@ -219,11 +221,11 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
 
     expect(res.isError).toBeFalsy();
     expect(calls.filter((c) => c === "graph_set_widget")).toHaveLength(2);
-    expect(calls).not.toContain("refresh_nodes");
+    expect(calls).toEqual(["graph_set_widget", "refresh_nodes", "graph_set_widget"]);
     expect(text).not.toMatch(/no whole schema/);
   });
 
-  it("retries EXACTLY once and says not to refresh_nodes", async () => {
+  it("refuses when the shared refresh does not return an authoritative schema", async () => {
     const { res, calls, text } = await callTool(
       "panel_set_widget",
       { node_id: 12, widget: "text", value: "hello" },
@@ -234,9 +236,132 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
     );
 
     expect(res.isError).toBe(true);
-    expect(calls.filter((c) => c === "graph_set_widget")).toHaveLength(2);
-    expect(text).toMatch(/already retried ONCE/);
-    expect(text).toMatch(/Do NOT call panel_refresh_nodes/);
+    expect(calls).toEqual(["graph_set_widget", "refresh_nodes"]);
+    expect(text).toMatch(/missing or malformed refresh result/);
+    expect(text).toMatch(/nothing was written/i);
+  });
+
+  it("shares an authoritative refresh across concurrent widget callers", async () => {
+    let writes = 0;
+    let resolveRefresh!: (value: unknown) => void;
+    const refresh = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        if (writes <= 2) throw new Error(SET_WIDGET_BUDGET);
+        return { ok: true, node_id: 12, widget: "text", previous: "", value: "hello" };
+      }
+      if (cmd.cmd === "refresh_nodes") return refresh;
+      return { ok: true };
+    });
+    const ctx1 = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const ctx2 = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const setWidget = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+    if (!setWidget) throw new Error("panel_set_widget is not registered");
+
+    const first = setWidget.handler(
+      { node_id: 12, widget: "text", value: "hello" } as never,
+      ctx1,
+    );
+    const second = setWidget.handler(
+      { node_id: 12, widget: "text", value: "hello" } as never,
+      ctx2,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.filter((cmd) => cmd === "refresh_nodes")).toHaveLength(1);
+
+    resolveRefresh({ refreshed: true });
+    const results = await Promise.all([first, second]);
+    expect(results.every((result) => !result.isError)).toBe(true);
+    expect(calls.filter((cmd) => cmd === "refresh_nodes")).toHaveLength(1);
+    expect(calls.filter((cmd) => cmd === "graph_set_widget")).toHaveLength(4);
+  });
+
+  it("keeps schema readiness blocked when the post-refresh retry still times out", async () => {
+    const { b } = bridge(async (cmd) => {
+      if (cmd.cmd === "graph_set_widget") throw new Error(SET_WIDGET_BUDGET);
+      if (cmd.cmd === "refresh_nodes") return { refreshed: true };
+      if (cmd.cmd === "graph_outline") {
+        return {
+          outline: "12 LoadImage",
+          node_count: 1,
+          backend_socket: "up",
+          mutations_ready: true,
+        };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const setWidget = defs.find((d) => d.name === "panel_set_widget");
+    const outline = defs.find((d) => d.name === "panel_graph_outline");
+    if (!setWidget || !outline) throw new Error("panel schema tools are not registered");
+
+    const refused = await setWidget.handler(
+      { node_id: 12, widget: "text", value: "hello" } as never,
+      ctx,
+    );
+    expect(refused.isError).toBe(true);
+    expect(textOf(refused)).toMatch(/retry still could not/i);
+    expect(parseJson(await outline.handler({} as never, ctx)).mutations_ready).toBe(false);
+  });
+
+  it("joins an explicit panel_refresh_nodes already in flight before retrying", async () => {
+    let writes = 0;
+    let resolveRefresh!: (value: unknown) => void;
+    const refresh = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "refresh_nodes") return refresh;
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        if (writes === 1) throw new Error(SET_WIDGET_BUDGET);
+        return { ok: true, node_id: 12, widget: "text", previous: "", value: "hello" };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const defs = buildPanelToolDefs();
+    const refreshNodes = defs.find((d) => d.name === "panel_refresh_nodes");
+    const setWidget = defs.find((d) => d.name === "panel_set_widget");
+    if (!refreshNodes || !setWidget) throw new Error("panel schema tools are not registered");
+
+    const refreshCall = refreshNodes.handler({} as never, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const writeCall = setWidget.handler(
+      { node_id: 12, widget: "text", value: "hello" } as never,
+      ctx,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.filter((cmd) => cmd === "refresh_nodes")).toHaveLength(1);
+
+    resolveRefresh({ refreshed: true });
+    const [refreshResult, writeResult] = await Promise.all([refreshCall, writeCall]);
+    expect(refreshResult.isError).toBeFalsy();
+    expect(writeResult.isError).toBeFalsy();
+    expect(calls).toEqual(["refresh_nodes", "graph_set_widget", "graph_set_widget"]);
+  });
+
+  it("keeps the write refused when the shared refresh acknowledgement times out", async () => {
+    const { res, calls, text } = await callTool(
+      "panel_set_widget",
+      { node_id: 12, widget: "text", value: "hello" },
+      async (cmd) => {
+        if (cmd.cmd === "graph_set_widget") throw new Error(SET_WIDGET_BUDGET);
+        if (cmd.cmd === "refresh_nodes") {
+          throw new Error('Panel tab wf did not reply to "refresh_nodes" within 90000 ms');
+        }
+        return { ok: true };
+      },
+    );
+
+    expect(res.isError).toBe(true);
+    expect(calls).toEqual(["graph_set_widget", "refresh_nodes"]);
+    expect(text).toMatch(/refresh acknowledgement timed out/i);
+    expect(text).toMatch(/nothing was written/i);
   });
 
   it("#2202 restores schema after a stale-combo refresh timeout before an unrelated write", async () => {
@@ -292,6 +417,9 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
   it("records a starvation refusal so the next outline does not advertise readiness", async () => {
     const { b } = bridge(async (cmd) => {
       if (cmd.cmd === "graph_set_widget") throw new Error(SET_WIDGET_STARVATION);
+      if (cmd.cmd === "refresh_nodes") {
+        return { refreshed: false, reason: "refresh_still_running" };
+      }
       if (cmd.cmd === "graph_outline") {
         return {
           outline: "12 OpenAICompatibleLLM",
@@ -313,7 +441,7 @@ describe("panel_set_widget retries a schema-budget refusal (#2007)", () => {
       ctx,
     );
     expect(refused.isError).toBe(true);
-    expect(textOf(refused)).toMatch(/refresh TIMEOUT, not a missing node/i);
+    expect(textOf(refused)).toMatch(/refresh.*still running/i);
 
     const next = parseJson(await outline.handler({} as never, ctx));
     expect(next.mutations_ready).toBe(false);

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -213,8 +213,8 @@ describe("panel_edit_node restores a collapsed zero height before dispatch (#200
   });
 });
 
-describe("panel_set_widget names object_info starvation (#2004)", () => {
-  it("THE REPORTED CASE: keeps the refusal and says this is a timeout, not a missing node", async () => {
+describe("panel_set_widget preserves object_info starvation refusal (#2004, #2274)", () => {
+  it("THE REPORTED CASE: keeps the refusal when refresh recovery is not authoritative", async () => {
     const calls: Forwarded[] = [];
     const ctx: PanelToolCtx = {
       call: async (cmd) => {
@@ -235,11 +235,11 @@ describe("panel_set_widget names object_info starvation (#2004)", () => {
     expect(res.isError).toBe(true);
     const text = textOf(res);
     expect(text).toContain(STARVATION);
-    expect(text).toMatch(/refresh TIMEOUT, not a missing node/i);
-    expect(text).toMatch(/already on the canvas/i);
-    expect(text).toMatch(/Do NOT reinstall a pack/);
-    // The refusal is pre-mutation — do not re-issue a write that will pay the same 15s.
+    expect(text).toMatch(/panel_refresh_nodes did not return an authoritative refreshed:true/i);
+    expect(text).toMatch(/nothing was written/i);
+    // The refusal is pre-mutation — do not re-issue a write without a proven schema.
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "refresh_nodes")).toHaveLength(1);
   });
 
   it("an unrelated set_widget refusal is not wrapped as starvation", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4971,36 +4971,6 @@ function isObjectInfoUnavailableRefusal(res: ToolResult): boolean {
   );
 }
 
-/**
- * #2004 — panel_set_widget refused an installed backend node because both
- * whole-schema routes exhausted their budget. Matched on the panel's own
- * wording (assertTypeAgainstFreshBackend / objectInfoOracleFailureNote) so a
- * miss costs a missing hint and a false positive costs an extra paragraph.
- * Used ONLY to APPEND advice to a refusal the panel already made — never to
- * authorize a write, and never to consult COMFYUI_URL (#1359).
- */
-function isObjectInfoStarvationRefusal(res: ToolResult): boolean {
-  if (!res.isError) return false;
-  const text = textOfToolResult(res);
-  return (
-    /no usable \/object_info schema was obtained/i.test(text) &&
-    (/Tried \d+ routes:/i.test(text) ||
-      (/api\.getNodeDefs\(\) did not answer/i.test(text) &&
-        /GET \/object_info did not answer/i.test(text)))
-  );
-}
-
-function objectInfoStarvationNote(): string {
-  return (
-    `\n\nThis is a live /object_info refresh TIMEOUT, not a missing node. ` +
-    `The write was refused before it mutated anything because the schema routes ` +
-    `exhausted their budget. The node is already on the canvas, so this type is in use. ` +
-    `Do NOT reinstall a pack. Retry panel_set_widget in a moment; if it keeps happening, ` +
-    `the tab's whole-schema snapshot was never populated — wait for a successful ` +
-    `panel_refresh_nodes, or reload the ComfyUI tab.`
-  );
-}
-
 /** #2004 — the panel's 13s save budget fired while the userdata write was still in flight. */
 function isWorkflowSaveBudgetTimeout(res: ToolResult): boolean {
   if (!res.isError) return false;
@@ -5137,6 +5107,83 @@ function isObjectInfoBudgetRefusal(res: ToolResult): boolean {
     /no usable \/?object_info|no whole (?:\/object_info|schema)|object_info_fetch_failed|did not answer within its \d+ms share|exceeded \d+ms share/i.test(
       textOfToolResult(res),
     )
+  );
+}
+
+/**
+ * #2274 — share one authoritative node-definition refresh per live panel tab.
+ *
+ * A schema-guarded widget write can time out its own /object_info routes while a
+ * refresh started by another panel command is still registering definitions. Starting
+ * one refresh per waiting write recreates the same stampede and makes every caller
+ * refuse before the already-useful refresh can land. The promise is keyed to the live
+ * tab incarnation, so a reconnect cannot let an old refresh authorize a new tab.
+ *
+ * The refresh is only a coordination primitive. Callers must still require the panel's
+ * explicit `refreshed:true` result before retrying a write; a timeout, malformed reply,
+ * `refresh_still_running`, or any other non-authoritative result remains fail-closed.
+ */
+const panelSchemaRefreshes = new Map<
+  string,
+  { token: object; promise: Promise<ToolResult> }
+>();
+
+function sharedPanelSchemaRefresh(ctx: PanelToolCtx): Promise<ToolResult> {
+  const key = panelSchemaKey(ctx);
+  const existing = panelSchemaRefreshes.get(key);
+  if (existing) return existing.promise;
+
+  const token = {};
+  // Yield before dispatch so the map is installed before even a synchronously-throwing
+  // bridge stub can settle this promise and run its cleanup.
+  const promise = (async () => {
+    await Promise.resolve();
+    try {
+      return await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);
+    } catch (err) {
+      return fail(err);
+    } finally {
+      if (panelSchemaRefreshes.get(key)?.token === token) panelSchemaRefreshes.delete(key);
+    }
+  })();
+  panelSchemaRefreshes.set(key, { token, promise });
+  return promise;
+}
+
+function panelSchemaRefreshSucceeded(res: ToolResult): boolean {
+  if (res.isError) return false;
+  return parseToolResultJson(res)?.refreshed === true;
+}
+
+function objectInfoWidgetRefreshNote(
+  refresh: ToolResult,
+  retryAfterRefresh = false,
+): string {
+  const payload = parseToolResultJson(refresh);
+  const stillRunning =
+    payload?.reason === "refresh_still_running" ||
+    /refresh_still_running|still running/i.test(textOfToolResult(refresh));
+  const timedOut = isReplyTimeoutResult(refresh) || /did not reply .*refresh_nodes/i.test(textOfToolResult(refresh));
+  if (retryAfterRefresh) {
+    return (
+      `\n\nThe authoritative panel_refresh_nodes completed, but the retry still could not ` +
+      `obtain a usable /object_info schema. Nothing was written; the value and node ` +
+      `validation refusal remain fail-closed. Retry after the panel settles, and do not ` +
+      `repeat the write if the node definition is genuinely missing or invalid.`
+    );
+  }
+  if (stillRunning || timedOut) {
+    return (
+      `\n\nThe widget write was refused before mutation because the authoritative node-definition ` +
+      `refresh did not settle inside its bounded window (${stillRunning ? "it is still running" : "the refresh acknowledgement timed out"}). ` +
+      `No usable schema was proven and nothing was written. Retry after that refresh settles.`
+    );
+  }
+  return (
+    `\n\nThe widget write was refused before mutation because panel_refresh_nodes did not ` +
+    `return an authoritative refreshed:true result (${payload?.reason ?? "missing or malformed refresh result"}). ` +
+    `No usable /object_info schema was proven and nothing was written; refusing to retry ` +
+    `the value against an unknown or stale definition.`
   );
 }
 
@@ -16154,14 +16201,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           markPanelSchemaReady(panelSchemaKey(ctx));
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);
         }
-        // #2004 — both whole-schema routes timed out. The panel refused BEFORE
-        // mutating, so this is not outcome-unknown. Name the timeout rather than
-        // leaving "cannot verify the node type" as "the type is missing".
-        if (isObjectInfoStarvationRefusal(first)) {
-          markPanelSchemaBlocked(panelSchemaKey(ctx));
-          return appendToolResultText(first, objectInfoStarvationNote());
-        }
-
         // #2202 — stale-combo recovery may have retired the panel's last usable
         // whole-schema snapshot before its bounded refresh wait abandoned. The
         // panel refused before writing, so dispatching its idempotent,
@@ -16273,18 +16312,30 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return explainAmbiguousPromotedWidgetRefusal(first, args, ctx);
         }
 
+        // #2274 — a whole-schema budget refusal can be caused by a refresh already
+        // registering definitions for this tab. Share one bounded refresh, and retry
+        // the exact write only after the panel authoritatively reports refreshed:true.
+        // This preserves the before-write refusal for a still-running/failed/malformed
+        // refresh, and avoids the N independent refresh paths that made a burst of
+        // otherwise-valid writes all refuse together.
         if (isObjectInfoBudgetRefusal(first)) {
-          // #2007 — same schema-budget refusal as panel_add_node, same
-          // before-write fail-closed, same "do not refresh_nodes" recovery.
-          markPanelSchemaBlocked(panelSchemaKey(ctx));
+          const schemaKey = panelSchemaKey(ctx);
+          markPanelSchemaBlocked(schemaKey);
+          const refreshed = await sharedPanelSchemaRefresh(ctx);
+          if (!panelSchemaRefreshSucceeded(refreshed)) {
+            return appendToolResultText(first, objectInfoWidgetRefreshNote(refreshed));
+          }
+          markPanelSchemaReady(schemaKey);
           const retried = await write(args.node_id, args.widget as string);
           if (!retried.isError) {
-            markPanelSchemaReady(panelSchemaKey(ctx));
             return persistUnpromotedControlAfterGenerate(retried, ctx, args.node_id);
           }
-          first = isObjectInfoBudgetRefusal(retried)
-            ? appendToolResultText(retried, objectInfoBudgetNote("widget"))
-            : retried;
+          if (isObjectInfoBudgetRefusal(retried)) {
+            markPanelSchemaBlocked(schemaKey);
+            first = appendToolResultText(retried, objectInfoWidgetRefreshNote(refreshed, true));
+          } else {
+            first = retried;
+          }
         }
 
         // #1655 — the panel listed this widget as promoted while refusing it as
@@ -17331,7 +17382,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // Same bounded ack budget as the refresh-before-validate writes (#599): a
         // fresh /object_info on a large install routinely exceeds the 6000 ms
         // default, and this command's WHOLE purpose is to await that fetch.
-        const res = await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);
+        const res = await sharedPanelSchemaRefresh(ctx);
         // #2007 — a failed whole-schema refresh is not a down backend. It is also
         // worse than a no-op: the panel CLEARS the last-known schema at the start
         // of the run, so a timed-out refresh is why the next panel_set_widget


### PR DESCRIPTION
## Summary

- Share one bounded `refresh_nodes` promise per live panel-tab incarnation for `panel_set_widget` schema-budget refusals.
- Retry the exact widget write only after an authoritative `refreshed:true` result; preserve fail-closed behavior for timeout, still-running, malformed/missing, stale, ambiguous, and unrelated refusals.
- Add production-path regressions for concurrent callers, an existing `panel_refresh_nodes`, timeout/malformed refreshes, and readiness state.

## Validation

- `npm.cmd exec vitest run src/__tests__/orchestrator/object-info-budget-mutations.test.ts src/__tests__/orchestrator/object-info-starvation.test.ts src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/orchestrator/panel-retry-identity.test.ts --reporter=dot`
- `npm.cmd run lint`
- `npm.cmd exec vitest run src/__tests__/services --reporter=dot`

Closes #2274