### PR TITLE
fix(2299): the dynamic-combo gate's own probe reads at pinpoint budget

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -684,6 +684,46 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     expect(res.content[0].text).toMatch(/is a STRING child/);
   });
 
+  it("probes with a pinpoint budget, so a long-prompt row is not degraded to a stub", async () => {
+    // The panel degrades an oversized detail line to an {id, type, title} stub.
+    // That stub has no `inputs`, so the shape becomes unprovable and the write
+    // falls open — on exactly the node #2299 reported, the one holding a long
+    // prompt. The survey cap has nothing to protect on a single-id, limit-1 read.
+    const sent: Array<Record<string, unknown>> = [];
+    await defByName("panel_set_widget").handler(
+      { node_id: 23, widget: "model.prompt", value: "NEW" },
+      {
+        call: async (cmd: Record<string, unknown>) => {
+          sent.push({ ...cmd });
+          if (cmd.cmd === "graph_query") {
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify(dynamicDetail, null, 2) }],
+            };
+          }
+          return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
+        },
+      } as unknown as PanelToolCtx,
+    );
+    const probe = sent.find((c) => c.cmd === "graph_query");
+    expect(probe).toBeDefined();
+    expect(probe?.fields).toBe("detail");
+    expect(probe?.limit).toBe(1);
+    expect(probe?.max_chars).toBe(60000);
+  });
+
+  it("falls open on a degraded/truncated detail row rather than refusing every dotted write", async () => {
+    // The documented residual: an unprovable shape keeps the setter path. Failing
+    // CLOSED here would refuse every dotted widget on every node whenever a probe
+    // hiccups. Pinned so that changing it is a deliberate decision, not a drift.
+    // A row the panel degraded to its {id, type, title} stub: no `inputs`, so
+    // neither half of the shape is provable.
+    const { res, cmds } = await run({
+      nodes: [{ id: 23, type: "MinimaxHailuo03TextToVideoNode", title: "MiniMax" }],
+    });
+    expect(res.isError).toBeUndefined();
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+  });
+
   it("documents that only a STRING child is refused", () => {
     const description = defByName("panel_set_widget").description;
     expect(description).toContain("COMFY_DYNAMICCOMBO_V3");

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6056,6 +6056,18 @@ function parseVerifiedQueriedNodeDetail(
  * So: prove STRING, or keep the normal setter path. */
 const DYNAMIC_COMBO_REFUSED_CHILD_TYPE = "STRING";
 
+/** Budget for the gate's own detail probe — the panel_query_graph `max_chars`
+ *  ceiling, not the default.
+ *
+ * This is a PINPOINT read: one id, `limit: 1`, one row. The survey cap exists to
+ *  keep a 200-node listing small and has nothing to protect here. Leaving it at the
+ *  default is what makes the gate miss the case it was written for: the panel caps a
+ *  detail row and, past a point, degrades it to an `{id, type, title}` stub — which
+ *  drops `inputs`, so the parse cannot prove the shape and the write falls open.
+ *  The node most likely to overflow that budget is the node already holding a long
+ *  prompt, i.e. exactly the #2299 report ("<any long prompt>"). */
+const DYNAMIC_COMBO_PROBE_MAX_CHARS = 60000;
+
 function dynamicComboSubWidgetRefusal(
   nodeType: string,
   parentInput: string,
@@ -6096,9 +6108,20 @@ async function refuseDynamicComboSubWidgetWrite(
     ids: [nodeId],
     fields: "detail",
     limit: 1,
+    max_chars: DYNAMIC_COMBO_PROBE_MAX_CHARS,
   });
   if (probe.isError) return null;
 
+  // An unreadable or truncated probe is NOT evidence of a dynamic combo, so it
+  // falls open — the same discipline as refuseAnimaRegionalPromptWrite. Failing
+  // CLOSED here would refuse every dotted widget on every node whenever a probe
+  // hiccups (rgthree `lora_N.*`, promoted subgraph paths, JSON composite fields),
+  // which is a far larger blast radius than the residual it would close. The
+  // residual is a slice of the PRE-EXISTING bug, not one this gate introduces:
+  // without the gate every one of these writes is a false success. Shrinking that
+  // slice is what the generous probe budget above is for. Closing it entirely
+  // needs #2299's option 2 — an honest "written, not confirmed persistent" receipt
+  // — which changes the success contract of the tool and is not this guard's call.
   const detail = parseVerifiedQueriedNodeDetail(parseToolResultJson(probe));
   const requestedId = canonicalQueriedNodeId(nodeId);
   if (!detail || !requestedId || detail.id !== requestedId) return null;


### PR DESCRIPTION
Follow-up to #2301 (merged as `bde3b50`), which landed while gate round 2 was still running. This is the one finding from that round that was not yet addressed.

## What the gate found

> [P1] `src/orchestrator/panel-tools.ts:6100` — A failed or unreadable detail probe falls through to `graph_set_widget` — with a live dynamic-combo STRING child such as `model.prompt`, a probe error/truncated response can still produce reported success while frontend reserialization overwrites the value, leaving the #2299 false-success reachable.

## What I did NOT change, and why

**Fail-open stays.** Failing closed would refuse *every* dotted widget on *every* node whenever a probe hiccups — rgthree `lora_N.*`, promoted subgraph paths, JSON composite dotted fields — which is a far larger blast radius than the residual it closes. It is also the discipline every other node-keyed refusal in this file already follows (`refuseAnimaRegionalPromptWrite`: "an unreadable probe is fail-open").

And the residual is a slice of the **pre-existing** bug, not one the guard introduced: without the guard, every one of these writes is already a false success. Closing it completely needs #2299's own option 2 — an honest "written, not confirmed persistent" receipt — which changes the success contract of `panel_set_widget` and should be its own decision, not something smuggled into a guard.

## What was worth fixing: how easily that branch is reached

The probe ran at the default `max_chars`. The panel degrades an oversized detail row to an `{id, type, title}` stub — which drops `inputs`, so neither half of the shape is provable and the write falls open.

The node most likely to overflow that budget is **the node already holding a long prompt** — i.e. exactly the reported case, whose repro step 2 is `value: "<any long prompt>"`. So the fail-open branch was not a remote edge case here; it lined up with the report.

This is a single id at `limit: 1` — one row. The survey cap exists to keep a 200-node listing small and has nothing to protect on a pinpoint read (the panel's own `#1634` comment makes exactly this distinction). Read at the `panel_query_graph` ceiling instead.

## Verification

- Affected suites: **497 passed** across `panel-tools`, `promoted-widget`, `panel-retry-identity`, `promoted-control-persist`.
- **Mutation proof.** Committed first, then removed `max_chars` from the probe and re-ran: `1 failed | 416 passed`.

```
× probes with a pinpoint budget, so a long-prompt row is not degraded to a stub
```

- The budget is asserted on the **emitted command** (`fields:"detail"`, `limit:1`, `max_chars:60000`), not on a helper — a constant alone would be invisible to the call site.
- A degraded stub row is separately pinned as keeping the setter path, so changing the fail-open decision has to be deliberate rather than drift.
- `npm run lint`, `npm run check:vocabulary` exit 0.

## Risky parts, named

- **The `60000` constant is the panel's `max_chars` ceiling**, matched to the 500–60000 clamp this repo already documents. If the panel's clamp ever moves, this silently reads at whatever the panel allows — it is a ceiling request, not a contract.
- **A generous budget is not free.** It is bounded by the node's real size and only ever one row, but it is a larger reply than before on every dotted-widget write.
- **No live ComfyUI on this host** (`127.0.0.1:8188` refused), so the truncation path is reasoned from the panel's `fitDetailLine` / `capSummaryWidgets` degradation, not reproduced by execution. Stating that plainly rather than implying coverage I do not have.

## Still open after this

`refuseAnimaRegionalPromptWrite` has the same outer-scope-only hole that #2301's `f5d2c53` fixed for dynamic-combo children: it is not re-checked on the promoted-inner retry. Untouched here — pre-existing and out of scope. Worth its own issue.

Refs #2299.
