### PR TITLE
fix(2057): reconcile download failure notifications with live jobs

### DIFF
--- a/src/__tests__/orchestrator/download-done-contradiction.test.ts
+++ b/src/__tests__/orchestrator/download-done-contradiction.test.ts
@@ -32,12 +32,17 @@ import {
   COMPLETION_DISAGREEMENT_NOTE,
   FAILURE_DISAGREEMENT_NOTE,
   completionDisagreesWithRecord,
+  failureErrorDetail,
   failureDisagreesWithRecord,
+  reconcileDownloadDoneFailures,
 } from "../../orchestrator/download-done-guard.js";
+
+const TARGET = "http://127.0.0.1:8188";
 
 /** A progress row: identified by the PROGRESS/TRAY id, as written on disk. */
 const row = (over: Record<string, unknown> = {}) => ({
   id: "93015fbfa0fa9933",
+  target: TARGET,
   name: "model.safetensors",
   status: "done",
   ...over,
@@ -47,6 +52,7 @@ const row = (over: Record<string, unknown> = {}) => ({
 const job = (over: Record<string, unknown> = {}) => ({
   id: "6226e26ba97f8527",
   trayId: "93015fbfa0fa9933",
+  target: TARGET,
   filename: "model.safetensors",
   status: "downloading",
   ...over,
@@ -144,8 +150,9 @@ describe("the disagreement actually reaches the user (#1574)", () => {
   it("the tick FLAGS the disagreeing entries", async () => {
     const src = await read("index.ts");
     expect(src).toMatch(/settled\.filter\(\(d\) => completionDisagreesWithRecord\(d, records\)\)/);
-    expect(src).toMatch(/settled\.filter\(\(d\) => failureDisagreesWithRecord\(d, records\)\)/);
-    expect(src).toMatch(/\.recordDisagrees = true/);
+    expect(src).toMatch(
+      /reconcileDownloadDoneBatch\(\s*settled,\s*records,\s*downloadSnapshots/,
+    );
   });
 
   it("and still injects EVERY settled entry", async () => {
@@ -154,8 +161,8 @@ describe("the disagreement actually reaches the user (#1574)", () => {
     const src = await read("index.ts");
     // EXACTLY settled, with nothing chained onto it. A .filter() appended here reads as
     // "still uses settled" to a looser regex, and is the exact regression this forbids.
-    expect(src).toMatch(/kind: "download_done", downloads: settled }/);
-    expect(src).not.toMatch(/downloads: settled\s*\.filter/);
+    expect(src).toMatch(/manager\.injectEvent\(key, event/);
+    expect(src).not.toMatch(/downloads: injected\s*\.filter/);
     expect(src).not.toMatch(/downloads: honest/);
     expect(src).not.toMatch(/if \(honest\.length === 0\) continue;/);
   });
@@ -201,12 +208,10 @@ describe("a row is identified by (id, target), not id alone (#1574)", () => {
     ).toBe(true);
   });
 
-  it("still matches when EITHER side has no target", () => {
-    // Rows and records predating the field, or a route that never sets it, must keep
-    // matching — requiring it on both sides would make the check inert again, which is
-    // exactly how the first version shipped.
-    expect(completionDisagreesWithRecord(row(), [job({ target: "/pod/models" })])).toBe(true);
-    expect(completionDisagreesWithRecord(row({ target: "/local" }), [job()])).toBe(true);
+  it("fails closed when EITHER side has no target", () => {
+    // Legacy targetless records are ambiguous once local and pod transfers share an id.
+    expect(completionDisagreesWithRecord(row({ target: undefined }), [job()])).toBe(false);
+    expect(completionDisagreesWithRecord(row(), [job({ target: undefined })])).toBe(false);
   });
 });
 
@@ -258,13 +263,13 @@ describe("an exact (id, target) record wins over a targetless one (#1574)", () =
     ).toBe(true);
   });
 
-  it("falls back to a targetless record only when nothing matches on target", () => {
+  it("does not fall back to a targetless record when nothing matches on target", () => {
     expect(
       completionDisagreesWithRecord(row({ target: "/local/models" }), [
         job({ target: "/pod/models", status: "done" }),
         job({ target: undefined, status: "downloading" }),
       ]),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 
@@ -280,7 +285,7 @@ describe("an exact (id, target) record wins over a targetless one (#1574)", () =
 // tray row, and here the tray row itself was the error.
 
 const errorRow = (over: Record<string, unknown> = {}) =>
-  row({ id: "31bba4a9cdb04e28", status: "error", ...over });
+  row({ id: "31bba4a9cdb04e28", status: "error", progressAdvanced: true, ...over });
 const liveJob = (over: Record<string, unknown> = {}) =>
   job({ id: "07d14bb0c73bc007", trayId: "31bba4a9cdb04e28", status: "downloading", ...over });
 
@@ -303,6 +308,23 @@ describe("a failure the record disagrees with is DISCLOSED (#2057)", () => {
 
   it("says nothing when the record agrees the download failed", () => {
     expect(failureDisagreesWithRecord(errorRow(), [liveJob({ status: "error" })])).toBe(false);
+  });
+
+  it("prefers a matching live record over an older terminal snapshot", () => {
+    expect(
+      failureDisagreesWithRecord(errorRow(), [
+        liveJob({ status: "error" }),
+        liveJob({ status: "downloading" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not treat a heartbeat-stale record as the live status", () => {
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ staleInflight: true })])).toBe(false);
+  });
+
+  it("does not treat a fresh heartbeat as byte advancement", () => {
+    expect(failureDisagreesWithRecord(errorRow({ progressAdvanced: false }), [liveJob()])).toBe(false);
   });
 
   it("says nothing when the record has no opinion", () => {
@@ -349,9 +371,51 @@ describe("a failure the record disagrees with is DISCLOSED (#2057)", () => {
     ).toBe(true);
   });
 
-  it("still matches when EITHER side has no target", () => {
-    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ target: "/pod/models" })])).toBe(true);
-    expect(failureDisagreesWithRecord(errorRow({ target: "/local" }), [liveJob()])).toBe(true);
+  it("fails closed when EITHER side has no target", () => {
+    expect(failureDisagreesWithRecord(errorRow({ target: undefined }), [liveJob()])).toBe(false);
+    expect(failureDisagreesWithRecord(errorRow(), [liveJob({ target: undefined })])).toBe(false);
+  });
+
+  it("carries useful terminal error detail without allowing unbounded lines", () => {
+    expect(
+      failureErrorDetail(errorRow(), [
+        liveJob({ status: "error", error: "HTTP 503\nupstream reset" }),
+      ]),
+    ).toBe("HTTP 503 upstream reset");
+    expect(failureErrorDetail(errorRow({ error: "HTTP 404" }), [liveJob({ status: "error" })])).toBe(
+      "HTTP 404",
+    );
+    expect(failureErrorDetail(errorRow(), [liveJob({ status: "downloading", error: "stale" })])).toBe(
+      undefined,
+    );
+    expect(failureErrorDetail(errorRow({ error: "x".repeat(401) }), [])).toBe("x".repeat(400));
+    expect(
+      failureErrorDetail(errorRow(), [
+        liveJob({ status: "downloading", staleInflight: true }),
+        liveJob({ status: "error", error: "HTTP 503" }),
+      ]),
+    ).toBe("HTTP 503");
+  });
+
+  it("reconciles the production download_done batch against fresh status", () => {
+    const fresh = errorRow({ id: "fresh-tray", error: "f".repeat(800) });
+    const stale = errorRow({ id: "stale-tray", error: "stale" });
+    const terminal = errorRow({ id: "terminal-tray" });
+    const flagged = reconcileDownloadDoneFailures(
+      [fresh, stale, terminal],
+      [
+        liveJob({ id: "fresh-job", trayId: "fresh-tray", status: "downloading" }),
+        liveJob({ id: "stale-job", trayId: "stale-tray", status: "downloading", staleInflight: true }),
+        liveJob({ id: "terminal-job", trayId: "terminal-tray", status: "error", error: "HTTP 503" }),
+      ],
+    );
+
+    expect(flagged).toEqual([fresh]);
+    expect(fresh.recordDisagrees).toBe(true);
+    expect(fresh.error).toBe("f".repeat(400));
+    expect(stale.recordDisagrees).toBeUndefined();
+    expect(terminal.recordDisagrees).toBeUndefined();
+    expect(terminal.error).toBe("HTTP 503");
   });
 
   it("does not let a targetless DOWNLOADING shadow the exact ERROR", () => {

--- a/src/__tests__/orchestrator/download-done-event.test.ts
+++ b/src/__tests__/orchestrator/download-done-event.test.ts
@@ -272,7 +272,8 @@ describe("a failed tray row whose job record is still downloading (#2057)", () =
     manager.injectEvent("tab-2057-mix", {
       kind: "download_done",
       downloads: [
-        { name: "gone.safetensors", status: "error" },
+        { name: "gone.safetensors", status: "error", error: "HTTP 503 upstream reset" },
+        { name: "long-error.safetensors", status: "error", error: "E".repeat(800) },
         { name: "live.safetensors", status: "error", recordDisagrees: true },
       ],
     });
@@ -281,6 +282,10 @@ describe("a failed tray row whose job record is still downloading (#2057)", () =
     const t = backend.turns[1];
     const failedList = /FAILED: ([^;]*)/.exec(t)?.[1] ?? "";
     expect(failedList).toContain("gone.safetensors");
+    expect(failedList).toContain("HTTP 503 upstream reset");
+    expect(failedList).toContain("long-error.safetensors");
+    expect(t).toContain("E".repeat(400));
+    expect(t).not.toContain("E".repeat(401));
     expect(failedList).not.toContain("live.safetensors");
     expect(t).toMatch(/tray reported a failure for live\.safetensors/);
     expect(t).not.toMatch(/NOTHING is claimed to have transferred/);

--- a/src/__tests__/orchestrator/download-done-loop.test.ts
+++ b/src/__tests__/orchestrator/download-done-loop.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  reconcileDownloadDoneBatch,
+  type DownloadDoneInjection,
+} from "../../orchestrator/download-done-loop.js";
+import { DownloadProgressSnapshots } from "../../orchestrator/index.js";
+import { failureRecordDisposition } from "../../orchestrator/download-done-guard.js";
+import { listDownloadJobs } from "../../services/download-jobs.js";
+import { listPersistedDownloadJobs, setProgressDir } from "../../services/download-progress.js";
+
+const URL = "https://huggingface.co/org/repo/resolve/main/active.safetensors";
+const LOCAL_TARGET = "http://127.0.0.1:8188";
+const POD_TARGET = "https://pod-3000.proxy.runpod.net";
+
+async function writeRecord(
+  dir: string,
+  rec: {
+    id: string;
+    trayId: string;
+    progressId: string;
+    owner: string;
+    target?: string;
+    status: "downloading" | "error";
+    updated: number;
+    error?: string;
+  },
+): Promise<void> {
+  await writeFile(
+    join(dir, `control-job-${rec.id}-${rec.owner}.json`),
+    JSON.stringify({
+      ...rec,
+      url: URL,
+      target: rec.target ?? LOCAL_TARGET,
+      target_subfolder: "checkpoints",
+      filename: "active.safetensors",
+      started_at: rec.updated - 1_000,
+      finished_at: rec.status === "downloading" ? undefined : rec.updated,
+    }),
+  );
+}
+
+describe("download_done production poll reconciliation (#2057)", () => {
+  it("does not suppress a real terminal failure for a six-hour-retained stale stream", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-stale-terminal";
+      const trayId = "loop-stale-tray";
+      const progressId = "loop-stale-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "terminal",
+        status: "error",
+        updated: now,
+        error: "HTTP 503 upstream reset",
+      });
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "stale-stream",
+        status: "downloading",
+        updated: now - 90_000,
+      });
+
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+      };
+      const failedDisagreeing = reconcileDownloadDoneBatch([row]);
+
+      expect(listDownloadJobs().find((job) => job.id === id)).toMatchObject({ status: "error" });
+      expect(failedDisagreeing).toEqual([]);
+      expect(row.recordDisagrees).toBeUndefined();
+      expect(row.error).toBe("HTTP 503 upstream reset");
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reconciles a fresh advancing stream and bounds its tray error before injection", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-fresh-stream";
+      const trayId = "loop-fresh-tray";
+      const progressId = "loop-fresh-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "older-terminal",
+        status: "error",
+        updated: now - 30_000,
+      });
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "active-stream",
+        status: "downloading",
+        updated: now,
+      });
+
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+        downloaded: 220_000_000,
+        total: 19_530_000_000,
+        error: "E".repeat(800),
+      };
+      const progress = new DownloadProgressSnapshots();
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 140_000_000, total: 19_530_000_000 },
+      ]);
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 220_000_000, total: 19_530_000_000 },
+      ]);
+      let injected: DownloadDoneInjection<typeof row> | undefined;
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        [row],
+        listDownloadJobs(),
+        progress,
+        (event) => {
+          injected = event;
+        },
+      );
+
+      expect(failedDisagreeing).toEqual([row]);
+      expect(injected).toEqual({ kind: "download_done", downloads: [row] });
+      expect(row.recordDisagrees).toBe(true);
+      expect(row).not.toHaveProperty("progressAdvanced");
+      expect(row.error).toBe("E".repeat(400));
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("promotes a fresh heartbeat with frozen bytes before injecting failure", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-stalled-stream";
+      const trayId = "loop-stalled-tray";
+      const progressId = "loop-stalled-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "active-stream",
+        status: "downloading",
+        updated: now,
+      });
+
+      const progress = new DownloadProgressSnapshots();
+      const heartbeat = { id: progressId, status: "downloading", downloaded: 220, total: 1_000 };
+      progress.record([heartbeat]);
+      progress.record([{ ...heartbeat, updated: now + 1 }]);
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      };
+      let injected: DownloadDoneInjection<typeof row> | undefined;
+      expect(failureRecordDisposition(row, listDownloadJobs()).disposition).toBe("stalled");
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        [row],
+        listDownloadJobs(),
+        progress,
+        (event) => {
+          injected = event;
+        },
+      );
+
+      expect(failedDisagreeing).toEqual([]);
+      expect(injected).toEqual({ kind: "download_done", downloads: [row] });
+      expect(listDownloadJobs().find((job) => job.id === id)).toMatchObject({
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      });
+      expect(listPersistedDownloadJobs().find((job) => job.id === id)).toMatchObject({
+        owner: "active-stream",
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      });
+      expect(row.recordDisagrees).toBeUndefined();
+      expect(row.error).toBe("HTTP 503 upstream reset");
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("promotes a stale-only downloading record before injecting its terminal failure", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-stale-only";
+      const trayId = "loop-stale-only-tray";
+      const progressId = "loop-stale-only-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "stale-stream",
+        target: LOCAL_TARGET,
+        status: "downloading",
+        updated: now - 90_000,
+      });
+
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      };
+      let injected: DownloadDoneInjection<typeof row> | undefined;
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        [row],
+        listDownloadJobs(),
+        undefined,
+        (event) => {
+          injected = event;
+        },
+      );
+
+      expect(failedDisagreeing).toEqual([]);
+      expect(injected).toEqual({ kind: "download_done", downloads: [row] });
+      expect(listDownloadJobs().find((job) => job.id === id)).toMatchObject({
+        status: "error",
+        target: LOCAL_TARGET,
+        error: "HTTP 503 upstream reset",
+      });
+      expect(listPersistedDownloadJobs().find((job) => job.id === id)).toMatchObject({
+        owner: "stale-stream",
+        status: "error",
+      });
+      expect(row.recordDisagrees).toBeUndefined();
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reconciles the matching local record when a pod record shares id and progress identity", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-local-pod";
+      const trayId = "loop-local-pod-tray";
+      const progressId = "loop-local-pod-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "local-stream",
+        target: LOCAL_TARGET,
+        status: "downloading",
+        updated: now,
+      });
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "pod-stream",
+        target: POD_TARGET,
+        status: "downloading",
+        updated: now,
+      });
+
+      const records = listDownloadJobs();
+      expect(records.filter((job) => job.id === id)).toHaveLength(2);
+      expect(new Set(records.filter((job) => job.id === id).map((job) => job.target))).toEqual(
+        new Set([LOCAL_TARGET, POD_TARGET]),
+      );
+
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      };
+      const progress = new DownloadProgressSnapshots();
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 100, total: 1_000 },
+      ]);
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 200, total: 1_000 },
+      ]);
+      let injected: DownloadDoneInjection<typeof row> | undefined;
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        [row],
+        records,
+        progress,
+        (event) => {
+          injected = event;
+        },
+      );
+
+      expect(failedDisagreeing).toEqual([row]);
+      expect(row.recordDisagrees).toBe(true);
+      expect(injected).toEqual({ kind: "download_done", downloads: [row] });
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not use a pod-only record for a local terminal row at the poll seam", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "download-done-loop-"));
+    setProgressDir(dir);
+    try {
+      const now = Date.now();
+      const id = "loop-pod-only";
+      const trayId = "loop-pod-only-tray";
+      const progressId = "loop-pod-only-progress";
+      await writeRecord(dir, {
+        id,
+        trayId,
+        progressId,
+        owner: "pod-stream",
+        target: POD_TARGET,
+        status: "downloading",
+        updated: now,
+      });
+
+      const records = listDownloadJobs();
+      const row = {
+        id: progressId,
+        target: LOCAL_TARGET,
+        name: "active.safetensors",
+        status: "error",
+        error: "HTTP 503 upstream reset",
+      };
+      const progress = new DownloadProgressSnapshots();
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 100, total: 1_000 },
+      ]);
+      progress.record([
+        { id: progressId, target: LOCAL_TARGET, status: "downloading", downloaded: 200, total: 1_000 },
+      ]);
+      let injected: DownloadDoneInjection<typeof row> | undefined;
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        [row],
+        records,
+        progress,
+        (event) => {
+          injected = event;
+        },
+      );
+
+      expect(failedDisagreeing).toEqual([]);
+      expect(injected).toEqual({ kind: "download_done", downloads: [row] });
+      expect(row.recordDisagrees).toBeUndefined();
+      expect(listDownloadJobs().find((job) => job.id === id)).toMatchObject({
+        target: POD_TARGET,
+        status: "downloading",
+      });
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/orchestrator/download-progress-snapshot.test.ts
+++ b/src/__tests__/orchestrator/download-progress-snapshot.test.ts
@@ -40,4 +40,25 @@ describe("download progress snapshot emission (#717)", () => {
     expect(snapshots.record(terminal)).toBe(true);
     expect(snapshots.forPanel()).toEqual(terminal);
   });
+
+  it("proves byte advancement separately from heartbeat-shaped row updates", () => {
+    const snapshots = new DownloadProgressSnapshots();
+    const first = { id: "model-a", status: "downloading", downloaded: 140, total: 1_000 };
+    const next = { id: "model-a", status: "downloading", downloaded: 220, total: 1_000 };
+
+    snapshots.record([first]);
+    expect(snapshots.hasAdvanced(first)).toBe(false);
+    snapshots.record([{ ...first, updated: 1 }]);
+    expect(snapshots.hasAdvanced(first)).toBe(false);
+    snapshots.record([next]);
+    expect(snapshots.hasAdvanced(next)).toBe(true);
+    snapshots.record([{ ...next, updated: 2 }]);
+    expect(snapshots.hasAdvanced(next)).toBe(true);
+    expect(
+      snapshots.hasAdvanced(
+        next,
+        Date.now() + DownloadProgressSnapshots.ADVANCEMENT_MAX_AGE_MS + 1,
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/__tests__/services/download-adopt-orphans.test.ts
+++ b/src/__tests__/services/download-adopt-orphans.test.ts
@@ -129,6 +129,7 @@ function writeForeignJobRecord(
     status?: "downloading" | "done" | "error" | "cancelled";
     ageMs?: number;
     pid?: number;
+    target?: string;
   },
 ): void {
   const status = rec.status ?? "downloading";
@@ -146,6 +147,7 @@ function writeForeignJobRecord(
       started_at: Date.now(),
       finished_at: status === "downloading" ? undefined : Date.now(),
       owner: rec.owner,
+      target: rec.target,
       pid: rec.pid,
       updated: Date.now() - (rec.ageMs ?? 0),
     }),
@@ -167,6 +169,7 @@ describe("adoptOrphanedDownloadJobs (#1567 item 3)", () => {
     saved.COMFYUI_MCP_DATA_DIR = process.env.COMFYUI_MCP_DATA_DIR;
     saved.COMFYUI_DOWNLOAD_CACHE_DIR = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
     saved.HF_ENDPOINT = process.env.HF_ENDPOINT;
+    saved.COMFYUI_URL = process.env.COMFYUI_URL;
     // A mirror endpoint would rewrite the HF URL and change the staged identity the
     // authed-partial case derives — pin it away rather than depend on CI's env.
     delete process.env.HF_ENDPOINT;
@@ -258,6 +261,29 @@ describe("adoptOrphanedDownloadJobs (#1567 item 3)", () => {
     expect(
       JSON.parse(readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8")).status,
     ).toBe("downloading");
+  });
+
+  it("does not adopt a pod record while this process targets local ComfyUI", async () => {
+    const id = "orphan-target-mismatch";
+    const owner = "dead-pod-session";
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    writeForeignJobRecord(recordDir, {
+      id,
+      trayId: downloadIdFor(URL_X),
+      progressId: "prog-pod-mismatch",
+      url: URL_X,
+      owner,
+      target: "https://pod-3000.proxy.runpod.net",
+      ageMs: 10 * 60 * 1000,
+      pid: deadPid(),
+    });
+    stagePartial(URL_X, 8192);
+
+    expect(await adoptOrphanedDownloadJobs()).toEqual([]);
+    expect(hoisted.calls).toEqual([]);
+    expect(() =>
+      readFileSync(pathJoin(recordDir, `control-job-${id}-${owner}.json`), "utf8"),
+    ).not.toThrow();
   });
 
   it("refuses an orphan whose writer process is still ALIVE — another session's live download is never touched", async () => {

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -1188,6 +1188,73 @@ describe("download job registry", () => {
 
   // ── #529: adopt an in-flight download after a session reconnect ─────────────
   describe("#529 reconnect adoption", () => {
+    it("does not let a heartbeat-stale record replace an in-memory terminal error (#2057)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const id = "recurrence-terminal-wins";
+        const trayId = "recurrence-terminal-tray";
+        const progressId = "recurrence-terminal-progress";
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId,
+          url: URL_A,
+          owner: "terminal-snapshot",
+          status: "error",
+        });
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId,
+          url: URL_A,
+          owner: "stale-stream",
+          status: "downloading",
+          ageMs: 90_000,
+        });
+
+        expect(listDownloadJobs().find((j) => j.id === id)).toMatchObject({ status: "error" });
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("lists the live record when an older terminal snapshot shares its identity (#2057)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const id = "recurrence-live-wins";
+        const trayId = "recurrence-tray";
+        const progressId = "recurrence-progress";
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId,
+          url: URL_A,
+          owner: "older-terminal",
+          status: "error",
+          ageMs: 30_000,
+        });
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId,
+          url: URL_A,
+          owner: "active-stream",
+          status: "downloading",
+        });
+
+        expect(listDownloadJobs().find((j) => j.id === id)).toMatchObject({
+          status: "downloading",
+          progressId,
+        });
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
     it("still resolves an in-flight download by id (and by URL) after a simulated reconnect", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
       setProgressDir(dir); // enable the cross-session persisted store (as the panel does)

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -121,6 +121,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { setProgressDir, PERSIST_OWNER, __resetStableRecordsDir } from "../../services/download-progress.js";
 import * as progressModule from "../../services/download-progress.js";
 import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
+import { reconcileDownloadDoneBatch } from "../../orchestrator/download-done-loop.js";
 import { mkdtemp, mkdir, symlink, writeFile, readFile, rm as fsRm } from "node:fs/promises";
 import { spawn, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -162,6 +163,8 @@ async function writeForeignJobRecord(
     /** The writing process's pid (#858) — present on records written after the
      *  liveness stamp was added; absent simulates a pre-fix (unprovable) record. */
     pid?: number;
+    /** The ComfyUI target this persisted record belongs to. */
+    target?: string;
   },
 ): Promise<void> {
   const status = rec.status ?? "downloading";
@@ -178,6 +181,7 @@ async function writeForeignJobRecord(
     started_at: Date.now(),
     finished_at: status === "downloading" ? undefined : Date.now(),
     owner: rec.owner,
+    target: rec.target,
     pid: rec.pid,
     updated: Date.now() - (rec.ageMs ?? 0),
   };
@@ -633,6 +637,111 @@ describe("download job registry", () => {
   // neither can be selected. The composite (id, trayId) is the real identity; this
   // block is about making it reachable from the public surface.
   describe("#822 selecting one download when an id names several", () => {
+    it("keeps a live in-memory writer authoritative over an older persisted terminal through list, poll, and status", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-live-order-"));
+      const savedTarget = process.env.COMFYUI_URL;
+      process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+      setProgressDir(dir);
+      try {
+        const active = await startDownloadJob(URL_A, "checkpoints");
+        const progressId = active.job.progressId;
+        expect(progressId).toBeTruthy();
+
+        await writeForeignJobRecord(dir, {
+          id: active.job.id,
+          trayId: active.job.trayId,
+          progressId: progressId!,
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-older-terminal`,
+          target: "http://127.0.0.1:8188",
+          status: "error",
+          ageMs: 30_000,
+        });
+
+        const listed = listDownloadJobs().find(
+          (job) => job.id === active.job.id && job.target === "http://127.0.0.1:8188",
+        );
+        expect(listed).toBe(active.job);
+        expect(listed?.status).toBe("downloading");
+        expect(getDownloadJob(active.job.id, active.job.trayId)?.status).toBe("downloading");
+
+        const row = {
+          id: progressId,
+          target: "http://127.0.0.1:8188",
+          name: "big.safetensors",
+          status: "error",
+          downloaded: 220,
+          total: 1_000,
+          error: "upstream reset",
+        };
+        const injected: Array<{ downloads: typeof row[] }> = [];
+        const disagreeing = reconcileDownloadDoneBatch(
+          [row],
+          listDownloadJobs(),
+          { hasAdvanced: () => true },
+          (event) => injected.push(event),
+        );
+        expect(disagreeing).toHaveLength(1);
+        expect(row.recordDisagrees).toBe(true);
+        expect(injected).toHaveLength(1);
+        expect(injected[0].downloads[0]).toBe(row);
+        expect(active.job.status).toBe("downloading");
+      } finally {
+        if (savedTarget === undefined) delete process.env.COMFYUI_URL;
+        else process.env.COMFYUI_URL = savedTarget;
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("keeps same-id/same-tray local and pod records separate in candidates, status, and URL adoption", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-target-select-"));
+      const savedTarget = process.env.COMFYUI_URL;
+      setProgressDir(dir);
+      const id = "same-target-selector";
+      const trayId = downloadIdFor(URL_A);
+      try {
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId: "local-progress",
+          url: URL_A,
+          owner: "local-session",
+          target: "http://127.0.0.1:8188",
+        });
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId,
+          progressId: "pod-progress",
+          url: URL_A,
+          owner: "pod-session",
+          target: "https://pod-3000.proxy.runpod.net",
+        });
+
+        expect(listDownloadJobCandidates(id)).toHaveLength(2);
+        expect(new Set(listDownloadJobCandidates(id).map((job) => job.target))).toEqual(
+          new Set(["http://127.0.0.1:8188", "https://pod-3000.proxy.runpod.net"]),
+        );
+
+        process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+        expect(getDownloadJob(id, trayId)?.target).toBe("http://127.0.0.1:8188");
+        expect(findDownloadJob({ url: URL_A })?.target).toBe("http://127.0.0.1:8188");
+
+        process.env.COMFYUI_URL = "https://pod-3000.proxy.runpod.net";
+        expect(getDownloadJob(id, trayId)?.target).toBe("https://pod-3000.proxy.runpod.net");
+        expect(findDownloadJob({ url: URL_A })?.target).toBe("https://pod-3000.proxy.runpod.net");
+
+        delete process.env.COMFYUI_URL;
+        expect(getDownloadJob(id, trayId)).toBeUndefined();
+        expect(findDownloadJob({ url: URL_A })).toBeUndefined();
+      } finally {
+        if (savedTarget === undefined) delete process.env.COMFYUI_URL;
+        else process.env.COMFYUI_URL = savedTarget;
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
     it("lists EVERY download an id answers to, keyed by the true (id, trayId) identity", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
       setProgressDir(dir);

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -404,7 +404,7 @@ describe("migrateInFlightJobs (#1148)", () => {
   // The structural hole that produced BOTH key bugs in this function: every
   // fixture here is hand-built, so a key the WRITER never emits still reads as
   // "carried" and the test agrees with the mistake. `tray_id` vs `trayId` was
-  // caught by hand; `name`/`dest`/`target`/`total`/`received` — five keys that
+  // caught by hand; `name`/`dest`/`total`/`received` — legacy tray-row keys that
   // belong to the tray-row interface, not this record — survived for months and
   // even had an assertion claiming bytes that are always undefined.
   //
@@ -420,6 +420,7 @@ describe("migrateInFlightJobs (#1148)", () => {
     writer.persistDownloadJob({
       id: "rt-1",
       trayId: "tray-rt",
+      target: "https://user:secret@podabc-3000.proxy.runpod.net",
       url: "https://example.invalid/m.safetensors",
       target_subfolder: "checkpoints",
       filename: "m.safetensors",
@@ -447,6 +448,7 @@ describe("migrateInFlightJobs (#1148)", () => {
     // Every field the migration claims to carry, verified against the writer's
     // own output rather than a fixture that could share my typo.
     expect(rec!.trayId).toBe("tray-rt");
+    expect(rec!.target).toBe("https://podabc-3000.proxy.runpod.net");
     expect(rec!.filename).toBe("m.safetensors");
     expect(rec!.target_subfolder).toBe("checkpoints");
     expect(rec!.started_at).toBe(1_700_000_000_000);
@@ -457,7 +459,8 @@ describe("migrateInFlightJobs (#1148)", () => {
 
     // ...and the half that actually closes the class: NO key may appear that the
     // writer does not emit. Asserting presence alone is what let five dead keys
-    // (`name`/`dest`/`target`/`total`/`received`, from the tray-row interface)
+    // (`name`/`dest`/`target`/`total`/`received`, with `target` now being a real
+    // persisted job identity rather than a dead tray-row key)
     // survive for months — restoring them passed every test AND tsc, because
     // `persistDownloadJob` spreads a variable (no excess-property check) and
     // tsconfig EXCLUDES src/__tests__, so no fixture is ever typechecked.

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../services/model-resolver.js", async () => {
 import { registerModelManagementTools } from "../../tools/model-management.js";
 import { setProgressDir } from "../../services/download-progress.js";
 import * as progressModule from "../../services/download-progress.js";
+import { resetDownloadJobs, startDownloadJob } from "../../services/download-jobs.js";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -237,6 +238,102 @@ describe("download_model tool", () => {
 });
 
 describe('download_model action:"status"', () => {
+  it("status selects the current target when local and pod records share id and tray", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-target-select-"));
+    const savedTarget = process.env.COMFYUI_URL;
+    setProgressDir(dir);
+    const id = "status-target-selector";
+    const trayId = "status-target-tray";
+    const base = {
+      id,
+      trayId,
+      progressId: "status-target-progress",
+      url: "https://example.com/status-target.safetensors",
+      target_subfolder: "checkpoints",
+      status: "downloading",
+      started_at: Date.now(),
+    };
+    try {
+      await writeFile(
+        join(dir, `control-job-${id}-local.json`),
+        JSON.stringify({
+          ...base,
+          target: "http://127.0.0.1:8188",
+          owner: "local-session",
+          updated: Date.now(),
+        }),
+      );
+      await writeFile(
+        join(dir, `control-job-${id}-pod.json`),
+        JSON.stringify({
+          ...base,
+          target: "https://pod-3000.proxy.runpod.net",
+          owner: "pod-session",
+          updated: Date.now(),
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+      const local = (await downloadStatus({ id, tray_id: trayId })).content[0].text;
+      expect(local).toContain("target: `http://127.0.0.1:8188`");
+      expect(local).not.toContain("target: `https://pod-3000.proxy.runpod.net`");
+
+      process.env.COMFYUI_URL = "https://pod-3000.proxy.runpod.net";
+      const pod = (await downloadStatus({ id, tray_id: trayId })).content[0].text;
+      expect(pod).toContain("target: `https://pod-3000.proxy.runpod.net`");
+      expect(pod).not.toContain("target: `http://127.0.0.1:8188`");
+    } finally {
+      if (savedTarget === undefined) delete process.env.COMFYUI_URL;
+      else process.env.COMFYUI_URL = savedTarget;
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("status keeps a live in-memory writer over an older persisted terminal", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-live-order-"));
+    const savedTarget = process.env.COMFYUI_URL;
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    setProgressDir(dir);
+    resetDownloadJobs();
+    downloadModelMock.mockReturnValue(new Promise<string>(() => {}));
+    try {
+      const active = await startDownloadJob(
+        "https://example.com/live-order.safetensors",
+        "checkpoints",
+      );
+      await writeFile(
+        join(dir, `control-job-${active.job.id}-older-terminal.json`),
+        JSON.stringify({
+          id: active.job.id,
+          trayId: active.job.trayId,
+          progressId: active.job.progressId,
+          target: "http://127.0.0.1:8188",
+          url: "https://example.com/live-order.safetensors",
+          target_subfolder: "checkpoints",
+          status: "error",
+          error: "HTTP 503 upstream reset",
+          started_at: Date.now() - 60_000,
+          finished_at: Date.now() - 30_000,
+          owner: "older-terminal",
+          updated: Date.now() - 30_000,
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      const text = (await downloadStatus({ id: active.job.id })).content[0].text;
+      expect(text).toContain("**downloading**");
+      expect(text).not.toContain("failed: HTTP 503 upstream reset");
+    } finally {
+      resetDownloadJobs();
+      setProgressDir("");
+      if (savedTarget === undefined) delete process.env.COMFYUI_URL;
+      else process.env.COMFYUI_URL = savedTarget;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces a landed-but-invisible download as a WARNING, not a bare 'landed at' (#369)", async () => {
     downloadModelMock.mockResolvedValueOnce("/stale/models/checkpoints/x.safetensors");
     verifyLandedModelMock.mockResolvedValueOnce({

--- a/src/orchestrator/download-done-guard.ts
+++ b/src/orchestrator/download-done-guard.ts
@@ -48,17 +48,23 @@ interface RowLike {
    *  LOCAL and POD transfer of the same URL share an id and must stay distinguishable. */
   target?: unknown;
   status?: unknown;
+  error?: unknown;
+  /** Derived from monotonic progress snapshots, never from heartbeat timestamps. */
+  progressAdvanced?: unknown;
 }
-interface JobLike {
+export interface DownloadDoneRecordLike {
   id?: unknown;
   trayId?: unknown;
   progressId?: unknown;
   target?: unknown;
   status?: unknown;
+  error?: unknown;
+  /** Persisted records set this when their heartbeat is outside status' live window. */
+  staleInflight?: unknown;
 }
 
 /** The identity a PROGRESS ROW is written under. */
-function progressIdentityOf(job: JobLike): string | null {
+function progressIdentityOf(job: DownloadDoneRecordLike): string | null {
   const progress = typeof job.progressId === "string" ? job.progressId : null;
   const tray = typeof job.trayId === "string" ? job.trayId : null;
   return progress ?? tray;
@@ -72,34 +78,53 @@ function progressIdentityOf(job: JobLike): string | null {
  * outcomes. Matching on id alone could annotate the wrong terminal, or miss a real
  * disagreement by finding the other one first (review).
  *
- * A target is compared only when BOTH sides carry one. Rows and records that predate the
- * field, or a route that never sets it, must not silently stop matching — that would make
- * the check inert again, which is exactly how the first version shipped.
- *
- * PREFER THE EXACT (id, target) MATCH (review, round 3). Taking the first id match in
- * array order let a TARGETLESS record shadow the exact one: a targetless "downloading"
- * sitting before an exact-target terminal reported a disagreement that does not exist.
- * The targetless record still stands in when nothing matches on target.
+ * Target identity is production data, not a test-only discriminator. A row or record
+ * without it is ambiguous when local and pod transfers share an id, so legacy targetless
+ * records fail closed and never suppress or promote a terminal event.
  */
-function matchingRecord(row: RowLike, jobs: readonly JobLike[]): JobLike | null {
+function matchingRecord(
+  row: RowLike,
+  jobs: readonly DownloadDoneRecordLike[],
+): DownloadDoneRecordLike | null {
   if (!row || typeof row !== "object") return null;
   const id = typeof row.id === "string" ? row.id : null;
   if (!id) return null;
   if (!Array.isArray(jobs)) return null;
-  const target = typeof row.target === "string" ? row.target : null;
-  const sameId = jobs.filter((j) => j && typeof j === "object" && progressIdentityOf(j) === id);
-  if (!sameId.length) return null;
+  const target = typeof row.target === "string" && row.target.length > 0 ? row.target : null;
+  if (!target) return null;
+  const candidates = jobs.filter(
+    (j) =>
+      j &&
+      typeof j === "object" &&
+      progressIdentityOf(j) === id &&
+      typeof j.target === "string" &&
+      j.target.length > 0 &&
+      j.target === target,
+  );
+  if (!candidates.length) return null;
+  // A reconnect can leave both an older terminal snapshot and the newer live record in
+  // the persisted store. `download_model action:"status"` resolves that ambiguity in
+  // favour of the live transfer; the tray guard must make the same choice or it can
+  // announce FAILED while status is still advancing.
+  // `download_model action:"status"` treats stale persisted rows as historical
+  // diagnostics and resolves the terminal record instead. Prefer a fresh live record
+  // when both snapshots are present, but keep a stale one available for error-detail
+  // lookup and explicit non-live handling below.
   return (
-    (target ? sameId.find((j) => j.target === target) : undefined) ??
-    sameId.find((j) => typeof j.target !== "string") ??
-    (target ? undefined : sameId[0]) ??
+    candidates.find((j) => j.status === "downloading" && j.staleInflight !== true) ??
+    candidates.find((j) => j.status !== "downloading") ??
+    candidates.find((j) => j.status === "downloading") ??
+    candidates[0] ??
     null
   );
 }
 
-function recordStillDownloading(row: RowLike, jobs: readonly JobLike[]): boolean {
+function recordStillDownloading(row: RowLike, jobs: readonly DownloadDoneRecordLike[]): boolean {
   const record = matchingRecord(row, jobs);
-  return record != null && record.status === "downloading";
+  // This is deliberately the same freshness boundary as the status action. A stale
+  // persisted heartbeat can remain on disk for six hours, but status resolves it as a
+  // terminal/no-live answer; it must not suppress a real FAILED tray notification.
+  return record != null && record.status === "downloading" && record.staleInflight !== true;
 }
 
 /**
@@ -109,12 +134,38 @@ function recordStillDownloading(row: RowLike, jobs: readonly JobLike[]): boolean
  * still says `downloading`. A missing record is not evidence — the record store resets on an
  * orchestrator respawn, which is exactly the reported session.
  */
-export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
+export function completionDisagreesWithRecord(
+  row: RowLike,
+  jobs: readonly DownloadDoneRecordLike[],
+): boolean {
   if (!row || typeof row !== "object") return false;
   // Completions only. Failures have their own check (#2057); #1150's live-tray hedge
   // stays a separate question (a different id writing the same filename).
   if (row.status !== "done") return false;
   return recordStillDownloading(row, jobs);
+}
+
+export type FailureRecordDisposition = "none" | "advancing" | "stalled" | "stale";
+
+export interface FailureRecordMatch {
+  disposition: FailureRecordDisposition;
+  record: DownloadDoneRecordLike | null;
+}
+
+/** Classify a terminal tray row against the exact production job identity. */
+export function failureRecordDisposition(
+  row: RowLike,
+  jobs: readonly DownloadDoneRecordLike[],
+): FailureRecordMatch {
+  if (!row || typeof row !== "object" || row.status !== "error") {
+    return { disposition: "none", record: null };
+  }
+  const record = matchingRecord(row, jobs);
+  if (!record || record.status !== "downloading") {
+    return { disposition: "none", record: null };
+  }
+  if (record.staleInflight === true) return { disposition: "stale", record };
+  return { disposition: row.progressAdvanced === true ? "advancing" : "stalled", record };
 }
 
 /**
@@ -125,10 +176,70 @@ export function completionDisagreesWithRecord(row: RowLike, jobs: readonly JobLi
  * `download_model action:"status"` reads. The reported case had no live tray row — the tray
  * itself was the error — while status still showed the same id streaming and advancing.
  */
-export function failureDisagreesWithRecord(row: RowLike, jobs: readonly JobLike[]): boolean {
+export function failureDisagreesWithRecord(
+  row: RowLike,
+  jobs: readonly DownloadDoneRecordLike[],
+): boolean {
   if (!row || typeof row !== "object") return false;
   if (row.status !== "error") return false;
-  return recordStillDownloading(row, jobs);
+  // A fresh heartbeat says only that persistence happened. The failure hedge requires
+  // an actual byte increase observed by the poller, or a stalled stream could suppress
+  // a genuine FAILED notification indefinitely. Stalled/stale records are reconciled to
+  // terminal state by the production poll seam instead of being treated as live.
+  return failureRecordDisposition(row, jobs).disposition === "advancing";
+}
+
+/** Bound one error string before it reaches the tray/agent event. */
+export function boundedDownloadError(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const compact = value.replace(/\s+/g, " ").trim();
+  return compact ? compact.slice(0, 400) : undefined;
+}
+
+/** Return the bounded error detail from the authoritative terminal record, when present. */
+export function failureErrorDetail(
+  row: RowLike,
+  jobs: readonly DownloadDoneRecordLike[],
+): string | undefined {
+  if (!row || typeof row !== "object" || row.status !== "error") return undefined;
+  const rowError = boundedDownloadError(row.error);
+  const record = matchingRecord(row, jobs);
+  return (
+    rowError ??
+    (record?.status !== "downloading" ? boundedDownloadError(record?.error) : undefined)
+  );
+}
+
+export interface DownloadDoneFailureLike {
+  id?: unknown;
+  target?: unknown;
+  status?: unknown;
+  error?: unknown;
+  recordDisagrees?: boolean;
+  progressAdvanced?: boolean;
+}
+
+/**
+ * Reconcile the failure half of one production download_done batch.
+ *
+ * The poll loop calls this after it has read the tray rows and authoritative job records,
+ * before injecting the batch into the panel agent. Keeping the mutation here makes that
+ * production seam directly testable without treating PanelAgentManager injection as the
+ * producer-side proof.
+ */
+export function reconcileDownloadDoneFailures<T extends DownloadDoneFailureLike>(
+  rows: T[],
+  jobs: readonly DownloadDoneRecordLike[],
+): T[] {
+  const disagreeing: T[] = [];
+  for (const row of rows) {
+    if (failureDisagreesWithRecord(row, jobs)) {
+      row.recordDisagrees = true;
+      disagreeing.push(row);
+    }
+    if (row.status === "error") row.error = failureErrorDetail(row, jobs);
+  }
+  return disagreeing;
 }
 
 /** The disclosure appended to a completion the record disagrees with. Deliberately states

--- a/src/orchestrator/download-done-loop.ts
+++ b/src/orchestrator/download-done-loop.ts
@@ -1,0 +1,55 @@
+import {
+  listDownloadJobs,
+  reconcileStalledDownloadRecord,
+  type DownloadJob,
+} from "../services/download-jobs.js";
+import {
+  failureErrorDetail,
+  failureRecordDisposition,
+  reconcileDownloadDoneFailures,
+  type DownloadDoneFailureLike,
+} from "./download-done-guard.js";
+
+export interface DownloadDoneInjection<T extends DownloadDoneFailureLike> {
+  kind: "download_done";
+  downloads: T[];
+}
+
+/**
+ * The failure-reconciliation stage used by the download poll loop.
+ *
+ * The live loop already has the authoritative records because the completion guard reads
+ * them once per flush; callers pass those records to avoid a second filesystem scan. Tests
+ * may omit them to exercise the same production lookup against the persisted job store.
+ */
+export function reconcileDownloadDoneBatch<T extends DownloadDoneFailureLike>(
+  rows: T[],
+  records?: readonly DownloadJob[],
+  progress?: { hasAdvanced: (row: { id?: unknown; target?: unknown; attempt?: unknown }) => boolean },
+  onInject?: (event: DownloadDoneInjection<T>) => void,
+): T[] {
+  let authoritative = records;
+  if (!authoritative) {
+    try {
+      authoritative = listDownloadJobs();
+    } catch {
+      authoritative = [];
+    }
+  }
+  for (const row of rows) row.progressAdvanced = progress?.hasAdvanced(row) === true;
+  for (const row of rows) {
+    const match = failureRecordDisposition(row, authoritative);
+    if (match.disposition !== "stalled" && match.disposition !== "stale") continue;
+    const durable = reconcileStalledDownloadRecord(
+      match.record as DownloadJob,
+      failureErrorDetail(row, authoritative),
+    );
+    if (!durable) row.recordDisagrees = true;
+  }
+  const disagreeing = reconcileDownloadDoneFailures(rows, authoritative);
+  // The advancement proof is producer-internal; recordDisagrees is the only reconciliation
+  // result the consumer needs. Do not add the polling detail to the agent event payload.
+  for (const row of rows) delete row.progressAdvanced;
+  onInject?.({ kind: "download_done", downloads: rows });
+  return disagreeing;
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -119,7 +119,11 @@ import {
 } from "../services/panel-template-relay.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
-import { completionDisagreesWithRecord, failureDisagreesWithRecord } from "./download-done-guard.js";
+import {
+  boundedDownloadError,
+  completionDisagreesWithRecord,
+} from "./download-done-guard.js";
+import { reconcileDownloadDoneBatch } from "./download-done-loop.js";
 import { assembleVocabularyHash, describeVocabularySkew } from "../tools/vocabulary.js";
 import { buildPanelToolDefs } from "./panel-tools.js";
 
@@ -749,15 +753,53 @@ export function pushModelsFrame(
  * hello/re-hello so a reconnect cannot retain rows from an old process.
  */
 export class DownloadProgressSnapshots {
+  /** A recent byte increase is required; heartbeat-only rows must not keep this hedge live. */
+  static readonly ADVANCEMENT_MAX_AGE_MS = 5_000;
   private lastSnapshot: string | null = null;
   private rows: Array<Record<string, unknown>> = [];
+  private progressByKey = new Map<string, { downloaded: number; total: number }>();
+  private lastAdvancedAt = new Map<string, number>();
+
+  private progressKey(row: Record<string, unknown>): string | null {
+    if (typeof row.id !== "string" || !row.id) return null;
+    const target = typeof row.target === "string" ? row.target : "";
+    const attempt = typeof row.attempt === "number" ? String(row.attempt) : "";
+    return `${row.id}\n${target}\n${attempt}`;
+  }
 
   record(rows: Array<Record<string, unknown>>): boolean {
+    for (const row of rows) {
+      if (row.status !== "downloading") continue;
+      const key = this.progressKey(row);
+      const downloaded = typeof row.downloaded === "number" ? row.downloaded : undefined;
+      const total = typeof row.total === "number" ? row.total : undefined;
+      if (
+        !key ||
+        downloaded === undefined ||
+        !Number.isFinite(downloaded) ||
+        downloaded < 0 ||
+        total === undefined ||
+        !Number.isFinite(total) ||
+        total < 0
+      ) continue;
+      const previous = this.progressByKey.get(key);
+      if (previous && downloaded > previous.downloaded) this.lastAdvancedAt.set(key, Date.now());
+      this.progressByKey.set(key, { downloaded, total });
+    }
     const snapshot = JSON.stringify(rows);
     if (snapshot === this.lastSnapshot) return false;
     this.lastSnapshot = snapshot;
     this.rows = rows;
     return true;
+  }
+
+  /** True only after a recent later progress row proves downloaded bytes increased. */
+  hasAdvanced(row: { id?: unknown; target?: unknown; attempt?: unknown }, now = Date.now()): boolean {
+    if (typeof row.id !== "string" || !row.id) return false;
+    const target = typeof row.target === "string" ? row.target : "";
+    const attempt = typeof row.attempt === "number" ? String(row.attempt) : "";
+    const advancedAt = this.lastAdvancedAt.get(`${row.id}\n${target}\n${attempt}`);
+    return advancedAt !== undefined && now - advancedAt <= DownloadProgressSnapshots.ADVANCEMENT_MAX_AGE_MS;
   }
 
   forPanel(): Array<Record<string, unknown>> {
@@ -5868,6 +5910,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           target?: string;
           name: string;
           status: string;
+          error?: string;
           attempt?: number;
           supKey: string;
           recordDisagrees?: boolean;
@@ -6024,6 +6067,11 @@ export async function runPanelOrchestrator(): Promise<void> {
         continue; // mid-write or corrupt — retry next tick
       }
       if (!row || typeof row !== "object") continue;
+      if ("error" in row) {
+        const error = boundedDownloadError(row.error);
+        if (error) row.error = error;
+        else delete row.error;
+      }
       const updated = typeof row.updated === "number" ? row.updated : now;
       parsed.push({ full, row, status: row.status, updated });
     }
@@ -6092,6 +6140,7 @@ export async function runPanelOrchestrator(): Promise<void> {
                     target?: string;
                     name: string;
                     status: string;
+                    error?: string;
                     attempt?: number;
                     supKey: string;
                     recordDisagrees?: boolean;
@@ -6114,6 +6163,7 @@ export async function runPanelOrchestrator(): Promise<void> {
               target: typeof row.target === "string" ? row.target : undefined,
               name: String(row.name ?? row.id ?? "model"),
               status: String(status),
+              error: boundedDownloadError(row.error),
               attempt: typeof row.attempt === "number" ? row.attempt : undefined,
               supKey,
             });
@@ -6197,8 +6247,15 @@ export async function runPanelOrchestrator(): Promise<void> {
       // advancing. #1150 only sees a live TRAY row of that filename; here the tray
       // row itself was the error, so that hedge never ran. Flag it so the formatter
       // will not say FAILED.
-      const failedDisagreeing = settled.filter((d) => failureDisagreesWithRecord(d, records));
-      for (const d of failedDisagreeing) (d as { recordDisagrees?: boolean }).recordDisagrees = true;
+      const failedDisagreeing = reconcileDownloadDoneBatch(
+        settled,
+        records,
+        downloadSnapshots,
+        (event) =>
+          manager.injectEvent(key, event, {
+            mid: turnOrigins.mintInheritedOrigin(),
+          }),
+      );
       if (failedDisagreeing.length) {
         logger.warn(
           "[panel-orchestrator] a download failure disagrees with the job record; disclosing rather than announcing FAILED (#2057)",
@@ -6214,9 +6271,6 @@ export async function runPanelOrchestrator(): Promise<void> {
       // ran — the turn routed to whatever tab was active (confirming gate 3,
       // P1). The minted mid contributes nothing and the batch close inherits
       // (or refuses, when no origin was ever established).
-      manager.injectEvent(key, { kind: "download_done", downloads: settled }, {
-        mid: turnOrigins.mintInheritedOrigin(),
-      });
     }
     // MCP-child control channel (#269): runpod_* tools that ran in spawned
     // agent children ask the orchestrator to retarget / watch / unwatch /

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,7 +23,11 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
-import { COMPLETION_DISAGREEMENT_NOTE, FAILURE_DISAGREEMENT_NOTE } from "./download-done-guard.js";
+import {
+  boundedDownloadError,
+  COMPLETION_DISAGREEMENT_NOTE,
+  FAILURE_DISAGREEMENT_NOTE,
+} from "./download-done-guard.js";
 import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
 import { orphanedByDeferredRespawnNote } from "../services/panel-secrets.js";
 import { errorText, promptText } from "./error-text.js";
@@ -894,6 +898,7 @@ export class PanelAgent {
       downloads?: Array<{
         name: string;
         status: string;
+        error?: string;
         supersededByLive?: boolean;
         recordDisagrees?: boolean;
       }>;
@@ -1185,7 +1190,16 @@ export class PanelAgent {
       // dropping the event would be the worse failure.
       const disagrees = dl.some((d) => d.status === "done" && d.recordDisagrees);
       if (disagrees) parts.push(COMPLETION_DISAGREEMENT_NOTE);
-      if (failedDead.length) parts.push(`FAILED: ${failedDead.map((d) => d.name).join(", ")}`);
+      if (failedDead.length) {
+        parts.push(
+          `FAILED: ${failedDead
+            .map((d) => {
+              const detail = boundedDownloadError(d.error);
+              return `${d.name}${detail ? ` (${detail})` : ""}`;
+            })
+            .join(", ")}`,
+        );
+      }
       if (failedRetried.length) {
         parts.push(
           `an EARLIER attempt failed for ${failedRetried.map((d) => d.name).join(", ")}, but a ` +
@@ -3319,6 +3333,7 @@ export class PanelAgentManager {
       downloads?: Array<{
         name: string;
         status: string;
+        error?: string;
         supersededByLive?: boolean;
         recordDisagrees?: boolean;
       }>;

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -36,6 +36,7 @@ import {
   readDownloadProgress,
   listInFlightDownloadProgress,
   persistDownloadJob,
+  currentDownloadTarget,
   readPersistedDownloadJob,
   listPersistedDownloadJobs,
   findPersistedDownloadJob,
@@ -65,6 +66,10 @@ export interface DownloadJob {
    *  (falling back to trayId when unset). Never used for URL adoption (that needs the
    *  stable original-URL trayId). */
   progressId?: string;
+  /** Credential-free ComfyUI endpoint this job serves; absent only on legacy records. */
+  target?: string;
+  /** Persisted record owner, retained so reconciliation updates that same file. */
+  owner?: string;
   /** This job's OWN resume decision (#467), reported by its physical download via
    *  a callback and stored here — so download_model action:"status" surfaces exactly this job's
    *  outcome and never a stale/other job's. Absent when no resumable download ran
@@ -77,6 +82,8 @@ export interface DownloadJob {
   /** "cancelled" is a user-requested abort (#515): the stream was aborted, no
    *  false-complete is reported, and the resumable .partial is left on disk. */
   status: "downloading" | "done" | "error" | "cancelled";
+  /** Persisted snapshot time when this view came from the cross-session store. */
+  updated?: number;
   /** Absolute path once the file has landed. */
   path?: string;
   error?: string;
@@ -592,6 +599,7 @@ export async function startDownloadJob(
   const job: DownloadJob = {
     id,
     trayId,
+    target: currentDownloadTarget(),
     url,
     target_subfolder: targetSubfolder,
     filename,
@@ -962,11 +970,12 @@ function finalizeCancelled(job: DownloadJob): void {
  *  URL. No-op outside the panel. Keeps the persisted copy in step with the job.
  *  Returns whether the record was DURABLY replaced (so the heartbeat can retry a
  *  transiently-failing terminal persist). */
-function persistJobRecord(job: DownloadJob): boolean {
+function persistJobRecord(job: DownloadJob, owner = PERSIST_OWNER): boolean {
   return persistDownloadJob({
     id: job.id,
     trayId: job.trayId,
     progressId: job.progressId,
+    target: job.target,
     url: job.url,
     target_subfolder: job.target_subfolder,
     filename: job.filename,
@@ -986,7 +995,33 @@ function persistJobRecord(job: DownloadJob): boolean {
     disk_verified: job.disk_verified,
     verified_root: job.verified_root,
     reclaimed_dead: job.reclaimedDead,
-  });
+  }, owner);
+}
+
+function boundedDownloadJobError(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const compact = value.replace(/\s+/g, " ").trim();
+  return compact ? compact.slice(0, 400) : undefined;
+}
+
+/** Turn a stale/frozen in-flight record into the terminal state the tray is reporting. */
+export function reconcileStalledDownloadRecord(job: DownloadJob, error?: string): boolean {
+  if (job.status !== "downloading") return true;
+  const wasPersisted = job.updated !== undefined;
+  job.status = "error";
+  job.error = boundedDownloadJobError(error);
+  job.finished_at = Date.now();
+  job.updated = job.finished_at;
+  // A reconstructed foreign record must be terminalized in its ORIGINAL owner file;
+  // writing a fresh current-owner snapshot leaves the original fresh downloading row
+  // authoritative to status. Legacy persisted records without an owner cannot be safely
+  // reconciled, so callers keep the event explicitly disclosed instead.
+  if (wasPersisted && !job.owner) return false;
+  const durable = persistJobRecord(job, job.owner ?? PERSIST_OWNER);
+  // In non-panel mode the in-memory object is the authoritative status store. In panel
+  // mode a failed persist leaves the old downloading snapshot visible, so the caller must
+  // keep the event explicitly reconciled instead of emitting an unflagged FAILED row.
+  return durable || !persistedRecordsEnabled();
 }
 
 /** Rebuild an in-memory DownloadJob view from a persisted record (#529 adoption
@@ -998,10 +1033,13 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
     id: rec.id,
     trayId: rec.trayId,
     progressId: rec.progressId,
+    target: rec.target,
+    owner: rec.owner,
     url: rec.url,
     target_subfolder: rec.target_subfolder,
     filename: rec.filename,
     status: rec.status,
+    updated: rec.updated,
     path: rec.path,
     error: rec.error,
     started_at: rec.started_at,
@@ -1528,12 +1566,11 @@ export function compareTrayIds(a: string | undefined, b: string | undefined): nu
 
 export function listDownloadJobs(): DownloadJob[] {
   // One Entry is indexed under multiple keys — dedup by identity so a job appears once
-  // regardless of how many keys point at it. Identity is (id, trayId), NOT id alone:
-  // two distinct URLs to one dest+auth share an id but are distinct physical downloads
-  // (different trayId), and both must be listed — download_model action:"status" with no selector
-  // promises EVERY tracked download.
+  // regardless of how many keys point at it. Identity is (id, trayId, target), NOT id alone:
+  // concurrent local and pod transfers can share the first two fields and must remain
+  // separately visible to the tray reconciliation and status action.
   const seen = new Set<Entry>();
-  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}`;
+  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}\n${j.target ?? ""}`;
   const byKey = new Map<string, DownloadJob>();
   for (const e of jobs.values()) {
     if (seen.has(e)) continue;
@@ -1544,18 +1581,26 @@ export function listDownloadJobs(): DownloadJob[] {
   }
   // #529: fold in persisted records for jobs THIS session's registry doesn't hold
   // (started before a reconnect), so download_model action:"status" still lists in-flight downloads.
-  // INTEGRITY TRUTH: a validated DONE (file landed) WINS over a cancelled/error record for
-  // the SAME (id, trayId) — whether that other record is a persisted counterpart OR this
-  // session's own in-memory cancelled/error. So a persisted DONE overrides any current
-  // entry that is neither DONE nor a LIVE in-memory download (which stays visible as the
-  // user's active action). The list never shows a cancelled in place of a validated file.
+  // INTEGRITY TRUTH: a LIVE or validated DONE record WINS over a cancelled/error snapshot
+  // for the SAME (id, trayId) — whether that other record is persisted or this session's
+  // in-memory terminal entry. A live record must stay visible as the user's active action,
+  // and the list must never replace a validated file with a terminal snapshot.
   for (const rec of listPersistedDownloadJobs()) {
     const job = jobFromPersisted(rec);
     const k = keyOf(job);
     const cur = byKey.get(k);
     if (!cur) {
       byKey.set(k, job);
-    } else if (job.status === "done" && cur.status !== "done" && cur.status !== "downloading") {
+    } else if (
+      (job.status === "downloading" &&
+        job.staleInflight !== true &&
+        cur.status !== "done" &&
+        !(cur.status === "downloading" && cur.staleInflight !== true)) ||
+      (job.status !== "downloading" &&
+        cur.status === "downloading" &&
+        (cur.staleInflight === true || (job.updated ?? job.finished_at ?? 0) >= (cur.updated ?? 0))) ||
+      (job.status === "done" && cur.status !== "done" && cur.status !== "downloading")
+    ) {
       byKey.set(k, job);
     }
   }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -37,7 +37,6 @@ import {
   listInFlightDownloadProgress,
   persistDownloadJob,
   currentDownloadTarget,
-  readPersistedDownloadJob,
   listPersistedDownloadJobs,
   findPersistedDownloadJob,
   removePersistedDownloadJobFor,
@@ -487,6 +486,7 @@ export async function startDownloadJob(
   // when locally resolvable (two-URLs-one-dest dedup).
   const lookupKeys = destKey ? [reqKey, destKey] : [reqKey];
   const trayId = downloadIdFor(url);
+  const downloadTarget = currentDownloadTarget();
 
   // ADOPT ONLY AN IN-FLIGHT ENTRY (#420 codex round 3, rule 3): a FINISHED entry
   // under any key is treated as absent — it must never shadow a currently-downloading
@@ -554,6 +554,7 @@ export async function startDownloadJob(
       rec.status === "downloading" &&
       nowForAdopt - (rec.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS &&
       rec.trayId === trayId &&
+      rec.target === downloadTarget &&
       (rec.id === id || (rec.req_key !== undefined && rec.req_key === reqKey)) &&
       // A FRESH HEARTBEAT IS NOT A LIVE WRITER. The heartbeat is written every
       // 15s and only goes stale after 60, so a process that died a moment ago
@@ -599,7 +600,7 @@ export async function startDownloadJob(
   const job: DownloadJob = {
     id,
     trayId,
-    target: currentDownloadTarget(),
+    target: downloadTarget,
     url,
     target_subfolder: targetSubfolder,
     filename,
@@ -1071,12 +1072,16 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
  *  distinct URLs resolving to the same dest+auth). The id alone can't disambiguate, so
  *  a by-id lookup/cancel must decline rather than silently act on the local one.
  *  Excludes this process's own records (same owner) and heartbeat-stale ones. */
-function hasAmbiguousForeignSibling(id: string, localTrayId: string): boolean {
+function hasAmbiguousForeignSibling(
+  id: string,
+  localTrayId: string,
+  localTarget?: string,
+): boolean {
   const now = Date.now();
   return listPersistedDownloadJobs().some(
     (rec) =>
       rec.id === id &&
-      rec.trayId !== localTrayId &&
+      (rec.trayId !== localTrayId || rec.target !== localTarget) &&
       rec.owner !== PERSIST_OWNER &&
       rec.status === "downloading" &&
       now - (rec.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
@@ -1287,7 +1292,7 @@ export function describePlacement(
 /**
  * Every DISTINCT tracked download that answers to `id`, across this process's
  * registry AND the persisted store, deduped by the TRUE composite identity
- * (id, trayId) — the same key `listDownloadJobs`/`findDownloadJob` already use.
+ * (id, trayId, target) — the same target-aware key `listDownloadJobs` uses.
  *
  * `id` is derived from destination+auth, so two different SOURCE URLs landing on
  * one file deliberately share it (#467 P1-A dedup). That makes `id` a
@@ -1299,7 +1304,7 @@ export function describePlacement(
  * Newest-started first, so a caller printing candidates leads with the live one.
  */
 export function listDownloadJobCandidates(id: string): DownloadJob[] {
-  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}`;
+  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}\n${j.target ?? ""}`;
   const byKey = new Map<string, DownloadJob>();
   for (const e of new Set(jobs.values())) {
     if (e.job.id !== id) continue;
@@ -1308,7 +1313,8 @@ export function listDownloadJobCandidates(id: string): DownloadJob[] {
   }
   // `trayId` is a hash of the URL, so it does NOT separate sessions: this
   // session's SETTLED record for a URL and ANOTHER session's still-running
-  // download of the same URL to the same destination collapse to one key. Which
+  // download of the same URL to the same destination collapse to one target-aware
+  // key. Which
   // one is reported matters — showing the local "cancelled" row while a foreign
   // transfer is live would hide a running download behind a stale verdict, and
   // that is worse than the ambiguity this function exists to surface.
@@ -1355,23 +1361,37 @@ export function listDownloadJobCandidates(id: string): DownloadJob[] {
  * Resolve ONE download.
  *
  * `trayId` is the DISAMBIGUATOR (#822): with it the lookup keys on the full
- * composite identity (id, trayId) and can always name exactly one row. Without
+ * composite identity (id, trayId, target) and can name exactly one row when the
+ * current target is known. Without
  * it, an id that denotes more than one download still resolves to nothing —
  * but callers can now distinguish that from "no such download" by asking
  * {@link listDownloadJobCandidates}, which is the difference between an
  * actionable "say which one" and a false "it never existed".
  */
-export function getDownloadJob(id: string, trayId?: string): DownloadJob | undefined {
-  if (trayId) {
-    return listDownloadJobCandidates(id).find((j) => j.trayId === trayId);
-  }
+export function getDownloadJob(id: string, trayId?: string, target?: string): DownloadJob | undefined {
+  const targetSelector = target ?? currentDownloadTarget();
+  const candidates = listDownloadJobCandidates(id).filter(
+    (j) =>
+      (!trayId || j.trayId === trayId) &&
+      (targetSelector === undefined || j.target === targetSelector),
+  );
+  const selectOne = (rows: DownloadJob[]): DownloadJob | undefined => {
+    const identities = new Set(rows.map((j) => `${j.id}\n${j.trayId}\n${j.target ?? ""}`));
+    return identities.size === 1 ? rows[0] : undefined;
+  };
+  if (trayId) return selectOne(candidates);
   // The registry indexes each job under its request key and (when local) its
   // destination key; the public id is one of those, so a direct get resolves it.
   const live = jobs.get(id)?.job;
   // A LIVE in-flight job in THIS process is authoritative (it's actively writing here) —
-  // but decline if a concurrent live FOREIGN session shares the id with a different trayId.
-  if (live && live.status === "downloading") {
-    if (hasAmbiguousForeignSibling(id, live.trayId)) return undefined;
+  // but decline if a concurrent live FOREIGN session shares the id with a different
+  // (trayId, target) identity.
+  if (
+    live &&
+    (targetSelector === undefined || live.target === targetSelector) &&
+    live.status === "downloading"
+  ) {
+    if (hasAmbiguousForeignSibling(id, live.trayId, live.target)) return undefined;
     return live;
   }
   // Otherwise resolve across this session's TERMINAL in-memory record AND the persisted
@@ -1380,9 +1400,28 @@ export function getDownloadJob(id: string, trayId?: string): DownloadJob | undef
   // same id. A cancel/error never lands a file, so it must never mask another session's
   // validated-complete file (cancelled-over-complete), and this holds whether the
   // cancelled/error record is in-memory or persisted.
-  if (live && live.status === "done") return live;
+  if (
+    live &&
+    (targetSelector === undefined || live.target === targetSelector) &&
+    live.status === "done"
+  ) return live;
   const now = Date.now();
-  const matches = listPersistedDownloadJobs().filter((r) => r.id === id);
+  const matches = listPersistedDownloadJobs().filter(
+    (r) => r.id === id && (targetSelector === undefined || r.target === targetSelector),
+  );
+  const freshIdentities = new Set(
+    matches
+      .filter((r) => r.status === "downloading" && now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS)
+      .map((r) => `${r.id}\n${r.trayId}\n${r.target ?? ""}`),
+  );
+  const settledIdentities = new Set(
+    matches
+      .filter((r) => r.status !== "downloading")
+      .map((r) => `${r.id}\n${r.trayId}\n${r.target ?? ""}`),
+  );
+  if (freshIdentities.size > 1 || (freshIdentities.size === 0 && settledIdentities.size > 1)) {
+    return undefined;
+  }
   const persistedDone = matches
     .filter((r) => r.status === "done")
     .sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
@@ -1394,10 +1433,13 @@ export function getDownloadJob(id: string, trayId?: string): DownloadJob | undef
     (r) => r.status === "downloading" && now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
   );
   if (foreignLive.length > 0) {
-    if (new Set(foreignLive.map((r) => r.trayId)).size > 1) return undefined; // ambiguous live
+    if (new Set(foreignLive.map((r) => `${r.trayId}\n${r.target ?? ""}`)).size > 1) return undefined; // ambiguous live
     return jobFromPersisted(foreignLive.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0]);
   }
-  if (live) return live; // this session's terminal (cancelled/error), no DONE to prefer
+  if (
+    live &&
+    (targetSelector === undefined || live.target === targetSelector)
+  ) return live; // this session's terminal (cancelled/error), no DONE to prefer
   const terminal = matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
   return terminal ? jobFromPersisted(terminal) : undefined;
 }
@@ -1428,9 +1470,18 @@ export function getDownloadJob(id: string, trayId?: string): DownloadJob | undef
  */
 export function describeUnresolvedDownload(id: string): string | undefined {
   const now = Date.now();
-  const liveInMemory = jobs.get(id)?.job;
+  const targetSelector = currentDownloadTarget();
+  const liveInMemoryCandidate = jobs.get(id)?.job;
+  const liveInMemory =
+    liveInMemoryCandidate &&
+    (targetSelector === undefined || liveInMemoryCandidate.target === targetSelector)
+      ? liveInMemoryCandidate
+      : undefined;
   const inFlight = listPersistedDownloadJobs().filter(
-    (r) => r.id === id && r.status === "downloading",
+    (r) =>
+      r.id === id &&
+      r.status === "downloading" &&
+      (targetSelector === undefined || r.target === targetSelector),
   );
   const livePersisted = inFlight.filter(
     (r) => now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
@@ -1497,9 +1548,10 @@ export function describeUnresolvedDownload(id: string): string | undefined {
  *  URL matching is EXACT (query included): in-memory by raw url, persisted by the
  *  trayId hash of the full url — so two distinct signed/versioned URLs are never
  *  conflated (the persisted url is credential-redacted and can't be compared safely). */
-export function findDownloadJob(query: { url?: string; destKey?: string }): DownloadJob | undefined {
+export function findDownloadJob(query: { url?: string; destKey?: string; target?: string }): DownloadJob | undefined {
   const trayId = query.url ? downloadIdFor(query.url) : undefined;
   const destKey = query.destKey;
+  const targetSelector = query.target ?? currentDownloadTarget();
   if (!trayId && !destKey) return undefined;
 
   // Gather candidate IN-FLIGHT jobs from BOTH this process's registry AND the cross-
@@ -1508,17 +1560,21 @@ export function findDownloadJob(query: { url?: string; destKey?: string }): Down
   // job for URL→destA plus another session's persisted in-flight job for URL→destB are
   // two DISTINCT jobs for the same URL, and adopting either by URL alone would be a
   // guess — so decline (the caller must use the exact id).
-  // Key candidates by (id, trayId): two distinct URLs to one dest+auth share an id but
+  // Key candidates by (id, trayId, target): two distinct URLs to one dest+auth share an id but
   // differ in trayId (distinct physical downloads), so id alone would wrongly collapse
   // them and mask the ambiguity. A live in-memory copy wins over its persisted snapshot
   // (same id+trayId key).
-  const keyOf = (id: string, tray: string): string => `${id}\n${tray}`;
+  const keyOf = (id: string, tray: string, targetValue?: string): string =>
+    `${id}\n${tray}\n${targetValue ?? ""}`;
   const now = Date.now();
   const inflightByKey = new Map<string, DownloadJob>();
   for (const e of new Set(jobs.values())) {
     if (e.job.status !== "downloading") continue;
-    if ((query.url && e.job.url === query.url) || (destKey && e.job.destKey === destKey)) {
-      inflightByKey.set(keyOf(e.job.id, e.job.trayId), e.job);
+    if (
+      ((query.url && e.job.url === query.url) || (destKey && e.job.destKey === destKey)) &&
+      (targetSelector === undefined || e.job.target === targetSelector)
+    ) {
+      inflightByKey.set(keyOf(e.job.id, e.job.trayId, e.job.target), e.job);
     }
   }
   for (const rec of listPersistedDownloadJobs()) {
@@ -1528,7 +1584,8 @@ export function findDownloadJob(query: { url?: string; destKey?: string }): Down
     if (rec.status !== "downloading" || now - (rec.updated ?? 0) >= PERSISTED_INFLIGHT_STALE_MS) {
       continue;
     }
-    const key = keyOf(rec.id, rec.trayId);
+    if (targetSelector !== undefined && rec.target !== targetSelector) continue;
+    const key = keyOf(rec.id, rec.trayId, rec.target);
     if (inflightByKey.has(key)) continue;
     if ((trayId && rec.trayId === trayId) || (destKey && rec.dest_key === destKey)) {
       inflightByKey.set(key, jobFromPersisted(rec));
@@ -1539,7 +1596,7 @@ export function findDownloadJob(query: { url?: string; destKey?: string }): Down
 
   // No in-flight match anywhere — fall back to a single unambiguous SETTLED persisted
   // record (for status reporting); findPersistedDownloadJob declines if ambiguous.
-  const persisted = findPersistedDownloadJob({ trayId, destKey });
+  const persisted = findPersistedDownloadJob({ trayId, destKey, target: targetSelector });
   return persisted ? jobFromPersisted(persisted) : undefined;
 }
 
@@ -1582,7 +1639,7 @@ export function listDownloadJobs(): DownloadJob[] {
   // #529: fold in persisted records for jobs THIS session's registry doesn't hold
   // (started before a reconnect), so download_model action:"status" still lists in-flight downloads.
   // INTEGRITY TRUTH: a LIVE or validated DONE record WINS over a cancelled/error snapshot
-  // for the SAME (id, trayId) — whether that other record is persisted or this session's
+  // for the SAME (id, trayId, target) — whether that other record is persisted or this session's
   // in-memory terminal entry. A live record must stay visible as the user's active action,
   // and the list must never replace a validated file with a terminal snapshot.
   for (const rec of listPersistedDownloadJobs()) {
@@ -1596,9 +1653,13 @@ export function listDownloadJobs(): DownloadJob[] {
         job.staleInflight !== true &&
         cur.status !== "done" &&
         !(cur.status === "downloading" && cur.staleInflight !== true)) ||
+      // A persisted terminal may replace a stale persisted in-flight snapshot, but
+      // never an active in-memory writer. The latter has no heartbeat `updated` field;
+      // comparing the terminal timestamp against zero made an old terminal shadow the
+      // bytes that are still advancing in this process (#2057 recurrence).
       (job.status !== "downloading" &&
         cur.status === "downloading" &&
-        (cur.staleInflight === true || (job.updated ?? job.finished_at ?? 0) >= (cur.updated ?? 0))) ||
+        cur.staleInflight === true) ||
       (job.status === "done" && cur.status !== "done" && cur.status !== "downloading")
     ) {
       byKey.set(k, job);
@@ -1806,6 +1867,7 @@ export async function adoptOrphanedDownloadJobs(): Promise<OrphanedDownloadAdopt
   if (routeToManager) return adopted;
 
   const now = Date.now();
+  const target = currentDownloadTarget();
   const records = listPersistedDownloadJobs();
   // Ids this pass already re-issued. `records` is a SNAPSHOT taken before the loop,
   // so without this a second dead record for the SAME id (two dead sessions each
@@ -1816,15 +1878,22 @@ export async function adoptOrphanedDownloadJobs(): Promise<OrphanedDownloadAdopt
   const adoptedIds = new Set<string>();
   for (const rec of records) {
     if (rec.status !== "downloading") continue;
+    // Adoption runs in the current target's process. A targetless record cannot
+    // be used to adopt a local/pod transfer when the process has a real target,
+    // and a targetful record must never be adopted by a targetless process.
+    if (rec.target !== target) continue;
     if (!rec.owner || rec.owner === PERSIST_OWNER) continue;
     if (rec.via_manager) continue;
     if (writerProcessGone(rec) !== true) continue;
     if (!rec.url || downloadIdFor(rec.url) !== rec.trayId) continue;
-    if (adoptedIds.has(rec.id)) continue;
+    const identity = `${rec.id}\n${rec.trayId}\n${rec.target ?? ""}`;
+    if (adoptedIds.has(identity)) continue;
     const alreadyAdopted = records.some(
       (other) =>
         other !== rec &&
         other.id === rec.id &&
+        other.trayId === rec.trayId &&
+        other.target === rec.target &&
         other.status === "downloading" &&
         now - (other.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
     );
@@ -1863,7 +1932,7 @@ export async function adoptOrphanedDownloadJobs(): Promise<OrphanedDownloadAdopt
       resumedBytes: partial.bytes,
       staleRecordLeft: reclaim.staleRecordLeft || undefined,
     });
-    adoptedIds.add(rec.id);
+    adoptedIds.add(identity);
   }
   return adopted;
 }
@@ -1916,12 +1985,39 @@ export function cancelDownloadJob(
   status?: DownloadJob["status"];
   job?: DownloadJob;
 } {
+  const targetSelector = currentDownloadTarget();
   if (trayId) {
+    const trayCandidates = listDownloadJobCandidates(id).filter(
+      (j) =>
+        j.trayId === trayId &&
+        (targetSelector === undefined || j.target === targetSelector),
+    );
+    if (targetSelector === undefined) {
+      const identities = new Set(
+        listDownloadJobCandidates(id)
+          .filter((j) => j.trayId === trayId)
+          .map((j) => `${j.id}\n${j.trayId}\n${j.target ?? ""}`),
+      );
+      if (identities.size > 1) {
+        return {
+          found: true,
+          owned: false,
+          aborted: false,
+          ambiguous: true,
+          candidates: listDownloadJobCandidates(id),
+          status: trayCandidates[0]?.status,
+          job: trayCandidates[0],
+        };
+      }
+    }
     // Explicit selection: find the ONE local entry with this composite identity.
     // Scanning entries (rather than jobs.get(id)) matters because the registry's
     // id row holds only one of several same-destination jobs.
     const entry = [...new Set(jobs.values())].find(
-      (e) => e.job.id === id && e.job.trayId === trayId,
+      (e) =>
+        e.job.id === id &&
+        e.job.trayId === trayId &&
+        (targetSelector === undefined || e.job.target === targetSelector),
     );
     if (entry) {
       const { job, controller } = entry;
@@ -1937,11 +2033,15 @@ export function cancelDownloadJob(
     // Not ours. It may be another session's (persisted). A LIVE one is reportable,
     // not abortable — but a STALE one whose writer is proven gone is reclaimed
     // (#858): closed as cancelled so the download can be safely re-issued.
-    const foreign = listDownloadJobCandidates(id).find((j) => j.trayId === trayId);
+    const foreign = trayCandidates[0];
     if (foreign) {
       if (foreign.status === "downloading" && foreign.staleInflight) {
         const rec = listPersistedDownloadJobs().find(
-          (r) => r.id === id && r.trayId === trayId && r.status === "downloading",
+          (r) =>
+            r.id === id &&
+            r.trayId === trayId &&
+            r.status === "downloading" &&
+            (targetSelector === undefined || r.target === targetSelector),
         );
         if (rec) {
           const re = reclaimDeadPersistedDownload(rec);
@@ -1972,12 +2072,17 @@ export function cancelDownloadJob(
   }
 
   const entry = jobs.get(id);
-  if (entry) {
-    const { job, controller } = entry;
+  const localEntry =
+    entry &&
+    (targetSelector === undefined || entry.job.target === targetSelector)
+      ? entry
+      : undefined;
+  if (localEntry) {
+    const { job, controller } = localEntry;
     // Cross-session ambiguity: a live foreign download shares this id with a DIFFERENT
     // trayId. Aborting by id could act on the wrong logical download — decline so a
     // cancel-by-id can never hit an unintended concurrent download (a #515 invariant).
-    if (job.status === "downloading" && hasAmbiguousForeignSibling(id, job.trayId)) {
+    if (job.status === "downloading" && hasAmbiguousForeignSibling(id, job.trayId, job.target)) {
       return {
         found: true,
         owned: true,
@@ -2023,7 +2128,9 @@ export function cancelDownloadJob(
   // tray id of the one they mean. Only STILL-DOWNLOADING records create that
   // ambiguity: a settled record cannot be cancelled wrongly (the call is a no-op
   // report either way), so it must not block the one row that could be acted on.
-  const persistedCandidates = listDownloadJobCandidates(id);
+  const persistedCandidates = listDownloadJobCandidates(id).filter(
+    (candidate) => targetSelector === undefined || candidate.target === targetSelector,
+  );
   if (persistedCandidates.filter((c) => c.status === "downloading").length > 1) {
     return {
       found: true,
@@ -2035,7 +2142,30 @@ export function cancelDownloadJob(
       job: persistedCandidates[0],
     };
   }
-  const persisted = readPersistedDownloadJob(id);
+  const persistedMatches = listPersistedDownloadJobs().filter(
+    (r) => r.id === id && (targetSelector === undefined || r.target === targetSelector),
+  );
+  const persistedLive = persistedMatches.filter(
+    (r) => r.status === "downloading" && Date.now() - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  const persistedIdentities = new Set(
+    persistedLive.map((r) => `${r.id}\n${r.trayId}\n${r.target ?? ""}`),
+  );
+  if (persistedIdentities.size > 1) {
+    return {
+      found: true,
+      owned: false,
+      aborted: false,
+      ambiguous: true,
+      candidates: persistedCandidates,
+      status: persistedCandidates[0]?.status,
+      job: persistedCandidates[0],
+    };
+  }
+  const persistedPool = persistedMatches.filter((r) => r.status === "done");
+  const persisted = (persistedLive[0] ?? (persistedPool.length > 0
+    ? persistedPool.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0]
+    : persistedMatches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0])) ?? null;
   if (persisted) {
     // A STALE in-flight record whose writer is proven gone is reclaimed (#858);
     // a live or unprovable one stays refused exactly as before (#761).

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -213,8 +213,8 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
           : undefined;
       // TYPED, not inferred: an annotated object literal gets excess-property
       // checking, so a key that is NOT on PersistedDownloadJob is a COMPILE
-      // error. The five dead keys that lived here for months (`name`, `dest`,
-      // `target`, `total`, `received` — from the tray-row interface) are caught
+      // error. The four dead keys that lived here for months (`name`, `dest`,
+      // `total`, `received` — from the tray-row interface) are caught
       // this way. `persistDownloadJob` cannot help: it spreads a variable, which
       // defeats the check.
       //
@@ -248,6 +248,7 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         // findable by id rather than emitting a malformed one.
         trayId: str("trayId") ?? "",
         filename: str("filename"),
+        target: str("target") ? redactUrl(str("target")!) : undefined,
         target_subfolder: str("target_subfolder") ?? "",
         started_at: num("started_at") ?? Date.now(),
         pid: num("pid"),
@@ -360,6 +361,14 @@ function redactUrl(raw: string): string {
   }
 }
 
+/** The credential-free ComfyUI endpoint that scopes a production download. */
+export function currentDownloadTarget(
+  raw: string | undefined = process.env.COMFYUI_URL,
+): string | undefined {
+  const value = raw?.trim();
+  return value ? redactUrl(value) : undefined;
+}
+
 /**
  * Write a progress snapshot for one download. The in-flight "downloading" state
  * is throttled to ~3/sec to avoid hammering the disk; terminal states
@@ -382,8 +391,7 @@ export function reportDownloadProgress(
     // reports against the new host while stale rows age out (codex finding:
     // a process-wide count let any download disable any pod's auto-stop).
     // Redacted — target URLs can carry userinfo (codex finding).
-    const rawTarget = p.target ?? (process.env.COMFYUI_URL?.trim() || undefined);
-    const target = rawTarget ? redactUrl(rawTarget) : undefined;
+    const target = p.target ? redactUrl(p.target) : currentDownloadTarget();
     // Stamp the panel tab that started this download (the spawned MCP child's own
     // COMFYUI_MCP_TAB) so the orchestrator can wake EXACTLY that tab's agent when
     // the download settles (#547), the same self-scoping trick `target` uses.
@@ -794,6 +802,8 @@ export interface PersistedDownloadJob {
   /** The id the physical progress rows are written under (post-auth/HF-rewrite);
    *  differs from trayId only for query-auth / mirror URLs. Optional/back-compat. */
   progressId?: string;
+  /** Credential-free ComfyUI endpoint this job serves; legacy records may omit it. */
+  target?: string;
   url: string;
   target_subfolder: string;
   filename?: string;
@@ -865,10 +875,9 @@ function sanitizeIdPart(id: string): string {
   return id.replace(/[^a-zA-Z0-9_.-]/g, "_");
 }
 
-/** THIS session's record file for a job id — owner-scoped, so a second session running
- *  the same id writes a DIFFERENT file rather than clobbering ours. */
-function jobFileFor(id: string): string {
-  return join(recordsDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${PERSIST_OWNER}.json`);
+/** Owner-scoped record file for a job id, so concurrent sessions write separate files. */
+function jobFileFor(id: string, owner = PERSIST_OWNER): string {
+  return join(recordsDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${sanitizeIdPart(owner)}.json`);
 }
 
 let persistSeq = 0;
@@ -929,20 +938,27 @@ function sleepSyncMs(ms: number): void {
   }
 }
 
-export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): boolean {
+/** Persist under the supplied owner when reconciling a reconstructed record; ordinary
+ * callers use the current session owner by default. */
+export function persistDownloadJob(
+  job: Omit<PersistedDownloadJob, "updated">,
+  owner = PERSIST_OWNER,
+): boolean {
   const dir = recordsDir();
   if (!dir) return false;
   try {
     mkdirSync(dir, { recursive: true });
+    const persistOwner = owner.trim() || PERSIST_OWNER;
     const safe: PersistedDownloadJob = {
       ...job,
-      owner: PERSIST_OWNER,
+      owner: persistOwner,
       pid: process.pid,
       url: job.url ? redactUrl(job.url) : job.url,
+      target: job.target ? redactUrl(job.target) : job.target,
       updated: Date.now(),
     };
     const body = JSON.stringify(safe);
-    const finalPath = jobFileFor(job.id);
+    const finalPath = jobFileFor(job.id, persistOwner);
     const tmpPath = `${finalPath}.${process.pid}-${persistSeq++}.tmp`;
     writeFileSync(tmpPath, body);
     // Atomic replace, retried a few times for a TRANSIENT Windows sharing violation (a

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -1173,21 +1173,32 @@ export function listPersistedDownloadJobs(): PersistedDownloadJob[] {
  *  the match exact AND credential-free. Prefers an in-flight ("downloading") match,
  *  then the most recently updated (a niche same-exact-URL-two-destinations case is
  *  inherently ambiguous from a URL alone — the id selector disambiguates it). */
-export function findPersistedDownloadJob(query: { trayId?: string; destKey?: string }): PersistedDownloadJob | null {
-  const { trayId, destKey } = query;
+export function findPersistedDownloadJob(query: {
+  trayId?: string;
+  destKey?: string;
+  target?: string;
+}): PersistedDownloadJob | null {
+  const { trayId, destKey, target } = query;
   if (!trayId && !destKey) return null;
   const matches = listPersistedDownloadJobs().filter(
-    (j) => (trayId && j.trayId === trayId) || (destKey && j.dest_key === destKey),
+    (j) =>
+      ((trayId && j.trayId === trayId) || (destKey && j.dest_key === destKey)) &&
+      (target === undefined || j.target === target),
   );
   if (matches.length === 0) return null;
   // AMBIGUITY GUARD: one URL can legitimately drive TWO jobs to different destinations
   // (they share a trayId), and one auth-free destination can back two different-auth
   // jobs (they share a dest_key). Adopting by URL/destination alone then can't tell them
   // apart — so REFUSE to guess when more than one DISTINCT LIVE job matches; the caller
-  // must use the exact id. Distinctness is (id, trayId). Ambiguity is judged over LIVE
+  // must use the exact id. Distinctness is (id, trayId, target). Ambiguity is judged over LIVE
   // (fresh in-flight) records ONLY: a heartbeat-stale record may still be streaming,
   // but must not block adoption or force a false decline.
-  const distinctKey = (j: PersistedDownloadJob): string => `${j.id}\n${j.trayId}`;
+  const distinctKey = (j: PersistedDownloadJob): string =>
+    `${j.id}\n${j.trayId}\n${j.target ?? ""}`;
+  // A URL/destination lookup without an explicit target cannot safely select
+  // between local, pod, and legacy targetless terminal rows. Keep the same
+  // fail-closed rule used by the in-flight path for the terminal fallback too.
+  if (target === undefined && new Set(matches.map(distinctKey)).size > 1) return null;
   const now = Date.now();
   const live = matches.filter(
     (j) => j.status === "downloading" && now - (j.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -952,7 +952,11 @@ async function statusAction(args: {
           // not "no such download" — reporting it as one turns "could not determine
           // which" into a definite (and wrong) verdict, and leaves the caller with
           // no move. Name the candidates and the exact selector that picks one.
-          const candidates = args.id && !args.tray_id ? listDownloadJobCandidates(args.id) : [];
+          const candidates = args.id
+            ? listDownloadJobCandidates(args.id).filter(
+                (c) => !args.tray_id || c.trayId === args.tray_id,
+              )
+            : [];
           if (candidates.length > 1) {
             const rows = candidates
               .map(
@@ -1008,7 +1012,7 @@ async function statusAction(args: {
         const liveModelsDir = await currentLiveModelsRoot();
         // #822: `id` is derived from the DESTINATION (+auth), so two rows fetching
         // different URLs into one file legitimately share it. The composite
-        // (id, trayId) is the real handle — render trayId on EVERY row so the
+        // (id, trayId, target) is the real handle — render trayId on EVERY row so the
         // printed handle always identifies exactly one download, and shout when a
         // listing actually contains a collision (two writers, one file).
         const idCounts = new Map<string, number>();
@@ -1033,11 +1037,11 @@ async function statusAction(args: {
           list
             .filter((j) => j.status === "cancelled" && !j.viaManager)
             .map(async (j) => {
-              partials.set(`${j.id}\n${j.trayId}`, await findResumablePartial(j.url));
+              partials.set(`${j.id}\n${j.trayId}\n${j.target ?? ""}`, await findResumablePartial(j.url));
             }),
         );
         const partialFor = (j: DownloadJob): { path: string; bytes: number } | null =>
-          partials.get(`${j.id}\n${j.trayId}`) ?? null;
+          partials.get(`${j.id}\n${j.trayId}\n${j.target ?? ""}`) ?? null;
         const collidingIds = [...idCounts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
         const lines = list.map((j) => {
           const p = readDownloadProgress(j.progressId ?? j.trayId);
@@ -1057,7 +1061,8 @@ async function statusAction(args: {
             j.status === "error" && j.interruptedByRestart && j.viaManager
               ? "unwatched (host may still be fetching)"
               : j.status;
-          const head = `- \`${j.id}\` (tray \`${j.trayId}\`) **${statusToken}**${bytes}`;
+          const targetLabel = j.target ? `  target: \`${j.target}\`` : "";
+          const head = `- \`${j.id}\` (tray \`${j.trayId}\`) **${statusToken}**${bytes}${targetLabel}`;
           const collisionNote = idCounts.get(j.id)! > 1
             ? `\n    AMBIGUOUS id: another row in this listing shares \`${j.id}\` — these are DIFFERENT source URLs writing the SAME destination file, so the last writer wins and the result may be a mix. Select this one with \`tray_id\`: \`${j.trayId}\`. Pass that same tray_id to \`action:"cancel"\` to stop THIS one specifically.`
             : "";


### PR DESCRIPTION
## Summary

- Suppress terminal FAILED wording only for a fresh, exact target-matched job whose poll snapshots prove recent monotonic byte advancement.
- Reconcile fresh-but-frozen and heartbeat-stale matched records in the original persisted owner file, so `download_model action:"status"` and the injected `download_done` event observe the same terminal state. Legacy persisted records without an owner fail closed and keep the event explicitly disclosed if persistence cannot publish.
- Persist and reconstruct the credential-free ComfyUI target on `DownloadJob`; keep target variants distinct in the authoritative list and fail closed for targetless rows/records.
- Bound parsed tray-row errors before production broadcasts and retain compacted terminal detail up to 400 characters.

## Validation

- `npm.cmd exec -- vitest run src/__tests__/orchestrator/download-done-loop.test.ts src/__tests__/orchestrator/download-done-contradiction.test.ts src/__tests__/orchestrator/download-done-event.test.ts src/__tests__/orchestrator/download-progress-snapshot.test.ts src/__tests__/services/download-progress.test.ts src/__tests__/services/download-jobs.test.ts --passWithNoTests` — 6 files, 198 passed
- `npm.cmd run lint` — passed
- `git diff --check` — passed

Regression coverage includes advancing transfers, frozen-byte terminalization in the original owner record, stale-only records, real production-poll injection, pod-only target mismatch, concurrent local/pod target identities, targetless fail-closed behavior, and persisted target redaction/round-trip.

Fixes #2057