### PR TITLE
fix(panel-tools): support workflow save subfolders

### DIFF
--- a/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
+++ b/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
@@ -83,11 +83,16 @@ describe("#814 panel_save_workflow trusts its OWN reply before the round trip", 
       workflow_instance_changed: true,
     };
     const res = await toolNamed("panel_save_workflow").handler(
-      { name: "renamed" },
+      { name: "renamed", subfolder: "nested/save-as" },
       ctxWith(bridgeFor("workflow_save_as", reply)),
     );
 
     expect(res.isError).toBeFalsy();
+    expect(sent[0]).toEqual({
+      cmd: "workflow_save_as",
+      name: "renamed",
+      subfolder: "nested/save-as",
+    });
     expect(fence).toBe(NEW_UUID);
     expect(fence).not.toBe(PRIOR_UUID);
     expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
@@ -95,8 +100,12 @@ describe("#814 panel_save_workflow trusts its OWN reply before the round trip", 
 
   it("adopts an in-place save's proven uuid too — the reply carries it unconditionally", async () => {
     const reply = { saved: true, workflow: "same", workflow_uuid: NEW_UUID, routing_key: "wf:workflows/same.json" };
-    await toolNamed("panel_save_workflow").handler({}, ctxWith(bridgeFor("workflow_save", reply)));
+    await toolNamed("panel_save_workflow").handler(
+      { subfolder: "nested/in-place" },
+      ctxWith(bridgeFor("workflow_save", reply)),
+    );
 
+    expect(sent[0]).toEqual({ cmd: "workflow_save", subfolder: "nested/in-place" });
     expect(fence).toBe(NEW_UUID);
     expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
   });

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -280,11 +280,14 @@ describe("#694 retry_of threading through the tool defs", () => {
     expect("retry_of" in calls[0]).toBe(false);
   });
 
-  it("panel_save_workflow attaches the token on BOTH branches and preserves Save-As subfolder", async () => {
+  it("panel_save_workflow attaches the token and subfolder on BOTH branches", async () => {
     const { ctx, calls } = makeRecordingCtx();
-    await defByName("panel_save_workflow").handler({ retry_of: "tok-a" }, ctx);
     await defByName("panel_save_workflow").handler(
-      { name: "copy", subfolder: "nested/safe", retry_of: "tok-b" },
+      { subfolder: "nested/in-place", retry_of: "tok-a" },
+      ctx,
+    );
+    await defByName("panel_save_workflow").handler(
+      { name: "copy", subfolder: "nested/save-as", retry_of: "tok-b" },
       ctx,
     );
     // Find the save frames by NAME, not by index: #1045 added a `workflow_list`
@@ -293,11 +296,15 @@ describe("#694 retry_of threading through the tool defs", () => {
     // is about which frame CARRIES it, not where it lands in the sequence.
     const save = calls.find((c) => c.cmd === "workflow_save");
     const saveAs = calls.find((c) => c.cmd === "workflow_save_as");
-    expect(save).toMatchObject({ cmd: "workflow_save", retry_of: "tok-a" });
+    expect(save).toMatchObject({
+      cmd: "workflow_save",
+      subfolder: "nested/in-place",
+      retry_of: "tok-a",
+    });
     expect(saveAs).toMatchObject({
       cmd: "workflow_save_as",
       name: "copy",
-      subfolder: "nested/safe",
+      subfolder: "nested/save-as",
       retry_of: "tok-b",
     });
     // …and the probe itself must never carry a caller's retry token.
@@ -306,7 +313,7 @@ describe("#694 retry_of threading through the tool defs", () => {
     }
   });
 
-  it("subfolder is optional, rejects unknown keys, and never changes in-place workflow_save", async () => {
+  it("subfolder is optional, rejects unknown keys, and preserves omission/bare-name behavior", async () => {
     const def = defByName("panel_save_workflow");
     const schema = strictPanelSchema(def.schema);
     expect(schema.parse({})).toEqual({});
@@ -318,7 +325,14 @@ describe("#694 retry_of threading through the tool defs", () => {
 
     const { ctx, calls } = makeRecordingCtx();
     await def.handler({ subfolder: "nested/safe" }, ctx);
-    expect(calls.find((c) => c.cmd === "workflow_save")).toEqual({ cmd: "workflow_save" });
+    expect(calls.find((c) => c.cmd === "workflow_save")).toEqual({
+      cmd: "workflow_save",
+      subfolder: "nested/safe",
+    });
+
+    await def.handler({}, ctx);
+    const omittedSave = calls.find((c, index) => c.cmd === "workflow_save" && index > 0);
+    expect(omittedSave).toEqual({ cmd: "workflow_save" });
 
     await def.handler({ name: "bare-name" }, ctx);
     const bareSaveAs = calls.find((c) => c.cmd === "workflow_save_as" && c.name === "bare-name");

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -20,6 +20,7 @@ import {
   makePanelToolCtx,
   RETRY_TOKEN_CMDS,
   RETRY_TOKEN_CMD_BY_TOOL,
+  strictPanelSchema,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -279,10 +280,13 @@ describe("#694 retry_of threading through the tool defs", () => {
     expect("retry_of" in calls[0]).toBe(false);
   });
 
-  it("panel_save_workflow attaches the token on BOTH the save and save_as branches", async () => {
+  it("panel_save_workflow attaches the token on BOTH branches and preserves Save-As subfolder", async () => {
     const { ctx, calls } = makeRecordingCtx();
     await defByName("panel_save_workflow").handler({ retry_of: "tok-a" }, ctx);
-    await defByName("panel_save_workflow").handler({ name: "copy", retry_of: "tok-b" }, ctx);
+    await defByName("panel_save_workflow").handler(
+      { name: "copy", subfolder: "nested/safe", retry_of: "tok-b" },
+      ctx,
+    );
     // Find the save frames by NAME, not by index: #1045 added a `workflow_list`
     // fence probe after each save (a Save-As re-points the active workflow, so
     // the session has to re-anchor), which sits between them. The token contract
@@ -290,11 +294,35 @@ describe("#694 retry_of threading through the tool defs", () => {
     const save = calls.find((c) => c.cmd === "workflow_save");
     const saveAs = calls.find((c) => c.cmd === "workflow_save_as");
     expect(save).toMatchObject({ cmd: "workflow_save", retry_of: "tok-a" });
-    expect(saveAs).toMatchObject({ cmd: "workflow_save_as", retry_of: "tok-b" });
+    expect(saveAs).toMatchObject({
+      cmd: "workflow_save_as",
+      name: "copy",
+      subfolder: "nested/safe",
+      retry_of: "tok-b",
+    });
     // …and the probe itself must never carry a caller's retry token.
     for (const probe of calls.filter((c) => c.cmd === "workflow_list")) {
       expect("retry_of" in probe).toBe(false);
     }
+  });
+
+  it("subfolder is optional, rejects unknown keys, and never changes in-place workflow_save", async () => {
+    const def = defByName("panel_save_workflow");
+    const schema = strictPanelSchema(def.schema);
+    expect(schema.parse({})).toEqual({});
+    expect(schema.parse({ name: "copy", subfolder: "nested/safe" })).toEqual({
+      name: "copy",
+      subfolder: "nested/safe",
+    });
+    expect(() => schema.parse({ name: "copy", subfolderr: "nested/safe" })).toThrow(/subfolderr/);
+
+    const { ctx, calls } = makeRecordingCtx();
+    await def.handler({ subfolder: "nested/safe" }, ctx);
+    expect(calls.find((c) => c.cmd === "workflow_save")).toEqual({ cmd: "workflow_save" });
+
+    await def.handler({ name: "bare-name" }, ctx);
+    const bareSaveAs = calls.find((c) => c.cmd === "workflow_save_as" && c.name === "bare-name");
+    expect(bareSaveAs).toEqual({ cmd: "workflow_save_as", name: "bare-name" });
   });
 
   it("a READ tool never forwards retry_of even when args smuggle one (belt-and-braces gate)", async () => {

--- a/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
+++ b/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
@@ -113,6 +113,33 @@ describe("panel-tools #754: strict schemas reject unknown argument keys", () => 
     expect(poisonedText).toContain(BOGUS_KEY);
   });
 
+  it("panel_save_workflow accepts subfolder on both save branches and rejects misspellings", async () => {
+    const inPlace = await client.callTool({
+      name: "panel_save_workflow",
+      arguments: { subfolder: "nested/in-place" },
+    });
+    const inPlaceText = (inPlace.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(inPlace.isError).not.toBe(true);
+    expect(inPlaceText).toContain('"cmd":"workflow_save"');
+    expect(inPlaceText).toContain('"subfolder":"nested/in-place"');
+
+    const saveAs = await client.callTool({
+      name: "panel_save_workflow",
+      arguments: { name: "copy", subfolder: "nested/save-as" },
+    });
+    const saveAsText = (saveAs.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(saveAs.isError).not.toBe(true);
+    expect(saveAsText).toContain('"cmd":"workflow_save_as"');
+    expect(saveAsText).toContain('"subfolder":"nested/save-as"');
+
+    const misspelled = await client.callTool({
+      name: "panel_save_workflow",
+      arguments: { subfolderr: "nested/typo" },
+    });
+    expect(misspelled.isError).toBe(true);
+    expect((misspelled.content as Array<{ text?: string }>)?.[0]?.text ?? "").toContain("subfolderr");
+  });
+
   it("WIRING: both registration call sites route through strictPanelSchema, not the raw shape", () => {
     // A green protocol-dispatch test above proves the CURRENT registration works;
     // it says nothing about whether a future edit reverts one of the two call

--- a/src/__tests__/orchestrator/save-as-fence.test.ts
+++ b/src/__tests__/orchestrator/save-as-fence.test.ts
@@ -130,12 +130,27 @@ describe("#1045: a save-as re-anchors the fence", () => {
     expect(sent.map((c) => c.cmd)).toEqual(["workflow_save_as", "workflow_list"]);
     expect(stamps).toEqual([NEW_UUID]);
   });
+
+  it("forwards an in-place subfolder verbatim before re-anchoring identity", async () => {
+    const res = await saveWorkflow().handler(
+      { subfolder: "nested/in-place" },
+      ctxWith(HEALTHY_LIST),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(sent[0]).toEqual({
+      cmd: "workflow_save",
+      subfolder: "nested/in-place",
+    });
+    expect(sent.map((c) => c.cmd)).toEqual(["workflow_save", "workflow_list"]);
+    expect(stamps).toEqual([NEW_UUID]);
+  });
+
   // An IN-PLACE save (no name) re-anchors too. Its identity normally follows the
   // workflow across the save, so this usually re-derives the same value and
   // changes nothing — but "normally" is exactly what failed in #1045, and one
   // round trip is cheap against a session that would otherwise be unusable.
   it("re-anchors after an in-place save as well", async () => {
-    const { bridge, sent } = (() => {
+    const { bridge, sent: commandNames } = (() => {
       const s2: string[] = [];
       const b = bridgeFor(HEALTHY_LIST);
       const orig = (b as unknown as { send: (c: Record<string, unknown>) => Promise<unknown> }).send;
@@ -147,8 +162,9 @@ describe("#1045: a save-as re-anchors the fence", () => {
     })();
     const ctx = makePanelToolCtx(bridge, "tab-1");
     await saveWorkflow().handler({}, ctx);
-    expect(sent).toContain("workflow_save");
-    expect(sent).toContain("workflow_list");
+    expect(commandNames[0]).toBe("workflow_save");
+    expect(sent[0]).toEqual({ cmd: "workflow_save" });
+    expect(commandNames).toContain("workflow_list");
   });
 
 });

--- a/src/__tests__/orchestrator/save-as-fence.test.ts
+++ b/src/__tests__/orchestrator/save-as-fence.test.ts
@@ -115,6 +115,21 @@ describe("#1045: a save-as re-anchors the fence", () => {
     expect(textOf(res)).not.toContain("WAS saved");
     expect(textOf(res)).not.toContain("STILL fenced");
   });
+
+  it("forwards a nested Save-As subfolder verbatim before re-anchoring identity", async () => {
+    const res = await saveWorkflow().handler(
+      { name: "new-name", subfolder: "nested/safe" },
+      ctxWith(HEALTHY_LIST),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(sent[0]).toEqual({
+      cmd: "workflow_save_as",
+      name: "new-name",
+      subfolder: "nested/safe",
+    });
+    expect(sent.map((c) => c.cmd)).toEqual(["workflow_save_as", "workflow_list"]);
+    expect(stamps).toEqual([NEW_UUID]);
+  });
   // An IN-PLACE save (no name) re-anchors too. Its identity normally follows the
   // workflow across the save, so this usually re-derives the same value and
   // changes nothing — but "normally" is exactly what failed in #1045, and one

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -18453,9 +18453,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 },
                 15000,
               )
-            : ctx.call({ cmd: "workflow_save" }, 15000, (rid) => {
-                saveRid = rid;
-              });
+            : ctx.call(
+                {
+                  cmd: "workflow_save",
+                  ...(args.subfolder !== undefined ? { subfolder: args.subfolder } : {}),
+                },
+                15000,
+                (rid) => {
+                  saveRid = rid;
+                },
+              );
         let res = await saveOnce();
         // #1710 — dest tab + dest nodes, extra still stamped as the save-as SOURCE.
         // Rebind extra to the confirmed dest, then retry the same save once.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -18428,7 +18428,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_save_workflow",
       "Save the user's open workflow PROGRAMMATICALLY — no Save/Rename dialog ever pops. With no `name`: saves in place (or auto-names + persists a never-saved workflow). With `name`: if the workflow is ALREADY saved under a different name this is a SAVE-AS — it writes a NEW file and leaves the original untouched on disk (it NEVER renames/moves/destroys the original); for a never-saved workflow it is simply the first save. The result reports what happened: `saved_as`+`copied_from`+`original_on_disk` (a disk-verified check that the original file still exists) for a Save-As copy, or `first_save` for a brand-new workflow. A Save-As onto an EXISTING name is a 409 Conflict (the copy never overwrites) — do NOT pick a third name; panel_rename_workflow can target a closed listed original to free the name, then rename the active copy onto it, then panel_save_workflow() in place. Use this freely (e.g. after building a graph) — it won't interrupt the user.",
-      { name: z.string().optional().describe("Name for the workflow (no .json needed). If the workflow is already saved under a different name, this writes a NEW file (Save-As COPY) and leaves the original in place — it never renames/moves/destroys it. An existing target name 409s; do not invent a third name — use panel_rename_workflow to free the original then rename the active copy onto it. Omit to save in place / auto-name an unsaved workflow.") },
+      {
+        name: z.string().optional().describe("Name for the workflow (no .json needed). If the workflow is already saved under a different name, this writes a NEW file (Save-As COPY) and leaves the original in place — it never renames/moves/destroys it. An existing target name 409s; do not invent a third name — use panel_rename_workflow to free the original then rename the active copy onto it. Omit to save in place / auto-name an unsaved workflow."),
+        subfolder: z.string().optional().describe("Optional Save-As subfolder, passed verbatim to Panel for validation."),
+      },
       async (args: A, ctx) => {
         // #402: await a stable tab binding before dispatching the (mutating) save, so
         // a save issued in the post-restart "Connected: none" window reaches a live
@@ -18442,7 +18445,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         let saveRid: string | undefined;
         const saveOnce = () =>
           args.name
-            ? ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)
+            ? ctx.call(
+                {
+                  cmd: "workflow_save_as",
+                  name: args.name,
+                  ...(args.subfolder !== undefined ? { subfolder: args.subfolder } : {}),
+                },
+                15000,
+              )
             : ctx.call({ cmd: "workflow_save" }, 15000, (rid) => {
                 saveRid = rid;
               });


### PR DESCRIPTION
## Summary
- add optional subfolder to panel_save_workflow
- forward it verbatim on both workflow_save (including no-name/auto-name first-save) and workflow_save_as
- preserve omitted subfolder and bare-name behavior, with coverage for strict schema, retry forwarding, and save identity fencing

Companion to artokun/comfyui-mcp-panel#1817, which addresses artokun/comfyui-mcp-panel#1794.