### PR TITLE
fix(runpod): the pod tells you the one command that connects it

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -242,7 +242,7 @@ RUN if [ -n "${WHEEL_SAGE}${WHEEL_XFORMERS}" ]; then \
 # Bump PANEL_CACHEBUST (e.g. to the target panel commit SHA) to force a fresh
 # panel clone WITHOUT busting the expensive torch/sage layers above. `git clone
 # --branch` only accepts a ref name (not a raw SHA), so pinning is done here.
-ARG PANEL_CACHEBUST=923330b
+ARG PANEL_CACHEBUST=7b477d55
 RUN echo "panel cachebust: ${PANEL_CACHEBUST}" \
  && git clone --depth 1 ${PANEL_REF:+--branch "${PANEL_REF}"} \
       "${PANEL_REPO}" "${COMFY_HOME}/custom_nodes/comfyui-mcp-panel" \

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -619,6 +619,31 @@ ARGS=(--listen 0.0.0.0 --port "${COMFY_PORT}"
 # shellcheck disable=SC2206
 [ -n "${COMFY_EXTRA_ARGS}" ] && ARGS+=(${COMFY_EXTRA_ARGS})
 
+# ---- The one line a user needs to drive this pod's Agent Panel ---------------
+#
+# The panel already builds this command itself (its connectCommand() appends the
+# page's own origin whenever the page is served over https), but only INSIDE the
+# sidebar's setup card. A user who has not opened that card - or who is looking at
+# the "starting" page because ComfyUI is still booting - never sees it, and the
+# panel's Bridge URL field reads ws://127.0.0.1:9199, which looks like the pod is
+# misconfigured. It is not: the orchestrator runs on the USER's machine and tunnels
+# back to the panel, so this proxy URL is the only part they cannot guess.
+POD_URL=""
+[ -n "${RUNPOD_POD_ID:-}" ] && POD_URL="https://${RUNPOD_POD_ID}-3000.proxy.runpod.net"
+POD_URL_LOG="${POD_URL:-https://<pod-id>-3000.proxy.runpod.net}"
+
+# Stamp it into the "ComfyUI is starting…" page (nginx serves that whenever :3001
+# is not reachable yet) - the FIRST thing anyone sees on a cold pod. Best-effort:
+# a missing or already-substituted page must never keep the pod from booting.
+STARTING_PAGE="${STARTING_PAGE:-/usr/share/nginx/html/readme.html}"
+if [ -f "${STARTING_PAGE}" ]; then
+  if sed -i "s|__POD_URL__|${POD_URL:-https://&lt;pod-id&gt;-3000.proxy.runpod.net}|g" "${STARTING_PAGE}" 2>/dev/null; then
+    log "starting page stamped with the connect command (${STARTING_PAGE})"
+  else
+    log "WARN: could not stamp ${STARTING_PAGE} — the starting page keeps its placeholder"
+  fi
+fi
+
 cd "${COMFY_HOME}"
 log "launching ComfyUI: ${VPY} main.py ${ARGS[*]}"
 log "  software   : ${COMFY_HOME}        (image; immutable, fast local import)"
@@ -626,10 +651,23 @@ log "  user dir   : ${USER_DIR}          (volume; workflows + settings)"
 log "  models     : ${MODELS_DIR}        (volume; downloads persist here)"
 log "  input/out  : ${INPUT_DIR} / ${OUTPUT_DIR}  (volume)"
 log "  HTTP (nginx): :3000  ->  ComfyUI :${COMFY_PORT}"
-log "  RunPod proxy: https://<pod-id>-3000.proxy.runpod.net"
+log "  RunPod proxy: ${POD_URL_LOG}"
 nohup "${VPY}" main.py "${ARGS[@]}" >>"${COMFY_LOG}" 2>&1 &
 COMFY_PID=$!
 log "ComfyUI started (pid=${COMFY_PID}); streaming ${COMFY_LOG}"
+
+# Printed AFTER the launch line so it is the last thing in the boot log before the
+# ComfyUI stream takes over - i.e. what a user actually sees in the RunPod console.
+log ""
+log "──────────────────────────────────────────────────────────────────────"
+log " Agent Panel — run this on YOUR machine to connect it to this pod:"
+log ""
+log "   npx -y comfyui-mcp@latest connect ${POD_URL_LOG}"
+log ""
+log " The agent runs on your own Claude / ChatGPT / Gemini login. Nothing"
+log " extra is installed here. Then click Connect in the Agent sidebar."
+log "──────────────────────────────────────────────────────────────────────"
+log ""
 
 # Stream ComfyUI's log to the pod console and hold the pod open. If tail is ever
 # killed, the base's `sleep infinity` still keeps the pod alive.

--- a/docker/runpod/starting.html
+++ b/docker/runpod/starting.html
@@ -31,6 +31,14 @@
     }
     @keyframes s { to { transform: rotate(360deg); } }
     code { background:#0b0e14; padding:.1rem .4rem; border-radius:6px; color:#c8d2e6; }
+    .sep { border: 0; border-top: 1px solid #222838; margin: 1.6rem 0 1.1rem; }
+    .lead { color: #d7dce5; }
+    .cmd {
+      margin: .6rem 0; padding: .7rem .9rem; overflow-x: auto; text-align: left;
+      background: #0b0e14; border: 1px solid #222838; border-radius: 8px;
+      font: 13px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; color: #c8d2e6;
+    }
+    .fine { font-size: .85rem; }
   </style>
 </head>
 <body>
@@ -42,6 +50,19 @@
        fast — no install or sync. ComfyUI initialization typically takes
        <strong>~30-60s</strong>.</p>
     <p>This page refreshes automatically.</p>
+
+    <!--
+      __POD_URL__ is substituted by post_start.sh at boot, which is the only place
+      that knows RUNPOD_POD_ID. The Agent Panel renders this same command inside its
+      setup card, but a user landing on a cold pod has no panel yet - and this URL is
+      the one thing they cannot guess.
+    -->
+    <hr class="sep" />
+    <p class="lead">To drive this pod with the Agent Panel, run this on <strong>your own machine</strong>:</p>
+    <pre class="cmd">npx -y comfyui-mcp@latest connect __POD_URL__</pre>
+    <p class="fine">The agent runs on your own Claude / ChatGPT / Gemini login &mdash; nothing
+       extra is installed on this pod. Then open ComfyUI and click <strong>Connect</strong>
+       in the Agent sidebar.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Why

A RunPod user's first encounter with the Agent Panel is a Bridge URL reading
`ws://127.0.0.1:9199`. That reads as a broken template — it was reported to me
as exactly that. It isn't broken: the orchestrator runs on the **user's**
machine and tunnels back (the panel dials the `wss://` URL the orchestrator
advertises, never loopback, on an https pod). The only thing a user genuinely
cannot guess is this pod's own proxy URL.

The panel *does* render the correct command — `connectCommand()` appends
`location.origin` whenever the page is https — but only inside the sidebar's
setup card. Someone who hasn't opened that card, or who is looking at the
"starting" page while ComfyUI boots, never sees it.

Meanwhile `post_start.sh` was logging a literal placeholder:

```
log "  RunPod proxy: https://<pod-id>-3000.proxy.runpod.net"
```

…while `RUNPOD_POD_ID` sat right there in the environment (already used at
line 288 for the deadman switch).

## What changed

Derive `POD_URL` from `RUNPOD_POD_ID` and surface it in the two places a user
looks *before the panel exists*:

1. **The boot log** — a banner printed after the launch line, so it's the last
   thing before the ComfyUI stream takes over, i.e. what the RunPod console
   shows.
2. **The "ComfyUI is starting…" page** — nginx serves this (`readme.html`)
   whenever `:3001` isn't reachable, so it is the *first* thing anyone sees on a
   cold pod. `starting.html` gains a `__POD_URL__` placeholder that
   `post_start.sh` stamps at boot, since boot is the only moment that knows the
   pod id.

Both fall back to the escaped `<pod-id>` form when `RUNPOD_POD_ID` is absent, so
a non-RunPod host is no worse off than today. The stamp is best-effort and can
never keep the pod from booting; a second boot finds no placeholder and no-ops.

## Verification

`bash -n docker/runpod/post_start.sh` clean. The substitution was exercised both
ways against the real `starting.html`:

```
TEST A (RUNPOD_POD_ID=testpod123):
  npx -y comfyui-mcp@latest connect https://testpod123-3000.proxy.runpod.net
  placeholders left: 0

TEST B (no pod id):
  npx -y comfyui-mcp@latest connect https://&lt;pod-id&gt;-3000.proxy.runpod.net
  placeholders left: 0
```

The `\&` escaping is load-bearing — an unescaped `&` in a sed replacement means
the entire match, which would have produced garbage. Test B is what proves it.

## Related

Pairs with panel #1821 (the setup card couldn't scroll, so the command was
clipped) and #1822 (the command was the card's last child). Those fix
discoverability *inside* the panel; this one puts it in front of a user who
hasn't got that far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y
