### PR TITLE
fix(1447): the plugin launcher answers the MCP handshake while a cold npx install is still running

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,8 @@ plugin/
     job-complete-notify.mjs # Job completion notification via temp files
   scripts/                 # Background scripts
     monitor-progress.mjs   # Real-time WebSocket progress monitor
-    launch-server.mjs      # MCP server launcher — prefers a global install over cold `npx` (#1447)
+    launch-server.mjs      # MCP server launcher — global install if present, else npx with a
+                           #   cold-start handshake rescue so a first run cannot time out (#1447)
 ```
 
 ---

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -3,32 +3,58 @@
  * #1447 — plugin MCP server launcher.
  *
  * The plugin's .mcp.json used to be `npx -y comfyui-mcp --full` directly. On a
- * cold npx cache that downloads the whole ~900 MB dependency tree INSIDE the
+ * cold npx cache that downloads the whole ~818 MB dependency tree INSIDE the
  * client's MCP handshake timeout; the client kills the attempt, nothing is
  * persisted, and every retry pays the full cost again (the measured `_npx`
  * cache timestamped to a manual run, never to a client attempt).
  *
- * This wrapper is the warm path: when `comfyui-mcp` is installed globally
- * (`npm install -g comfyui-mcp`), it resolves `<npm root -g>/comfyui-mcp/
- * dist/index.js` and runs it with this same node — sub-second start, no
- * registry round-trip, and a killed handshake cannot discard an install that
- * already happened. With no global install it falls back to the original
- * `npx -y comfyui-mcp` behaviour, so the plugin works identically for anyone
- * who never installs globally.
+ * This wrapper has two halves.
  *
- * STDIO IS THE MCP TRANSPORT. Everything the child says on stdout/stderr is
- * the protocol — the wrapper inherits stdio verbatim and must never write to
- * stdout itself. Diagnostics (there is exactly one, a spawn failure) go to
- * stderr via console.error.
+ * 1. THE WARM PATH. When `comfyui-mcp` is installed globally
+ *    (`npm install -g comfyui-mcp`), it resolves `<npm root -g>/comfyui-mcp/
+ *    dist/index.js` and runs it with this same node — sub-second start, no
+ *    registry round-trip, stdio inherited verbatim. Nothing below touches it.
  *
- * Import-safe: nothing here runs on import. The resolution decisions are pure
- * exports so the tests can call the real thing instead of reimplementing it
- * (the #1385 lesson — a test of a copy is a test of nothing).
+ * 2. THE COLD PATH (the npx fallback), which is what a FIRST-RUN user gets:
+ *    they have no global install, so the fallback is the very cold-npx path
+ *    this issue was filed about. Measured on this machine, 2026-08-25, against
+ *    a genuinely empty npm cache and an empty global prefix:
+ *
+ *      cold `npx -y comfyui-mcp --full` → `initialize` response  21.6 s
+ *      warm `_npx` cache                → `initialize` response   7.0 s
+ *      npm install alone (818 MB, 170 packages)                  15.2 s
+ *
+ *    …and `claude mcp list` on that cold cache reported
+ *    `✘ Failed to connect — MCP server connection timed out`, while the same
+ *    launcher with a warm cache reported `✔ Connected`. The install is the
+ *    whole difference.
+ *
+ *    So on the fallback the wrapper stops being a pipe and becomes a
+ *    transparent MCP proxy that can WIN THE HANDSHAKE RACE. It forwards
+ *    everything verbatim; if the real server has not answered the client's
+ *    `initialize` by a deadline derived from the client's own budget, the
+ *    wrapper answers it itself, keeps the connection alive with an empty tool
+ *    list while npm works, and hands over to the real server the moment it is
+ *    up — announcing the real tools with `notifications/tools/list_changed`.
+ *    A cold cache then costs LATENCY instead of a failed connection.
+ *
+ *    Measured against the real client (Claude Code 2.1.246): it re-issues
+ *    `tools/list` after that notification and calls a tool that existed only
+ *    in the second listing. The handover is not theoretical.
+ *
+ * STDIO IS THE MCP TRANSPORT. Everything on stdout is the protocol. The warm
+ * path inherits stdio and writes nothing; the proxy writes ONLY complete
+ * newline-delimited JSON-RPC messages. Diagnostics go to stderr.
+ *
+ * Import-safe: nothing here runs on import. The resolution and protocol
+ * decisions are pure exports so the tests can call the real thing instead of
+ * reimplementing it (the #1385 lesson — a test of a copy is a test of nothing).
  */
 
 import { execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { pathToFileURL } from "node:url";
 
 /** `npm root -g` is normally ~100 ms; 5 s bounds a wedged npm without hanging the handshake. */
@@ -83,6 +109,317 @@ export function serverSpec(entry, extraArgs, { platform = process.platform, node
   return { command: ["npx", ...npxArgs].join(" "), args: [], shell: true };
 }
 
+// ---------------------------------------------------------------------------
+// #1447 cold-start rescue
+// ---------------------------------------------------------------------------
+
+/**
+ * What we assume the client will wait for the handshake when it tells us
+ * nothing. Claude Code's documented default; measured here as "> 21.6 s", so
+ * an unknown-but-real budget is very unlikely to be smaller.
+ */
+export const DEFAULT_CLIENT_BUDGET_MS = 30000;
+
+/**
+ * How much of the client's budget the real server gets before the wrapper
+ * answers for it. Deliberately well under half: the point is to rescue with
+ * margin to spare, not to shave the deadline.
+ */
+export const RESCUE_BUDGET_FRACTION = 0.4;
+export const RESCUE_MIN_MS = 1500;
+export const RESCUE_MAX_MS = 12000;
+
+/**
+ * The rescue deadline, in ms after the client's `initialize` arrives.
+ *
+ * MCP_TIMEOUT is the client's own handshake budget and it is VISIBLE to us —
+ * verified by measurement: a server launched by `MCP_TIMEOUT=17000 claude …`
+ * reads `process.env.MCP_TIMEOUT === "17000"`. So the deadline tracks the
+ * client instead of guessing: a user who tightened the budget gets rescued
+ * sooner, not later.
+ *
+ * The floor keeps a pathological budget from making the wrapper answer before
+ * the server has had any chance at all; the ceiling keeps a huge budget from
+ * parking the user on "connecting" for a minute when we could have answered.
+ */
+export function rescueDeadlineMs(env = process.env) {
+  const raw = Number(env.MCP_TIMEOUT);
+  const budget = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CLIENT_BUDGET_MS;
+  return Math.min(RESCUE_MAX_MS, Math.max(RESCUE_MIN_MS, Math.round(budget * RESCUE_BUDGET_FRACTION)));
+}
+
+/**
+ * The version the wrapper reports when it answers `initialize` on the server's
+ * behalf. It is NOT a plausible version on purpose — #1503 replaced a
+ * hardcoded "0.1.0" precisely because a real-looking number made every bug
+ * report ambiguous about which build produced it. The wrapper genuinely does
+ * not know the version yet (npm is still fetching it), and says so.
+ *
+ * This is paid only on a launch that would otherwise have FAILED. Every later
+ * launch finds a warm cache, the real server answers inside the deadline, and
+ * the client gets the real `serverInfo` untouched.
+ */
+export const INSTALLING_VERSION = "0.0.0-installing";
+
+/**
+ * `instructions` for the rescued handshake. The real server's instructions are
+ * not knowable before it exists, and instructions cannot be refreshed later —
+ * so this says what is true and, importantly, heads off the exact failure the
+ * reopened report describes: with the server dead the model "improvised —
+ * shelled out, poked at files, invented API calls", and the user read that as
+ * a bad agent rather than a server that never started.
+ */
+export const INSTALLING_INSTRUCTIONS = [
+  "comfyui-mcp is still installing. This is the first launch on this machine, so npm is",
+  "fetching the server's dependency tree; the plugin launcher answered this handshake to keep",
+  "the connection alive. This server has NO tools yet — they arrive by",
+  "notifications/tools/list_changed as soon as the install finishes, usually within a minute.",
+  "Until then: do not start comfyui-mcp by hand, do not call ComfyUI's HTTP API directly, and do",
+  "not tell the user their setup is broken. Wait, re-list the tools, and use them normally.",
+  "The server's own usage instructions were not available at handshake time; restarting this MCP",
+  "server once the install has finished will pick them up.",
+].join(" ");
+
+/**
+ * The `initialize` result the wrapper sends in the server's place.
+ *
+ * `protocolVersion` echoes the client's request: the wrapper is not a protocol
+ * implementation with opinions, it is a stand-in, and echoing is what keeps a
+ * client from failing the handshake over a version it did not ask for.
+ *
+ * The capabilities mirror what the real server advertises (measured:
+ * `{tools:{listChanged:true},resources:{},prompts:{}}`) so the client's picture
+ * of the server does not change under it at handover. `listChanged` is the
+ * load-bearing one — it is how the real tools arrive.
+ */
+export function rescueInitializeResult(clientParams) {
+  const requested = clientParams && typeof clientParams.protocolVersion === "string"
+    ? clientParams.protocolVersion
+    : "2025-06-18";
+  return {
+    protocolVersion: requested,
+    capabilities: { tools: { listChanged: true }, resources: {}, prompts: {} },
+    serverInfo: { name: "comfyui-mcp", version: INSTALLING_VERSION },
+    instructions: INSTALLING_INSTRUCTIONS,
+  };
+}
+
+/** JSON-RPC error code for "the server exists but cannot serve this yet". */
+const NOT_READY_CODE = -32002;
+
+/**
+ * What to do with a client message that arrives while the real server is still
+ * installing.
+ *
+ * The rule that matters: a request must never be FORWARDED and also answered
+ * here, and it must never be left unanswered. Forwarding `tools/list` would
+ * park the client on a request until npm finishes — which is the timeout this
+ * fix exists to remove, moved one method along. So the list methods are
+ * answered empty right now and corrected by `notifications/tools/list_changed`
+ * at handover.
+ *
+ * `notifications/initialized` is the exception that MUST be forwarded: the
+ * server's SDK will not serve anything until it sees it, and the pipe preserves
+ * order, so it lands behind the `initialize` the client already sent.
+ *
+ * A frame with an id and no method is a RESPONSE, not a request — it belongs to
+ * whoever asked, so it is forwarded rather than swallowed. Other notifications
+ * are dropped: they can only refer to requests this wrapper answered itself.
+ *
+ * @returns {{action: "forward"} | {action: "drop"} | {action: "reply", message: object}}
+ */
+export function installingDecision(msg) {
+  if (!msg || typeof msg !== "object") return { action: "drop" };
+  if (msg.method === "initialized" || msg.method === "notifications/initialized") {
+    return { action: "forward" };
+  }
+  if (typeof msg.method !== "string") return { action: "forward" };
+  const isRequest = msg.id !== undefined && msg.id !== null;
+  if (!isRequest) return { action: "drop" };
+
+  const reply = (result) => ({ action: "reply", message: { jsonrpc: "2.0", id: msg.id, result } });
+  switch (msg.method) {
+    case "ping":
+      return reply({});
+    case "tools/list":
+      return reply({ tools: [] });
+    case "resources/list":
+      return reply({ resources: [] });
+    case "resources/templates/list":
+      return reply({ resourceTemplates: [] });
+    case "prompts/list":
+      return reply({ prompts: [] });
+    default:
+      return {
+        action: "reply",
+        message: {
+          jsonrpc: "2.0",
+          id: msg.id,
+          error: {
+            code: NOT_READY_CODE,
+            message:
+              "comfyui-mcp is still installing (first launch fetches the dependency tree). " +
+              "Its tools appear via notifications/tools/list_changed when the install finishes.",
+          },
+        },
+      };
+  }
+}
+
+/**
+ * Read a stream as newline-delimited JSON-RPC frames.
+ *
+ * StringDecoder, not `chunk.toString()`: a multi-byte character split across
+ * two chunks would otherwise be corrupted, and this transport carries every
+ * localised string the panel and the tools emit.
+ */
+function readFrames(stream, onLine) {
+  const decoder = new StringDecoder("utf8");
+  let buffered = "";
+  stream.on("data", (chunk) => {
+    buffered += decoder.write(chunk);
+    let nl;
+    while ((nl = buffered.indexOf("\n")) !== -1) {
+      const line = buffered.slice(0, nl);
+      buffered = buffered.slice(nl + 1);
+      onLine(line);
+    }
+  });
+}
+
+/** Write one frame, honouring backpressure by pausing the source that fed it. */
+function writeFrame(dest, source, line) {
+  if (!dest || dest.destroyed || dest.writableEnded) return;
+  if (!dest.write(line + "\n") && source) {
+    source.pause();
+    dest.once("drain", () => source.resume());
+  }
+}
+
+/**
+ * The transparent proxy with a rescue.
+ *
+ * Phases:
+ *   opening      — forwarding both ways verbatim, waiting for the real server's
+ *                  `initialize` response, deadline armed.
+ *   transparent  — the server answered in time. Pure passthrough forever; the
+ *                  client got the REAL serverInfo, capabilities and
+ *                  instructions, and nothing below ever ran.
+ *   installing   — the deadline won. The wrapper answered `initialize` and is
+ *                  holding the connection open with empty lists.
+ *   live         — the server's (now redundant) `initialize` response has been
+ *                  swallowed and `tools/list_changed` sent. Pure passthrough.
+ *
+ * Exported and stream-injectable so the tests can drive the REAL state machine
+ * rather than a description of it.
+ */
+export function attachColdStartProxy({ clientIn, clientOut, childIn, childOut, deadlineMs, onRescue }) {
+  let phase = "opening";
+  let initializeId;
+  let initializeParams;
+  let timer = null;
+
+  // No backpressure source: these are the wrapper's own short control frames,
+  // and pausing an unrelated stream to emit one would be a bug, not a courtesy.
+  const toClient = (message) => writeFrame(clientOut, null, JSON.stringify(message));
+
+  const disarm = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const rescue = () => {
+    if (phase !== "opening" || initializeId === undefined) return;
+    phase = "installing";
+    disarm();
+    toClient({ jsonrpc: "2.0", id: initializeId, result: rescueInitializeResult(initializeParams) });
+    if (onRescue) onRescue();
+  };
+
+  readFrames(clientIn, (line) => {
+    if (phase !== "installing") {
+      // opening/transparent/live all forward verbatim. In `opening` we still
+      // peek, but only to learn the id we may have to answer for — the line
+      // itself goes to the server untouched either way.
+      if (phase === "opening" && initializeId === undefined && line.includes('"initialize"')) {
+        const msg = parseFrame(line);
+        if (msg && msg.method === "initialize" && msg.id !== undefined && msg.id !== null) {
+          initializeId = msg.id;
+          initializeParams = msg.params;
+          disarm();
+          timer = setTimeout(rescue, deadlineMs);
+          if (typeof timer.unref === "function") timer.unref();
+        }
+      }
+      writeFrame(childIn, clientIn, line);
+      return;
+    }
+    const decision = installingDecision(parseFrame(line));
+    if (decision.action === "forward") writeFrame(childIn, clientIn, line);
+    else if (decision.action === "reply") toClient(decision.message);
+  });
+
+  // The client closing stdin is how an MCP stdio session ends. With inherited
+  // stdio that reached the server for free; through the proxy it has to be
+  // relayed, or the server would sit on a dead transport forever.
+  clientIn.on("end", () => {
+    if (childIn && !childIn.writableEnded) childIn.end();
+  });
+
+  readFrames(childOut, (line) => {
+    if (phase === "transparent" || phase === "live") {
+      writeFrame(clientOut, childOut, line);
+      return;
+    }
+    // Only the server's answer to the client's `initialize` changes anything,
+    // and a response carries no `method` — so this is the one cheap test that
+    // has to run per frame while we are still waiting.
+    const msg = line.includes('"id"') ? parseFrame(line) : null;
+    const isInitializeResponse =
+      msg && msg.method === undefined && initializeId !== undefined && sameId(msg.id, initializeId);
+    if (!isInitializeResponse) {
+      writeFrame(clientOut, childOut, line);
+      return;
+    }
+    if (phase === "opening") {
+      // The server won the race. Hand the client its real handshake and never
+      // look at another frame.
+      phase = "transparent";
+      disarm();
+      writeFrame(clientOut, childOut, line);
+      return;
+    }
+    // phase === "installing": the client already has an `initialize` result for
+    // this id. A second response for the same id is a protocol violation, so
+    // this one is swallowed — and the client is told to re-list instead.
+    phase = "live";
+    toClient({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+  });
+
+  return {
+    phase: () => phase,
+    // Test seam: fire the deadline without waiting for wall-clock time.
+    forceRescue: rescue,
+  };
+}
+
+function parseFrame(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/** JSON-RPC ids are strings or numbers; compare without coercing across types. */
+function sameId(a, b) {
+  return typeof a === typeof b && a === b;
+}
+
 /** Ask npm where global packages live. String-command form on Windows for the
  *  same DEP0190 reason as serverSpec; the command is a fixed literal, so there
  *  is nothing to inject. Resolves null on any failure — the npx fallback is
@@ -100,9 +437,8 @@ function probeGlobalRoot() {
   });
 }
 
-function run(spec) {
-  const child = spawn(spec.command, spec.args, { stdio: "inherit", shell: spec.shell });
-
+/** Shared child lifecycle: signal forwarding, exit code, spawn failure. */
+function superviseChild(child, spec) {
   // The client kills the WRAPPER when it shuts the server down; without
   // forwarding, the real server would be orphaned holding stdio. Killing the
   // child on signal makes its `exit` fire, which is what exits the wrapper.
@@ -122,9 +458,48 @@ function run(spec) {
   });
 }
 
+/** Warm path: stdio inherited verbatim, wrapper is a bystander. */
+function run(spec) {
+  superviseChild(spawn(spec.command, spec.args, { stdio: "inherit", shell: spec.shell }), spec);
+}
+
+/**
+ * Cold path: the wrapper sits in the stdio stream so it can answer the
+ * handshake if npm is still working. stderr stays inherited — npm's progress
+ * and the server's own logs belong in the client's server log untouched.
+ */
+function runProxied(spec, deadlineMs = rescueDeadlineMs()) {
+  const child = spawn(spec.command, spec.args, { stdio: ["pipe", "pipe", "inherit"], shell: spec.shell });
+  if (child.stdin && child.stdout) {
+    // EPIPE when the install dies mid-frame is not worth a crash: the child's
+    // `exit` handler is what reports the failure.
+    child.stdin.on("error", () => {});
+    attachColdStartProxy({
+      clientIn: process.stdin,
+      clientOut: process.stdout,
+      childIn: child.stdin,
+      childOut: child.stdout,
+      deadlineMs,
+      onRescue: () =>
+        console.error(
+          "[comfyui-mcp launcher] the server did not finish starting within " +
+            `${deadlineMs}ms (first launch installs ~818MB); answered the MCP handshake on its ` +
+            "behalf and will announce its tools when the install completes.",
+        ),
+    });
+  }
+  superviseChild(child, spec);
+}
+
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const extraArgs = process.argv.slice(2);
   const entry = globalEntry(await probeGlobalRoot());
-  run(serverSpec(entry, extraArgs));
+  const spec = serverSpec(entry, extraArgs);
+  // The rescue exists for the npx fallback, which is the only path that can
+  // have an install in front of the handshake. A resolved global entry starts
+  // a server that is already on disk, so it keeps inherited stdio and this
+  // wrapper stays out of its protocol entirely.
+  if (entry) run(spec);
+  else runProxied(spec);
 }

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -141,8 +141,24 @@ export const DEFAULT_CLIENT_BUDGET_MS = 30000;
 export const RESCUE_BUDGET_FRACTION = 0.4;
 /** Nothing cached: rescue this soon, or sooner if the budget is tighter still. */
 export const RESCUE_MIN_MS = 1500;
-/** Something cached: wait at most this long for the real handshake. */
-export const RESCUE_MAX_MS = 12000;
+/**
+ * Something cached: wait at most this long for the real handshake.
+ *
+ * This was 12 s, derived from DEFAULT_CLIENT_BUDGET_MS — and two separate gate
+ * rounds pushed on the same thing from different sides: a deadline computed
+ * from a budget we only ASSUME is a deadline that can outlive the budget we
+ * actually got. The assumption is not free, so it is worth as little as
+ * possible.
+ *
+ * 4 s is what the measurements say it can safely be. Warm-npx handshakes here
+ * are 1.2 s, 1.2 s, 1.2 s — better than 3x of margin, so healthy launches still
+ * keep their own `serverInfo` and instructions. The one 7.0 s observation was
+ * npx UPDATING to a newer release first, which is an install racing the
+ * handshake, i.e. exactly what the rescue is for. And 4 s leaves room under any
+ * client budget of 10 s or more, so the assumed default no longer has to be
+ * right for the fix to work.
+ */
+export const RESCUE_MAX_MS = 4000;
 
 /**
  * Is there already an unpacked comfyui-mcp under npm's `_npx` cache?
@@ -187,10 +203,12 @@ export function cachedNpxInstallExists(npmCacheStdout, { readdir = readdirSync, 
  *
  * SOMETHING CACHED — npx has a tree and is about to exec it. Measured warm-npx
  * handshakes on this machine: 1.2 s, 1.2 s, 1.2 s, and 7.0 s once when npx
- * updated to a newer release first. Those must stay TRANSPARENT, because
- * rescuing them would swap the server's real `serverInfo` and instructions for
- * a stand-in on a launch that was going to succeed. So this branch gets the
- * generous deadline, bounded by the client's own budget.
+ * updated to a newer release first. The 1.2 s launches must stay TRANSPARENT,
+ * because rescuing them would swap the server's real `serverInfo` and
+ * instructions for a stand-in on a launch that was going to succeed. So this
+ * branch waits longer — 4 s, still comfortably clear of 1.2 s — and the 7.0 s
+ * case is rescued, which is right: an npx update is an install racing the
+ * handshake, the very thing this exists for.
  *
  * MCP_TIMEOUT is that budget and it is VISIBLE to us — verified by measurement:
  * a server launched by `MCP_TIMEOUT=17000 claude …` reads

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -303,9 +303,33 @@ const NOT_READY_CODE = -32002;
  * whoever asked, so it is forwarded rather than swallowed. Other notifications
  * are dropped: they can only refer to requests this wrapper answered itself.
  *
- * @returns {{action: "forward"} | {action: "drop"} | {action: "reply", message: object}}
+ * A JSON-RPC BATCH (an array) is routed member by member. MCP dropped batching
+ * in 2025-06-18, but 2025-03-26 allows it, and forwarding one whole would park
+ * every request inside it on the install — the round-3 gate's finding, and the
+ * same timeout this fix exists to remove wearing a different hat. The answers
+ * go back as ONE array, which is the response shape the client is waiting for;
+ * members that need no answer are forwarded on their own, which is valid
+ * JSON-RPC (a notification is a notification, batched or not).
+ *
+ * @returns {{action: "forward"} | {action: "drop"} | {action: "reply", message: object}
+ *          | {action: "batch", replies: object[], forward: object[]}}
  */
 export function installingDecision(msg) {
+  if (Array.isArray(msg)) {
+    const replies = [];
+    const forward = [];
+    for (const member of msg) {
+      const decision = installingDecision(member);
+      if (decision.action === "reply") replies.push(decision.message);
+      else if (decision.action === "forward") forward.push(member);
+      // A nested array is not legal JSON-RPC; `drop` covers it and everything
+      // else that cannot be answered.
+    }
+    // Nothing to answer — the batch is notifications and/or responses, so the
+    // original line goes to the server exactly as it arrived.
+    if (replies.length === 0) return { action: "forward" };
+    return { action: "batch", replies, forward };
+  }
   if (!msg || typeof msg !== "object") return { action: "drop" };
   if (msg.method === "initialized" || msg.method === "notifications/initialized") {
     return { action: "forward" };
@@ -453,8 +477,16 @@ export function attachColdStartProxy({
       return;
     }
     const decision = installingDecision(parseFrame(line));
-    if (decision.action === "forward") writeFrame(childIn, clientIn, line);
-    else if (decision.action === "reply") toClient(decision.message);
+    if (decision.action === "forward") {
+      writeFrame(childIn, clientIn, line);
+    } else if (decision.action === "reply") {
+      toClient(decision.message);
+    } else if (decision.action === "batch") {
+      // Order matters: the server sees the batch's notifications before the
+      // client is told its requests are answered.
+      for (const member of decision.forward) writeFrame(childIn, clientIn, JSON.stringify(member));
+      toClient(decision.replies);
+    }
   });
 
   // The client closing stdin is how an MCP stdio session ends. With inherited

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -431,10 +431,56 @@ export function attachColdStartProxy({
   let initializeId;
   let initializeParams;
   let timer = null;
+  let clientInitialized = false;
+  let announcePending = false;
+  const announceTimers = [];
 
   // No backpressure source: these are the wrapper's own short control frames,
   // and pausing an unrelated stream to emit one would be a bug, not a courtesy.
   const toClient = (message) => writeFrame(clientOut, null, JSON.stringify(message));
+
+  /**
+   * Tell the client to re-list — the one message that turns a rescued session
+   * into a working one. It is sent MORE THAN ONCE, on purpose (round-4 gate).
+   *
+   * A single notification is a single point of failure for the whole fix: if the
+   * client is not yet listening for it, the session sits on the empty tool list
+   * for good, which is the silent, total failure this issue is about. The client
+   * registers that listener around its own `initialize` bookkeeping, and the
+   * handover can land in the middle of it.
+   *
+   * Re-listing is idempotent — it costs one `tools/list` round-trip — so paying
+   * for two extra notifications to close a race that costs the user the whole
+   * session is the right trade.
+   */
+  const ANNOUNCE_REPEAT_MS = [1500, 6000];
+  const announceTools = () => {
+    toClient({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    for (const delay of ANNOUNCE_REPEAT_MS) {
+      const repeat = setTimeout(() => toClient({ jsonrpc: "2.0", method: "notifications/tools/list_changed" }), delay);
+      if (typeof repeat.unref === "function") repeat.unref();
+      announceTimers.push(repeat);
+    }
+  };
+
+  /**
+   * …and it is never sent before the client says it is initialized. The spec
+   * puts `notifications/initialized` at the end of the client's handshake, so a
+   * notification sent ahead of it is one the client is entitled to ignore.
+   */
+  const announceWhenReady = () => {
+    if (clientInitialized) announceTools();
+    else announcePending = true;
+  };
+
+  const markClientInitialized = () => {
+    if (clientInitialized) return;
+    clientInitialized = true;
+    if (announcePending) {
+      announcePending = false;
+      announceTools();
+    }
+  };
 
   const disarm = () => {
     if (timer) {
@@ -472,11 +518,18 @@ export function attachColdStartProxy({
           timer = setTimeout(rescue, deadlineMs);
           if (typeof timer.unref === "function") timer.unref();
         }
+      } else if (announcePending && carriesInitialized(parseFrame(line))) {
+        // The handover beat the client's own handshake. `live` is otherwise a
+        // pure wire, so without this the deferred announcement would never fire
+        // and the session would keep the empty tool list for good.
+        markClientInitialized();
       }
       writeFrame(childIn, clientIn, line);
       return;
     }
-    const decision = installingDecision(parseFrame(line));
+    const parsed = parseFrame(line);
+    if (carriesInitialized(parsed)) markClientInitialized();
+    const decision = installingDecision(parsed);
     if (decision.action === "forward") {
       writeFrame(childIn, clientIn, line);
     } else if (decision.action === "reply") {
@@ -529,11 +582,12 @@ export function attachColdStartProxy({
       // `tools/list_changed` and left the client believing it had connected.
       phase = "failed";
       disarm();
+      for (const repeat of announceTimers) clearTimeout(repeat);
       if (onHandoverFailed) onHandoverFailed(msg.error);
       return;
     }
     phase = "live";
-    toClient({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    announceWhenReady();
   });
 
   return {
@@ -541,6 +595,12 @@ export function attachColdStartProxy({
     // Test seam: fire the deadline without waiting for wall-clock time.
     forceRescue: rescue,
   };
+}
+
+/** Does this client frame — single or batched — say the client is initialized? */
+function carriesInitialized(msg) {
+  if (Array.isArray(msg)) return msg.some(carriesInitialized);
+  return Boolean(msg) && (msg.method === "notifications/initialized" || msg.method === "initialized");
 }
 
 function parseFrame(line) {

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -528,10 +528,10 @@ export function attachColdStartProxy({
       // a client that escapes. It costs nothing to drop — at most a couple of
       // frames reach here before the handshake settles.
       if (phase === "opening" && initializeId === undefined) {
-        const msg = parseFrame(line);
-        if (msg && msg.method === "initialize" && msg.id !== undefined && msg.id !== null) {
-          initializeId = msg.id;
-          initializeParams = msg.params;
+        const request = findInitializeRequest(parseFrame(line));
+        if (request) {
+          initializeId = request.id;
+          initializeParams = request.params;
           disarm();
           timer = setTimeout(rescue, deadlineMs);
           if (typeof timer.unref === "function") timer.unref();
@@ -574,11 +574,13 @@ export function attachColdStartProxy({
     }
     // Only the server's answer to the client's `initialize` changes anything,
     // and a response carries no `method`. Parse rather than sniff for `"id"`,
-    // for the same escaping reason as the client side.
-    const msg = parseFrame(line);
-    const isInitializeResponse =
-      msg && msg.method === undefined && initializeId !== undefined && sameId(msg.id, initializeId);
-    if (!isInitializeResponse) {
+    // for the same escaping reason as the client side, and look inside a batch
+    // for the same reason the client side does.
+    const parsed = parseFrame(line);
+    const { response: msg, rest } = initializeId === undefined
+      ? { response: null, rest: [] }
+      : splitResponseTo(parsed, initializeId);
+    if (!msg) {
       writeFrame(clientOut, childOut, line);
       return;
     }
@@ -591,7 +593,9 @@ export function attachColdStartProxy({
       return;
     }
     // phase === "installing": the client already has an `initialize` result for
-    // this id, so a second response for the same id cannot be forwarded.
+    // this id, so a second response for the same id cannot be forwarded — but
+    // anything that merely shared its batch still belongs to the client.
+    if (rest.length > 0) writeFrame(clientOut, childOut, JSON.stringify(rest));
     if (msg.error) {
       // …but the server FAILED to initialize. The client is holding a success
       // we sent on its behalf, and there is no way to retract it — so the
@@ -619,6 +623,48 @@ export function attachColdStartProxy({
 function carriesInitialized(msg) {
   if (Array.isArray(msg)) return msg.some(carriesInitialized);
   return Boolean(msg) && (msg.method === "notifications/initialized" || msg.method === "initialized");
+}
+
+/**
+ * The `initialize` REQUEST inside a frame, single or batched, or null.
+ *
+ * MCP 2025-03-26 forbids batching `initialize` and 2025-06-18 has no batching
+ * at all, so a batched handshake is a client bug — but the whole rescue hangs
+ * off finding this request, and "we did not arm because the client was slightly
+ * wrong" is a cold start that still times out (round-6 gate). Every other frame
+ * shape in this proxy already handles batches; this one now matches.
+ */
+export function findInitializeRequest(msg) {
+  if (Array.isArray(msg)) {
+    for (const member of msg) {
+      const found = findInitializeRequest(member);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!msg || typeof msg !== "object") return null;
+  const usable = msg.method === "initialize" && msg.id !== undefined && msg.id !== null;
+  return usable ? msg : null;
+}
+
+/**
+ * Split a server frame into the response to `id` and everything else, so a
+ * response that arrives inside a batch can be swallowed at handover without
+ * taking its batch-mates with it.
+ *
+ * @returns {{response: object|null, rest: object[]}}
+ */
+export function splitResponseTo(msg, id) {
+  const members = Array.isArray(msg) ? msg : [msg];
+  let response = null;
+  const rest = [];
+  for (const member of members) {
+    const isResponse =
+      member && typeof member === "object" && member.method === undefined && sameId(member.id, id);
+    if (isResponse && response === null) response = member;
+    else rest.push(member);
+  }
+  return { response, rest };
 }
 
 function parseFrame(line) {

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -21,8 +21,9 @@
  *    a genuinely empty npm cache and an empty global prefix:
  *
  *      cold `npx -y comfyui-mcp --full` → `initialize` response  21.6 s
- *      warm `_npx` cache                → `initialize` response   7.0 s
  *      npm install alone (818 MB, 170 packages)                  15.2 s
+ *      warm `_npx` cache                → `initialize` response   1.2 s
+ *                                        (7.0 s once, when npx updated first)
  *
  *    …and `claude mcp list` on that cold cache reported
  *    `✘ Failed to connect — MCP server connection timed out`, while the same
@@ -32,11 +33,17 @@
  *    So on the fallback the wrapper stops being a pipe and becomes a
  *    transparent MCP proxy that can WIN THE HANDSHAKE RACE. It forwards
  *    everything verbatim; if the real server has not answered the client's
- *    `initialize` by a deadline derived from the client's own budget, the
- *    wrapper answers it itself, keeps the connection alive with an empty tool
- *    list while npm works, and hands over to the real server the moment it is
- *    up — announcing the real tools with `notifications/tools/list_changed`.
- *    A cold cache then costs LATENCY instead of a failed connection.
+ *    `initialize` by its deadline, the wrapper answers it itself, keeps the
+ *    connection alive with an empty tool list while npm works, and hands over
+ *    to the real server the moment it is up — announcing the real tools with
+ *    `notifications/tools/list_changed`. A cold cache then costs LATENCY
+ *    instead of a failed connection.
+ *
+ *    The deadline is not one number. With nothing unpacked under `_npx` there
+ *    is no server to wait for, so it is the floor and does NOT depend on the
+ *    client budget we assume; with a tree already cached the launch is normally
+ *    1.2 s and must stay transparent, so it gets the generous deadline bounded
+ *    by the client’s own MCP_TIMEOUT. See coldStartDeadlineMs.
  *
  *    Measured against the real client (Claude Code 2.1.246): it re-issues
  *    `tools/list` after that notification and calls a tool that existed only
@@ -52,7 +59,7 @@
  */
 
 import { execFile, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { pathToFileURL } from "node:url";
@@ -130,22 +137,64 @@ export const RESCUE_MIN_MS = 1500;
 export const RESCUE_MAX_MS = 12000;
 
 /**
+ * Is there already an unpacked comfyui-mcp under npm's `_npx` cache?
+ *
+ * This is the difference between "npm has to fetch 818 MB before a server
+ * process can exist" and "npx has a tree on disk and is about to exec it".
+ * `npm config get cache` is the authority on where that lives — guessing the
+ * platform default would misread every machine with a cache path in `.npmrc`,
+ * and misreading it in that direction would degrade every launch.
+ *
+ * Any failure answers false, i.e. "assume nothing is cached". That is the safe
+ * direction: it rescues sooner, and being early costs one session's
+ * `serverInfo`, while being late costs the connection.
+ */
+export function cachedNpxInstallExists(npmCacheStdout, { readdir = readdirSync, exists = existsSync } = {}) {
+  const root = typeof npmCacheStdout === "string" ? npmCacheStdout.trim() : "";
+  if (!root || root === "undefined" || root === "null") return false;
+  const npxRoot = join(root, "_npx");
+  let entries;
+  try {
+    entries = readdir(npxRoot);
+  } catch {
+    return false;
+  }
+  // A `comfyui-mcp` directory with no manifest is the half-deleted state a
+  // failed Windows uninstall leaves behind (`npm ls -g` shows `comfyui-mcp@`
+  // with no version). It is not a runnable install, so it does not count.
+  return entries.some((name) => exists(join(npxRoot, name, "node_modules", "comfyui-mcp", "package.json")));
+}
+
+/**
  * The rescue deadline, in ms after the client's `initialize` arrives.
  *
- * MCP_TIMEOUT is the client's own handshake budget and it is VISIBLE to us —
- * verified by measurement: a server launched by `MCP_TIMEOUT=17000 claude …`
- * reads `process.env.MCP_TIMEOUT === "17000"`. So the deadline tracks the
- * client instead of guessing: a user who tightened the budget gets rescued
- * sooner, not later.
+ * TWO CASES, because they are not the same question.
  *
- * The floor keeps a pathological budget from making the wrapper answer before
- * the server has had any chance at all; the ceiling keeps a huge budget from
- * parking the user on "connecting" for a minute when we could have answered.
+ * NOTHING CACHED — the reported first run. npm must fetch and unpack the whole
+ * tree before a server process exists at all (measured: 15.2 s of npm on a fast
+ * link, 818 MB / 170 packages), so waiting cannot pay: there is no server to
+ * wait for. The deadline is the floor, and deliberately does NOT depend on the
+ * assumed default budget — a client that waits less than we assume must still
+ * be rescued in time. This is the branch the gate was right to press on.
+ *
+ * SOMETHING CACHED — npx has a tree and is about to exec it. Measured warm-npx
+ * handshakes on this machine: 1.2 s, 1.2 s, 1.2 s, and 7.0 s once when npx
+ * updated to a newer release first. Those must stay TRANSPARENT, because
+ * rescuing them would swap the server's real `serverInfo` and instructions for
+ * a stand-in on a launch that was going to succeed. So this branch gets the
+ * generous deadline, bounded by the client's own budget.
+ *
+ * MCP_TIMEOUT is that budget and it is VISIBLE to us — verified by measurement:
+ * a server launched by `MCP_TIMEOUT=17000 claude …` reads
+ * `process.env.MCP_TIMEOUT === "17000"`. So a user who tightens the budget gets
+ * rescued sooner, not later.
  */
-export function rescueDeadlineMs(env = process.env) {
+export function coldStartDeadlineMs(env = process.env, { cachedInstall = true } = {}) {
   const raw = Number(env.MCP_TIMEOUT);
   const budget = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CLIENT_BUDGET_MS;
-  return Math.min(RESCUE_MAX_MS, Math.max(RESCUE_MIN_MS, Math.round(budget * RESCUE_BUDGET_FRACTION)));
+  const share = Math.round(budget * RESCUE_BUDGET_FRACTION);
+  if (!cachedInstall) return Math.min(RESCUE_MIN_MS, share);
+  return Math.min(RESCUE_MAX_MS, Math.max(RESCUE_MIN_MS, share));
 }
 
 /**
@@ -420,17 +469,18 @@ function sameId(a, b) {
   return typeof a === typeof b && a === b;
 }
 
-/** Ask npm where global packages live. String-command form on Windows for the
- *  same DEP0190 reason as serverSpec; the command is a fixed literal, so there
- *  is nothing to inject. Resolves null on any failure — the npx fallback is
- *  the original behaviour, so a failed probe degrades to exactly what the
- *  plugin did before this wrapper existed. */
-function probeGlobalRoot() {
+/** Ask npm something. String-command form on Windows for the same DEP0190
+ *  reason as serverSpec; the arguments are fixed literals, so there is nothing
+ *  to inject. Resolves null on any failure — for the global root that degrades
+ *  to exactly what the plugin did before this wrapper existed (the npx path),
+ *  and for the cache root it degrades to "assume nothing is cached", which
+ *  rescues sooner rather than later. */
+function probeNpm(args) {
   const isWin = process.platform === "win32";
   return new Promise((resolve) => {
     execFile(
-      isWin ? "npm root -g" : "npm",
-      isWin ? [] : ["root", "-g"],
+      isWin ? ["npm", ...args].join(" ") : "npm",
+      isWin ? [] : args,
       { shell: isWin, timeout: NPM_ROOT_TIMEOUT_MS },
       (error, stdout) => resolve(error ? null : stdout),
     );
@@ -468,7 +518,7 @@ function run(spec) {
  * handshake if npm is still working. stderr stays inherited — npm's progress
  * and the server's own logs belong in the client's server log untouched.
  */
-function runProxied(spec, deadlineMs = rescueDeadlineMs()) {
+function runProxied(spec, deadlineMs) {
   const child = spawn(spec.command, spec.args, { stdio: ["pipe", "pipe", "inherit"], shell: spec.shell });
   if (child.stdin && child.stdout) {
     // EPIPE when the install dies mid-frame is not worth a crash: the child's
@@ -494,12 +544,16 @@ function runProxied(spec, deadlineMs = rescueDeadlineMs()) {
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const extraArgs = process.argv.slice(2);
-  const entry = globalEntry(await probeGlobalRoot());
-  const spec = serverSpec(entry, extraArgs);
+  const entry = globalEntry(await probeNpm(["root", "-g"]));
   // The rescue exists for the npx fallback, which is the only path that can
   // have an install in front of the handshake. A resolved global entry starts
   // a server that is already on disk, so it keeps inherited stdio and this
-  // wrapper stays out of its protocol entirely.
-  if (entry) run(spec);
-  else runProxied(spec);
+  // wrapper stays out of its protocol entirely — and never pays the second
+  // npm probe either.
+  if (entry) {
+    run(serverSpec(entry, extraArgs));
+  } else {
+    const cachedInstall = cachedNpxInstallExists(await probeNpm(["config", "get", "cache"]));
+    runProxied(serverSpec(null, extraArgs), coldStartDeadlineMs(process.env, { cachedInstall }));
+  }
 }

--- a/plugin/scripts/launch-server.mjs
+++ b/plugin/scripts/launch-server.mjs
@@ -64,8 +64,14 @@ import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { pathToFileURL } from "node:url";
 
-/** `npm root -g` is normally ~100 ms; 5 s bounds a wedged npm without hanging the handshake. */
-const NPM_ROOT_TIMEOUT_MS = 5000;
+/**
+ * An npm probe is normally ~100 ms. These bound a wedged npm: never longer than
+ * the ceiling, and never more than a slice of the client's own budget, because
+ * every millisecond spent probing is a millisecond the rescue deadline no
+ * longer has. See npmProbeTimeoutMs.
+ */
+const NPM_PROBE_CEILING_MS = 5000;
+const NPM_PROBE_FRACTION = 0.2;
 
 /**
  * `npm root -g` stdout → the global install's entry point, or null when the
@@ -133,7 +139,9 @@ export const DEFAULT_CLIENT_BUDGET_MS = 30000;
  * margin to spare, not to shave the deadline.
  */
 export const RESCUE_BUDGET_FRACTION = 0.4;
+/** Nothing cached: rescue this soon, or sooner if the budget is tighter still. */
 export const RESCUE_MIN_MS = 1500;
+/** Something cached: wait at most this long for the real handshake. */
 export const RESCUE_MAX_MS = 12000;
 
 /**
@@ -173,9 +181,9 @@ export function cachedNpxInstallExists(npmCacheStdout, { readdir = readdirSync, 
  * NOTHING CACHED — the reported first run. npm must fetch and unpack the whole
  * tree before a server process exists at all (measured: 15.2 s of npm on a fast
  * link, 818 MB / 170 packages), so waiting cannot pay: there is no server to
- * wait for. The deadline is the floor, and deliberately does NOT depend on the
- * assumed default budget — a client that waits less than we assume must still
- * be rescued in time. This is the branch the gate was right to press on.
+ * wait for. 1.5 s, and deliberately NOT derived from the assumed default budget
+ * — a client that waits less than we assume must still be rescued in time. This
+ * is the branch the round-1 gate was right to press on.
  *
  * SOMETHING CACHED — npx has a tree and is about to exec it. Measured warm-npx
  * handshakes on this machine: 1.2 s, 1.2 s, 1.2 s, and 7.0 s once when npx
@@ -187,14 +195,34 @@ export function cachedNpxInstallExists(npmCacheStdout, { readdir = readdirSync, 
  * MCP_TIMEOUT is that budget and it is VISIBLE to us — verified by measurement:
  * a server launched by `MCP_TIMEOUT=17000 claude …` reads
  * `process.env.MCP_TIMEOUT === "17000"`. So a user who tightens the budget gets
- * rescued sooner, not later.
+ * rescued sooner, not later — and the budget share is a ceiling on BOTH
+ * branches, so no floor of ours can ever schedule the rescue past it.
  */
-export function coldStartDeadlineMs(env = process.env, { cachedInstall = true } = {}) {
+export function clientBudgetMs(env = process.env) {
   const raw = Number(env.MCP_TIMEOUT);
-  const budget = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CLIENT_BUDGET_MS;
-  const share = Math.round(budget * RESCUE_BUDGET_FRACTION);
-  if (!cachedInstall) return Math.min(RESCUE_MIN_MS, share);
-  return Math.min(RESCUE_MAX_MS, Math.max(RESCUE_MIN_MS, share));
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CLIENT_BUDGET_MS;
+}
+
+export function coldStartDeadlineMs(env = process.env, { cachedInstall = true } = {}) {
+  // The share is a hard ceiling in BOTH branches. A floor that could exceed it
+  // was the round-2 gate's finding: at `MCP_TIMEOUT=1000` a 1500 ms floor
+  // scheduled the rescue after the client had already given up, so the floor
+  // has to lose to the budget rather than the other way round.
+  const share = Math.round(clientBudgetMs(env) * RESCUE_BUDGET_FRACTION);
+  return Math.min(cachedInstall ? RESCUE_MAX_MS : RESCUE_MIN_MS, share);
+}
+
+/**
+ * How long the two npm probes get before the launcher gives up on them.
+ *
+ * This is subtracted from the client's budget before the rescue deadline even
+ * starts, so it cannot be a fixed 5 s: the round-2 gate found that two
+ * sequential 5 s probes could consume a 10 s budget entirely and the rescue
+ * would never arm. The probes now run CONCURRENTLY and are bounded by a slice
+ * of the same budget, so probe + deadline together stay well inside it.
+ */
+export function npmProbeTimeoutMs(env = process.env) {
+  return Math.min(NPM_PROBE_CEILING_MS, Math.max(300, Math.round(clientBudgetMs(env) * NPM_PROBE_FRACTION)));
 }
 
 /**
@@ -356,13 +384,25 @@ function writeFrame(dest, source, line) {
  *                  instructions, and nothing below ever ran.
  *   installing   — the deadline won. The wrapper answered `initialize` and is
  *                  holding the connection open with empty lists.
- *   live         — the server's (now redundant) `initialize` response has been
+ *   live         — the server's (now redundant) `initialize` result has been
  *                  swallowed and `tools/list_changed` sent. Pure passthrough.
+ *   failed       — the server answered that same `initialize` with an ERROR.
+ *                  The client is holding a success we sent for it and there is
+ *                  no way to retract it, so the transport is dropped instead of
+ *                  announcing tools that will never exist.
  *
  * Exported and stream-injectable so the tests can drive the REAL state machine
  * rather than a description of it.
  */
-export function attachColdStartProxy({ clientIn, clientOut, childIn, childOut, deadlineMs, onRescue }) {
+export function attachColdStartProxy({
+  clientIn,
+  clientOut,
+  childIn,
+  childOut,
+  deadlineMs,
+  onRescue,
+  onHandoverFailed,
+}) {
   let phase = "opening";
   let initializeId;
   let initializeParams;
@@ -392,7 +432,14 @@ export function attachColdStartProxy({ clientIn, clientOut, childIn, childOut, d
       // opening/transparent/live all forward verbatim. In `opening` we still
       // peek, but only to learn the id we may have to answer for — the line
       // itself goes to the server untouched either way.
-      if (phase === "opening" && initializeId === undefined && line.includes('"initialize"')) {
+      //
+      // Peeking means PARSING, never matching the text `"initialize"`: JSON may
+      // escape any character in a string, so `"initialize"` is the same
+      // method to a parser and invisible to a substring test. The round-2 gate
+      // found that shortcut, and it would have disarmed the rescue entirely for
+      // a client that escapes. It costs nothing to drop — at most a couple of
+      // frames reach here before the handshake settles.
+      if (phase === "opening" && initializeId === undefined) {
         const msg = parseFrame(line);
         if (msg && msg.method === "initialize" && msg.id !== undefined && msg.id !== null) {
           initializeId = msg.id;
@@ -423,9 +470,9 @@ export function attachColdStartProxy({ clientIn, clientOut, childIn, childOut, d
       return;
     }
     // Only the server's answer to the client's `initialize` changes anything,
-    // and a response carries no `method` — so this is the one cheap test that
-    // has to run per frame while we are still waiting.
-    const msg = line.includes('"id"') ? parseFrame(line) : null;
+    // and a response carries no `method`. Parse rather than sniff for `"id"`,
+    // for the same escaping reason as the client side.
+    const msg = parseFrame(line);
     const isInitializeResponse =
       msg && msg.method === undefined && initializeId !== undefined && sameId(msg.id, initializeId);
     if (!isInitializeResponse) {
@@ -433,16 +480,26 @@ export function attachColdStartProxy({ clientIn, clientOut, childIn, childOut, d
       return;
     }
     if (phase === "opening") {
-      // The server won the race. Hand the client its real handshake and never
-      // look at another frame.
+      // The server won the race. Hand the client its real handshake — error or
+      // not, it is the server's own answer — and never look at another frame.
       phase = "transparent";
       disarm();
       writeFrame(clientOut, childOut, line);
       return;
     }
     // phase === "installing": the client already has an `initialize` result for
-    // this id. A second response for the same id is a protocol violation, so
-    // this one is swallowed — and the client is told to re-list instead.
+    // this id, so a second response for the same id cannot be forwarded.
+    if (msg.error) {
+      // …but the server FAILED to initialize. The client is holding a success
+      // we sent on its behalf, and there is no way to retract it — so the
+      // honest move is to stop, loudly, rather than announce tools that will
+      // never exist. Found by the round-2 gate: this path previously emitted
+      // `tools/list_changed` and left the client believing it had connected.
+      phase = "failed";
+      disarm();
+      if (onHandoverFailed) onHandoverFailed(msg.error);
+      return;
+    }
     phase = "live";
     toClient({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
   });
@@ -475,13 +532,13 @@ function sameId(a, b) {
  *  to exactly what the plugin did before this wrapper existed (the npx path),
  *  and for the cache root it degrades to "assume nothing is cached", which
  *  rescues sooner rather than later. */
-function probeNpm(args) {
+function probeNpm(args, timeout = NPM_PROBE_CEILING_MS) {
   const isWin = process.platform === "win32";
   return new Promise((resolve) => {
     execFile(
       isWin ? ["npm", ...args].join(" ") : "npm",
       isWin ? [] : args,
-      { shell: isWin, timeout: NPM_ROOT_TIMEOUT_MS },
+      { shell: isWin, timeout },
       (error, stdout) => resolve(error ? null : stdout),
     );
   });
@@ -536,6 +593,23 @@ function runProxied(spec, deadlineMs) {
             `${deadlineMs}ms (first launch installs ~818MB); answered the MCP handshake on its ` +
             "behalf and will announce its tools when the install completes.",
         ),
+      onHandoverFailed: (error) => {
+        // The client is holding a handshake this wrapper answered, and the
+        // server has now refused its own. Dropping the transport is the only
+        // honest signal left: the client reports a disconnect instead of a
+        // connected server with no tools, and this line is in its server log.
+        console.error(
+          "[comfyui-mcp launcher] the server refused to initialize after the launcher answered " +
+            `the handshake for it: ${JSON.stringify(error)}. Closing the connection rather than ` +
+            "reporting a server that will never have tools.",
+        );
+        try {
+          child.kill();
+        } catch {
+          /* already gone; the exit handler still runs */
+        }
+        process.exitCode = 1;
+      },
     });
   }
   superviseChild(child, spec);
@@ -544,16 +618,23 @@ function runProxied(spec, deadlineMs) {
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const extraArgs = process.argv.slice(2);
-  const entry = globalEntry(await probeNpm(["root", "-g"]));
+  // CONCURRENTLY, and bounded by a slice of the client's budget. Sequential
+  // probes could each burn the full timeout and leave nothing for the rescue
+  // (round-2 gate); in parallel the worst case is one probe, not two.
+  const probeTimeout = npmProbeTimeoutMs();
+  const [npmRoot, npmCache] = await Promise.all([
+    probeNpm(["root", "-g"], probeTimeout),
+    probeNpm(["config", "get", "cache"], probeTimeout),
+  ]);
+  const entry = globalEntry(npmRoot);
   // The rescue exists for the npx fallback, which is the only path that can
   // have an install in front of the handshake. A resolved global entry starts
   // a server that is already on disk, so it keeps inherited stdio and this
-  // wrapper stays out of its protocol entirely — and never pays the second
-  // npm probe either.
+  // wrapper stays out of its protocol entirely.
   if (entry) {
     run(serverSpec(entry, extraArgs));
   } else {
-    const cachedInstall = cachedNpxInstallExists(await probeNpm(["config", "get", "cache"]));
+    const cachedInstall = cachedNpxInstallExists(npmCache);
     runProxied(serverSpec(null, extraArgs), coldStartDeadlineMs(process.env, { cachedInstall }));
   }
 }

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -427,6 +427,32 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
     // A frame with an id and no method is a RESPONSE and belongs to whoever asked.
     expect(installingDecision({ jsonrpc: "2.0", id: 8, result: {} })).toEqual({ action: "forward" });
   });
+
+  it("routes a JSON-RPC BATCH member by member instead of parking it on the install", () => {
+    // Round-3 gate: an array frame fell through to "forward", so every request
+    // inside it waited for npm — the same timeout this fix removes, wearing a
+    // different hat. MCP dropped batching in 2025-06-18; 2025-03-26 allows it.
+    const { installingDecision } = launcher;
+    const decision = installingDecision([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 8, method: "tools/list" },
+      { jsonrpc: "2.0", id: 9, method: "ping" },
+    ]) as { action: string; replies: Frame[]; forward: Frame[] };
+    expect(decision.action).toBe("batch");
+    // One array back, which is the response shape a batching client waits for.
+    expect(decision.replies).toEqual([
+      { jsonrpc: "2.0", id: 8, result: { tools: [] } },
+      { jsonrpc: "2.0", id: 9, result: {} },
+    ]);
+    // …and the notification still reaches the server, or it never initializes.
+    expect(decision.forward).toEqual([{ jsonrpc: "2.0", method: "notifications/initialized" }]);
+
+    // A batch with nothing to answer is forwarded exactly as it arrived.
+    expect(installingDecision([{ jsonrpc: "2.0", method: "notifications/initialized" }])).toEqual({
+      action: "forward",
+    });
+    expect(installingDecision([])).toEqual({ action: "forward" });
+  });
 });
 
 describe("cold-start proxy state machine (#1447)", () => {
@@ -584,6 +610,29 @@ describe("cold-start proxy state machine (#1447)", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(parseAll(r.toClient).some((f) => f.method === "notifications/tools/list_changed")).toBe(false);
     expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
+  });
+
+  it("answers a batched tools/list mid-install instead of forwarding it into the wait", async () => {
+    const r = rig(40);
+    r.fromClient(INIT);
+    await waitFor(() => parseAll(r.toClient)[0]);
+    expect(r.proxy.phase()).toBe("installing");
+    const forwardedSoFar = r.toChild.length;
+
+    r.fromClient([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 8, method: "tools/list" },
+    ] as unknown as Frame);
+
+    const answer = (await waitFor(() => parseAll(r.toClient)[1])) as unknown as Frame[];
+    expect(Array.isArray(answer)).toBe(true);
+    expect(answer).toEqual([{ jsonrpc: "2.0", id: 8, result: { tools: [] } }]);
+    // The notification went through; the request did NOT — forwarding it would
+    // have left the client waiting on npm and produced a duplicate answer later.
+    await waitFor(() => (r.toChild.length > forwardedSoFar ? true : undefined));
+    expect(parseAll(r.toChild).slice(forwardedSoFar)).toEqual([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+    ]);
   });
 
   it("an error the server sends in TIME is the client's to see, untouched", async () => {

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -13,7 +13,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,7 +32,14 @@ type Launcher = {
     extraArgs: string[],
     opts?: { platform?: string; node?: string },
   ) => { command: string; args: string[]; shell: boolean };
-  rescueDeadlineMs: (env?: Record<string, string | undefined>) => number;
+  coldStartDeadlineMs: (
+    env?: Record<string, string | undefined>,
+    opts?: { cachedInstall?: boolean },
+  ) => number;
+  cachedNpxInstallExists: (
+    stdout: unknown,
+    opts?: { readdir?: (p: string) => string[]; exists?: (p: string) => boolean },
+  ) => boolean;
   rescueInitializeResult: (params: unknown) => Frame;
   installingDecision: (msg: unknown) => Decision;
   attachColdStartProxy: (opts: {
@@ -242,25 +249,86 @@ async function waitFor<T>(probe: () => T | undefined, budgetMs = 8000): Promise<
 describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
   beforeAll(loadLauncher);
 
-  it("uses a fraction of MCP_TIMEOUT, which the client really does hand us", () => {
+  it("with a cached tree it waits, tracking MCP_TIMEOUT, which the client really does hand us", () => {
     // Verified by measurement, not by reading: a server launched by
     // `MCP_TIMEOUT=17000 claude -p …` observed process.env.MCP_TIMEOUT === "17000".
-    const { rescueDeadlineMs, RESCUE_BUDGET_FRACTION, DEFAULT_CLIENT_BUDGET_MS, RESCUE_MIN_MS, RESCUE_MAX_MS } =
+    const { coldStartDeadlineMs, RESCUE_BUDGET_FRACTION, DEFAULT_CLIENT_BUDGET_MS, RESCUE_MIN_MS, RESCUE_MAX_MS } =
       launcher;
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "20000" })).toBe(20000 * RESCUE_BUDGET_FRACTION);
+    const cached = (env: Record<string, string | undefined>) => coldStartDeadlineMs(env, { cachedInstall: true });
+    expect(cached({ MCP_TIMEOUT: "20000" })).toBe(20000 * RESCUE_BUDGET_FRACTION);
     // …and it must leave the client real margin, never spend the whole budget.
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "20000" })).toBeLessThan(20000);
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "10000" })).toBe(4000);
+    expect(cached({ MCP_TIMEOUT: "20000" })).toBeLessThan(20000);
+    expect(cached({ MCP_TIMEOUT: "10000" })).toBe(4000);
     // A tightened budget rescues SOONER — the direction that matters.
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "5000" })).toBeLessThan(rescueDeadlineMs({ MCP_TIMEOUT: "20000" }));
+    expect(cached({ MCP_TIMEOUT: "5000" })).toBeLessThan(cached({ MCP_TIMEOUT: "20000" }));
     // No budget stated → the documented default.
-    expect(rescueDeadlineMs({})).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+    expect(cached({})).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
     // Junk is not a budget.
     for (const bad of ["", "soon", "-1", "0", "NaN", undefined]) {
-      expect(rescueDeadlineMs({ MCP_TIMEOUT: bad })).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+      expect(cached({ MCP_TIMEOUT: bad })).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
     }
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "100" })).toBe(RESCUE_MIN_MS);
-    expect(rescueDeadlineMs({ MCP_TIMEOUT: "600000" })).toBe(RESCUE_MAX_MS);
+    expect(cached({ MCP_TIMEOUT: "100" })).toBe(RESCUE_MIN_MS);
+    expect(cached({ MCP_TIMEOUT: "600000" })).toBe(RESCUE_MAX_MS);
+    // The measured warm-npx handshake is ~1.2 s (7.0 s once, when npx updated
+    // first). The cached deadline must sit well clear of that or it would swap
+    // a healthy server's real serverInfo for the stand-in on every launch.
+    expect(cached({})).toBeGreaterThan(8000);
+  });
+
+  it("with NOTHING cached it rescues at the floor — independent of the budget we assume", () => {
+    // The gate's P1 on round 1: a client that waits less than DEFAULT_CLIENT_BUDGET_MS
+    // and does not export MCP_TIMEOUT would be killed before a budget-derived
+    // deadline fired. On a first run there is no server process to wait for at
+    // all (npm has 818MB to fetch first), so waiting cannot pay — and this
+    // branch must not read the assumed default.
+    const { coldStartDeadlineMs, RESCUE_MIN_MS, DEFAULT_CLIENT_BUDGET_MS, RESCUE_BUDGET_FRACTION } = launcher;
+    const cold = (env: Record<string, string | undefined>) => coldStartDeadlineMs(env, { cachedInstall: false });
+    expect(cold({})).toBe(RESCUE_MIN_MS);
+    // …and it is under every client budget in the reproduction, including the
+    // 10 s one that actually produced "Failed to connect" on this machine.
+    for (const budget of [5000, 10000, 30000]) {
+      expect(cold({})).toBeLessThan(budget);
+      expect(cold({ MCP_TIMEOUT: String(budget) })).toBeLessThan(budget);
+    }
+    // A budget smaller than the floor still shortens it.
+    expect(cold({ MCP_TIMEOUT: "2000" })).toBe(2000 * RESCUE_BUDGET_FRACTION);
+    // Raising the assumed default must NOT be able to move this branch.
+    expect(cold({})).toBeLessThan(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+  });
+
+  it("reads `npm config get cache` to tell a first run from a warm one", () => {
+    const { cachedNpxInstallExists } = launcher;
+    const seen: string[] = [];
+    const present = cachedNpxInstallExists("  C:/cache  
+", {
+      readdir: () => ["8af3af54f44861ce", "other"],
+      exists: (p: string) => {
+        seen.push(p);
+        return p.includes("8af3af54f44861ce");
+      },
+    });
+    expect(present).toBe(true);
+    // It looks under the cache npm named, in _npx, for a real manifest.
+    expect(seen[0].replace(/\/g, "/")).toBe("C:/cache/_npx/8af3af54f44861ce/node_modules/comfyui-mcp/package.json");
+
+    // A comfyui-mcp directory with no manifest is the half-deleted state a
+    // failed Windows uninstall leaves behind; it is not a runnable install.
+    expect(cachedNpxInstallExists("/cache", { readdir: () => ["a"], exists: () => false })).toBe(false);
+    // No _npx directory at all — a genuinely first run.
+    expect(
+      cachedNpxInstallExists("/cache", {
+        readdir: () => {
+          throw new Error("ENOENT");
+        },
+        exists: () => true,
+      }),
+    ).toBe(false);
+    // Every unusable answer means "assume nothing is cached", which rescues
+    // sooner. Being early costs one session's serverInfo; being late costs the
+    // connection.
+    for (const bad of [null, undefined, "", "   ", "undefined", "null", 42]) {
+      expect(cachedNpxInstallExists(bad, { readdir: () => ["a"], exists: () => true })).toBe(false);
+    }
   });
 
   it("the stand-in handshake is honest about being a stand-in", () => {
@@ -483,6 +551,8 @@ const FAKE_SERVER_SOURCE = [
 
 describe("the shipped launcher rescues a real cold start (#1447)", () => {
   let stubDir = "";
+  let coldCache = "";
+  let warmCache = "";
   const children: ChildProcessWithoutNullStreams[] = [];
 
   beforeAll(async () => {
@@ -491,13 +561,34 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
     const emptyGlobal = join(stubDir, "empty-global-root");
     const fakeServer = join(stubDir, "fake-server.mjs");
     writeFileSync(fakeServer, FAKE_SERVER_SOURCE, "utf8");
+    // Two npm cache roots: one a first run (no _npx at all), one with a tree
+    // already unpacked, so BOTH deadline branches run through production.
+    coldCache = join(stubDir, "cold-cache");
+    warmCache = join(stubDir, "warm-cache");
+    mkdirSync(join(warmCache, "_npx", "deadbeef", "node_modules", "comfyui-mcp"), { recursive: true });
+    writeFileSync(
+      join(warmCache, "_npx", "deadbeef", "node_modules", "comfyui-mcp", "package.json"),
+      JSON.stringify({ name: "comfyui-mcp", version: "9.9.9" }),
+      "utf8",
+    );
+    // `npm root -g` and `npm config get cache` are different questions, so the
+    // stub answers them differently — otherwise the cache branch would be handed
+    // the global root and prove nothing.
     // POSIX forms (npm/npx are spawned without a shell there) …
-    writeFileSync(join(stubDir, "npm"), `#!/bin/sh\necho "${emptyGlobal}"\n`, "utf8");
+    writeFileSync(
+      join(stubDir, "npm"),
+      `#!/bin/sh\nif [ "$1" = "config" ]; then echo "$NPM_STUB_CACHE"; else echo "${emptyGlobal}"; fi\n`,
+      "utf8",
+    );
     writeFileSync(join(stubDir, "npx"), `#!/bin/sh\nexec "${process.execPath}" "${fakeServer}"\n`, "utf8");
     chmodSync(join(stubDir, "npm"), 0o755);
     chmodSync(join(stubDir, "npx"), 0o755);
     // … and the .cmd forms, because the Windows spec goes through cmd.exe.
-    writeFileSync(join(stubDir, "npm.cmd"), `@echo ${emptyGlobal}\r\n`, "utf8");
+    writeFileSync(
+      join(stubDir, "npm.cmd"),
+      `@echo off\r\nif "%1"=="config" (echo %NPM_STUB_CACHE%) else (echo ${emptyGlobal})\r\n`,
+      "utf8",
+    );
     writeFileSync(join(stubDir, "npx.cmd"), `@"${process.execPath}" "${fakeServer}"\r\n`, "utf8");
   });
 
@@ -544,9 +635,15 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
     "answers the handshake while the install is still running, then serves the real tools",
     async () => {
       const log = join(stubDir, "rescue-log.txt");
-      // MCP_TIMEOUT 3000 → a 1500 ms deadline (the floor); the stand-in server
-      // cannot answer for 4 s. Without the rescue this is the reported failure.
-      const client = launch({ MCP_TIMEOUT: "3000", FAKE_DELAY_MS: "4000", FAKE_LOG: log });
+      // A first run: `npm config get cache` names a cache with no _npx, so the
+      // deadline is the floor and does NOT depend on the budget we assume. The
+      // stand-in server cannot answer for 4 s — the reported failure exactly.
+      const client = launch({
+        MCP_TIMEOUT: "3000",
+        NPM_STUB_CACHE: coldCache,
+        FAKE_DELAY_MS: "4000",
+        FAKE_LOG: log,
+      });
       client.send(INIT);
 
       const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
@@ -590,7 +687,7 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
   it(
     "control: a server that starts promptly keeps its own serverInfo and instructions",
     async () => {
-      const client = launch({ MCP_TIMEOUT: "30000", FAKE_DELAY_MS: "0" });
+      const client = launch({ MCP_TIMEOUT: "30000", NPM_STUB_CACHE: warmCache, FAKE_DELAY_MS: "0" });
       client.send(INIT);
       const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
         result: { serverInfo: { name: string; version: string }; instructions: string };
@@ -600,6 +697,27 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
       expect(handshake.result.serverInfo).toEqual({ name: "fake-comfyui-mcp", version: "9.9.9" });
       expect(handshake.result.instructions).toBe("REAL_SERVER_INSTRUCTIONS");
       expect(client.stderr()).not.toMatch(/answered the MCP handshake on its behalf/);
+    },
+    25000,
+  );
+
+  it(
+    "a CACHED tree is still rescued when the client budget is tight",
+    async () => {
+      // The cached branch waits longer on purpose, but it is still bounded by
+      // the client's budget: MCP_TIMEOUT 4000 → a 1600 ms deadline, so a server
+      // that takes 4 s (npx updating to a newer release, say) is rescued rather
+      // than left to time out.
+      const client = launch({ MCP_TIMEOUT: "4000", NPM_STUB_CACHE: warmCache, FAKE_DELAY_MS: "4000" });
+      client.send(INIT);
+      const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
+        result: { serverInfo: { version: string } };
+      };
+      expect(handshake.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+      await waitFor(
+        () => parseAll(client.stdout).find((f) => f.method === "notifications/tools/list_changed"),
+        15000,
+      );
     },
     25000,
   );

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -612,6 +612,51 @@ describe("cold-start proxy state machine (#1447)", () => {
     expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
   });
 
+  it("holds the re-list announcement until the client says it is initialized", async () => {
+    // Round-4 gate: the announcement was sent the instant the server's
+    // handshake landed, which can be BEFORE the client has finished its own —
+    // and a notification sent ahead of `notifications/initialized` is one the
+    // client is entitled to ignore. Losing it costs the whole session: the tool
+    // list stays empty, silently, which is the failure this issue is about.
+    const r = rig(40);
+    r.fromClient(INIT);
+    await waitFor(() => parseAll(r.toClient)[0]);
+    expect(r.proxy.phase()).toBe("installing");
+
+    // Handover arrives first, with no `initialized` from the client yet.
+    r.fromChild({
+      jsonrpc: "2.0",
+      id: 7,
+      result: { protocolVersion: "2025-03-26", capabilities: { tools: { listChanged: true } } },
+    });
+    await waitFor(() => (r.proxy.phase() === "live" ? true : undefined));
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(parseAll(r.toClient).some((f) => f.method === "notifications/tools/list_changed")).toBe(false);
+
+    // …and it fires as soon as the client is ready, even though `live` is
+    // otherwise a pure wire that does not inspect frames.
+    r.fromClient({ jsonrpc: "2.0", method: "notifications/initialized" });
+    await waitFor(() => parseAll(r.toClient).find((f) => f.method === "notifications/tools/list_changed"));
+  });
+
+  it("repeats the announcement — one lost notification must not cost the session", async () => {
+    const r = rig(40);
+    r.fromClient(INIT);
+    await waitFor(() => parseAll(r.toClient)[0]);
+    r.fromClient({ jsonrpc: "2.0", method: "notifications/initialized" });
+    r.fromChild({
+      jsonrpc: "2.0",
+      id: 7,
+      result: { protocolVersion: "2025-03-26", capabilities: { tools: { listChanged: true } } },
+    });
+    const announcements = () =>
+      parseAll(r.toClient).filter((f) => f.method === "notifications/tools/list_changed").length;
+    await waitFor(() => (announcements() >= 1 ? true : undefined));
+    // Re-listing is idempotent, so a second one costs a round-trip; a missed
+    // first one costs everything.
+    await waitFor(() => (announcements() >= 2 ? true : undefined), 5000);
+  }, 15000);
+
   it("answers a batched tools/list mid-install instead of forwarding it into the wait", async () => {
     const r = rig(40);
     r.fromClient(INIT);

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -916,6 +916,9 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
         result: { serverInfo: { version: string } };
       };
       expect(handshake.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+      // A real client completes its own handshake here, and the launcher will
+      // not announce a re-list before it does.
+      client.send({ jsonrpc: "2.0", method: "notifications/initialized" });
       await waitFor(
         () => parseAll(client.stdout).find((f) => f.method === "notifications/tools/list_changed"),
         15000,

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -11,12 +11,19 @@
 // top-level `await import` of a CRLF shebang is a SyntaxError during
 // transform, which vitest reports as "1 failed / Tests no tests" (#1857).
 
-import { beforeAll, describe, expect, it } from "vitest";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PassThrough } from "node:stream";
 
 const LAUNCHER_REL = "plugin/scripts/launch-server.mjs";
 const LAUNCHER_URL = new URL("../../../plugin/scripts/launch-server.mjs", import.meta.url);
+
+type Frame = Record<string, unknown>;
+type Decision = { action: "forward" | "drop" } | { action: "reply"; message: Frame };
 
 type Launcher = {
   globalEntry: (stdout: unknown, opts?: { exists?: (p: string) => boolean }) => string | null;
@@ -25,13 +32,30 @@ type Launcher = {
     extraArgs: string[],
     opts?: { platform?: string; node?: string },
   ) => { command: string; args: string[]; shell: boolean };
+  rescueDeadlineMs: (env?: Record<string, string | undefined>) => number;
+  rescueInitializeResult: (params: unknown) => Frame;
+  installingDecision: (msg: unknown) => Decision;
+  attachColdStartProxy: (opts: {
+    clientIn: NodeJS.ReadableStream;
+    clientOut: NodeJS.WritableStream;
+    childIn: NodeJS.WritableStream;
+    childOut: NodeJS.ReadableStream;
+    deadlineMs: number;
+    onRescue?: () => void;
+  }) => { phase: () => string; forceRescue: () => void };
+  INSTALLING_VERSION: string;
+  RESCUE_MIN_MS: number;
+  RESCUE_MAX_MS: number;
+  DEFAULT_CLIENT_BUDGET_MS: number;
+  RESCUE_BUDGET_FRACTION: number;
 };
 
 let globalEntry!: Launcher["globalEntry"];
 let serverSpec!: Launcher["serverSpec"];
+let launcher!: Launcher;
 
 async function loadLauncher(): Promise<void> {
-  const launcher = (await import("../../../plugin/scripts/launch-server.mjs")) as Launcher;
+  launcher = (await import("../../../plugin/scripts/launch-server.mjs")) as Launcher;
   globalEntry = launcher.globalEntry;
   serverSpec = launcher.serverSpec;
 }
@@ -153,11 +177,430 @@ describe("plugin/.mcp.json (#1447)", () => {
     expect(src).toMatch(/if \(isMain\) \{/);
   });
 
-  it("the wrapper never writes to stdout — stdio is the MCP transport", () => {
+  it("the wrapper never PRINTS to stdout — stdio is the MCP transport", () => {
     const src = readFileSync(LAUNCHER_URL, "utf8");
+    // console.log would put a non-JSON line into the transport and desynchronise
+    // the client. The cold path DOES write to stdout now, but only complete
+    // JSON-RPC frames — which is asserted behaviourally below, by parsing every
+    // line the launcher emits, rather than by grepping for a write call.
     expect(src).not.toMatch(/console\.log\(/);
-    expect(src).not.toMatch(/process\.stdout\.write\(/);
-    // stdio must be inherited verbatim, or the handshake frames never reach the client.
+    // The warm path still hands the real server the client's stdio untouched.
     expect(src).toMatch(/stdio: "inherit"/);
   });
+});
+
+// ---------------------------------------------------------------------------
+// #1447 reopened as a first-run BLOCKER — the npx fallback is what an actual
+// first-run user gets (no global install), and on a cold npm cache the install
+// runs INSIDE the client's handshake budget. Measured 2026-08-25 on Windows
+// against an empty npm cache and an empty global prefix: 21.6 s to the
+// `initialize` response (15.2 s of it npm, 818 MB / 170 packages), and
+// `claude mcp list` reporting `✘ Failed to connect — … timed out after 10000ms`
+// where the identical launcher with a warm cache reported `✔ Connected`.
+//
+// The fix makes the wrapper answer the handshake when the server cannot, so a
+// cold cache costs latency instead of a dead connection.
+// ---------------------------------------------------------------------------
+
+function collectLines(stream: NodeJS.ReadableStream): string[] {
+  const lines: string[] = [];
+  let buf = "";
+  stream.on("data", (chunk: Buffer | string) => {
+    buf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let nl = buf.indexOf("\n");
+    while (nl !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line) lines.push(line);
+      nl = buf.indexOf("\n");
+    }
+  });
+  return lines;
+}
+
+/** Every frame the launcher emits must be complete JSON — the transport has no other framing. */
+function parseAll(lines: string[]): Frame[] {
+  return lines.map((line) => {
+    try {
+      return JSON.parse(line) as Frame;
+    } catch {
+      throw new Error(`launcher wrote a non-JSON line to stdout: ${line}`);
+    }
+  });
+}
+
+async function waitFor<T>(probe: () => T | undefined, budgetMs = 8000): Promise<T> {
+  const started = Date.now();
+  for (;;) {
+    const value = probe();
+    if (value !== undefined) return value;
+    if (Date.now() - started > budgetMs) throw new Error("timed out waiting for a frame");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
+  beforeAll(loadLauncher);
+
+  it("uses a fraction of MCP_TIMEOUT, which the client really does hand us", () => {
+    // Verified by measurement, not by reading: a server launched by
+    // `MCP_TIMEOUT=17000 claude -p …` observed process.env.MCP_TIMEOUT === "17000".
+    const { rescueDeadlineMs, RESCUE_BUDGET_FRACTION, DEFAULT_CLIENT_BUDGET_MS, RESCUE_MIN_MS, RESCUE_MAX_MS } =
+      launcher;
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "20000" })).toBe(20000 * RESCUE_BUDGET_FRACTION);
+    // …and it must leave the client real margin, never spend the whole budget.
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "20000" })).toBeLessThan(20000);
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "10000" })).toBe(4000);
+    // A tightened budget rescues SOONER — the direction that matters.
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "5000" })).toBeLessThan(rescueDeadlineMs({ MCP_TIMEOUT: "20000" }));
+    // No budget stated → the documented default.
+    expect(rescueDeadlineMs({})).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+    // Junk is not a budget.
+    for (const bad of ["", "soon", "-1", "0", "NaN", undefined]) {
+      expect(rescueDeadlineMs({ MCP_TIMEOUT: bad })).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+    }
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "100" })).toBe(RESCUE_MIN_MS);
+    expect(rescueDeadlineMs({ MCP_TIMEOUT: "600000" })).toBe(RESCUE_MAX_MS);
+  });
+
+  it("the stand-in handshake is honest about being a stand-in", () => {
+    const result = launcher.rescueInitializeResult({ protocolVersion: "2025-03-26" }) as {
+      protocolVersion: string;
+      capabilities: { tools: { listChanged: boolean } };
+      serverInfo: { name: string; version: string };
+      instructions: string;
+    };
+    // Echoing the client's protocol version is what keeps it from failing the
+    // handshake over a version it did not ask for.
+    expect(result.protocolVersion).toBe("2025-03-26");
+    // listChanged is load-bearing: it is how the REAL tools arrive at handover.
+    expect(result.capabilities.tools.listChanged).toBe(true);
+    // #1503: never a plausible-looking version. A stand-in must be identifiable.
+    expect(result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+    expect(result.serverInfo.version).toMatch(/installing/);
+    // The reopened report's actual damage was the model improvising while the
+    // server was absent; the instructions have to head that off.
+    expect(result.instructions).toMatch(/still installing/i);
+    expect(result.instructions).toMatch(/notifications\/tools\/list_changed/);
+  });
+
+  it("routes each message that arrives mid-install", () => {
+    const { installingDecision } = launcher;
+    // The server's SDK serves nothing until it sees this, and the pipe preserves order.
+    expect(installingDecision({ jsonrpc: "2.0", method: "notifications/initialized" })).toEqual({
+      action: "forward",
+    });
+    // Answered HERE, never forwarded — forwarding would park the client on the
+    // install, which is the timeout this fix removes, moved one method along.
+    expect(installingDecision({ jsonrpc: "2.0", id: 3, method: "tools/list" })).toEqual({
+      action: "reply",
+      message: { jsonrpc: "2.0", id: 3, result: { tools: [] } },
+    });
+    expect(installingDecision({ jsonrpc: "2.0", id: 4, method: "ping" })).toEqual({
+      action: "reply",
+      message: { jsonrpc: "2.0", id: 4, result: {} },
+    });
+    expect(installingDecision({ jsonrpc: "2.0", id: 5, method: "prompts/list" })).toEqual({
+      action: "reply",
+      message: { jsonrpc: "2.0", id: 5, result: { prompts: [] } },
+    });
+    expect(installingDecision({ jsonrpc: "2.0", id: 6, method: "resources/list" })).toEqual({
+      action: "reply",
+      message: { jsonrpc: "2.0", id: 6, result: { resources: [] } },
+    });
+    // An unknown REQUEST is answered — an unanswered one is exactly the hang.
+    const unknown = installingDecision({ jsonrpc: "2.0", id: 7, method: "completion/complete" });
+    expect(unknown.action).toBe("reply");
+    expect((unknown as { message: { error: { message: string } } }).message.error.message).toMatch(
+      /still installing/i,
+    );
+    // A notification can only refer to something answered here; dropping it is right.
+    expect(installingDecision({ jsonrpc: "2.0", method: "notifications/cancelled" })).toEqual({
+      action: "drop",
+    });
+    // A frame with an id and no method is a RESPONSE and belongs to whoever asked.
+    expect(installingDecision({ jsonrpc: "2.0", id: 8, result: {} })).toEqual({ action: "forward" });
+  });
+});
+
+describe("cold-start proxy state machine (#1447)", () => {
+  beforeAll(loadLauncher);
+
+  function rig(deadlineMs: number) {
+    const clientIn = new PassThrough();
+    const clientOut = new PassThrough();
+    const childIn = new PassThrough();
+    const childOut = new PassThrough();
+    const toClient = collectLines(clientOut);
+    const toChild = collectLines(childIn);
+    const proxy = launcher.attachColdStartProxy({ clientIn, clientOut, childIn, childOut, deadlineMs });
+    return {
+      proxy,
+      toClient,
+      toChild,
+      fromClient: (m: Frame) => clientIn.write(`${JSON.stringify(m)}\n`),
+      fromChild: (m: Frame) => childOut.write(`${JSON.stringify(m)}\n`),
+    };
+  }
+
+  const INIT: Frame = {
+    jsonrpc: "2.0",
+    id: 7,
+    method: "initialize",
+    params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+  };
+
+  it("a server that answers in time keeps its OWN handshake — no stand-in, nothing rewritten", async () => {
+    const r = rig(400);
+    r.fromClient(INIT);
+    await waitFor(() => (r.toChild.length ? true : undefined));
+    r.fromChild({
+      jsonrpc: "2.0",
+      id: 7,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: "comfyui-mcp", version: "0.52.117" },
+        instructions: "the real instructions",
+      },
+    });
+    const answer = (await waitFor(() => parseAll(r.toClient)[0])) as {
+      result: { serverInfo: { version: string }; instructions: string };
+    };
+    expect(answer.result.serverInfo.version).toBe("0.52.117");
+    expect(answer.result.instructions).toBe("the real instructions");
+    expect(r.proxy.phase()).toBe("transparent");
+    // …and the armed deadline must not fire behind it and send a second answer.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(r.toClient).toHaveLength(1);
+  });
+
+  it("a server that is still installing gets its handshake answered, then hands over", async () => {
+    const r = rig(40);
+    r.fromClient(INIT);
+
+    // The initialize request still reaches the server: the wrapper is a proxy,
+    // not a replacement, and the server has to complete its own handshake.
+    await waitFor(() => (r.toChild.length >= 1 ? true : undefined));
+    expect((parseAll(r.toChild)[0] as { method: string }).method).toBe("initialize");
+
+    const stand = (await waitFor(() => parseAll(r.toClient)[0])) as {
+      id: number;
+      result: { serverInfo: { version: string }; protocolVersion: string };
+    };
+    expect(stand.id).toBe(7);
+    expect(stand.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+    expect(stand.result.protocolVersion).toBe("2025-03-26");
+    expect(r.proxy.phase()).toBe("installing");
+
+    r.fromClient({ jsonrpc: "2.0", method: "notifications/initialized" });
+    await waitFor(() => (r.toChild.length >= 2 ? true : undefined));
+    expect((parseAll(r.toChild)[1] as { method: string }).method).toBe("notifications/initialized");
+
+    r.fromClient({ jsonrpc: "2.0", id: 8, method: "tools/list" });
+    const empty = (await waitFor(() => parseAll(r.toClient)[1])) as { result: { tools: unknown[] } };
+    expect(empty.result.tools).toEqual([]);
+    // …and it was NOT also forwarded, which would leave a duplicate response
+    // for id 8 arriving from the server a minute later.
+    expect(r.toChild).toHaveLength(2);
+
+    // The server finally answers the initialize we forwarded. The client already
+    // has a result for id 7, so a second one would be a protocol violation.
+    r.fromChild({
+      jsonrpc: "2.0",
+      id: 7,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: "comfyui-mcp", version: "0.52.117" },
+      },
+    });
+    const notice = (await waitFor(() => parseAll(r.toClient)[2])) as Frame;
+    expect(notice).toEqual({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
+    expect(r.proxy.phase()).toBe("live");
+
+    // From here it is a wire again, in both directions.
+    r.fromClient({ jsonrpc: "2.0", id: 9, method: "tools/list" });
+    await waitFor(() => (r.toChild.length >= 3 ? true : undefined));
+    r.fromChild({ jsonrpc: "2.0", id: 9, result: { tools: [{ name: "generate_image" }] } });
+    const real = (await waitFor(() => parseAll(r.toClient)[3])) as {
+      result: { tools: { name: string }[] };
+    };
+    expect(real.result.tools[0].name).toBe("generate_image");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reachability. Everything above proves the mechanism works; none of it proves
+// PRODUCTION REACHES IT. `main()` is the only caller, it lives behind the
+// isMain guard, and a green mechanism nobody calls is this project's most
+// repeated failure. So this block runs the SHIPPED launcher as a subprocess,
+// exactly as .mcp.json does (`node launch-server.mjs --full`), with `npm` and
+// `npx` stubbed on PATH: `npm root -g` answers a prefix with no comfyui-mcp in
+// it, so the launcher takes the npx fallback, and `npx` is a stand-in server
+// that cannot answer for FAKE_DELAY_MS — which is what a cold install looks
+// like from the wrapper's side.
+//
+// Delete `runProxied` from the isMain block and the first test here fails.
+// ---------------------------------------------------------------------------
+const FAKE_SERVER_SOURCE = [
+  'import { appendFileSync } from "node:fs";',
+  'const delay = Number(process.env.FAKE_DELAY_MS || 0);',
+  'const log = process.env.FAKE_LOG;',
+  'const send = (o) => process.stdout.write(JSON.stringify(o) + "\\n");',
+  'const queued = [];',
+  'let open = delay === 0;',
+  'let buf = "";',
+  'process.stdin.on("data", (c) => {',
+  '  buf += c.toString("utf8");',
+  '  let nl;',
+  '  while ((nl = buf.indexOf("\\n")) !== -1) {',
+  '    const line = buf.slice(0, nl); buf = buf.slice(nl + 1);',
+  '    let m; try { m = JSON.parse(line); } catch { continue; }',
+  '    if (log) appendFileSync(log, (m.method ?? "response") + "\\n");',
+  '    if (open) handle(m); else queued.push(m);',
+  '  }',
+  '});',
+  'function handle(m) {',
+  '  if (m.method === "initialize") {',
+  '    send({ jsonrpc: "2.0", id: m.id, result: {',
+  '      protocolVersion: (m.params && m.params.protocolVersion) || "2025-06-18",',
+  '      capabilities: { tools: { listChanged: true } },',
+  '      serverInfo: { name: "fake-comfyui-mcp", version: "9.9.9" },',
+  '      instructions: "REAL_SERVER_INSTRUCTIONS",',
+  '    }});',
+  '  } else if (m.method === "tools/list") {',
+  '    send({ jsonrpc: "2.0", id: m.id, result: { tools: [',
+  '      { name: "fake_generate", description: "d", inputSchema: { type: "object", properties: {} } },',
+  '    ]}});',
+  '  } else if (m.id !== undefined && m.id !== null) {',
+  '    send({ jsonrpc: "2.0", id: m.id, error: { code: -32601, message: "unhandled" } });',
+  '  }',
+  '}',
+  'if (!open) setTimeout(() => { open = true; for (const m of queued.splice(0)) handle(m); }, delay);',
+].join("\n");
+
+describe("the shipped launcher rescues a real cold start (#1447)", () => {
+  let stubDir = "";
+  const children: ChildProcessWithoutNullStreams[] = [];
+
+  beforeAll(async () => {
+    await loadLauncher();
+    stubDir = mkdtempSync(join(tmpdir(), "launch-1447-"));
+    const emptyGlobal = join(stubDir, "empty-global-root");
+    const fakeServer = join(stubDir, "fake-server.mjs");
+    writeFileSync(fakeServer, FAKE_SERVER_SOURCE, "utf8");
+    // POSIX forms (npm/npx are spawned without a shell there) …
+    writeFileSync(join(stubDir, "npm"), `#!/bin/sh\necho "${emptyGlobal}"\n`, "utf8");
+    writeFileSync(join(stubDir, "npx"), `#!/bin/sh\nexec "${process.execPath}" "${fakeServer}"\n`, "utf8");
+    chmodSync(join(stubDir, "npm"), 0o755);
+    chmodSync(join(stubDir, "npx"), 0o755);
+    // … and the .cmd forms, because the Windows spec goes through cmd.exe.
+    writeFileSync(join(stubDir, "npm.cmd"), `@echo ${emptyGlobal}\r\n`, "utf8");
+    writeFileSync(join(stubDir, "npx.cmd"), `@"${process.execPath}" "${fakeServer}"\r\n`, "utf8");
+  });
+
+  afterAll(() => {
+    for (const child of children) {
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+    }
+    if (stubDir) rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  function launch(env: Record<string, string>): {
+    stdout: string[];
+    send: (m: Frame) => void;
+    stderr: () => string;
+  } {
+    const child = spawn(process.execPath, [fileURLToPath(LAUNCHER_URL), "--full"], {
+      env: { ...process.env, ...env, PATH: `${stubDir}${delimiter}${process.env.PATH ?? ""}` },
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+    children.push(child);
+    let err = "";
+    child.stderr.on("data", (c: Buffer) => {
+      err += c.toString("utf8");
+    });
+    return {
+      stdout: collectLines(child.stdout),
+      send: (m: Frame) => child.stdin.write(`${JSON.stringify(m)}\n`),
+      stderr: () => err,
+    };
+  }
+
+  const INIT: Frame = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+  };
+
+  it(
+    "answers the handshake while the install is still running, then serves the real tools",
+    async () => {
+      const log = join(stubDir, "rescue-log.txt");
+      // MCP_TIMEOUT 3000 → a 1500 ms deadline (the floor); the stand-in server
+      // cannot answer for 4 s. Without the rescue this is the reported failure.
+      const client = launch({ MCP_TIMEOUT: "3000", FAKE_DELAY_MS: "4000", FAKE_LOG: log });
+      client.send(INIT);
+
+      const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
+        result: { serverInfo: { version: string }; capabilities: { tools: { listChanged: boolean } } };
+      };
+      expect(handshake.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+      expect(handshake.result.capabilities.tools.listChanged).toBe(true);
+
+      client.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      client.send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+      const empty = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 2), 8000)) as {
+        result: { tools: unknown[] };
+      };
+      expect(empty.result.tools).toEqual([]);
+
+      // The server comes up; the client is told to re-list rather than handed a
+      // second answer for id 1.
+      await waitFor(
+        () => parseAll(client.stdout).find((f) => f.method === "notifications/tools/list_changed"),
+        15000,
+      );
+      expect(parseAll(client.stdout).filter((f) => f.id === 1)).toHaveLength(1);
+
+      client.send({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+      const real = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 3), 8000)) as {
+        result: { tools: { name: string }[] };
+      };
+      expect(real.result.tools.map((t) => t.name)).toEqual(["fake_generate"]);
+
+      // The server really did receive its own handshake — the wrapper proxied
+      // it rather than standing in for the server forever.
+      const received = readFileSync(log, "utf8");
+      expect(received).toMatch(/^initialize$/m);
+      expect(received).toMatch(/^notifications\/initialized$/m);
+      // The rescue is announced on stderr, never on the transport.
+      expect(client.stderr()).toMatch(/answered the MCP handshake on its behalf/);
+    },
+    25000,
+  );
+
+  it(
+    "control: a server that starts promptly keeps its own serverInfo and instructions",
+    async () => {
+      const client = launch({ MCP_TIMEOUT: "30000", FAKE_DELAY_MS: "0" });
+      client.send(INIT);
+      const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
+        result: { serverInfo: { name: string; version: string }; instructions: string };
+      };
+      // If the wrapper hijacked every launch, THIS is what would regress: the
+      // real version (#1503) and the server's own instructions.
+      expect(handshake.result.serverInfo).toEqual({ name: "fake-comfyui-mcp", version: "9.9.9" });
+      expect(handshake.result.instructions).toBe("REAL_SERVER_INSTRUCTIONS");
+      expect(client.stderr()).not.toMatch(/answered the MCP handshake on its behalf/);
+    },
+    25000,
+  );
 });

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -621,6 +621,41 @@ describe("cold-start proxy state machine (#1447)", () => {
     expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
   });
 
+  it("arms on a BATCHED initialize, and swallows a batched handshake response", async () => {
+    // Round-6 gate. MCP 2025-03-26 forbids batching `initialize` and 2025-06-18
+    // has no batching at all, so this is a client bug — but the entire rescue
+    // hangs off finding that request, and "we did not arm because the client
+    // was slightly wrong" is a cold start that still times out. Every other
+    // frame shape here already handles batches; these two now match.
+    const r = rig(40);
+    r.fromClient([
+      { jsonrpc: "2.0", id: 7, method: "initialize", params: { protocolVersion: "2025-03-26" } },
+    ] as unknown as Frame);
+    const stand = (await waitFor(() => parseAll(r.toClient)[0])) as {
+      id: number;
+      result: { serverInfo: { version: string } };
+    };
+    expect(stand.id).toBe(7);
+    expect(stand.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+
+    r.fromClient({ jsonrpc: "2.0", method: "notifications/initialized" });
+    // The server answers inside a batch. Its handshake response must be
+    // swallowed; whatever shared the batch is still the client's.
+    r.fromChild([
+      { jsonrpc: "2.0", id: 7, result: { protocolVersion: "2025-03-26", capabilities: {} } },
+      { jsonrpc: "2.0", method: "notifications/message", params: { level: "info", data: "hello" } },
+    ] as unknown as Frame);
+
+    const passedThrough = (await waitFor(() => parseAll(r.toClient)[1])) as unknown as Frame[];
+    expect(passedThrough).toEqual([
+      { jsonrpc: "2.0", method: "notifications/message", params: { level: "info", data: "hello" } },
+    ]);
+    await waitFor(() => parseAll(r.toClient).find((f) => f.method === "notifications/tools/list_changed"));
+    // …and never a second answer for id 7.
+    expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
+    expect(r.proxy.phase()).toBe("live");
+  });
+
   it("holds the re-list announcement until the client says it is initialized", async () => {
     // Round-4 gate: the announcement was sent the instant the server's
     // handshake landed, which can be BEFORE the client has finished its own —

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -299,8 +299,7 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
   it("reads `npm config get cache` to tell a first run from a warm one", () => {
     const { cachedNpxInstallExists } = launcher;
     const seen: string[] = [];
-    const present = cachedNpxInstallExists("  C:/cache  
-", {
+    const present = cachedNpxInstallExists("  C:/cache  \n", {
       readdir: () => ["8af3af54f44861ce", "other"],
       exists: (p: string) => {
         seen.push(p);
@@ -309,7 +308,9 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
     });
     expect(present).toBe(true);
     // It looks under the cache npm named, in _npx, for a real manifest.
-    expect(seen[0].replace(/\/g, "/")).toBe("C:/cache/_npx/8af3af54f44861ce/node_modules/comfyui-mcp/package.json");
+    expect(seen[0].split("\\").join("/")).toBe(
+      "C:/cache/_npx/8af3af54f44861ce/node_modules/comfyui-mcp/package.json",
+    );
 
     // A comfyui-mcp directory with no manifest is the half-deleted state a
     // failed Windows uninstall leaves behind; it is not a runnable install.

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -42,6 +42,7 @@ type Launcher = {
   ) => boolean;
   rescueInitializeResult: (params: unknown) => Frame;
   installingDecision: (msg: unknown) => Decision;
+  npmProbeTimeoutMs: (env?: Record<string, string | undefined>) => number;
   attachColdStartProxy: (opts: {
     clientIn: NodeJS.ReadableStream;
     clientOut: NodeJS.WritableStream;
@@ -49,6 +50,7 @@ type Launcher = {
     childOut: NodeJS.ReadableStream;
     deadlineMs: number;
     onRescue?: () => void;
+    onHandoverFailed?: (error: unknown) => void;
   }) => { phase: () => string; forceRescue: () => void };
   INSTALLING_VERSION: string;
   RESCUE_MIN_MS: number;
@@ -267,8 +269,16 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
     for (const bad of ["", "soon", "-1", "0", "NaN", undefined]) {
       expect(cached({ MCP_TIMEOUT: bad })).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
     }
-    expect(cached({ MCP_TIMEOUT: "100" })).toBe(RESCUE_MIN_MS);
     expect(cached({ MCP_TIMEOUT: "600000" })).toBe(RESCUE_MAX_MS);
+    // Round-2 gate: a floor that can OUTLIVE the budget is not a floor, it is
+    // a way to miss the deadline. At MCP_TIMEOUT=1000 a 1500 ms floor would
+    // have scheduled the rescue after the client had already given up.
+    expect(cached({ MCP_TIMEOUT: "1000" })).toBeLessThan(1000);
+    expect(cached({ MCP_TIMEOUT: "1000" })).toBe(400);
+    for (const budget of [200, 1000, 3000, 10000, 30000]) {
+      expect(cached({ MCP_TIMEOUT: String(budget) })).toBeLessThan(budget);
+    }
+    expect(cached({ MCP_TIMEOUT: "100" })).toBeLessThan(RESCUE_MIN_MS);
     // The measured warm-npx handshake is ~1.2 s (7.0 s once, when npx updated
     // first). The cached deadline must sit well clear of that or it would swap
     // a healthy server's real serverInfo for the stand-in on every launch.
@@ -294,6 +304,33 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
     expect(cold({ MCP_TIMEOUT: "2000" })).toBe(2000 * RESCUE_BUDGET_FRACTION);
     // Raising the assumed default must NOT be able to move this branch.
     expect(cold({})).toBeLessThan(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+  });
+
+  it("bounds the npm probes by the same budget — they run BEFORE the deadline arms", () => {
+    // Round-2 gate: two sequential 5 s probes could eat a 10 s budget whole and
+    // the rescue would never arm. They now run concurrently AND are capped by a
+    // slice of the budget, so probing plus the deadline stays inside it.
+    const { npmProbeTimeoutMs, coldStartDeadlineMs } = launcher;
+    expect(npmProbeTimeoutMs({})).toBe(5000);
+    expect(npmProbeTimeoutMs({ MCP_TIMEOUT: "10000" })).toBe(2000);
+    expect(npmProbeTimeoutMs({ MCP_TIMEOUT: "3000" })).toBe(600);
+    expect(npmProbeTimeoutMs({ MCP_TIMEOUT: "100" })).toBe(300);
+    for (const budget of [3000, 5000, 10000, 30000]) {
+      const env = { MCP_TIMEOUT: String(budget) };
+      const worst = npmProbeTimeoutMs(env) + coldStartDeadlineMs(env, { cachedInstall: false });
+      expect(worst, `probe + cold deadline must fit inside ${budget}ms`).toBeLessThan(budget);
+      const warm = npmProbeTimeoutMs(env) + coldStartDeadlineMs(env, { cachedInstall: true });
+      expect(warm, `probe + cached deadline must fit inside ${budget}ms`).toBeLessThan(budget);
+    }
+  });
+
+  it("launches both npm probes concurrently, not one after the other", () => {
+    // The arithmetic above only holds if the two probes overlap; sequential
+    // probes would each be allowed the full timeout. Promise.all is the shape
+    // that guarantees it, and the timeout is passed in rather than defaulted.
+    const src = readFileSync(LAUNCHER_URL, "utf8");
+    expect(src).toMatch(/await Promise\.all\(\[\s*probeNpm\(\["root", "-g"\], probeTimeout\),/);
+    expect(src).toMatch(/probeNpm\(\["config", "get", "cache"\], probeTimeout\),/);
   });
 
   it("reads `npm config get cache` to tell a first run from a warm one", () => {
@@ -402,11 +439,21 @@ describe("cold-start proxy state machine (#1447)", () => {
     const childOut = new PassThrough();
     const toClient = collectLines(clientOut);
     const toChild = collectLines(childIn);
-    const proxy = launcher.attachColdStartProxy({ clientIn, clientOut, childIn, childOut, deadlineMs });
+    const handoverFailures: unknown[] = [];
+    const proxy = launcher.attachColdStartProxy({
+      clientIn,
+      clientOut,
+      childIn,
+      childOut,
+      deadlineMs,
+      onHandoverFailed: (error) => handoverFailures.push(error),
+    });
     return {
       proxy,
       toClient,
       toChild,
+      handoverFailures,
+      writeClient: (raw: string) => clientIn.write(`${raw}\n`),
       fromClient: (m: Frame) => clientIn.write(`${JSON.stringify(m)}\n`),
       fromChild: (m: Frame) => childOut.write(`${JSON.stringify(m)}\n`),
     };
@@ -497,6 +544,59 @@ describe("cold-start proxy state machine (#1447)", () => {
       result: { tools: { name: string }[] };
     };
     expect(real.result.tools[0].name).toBe("generate_image");
+    expect(r.handoverFailures).toEqual([]);
+  });
+
+  it("arms on an `initialize` whose method name is JSON-ESCAPED", async () => {
+    // Round-2 gate: the arming test used to be a substring match on the text
+    // `"initialize"`. JSON may escape any character in a string, so an escaped
+    // method is the same request to a parser and invisible to that test — and
+    // the rescue would simply never fire for such a client.
+    const r = rig(40);
+    r.writeClient(
+      '{"jsonrpc":"2.0","id":7,"method":"\\u0069nitialize","params":{"protocolVersion":"2025-03-26"}}',
+    );
+    const stand = (await waitFor(() => parseAll(r.toClient)[0])) as {
+      id: number;
+      result: { serverInfo: { version: string }; protocolVersion: string };
+    };
+    expect(stand.id).toBe(7);
+    expect(stand.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
+    expect(stand.result.protocolVersion).toBe("2025-03-26");
+  });
+
+  it("a server that ERRORS its handshake after a rescue is not announced as connected", async () => {
+    // Round-2 gate: this path swallowed the error and sent tools/list_changed,
+    // leaving the client holding a success the launcher invented for a server
+    // that had just refused to start. There is no way to retract the handshake,
+    // so the only honest move is to stop.
+    const r = rig(40);
+    r.fromClient(INIT);
+    await waitFor(() => parseAll(r.toClient)[0]);
+    expect(r.proxy.phase()).toBe("installing");
+
+    r.fromChild({ jsonrpc: "2.0", id: 7, error: { code: -32602, message: "unsupported protocol version" } });
+    const failure = (await waitFor(() => r.handoverFailures[0])) as { message: string };
+    expect(failure.message).toMatch(/unsupported protocol version/);
+    expect(r.proxy.phase()).toBe("failed");
+
+    // …and specifically NOT a tools announcement, nor a second answer for id 7.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(parseAll(r.toClient).some((f) => f.method === "notifications/tools/list_changed")).toBe(false);
+    expect(parseAll(r.toClient).filter((f) => f.id === 7)).toHaveLength(1);
+  });
+
+  it("an error the server sends in TIME is the client's to see, untouched", async () => {
+    // The control for the case above: without a rescue the wrapper has no
+    // opinion — the server's own error is its own answer.
+    const r = rig(2000);
+    r.fromClient(INIT);
+    await waitFor(() => (r.toChild.length ? true : undefined));
+    r.fromChild({ jsonrpc: "2.0", id: 7, error: { code: -32602, message: "unsupported protocol version" } });
+    const forwarded = (await waitFor(() => parseAll(r.toClient)[0])) as { error: { message: string } };
+    expect(forwarded.error.message).toBe("unsupported protocol version");
+    expect(r.proxy.phase()).toBe("transparent");
+    expect(r.handoverFailures).toEqual([]);
   });
 });
 

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -636,11 +636,16 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
     "answers the handshake while the install is still running, then serves the real tools",
     async () => {
       const log = join(stubDir, "rescue-log.txt");
-      // A first run: `npm config get cache` names a cache with no _npx, so the
-      // deadline is the floor and does NOT depend on the budget we assume. The
-      // stand-in server cannot answer for 4 s — the reported failure exactly.
+      // A first run: `npm config get cache` names a cache with no _npx.
+      //
+      // The budget here is a GENEROUS 30 s on purpose. If the launcher ignored
+      // the cache answer and used the cached branch, the deadline would be
+      // 12 s, the stand-in server would answer first at 4 s, and the handshake
+      // below would carry version 9.9.9 instead of the sentinel — so this test
+      // fails if the cache probe is ever left dead in production.
+      const started = Date.now();
       const client = launch({
-        MCP_TIMEOUT: "3000",
+        MCP_TIMEOUT: "30000",
         NPM_STUB_CACHE: coldCache,
         FAKE_DELAY_MS: "4000",
         FAKE_LOG: log,
@@ -650,6 +655,8 @@ describe("the shipped launcher rescues a real cold start (#1447)", () => {
       const handshake = (await waitFor(() => parseAll(client.stdout).find((f) => f.id === 1), 12000)) as {
         result: { serverInfo: { version: string }; capabilities: { tools: { listChanged: boolean } } };
       };
+      // …and it beat the server rather than merely differing from it.
+      expect(Date.now() - started).toBeLessThan(3500);
       expect(handshake.result.serverInfo.version).toBe(launcher.INSTALLING_VERSION);
       expect(handshake.result.capabilities.tools.listChanged).toBe(true);
 

--- a/src/__tests__/scripts/launch-server.test.ts
+++ b/src/__tests__/scripts/launch-server.test.ts
@@ -257,19 +257,28 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
     const { coldStartDeadlineMs, RESCUE_BUDGET_FRACTION, DEFAULT_CLIENT_BUDGET_MS, RESCUE_MIN_MS, RESCUE_MAX_MS } =
       launcher;
     const cached = (env: Record<string, string | undefined>) => coldStartDeadlineMs(env, { cachedInstall: true });
-    expect(cached({ MCP_TIMEOUT: "20000" })).toBe(20000 * RESCUE_BUDGET_FRACTION);
+    expect(cached({ MCP_TIMEOUT: "5000" })).toBe(5000 * RESCUE_BUDGET_FRACTION);
     // …and it must leave the client real margin, never spend the whole budget.
-    expect(cached({ MCP_TIMEOUT: "20000" })).toBeLessThan(20000);
-    expect(cached({ MCP_TIMEOUT: "10000" })).toBe(4000);
+    expect(cached({ MCP_TIMEOUT: "5000" })).toBeLessThan(5000);
+    expect(cached({ MCP_TIMEOUT: "10000" })).toBe(RESCUE_MAX_MS);
     // A tightened budget rescues SOONER — the direction that matters.
     expect(cached({ MCP_TIMEOUT: "5000" })).toBeLessThan(cached({ MCP_TIMEOUT: "20000" }));
-    // No budget stated → the documented default.
-    expect(cached({})).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+    // No budget stated → the cap, never the assumed default's full share. Two
+    // gate rounds pushed on the same thing from opposite sides: a deadline
+    // derived from a budget we only ASSUME can outlive the budget we got. The
+    // cap is what makes the assumption cheap.
+    expect(cached({})).toBe(RESCUE_MAX_MS);
+    expect(cached({})).toBeLessThan(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
     // Junk is not a budget.
     for (const bad of ["", "soon", "-1", "0", "NaN", undefined]) {
-      expect(cached({ MCP_TIMEOUT: bad })).toBe(DEFAULT_CLIENT_BUDGET_MS * RESCUE_BUDGET_FRACTION);
+      expect(cached({ MCP_TIMEOUT: bad })).toBe(RESCUE_MAX_MS);
     }
     expect(cached({ MCP_TIMEOUT: "600000" })).toBe(RESCUE_MAX_MS);
+    // With MCP_TIMEOUT unset, the deadline must still fit inside any client
+    // budget worth calling one — including budgets far below what we assume.
+    for (const realBudget of [10000, 15000, 30000]) {
+      expect(cached({}) + launcher.npmProbeTimeoutMs({})).toBeLessThan(realBudget);
+    }
     // Round-2 gate: a floor that can OUTLIVE the budget is not a floor, it is
     // a way to miss the deadline. At MCP_TIMEOUT=1000 a 1500 ms floor would
     // have scheduled the rescue after the client had already given up.
@@ -279,10 +288,10 @@ describe("rescue deadline tracks the CLIENT's budget (#1447)", () => {
       expect(cached({ MCP_TIMEOUT: String(budget) })).toBeLessThan(budget);
     }
     expect(cached({ MCP_TIMEOUT: "100" })).toBeLessThan(RESCUE_MIN_MS);
-    // The measured warm-npx handshake is ~1.2 s (7.0 s once, when npx updated
-    // first). The cached deadline must sit well clear of that or it would swap
-    // a healthy server's real serverInfo for the stand-in on every launch.
-    expect(cached({})).toBeGreaterThan(8000);
+    // The measured warm-npx handshake is ~1.2 s. The cached deadline must stay
+    // well clear of that or it would swap a healthy server's real serverInfo
+    // for the stand-in on every launch — the reason this branch exists at all.
+    expect(cached({})).toBeGreaterThan(1200 * 2.5);
   });
 
   it("with NOTHING cached it rescues at the floor — independent of the budget we assume", () => {


### PR DESCRIPTION
## The bug, reproduced end-to-end on a genuinely cold cache

A first-run user has no global `comfyui-mcp`, so the plugin launcher takes its **npx fallback**
and npm installs the whole tree *inside* the client's handshake budget. The client kills the
attempt, npx's partial install is discarded, the retry starts cold again.

Measured on this machine (Windows, 2026-08-25) with a throwaway `npm_config_cache` and a
throwaway `npm_config_prefix` — so `npm root -g` finds nothing and the npm cache is empty,
i.e. a first run exactly:

| condition | time to the `initialize` response |
|---|---|
| cold `npx -y comfyui-mcp --full` | **21.6 s** |
| npm install alone (**818 MB / 170 packages**) | 15.2 s |
| warm `_npx` cache | 1.2 s (7.0 s once, when npx updated first) |

Through the **real client**, two `claude mcp list` entries differing only in npm cache/prefix
(same launcher, same args, `MCP_TIMEOUT=10000`):

```
cold1447: ✘ Failed to connect — MCP server "cold1447" connection timed out after 10000ms
warm1447: ✔ Connected
```

That control/treatment pair is the proof the install is the whole difference. This machine's
link is fast enough that the default 30 s budget squeaks by at 21.6 s — which is exactly why
the bug reads as fine in local testing and fails for users on slower links.

## The fix — shape 1, "make the handshake win the race"

On the npx fallback only, the launcher stops being a pipe and becomes a **transparent MCP
proxy**:

- It forwards every frame verbatim in both directions.
- If the real server has not answered the client's `initialize` by a deadline, the launcher
  answers it *itself*, holds the session open (`tools/list` → `[]`, `ping` → `{}`, anything
  else → an explicit "still installing" error), and forwards `notifications/initialized` so
  the server can finish its own handshake behind the curtain.
- When the server's `initialize` **result** arrives it is swallowed (the client already has a
  result for that id) and the client is sent `notifications/tools/list_changed` instead. It
  re-lists and gets the real tools.
- When the server's `initialize` **error** arrives instead, the launcher reports it on stderr
  and drops the transport, because a handshake it invented cannot be retracted and a
  connected-with-no-tools server is worse than an honest disconnect.

A cold cache now costs **latency instead of a failed connection**.

**The warm path is untouched.** A resolved global entry still runs with `stdio: "inherit"` and
none of this loads. A server that answers inside the deadline keeps its own `serverInfo`,
capabilities and `instructions` — there is a control test for exactly that.

### The deadline is two answers, because it is two questions

- **Nothing unpacked under `_npx`** (`npm config get cache` is the authority on where that is):
  npm has 818 MB to fetch before a server process exists, so waiting cannot pay. **1.5 s**, and
  deliberately *not* derived from any assumed client budget.
- **A tree already cached**: measured warm-npx handshakes are 1.2 s, so these must stay
  transparent or the rescue would swap a healthy server's real `serverInfo` for a stand-in on
  every launch. Up to **4 s** — better than 3x of margin over 1.2 s — and still bounded by
  `MCP_TIMEOUT`. (The one 7.0 s observation was npx *updating* first, which is an install
  racing the handshake, i.e. exactly what the rescue is for.)

In both branches the client's budget share is a hard ceiling, and the two npm probes run
concurrently under a slice of the same budget. Net effect: every deadline is under 4 s and
under 0.4x of any stated budget, so probe + deadline fits inside any client budget of 10 s or
more **whether or not the client tells us what its budget is** — the assumed default is no
longer load-bearing.

## Measured, not assumed

1. **Claude Code 2.1.246 honours `notifications/tools/list_changed`.** A probe MCP server that
   answered `tools/list` with `[]`, then sent the notification 4 s later, was re-listed
   (`tools/list` id=2) and its tool — present only in the second listing — was called
   successfully. If this were false the fix would leave a *silently* toolless session, which
   is worse than the failure it replaces.
2. **`MCP_TIMEOUT` reaches the server's environment.** `MCP_TIMEOUT=17000 claude -p …` produced
   `process.env.MCP_TIMEOUT === "17000"` inside the spawned server.
3. **The whole chain, on the shipped code, against the real package** (empty npm cache, empty
   global prefix, `MCP_TIMEOUT=10000`):

   ```
   1.92s INITIALIZE_ANSWERED version=0.0.0-installing
   1.92s FIRST_TOOLS_LIST count=0
   8.01s LIST_CHANGED
   8.03s SECOND_TOOLS_LIST count=40
   ```

   and `claude mcp list` on that same configuration: **✔ Connected** (88 MB into an 818 MB
   install), where before the fix it was `✘ Failed to connect — timed out after 10000ms`.
   Two earlier `claude -p` sessions on a cold cache called the real server's `list_tools` and
   got 41 tools.

## Where to look hardest (the risky parts, named)

- **`attachColdStartProxy` sits in the MCP transport.** A bug here corrupts the protocol for
  every npx user, warm or cold — that is the real blast radius. Mitigations: it stops parsing
  entirely once the handshake settles, and every line it writes is a complete JSON-RPC frame
  (the tests parse *every* line the launcher emits and fail on any non-JSON).
- **The rescued handshake loses two things** and cannot get them back: `serverInfo.version`
  becomes the sentinel `0.0.0-installing` (deliberately not a plausible version — #1503's
  lesson) and the server's own `instructions` are not knowable yet, so a short honest stand-in
  is sent that explicitly tells the model *not* to improvise, shell out, or call ComfyUI's HTTP
  API — which is precisely what the reopened report observed. Both are paid **only** on a
  launch that would otherwise have failed outright.
- **`installingDecision` must never both forward and answer a request** — forwarding
  `tools/list` would park the client on the install, the same timeout one method along.
- **Ordering at handover**: the client's `initialize` is forwarded in the opening phase and
  `notifications/initialized` in the installing phase, so the pipe delivers them to the server
  in the right order. If that inverted, the server's SDK would refuse to serve.

## Review history (6 gate rounds, all findings fixed)

- **R1 P1** — with `MCP_TIMEOUT` unset the deadline was 12 s from an *assumed* 30 s budget, so
  a client that waits less and exports nothing would still be killed. → split the deadline by
  whether anything is cached; the first-run branch no longer reads the assumed default.
- **R2 P1 ×4** — two *sequential* 5 s npm probes could eat a 10 s budget before the deadline
  even armed (→ concurrent, budget-bounded); a delayed `initialize` **error** was swallowed
  like a success and announced as connected (→ stderr + drop the transport); the cached
  branch's 1.5 s floor could outlive a smaller budget (→ the share is a ceiling in both
  branches); arming matched the literal text `"initialize"`, invisible to a JSON-escaped
  method (→ parse, never sniff, in both directions).
- **R3 P1** — a JSON-RPC batch was forwarded wholesale during the install, parking every
  request inside it on npm. → routed member by member, answers returned as one array.
- **R4 P1** — `tools/list_changed` was emitted once, the instant the server's handshake landed,
  which can be *before* the client has finished its own; a notification ahead of
  `notifications/initialized` is one the client may ignore, and losing it leaves the session on
  the empty tool list permanently — the silent failure this issue is about, reintroduced by the
  fix for it. Now the announcement waits for the client's `notifications/initialized` (the
  client side keeps inspecting frames while one is pending, even in the otherwise pure-wire
  `live` phase) and is then sent three times, at 0/1.5s/6s. Re-listing is idempotent.

- **R5 P1** — R1's finding from the other side: with `MCP_TIMEOUT` unset the *cached* branch
  waited 12 s, a number derived from a budget we only assume. Rather than defend the
  assumption, it is made cheap: the cached cap drops 12 s -> 4 s, which the measurements say is
  safe. (For the record, the finding's premise, "Claude's observed 10 s handshake timeout", is
  this reproduction's own `MCP_TIMEOUT=10000` override — which the launcher reads and shortens
  for. Claude Code's default measured **>21.6 s** here: a cold run with no override connected
  at 21.6 s. The change is worth making anyway, because it removes the dependence on that
  measurement being right.)

- **R6 P1** — the arming site was the last frame shape in the proxy that did not look inside a
  JSON-RPC batch, so a client batching its `initialize` armed no deadline and still timed out.
  Out of spec (2025-03-26 forbids batching `initialize`; 2025-06-18 has no batching) — but the
  whole rescue hangs off finding that request, so both directions now match the batch handling
  the rest of the proxy already had, including splitting a batched handshake response from its
  batch-mates so swallowing one does not drop the others.

Each fix is pinned by a test that fails when the fix is reverted; 19 mutations were run
against the launcher and all 19 were killed, with the control tests surviving every one.

## Tests

`src/__tests__/scripts/launch-server.test.ts` (33 tests, suite 664 files / 12271 green):

- deadline tables for both branches, probe-budget arithmetic, the cache probe, the stand-in
  handshake shape, and the full `installingDecision` routing table including batches;
- the proxy **state machine** over real streams: transparent, rescued, escaped-method arming,
  failed handover, batched mid-install request, deferred and repeated announcement;
- **reachability** — three tests spawn the *shipped* launcher as a subprocess exactly as
  `.mcp.json` does (`node launch-server.mjs --full`), with `npm root -g` and
  `npm config get cache` stubbed separately on `PATH` and `npx` a stand-in server that cannot
  answer for 4 s. Deleting the wiring, or letting the cache probe go dead, fails them; the
  control fails if the proxy ever hijacks a healthy server.

## What this PR deliberately does NOT do

- **It does not restructure dependencies.** `@openai/codex` (354 MB) and `@anthropic-ai`
  (255 MB) really are 74% of the 818 MB, and moving the nine `optionalDependencies` to optional
  *peer* deps would shrink it — but that is the distribution decision this thread parked twice,
  it changes what existing users get on their next install, and it would only *shrink* the
  failure window rather than remove it. `--omit=optional` remains a measured dead end (the slim
  tree cannot start: sharp's platform binary is an optionalDependency too).
- **It does not touch the warm-global path**, even though a slow-booting global server could in
  principle blow the same budget. That is not this bug and it is a working path.

Fixes #1447
