### PR TITLE
fix(2305): the LC123 regional-prompt refusal also covers the promoted-inner retry

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -77,6 +77,10 @@ function bridge(opts: {
    *  probe (which cannot prove the dynamic-combo shape) and the post-enter inner
    *  probe (which can) return different rows. */
   detailById?: Record<string, unknown>;
+  /** #2305: the contradictory refusal the FIRST write throws, for a promoted
+   *  widget that is not #2299's `model.prompt`. Wins over the default above so
+   *  the recovery resolves the name under test. */
+  firstWriteError?: string;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -89,6 +93,7 @@ function bridge(opts: {
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
         if (writes === 1 && opts.stackDataIdentity) throw new Error(STACK_DATA_CONTRADICTORY);
+        if (writes === 1 && opts.firstWriteError) throw new Error(opts.firstWriteError);
         if (writes === 1 && opts.detailById) throw new Error(DYNAMIC_CHILD_CONTRADICTORY);
         const which =
           writes === 1
@@ -253,6 +258,94 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
               },
             ],
           },
+        },
+      },
+    );
+    expect(isError).toBe(false);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes.some((c) => String(c.node_id) === "76")).toBe(true);
+  });
+});
+
+// #2305 — an LC123 regional-canvas prompt widget promoted out of a subgraph. The
+// outer #1658 guard probed the CONTAINER, which is never one of the regional-canvas
+// types, so it fell open; the write is refused as "not promoted", and recovery
+// retries on the INNER node — the node whose custom JS owns the prompt.
+const ANIMA_CONTRADICTORY =
+  `Cannot set widget on subgraph node 78: "quality_prompt" is not a promoted widget on this ` +
+  `subgraph (promoted: quality_prompt, scene_prompt).`;
+
+const ANIMA_SUBGRAPH = {
+  subgraph_of: { node_id: 78, title: "Regional" },
+  instance_widgets: { quality_prompt: "", scene_prompt: "" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 76,
+      type: "AnimaRegionalCanvasInline",
+      widgets: { quality_prompt: "", scene_prompt: "" },
+    },
+  ],
+};
+
+/** The outer probe sees the container's own type and must fall open; only the
+ *  inner row names a regional-canvas node. */
+const ANIMA_IDENTITY_BY_ID = {
+  "78": { nodes: [{ id: 78, type: "SubgraphNode" }] },
+  "76": { nodes: [{ id: 76, type: "AnimaRegionalCanvasInline" }] },
+};
+
+describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => {
+  it("refuses the inner write instead of reporting a false success", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece, best quality" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        subgraph: ANIMA_SUBGRAPH,
+        detailById: ANIMA_IDENTITY_BY_ID,
+      },
+    );
+    expect(isError).toBe(true);
+    expect(text).toContain("LC123 regional-canvas prompt");
+    // The real #1658 refusal body, not a lookalike message.
+    expect(text).toContain("AnimaRegionalCanvasInline");
+    expect(text).toContain("animaPrompts");
+    expect(text).toContain("No inner graph_set_widget was dispatched");
+    // The recovery entered the subgraph and left it again...
+    expect(calls.some((c) => c.cmd === "graph_enter_subgraph")).toBe(true);
+    expect(calls.some((c) => c.cmd === "graph_exit_subgraph")).toBe(true);
+    // ...the guard was re-probed against the INNER id, not the container...
+    expect(
+      calls.some(
+        (c) =>
+          c.cmd === "graph_query" &&
+          Array.isArray(c.ids) &&
+          String((c.ids as unknown[])[0]) === "76",
+      ),
+    ).toBe(true);
+    // ...and the INNER node was never written. Only the outer attempt happened.
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes.every((c) => String(c.node_id) !== "76")).toBe(true);
+  });
+
+  it("still applies a promoted inner write when the inner node is NOT a regional canvas", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece, best quality" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        innerWrite: "ok",
+        subgraph: {
+          ...ANIMA_SUBGRAPH,
+          nodes: [
+            { id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "" } },
+          ],
+        },
+        detailById: {
+          "78": ANIMA_IDENTITY_BY_ID["78"],
+          // Same widget name, ordinary node — not the #1658 shape.
+          "76": { nodes: [{ id: 76, type: "PrimitiveStringMultiline" }] },
         },
       },
     );

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16740,6 +16740,41 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           innerExpectedNodeType = innerIdentity.type;
         }
 
+        // #2305 — the same omission as #2299, in the neighbouring guard. The #1658
+        // LC123 regional-canvas refusal also ran against the OUTER node id, and the
+        // subgraph container is never one of ANIMA_REGIONAL_CANVAS_TYPES, so it
+        // correctly fell open. The node this retry actually writes is the INNER one,
+        // and that is the node whose custom JS copies its hidden textarea back over
+        // widget.value — a success echo from the write below is exactly the lie the
+        // refusal exists to stop.
+        //
+        // The post-enter identity probe above cannot cover it either: it is gated on
+        // `expectedNodeType`, which is set only when the addressed widget IS
+        // `stack_data`, so it never runs for a prompt widget. This re-probes the inner
+        // node for the six regional-prompt names — the canvas is already inside the
+        // subgraph here, so `inner.innerNodeId` resolves — and exits before returning
+        // so the caller's scope is unchanged.
+        const innerAnimaBlocked = await refuseAnimaRegionalPromptWrite(
+          ctx,
+          inner.innerNodeId,
+          inner.widget,
+        );
+        if (innerAnimaBlocked) {
+          const exitedEarly = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `
+
+(The promoted inner node ${inner.innerNodeId} owns "${inner.widget}" as an ` +
+              `LC123 regional-canvas prompt; ${textOfToolResult(innerAnimaBlocked)} ` +
+              `No inner graph_set_widget was dispatched.${
+                exitedEarly.isError
+                  ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exitedEarly)}`
+                  : ""
+              })`,
+          );
+        }
+
         // #2299 — every pre-write guard above probed the OUTER scope, but this retry
         // writes a DIFFERENT node: the promoted inner one. For a dynamic-combo child
         // that is exactly the false success the guard exists to stop. The outer probe


### PR DESCRIPTION
Fixes #2305

## The bug

`refuseAnimaRegionalPromptWrite` runs **once**, against the node id the caller passed, in
the current scope. The #1655 promoted-widget recovery then writes a **different** node: on
a contradictory "not a promoted widget" refusal it resolves the displayed name to an inner
mapping, enters the subgraph, and retries `graph_set_widget` on `inner.innerNodeId`.

Nothing re-checked the #1658 guard for that inner node. The outer probe cannot catch it and
correctly falls open — the subgraph container is never one of `ANIMA_REGIONAL_CANVAS_TYPES`,
so the identity read answers "not a regional canvas" *about the wrong node*. The inner node
is the one whose custom JS (`ComfyUI_LC123_nodes/web/inline_regional_canvas.js`) keeps the
prompt in `node.properties.animaPrompts` plus a hidden textarea and copies it back over
`widget.value` on APPLY — so the inner write's success echo is exactly the lie the refusal
exists to prevent.

## The fix

One new call site, mirroring `f5d2c53` (#2299) which fixed this identical shape for
`refuseDynamicComboSubWidgetWrite` at the same point: re-probe the inner node after
`graph_enter_subgraph` succeeds and before `write(inner.innerNodeId, …)`, and exit the
subgraph before returning so the caller's scope is unchanged.

Call site changed: `src/orchestrator/panel-tools.ts`, the promoted-inner retry inside the
`panel_set_widget` handler (immediately before the #2299 dynamic-combo re-probe, so the
inner order matches the outer order Anima → dynamic-combo).

## Reachability evidence — this is the load-bearing part

A test that calls `refuseAnimaRegionalPromptWrite` directly would prove nothing here: the
defect is that the inner retry never called it. So the new tests drive the **shipped
`panel_set_widget` handler** end to end over a fake bridge, with an
`AnimaRegionalCanvasInline` node whose `quality_prompt` is promoted out of a subgraph, and
assert the refusal comes back instead of a success echo — including that the guard was
re-probed against the **inner** id (`graph_query ids:[76]`) and that no `graph_set_widget`
ever targeted it.

Two mutations, both run against the committed fix:

1. **Remove the new call site** → the #2305 test fails with `expected false to be true` on
   `isError`, i.e. the handler returns a **success echo** for the promoted-inner write. The
   other 30 tests in the file — every outer-path test and both #2299 inner-path tests —
   stay green.
2. **Remove the #2299 call site instead** (control) → only the #2299 test fails; the #2305
   test survives. The two guards are independently bound, so the new test is not passing on
   a neighbouring clause.

The DaSiWa guard was checked and is *not* a third gap: its post-enter identity branch
(`innerIdentity.type === DASIWA_LTX2_LORA_LOADER`) sits inside `if (expectedNodeType !==
undefined)`, and `expectedNodeType` is set only when the addressed widget IS `stack_data` —
so it can never incidentally cover a prompt widget. Verified, not assumed.

## Where the risk is

- The guard is **fail-open on an unreadable probe**, unchanged from the outer call. That is
  deliberate (an unreadable `graph_query` is not evidence of a regional canvas), and it
  means this closes the proven case, not every case.
- One extra `graph_query` on the inner retry — but only for the six regional-prompt names,
  since `isAnimaRegionalPromptWidget` short-circuits first. No cost on any other widget.
- `appendToolResultText(first, …)` is used so the reply keeps the outer refusal's
  `isError: true` rather than manufacturing a new error shape.

## Deliberately NOT in this PR

I found a broader family of the same class and am filing it separately rather than widening
this diff (per the "land the reported bug, file the rest" rule):

- **The direct-success promoted path.** If the panel's promoted write on the container
  *succeeds* (no contradictory refusal), it propagates to the inner node and none of the
  three guards ever see it. That is a bigger hole than the retry path and would need a
  different mechanism — probing subgraph contents on every write.
- **The same-node remapped write** at `write(args.node_id, refusal.widget)` uses
  `refusal.widget` while the guards ran on `args.widget`; a case-only difference slips past
  `isAnimaRegionalPromptWidget`. Narrower, and subsumed by the above.
- **`panel_kitchen`'s `applyWidget`** dispatches `graph_set_widget` with no guard at all.
  Low confidence that a perf recommendation ever names one of these widgets, but it is a
  guard-free write path.

Also checked and clean: `persistUnpromotedControlAfterGenerate`'s inner write only ever
targets a `control_after_generate` widget, which is in none of the three refused sets.

## Verification

- `npx vitest run` in the worktree: **12322 passed**, 6 skipped, 1 failed —
  `late-mutation-e2e.test.ts`, the known load flake, which passes **5/5 in isolation**.
- `npm run lint` (tsc --noEmit) clean; `npm run check:vocabulary` clean.
- No panel-repo code changed, so the Playwright browser suite is not implicated by this
  diff — the change is orchestrator-side tool-result behaviour, not anything the sidebar
  renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
