### PR TITLE
chore: release v0.52.121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.121] - 2026-08-25
+
+### MCP
+
+#### Fixed
+- the plugin's first run no longer fails silently: on the cold `npx` path the launcher
+  answers the MCP handshake itself while the ~818 MB install is still running, holds the
+  session with an empty tool list, then announces the real tools via `tools/list_changed`
+  (#1447). Measured cold, a first `initialize` took 21.6 s against a 10 s budget - so the
+  server never registered, ~40 skills still loaded and told the model to call tools that
+  were not there, and the failure read as "the agent is bad" rather than as an install
+  problem. The warm global path is untouched. A rescued handshake reports `serverInfo.version`
+  as `0.0.0-installing` and carries a stand-in `instructions` string until the real server
+  takes over.
+- the merge gate's own probe reads at pinpoint budget rather than the survey cap (#2304)
+
+
 ## [0.52.120] - 2026-08-25
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.120",
+  "version": "0.52.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.120",
+      "version": "0.52.121",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.120",
+  "version": "0.52.121",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **v0.52.121** with the two commits that landed after v0.52.120.

## The headline: mcp#1447 is fixed and this is the release that ships it

The plugin's **first run** failed silently. On a cold `npx` path the MCP handshake timed out before the server registered — but the plugin still installed "successfully", ~40 skills still loaded, and they told the model to call tools that were never there. The model then improvised and failed, so the user read it as *"the agent is bad"*, never as a server that did not start. The only working path was an undocumented `npm install -g`, which itself breaks on Windows while Claude Code is running.

It is fixed by making the handshake win the race rather than by restructuring dependencies: on the npx fallback only, the launcher answers `initialize` itself, holds the session with an empty tool list, then announces the real tools via `tools/list_changed`. The warm global path is untouched.

Measured, not assumed — reproduced with a throwaway `npm_config_cache` **and** `npm_config_prefix`, so `npm root -g` finds nothing the way a real first run doesn't:

```
cold1447: ✘ Failed to connect — connection timed out after 10000ms
warm1447: ✔ Connected
```

Cold `initialize` 21.6 s (15.2 s of it npm, 818 MB / 170 packages) against a 10 s budget; warm 1.2 s. After the fix, same configuration: connected 88 MB into the install, 1.91 s handshake → 40 real tools at 8.14 s.

## Changelog note

The `#1447` entry is hand-written. `gen-changelog.mjs` dedupes highlights against git history **by PR number**, and that entry cites the issue (`#1447`) rather than its PR (`#2296`) — so the generator did not match it and appended a second `### MCP / #### Fixed` block restating the same fix under the other number. Merged by hand. Worth knowing for any future note that cites an issue.

## Verification before cutting

- `main` CI green on `0794b1b` (Build ×3 + Pack & install smoke) — the tag will not be pushed at an unverified head.
- `git log v0.52.120..origin/main` is exactly these two commits; everything else from tonight (#2289, the seven #2003 merges, the three dependency bumps) is already in v0.52.120 on npm.
- No competing release branch was open when this was cut.

After merge the tag is pointed at the **merged** commit and `git merge-base --is-ancestor 0794b1b <tag>` is checked before pushing it, so the published artifact provably contains the headline fix.

## Not included

A stray `## Unreleased` heading sits at CHANGELOG.md line 1631, between the 0.52.44 and 0.52.43 sections — a leftover from an old release whose stub was never reset. Left alone rather than folding an unrelated history edit into a release PR.
