### PR TITLE
fix(orchestrator): acknowledge panel completion receipts (#1824)

### DIFF
--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -64,17 +64,30 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
   it("turns an id-less queued_unknown receipt into one ticket without redispatch", async () => {
     let calls = 0;
     let receiptTaken = false;
+    const completionKey = JSON.stringify(["panel-1728", "orchestrator::claude", "prompt-1728", "generation-a"]);
     const bridge = {
       send: async () => ({}),
       canReach: () => true,
       peekLateRunReceipt: (runRid: string) =>
         runRid === "run-rid-1728"
-          ? { runRid, tabId: "panel-1728", promptIds: ["prompt-1728"], lateByMs: 25 }
+          ? {
+              runRid,
+              tabId: "panel-1728",
+              promptIds: ["prompt-1728"],
+              completionKeys: [{ promptId: "prompt-1728", completionKey }],
+              lateByMs: 25,
+            }
           : undefined,
       takeLateRunReceipt: (runRid: string) => {
         if (runRid !== "run-rid-1728" || receiptTaken) return undefined;
         receiptTaken = true;
-        return { runRid, tabId: "panel-1728", promptIds: ["prompt-1728"], lateByMs: 25 };
+        return {
+          runRid,
+          tabId: "panel-1728",
+          promptIds: ["prompt-1728"],
+          completionKeys: [{ promptId: "prompt-1728", completionKey }],
+          lateByMs: 25,
+        };
       },
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "panel-1728");
@@ -106,7 +119,10 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
     expect(text).toMatch(/"prompt_id"\s*:\s*"prompt-1728"/);
     expect(text).toContain("[RECOVERED]");
     expect(text).toContain("completion ticket");
-    expect(RunCompletions.ticketFor("prompt-1728")?.promptId).toBe("prompt-1728");
+    expect(RunCompletions.ticketFor("prompt-1728")).toMatchObject({
+      promptId: "prompt-1728",
+      completionKey,
+    });
     expect(receiptTaken).toBe(true);
 
     // The real journal path now correlates the later bridge executed frame to

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -189,8 +189,158 @@ function makeHarness(backend: AgentBackend) {
     journal.record(tab, payload);
     flush(tab);
   };
-  return { journal, manager, flush, arrive };
+  /** Mirrors index.ts's keyed executed ingress, including the ACK gate. */
+  const arriveProduction = (tab: string, payload: CompletionPayload, conversation: string) => {
+    const completionKey =
+      typeof payload.completion_key === "string" && payload.completion_key.length > 0
+        ? payload.completion_key
+        : null;
+    const promptId = typeof payload.prompt_id === "string" ? payload.prompt_id : null;
+    const alreadyKnown =
+      completionKey !== null &&
+      promptId !== null &&
+      journal.hasCompletionReceipt(completionKey, { promptId, key: tab, conversation });
+    const entry =
+      alreadyKnown || promptId === null
+        ? alreadyKnown
+          ? null
+          : journal.record(tab, payload, { conversation })
+        : journal.record(tab, payload, { conversation });
+    const acked =
+      completionKey !== null &&
+      promptId !== null &&
+      journal.acceptsCompletionReceipt(completionKey, promptId, tab, conversation);
+    flush(tab);
+    return { entry, acked };
+  };
+  return { journal, manager, flush, arrive, arriveProduction };
 }
+
+describe("#1824 production keyed completion ingress", () => {
+  it("ACKs a keyed completion only for the current ticket generation", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-production-1824";
+    const conversation = "orchestrator::claude";
+    const keyA = JSON.stringify([tab, conversation, PROMPT_A, "generation-a"]);
+    const keyB = JSON.stringify([tab, conversation, PROMPT_A, "generation-b"]);
+
+    journal.openRun(PROMPT_A, { tabId: tab, conversation, completionKey: keyA });
+    const first = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_A, completion_key: keyA },
+      conversation,
+    );
+    expect(first.acked).toBe(true);
+    const firstEntry = journal.outstanding(tab)[0];
+    expect(firstEntry).toBeDefined();
+    journal.ack(firstEntry!.token);
+
+    // ComfyUI reused the prompt id. A late frame from generation A must be
+    // journaled as foreign and must not be mistaken for B's receipt.
+    journal.openRun(PROMPT_A, { tabId: tab, conversation, completionKey: keyB });
+    const stale = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_A, completion_key: keyA, note: "stale A" },
+      conversation,
+    );
+    expect(stale.acked).toBe(false);
+    expect(stale.entry?.correlation.status).toBe("foreign");
+    expect(journal.outstanding(tab)).toHaveLength(1);
+  });
+
+  it("fences a watchdog handoff against the panel's keyed completion", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-watchdog-1824";
+    const conversation = "orchestrator::claude";
+    const key = JSON.stringify([tab, conversation, PROMPT_B, "generation-watchdog"]);
+
+    // The history watchdog wins just before the panel frame reaches the
+    // executed ingress. Both observations are the same current ticket.
+    journal.openRun(PROMPT_B, { tabId: tab, conversation, completionKey: key });
+    const watchdog = journal.record(
+      tab,
+      {
+        kind: "executed",
+        prompt_id: PROMPT_B,
+        completion_source: "orchestrator-history-watchdog",
+        images: [{ filename: "watchdog.png" }],
+      },
+      { conversation },
+    );
+    const panel = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_B, completion_key: key, images: [{ filename: "panel.png" }] },
+      conversation,
+    );
+
+    expect(journal.ticketFor(PROMPT_B)).toMatchObject({ completionKey: key });
+    expect(journal.ticketFor(PROMPT_B)?.reused).toBeUndefined();
+    expect(panel.entry?.token).toBe(watchdog.token);
+    expect(panel.entry?.payload.completion_key).toBe(key);
+    expect(panel.entry).toMatchObject({
+      ticketSeq: journal.ticketFor(PROMPT_B)?.seq,
+      correlation: { status: "matched", promptId: PROMPT_B },
+    });
+    expect(panel.acked).toBe(true);
+    expect(journal.outstanding(tab)).toHaveLength(1);
+    expect(journal.outstanding(tab)[0].payload.completion_key).toBe(key);
+  });
+
+  it("keeps a delivered watchdog fallback fenced until the keyed frame arrives", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-watchdog-delivered-1824";
+    const conversation = "orchestrator::claude";
+    const key = JSON.stringify([tab, conversation, PROMPT_C, "generation-watchdog"]);
+
+    journal.openRun(PROMPT_C, { tabId: tab, conversation, completionKey: key });
+    const watchdog = journal.record(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_C, completion_source: "orchestrator-history-watchdog" },
+      { conversation },
+    );
+    journal.deliverPending(tab, () => true);
+    journal.ack(watchdog.token);
+
+    const panel = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_C, completion_key: key },
+      conversation,
+    );
+    expect(panel.entry).toBeNull();
+    expect(panel.acked).toBe(true);
+    expect(journal.outstanding(tab)).toHaveLength(0);
+  });
+
+  it("lets a late receipt bind a settled watchdog ticket without reopening it", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-watchdog-receipt-1824";
+    const conversation = "orchestrator::claude";
+    const key = JSON.stringify([tab, conversation, PROMPT_D, "generation-watchdog"]);
+
+    journal.openRun(PROMPT_D, { tabId: tab, conversation });
+    const watchdog = journal.record(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_D, completion_source: "orchestrator-history-watchdog" },
+      { conversation },
+    );
+    journal.deliverPending(tab, () => true);
+    journal.ack(watchdog.token);
+
+    expect(journal.bindCompletionKey(PROMPT_D, key)).toBe(true);
+    const panel = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_D, completion_key: key },
+      conversation,
+    );
+    expect(panel.entry).toBeNull();
+    expect(panel.acked).toBe(true);
+    expect(journal.outstanding(tab)).toHaveLength(0);
+  });
+});
 
 describe("run completion across automatic goal continuation (#468)", () => {
   it("delivers the completion into the next turn while the agent is busy continuing a goal", async () => {

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -161,7 +161,8 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
 
 describe("#1824 panel completion receipt keys", () => {
   it("coalesces a replay while the first completion is still outstanding", () => {
-    const completionKey = JSON.stringify([TAB, 1824, PID]);
+    const completionKey = JSON.stringify([TAB, CONV, PID, "generation-a"]);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, completionKey });
     const first = journal.record(
       TAB,
       { prompt_id: PID, completion_key: completionKey },
@@ -179,17 +180,18 @@ describe("#1824 panel completion receipt keys", () => {
   });
 
   it("remembers an acknowledged key so a lost panel ack cannot create a second turn", () => {
-    const completionKey = JSON.stringify([TAB, 1824, PID]);
+    const completionKey = JSON.stringify([TAB, CONV, PID, "generation-a"]);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, completionKey });
     journal.record(TAB, { prompt_id: PID, completion_key: completionKey }, { conversation: CONV });
     const [entry] = journal.allOutstanding();
     expect(entry).toBeDefined();
     journal.deliverPending(TAB, () => true);
     journal.ack(entry.token);
 
-    expect(journal.hasCompletionReceipt(completionKey)).toBe(true);
+    expect(journal.hasCompletionReceipt(completionKey, { promptId: PID, key: TAB, conversation: CONV })).toBe(true);
     // This is the guard used by the agent_event ingress: a retry sends the ack
     // again, but does not record another agent-facing completion.
-    if (!journal.hasCompletionReceipt(completionKey)) {
+    if (!journal.hasCompletionReceipt(completionKey, { promptId: PID, key: TAB, conversation: CONV })) {
       journal.record(TAB, { prompt_id: PID, completion_key: completionKey }, { conversation: CONV });
     }
     expect(journal.allOutstanding()).toHaveLength(0);

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -159,6 +159,43 @@ describe("a completion that beats its own ticket is still OURS (#1327)", () => {
   });
 });
 
+describe("#1824 panel completion receipt keys", () => {
+  it("coalesces a replay while the first completion is still outstanding", () => {
+    const completionKey = JSON.stringify([TAB, 1824, PID]);
+    const first = journal.record(
+      TAB,
+      { prompt_id: PID, completion_key: completionKey },
+      { conversation: CONV },
+    );
+
+    const replay = journal.record(
+      TAB,
+      { prompt_id: PID, completion_key: completionKey, note: "same completion replay" },
+      { conversation: CONV },
+    );
+
+    expect(replay.token).toBe(first.token);
+    expect(journal.allOutstanding()).toHaveLength(1);
+  });
+
+  it("remembers an acknowledged key so a lost panel ack cannot create a second turn", () => {
+    const completionKey = JSON.stringify([TAB, 1824, PID]);
+    journal.record(TAB, { prompt_id: PID, completion_key: completionKey }, { conversation: CONV });
+    const [entry] = journal.allOutstanding();
+    expect(entry).toBeDefined();
+    journal.deliverPending(TAB, () => true);
+    journal.ack(entry.token);
+
+    expect(journal.hasCompletionReceipt(completionKey)).toBe(true);
+    // This is the guard used by the agent_event ingress: a retry sends the ack
+    // again, but does not record another agent-facing completion.
+    if (!journal.hasCompletionReceipt(completionKey)) {
+      journal.record(TAB, { prompt_id: PID, completion_key: completionKey }, { conversation: CONV });
+    }
+    expect(journal.allOutstanding()).toHaveLength(0);
+  });
+});
+
 // #1327 RECURRENCE — reported 2026-08-15 on comfyui-mcp 0.51.56, five releases after
 // the fix above shipped (v0.50.100). Same symptom, exact prompt-id match, same tool:
 // `panel_run({to_node_id: 19})` came back RE-DELIVERED with origin UNDETERMINED.

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5547,12 +5547,14 @@ describe("#1728: late panel run receipts", () => {
     const events: unknown[] = [];
     const sock = await connectPanel("tab-1728-receipt");
     bridge.onPanelMessage = (event) => events.push(event);
+    const completionKey = JSON.stringify(["tab-1728-receipt", "session-1728", "prompt-1728", "generation-a"]);
 
     sock.send(
       JSON.stringify({
         type: "run_receipt",
         run_rid: "run-rid-1728",
         prompt_id: "prompt-1728",
+        completion_key: completionKey,
       }),
     );
 
@@ -5561,6 +5563,7 @@ describe("#1728: late panel run receipts", () => {
         runRid: "run-rid-1728",
         tabId: "tab-1728-receipt",
         promptIds: ["prompt-1728"],
+        completionKeys: [{ promptId: "prompt-1728", completionKey }],
       }),
     );
     expect(events.some((event) => (event as { type?: string }).type === "run_receipt")).toBe(false);
@@ -5568,6 +5571,7 @@ describe("#1728: late panel run receipts", () => {
     expect(bridge.takeLateRunReceipt("run-rid-1728")).toMatchObject({
       runRid: "run-rid-1728",
       promptIds: ["prompt-1728"],
+      completionKeys: [{ promptId: "prompt-1728", completionKey }],
     });
     expect(bridge.peekLateRunReceipt("run-rid-1728")).toBeUndefined();
     sock.close();

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5374,13 +5374,29 @@ export async function runPanelOrchestrator(): Promise<void> {
             ? ev.completion_key
             : null;
         const alreadyKnown =
-          completionKey !== null && RunCompletions.hasCompletionReceipt(completionKey);
+          completionKey !== null &&
+          typeof ev.prompt_id === "string" &&
+          RunCompletions.hasCompletionReceipt(completionKey, {
+            promptId: ev.prompt_id,
+            key: event.tab_id,
+            conversation: agentKeyFor(event.tab_id),
+          });
         const entry = alreadyKnown
           ? null
           : RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
               conversation: agentKeyFor(event.tab_id),
             });
-        if (completionKey && typeof ev.prompt_id === "string" && ev.prompt_id.length > 0) {
+        const receiptAccepted =
+          completionKey !== null &&
+          typeof ev.prompt_id === "string" &&
+          ev.prompt_id.length > 0 &&
+          RunCompletions.acceptsCompletionReceipt(
+            completionKey,
+            ev.prompt_id,
+            event.tab_id,
+            agentKeyFor(event.tab_id),
+          );
+        if (receiptAccepted) {
           bridge.push(
             {
               type: "ack",

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5308,6 +5308,8 @@ export async function runPanelOrchestrator(): Promise<void> {
         images?: Array<{ filename: string; subfolder?: string; type?: string }>;
         error?: string;
         note?: string;
+        prompt_id?: string;
+        completion_key?: string;
       };
       // A run error is URGENT: interrupt the live turn + front-queue it ("hey,
       // look at me") so the agent stops and fixes it instead of running blind.
@@ -5355,18 +5357,45 @@ export async function runPanelOrchestrator(): Promise<void> {
       // path — nothing is waiting on them the way a render is.
       if (ev.kind === "executed") {
         // Journal the BLIND-STRIPPED copy: a replay must not resurrect pixels
-        // the blind gate removed on arrival. `null` = the panel re-sent a
-        // completion this tab was already given; suppressed, never duplicated.
+        // the blind gate removed on arrival. A known completion key is the same
+        // completion being retried after a lost receipt, never a new turn.
         // #704 — WHO this completion is being reported to. The tab it arrived on
         // is an address that churns across a panel reconnect (a new `tmp:` id, no
         // same-socket migration to follow); the conversation is what actually
         // queued the run, so it is what decides "this is the run YOU queued"
         // versus the origin-UNDETERMINED warning.
-        const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
-          conversation: agentKeyFor(event.tab_id),
-        });
+        // #1824 — panel_run keeps its completion pending until this receipt. The
+        // key is route/session-scoped by the panel; recognize a replay of that
+        // same key before journaling so a lost ack cannot create a second turn.
+        const completionKey =
+          typeof ev.completion_key === "string" &&
+          ev.completion_key.length > 0 &&
+          ev.completion_key.length <= 512
+            ? ev.completion_key
+            : null;
+        const alreadyKnown =
+          completionKey !== null && RunCompletions.hasCompletionReceipt(completionKey);
+        const entry = alreadyKnown
+          ? null
+          : RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
+              conversation: agentKeyFor(event.tab_id),
+            });
+        if (completionKey && typeof ev.prompt_id === "string" && ev.prompt_id.length > 0) {
+          bridge.push(
+            {
+              type: "ack",
+              ok: true,
+              kind: "completion",
+              prompt_id: ev.prompt_id,
+              completion_key: completionKey,
+            },
+            event.tab_id,
+          );
+        }
         logger.info(
-          `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`,
+          entry
+            ? `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`
+            : `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} replayed an acknowledged run completion key`,
         );
         flushRunCompletions(event.tab_id);
         return;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14180,7 +14180,12 @@ async function reconcileLateRunAck(
   allowPanelQueueUnknown = false,
   expectedTabId?: string,
   expectedPromptCount = 1,
-): Promise<{ result: unknown; lateByMs: number; via: "ack" | "queue" | "queue-uncertain" | "receipt" } | null> {
+): Promise<{
+  result: unknown;
+  lateByMs: number;
+  via: "ack" | "queue" | "queue-uncertain" | "receipt";
+  completionKeys?: Array<{ promptId: string; completionKey: string }>;
+} | null> {
   const parsed = parseToolResultJson(res);
   // An exact Panel receipt is safe even when a queued_unknown reply already
   // carried some ids: the bridge event is the producer's own prompt capture,
@@ -14242,7 +14247,12 @@ async function reconcileLateRunAck(
           const takenReceipt = bridge.takeLateRunReceipt(rid!);
           const result = takenReceipt ? latePanelReceiptResult(parsed, takenReceipt.promptIds) : null;
           if (takenReceipt && result) {
-            return { result, lateByMs: takenReceipt.lateByMs, via: "receipt" };
+            return {
+              result,
+              lateByMs: takenReceipt.lateByMs,
+              via: "receipt",
+              completionKeys: takenReceipt.completionKeys,
+            };
           }
         }
       }
@@ -14279,6 +14289,7 @@ async function reconcileLateRunAck(
             result,
             lateByMs: takenReceipt?.lateByMs ?? Date.now() - startedAt,
             via: "receipt",
+            completionKeys: takenReceipt?.completionKeys,
           };
         }
       }
@@ -17219,15 +17230,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               for (const rawId of promptIds) {
                 const id = typeof rawId === "string" ? rawId.trim() : "";
                 if (!id) continue;
+                const completionKey =
+                  receipt.completionKeys?.find((entry) => entry.promptId === id)?.completionKey ??
+                  taken?.completionKeys?.find((entry) => entry.promptId === id)?.completionKey;
                 // The normal reply/queue fallback owns the same stable prompt
                 // identity when it wins the race. A late receipt is only a
                 // transport retry of that identity; reopening the journal
                 // ticket would mark it reused and disable exact correlation.
                 // A settled ticket is equally authoritative: late
                 // at-least-once receipt frames must be a no-op.
-                if (RunCompletions.hasTicket(id)) continue;
+                if (RunCompletions.hasTicket(id)) {
+                  if (completionKey) RunCompletions.bindCompletionKey(id, completionKey);
+                  continue;
+                }
                 QueueMonitor.markSelfQueued(id);
-                if (RunCompletions.openRun(id, ticketOpts)) opened.push(id);
+                if (
+                  RunCompletions.openRun(id, {
+                    ...ticketOpts,
+                    ...(completionKey ? { completionKey } : {}),
+                  })
+                )
+                  opened.push(id);
               }
               if (opened.length) ctx.onRunTicketOpened?.(opened);
             });
@@ -17238,6 +17261,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         };
         let lateAckNote = "";
+        let lateReceiptCompletionKeys = new Map<string, string>();
         let res: ToolResult;
         try {
           res = await ctx.call(runCmd, 20000, observeRunRid);
@@ -17271,6 +17295,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               : 1,
           );
           if (!recovered) return;
+          for (const entry of recovered.completionKeys ?? []) {
+            if (
+              typeof entry?.promptId === "string" &&
+              typeof entry?.completionKey === "string" &&
+              entry.completionKey.length > 0
+            ) {
+              lateReceiptCompletionKeys.set(entry.promptId, entry.completionKey);
+            }
+          }
           res = ok(recovered.result);
           const promptId =
             typeof (recovered.result as { prompt_id?: unknown }).prompt_id === "string"
@@ -17453,6 +17486,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             if (pendingReceipt && pendingReceipt.tabId === runTicketTab) {
               const takenReceipt = ctx.bridge.takeLateRunReceipt(runRid);
               lateReceiptPromptIds = takenReceipt?.promptIds ?? [];
+              for (const entry of takenReceipt?.completionKeys ?? []) {
+                if (
+                  typeof entry?.promptId === "string" &&
+                  typeof entry?.completionKey === "string" &&
+                  entry.completionKey.length > 0
+                ) {
+                  lateReceiptCompletionKeys.set(entry.promptId, entry.completionKey);
+                }
+              }
             }
           } catch {}
         }
@@ -17505,7 +17547,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             : queuedIds.length === 0
             ? RunCompletions.openRun(undefined, ticketOpts)
             : queuedIds.map((id) => {
-                const opened = RunCompletions.openRun(id, ticketOpts);
+                const completionKey = lateReceiptCompletionKeys.get(id);
+                const opened = RunCompletions.openRun(id, {
+                  ...ticketOpts,
+                  ...(completionKey ? { completionKey } : {}),
+                });
                 if (opened) ticketedPromptIds.push(id);
                 return opened;
               }).some(Boolean);

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -129,6 +129,8 @@ export interface RunTicket {
    * this to reject an unknown completion observed before this run existed. */
   dispatchedAt?: number;
   toNodeId?: number;
+  /** Panel-issued completion identity bound to this ticket generation. */
+  completionKey?: string;
   /**
    * Generation of THIS ticket. Bumped whenever the id is opened again (a fresh
    * ticket after the old one was evicted, or a reopen), so a completion can only
@@ -141,6 +143,8 @@ export interface RunTicket {
   seq: number;
   /** True once a completion for this exact prompt id was acked as delivered. */
   settled: boolean;
+  /** The settled completion came from the history watchdog before Panel's key arrived. */
+  watchdogSettled?: boolean;
   /**
    * This prompt id was queued MORE THAN ONCE, so it no longer identifies a
    * single run.
@@ -345,6 +349,12 @@ function idlessFingerprint(key: string, payload: CompletionPayload): string {
 
 const MAX_COMPLETION_KEY_LENGTH = 512;
 
+type CompletionReceiptIdentity = {
+  promptId: string;
+  owner: string;
+  ticketSeq: number;
+};
+
 function validCompletionKey(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 && value.length <= MAX_COMPLETION_KEY_LENGTH
     ? value
@@ -367,7 +377,7 @@ export class RunCompletionJournalImpl {
   private delivered = new Set<string>();
   /** Route/session-scoped completion keys already acknowledged. The route/session
    * identity is part of the opaque key supplied by the panel. */
-  private completionReceipts = new Set<string>();
+  private completionReceipts = new Map<string, CompletionReceiptIdentity>();
   /** Content fingerprint → delivery time, for ID-LESS completions (which have no
    *  run identity to memoize). Bounded FIFO + a time window, so an identical
    *  re-send is suppressed but a later genuinely-different render is not. */
@@ -508,7 +518,7 @@ export class RunCompletionJournalImpl {
    */
   private claimRaced(
     promptId: string,
-    meta: { tabId: string; conversation?: string; dispatchedAt?: number },
+    meta: { tabId: string; conversation?: string; dispatchedAt?: number; completionKey?: string },
   ): { claimed: Set<JournalEntry>; reissue: Set<string> } {
     const claimed = new Set<JournalEntry>();
     /** Keys whose queued copy was pulled back and must now be re-delivered. */
@@ -520,6 +530,7 @@ export class RunCompletionJournalImpl {
       // belongs here — it stays unidentified rather than being claimed on timing alone.
       if (entry.correlation.status === "unidentified") continue;
       if (entry.correlation.promptId !== promptId) continue;
+      if (meta.completionKey && entry.payload.completion_key !== meta.completionKey) continue;
       if (entry.arrivedAt < meta.dispatchedAt) continue;
       // Only for the party this dispatch belongs to; another tab's completion for
       // the same id is not ours to claim.
@@ -688,7 +699,13 @@ export class RunCompletionJournalImpl {
    *  attribute. */
   openRun(
     promptId: string | null | undefined,
-    meta: { tabId: string; conversation?: string; toNodeId?: number; dispatchedAt?: number },
+    meta: {
+      tabId: string;
+      conversation?: string;
+      toNodeId?: number;
+      dispatchedAt?: number;
+      completionKey?: string;
+    },
   ): boolean {
     if (typeof promptId !== "string" || !promptId) return false;
     // #1327 — CLAIM THE COMPLETION THAT BEAT ITS OWN TICKET.
@@ -730,6 +747,9 @@ export class RunCompletionJournalImpl {
       existing.queuedAt = Date.now();
       if (typeof meta.dispatchedAt === "number") existing.dispatchedAt = meta.dispatchedAt;
       else delete existing.dispatchedAt;
+      const completionKey = validCompletionKey(meta.completionKey);
+      if (completionKey) existing.completionKey = completionKey;
+      else delete existing.completionKey;
       existing.seq = ++this.ticketSeq; // a NEW generation of this id
       // The id no longer identifies ONE run. Every completion for it from here
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
@@ -762,6 +782,7 @@ export class RunCompletionJournalImpl {
       queuedAt: Date.now(),
       ...(typeof meta.dispatchedAt === "number" ? { dispatchedAt: meta.dispatchedAt } : {}),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
+      ...(validCompletionKey(meta.completionKey) ? { completionKey: validCompletionKey(meta.completionKey) } : {}),
       settled: false,
       ...(hasHistory ? { reused: true } : {}),
     });
@@ -800,7 +821,13 @@ export class RunCompletionJournalImpl {
     // A REUSED id proves nothing: the panel sends only the id, so a completion
     // for it could belong to either generation. Report it as foreign — real, but
     // UNDETERMINED — rather than claiming it is the run now outstanding.
-    if (ticket && ownsRun(ticket, key, conversation) && !ticket.reused) {
+    const completionKey = validCompletionKey(payload.completion_key);
+    if (
+      ticket &&
+      ownsRun(ticket, key, conversation) &&
+      !ticket.reused &&
+      (!ticket.completionKey || !completionKey || ticket.completionKey === completionKey)
+    ) {
       return { status: "matched", promptId: pid };
     }
     // #925 — SAY WHICH KIND OF UNDETERMINED THIS IS. The refusal is unchanged;
@@ -850,13 +877,32 @@ export class RunCompletionJournalImpl {
     opts: { conversation?: string } = {},
   ): JournalEntry {
     const completionKey = validCompletionKey(payload.completion_key);
-    if (completionKey) {
-      const existing = [...this.entries.values()].find(
-        (entry) => entry.payload.completion_key === completionKey,
-      );
-      if (existing) return existing;
-    }
     const conversation = opts.conversation;
+    const promptId = typeof payload.prompt_id === "string" ? payload.prompt_id.trim() : "";
+    const ticket = promptId ? this.tickets.get(promptId) : undefined;
+    if (completionKey) {
+      const sameReceipt = [...this.entries.values()].find((entry) => {
+        if (entry.payload.completion_key !== completionKey || entry.key !== key) return false;
+        if (entry.correlation.status === "unidentified" || entry.correlation.promptId !== promptId || entry.superseded) return false;
+        // With no ticket yet, the exact opaque receipt is still safe to
+        // coalesce; it is not an ACK proof. With a ticket, require its exact
+        // generation so prompt-id reuse cannot collapse into the old entry.
+        return !ticket || (entry.ticketSeq ?? 0) === ticket.seq;
+      });
+      if (sameReceipt) return sameReceipt;
+    }
+    // A keyed frame can be the first proof that the panel received its prompt
+    // ticket. Bind it only to the current, non-reused generation; a reused id
+    // must never let an old key become the new run's ACK proof.
+    if (
+      completionKey &&
+      ticket &&
+      !ticket.reused &&
+      ownsRun(ticket, key, conversation) &&
+      !ticket.completionKey
+    ) {
+      ticket.completionKey = completionKey;
+    }
     const correlation = this.correlate(key, payload, conversation);
     let idlessRepeat = false;
     /** This id already stands for more than one run (see RunTicket.reused). */
@@ -888,6 +934,40 @@ export class RunCompletionJournalImpl {
       // ticket after the old one was evicted): different generation, different
       // key, no match.
       gen = this.generationOf(key, correlation.promptId, conversation);
+      if (completionKey) {
+        // Watchdog handoff fence: if the history fallback won the small race
+        // between its final awaiting check and this panel frame, the panel's
+        // keyed event is the same current ticket generation. Reuse the already
+        // journaled fallback and bind the key to it instead of creating a second
+        // agent turn. A reused/foreign generation fails these exact checks and
+        // remains a separately disclosed completion.
+        const watchdogEntry = [...this.entries.values()].find((entry) => {
+          if (entry.payload.completion_source !== "orchestrator-history-watchdog") return false;
+          if (entry.superseded || entry.correlation.status !== "matched") return false;
+          return (
+            entry.key === key &&
+            entry.conversation === conversation &&
+            entry.correlation.promptId === correlation.promptId &&
+            (entry.ticketSeq ?? 0) === gen &&
+            gen > 0
+          );
+        });
+        if (watchdogEntry) {
+          watchdogEntry.payload = { ...watchdogEntry.payload, completion_key: completionKey };
+          return watchdogEntry;
+        }
+        const existing = [...this.entries.values()].find((entry) => {
+          if (entry.payload.completion_key !== completionKey) return false;
+          if (entry.superseded || entry.correlation.status === "unidentified") return false;
+          return (
+            entry.key === key &&
+            entry.correlation.promptId === correlation.promptId &&
+            (entry.ticketSeq ?? 0) === gen &&
+            gen > 0
+          );
+        });
+        if (existing) return existing;
+      }
       // UNPROVABLE identity — no dedupe of any kind is safe:
       //  • `reused`: the id stands for more than one run (see RunTicket.reused).
       //  • gen 0: this tab never ticketed the id, so there is NO generation to
@@ -1240,8 +1320,38 @@ export class RunCompletionJournalImpl {
     // and must not memoize the id as delivered, which would then suppress the new
     // run's real completion.
     if (entry.superseded) return;
-    const completionKey = validCompletionKey(entry.payload.completion_key);
-    if (completionKey) this.memoCompletionReceipt(completionKey);
+    const ticketForEntry =
+      entry.correlation.status === "unidentified"
+        ? undefined
+        : this.tickets.get(entry.correlation.promptId);
+    if (
+      entry.payload.completion_source === "orchestrator-history-watchdog" &&
+      entry.correlation.status === "matched" &&
+      ticketForEntry &&
+      ticketForEntry.seq === entry.ticketSeq &&
+      ticketForEntry.reused !== true
+    ) {
+      ticketForEntry.watchdogSettled = true;
+    }
+    const completionKey =
+      validCompletionKey(entry.payload.completion_key) ??
+      (entry.correlation.status === "matched" &&
+      ticketForEntry &&
+      ticketForEntry.seq === entry.ticketSeq &&
+      ticketForEntry.reused !== true
+        ? validCompletionKey(ticketForEntry.completionKey)
+        : null);
+    if (
+      completionKey &&
+      entry.correlation.status === "matched" &&
+      (entry.ticketSeq ?? 0) > 0
+    ) {
+      this.memoCompletionReceipt(completionKey, {
+        promptId: entry.correlation.promptId,
+        owner: ownerOf(entry.key, entry.conversation),
+        ticketSeq: entry.ticketSeq ?? 0,
+      });
+    }
     if (entry.correlation.status !== "unidentified") {
       // …and do not memoize a REUSED id either. DEFENSE IN DEPTH, not a live
       // defect: `openRun` already clears the memo on every path, so no reachable
@@ -1474,23 +1584,89 @@ export class RunCompletionJournalImpl {
    * The panel uses the answer to resend after a lost receipt without creating
    * a second journal entry/agent turn.
    */
-  hasCompletionReceipt(completionKey: string): boolean {
+  hasCompletionReceipt(
+    completionKey: string,
+    opts: { promptId: string; key?: string; conversation?: string },
+  ): boolean {
     const value = validCompletionKey(completionKey);
     if (!value) return false;
-    if (this.completionReceipts.has(value)) return true;
-    return [...this.entries.values()].some((entry) => entry.payload.completion_key === value);
+    const matchesCurrent = (promptId: string, key?: string, conversation?: string): boolean => {
+      const ticket = this.tickets.get(promptId);
+      if (!ticket || ticket.reused) return false;
+      if (key !== undefined && !ownsRun(ticket, key, conversation)) return false;
+      if (ticket.completionKey !== value) return false;
+      const identity = this.completionReceipts.get(value);
+      if (
+        identity &&
+        identity.promptId === promptId &&
+        identity.ticketSeq === ticket.seq &&
+        identity.owner === ownerOf(key ?? ticket.tabId, conversation ?? ticket.conversation)
+      ) {
+        return true;
+      }
+      return [...this.entries.values()].some(
+        (entry) =>
+          entry.payload.completion_key === value &&
+          !entry.superseded &&
+          entry.correlation.status === "matched" &&
+          entry.correlation.promptId === promptId &&
+          (entry.ticketSeq ?? 0) === ticket.seq &&
+          (entry.key === ticket.tabId ||
+            (ticket.conversation !== undefined && entry.conversation === ticket.conversation)),
+      );
+    };
+    return matchesCurrent(opts.promptId, opts.key, opts.conversation);
   }
 
-  private memoCompletionReceipt(completionKey: string): void {
-    this.completionReceipts.add(completionKey);
+  private memoCompletionReceipt(completionKey: string, identity: CompletionReceiptIdentity): void {
+    this.completionReceipts.delete(completionKey);
+    this.completionReceipts.set(completionKey, identity);
     while (this.completionReceipts.size > MAX_COMPLETION_KEY_MEMO) {
-      const oldest = this.completionReceipts.values().next().value;
+      const oldest = this.completionReceipts.keys().next().value;
       if (oldest === undefined) break;
       this.completionReceipts.delete(oldest);
     }
   }
 
+  /** True only when a keyed panel frame is valid for the current ticket generation. */
+  acceptsCompletionReceipt(
+    completionKey: string,
+    promptId: string,
+    key: string,
+    conversation?: string,
+  ): boolean {
+    const value = validCompletionKey(completionKey);
+    const pid = typeof promptId === "string" ? promptId.trim() : "";
+    if (!value || !pid) return false;
+    const ticket = this.tickets.get(pid);
+    if (!ticket || ticket.reused || !ownsRun(ticket, key, conversation)) return false;
+    if (ticket.completionKey !== value) return false;
+    return this.hasCompletionReceipt(value, { promptId: pid, key, conversation });
+  }
+
   /** Test/diagnostic helpers. */
+  /** Bind a late Panel run receipt to the ticket's current generation. */
+  bindCompletionKey(promptId: string, completionKey: string): boolean {
+    const pid = typeof promptId === "string" ? promptId.trim() : "";
+    const value = validCompletionKey(completionKey);
+    const ticket = pid ? this.tickets.get(pid) : undefined;
+    if (!pid || !value || !ticket || ticket.reused) return false;
+    if (ticket.completionKey && ticket.completionKey !== value) return false;
+    if (ticket.settled && !ticket.completionKey && ticket.watchdogSettled !== true) return false;
+    for (const [otherPromptId, other] of this.tickets) {
+      if (otherPromptId !== pid && other.completionKey === value && other.seq !== ticket.seq) return false;
+    }
+    ticket.completionKey = value;
+    if (ticket.settled && ticket.watchdogSettled === true) {
+      this.memoCompletionReceipt(value, {
+        promptId: pid,
+        owner: ownerOf(ticket.tabId, ticket.conversation),
+        ticketSeq: ticket.seq,
+      });
+    }
+    return true;
+  }
+
   /** Whether this prompt identity still has an open or terminal ticket. */
   hasTicket(promptId: string): boolean {
     return this.tickets.has(promptId);

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -92,6 +92,9 @@ export interface CompletionPayload {
   error?: string;
   note?: string;
   prompt_id?: string;
+  /** Stable panel delivery identity. Replays with this key are the same
+   * completion even when the first WebSocket write was not acknowledged. */
+  completion_key?: string;
   [k: string]: unknown;
 }
 
@@ -265,6 +268,9 @@ const MAX_ENTRIES_TOTAL = 96;
  *  it outlives the tickets that feed it; a resend later than THIS is delivered
  *  again, but as `foreign` — flagged UNDETERMINED, never as the awaited run. */
 const MAX_DELIVERED_MEMO = 512;
+/** Stable panel completion keys remembered after acknowledgement so a lost ack
+ * can be retried without creating a second agent turn. */
+const MAX_COMPLETION_KEY_MEMO = 512;
 /** Tabs whose evicted-completion counter is retained. */
 const MAX_DROPPED_KEYS = 64;
 /** Prompt ids whose ticket THIS party opened and which have since been evicted
@@ -337,6 +343,14 @@ function idlessFingerprint(key: string, payload: CompletionPayload): string {
   return `${key}|~idless~|${payload.kind ?? ""}|${payload.note ?? ""}|${payload.error ?? ""}|${files}`;
 }
 
+const MAX_COMPLETION_KEY_LENGTH = 512;
+
+function validCompletionKey(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_COMPLETION_KEY_LENGTH
+    ? value
+    : undefined;
+}
+
 export class RunCompletionJournalImpl {
   /** prompt id → ticket. Keyed globally: ComfyUI prompt ids are UUIDs, so an
    *  exact match is proof of identity on its own and survives a session's tab
@@ -351,6 +365,9 @@ export class RunCompletionJournalImpl {
    *  panel that re-sends the frame after the entry was removed can't produce a
    *  second delivery. */
   private delivered = new Set<string>();
+  /** Route/session-scoped completion keys already acknowledged. The route/session
+   * identity is part of the opaque key supplied by the panel. */
+  private completionReceipts = new Set<string>();
   /** Content fingerprint → delivery time, for ID-LESS completions (which have no
    *  run identity to memoize). Bounded FIFO + a time window, so an identical
    *  re-send is suppressed but a later genuinely-different render is not. */
@@ -832,6 +849,13 @@ export class RunCompletionJournalImpl {
     payload: CompletionPayload,
     opts: { conversation?: string } = {},
   ): JournalEntry {
+    const completionKey = validCompletionKey(payload.completion_key);
+    if (completionKey) {
+      const existing = [...this.entries.values()].find(
+        (entry) => entry.payload.completion_key === completionKey,
+      );
+      if (existing) return existing;
+    }
     const conversation = opts.conversation;
     const correlation = this.correlate(key, payload, conversation);
     let idlessRepeat = false;
@@ -1216,6 +1240,8 @@ export class RunCompletionJournalImpl {
     // and must not memoize the id as delivered, which would then suppress the new
     // run's real completion.
     if (entry.superseded) return;
+    const completionKey = validCompletionKey(entry.payload.completion_key);
+    if (completionKey) this.memoCompletionReceipt(completionKey);
     if (entry.correlation.status !== "unidentified") {
       // …and do not memoize a REUSED id either. DEFENSE IN DEPTH, not a live
       // defect: `openRun` already clears the memo on every path, so no reachable
@@ -1443,6 +1469,27 @@ export class RunCompletionJournalImpl {
     }
   }
 
+  /**
+   * Is this route-scoped completion already outstanding or acknowledged?
+   * The panel uses the answer to resend after a lost receipt without creating
+   * a second journal entry/agent turn.
+   */
+  hasCompletionReceipt(completionKey: string): boolean {
+    const value = validCompletionKey(completionKey);
+    if (!value) return false;
+    if (this.completionReceipts.has(value)) return true;
+    return [...this.entries.values()].some((entry) => entry.payload.completion_key === value);
+  }
+
+  private memoCompletionReceipt(completionKey: string): void {
+    this.completionReceipts.add(completionKey);
+    while (this.completionReceipts.size > MAX_COMPLETION_KEY_MEMO) {
+      const oldest = this.completionReceipts.values().next().value;
+      if (oldest === undefined) break;
+      this.completionReceipts.delete(oldest);
+    }
+  }
+
   /** Test/diagnostic helpers. */
   /** Whether this prompt identity still has an open or terminal ticket. */
   hasTicket(promptId: string): boolean {
@@ -1456,6 +1503,7 @@ export class RunCompletionJournalImpl {
     this.entries.clear();
     this.dropped.clear();
     this.delivered.clear();
+    this.completionReceipts.clear();
     this.idlessSeen.clear();
     this.forgottenOwnRuns.clear();
     this.seq = 0;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1739,6 +1739,7 @@ export type LateRunReceipt = {
   runRid: string;
   tabId: string;
   promptIds: string[];
+  completionKeys: Array<{ promptId: string; completionKey: string }>;
   lateByMs: number;
 };
 
@@ -2166,7 +2167,10 @@ export class UiBridge {
     { ok: true; cmd: string; tabId: string; ts: number; lateByMs: number; result?: unknown }
   >();
   /** Exact prompt receipts sent by the Panel after its graph_run command returned. */
-  private lateRunReceipts = new Map<string, { tabId: string; promptIds: string[]; ts: number }>();
+  private lateRunReceipts = new Map<
+    string,
+    { tabId: string; promptIds: string[]; completionKeys: Map<string, string>; ts: number }
+  >();
   /** Bounded post-reconcile owners for exact receipts that arrive after panel_run returned. */
   private lateRunReceiptHandoffs = new Map<
     string,
@@ -4265,12 +4269,17 @@ export class UiBridge {
   private recordLateRunReceipt(msg: Record<string, unknown>, tabId: string | null): void {
     const runRid = typeof msg.run_rid === "string" ? msg.run_rid.trim() : "";
     const promptId = typeof msg.prompt_id === "string" ? msg.prompt_id.trim() : "";
+    const completionKey =
+      typeof msg.completion_key === "string" && msg.completion_key.length > 0 && msg.completion_key.length <= 512
+        ? msg.completion_key
+        : "";
     if (!runRid || !promptId || !tabId) return;
     this.pruneLateMutations();
     const prior = this.lateRunReceipts.get(runRid);
     if (prior && prior.tabId !== tabId) return;
     const handoff = this.lateRunReceiptHandoffs.get(runRid);
     const promptIds = prior?.promptIds ?? [];
+    const completionKeys = prior?.completionKeys ?? new Map<string, string>();
     const isNewPromptId = !promptIds.includes(promptId);
     if (
       handoff &&
@@ -4288,7 +4297,8 @@ export class UiBridge {
       if (promptIds.length >= UiBridge.MAX_LATE_MUTATIONS) return;
       promptIds.push(promptId);
     }
-    this.lateRunReceipts.set(runRid, { tabId, promptIds, ts: prior?.ts ?? Date.now() });
+    if (completionKey) completionKeys.set(promptId, completionKey);
+    this.lateRunReceipts.set(runRid, { tabId, promptIds, completionKeys, ts: prior?.ts ?? Date.now() });
     if (
       handoff &&
       handoff.expiresAt > Date.now() &&
@@ -4362,6 +4372,7 @@ export class UiBridge {
       runRid,
       tabId: hit.tabId,
       promptIds: [...hit.promptIds],
+      completionKeys: [...hit.completionKeys.entries()].map(([promptId, completionKey]) => ({ promptId, completionKey })),
       lateByMs: Math.max(0, Date.now() - hit.ts),
     };
   }
@@ -4375,6 +4386,7 @@ export class UiBridge {
       runRid,
       tabId: hit.tabId,
       promptIds: [...hit.promptIds],
+      completionKeys: [...hit.completionKeys.entries()].map(([promptId, completionKey]) => ({ promptId, completionKey })),
       lateByMs: Math.max(0, Date.now() - hit.ts),
     };
   }


### PR DESCRIPTION
Companion protocol change for Artokun/comfyui-mcp-panel#1824.\n\nThe panel now keeps a panel_run completion pending after the browser WebSocket accepts it. This adds a bounded completion_key receipt journal, idempotent replay coalescing, and an explicit completion acknowledgement back to the panel.\n\nTests: run-completion Vitest cluster (6 files, 171 tests); npm run build; npm run lint.