### PR TITLE
fix(panel-tools): refuse V3 dynamic-combo child writes

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -465,6 +465,127 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
   });
 });
 
+describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", () => {
+  const SET_OK = {
+    set: { node_id: 23, widget: "model.prompt", previous: "", value: "NEW" },
+  };
+
+  const dynamicDetail = {
+    nodes: [
+      {
+        id: 23,
+        type: "MinimaxHailuo03TextToVideoNode",
+        widgets: { model: "text-to-video", "model.prompt": "" },
+        inputs: [
+          { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+          { name: "model.prompt", type: "STRING" },
+        ],
+      },
+    ],
+  };
+
+  async function run(
+    detail: unknown,
+    args: Record<string, unknown> = { node_id: 23, widget: "model.prompt", value: "NEW" },
+  ): Promise<{ res: ToolResult; cmds: string[] }> {
+    const cmds: string[] = [];
+    const res = (await defByName("panel_set_widget").handler(args, {
+      call: async (cmd: Record<string, unknown>) => {
+        cmds.push(String(cmd.cmd));
+        if (cmd.cmd === "graph_query") {
+          return { content: [{ type: "text" as const, text: JSON.stringify(detail, null, 2) }] };
+        }
+        return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
+      },
+    } as unknown as PanelToolCtx)) as ToolResult;
+    return { res, cmds };
+  }
+
+  it("refuses the exact live parent/type/path shape before graph_set_widget", async () => {
+    const { res, cmds } = await run(dynamicDetail);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/dynamic-combo sub-widget "model\.prompt"/);
+    expect(res.content[0].text).toMatch(/parent input "model" is COMFY_DYNAMICCOMBO_V3/);
+    expect(res.content[0].text).toMatch(/PrimitiveStringMultiline/);
+    expect(res.content[0].text).toMatch(/STRING output/);
+    expect(res.content[0].text).toMatch(/No graph_set_widget was dispatched/);
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("recognizes the production JSON-lines detail shape", async () => {
+    const detailLine = JSON.stringify(dynamicDetail.nodes[0]);
+    const { res, cmds } = await run({
+      text: `1 match(es) of 1 in scope (graph: 1 nodes)\n${detailLine}`,
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("COMFY_DYNAMICCOMBO_V3");
+    expect(cmds).toEqual(["graph_query"]);
+  });
+
+  it("keeps an ordinary dotted composite widget writable", async () => {
+    const { res, cmds } = await run(
+      {
+        nodes: [
+          {
+            id: 3,
+            type: "PowerLoraLoader",
+            widgets: { lora_1: { lora: "old", on: true } },
+            inputs: [{ name: "lora_1", type: "COMBO" }, { name: "lora_1.on", type: "BOOLEAN" }],
+          },
+        ],
+      },
+      { node_id: 3, widget: "lora_1.on", value: false },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("keeps an ordinary dotted STRING widget writable", async () => {
+    const { res, cmds } = await run(
+      {
+        nodes: [
+          {
+            id: 4,
+            type: "OrdinaryNode",
+            widgets: { "prompt.foo": "old" },
+            inputs: [{ name: "prompt", type: "STRING" }, { name: "prompt.foo", type: "STRING" }],
+          },
+        ],
+      },
+      { node_id: 4, widget: "prompt.foo", value: "safe" },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("keeps the V3 parent selector writable", async () => {
+    const { res, cmds } = await run(dynamicDetail, {
+      node_id: 23,
+      widget: "model",
+      value: "text-to-video",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_set_widget"]);
+  });
+
+  it("does not classify an unresolved dotted path as the known failure", async () => {
+    const { res, cmds } = await run(dynamicDetail, {
+      node_id: 23,
+      widget: "model.typo",
+      value: "safe",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("documents the refusal and socket workaround", () => {
+    const description = defByName("panel_set_widget").description;
+    expect(description).toContain("COMFY_DYNAMICCOMBO_V3");
+    expect(description).toContain("PrimitiveStringMultiline");
+    expect(description).toContain("model.prompt");
+  });
+});
+
 describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
   const SET_OK = {
     set: { node_id: 2571, widget: "stack_data", previous: "old", value: "NEW" },

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -578,6 +578,121 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
+  // ---- the over-refusal controls -------------------------------------------
+  //
+  // Every control above varies the PARENT type, so none of them can see a
+  // refusal that fires on the parent alone. These vary the CHILD under a proven
+  // COMFY_DYNAMICCOMBO_V3 parent — the Nano Banana 2 shape already fixtured in
+  // src/__tests__/services/api-nodes.test.ts, whose model.aspect_ratio /
+  // model.resolution / model.thinking_level children are COMBO and REQUIRED
+  // (api-nodes.ts: the server 400s with required_input_missing without them).
+  // Refusing those would strand a required input behind a remedy that does not
+  // exist for it — a STRING output does not reach a COMBO input.
+
+  const nanoBanana2Detail = {
+    nodes: [
+      {
+        id: 31,
+        type: "GeminiNanoBanana2V2",
+        widgets: {
+          model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+          "model.aspect_ratio": "auto",
+          "model.resolution": "1K",
+          "model.thinking_level": "MINIMAL",
+        },
+        inputs: [
+          { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+          { name: "model.aspect_ratio", type: "COMBO" },
+          { name: "model.resolution", type: "COMBO" },
+          { name: "model.thinking_level", type: "COMBO" },
+        ],
+      },
+    ],
+  };
+
+  it("keeps a COMBO child of a V3 dynamic combo writable (Nano Banana 2 model.resolution)", async () => {
+    const { res, cmds } = await run(nanoBanana2Detail, {
+      node_id: 31,
+      widget: "model.resolution",
+      value: "4K",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("keeps every non-STRING child of the same V3 parent writable", async () => {
+    for (const [widget, value] of [
+      ["model.aspect_ratio", "16:9"],
+      ["model.thinking_level", "HIGH"],
+    ] as Array<[string, string]>) {
+      const { res, cmds } = await run(nanoBanana2Detail, { node_id: 31, widget, value });
+      expect(res.isError, `${widget} must stay writable`).toBeUndefined();
+      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    }
+  });
+
+  it("keeps INT / FLOAT / BOOLEAN children of a V3 parent writable", async () => {
+    const detail = {
+      nodes: [
+        {
+          id: 32,
+          type: "SomeV3ApiNode",
+          widgets: { model: "opt", "model.steps": 20, "model.cfg": 3.5, "model.fast": false },
+          inputs: [
+            { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+            { name: "model.steps", type: "INT" },
+            { name: "model.cfg", type: "FLOAT" },
+            { name: "model.fast", type: "BOOLEAN" },
+          ],
+        },
+      ],
+    };
+    for (const [widget, value] of [
+      ["model.steps", 30],
+      ["model.cfg", 7.5],
+      ["model.fast", true],
+    ] as Array<[string, unknown]>) {
+      const { res, cmds } = await run(detail, { node_id: 32, widget, value });
+      expect(res.isError, `${widget} must stay writable`).toBeUndefined();
+      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    }
+  });
+
+  it("falls open when the detail row carries no declared type for the child", async () => {
+    // Present in the widgets map but absent from inputs: the probe cannot PROVE
+    // STRING, so this keeps the setter path rather than broadening the refusal.
+    const { res, cmds } = await run(
+      {
+        nodes: [
+          {
+            id: 33,
+            type: "MinimaxHailuo03TextToVideoNode",
+            widgets: { model: "text-to-video", "model.prompt": "" },
+            inputs: [{ name: "model", type: "COMFY_DYNAMICCOMBO_V3" }],
+          },
+        ],
+      },
+      { node_id: 33, widget: "model.prompt", value: "NEW" },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
+  it("names the proven child type in the refusal, so the STRING remedy always fits", async () => {
+    const { res } = await run(dynamicDetail);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/is a STRING child/);
+  });
+
+  it("documents that only a STRING child is refused", () => {
+    const description = defByName("panel_set_widget").description;
+    expect(description).toContain("COMFY_DYNAMICCOMBO_V3");
+    expect(description).toContain("PrimitiveStringMultiline");
+    expect(description).toContain("model.prompt");
+    expect(description).toMatch(/STRING child/);
+    expect(description).toContain("model.resolution");
+  });
+
   it("documents the refusal and socket workaround", () => {
     const description = defByName("panel_set_widget").description;
     expect(description).toContain("COMFY_DYNAMICCOMBO_V3");

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -73,6 +73,10 @@ function bridge(opts: {
   promotedDetail?: Record<string, unknown>;
   stackDataIdentity?: Record<string, unknown>;
   stackDataInnerIdentity?: Record<string, unknown> | null;
+  /** #2299: graph_query detail keyed by the id the call asked for, so the outer
+   *  probe (which cannot prove the dynamic-combo shape) and the post-enter inner
+   *  probe (which can) return different rows. */
+  detailById?: Record<string, unknown>;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -85,6 +89,7 @@ function bridge(opts: {
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
         if (writes === 1 && opts.stackDataIdentity) throw new Error(STACK_DATA_CONTRADICTORY);
+        if (writes === 1 && opts.detailById) throw new Error(DYNAMIC_CHILD_CONTRADICTORY);
         const which =
           writes === 1
             ? (opts.firstWrite ?? "contradict")
@@ -111,6 +116,10 @@ function bridge(opts: {
       }
       if (cmd.cmd === "graph_query") {
         graphQueries += 1;
+        const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
+          return opts.detailById[wantId];
+        }
         if (opts.stackDataIdentity && graphQueries <= 2) return opts.stackDataIdentity;
         if (opts.stackDataIdentity && graphQueries === 3) {
           return opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] };
@@ -159,6 +168,99 @@ async function setWidget(
     calls,
   };
 }
+
+// #2299 — a COMFY_DYNAMICCOMBO_V3 child promoted out of a subgraph. The write is
+// refused as "not promoted", recovery enters the subgraph and retries on the INNER
+// node — a node no pre-write guard ever probed.
+const DYNAMIC_CHILD_CONTRADICTORY =
+  `Cannot set widget on subgraph node 78: "model.prompt" is not a promoted widget on this subgraph ` +
+  `(promoted: model.prompt).`;
+
+const DYNAMIC_SUBGRAPH = {
+  subgraph_of: { node_id: 78, title: "H3" },
+  instance_widgets: { "model.prompt": "" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 76,
+      type: "MinimaxHailuo03TextToVideoNode",
+      widgets: { model: "text-to-video", "model.prompt": "" },
+    },
+  ],
+};
+
+// Only the INNER node carries both halves of the shape. The container exposes the
+// promoted child but not the `model` parent, so id 190 here stands in for an outer
+// probe that cannot prove it and must fall open.
+const DYNAMIC_DETAIL_BY_ID = {
+  "78": { nodes: [{ id: 190, inputs: [{ slot: 0, name: "model.prompt" }] }] },
+  "76": {
+    nodes: [
+      {
+        id: 76,
+        type: "MinimaxHailuo03TextToVideoNode",
+        widgets: { model: "text-to-video", "model.prompt": "" },
+        inputs: [
+          { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+          { name: "model.prompt", type: "STRING" },
+        ],
+      },
+    ],
+  },
+};
+
+describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
+  it("refuses the inner write instead of reporting a false success", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "model.prompt", value: "a long prompt" },
+      {
+        firstWrite: "contradict",
+        subgraph: DYNAMIC_SUBGRAPH,
+        detailById: DYNAMIC_DETAIL_BY_ID,
+      },
+    );
+    expect(isError).toBe(true);
+    expect(text).toContain("dynamic-combo");
+    expect(text).toContain("No inner graph_set_widget was dispatched");
+    // The recovery entered the subgraph and left it again...
+    expect(calls.some((c) => c.cmd === "graph_enter_subgraph")).toBe(true);
+    expect(calls.some((c) => c.cmd === "graph_exit_subgraph")).toBe(true);
+    // ...and the INNER node was never written. Only the outer attempt happened.
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes.every((c) => String(c.node_id) !== "76")).toBe(true);
+  });
+
+  it("still applies a promoted inner write when the inner node is NOT a dynamic combo", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "model.prompt", value: "a long prompt" },
+      {
+        firstWrite: "contradict",
+        innerWrite: "ok",
+        subgraph: DYNAMIC_SUBGRAPH,
+        detailById: {
+          "78": DYNAMIC_DETAIL_BY_ID["78"],
+          // Same dotted name, ordinary STRING parent — not the #2299 shape.
+          "76": {
+            nodes: [
+              {
+                id: 76,
+                type: "OrdinaryNode",
+                widgets: { "model.prompt": "" },
+                inputs: [
+                  { name: "model", type: "STRING" },
+                  { name: "model.prompt", type: "STRING" },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    );
+    expect(isError).toBe(false);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes.some((c) => String(c.node_id) === "76")).toBe(true);
+  });
+});
 
 describe("parseContradictoryPromotedWidgetRefusal", () => {
   it("the reporter's error is contradictory — width is listed as promoted", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6035,6 +6035,27 @@ function parseVerifiedQueriedNodeDetail(
   return { ...identity, inputs: record.inputs, widgets };
 }
 
+/** The ONLY dynamic-combo child type this refuses.
+ *
+ * #2299 measured exactly one reverting child — `model.prompt`, a STRING — and a
+ * STRING child is the only one with a durable escape: it is exposed as a real
+ * input socket, so a PrimitiveStringMultiline link survives the frontend's
+ * re-serialize pass and wins at execution.
+ *
+ * Refusing the parent's whole child set instead would be a capability removal.
+ * `src/services/api-nodes.ts` classifies a v3 dynamic combo's children as
+ * INT | FLOAT | STRING | BOOLEAN | COMBO, and the Nano Banana 2 shape fixtured in
+ * `src/__tests__/services/api-nodes.test.ts` reveals `model.aspect_ratio`,
+ * `model.resolution` and `model.thinking_level` — all COMBO, and all REQUIRED:
+ * the server 400s with `required_input_missing` when a dotted child is absent.
+ * A refusal there would leave a required input with NO route, while naming a
+ * remedy that cannot be carried out (a STRING output does not reach a COMBO
+ * input). No non-STRING child has been measured reverting; if one ever is, it
+ * needs an honest receipt ("written, not confirmed persistent"), not a refusal.
+ *
+ * So: prove STRING, or keep the normal setter path. */
+const DYNAMIC_COMBO_REFUSED_CHILD_TYPE = "STRING";
+
 function dynamicComboSubWidgetRefusal(
   nodeType: string,
   parentInput: string,
@@ -6042,7 +6063,8 @@ function dynamicComboSubWidgetRefusal(
 ): ToolResult {
   return fail(
     `panel_set_widget cannot set dynamic-combo sub-widget "${widget}" on ${nodeType}. ` +
-      `The parent input "${parentInput}" is ${COMFY_DYNAMICCOMBO_V3}; its frontend ` +
+      `The parent input "${parentInput}" is ${COMFY_DYNAMICCOMBO_V3} and "${widget}" is a ` +
+      `${DYNAMIC_COMBO_REFUSED_CHILD_TYPE} child; its frontend ` +
       `serializer can re-materialize the combo and overwrite widget.value after a ` +
       `successful write and immediate readback, so panel_run could queue an empty or ` +
       `stale value. Drive the child input by link instead: add a ` +
@@ -6053,8 +6075,10 @@ function dynamicComboSubWidgetRefusal(
   );
 }
 
-/** Refuse a dotted widget only when the live detail row proves that its prefix
- * is a COMFY_DYNAMICCOMBO_V3 input and the addressed child actually exists.
+/** Refuse a dotted widget only when the live detail row proves BOTH that its
+ * prefix is a COMFY_DYNAMICCOMBO_V3 input and that the addressed child is a
+ * STRING (see {@link DYNAMIC_COMBO_REFUSED_CHILD_TYPE} for why the child type is
+ * load-bearing rather than the parent type alone).
  * Ordinary composite widgets (for example rgthree `lora_1.on`) and ordinary
  * dotted STRING names remain on the normal setter path. An unreadable detail
  * probe is not evidence of a dynamic combo, so it falls through to the panel's
@@ -6080,14 +6104,15 @@ async function refuseDynamicComboSubWidgetWrite(
   if (!detail || !requestedId || detail.id !== requestedId) return null;
 
   const parentInput = widget.slice(0, dot);
+  const childInput = detail.inputs.find(
+    (input) =>
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      (input as Record<string, unknown>).name === widget,
+  );
   const childExists =
-    detail.inputs.some(
-      (input) =>
-        input &&
-        typeof input === "object" &&
-        !Array.isArray(input) &&
-        (input as Record<string, unknown>).name === widget,
-    ) ||
+    childInput !== undefined ||
     (detail.widgets !== null && Object.prototype.hasOwnProperty.call(detail.widgets, widget));
   if (!childExists) return null;
 
@@ -6099,9 +6124,18 @@ async function refuseDynamicComboSubWidgetWrite(
       (input as Record<string, unknown>).name === parentInput,
   );
   if (!parent || typeof parent !== "object" || Array.isArray(parent)) return null;
-  return (parent as Record<string, unknown>).type === COMFY_DYNAMICCOMBO_V3
-    ? dynamicComboSubWidgetRefusal(detail.type, parentInput, widget)
-    : null;
+  if ((parent as Record<string, unknown>).type !== COMFY_DYNAMICCOMBO_V3) return null;
+
+  // A dynamic-combo parent is not on its own the #2299 shape. Only a child the
+  // probe PROVES is STRING is refused; a COMBO/INT/FLOAT/BOOLEAN child, or one
+  // whose declared type this row does not carry, keeps the normal setter path.
+  const childType =
+    childInput && typeof childInput === "object" && !Array.isArray(childInput)
+      ? (childInput as Record<string, unknown>).type
+      : undefined;
+  if (childType !== DYNAMIC_COMBO_REFUSED_CHILD_TYPE) return null;
+
+  return dynamicComboSubWidgetRefusal(detail.type, parentInput, widget);
 }
 
 /** Refuse the known LC123 regional-canvas prompt widgets. Identity is read
@@ -15228,7 +15262,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     // expose the same actionable workaround.
     description:
       name === "panel_set_widget"
-        ? `${description} Dotted children of a live COMFY_DYNAMICCOMBO_V3 input (for example model.prompt) are refused when the live detail proves that shape: the frontend can reserialize the combo after immediate readback and panel_run may then use an empty/stale child. Drive the corresponding STRING child input with a PrimitiveStringMultiline link instead; set the parent only to choose the combo option.`
+        ? `${description} A dotted STRING child of a live COMFY_DYNAMICCOMBO_V3 input (for example model.prompt) is refused when the live detail proves both halves of that shape (non-STRING children such as Nano Banana 2's model.resolution stay writable): the frontend can reserialize the combo after immediate readback and panel_run may then use an empty/stale child. Drive the corresponding STRING child input with a PrimitiveStringMultiline link instead; set the parent only to choose the combo option.`
         : description,
     schema,
     handler,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16717,6 +16717,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           innerExpectedNodeType = innerIdentity.type;
         }
 
+        // #2299 — every pre-write guard above probed the OUTER scope, but this retry
+        // writes a DIFFERENT node: the promoted inner one. For a dynamic-combo child
+        // that is exactly the false success the guard exists to stop. The outer probe
+        // cannot see it and correctly falls open — the container exposes the promoted
+        // child but not the `model` PARENT, so the COMFY_DYNAMICCOMBO_V3 half of the
+        // shape is unprovable there. Only the inner node carries both halves.
+        //
+        // The stack_data fence above does re-query after entering, but it is gated on
+        // `expectedNodeType`, which is set only when the addressed widget IS stack_data
+        // — so it never runs for any other widget. This is the same re-probe for the
+        // dotted-child case, and the canvas is already inside the subgraph here, so
+        // `inner.innerNodeId` resolves.
+        const innerDynamicComboBlocked = await refuseDynamicComboSubWidgetWrite(
+          ctx,
+          inner.innerNodeId,
+          inner.widget,
+        );
+        if (innerDynamicComboBlocked) {
+          const exitedEarly = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `
+
+(The promoted inner node ${inner.innerNodeId} owns "${inner.widget}" as a ` +
+              `dynamic-combo child; ${textOfToolResult(innerDynamicComboBlocked)} ` +
+              `No inner graph_set_widget was dispatched.${
+                exitedEarly.isError
+                  ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exitedEarly)}`
+                  : ""
+              })`,
+          );
+        }
+
         const written = await write(inner.innerNodeId, inner.widget, innerExpectedNodeType);
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
         if (!written.isError) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5820,6 +5820,7 @@ const ANIMA_REGIONAL_WIRED_PROMPT_INPUT: Record<string, string> = {
 
 const DASIWA_STACK_WIDGET = "stack_data";
 const DASIWA_LTX2_LORA_LOADER = "DaSiWa_LTX2LoraLoader";
+const COMFY_DYNAMICCOMBO_V3 = "COMFY_DYNAMICCOMBO_V3";
 
 function isAnimaRegionalPromptWidget(widget: string): boolean {
   return ANIMA_REGIONAL_PROMPT_WIDGETS.has(widget);
@@ -5973,6 +5974,134 @@ function animaRegionalPromptRefusal(type: string, widget: string): ToolResult {
       `APPLY / savePrompts() copies the textarea back over widget.value, so a success here would be a lie. ` +
       `${route} Do not retry panel_set_widget on this widget.`,
   );
+}
+
+type QueriedNodeDetail = QueriedNodeIdentity & {
+  inputs: unknown[];
+  widgets: Record<string, unknown> | null;
+};
+
+/** Strictly parse one detail row for the dynamic-combo child gate. A compact
+ * response is intentionally not enough: this guard needs the live input names
+ * and types, not just the node type. */
+function parseVerifiedQueriedNodeDetail(
+  payload: Record<string, unknown> | null,
+): QueriedNodeDetail | null {
+  if (!payload) return null;
+  if (
+    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
+    payload.truncated !== false
+  ) {
+    return null;
+  }
+
+  let row: unknown;
+  if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
+    if (!Array.isArray(payload.nodes) || payload.nodes.length !== 1) return null;
+    row = payload.nodes[0];
+  } else if (typeof payload.text === "string") {
+    let headerSeen = false;
+    for (const line of payload.text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (!headerSeen && /^\d+ match\(es\) of \d+ in scope/.test(trimmed)) {
+        headerSeen = true;
+        continue;
+      }
+      if (!trimmed.startsWith("{")) {
+        // Detail replies may carry a bounded clipping/truncation footer after
+        // the one JSON row. It cannot establish a second node identity.
+        if (row !== undefined) continue;
+        return null;
+      }
+      if (row !== undefined) return null;
+      try {
+        row = JSON.parse(trimmed) as unknown;
+      } catch {
+        return null;
+      }
+      headerSeen = true;
+    }
+  }
+
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const record = row as Record<string, unknown>;
+  const identity = parseQueriedNodeIdentityRow(record);
+  if (!identity || !Array.isArray(record.inputs)) return null;
+  const widgets =
+    record.widgets && typeof record.widgets === "object" && !Array.isArray(record.widgets)
+      ? (record.widgets as Record<string, unknown>)
+      : null;
+  return { ...identity, inputs: record.inputs, widgets };
+}
+
+function dynamicComboSubWidgetRefusal(
+  nodeType: string,
+  parentInput: string,
+  widget: string,
+): ToolResult {
+  return fail(
+    `panel_set_widget cannot set dynamic-combo sub-widget "${widget}" on ${nodeType}. ` +
+      `The parent input "${parentInput}" is ${COMFY_DYNAMICCOMBO_V3}; its frontend ` +
+      `serializer can re-materialize the combo and overwrite widget.value after a ` +
+      `successful write and immediate readback, so panel_run could queue an empty or ` +
+      `stale value. Drive the child input by link instead: add a ` +
+      `PrimitiveStringMultiline, set its STRING widget, then panel_connect its ` +
+      `STRING output to this node's "${widget}" input. Set the parent "${parentInput}" ` +
+      `only to choose the combo option. No graph_set_widget was dispatched; do not ` +
+      `retry this dotted child write.`,
+  );
+}
+
+/** Refuse a dotted widget only when the live detail row proves that its prefix
+ * is a COMFY_DYNAMICCOMBO_V3 input and the addressed child actually exists.
+ * Ordinary composite widgets (for example rgthree `lora_1.on`) and ordinary
+ * dotted STRING names remain on the normal setter path. An unreadable detail
+ * probe is not evidence of a dynamic combo, so it falls through to the panel's
+ * existing validation rather than broadening this refusal. */
+async function refuseDynamicComboSubWidgetWrite(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<ToolResult | null> {
+  const dot = widget.indexOf(".");
+  if (dot <= 0 || dot === widget.length - 1) return null;
+
+  const probe = await ctx.call({
+    cmd: "graph_query",
+    ids: [nodeId],
+    fields: "detail",
+    limit: 1,
+  });
+  if (probe.isError) return null;
+
+  const detail = parseVerifiedQueriedNodeDetail(parseToolResultJson(probe));
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!detail || !requestedId || detail.id !== requestedId) return null;
+
+  const parentInput = widget.slice(0, dot);
+  const childExists =
+    detail.inputs.some(
+      (input) =>
+        input &&
+        typeof input === "object" &&
+        !Array.isArray(input) &&
+        (input as Record<string, unknown>).name === widget,
+    ) ||
+    (detail.widgets !== null && Object.prototype.hasOwnProperty.call(detail.widgets, widget));
+  if (!childExists) return null;
+
+  const parent = detail.inputs.find(
+    (input) =>
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      (input as Record<string, unknown>).name === parentInput,
+  );
+  if (!parent || typeof parent !== "object" || Array.isArray(parent)) return null;
+  return (parent as Record<string, unknown>).type === COMFY_DYNAMICCOMBO_V3
+    ? dynamicComboSubWidgetRefusal(detail.type, parentInput, widget)
+    : null;
 }
 
 /** Refuse the known LC123 regional-canvas prompt widgets. Identity is read
@@ -15092,7 +15221,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     description: string,
     schema: PanelToolArgSchemas,
     handler: (args: Record<string, unknown>, ctx: PanelToolCtx) => Promise<ToolResult>,
-  ): PanelToolDef => ({ name, description, schema, handler });
+  ): PanelToolDef => ({
+    name,
+    // Keep the long historical setter description readable at its call site;
+    // #2299's dynamic-combo warning is appended here so both registrations
+    // expose the same actionable workaround.
+    description:
+      name === "panel_set_widget"
+        ? `${description} Dotted children of a live COMFY_DYNAMICCOMBO_V3 input (for example model.prompt) are refused when the live detail proves that shape: the frontend can reserialize the combo after immediate readback and panel_run may then use an empty/stale child. Drive the corresponding STRING child input with a PrimitiveStringMultiline link instead; set the parent only to choose the combo option.`
+        : description,
+    schema,
+    handler,
+  });
 
   // Args are validated by zod before the handler runs (both transports parse with
   // the same shape), so handlers read fields off a loosely-typed bag.
@@ -16238,6 +16378,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           args.widget as string,
         );
         if (blocked) return blocked;
+        const dynamicComboBlocked = await refuseDynamicComboSubWidgetWrite(
+          ctx,
+          args.node_id,
+          args.widget as string,
+        );
+        if (dynamicComboBlocked) return dynamicComboBlocked;
         const daSiWaBlocked = await refuseDaSiWaStackWrite(
           ctx,
           args.node_id,


### PR DESCRIPTION
## Summary

- Narrow #2299 refusal to the proven shape: exact dotted child declared in live inputs metadata with type STRING, under a COMFY_DYNAMICCOMBO_V3 parent.
- A widgets-map entry alone is not child metadata; undeclared dotted names fail open.
- V3 COMBO/INT/FLOAT/BOOLEAN children, ordinary dotted composite/string widgets, parent selectors, and unavailable metadata remain on the existing path.
- Preserve the PrimitiveStringMultiline STRING-link workaround for model.prompt and cover the regression matrix.

## Validation

- Focused panel-tools suite: 415 passed
- npm run lint (typecheck): passed
- npm run build: passed
- npm run check:vocabulary: passed
- npm run check:unknown-collapse: passed
- git diff --check: passed
- The prior full npm test attempt was not completed because long-running bridge/cancellation tests hung after reporting 3 unrelated failures in untouched node-id-union-message.test.ts (53 passed, 3 failed in isolation).

Refs #2299; related behavior reconciled with #2107 and #2254. No Panel changes are required for this narrow MCP-side guard. No merge or release.