### PR TITLE
fix(rate-limit): redact all-alphabetic identifiers

### DIFF
--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -160,9 +160,10 @@ describe("sanitizeDetail", () => {
   });
 
   it("leaves long ordinary prose words readable", () => {
-    for (const word of ["uncharacteristically", "compartmentalization"]) {
-      expect(sanitizeDetail(word)).toBe(word);
-    }
+    expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
+    expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
+      "the user uncharacteristically exceeded the limit",
+    );
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -284,6 +284,25 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("masks prose-looking ids behind quoted JSON-like labels", () => {
+    const proseLookingId = "counterrevolutionary";
+    const cases = [
+      [`{"account_id":"${proseLookingId}"}`, `{"account_id":"<redacted>"}`],
+      [`{"user_id" : "${proseLookingId}"}`, `{"user_id" : "<redacted>"}`],
+      [`{"account_id":${proseLookingId}}`, `{"account_id":<redacted>}`],
+      [`{"outer":{"account_id":"${proseLookingId}"}}`, `{"outer":{"account_id":"<redacted>"}}`],
+      [
+        `{ "payload": { "user_id": [ "${proseLookingId}" ] } }`,
+        `{ "payload": { "user_id": [ "<redacted>" ] } }`,
+      ],
+      [`{"details":{"user_id":("${proseLookingId}")}}`, `{"details":{"user_id":("<redacted>")}}`],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("compartmentalization_v2")).toBe("compartmentalization_v2");
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -150,6 +150,12 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("leaves long ordinary prose words readable", () => {
+    for (const word of ["uncharacteristically", "compartmentalization"]) {
+      expect(sanitizeDetail(word)).toBe(word);
+    }
+  });
+
   it("leaves an ordinary sentence readable", () => {
     const out = sanitizeDetail("Rate limit reached for gpt-4o in organization on requests per min (RPM): Limit 500");
     expect(out).toContain("requests per min");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -168,6 +168,24 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("user_id qavexidopulnertiskym is limited")).toBe("user_id <redacted> is limited");
   });
 
+  it("redacts user-labeled identifiers for terminal statuses", () => {
+    for (const status of ["disabled", "blocked", "expired"]) {
+      expect(sanitizeDetail(`user abcdefghijklmnopqrstuv is ${status}`)).toBe(
+        `user <redacted> is ${status}`,
+      );
+    }
+  });
+
+  it("redacts punctuation-wrapped and bracketed labels", () => {
+    expect(sanitizeDetail("account: abcdefghijklmnopqrstuv is limited")).toBe(
+      "account: <redacted> is limited",
+    );
+    expect(sanitizeDetail("account (abcdefghijklmnopqrstuv) is limited")).toBe(
+      "account (<redacted>) is limited",
+    );
+    expect(sanitizeDetail("account_id=[abcdefghijklmnopqrstuv]")).toBe("account_id=[<redacted>]");
+  });
+
   it("redacts a hyphen-attached identifier atomically", () => {
     expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
       "account <redacted> is limited",
@@ -179,6 +197,8 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",
     );
+    expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
+    expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -220,9 +220,27 @@ describe("sanitizeDetail", () => {
 
   it("redacts punctuation, hyphen labels, and composite labels atomically", () => {
     expect(sanitizeDetail("account, abcdefghijklmnopqrstuv")).toBe("account, <redacted>");
+    expect(sanitizeDetail("account.abcdefghijklmnopqrstuv")).toBe("account.<redacted>");
+    expect(sanitizeDetail("account!abcdefghijklmnopqrstuv")).toBe("account!<redacted>");
+    expect(sanitizeDetail("account?abcdefghijklmnopqrstuv")).toBe("account?<redacted>");
     expect(sanitizeDetail("account--abcdefghijklmnopqrstuv")).toBe("account--<redacted>");
+    expect(sanitizeDetail("account-[abcdefghijklmnopqrstuv]")).toBe("account-[<redacted>]");
+    expect(sanitizeDetail("account_[abcdefghijklmnopqrstuv]")).toBe("account_[<redacted>]");
     expect(sanitizeDetail("the-user-abcdefghijklmnopqrstuv")).toBe("the-user-<redacted>");
+    expect(sanitizeDetail("the-user_abcdefghijklmnopqrstuv")).toBe("the-user_<redacted>");
     expect(sanitizeDetail("your-user-abcdefghijklmnopqrstuv")).toBe("your-user-<redacted>");
+    expect(sanitizeDetail("your-user_abcdefghijklmnopqrstuv")).toBe("your-user_<redacted>");
+    expect(sanitizeDetail("account_abcdefghijklmnopqrstuv")).toBe("account_<redacted>");
+    expect(sanitizeDetail("user_abcdefghijklmnopqrstuv")).toBe("user_<redacted>");
+    expect(sanitizeDetail("account_identifier_abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier_<redacted>",
+    );
+    expect(sanitizeDetail("account_identifier_[abcdefghijklmnopqrstuv]")).toBe(
+      "account_identifier_[<redacted>]",
+    );
+    expect(sanitizeDetail("account_identifier-abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier-<redacted>",
+    );
     expect(sanitizeDetail("account_identifier=abcdefghijklmnopqrstuv")).toBe(
       "account_identifier=<redacted>",
     );
@@ -244,6 +262,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
     expect(sanitizeDetail("user_uncharacteristically")).toBe("user_uncharacteristically");
     expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
+    expect(sanitizeDetail("account compartmentalization_v2 is limited")).toBe(
+      "account compartmentalization_v2 is limited",
+    );
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -159,6 +159,21 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("redacts low-diversity all-alphabetic account identifiers", () => {
+    expect(sanitizeDetail("account aeiouaeiouaeiouaeiou is limited")).toBe("account <redacted> is limited");
+  });
+
+  it("redacts all-alphabetic identifiers with structured labels", () => {
+    expect(sanitizeDetail("account_id=abcdefghijklmnopqrstuv")).toBe("account_id=<redacted>");
+    expect(sanitizeDetail("user_id qavexidopulnertiskym is limited")).toBe("user_id <redacted> is limited");
+  });
+
+  it("redacts a hyphen-attached identifier atomically", () => {
+    expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
+      "account <redacted> is limited",
+    );
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -46,6 +46,15 @@ describe("classifyRateLimit", () => {
     expect(v?.retryAfterMs).toBe(1000);
   });
 
+  it("sanitizes a high-vowel labeled bare id in fallback detail", () => {
+    const v = classifyRateLimit(
+      429,
+      h(),
+      JSON.stringify({ error: { message: "account qavexidopulnertiskym is limited" } }),
+    );
+    expect(v?.detail).toBe("account <redacted> is limited");
+  });
+
   it("prefers Retry-After over the prose, in seconds or as a date", () => {
     expect(classifyRateLimit(429, h({ "retry-after": "20" }), KIMI_429)?.retryAfterMs).toBe(20_000);
     const soon = new Date(Date.now() + 30_000).toUTCString();
@@ -184,6 +193,12 @@ describe("sanitizeDetail", () => {
 
   it("redacts an email address", () => {
     expect(sanitizeDetail("quota for art@example.com exhausted")).not.toContain("art@example.com");
+  });
+
+  it("masks a long email local part as one address", () => {
+    expect(sanitizeDetail("quota for abcdefghijklmnopqrstuv@example.com exhausted")).toBe(
+      "quota for <redacted> exhausted",
+    );
   });
 
   // Hyphens defeated both shape rules: the longest unbroken run inside a UUID is 12

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -267,7 +267,25 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("does not let prose exceptions exempt explicit identifier shapes", () => {
+    const proseLookingId = "counterrevolutionary";
+    const cases = [
+      [`account_id=${proseLookingId}`, "account_id=<redacted>"],
+      [`user_id ${proseLookingId} is limited`, "user_id <redacted> is limited"],
+      [`account_${proseLookingId}`, "account_<redacted>"],
+      [`acct-${proseLookingId}`, "acct-<redacted>"],
+      [`wrapper_${proseLookingId}_suffix`, "wrapper_<redacted>"],
+      [`account-[${proseLookingId}]`, "account-[<redacted>]"],
+      [`account (${proseLookingId})`, "account (<redacted>)"],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
+    expect(sanitizeDetail("compartmentalization_v2")).toBe("compartmentalization_v2");
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -169,10 +169,12 @@ describe("sanitizeDetail", () => {
   });
 
   it("redacts user-labeled identifiers for terminal statuses", () => {
-    for (const status of ["disabled", "blocked", "expired"]) {
-      expect(sanitizeDetail(`user abcdefghijklmnopqrstuv is ${status}`)).toBe(
-        `user <redacted> is ${status}`,
-      );
+    for (const label of ["user", "the user", "your user"]) {
+      for (const status of ["disabled", "blocked", "expired"]) {
+        expect(sanitizeDetail(`${label} abcdefghijklmnopqrstuv is ${status}`)).toBe(
+          `${label} <redacted> is ${status}`,
+        );
+      }
     }
   });
 
@@ -183,11 +185,18 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account (abcdefghijklmnopqrstuv) is limited")).toBe(
       "account (<redacted>) is limited",
     );
+    expect(sanitizeDetail("account: [abcdefghijklmnopqrstuv] is limited")).toBe(
+      "account: [<redacted>] is limited",
+    );
+    expect(sanitizeDetail("account=[abcdefghijklmnopqrstuv]")).toBe("account=[<redacted>]");
+    expect(sanitizeDetail("user: [abcdefghijklmnopqrstuv] is disabled")).toBe(
+      "user: [<redacted>] is disabled",
+    );
     expect(sanitizeDetail("account_id=[abcdefghijklmnopqrstuv]")).toBe("account_id=[<redacted>]");
   });
 
   it("redacts a hyphen-attached identifier atomically", () => {
-    expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
+    expect(sanitizeDetail("account qavexidopulnertiskym-extra-more is limited")).toBe(
       "account <redacted> is limited",
     );
   });
@@ -196,6 +205,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",
+    );
+    expect(sanitizeDetail("account compartmentalization is limited")).toBe(
+      "account compartmentalization is limited",
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -246,6 +246,27 @@ describe("sanitizeDetail", () => {
     );
   });
 
+  it("uses the explicit alpha-run table across identifier boundaries", () => {
+    const alphaId = "aeiouaeiouaeiouaeiotion";
+    const cases = [
+      [`account ${alphaId} is limited`, "account <redacted> is limited"],
+      [`user ${alphaId} is blocked`, "user <redacted> is blocked"],
+      [`account_id=${alphaId}`, "account_id=<redacted>"],
+      [`user_id ${alphaId} is limited`, "user_id <redacted> is limited"],
+      [`account_${alphaId}`, "account_<redacted>"],
+      [`acct_${alphaId}`, "acct_<redacted>"],
+      [`org-${alphaId}`, "org-<redacted>"],
+      [`wrapper_${alphaId}_suffix`, "wrapper_<redacted>"],
+      [`account-[${alphaId}]`, "account-[<redacted>]"],
+      ["account counterrevolutionary is limited", "account counterrevolutionary is limited"],
+      ["account compartmentalization_v2 is limited", "account compartmentalization_v2 is limited"],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
@@ -264,6 +285,12 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
     expect(sanitizeDetail("account compartmentalization_v2 is limited")).toBe(
       "account compartmentalization_v2 is limited",
+    );
+    expect(sanitizeDetail("account internationalization is limited")).toBe(
+      "account internationalization is limited",
+    );
+    expect(sanitizeDetail("account nondeterministically is limited")).toBe(
+      "account nondeterministically is limited",
     );
   });
 

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -202,6 +202,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account qavexidopulnertiskymtion is limited")).toBe(
       "account <redacted> is limited",
     );
+    expect(sanitizeDetail("account qavexidopulnertisktion is limited")).toBe(
+      "account <redacted> is limited",
+    );
     expect(sanitizeDetail("account qavexidopulnertiskymaeiotion is limited")).toBe(
       "account <redacted> is limited",
     );
@@ -213,6 +216,16 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("wrapper_qavexidopulnertiskym_suffix")).toBe("wrapper_<redacted>");
     expect(sanitizeDetail("wrapper--qavexidopulnertiskym--suffix")).toBe("wrapper--<redacted>");
+  });
+
+  it("redacts punctuation, hyphen labels, and composite labels atomically", () => {
+    expect(sanitizeDetail("account, abcdefghijklmnopqrstuv")).toBe("account, <redacted>");
+    expect(sanitizeDetail("account--abcdefghijklmnopqrstuv")).toBe("account--<redacted>");
+    expect(sanitizeDetail("the-user-abcdefghijklmnopqrstuv")).toBe("the-user-<redacted>");
+    expect(sanitizeDetail("your-user-abcdefghijklmnopqrstuv")).toBe("your-user-<redacted>");
+    expect(sanitizeDetail("account_identifier=abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier=<redacted>",
+    );
   });
 
   it("leaves long ordinary prose words readable", () => {
@@ -229,6 +242,8 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
+    expect(sanitizeDetail("user_uncharacteristically")).toBe("user_uncharacteristically");
+    expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -199,6 +199,20 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account qavexidopulnertiskym-extra-more is limited")).toBe(
       "account <redacted> is limited",
     );
+    expect(sanitizeDetail("account qavexidopulnertiskymtion is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskymaeiotion is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskym_extra_more is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskym--extra--more is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("wrapper_qavexidopulnertiskym_suffix")).toBe("wrapper_<redacted>");
+    expect(sanitizeDetail("wrapper--qavexidopulnertiskym--suffix")).toBe("wrapper--<redacted>");
   });
 
   it("leaves long ordinary prose words readable", () => {
@@ -208,6 +222,10 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("account compartmentalization is limited")).toBe(
       "account compartmentalization is limited",
+    );
+    expect(sanitizeDetail("account: compartmentalization policy")).toBe("account: compartmentalization policy");
+    expect(sanitizeDetail("the user: uncharacteristically exceeded")).toBe(
+      "the user: uncharacteristically exceeded",
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -173,28 +173,32 @@ function parseWaitFromProse(text: string): number | null {
  * `redactTokens` covers credentials in the shapes OAuth uses, and it is applied
  * first — but it knows nothing about `org-7df23a26037240f88f967fb1c64d8e3f` or
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
- * SHAPE, not a list of known prefixes: a prefixed opaque run, or a long bare
- * run, is an identifier whatever the vendor calls it, and no rate-limit
- * explanation needs one to be useful. A vendor inventing a new prefix tomorrow is
- * covered without a code change, and so is one that mints ids with no digit in
- * them (#2313) — shape here means LENGTH and the absence of a space, never a
- * character class, and never a guess at whether a run reads like English.
+ * SHAPE plus minimal CONTEXT, not a list of known prefixes: a prefixed opaque
+ * run, or a long digit-bearing bare run, is an identifier whatever the vendor
+ * calls it. A digit-free run is only an identifier when a generic label such as
+ * `account` or `token` immediately identifies it; otherwise it may be prose.
+ * A vendor inventing a new prefix tomorrow is covered without a code change.
  *
  * Deliberately aggressive. Over-redaction costs a few characters of an error
  * message; under-redaction publishes an account id into a chat log that gets
  * screenshotted.
  */
-export function sanitizeDetail(raw: string, max = 200): string {
-  const looksLikeOpaqueAlphaRun = (value: string): boolean => {
-    const vowelCount = value.match(/[aeiou]/gi)?.length ?? 0;
-    // Natural-language words need more vowels than opaque base62-like ids.
-    return vowelCount * 3 < value.length;
-  };
+const ALPHA_IDENTIFIER_LABEL =
+  /\b(?:account|acct|id|identifier|token|key|workspace|user)\b(?:\s+(?:id|identifier))?\s*(?:[:=]\s*)?$/i;
 
+function hasAlphaIdentifierContext(input: string, offset: number): boolean {
+  return ALPHA_IDENTIFIER_LABEL.test(input.slice(Math.max(0, offset - 64), offset));
+}
+
+export function sanitizeDetail(raw: string, max = 200): string {
   const masked = redactTokens(raw)
-    // UUID-shaped ids FIRST, with any prefix attached. Their hyphens defeat both
-    // rules below: the longest unbroken run inside a UUID is 12 characters, so the
-    // bare-run rule never fires, and the prefixed rule matches only the TAIL —
+    // E-mail addresses FIRST: the local part may itself look like a bare id,
+    // but #2294's contract is to mask the whole address atomically.
+    .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>")
+    // UUID-shaped ids next, before the other identifier rules, with any prefix
+    // attached. Their hyphens defeat both rules below: the longest unbroken run
+    // inside a UUID is 12 characters, so the bare-run rule never fires, and the
+    // prefixed rule matches only the TAIL —
     // which is worse than missing it outright, because
     // `550e8400-e29b-41d4-a716-<redacted>` reads as sanitized while 24 of its 36
     // characters shipped. A partial redaction nobody re-checks is the dangerous
@@ -205,24 +209,14 @@ export function sanitizeDetail(raw: string, max = 200): string {
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
-<<<<<<< HEAD
-    // bare long runs (an id that came without a prefix). LENGTH is the whole
-    // test: there is deliberately no `(?=[A-Za-z0-9]*\d)` lookahead requiring
-    // a digit. That lookahead was here until #2313, and it meant an all-alphabetic
-    // id — `account abcdefghijklmnopqrstuv is limited` — passed through untouched
-    // while the same string ending in a digit was redacted. Neither other rule
-    // caught it: the prefixed rule needs a `-`/`_`, and the UUID rule needs the
-    // UUID shape.
-    //
-    // Do NOT put it back to protect prose — it does not buy what it looks like it
-    // buys. Measured over 1.19M word tokens of this repo's comments, docs and
-    // user-facing strings, exactly ONE all-lowercase run of 20+ characters is an
-    // English word (`nondeterministically`, once), and it has never appeared in a
-    // 429. An unbroken 20-character alphanumeric run is an identifier; an
-    // explanatory sentence has spaces in it, and every space ends a run.
-    .replace(/\b[A-Za-z0-9]{20,}\b/g, "<redacted>")
-    // e-mail addresses occasionally appear in quota messages
-    .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>");
+    // bare long hex / base62 runs (an id that came without a prefix). Digits
+    // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
+    // so require nearby identifier context before masking them.
+    .replace(
+      /\b[A-Za-z0-9]{20,}\b/g,
+      (run, offset, input: string) =>
+        /\d/.test(run) || hasAlphaIdentifierContext(input, offset) ? "<redacted>" : run,
+    );
   return masked.replace(/\s+/g, " ").trim().slice(0, max);
 }
 

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -209,9 +209,12 @@ function classifyAlphaRun(run: string, boundary: AlphaRunBoundary = "bare-prose"
 
 function hasExplicitAlphaIdentifierBoundary(input: string, offset: number): boolean {
   const before = input.slice(Math.max(0, offset - 64), offset);
+  const withoutJsonQuotes = before.replace(/\\?["']/g, "");
   return (
     ALPHA_IDENTIFIER_LABEL.test(before) ||
-    (DIRECT_PUNCTUATED_LABEL.test(before) && /(?:=|[\[({])\s*$/.test(before))
+    ALPHA_IDENTIFIER_LABEL.test(withoutJsonQuotes) ||
+    (DIRECT_PUNCTUATED_LABEL.test(before) && /(?:=|[\[({])\s*$/.test(before)) ||
+    (DIRECT_PUNCTUATED_LABEL.test(withoutJsonQuotes) && /(?:=|[\[({])\s*$/.test(withoutJsonQuotes))
   );
 }
 

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -184,17 +184,24 @@ function parseWaitFromProse(text: string): number | null {
  * screenshotted.
  */
 const ALPHA_IDENTIFIER_LABEL =
-  /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*)?$/i;
-const DIRECT_ACCOUNT_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)account\s*$/i;
-const ACCOUNT_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
+  /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*[\[({]?\s*|[\[({]\s*)?$/i;
+const DIRECT_ACCOUNT_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)account\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
+const DIRECT_USER_LABEL = /(?:^|[.!?;]\s*)user\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
+const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
   const before = input.slice(Math.max(0, offset - 64), offset);
   if (ALPHA_IDENTIFIER_LABEL.test(before)) return true;
-  if (!DIRECT_ACCOUNT_LABEL.test(before)) return false;
+  if (!DIRECT_ACCOUNT_LABEL.test(before) && !DIRECT_USER_LABEL.test(before)) return false;
 
   const after = input.slice(offset + run.length);
-  return run.includes("-") || !after.trim() || /^[\s]*[.,;!?)]/.test(after) || ACCOUNT_STATUS.test(after);
+  const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
+  return (
+    run.includes("-") ||
+    !after.trim() ||
+    /^[\s]*[.,;!?)]/.test(after) ||
+    IDENTIFIER_STATUS.test(afterClosingPunctuation)
+  );
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -214,8 +221,9 @@ export function sanitizeDetail(raw: string, max = 200): string {
       /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
       (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
     )
-    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
-    .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
+    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Common
+    // label words followed by a hyphen are prose, not vendor prefixes.
+    .replace(/\b(?!(?:account|user)-)([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/gi, "$1<redacted>")
     // bare long hex / base62 runs (an id that came without a prefix). Digits
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
     // so require explicit label syntax or an account-status boundary.

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -193,23 +193,23 @@ const DIRECT_PUNCTUATED_LABEL =
   /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])\s*$/i;
 const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 type AlphaRunClassification = "identifier" | "prose";
+type AlphaRunBoundary = "bare-prose" | "lexical-label-prose";
 
 // There is no reliable morphology or vowel heuristic that can distinguish a
 // minted all-alpha id from an English word. Keep the small prose exception
-// explicit and table-driven; every unlisted long alpha run is classified as an
-// identifier, then bare alpha runs still require an explicit label/status
-// boundary before they are masked.
-const ALPHA_RUN_CLASSIFICATION: ReadonlyMap<string, AlphaRunClassification> = new Map([
-  ["compartmentalization", "prose"],
-  ["counterrevolutionary", "prose"],
-  ["internationalization", "prose"],
-  ["nondeterministically", "prose"],
-  ["uncharacteristically", "prose"],
+// explicit and table-driven. The boundary column keeps those exceptions from
+// exempting an explicitly labeled or wrapped identifier.
+const ALPHA_RUN_CLASSIFICATION: ReadonlyMap<string, ReadonlySet<AlphaRunBoundary>> = new Map([
+  ["compartmentalization", new Set(["bare-prose", "lexical-label-prose"])],
+  ["counterrevolutionary", new Set(["bare-prose"])],
+  ["internationalization", new Set(["bare-prose"])],
+  ["nondeterministically", new Set(["bare-prose"])],
+  ["uncharacteristically", new Set(["bare-prose", "lexical-label-prose"])],
 ]);
 
-function classifyAlphaRun(run: string): AlphaRunClassification {
+function classifyAlphaRun(run: string, boundary: AlphaRunBoundary = "bare-prose"): AlphaRunClassification {
   const base = run.split(/[-_]+/)[0].toLowerCase();
-  return ALPHA_RUN_CLASSIFICATION.get(base) ?? "identifier";
+  return ALPHA_RUN_CLASSIFICATION.get(base)?.has(boundary) ? "prose" : "identifier";
 }
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
@@ -229,9 +229,18 @@ function hasAlphaIdentifierContext(input: string, offset: number, run: string): 
   );
 }
 
+function hasExplicitAlphaIdentifierBoundary(input: string, offset: number): boolean {
+  const before = input.slice(Math.max(0, offset - 64), offset);
+  return (
+    ALPHA_IDENTIFIER_LABEL.test(before) ||
+    (DIRECT_PUNCTUATED_LABEL.test(before) && /(?:=|[\[({])\s*$/.test(before))
+  );
+}
+
 function preserveNaturalLanguagePrefixedRun(run: string, prefix: string): boolean {
   const tail = run.slice(prefix.length).split(/[-_]+/)[0];
-  return classifyAlphaRun(tail) === "prose";
+  const label = prefix.replace(/[-_]+$/, "").toLowerCase();
+  return /^(?:account|user)$/.test(label) && classifyAlphaRun(tail, "lexical-label-prose") === "prose";
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -251,8 +260,8 @@ export function sanitizeDetail(raw: string, max = 200): string {
       /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
       (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
     )
-    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Natural
-    // language tails listed in ALPHA_RUN_CLASSIFICATION remain readable.
+    // Prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Only the
+    // explicit account/user lexical-label prose cases remain readable.
     .replace(
       /\b(?!(?:(?:account|acct|user|workspace|token|key)[_-](?:id|identifier)(?=$|[:=\s])))((?:[A-Za-z][A-Za-z0-9]{0,12}[-_]+)+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
       (run, prefix: string) =>
@@ -264,10 +273,9 @@ export function sanitizeDetail(raw: string, max = 200): string {
     .replace(
       /\b[A-Za-z0-9]{20,}(?:[-_]+[A-Za-z0-9]+)*\b/g,
       (run, offset, input: string) => {
-        return classifyAlphaRun(run) === "identifier" &&
-          (/\d/.test(run) || hasAlphaIdentifierContext(input, offset, run))
-          ? "<redacted>"
-          : run;
+        const explicitIdentifier = hasExplicitAlphaIdentifierBoundary(input, offset);
+        if (!explicitIdentifier && classifyAlphaRun(run) === "prose") return run;
+        return /\d/.test(run) || hasAlphaIdentifierContext(input, offset, run) ? "<redacted>" : run;
       },
     );
   return masked.replace(/\s+/g, " ").trim().slice(0, max);

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -175,26 +175,26 @@ function parseWaitFromProse(text: string): number | null {
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
  * SHAPE plus minimal CONTEXT, not a list of known prefixes: a prefixed opaque
  * run, or a long digit-bearing bare run, is an identifier whatever the vendor
- * calls it. A digit-free run is only an identifier when it has opaque character
- * diversity and a generic label such as `account` or `token` immediately
- * identifies it; otherwise it may be prose. A vendor inventing a new prefix
- * tomorrow is covered without a code change.
+ * calls it. A digit-free run is only an identifier when explicit label syntax
+ * or an account-status context identifies it; otherwise it may be prose. A
+ * vendor inventing a new prefix tomorrow is covered without a code change.
  *
  * Deliberately aggressive. Over-redaction costs a few characters of an error
  * message; under-redaction publishes an account id into a chat log that gets
  * screenshotted.
  */
 const ALPHA_IDENTIFIER_LABEL =
-  /\b(?:account|acct|id|identifier|token|key|workspace|user)\b(?:\s+(?:id|identifier))?\s*(?:[:=]\s*)?$/i;
+  /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*)?$/i;
+const DIRECT_ACCOUNT_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)account\s*$/i;
+const ACCOUNT_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 
-function hasAlphaIdentifierContext(input: string, offset: number): boolean {
-  return ALPHA_IDENTIFIER_LABEL.test(input.slice(Math.max(0, offset - 64), offset));
-}
+function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
+  const before = input.slice(Math.max(0, offset - 64), offset);
+  if (ALPHA_IDENTIFIER_LABEL.test(before)) return true;
+  if (!DIRECT_ACCOUNT_LABEL.test(before)) return false;
 
-function looksLikeOpaqueAlphaRun(value: string): boolean {
-  const uniqueCharacters = new Set(value.toLowerCase()).size;
-  // Ordinary words reuse letters; opaque tokens tend to have high diversity.
-  return uniqueCharacters * 5 >= value.length * 4;
+  const after = input.slice(offset + run.length);
+  return run.includes("-") || !after.trim() || /^[\s]*[.,;!?)]/.test(after) || ACCOUNT_STATUS.test(after);
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -218,12 +218,12 @@ export function sanitizeDetail(raw: string, max = 200): string {
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
     // bare long hex / base62 runs (an id that came without a prefix). Digits
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
-    // so require both high character diversity and nearby identifier context.
+    // so require explicit label syntax or an account-status boundary.
     .replace(
-      /\b[A-Za-z0-9]{20,}\b/g,
+      /\b[A-Za-z0-9]{20,}(?:-[A-Za-z0-9]+)?\b/g,
       (run, offset, input: string) =>
         /\d/.test(run) ||
-        (looksLikeOpaqueAlphaRun(run) && hasAlphaIdentifierContext(input, offset))
+        hasAlphaIdentifierContext(input, offset, run)
           ? "<redacted>"
           : run,
     );

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -194,18 +194,22 @@ const NATURAL_LANGUAGE_SUFFIX =
   /(?:istically|ization|isation|tion|sion|ment|ness|ity|ically|ingly|edly|ful|less|able|ible|ive|ous|ance|ence)$/i;
 
 function looksLikeNaturalLanguageWord(value: string): boolean {
-  return NATURAL_LANGUAGE_SUFFIX.test(value);
+  const suffix = value.match(NATURAL_LANGUAGE_SUFFIX)?.[0];
+  // A long opaque stem followed by an English-looking suffix is still an id
+  // (for example, qavexidopulnertiskymtion), not ordinary prose.
+  return suffix !== undefined && value.length - suffix.length < 20;
 }
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
   const before = input.slice(Math.max(0, offset - 64), offset);
   if (ALPHA_IDENTIFIER_LABEL.test(before)) return true;
-  if (DIRECT_PUNCTUATED_LABEL.test(before)) return true;
+  const explicitWrapper = DIRECT_PUNCTUATED_LABEL.test(before) && /(?:=|[\[({])\s*$/.test(before);
+  if (explicitWrapper) return true;
   if (!DIRECT_ACCOUNT_LABEL.test(before) && !DIRECT_USER_LABEL.test(before)) return false;
 
   const after = input.slice(offset + run.length);
   const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
-  if (looksLikeNaturalLanguageWord(run.split("-")[0])) return false;
+  if (looksLikeNaturalLanguageWord(run.split(/[-_]+/)[0])) return false;
   return (
     run.includes("-") ||
     !afterClosingPunctuation.trim() ||
@@ -233,12 +237,15 @@ export function sanitizeDetail(raw: string, max = 200): string {
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Common
     // label words followed by a hyphen are prose, not vendor prefixes.
-    .replace(/\b(?!(?:account|user)-)([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/gi, "$1<redacted>")
+    .replace(
+      /\b(?!(?:account|user)-)([A-Za-z][A-Za-z0-9]{1,12}[-_]+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
+      "$1<redacted>",
+    )
     // bare long hex / base62 runs (an id that came without a prefix). Digits
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
     // so require explicit label syntax or an account-status boundary.
     .replace(
-      /\b[A-Za-z0-9]{20,}(?:-[A-Za-z0-9]+)*\b/g,
+      /\b[A-Za-z0-9]{20,}(?:[-_]+[A-Za-z0-9]+)*\b/g,
       (run, offset, input: string) =>
         /\d/.test(run) ||
         hasAlphaIdentifierContext(input, offset, run)

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -185,19 +185,24 @@ function parseWaitFromProse(text: string): number | null {
  */
 const ALPHA_IDENTIFIER_LABEL =
   /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*[\[({]?\s*|[\[({]\s*)?$/i;
-const DIRECT_ACCOUNT_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)account\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
-const DIRECT_USER_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)user\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
+const DIRECT_ACCOUNT_LABEL =
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)account\s*(?:[,;:=]\s*|[\[({]\s*|[-_]+\s*|\s+)$/i;
+const DIRECT_USER_LABEL =
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)user\s*(?:[,;:=]\s*|[\[({]\s*|[-_]+\s*|\s+)$/i;
 const DIRECT_PUNCTUATED_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)\s+)(?:account|user)\s*(?:[:=]\s*[\[({]?|[\[({])\s*$/i;
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;:=]\s*[\[({]?|[-_]+\s*|[\[({])\s*$/i;
 const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 const NATURAL_LANGUAGE_SUFFIX =
   /(?:istically|ization|isation|tion|sion|ment|ness|ity|ically|ingly|edly|ful|less|able|ible|ive|ous|ance|ence)$/i;
 
 function looksLikeNaturalLanguageWord(value: string): boolean {
   const suffix = value.match(NATURAL_LANGUAGE_SUFFIX)?.[0];
-  // A long opaque stem followed by an English-looking suffix is still an id
-  // (for example, qavexidopulnertiskymtion), not ordinary prose.
-  return suffix !== undefined && value.length - suffix.length < 20;
+  if (suffix === undefined) return false;
+
+  const stem = value.slice(0, -suffix.length);
+  // A short stem with a non-English q-shape is an opaque id plus a prose-like
+  // suffix (for example, qavexidopulnertisktion), not ordinary prose.
+  return stem.length < 20 && !/q(?!u)/i.test(stem);
 }
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
@@ -238,7 +243,7 @@ export function sanitizeDetail(raw: string, max = 200): string {
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Common
     // label words followed by a hyphen are prose, not vendor prefixes.
     .replace(
-      /\b(?!(?:account|user)-)([A-Za-z][A-Za-z0-9]{1,12}[-_]+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
+      /\b(?!(?:(?:account|acct|user|workspace|token|key)[_-](?:id|identifier)\b))(?!(?:account|user)[-_])([A-Za-z][A-Za-z0-9]{1,12}[-_]+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
       "$1<redacted>",
     )
     // bare long hex / base62 runs (an id that came without a prefix). Digits

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -175,9 +175,10 @@ function parseWaitFromProse(text: string): number | null {
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
  * SHAPE plus minimal CONTEXT, not a list of known prefixes: a prefixed opaque
  * run, or a long digit-bearing bare run, is an identifier whatever the vendor
- * calls it. A digit-free run is only an identifier when a generic label such as
- * `account` or `token` immediately identifies it; otherwise it may be prose.
- * A vendor inventing a new prefix tomorrow is covered without a code change.
+ * calls it. A digit-free run is only an identifier when it has opaque character
+ * diversity and a generic label such as `account` or `token` immediately
+ * identifies it; otherwise it may be prose. A vendor inventing a new prefix
+ * tomorrow is covered without a code change.
  *
  * Deliberately aggressive. Over-redaction costs a few characters of an error
  * message; under-redaction publishes an account id into a chat log that gets
@@ -188,6 +189,12 @@ const ALPHA_IDENTIFIER_LABEL =
 
 function hasAlphaIdentifierContext(input: string, offset: number): boolean {
   return ALPHA_IDENTIFIER_LABEL.test(input.slice(Math.max(0, offset - 64), offset));
+}
+
+function looksLikeOpaqueAlphaRun(value: string): boolean {
+  const uniqueCharacters = new Set(value.toLowerCase()).size;
+  // Ordinary words reuse letters; opaque tokens tend to have high diversity.
+  return uniqueCharacters * 5 >= value.length * 4;
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -211,11 +218,14 @@ export function sanitizeDetail(raw: string, max = 200): string {
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
     // bare long hex / base62 runs (an id that came without a prefix). Digits
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
-    // so require nearby identifier context before masking them.
+    // so require both high character diversity and nearby identifier context.
     .replace(
       /\b[A-Za-z0-9]{20,}\b/g,
       (run, offset, input: string) =>
-        /\d/.test(run) || hasAlphaIdentifierContext(input, offset) ? "<redacted>" : run,
+        /\d/.test(run) ||
+        (looksLikeOpaqueAlphaRun(run) && hasAlphaIdentifierContext(input, offset))
+          ? "<redacted>"
+          : run,
     );
   return masked.replace(/\s+/g, " ").trim().slice(0, max);
 }

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -184,13 +184,13 @@ function parseWaitFromProse(text: string): number | null {
  * screenshotted.
  */
 const ALPHA_IDENTIFIER_LABEL =
-  /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*[\[({]?\s*|[\[({]\s*)?$/i;
+  /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])?\s*$/i;
 const DIRECT_ACCOUNT_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)account\s*(?:[,;:=]\s*|[\[({]\s*|[-_]+\s*|\s+)$/i;
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)account\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({]|\s+)$/i;
 const DIRECT_USER_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)user\s*(?:[,;:=]\s*|[\[({]\s*|[-_]+\s*|\s+)$/i;
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)user\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({]|\s+)$/i;
 const DIRECT_PUNCTUATED_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;:=]\s*[\[({]?|[-_]+\s*|[\[({])\s*$/i;
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])\s*$/i;
 const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 const NATURAL_LANGUAGE_SUFFIX =
   /(?:istically|ization|isation|tion|sion|ment|ness|ity|ically|ingly|edly|ful|less|able|ible|ive|ous|ance|ence)$/i;
@@ -223,6 +223,11 @@ function hasAlphaIdentifierContext(input: string, offset: number, run: string): 
   );
 }
 
+function preserveNaturalLanguagePrefixedRun(run: string, prefix: string): boolean {
+  const tail = run.slice(prefix.length).split(/[-_]+/)[0];
+  return looksLikeNaturalLanguageWord(tail);
+}
+
 export function sanitizeDetail(raw: string, max = 200): string {
   const masked = redactTokens(raw)
     // E-mail addresses FIRST: the local part may itself look like a bare id,
@@ -240,22 +245,24 @@ export function sanitizeDetail(raw: string, max = 200): string {
       /\b(?:([A-Za-z][A-Za-z0-9]{1,12})[-_])?[A-Za-z0-9]{0,32}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[A-Za-z0-9]{0,32}\b/g,
       (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
     )
-    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Common
-    // label words followed by a hyphen are prose, not vendor prefixes.
+    // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Natural
+    // language tails such as compartmentalization_v2 remain readable.
     .replace(
-      /\b(?!(?:(?:account|acct|user|workspace|token|key)[_-](?:id|identifier)\b))(?!(?:account|user)[-_])([A-Za-z][A-Za-z0-9]{1,12}[-_]+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
-      "$1<redacted>",
+      /\b(?!(?:(?:account|acct|user|workspace|token|key)[_-](?:id|identifier)(?=$|[:=\s])))((?:[A-Za-z][A-Za-z0-9]{0,12}[-_]+)+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
+      (run, prefix: string) =>
+        preserveNaturalLanguagePrefixedRun(run, prefix) ? run : `${prefix}<redacted>`,
     )
     // bare long hex / base62 runs (an id that came without a prefix). Digits
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
     // so require explicit label syntax or an account-status boundary.
     .replace(
       /\b[A-Za-z0-9]{20,}(?:[-_]+[A-Za-z0-9]+)*\b/g,
-      (run, offset, input: string) =>
-        /\d/.test(run) ||
-        hasAlphaIdentifierContext(input, offset, run)
+      (run, offset, input: string) => {
+        const naturalLanguage = looksLikeNaturalLanguageWord(run.split(/[-_]+/)[0]);
+        return !naturalLanguage && (/\d/.test(run) || hasAlphaIdentifierContext(input, offset, run))
           ? "<redacted>"
-          : run,
+          : run;
+      },
     );
   return masked.replace(/\s+/g, " ").trim().slice(0, max);
 }

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -185,13 +185,8 @@ function parseWaitFromProse(text: string): number | null {
  */
 const ALPHA_IDENTIFIER_LABEL =
   /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])?\s*$/i;
-const DIRECT_ACCOUNT_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)account\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({]|\s+)$/i;
-const DIRECT_USER_LABEL =
-  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)user\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({]|\s+)$/i;
 const DIRECT_PUNCTUATED_LABEL =
   /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])\s*$/i;
-const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
 type AlphaRunClassification = "identifier" | "prose";
 type AlphaRunBoundary = "bare-prose" | "lexical-label-prose";
 
@@ -210,23 +205,6 @@ const ALPHA_RUN_CLASSIFICATION: ReadonlyMap<string, ReadonlySet<AlphaRunBoundary
 function classifyAlphaRun(run: string, boundary: AlphaRunBoundary = "bare-prose"): AlphaRunClassification {
   const base = run.split(/[-_]+/)[0].toLowerCase();
   return ALPHA_RUN_CLASSIFICATION.get(base)?.has(boundary) ? "prose" : "identifier";
-}
-
-function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
-  const before = input.slice(Math.max(0, offset - 64), offset);
-  if (ALPHA_IDENTIFIER_LABEL.test(before)) return true;
-  const explicitWrapper = DIRECT_PUNCTUATED_LABEL.test(before) && /(?:=|[\[({])\s*$/.test(before);
-  if (explicitWrapper) return true;
-  if (!DIRECT_ACCOUNT_LABEL.test(before) && !DIRECT_USER_LABEL.test(before)) return false;
-
-  const after = input.slice(offset + run.length);
-  const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
-  return (
-    run.includes("-") ||
-    !afterClosingPunctuation.trim() ||
-    /^[\s]*[.,;!?)]/.test(after) ||
-    IDENTIFIER_STATUS.test(afterClosingPunctuation)
-  );
 }
 
 function hasExplicitAlphaIdentifierBoundary(input: string, offset: number): boolean {
@@ -267,15 +245,14 @@ export function sanitizeDetail(raw: string, max = 200): string {
       (run, prefix: string) =>
         preserveNaturalLanguagePrefixedRun(run, prefix) ? run : `${prefix}<redacted>`,
     )
-    // bare long hex / base62 runs (an id that came without a prefix). Digits
-    // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
-    // so require explicit label syntax or an account-status boundary.
+    // Bare long runs are identifiers unless the explicit prose table recognizes
+    // a bare prose boundary. Structured labels and wrappers override that table.
     .replace(
       /\b[A-Za-z0-9]{20,}(?:[-_]+[A-Za-z0-9]+)*\b/g,
       (run, offset, input: string) => {
         const explicitIdentifier = hasExplicitAlphaIdentifierBoundary(input, offset);
         if (!explicitIdentifier && classifyAlphaRun(run) === "prose") return run;
-        return /\d/.test(run) || hasAlphaIdentifierContext(input, offset, run) ? "<redacted>" : run;
+        return "<redacted>";
       },
     );
   return masked.replace(/\s+/g, " ").trim().slice(0, max);

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -192,17 +192,24 @@ const DIRECT_USER_LABEL =
 const DIRECT_PUNCTUATED_LABEL =
   /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|[\[({])\s*$/i;
 const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
-const NATURAL_LANGUAGE_SUFFIX =
-  /(?:istically|ization|isation|tion|sion|ment|ness|ity|ically|ingly|edly|ful|less|able|ible|ive|ous|ance|ence)$/i;
+type AlphaRunClassification = "identifier" | "prose";
 
-function looksLikeNaturalLanguageWord(value: string): boolean {
-  const suffix = value.match(NATURAL_LANGUAGE_SUFFIX)?.[0];
-  if (suffix === undefined) return false;
+// There is no reliable morphology or vowel heuristic that can distinguish a
+// minted all-alpha id from an English word. Keep the small prose exception
+// explicit and table-driven; every unlisted long alpha run is classified as an
+// identifier, then bare alpha runs still require an explicit label/status
+// boundary before they are masked.
+const ALPHA_RUN_CLASSIFICATION: ReadonlyMap<string, AlphaRunClassification> = new Map([
+  ["compartmentalization", "prose"],
+  ["counterrevolutionary", "prose"],
+  ["internationalization", "prose"],
+  ["nondeterministically", "prose"],
+  ["uncharacteristically", "prose"],
+]);
 
-  const stem = value.slice(0, -suffix.length);
-  // A short stem with a non-English q-shape is an opaque id plus a prose-like
-  // suffix (for example, qavexidopulnertisktion), not ordinary prose.
-  return stem.length < 20 && !/q(?!u)/i.test(stem);
+function classifyAlphaRun(run: string): AlphaRunClassification {
+  const base = run.split(/[-_]+/)[0].toLowerCase();
+  return ALPHA_RUN_CLASSIFICATION.get(base) ?? "identifier";
 }
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
@@ -214,7 +221,6 @@ function hasAlphaIdentifierContext(input: string, offset: number, run: string): 
 
   const after = input.slice(offset + run.length);
   const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
-  if (looksLikeNaturalLanguageWord(run.split(/[-_]+/)[0])) return false;
   return (
     run.includes("-") ||
     !afterClosingPunctuation.trim() ||
@@ -225,7 +231,7 @@ function hasAlphaIdentifierContext(input: string, offset: number, run: string): 
 
 function preserveNaturalLanguagePrefixedRun(run: string, prefix: string): boolean {
   const tail = run.slice(prefix.length).split(/[-_]+/)[0];
-  return looksLikeNaturalLanguageWord(tail);
+  return classifyAlphaRun(tail) === "prose";
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -246,7 +252,7 @@ export function sanitizeDetail(raw: string, max = 200): string {
       (_m, prefix: string | undefined) => (prefix ? `${prefix}-<redacted>` : "<redacted>"),
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…. Natural
-    // language tails such as compartmentalization_v2 remain readable.
+    // language tails listed in ALPHA_RUN_CLASSIFICATION remain readable.
     .replace(
       /\b(?!(?:(?:account|acct|user|workspace|token|key)[_-](?:id|identifier)(?=$|[:=\s])))((?:[A-Za-z][A-Za-z0-9]{0,12}[-_]+)+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*\b/gi,
       (run, prefix: string) =>
@@ -258,8 +264,8 @@ export function sanitizeDetail(raw: string, max = 200): string {
     .replace(
       /\b[A-Za-z0-9]{20,}(?:[-_]+[A-Za-z0-9]+)*\b/g,
       (run, offset, input: string) => {
-        const naturalLanguage = looksLikeNaturalLanguageWord(run.split(/[-_]+/)[0]);
-        return !naturalLanguage && (/\d/.test(run) || hasAlphaIdentifierContext(input, offset, run))
+        return classifyAlphaRun(run) === "identifier" &&
+          (/\d/.test(run) || hasAlphaIdentifierContext(input, offset, run))
           ? "<redacted>"
           : run;
       },

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -186,19 +186,29 @@ function parseWaitFromProse(text: string): number | null {
 const ALPHA_IDENTIFIER_LABEL =
   /\b(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\s*(?:[:=]\s*[\[({]?\s*|[\[({]\s*)?$/i;
 const DIRECT_ACCOUNT_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)account\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
-const DIRECT_USER_LABEL = /(?:^|[.!?;]\s*)user\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
+const DIRECT_USER_LABEL = /(?:^|[.!?;]\s*|(?:your|the)\s+)user\s*(?:[:=]\s*|[\[({]\s*|\s+)$/i;
+const DIRECT_PUNCTUATED_LABEL =
+  /(?:^|[.!?;]\s*|(?:your|the)\s+)(?:account|user)\s*(?:[:=]\s*[\[({]?|[\[({])\s*$/i;
 const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
+const NATURAL_LANGUAGE_SUFFIX =
+  /(?:istically|ization|isation|tion|sion|ment|ness|ity|ically|ingly|edly|ful|less|able|ible|ive|ous|ance|ence)$/i;
+
+function looksLikeNaturalLanguageWord(value: string): boolean {
+  return NATURAL_LANGUAGE_SUFFIX.test(value);
+}
 
 function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
   const before = input.slice(Math.max(0, offset - 64), offset);
   if (ALPHA_IDENTIFIER_LABEL.test(before)) return true;
+  if (DIRECT_PUNCTUATED_LABEL.test(before)) return true;
   if (!DIRECT_ACCOUNT_LABEL.test(before) && !DIRECT_USER_LABEL.test(before)) return false;
 
   const after = input.slice(offset + run.length);
   const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
+  if (looksLikeNaturalLanguageWord(run.split("-")[0])) return false;
   return (
     run.includes("-") ||
-    !after.trim() ||
+    !afterClosingPunctuation.trim() ||
     /^[\s]*[.,;!?)]/.test(after) ||
     IDENTIFIER_STATUS.test(afterClosingPunctuation)
   );
@@ -228,7 +238,7 @@ export function sanitizeDetail(raw: string, max = 200): string {
     // remain a strong shape signal. Alpha-only runs are ambiguous with prose,
     // so require explicit label syntax or an account-status boundary.
     .replace(
-      /\b[A-Za-z0-9]{20,}(?:-[A-Za-z0-9]+)?\b/g,
+      /\b[A-Za-z0-9]{20,}(?:-[A-Za-z0-9]+)*\b/g,
       (run, offset, input: string) =>
         /\d/.test(run) ||
         hasAlphaIdentifierContext(input, offset, run)

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -185,6 +185,12 @@ function parseWaitFromProse(text: string): number | null {
  * screenshotted.
  */
 export function sanitizeDetail(raw: string, max = 200): string {
+  const looksLikeOpaqueAlphaRun = (value: string): boolean => {
+    const vowelCount = value.match(/[aeiou]/gi)?.length ?? 0;
+    // Natural-language words need more vowels than opaque base62-like ids.
+    return vowelCount * 3 < value.length;
+  };
+
   const masked = redactTokens(raw)
     // UUID-shaped ids FIRST, with any prefix attached. Their hyphens defeat both
     // rules below: the longest unbroken run inside a UUID is 12 characters, so the
@@ -199,6 +205,7 @@ export function sanitizeDetail(raw: string, max = 200): string {
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
+<<<<<<< HEAD
     // bare long runs (an id that came without a prefix). LENGTH is the whole
     // test: there is deliberately no `(?=[A-Za-z0-9]*\d)` lookahead requiring
     // a digit. That lookahead was here until #2313, and it meant an all-alphabetic


### PR DESCRIPTION
## Summary\n\n- remove the digit requirement from sanitizeDetail's bare identifier-run rule\n- redact all-alphabetic 20+ character identifier runs\n- preserve ordinary explanatory sentences with regression coverage\n\nFixes #2313\n\nThis is stacked on PR #2294 (fix/rate-limit-429).\n\n## Validation\n\n- npm.cmd exec vitest -- run src/__tests__/orchestrator/rate-limit.test.ts\n- npm.cmd run build