### PR TITLE
fix(2308): a guard stored as backspace bytes could not fail, and nothing could see it

### DIFF
--- a/src/__tests__/no-stray-control-bytes.test.ts
+++ b/src/__tests__/no-stray-control-bytes.test.ts
@@ -1,0 +1,66 @@
+// A stray control byte is invisible, keeps the file valid UTF-8, keeps git calling it
+// TEXT, and survives review — so nothing in this repo noticed one for as long as it was
+// there. #2308: `/\bRe-issue the download\b/` in download-progress.test.ts had both
+// boundaries stored as literal 0x08 BACKSPACE instead of the two characters `\\b`. The
+// pattern could then match nothing, so its `not.toMatch` was satisfied unconditionally —
+// a guard that passed whether the behaviour was right or wrong, while still reading as
+// coverage in the file and counting in the pass total.
+//
+// The escape-mangling that produces this happens in tooling, not in an editor, so it can
+// recur in any file. This scans the tracked tree instead of that one site.
+
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCANNED = /[.](ts|mts|cts|js|mjs|cjs|json|md|yml|yaml)$/;
+
+// TAB, LF, CR are ordinary text. Everything else below 0x20 is not.
+const isStray = (byte: number): boolean => byte < 0x20 && byte !== 9 && byte !== 10 && byte !== 13;
+
+// ANSI escapes are the one legitimate use: this fixture feeds coloured CLI output to a
+// parser, and rewriting it to build the escape at runtime would stop it testing the bytes
+// the CLI actually emits. Listed by path so a NEW file cannot inherit the exemption.
+const ALLOWED = new Set(["src/__tests__/orchestrator/antigravity-backend.test.ts"]);
+
+describe("no stray control bytes in tracked text files", () => {
+  it("finds none outside the documented ANSI fixture", () => {
+    const tracked = execFileSync("git", ["ls-tree", "-r", "--name-only", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split("\n")
+      .filter((f) => f && SCANNED.test(f));
+
+    // A scan that walked nothing would report a clean tree, which is the same shape as
+    // the bug it looks for. Refuse to pass on an empty file list.
+    expect(tracked.length).toBeGreaterThan(500);
+
+    const offenders: string[] = [];
+    for (const file of tracked) {
+      if (ALLOWED.has(file)) continue;
+      let bytes: Buffer;
+      try {
+        bytes = readFileSync(join(ROOT, file));
+      } catch {
+        continue; // listed in the index but absent from the worktree
+      }
+      const found = new Set<string>();
+      for (const b of bytes) if (isStray(b)) found.add("0x" + b.toString(16).padStart(2, "0"));
+      if (found.size) offenders.push(file + " -> " + [...found].sort().join(", "));
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("the scanner actually sees a backspace (it is not a check that cannot fail)", () => {
+    // The defect this guards against was itself a check that could not fail, so the
+    // detector gets its own positive control.
+    expect(isStray(0x08)).toBe(true);
+    expect(isStray(0x1b)).toBe(true);
+    expect([9, 10, 13, 0x20, 0x41].some(isStray)).toBe(false);
+  });
+});

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -500,7 +500,7 @@ describe("migrateInFlightJobs (#1148)", () => {
       // The old text said all three of these, and every one was false here.
       expect(msg).not.toMatch(/the transfer stopped/i);
       expect(msg).not.toMatch(/will not resume on its own/i);
-      expect(msg).not.toMatch(/Re-issue the download/);
+      expect(msg).not.toMatch(/\bRe-issue the download\b/);
     });
 
     it("does not offer a timer or an empty-listing check as proof", () => {


### PR DESCRIPTION
Closes #2308.

## The defect

`src/__tests__/services/download-progress.test.ts` held, in a live assertion:

```
expect(msg).not.toMatch(/<0x08>Re-issue the download<0x08>/);
```

Both word boundaries were stored as literal **0x08 BACKSPACE** bytes rather than the two characters that spell an escape. The pattern could therefore match nothing, `not.toMatch` was satisfied unconditionally, and the guard passed whether the behaviour was right or wrong — while still reading as coverage in the file and counting in the pass total.

## Proved in both directions, on the same mutant

Making the production message in `download-progress.ts` say the forbidden phrase:

| regex | result |
|---|---|
| repaired (`\b…\b`) | **1 failed** / 42 passed |
| original bytes | **43 passed** |

So the assertion is live now and was vacuous before. That second row is the part worth keeping — it is the evidence the guard never worked, not an inference from reading it.

## The second half: the class, not the instance

The mangling that produces this happens in tooling, not in an editor. It leaves the file valid UTF-8 and git-`TEXT`, renders invisibly in every diff and terminal, and survives review — which is why this sat undetected. I hit the identical corruption in my own edit on #2294 an hour ago, which is what prompted the sweep that found this one.

So this adds `src/__tests__/no-stray-control-bytes.test.ts`, scanning every tracked `.ts/.mts/.cts/.js/.mjs/.cjs/.json/.md/.yml/.yaml` file for bytes below 0x20 other than TAB/LF/CR. It is a test rather than a CI step deliberately: a `.github/` or `package.json` change would trip the gate's supply-chain hold and need a human ack for what is a one-file guard.

Two properties it was given on purpose, both mutation-proved:

- **It refuses to pass on an empty file list** (`expect(tracked.length).toBeGreaterThan(500)`). A scanner that walked nothing reports a clean tree — the same shape as the bug it hunts. Mutant: make the list empty → the test fails instead of passing.
- **It carries a positive control.** A detector for checks-that-cannot-fail should not be one. Mutant: plant a 0x08 in `src/config.ts` → `['src/config.ts -> 0x08']`.

The one legitimate hit, `antigravity-backend.test.ts`'s `"\x1b[32m…"` ANSI fixture, is exempted **by path** so a new file cannot inherit the exemption. Rewriting it to build the escape at runtime would stop it testing the bytes the CLI actually emits.

## Verification

`src/__tests__/services/` — 247 files / 5774 passed, 6 skipped. `tsc --noEmit` clean. Whole tracked tree scans clean apart from the documented fixture.
