### PR TITLE
fix: apply panel kitchen launch flags safely

### DIFF
--- a/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const restartMock = vi.hoisted(() => vi.fn());
+const kitchenFixture = vi.hoisted(() => ({
+  rec: {
+    id: "ck_attention",
+    kind: "ck_attention",
+    why: "INT8 attention is available.",
+    safe: "Restart required; consent-gated.",
+    restart: true,
+    download: false,
+    change: { type: "flag", flag: "--use-ck-attention" },
+  },
+}));
+
+vi.mock("../../services/workspace-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/workspace-env.js")>();
+  return { ...actual, resolveComfyuiPython: () => ({ python: undefined }) };
+});
+
+vi.mock("../../services/instance-witness.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/instance-witness.js")>();
+  return { ...actual, acquireInstanceWitness: async () => undefined };
+});
+
+vi.mock("../../comfyui/client.js", () => ({
+  getLogs: vi.fn(async () => []),
+  getSystemStats: vi.fn(async () => ({ system: { argv: [] }, devices: [] })),
+}));
+
+vi.mock("../../services/process-control.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/process-control.js")>();
+  return { ...actual, restartComfyUI: restartMock };
+});
+
+vi.mock("../../services/kitchen.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/kitchen.js")>();
+  return {
+    ...actual,
+    gatherKitchenStatus: vi.fn(async () => ({})),
+    assessKitchenGraph: vi.fn(async () => [kitchenFixture.rec]),
+  };
+});
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+}
+
+function panelKitchenHarness() {
+  const sent: Array<Record<string, unknown>> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "graph_query") return { nodes: [] };
+      return {};
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: false }),
+    refreshWorkflowUuid: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
+  return { ctx, def, sent };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("panel_kitchen flag apply (#2277)", () => {
+  it("reports applied only when the owned relaunch and serving argv prove the flag", async () => {
+    restartMock.mockResolvedValue({
+      stopped: true,
+      started: true,
+      startup: "confirmed",
+      listener_ownership: "ours",
+      message: "ComfyUI restarted successfully.",
+      serving_argv: ["main.py", "--use-ck-attention"],
+    });
+    const { ctx, def } = panelKitchenHarness();
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: "ck_attention", confirm: true, skip_proof: true } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(true);
+    expect(body.flag_note).toMatch(/observed it in the serving ComfyUI argv/i);
+    expect(restartMock).toHaveBeenCalledWith({ additionalFlags: ["--use-ck-attention"] });
+  });
+
+  it("returns the launcher-specific refusal and applied:false when restart cannot inject it", async () => {
+    restartMock.mockResolvedValue({
+      stopped: false,
+      started: false,
+      startup: "not-attempted",
+      listener_ownership: "unconfirmed",
+      message:
+        "Refusing to apply --use-ck-attention: ComfyUI Desktop owns the saved launch settings. " +
+        "No launch argument was changed and ComfyUI was not stopped.",
+    });
+    const { ctx, def } = panelKitchenHarness();
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: "ck_attention", confirm: true, skip_proof: true } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(false);
+    expect(body.flag_note).toMatch(/Desktop owns the saved launch settings/i);
+    expect(body.flag_note).toMatch(/applied:false/i);
+  });
+
+  it("keeps the consent gate before any launcher mutation", async () => {
+    const { ctx, def } = panelKitchenHarness();
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: "ck_attention", confirm: false, skip_proof: true } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(false);
+    expect(body.needs_confirm).toBe(true);
+    expect(restartMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const restartMock = vi.hoisted(() => vi.fn());
+const panelTarget = vi.hoisted(() => ({
+  baseUrl: "http://127.0.0.1:8188",
+  generation: 0,
+}));
+const panelTabTarget = vi.hoisted(() => ({
+  baseUrl: "http://127.0.0.1:8188",
+}));
 const kitchenFixture = vi.hoisted(() => ({
   rec: {
     id: "ck_attention",
@@ -28,6 +35,15 @@ vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: vi.fn(async () => ({ system: { argv: [] }, devices: [] })),
 }));
 
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    getComfyUIBaseUrl: () => panelTarget.baseUrl,
+    getComfyuiTargetGeneration: () => panelTarget.generation,
+  };
+});
+
 vi.mock("../../services/process-control.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/process-control.js")>();
   return { ...actual, restartComfyUI: restartMock };
@@ -48,6 +64,7 @@ import {
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
+import { captureComfyUITargetFence } from "../../services/process-control.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "wf:workflows/a.json";
@@ -55,18 +72,24 @@ function textOf(res: ToolResult): string {
   return res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
 }
 
-function panelKitchenHarness() {
+function panelKitchenHarness(onGraphQuery?: () => void) {
   const sent: Array<Record<string, unknown>> = [];
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(cmd);
-      if (cmd.cmd === "graph_query") return { nodes: [] };
+      if (cmd.cmd === "graph_query") {
+        onGraphQuery?.();
+        return { nodes: [] };
+      }
       return {};
     },
     push: () => 1,
     canReach: () => true,
     isHeadless: () => false,
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    tabOrigin: () => panelTabTarget.baseUrl,
+    tabServerOrigin: () => new URL(panelTabTarget.baseUrl).origin,
+    tabIsLocal: () => true,
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
@@ -80,6 +103,9 @@ function panelKitchenHarness() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  panelTarget.baseUrl = "http://127.0.0.1:8188";
+  panelTarget.generation = 0;
+  panelTabTarget.baseUrl = "http://127.0.0.1:8188";
 });
 
 describe("panel_kitchen flag apply (#2277)", () => {
@@ -91,6 +117,8 @@ describe("panel_kitchen flag apply (#2277)", () => {
       listener_ownership: "ours",
       message: "ComfyUI restarted successfully.",
       serving_argv: ["main.py", "--use-ck-attention"],
+      target_fence: captureComfyUITargetFence(),
+      target_stable: true,
     });
     const { ctx, def } = panelKitchenHarness();
 
@@ -102,7 +130,10 @@ describe("panel_kitchen flag apply (#2277)", () => {
 
     expect(body.applied).toBe(true);
     expect(body.flag_note).toMatch(/observed it in the serving ComfyUI argv/i);
-    expect(restartMock).toHaveBeenCalledWith({ additionalFlags: ["--use-ck-attention"] });
+    expect(restartMock).toHaveBeenCalledWith({
+      additionalFlags: ["--use-ck-attention"],
+      targetFence: captureComfyUITargetFence(),
+    });
   });
 
   it("returns the launcher-specific refusal and applied:false when restart cannot inject it", async () => {
@@ -114,6 +145,8 @@ describe("panel_kitchen flag apply (#2277)", () => {
       message:
         "Refusing to apply --use-ck-attention: ComfyUI Desktop owns the saved launch settings. " +
         "No launch argument was changed and ComfyUI was not stopped.",
+      target_fence: captureComfyUITargetFence(),
+      target_stable: true,
     });
     const { ctx, def } = panelKitchenHarness();
 
@@ -126,6 +159,53 @@ describe("panel_kitchen flag apply (#2277)", () => {
     expect(body.applied).toBe(false);
     expect(body.flag_note).toMatch(/Desktop owns the saved launch settings/i);
     expect(body.flag_note).toMatch(/applied:false/i);
+  });
+
+  it("refuses a cross-tab retarget during graph assessment before restart", async () => {
+    const { ctx, def } = panelKitchenHarness(() => {
+      panelTarget.baseUrl = "http://127.0.0.1:8288";
+      panelTarget.generation = 1;
+    });
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: "ck_attention", confirm: true, skip_proof: true } as never,
+      ctx,
+    );
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/target changed/i);
+    expect(restartMock).not.toHaveBeenCalled();
+  });
+
+  it("returns applied:false when the target changes during the relaunch result", async () => {
+    restartMock.mockImplementation(async () => {
+      panelTarget.baseUrl = "http://127.0.0.1:8288";
+      panelTarget.generation = 1;
+      return {
+        stopped: true,
+        started: true,
+        startup: "confirmed",
+        listener_ownership: "ours",
+        message: "ComfyUI restarted successfully.",
+        serving_argv: ["main.py", "--use-ck-attention"],
+        target_fence: {
+          baseUrl: "http://127.0.0.1:8188",
+          generation: 0,
+        },
+        target_stable: true,
+      };
+    });
+    const { ctx, def } = panelKitchenHarness();
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: "ck_attention", confirm: true, skip_proof: true } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(false);
+    expect(body.flag_note).toMatch(/target changed/i);
+    expect(restartMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the consent gate before any launcher mutation", async () => {

--- a/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
@@ -17,7 +17,9 @@ const kitchenFixture = vi.hoisted(() => ({
     restart: true,
     download: false,
     change: { type: "flag", flag: "--use-ck-attention" },
-  },
+  } as any,
+  raceWidgetDispatch: false,
+  widgetReachabilityArmed: false,
 }));
 
 vi.mock("../../services/workspace-env.js", async (importOriginal) => {
@@ -54,7 +56,10 @@ vi.mock("../../services/kitchen.js", async (importOriginal) => {
   return {
     ...actual,
     gatherKitchenStatus: vi.fn(async () => ({})),
-    assessKitchenGraph: vi.fn(async () => [kitchenFixture.rec]),
+    assessKitchenGraph: vi.fn(async () => {
+      if (kitchenFixture.raceWidgetDispatch) kitchenFixture.widgetReachabilityArmed = true;
+      return [kitchenFixture.rec];
+    }),
   };
 });
 
@@ -72,8 +77,9 @@ function textOf(res: ToolResult): string {
   return res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
 }
 
-function panelKitchenHarness(onGraphQuery?: () => void) {
+function panelKitchenHarness(onGraphQuery?: () => void, onGraphRun?: () => void) {
   const sent: Array<Record<string, unknown>> = [];
+  let widgetReachabilityRetargeted = false;
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(cmd);
@@ -81,12 +87,20 @@ function panelKitchenHarness(onGraphQuery?: () => void) {
         onGraphQuery?.();
         return { nodes: [] };
       }
+      if (cmd.cmd === "graph_run") onGraphRun?.();
       return {};
     },
     push: () => 1,
-    canReach: () => true,
+    canReach: () => !kitchenFixture.widgetReachabilityArmed || widgetReachabilityRetargeted,
     isHeadless: () => false,
-    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    tabs: () => {
+      if (kitchenFixture.widgetReachabilityArmed && !widgetReachabilityRetargeted) {
+        widgetReachabilityRetargeted = true;
+        panelTarget.baseUrl = "http://127.0.0.1:8288";
+        panelTarget.generation = 1;
+      }
+      return [{ tab_id: TAB, title: "wf", connected_at: 0 }];
+    },
     tabOrigin: () => panelTabTarget.baseUrl,
     tabServerOrigin: () => new URL(panelTabTarget.baseUrl).origin,
     tabIsLocal: () => true,
@@ -106,7 +120,34 @@ beforeEach(() => {
   panelTarget.baseUrl = "http://127.0.0.1:8188";
   panelTarget.generation = 0;
   panelTabTarget.baseUrl = "http://127.0.0.1:8188";
+  kitchenFixture.rec = {
+    id: "ck_attention",
+    kind: "ck_attention",
+    why: "INT8 attention is available.",
+    safe: "Restart required; consent-gated.",
+    restart: true,
+    download: false,
+    change: { type: "flag", flag: "--use-ck-attention" },
+  } as any;
+  kitchenFixture.raceWidgetDispatch = false;
+  kitchenFixture.widgetReachabilityArmed = false;
 });
+
+const widgetRecommendation = {
+  id: "fp8_unet_fast:12",
+  kind: "fp8_unet_fast",
+  node_id: "12",
+  why: "The live graph can use the faster FP8 dtype.",
+  safe: "Widget-only change.",
+  restart: false,
+  download: false,
+  change: {
+    type: "widget",
+    widget: "weight_dtype",
+    value: "fp8_e4m3fn_fast",
+    previous: "default",
+  },
+};
 
 describe("panel_kitchen flag apply (#2277)", () => {
   it("reports applied only when the owned relaunch and serving argv prove the flag", async () => {
@@ -220,5 +261,45 @@ describe("panel_kitchen flag apply (#2277)", () => {
     expect(body.applied).toBe(false);
     expect(body.needs_confirm).toBe(true);
     expect(restartMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses widget dispatch when retargeting occurs during reachability wait", async () => {
+    kitchenFixture.rec = widgetRecommendation as any;
+    kitchenFixture.raceWidgetDispatch = true;
+    const { ctx, def, sent } = panelKitchenHarness();
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: widgetRecommendation.id, skip_proof: true } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(false);
+    expect(body.stale).toBe(true);
+    expect(textOf(res)).toMatch(/target changed/i);
+    expect(sent.some((cmd) => cmd.cmd === "graph_query")).toBe(true);
+    expect(sent.some((cmd) => cmd.cmd === "graph_set_widget")).toBe(false);
+  });
+
+  it("returns applied:false/stale when retargeting occurs during post-apply graph_run", async () => {
+    kitchenFixture.rec = widgetRecommendation as any;
+    const { ctx, def, sent } = panelKitchenHarness(undefined, () => {
+      panelTarget.baseUrl = "http://127.0.0.1:8288";
+      panelTarget.generation = 1;
+    });
+
+    const res = await def.handler(
+      { action: "apply", recommendation_id: widgetRecommendation.id } as never,
+      ctx,
+    );
+    const body = JSON.parse(textOf(res));
+
+    expect(body.applied).toBe(false);
+    expect(body.stale).toBe(true);
+    expect(body.target_stable).toBe(false);
+    expect(body.proof.status).toBe("stale");
+    expect(textOf(res)).toMatch(/proof graph_run was in flight/i);
+    expect(sent.some((cmd) => cmd.cmd === "graph_set_widget")).toBe(true);
+    expect(sent.some((cmd) => cmd.cmd === "graph_run")).toBe(true);
   });
 });

--- a/src/__tests__/orchestrator/panel-kitchen.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import { resetKitchenHintSession } from "../../services/kitchen.js";
+import { getComfyUIBaseUrl } from "../../config.js";
 
 const TAB = "wf:workflows/a.json";
 
@@ -40,6 +41,9 @@ function panelKitchenHarness(graphQueryReply: unknown) {
     canReach: () => true,
     isHeadless: () => false,
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    tabOrigin: () => getComfyUIBaseUrl(),
+    tabServerOrigin: () => getComfyUIBaseUrl(),
+    tabIsLocal: () => true,
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
@@ -156,6 +160,9 @@ describe("panel_kitchen", () => {
       canReach: () => true,
       isHeadless: () => false,
       tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+      tabOrigin: () => getComfyUIBaseUrl(),
+      tabServerOrigin: () => getComfyUIBaseUrl(),
+      tabIsLocal: () => true,
       resolveActiveTabId: () => TAB,
       tabCanMutateGraph: () => true,
       tabGraphMutationCapability: () => ({ known: true, canMutate: true }),

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -9,6 +9,11 @@ const mockConfig = vi.hoisted(() => ({
   comfyuiRestartCommand: undefined as string | undefined,
 }));
 
+const mockTarget = vi.hoisted(() => ({
+  baseUrl: "http://127.0.0.1:8188",
+  generation: 0,
+}));
+
 // #742: the two classifications the preflight now distinguishes. `remote` is
 // how the target is ADDRESSED; `onThisMachine` is where the instance actually
 // runs. They disagree for a local install reached by its own LAN address, and
@@ -22,10 +27,10 @@ const mockResetClient = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
-  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIBaseUrl: () => mockTarget.baseUrl,
   getComfyUIAuthHeaders: () => ({}),
   // #848 instance fence — a stable target here; the retarget case has its own test.
-  getComfyuiTargetGeneration: () => 0,
+  getComfyuiTargetGeneration: () => mockTarget.generation,
   isRemoteMode: () => mockLocality.remote,
   targetIsOnThisMachine: () => mockLocality.onThisMachine,
 }));
@@ -166,8 +171,8 @@ function mockNoPortProcess(): void {
   });
 }
 
-function mockFetchOk(ok: boolean): Mock {
-  const fetchMock = vi.fn(async () => ({ ok }) as Response);
+function mockFetchOk(ok: boolean, body?: unknown): Mock {
+  const fetchMock = vi.fn(async () => ({ ok, json: async () => body }) as Response);
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
@@ -197,6 +202,8 @@ beforeEach(() => {
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = "/fake/ComfyUI";
   mockConfig.comfyuiRestartCommand = undefined;
+  mockTarget.baseUrl = "http://127.0.0.1:8188";
+  mockTarget.generation = 0;
   mockFindComfyuiPython.mockReturnValue("/fake/ComfyUI/python_embeded/python.exe");
   mockExistsSync.mockImplementation(() => true);
   mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
@@ -785,7 +792,7 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
       system: { argv: statsCalls++ < 2 ? currentArgv : augmentedArgv },
     }));
     mockSpawnedChildren();
-    mockFetchOk(true);
+    mockFetchOk(true, { system: { argv: augmentedArgv } });
 
     const restarted = await restartComfyUI({ additionalFlags: [flag] });
 
@@ -804,6 +811,45 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     expect(laterStart.started).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(2);
     expect(mockSpawn.mock.calls[1][1]).toEqual(expect.arrayContaining([flag]));
+  });
+
+  it("refuses before killing when the target switches while process evidence is gathered (#2277)", async () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes("netstat"))
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      if (cmd.includes("lsof")) return "p4321\nn127.0.0.1:8188\n";
+      return "";
+    });
+    mockGetSystemStats.mockImplementation(async () => {
+      mockTarget.baseUrl = "http://127.0.0.1:8288";
+      mockTarget.generation = 1;
+      return { system: { argv: ["/fake/ComfyUI/main.py", "--port", "8188"] } };
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI({ additionalFlags: ["--use-ck-attention"] });
+
+    expect(result.started).toBe(false);
+    expect(result.stopped).toBe(false);
+    expect(result.startup).toBe("not-attempted");
+    expect(result.target_stable).toBe(false);
+    expect(result.message).toMatch(/target changed/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not consume an augmented recipe saved for an older target (#2277)", async () => {
+    setLaunchInfo();
+    mockTarget.baseUrl = "http://127.0.0.1:8288";
+    mockTarget.generation = 1;
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(false);
+    expect(result.startup).toBe("not-attempted");
+    expect(result.target_stable).toBe(false);
+    expect(result.message).toMatch(/older ComfyUI target/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it("refuses launch-flag mutation for an opaque external launcher without touching it (#2277)", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -6,6 +6,7 @@ import { waitFor } from "../helpers/wait-for.js";
 const mockConfig = vi.hoisted(() => ({
   resolvedPort: 8188,
   comfyuiPath: "/fake/ComfyUI" as string | undefined,
+  comfyuiRestartCommand: undefined as string | undefined,
 }));
 
 // #742: the two classifications the preflight now distinguishes. `remote` is
@@ -195,6 +196,7 @@ beforeEach(() => {
   delete process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES;
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = "/fake/ComfyUI";
+  mockConfig.comfyuiRestartCommand = undefined;
   mockFindComfyuiPython.mockReturnValue("/fake/ComfyUI/python_embeded/python.exe");
   mockExistsSync.mockImplementation(() => true);
   mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
@@ -755,6 +757,97 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     expect(
       fetchMock.mock.calls.some(([u]) => String(u).includes("/manager/reboot")),
     ).toBe(true);
+
+    killSpy.mockRestore();
+  });
+
+  it("appends a confirmed flag only to a proven local relaunch and retains it for later starts (#2277)", async () => {
+    const flag = "--use-ck-attention";
+    const currentArgv = ["/fake/ComfyUI/main.py", "--port", "8188"];
+    const augmentedArgv = [...currentArgv, flag];
+    let killed = false;
+    let statsCalls = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill/i.test(String(cmd))) {
+        killed = true;
+        return "";
+      }
+      if (cmd.includes("netstat")) {
+        return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (cmd.includes("lsof")) {
+        if (killed) throw noListener();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    mockGetSystemStats.mockImplementation(async () => ({
+      system: { argv: statsCalls++ < 2 ? currentArgv : augmentedArgv },
+    }));
+    mockSpawnedChildren();
+    mockFetchOk(true);
+
+    const restarted = await restartComfyUI({ additionalFlags: [flag] });
+
+    expect(restarted.stopped).toBe(true);
+    expect(restarted.started).toBe(true);
+    expect(restarted.serving_argv).toEqual(augmentedArgv);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["/fake/ComfyUI/main.py", flag]),
+      expect.any(Object),
+    );
+
+    // The committed restart's launch recipe is persistent within the process:
+    // a later explicit start reuses the augmented argv instead of dropping the flag.
+    const laterStart = await startComfyUI();
+    expect(laterStart.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn.mock.calls[1][1]).toEqual(expect.arrayContaining([flag]));
+  });
+
+  it("refuses launch-flag mutation for an opaque external launcher without touching it (#2277)", async () => {
+    mockConfig.comfyuiRestartCommand = "docker restart comfyui";
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI({ additionalFlags: ["--use-ck-attention"] });
+
+    expect(result.started).toBe(false);
+    expect(result.stopped).toBe(false);
+    expect(result.startup).toBe("not-attempted");
+    expect(result.message).toMatch(/COMFYUI_RESTART_COMMAND.*opaque external launcher/i);
+    expect(result.message).toMatch(/No launch argument was changed/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("refuses Desktop launch-flag mutation and leaves Manager, process, and launcher settings untouched (#2277)", async () => {
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    installLiveDesktopSupervisor();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const fetchMock = mockFetchOk(true);
+
+    const result = await restartComfyUI({ additionalFlags: ["--use-ck-attention"] });
+
+    expect(result.started).toBe(false);
+    expect(result.stopped).toBe(false);
+    expect(result.startup).toBe("not-attempted");
+    expect(result.message).toMatch(/ComfyUI Desktop owns the saved launch settings/i);
+    expect(result.message).toMatch(/fully quit and relaunch the Desktop app/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/manager/reboot"))).toBe(false);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -783,7 +783,10 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     let killed = false;
     let statsCalls = 0;
     mockExecSync.mockImplementation((cmd: string) => {
-      if (/taskkill/i.test(String(cmd))) {
+      // Relaunch uses taskkill on native Windows and kill -9 on POSIX hosts;
+      // model either path so the fixture tests port release rather than shell
+      // selection or runner emulation details.
+      if (/\btaskkill\b/i.test(String(cmd)) || /\bkill\s+-9\b/i.test(String(cmd))) {
         killed = true;
         return "";
       }

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -770,7 +770,15 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
 
   it("appends a confirmed flag only to a proven local relaunch and retains it for later starts (#2277)", async () => {
     const flag = "--use-ck-attention";
-    const currentArgv = ["/fake/ComfyUI/main.py", "--port", "8188"];
+    // The relaunch preflight intentionally applies the host's absolute-path rules.
+    // Keep this production-path fixture valid on both POSIX and Windows; using the
+    // POSIX spelling on Windows makes the safety refusal fire before stop, which
+    // hides the flag-persistence behavior this test is meant to prove.
+    const installRoot = process.platform === "win32" ? "C:\\fake\\ComfyUI" : "/fake/ComfyUI";
+    const mainScript = join(installRoot, "main.py");
+    mockConfig.comfyuiPath = installRoot;
+    mockFindComfyuiPython.mockReturnValue(join(installRoot, "python_embeded", "python.exe"));
+    const currentArgv = [mainScript, "--port", "8188"];
     const augmentedArgv = [...currentArgv, flag];
     let killed = false;
     let statsCalls = 0;
@@ -801,7 +809,7 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     expect(restarted.serving_argv).toEqual(augmentedArgv);
     expect(mockSpawn).toHaveBeenCalledWith(
       expect.any(String),
-      expect.arrayContaining(["/fake/ComfyUI/main.py", flag]),
+      expect.arrayContaining([mainScript, flag]),
       expect.any(Object),
     );
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -2444,13 +2444,17 @@ n127.0.0.1:8188
       }
       return "";
     });
+    let spawnErrorScheduled = false;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
         relaunched = true;
         // Readiness WINS the race — the spawn error lands later, so ownership must
         // be decided from the missing pid alone.
-        setTimeout(() => children[0]?.emit("error", new Error("spawn EACCES")), 50);
+        if (!spawnErrorScheduled) {
+          spawnErrorScheduled = true;
+          setTimeout(() => children[0]?.emit("error", new Error("spawn EACCES")), 50);
+        }
         return { ok: true } as Response;
       }),
     );
@@ -2932,14 +2936,11 @@ n127.0.0.1:8188
     killSpy.mockRestore();
   });
 
-  it("the relaunch is ANCHORED to the instance that was stopped, not the live target", async () => {
+  it("refuses a stale relaunch recipe after the target moves at the stop", async () => {
     // After the kill, restartComfyUI awaits the port release and a settle delay. A
-    // retarget in that window used to leave the relaunch probing the NEW target's
-    // port: if that port was occupied it returned "already running" WITHOUT
-    // spawning, and the instance just killed stayed dead (codex gate round 12).
-    //
-    // Modelled by pointing the live config at a DIFFERENT, occupied port after the
-    // stop. Anchored, the restart still relaunches and grades the original.
+    // retarget in that window must not replay the old recipe onto the new target.
+    // The committed stop is disclosed, and the caller can retry against the new
+    // target once it has settled.
     usePlainInstall();
     mockLivePortThenFree();
     spawnCapturingChildren();
@@ -2949,9 +2950,8 @@ n127.0.0.1:8188
     );
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     // The retarget lands at the KILL — after the resolve, so the pre-stop fence
-    // (which spans only the resolve) passes and the post-stop window is what is
-    // exercised. Port 9999 is OCCUPIED, which is what makes the un-anchored version
-    // bail out with "already running" instead of relaunching.
+    // passes and the post-stop window is what is exercised. Port 9999 is OCCUPIED,
+    // and the generation/base fence must refuse before replaying A's recipe.
     let killed = false;
     mockExecSync.mockImplementation((cmd: string) => {
       if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
@@ -2979,13 +2979,13 @@ n127.0.0.1:8188
 
     expect(killed).toBe(true);
     expect(mockConfig.resolvedPort).toBe(9999); // the retarget really happened
-    // It RELAUNCHED rather than bailing out on the other target's occupied port…
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    // It refuses rather than replaying A's recipe onto the moved target.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(false);
+    expect(result.startup).toBe("not-attempted");
+    expect(result.message).toMatch(/target changed/i);
     expect(result.message).not.toMatch(/already running/i);
-    // …and the readiness verdict is about the anchored instance's URL, not the
-    // config's current one.
-    expect(result.readiness?.probe_url).toBe("http://127.0.0.1:8188/system_stats");
-    expect(result.ready).toBe(true);
 
     killSpy.mockRestore();
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -383,6 +383,7 @@ import {
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import {
+  captureComfyUITargetFence,
   restartComfyUI,
   preflightLocalRestart,
   readServingArgv,
@@ -395,6 +396,9 @@ import {
   RESTART_DISPATCH_CAUSATION_WINDOW_MS,
   PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
   __processControlTestHooks,
+  targetFenceMatchesCurrent,
+  targetFencesEqual,
+  type ComfyUITargetFence,
 } from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
@@ -15056,6 +15060,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   // the same shape), so handlers read fields off a loosely-typed bag.
   type A = Record<string, unknown>;
 
+  interface PanelKitchenTarget {
+    fence: ComfyUITargetFence;
+    tabId: string;
+  }
+
+  const capturePanelKitchenTarget = (ctx: PanelToolCtx): PanelKitchenTarget | undefined => {
+    const base = getComfyUIBaseUrl().replace(/\/+$/, "");
+    const observed = ctx.bridge.tabServerOrigin?.(ctx.tabId);
+    // A hello.comfyui_url/tabOrigin value is page-JS-writable and cannot authorize
+    // a process mutation. The server-observed handshake proves only the origin,
+    // not a path mount; refuse mounted targets rather than guessing which instance
+    // this tab fronts. This is the same fail-closed rule used by panel_reboot.
+    if (
+      ctx.bridge.tabIsLocal?.(ctx.tabId) !== true ||
+      !observed ||
+      !sameHttpOrigin(observed, base) ||
+      (() => {
+        try {
+          return new URL(base).pathname.replace(/\/+$/, "") !== "";
+        } catch {
+          return true;
+        }
+      })()
+    ) {
+      return undefined;
+    }
+    return { fence: captureComfyUITargetFence(), tabId: ctx.tabId };
+  };
+
+  const panelKitchenTargetStillCurrent = (
+    ctx: PanelToolCtx,
+    target: PanelKitchenTarget,
+  ): boolean => {
+    if (ctx.tabId !== target.tabId || !targetFenceMatchesCurrent(target.fence)) return false;
+    const observed = ctx.bridge.tabServerOrigin?.(target.tabId);
+    return (
+      ctx.bridge.tabIsLocal?.(target.tabId) === true &&
+      observed != null &&
+      sameHttpOrigin(observed, target.fence.baseUrl) &&
+      (() => {
+        try {
+          return new URL(target.fence.baseUrl).pathname.replace(/\/+$/, "") === "";
+        } catch {
+          return false;
+        }
+      })()
+    );
+  };
+
   const defs: PanelToolDef[] = [
     def(
       "panel_query_graph",
@@ -15141,6 +15194,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         );
       },
     ),
+    // panel_kitchen mixes panel-routed graph evidence with process-global
+    // ComfyUI probes. Bind both halves to the same tab target before allowing
+    // an assessment or mutation; a concurrent hello from another tab must
+    // produce a refusal, never a cross-instance apply.
     def(
       "panel_graph_outline",
       "READ THE LIVE CANVAS the user is looking at, as text. 'Show me what's on the canvas' / 'what's on the graph right now' / 'read the current workflow' / 'describe the open graph' -> THIS TOOL, with no arguments. NOT visualize_workflow (it DRAWS A DIAGRAM of a workflow you PASS IN — a saved file or JSON — and never sees the live canvas). NOT panel_query_graph (that FILTERS a SUBSET, for when you already know what you're looking for). Returns one `outline` string covering the WHOLE open graph, topologically sorted (sources first, sinks last): each node as `id Type \"title\" [bypass/mute] [OUTPUT] · group:X  widget=value …` with `← inputs` (source_node.output_name) and `→ outputs` (target_node.input_name), after a GROUPS index (title → member node ids). It gives you the WIRING you would otherwise reconstruct by hand — read it FIRST to get oriented, then panel_query_graph to inspect one node ({ids:[42], fields:'detail'}) or panel_find_nodes for free-text search. Over `max_chars` it never cuts the graph short: it sheds per-node detail, or refuses with a reason — never a partial outline. Read-only.",
@@ -21866,10 +21923,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           .describe("If true, apply the widget/flag plan without queueing a proof panel_run."),
       },
       async (args: A, ctx) => {
+        const target = capturePanelKitchenTarget(ctx);
+        if (!target) {
+          return fail(
+            "panel_kitchen refused: the process target could not be tied to this panel tab's exact ComfyUI target and generation. Keep one target selected, then retry.",
+          );
+        }
         const status = await gatherKitchenStatus();
+        if (!panelKitchenTargetStillCurrent(ctx, target)) {
+          return fail(
+            "panel_kitchen refused: the ComfyUI target changed while status was being assessed. No recommendation was applied; retry after the target settles.",
+          );
+        }
         if (args.action === "status") {
           const hint = kitchenProactiveHint(status, assessKitchen(status, {}));
-          return ok(hint ? { status, hint } : { status });
+          return ok(hint ? { status, hint, target_fence: target.fence } : { status, target_fence: target.fence });
         }
         const query = await ctx.call({
           cmd: "graph_query",
@@ -21879,6 +21947,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           max_chars: 60000,
         });
         if (query.isError) return query;
+        if (!panelKitchenTargetStillCurrent(ctx, target)) {
+          return fail(
+            "panel_kitchen refused: the ComfyUI target changed while the live graph was being read. No recommendation was applied; retry after the target settles.",
+          );
+        }
         const graph = normalizeGraphQueryResult(query);
         if (graph.truncated === true) {
           const truncationCause =
@@ -21894,12 +21967,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           );
         }
         const recs = await assessKitchenGraph(status, graph);
+        if (!panelKitchenTargetStillCurrent(ctx, target)) {
+          return fail(
+            "panel_kitchen refused: the ComfyUI target changed during assessment. No recommendation was applied; retry after the target settles.",
+          );
+        }
         if (args.action === "assess") {
           const hint = kitchenProactiveHint(status, recs);
           return ok({
             status,
             loaders: extractLoaders(graph),
             recommendations: recs,
+            target_fence: target.fence,
             ...(hint ? { hint } : {}),
           });
         }
@@ -21921,9 +22000,20 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           applyFlag:
             rec.change.type === "flag"
               ? async (flag): Promise<KitchenFlagApplyOutcome> => {
+                  if (!panelKitchenTargetStillCurrent(ctx, target)) {
+                    return {
+                      applied: false,
+                      note:
+                        `Refusing to apply ${flag}: the ComfyUI target changed after assessment. ` +
+                        "No launch argument was changed and no restart was attempted.",
+                    };
+                  }
                   let restart: Awaited<ReturnType<typeof restartComfyUI>>;
                   try {
-                    restart = await restartComfyUI({ additionalFlags: [flag] });
+                    restart = await restartComfyUI({
+                      additionalFlags: [flag],
+                      targetFence: target.fence,
+                    });
                   } catch (err) {
                     return {
                       applied: false,
@@ -21933,18 +22023,23 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                     };
                   }
                   const flagObserved = restart.serving_argv?.includes(flag) === true;
+                  const targetProven =
+                    restart.target_stable !== false &&
+                    targetFencesEqual(restart.target_fence, target.fence) &&
+                    panelKitchenTargetStillCurrent(ctx, target);
                   const applied =
                     restart.started === true &&
                     restart.startup === "confirmed" &&
                     restart.listener_ownership === "ours" &&
-                    flagObserved;
+                    flagObserved &&
+                    targetProven;
                   return {
                     applied,
                     note: applied
                       ? `Applied ${flag} through the proven local relaunch and observed it in the serving ComfyUI argv. The augmented launch recipe is retained for later managed starts.`
                       :
                         `Did not confirm ${flag} in effect: ${restart.message} ` +
-                        "panel_kitchen reports applied:false because the relaunch and the new serving argv were not both proven.",
+                        "panel_kitchen reports applied:false because the relaunch, target fence, and new serving argv were not all proven.",
                     restart,
                   };
                 }
@@ -21972,10 +22067,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 }
               : undefined,
         });
-        if (result.applied && args.skip_proof !== true && rec.change.type !== "flag") {
-          const run = await ctx.call({ cmd: "graph_run" });
+        if (!panelKitchenTargetStillCurrent(ctx, target)) {
           return ok({
             ...result,
+            applied: false,
+            target_fence: target.fence,
+            flag_note:
+              (result.flag_note ? `${result.flag_note} ` : "") +
+              "panel_kitchen reports applied:false because the ComfyUI target changed before the result was returned.",
+          });
+        }
+        const fencedResult = { ...result, target_fence: target.fence };
+        if (fencedResult.applied && args.skip_proof !== true && rec.change.type !== "flag") {
+          const run = await ctx.call({ cmd: "graph_run" });
+          return ok({
+            ...fencedResult,
             proof: {
               ...result.proof,
               status: "queued",
@@ -21986,7 +22092,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             run: parseToolResultJson(run),
           });
         }
-        return ok(result);
+        return ok(fencedResult);
       },
     ),
     def(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -151,6 +151,7 @@ import {
   extractLoaders,
   gatherKitchenStatus,
   kitchenProactiveHint,
+  type KitchenFlagApplyOutcome,
 } from "../services/kitchen.js";
 
 /**
@@ -21846,7 +21847,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       "See what comfy-kitchen can do on this GPU against the OPEN canvas, find where the live graph leaves it on the table, and apply the faster path. Same actions as the core `kitchen` tool, fenced like every other panel mutation. Driven by `action`:\n" +
         '- action:"status" — kitchen version, backends (hip/cuda/triton/eager), INT8 attention, GPU fp8/NVFP4/MXFP8, launch flags. Remote sessions report the import probe and model.quant as unknown.\n' +
         '- action:"assess" — walk the live graph\'s UNETLoaders. A recommendation fires only when every fact it needs is known (fp8_e4m3fn_fast widget; --use-ck-attention flag; NVFP4 swap; ROCm --enable-triton-backend).\n' +
-        '- action:"apply" — apply one recommendation_id. Widget edits go through graph_set_widget (Ctrl+Z). Flags need confirm:true; restart_comfyui / panel_restart_comfyui replay argv and do not inject flags. skip_proof:true skips the follow-up panel_run. A black or slower after-run reverts the widget.',
+        '- action:"apply" — apply one recommendation_id. Widget edits go through graph_set_widget (Ctrl+Z). Flags need confirm:true; directly managed local Python installs get a proven relaunch with the flag appended and retained for later managed starts, while Desktop/remote/external launchers receive an actionable refusal without being stopped or edited. skip_proof:true skips the follow-up panel_run. A black or slower after-run reverts the widget.',
       {
         action: z
           .enum(["status", "assess", "apply"])
@@ -21917,6 +21918,37 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const result = await applyKitchenRecommendation({
           rec,
           confirm: args.confirm === true,
+          applyFlag:
+            rec.change.type === "flag"
+              ? async (flag): Promise<KitchenFlagApplyOutcome> => {
+                  let restart: Awaited<ReturnType<typeof restartComfyUI>>;
+                  try {
+                    restart = await restartComfyUI({ additionalFlags: [flag] });
+                  } catch (err) {
+                    return {
+                      applied: false,
+                      note:
+                        `Could not apply ${flag}: ${err instanceof Error ? err.message : String(err)} ` +
+                        "No launch argument was changed; verify the launcher and current ComfyUI argv before retrying.",
+                    };
+                  }
+                  const flagObserved = restart.serving_argv?.includes(flag) === true;
+                  const applied =
+                    restart.started === true &&
+                    restart.startup === "confirmed" &&
+                    restart.listener_ownership === "ours" &&
+                    flagObserved;
+                  return {
+                    applied,
+                    note: applied
+                      ? `Applied ${flag} through the proven local relaunch and observed it in the serving ComfyUI argv. The augmented launch recipe is retained for later managed starts.`
+                      :
+                        `Did not confirm ${flag} in effect: ${restart.message} ` +
+                        "panel_kitchen reports applied:false because the relaunch and the new serving argv were not both proven.",
+                    restart,
+                  };
+                }
+              : undefined,
           applyWidget:
             rec.change.type === "widget" || rec.change.type === "model_swap"
               ? async (nodeId, widget, value) => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11729,11 +11729,15 @@ export interface ConfirmOptions {
 export interface PanelToolCtx {
   /** Forward a command to the panel and wrap the reply as a tool result. An
    *  optional observer receives the bridge request id after the frame is written,
-   *  for commands that can later be proven only by a panel-side receipt. */
+   *  for commands that can later be proven only by a panel-side receipt. The
+   *  optional final guard is synchronous: it runs after any mutating reachability
+   *  wait and immediately before the bridge dispatch, and may throw to refuse the
+   *  write. It must not await. */
   call: (
     cmd: Record<string, unknown>,
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
+    beforeDispatch?: () => void,
   ) => Promise<ToolResult>;
   /** Human-in-the-loop yes/no confirm card. Tri-state (#360): "yes" on an explicit
    *  affirmative, "no" on a decline / no-panel / transport error, "timeout" when the
@@ -12089,6 +12093,7 @@ export function makePanelToolCtx(
     cmd: Record<string, unknown>,
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
+    beforeDispatch?: () => void,
     // #1560 — reports the error each attempt failed on, so the wrapper below can
     // stamp the bridge's structural marks onto the ToolResult from ONE place. The
     // catch has more than a dozen `fail(...)` exits, each shaping its own message;
@@ -12130,6 +12135,10 @@ export function makePanelToolCtx(
       // so they are dispatched on the bounded budget above instead.
       const blocked = graphCmdBlockedByRunningPrompt(cmd);
       if (blocked) return fail(blocked);
+      // A caller may hold a target/generation fence across the reachability wait.
+      // Run it synchronously in the final gap before sendRouted: an async check here
+      // would reopen the exact retarget window this guard closes.
+      beforeDispatch?.();
       const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid));
       // panel#1097 — a guard-domain command that SUCCEEDS is the evidence that the
       // switch is over, whichever attempt lands it. Without this an ordinary
@@ -12214,6 +12223,7 @@ export function makePanelToolCtx(
           await awaitReachable();
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
+          beforeDispatch?.();
           const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
           // Cleared HERE and nowhere else, and only when the failure this retried
           // was a SWITCH refusal. Clearing on every routed success let an unguarded
@@ -13046,9 +13056,10 @@ export function makePanelToolCtx(
     cmd: Record<string, unknown>,
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
+    beforeDispatch?: () => void,
   ): Promise<ToolResult> => {
     let failure: unknown;
-    const res = await callOnce(cmd, timeoutMs, onDispatchedRid, (err) => {
+    const res = await callOnce(cmd, timeoutMs, onDispatchedRid, beforeDispatch, (err) => {
       failure = err;
     });
     return carryWorkflowListReadinessMark(
@@ -14976,6 +14987,7 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
         cmd: Record<string, unknown>,
         timeoutMs?: number,
         onDispatchedRid?: (rid: string) => void,
+        beforeDispatch?: () => void,
       ) =>
         ctx.call(
           // Ask the RETRY MAP's question, not the workflow fence's (codex gate).
@@ -14996,6 +15008,7 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
             : cmd,
           timeoutMs,
           onDispatchedRid,
+          beforeDispatch,
         );
       const out = await d.handler(args, wrapped);
       // Drained AFTER the handler, deliberately, for two measured reasons.
@@ -21994,12 +22007,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             `No recommendation "${args.recommendation_id}" on the live graph. Call panel_kitchen action:"assess" first. Known: ${recs.map((r) => r.id).join(", ") || "(none)"}`,
           );
         }
-        const result = await applyKitchenRecommendation({
-          rec,
-          confirm: args.confirm === true,
-          applyFlag:
-            rec.change.type === "flag"
-              ? async (flag): Promise<KitchenFlagApplyOutcome> => {
+        let result: Awaited<ReturnType<typeof applyKitchenRecommendation>>;
+        try {
+          result = await applyKitchenRecommendation({
+            rec,
+            confirm: args.confirm === true,
+            applyFlag:
+              rec.change.type === "flag"
+                ? async (flag): Promise<KitchenFlagApplyOutcome> => {
                   if (!panelKitchenTargetStillCurrent(ctx, target)) {
                     return {
                       applied: false,
@@ -22042,35 +22057,66 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                         "panel_kitchen reports applied:false because the relaunch, target fence, and new serving argv were not all proven.",
                     restart,
                   };
-                }
-              : undefined,
-          applyWidget:
-            rec.change.type === "widget" || rec.change.type === "model_swap"
-              ? async (nodeId, widget, value) => {
+                  }
+                : undefined,
+            applyWidget:
+              rec.change.type === "widget" || rec.change.type === "model_swap"
+                ? async (nodeId, widget, value) => {
                   const write = await ctx.call(
                     { cmd: "graph_set_widget", node_id: nodeId, widget, value },
                     OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+                    undefined,
+                    () => {
+                      if (!panelKitchenTargetStillCurrent(ctx, target)) {
+                        throw new Error(
+                          "Refusing graph_set_widget: the ComfyUI target changed after the reachability wait. No widget mutation was dispatched.",
+                        );
+                      }
+                    },
                   );
                   if (write.isError) {
                     throw new Error(write.content.map((c) => ("text" in c ? c.text : "")).join("\n"));
                   }
                   return parseToolResultJson(write);
-                }
-              : undefined,
-          revertWidget:
-            rec.change.type === "widget" || rec.change.type === "model_swap"
-              ? async (nodeId, widget, value) => {
-                  await ctx.call(
+                  }
+                : undefined,
+            revertWidget:
+              rec.change.type === "widget" || rec.change.type === "model_swap"
+                ? async (nodeId, widget, value) => {
+                  const revert = await ctx.call(
                     { cmd: "graph_set_widget", node_id: nodeId, widget, value },
                     OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+                    undefined,
+                    () => {
+                      if (!panelKitchenTargetStillCurrent(ctx, target)) {
+                        throw new Error(
+                          "Refusing graph_set_widget revert: the ComfyUI target changed after the reachability wait. No widget mutation was dispatched.",
+                        );
+                      }
+                    },
                   );
-                }
-              : undefined,
-        });
+                  if (revert.isError) {
+                    throw new Error(revert.content.map((c) => ("text" in c ? c.text : "")).join("\n"));
+                  }
+                  }
+                : undefined,
+          });
+        } catch (err) {
+          result = {
+            applied: false,
+            recommendation: rec,
+            proof: { status: "failed" },
+            flag_note:
+              `Could not apply the recommendation: ${err instanceof Error ? err.message : String(err)} ` +
+              "No further widget mutation was dispatched and the launch outcome is not confirmed.",
+          };
+        }
         if (!panelKitchenTargetStillCurrent(ctx, target)) {
           return ok({
             ...result,
             applied: false,
+            stale: true,
+            target_stable: false,
             target_fence: target.fence,
             flag_note:
               (result.flag_note ? `${result.flag_note} ` : "") +
@@ -22080,6 +22126,26 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const fencedResult = { ...result, target_fence: target.fence };
         if (fencedResult.applied && args.skip_proof !== true && rec.change.type !== "flag") {
           const run = await ctx.call({ cmd: "graph_run" });
+          if (!panelKitchenTargetStillCurrent(ctx, target)) {
+            return ok({
+              ...fencedResult,
+              applied: false,
+              stale: true,
+              target_stable: false,
+              proof: {
+                ...fencedResult.proof,
+                status: "stale",
+                summary:
+                  (fencedResult.proof.summary ? `${fencedResult.proof.summary}; ` : "") +
+                  "graph_run was dispatched for the previously fenced target, but the target changed before its result was returned; no success is claimed for the current target.",
+              },
+              run: parseToolResultJson(run),
+              flag_note:
+                "panel_kitchen reports applied:false/stale because the ComfyUI target changed while the proof graph_run was in flight.",
+              target_note:
+                "panel_kitchen reports applied:false/stale because the ComfyUI target changed while the proof graph_run was in flight.",
+            });
+          }
           return ok({
             ...fencedResult,
             proof: {

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -142,7 +142,7 @@ export interface KitchenApplyResult {
   revert_reason?: string;
   recommendation: KitchenRecommendation;
   proof: {
-    status: "proven" | "not_run" | "queued" | "reverted" | "failed";
+    status: "proven" | "not_run" | "queued" | "reverted" | "failed" | "stale";
     before?: ProofSample;
     after?: ProofSample;
     summary?: string;

--- a/src/services/kitchen.ts
+++ b/src/services/kitchen.ts
@@ -148,7 +148,14 @@ export interface KitchenApplyResult {
     summary?: string;
   };
   flag_note?: string;
+  restart?: unknown;
   previous?: unknown;
+}
+
+export interface KitchenFlagApplyOutcome {
+  applied: boolean;
+  note: string;
+  restart?: unknown;
 }
 
 export interface KitchenLogParse {
@@ -1005,6 +1012,7 @@ export function formatProofSummary(before: ProofSample, after: ProofSample, rec:
 export async function applyKitchenRecommendation(opts: {
   rec: KitchenRecommendation;
   confirm?: boolean;
+  applyFlag?: (flag: string) => Promise<KitchenFlagApplyOutcome>;
   applyWidget?: (nodeId: string, widget: string, value: string) => Promise<unknown>;
   revertWidget?: (nodeId: string, widget: string, value: string) => Promise<unknown>;
   runProof?: (phase: "before" | "after") => Promise<ProofSample>;
@@ -1021,14 +1029,45 @@ export async function applyKitchenRecommendation(opts: {
   }
 
   if (rec.change.type === "flag") {
-    // restart_comfyui replays the previous argv; this process does not inject flags.
+    const flag = rec.change.flag;
+    if (!flag) {
+      return {
+        applied: false,
+        recommendation: rec,
+        proof: { status: "failed" },
+        flag_note: "This flag recommendation is malformed: it has no launch flag.",
+      };
+    }
+    if (opts.applyFlag) {
+      try {
+        const outcome = await opts.applyFlag(flag);
+        return {
+          applied: outcome.applied,
+          recommendation: rec,
+          proof: { status: "not_run" },
+          flag_note: outcome.note,
+          restart: outcome.restart,
+        };
+      } catch (err) {
+        return {
+          applied: false,
+          recommendation: rec,
+          proof: { status: "failed" },
+          flag_note:
+            `Could not apply ${flag}: ${err instanceof Error ? err.message : String(err)} ` +
+            "The launch outcome is not confirmed; verify ComfyUI's current launch arguments before retrying.",
+        };
+      }
+    }
+    // restart_comfyui replays the previous argv; without a bound flag mutator this
+    // process does not inject flags and must not claim that it did.
     return {
       applied: false,
       needs_confirm: false,
       recommendation: rec,
       proof: { status: "not_run" },
       flag_note:
-        `Add ${rec.change.flag} to the ComfyUI launch line, then restart_comfyui / panel_restart_comfyui. ` +
+        `Add ${flag} to the ComfyUI launch line, then restart_comfyui / panel_restart_comfyui. ` +
         `Those tools replay the previous argv and do not compose a new one — applying the flag here would claim a restart that did not change argv.`,
     };
   }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -89,10 +89,21 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+export interface ComfyUITargetFence {
+  /** The exact configured ComfyUI base, including any reverse-proxy path. */
+  baseUrl: string;
+  /** Monotonic target generation; catches A→B→A round trips. */
+  generation: number;
+  /** The local install selected for this target, when process control can see one. */
+  comfyuiPath?: string;
+}
+
 interface ProcessInfo {
   pid: number;
   port: number;
   argv: string[];
+  /** Target identity captured with this process recipe; never reuse it after retarget. */
+  targetFence?: ComfyUITargetFence;
   /**
    * The port owner's argv as the OS reports it, captured when the SERVER could not
    * report its own (#767).
@@ -288,6 +299,10 @@ interface StartResult {
   launch_env?: LaunchEnvInfo;
   /** The server argv observed after a relaunch, when the endpoint answered. */
   serving_argv?: string[];
+  /** Target identity this start was fenced to, when available. */
+  target_fence?: ComfyUITargetFence;
+  /** False when the target changed during the start and no success claim is safe. */
+  target_stable?: boolean;
   /**
    * Whether the process now listening on the port is the one WE launched.
    *
@@ -321,6 +336,10 @@ interface RestartResult {
   launch_env?: LaunchEnvInfo;
   /** The server argv observed after a relaunch, when the endpoint answered. */
   serving_argv?: string[];
+  /** Target identity this restart was fenced to, when available. */
+  target_fence?: ComfyUITargetFence;
+  /** False when the target changed during the restart and no success claim is safe. */
+  target_stable?: boolean;
   /**
    * Whether the process now listening on the port is the one WE launched.
    *
@@ -338,6 +357,37 @@ interface RestartResult {
 export interface RestartComfyUIOptions {
   /** Boolean ComfyUI launch flags to append to a proven local relaunch. */
   additionalFlags?: readonly string[];
+  /** Exact target identity the caller assessed and authorized for this restart. */
+  targetFence?: ComfyUITargetFence;
+}
+
+function currentTargetFence(): ComfyUITargetFence {
+  return {
+    baseUrl: getComfyUIBaseUrl().replace(/\/+$/, ""),
+    generation: getComfyuiTargetGeneration(),
+    comfyuiPath: config.comfyuiPath,
+  };
+}
+
+export function captureComfyUITargetFence(): ComfyUITargetFence {
+  return currentTargetFence();
+}
+
+export function targetFencesEqual(
+  a: ComfyUITargetFence | undefined,
+  b: ComfyUITargetFence | undefined,
+): boolean {
+  return (
+    a != null &&
+    b != null &&
+    a.baseUrl.replace(/\/+$/, "") === b.baseUrl.replace(/\/+$/, "") &&
+    a.generation === b.generation &&
+    a.comfyuiPath === b.comfyuiPath
+  );
+}
+
+export function targetFenceMatchesCurrent(fence: ComfyUITargetFence): boolean {
+  return targetFencesEqual(fence, currentTargetFence());
 }
 
 interface StartupReadinessResult {
@@ -1820,12 +1870,48 @@ function withAdditionalLaunchFlags(info: ProcessInfo, flags: string[]): ProcessI
 }
 
 function launchFlagMutationRefusal(flag: string, reason: string): RestartResult {
+  const targetFence = currentTargetFence();
   return {
     stopped: false,
     started: false,
     startup: "not-attempted",
     message:
       `Refusing to apply ${flag}: ${reason} No launch argument was changed and ComfyUI was not stopped.`,
+    target_fence: targetFence,
+    target_stable: true,
+    listener_ownership: unclassifiedOwnership(),
+  };
+}
+
+function startTargetFenceRefusal(fence: ComfyUITargetFence, reason: string): StartResult {
+  return {
+    started: false,
+    startup: "not-attempted",
+    message:
+      `Refusing to start ComfyUI: ${reason} No process was spawned and the saved launch recipe was not consumed.`,
+    target_fence: fence,
+    target_stable: false,
+    listener_ownership: unclassifiedOwnership(),
+  };
+}
+
+function restartTargetFenceRefusal(
+  fence: ComfyUITargetFence,
+  reason: string,
+  stopped = false,
+  restartHint?: RecoveryHint,
+): RestartResult {
+  return {
+    stopped,
+    started: false,
+    startup: "not-attempted",
+    message:
+      stopped
+        ? `Refusing to restart ComfyUI: ${reason} The old process was stopped, but no launch recipe was consumed for the changed target.`
+        : `Refusing to restart ComfyUI: ${reason} Nothing was stopped and no launch recipe was consumed for the changed target.`,
+    restart_hint: restartHint,
+    target_fence: fence,
+    target_stable: false,
     listener_ownership: unclassifiedOwnership(),
   };
 }
@@ -3182,6 +3268,7 @@ async function acquireProcessInfo(): Promise<{
           pid: desktopPids[0],
           port: config.resolvedPort,
           argv: [],
+          targetFence: currentTargetFence(),
           isDesktopApp: true,
           desktopExePath: findDesktopExeFromCommonPaths(),
           // FOUND BY NAME, NOT BY PORT — nothing ties this shell to the server on
@@ -3439,6 +3526,7 @@ function recoverDesktopProcessFromAncestry(
 
 async function gatherProcessInfo(): Promise<ProcessInfo> {
   const port = config.resolvedPort;
+  const targetFence = currentTargetFence();
 
   // 1. Get argv from /system_stats, BRACKETED by port-owner lookups.
   //
@@ -3604,7 +3692,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     // independently verified, so the ordinary fail-closed error remains intact.
     if (argv.length > 0) {
       const recovered = recoverDesktopProcessFromAncestry(port, argv);
-      if (recovered) return recovered;
+      if (recovered) return { ...recovered, targetFence };
     }
     // Liveness is the reachable SERVER, not only a local PID scan. If
     // /system_stats just answered (argv populated) yet we still can't map the
@@ -3769,6 +3857,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     liveCwd,
     liveEnv,
     startedAt,
+    targetFence,
   };
 }
 
@@ -3838,6 +3927,20 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
         "configured for — and restart_comfyui (action:\"start\") afterwards would consult the NEW target, which may " +
         "not bring this one back. Nothing was killed. Let the target settle, then retry." +
         describeRecovery(retargetHint),
+      has_restart_info: false,
+      restart_hint: retargetHint,
+    };
+  }
+
+  const currentFence = currentTargetFence();
+  if (!info.targetFence || !targetFencesEqual(info.targetFence, currentFence)) {
+    const retargetHint = recoveryHint(info);
+    return {
+      stopped: false,
+      message:
+        "Refusing to stop: the running process is not bound to the exact current ComfyUI target, " +
+        "so killing it could stop another tab's instance and leave its launch recipe stale. " +
+        "Nothing was killed. Let the target settle, then retry.",
       has_restart_info: false,
       restart_hint: retargetHint,
     };
@@ -4071,7 +4174,36 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
 export async function startComfyUI(anchor?: {
   port?: number;
   probeUrl?: string;
+  targetFence?: ComfyUITargetFence;
 }): Promise<StartResult> {
+  const savedInfo = lastProcessInfo;
+  const targetFence = anchor?.targetFence ?? savedInfo?.targetFence ?? currentTargetFence();
+  if (anchor?.targetFence && !targetFenceMatchesCurrent(anchor.targetFence)) {
+    return startTargetFenceRefusal(
+      anchor.targetFence,
+      "the requested target changed before the anchored start began",
+    );
+  }
+  if (savedInfo && !savedInfo.targetFence) {
+    lastProcessInfo = null;
+    return startTargetFenceRefusal(
+      targetFence,
+      "the saved launch recipe has no target identity and cannot be proven to belong to the current instance",
+    );
+  }
+  if (savedInfo?.targetFence && !targetFenceMatchesCurrent(savedInfo.targetFence)) {
+    lastProcessInfo = null;
+    return startTargetFenceRefusal(
+      savedInfo.targetFence,
+      "the saved launch recipe belongs to an older ComfyUI target",
+    );
+  }
+  if (anchor?.targetFence && savedInfo?.targetFence && !targetFencesEqual(anchor.targetFence, savedInfo.targetFence)) {
+    return startTargetFenceRefusal(
+      anchor.targetFence,
+      "the anchored target does not match the saved launch recipe",
+    );
+  }
   // The refusal is for a DIRECT `restart_comfyui (action:"start")`, which has no instance in mind
   // and would otherwise launch a local server while the caller is looking at a
   // remote one. An ANCHORED call is a different question: a restart already
@@ -4115,7 +4247,7 @@ export async function startComfyUI(anchor?: {
     );
   }
 
-  let info = lastProcessInfo;
+  let info = savedInfo;
   if (!info) {
     // No saved info — try to detect and launch the Desktop app
     const desktopExe = findDesktopExeFromCommonPaths();
@@ -4127,6 +4259,7 @@ export async function startComfyUI(anchor?: {
         argv: [],
         isDesktopApp: true,
         desktopExePath: desktopExe,
+        targetFence,
       };
     } else {
       return {
@@ -4137,6 +4270,13 @@ export async function startComfyUI(anchor?: {
         listener_ownership: unclassifiedOwnership(),
       };
     }
+  }
+
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return startTargetFenceRefusal(
+      targetFence,
+      "the target changed while the launch recipe was being prepared",
+    );
   }
 
   logger.info("Starting ComfyUI...", {
@@ -4208,6 +4348,22 @@ export async function startComfyUI(anchor?: {
     ).then((readiness) => ({ readiness })),
     spawnError.then((error) => ({ spawn_error: error })),
   ]);
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return {
+      started: false,
+      ready: "readiness" in startupResult ? startupResult.readiness.ready : false,
+      startup: "unconfirmed",
+      readiness: "readiness" in startupResult ? startupResult.readiness : undefined,
+      message:
+        `The ComfyUI target changed while the anchored launch was starting at ${targetFence.baseUrl}. ` +
+        "The target-specific launch result is unconfirmed; no success is claimed for the new target.",
+      target_fence: targetFence,
+      target_stable: false,
+      auto_restart: supervisorResult(info),
+      launch_env: launchEnvInfo(info),
+      listener_ownership: unclassifiedOwnership(),
+    };
+  }
   if ("spawn_error" in startupResult) {
     return {
       started: false,
@@ -4373,9 +4529,36 @@ export async function startComfyUI(anchor?: {
   // port-owner lookup from getting a permanent "cannot tell".
   let servingArgv: string[] | undefined;
   try {
-    servingArgv = (await getSystemStats()).system.argv ?? undefined;
+    if (anchor?.targetFence) {
+      servingArgv = await readServingArgvAtBase(targetFence.baseUrl);
+      // Keep the proof anchored in production, but tolerate test/legacy clients
+      // that expose system_stats only through the configured client. This fallback
+      // is allowed only while the exact target fence is still current; the final
+      // fence check below rejects any concurrent retarget.
+      if (!servingArgv && targetFenceMatchesCurrent(targetFence)) {
+        servingArgv = await readServingArgv();
+      }
+    } else {
+      servingArgv = (await getSystemStats()).system.argv ?? undefined;
+    }
   } catch {
     servingArgv = undefined;
+  }
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return {
+      started: false,
+      ready: true,
+      startup: "unconfirmed",
+      readiness,
+      message:
+        `The ComfyUI target changed after the anchored launch at ${targetFence.baseUrl} became healthy. ` +
+        "The serving argv was not attributed to the new target, so no success is claimed.",
+      target_fence: targetFence,
+      target_stable: false,
+      auto_restart: supervisorResult(info),
+      launch_env: env,
+      listener_ownership: unclassifiedOwnership(),
+    };
   }
   // Is the healthy listener actually OURS?
   //   • A Desktop launch is UNDECIDABLE by design: we spawn the Electron shell (or
@@ -4487,6 +4670,8 @@ export async function startComfyUI(anchor?: {
     auto_restart: supervisorResult(info),
     launch_env: env,
     serving_argv: servingArgv,
+    target_fence: targetFence,
+    target_stable: true,
     listener_ownership: ownership,
   };
 }
@@ -5415,6 +5600,13 @@ async function restartViaConfiguredCommand(command: string): Promise<RestartResu
 export async function restartComfyUI(
   options: RestartComfyUIOptions = {},
 ): Promise<RestartResult> {
+  const targetFence = options.targetFence ?? currentTargetFence();
+  if (options.targetFence && !targetFenceMatchesCurrent(options.targetFence)) {
+    return restartTargetFenceRefusal(
+      options.targetFence,
+      "the requested target changed before the restart began",
+    );
+  }
   const normalizedFlags = normalizeAdditionalLaunchFlags(options.additionalFlags);
   if (normalizedFlags.error) {
     return launchFlagMutationRefusal("the requested launch flag", normalizedFlags.error);
@@ -5453,6 +5645,12 @@ export async function restartComfyUI(
   // corroborate the same explicit backend argv, use Manager against that backend
   // and keep the ordinary process-ownership refusal for every other shape.
   const verifiedProxy = await resolveVerifiedProxyRestartTarget();
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed while restart ownership was being resolved",
+    );
+  }
   if (verifiedProxy) {
     if (additionalFlags.length > 0) {
       return launchFlagMutationRefusal(
@@ -5473,7 +5671,7 @@ export async function restartComfyUI(
   // that resolution observes can be fenced to the instance it was actually read
   // from. It travels with the argv into the Desktop reboot below; capturing it
   // there instead would leave the read itself outside the fence (codex gate r2).
-  const infoGeneration = getComfyuiTargetGeneration();
+  const infoGeneration = targetFence.generation;
   // …and the ADDRESS of the instance this call is about, captured at the same
   // moment. The stop, the port-free wait and the settle delay are all awaits, and
   // the configured target is mutable across every one of them, so the relaunch is
@@ -5481,7 +5679,7 @@ export async function restartComfyUI(
   // (codex gate round 12 — otherwise the relaunch probes the NEW target's port,
   // finds it occupied, returns "already running", and the instance we killed stays
   // dead).
-  const restartProbeUrl = `${getComfyUIBaseUrl()}/system_stats`;
+  const restartProbeUrl = `${targetFence.baseUrl}/system_stats`;
 
   // Preflight: resolve the RUNNING instance and confirm we can relaunch it
   // BEFORE stopping anything. A restart must be atomic-ish — if the relaunch
@@ -5501,6 +5699,22 @@ export async function restartComfyUI(
       listener_ownership: unclassifiedOwnership(),
     };
   }
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed while the running instance was being identified",
+      false,
+      recoveryHint(info),
+    );
+  }
+  if (!info.targetFence || !targetFencesEqual(info.targetFence, targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the running process identity is not bound to the exact target this restart was authorized for",
+      false,
+      recoveryHint(info),
+    );
+  }
   // NEVER STOP AN INSTANCE THE REST OF THIS CALL WILL NOT BE ACTING ON (codex gate
   // round 11). `acquireProcessInfo` is awaited, and the target is MUTABLE: a hello
   // retarget landing inside that await leaves `info` describing instance A while the
@@ -5517,19 +5731,12 @@ export async function restartComfyUI(
   // final-state comparison. REFUSE, because nothing has been stopped yet — the
   // refuse-before/disclose-after rule this whole path is built on.
   if (getComfyuiTargetGeneration() !== infoGeneration) {
-    return {
-      stopped: false,
-      started: false,
-      startup: "not-attempted",
-      restart_hint: recoveryHint(info),
-      message:
-        "Refusing to restart: the ComfyUI target changed while the running instance was " +
-        "being identified, so the instance that was checked is not provably the one this " +
-        "restart would act on — and a stop is never sent to an instance whose relaunch was " +
-        "not the one verified. Nothing was stopped. Let the target settle, then retry." +
-        describeRecovery(recoveryHint(info)),
-      listener_ownership: unclassifiedOwnership(),
-    };
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed while the running instance was being identified",
+      false,
+      recoveryHint(info),
+    );
   }
   const launchInfo = withAdditionalLaunchFlags(info, additionalFlags);
   if (additionalFlags.length > 0) {
@@ -5636,13 +5843,28 @@ export async function restartComfyUI(
       listener_ownership: unclassifiedOwnership(),
     };
   }
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed after the old instance stopped; the old launch recipe was not replayed",
+      true,
+    );
+  }
   // #742 r4/r5: the stop DID happen — record the dispatch. No session identity
   // exists here, so stamp the shared PROCESS-WIDE slot (never grounds causation
   // on its own; a panel caller stamps its own session token from the result).
-  recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
+  recordRestartDispatch(targetFence.baseUrl, PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   // Brief pause to let OS fully release resources
   await sleep(1000);
+
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed after the old instance stopped; the old launch recipe was not replayed",
+      true,
+    );
+  }
 
   // `stopComfyUI` records the observed recipe before killing. Replace that
   // record only after the stop committed, so a failed pre-stop safety check or
@@ -5669,6 +5891,7 @@ export async function restartComfyUI(
     startResult = await startComfyUI({
       port: info.port,
       probeUrl: restartProbeUrl,
+      targetFence,
     });
   } catch (err) {
     // DISCLOSE, do not refuse: the stop is not undoable, so the caller needs a
@@ -5740,6 +5963,8 @@ export async function restartComfyUI(
       auto_restart: startResult.auto_restart,
       launch_env: startResult.launch_env,
       serving_argv: startResult.serving_argv,
+      target_fence: targetFence,
+      target_stable: startResult.target_stable,
       listener_ownership: startResult.listener_ownership,
     };
   }
@@ -5769,12 +5994,21 @@ export async function restartComfyUI(
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
       serving_argv: startResult.serving_argv,
+      target_fence: targetFence,
+      target_stable: startResult.target_stable,
       listener_ownership: startResult.listener_ownership,
     };
   }
 
   // #742 r4/r5: the restart was observed back — clear OUR record (the
   // process-wide slot only; never another session's record).
+  if (!targetFenceMatchesCurrent(targetFence)) {
+    return restartTargetFenceRefusal(
+      targetFence,
+      "the ComfyUI target changed after the relaunch completed; its serving argv was not attributed to the new target",
+      true,
+    );
+  }
   clearRestartDispatch(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   return {
@@ -5802,6 +6036,8 @@ export async function restartComfyUI(
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
     serving_argv: startResult.serving_argv,
+    target_fence: targetFence,
+    target_stable: startResult.target_stable ?? true,
     listener_ownership: startResult.listener_ownership,
   };
 }
@@ -6113,7 +6349,10 @@ export const __processControlTestHooks = {
     liveCwdResolverOverride = fn;
   },
   setLastProcessInfo(info: ProcessInfo): void {
-    lastProcessInfo = info;
+    lastProcessInfo = {
+      ...info,
+      targetFence: info.targetFence ?? currentTargetFence(),
+    };
   },
   /** Seed/remove a #742 r4/r5 restart-dispatch record directly (fresh/stale/
    *  foreign base) so decline-path causation tests don't run a real restart. */

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -286,6 +286,8 @@ interface StartResult {
   spawn_error?: ChildProcessErrorDetails;
   /** How the relaunch environment was resolved (#776). */
   launch_env?: LaunchEnvInfo;
+  /** The server argv observed after a relaunch, when the endpoint answered. */
+  serving_argv?: string[];
   /**
    * Whether the process now listening on the port is the one WE launched.
    *
@@ -317,6 +319,8 @@ interface RestartResult {
   spawn_error?: ChildProcessErrorDetails;
   /** How the relaunch environment was resolved (#776). */
   launch_env?: LaunchEnvInfo;
+  /** The server argv observed after a relaunch, when the endpoint answered. */
+  serving_argv?: string[];
   /**
    * Whether the process now listening on the port is the one WE launched.
    *
@@ -329,6 +333,11 @@ interface RestartResult {
    * it explicitly.
    */
   listener_ownership: ListenerOwnership;
+}
+
+export interface RestartComfyUIOptions {
+  /** Boolean ComfyUI launch flags to append to a proven local relaunch. */
+  additionalFlags?: readonly string[];
 }
 
 interface StartupReadinessResult {
@@ -1770,6 +1779,55 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   // above: that exe is a launcher, not an interpreter.)
   if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
   return { child, launchArgv: [cmd.exe, ...cmd.args], launchLogPath: launchLog?.path };
+}
+
+const ADDITIONAL_LAUNCH_FLAG = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
+
+function normalizeAdditionalLaunchFlags(
+  flags: readonly string[] | undefined,
+): { flags: string[]; error?: string } {
+  if (flags === undefined) return { flags: [] };
+  if (!Array.isArray(flags)) return { flags: [], error: "the additional launch flags were not an array" };
+  const unique: string[] = [];
+  for (const flag of flags) {
+    if (typeof flag !== "string" || !ADDITIONAL_LAUNCH_FLAG.test(flag)) {
+      return {
+        flags: [],
+        error: `the additional launch flag ${JSON.stringify(flag)} is not a boolean --flag`,
+      };
+    }
+    if (!unique.includes(flag)) unique.push(flag);
+  }
+  return { flags: unique };
+}
+
+/**
+ * Add a flag only to the exact argv that was observed for the process being
+ * restarted. The returned record is a copy: the live-process evidence remains
+ * untouched until the stop has committed, and the augmented record then becomes
+ * the persisted in-process relaunch recipe for manual/automatic future starts.
+ */
+function withAdditionalLaunchFlags(info: ProcessInfo, flags: string[]): ProcessInfo | null {
+  if (flags.length === 0) return info;
+  const observed =
+    info.argv.length > 0 ? info.argv : info.osArgvExact === true ? (info.osArgv ?? []) : [];
+  if (observed.length === 0) return null;
+  const argv = [...observed];
+  for (const flag of flags) {
+    if (!argv.includes(flag)) argv.push(flag);
+  }
+  return info.argv.length > 0 ? { ...info, argv } : { ...info, osArgv: argv };
+}
+
+function launchFlagMutationRefusal(flag: string, reason: string): RestartResult {
+  return {
+    stopped: false,
+    started: false,
+    startup: "not-attempted",
+    message:
+      `Refusing to apply ${flag}: ${reason} No launch argument was changed and ComfyUI was not stopped.`,
+    listener_ownership: unclassifiedOwnership(),
+  };
 }
 
 /**
@@ -4428,6 +4486,7 @@ export async function startComfyUI(anchor?: {
     pid: newPid ?? undefined,
     auto_restart: supervisorResult(info),
     launch_env: env,
+    serving_argv: servingArgv,
     listener_ownership: ownership,
   };
 }
@@ -5353,8 +5412,21 @@ async function restartViaConfiguredCommand(command: string): Promise<RestartResu
   }
 }
 
-export async function restartComfyUI(): Promise<RestartResult> {
+export async function restartComfyUI(
+  options: RestartComfyUIOptions = {},
+): Promise<RestartResult> {
+  const normalizedFlags = normalizeAdditionalLaunchFlags(options.additionalFlags);
+  if (normalizedFlags.error) {
+    return launchFlagMutationRefusal("the requested launch flag", normalizedFlags.error);
+  }
+  const additionalFlags = normalizedFlags.flags;
   if (isRemoteMode()) {
+    if (additionalFlags.length > 0) {
+      return launchFlagMutationRefusal(
+        additionalFlags.join(", "),
+        "the ComfyUI target is remote and this process does not own its launcher; add the flag to the remote launcher's configuration and restart that instance there",
+      );
+    }
     // Remote target: can't process-control it, but a Manager HTTP reboot brings
     // back a self-supervised ComfyUI (e.g. the tunnelled Desktop app).
     return restartViaManagerReboot({ label: "remote" });
@@ -5367,6 +5439,12 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // every inferred path below (including Desktop's), and it needs no live
   // process info, so it also works when the server is too wedged to answer.
   if (config.comfyuiRestartCommand) {
+    if (additionalFlags.length > 0) {
+      return launchFlagMutationRefusal(
+        additionalFlags.join(", "),
+        "COMFYUI_RESTART_COMMAND is an opaque external launcher command that this process cannot safely edit; update that launcher command/configuration to include the flag, then restart it there",
+      );
+    }
     return restartViaConfiguredCommand(config.comfyuiRestartCommand);
   }
   // EZi/CEI can serve the panel through a local helper port while the real
@@ -5376,6 +5454,12 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // and keep the ordinary process-ownership refusal for every other shape.
   const verifiedProxy = await resolveVerifiedProxyRestartTarget();
   if (verifiedProxy) {
+    if (additionalFlags.length > 0) {
+      return launchFlagMutationRefusal(
+        additionalFlags.join(", "),
+        "the ComfyUI process is behind a verified proxy and its launcher is not owned by this process; add the flag to the backend launcher's configuration and restart it there",
+      );
+    }
     return restartViaManagerReboot({
       label: "EZi/CEI-proxied",
       prior: { argv: verifiedProxy.argv, generation: verifiedProxy.generation },
@@ -5404,7 +5488,8 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // command can't be built/validated (stale COMFYUI_PATH, unknown Desktop exe),
   // refuse and leave the server up rather than take it down with no way back
   // (issues #368/#370).
-  const { info, diagnostic } = await acquireProcessInfo();
+  const acquired = await acquireProcessInfo();
+  const { info, diagnostic } = acquired;
   if (!info) {
     return {
       stopped: false,
@@ -5446,6 +5531,22 @@ export async function restartComfyUI(): Promise<RestartResult> {
       listener_ownership: unclassifiedOwnership(),
     };
   }
+  const launchInfo = withAdditionalLaunchFlags(info, additionalFlags);
+  if (additionalFlags.length > 0) {
+    if (info.isDesktopApp) {
+      return launchFlagMutationRefusal(
+        additionalFlags.join(", "),
+        "ComfyUI Desktop owns the saved launch settings and its supervised restart re-execs the existing process. Add the flag in ComfyUI Desktop's launch settings for this install, then fully quit and relaunch the Desktop app",
+      );
+    }
+    if (!launchInfo) {
+      return launchFlagMutationRefusal(
+        additionalFlags.join(", "),
+        "the running ComfyUI did not expose an exact launch argv that can be safely extended; add the flag through the launcher or console that owns this instance, then restart it there",
+      );
+    }
+  }
+  const relaunchInfo = launchInfo ?? info;
   // A locally-installed ComfyUI **Desktop** instance is Electron-supervised.
   // Killing it (Python backend or Electron shell) and re-spawning the exe does
   // not reliably bring the :PORT listener back (issue #400: stopped:true,
@@ -5497,7 +5598,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
 
   // requireReproducibleEnv: this path KILLS the process and spawns a fresh one, so
   // the launch ENVIRONMENT has to be rebuilt as well as the command (#776).
-  const relaunch = assessRelaunch(info, { requireReproducibleEnv: true });
+  const relaunch = assessRelaunch(relaunchInfo, { requireReproducibleEnv: true });
   if (!relaunch.ok) {
     return {
       stopped: false,
@@ -5542,6 +5643,12 @@ export async function restartComfyUI(): Promise<RestartResult> {
 
   // Brief pause to let OS fully release resources
   await sleep(1000);
+
+  // `stopComfyUI` records the observed recipe before killing. Replace that
+  // record only after the stop committed, so a failed pre-stop safety check or
+  // failed kill cannot silently turn a live server's current state into a new
+  // launch configuration.
+  lastProcessInfo = relaunchInfo;
 
   // A caveat from the stop must survive into whatever we report: the stop can
   // commit WITHOUT confirming the process exited (every port probe failed after
@@ -5632,6 +5739,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
         stopCaveat,
       auto_restart: startResult.auto_restart,
       launch_env: startResult.launch_env,
+      serving_argv: startResult.serving_argv,
       listener_ownership: startResult.listener_ownership,
     };
   }
@@ -5660,6 +5768,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
+      serving_argv: startResult.serving_argv,
       listener_ownership: startResult.listener_ownership,
     };
   }
@@ -5692,6 +5801,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       stopCaveat,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
+    serving_argv: startResult.serving_argv,
     listener_ownership: startResult.listener_ownership,
   };
 }


### PR DESCRIPTION
Closes #2277

Summary:
- Add a target fence (base URL, monotonic target generation, and selected local install) to panel_kitchen assessment, flag mutation, restart, serving-argv proof, and result reporting.
- Require the panel tab's server-observed local handshake to match the target; refuse path-mounted targets when the path cannot be proven instead of trusting the page-controlled tab URL.
- Bind the persistent augmented launch recipe to the captured target and refuse stale recipes or retargets before killing/spawning; anchor restart probes and serving-argv proof to the same target.
- Add a synchronous last-moment pre-dispatch fence after graph reachability waits, so panel_kitchen widget apply/revert cannot mutate a retargeted tab.
- Recheck the exact target after the optional proof graph_run; a retarget during that await returns applied:false, stale:true, target_stable:false and never claims the old proof for the new target.
- Preserve launcher-specific refusal for Desktop, remote, opaque external, and unverifiable launchers without unsafe stop/config mutation.
- Use a host-native absolute-path fixture for the production launch-flag persistence test, fixing the hosted Windows preflight refusal while retaining the safety checks.
- Add production-path success, unsupported-launcher, persistence, concurrent cross-tab/target-switch, widget-dispatch race, post-graph_run race, stale-recipe, result-fence, consent, and no-unsafe-mutation coverage.

Validation at pushed head 3685bba2ed9ff5e36498bc0a67725b8594cde00b:
- npm.cmd run build — passed.
- npm.cmd run lint — passed.
- Focused Vitest: npx.cmd vitest run src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts src/__tests__/services/kitchen.test.ts src/__tests__/services/process-control.test.ts --reporter=dot — 3 files, 97 passed.
- Panel plumbing/retry Vitest: npx.cmd vitest run src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/orchestrator/panel-retry-identity.test.ts src/__tests__/orchestrator/switch-guard-retry.test.ts src/__tests__/orchestrator/no-reachable-tab-remedy.test.ts --reporter=dot — 4 files, 458 passed.
- Full Vitest: 661 files passed, 12,222 passed, 6 skipped; 3 failures remain in untouched src/__tests__/orchestrator/node-id-union-message.test.ts due existing Zod error-shape expectations.

PR remains open; no merge performed.