### PR TITLE
fix(backends): 429 is detected, waited out, and never dumped raw

### DIFF
--- a/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
+++ b/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
@@ -21,6 +21,10 @@ type ResponsesBody = {
 
 let responsesRequests: ResponsesBody[] = [];
 let rejectNextWith: string | null = null;
+/** Answer the next Responses call with a 429 carrying this body. */
+let rateLimitNextWith: { body: string; headers?: Record<string, string> } | null = null;
+/** Runs as that 429 goes out — stands in for the user switching model during the backoff. */
+let onRateLimited: (() => void) | null = null;
 
 function sse(blocks: Array<{ event: string; data: Record<string, unknown> }>): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
@@ -34,7 +38,12 @@ function sse(blocks: Array<{ event: string; data: Record<string, unknown> }>): R
   });
 }
 
-const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+// Named so beforeEach can REINSTALL it. One case below calls
+// fetchMock.mockImplementation() to make every request fail, and mockClear() does
+// not undo that — it only forgets the calls. So every test declared after that one
+// silently ran against a 400-always endpoint. The two that follow were written
+// against a 429 and saw a 400 instead, which is how this was found.
+const defaultFetchImpl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = String(input);
   if (url.includes("/view?")) {
     return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
@@ -44,6 +53,12 @@ const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Pr
   }
   if (url.includes("/backend-api/codex/responses")) {
     responsesRequests.push(JSON.parse(String(init?.body)) as ResponsesBody);
+    if (rateLimitNextWith) {
+      const { body, headers } = rateLimitNextWith;
+      rateLimitNextWith = null;
+      onRateLimited?.();
+      return new Response(body, { status: 429, headers: headers ?? {} });
+    }
     if (rejectNextWith) {
       const msg = rejectNextWith;
       rejectNextWith = null;
@@ -54,7 +69,9 @@ const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Pr
     });
   }
   return new Response("not found", { status: 404 });
-});
+};
+
+const fetchMock = vi.fn(defaultFetchImpl);
 
 function fakeMcpClient(): McpToolClient {
   return {
@@ -97,8 +114,11 @@ function userContent(req: ResponsesBody): Array<Record<string, unknown>> {
 beforeEach(() => {
   responsesRequests = [];
   rejectNextWith = null;
+  rateLimitNextWith = null;
+  onRateLimited = null;
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockClear();
+  fetchMock.mockImplementation(defaultFetchImpl);
 });
 
 afterEach(() => {
@@ -244,5 +264,56 @@ describe("GPT-5.6-only model policy (issue #241 + 2026-07-20 deprecation)", () =
       if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
       rmSync(home, { recursive: true, force: true });
     }
+  });
+});
+
+// Both cases below came from the merge gate on this PR, not from the report.
+describe("ChatGptOAuthBackend — a 429 is neither an image rejection nor a model switch", () => {
+  it("a rate limit on a turn carrying an image does NOT strip the image", async () => {
+    // The catch that handles image rejection fires on ANY error once the history holds an
+    // image. A RateLimitError landing there tells the user this endpoint refused image
+    // input — which is false — and then answers WITHOUT the image they attached. A 429
+    // with no parseable window classifies as `unknown` and is never retried, so with the
+    // guard absent the strip-and-retry path is the only thing that can run.
+    rateLimitNextWith = { body: JSON.stringify({ error: { message: "slow down" } }) };
+    const events = await collect(makeBackend(), turnsOf(IMG_TURN));
+
+    // The image survives on EVERY request that went out — nothing silently dropped it.
+    for (const req of responsesRequests) {
+      expect(userContent(req).some((c) => c.type === "input_image")).toBe(true);
+    }
+
+    // And the user is never told this endpoint refused images, because it did not.
+    const said = events
+      .filter((e) => e.type === "assistant")
+      .map((e) => (e as { text: string }).text)
+      .join(" ");
+    expect(said).not.toContain("rejected image input");
+    // The note the strip path writes into history must be absent too.
+    const historyNotes = responsesRequests.flatMap((r) =>
+      userContent(r).map((c) => String(c.text ?? "")),
+    );
+    expect(historyNotes.some((t) => t.includes("were removed"))).toBe(false);
+  });
+
+  it("a retried request keeps the model the notice named, not one chosen mid-backoff", async () => {
+    // The retry thunk re-read `this.model`, so a switch during the wait sent the SAME turn
+    // to a different model while the notice the user had already read named the old one.
+    const backend = makeBackend();
+    onRateLimited = () => {
+      void backend.setModel("gpt-5.4");
+    };
+    rateLimitNextWith = {
+      body: JSON.stringify({ error: { message: "rate limited" } }),
+      headers: { "retry-after": "1" },
+    };
+
+    await collect(backend, turnsOf({ text: "hello" }));
+
+    expect(responsesRequests.length).toBeGreaterThanOrEqual(2);
+    expect(responsesRequests[0].model).toBe("gpt-5.4-mini");
+    // The switch DID land on the instance — this pins the capture, not inertia.
+    expect(backend.model).toBe("gpt-5.4");
+    expect(responsesRequests[1].model).toBe("gpt-5.4-mini");
   });
 });

--- a/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
+++ b/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
@@ -121,7 +121,10 @@ describe("a rate-limit WAIT is narrated, not mourned", () => {
 
 describe("a rate limit that could NOT be waited out", () => {
   const FINISHED =
-    "⚠️ kimi-k3 hit its rate limit — max RPM: 3. Nothing was lost — try again in a moment, or switch models from the composer picker.";
+    "⚠️ kimi-k3 hit its rate limit — max RPM: 3. " + 
+    "Try again in a moment or switch models from the composer picker — but if the turn had " +
+    "already started changing the graph, check the canvas before re-sending, because " +
+    "re-sending runs those steps again.";
 
   it("renders the finished sentence without the generic turn-failure wrapper", async () => {
     const said = await saidDuring(() => [

--- a/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
+++ b/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
@@ -121,7 +121,7 @@ describe("a rate-limit WAIT is narrated, not mourned", () => {
 
 describe("a rate limit that could NOT be waited out", () => {
   const FINISHED =
-    "⚠️ kimi-k3 hit its rate limit — max RPM: 3. " + 
+    "⚠️ kimi-k3 hit its rate limit — max RPM: 3. " +
     "Try again in a moment or switch models from the composer picker — but if the turn had " +
     "already started changing the graph, check the canvas before re-sending, because " +
     "re-sending runs those steps again.";

--- a/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
+++ b/src/__tests__/orchestrator/panel-agent-rate-limit.test.ts
@@ -1,0 +1,159 @@
+// What the USER sees when a provider rate-limits their turn.
+//
+// `rate_limit` was declared on AgentEvent and consumed by nobody — claude-backend
+// even carried a comment noting the panel never read them. So the only rate-limit
+// signal that reached a user was whatever raw text a backend happened to throw,
+// rendered through the generic "The <model> turn failed: <backend>: …" wrapper.
+//
+// These cases pin the two halves of the fix at the panel boundary: a wait is
+// narrated once and does NOT end the turn, and a rate limit that could not be
+// waited out is rendered as its own sentence instead of being buried under
+// prefixes that name the adapter rather than the limit.
+
+import { describe, expect, it } from "vitest";
+import { PanelAgent } from "../../orchestrator/panel-agent.js";
+import type {
+  AgentBackend,
+  AgentCapabilities,
+  AgentEvent,
+  BackendStartOptions,
+} from "../../orchestrator/agent-backend.js";
+
+const CAPS: AgentCapabilities = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: false,
+  modelEnumeration: false,
+  slashCommands: false,
+  hooks: false,
+  vision: true,
+  turnMarkers: true,
+};
+
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 10));
+
+/** A backend that replays a fixed script of events for each turn it receives. */
+function scriptedBackend(script: (turnNo: number) => AgentEvent[]) {
+  let turns = 0;
+  const backend: AgentBackend = {
+    id: "claude" as AgentBackend["id"],
+    capabilities: CAPS,
+    async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+      yield { type: "session", sessionId: "s1" };
+      for await (const _turn of opts.channel) {
+        turns += 1;
+        for (const ev of script(turns)) yield { ...ev, turn: turns };
+      }
+    },
+    async interrupt() {},
+    async listModels() {
+      return [];
+    },
+  };
+  return backend;
+}
+
+async function saidDuring(script: (turnNo: number) => AgentEvent[]): Promise<string[]> {
+  const said: string[] = [];
+  const agent = new PanelAgent(
+    "tab1",
+    { mcpServers: undefined, systemAppend: "", model: "kimi-k3", onSay: (_tab, text) => said.push(text) },
+    scriptedBackend(script),
+  );
+  const running = agent.start();
+  agent.send("hello");
+  await settle();
+  void running;
+  await agent.stop().catch(() => {});
+  return said;
+}
+
+describe("a rate-limit WAIT is narrated, not mourned", () => {
+  it("shows the backend's line and lets the turn finish normally", async () => {
+    const said = await saidDuring(() => [
+      { type: "rate_limit", kind: "retryable", retryInMs: 20_000, message: "⏳ kimi-k3 is rate limited. Retrying in 20s…" },
+      { type: "assistant", text: "done" },
+      { type: "result", ok: true },
+    ]);
+    expect(said.some((s) => s.includes("Retrying in 20s"))).toBe(true);
+    // It is NOT a failure: nothing may claim the turn died.
+    expect(said.some((s) => s.includes("turn failed"))).toBe(false);
+    expect(said.some((s) => s === "done")).toBe(true);
+  });
+
+  it("says it once, however many rounds of one turn get limited", async () => {
+    // A 3-req/min limiter can 429 several rounds of the same turn. A bubble per
+    // retry would bury the conversation under status about itself.
+    const said = await saidDuring(() => [
+      { type: "rate_limit", retryInMs: 20_000, message: "⏳ kimi-k3 is rate limited. Retrying in 20s…" },
+      { type: "rate_limit", retryInMs: 20_000, message: "⏳ kimi-k3 is rate limited. Retrying in 20s…" },
+      { type: "rate_limit", retryInMs: 20_000, message: "⏳ kimi-k3 is rate limited. Retrying in 20s…" },
+      { type: "result", ok: true },
+    ]);
+    expect(said.filter((s) => s.includes("Retrying in 20s"))).toHaveLength(1);
+  });
+
+  it("does not spend the once-per-turn error slot", async () => {
+    // A wait that swallowed the slot would silence the first REAL error after it.
+    const said = await saidDuring(() => [
+      { type: "rate_limit", retryInMs: 20_000, message: "⏳ kimi-k3 is rate limited. Retrying in 20s…" },
+      { type: "error", message: "something else broke" },
+      { type: "result", ok: false },
+    ]);
+    expect(said.some((s) => s.includes("Retrying in 20s"))).toBe(true);
+    expect(said.some((s) => s.includes("something else broke"))).toBe(true);
+  });
+
+  it("a silent sub-second wait puts nothing in the chat", async () => {
+    // The backend omits `message` for waits too short to be worth a word; the
+    // panel must not invent one.
+    const said = await saidDuring(() => [
+      { type: "rate_limit", retryInMs: 800 },
+      { type: "assistant", text: "done" },
+      { type: "result", ok: true },
+    ]);
+    expect(said.some((s) => s.includes("rate limit"))).toBe(false);
+    expect(said).toContain("done");
+  });
+});
+
+describe("a rate limit that could NOT be waited out", () => {
+  const FINISHED =
+    "⚠️ kimi-k3 hit its rate limit — max RPM: 3. Nothing was lost — try again in a moment, or switch models from the composer picker.";
+
+  it("renders the finished sentence without the generic turn-failure wrapper", async () => {
+    const said = await saidDuring(() => [
+      { type: "error", message: FINISHED, rateLimit: true },
+      { type: "result", ok: false, subtype: "rate_limit" },
+    ]);
+    const line = said.find((s) => s.includes("rate limit"));
+    expect(line).toBeDefined();
+    // No "The kimi-k3 turn failed: ollama backend: …" stack of prefixes, and the
+    // model is named once rather than twice.
+    expect(line).not.toContain("turn failed");
+    expect(line).not.toContain("check the terminal");
+    expect(line?.match(/kimi-k3/g)).toHaveLength(1);
+    // Exactly one ⚠️: the backend's own marker is not doubled by the renderer.
+    expect(line?.match(/⚠️/g)).toHaveLength(1);
+  });
+
+  it("still consumes the error slot, so the failing result does not report twice", async () => {
+    const said = await saidDuring(() => [
+      { type: "error", message: FINISHED, rateLimit: true },
+      { type: "result", ok: false, subtype: "rate_limit" },
+    ]);
+    expect(said.filter((s) => s.includes("⚠️"))).toHaveLength(1);
+  });
+
+  it("an ordinary error is untouched — it keeps the turn-failure framing", async () => {
+    const said = await saidDuring(() => [
+      { type: "error", message: "ollama backend: connect ECONNREFUSED" },
+      { type: "result", ok: false },
+    ]);
+    const line = said.find((s) => s.includes("ECONNREFUSED"));
+    expect(line).toContain("The kimi-k3 turn failed:");
+    expect(line).toContain("check the terminal");
+  });
+});

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -125,10 +125,55 @@ describe("sanitizeDetail", () => {
     expect(out).not.toContain("abcdefghijklmnop");
   });
 
+  it("redacts an identifier that has no digit in it at all", () => {
+    // The reported case. 22 alphabetic characters, no separator, no digit.
+    const alpha = sanitizeDetail("account abcdefghijklmnopqrstuv is limited");
+    expect(alpha).not.toContain("abcdefghijklmnopqrstuv");
+    expect(alpha).toContain("is limited");
+
+    // The control that made the hole visible: the SAME string with its last
+    // character changed to a digit was already redacted. Both must behave alike —
+    // whether a vendor happened to mint an id with a digit in it is not a
+    // property of how secret the id is.
+    const digit = sanitizeDetail("account abcdefghijklmnopqrstu9 is limited");
+    expect(digit).not.toContain("abcdefghijklmnopqrstu9");
+
+    // …and it must not depend on a label sitting in front of the id, either. An
+    // id is redacted for its shape, not for the word that happens to precede it.
+    for (const sentence of [
+      "rate limit reached for abcdefghijklmnopqrstuv",
+      "the tenant abcdefghijklmnopqrstuv exceeded its quota",
+      "your plan abcdefghijklmnopqrstuv has no credits",
+      "rate limited (abcdefghijklmnopqrstuv)",
+    ]) {
+      expect(sanitizeDetail(sentence)).not.toContain("abcdefghijklmnopqrstuv");
+    }
+  });
+
   it("leaves an ordinary sentence readable", () => {
     const out = sanitizeDetail("Rate limit reached for gpt-4o in organization on requests per min (RPM): Limit 500");
     expect(out).toContain("requests per min");
     expect(out).toContain("Limit 500");
+
+    // The other half of #2313. Dropping the digit requirement widened the bare-run
+    // rule, and the whole point of showing a 429 is the explanation — so the
+    // explanations have to keep arriving intact. None of these contains an
+    // unbroken 20-character run, because sentences have spaces in them.
+    for (const sentence of [
+      "organization requests per minute exceeded",
+      "You exceeded your current quota, please check your plan and billing details.",
+      "Your credit balance is too low to access the API.",
+      "request reached organization max RPM: 3, please try again after 1 seconds",
+      "Too many concurrent requests. Reduce concurrency and retry.",
+      "Free tier limit reached. Upgrade your plan at the billing dashboard to continue.",
+    ]) {
+      expect(sanitizeDetail(sentence)).not.toContain("<redacted>");
+    }
+
+    // The threshold is bracketed from BOTH sides on purpose. The case above pins
+    // it at or below 22 characters (a 22-character id must vanish); this pins it
+    // above 18, so nobody "hardens" the rule down into ordinary long words.
+    expect(sanitizeDetail("this request was disproportionately large")).toContain("disproportionately");
   });
 
   it("redacts an email address", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -198,10 +198,15 @@ describe("gaveUpNotice", () => {
     expect(line).toContain("composer picker");
   });
 
-  it("a quota wall keeps its own remedy and does not gain the retry advice", () => {
+  it("a quota wall keeps its own remedy AND still warns the turn stopped part-way", () => {
+    // Gate round 3: the partial-turn warning was added to the two retryable branches and
+    // not to this one. A quota 429 arrives at the same point in the tool loop and leaves
+    // the same half-applied graph — and this branch actively tells the user to top up and
+    // resend, so it is the branch where the omission does the most damage.
     const line = gaveUpNotice("m", { kind: "quota", detail: "out of credit" }, 0);
     expect(line).toMatch(/Retrying will not help/i);
     expect(line).not.toMatch(/nothing was lost/i);
+    expect(line).toMatch(/check the canvas before you resend/i);
   });
 });
 

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -14,6 +14,7 @@ import {
   asRateLimitError,
   classifyRateLimit,
   humanWait,
+  gaveUpNotice,
   sanitizeDetail,
   sendWithRateLimitRetry,
 } from "../../orchestrator/rate-limit.js";
@@ -167,6 +168,40 @@ describe("sanitizeDetail", () => {
     // would eat the parts of a 429 that explain the limit, which is why it is shown.
     const out = sanitizeDetail("rate limit exceeded; see x-ratelimit-reset-requests");
     expect(out).toContain("x-ratelimit-reset-requests");
+  });
+});
+
+describe("gaveUpNotice", () => {
+  // agent-backend.ts documents `outcomeUnknown` as "renderers must NOT add the generic
+  // 'Nothing was lost — try again' prompt", and codex-backend.ts calls that phrase unsafe
+  // "when a mutation's dispatch/outcome was not established". A 429 mid tool-loop is that
+  // case: this module exists because completed tool rounds were being discarded, which
+  // means they RAN. Promising nothing was lost invites re-sending a prompt whose earlier
+  // steps already changed the graph.
+  it("never tells the user nothing was lost", () => {
+    const cases = [
+      gaveUpNotice("m", { kind: "unknown", detail: "slow down" }, 0),
+      gaveUpNotice("m", { kind: "unknown", detail: "slow down" }, 2),
+      gaveUpNotice("m", { kind: "unknown" }, 0, false),
+    ];
+    for (const line of cases) {
+      expect(line).not.toMatch(/nothing was lost/i);
+      // …and says the thing that replaces it, so this is not satisfied by an empty string.
+      expect(line).toMatch(/re-sending runs those steps again/i);
+    }
+  });
+
+  it("still names the model and the remedy", () => {
+    const line = gaveUpNotice("kimi-k3", { kind: "unknown", detail: "max RPM: 3" }, 0);
+    expect(line).toContain("kimi-k3");
+    expect(line).toContain("max RPM: 3");
+    expect(line).toContain("composer picker");
+  });
+
+  it("a quota wall keeps its own remedy and does not gain the retry advice", () => {
+    const line = gaveUpNotice("m", { kind: "quota", detail: "out of credit" }, 0);
+    expect(line).toMatch(/Retrying will not help/i);
+    expect(line).not.toMatch(/nothing was lost/i);
   });
 });
 

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -151,6 +151,14 @@ describe("sanitizeDetail", () => {
       expect(bare).not.toContain(part);
     }
     expect(bare).toContain("account");
+
+    // Gate round 2: a prefix GLUED to the uuid with no separator slipped past the
+    // optional-prefix group and left the same misleading partial one layer down.
+    const glued = sanitizeDetail("org550e8400-e29b-41d4-a716-446655440000 hit its cap");
+    for (const part of ["org550e8400", "550e8400", "e29b", "41d4", "a716", "446655440000"]) {
+      expect(glued).not.toContain(part);
+    }
+    expect(glued).toContain("hit its cap");
     expect(bare).toContain("limit");
   });
 

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -125,6 +125,22 @@ describe("sanitizeDetail", () => {
     expect(out).not.toContain("abcdefghijklmnop");
   });
 
+  it("redacts segmented opaque ids as one atom", () => {
+    const cases = [
+      "org_1234567890_abcdefghi",
+      "tenant_account_1234567890_abcdefghi",
+      "wrapper_qavexidopulnertiskym_extra_more",
+    ];
+    for (const value of cases) {
+      const out = sanitizeDetail(`rate limit reached for ${value}`);
+      expect(out).not.toContain(value);
+      for (const segment of value.split(/[-_]/).filter((segment) => segment.length >= 9)) {
+        expect(out).not.toContain(segment);
+      }
+      expect(out).toContain("rate limit reached for");
+    }
+  });
+
   it("redacts an identifier that has no digit in it at all", () => {
     // The reported case. 22 alphabetic characters, no separator, no digit.
     const alpha = sanitizeDetail("account abcdefghijklmnopqrstuv is limited");
@@ -174,6 +190,29 @@ describe("sanitizeDetail", () => {
     // it at or below 22 characters (a 22-character id must vanish); this pins it
     // above 18, so nobody "hardens" the rule down into ordinary long words.
     expect(sanitizeDetail("this request was disproportionately large")).toContain("disproportionately");
+  });
+
+  it("keeps long prose while retaining opaque and explicitly labelled masking", () => {
+    const prose = [
+      "account counterrevolutionary policy",
+      "the user uncharacteristically exceeded the limit",
+      "account compartmentalization policy",
+      "internationalization is enabled",
+    ];
+    for (const sentence of prose) {
+      expect(sanitizeDetail(sentence)).toBe(sentence);
+    }
+
+    const labelled = [
+      "account_id=abcdefghijklmnopqrstuv",
+      "user_id: qavexidopulnertiskym",
+      '{"account_id":"counterrevolutionary"}',
+    ];
+    for (const sentence of labelled) {
+      expect(sanitizeDetail(sentence)).not.toMatch(
+        /(?:abcdefghijklmnopqrstuv|qavexidopulnertiskym|counterrevolutionary)/,
+      );
+    }
   });
 
   it("redacts an email address", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -133,6 +133,33 @@ describe("sanitizeDetail", () => {
   it("redacts an email address", () => {
     expect(sanitizeDetail("quota for art@example.com exhausted")).not.toContain("art@example.com");
   });
+
+  // Hyphens defeated both shape rules: the longest unbroken run inside a UUID is 12
+  // characters, so the bare-run rule (20+) never fired, and the prefixed rule matched
+  // only the TAIL. The second case below is the dangerous one — it used to come back as
+  // "550e8400-e29b-41d4-a716-<redacted>", which READS as sanitized while 24 of its 36
+  // characters shipped. Nobody re-checks a redaction that already looks done.
+  it("redacts a UUID-shaped account id whole, with or without a vendor prefix", () => {
+    const prefixed = sanitizeDetail("org-12345678-1234-1234-1234-123456789012 reached its limit");
+    expect(prefixed).not.toContain("12345678");
+    expect(prefixed).not.toContain("123456789012");
+    expect(prefixed).toContain("org-");
+
+    const bare = sanitizeDetail("account 550e8400-e29b-41d4-a716-446655440000 limit");
+    // No FRAGMENT survives — asserting only on the full string would pass on the partial.
+    for (const part of ["550e8400", "e29b", "41d4", "a716", "446655440000"]) {
+      expect(bare).not.toContain(part);
+    }
+    expect(bare).toContain("account");
+    expect(bare).toContain("limit");
+  });
+
+  it("still leaves hyphenated prose and header names alone", () => {
+    // The UUID rule is shape-specific on purpose: widening it to any hyphenated run
+    // would eat the parts of a 429 that explain the limit, which is why it is shown.
+    const out = sanitizeDetail("rate limit exceeded; see x-ratelimit-reset-requests");
+    expect(out).toContain("x-ratelimit-reset-requests");
+  });
 });
 
 describe("humanWait", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -185,27 +185,33 @@ describe("sanitizeDetail", () => {
   // only the TAIL. The second case below is the dangerous one — it used to come back as
   // "550e8400-e29b-41d4-a716-<redacted>", which READS as sanitized while 24 of its 36
   // characters shipped. Nobody re-checks a redaction that already looks done.
-  it("redacts a UUID-shaped account id whole, with or without a vendor prefix", () => {
-    const prefixed = sanitizeDetail("org-12345678-1234-1234-1234-123456789012 reached its limit");
-    expect(prefixed).not.toContain("12345678");
-    expect(prefixed).not.toContain("123456789012");
-    expect(prefixed).toContain("org-");
-
-    const bare = sanitizeDetail("account 550e8400-e29b-41d4-a716-446655440000 limit");
-    // No FRAGMENT survives — asserting only on the full string would pass on the partial.
+  // Every shape below has defeated a previous version of this rule. They are kept
+  // together because the lesson is the CLASS, not any one of them: each earlier fix
+  // preserved the vendor prefix, so it had to know where the prefix ended, and each
+  // review found a new way for that to be wrong. The rule no longer tries.
+  it.each([
+    ["bare", "account 550e8400-e29b-41d4-a716-446655440000 limit"],
+    ["hyphen prefix", "org-550e8400-e29b-41d4-a716-446655440000 reached its limit"],
+    ["glued prefix (gate round 2)", "org550e8400-e29b-41d4-a716-446655440000 hit its cap"],
+    ["single-char prefix (#2333)", "x_550e8400-e29b-41d4-a716-446655440000 rate limited"],
+    ["two segments (#2333)", "x_y_550e8400-e29b-41d4-a716-446655440000 rate limited"],
+    ["the reported case (#2333)", "tenant_account_550e8400-e29b-41d4-a716-446655440000 rate limited"],
+    ["uppercase hex", "ACCT_550E8400-E29B-41D4-A716-446655440000 limited"],
+  ])("leaves no fragment of a UUID-shaped id: %s", (_name, input) => {
+    const out = sanitizeDetail(input);
+    // Asserting on the whole string would PASS on a partial redaction — which is the
+    // exact defect: `…-a716-<redacted>` reads as sanitized while 24 of 36 chars ship.
+    // Every segment must be gone, case-insensitively.
     for (const part of ["550e8400", "e29b", "41d4", "a716", "446655440000"]) {
-      expect(bare).not.toContain(part);
+      expect(out.toUpperCase()).not.toContain(part.toUpperCase());
     }
-    expect(bare).toContain("account");
+    expect(out).toContain("<redacted>");
+  });
 
-    // Gate round 2: a prefix GLUED to the uuid with no separator slipped past the
-    // optional-prefix group and left the same misleading partial one layer down.
-    const glued = sanitizeDetail("org550e8400-e29b-41d4-a716-446655440000 hit its cap");
-    for (const part of ["org550e8400", "550e8400", "e29b", "41d4", "a716", "446655440000"]) {
-      expect(glued).not.toContain(part);
-    }
-    expect(glued).toContain("hit its cap");
-    expect(bare).toContain("limit");
+  it("keeps the surrounding sentence, which is why the message is shown at all", () => {
+    expect(sanitizeDetail("account 550e8400-e29b-41d4-a716-446655440000 limit")).toBe(
+      "account <redacted> limit",
+    );
   });
 
   it("still leaves hyphenated prose and header names alone", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -1,0 +1,333 @@
+// 429, and what a turn does about it.
+//
+// The reported failure: kimi-k3 returned `429 … organization max RPM: 3, please
+// try again after 1 seconds` FOUR tool rounds into a turn, and the turn died —
+// with the provider's raw envelope, account id included, pasted into the chat.
+// Three separate things had to be true for that, and each gets a case here: the
+// wait was never read, the retry never happened, and the body was never
+// sanitized.
+
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+import {
+  RateLimitError,
+  asRateLimitError,
+  classifyRateLimit,
+  humanWait,
+  sanitizeDetail,
+  sendWithRateLimitRetry,
+} from "../../orchestrator/rate-limit.js";
+
+const h = (init: Record<string, string> = {}) => new Headers(init);
+
+/** The exact body from the bug report, account identifiers and all. */
+const KIMI_429 = JSON.stringify({
+  error: {
+    message:
+      "Your account org-7df23a26037240f88f967fb1c64d8e3f<cak-fc91zq3o4h0b111bug391> request reached organization max RPM: 3, please try again after 1 seconds",
+    type: "rate_limit_reached_error",
+  },
+});
+
+describe("classifyRateLimit", () => {
+  it("is silent on anything that is not a 429", () => {
+    // The module owns ONE status. A 500 or a 400 must reach each backend's
+    // existing error path untouched, or this becomes a rewrite of every failure.
+    expect(classifyRateLimit(200, h(), "")).toBeNull();
+    expect(classifyRateLimit(400, h(), "rate limit")).toBeNull();
+    expect(classifyRateLimit(500, h(), "")).toBeNull();
+    expect(classifyRateLimit(402, h(), "insufficient_quota")).toBeNull();
+  });
+
+  it("reads the wait out of the provider's prose (the reported case)", () => {
+    const v = classifyRateLimit(429, h(), KIMI_429);
+    expect(v?.kind).toBe("retryable");
+    expect(v?.retryAfterMs).toBe(1000);
+  });
+
+  it("prefers Retry-After over the prose, in seconds or as a date", () => {
+    expect(classifyRateLimit(429, h({ "retry-after": "20" }), KIMI_429)?.retryAfterMs).toBe(20_000);
+    const soon = new Date(Date.now() + 30_000).toUTCString();
+    const ms = classifyRateLimit(429, h({ "retry-after": soon }), "")?.retryAfterMs ?? 0;
+    expect(ms).toBeGreaterThan(25_000);
+    expect(ms).toBeLessThanOrEqual(30_000);
+  });
+
+  it("never returns a NEGATIVE wait from a Retry-After date in the past", () => {
+    // Some limiters send the window's start. A negative sleep would silently
+    // become an instant retry — the one thing a 429 asked us not to do.
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(classifyRateLimit(429, h({ "retry-after": past }), "")?.retryAfterMs).toBe(0);
+  });
+
+  it("falls back to the OpenAI-style reset counters", () => {
+    expect(classifyRateLimit(429, h({ "x-ratelimit-reset-requests": "6m0s" }), "")?.retryAfterMs).toBe(360_000);
+    expect(classifyRateLimit(429, h({ "x-ratelimit-reset-tokens": "500ms" }), "")?.retryAfterMs).toBe(500);
+  });
+
+  it("does not mistake a non-duration header for a wait", () => {
+    // "3 requests" parses as "3" under a lax reader, and a 3ms backoff against a
+    // per-minute limiter is a retry storm.
+    const v = classifyRateLimit(429, h({ "x-ratelimit-reset-requests": "3 requests" }), "");
+    expect(v?.kind).toBe("unknown");
+    expect(v?.retryAfterMs).toBeUndefined();
+  });
+
+  it("calls an exhausted quota QUOTA even when a retry window came with it", () => {
+    // Both OpenAI and moonshot answer an empty balance with a 429 that still
+    // carries a hint. Honouring it would sleep, retry, and fail identically.
+    const v = classifyRateLimit(
+      429,
+      h({ "retry-after": "5" }),
+      JSON.stringify({ error: { message: "You exceeded your current quota", type: "insufficient_quota" } }),
+    );
+    expect(v?.kind).toBe("quota");
+  });
+
+  it("does not quote the provider's retry instruction back at the user", () => {
+    // We already obeyed it — the wait was parsed out of this very sentence. Left
+    // in, it reads as a contradiction beside the outcome ("did not recover after
+    // 3 attempts … please try again after 1 seconds").
+    const v = classifyRateLimit(429, h(), KIMI_429);
+    expect(v?.detail).not.toMatch(/try again/i);
+    // …and the part the user cannot learn any other way survives.
+    expect(v?.detail).toContain("max RPM: 3");
+  });
+
+  it("reports a 429 with no readable window as unknown, not as a guess", () => {
+    const v = classifyRateLimit(429, h(), "Too Many Requests");
+    expect(v?.kind).toBe("unknown");
+    expect(v?.retryAfterMs).toBeUndefined();
+  });
+
+  it("ignores an HTML block page instead of quoting it at the user", () => {
+    const v = classifyRateLimit(429, h(), "<html><body><h1>429 Too Many Requests</h1></body></html>");
+    expect(v?.kind).toBe("unknown");
+    expect(v?.detail).toBeUndefined();
+  });
+});
+
+describe("sanitizeDetail", () => {
+  it("strips the account identifiers the reported error published", () => {
+    const out = sanitizeDetail(JSON.parse(KIMI_429).error.message);
+    expect(out).not.toContain("org-7df23a26037240f88f967fb1c64d8e3f");
+    expect(out).not.toContain("cak-fc91zq3o4h0b111bug391");
+    // …while keeping the part that explains the limit, which is why the message
+    // is shown at all.
+    expect(out).toContain("max RPM: 3");
+  });
+
+  it("masks identifier SHAPES, not a list of known vendor prefixes", () => {
+    // The next provider's prefix is not in any list we could have written.
+    const out = sanitizeDetail("workspace wsp_9f8e7d6c5b4a3f2e1d0c and key sk-abcdefghijklmnop are limited");
+    expect(out).not.toContain("9f8e7d6c5b4a3f2e1d0c");
+    expect(out).not.toContain("abcdefghijklmnop");
+  });
+
+  it("leaves an ordinary sentence readable", () => {
+    const out = sanitizeDetail("Rate limit reached for gpt-4o in organization on requests per min (RPM): Limit 500");
+    expect(out).toContain("requests per min");
+    expect(out).toContain("Limit 500");
+  });
+
+  it("redacts an email address", () => {
+    expect(sanitizeDetail("quota for art@example.com exhausted")).not.toContain("art@example.com");
+  });
+});
+
+describe("humanWait", () => {
+  it("reads as a duration a person would say", () => {
+    expect(humanWait(900)).toBe("900ms");
+    expect(humanWait(1000)).toBe("1s");
+    expect(humanWait(20_000)).toBe("20s");
+    expect(humanWait(150_000)).toBe("2m30s");
+    expect(humanWait(120_000)).toBe("2m");
+  });
+});
+
+/** A send() that answers with the queued statuses, then 200 forever. */
+function scriptedSend(responses: Array<{ status: number; body?: string; headers?: Record<string, string> }>) {
+  const calls: number[] = [];
+  let i = 0;
+  const send = async (): Promise<Response> => {
+    calls.push(Date.now());
+    const spec = responses[i] ?? { status: 200 };
+    i += 1;
+    return new Response(spec.body ?? "", { status: spec.status, headers: spec.headers });
+  };
+  return { send, sent: () => i, calls };
+}
+
+async function drain(gen: AsyncGenerator<AgentEvent, Response>): Promise<{ events: AgentEvent[]; res: Response }> {
+  const events: AgentEvent[] = [];
+  for (;;) {
+    const step = await gen.next();
+    if (step.done) return { events, res: step.value };
+    events.push(step.value);
+  }
+}
+
+describe("sendWithRateLimitRetry", () => {
+  const opts = () => ({ model: "kimi-k3", label: "test-backend", signal: new AbortController().signal });
+
+  it("waits out the reported one-second window and lets the turn continue", async () => {
+    vi.useFakeTimers();
+    try {
+      const { send, sent } = scriptedSend([{ status: 429, body: KIMI_429 }]);
+      const run = drain(sendWithRateLimitRetry(send, opts()));
+      await vi.advanceTimersByTimeAsync(1000);
+      const { events, res } = await run;
+      expect(res.status).toBe(200);
+      expect(sent()).toBe(2); // the 429, then the retry that worked
+      // A one-second wait is invisible to the user; announcing it would be noise
+      // about a non-event.
+      expect(events).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("announces a wait long enough to look like a hang", async () => {
+    vi.useFakeTimers();
+    try {
+      const { send } = scriptedSend([{ status: 429, headers: { "retry-after": "20" }, body: KIMI_429 }]);
+      const run = drain(sendWithRateLimitRetry(send, opts()));
+      await vi.advanceTimersByTimeAsync(20_000);
+      const { events, res } = await run;
+      expect(res.status).toBe(200);
+      expect(events).toHaveLength(1);
+      const ev = events[0];
+      expect(ev.type).toBe("rate_limit");
+      if (ev.type !== "rate_limit") throw new Error("unreachable");
+      expect(ev.retryInMs).toBe(20_000);
+      expect(ev.message).toContain("kimi-k3");
+      expect(ev.message).toContain("20s");
+      // The line a user reads must not carry what the body carried.
+      expect(ev.message).not.toContain("org-7df23a26037240f88f967fb1c64d8e3f");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hands back every other status untouched, body unread", async () => {
+    // The callers' error paths all do `await res.text()`. Consuming the body
+    // here would turn their messages into empty strings.
+    const { send, sent } = scriptedSend([{ status: 500, body: "upstream exploded" }]);
+    const { events, res } = await drain(sendWithRateLimitRetry(send, opts()));
+    expect(res.status).toBe(500);
+    expect(sent()).toBe(1);
+    expect(events).toHaveLength(0);
+    expect(await res.text()).toBe("upstream exploded");
+  });
+
+  it("gives up after the retry budget and throws a finished sentence", async () => {
+    vi.useFakeTimers();
+    try {
+      const always = Array.from({ length: 9 }, () => ({ status: 429, body: KIMI_429 }));
+      const { send, sent } = scriptedSend(always);
+      const run = drain(sendWithRateLimitRetry(send, opts())).catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const err = asRateLimitError(await run);
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect(sent()).toBe(4); // the original + 3 retries
+      expect(err?.message).toContain("kimi-k3");
+      expect(err?.message).toContain("3 attempts");
+      expect(err?.message).not.toContain("org-7df23a26037240f88f967fb1c64d8e3f");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("declines a window that would blow the total-wait budget, rather than truncating it", async () => {
+    // Sleeping LESS than the provider asked for is a retry we already know is
+    // too early — so an over-budget window is refused outright.
+    const { send, sent } = scriptedSend([{ status: 429, headers: { "retry-after": "600" }, body: "slow down" }]);
+    const err = asRateLimitError(await drain(sendWithRateLimitRetry(send, opts())).catch((e: unknown) => e));
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(sent()).toBe(1);
+  });
+
+  it("never retries an exhausted quota, however short the window it came with", async () => {
+    const body = JSON.stringify({ error: { message: "You exceeded your current quota", type: "insufficient_quota" } });
+    const { send, sent } = scriptedSend([{ status: 429, headers: { "retry-after": "1" }, body }]);
+    const err = asRateLimitError(await drain(sendWithRateLimitRetry(send, opts())).catch((e: unknown) => e));
+    expect(sent()).toBe(1);
+    expect(err?.kind).toBe("quota");
+    expect(err?.message).toContain("Retrying will not help");
+  });
+
+  it("does not retry a 429 that named no window", async () => {
+    const { send, sent } = scriptedSend([{ status: 429, body: "Too Many Requests" }]);
+    const err = asRateLimitError(await drain(sendWithRateLimitRetry(send, opts())).catch((e: unknown) => e));
+    expect(sent()).toBe(1);
+    expect(err?.kind).toBe("unknown");
+    expect(err?.message).toContain("did not say how long to wait");
+  });
+
+  it("does not claim the provider stayed silent when the body was unreadable", async () => {
+    // #796 — an unreadable body and an empty one leave us equally uninformed, but
+    // "it did not say how long to wait" is a claim about what ARRIVED.
+    const send = async (): Promise<Response> =>
+      new Response(new ReadableStream({ start: (c) => c.error(new Error("connection reset")) }), { status: 429 });
+    const err = asRateLimitError(await drain(sendWithRateLimitRetry(send, opts())).catch((e: unknown) => e));
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.message).toContain("could not be read");
+    expect(err?.message).not.toContain("did not say how long to wait");
+  });
+
+  it("still honours a Retry-After header when the body is unreadable", async () => {
+    // The headers survive a body we could not read, so a real window is still a
+    // real window — refusing to retry here would be over-caution, not caution.
+    vi.useFakeTimers();
+    try {
+      let n = 0;
+      const send = async (): Promise<Response> => {
+        n += 1;
+        if (n > 1) return new Response("", { status: 200 });
+        return new Response(new ReadableStream({ start: (c) => c.error(new Error("reset")) }), {
+          status: 429,
+          headers: { "retry-after": "1" },
+        });
+      };
+      const run = drain(sendWithRateLimitRetry(send, opts()));
+      await vi.advanceTimersByTimeAsync(1000);
+      expect((await run).res.status).toBe(200);
+      expect(n).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("abandons the wait when the turn is interrupted", async () => {
+    vi.useFakeTimers();
+    try {
+      const ac = new AbortController();
+      const { send, sent } = scriptedSend([{ status: 429, headers: { "retry-after": "30" }, body: "slow down" }]);
+      const run = drain(sendWithRateLimitRetry(send, { ...opts(), signal: ac.signal })).catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(100);
+      ac.abort();
+      const err = await run;
+      expect(err).toBeInstanceOf(Error);
+      // The retry never fired: an interrupt must not sit out a 30-second window.
+      expect(sent()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the turn watchdog fed across the wait", async () => {
+    // 3.5 minutes of silence trips the stall watchdog. A wait is the request
+    // making progress, not a wedged backend.
+    vi.useFakeTimers();
+    try {
+      const onActivity = vi.fn();
+      const { send } = scriptedSend([{ status: 429, headers: { "retry-after": "20" }, body: "slow down" }]);
+      const run = drain(sendWithRateLimitRetry(send, { ...opts(), onActivity }));
+      await vi.advanceTimersByTimeAsync(20_000);
+      await run;
+      expect(onActivity).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -141,7 +141,13 @@ export type AgentEvent = (
       contextWindow?: number;
       costUsd?: number;
     }
-  | { type: "rate_limit"; resetsAt?: number; kind?: string }
+  /** The provider asked us to slow down and the request is being waited out
+   *  (see orchestrator/rate-limit.ts). NOT a failure: the turn is still running,
+   *  and a `result` will follow normally once the retry lands. `message`, when
+   *  present, is a finished user-facing line — renderers show it as-is rather
+   *  than composing their own, because only the emitter knows whether the wait
+   *  came from a header, a reset counter, or the provider's prose. */
+  | { type: "rate_limit"; resetsAt?: number; kind?: string; retryInMs?: number; message?: string }
   | {
       type: "error";
       message: string;
@@ -163,6 +169,13 @@ export type AgentEvent = (
        *  must show the backend's self-contained recovery guidance rather than
        *  adding the generic "Nothing was lost — try again" prompt. */
       outcomeUnknown?: boolean;
+      /** The turn ended on a provider RATE LIMIT that could not be waited out.
+       *  `message` is already the finished sentence — it names the model, the
+       *  reason, and the remedy — so renderers must not wrap it in the generic
+       *  "the <model> turn failed: <backend>: …" framing, which would bury the
+       *  one actionable fact under a stack of prefixes. It IS a turn failure,
+       *  so it still consumes the once-per-turn error slot. */
+      rateLimit?: boolean;
     }
 ) & {
   /** Backend-minted TURN MARKER (#728): a monotonically increasing id (1 = the

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -10,6 +10,7 @@ import { errorText } from "./error-text.js";
 import type { AgentEvent, BackendStartOptions, ModelChoice, NeutralTurn } from "./agent-backend.js";
 import { CHATGPT_CAPABILITIES, stampTurn } from "./agent-backend.js";
 import { resolveOpenAICodexOAuth } from "../services/code-provider-auth.js";
+import { asRateLimitError, sanitizeDetail, sendWithRateLimitRetry } from "./rate-limit.js";
 import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
 
 const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
@@ -198,32 +199,42 @@ export class ChatGptOAuthBackend extends OllamaBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
-      res = await fetch(CODEX_RESPONSES_URL, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "text/event-stream",
-          ...this.codexAuthHeaders(),
-        },
-        body: JSON.stringify({
-          model: this.model,
-          instructions,
-          input,
-          tools: toResponsesTools(tools),
-          stream: true,
-          store: false,
-        }),
-        signal,
-      });
+      // 429s are waited out when the window is bounded and named; every other
+      // status falls through unchanged (orchestrator/rate-limit.ts).
+      res = yield* sendWithRateLimitRetry(
+        () =>
+          fetch(CODEX_RESPONSES_URL, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              accept: "text/event-stream",
+              ...this.codexAuthHeaders(),
+            },
+            body: JSON.stringify({
+              model: this.model,
+              instructions,
+              input,
+              tools: toResponsesTools(tools),
+              stream: true,
+              store: false,
+            }),
+            signal,
+          }),
+        { model: this.model, label: "chatgpt-oauth-backend", signal, onActivity },
+      );
     } finally {
       if (keepalive) clearInterval(keepalive);
     }
     if (!res.ok || !res.body) {
+      // Never a 429 — sendWithRateLimitRetry owns that status.
       throw new Error(
         // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
         // HTTP status is reported either way, so an unreadable body costs detail in the
         // text, never a wrong conclusion. Verified there is no branch on this value.
-        `Codex Responses http ${res.status}: ${(await res.text().catch(() => "")).slice(0, 400)}`,
+        // Redacted like grok's sibling path: a provider error body can carry an
+        // account id or a credential-shaped token, and this string is rendered
+        // into the panel chat verbatim.
+        `Codex Responses http ${res.status}: ${sanitizeDetail(await res.text().catch(() => ""), 400)}`,
       );
     }
 
@@ -431,16 +442,28 @@ export class ChatGptOAuthBackend extends OllamaBackend {
       resultEmitted = true;
     } catch (err) {
       const interrupted = abort.signal.aborted;
+      const rateLimited = asRateLimitError(err);
       if (!interrupted) {
         logger.warn(`[chatgpt-oauth-backend] turn failed: ${msgOf(err)}`);
-        yield { type: "error", message: `chatgpt backend: ${msgOf(err)}` };
-        yield {
-          type: "assistant",
-          text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
-        };
+        if (rateLimited) {
+          // Already a finished sentence naming the model, the reason and the
+          // remedy — it travels alone rather than under a "chatgpt backend:" prefix
+          // that would blame this adapter for the provider's limit.
+          yield { type: "error", message: rateLimited.message, rateLimit: true };
+        } else {
+          yield { type: "error", message: `chatgpt backend: ${msgOf(err)}` };
+          yield {
+            type: "assistant",
+            text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+          };
+        }
       }
       if (!resultEmitted) {
-        yield { type: "result", ok: false, subtype: interrupted ? "interrupted" : "error" };
+        yield {
+          type: "result",
+          ok: false,
+          subtype: interrupted ? "interrupted" : rateLimited ? "rate_limit" : "error",
+        };
       }
     } finally {
       if (this.turnAbort === abort) this.turnAbort = null;

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -199,6 +199,11 @@ export class ChatGptOAuthBackend extends OllamaBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
+      // Capture the model BEFORE the async boundary. The thunk below is re-invoked
+      // after a rate-limit backoff, and re-reading `this.model` there sends the retried
+      // request to whatever the user switched to during the wait — while the notice they
+      // already saw names the old one. One turn, two models, no way to tell from the log.
+      const model = this.model;
       // 429s are waited out when the window is bounded and named; every other
       // status falls through unchanged (orchestrator/rate-limit.ts).
       res = yield* sendWithRateLimitRetry(
@@ -211,7 +216,7 @@ export class ChatGptOAuthBackend extends OllamaBackend {
               ...this.codexAuthHeaders(),
             },
             body: JSON.stringify({
-              model: this.model,
+              model,
               instructions,
               input,
               tools: toResponsesTools(tools),
@@ -220,7 +225,7 @@ export class ChatGptOAuthBackend extends OllamaBackend {
             }),
             signal,
           }),
-        { model: this.model, label: "chatgpt-oauth-backend", signal, onActivity },
+        { model, label: "chatgpt-oauth-backend", signal, onActivity },
       );
     } finally {
       if (keepalive) clearInterval(keepalive);
@@ -389,7 +394,17 @@ export class ChatGptOAuthBackend extends OllamaBackend {
             yield r.value;
           }
         } catch (err) {
-          if (!abort.signal.aborted && !imagesStripped && this.turnHistory.some((m) => m.images?.length)) {
+          // A RateLimitError is NOT an image rejection. Without this clause a 429 on any
+          // history carrying an image lands here, strips the images, tells the user this
+          // endpoint rejected image input, and then answers WITHOUT the image — a false
+          // explanation and a silently degraded answer, both from a rate limit the retry
+          // above already knows how to wait out. Let it through to the 429 handling.
+          if (
+            !abort.signal.aborted &&
+            !asRateLimitError(err) &&
+            !imagesStripped &&
+            this.turnHistory.some((m) => m.images?.length)
+          ) {
             imagesStripped = true;
             logger.warn(
               `[chatgpt-oauth-backend] image input rejected (${msgOf(err).slice(0, 200)}) — retrying without images`,

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -83,6 +83,7 @@ import {
 } from "../services/code-provider-auth.js";
 import { OAUTH_PROVIDERS, assertAllowedTokenHost, grokTokenFile, redactTokens } from "../services/oauth-flow.js";
 import { OllamaBackend } from "./ollama-backend.js";
+import { asRateLimitError, sendWithRateLimitRetry } from "./rate-limit.js";
 
 function msgOf(err: unknown): string {
   return errorText(err);
@@ -1411,27 +1412,34 @@ export class GrokDirectBackend extends OllamaBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
-      res = await fetch(GROK_XAI_RESPONSES_URL, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "text/event-stream",
-          authorization: `Bearer ${this.accessToken}`,
-        },
-        body: JSON.stringify({
-          model: this.model,
-          instructions,
-          input,
-          tools: grokToolsToResponses(tools),
-          stream: true,
-          store: false,
-        }),
-        signal,
-      });
+      // 429s are waited out when xAI names a bounded window; every other status
+      // falls through to the error below unchanged (orchestrator/rate-limit.ts).
+      res = yield* sendWithRateLimitRetry(
+        () =>
+          fetch(GROK_XAI_RESPONSES_URL, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              accept: "text/event-stream",
+              authorization: `Bearer ${this.accessToken}`,
+            },
+            body: JSON.stringify({
+              model: this.model,
+              instructions,
+              input,
+              tools: grokToolsToResponses(tools),
+              stream: true,
+              store: false,
+            }),
+            signal,
+          }),
+        { model: this.model, label: "grok-backend", signal, onActivity },
+      );
     } finally {
       if (keepalive) clearInterval(keepalive);
     }
     if (!res.ok || !res.body) {
+      // Never a 429 — sendWithRateLimitRetry owns that status.
       // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
       // HTTP status is reported either way, so an unreadable body costs detail in the
       // text, never a wrong conclusion. Verified there is no branch on this value.
@@ -1610,16 +1618,28 @@ export class GrokDirectBackend extends OllamaBackend {
       resultEmitted = true;
     } catch (err) {
       const interrupted = abort.signal.aborted;
+      const rateLimited = asRateLimitError(err);
       if (!interrupted) {
         logger.warn(`[grok-backend] direct-token turn failed: ${msgOf(err)}`);
-        yield { type: "error", message: `grok backend: ${msgOf(err)}` };
-        yield {
-          type: "assistant",
-          text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
-        };
+        if (rateLimited) {
+          // Already a finished sentence naming the model, the reason and the
+          // remedy — it travels alone rather than under a "grok backend:" prefix
+          // that would blame this adapter for the provider's limit.
+          yield { type: "error", message: rateLimited.message, rateLimit: true };
+        } else {
+          yield { type: "error", message: `grok backend: ${msgOf(err)}` };
+          yield {
+            type: "assistant",
+            text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+          };
+        }
       }
       if (!resultEmitted) {
-        yield { type: "result", ok: false, subtype: interrupted ? "interrupted" : "error" };
+        yield {
+          type: "result",
+          ok: false,
+          subtype: interrupted ? "interrupted" : rateLimited ? "rate_limit" : "error",
+        };
       }
     } finally {
       if (this.turnAbort === abort) this.turnAbort = null;

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -1412,6 +1412,11 @@ export class GrokDirectBackend extends OllamaBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
+      // Capture the model BEFORE the async boundary. The thunk below is re-invoked
+      // after a rate-limit backoff, and re-reading `this.model` there sends the retried
+      // request to whatever the user switched to during the wait — while the notice they
+      // already saw names the old one. One turn, two models, no way to tell from the log.
+      const model = this.model;
       // 429s are waited out when xAI names a bounded window; every other status
       // falls through to the error below unchanged (orchestrator/rate-limit.ts).
       res = yield* sendWithRateLimitRetry(
@@ -1424,7 +1429,7 @@ export class GrokDirectBackend extends OllamaBackend {
               authorization: `Bearer ${this.accessToken}`,
             },
             body: JSON.stringify({
-              model: this.model,
+              model,
               instructions,
               input,
               tools: grokToolsToResponses(tools),
@@ -1433,7 +1438,7 @@ export class GrokDirectBackend extends OllamaBackend {
             }),
             signal,
           }),
-        { model: this.model, label: "grok-backend", signal, onActivity },
+        { model, label: "grok-backend", signal, onActivity },
       );
     } finally {
       if (keepalive) clearInterval(keepalive);

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -965,6 +965,11 @@ export class OllamaBackend implements AgentBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
+      // Capture the model BEFORE the async boundary. The thunk below is re-invoked
+      // after a rate-limit backoff, and re-reading `this.model` there sends the retried
+      // request to whatever the user switched to during the wait — while the notice they
+      // already saw names the old one. One turn, two models, no way to tell from the log.
+      const model = this.model;
       // A 429 that names a bounded wait is waited out here rather than ending the
       // turn: this endpoint serves every OpenAI-compatible provider (moonshot,
       // glm, minimax, openrouter, …), several of which limit by requests-per-
@@ -978,7 +983,7 @@ export class OllamaBackend implements AgentBackend {
               method: "POST",
               headers: { "content-type": "application/json", ...this.authHeaders() },
               body: JSON.stringify({
-                model: this.model,
+                model,
                 messages: toOpenAiMessages(messages),
                 tools,
                 tool_choice: "auto",
@@ -1004,7 +1009,7 @@ export class OllamaBackend implements AgentBackend {
               method: "POST",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({
-                model: this.model,
+                model,
                 messages: toOllamaMessages(messages),
                 tools,
                 stream: true,
@@ -1018,7 +1023,7 @@ export class OllamaBackend implements AgentBackend {
               }),
               signal,
             }),
-        { model: this.model, label: "ollama-backend", signal, onActivity },
+        { model, label: "ollama-backend", signal, onActivity },
       );
     } finally {
       if (keepalive) clearInterval(keepalive);

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -48,6 +48,7 @@ import {
 import { OLLAMA_CAPABILITIES, stampTurn } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 import { resolvePrompt } from "../services/prompt-overrides.js";
+import { asRateLimitError, sanitizeDetail, sendWithRateLimitRetry } from "./rate-limit.js";
 import { retiredToolMessage } from "../tools/vocabulary.js";
 import { PANEL_TOOL_MCP_TIMEOUT_MS } from "./panel-tools.js";
 
@@ -964,9 +965,16 @@ export class OllamaBackend implements AgentBackend {
     const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
     let res: Response;
     try {
-      res =
-        this.api === "openai"
-          ? await fetch(`${this.host}/chat/completions`, {
+      // A 429 that names a bounded wait is waited out here rather than ending the
+      // turn: this endpoint serves every OpenAI-compatible provider (moonshot,
+      // glm, minimax, openrouter, …), several of which limit by requests-per-
+      // minute, and a mid-tool-loop 429 asking for one second used to throw away
+      // every round the turn had already completed. Only 429 is intercepted —
+      // every other status reaches the error below exactly as before.
+      res = yield* sendWithRateLimitRetry(
+        () =>
+          this.api === "openai"
+          ? fetch(`${this.host}/chat/completions`, {
               method: "POST",
               headers: { "content-type": "application/json", ...this.authHeaders() },
               body: JSON.stringify({
@@ -992,7 +1000,7 @@ export class OllamaBackend implements AgentBackend {
               }),
               signal,
             })
-          : await fetch(`${this.host}/api/chat`, {
+          : fetch(`${this.host}/api/chat`, {
               method: "POST",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({
@@ -1009,11 +1017,15 @@ export class OllamaBackend implements AgentBackend {
                 },
               }),
               signal,
-            });
+            }),
+        { model: this.model, label: "ollama-backend", signal, onActivity },
+      );
     } finally {
       if (keepalive) clearInterval(keepalive);
     }
     if (!res.ok || !res.body) {
+      // Never a 429: sendWithRateLimitRetry either waited that out or threw a
+      // RateLimitError with a finished sentence (see runTurn's catch).
       // Stamp the HTTP status on the error. The media strip-and-retry (#790)
       // must fire ONLY on a request the endpoint actually rejected: a connection
       // reset or a truncated stream is not evidence that the model refused the
@@ -1024,7 +1036,12 @@ export class OllamaBackend implements AgentBackend {
           // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
           // HTTP status is reported either way, so an unreadable body costs detail in the
           // text, never a wrong conclusion. Verified there is no branch on this value.
-          `${this.api === "openai" ? `${this.host}/chat/completions` : "ollama /api/chat"} http ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`,
+          // Sanitized, not raw: a hosted endpoint's error body carries account
+          // ids and credential-shaped tokens (moonshot's 429 carried both), and
+          // this string is rendered into the panel chat verbatim. The 429 that
+          // exposed it is handled above; every OTHER status reaches this line
+          // and can carry exactly the same envelope.
+          `${this.api === "openai" ? `${this.host}/chat/completions` : "ollama /api/chat"} http ${res.status}: ${sanitizeDetail(await res.text().catch(() => ""), 300)}`,
         ),
         { httpStatus: res.status },
       );
@@ -1934,28 +1951,41 @@ export class OllamaBackend implements AgentBackend {
       resultEmitted = true;
     } catch (err) {
       const interrupted = abort.signal.aborted;
+      const rateLimited = asRateLimitError(err);
       if (!interrupted) {
         // Surface the failure IN the chat too — an error event alone leaves the
         // panel silent (the turn just ends), which reads as a wedge.
         logger.warn(`[ollama-backend] turn failed: ${msgOf(err)}`);
-        yield { type: "error", message: `ollama backend: ${msgOf(err)}` };
-        // #2221 — a 413 that got this far is one the strip could not rescue
-        // (nothing left to remove, or it had already fired once this turn). It
-        // still must not be handed to the user as an anonymous failure: the
-        // panel's fallback advice for a dead turn is "try again", and size is
-        // precisely the cause for which that is guaranteed wrong. Name it, and
-        // keep the raw body — the provider's own text ("Downloaded image content
-        // cannot exceed 30MB") is the most useful sentence available.
-        const tooLarge = (err as { httpStatus?: number } | null)?.httpStatus === 413;
-        yield {
-          type: "assistant",
-          text: tooLarge
-            ? `📦 The request was too large for this endpoint to accept (http 413), so the turn could not run. Retrying the same message will not help — the payload is rebuilt identically each time. Start a fresh chat to clear what this conversation has accumulated, or re-send with a smaller attachment.\n\nEndpoint said: ${msgOf(err).slice(0, 400)}`
-            : `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
-        };
+        if (rateLimited) {
+          // The rate-limit message is already a finished sentence naming the
+          // model, the reason and the remedy, so it travels alone: prefixing it
+          // with "ollama backend:" would attribute the provider's limit to this
+          // adapter, and the second bubble below would repeat it verbatim.
+          yield { type: "error", message: rateLimited.message, rateLimit: true };
+        } else {
+          yield { type: "error", message: `ollama backend: ${msgOf(err)}` };
+          // #2221 — a 413 that got this far is one the strip could not rescue
+          // (nothing left to remove, or it had already fired once this turn). It
+          // still must not be handed to the user as an anonymous failure: the
+          // panel's fallback advice for a dead turn is "try again", and size is
+          // precisely the cause for which that is guaranteed wrong. Name it, and
+          // keep the raw body — the provider's own text ("Downloaded image content
+          // cannot exceed 30MB") is the most useful sentence available.
+          const tooLarge = (err as { httpStatus?: number } | null)?.httpStatus === 413;
+          yield {
+            type: "assistant",
+            text: tooLarge
+              ? `📦 The request was too large for this endpoint to accept (http 413), so the turn could not run. Retrying the same message will not help — the payload is rebuilt identically each time. Start a fresh chat to clear what this conversation has accumulated, or re-send with a smaller attachment.\n\nEndpoint said: ${msgOf(err).slice(0, 400)}`
+              : `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+          };
+        }
       }
       if (!resultEmitted) {
-        yield { type: "result", ok: false, subtype: interrupted ? "interrupted" : "error" };
+        yield {
+          type: "result",
+          ok: false,
+          subtype: interrupted ? "interrupted" : rateLimited ? "rate_limit" : "error",
+        };
       }
     } finally {
       if (this.turnAbort === abort) this.turnAbort = null;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -479,6 +479,8 @@ export class PanelAgent {
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   /** Guards against a trip firing twice / racing a real result for one turn. */
   private idleTripped = false;
+  /** One "waiting out a rate limit" line per turn (see the rate_limit case). */
+  private rateLimitSurfaced = false;
   /** A provider-native, non-user-cancel recovery is attempted at most once per turn. */
   private stallRecoverySteered = false;
   /** Tool calls started (item/started) but not yet ended (item/completed). A tool
@@ -1771,6 +1773,7 @@ export class PanelAgent {
       // it's meant to catch, so onTurnStalled() would no-op. (handleEvent's later
       // `busy = true` becomes a harmless no-op.) Also shows "working" immediately.
       this.errorSurfaced = false; // fresh turn → its failure (if any) is unreported
+      this.rateLimitSurfaced = false; // …and its first rate-limit wait is unannounced
       this.interruptRequested = false; // a stale interrupt can't mute THIS turn's failure
       this.busy = true;
       // Snapshot the model this turn runs on, so a live setModel mid-turn can't let
@@ -2266,6 +2269,26 @@ export class PanelAgent {
         }
         break;
       }
+      case "rate_limit": {
+        // The provider asked us to slow down and the backend is waiting the
+        // window out. NOT a failure: the turn is still in flight and its result
+        // will arrive normally, so this neither ends the turn nor spends the
+        // once-per-turn error slot — a rate limit that swallowed the slot would
+        // silence the first genuine error after it.
+        this.busy = true;
+        this.deps.onTurn?.(this.tabId, "working");
+        // ONE line per turn. A 3-req/min limiter can 429 several rounds of the
+        // same turn, and a bubble per retry would bury the conversation under
+        // status about itself. The first one already says what is happening.
+        if (ev.message && !this.rateLimitSurfaced) {
+          this.rateLimitSurfaced = true;
+          this.deps.onSay(this.tabId, ev.message);
+        }
+        logger.info(
+          `[panel-agent ${this.short()}] rate limited${ev.retryInMs ? ` — waiting ${Math.round(ev.retryInMs / 1000)}s` : ""}`,
+        );
+        break;
+      }
       case "error": {
         // A backend-reported turn error (codex/gemini/grok emit these before
         // their error result). Without this case the message fell through
@@ -2294,10 +2317,16 @@ export class PanelAgent {
           // self-contained. Framing it as "turn failed … nothing was lost, try
           // again" would be two lies (it didn't fail; something may have been
           // DONE) and would invite a destructive duplicate retry.
+          // A RATE LIMIT is a turn failure — it takes the slot — but its message
+          // is already a finished sentence that names the model, the reason and
+          // the remedy. Wrapping it in "The <model> turn failed: …" would say the
+          // model twice and bury the one actionable fact behind two prefixes, and
+          // the generic tail would offer "check the terminal" for a condition the
+          // terminal has nothing to add to.
           this.deps.onSay(
             this.tabId,
-            ev.unverifiedCompletion || ev.outcomeUnknown
-              ? `⚠️ ${detail}`
+            ev.unverifiedCompletion || ev.outcomeUnknown || ev.rateLimit
+              ? `⚠️ ${detail.replace(/^⚠️\s*/, "")}`
               : `⚠️ The ${this.model} turn failed: ${detail}\n\nNothing was lost — try again, switch models from the composer picker, or check the terminal running the orchestrator for more detail.`,
           );
         }

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -174,9 +174,11 @@ function parseWaitFromProse(text: string): number | null {
  * first — but it knows nothing about `org-7df23a26037240f88f967fb1c64d8e3f` or
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
  * SHAPE, not a list of known prefixes: a prefixed opaque run, or a long bare
- * hex/base62 run, is an identifier whatever the vendor calls it, and no
- * rate-limit explanation needs one to be useful. A vendor inventing a new prefix
- * tomorrow is covered without a code change.
+ * run, is an identifier whatever the vendor calls it, and no rate-limit
+ * explanation needs one to be useful. A vendor inventing a new prefix tomorrow is
+ * covered without a code change, and so is one that mints ids with no digit in
+ * them (#2313) — shape here means LENGTH and the absence of a space, never a
+ * character class, and never a guess at whether a run reads like English.
  *
  * Deliberately aggressive. Over-redaction costs a few characters of an error
  * message; under-redaction publishes an account id into a chat log that gets
@@ -197,8 +199,21 @@ export function sanitizeDetail(raw: string, max = 200): string {
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
-    // bare long hex / base62 runs (an id that came without a prefix)
-    .replace(/\b(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{20,}\b/g, "<redacted>")
+    // bare long runs (an id that came without a prefix). LENGTH is the whole
+    // test: there is deliberately no `(?=[A-Za-z0-9]*\d)` lookahead requiring
+    // a digit. That lookahead was here until #2313, and it meant an all-alphabetic
+    // id — `account abcdefghijklmnopqrstuv is limited` — passed through untouched
+    // while the same string ending in a digit was redacted. Neither other rule
+    // caught it: the prefixed rule needs a `-`/`_`, and the UUID rule needs the
+    // UUID shape.
+    //
+    // Do NOT put it back to protect prose — it does not buy what it looks like it
+    // buys. Measured over 1.19M word tokens of this repo's comments, docs and
+    // user-facing strings, exactly ONE all-lowercase run of 20+ characters is an
+    // English word (`nondeterministically`, once), and it has never appeared in a
+    // 429. An unbroken 20-character alphanumeric run is an identifier; an
+    // explanatory sentence has spaces in it, and every space ends a run.
+    .replace(/\b[A-Za-z0-9]{20,}\b/g, "<redacted>")
     // e-mail addresses occasionally appear in quota messages
     .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>");
   return masked.replace(/\s+/g, " ").trim().slice(0, max);

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -184,6 +184,17 @@ function parseWaitFromProse(text: string): number | null {
  */
 export function sanitizeDetail(raw: string, max = 200): string {
   const masked = redactTokens(raw)
+    // UUID-shaped ids FIRST, with any prefix attached. Their hyphens defeat both
+    // rules below: the longest unbroken run inside a UUID is 12 characters, so the
+    // bare-run rule never fires, and the prefixed rule matches only the TAIL —
+    // which is worse than missing it outright, because
+    // `550e8400-e29b-41d4-a716-<redacted>` reads as sanitized while 24 of its 36
+    // characters shipped. A partial redaction nobody re-checks is the dangerous
+    // shape here, so this runs before anything can produce one.
+    .replace(
+      /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g,
+      (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
+    )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
     // bare long hex / base62 runs (an id that came without a prefix)

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -1,0 +1,429 @@
+// HTTP 429 across every backend that talks to a provider over HTTP.
+//
+// WHY THIS EXISTS
+// Each streaming backend had the same three lines — `if (!res.ok) throw new
+// Error(\`… http ${status}: ${await res.text()}\`)` — and a 429 fell through them
+// like any other failure: the turn died, and the provider's raw JSON was pasted
+// into the panel. Live on kimi-k3 that read:
+//
+//   ⚠️ The kimi-k3 turn failed: ollama backend: https://api.moonshot.ai/v1/chat/
+//   completions http 429: {"error":{"message":"Your account org-7df23a…<cak-fc91…>
+//   request reached organization max RPM: 3, please try again after 1 seconds"}}
+//
+// Three separate defects in one line. The turn was thrown away over a ONE SECOND
+// wait, after four successful tool rounds. The user was handed a provider's
+// internal envelope instead of a sentence. And that envelope carried their
+// organization id and a credential-shaped token into the chat log — from which it
+// went into a screenshot, which is how this bug was reported.
+//
+// WHAT THIS MODULE DECIDES, AND WHAT IT REFUSES TO
+// A 429 is the provider telling us to wait, so the honest response is to wait —
+// but only when it says HOW LONG and the wait is bounded. Everything here is
+// built around that distinction:
+//
+//   retryable — a wait window we can sit out. Retried, within a hard budget.
+//   quota     — the account is out of credit/quota. More requests cannot help;
+//               retrying would burn the budget to arrive at the same answer, so
+//               this NEVER retries however short a window came with it.
+//   unknown   — a 429 with no window we could parse. Surfaced immediately rather
+//               than retried on a guessed delay: a fabricated backoff against an
+//               unknown limiter is how a rate limit becomes a rate-limit storm.
+//
+// The default is to NOT retry. A 429 opts in by carrying a parseable window, the
+// same direction of default services/download-retry.ts takes, and for the same
+// reason: a wrongly-not-retried request reproduces exactly today's behaviour,
+// while a wrongly-retried one hammers a limiter that just asked us to stop.
+//
+// NOTHING FROM THE PROVIDER IS ECHOED RAW. See sanitizeDetail.
+
+import type { AgentEvent } from "./agent-backend.js";
+import { redactTokens } from "../services/oauth-flow.js";
+import { logger } from "../utils/logger.js";
+
+/** How many times one request may be re-sent after a 429. */
+export function rateLimitMaxRetries(): number {
+  const n = Number(process.env.COMFYUI_MCP_RATE_LIMIT_RETRIES);
+  return Number.isFinite(n) && n >= 0 ? n : 3;
+}
+
+/**
+ * Ceiling on the TOTAL time one request may spend waiting out 429s.
+ *
+ * A per-attempt cap is not enough: three 25s windows are individually reasonable
+ * and together are 75 seconds of a user watching a spinner. The budget is spent
+ * across attempts, and a window that would overrun it is declined rather than
+ * truncated — sleeping less than the provider asked for is a retry we already
+ * know is too early.
+ */
+export function rateLimitMaxTotalWaitMs(): number {
+  const n = Number(process.env.COMFYUI_MCP_RATE_LIMIT_MAX_WAIT_MS);
+  return Number.isFinite(n) && n > 0 ? n : 60_000;
+}
+
+/**
+ * Waits at or above this get a line in the chat; shorter ones pass in silence.
+ *
+ * A sub-second retry is invisible to the user — the turn just continues, a beat
+ * later — and announcing it would be noise about a non-event. A 20-second one is
+ * indistinguishable from a hang unless we say what is happening.
+ */
+export function rateLimitAnnounceMs(): number {
+  const n = Number(process.env.COMFYUI_MCP_RATE_LIMIT_ANNOUNCE_MS);
+  return Number.isFinite(n) && n >= 0 ? n : 2_000;
+}
+
+export type RateLimitKind = "retryable" | "quota" | "unknown";
+
+export interface RateLimitVerdict {
+  kind: RateLimitKind;
+  /** The wait the provider named. Present only for `retryable`. */
+  retryAfterMs?: number;
+  /** A SANITIZED fragment of the provider's explanation, or undefined. */
+  detail?: string;
+}
+
+/** An error whose `message` is already the finished, user-facing sentence. */
+export class RateLimitError extends Error {
+  readonly kind: RateLimitKind;
+  readonly retryAfterMs?: number;
+  constructor(message: string, kind: RateLimitKind, retryAfterMs?: number) {
+    super(message);
+    this.name = "RateLimitError";
+    this.kind = kind;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/** Is this the error the retry driver gave up with? (Backends branch on it.) */
+export function asRateLimitError(err: unknown): RateLimitError | null {
+  return err instanceof RateLimitError ? err : null;
+}
+
+/** Body markers that mean "more requests will not help until the user acts". */
+const QUOTA_MARKERS = [
+  "insufficient_quota",
+  "quota_exceeded",
+  "billing_hard_limit_reached",
+  "exceeded your current quota",
+  "credit balance is too low",
+  "out of credits",
+  "no remaining credits",
+  "payment required",
+];
+
+/** `1s`, `500ms`, `6m0s`, `1.5s` — the duration form OpenAI-compatible endpoints
+ *  use for `x-ratelimit-reset-*`. Returns ms, or null if it is not that shape. */
+function parseResetDuration(raw: string): number | null {
+  const s = raw.trim().toLowerCase();
+  if (!s) return null;
+  const re = /(\d+(?:\.\d+)?)\s*(ms|s|m|h)/g;
+  let total = 0;
+  let saw = false;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(s)) !== null) {
+    saw = true;
+    const n = Number(m[1]);
+    if (!Number.isFinite(n)) return null;
+    total += n * (m[2] === "ms" ? 1 : m[2] === "s" ? 1000 : m[2] === "m" ? 60_000 : 3_600_000);
+  }
+  // Reject trailing junk: "6m0s" is a duration, "6 messages" is not. The matches
+  // must account for the whole string once the separators are removed.
+  if (!saw || s.replace(re, "").replace(/[\s,]/g, "") !== "") return null;
+  return Math.round(total);
+}
+
+/**
+ * `Retry-After`: delta-seconds or an HTTP-date (RFC 9110 §10.2.3).
+ *
+ * A date in the PAST yields 0, not a negative wait — some limiters send the
+ * window's start rather than its end, and a negative sleep would silently become
+ * an instant retry with no wait at all.
+ */
+function parseRetryAfter(raw: string | null): number | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (/^\d+(\.\d+)?$/.test(s)) return Math.round(Number(s) * 1000);
+  const at = Date.parse(s);
+  if (Number.isFinite(at)) return Math.max(0, at - Date.now());
+  return null;
+}
+
+/** "please try again after 1 seconds", "retry in 500ms", "try again in 2 minutes". */
+function parseWaitFromProse(text: string): number | null {
+  const m = text.match(
+    /\b(?:try again|retry|retry again|wait)\b[^.\n]{0,40}?\b(\d+(?:\.\d+)?)\s*(ms|millis(?:econds?)?|s|secs?|seconds?|m|mins?|minutes?|h|hours?)\b/i,
+  );
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  const unit = m[2].toLowerCase();
+  const mult = unit.startsWith("ms") || unit.startsWith("milli")
+    ? 1
+    : unit.startsWith("s")
+      ? 1000
+      : unit.startsWith("m")
+        ? 60_000
+        : 3_600_000;
+  return Math.round(n * mult);
+}
+
+/**
+ * Strip anything that identifies the ACCOUNT out of a provider message.
+ *
+ * `redactTokens` covers credentials in the shapes OAuth uses, and it is applied
+ * first — but it knows nothing about `org-7df23a26037240f88f967fb1c64d8e3f` or
+ * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
+ * SHAPE, not a list of known prefixes: a prefixed opaque run, or a long bare
+ * hex/base62 run, is an identifier whatever the vendor calls it, and no
+ * rate-limit explanation needs one to be useful. A vendor inventing a new prefix
+ * tomorrow is covered without a code change.
+ *
+ * Deliberately aggressive. Over-redaction costs a few characters of an error
+ * message; under-redaction publishes an account id into a chat log that gets
+ * screenshotted.
+ */
+export function sanitizeDetail(raw: string, max = 200): string {
+  const masked = redactTokens(raw)
+    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
+    .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
+    // bare long hex / base62 runs (an id that came without a prefix)
+    .replace(/\b(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{20,}\b/g, "<redacted>")
+    // e-mail addresses occasionally appear in quota messages
+    .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>");
+  return masked.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/**
+ * Pull the human sentence out of a provider error body.
+ *
+ * OpenAI-compatible bodies nest it at `error.message`; some endpoints answer with
+ * bare text or HTML. Anything not JSON is used only if it is SHORT — a limiter's
+ * HTML block page has no sentence worth showing, and pasting its first 200
+ * characters is how the raw-dump problem started.
+ */
+function extractMessage(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const err = parsed?.error;
+    const candidate =
+      (err && typeof err === "object" ? (err as Record<string, unknown>).message : undefined) ??
+      (typeof err === "string" ? err : undefined) ??
+      parsed?.message ??
+      parsed?.detail;
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+    return undefined;
+  } catch {
+    if (trimmed.length > 300 || /^\s*</.test(trimmed)) return undefined;
+    return trimmed;
+  }
+}
+
+/**
+ * Drop the provider's "please try again after N seconds" clause from the text
+ * shown to a user.
+ *
+ * That clause is an instruction to the CLIENT, and the client has already obeyed
+ * it — the wait was parsed out of this very sentence. Quoting it back reads as a
+ * contradiction next to the outcome ("did not recover after 3 attempts … please
+ * try again after 1 seconds") and tells the user to do something we did for them.
+ * What is left is the part they cannot act on any other way: WHICH limit was hit.
+ */
+function stripRetryHint(text: string): string {
+  return text
+    .replace(
+      /[,;.]?\s*(?:please\s+)?(?:try again|retry(?: again)?|wait)\b[^.\n]{0,40}?\b\d+(?:\.\d+)?\s*(?:ms|millis(?:econds?)?|s|secs?|seconds?|m|mins?|minutes?|h|hours?)\b\.?/gi,
+      "",
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Classify a response as a rate limit, or not at all.
+ *
+ * 429 ONLY. A 402/403 for billing is a different conversation with the user (and
+ * a different remedy), and folding it in here would have this module telling
+ * someone to "wait" for a limit that no amount of waiting clears.
+ */
+export function classifyRateLimit(status: number, headers: Headers, body: string): RateLimitVerdict | null {
+  if (status !== 429) return null;
+  const message = extractMessage(body);
+  const haystack = `${body} ${message ?? ""}`.toLowerCase();
+  const detail = message ? sanitizeDetail(stripRetryHint(message)) : undefined;
+
+  // Quota is decided BEFORE the window is read, and outranks it. Moonshot and
+  // OpenAI both answer an exhausted balance with a 429 that still carries a
+  // retry hint; honouring that hint would sleep, retry, and fail identically.
+  if (QUOTA_MARKERS.some((marker) => haystack.includes(marker))) {
+    return { kind: "quota", detail };
+  }
+
+  const waitMs =
+    parseRetryAfter(headers.get("retry-after")) ??
+    parseResetDuration(headers.get("x-ratelimit-reset-requests") ?? "") ??
+    parseResetDuration(headers.get("x-ratelimit-reset-tokens") ?? "") ??
+    parseResetDuration(headers.get("x-ratelimit-reset") ?? "") ??
+    (message ? parseWaitFromProse(message) : null);
+
+  if (waitMs === null) return { kind: "unknown", detail };
+  return { kind: "retryable", retryAfterMs: waitMs, detail };
+}
+
+/** "1s" / "20s" / "2m30s" — for a sentence a person reads, not a machine. */
+export function humanWait(ms: number): string {
+  if (ms < 1000) return `${Math.max(1, Math.round(ms))}ms`;
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return s ? `${m}m${s}s` : `${m}m`;
+}
+
+/** The line shown while waiting out a window (announced waits only). */
+export function retryingNotice(model: string, waitMs: number, verdict: RateLimitVerdict): string {
+  const because = verdict.detail ? ` (${verdict.detail})` : "";
+  return `⏳ ${model} is rate limited${because}. Retrying in ${humanWait(waitMs)}…`;
+}
+
+/** The sentence the turn ends on when waiting is not an option, or did not work. */
+export function gaveUpNotice(
+  model: string,
+  verdict: RateLimitVerdict,
+  attempts: number,
+  /** Whether the provider's response body could be read at all (#796): "it did
+   *  not say how long to wait" is a claim about what arrived, and must not be
+   *  made about a body we never managed to read. */
+  bodyReadable = true,
+): string {
+  const because = verdict.detail ? ` — ${verdict.detail}` : "";
+  if (verdict.kind === "quota") {
+    return (
+      `⚠️ ${model} rejected the request: the account is out of quota or credit${because}. ` +
+      `Retrying will not help — top up or change plan with the provider, or switch models from the composer picker.`
+    );
+  }
+  if (attempts > 0) {
+    return (
+      `⚠️ ${model} is rate limited and did not recover after ${attempts} ${attempts === 1 ? "attempt" : "attempts"}${because}. ` +
+      `Nothing was lost — try again in a moment, or switch models from the composer picker.`
+    );
+  }
+  const why =
+    verdict.kind !== "unknown"
+      ? ""
+      : bodyReadable
+        ? "The provider did not say how long to wait, so the request was not retried automatically. "
+        : "Its response could not be read, so there was no wait to honour and the request was not retried automatically. ";
+  return (
+    `⚠️ ${model} hit its rate limit${because}. ${why}` +
+    `Nothing was lost — try again in a moment, or switch models from the composer picker.`
+  );
+}
+
+/** Abort-aware sleep: an interrupt during a backoff must not sit out the window. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Send a request, waiting out 429s that name a bounded window.
+ *
+ * Yields `rate_limit` events for waits worth announcing and RETURNS the response
+ * to the caller, which keeps its own handling for every other status — a 500 or a
+ * 400 reaches the existing error path untouched, so this changes one status and
+ * nothing else.
+ *
+ * BODY OWNERSHIP: the body is read here ONLY on a 429 (to classify it). A
+ * response returned to the caller therefore always has its body unread, which is
+ * what the callers' `await res.text()` error paths assume. A 429 we give up on
+ * never comes back as a response — it is thrown as a RateLimitError whose message
+ * is already the finished sentence — so no caller is ever handed a response whose
+ * body this consumed.
+ */
+export async function* sendWithRateLimitRetry(
+  send: () => Promise<Response>,
+  opts: { model: string; label: string; signal: AbortSignal; onActivity?: () => void },
+): AsyncGenerator<AgentEvent, Response> {
+  const maxRetries = rateLimitMaxRetries();
+  const budgetMs = rateLimitMaxTotalWaitMs();
+  let spentMs = 0;
+  let attempts = 0;
+
+  for (;;) {
+    const res = await send();
+    if (res.status !== 429) return res;
+
+    // 429 — from here the body belongs to us.
+    //
+    // An UNREADABLE body is not an empty one (#796). Both leave us without the
+    // provider's explanation, but they support different sentences: "it did not
+    // say how long to wait" is a claim about what the provider sent, and making
+    // it about a body we failed to read would be a confident wrong answer. The
+    // headers survive either way, so a Retry-After still yields a real retry.
+    const read = await res
+      .text()
+      .then((text) => ({ readable: true, text }))
+      .catch(() => ({ readable: false, text: "" }));
+    const verdict = classifyRateLimit(res.status, res.headers, read.text) ?? { kind: "unknown" as const };
+    const waitMs = verdict.retryAfterMs;
+
+    const outOfAttempts = attempts >= maxRetries;
+    const overBudget = typeof waitMs === "number" && spentMs + waitMs > budgetMs;
+    const retryable = verdict.kind === "retryable" && typeof waitMs === "number";
+
+    if (!retryable || outOfAttempts || overBudget) {
+      const why =
+        verdict.kind === "quota"
+          ? "quota exhausted"
+          : outOfAttempts
+            ? `out of retries after ${attempts}`
+            : overBudget
+              ? `window ${humanWait(waitMs ?? 0)} would exceed the ${humanWait(budgetMs)} budget`
+              : read.readable
+                ? "no retry window given"
+                : "response body unreadable";
+      logger.warn(`[${opts.label}] 429 from ${opts.model}, not retrying (${why})`);
+      throw new RateLimitError(
+        gaveUpNotice(opts.model, verdict, attempts, read.readable),
+        verdict.kind,
+        waitMs,
+      );
+    }
+
+    attempts += 1;
+    spentMs += waitMs;
+    logger.info(
+      `[${opts.label}] 429 from ${opts.model} — waiting ${humanWait(waitMs)} (attempt ${attempts}/${maxRetries}, ${humanWait(spentMs)} of ${humanWait(budgetMs)} spent)`,
+    );
+    if (waitMs >= rateLimitAnnounceMs()) {
+      yield {
+        type: "rate_limit",
+        kind: verdict.kind,
+        resetsAt: Date.now() + waitMs,
+        retryInMs: waitMs,
+        message: retryingNotice(opts.model, waitMs, verdict),
+      };
+    }
+    // The turn watchdog must keep seeing life: this IS the request making
+    // progress, and a silent 20s would otherwise read like a stalled backend.
+    opts.onActivity?.();
+    await sleep(waitMs, opts.signal);
+    opts.onActivity?.();
+  }
+}

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -186,17 +186,31 @@ function parseWaitFromProse(text: string): number | null {
  */
 export function sanitizeDetail(raw: string, max = 200): string {
   const masked = redactTokens(raw)
-    // UUID-shaped ids FIRST, with any prefix attached. Their hyphens defeat both
-    // rules below: the longest unbroken run inside a UUID is 12 characters, so the
-    // bare-run rule never fires, and the prefixed rule matches only the TAIL —
-    // which is worse than missing it outright, because
-    // `550e8400-e29b-41d4-a716-<redacted>` reads as sanitized while 24 of its 36
-    // characters shipped. A partial redaction nobody re-checks is the dangerous
-    // shape here, so this runs before anything can produce one.
-    .replace(
-      /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
-      (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
-    )
+    // A UUID anywhere in a token redacts the WHOLE token. Not the UUID, not the
+    // UUID-plus-a-recognised-prefix — the entire run of non-space characters it
+    // sits in.
+    //
+    // Every earlier version of this rule tried to PRESERVE the vendor prefix, so it
+    // had to know exactly where the prefix ended, and four separate reviews each
+    // found a different way for that to be wrong: the UUID missed entirely, then a
+    // prefix glued on with no separator, then a prefix with no digit in it (#2313),
+    // then `tenant_account_<uuid>` — where `_` is a word character, so \b offers no
+    // anchor inside the run and the optional single 2-13 character prefix segment
+    // cannot span it (#2333). Each fix was correct about its own case and left the
+    // class open.
+    //
+    // The failure mode is always the same and is worse than missing the id: the
+    // prefixed rule below then matches the UUID's own TAIL, and
+    // `tenant_account_550e8400-e29b-41d4-a716-<redacted>` ships 24 of 36 characters
+    // while READING as sanitized. Nobody re-checks a redaction that already looks
+    // done.
+    //
+    // \S has no such boundary to defeat: it does not care whether the separator is
+    // `-`, `_`, or nothing at all. The cost is the `org-` hint on a separated
+    // prefix, which is worth losing — it is the thing that caused all four leaks,
+    // and a rate-limit sentence is readable without it. A token is delimited by
+    // whitespace, so an explanatory sentence is untouched: every space ends a run.
+    .replace(/\S*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\S*/g, "<redacted>")
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
     // bare long runs (an id that came without a prefix). LENGTH is the whole

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -312,7 +312,8 @@ export function gaveUpNotice(
   if (verdict.kind === "quota") {
     return (
       `⚠️ ${model} rejected the request: the account is out of quota or credit${because}. ` +
-      `Retrying will not help — top up or change plan with the provider, or switch models from the composer picker.`
+      `Retrying will not help — top up or change plan with the provider, or switch models from the composer picker. ` +
+      `The turn stopped part-way, so if it had already started changing the graph, check the canvas before you resend.`
     );
   }
   if (attempts > 0) {

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -173,49 +173,118 @@ function parseWaitFromProse(text: string): number | null {
  * `redactTokens` covers credentials in the shapes OAuth uses, and it is applied
  * first — but it knows nothing about `org-7df23a26037240f88f967fb1c64d8e3f` or
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
- * SHAPE, not a list of known prefixes: a prefixed opaque run, or a long bare
- * run, is an identifier whatever the vendor calls it, and no rate-limit
- * explanation needs one to be useful. A vendor inventing a new prefix tomorrow is
- * covered without a code change, and so is one that mints ids with no digit in
- * them (#2313) — shape here means LENGTH and the absence of a space, never a
- * character class, and never a guess at whether a run reads like English.
+ * shape plus the smallest amount of context needed for the one ambiguous case:
+ * an all-alpha long run can be either a minted id or an English word. A
+ * prefixed/segmented opaque run, UUID, e-mail, or explicitly labelled value is
+ * an id regardless of its contents. Bare all-alpha runs need either a
+ * rate-limit label/status context or a shape that is not one of the ordinary
+ * prose words covered by the table below.
  *
- * Deliberately aggressive. Over-redaction costs a few characters of an error
- * message; under-redaction publishes an account id into a chat log that gets
- * screenshotted.
+ * This is deliberately fail-closed for structured labels and fail-readable for
+ * prose. There is no morphology heuristic that can reliably distinguish a
+ * vendor-minted all-alpha id from an English word, so the small prose table is
+ * explicit and testable rather than pretending that vowel counts solve it.
  */
+const EXPLICIT_ALPHA_IDENTIFIER_LABEL =
+  /(?:^|[\s"'([{])(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\b\s*["']?\s*(?:[:=]\s*)?["'([{]?\s*$/i;
+const DIRECT_ALPHA_IDENTIFIER_LABEL =
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|acct|user|tenant|plan)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|\s+)$/i;
+const GENERIC_ALPHA_IDENTIFIER_CONTEXT = /(?:\b(?:for|from|of|tenant|plan)\s*|[\[({]\s*)$/i;
+const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
+const NATURAL_LANGUAGE_ALPHA_RUNS = new Set([
+  "compartmentalization",
+  "counterrevolutionary",
+  "internationalization",
+  "nondeterministically",
+  "uncharacteristically",
+]);
+
+function isNaturalLanguageAlphaRun(run: string): boolean {
+  return NATURAL_LANGUAGE_ALPHA_RUNS.has(run.split(/[-_]+/, 1)[0].toLowerCase());
+}
+
+function isExplicitIdentifierValue(run: string): boolean {
+  return /^(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier))[-_]/i.test(run);
+}
+
+function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
+  const before = input.slice(Math.max(0, offset - 96), offset);
+  if (EXPLICIT_ALPHA_IDENTIFIER_LABEL.test(before)) return true;
+
+  const after = input.slice(offset + run.length);
+  const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
+  const terminal =
+    !afterClosingPunctuation.trim() ||
+    /^[\s]*[.,;!?]/.test(after) ||
+    IDENTIFIER_STATUS.test(afterClosingPunctuation);
+  if (!terminal) return false;
+
+  return DIRECT_ALPHA_IDENTIFIER_LABEL.test(before) || GENERIC_ALPHA_IDENTIFIER_CONTEXT.test(before);
+}
+
+function firstIdentifierPrefix(run: string): string {
+  const prefix = run.match(/^[A-Za-z][A-Za-z0-9]{0,12}[-_]/)?.[0] ?? "";
+  // A UUID glued directly to a vendor word (org550e8400-...) has no safe
+  // prefix boundary. Preserving that whole digit-bearing fragment would defeat
+  // the atomic UUID replacement, so only retain alphabetic prefix segments.
+  return /\d/.test(prefix.slice(0, -1)) ? "" : prefix;
+}
+
+function preserveNaturalLanguagePrefixedRun(run: string): boolean {
+  if (isExplicitIdentifierValue(run)) return false;
+  return isNaturalLanguageAlphaRun(run);
+}
+
 export function sanitizeDetail(raw: string, max = 200): string {
   const masked = redactTokens(raw)
-    // UUID-shaped ids FIRST, with any prefix attached. Their hyphens defeat both
-    // rules below: the longest unbroken run inside a UUID is 12 characters, so the
-    // bare-run rule never fires, and the prefixed rule matches only the TAIL —
-    // which is worse than missing it outright, because
-    // `550e8400-e29b-41d4-a716-<redacted>` reads as sanitized while 24 of its 36
-    // characters shipped. A partial redaction nobody re-checks is the dangerous
-    // shape here, so this runs before anything can produce one.
+    // E-mail addresses FIRST: the local part may itself look like a bare id, but
+    // #2294's contract is to mask the whole address atomically.
+    .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>")
+    // UUID-shaped ids next, before the other identifier rules. The boundary is
+    // deliberately non-alphanumeric instead of `\b`: `_` is a word character,
+    // and `tenant_account_<uuid>` must be consumed as one value rather than
+    // leaving a partial UUID for the next rule to redact.
     .replace(
-      /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
-      (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
+      /(^|[^A-Za-z0-9])((?:(?:[A-Za-z][A-Za-z0-9]{0,12}[-_])+)?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32})(?=$|[^A-Za-z0-9])/g,
+      (_m, boundary: string, value: string) => {
+        const prefix = firstIdentifierPrefix(value);
+        return `${boundary}${prefix ? `${prefix}<redacted>` : "<redacted>"}`;
+      },
     )
-    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
-    .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
-    // bare long runs (an id that came without a prefix). LENGTH is the whole
-    // test: there is deliberately no `(?=[A-Za-z0-9]*\d)` lookahead requiring
-    // a digit. That lookahead was here until #2313, and it meant an all-alphabetic
-    // id — `account abcdefghijklmnopqrstuv is limited` — passed through untouched
-    // while the same string ending in a digit was redacted. Neither other rule
-    // caught it: the prefixed rule needs a `-`/`_`, and the UUID rule needs the
-    // UUID shape.
-    //
-    // Do NOT put it back to protect prose — it does not buy what it looks like it
-    // buys. Measured over 1.19M word tokens of this repo's comments, docs and
-    // user-facing strings, exactly ONE all-lowercase run of 20+ characters is an
-    // English word (`nondeterministically`, once), and it has never appeared in a
-    // 429. An unbroken 20-character alphanumeric run is an identifier; an
-    // explanatory sentence has spaces in it, and every space ends a run.
-    .replace(/\b[A-Za-z0-9]{20,}\b/g, "<redacted>")
-    // e-mail addresses occasionally appear in quota messages
-    .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>");
+    // Prefixed and segmented opaque identifiers: org-…, org_…_…, cak-…, key_…,
+    // and long wrapper/value forms. The entire atom is matched before replacing
+    // it, so no later rule can turn a segmented value into a misleading partial.
+    .replace(
+      /(^|[^A-Za-z0-9])(((?:[A-Za-z][A-Za-z0-9]{0,12}[-_])+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/g,
+      (_m, boundary: string, run: string) =>
+        preserveNaturalLanguagePrefixedRun(run)
+          ? `${boundary}${run}`
+          : `${boundary}${firstIdentifierPrefix(run)}<redacted>`,
+    )
+    // Machine-labelled values are identifiers even when their alphabetic
+    // payload happens to be an English word. This also handles JSON-like
+    // `account_id: "..."` forms that are shorter than the bare-run threshold.
+    .replace(
+      /((?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\b\s*["']?\s*[:=]\s*["'([{]?\s*)([A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/gi,
+      (_m, label: string) => `${label}<redacted>`,
+    )
+    // Long segmented values whose first segment is itself longer than a normal
+    // prefix (for example qavexidopulnertiskym_extra) are still one atom.
+    .replace(
+      /(^|[^A-Za-z0-9])([A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)+)(?=$|[^A-Za-z0-9])/g,
+      (_m, boundary: string, run: string) =>
+        preserveNaturalLanguagePrefixedRun(run) ? `${boundary}${run}` : `${boundary}<redacted>`,
+    )
+    // Bare long runs: digits are an opaque shape by themselves. An all-alpha
+    // run is masked only in an identifier/status context, with ordinary prose
+    // words explicitly retained. Explicit machine labels (account_id, user_id,
+    // and their JSON-like forms) are always handled by that context check.
+    .replace(/\b[A-Za-z0-9]{20,}\b/g, (run, offset, input: string) => {
+      if (/\d/.test(run)) return "<redacted>";
+      return !isNaturalLanguageAlphaRun(run) && hasAlphaIdentifierContext(input, offset, run)
+        ? "<redacted>"
+        : run;
+    });
   return masked.replace(/\s+/g, " ").trim().slice(0, max);
 }
 

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -192,7 +192,7 @@ export function sanitizeDetail(raw: string, max = 200): string {
     // characters shipped. A partial redaction nobody re-checks is the dangerous
     // shape here, so this runs before anything can produce one.
     .replace(
-      /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g,
+      /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
       (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
@@ -318,7 +318,7 @@ export function gaveUpNotice(
   if (attempts > 0) {
     return (
       `⚠️ ${model} is rate limited and did not recover after ${attempts} ${attempts === 1 ? "attempt" : "attempts"}${because}. ` +
-      `Nothing was lost — try again in a moment, or switch models from the composer picker.`
+      `Try again in a moment or switch models from the composer picker — but if the turn had already started changing the graph, check the canvas before re-sending, because re-sending runs those steps again.`
     );
   }
   const why =
@@ -329,7 +329,7 @@ export function gaveUpNotice(
         : "Its response could not be read, so there was no wait to honour and the request was not retried automatically. ";
   return (
     `⚠️ ${model} hit its rate limit${because}. ${why}` +
-    `Nothing was lost — try again in a moment, or switch models from the composer picker.`
+    `Try again in a moment or switch models from the composer picker — but if the turn had already started changing the graph, check the canvas before re-sending, because re-sending runs those steps again.`
   );
 }
 


### PR DESCRIPTION
## The report

Live on kimi-k3, **four tool rounds into a turn**:

> ⚠️ The kimi-k3 turn failed: ollama backend: https://api.moonshot.ai/v1/chat/completions http 429: `{"error":{"message":"Your account org-7df23a…<cak-fc91…> request reached organization max RPM: 3, please try again after 1 seconds"}}`

Three separate defects in one line:

1. **The turn was thrown away over a one-second wait**, discarding four completed tool rounds (read graph → find nodes → check errors) that were still sitting in history.
2. **The provider's internal envelope was the user-facing message** — a JSON blob where a sentence belongs.
3. **That envelope carried the account's organization id and a credential-shaped token into the chat**, from which it went into a screenshot. That is how this was reported.

`AgentEvent` has declared `{ type: "rate_limit" }` since the backend abstraction landed, emitted by nobody and consumed by nobody — `claude-backend.ts:1334` even carried a comment saying the panel never consumed them. This makes it real.

## Classification, not guessing

New `src/orchestrator/rate-limit.ts` owns HTTP 429 for every backend that speaks to a provider over HTTP:

| kind | meaning | behaviour |
|---|---|---|
| `retryable` | a bounded window — `Retry-After` (seconds or HTTP-date), the `x-ratelimit-reset-*` counters, or the provider's prose | waited out and retried |
| `quota` | an exhausted balance | **never** retried, however short a window came with it |
| `unknown` | a 429 with no window we could parse | surfaced, never retried on a fabricated delay |

Not retrying is the default; a 429 opts in by carrying a parseable window — the same direction of default `services/download-retry.ts` takes, and for the same reason: a wrongly-not-retried request reproduces exactly today's behaviour, while a wrongly-retried one hammers a limiter that just asked us to stop.

`quota` outranks a retry hint deliberately. OpenAI and moonshot both answer an empty balance with a 429 that still carries one; honouring it would sleep, retry, and fail identically.

## Policy

- **3 retries, 60s total wait** (`COMFYUI_MCP_RATE_LIMIT_RETRIES`, `_MAX_WAIT_MS`). The budget is spent across attempts — three individually-reasonable 25s windows are 75 seconds of a user watching a spinner.
- **An over-budget window is declined outright, not truncated.** Sleeping less than the provider asked is a retry we already know is too early.
- **Waits under 2s pass in silence** (`_ANNOUNCE_MS`); longer ones emit **one** `rate_limit` event per turn, so a 20s wait does not read as a hang and a 3-req/min limiter cannot bury the conversation under status about itself.
- The turn watchdog is fed across the wait, and an interrupt abandons it immediately rather than sitting out a 30s window.
- A rate-limit event does **not** spend the once-per-turn error slot — that would silence the first genuine error after it.

## Scope

Wired into all three direct-HTTP chat paths: `ollama-backend` (every OpenAI-compatible provider — moonshot, glm, minimax, openrouter, deepseek), `grok-backend`, `chatgpt-oauth-backend`. **Only 429 is intercepted**; every other status reaches each backend's existing error path unchanged, with its body unread, which is what those paths' `await res.text()` assumes.

## Redaction

`sanitizeDetail` masks identifier **shapes** rather than a list of vendor prefixes, so the next provider's format is covered without a code change. Applied to the `ollama` and `chatgpt-oauth` error bodies too — grok's sibling path already called `redactTokens` and those two did not, which is why this particular body leaked.

It also drops the provider's own "please try again after N seconds" clause from what the user reads: we already obeyed it, and quoting it back reads as a contradiction next to "did not recover after 3 attempts".

## #796

The repo's own `check-unknown-collapse` gate caught `await res.text().catch(() => "")` here, correctly. An unreadable body is now kept distinct from an empty one: the headers still carry a usable `Retry-After` (so a real window is still honoured), and "the provider did not say how long to wait" is never claimed about a body we failed to read.

## Testing

- **33 new tests** across `rate-limit.test.ts` (classifier, sanitizer, retry driver) and `panel-agent-rate-limit.test.ts` (what the user actually sees).
- **End-to-end against the real `OllamaBackend`** and a server replaying the exact reported 429:

```
MODE=retry    requests=2  elapsed=1029ms   assistant "KIMI WORKS"   result ok=true
MODE=giveup   requests=4  elapsed=3035ms   error rateLimit=true     result ok=false subtype=rate_limit
MODE=quota    requests=1  elapsed=24ms     error rateLimit=true     result ok=false subtype=rate_limit
```
Org id and token absent from every emitted event in all three.

- Full suite: 12248 passed. The 10 failing files are **identical to the set failing on `origin/main`** — verified by running both and diffing the failure sets.
- `tsc --noEmit` clean; rebased onto current `origin/main` (the 413/`outcomeUnknown` work from #2221 merged alongside, both sides kept).

comfyui-mcp-6cf

🤖 Generated with [Claude Code](https://claude.com/claude-code)