### PR TITLE
fix(2302): the RunPod image maps Impact Pack's model categories onto the volume

### DIFF
--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -175,16 +175,22 @@ So SSH + Jupyter + nginx come from the base; **our hook adds everything else**.
   volume.
 * **`--input-directory` / `--output-directory`** — inputs and generated images on
   the volume.
+* **`--models-directory /workspace/models`** — makes ComfyUI's
+  `folder_paths.models_dir` the persistent volume root. This is required for
+  ComfyUI-Manager's explicit relative `save_path` values; `is_default` only
+  changes the ordering of category search paths.
 * **`--extra-model-paths-config`** — points every model category at
   `/workspace/models` (see below). MODELS persist on the volume.
 * **We deliberately do NOT use `--base-directory`.** It would relocate
   `custom_nodes` (and temp) onto the volume too — but we want `custom_nodes` to
-  stay **in the image**. The per-dir flags + `extra_model_paths.yaml` give us
-  exactly the split we want (data on the volume, software in the image).
+  stay **in the image**. The per-dir flags, explicit `--models-directory`, and
+  `extra_model_paths.yaml` give us exactly the split we want (data on the
+  volume, software in the image).
 
 > **Flag verification.** These flag names were verified against ComfyUI `master`
-> (`comfy/cli_args.py`): `--user-directory`, `--input-directory`,
-> `--output-directory`, `--base-directory`, and `--extra-model-paths-config` all
+> (`comfy/cli_args.py`): `--user-directory`, `--models-directory`,
+> `--input-directory`, `--output-directory`, `--base-directory`, and
+> `--extra-model-paths-config` all
 > exist with these exact spellings, and `--base-directory`'s own help text states
 > it sets the base for "models, custom_nodes, input, output, temp, and user
 > directories" — confirming why we avoid it. **Assumption to confirm at build:**
@@ -249,11 +255,12 @@ comfyui_mcp_volume:
 
 Notes:
 
-* **`is_default: true`** is the load-bearing line. ComfyUI's
+* **`is_default: true`** keeps the volume category paths first for lookup. ComfyUI's
   `add_model_folder_path(..., is_default=True)` **inserts** the path at the front
-  of each category's list, so `/workspace/models/<cat>` becomes the default
-  download target. Without it, the image's `/opt/ComfyUI/models/<cat>` (ephemeral)
-  would stay first and Manager downloads would **not** persist.
+  of each category's list, so `/workspace/models/<cat>` is preferred for lookup.
+  The launch's explicit `--models-directory /workspace/models` is the separate
+  guarantee that Manager's explicit relative `save_path` writes also land on the
+  volume; `is_default` alone cannot change `folder_paths.models_dir`.
 * **No `custom_nodes:` key** — on purpose. Mapping `custom_nodes` to the volume
   would break the fast-restart contract.
 * `base_path: /workspace` with `models/...` relative subpaths mirrors ComfyUI's

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -198,10 +198,10 @@ So SSH + Jupyter + nginx come from the base; **our hook adds everything else**.
 ## Model paths (`extra_model_paths.yaml`)
 
 `extra_model_paths.yaml` is baked at `/opt/ComfyUI/extra_model_paths.yaml` and
-loaded via `--extra-model-paths-config`. It maps **every** model category to a
-subfolder under `/workspace/models`, with `is_default: true` so the volume is the
-**primary** (download) location — i.e. Manager's install-model writes there and
-the files persist.
+loaded via `--extra-model-paths-config`. It maps every model category **this
+image knows about** to a subfolder under `/workspace/models`, with
+`is_default: true` so the volume is the **primary** (download) location — i.e.
+Manager's install-model writes there and the files persist.
 
 ```yaml
 comfyui_mcp_volume:
@@ -239,6 +239,12 @@ comfyui_mcp_volume:
     geometry_estimation: models/geometry_estimation/
     optical_flow: models/optical_flow/
     detection: models/detection/
+
+    # registered by the node packs themselves, not by ComfyUI core:
+    ultralytics: models/ultralytics/          # Impact Subpack
+    ultralytics_bbox: models/ultralytics/bbox/
+    ultralytics_segm: models/ultralytics/segm/
+    sams: models/sams/                       # Impact Pack (SAMLoader)
 ```
 
 Notes:
@@ -255,6 +261,16 @@ Notes:
 * The category **keys** match ComfyUI's `folder_names_and_paths` keys (verified
   against `master`'s `folder_paths.py`). The category list mirrors the example's
   full set; harmless if a future ComfyUI renames one.
+* **Custom node packs register their own categories, and those are NOT in ComfyUI's
+  example.** A category absent from this file has no `/workspace` entry at all, so
+  `/opt/ComfyUI/models/<cat>` stays its only path and downloads land on the ephemeral
+  image layer - no error, just gone after the next rebuild (#2302). Adding the key is
+  sufficient and order-independent: packs register via a helper that calls
+  `add_model_folder_path` **without** `is_default`, i.e. it appends behind whatever this
+  file already put at the front. Impact Pack also registers `onnx` (read from its
+  source, deliberately left out of #2302's fix as it is a deprecated provider);
+  `insightface`, `facerestore_models` and `rembg` are the same shape but have NOT
+  been audited — do that before adding them.
 * `/post_start.sh` pre-creates the matching subfolders under `/workspace/models`
   so they exist on a cold volume.
 

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -273,6 +273,16 @@ Notes:
   been audited — do that before adding them.
 * `/post_start.sh` pre-creates the matching subfolders under `/workspace/models`
   so they exist on a cold volume.
+* **This file does not reach a node pack's OWN installer.** It adds *search* paths;
+  it does not move `folder_paths.models_dir`, which is what Impact Pack's and Impact
+  Subpack's `install.py` derive their download directory from (Subpack has no
+  `folder_paths` fallback at all). So `post_start.sh` also exports
+  `COMFYUI_MODEL_PATH=/workspace/models` before launching ComfyUI - pack installers
+  read that first, and Manager runs them as children of the ComfyUI process, so they
+  inherit it. Without it, installing Impact Subpack drops `face_yolov8m.pt` into
+  `/opt/ComfyUI/models/ultralytics/bbox` and Impact Pack drops `sam_vit_b_01ec64.pth`
+  into `/opt/ComfyUI/models/sams`, both on the ephemeral layer. ComfyUI core never
+  reads `COMFYUI_MODEL_PATH`, so this redirects only the packs' installers.
 
 ### Warm model volume (skip the cold HF pull)
 

--- a/docker/runpod/extra_model_paths.yaml
+++ b/docker/runpod/extra_model_paths.yaml
@@ -59,3 +59,19 @@ comfyui_mcp_volume:
     geometry_estimation: models/geometry_estimation/
     optical_flow: models/optical_flow/
     detection: models/detection/
+
+    # Impact Pack / Impact Subpack register these categories THEMSELVES at import
+    # time (Subpack: ultralytics, ultralytics_bbox, ultralytics_segm — Pack: sams),
+    # so without the entries below the categories exist only as the in-image
+    # /opt/ComfyUI/models/<cat> and a FaceDetailer user's YOLO/SAM weights land on
+    # the ephemeral layer and vanish on the next rebuild (#2302).
+    #
+    # Order is safe either way round: both packs register via a helper that calls
+    # folder_paths.add_model_folder_path WITHOUT is_default, i.e. it APPENDS. So if
+    # this file loads first the volume path is already index 0 and the pack appends
+    # behind it; if the pack loads first, `is_default: true` above inserts the
+    # volume path at the FRONT. Either way /workspace stays the download target.
+    ultralytics: models/ultralytics/
+    ultralytics_bbox: models/ultralytics/bbox/
+    ultralytics_segm: models/ultralytics/segm/
+    sams: models/sams/

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -581,10 +581,12 @@ fi
 # -----------------------------------------------------------------------------
 # 5. Launch ComfyUI from the BAKED venv (image), pointed at the volume dirs.
 #    Invoke the venv python by ABSOLUTE PATH (no `activate` needed).
-#    Per-directory flags keep user/input/output on /workspace; models come from
-#    extra_model_paths.yaml (is_default → volume is primary). custom_nodes are
-#    symlinked onto the volume in §4.5 above (so runtime installs persist); we do
-#    NOT use --base-directory (it would relocate the whole tree, incl. the venv).
+#    Per-directory flags keep user/input/output on /workspace. --models-directory
+#    makes ComfyUI's folder_paths.models_dir the persistent volume root, which is
+#    required for Manager's explicit relative save_path values; the extra path map
+#    still puts every category's volume subfolder first. custom_nodes are symlinked
+#    onto the volume in §4.5 above (so runtime installs persist); we do NOT use
+#    --base-directory (it would relocate the whole tree, incl. the venv).
 # -----------------------------------------------------------------------------
 VPY="${COMFY_HOME}/venv/bin/python"
 if [ ! -x "${VPY}" ]; then
@@ -624,6 +626,7 @@ ARGS=(--listen 0.0.0.0 --port "${COMFY_PORT}"
       --enable-manager --enable-cors-header
       "${ATTN_ARGS[@]}"
       --user-directory  "${USER_DIR}"
+      --models-directory "${MODELS_DIR}"
       --input-directory "${INPUT_DIR}"
       --output-directory "${OUTPUT_DIR}")
 # Load the volume model map only if the file exists (it's baked, but be defensive).

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -443,6 +443,17 @@ CN_VOL="${WORKSPACE}/custom_nodes"
 CN_LINK="${COMFY_HOME}/custom_nodes"
 CN_SEED="${COMFY_HOME}/custom_nodes_seed"
 export PIP_CACHE_DIR="${WORKSPACE}/.cache/pip"
+# Pack install scripts resolve their OWN download dir from $COMFYUI_MODEL_PATH and
+# fall back to the IMAGE's models dir when it is unset. extra_model_paths.yaml cannot
+# reach them: it adds SEARCH paths, it does not move folder_paths.models_dir. So
+# Impact Subpack's installer drops face_yolov8m.pt into
+# /opt/ComfyUI/models/ultralytics/bbox (it has no folder_paths fallback at all) and
+# Impact Pack's drops sam_vit_b_01ec64.pth into /opt/ComfyUI/models/sams - both on the
+# ephemeral layer, both gone on the next rebuild (#2302). ComfyUI core never reads this
+# variable (models_dir comes from --models-directory or base_path), so setting it
+# redirects ONLY the node packs' own installers, and onto the same dirs
+# extra_model_paths.yaml already maps.
+export COMFYUI_MODEL_PATH="${MODELS_DIR}"
 mkdir -p "${CN_VOL}" "${PIP_CACHE_DIR}"
 
 # (a) Point the image's custom_nodes at the volume. Replace whatever is there — a

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -141,7 +141,8 @@ for sub in checkpoints configs loras vae text_encoders clip diffusion_models \
            controlnet t2i_adapter gligen upscale_models latent_upscale_models \
            hypernetworks photomaker classifiers model_patches audio_encoders \
            background_removal frame_interpolation geometry_estimation \
-           optical_flow detection; do
+           optical_flow detection \
+           sams ultralytics ultralytics/bbox ultralytics/segm; do
   mkdir -p "${MODELS_DIR}/${sub}"
 done
 

--- a/src/__tests__/runpod-impact-model-paths.test.ts
+++ b/src/__tests__/runpod-impact-model-paths.test.ts
@@ -1,0 +1,101 @@
+// #2302 — the RunPod image's extra_model_paths.yaml mapped ~25 model categories onto the
+// /workspace network volume but omitted the four that ComfyUI-Impact-Pack and
+// ComfyUI-Impact-Subpack register for THEMSELVES at import time. Those categories therefore
+// resolved only to the in-image /opt/ComfyUI/models/<cat>, so a FaceDetailer user's YOLO and
+// SAM weights were written to the ephemeral image layer: the download reported success, the
+// node resolved, and the file was silently gone after the next pod rebuild.
+//
+// This file is a DATA pin, not a behaviour test — the yaml is baked into a Docker image and
+// consumed by ComfyUI's python, so nothing in this package ever executes it. What a test CAN
+// do is hold the two facts that made the bug possible:
+//
+//   1. the four keys are present, and mapped relative to base_path (delete either and the
+//      first describe below goes red);
+//   2. post_start.sh's cold-volume `mkdir -p` list still covers every category the yaml maps.
+//      That list is a SECOND copy of the same category set — its own comment says it exists
+//      for "the model category subfolders that extra_model_paths.yaml maps" — and a fix that
+//      updated only the yaml would leave the two silently out of step. Checking parity by
+//      parsing both files catches the whole drift class, not just this instance of it.
+//
+// Deliberately directional: the assertion is yaml ⊆ post_start.sh. A category the yaml maps
+// but the volume never gets a directory for is the defect; an extra directory in the shell
+// list is harmless, and pinning exact equality would make an unrelated addition fail here.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+
+const yamlSrc = readFileSync(
+  new URL("../../docker/runpod/extra_model_paths.yaml", import.meta.url),
+  "utf-8",
+);
+const postStartSrc = readFileSync(
+  new URL("../../docker/runpod/post_start.sh", import.meta.url),
+  "utf-8",
+);
+
+const block = (parseYaml(yamlSrc) as Record<string, Record<string, unknown>>)
+  .comfyui_mcp_volume;
+
+/**
+ * Every directory the yaml maps, expressed relative to `<base_path>/models` — i.e. exactly
+ * the `sub` values post_start.sh iterates. Multi-line block scalars (`text_encoders` maps
+ * both text_encoders/ and clip/) contribute one entry per line.
+ */
+const mappedSubdirs = (): string[] => {
+  const dirs: string[] = [];
+  for (const [key, value] of Object.entries(block)) {
+    if (key === "base_path" || key === "is_default") continue;
+    for (const line of String(value).split("\n")) {
+      const entry = line.trim();
+      if (entry === "") continue;
+      // base_path only applies to RELATIVE values; an absolute one would silently escape
+      // the volume, which is the same class of failure as omitting the key entirely.
+      expect(entry.startsWith("models/"), `${key} -> ${entry}`).toBe(true);
+      dirs.push(entry.slice("models/".length).replace(/\/$/, ""));
+    }
+  }
+  return dirs;
+};
+
+describe("the RunPod image maps Impact Pack's model categories onto the volume (#2302)", () => {
+  it("keeps the volume the DEFAULT target for every mapped category", () => {
+    // Without both of these the whole file is decorative: base_path is what makes the
+    // relative values land on the network volume, and is_default is what puts them at the
+    // FRONT of each category's folder list, ahead of the in-image /opt/ComfyUI/models/<cat>.
+    expect(block.base_path).toBe("/workspace");
+    expect(block.is_default).toBe(true);
+  });
+
+  it("maps the four categories Impact Pack / Impact Subpack register themselves", () => {
+    // Subpack registers ultralytics, ultralytics_bbox and ultralytics_segm; Pack registers
+    // sams (SAMLoader, which feeds FaceDetailer's sam_model_opt). The bbox case and the sam
+    // case are hit back to back by the same user, so all four belong together.
+    expect(block.ultralytics).toBe("models/ultralytics/");
+    expect(block.ultralytics_bbox).toBe("models/ultralytics/bbox/");
+    expect(block.ultralytics_segm).toBe("models/ultralytics/segm/");
+    expect(block.sams).toBe("models/sams/");
+  });
+
+  it("pre-creates every mapped category on a cold volume", () => {
+    const loop = postStartSrc.match(/for sub in ([\s\S]*?); do/);
+    // If post_start.sh's loop is ever restructured this must fail loudly rather than
+    // silently assert nothing — an unparsed list would otherwise read as full coverage.
+    expect(loop, "post_start.sh no longer has a parsable `for sub in ...; do` list").not.toBe(
+      null,
+    );
+
+    const created = new Set(
+      (loop as RegExpMatchArray)[1]
+        .replace(/\\\s*\n/g, " ")
+        .trim()
+        .split(/\s+/)
+        .filter((s) => s !== ""),
+    );
+    expect(created.size).toBeGreaterThan(20);
+
+    const missing = mappedSubdirs().filter((dir) => !created.has(dir));
+    expect(missing, "extra_model_paths.yaml maps these, post_start.sh never mkdirs them").toEqual(
+      [],
+    );
+  });
+});

--- a/src/__tests__/runpod-impact-model-paths.test.ts
+++ b/src/__tests__/runpod-impact-model-paths.test.ts
@@ -32,6 +32,7 @@ const postStartSrc = readFileSync(
   new URL("../../docker/runpod/post_start.sh", import.meta.url),
   "utf-8",
 );
+const readmeSrc = readFileSync(new URL("../../docker/runpod/README.md", import.meta.url), "utf-8");
 
 const block = (parseYaml(yamlSrc) as Record<string, Record<string, unknown>>)
   .comfyui_mcp_volume;
@@ -97,5 +98,19 @@ describe("the RunPod image maps Impact Pack's model categories onto the volume (
     expect(missing, "extra_model_paths.yaml maps these, post_start.sh never mkdirs them").toEqual(
       [],
     );
+  });
+
+  it("documents the same category set it ships", () => {
+    // README.md embeds a full copy of the yaml under "Model paths". That copy is what a
+    // maintainer reads when adding the NEXT category, so a stale one does not just mislead —
+    // it reproduces this bug. Compare key sets, not text: the README annotates its copy with
+    // inline comments and those must stay free to change.
+    const fenced = readmeSrc.match(/```yaml\r?\n(comfyui_mcp_volume:[\s\S]*?)```/);
+    expect(fenced, "README.md no longer embeds a ```yaml comfyui_mcp_volume block").not.toBe(null);
+
+    const documented = (
+      parseYaml((fenced as RegExpMatchArray)[1]) as Record<string, Record<string, unknown>>
+    ).comfyui_mcp_volume;
+    expect(Object.keys(documented).sort()).toEqual(Object.keys(block).sort());
   });
 });

--- a/src/__tests__/runpod-impact-model-paths.test.ts
+++ b/src/__tests__/runpod-impact-model-paths.test.ts
@@ -122,6 +122,28 @@ describe("the RunPod image maps Impact Pack's model categories onto the volume (
     expect(exported).toBeLessThan(launch);
   });
 
+  it("makes ComfyUI Manager's explicit save_path writes use the volume root", () => {
+    // managerModelDestination() deliberately sends a relative `save_path` for nested
+    // destinations and categories without a Manager type-map entry. Manager resolves
+    // those relative paths under folder_paths.models_dir, which is NOT changed by
+    // extra_model_paths.yaml's is_default flag. The launch flag is therefore the
+    // production proof that e.g. `diffusers/foo` cannot fall back to /opt/ComfyUI/models.
+    const modelsFlag = postStartSrc.search(
+      /^\s+--models-directory "\$\{MODELS_DIR\}"\r?$/m,
+    );
+    expect(modelsFlag, "ComfyUI must launch with the persistent models root").toBeGreaterThan(-1);
+
+    const argsStart = postStartSrc.search(/^ARGS=\(/m);
+    const extraFlag = postStartSrc.indexOf("--extra-model-paths-config");
+    const launch = postStartSrc.search(/^nohup .*main\.py/m);
+    expect(argsStart).toBeGreaterThan(-1);
+    expect(extraFlag).toBeGreaterThan(-1);
+    expect(launch).toBeGreaterThan(-1);
+    expect(argsStart).toBeLessThan(modelsFlag);
+    expect(modelsFlag).toBeLessThan(launch);
+    expect(extraFlag).toBeLessThan(launch);
+  });
+
   it("documents the same category set it ships", () => {
     // README.md embeds a full copy of the yaml under "Model paths". That copy is what a
     // maintainer reads when adding the NEXT category, so a stale one does not just mislead —

--- a/src/__tests__/runpod-impact-model-paths.test.ts
+++ b/src/__tests__/runpod-impact-model-paths.test.ts
@@ -100,6 +100,28 @@ describe("the RunPod image maps Impact Pack's model categories onto the volume (
     );
   });
 
+  it("points the node packs' OWN installers at the volume too", () => {
+    // The yaml adds SEARCH paths; it does not move `folder_paths.models_dir`, and that is
+    // what both packs' install.py resolve their download directory from. Impact Subpack's
+    // has no folder_paths fallback at all (install.py:15-17), so with COMFYUI_MODEL_PATH
+    // unset it writes face_yolov8m.pt to the image layer no matter what this yaml maps —
+    // every mapping above can be correct and the file still dies on the next rebuild.
+    const exported = postStartSrc.search(/^export COMFYUI_MODEL_PATH="\$\{MODELS_DIR\}"\r?$/m);
+    expect(exported, "post_start.sh must export COMFYUI_MODEL_PATH at top level").toBeGreaterThan(
+      -1,
+    );
+
+    // Ordering IS the mechanism, so assert on it rather than on the line's existence:
+    // MODELS_DIR must already be set, and the export must happen before ComfyUI launches,
+    // since Manager runs pack installers as children of that process and they inherit it.
+    const modelsDir = postStartSrc.search(/^MODELS_DIR=/m);
+    const launch = postStartSrc.search(/^nohup .*main\.py/m);
+    expect(modelsDir, "MODELS_DIR assignment not found").toBeGreaterThan(-1);
+    expect(launch, "ComfyUI launch line not found").toBeGreaterThan(-1);
+    expect(modelsDir).toBeLessThan(exported);
+    expect(exported).toBeLessThan(launch);
+  });
+
   it("documents the same category set it ships", () => {
     // README.md embeds a full copy of the yaml under "Model paths". That copy is what a
     // maintainer reads when adding the NEXT category, so a stale one does not just mislead —


### PR DESCRIPTION
Fixes #2302.

## What was wrong

`docker/runpod/extra_model_paths.yaml` maps ~25 model categories to `/workspace/models/<cat>` with `is_default: true`, which is what makes Manager's install-model write to the network volume instead of the image. It omitted the four categories that **the Impact packs register for themselves at import time** — ComfyUI core never registers them, so they were not in the ComfyUI example the list was mirrored from.

With no `/workspace` entry, those categories resolved only to the in-image `/opt/ComfyUI/models/<cat>`. A FaceDetailer user's YOLO/SAM weights were written to the ephemeral layer: the download reports success, `list_local_models` lists the file, the node resolves — and it is silently gone after the next pod rebuild, so they re-download the same weights on every provision.

## The mechanism, verified against upstream source (not assumed)

The load-bearing question is whether the packs' own registration **overwrites** our yaml entry — if it did, adding the keys would be a no-op. It does not:

- `ComfyUI-Impact-Subpack/modules/subpack_nodes.py:9-11` registers `ultralytics_bbox`, `ultralytics_segm`, `ultralytics`
- `ComfyUI-Impact-Pack/modules/impact/impact_pack.py:51` registers `sams`

Both go through a helper (`utils.add_folder_path_and_extensions`) that calls `folder_paths.add_model_folder_path(name, path)` **without** `is_default`, i.e. it takes the `paths.append(...)` branch, then unions the extension set.

So the fix is **order-independent**, which is worth stating explicitly:

| load order | result |
|---|---|
| yaml first | key created with `/workspace` at index 0; the pack **appends** `/opt/...` behind it |
| pack first | key exists with `/opt/...`; the yaml's `is_default: true` **inserts** `/workspace` at the front |

Either way `/workspace` ends up first, which is the download target. The issue's claim that "`is_default: true` never applies to them" is correct for the first row specifically — with the key absent, `add_model_folder_path` takes its `else` branch and creates `([path], set())`, ignoring `is_default` — and the empty extension set is then repaired by the pack's union. Checked `map_legacy` too: it only rewrites `unet`/`clip`, so none of these four keys are remapped.

## Scope — three copies of one list

The category list exists in **three** places, and fixing only the yaml would leave the others silently out of step:

1. `docker/runpod/extra_model_paths.yaml` — the four keys (the actual fix)
2. `docker/runpod/post_start.sh` — the cold-volume `mkdir -p` loop, whose own comment says it creates "the model category subfolders that `extra_model_paths.yaml` maps"
3. `docker/runpod/README.md` — embeds a full copy of the yaml and claimed it mapped "**every**" model category. That claim is the assumption that produced this bug, and that copy is what a maintainer reads when adding the *next* category.

## Where to look hardest (the risky parts)

- **The `for sub in` regex** in the test. If `post_start.sh`'s loop is restructured, a naive parse would match nothing and the parity assertion would pass vacuously — the exact "a count cannot see a parse failure" shape. Guarded with a non-null assert on the match plus `created.size > 20`, and mutation-tested below.
- **Direction of the parity assertion.** It is deliberately `yaml ⊆ post_start.sh`, not set equality: an unmapped category with no directory is the defect; a spare directory is harmless. Exact equality would make an unrelated addition fail here.
- **`onnx` is deliberately NOT added.** Impact Pack registers it at `impact_pack.py:52`, but it backs a deprecated ONNX provider, so it is documented rather than mapped. `insightface` / `facerestore_models` / `rembg` are named in the issue as the same shape — I did **not** audit them and the README says so rather than implying they were checked.

## Verification

Full suite in the worktree: **669 files, 12325 passed, 6 skipped, 0 failed**. `tsc --noEmit` clean.

Note `vitest.config.ts` excludes `**/.claude/**` and excludes are additive, so a run from inside the mandated worktree collects **zero** files and reports it as a clean run. Ran against a self-contained scratch config (untracked, not in this branch) that drops only that exclude — `Test Files 669 passed` is the line I read, not the absence of FAIL.

The fix was **deleted and watched to fail**, one mutant at a time, each with the other tests as surviving controls:

| mutant | killed | survived |
|---|---|---|
| remove the four yaml keys | `maps the four categories…`, `documents the same category set…` | 2 |
| remove the four `post_start.sh` dirs | `pre-creates every mapped category…` | 3 |
| break the `for sub in` loop header | `pre-creates every mapped category…` | 3 |
| revert the README yaml copy | `documents the same category set…` | 3 |

Restored tree back to 4/4 green. The `for sub in` list was also verified by **executing** the patched loop rather than reading it — it expands to 32 dirs ending in `sams`, `ultralytics`, `ultralytics/bbox`, `ultralytics/segm`.

## What I could NOT verify

**This change reaches users only through an image rebuild** — it is baked content, so nothing here is exercised by CI or by a running orchestrator. I did not build or launch a pod. The runtime behaviour above is derived from upstream source read directly (linked by file:line), not observed on a pod.

Not panel-visible, so the Playwright browser gate does not apply — no panel code path is touched.

## Executed reproduction (added after the first draft)

Reading upstream source establishes the mechanism but not the outcome, so I re-implemented ComfyUI's `add_model_folder_path` + `load_extra_path_config` and the packs' `add_folder_path_and_extensions` verbatim and **ran the real yaml through them** in both load orders.

Against this branch's yaml — both orders identical:

```
OK  ultralytics_bbox   download_target=/workspace/models/ultralytics/bbox  exts=8
    all=['/workspace/models/ultralytics/bbox', '/opt/ComfyUI/models/ultralytics/bbox']
OK  sams               download_target=/workspace/models/sams              exts=8
RESULT: volume wins in this order
```

The control — the **same** simulation against `origin/main`'s yaml — reproduces the reported failure rather than passing anyway, which is what makes the run above worth anything:

```
BAD ultralytics_bbox   download_target=/opt/ComfyUI/models/ultralytics/bbox
    all=['/opt/ComfyUI/models/ultralytics/bbox']
RESULT: *** VOLUME DID NOT WIN ***
```

That is exactly what the reporter saw Manager say (`writing it to /opt/ComfyUI/models/ultralytics/bbox/face_yolov8m.pt`). Note the `exts=8` in both columns: the yaml creates the key with an **empty** extension set, and the pack's union repairs it — so no category ends up unable to list its own files.

Parsed with **PyYAML 6.0.3**, the parser ComfyUI actually uses, not the JS `yaml` package the test uses.

## Shipping

The image version is resolved from Docker Hub tags at release time by `scripts/runpod-release.mjs`, not from a file in the repo, so there is nothing to bump here. Merging does **not** by itself reach pod users — this is baked image content and needs an `npm run runpod:release` rebuild to land.
