### PR TITLE
fix: add panel-backed ComfyUI read fallback

### DIFF
--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const panelRead = vi.hoisted(() => vi.fn());
+const fetchApi = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    config: { ...actual.config, comfyuiBasePath: "/comfyapi", comfyuiPath: "" },
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+    getComfyUIBasePath: () => "/comfyapi",
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188/comfyapi",
+    getComfyUIAuthHeaders: () => ({ Authorization: "Bearer headless-token" }),
+    isCloudMode: () => false,
+    isRemoteMode: () => true,
+  };
+});
+
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    apiURL(path: string): string {
+      return path;
+    }
+
+    apiHeaders(init?: { headers?: unknown }): unknown {
+      return init?.headers ?? {};
+    }
+
+    async fetch(url: string, init?: unknown): Promise<unknown> {
+      return await fetchApi(url, init);
+    }
+
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+vi.mock("../../services/panel-image-relay.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/panel-image-relay.js")>(
+    "../../services/panel-image-relay.js",
+  );
+  return { ...actual, requestPanelComfyUIRead: panelRead };
+});
+
+import {
+  fetchImage,
+  getHistory,
+  getLogs,
+  getSystemStats,
+  resetClient,
+} from "../../comfyui/client.js";
+import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
+
+function transportFailure(): TypeError {
+  return new TypeError(
+    "fetch failed",
+    { cause: Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }) },
+  );
+}
+
+beforeEach(() => {
+  fetchApi.mockReset();
+  panelRead.mockReset();
+  resetClient();
+  vi.stubGlobal("fetch", vi.fn(async () => { throw transportFailure(); }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
+  it("maps history, system_stats, and logs to the panel operations and parses bodies", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation === "history") {
+        const body = '{"prompt-1":{"status":{"status_str":"success"}}}';
+        return {
+          operation,
+          body,
+          contentType: "application/json",
+          bytes: Buffer.byteLength(body, "utf8"),
+        };
+      }
+      if (operation === "logs") {
+        const body = JSON.stringify("line one\nline two");
+        return { operation, body, contentType: "text/plain", bytes: Buffer.byteLength(body, "utf8") };
+      }
+      const body = '{"system":{"os":"windows"},"devices":[]}';
+      return { operation, body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") };
+    });
+
+    await expect(getHistory()).resolves.toEqual({
+      "prompt-1": { status: { status_str: "success" } },
+    });
+    await expect(getSystemStats()).resolves.toMatchObject({ system: { os: "windows" }, devices: [] });
+    await expect(getLogs()).resolves.toEqual(["line one", "line two"]);
+    expect(panelRead.mock.calls.map(([operation]) => operation)).toEqual([
+      "history",
+      "system_stats",
+      "logs",
+    ]);
+  });
+
+  it("does not use the panel for a configured-route HTTP error, timeout, or prompt-scoped history", async () => {
+    fetchApi.mockResolvedValue(new Response("gateway down", { status: 503 }));
+    await expect(getHistory()).rejects.toThrow();
+    expect(panelRead).not.toHaveBeenCalled();
+
+    fetchApi.mockReset();
+    fetchApi.mockRejectedValue(transportFailure());
+    const timedOut = new Error("request timed out");
+    timedOut.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn(async () => { throw timedOut; }));
+    await expect(getSystemStats()).rejects.toThrow(/No reply from ComfyUI within/);
+    expect(panelRead).not.toHaveBeenCalled();
+
+    vi.stubGlobal("fetch", vi.fn(async () => { throw transportFailure(); }));
+    await expect(getHistory("prompt-1")).rejects.toThrow(/fetch failed/);
+    await expect(fetchImage("render.png")).rejects.toThrow(/fetch failed/);
+    expect(panelRead).not.toHaveBeenCalled();
+
+    fetchApi.mockReset();
+    fetchApi.mockRejectedValueOnce(new Error("HTTP 503 from the configured route"));
+    fetchApi.mockRejectedValueOnce(transportFailure());
+    await expect(getLogs()).rejects.toThrow(/ECONNREFUSED|Failed to fetch ComfyUI logs/);
+    expect(panelRead).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an authenticated panel timeout/error without retrying unrelated origins", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockRejectedValue(new PanelComfyUIReadRelayError("panel timed out", "TIMEOUT"));
+
+    await expect(getLogs()).rejects.toThrow(/read fallback failed safely \(TIMEOUT\)/);
+    expect(panelRead).toHaveBeenCalledWith("logs");
+  });
+});

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, truncateSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  PANEL_COMFYUI_READ_MAX_BYTES,
   PANEL_IMAGE_RELAY_MAX_BYTES,
   PANEL_IMAGE_RELAY_MAX_CONCURRENT,
   PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS,
@@ -17,11 +18,15 @@ import {
   PANEL_IMAGE_RELAY_RESPONSE_PREFIX,
   PANEL_IMAGE_RELAY_STALE_MS,
   makePanelImageRelayCapability,
+  makePanelComfyUIReadRelayCapability,
   processPanelImageRequests,
   requestPanelImageFromFileChannel,
   requestPanelImage,
+  requestPanelComfyUIRead,
   startPanelImageRelayServer,
   verifyPanelImageRelayCapability,
+  verifyPanelComfyUIReadRelayCapability,
+  type PanelComfyUIReadRelayRequest,
   type PanelImageRelayRequest,
 } from "../../services/panel-image-relay.js";
 
@@ -56,6 +61,21 @@ function request(id: string, patch: Partial<PanelImageRelayRequest> = {}): Panel
 
 function requestFile(dir: string, id: string): string {
   return join(dir, `${PANEL_IMAGE_RELAY_REQUEST_PREFIX}${id}.json`);
+}
+
+function readRequest(id: string, operation: PanelComfyUIReadRelayRequest["operation"]): PanelComfyUIReadRelayRequest {
+  const createdAt = Date.now();
+  const value = {
+    version: 1 as const,
+    requestId: id,
+    operation,
+    createdAt,
+    deadlineAt: createdAt + 8_000,
+  };
+  return {
+    ...value,
+    capability: makePanelComfyUIReadRelayCapability(SECRET, value),
+  };
 }
 
 function responseFile(dir: string, id: string): string {
@@ -633,6 +653,84 @@ describe("authenticated loopback panel image relay", () => {
     try {
       const createdAt = Date.now();
       const short = request("short-deadline-123456", { createdAt, deadlineAt: createdAt + 30 });
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(short),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "TIMEOUT", requestId: short.requestId });
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThanOrEqual(30);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it.each(["history", "system_stats", "logs"] as const)(
+    "relays the fixed %s ComfyUI read and authenticates/parses its reply",
+    async (operation) => {
+      const seen: Array<{ cmd: string; operation?: string }> = [];
+      const body = operation === "logs" ? "ERROR: render failed\n" : JSON.stringify({ operation });
+      const server = await startPanelImageRelayServer({
+        resolvePanelAgent: (value) =>
+          "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+            ? { agentKey: "orchestrator::claude", secret: SECRET }
+            : undefined,
+        resolvePanelTab: () => "panel-tab",
+        bridge: {
+          canReach: () => true,
+          send: async (command) => {
+            seen.push(command);
+            return {
+              operation,
+              body,
+              contentType: operation === "logs" ? "text/plain" : "application/json",
+              bytes: Buffer.byteLength(body, "utf8"),
+            };
+          },
+        },
+      });
+      try {
+        process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+        process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+        await expect(requestPanelComfyUIRead(operation)).resolves.toEqual({
+          operation,
+          body,
+          contentType: operation === "logs" ? "text/plain" : "application/json",
+          bytes: Buffer.byteLength(body, "utf8"),
+        });
+        expect(seen).toEqual([{ cmd: "fetch_comfyui_read", operation }]);
+        expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(PANEL_COMFYUI_READ_MAX_BYTES);
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  it("applies the read relay deadline to the authenticated bridge command", async () => {
+    let timeoutMs = 0;
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async (_command, options) => {
+          timeoutMs = options.timeoutMs;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return { operation: "history", body: "{}", contentType: "application/json", bytes: 2 };
+        },
+      },
+    });
+    try {
+      const createdAt = Date.now();
+      const short = readRequest("short-read-deadline-123", "history");
+      short.createdAt = createdAt;
+      short.deadlineAt = createdAt + 30;
+      short.capability = makePanelComfyUIReadRelayCapability(SECRET, short);
       const response = await fetch(server.endpointUrl, {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -29,8 +29,11 @@ import {
 } from "../services/panel-fallback-target.js";
 import {
   PANEL_IMAGE_RELAY_MAX_BYTES,
+  PanelComfyUIReadRelayError,
   PanelImageRelayError,
+  requestPanelComfyUIRead,
   requestPanelImage,
+  type PanelComfyUIReadSuccess,
 } from "../services/panel-image-relay.js";
 import {
   bodyPrefixOf,
@@ -215,6 +218,31 @@ function looksLikeSystemStats(body: unknown): boolean {
   return (b.system != null && typeof b.system === "object") || Array.isArray(b.devices);
 }
 
+function panelReadResponse(read: PanelComfyUIReadSuccess): Response {
+  const headers = new Headers();
+  if (read.contentType) headers.set("content-type", read.contentType);
+  return new Response(read.body, { status: 200, headers });
+}
+
+/** Ask the authenticated panel only after the configured headless route failed
+ * at the transport layer. No browser origin is selected or contacted here. */
+async function panelReadFallback(
+  operation: "history" | "system_stats" | "logs",
+  primaryError: unknown,
+): Promise<PanelComfyUIReadSuccess | undefined> {
+  try {
+    return await requestPanelComfyUIRead(operation);
+  } catch (error) {
+    if (error instanceof PanelComfyUIReadRelayError && error.unavailable) return undefined;
+    const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+    const code = error instanceof PanelComfyUIReadRelayError ? error.code : "RELAY_ERROR";
+    throw new Error(
+      `${primary} The connected panel ComfyUI read fallback failed safely (${code}).`,
+      { cause: error },
+    );
+  }
+}
+
 /** Budget for the /system_stats probe. Short on purpose: this is a liveness
  *  read, and a ComfyUI mid-decode will not answer in time. Exported so the
  *  call_tool timeout test can shrink only THIS deadline. */
@@ -258,6 +286,17 @@ export async function getSystemStats(
     noteComfyApiRootValidated(getComfyUIBaseUrl());
     return stats;
   } catch (err) {
+    if (isComfyTransportFailure(err)) {
+      const relayed = await panelReadFallback("system_stats", err);
+      if (relayed) {
+        return await readComfyJson<SystemStats>(panelReadResponse(relayed), {
+          url: "/system_stats",
+          expectShape: looksLikeSystemStats,
+          shapeHint:
+            "a ComfyUI /system_stats document (it has no `system` object and no `devices` array)",
+        });
+      }
+    }
     if (!isTimeoutAbort(err)) throw err;
     // Structured, not the raw AbortSignal.timeout string: call_tool must
     // settle with a result the caller can act on, not hang and not dump
@@ -960,10 +999,22 @@ export async function getLogs(opts?: GetLogsOptions): Promise<string[]> {
       // titled "Failed to fetch" contradicted its own contents and sent readers
       // to check whether ComfyUI was up when it demonstrably was (#828).
       if (isNonJsonResponseError(err2)) throw err2;
-      const detail = err2 instanceof Error ? err2.message : String(err2);
-      throw new ConnectionError(
-        `Failed to fetch ComfyUI logs after reconnect retry: ${detail}`,
-      );
+      if (isComfyTransportFailure(err) && isComfyTransportFailure(err2)) {
+        const relayed = await panelReadFallback("logs", err2);
+        if (relayed) {
+          text = relayed.body;
+        } else {
+          const detail = err2 instanceof Error ? err2.message : String(err2);
+          throw new ConnectionError(
+            `Failed to fetch ComfyUI logs after reconnect retry: ${detail}`,
+          );
+        }
+      } else {
+        const detail = err2 instanceof Error ? err2.message : String(err2);
+        throw new ConnectionError(
+          `Failed to fetch ComfyUI logs after reconnect retry: ${detail}`,
+        );
+      }
     }
   }
 
@@ -1171,9 +1222,19 @@ export async function getHistory(
   promptId?: string,
 ): Promise<Record<string, HistoryEntry>> {
   if (isCloudMode()) return cloudClient.getHistory(promptId);
-  const client = getClient();
   const path = promptId ? `/history/${promptId}` : "/history";
-  const res = await comfyApiFetch(path);
+  let res: Response;
+  try {
+    res = await comfyApiFetch(path);
+  } catch (err) {
+    // The panel command has one fixed global /history route. A prompt-scoped
+    // request is therefore deliberately not eligible for this fallback.
+    if (!promptId && isComfyTransportFailure(err)) {
+      const relayed = await panelReadFallback("history", err);
+      if (relayed) return await readComfyJson<Record<string, HistoryEntry>>(panelReadResponse(relayed), { url: path });
+    }
+    throw err;
+  }
   // #1149 — this was a bare res.json(), the last unguarded parse on the media
   // read paths. A reporter on a remote H100 got `Unexpected end of JSON input`
   // from get_history and get_image after a completed video render, which

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -106,9 +106,12 @@ import { publishConnectedPanelOrigins } from "../services/panel-origin-channel.j
 import {
   startPanelImageRelayServer,
   verifyPanelImageRelayCapability,
+  verifyPanelComfyUIReadRelayCapability,
   type PanelImageRelayResolvedAgent,
   type PanelImageRelayServer,
   type PanelImageRelayRequest,
+  type PanelComfyUIReadRelayRequest,
+  type PanelRelayRequest,
 } from "../services/panel-image-relay.js";
 import {
   startPanelTemplateRelayServer,
@@ -1723,9 +1726,13 @@ export async function runPanelOrchestrator(): Promise<void> {
     panelImageRelaySecrets.set(secret, agentKey);
     return secret;
   };
-  const panelImageRelayAgentFor = (request: PanelImageRelayRequest): PanelImageRelayResolvedAgent | undefined => {
+  const panelImageRelayAgentFor = (request: PanelRelayRequest): PanelImageRelayResolvedAgent | undefined => {
     for (const [secret, agentKey] of panelImageRelaySecrets) {
-      if (verifyPanelImageRelayCapability(secret, request)) return { agentKey, secret };
+      if (
+        ("operation" in request
+          ? verifyPanelComfyUIReadRelayCapability(secret, request as PanelComfyUIReadRelayRequest)
+          : verifyPanelImageRelayCapability(secret, request as PanelImageRelayRequest))
+      ) return { agentKey, secret };
     }
     return undefined;
   };
@@ -1747,8 +1754,8 @@ export async function runPanelOrchestrator(): Promise<void> {
     const i = key.lastIndexOf(AGENT_KEY_SEP);
     return i >= 0 ? key.slice(i + AGENT_KEY_SEP.length) : defaultBackend;
   };
-  // #2149 — shared agent keys are not panel tab ids. Resolve through the
-  // bridge's pinned shared-tab mapping before dispatching fetch_image.
+  // #2149/#2283 — shared agent keys are not panel tab ids. Resolve through the
+  // bridge's pinned shared-tab mapping before dispatching authenticated relay commands.
   const scopeToRealTab = (tabId: string): string | undefined =>
     isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
   let panelImageRelayServer: PanelImageRelayServer | undefined;

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -23,6 +23,7 @@ export const PANEL_IMAGE_RELAY_TIMEOUT_MS = 8_000;
 export const PANEL_IMAGE_RELAY_STALE_MS = 15_000;
 export const PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES = 16 * 1024;
 export const PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES = 48 * 1024 * 1024;
+export const PANEL_COMFYUI_READ_MAX_BYTES = 16 * 1024 * 1024;
 export const PANEL_IMAGE_RELAY_MAX_CONCURRENT = 4;
 export const PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK = 4;
 export const PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK = 128;
@@ -38,9 +39,11 @@ const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const RELAY_CAPABILITY_RE = /^[a-f0-9]{64}$/;
 const RELAY_SECRET_RE = /^[a-f0-9]{64}$/;
 const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
+const READ_OPERATIONS = new Set<PanelComfyUIReadOperation>(["history", "system_stats", "logs"]);
 const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
 
 export type PanelImageType = "output" | "input" | "temp";
+export type PanelComfyUIReadOperation = "history" | "system_stats" | "logs";
 
 export interface PanelImageRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
@@ -53,6 +56,17 @@ export interface PanelImageRelayRequest {
   deadlineAt: number;
 }
 
+export interface PanelComfyUIReadRelayRequest {
+  version: typeof PANEL_IMAGE_RELAY_VERSION;
+  requestId: string;
+  capability: string;
+  operation: PanelComfyUIReadOperation;
+  createdAt: number;
+  deadlineAt: number;
+}
+
+export type PanelRelayRequest = PanelImageRelayRequest | PanelComfyUIReadRelayRequest;
+
 export type PanelImageRelayAuthInput = Pick<
   PanelImageRelayRequest,
   "requestId" | "filename" | "subfolder" | "type" | "createdAt" | "deadlineAt"
@@ -61,6 +75,13 @@ export type PanelImageRelayAuthInput = Pick<
 export interface PanelImageRelaySuccess {
   base64: string;
   mimeType: string;
+  bytes: number;
+}
+
+export interface PanelComfyUIReadSuccess {
+  operation: PanelComfyUIReadOperation;
+  body: string;
+  contentType: string | null;
   bytes: number;
 }
 
@@ -79,17 +100,31 @@ interface PanelImageRelayResponseSuccess extends PanelImageRelaySuccess {
   updated: number;
 }
 
+interface PanelComfyUIReadRelayResponseSuccess extends PanelComfyUIReadSuccess {
+  version: typeof PANEL_IMAGE_RELAY_VERSION;
+  requestId: string;
+  ok: true;
+  updated: number;
+}
+
 type PanelImageRelayResponse =
   | PanelImageRelayResponseSuccess
   | PanelImageRelayResponseFailure;
 
-type PanelImageRelayTransportResponse = PanelImageRelayResponse & { responseMac: string };
+type PanelRelayResponse =
+  | PanelImageRelayResponseSuccess
+  | PanelComfyUIReadRelayResponseSuccess
+  | PanelImageRelayResponseFailure;
+
+type PanelImageRelayTransportResponse = PanelRelayResponse & { responseMac: string };
 
 export interface PanelImageRelayBridge {
   canReach(tabId: string): boolean;
   resolveFailure?: (tabId: string) => "ambiguous" | "unresolved" | undefined;
   send(
-    command: { cmd: "fetch_image"; filename: string; subfolder: string; type: PanelImageType },
+    command:
+      | { cmd: "fetch_image"; filename: string; subfolder: string; type: PanelImageType }
+      | { cmd: "fetch_comfyui_read"; operation: PanelComfyUIReadOperation },
     options: { tabId: string; timeoutMs: number },
   ): Promise<unknown>;
 }
@@ -101,6 +136,18 @@ export class PanelImageRelayError extends Error {
   constructor(message: string, code: string, unavailable = false) {
     super(message);
     this.name = "PanelImageRelayError";
+    this.code = code;
+    this.unavailable = unavailable;
+  }
+}
+
+export class PanelComfyUIReadRelayError extends Error {
+  readonly code: string;
+  readonly unavailable: boolean;
+
+  constructor(message: string, code: string, unavailable = false) {
+    super(message);
+    this.name = "PanelComfyUIReadRelayError";
     this.code = code;
     this.unavailable = unavailable;
   }
@@ -189,6 +236,30 @@ export function verifyPanelImageRelayCapability(
 ): boolean {
   if (!isSafeRelaySecret(secret) || !isSafeRelayCapability(request.capability)) return false;
   const expected = makePanelImageRelayCapability(secret, request);
+  return timingSafeEqual(Buffer.from(request.capability, "hex"), Buffer.from(expected, "hex"));
+}
+
+function readRelayAuthPayload(input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "operation" | "createdAt" | "deadlineAt">): string {
+  return JSON.stringify(["fetch_comfyui_read", input.requestId, input.operation, input.createdAt, input.deadlineAt]);
+}
+
+export function makePanelComfyUIReadRelayCapability(
+  secret: string,
+  input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "operation" | "createdAt" | "deadlineAt">,
+): string {
+  return createHmac("sha256", secret).update(readRelayAuthPayload(input)).digest("hex");
+}
+
+export function verifyPanelComfyUIReadRelayCapability(
+  secret: string,
+  request: PanelComfyUIReadRelayRequest,
+): boolean {
+  if (
+    !isSafeRelaySecret(secret) ||
+    !isSafeRelayCapability(request.capability) ||
+    !READ_OPERATIONS.has(request.operation)
+  ) return false;
+  const expected = makePanelComfyUIReadRelayCapability(secret, request);
   return timingSafeEqual(Buffer.from(request.capability, "hex"), Buffer.from(expected, "hex"));
 }
 
@@ -322,6 +393,33 @@ function validateImagePayload(
   return { base64: record.base64, mimeType: record.mimeType, bytes };
 }
 
+function validateReadPayload(value: unknown): PanelComfyUIReadSuccess | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes"]) ||
+    typeof record.operation !== "string" ||
+    !READ_OPERATIONS.has(record.operation as PanelComfyUIReadOperation) ||
+    typeof record.body !== "string" ||
+    (record.contentType !== null &&
+      (typeof record.contentType !== "string" || !isSafeText(record.contentType, 128)))
+  ) return undefined;
+  const bytes = record.bytes;
+  if (
+    typeof bytes !== "number" ||
+    !Number.isSafeInteger(bytes) ||
+    bytes < 0 ||
+    bytes > PANEL_COMFYUI_READ_MAX_BYTES ||
+    Buffer.byteLength(record.body, "utf8") !== bytes
+  ) return undefined;
+  return {
+    operation: record.operation as PanelComfyUIReadOperation,
+    body: record.body,
+    contentType: record.contentType as string | null,
+    bytes,
+  };
+}
+
 function validateRequest(value: unknown, requestId: string): PanelImageRelayRequest | undefined {
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
@@ -342,6 +440,33 @@ function validateRequest(value: unknown, requestId: string): PanelImageRelayRequ
     deadlineAt - createdAt > PANEL_IMAGE_RELAY_TIMEOUT_MS
   ) return undefined;
   return record as unknown as PanelImageRelayRequest;
+}
+
+function validateReadRequest(value: unknown, requestId: string): PanelComfyUIReadRelayRequest | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const capability = record.capability;
+  const createdAt = record.createdAt;
+  const deadlineAt = record.deadlineAt;
+  if (
+    !hasOnlyKeys(record, ["version", "requestId", "capability", "operation", "createdAt", "deadlineAt"]) ||
+    record.version !== PANEL_IMAGE_RELAY_VERSION ||
+    record.requestId !== requestId ||
+    !isSafeRelayCapability(capability) ||
+    typeof record.operation !== "string" ||
+    !READ_OPERATIONS.has(record.operation as PanelComfyUIReadOperation) ||
+    typeof createdAt !== "number" ||
+    typeof deadlineAt !== "number" ||
+    !Number.isSafeInteger(createdAt) ||
+    !Number.isSafeInteger(deadlineAt) ||
+    deadlineAt < createdAt ||
+    deadlineAt - createdAt > PANEL_IMAGE_RELAY_TIMEOUT_MS
+  ) return undefined;
+  return record as unknown as PanelComfyUIReadRelayRequest;
+}
+
+function isReadRelayRequest(request: PanelRelayRequest): request is PanelComfyUIReadRelayRequest {
+  return "operation" in request;
 }
 
 function validateResponse(value: unknown, requestId: string): PanelImageRelayResponse {
@@ -409,25 +534,100 @@ function responseFailureMessage(response: PanelImageRelayResponseFailure): never
   );
 }
 
-function responseMacPayload(response: PanelImageRelayResponse): string {
-  return response.ok
-    ? JSON.stringify([
-        response.version,
-        response.requestId,
-        true,
-        response.base64,
-        response.mimeType,
-        response.bytes,
-        response.updated,
-      ])
-    : JSON.stringify([response.version, response.requestId, false, response.error, response.updated]);
+function responseMacPayload(response: PanelRelayResponse): string {
+  if (!response.ok) {
+    return JSON.stringify([response.version, response.requestId, false, response.error, response.updated]);
+  }
+  if ("operation" in response) {
+    return JSON.stringify([
+      response.version,
+      response.requestId,
+      true,
+      response.operation,
+      response.body,
+      response.contentType,
+      response.bytes,
+      response.updated,
+    ]);
+  }
+  return JSON.stringify([
+    response.version,
+    response.requestId,
+    true,
+    response.base64,
+    response.mimeType,
+    response.bytes,
+    response.updated,
+  ]);
 }
 
-function addResponseMac(secret: string, response: PanelImageRelayResponse): PanelImageRelayTransportResponse {
+function addResponseMac(secret: string, response: PanelRelayResponse): PanelImageRelayTransportResponse {
   return {
     ...response,
     responseMac: createHmac("sha256", secret).update(responseMacPayload(response)).digest("hex"),
   };
+}
+
+function validateReadResponse(
+  value: unknown,
+  requestId: string,
+  operation: PanelComfyUIReadOperation,
+): PanelComfyUIReadRelayResponseSuccess | PanelImageRelayResponseFailure {
+  if (!value || typeof value !== "object") {
+    throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== PANEL_IMAGE_RELAY_VERSION ||
+    record.requestId !== requestId ||
+    !hasOwn(record, "ok") ||
+    !Number.isSafeInteger(record.updated)
+  ) throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  if (record.ok === false) {
+    if (
+      typeof record.error === "string" &&
+      record.error.length <= 160 &&
+      isSafeText(record.error, 160) &&
+      hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated"])
+    ) return record as unknown as PanelImageRelayResponseFailure;
+    throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  const payload = validateReadPayload({
+    operation: record.operation,
+    body: record.body,
+    contentType: record.contentType,
+    bytes: record.bytes,
+  });
+  if (
+    record.ok !== true ||
+    !payload ||
+    payload.operation !== operation ||
+    !hasOnlyKeys(record, ["version", "requestId", "ok", "operation", "body", "contentType", "bytes", "updated"])
+  ) throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  return { ...payload, version: PANEL_IMAGE_RELAY_VERSION, requestId, ok: true, updated: record.updated as number };
+}
+
+function validateReadTransportResponse(
+  value: unknown,
+  requestId: string,
+  secret: string,
+  operation: PanelComfyUIReadOperation,
+): PanelComfyUIReadRelayResponseSuccess | PanelImageRelayResponseFailure {
+  if (!value || typeof value !== "object") {
+    throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  const record = value as Record<string, unknown>;
+  const responseMac = record.responseMac;
+  if (!isSafeRelayCapability(responseMac) || !hasOwn(record, "responseMac")) {
+    throw new PanelComfyUIReadRelayError("The panel returned an unauthenticated ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  const { responseMac: ignored, ...unsigned } = record;
+  const response = validateReadResponse(unsigned, requestId, operation);
+  const expected = createHmac("sha256", secret).update(responseMacPayload(response)).digest("hex");
+  if (!timingSafeEqual(Buffer.from(responseMac, "hex"), Buffer.from(expected, "hex"))) {
+    throw new PanelComfyUIReadRelayError("The panel returned an unauthenticated ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  return response;
 }
 
 function validateTransportResponse(
@@ -510,7 +710,7 @@ async function readHttpResponseBounded(response: Response, maxBytes: number): Pr
   return JSON.parse(Buffer.concat(chunks, total).toString("utf8")) as unknown;
 }
 
-function requestDeadline(request: PanelImageRelayRequest): number {
+function requestDeadline(request: PanelRelayRequest): number {
   return Math.min(request.deadlineAt, request.createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS);
 }
 
@@ -611,7 +811,7 @@ export interface PanelImageRelayResolvedAgent {
 
 export interface PanelImageRelayServerOptions {
   bridge: PanelImageRelayBridge;
-  resolvePanelAgent: (request: PanelImageRelayRequest) => PanelImageRelayResolvedAgent | undefined;
+  resolvePanelAgent: (request: PanelRelayRequest) => PanelImageRelayResolvedAgent | undefined;
   resolvePanelTab: (agentKey: string) => string | undefined;
 }
 
@@ -659,7 +859,11 @@ export async function startPanelImageRelayServer(
         }
         const rawRecord = raw && typeof raw === "object" ? raw as Record<string, unknown> : undefined;
         const requestId = rawRecord?.requestId;
-        const request = isSafeRelayId(requestId) ? validateRequest(raw, requestId) : undefined;
+        const request = isSafeRelayId(requestId)
+          ? rawRecord && hasOwn(rawRecord, "operation")
+            ? validateReadRequest(raw, requestId)
+            : validateRequest(raw, requestId)
+          : undefined;
         if (!request) {
           writeHttpJson(res, 400, { ok: false, error: "MALFORMED_REQUEST" });
           return;
@@ -671,7 +875,7 @@ export async function startPanelImageRelayServer(
         }
         const now = Date.now();
         const age = now - request.createdAt;
-        let response: PanelImageRelayResponse;
+        let response: PanelRelayResponse;
         if (age < -5_000 || age > PANEL_IMAGE_RELAY_STALE_MS || now >= requestDeadline(request)) {
           response = failureResponse(
             request.requestId,
@@ -693,23 +897,38 @@ export async function startPanelImageRelayServer(
               try {
                 const reply = await withinDeadline(
                   options.bridge.send(
-                    { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
+                    isReadRelayRequest(request)
+                      ? { cmd: "fetch_comfyui_read", operation: request.operation }
+                      : { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
                     { tabId: panelTab, timeoutMs: Math.min(PANEL_IMAGE_RELAY_TIMEOUT_MS, remainingMs) },
                   ),
                   requestDeadline(request),
                 );
                 const replyRecord = reply && typeof reply === "object" ? reply as Record<string, unknown> : undefined;
-                const payload = replyRecord
+                const imagePayload = !isReadRelayRequest(request) && replyRecord
                   ? validateImagePayload({ base64: replyRecord.base64, mimeType: replyRecord.mimeType, bytes: replyRecord.bytes })
                   : undefined;
                 if (Date.now() >= requestDeadline(request)) {
                   response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
+                } else if (isReadRelayRequest(request)) {
+                  const payload = replyRecord ? validateReadPayload(replyRecord) : undefined;
+                  if (!payload || payload.operation !== request.operation) {
+                    response = failureResponse(request.requestId, "MALFORMED_REPLY");
+                  } else {
+                    response = {
+                      version: PANEL_IMAGE_RELAY_VERSION,
+                      requestId: request.requestId,
+                      ok: true,
+                      ...payload,
+                      updated: Date.now(),
+                    };
+                  }
                 } else if (replyRecord?.ok === false && hasOnlyKeys(replyRecord, ["ok", "error"]) && isSafeText(replyRecord.error, 160)) {
                   response = failureResponse(request.requestId, "PANEL_FETCH_FAILED");
-                } else if (!replyRecord || replyRecord.ok !== true || !payload || !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])) {
+                } else if (!replyRecord || replyRecord.ok !== true || !imagePayload || !hasOnlyKeys(replyRecord, ["ok", "base64", "mimeType", "bytes"])) {
                   response = failureResponse(request.requestId, "MALFORMED_REPLY");
                 } else {
-                  response = { version: PANEL_IMAGE_RELAY_VERSION, requestId: request.requestId, ok: true, ...payload, updated: Date.now() };
+                  response = { version: PANEL_IMAGE_RELAY_VERSION, requestId: request.requestId, ok: true, ...imagePayload, updated: Date.now() };
                 }
               } catch (error) {
                 const timedOut = error instanceof PanelImageRelayError && error.code === "TIMEOUT";
@@ -832,6 +1051,100 @@ export async function requestPanelImage(
   }
   if (response.ok === false) responseFailureMessage(response);
   return { base64: response.base64, mimeType: response.mimeType, bytes: response.bytes };
+}
+
+/** Child-side production request for one fixed ComfyUI read over the same
+ * authenticated loopback channel as the image relay. */
+export async function requestPanelComfyUIRead(
+  operation: PanelComfyUIReadOperation,
+): Promise<PanelComfyUIReadSuccess | undefined> {
+  if (!READ_OPERATIONS.has(operation)) {
+    throw new PanelComfyUIReadRelayError("The ComfyUI read operation was refused.", "UNSAFE_OPERATION");
+  }
+  const endpoint = relayEndpoint();
+  const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
+  if (!endpoint || !isSafeRelaySecret(secret)) return undefined;
+  const createdAt = Date.now();
+  const request: PanelComfyUIReadRelayRequest = {
+    version: PANEL_IMAGE_RELAY_VERSION,
+    requestId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`,
+    capability: "",
+    operation,
+    createdAt,
+    deadlineAt: createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS,
+  };
+  request.capability = makePanelComfyUIReadRelayCapability(secret, request);
+  const body = Buffer.from(JSON.stringify(request), "utf8");
+  if (body.byteLength > PANEL_IMAGE_RELAY_MAX_HTTP_REQUEST_BYTES) {
+    throw new PanelComfyUIReadRelayError("The relay request exceeded its safety limit.", "REQUEST_TOO_LARGE");
+  }
+  let httpResponse: Response;
+  try {
+    httpResponse = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(body.byteLength) },
+      body,
+      redirect: "error",
+      signal: AbortSignal.timeout(PANEL_IMAGE_RELAY_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof PanelComfyUIReadRelayError) throw error;
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new PanelComfyUIReadRelayError("The connected panel read relay timed out.", "TIMEOUT");
+    }
+    throw new PanelComfyUIReadRelayError("The connected panel read relay is unavailable.", "RELAY_UNAVAILABLE", true);
+  }
+  let decoded: unknown;
+  try {
+    decoded = await readHttpResponseBounded(httpResponse, PANEL_IMAGE_RELAY_MAX_HTTP_RESPONSE_BYTES);
+  } catch (error) {
+    if (error instanceof PanelComfyUIReadRelayError) throw error;
+    throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
+  }
+  if (!httpResponse.ok) {
+    const code = errorCodeFromHttpBody(decoded, httpResponse.status);
+    throw new PanelComfyUIReadRelayError(
+      code === "RELAY_UNAVAILABLE" ? "The connected panel read relay is unavailable." : `The connected panel read relay failed (${code}).`,
+      code,
+      httpResponse.status >= 500,
+    );
+  }
+  const response = validateReadTransportResponse(decoded, request.requestId, secret, operation);
+  const responseAge = Date.now() - response.updated;
+  const authenticatedTimeout = response.ok === false && response.error === "TIMEOUT";
+  if (
+    !authenticatedTimeout &&
+    (response.updated < request.createdAt ||
+      response.updated > request.deadlineAt ||
+      responseAge < -5_000 ||
+      responseAge > PANEL_IMAGE_RELAY_STALE_MS)
+  ) {
+    throw new PanelComfyUIReadRelayError("The panel returned a stale ComfyUI read reply.", "STALE_REPLY");
+  }
+  if (response.ok === false) {
+    const known = new Set([
+      "AMBIGUOUS_REQUESTER",
+      "BACKLOG_FULL",
+      "MALFORMED_REPLY",
+      "NO_LIVE_PANEL",
+      "PANEL_FETCH_FAILED",
+      "STALE_REQUEST",
+      "TIMEOUT",
+    ]);
+    const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
+    throw new PanelComfyUIReadRelayError(
+      code === "PANEL_FETCH_FAILED"
+        ? "The connected panel could not read ComfyUI."
+        : `The connected panel ComfyUI read relay failed (${code}).`,
+      code,
+    );
+  }
+  return {
+    operation: response.operation,
+    body: response.body,
+    contentType: response.contentType,
+    bytes: response.bytes,
+  };
 }
 
 /** Legacy file-channel request writer, retained for focused/unit coverage only. */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1112,6 +1112,9 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // #2181: Manager queue status only observes install progress; it is safe to
   // re-dispatch after a reconnect and must not report mutation outcome warnings.
   "nodes_queue_status",
+  // #2283: fixed ComfyUI diagnostics reads relayed through the authenticated
+  // panel channel; safe to resume after a bridge reconnect.
+  "fetch_comfyui_read",
   "get_todo",
   // #608: a forced /object_info re-register + combo refresh. It has NO effect on
   // graph content — it only re-registers node defs and rebuilds combo option lists


### PR DESCRIPTION
Implements MCP #2283 on the MCP side.\n\nWhen the configured headless route is unreachable, the MCP read paths can use the authenticated connected-panel relay for fixed operations only: history, system_stats, and logs. Prompt-scoped history remains headless-only; no direct-origin fallback or arbitrary proxying is added.\n\nPanel companion: artokun/comfyui-mcp-panel#2283\n\nCloses #2283