### PR TITLE
fix(2314): guard promoted container widget writes

### DIFF
--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -124,6 +124,7 @@ function runScenario(task) {
           enforces_expected_node_type_at_write: true,
           enforces_expected_scope_at_write: true,
           enforces_expected_scope_graph_identity_at_write: true,
+          enforces_promoted_parent_rail_at_write: true,
           workflow_uuid: MOCK_WORKFLOW_UUID,
         }),
       );

--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -29,7 +29,7 @@ import { WebSocket } from "ws";
 /** Panel version the mock advertises (#1384). Kept in step with the product's own derived
  *  fence minimum by src/__tests__/scripts/knowledge-parity-mock-version.test.ts — a raised
  *  floor fails that test instead of silently refusing every graph write in the smoke. */
-const MOCK_PANEL_VERSION = "0.15.58";
+const MOCK_PANEL_VERSION = "0.15.97";
 /** A well-formed workflow uuid, so the per-command stamp fence has something to fence on. */
 // MOCK_WORKFLOW_UUID is imported above — it belongs with the executors that answer with it.
 
@@ -122,6 +122,8 @@ function runScenario(task) {
           enforces_workflow_stamp: true,
           enforces_workflow_stamp_at_write: true,
           enforces_expected_node_type_at_write: true,
+          enforces_expected_scope_at_write: true,
+          enforces_expected_scope_graph_identity_at_write: true,
           workflow_uuid: MOCK_WORKFLOW_UUID,
         }),
       );

--- a/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
+++ b/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
@@ -155,7 +155,7 @@ const UNAVAILABLE_REFUSAL =
 
 describe("#2000 frontend-only type refused for an unavailable /object_info", () => {
   it("THE REPORTED CASE: names the fact that /object_info never lists this type, and says not to reinstall", async () => {
-    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.60");
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.97");
     expect(r.isError).toBe(true);
     // The panel's own refusal is KEPT — the note is appended, never a replacement.
     expect(r.text).toContain("object_info is unavailable");
@@ -188,11 +188,11 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
 
   it("THE REPORTER'S OWN VERSION is ABOVE the floor — so the note must not depend on skew", async () => {
     // Measured, and it is the reason this note is not gated on the version floor at
-    // all: the reporter ran panel 0.15.60 while the floor is lower, because the floor
+    // all: the reporter ran panel 0.15.98 while the floor is lower, because the floor
     // tracks BRIDGE CAPABILITY requirements, not "the version with the latest fixes".
     // Gating on it would have made this hint fire for almost nobody — and it is also
     // why #1828's skew note could never have fired for this reporter.
-    const REPORTER_VERSION = "0.15.60";
+    const REPORTER_VERSION = "0.15.98";
     expect(compareSemver(REPORTER_VERSION, requiredPanelVersion())).toBeGreaterThan(0);
     const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, REPORTER_VERSION);
     expect(r.text).toContain("FRONTEND-ONLY");
@@ -207,7 +207,7 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
     const r = await addNode(
       "KSampler",
       UNAVAILABLE_REFUSAL.replace("MarkdownNote", "KSampler"),
-      "0.15.60",
+      "0.15.97",
     );
     expect(r.isError).toBe(true);
     expect(r.text).toContain("object_info is unavailable");

--- a/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
+++ b/src/__tests__/orchestrator/panel-kitchen-launch-flag.test.ts
@@ -79,9 +79,17 @@ function textOf(res: ToolResult): string {
 
 function panelKitchenHarness(onGraphQuery?: () => void, onGraphRun?: () => void) {
   const sent: Array<Record<string, unknown>> = [];
+  const beforeDispatch = { count: 0 };
   let widgetReachabilityRetargeted = false;
   const bridge = {
-    send: async (cmd: Record<string, unknown>) => {
+    send: async (
+      cmd: Record<string, unknown>,
+      sendOpts?: { beforeDispatch?: () => void },
+    ) => {
+      if (cmd.cmd === "graph_set_widget") {
+        beforeDispatch.count += 1;
+        sendOpts?.beforeDispatch?.();
+      }
       sent.push(cmd);
       if (cmd.cmd === "graph_query") {
         onGraphQuery?.();
@@ -112,7 +120,7 @@ function panelKitchenHarness(onGraphQuery?: () => void, onGraphRun?: () => void)
   } as unknown as PanelToolCtx["bridge"];
   const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_kitchen")!;
-  return { ctx, def, sent };
+  return { ctx, def, sent, beforeDispatch };
 }
 
 beforeEach(() => {
@@ -266,7 +274,7 @@ describe("panel_kitchen flag apply (#2277)", () => {
   it("refuses widget dispatch when retargeting occurs during reachability wait", async () => {
     kitchenFixture.rec = widgetRecommendation as any;
     kitchenFixture.raceWidgetDispatch = true;
-    const { ctx, def, sent } = panelKitchenHarness();
+    const { ctx, def, sent, beforeDispatch } = panelKitchenHarness();
 
     const res = await def.handler(
       { action: "apply", recommendation_id: widgetRecommendation.id, skip_proof: true } as never,
@@ -279,6 +287,7 @@ describe("panel_kitchen flag apply (#2277)", () => {
     expect(textOf(res)).toMatch(/target changed/i);
     expect(sent.some((cmd) => cmd.cmd === "graph_query")).toBe(true);
     expect(sent.some((cmd) => cmd.cmd === "graph_set_widget")).toBe(false);
+    expect(beforeDispatch.count).toBe(1);
   });
 
   it("returns applied:false/stale when retargeting occurs during post-apply graph_run", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -439,7 +439,7 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
     const { res, cmds } = await run({ widget: "red_prompt" }, { text: "#3 KSampler" });
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("does not probe a generic widget (existing writes stay one hop)", async () => {
@@ -454,13 +454,13 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
       { isError: true, content: [{ type: "text", text: "Error: no connected tab" }] },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("fail-open: a probe with no type still writes", async () => {
     const { res, cmds } = await run({ widget: "negative_prompt" }, { text: "0 match(es)" });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("documents the refusal and the wired-input route on the tool itself", () => {
@@ -549,7 +549,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 3, widget: "lora_1.on", value: false },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("keeps an ordinary dotted STRING widget writable", async () => {
@@ -567,7 +567,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 4, widget: "prompt.foo", value: "safe" },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("keeps the V3 parent selector writable", async () => {
@@ -587,7 +587,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       value: "safe",
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   // ---- the over-refusal controls -------------------------------------------
@@ -629,7 +629,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       value: "4K",
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("keeps every non-STRING child of the same V3 parent writable", async () => {
@@ -639,7 +639,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     ] as Array<[string, string]>) {
       const { res, cmds } = await run(nanoBanana2Detail, { node_id: 31, widget, value });
       expect(res.isError, `${widget} must stay writable`).toBeUndefined();
-      expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
     }
   });
 
@@ -666,7 +666,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     ] as Array<[string, unknown]>) {
       const { res, cmds } = await run(detail, { node_id: 32, widget, value });
       expect(res.isError, `${widget} must stay writable`).toBeUndefined();
-      expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
     }
   });
 
@@ -687,7 +687,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 33, widget: "model.prompt", value: "NEW" },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("names the proven child type in the refusal, so the STRING remedy always fits", async () => {
@@ -733,7 +733,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       nodes: [{ id: 23, type: "MinimaxHailuo03TextToVideoNode", title: "MiniMax" }],
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
   });
 
   it("documents that only a STRING child is refused", () => {
@@ -875,8 +875,8 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query", "graph_set_widget"]);
-    expect(calls[3]).toMatchObject({
+    expect(cmds).toEqual(["graph_query", "graph_query", "graph_set_widget"]);
+    expect(calls[2]).toMatchObject({
       cmd: "graph_set_widget",
       expected_node_type: "OtherLoraLoader",
     });
@@ -975,7 +975,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/cannot set "stack_data"/);
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query"]);
+    expect(cmds).toEqual(["graph_query", "graph_query"]);
   });
 
   it("refuses if the panel tab changes during the final fence", async () => {
@@ -986,7 +986,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/final fence.*different panel tab/);
-    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query"]);
+    expect(cmds).toEqual(["graph_query", "graph_query"]);
   });
 
   it("keeps a different widget writable on the exact DaSiWa node", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -433,7 +433,7 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
     const { res, cmds } = await run({ widget: "red_prompt" }, { text: "#3 KSampler" });
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("does not probe a generic widget (existing writes stay one hop)", async () => {
@@ -448,13 +448,13 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
       { isError: true, content: [{ type: "text", text: "Error: no connected tab" }] },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("fail-open: a probe with no type still writes", async () => {
     const { res, cmds } = await run({ widget: "negative_prompt" }, { text: "0 match(es)" });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("documents the refusal and the wired-input route on the tool itself", () => {
@@ -537,7 +537,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 3, widget: "lora_1.on", value: false },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("keeps an ordinary dotted STRING widget writable", async () => {
@@ -555,7 +555,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 4, widget: "prompt.foo", value: "safe" },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("keeps the V3 parent selector writable", async () => {
@@ -575,7 +575,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       value: "safe",
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   // ---- the over-refusal controls -------------------------------------------
@@ -617,7 +617,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       value: "4K",
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("keeps every non-STRING child of the same V3 parent writable", async () => {
@@ -627,7 +627,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     ] as Array<[string, string]>) {
       const { res, cmds } = await run(nanoBanana2Detail, { node_id: 31, widget, value });
       expect(res.isError, `${widget} must stay writable`).toBeUndefined();
-      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+      expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
     }
   });
 
@@ -654,7 +654,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
     ] as Array<[string, unknown]>) {
       const { res, cmds } = await run(detail, { node_id: 32, widget, value });
       expect(res.isError, `${widget} must stay writable`).toBeUndefined();
-      expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+      expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
     }
   });
 
@@ -675,7 +675,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       { node_id: 33, widget: "model.prompt", value: "NEW" },
     );
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("names the proven child type in the refusal, so the STRING remedy always fits", async () => {
@@ -721,7 +721,7 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
       nodes: [{ id: 23, type: "MinimaxHailuo03TextToVideoNode", title: "MiniMax" }],
     });
     expect(res.isError).toBeUndefined();
-    expect(cmds).toEqual(["graph_query", "graph_set_widget"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("documents that only a STRING child is refused", () => {
@@ -857,8 +857,8 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBeUndefined();
     expect(JSON.parse(res.content[0].text!).set.value).toBe("NEW");
-    expect(cmds).toEqual(["graph_query", "graph_query", "graph_set_widget"]);
-    expect(calls[2]).toMatchObject({
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query", "graph_set_widget"]);
+    expect(calls[3]).toMatchObject({
       cmd: "graph_set_widget",
       expected_node_type: "OtherLoraLoader",
     });
@@ -957,7 +957,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/cannot set "stack_data"/);
-    expect(cmds).toEqual(["graph_query", "graph_query"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query"]);
   });
 
   it("refuses if the panel tab changes during the final fence", async () => {
@@ -968,7 +968,7 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/final fence.*different panel tab/);
-    expect(cmds).toEqual(["graph_query", "graph_query"]);
+    expect(cmds).toEqual(["graph_query", "graph_get_subgraph", "graph_query"]);
   });
 
   it("keeps a different widget writable on the exact DaSiWa node", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -375,6 +375,12 @@ describe("panel-tools: panel_set_widget Anima regional textarea (#1658)", () => 
             }
             return { content: [{ type: "text" as const, text: JSON.stringify(queryReply, null, 2) }] };
           }
+          if (cmd.cmd === "graph_get_subgraph") {
+            return {
+              isError: true,
+              content: [{ type: "text" as const, text: "Error: Node 2768 (KSampler) is not a subgraph" }],
+            };
+          }
           return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
         },
       } as unknown as PanelToolCtx,
@@ -494,6 +500,12 @@ describe("panel-tools: panel_set_widget V3 dynamic-combo sub-widgets (#2299)", (
         cmds.push(String(cmd.cmd));
         if (cmd.cmd === "graph_query") {
           return { content: [{ type: "text" as const, text: JSON.stringify(detail, null, 2) }] };
+        }
+        if (cmd.cmd === "graph_get_subgraph") {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: "Error: Node 23 (OrdinaryNode) is not a subgraph" }],
+          };
         }
         return { content: [{ type: "text" as const, text: JSON.stringify(SET_OK, null, 2) }] };
       },
@@ -798,6 +810,12 @@ describe("panel-tools: panel_set_widget DaSiWa stack_data (#2107)", () => {
             return reply as ToolResult;
           }
           return { content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }] };
+        }
+        if (cmd.cmd === "graph_get_subgraph") {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: "Error: Node 2571 (OtherLoraLoader) is not a subgraph" }],
+          };
         }
         return {
           content: [

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -111,6 +111,11 @@ function bridge(opts: {
   /** #2314 P1: emulate a current receiver that publishes the recursive
    * renamed-promotion terminal witness. */
   promotedTerminalWitnesses?: boolean;
+  /** #2314 final-rail race: relink the parent input after MCP's last
+   * synchronous callback but before the receiver applies graph_set_widget. */
+  parentRailRelinkAfterMcpFence?: boolean;
+  /** Whether the fake receiver enforces the final parent-rail witness. */
+  promotedParentRailFence?: boolean;
   /** Receiver navigation to another graph with the SAME owner/workflow and
    * colliding inner ids. Only graph_identity may distinguish this target. */
   receiverGraphIdentityCollisionAfterMcpFence?: boolean;
@@ -240,6 +245,12 @@ function bridge(opts: {
           mutation?.();
           sendOpts.beforeDispatch();
         }
+        if (opts.parentRailRelinkAfterMcpFence) {
+          // The final MCP callback has already returned. A live panel relation
+          // can change in this window; the expected_scope parent_rail must be
+          // the thing that makes the receiver refuse before mutation.
+          (b as { liveParentRailWidget?: string }).liveParentRailWidget = "relinked_quality_prompt";
+        }
       }
       calls.push({ ...cmd });
       if (cmd.cmd === "graph_set_widget") {
@@ -257,6 +268,18 @@ function bridge(opts: {
             expected.graph_identity !== currentGraphIdentity
           ) {
             throw new Error("graph_set_widget promoted receiver changed before dispatch: Nothing was applied.");
+          }
+          if (
+            expectedScope &&
+            typeof expectedScope === "object" &&
+            !Array.isArray(expectedScope) &&
+            Object.prototype.hasOwnProperty.call(expectedScope, "parent_rail") &&
+            opts.promotedParentRailFence !== false &&
+            (b as { liveParentRailWidget?: string }).liveParentRailWidget !== undefined &&
+            ((expectedScope.parent_rail as Record<string, unknown>)?.widget !==
+              (b as { liveParentRailWidget?: string }).liveParentRailWidget)
+          ) {
+            throw new Error("graph_set_widget promoted parent rail changed before dispatch: Nothing was applied.");
           }
         }
         writes += 1;
@@ -406,6 +429,8 @@ function bridge(opts: {
     tabExpectedNodeTypeFenceCapability: () => true,
     tabExpectedScopeGraphIdentityFenceCapability: () => opts.scopeGraphIdentityFence !== false,
     tabPromotedTerminalWitnessCapability: () => opts.promotedTerminalWitnesses === true,
+    tabPromotedParentRailFenceCapability: () =>
+      opts.promotedParentRailFence ?? opts.promotedTerminalWitnesses === true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
   } as unknown as PanelToolCtx["bridge"];
@@ -1345,6 +1370,33 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
+  it("binds parent-rail authority into final graph_set_widget after graph_enter_subgraph", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        parentRailRelinkAfterMcpFence: true,
+        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/parent rail changed before dispatch/);
+    expect(mutations).toBe(0);
+    expect(calls.map((call) => call.cmd)).toContain("graph_enter_subgraph");
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: 76,
+        widget: "quality_prompt",
+        expected_scope: expect.objectContaining({
+          promoted_widget: "quality_prompt",
+          parent_rail: { authoritative: true, widget: "quality_prompt" },
+        }),
+      }),
+    ]);
+  });
+
   it("refuses a promoted mapping for an old receiver without the graph-identity fence", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
@@ -1358,6 +1410,23 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(true);
     expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedParentRailFence: false,
+        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/lacks the atomic promoted parent-rail write fence/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -304,6 +304,9 @@ function bridge(opts: {
         if (inSubgraph) {
           if (opts.nestedSubgraph instanceof Error) throw opts.nestedSubgraph;
           if (opts.nestedSubgraph) return withCurrentViewing(opts.nestedSubgraph);
+          if (String(cmd.node_id) !== "78") {
+            throw new Error(`Node ${cmd.node_id} (OrdinaryNode) is not a subgraph`);
+          }
           throw new Error("No node with id 78 in the current graph");
         }
         if (opts.subgraph instanceof Error) throw opts.subgraph;
@@ -1065,7 +1068,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/missing, ambiguous, stale, or unresolved/);
+    expect(text).toMatch(/ambiguous|missing, stale, or unresolved/);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -1104,7 +1107,28 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/missing, ambiguous, stale, or unresolved/);
+    expect(text).toMatch(/incomplete or unresolved|missing, ambiguous, stale, or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("does not treat an unrelated witness error as proof that this alias is ordinary", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "ordinary", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: {
+          ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+          promoted_terminals: [
+            ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals,
+            { widget: "<proxyWidgets>", error: "proxyWidgets could not be enumerated" },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -1129,9 +1153,21 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     ]);
   });
 
-  it("preserves the legacy panel path for an alias the old panel cannot witness", async () => {
+  it("keeps the legacy ordinary path only after a definitive non-subgraph response", async () => {
     const { isError, calls } = await setWidget(
-      { node_id: 78, widget: "renamed_alias", value: "new" },
+      { node_id: 78, widget: "ordinary", value: "new" },
+      { firstWrite: "ok", subgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "ordinary" }),
+    ]);
+  });
+
+  it("preserves the legacy same-name promoted mapping without authorizing an outer fallback", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
       {
         firstWrite: "ok",
         subgraph: {
@@ -1143,8 +1179,58 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(false);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
-      expect.objectContaining({ node_id: 78, widget: "renamed_alias" }),
+      expect.objectContaining({ node_id: 76, widget: "quality_prompt" }),
     ]);
+  });
+
+  it.each([
+    ["renamed Anima alias", "quality_alias", "AnimaRegionalCanvasInline", { quality_prompt: "old" }],
+    ["renamed dynamic alias", "dynamic_alias", "DynamicOwner", { model: "owner", "model.prompt": "old" }],
+    ["renamed DaSiWa alias", "stack_alias", "DaSiWa_LTX2LoraLoader", { stack_data: "old" }],
+    ["renamed dotted alias", "model.renamed", "DynamicOwner", { model: "owner", "model.prompt": "old" }],
+  ] as const)("fails closed for a capability-skewed %s instead of writing the outer container", async (
+    _name,
+    widget,
+    type,
+    widgets,
+  ) => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget, value: "new" },
+      {
+        firstWrite: "ok",
+        // A partial/old receiver may even return an empty witness array. It is
+        // not authoritative when hello did not advertise the complete witness
+        // capability, so the renamed relation must still refuse.
+        subgraph: {
+          ...SAFE_ANIMA_SUBGRAPH,
+          nodes: [{ id: 76, type, widgets }],
+          promoted_terminals: [],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/legacy receiver could not prove|No graph_set_widget was dispatched/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("does not ignore an ambiguous unadvertised witness and revive a legacy write", async () => {
+    const entry = CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0];
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        subgraph: {
+          ...SAFE_ANIMA_SUBGRAPH,
+          nodes: [{ id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } }],
+          promoted_terminals: [entry, { ...entry }],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was ambiguous|No graph_set_widget was dispatched/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
   it("does not compare the child graph token with a parent view before entering it", async () => {
@@ -1473,23 +1559,23 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget" && c.node_id === 78)).toHaveLength(1);
   });
 
-  it("fails closed when a scope retry cannot classify the current target", async () => {
+  it("keeps a current-child ordinary write after re-entering its panel route", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 188, widget: "quality_prompt", value: "masterpiece" },
       {
         scopeLost: true,
         preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: new Error("outer wrapper is unavailable after navigation"),
-        detailById: {
-          "188": SAFE_ANIMA_IDENTITY_BY_ID["76"],
+        postEnterGraphQueryById: {
+          "188": new Error("the current child graph could not be classified after entry"),
         },
       },
     );
 
-    expect(isError).toBe(true);
-    expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(isError).toBe(false);
+    expect(text).toMatch(/route was re-entered and the write was retried once/);
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
     expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
   });
 
@@ -2059,6 +2145,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { node_id: 190, widget: "text", value: "hello" },
       {
         ambiguous: true,
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         promotedDetail: {
           nodes: [
             {
@@ -2074,7 +2161,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget", "graph_query"]);
     expect(text).toMatch(/slot:1, name:"text", label:null/);
     expect(text).toMatch(/slot:2, name:"text_1", label:"text"/);
     expect(text).toMatch(/no second write was attempted/i);
@@ -2083,26 +2170,33 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
   it("re-enters the panel-provided scope and retries the inner write once (#2015)", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 188, widget: "text", value: "hello" },
-      { scopeLost: true },
+      { scopeLost: true, preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
       "graph_set_widget",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
       "graph_set_widget",
     ]);
-    expect(calls[1]).toMatchObject({ node_id: "190" });
-    expect(calls[2]).toMatchObject({ node_id: 188, widget: "text", value: "hello" });
+    expect(calls[2]).toMatchObject({ node_id: "190" });
+    expect(calls[4]).toMatchObject({ node_id: 188, widget: "text", value: "hello" });
     expect(text).toMatch(/route was re-entered and the write was retried once/i);
   });
 
   it("uses the captured inner target after navigation when the outer id is unavailable", async () => {
-    const { text, isError, calls } = await setWidget({ node_id: 78, widget: "width", value: 1024 });
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      { preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
+    );
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
       "graph_set_widget",
+      "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
       "graph_query",
@@ -2110,11 +2204,12 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
-    expect(calls[0]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
-    expect(calls[5]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes[0]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
+    expect(writes[1]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
     // Production seam: the outer wrapper is queried only before entry. Both
     // post-entry fences query the captured inner receiver in the current graph.
-    expect(calls.filter((c) => c.cmd === "graph_get_subgraph")).toHaveLength(1);
+    expect(calls.filter((c) => c.cmd === "graph_get_subgraph")).toHaveLength(3);
     expect(
       calls.filter(
         (c) =>
@@ -2123,17 +2218,17 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           String((c.ids as unknown[])[0]) === "76",
       ),
     ).toHaveLength(2);
-    expect(text).toMatch(/inner widget this promotion lists: node 76 "width"/);
+    expect(text).toMatch(/validated promoted inner widget: node 76 "width"/);
     expect(text).not.toMatch(/is not a promoted widget/);
   });
 
   it("a healthy write is untouched — one call, no enter", async () => {
     const { isError, calls } = await setWidget(
       { node_id: 3, widget: "steps", value: 20 },
-      { firstWrite: "ok" },
+      { firstWrite: "ok", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(false);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("a genuine miss is never retried", async () => {
@@ -2154,24 +2249,25 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     const res = await def.handler({ node_id: 78, widget: "foo", value: 1 } as never, ctx);
 
     expect(res.isError).toBe(true);
-    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
-    expect(calls.map((c) => c.cmd)).not.toContain("graph_get_subgraph");
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).toContain("graph_get_subgraph");
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
   it("an UNRELATED failure is never retried", async () => {
     const { isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
-      { firstWrite: "fail" },
+      { firstWrite: "fail", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(true);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("an ambiguous inner mapping is not guessed", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
       {
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: {
           subgraph_of: { node_id: 78, title: "Container" },
           node_count: 2,
@@ -2184,8 +2280,12 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
     expect(isError).toBe(true);
     expect(text).toMatch(/is not a promoted widget/);
-    expect(text).toMatch(/did not uniquely identify/);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_get_subgraph"]);
+    expect(text).toMatch(/ambiguously to 2 inner nodes|did not uniquely identify/);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_get_subgraph",
+    ]);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
@@ -2202,34 +2302,44 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
   it("a failed subgraph read keeps the original refusal", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
-      { subgraph: new Error("Node 78 is not a subgraph") },
+      {
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
+        subgraph: new Error("Node 78 is not a subgraph"),
+      },
     );
     expect(isError).toBe(true);
     expect(text).toMatch(/is not a promoted widget/);
     expect(text).toMatch(/graph_get_subgraph FAILED/);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_get_subgraph"]);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
+    ]);
   });
 
   it("always exits after a successful inner write, and discloses an exit failure", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
-      { exitFails: true },
+      { exitFails: true, preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
-    expect(text).toMatch(/inner widget this promotion lists/);
+    expect(text).toMatch(/validated promoted inner widget/);
     expect(text).toMatch(/panel_exit_subgraph then FAILED/);
-    expect(text).toMatch(/Call panel_exit_subgraph/);
+    expect(text).toMatch(/call panel_exit_subgraph/);
   });
 
   it("exits even when the inner write fails, and keeps the original refusal", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
-      { innerWrite: "fail" },
+      { innerWrite: "fail", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
       "graph_set_widget",
+      "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
       "graph_query",
@@ -2238,19 +2348,30 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_exit_subgraph",
     ]);
     expect(text).toMatch(/is not a promoted widget/);
-    expect(text).toMatch(/Tried the inner mapping node 76 "width"/);
+    expect(text).toMatch(/Tried the promoted inner mapping node 76 "width"/);
     expect(text).toMatch(/inner write rejected/);
   });
 
   it("retries the listed spelling on the wrapper when only the case differed", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "Width", value: 1024 },
-      { remappedWrite: "ok" },
+      { remappedWrite: "ok", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(false);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_set_widget", "graph_set_widget"]);
-    expect(calls[0]).toMatchObject({ widget: "Width" });
-    expect(calls[1]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
+      "graph_enter_subgraph",
+      "graph_query",
+      "graph_query",
+      "graph_set_widget",
+      "graph_exit_subgraph",
+    ]);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes[0]).toMatchObject({ widget: "Width" });
+    expect(writes[1]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
     expect(text).not.toMatch(/is not a promoted widget/);
   });
 });

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -689,6 +689,7 @@ const CURRENT_SAFE_PROMOTED_SUBGRAPH = {
   promoted_terminals: [
     {
       widget: "quality_prompt",
+      parent_rail: { authoritative: true, widget: "quality_prompt" },
       immediate_node_id: 76,
       immediate_widget: "quality_prompt",
       terminal_node_id: 76,
@@ -721,6 +722,7 @@ function nestedTerminalSubgraph(
     promoted_terminals: [
       {
         widget,
+        parent_rail: { authoritative: true, widget },
         immediate_node_id: 188,
         immediate_widget: widget,
         terminal_node_id: terminal.nodeId,
@@ -787,6 +789,7 @@ const NESTED_SAFE_INNER_SUBGRAPH = {
   promoted_terminals: [
     {
       widget: "quality_prompt",
+      parent_rail: { authoritative: true, widget: "quality_prompt" },
       immediate_node_id: 2768,
       immediate_widget: "quality_prompt",
       terminal_node_id: 2768,
@@ -1111,6 +1114,42 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
+  it.each([
+    [
+      "missing parent-rail authority",
+      { ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0], parent_rail: undefined },
+    ],
+    [
+      "externally-linked parent rail",
+      {
+        ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0],
+        parent_rail: { authoritative: false, widget: "quality_prompt" },
+      },
+    ],
+    [
+      "producer refusal for an externally-linked parent rail",
+      {
+        widget: "quality_prompt",
+        immediate_node_id: 76,
+        immediate_widget: "quality_prompt",
+        error: "the promoted parent rail was missing, externally linked, or not authoritative",
+      },
+    ],
+  ])("never authorizes an inner write with %s", async (_name, entry) => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: { ...CURRENT_SAFE_PROMOTED_SUBGRAPH, promoted_terminals: [entry] },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/parent rail|malformed|incomplete|unresolved/i);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
   it("does not treat an unrelated witness error as proof that this alias is ordinary", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "ordinary", value: "new" },
@@ -1271,6 +1310,30 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
             {
               ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0],
               terminal_node_id: 99,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/mapping changed or became unverifiable/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("fails closed when the live parent rail relinks before dispatch", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        preflightSubgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+        subgraph: {
+          ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+          promoted_terminals: [
+            {
+              ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0],
+              parent_rail: { authoritative: true, widget: "relinked_quality_prompt" },
             },
           ],
         },
@@ -1888,6 +1951,7 @@ describe("resolveInnerPromotedTarget", () => {
       promoted_terminals: [
         {
           widget: "width",
+          parent_rail: { authoritative: true, widget: "width" },
           immediate_node_id: 188,
           immediate_widget: "width",
           terminal_node_id: 2768,
@@ -1901,6 +1965,7 @@ describe("resolveInnerPromotedTarget", () => {
     expect(resolveInnerPromotedTarget(nested, "width", 78)).toEqual({
       innerNodeId: 188,
       widget: "width",
+      parentRail: { authoritative: true, widget: "width" },
       terminal: {
         nodeId: 2768,
         nodeType: "KSampler",
@@ -1921,6 +1986,7 @@ describe("resolveInnerPromotedTarget", () => {
       promoted_terminals: [
         {
           widget: "prompt_alias",
+          parent_rail: { authoritative: true, widget: "prompt_b" },
           immediate_node_id: 188,
           immediate_widget: "prompt_b",
           terminal_node_id: 2768,
@@ -1934,6 +2000,7 @@ describe("resolveInnerPromotedTarget", () => {
     expect(resolveInnerPromotedTarget(renamed, "prompt_alias", 78)).toEqual({
       innerNodeId: 188,
       widget: "prompt_b",
+      parentRail: { authoritative: true, widget: "prompt_b" },
       terminal: {
         nodeId: 2768,
         nodeType: "AnimaRegionalCanvasInline",
@@ -2024,6 +2091,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           promoted_terminals: [
             {
               widget: "prompt_alias",
+              parent_rail: { authoritative: true, widget: "prompt_b" },
               immediate_node_id: 188,
               immediate_widget: "prompt_b",
               terminal_node_id: 2768,

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -87,7 +87,9 @@ function bridge(opts: {
    *  continue into the existing post-refusal retry branch. */
   preflightSubgraph?: Record<string, unknown> | Error;
   recoveryPreflightSubgraph?: Record<string, unknown> | Error;
-  subgraphAfterEnter?: Record<string, unknown> | Error;
+  /** #2314: graph_get_subgraph cannot resolve the outer wrapper after entry;
+   * post-entry fences must use a current-graph query of the captured inner id. */
+  postEnterGraphQueryById?: Record<string, Record<string, unknown> | Error>;
   objectInfoRefusal?: boolean;
   refreshNodes?: Record<string, unknown>;
   remappedWriteError?: string;
@@ -154,10 +156,7 @@ function bridge(opts: {
           if (opts.recoveryPreflightSubgraph instanceof Error) throw opts.recoveryPreflightSubgraph;
           return opts.recoveryPreflightSubgraph;
         }
-        if (inSubgraph && opts.subgraphAfterEnter !== undefined) {
-          if (opts.subgraphAfterEnter instanceof Error) throw opts.subgraphAfterEnter;
-          return opts.subgraphAfterEnter;
-        }
+        if (inSubgraph) throw new Error("No node with id 78 in the current graph");
         if (opts.subgraph instanceof Error) throw opts.subgraph;
         return opts.subgraph ?? SUBGRAPH;
       }
@@ -173,12 +172,28 @@ function bridge(opts: {
       }
       if (cmd.cmd === "graph_query") {
         const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        const postEnter =
+          inSubgraph && wantId ? opts.postEnterGraphQueryById?.[wantId] : undefined;
+        if (postEnter !== undefined) {
+          if (postEnter instanceof Error) throw postEnter;
+          return postEnter;
+        }
         if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
           return opts.detailById[wantId];
         }
         if (opts.stackDataIdentity && !inSubgraph) return opts.stackDataIdentity;
         if (opts.stackDataIdentity && inSubgraph) {
           return opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] };
+        }
+        if (inSubgraph && wantId) {
+          const subgraph = opts.subgraph && !(opts.subgraph instanceof Error) ? opts.subgraph : SUBGRAPH;
+          const nodes = Array.isArray(subgraph.nodes) ? subgraph.nodes : [];
+          const node = nodes.find((candidate) =>
+            candidate && typeof candidate === "object" && String(candidate.id) === wantId,
+          );
+          if (node && typeof node.type === "string") {
+            return { nodes: [{ id: node.id, type: node.type }] };
+          }
         }
         return (
           opts.promotedDetail ?? {
@@ -726,13 +741,9 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       {
         scopeLost: true,
         preflightSubgraph: new Error("preflight unavailable"),
-        subgraph: {
-          ...SAFE_ANIMA_SUBGRAPH,
-          subgraph_of: { node_id: 188, title: "Container" },
-        },
+        subgraph: new Error("outer wrapper is unavailable after navigation"),
         detailById: {
-          "188": { nodes: [{ id: 188, type: "SubgraphNode" }] },
-          "76": SAFE_ANIMA_IDENTITY_BY_ID["76"],
+          "188": SAFE_ANIMA_IDENTITY_BY_ID["76"],
         },
       },
     );
@@ -741,7 +752,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
     expect(writes).toHaveLength(2);
     expect(writes[0]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
-    expect(writes[1]).toMatchObject({ node_id: 76, widget: "quality_prompt" });
+    expect(writes[1]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
   });
 
   it("routes a successful object-info retry through the promoted inner guards", async () => {
@@ -786,13 +797,35 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       {
         scopeLost: true,
         preflightSubgraph: new Error("preflight unavailable"),
-        subgraph: {
-          ...DYNAMIC_SUBGRAPH,
-          subgraph_of: { node_id: 188, title: "Container" },
-        },
+        subgraph: new Error("outer wrapper is unavailable after navigation"),
         detailById: {
-          "188": { nodes: [{ id: 188, type: "SubgraphNode" }] },
-          "76": DYNAMIC_DETAIL_BY_ID["76"],
+          "188": {
+            nodes: [
+              {
+                id: 188,
+                type: "OrdinaryNode",
+                widgets: { "model.prompt": "" },
+                inputs: [
+                  { name: "model.prompt", type: "STRING" },
+                ],
+              },
+            ],
+          },
+        },
+        postEnterGraphQueryById: {
+          "188": {
+            nodes: [
+              {
+                id: 188,
+                type: "MinimaxHailuo03TextToVideoNode",
+                widgets: { model: "text-to-video", "model.prompt": "" },
+                inputs: [
+                  { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+                  { name: "model.prompt", type: "STRING" },
+                ],
+              },
+            ],
+          },
         },
       },
     );
@@ -830,13 +863,13 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         firstWriteError: ANIMA_CONTRADICTORY,
         preflightSubgraph: new Error("preflight unavailable"),
         subgraph: SAFE_ANIMA_SUBGRAPH,
-        subgraphAfterEnter: ANIMA_SUBGRAPH,
+        postEnterGraphQueryById: { "76": ANIMA_IDENTITY_BY_ID["76"] },
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
       },
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering/);
+    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering|captured promoted inner receiver/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
   });
 
@@ -848,13 +881,13 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         preflightSubgraph: new Error("preflight unavailable"),
         recoveryPreflightSubgraph: new Error("recovery preflight unavailable"),
         subgraph: SAFE_ANIMA_SUBGRAPH,
-        subgraphAfterEnter: ANIMA_SUBGRAPH,
+        postEnterGraphQueryById: { "76": ANIMA_IDENTITY_BY_ID["76"] },
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
       },
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering/);
+    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering|captured promoted inner receiver/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
   });
 
@@ -1014,9 +1047,9 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
-      "graph_get_subgraph",
       "graph_query",
-      "graph_get_subgraph",
+      "graph_query",
+      "graph_query",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
@@ -1049,12 +1082,11 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
-      "graph_get_subgraph",
       "graph_query",
       "graph_exit_subgraph",
     ]);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
-    expect(text).toMatch(/different node_id|No inner graph_set_widget/);
+    expect(text).toMatch(/different node_id|captured promoted inner receiver|No inner graph_set_widget/);
   });
 
   it("refuses a promoted inner DaSiWa stack write without a second mutation", async () => {
@@ -1081,7 +1113,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
-      "graph_get_subgraph",
+      "graph_query",
       "graph_query",
       "graph_exit_subgraph",
     ]);
@@ -1133,7 +1165,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(text).toMatch(/route was re-entered and the write was retried once/i);
   });
 
-  it("the reporter's case: refuse → get_subgraph → enter → set inner → exit", async () => {
+  it("uses the captured inner target after navigation when the outer id is unavailable", async () => {
     const { text, isError, calls } = await setWidget({ node_id: 78, widget: "width", value: 1024 });
 
     expect(isError).toBe(false);
@@ -1141,13 +1173,24 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_get_subgraph",
       "graph_enter_subgraph",
-      "graph_get_subgraph",
-      "graph_get_subgraph",
+      "graph_query",
+      "graph_query",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
     expect(calls[0]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
     expect(calls[5]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
+    // Production seam: the outer wrapper is queried only before entry. Both
+    // post-entry fences query the captured inner receiver in the current graph.
+    expect(calls.filter((c) => c.cmd === "graph_get_subgraph")).toHaveLength(1);
+    expect(
+      calls.filter(
+        (c) =>
+          c.cmd === "graph_query" &&
+          Array.isArray(c.ids) &&
+          String((c.ids as unknown[])[0]) === "76",
+      ),
+    ).toHaveLength(2);
     expect(text).toMatch(/inner widget this promotion lists: node 76 "width"/);
     expect(text).not.toMatch(/is not a promoted widget/);
   });
@@ -1257,8 +1300,8 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_get_subgraph",
       "graph_enter_subgraph",
-      "graph_get_subgraph",
-      "graph_get_subgraph",
+      "graph_query",
+      "graph_query",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -114,6 +114,15 @@ function bridge(opts: {
   /** Receiver navigation to another graph with the SAME owner/workflow and
    * colliding inner ids. Only graph_identity may distinguish this target. */
   receiverGraphIdentityCollisionAfterMcpFence?: boolean;
+  /** A parent/subgraph scope cached before graph_enter_subgraph. The child
+   * graph token must not be compared against this pre-entry graph. */
+  preEntryScopeRead?: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid?: string;
+    graphIdentity?: string;
+  };
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
@@ -366,7 +375,10 @@ function bridge(opts: {
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
     tabConnectionIdentity: () => connectionIdentity,
-    promotedScopeFor: () => observedPromotedScope,
+    promotedScopeFor: () =>
+      !inSubgraph && opts.preEntryScopeRead
+        ? opts.preEntryScopeRead
+        : observedPromotedScope,
     ...(opts.authoritativeScopeRead
       ? {
           readPromotedScope: async () => {
@@ -667,6 +679,22 @@ const SAFE_ANIMA_SUBGRAPH = {
 const SAFE_ANIMA_IDENTITY_BY_ID = {
   "78": ANIMA_IDENTITY_BY_ID["78"],
   "76": { nodes: [{ id: 76, type: "PrimitiveStringMultiline" }] },
+};
+
+const CURRENT_SAFE_PROMOTED_SUBGRAPH = {
+  ...SAFE_ANIMA_SUBGRAPH,
+  promoted_terminals: [
+    {
+      widget: "quality_prompt",
+      immediate_node_id: 76,
+      immediate_widget: "quality_prompt",
+      terminal_node_id: 76,
+      terminal_node_type: "PrimitiveStringMultiline",
+      terminal_widget: "quality_prompt",
+      terminal_inputs: [],
+      chain_depth: 0,
+    },
+  ],
 };
 
 /** The outer read lists only B. The receiver's terminal witness proves that
@@ -1003,6 +1031,169 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       "graph_get_subgraph",
       "graph_set_widget",
     ]);
+  });
+
+  it("fails closed before the outer write when a current panel omits its witness array", async () => {
+    const missingWitness: Record<string, unknown> = { ...CURRENT_SAFE_PROMOTED_SUBGRAPH };
+    delete missingWitness.promoted_terminals;
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "renamed_alias", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: {
+          ...missingWitness,
+          nodes: [{ id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/omitted the witness array/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("fails closed before any write for an ambiguous current terminal alias", async () => {
+    const entry = CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0];
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: { ...CURRENT_SAFE_PROMOTED_SUBGRAPH, promoted_terminals: [entry, { ...entry }] },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/missing, ambiguous, stale, or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("fails closed before any write for a malformed current terminal witness", async () => {
+    const entry = CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0];
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: { ...CURRENT_SAFE_PROMOTED_SUBGRAPH, promoted_terminals: [{ ...entry, terminal_inputs: "bad" }] },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("fails closed before any write when the current alias loses its _subgraphSlot proof", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: {
+          ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+          promoted_terminals: [
+            {
+              widget: "quality_prompt",
+              error: "_subgraphSlot missing or unresolved",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/missing, ambiguous, stale, or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("keeps a current-panel ordinary subgraph widget on the original outer path", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "ordinary", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: {
+          subgraph_of: { node_id: 78, title: "Ordinary container" },
+          node_count: 1,
+          nodes: [{ id: 76, type: "PrimitiveStringMultiline", widgets: { ordinary: "old" } }],
+          promoted_terminals: [],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "ordinary" }),
+    ]);
+  });
+
+  it("preserves the legacy panel path for an alias the old panel cannot witness", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "renamed_alias", value: "new" },
+      {
+        firstWrite: "ok",
+        subgraph: {
+          ...SAFE_ANIMA_SUBGRAPH,
+          nodes: [{ id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "renamed_alias" }),
+    ]);
+  });
+
+  it("does not compare the child graph token with a parent view before entering it", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        preEntryScopeRead: {
+          known: true,
+          scope: "subgraph",
+          ownerNodeId: "500",
+          workflowUuid: "workflow-a",
+          graphIdentity: "graph:workflow-a-parent",
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.map((call) => call.cmd)).toContain("graph_enter_subgraph");
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 76, widget: "quality_prompt" }),
+    ]);
+  });
+
+  it("fails closed when the current terminal witness relinks before dispatch", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        preflightSubgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+        subgraph: {
+          ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+          promoted_terminals: [
+            {
+              ...CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0],
+              terminal_node_id: 99,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/mapping changed or became unverifiable/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
   it("refuses a promoted mapping for an old receiver without the graph-identity fence", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -100,6 +100,9 @@ function bridge(opts: {
   /** Navigation after MCP's final synchronous callback but before the panel
    * receiver evaluates the expected_scope envelope. */
   receiverNavigationAfterMcpFence?: boolean;
+  /** Receiver navigation to another graph with the SAME owner/workflow and
+   * colliding inner ids. Only graph_identity may distinguish this target. */
+  receiverGraphIdentityCollisionAfterMcpFence?: boolean;
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
@@ -111,12 +114,15 @@ function bridge(opts: {
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let currentOwnerNodeId = 78;
+  let currentGraphIdentity = "graph:workflow-a-root";
+  const targetGraphIdentity = "graph:workflow-a-container-a";
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
   let observedPromotedScope: {
     known: true;
     scope: "root" | "subgraph";
     ownerNodeId: string | null;
     workflowUuid?: string;
+    graphIdentity?: string;
   } | { known: false; reason: string } = {
     known: false,
     reason: "no current panel graph-scope witness has been observed",
@@ -125,27 +131,45 @@ function bridge(opts: {
   const currentViewing = () => ({
     scope: inSubgraph ? "subgraph" : "root",
     ...(inSubgraph ? { owner_node_id: currentOwnerNodeId } : {}),
+    graph_identity: currentGraphIdentity,
     ...(opts.omitWorkflowUuid ? {} : { workflow_uuid: workflowUuid }),
   });
   const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> => {
-    const result = Object.prototype.hasOwnProperty.call(value, "viewing")
+    let result = Object.prototype.hasOwnProperty.call(value, "viewing")
       ? value
       : { ...value, viewing: currentViewing() };
+    const rawOwnerEnvelope = result.subgraph_of;
+    if (rawOwnerEnvelope && typeof rawOwnerEnvelope === "object" && !Array.isArray(rawOwnerEnvelope)) {
+      const owner = rawOwnerEnvelope as Record<string, unknown>;
+      if (!Object.prototype.hasOwnProperty.call(owner, "graph_identity")) {
+        result = { ...result, subgraph_of: { ...owner, graph_identity: targetGraphIdentity } };
+      }
+    }
+    const rawViewing = result.viewing;
+    if (rawViewing && typeof rawViewing === "object" && !Array.isArray(rawViewing)) {
+      const viewingValue = rawViewing as Record<string, unknown>;
+      if (!Object.prototype.hasOwnProperty.call(viewingValue, "graph_identity")) {
+        result = { ...result, viewing: { ...viewingValue, graph_identity: currentGraphIdentity } };
+      }
+    }
     const viewing = result.viewing;
     if (viewing && typeof viewing === "object" && !Array.isArray(viewing)) {
       const identity = viewing as Record<string, unknown>;
       const rawOwner = identity.owner_node_id;
       const rawWorkflowUuid = identity.workflow_uuid;
+      const rawGraphIdentity = identity.graph_identity;
       if (
         (identity.scope === "root" || identity.scope === "subgraph") &&
         (rawOwner === undefined || rawOwner === null || typeof rawOwner === "number" || typeof rawOwner === "string") &&
-        (rawWorkflowUuid === undefined || typeof rawWorkflowUuid === "string")
+        (rawWorkflowUuid === undefined || typeof rawWorkflowUuid === "string") &&
+        (rawGraphIdentity === undefined || typeof rawGraphIdentity === "string")
       ) {
         observedPromotedScope = {
           known: true,
           scope: identity.scope,
           ownerNodeId: rawOwner == null ? null : String(rawOwner),
           ...(rawWorkflowUuid !== undefined ? { workflowUuid: rawWorkflowUuid } : {}),
+          ...(rawGraphIdentity !== undefined ? { graphIdentity: rawGraphIdentity } : {}),
         };
       } else {
         observedPromotedScope = {
@@ -184,6 +208,12 @@ function bridge(opts: {
           // handler applies the frame; this is the architectural race the
           // expected_scope envelope must fence.
           sendOpts.beforeDispatch();
+          if (opts.receiverGraphIdentityCollisionAfterMcpFence) {
+            currentOwnerNodeId = 78;
+            currentGraphIdentity = "graph:workflow-a-container-b";
+          } else {
+            currentOwnerNodeId = 79;
+          }
           mutation?.();
         } else {
           mutation?.();
@@ -202,7 +232,8 @@ function bridge(opts: {
           if (
             expected.scope !== "subgraph" ||
             String(expected.owner_node_id) !== actualOwner ||
-            (expected.workflow_uuid !== undefined && expected.workflow_uuid !== workflowUuid)
+            (expected.workflow_uuid !== undefined && expected.workflow_uuid !== workflowUuid) ||
+            expected.graph_identity !== currentGraphIdentity
           ) {
             throw new Error("graph_set_widget promoted receiver changed before dispatch: Nothing was applied.");
           }
@@ -254,13 +285,15 @@ function bridge(opts: {
         return subgraph instanceof Error ? subgraph : withCurrentViewing(subgraph);
       }
       if (cmd.cmd === "graph_enter_subgraph") {
-        if (opts.enterFails) throw new Error("could not enter subgraph 78");
+      if (opts.enterFails) throw new Error("could not enter subgraph 78");
         inSubgraph = true;
+        currentGraphIdentity = targetGraphIdentity;
         return { scope: "subgraph", node_id: cmd.node_id };
       }
       if (cmd.cmd === "graph_exit_subgraph") {
         if (opts.exitFails) throw new Error("could not confirm exit");
         inSubgraph = false;
+        currentGraphIdentity = "graph:workflow-a-root";
         return { scope: "root" };
       }
       if (cmd.cmd === "graph_query") {
@@ -330,6 +363,7 @@ function bridge(opts: {
               scope: inSubgraph ? "subgraph" : "root",
               ownerNodeId,
               ...(opts.omitWorkflowUuid ? {} : { workflowUuid }),
+              graphIdentity: currentGraphIdentity,
             };
             // Keep the cached reply as a separate value. The live result is
             // the witness the final callback must carry forward.
@@ -797,6 +831,14 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       "malformed viewing workflow identity",
       { ...SAFE_ANIMA_SUBGRAPH, viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: 42 } },
     ],
+    [
+      "malformed viewing graph identity",
+      { ...SAFE_ANIMA_SUBGRAPH, viewing: { scope: "subgraph", owner_node_id: 78, graph_identity: "" } },
+    ],
+    [
+      "malformed target graph identity",
+      { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 78, graph_identity: "" } },
+    ],
   ])("refuses a %s envelope before writing the container", async (_name, subgraph) => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
@@ -817,7 +859,12 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         postEnterGraphQueryById: {
           "76": {
-            viewing: { scope: "subgraph", owner_node_id: 79, workflow_uuid: "workflow-a" },
+            viewing: {
+              scope: "subgraph",
+              owner_node_id: 79,
+              workflow_uuid: "workflow-a",
+              graph_identity: "graph:workflow-a-container-a",
+            },
             nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
           },
         },
@@ -839,7 +886,12 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         postEnterGraphQueryById: {
           "76": {
-            viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-b" },
+            viewing: {
+              scope: "subgraph",
+              owner_node_id: 78,
+              workflow_uuid: "workflow-b",
+              graph_identity: "graph:workflow-a-container-a",
+            },
             nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
           },
         },
@@ -887,6 +939,33 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
     expect(writesApplied).toBe(0);
     expect(authoritativeScopeReads).toBe(1);
+  });
+
+  it("refuses a normal write when a same-id receiver graph changes after the MCP fence", async () => {
+    const { text, isError, calls, writesApplied } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        authoritativeScopeRead: true,
+        receiverNavigationAfterMcpFence: true,
+        receiverGraphIdentityCollisionAfterMcpFence: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/promoted receiver changed|Nothing was applied/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(calls.find((c) => c.cmd === "graph_set_widget")).toMatchObject({
+      expected_scope: {
+        scope: "subgraph",
+        owner_node_id: "78",
+        workflow_uuid: "workflow-a",
+        graph_identity: "graph:workflow-a-container-a",
+      },
+    });
+    expect(writesApplied).toBe(0);
   });
 
   it("keeps a valid same-owner write when workflow_uuid is unavailable", async () => {
@@ -1023,9 +1102,47 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(2);
     expect(writesApplied).toBe(1);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")[1]).toMatchObject({
-      expected_scope: { scope: "subgraph", owner_node_id: "78", workflow_uuid: "workflow-a" },
+      expected_scope: {
+        scope: "subgraph",
+        owner_node_id: "78",
+        workflow_uuid: "workflow-a",
+        graph_identity: "graph:workflow-a-container-a",
+      },
     });
     expect(authoritativeScopeReads).toBe(1);
+  });
+
+  it("refuses a legacy retry when a same-id receiver graph changes after the MCP fence", async () => {
+    const { text, isError, calls, writesApplied } = await setWidget(
+      { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        authoritativeScopeRead: true,
+        receiverNavigationAfterMcpFence: true,
+        receiverGraphIdentityCollisionAfterMcpFence: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/promoted receiver changed|Nothing was applied/);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toMatchObject({
+      node_id: 76,
+      expected_scope: {
+        scope: "subgraph",
+        owner_node_id: "78",
+        workflow_uuid: "workflow-a",
+        graph_identity: "graph:workflow-a-container-a",
+      },
+    });
+    // The outer contradictory attempt is the only receiver-side application;
+    // the remapped inner write is refused by graph identity before apply.
+    expect(writesApplied).toBe(1);
   });
 
   it("routes a successful object-info retry through the promoted inner guards", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -72,6 +72,7 @@ function bridge(opts: {
   remappedWrite?: Outcome;
   innerWrite?: Outcome;
   subgraph?: Record<string, unknown> | Error;
+  nestedSubgraph?: Record<string, unknown> | Error;
   enterFails?: boolean;
   exitFails?: boolean;
   ambiguous?: boolean;
@@ -115,6 +116,7 @@ function bridge(opts: {
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
+  let mutations = 0;
   let subgraphReads = 0;
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
@@ -274,6 +276,7 @@ function bridge(opts: {
               : (opts.remappedWrite ?? "contradict");
         if (which === "contradict") throw new Error(CONTRADICTORY);
         if (which === "fail") throw new Error("inner write rejected");
+        mutations += 1;
         return { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
       }
       if (cmd.cmd === "graph_get_subgraph") {
@@ -286,7 +289,11 @@ function bridge(opts: {
           if (opts.recoveryPreflightSubgraph instanceof Error) throw opts.recoveryPreflightSubgraph;
           return withCurrentViewing(opts.recoveryPreflightSubgraph);
         }
-        if (inSubgraph) throw new Error("No node with id 78 in the current graph");
+        if (inSubgraph) {
+          if (opts.nestedSubgraph instanceof Error) throw opts.nestedSubgraph;
+          if (opts.nestedSubgraph) return withCurrentViewing(opts.nestedSubgraph);
+          throw new Error("No node with id 78 in the current graph");
+        }
         if (opts.subgraph instanceof Error) throw opts.subgraph;
         const subgraph = opts.subgraph ?? SUBGRAPH;
         return subgraph instanceof Error ? subgraph : withCurrentViewing(subgraph);
@@ -416,6 +423,9 @@ function bridge(opts: {
     get writesApplied() {
       return writes;
     },
+    get mutations() {
+      return mutations;
+    },
   };
 }
 
@@ -436,6 +446,7 @@ async function setWidget(
     authoritativeScopeReads: harness.authoritativeScopeReads,
     postEnterGraphQueries: harness.postEnterGraphQueries,
     writesApplied: harness.writesApplied,
+    mutations: harness.mutations,
   };
 }
 
@@ -653,6 +664,168 @@ const SAFE_ANIMA_IDENTITY_BY_ID = {
   "78": ANIMA_IDENTITY_BY_ID["78"],
   "76": { nodes: [{ id: 76, type: "PrimitiveStringMultiline" }] },
 };
+
+/** The outer read lists only B. The receiver's terminal witness proves that
+ * B's own promoted rail continues to the concrete endpoint, so MCP can apply
+ * the three known-bad guards to the node the panel will actually mutate. */
+function nestedTerminalSubgraph(
+  widget: string,
+  terminal: { nodeId: number; nodeType: string; inputs: Array<Record<string, string>> },
+) {
+  return {
+    subgraph_of: { node_id: 78, title: "Nested container" },
+    node_count: 1,
+    nodes: [
+      {
+        id: 188,
+        type: "SubgraphB",
+        is_subgraph: true,
+        widgets: { [widget]: "old" },
+      },
+    ],
+    promoted_terminals: [
+      {
+        widget,
+        immediate_node_id: 188,
+        immediate_widget: widget,
+        terminal_node_id: terminal.nodeId,
+        terminal_node_type: terminal.nodeType,
+        terminal_widget: widget,
+        terminal_inputs: terminal.inputs,
+        chain_depth: 1,
+      },
+    ],
+  };
+}
+
+const NESTED_TERMINAL_CASES = [
+  {
+    name: "Anima regional prompt",
+    widget: "quality_prompt",
+    value: "masterpiece",
+    subgraph: nestedTerminalSubgraph("quality_prompt", {
+      nodeId: 2768,
+      nodeType: "AnimaRegionalCanvasInline",
+      inputs: [],
+    }),
+    firstWriteError: ANIMA_CONTRADICTORY,
+    message: /animaPrompts/,
+  },
+  {
+    name: "dynamic-combo STRING child",
+    widget: "model.prompt",
+    value: "a long prompt",
+    subgraph: nestedTerminalSubgraph("model.prompt", {
+      nodeId: 2769,
+      nodeType: "NestedConcreteNode",
+      inputs: [
+        { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+        { name: "model.prompt", type: "STRING" },
+      ],
+    }),
+    firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
+    message: /dynamic-combo (?:sub-widget|child)/,
+  },
+  {
+    name: "DaSiWa stack",
+    widget: "stack_data",
+    value: "NEW",
+    subgraph: nestedTerminalSubgraph("stack_data", {
+      nodeId: 2770,
+      nodeType: "DaSiWa_LTX2LoraLoader",
+      inputs: [],
+    }),
+    firstWriteError: STACK_DATA_CONTRADICTORY,
+    message: /DaSiWa_LTX2LoraLoader/,
+  },
+] as const;
+
+const NESTED_SAFE_SUBGRAPH = nestedTerminalSubgraph("quality_prompt", {
+  nodeId: 2768,
+  nodeType: "PrimitiveStringMultiline",
+  inputs: [],
+});
+const NESTED_SAFE_INNER_SUBGRAPH = {
+  subgraph_of: { node_id: 188, title: "Nested B" },
+  node_count: 1,
+  nodes: [{ id: 2768, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } }],
+  promoted_terminals: [
+    {
+      widget: "quality_prompt",
+      immediate_node_id: 2768,
+      immediate_widget: "quality_prompt",
+      terminal_node_id: 2768,
+      terminal_node_type: "PrimitiveStringMultiline",
+      terminal_widget: "quality_prompt",
+      terminal_inputs: [],
+      chain_depth: 0,
+    },
+  ],
+};
+
+describe("panel_set_widget nested promoted terminal guards (#2314)", () => {
+  it("rechecks a safe A-to-B-to-concrete endpoint after entry and before dispatch", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        subgraph: NESTED_SAFE_SUBGRAPH,
+        nestedSubgraph: NESTED_SAFE_INNER_SUBGRAPH,
+      },
+    );
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(text).toMatch(/validated promoted inner widget/);
+    expect(calls.filter((c) => c.cmd === "graph_get_subgraph")).toHaveLength(4);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 188, widget: "quality_prompt" }),
+    ]);
+  });
+
+  it.each(NESTED_TERMINAL_CASES)("refuses the nested terminal before a successful write", async ({
+    widget,
+    value,
+    subgraph,
+    message,
+  }) => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget, value },
+      { firstWrite: "ok", subgraph },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(message);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(mutations).toBe(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it.each(NESTED_TERMINAL_CASES)("refuses the nested terminal on the legacy recovery path", async ({
+    widget,
+    value,
+    subgraph,
+    firstWriteError,
+    message,
+  }) => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget, value },
+      {
+        firstWrite: "contradict",
+        firstWriteError,
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
+        subgraph,
+      },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(message);
+    expect(mutations).toBe(0);
+    // Legacy recovery may have made its one contradictory outer attempt before
+    // the terminal witness was read; it must never dispatch the inner/container
+    // success path, and the simulated bridge records zero actual mutations.
+    expect(calls.filter((c) => c.cmd === "graph_set_widget").length).toBeLessThanOrEqual(1);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+    expect(text).toMatch(/No inner graph_set_widget was dispatched|not retried|not applied|Do not retry|No graph_set_widget was dispatched/i);
+  });
+});
 
 describe("panel_set_widget promoted container success guards (#2314)", () => {
   it.each([
@@ -1425,6 +1598,73 @@ describe("resolveInnerPromotedTarget", () => {
 
   it("returns null when no inner node owns the widget", () => {
     expect(resolveInnerPromotedTarget(SUBGRAPH, "denoise", 78)).toBeNull();
+  });
+
+  it("retains a validated terminal concrete witness for a nested promotion", () => {
+    const nested = {
+      ...SUBGRAPH,
+      nodes: [{ id: 188, type: "SubgraphB", is_subgraph: true, widgets: { width: 1920 } }, SUBGRAPH.nodes[1]],
+      promoted_terminals: [
+        {
+          widget: "width",
+          immediate_node_id: 188,
+          immediate_widget: "width",
+          terminal_node_id: 2768,
+          terminal_node_type: "KSampler",
+          terminal_widget: "steps",
+          terminal_inputs: [{ name: "steps", type: "INT" }],
+          chain_depth: 1,
+        },
+      ],
+    };
+    expect(resolveInnerPromotedTarget(nested, "width", 78)).toEqual({
+      innerNodeId: 188,
+      widget: "width",
+      terminal: {
+        nodeId: 2768,
+        nodeType: "KSampler",
+        widget: "steps",
+        inputs: [{ name: "steps", type: "INT" }],
+        chainDepth: 1,
+      },
+    });
+  });
+
+  it.each([
+    ["malformed terminal shape", { terminal_node_id: 2768, terminal_node_type: "KSampler", terminal_widget: "steps", chain_depth: 1 }],
+    ["depth-limited terminal", { terminal_node_id: 2768, terminal_node_type: "KSampler", terminal_widget: "steps", terminal_inputs: [], chain_depth: 17 }],
+  ])("rejects a %s nested terminal envelope", (_name, terminal) => {
+    const nested = {
+      ...SUBGRAPH,
+      nodes: [{ id: 188, type: "SubgraphB", is_subgraph: true, widgets: { width: 1920 } }, SUBGRAPH.nodes[1]],
+      promoted_terminals: [
+        {
+          widget: "width",
+          immediate_node_id: 188,
+          immediate_widget: "width",
+          ...terminal,
+        },
+      ],
+    };
+    expect(validatePromotedSubgraphEnvelope(nested, 78)).toBeNull();
+    expect(resolveInnerPromotedTarget(nested, "width", 78)).toBeNull();
+  });
+
+  it("accepts an explicit unresolved terminal marker but never resolves it", () => {
+    const nested = {
+      ...SUBGRAPH,
+      nodes: [{ id: 188, type: "SubgraphB", is_subgraph: true, widgets: { width: 1920 } }, SUBGRAPH.nodes[1]],
+      promoted_terminals: [
+        {
+          widget: "width",
+          immediate_node_id: 188,
+          immediate_widget: "width",
+          error: "promotion chain is cyclic",
+        },
+      ],
+    };
+    expect(validatePromotedSubgraphEnvelope(nested, 78)).not.toBeNull();
+    expect(resolveInnerPromotedTarget(nested, "width", 78)).toBeNull();
   });
 
   it("rejects an envelope owned by a different outer node", () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -61,6 +61,10 @@ const SUBGRAPH = {
   ],
 };
 
+const DEFINITIVE_NON_PROMOTED_SUBGRAPH = new Error(
+  "Node 78 (OrdinaryNode) is not a subgraph",
+);
+
 type Outcome = "contradict" | "ok" | "fail";
 
 function bridge(opts: {
@@ -100,6 +104,9 @@ function bridge(opts: {
   /** Navigation after MCP's final synchronous callback but before the panel
    * receiver evaluates the expected_scope envelope. */
   receiverNavigationAfterMcpFence?: boolean;
+  /** #2314 P1: emulate an old receiver that does not atomically enforce the
+   * stable graph identity carried by expected_scope. */
+  scopeGraphIdentityFence?: boolean;
   /** Receiver navigation to another graph with the SAME owner/workflow and
    * colliding inner ids. Only graph_identity may distinguish this target. */
   receiverGraphIdentityCollisionAfterMcpFence?: boolean;
@@ -372,6 +379,7 @@ function bridge(opts: {
         }
       : {}),
     tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => opts.scopeGraphIdentityFence !== false,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
   } as unknown as PanelToolCtx["bridge"];
@@ -484,7 +492,7 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
         firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
         subgraph: DYNAMIC_SUBGRAPH,
         detailById: DYNAMIC_DETAIL_BY_ID,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
     expect(isError).toBe(true);
@@ -505,7 +513,7 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
         firstWrite: "contradict",
         firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
         innerWrite: "ok",
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: {
           ...DYNAMIC_SUBGRAPH,
           nodes: [
@@ -582,7 +590,7 @@ describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => 
         firstWriteError: ANIMA_CONTRADICTORY,
         subgraph: ANIMA_SUBGRAPH,
         detailById: ANIMA_IDENTITY_BY_ID,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
     expect(isError).toBe(true);
@@ -615,7 +623,7 @@ describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => 
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
         innerWrite: "ok",
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: {
           ...ANIMA_SUBGRAPH,
           nodes: [
@@ -786,12 +794,29 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(writes[0]).toMatchObject({ node_id: 76, widget });
   });
 
-  it("keeps a successful container write when promotion preflight is unavailable", async () => {
-    const { isError, calls } = await setWidget(
+  it("refuses an indeterminate graph_get_subgraph error before any container write", async () => {
+    const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
         subgraph: new Error("graph_get_subgraph unavailable"),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+    ]);
+  });
+
+  it("keeps a definitive non-promoted write valid", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: new Error("Node 78 (OrdinaryNode) is not a subgraph"),
       },
     );
 
@@ -801,6 +826,23 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       "graph_get_subgraph",
       "graph_set_widget",
     ]);
+  });
+
+  it("refuses a promoted mapping for an old receiver without the graph-identity fence", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        scopeGraphIdentityFence: false,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
   it("refuses when the promotion relinks after classification", async () => {
@@ -1031,7 +1073,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         remappedWriteError: ANIMA_CONTRADICTORY,
         subgraph: ANIMA_SUBGRAPH,
         detailById: ANIMA_IDENTITY_BY_ID,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
 
@@ -1048,7 +1090,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       {
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
       },
@@ -1063,12 +1105,12 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget" && c.node_id === 78)).toHaveLength(1);
   });
 
-  it("routes a successful scope retry through the promoted inner guards", async () => {
-    const { isError, calls } = await setWidget(
+  it("fails closed when a scope retry cannot classify the current target", async () => {
+    const { text, isError, calls } = await setWidget(
       { node_id: 188, widget: "quality_prompt", value: "masterpiece" },
       {
         scopeLost: true,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: new Error("outer wrapper is unavailable after navigation"),
         detailById: {
           "188": SAFE_ANIMA_IDENTITY_BY_ID["76"],
@@ -1076,11 +1118,11 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       },
     );
 
-    expect(isError).toBe(false);
+    expect(isError).toBe(true);
+    expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
-    expect(writes).toHaveLength(2);
-    expect(writes[0]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
-    expect(writes[1]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
+    expect(writes).toHaveLength(1);
+    expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
   });
 
   it("refuses legacy recovery navigation after the live read before inner dispatch", async () => {
@@ -1089,7 +1131,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       {
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         authoritativeScopeRead: true,
@@ -1118,7 +1160,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       {
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         authoritativeScopeRead: true,
@@ -1150,7 +1192,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWriteError: "no usable /object_info was available for this widget write",
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         refreshNodes: { refreshed: true },
@@ -1169,7 +1211,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWriteError: "no usable /object_info was available for this widget write",
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: ANIMA_SUBGRAPH,
         detailById: ANIMA_IDENTITY_BY_ID,
         refreshNodes: { refreshed: true },
@@ -1186,7 +1228,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 188, widget: "model.prompt", value: "a long prompt" },
       {
         scopeLost: true,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: new Error("outer wrapper is unavailable after navigation"),
         detailById: {
           "188": {
@@ -1221,7 +1263,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/dynamic-combo/);
+    expect(text).toMatch(/dynamic-combo|could not determine whether the addressed node is a promoted container/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
   });
 
@@ -1230,7 +1272,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 78, widget: "Stack_Data", value: "NEW" },
       {
         firstWriteError: STACK_DATA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: {
           subgraph_of: { node_id: 78, title: "Container" },
           node_count: 1,
@@ -1251,7 +1293,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWriteError: ANIMA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         postEnterGraphQueryById: { "76": ANIMA_IDENTITY_BY_ID["76"] },
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
@@ -1268,8 +1310,8 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWriteError: ANIMA_CONTRADICTORY,
-        preflightSubgraph: new Error("preflight unavailable"),
-        recoveryPreflightSubgraph: new Error("recovery preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
+        recoveryPreflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
         subgraph: SAFE_ANIMA_SUBGRAPH,
         postEnterGraphQueryById: { "76": ANIMA_IDENTITY_BY_ID["76"] },
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
@@ -1424,7 +1466,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
         },
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
 
@@ -1459,7 +1501,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
         },
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
 
@@ -1490,7 +1532,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader", widgets: { stack_data: "old" } }],
         },
-        preflightSubgraph: new Error("preflight unavailable"),
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
       },
     );
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -108,6 +108,9 @@ function bridge(opts: {
   /** #2314 P1: emulate an old receiver that does not atomically enforce the
    * stable graph identity carried by expected_scope. */
   scopeGraphIdentityFence?: boolean;
+  /** #2314 P1: emulate a current receiver that publishes the recursive
+   * renamed-promotion terminal witness. */
+  promotedTerminalWitnesses?: boolean;
   /** Receiver navigation to another graph with the SAME owner/workflow and
    * colliding inner ids. Only graph_identity may distinguish this target. */
   receiverGraphIdentityCollisionAfterMcpFence?: boolean;
@@ -387,6 +390,7 @@ function bridge(opts: {
       : {}),
     tabExpectedNodeTypeFenceCapability: () => true,
     tabExpectedScopeGraphIdentityFenceCapability: () => opts.scopeGraphIdentityFence !== false,
+    tabPromotedTerminalWitnessCapability: () => opts.promotedTerminalWitnesses === true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
   } as unknown as PanelToolCtx["bridge"];
@@ -1630,6 +1634,39 @@ describe("resolveInnerPromotedTarget", () => {
     });
   });
 
+  it("resolves renamed outer and immediate aliases from the terminal witness", () => {
+    const renamed = {
+      ...SUBGRAPH,
+      nodes: [
+        { id: 188, type: "SubgraphB", is_subgraph: true, widgets: { prompt_b: "old" } },
+        SUBGRAPH.nodes[1],
+      ],
+      promoted_terminals: [
+        {
+          widget: "prompt_alias",
+          immediate_node_id: 188,
+          immediate_widget: "prompt_b",
+          terminal_node_id: 2768,
+          terminal_node_type: "AnimaRegionalCanvasInline",
+          terminal_widget: "quality_prompt",
+          terminal_inputs: [{ name: "quality_prompt", type: "STRING" }],
+          chain_depth: 1,
+        },
+      ],
+    };
+    expect(resolveInnerPromotedTarget(renamed, "prompt_alias", 78)).toEqual({
+      innerNodeId: 188,
+      widget: "prompt_b",
+      terminal: {
+        nodeId: 2768,
+        nodeType: "AnimaRegionalCanvasInline",
+        widget: "quality_prompt",
+        inputs: [{ name: "quality_prompt", type: "STRING" }],
+        chainDepth: 1,
+      },
+    });
+  });
+
   it.each([
     ["malformed terminal shape", { terminal_node_id: 2768, terminal_node_type: "KSampler", terminal_widget: "steps", chain_depth: 1 }],
     ["depth-limited terminal", { terminal_node_id: 2768, terminal_node_type: "KSampler", terminal_widget: "steps", terminal_inputs: [], chain_depth: 17 }],
@@ -1696,6 +1733,38 @@ describe("resolveInnerPromotedTarget", () => {
 });
 
 describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
+  it("refuses a renamed nested terminal before the first container write (#2314 P1)", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "prompt_alias", value: "unsafe" },
+      {
+        promotedTerminalWitnesses: true,
+        subgraph: {
+          ...SUBGRAPH,
+          nodes: [
+            { id: 188, type: "SubgraphB", is_subgraph: true, widgets: { prompt_b: "old" } },
+            SUBGRAPH.nodes[1],
+          ],
+          promoted_terminals: [
+            {
+              widget: "prompt_alias",
+              immediate_node_id: 188,
+              immediate_widget: "prompt_b",
+              terminal_node_id: 2768,
+              terminal_node_type: "AnimaRegionalCanvasInline",
+              terminal_widget: "quality_prompt",
+              terminal_inputs: [{ name: "quality_prompt", type: "STRING" }],
+              chain_depth: 1,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/AnimaRegionalCanvasInline/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
   it("does not carry the outer node-type fence into a promoted inner retry (#2107)", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "stack_data", value: "NEW" },

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -95,6 +95,8 @@ function bridge(opts: {
   remappedWriteError?: string;
   reconnectBeforeWrite?: boolean;
   tabRebindBeforeWrite?: boolean;
+  ownerRebindBeforeWrite?: boolean;
+  omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
   const calls: Array<Record<string, unknown>> = [];
@@ -102,12 +104,13 @@ function bridge(opts: {
   let subgraphReads = 0;
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
+  let currentOwnerNodeId = 78;
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
   const beforeWrite = { mutate: undefined as (() => void) | undefined };
   const currentViewing = () => ({
     scope: inSubgraph ? "subgraph" : "root",
-    ...(inSubgraph ? { owner_node_id: 78 } : {}),
-    workflow_uuid: workflowUuid,
+    ...(inSubgraph ? { owner_node_id: currentOwnerNodeId } : {}),
+    ...(opts.omitWorkflowUuid ? {} : { workflow_uuid: workflowUuid }),
   });
   const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> =>
     Object.prototype.hasOwnProperty.call(value, "viewing")
@@ -233,6 +236,12 @@ function bridge(opts: {
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
     tabConnectionIdentity: () => connectionIdentity,
+    promotedScopeFor: () => ({
+      known: true,
+      scope: inSubgraph ? "subgraph" : "root",
+      ownerNodeId: inSubgraph ? String(currentOwnerNodeId) : null,
+      ...(opts.omitWorkflowUuid ? {} : { workflowUuid }),
+    }),
     tabExpectedNodeTypeFenceCapability: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
@@ -248,6 +257,13 @@ function bridge(opts: {
       // A second browser tab for the same workflow keeps the workflow route
       // but has a different receiver session.
       connectionIdentity = { generation: 1, tabSessionId: "browser-tab-b" };
+    };
+  } else if (opts.ownerRebindBeforeWrite) {
+    beforeWrite.mutate = () => {
+      // Same workflow, same browser-tab session, different open subgraph. The
+      // inner id/type deliberately remain colliding; only the owner witness
+      // distinguishes the receiver at the final dispatch fence.
+      currentOwnerNodeId = 79;
     };
   }
   return { b, calls, beforeWrite };
@@ -665,6 +681,10 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     ["stale owner", { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 79 } }],
     ["wrong node count", { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 }],
     ["malformed viewing identity", { ...SAFE_ANIMA_SUBGRAPH, viewing: null }],
+    [
+      "malformed viewing workflow identity",
+      { ...SAFE_ANIMA_SUBGRAPH, viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: 42 } },
+    ],
   ])("refuses a %s envelope before writing the container", async (_name, subgraph) => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
@@ -717,6 +737,41 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(isError).toBe(true);
     expect(text).toMatch(/current graph scope changed|inner receiver changed|unverifiable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("refuses an owner A to owner B navigation at the final dispatch fence", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        ownerRebindBeforeWrite: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/current subgraph owner changed|unverifiable/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("keeps a valid same-owner write when workflow_uuid is unavailable", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        omitWorkflowUuid: true,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(calls.find((c) => c.cmd === "graph_set_widget")).toMatchObject({
+      node_id: 76,
+      widget: "quality_prompt",
+    });
   });
 
   it("refuses when the bound panel reconnects before the inner dispatch", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -97,6 +97,7 @@ function bridge(opts: {
   tabRebindBeforeWrite?: boolean;
   authoritativeScopeRead?: boolean;
   ownerNavigationAfterFinalQuery?: boolean;
+  ownerNavigationAfterReadBeforeDispatch?: boolean;
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
@@ -105,6 +106,9 @@ function bridge(opts: {
   let subgraphReads = 0;
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
+  let authoritativeScopeWitness:
+    | { known: true; scope: "root" | "subgraph"; ownerNodeId: string | null; workflowUuid?: string }
+    | undefined;
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let currentOwnerNodeId = 78;
@@ -298,13 +302,17 @@ function bridge(opts: {
             // race navigation has happened.
             authoritativeScopeReads += 1;
             const ownerNodeId = inSubgraph ? String(currentOwnerNodeId) : null;
-            observedPromotedScope = {
+            const liveWitness = {
               known: true,
               scope: inSubgraph ? "subgraph" : "root",
               ownerNodeId,
               ...(opts.omitWorkflowUuid ? {} : { workflowUuid }),
             };
-            return observedPromotedScope;
+            // Keep the cached reply as a separate value. The live result is
+            // the witness the final callback must carry forward.
+            authoritativeScopeWitness = liveWitness;
+            observedPromotedScope = { ...liveWitness };
+            return liveWitness;
           },
         }
       : {}),
@@ -323,6 +331,17 @@ function bridge(opts: {
       // A second browser tab for the same workflow keeps the workflow route
       // but has a different receiver session.
       connectionIdentity = { generation: 1, tabSessionId: "browser-tab-b" };
+    };
+  } else if (opts.ownerNavigationAfterReadBeforeDispatch) {
+    beforeWrite.mutate = () => {
+      // The live graph_query has already returned owner A. Navigation to owner
+      // B happens in the bridge's final dispatch seam, before the synchronous
+      // callback. Mutate the returned live witness to model the authoritative
+      // receiver token becoming stale in that window; the cached copy remains A.
+      currentOwnerNodeId = 79;
+      if (authoritativeScopeWitness?.known) {
+        authoritativeScopeWitness.ownerNodeId = String(currentOwnerNodeId);
+      }
     };
   }
   return {
@@ -830,6 +849,24 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(postEnterGraphQueries).toBe(3);
   });
 
+  it("uses the live scope witness at the normal final dispatch fence", async () => {
+    const { text, isError, calls, authoritativeScopeReads } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        authoritativeScopeRead: true,
+        ownerNavigationAfterReadBeforeDispatch: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/current subgraph owner changed|unverifiable/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(authoritativeScopeReads).toBe(1);
+  });
+
   it("keeps a valid same-owner write when workflow_uuid is unavailable", async () => {
     const { isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
@@ -943,6 +980,26 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(writes).toHaveLength(2);
     expect(writes[0]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
     expect(writes[1]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
+  });
+
+  it("refuses legacy recovery navigation after the live read before inner dispatch", async () => {
+    const { text, isError, calls, authoritativeScopeReads } = await setWidget(
+      { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        authoritativeScopeRead: true,
+        ownerNavigationAfterReadBeforeDispatch: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/current subgraph owner changed|unverifiable/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(authoritativeScopeReads).toBe(1);
   });
 
   it("routes a successful object-info retry through the promoted inner guards", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -29,6 +29,7 @@ import {
   parseContradictoryPromotedWidgetRefusal,
   parseSubgraphScopeRefusal,
   resolveInnerPromotedTarget,
+  validatePromotedSubgraphEnvelope,
 } from "../../orchestrator/promoted-widget.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
@@ -85,13 +86,27 @@ function bridge(opts: {
   /** #2314: make the first subgraph read unavailable so a recovery test can
    *  continue into the existing post-refusal retry branch. */
   preflightSubgraph?: Record<string, unknown> | Error;
+  remappedWriteError?: string;
+  reconnectBeforeWrite?: boolean;
+  tabRebindBeforeWrite?: boolean;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
   let subgraphReads = 0;
   let inSubgraph = false;
+  let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
+  const beforeWrite = { mutate: undefined as (() => void) | undefined };
   const b = {
-    send: async (cmd: Record<string, unknown>) => {
+    send: async (
+      cmd: Record<string, unknown>,
+      sendOpts?: { beforeDispatch?: () => void },
+    ) => {
+      if (cmd.cmd === "graph_set_widget" && sendOpts?.beforeDispatch) {
+        const mutation = beforeWrite.mutate;
+        beforeWrite.mutate = undefined;
+        mutation?.();
+        sendOpts.beforeDispatch();
+      }
       calls.push({ ...cmd });
       if (cmd.cmd === "graph_set_widget") {
         writes += 1;
@@ -101,6 +116,7 @@ function bridge(opts: {
           throw new Error(STACK_DATA_CONTRADICTORY);
         }
         if (writes === 1 && opts.firstWriteError) throw new Error(opts.firstWriteError);
+        if (writes === 2 && opts.remappedWriteError) throw new Error(opts.remappedWriteError);
         if (
           writes === 1 &&
           opts.detailById &&
@@ -171,18 +187,31 @@ function bridge(opts: {
     tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
-    tabConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
+    tabConnectionIdentity: () => connectionIdentity,
     tabExpectedNodeTypeFenceCapability: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];
-  return { b, calls };
+  if (opts.reconnectBeforeWrite) {
+    beforeWrite.mutate = () => {
+      // The same browser tab returns after a reconnect: its session id is
+      // stable, but the connection generation advances.
+      connectionIdentity = { generation: 2, tabSessionId: "browser-tab-a" };
+    };
+  } else if (opts.tabRebindBeforeWrite) {
+    beforeWrite.mutate = () => {
+      // A second browser tab for the same workflow keeps the workflow route
+      // but has a different receiver session.
+      connectionIdentity = { generation: 1, tabSessionId: "browser-tab-b" };
+    };
+  }
+  return { b, calls, beforeWrite };
 }
 
 async function setWidget(
   args: { node_id: number | string; widget: string; value: number | string },
   opts: Parameters<typeof bridge>[0] = {},
 ) {
-  const { b, calls } = bridge(opts);
+  const { b, calls, beforeWrite } = bridge(opts);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
   if (!def) throw new Error("panel_set_widget is not registered");
@@ -268,8 +297,8 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
         firstWrite: "contradict",
         firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
         innerWrite: "ok",
-        subgraph: DYNAMIC_SUBGRAPH,
-        preflightSubgraph: {
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: {
           ...DYNAMIC_SUBGRAPH,
           nodes: [
             {
@@ -378,6 +407,7 @@ describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => 
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
         innerWrite: "ok",
+        preflightSubgraph: new Error("preflight unavailable"),
         subgraph: {
           ...ANIMA_SUBGRAPH,
           nodes: [
@@ -518,7 +548,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
       },
       undefined,
     ],
-  ] as const)("keeps a safe %s promoted write successful on the container", async (
+  ] as const)("keeps a safe %s promoted write successful via the inner node", async (
     _name,
     widget,
     subgraph,
@@ -541,16 +571,11 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
     expect(isError).toBe(false);
     expect(calls.some((c) => c.cmd === "graph_get_subgraph")).toBe(true);
-    if (widget === "stack_data") {
-      expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
-      expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
-    } else {
-      expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
-      expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
-    }
+    expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
+    expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
     expect(writes).toHaveLength(1);
-    expect(writes[0]).toMatchObject({ node_id: 78, widget });
+    expect(writes[0]).toMatchObject({ node_id: 76, widget });
   });
 
   it("keeps a successful container write when promotion preflight is unavailable", async () => {
@@ -570,12 +595,81 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     ]);
   });
 
+  it("refuses when the promotion relinks after classification", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        // The first read classified a safe inner node; the confirmation read
+        // observes a relink to the known-bad regional-canvas node.
+        preflightSubgraph: SAFE_ANIMA_SUBGRAPH,
+        subgraph: ANIMA_SUBGRAPH,
+        detailById: ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/mapping changed or became unverifiable|inner node type changed/);
+    expect(calls.filter((c) => c.cmd === "graph_get_subgraph")).toHaveLength(2);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+  });
+
+  it.each([
+    ["stale owner", { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 79 } }],
+    ["wrong node count", { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 }],
+  ])("refuses a %s envelope before writing the container", async (_name, subgraph) => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      { firstWrite: "ok", subgraph },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("refuses when the bound panel reconnects before the inner dispatch", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        reconnectBeforeWrite: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/session or connection changed|No graph_set_widget was dispatched/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls).toEqual(expect.arrayContaining([{ cmd: "graph_exit_subgraph" }]));
+  });
+
+  it("refuses when the same-workflow panel tab is rebound before the inner dispatch", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        tabRebindBeforeWrite: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/session or connection changed|No graph_set_widget was dispatched/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls).toEqual(expect.arrayContaining([{ cmd: "graph_exit_subgraph" }]));
+  });
+
   it("re-runs the guards for a case-only remapped container widget", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
       {
         firstWrite: "contradict",
         firstWriteError: ANIMA_CONTRADICTORY,
+        remappedWriteError: ANIMA_CONTRADICTORY,
         subgraph: ANIMA_SUBGRAPH,
         detailById: ANIMA_IDENTITY_BY_ID,
         preflightSubgraph: new Error("preflight unavailable"),
@@ -585,7 +679,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(isError).toBe(true);
     expect(text).toContain("animaPrompts");
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
     expect(writes[0]).toMatchObject({ node_id: 78, widget: "Quality_Prompt" });
   });
 
@@ -661,14 +755,14 @@ describe("parseContradictoryPromotedWidgetRefusal", () => {
 
 describe("resolveInnerPromotedTarget", () => {
   it("maps width to the unique EmptyLatentImage inner node", () => {
-    expect(resolveInnerPromotedTarget(SUBGRAPH, "width")).toEqual({
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "width", 78)).toEqual({
       innerNodeId: 76,
       widget: "width",
     });
   });
 
   it("maps seed to the unique KSampler inner node", () => {
-    expect(resolveInnerPromotedTarget(SUBGRAPH, "seed")).toEqual({
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "seed", 78)).toEqual({
       innerNodeId: 75,
       widget: "seed",
     });
@@ -682,15 +776,41 @@ describe("resolveInnerPromotedTarget", () => {
         { id: 99, widgets: { width: 512 } },
       ],
     };
-    expect(resolveInnerPromotedTarget(ambiguous, "width")).toBeNull();
+    expect(resolveInnerPromotedTarget(ambiguous, "width", 78)).toBeNull();
   });
 
   it("refuses to guess from a truncated inner list", () => {
-    expect(resolveInnerPromotedTarget({ ...SUBGRAPH, truncated: true }, "width")).toBeNull();
+    expect(resolveInnerPromotedTarget({ ...SUBGRAPH, truncated: true }, "width", 78)).toBeNull();
   });
 
   it("returns null when no inner node owns the widget", () => {
-    expect(resolveInnerPromotedTarget(SUBGRAPH, "denoise")).toBeNull();
+    expect(resolveInnerPromotedTarget(SUBGRAPH, "denoise", 78)).toBeNull();
+  });
+
+  it("rejects an envelope owned by a different outer node", () => {
+    expect(
+      validatePromotedSubgraphEnvelope(
+        { ...SUBGRAPH, subgraph_of: { node_id: 79, title: "stale" } },
+        78,
+      ),
+    ).toBeNull();
+    expect(
+      resolveInnerPromotedTarget(
+        { ...SUBGRAPH, subgraph_of: { node_id: 79, title: "stale" } },
+        "width",
+        78,
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["missing subgraph_of", { ...SUBGRAPH, subgraph_of: undefined }],
+    ["wrong node_count", { ...SUBGRAPH, node_count: 1 }],
+    ["non-integer node_count", { ...SUBGRAPH, node_count: "2" }],
+    ["truncated envelope", { ...SUBGRAPH, truncated: true }],
+  ])("rejects a %s instead of trusting its inner mapping", (_name, malformed) => {
+    expect(validatePromotedSubgraphEnvelope(malformed, 78)).toBeNull();
+    expect(resolveInnerPromotedTarget(malformed, "width", 78)).toBeNull();
   });
 });
 
@@ -716,14 +836,15 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",
+      "graph_get_subgraph",
       "graph_enter_subgraph",
       "graph_query",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
     expect(calls[3]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(calls[7]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(text).toMatch(/inner widget this promotion lists/);
+    expect(calls[8]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(text).toMatch(/validated promoted inner widget/);
   });
 
   it("refuses a promoted inner retry when the post-enter identity is stale", async () => {
@@ -748,12 +869,13 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",
+      "graph_get_subgraph",
       "graph_enter_subgraph",
       "graph_query",
       "graph_exit_subgraph",
     ]);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
-    expect(text).toMatch(/post-enter identity probe did not verify/);
+    expect(text).toMatch(/different node_id|No inner graph_set_widget/);
   });
 
   it("refuses a promoted inner DaSiWa stack write without a second mutation", async () => {
@@ -778,12 +900,13 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",
+      "graph_get_subgraph",
       "graph_enter_subgraph",
       "graph_query",
       "graph_exit_subgraph",
     ]);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
-    expect(text).toMatch(/promoted inner node 76 was identified as DaSiWa_LTX2LoraLoader/);
+    expect(text).toMatch(/cannot set "stack_data" on DaSiWa_LTX2LoraLoader/);
     expect(text).toMatch(/No inner graph_set_widget was dispatched/);
   });
 
@@ -893,6 +1016,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { node_id: 78, widget: "width", value: 1024 },
       {
         subgraph: {
+          subgraph_of: { node_id: 78, title: "Container" },
           node_count: 2,
           nodes: [
             { id: 76, widgets: { width: 1920 } },
@@ -914,7 +1038,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { subgraph: { ...SUBGRAPH, truncated: true } },
     );
     expect(isError).toBe(true);
-    expect(text).toMatch(/did not uniquely identify/);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -10,8 +10,9 @@
 // inner widget and write it there, then leave the subgraph.
 //
 // These tests drive the SHIPPED handler (and the parse/resolve helpers it uses).
-// A first-write success is untouched. A genuine miss (name not in the listed
-// set) is never retried. An ambiguous or truncated inner mapping is never guessed.
+// A first-write success stays successful for safe or unprovable mappings. A genuine
+// miss (name not in the listed set) is never retried. An ambiguous or truncated inner
+// mapping is never guessed.
 
 import { describe, expect, it } from "vitest";
 
@@ -81,10 +82,14 @@ function bridge(opts: {
    *  widget that is not #2299's `model.prompt`. Wins over the default above so
    *  the recovery resolves the name under test. */
   firstWriteError?: string;
+  /** #2314: make the first subgraph read unavailable so a recovery test can
+   *  continue into the existing post-refusal retry branch. */
+  preflightSubgraph?: Record<string, unknown> | Error;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
-  let graphQueries = 0;
+  let subgraphReads = 0;
+  let inSubgraph = false;
   const b = {
     send: async (cmd: Record<string, unknown>) => {
       calls.push({ ...cmd });
@@ -92,9 +97,18 @@ function bridge(opts: {
         writes += 1;
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
-        if (writes === 1 && opts.stackDataIdentity) throw new Error(STACK_DATA_CONTRADICTORY);
+        if (writes === 1 && opts.stackDataIdentity && opts.firstWrite !== "ok") {
+          throw new Error(STACK_DATA_CONTRADICTORY);
+        }
         if (writes === 1 && opts.firstWriteError) throw new Error(opts.firstWriteError);
-        if (writes === 1 && opts.detailById) throw new Error(DYNAMIC_CHILD_CONTRADICTORY);
+        if (
+          writes === 1 &&
+          opts.detailById &&
+          opts.firstWrite !== "ok" &&
+          !opts.firstWriteError
+        ) {
+          throw new Error(DYNAMIC_CHILD_CONTRADICTORY);
+        }
         const which =
           writes === 1
             ? (opts.firstWrite ?? "contradict")
@@ -108,25 +122,31 @@ function bridge(opts: {
         return { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
       }
       if (cmd.cmd === "graph_get_subgraph") {
+        subgraphReads += 1;
+        if (subgraphReads === 1 && opts.preflightSubgraph !== undefined) {
+          if (opts.preflightSubgraph instanceof Error) throw opts.preflightSubgraph;
+          return opts.preflightSubgraph;
+        }
         if (opts.subgraph instanceof Error) throw opts.subgraph;
         return opts.subgraph ?? SUBGRAPH;
       }
       if (cmd.cmd === "graph_enter_subgraph") {
         if (opts.enterFails) throw new Error("could not enter subgraph 78");
+        inSubgraph = true;
         return { scope: "subgraph", node_id: cmd.node_id };
       }
       if (cmd.cmd === "graph_exit_subgraph") {
         if (opts.exitFails) throw new Error("could not confirm exit");
+        inSubgraph = false;
         return { scope: "root" };
       }
       if (cmd.cmd === "graph_query") {
-        graphQueries += 1;
         const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
         if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
           return opts.detailById[wantId];
         }
-        if (opts.stackDataIdentity && graphQueries <= 2) return opts.stackDataIdentity;
-        if (opts.stackDataIdentity && graphQueries === 3) {
+        if (opts.stackDataIdentity && !inSubgraph) return opts.stackDataIdentity;
+        if (opts.stackDataIdentity && inSubgraph) {
           return opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] };
         }
         return (
@@ -190,6 +210,10 @@ const DYNAMIC_SUBGRAPH = {
       id: 76,
       type: "MinimaxHailuo03TextToVideoNode",
       widgets: { model: "text-to-video", "model.prompt": "" },
+      inputs: [
+        { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+        { name: "model.prompt", type: "STRING" },
+      ],
     },
   ],
 };
@@ -220,8 +244,10 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
       { node_id: 78, widget: "model.prompt", value: "a long prompt" },
       {
         firstWrite: "contradict",
+        firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
         subgraph: DYNAMIC_SUBGRAPH,
         detailById: DYNAMIC_DETAIL_BY_ID,
+        preflightSubgraph: new Error("preflight unavailable"),
       },
     );
     expect(isError).toBe(true);
@@ -240,8 +266,23 @@ describe("panel_set_widget promoted inner dynamic-combo child (#2299)", () => {
       { node_id: 78, widget: "model.prompt", value: "a long prompt" },
       {
         firstWrite: "contradict",
+        firstWriteError: DYNAMIC_CHILD_CONTRADICTORY,
         innerWrite: "ok",
         subgraph: DYNAMIC_SUBGRAPH,
+        preflightSubgraph: {
+          ...DYNAMIC_SUBGRAPH,
+          nodes: [
+            {
+              id: 76,
+              type: "OrdinaryNode",
+              widgets: { "model.prompt": "" },
+              inputs: [
+                { name: "model", type: "STRING" },
+                { name: "model.prompt", type: "STRING" },
+              ],
+            },
+          ],
+        },
         detailById: {
           "78": DYNAMIC_DETAIL_BY_ID["78"],
           // Same dotted name, ordinary STRING parent — not the #2299 shape.
@@ -304,6 +345,7 @@ describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => 
         firstWriteError: ANIMA_CONTRADICTORY,
         subgraph: ANIMA_SUBGRAPH,
         detailById: ANIMA_IDENTITY_BY_ID,
+        preflightSubgraph: new Error("preflight unavailable"),
       },
     );
     expect(isError).toBe(true);
@@ -353,6 +395,200 @@ describe("panel_set_widget promoted inner LC123 regional prompt (#2305)", () => 
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
     expect(writes.some((c) => String(c.node_id) === "76")).toBe(true);
   });
+});
+
+const SAFE_ANIMA_SUBGRAPH = {
+  subgraph_of: { node_id: 78, title: "Container" },
+  node_count: 1,
+  nodes: [{ id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } }],
+};
+
+const SAFE_ANIMA_IDENTITY_BY_ID = {
+  "78": ANIMA_IDENTITY_BY_ID["78"],
+  "76": { nodes: [{ id: 76, type: "PrimitiveStringMultiline" }] },
+};
+
+describe("panel_set_widget promoted container success guards (#2314)", () => {
+  it.each([
+    [
+      "Anima regional prompt",
+      "quality_prompt",
+      "masterpiece",
+      ANIMA_SUBGRAPH,
+      ANIMA_IDENTITY_BY_ID,
+      undefined,
+      /animaPrompts/,
+    ],
+    [
+      "dynamic-combo STRING child",
+      "model.prompt",
+      "a long prompt",
+      DYNAMIC_SUBGRAPH,
+      DYNAMIC_DETAIL_BY_ID,
+      undefined,
+      /dynamic-combo (?:sub-widget|child)/,
+    ],
+    [
+      "DaSiWa stack",
+      "stack_data",
+      "NEW",
+      {
+        subgraph_of: { node_id: 78, title: "Container" },
+        node_count: 1,
+        nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader", widgets: { stack_data: "old" } }],
+      },
+      undefined,
+      {
+        stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+        stackDataInnerIdentity: { nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader" }] },
+      },
+      /DaSiWa_LTX2LoraLoader/,
+    ],
+  ] as const)("refuses %s before a successful container write", async (
+    _name,
+    widget,
+    value,
+    subgraph,
+    probe,
+    stack,
+    message,
+  ) => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget, value },
+      {
+        firstWrite: "ok",
+        subgraph,
+        ...(probe ? { detailById: probe } : {}),
+        ...(stack ?? {}),
+      },
+    );
+    expect(isError).toBe(true);
+    expect(text).toMatch(message);
+    expect(calls.map((c) => c.cmd)).toContain("graph_get_subgraph");
+    if (widget === "stack_data") {
+      expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
+      expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
+    }
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it.each([
+    ["Anima regional prompt", "quality_prompt", SAFE_ANIMA_SUBGRAPH, SAFE_ANIMA_IDENTITY_BY_ID],
+    [
+      "dynamic-combo STRING child",
+      "model.prompt",
+      {
+        ...DYNAMIC_SUBGRAPH,
+        nodes: [
+          {
+            id: 76,
+            type: "OrdinaryNode",
+            widgets: { "model.prompt": "old" },
+            inputs: [
+              { name: "model", type: "STRING" },
+              { name: "model.prompt", type: "STRING" },
+            ],
+          },
+        ],
+      },
+      {
+        "78": DYNAMIC_DETAIL_BY_ID["78"],
+        "76": {
+          nodes: [
+            {
+              id: 76,
+              type: "OrdinaryNode",
+              widgets: { "model.prompt": "old" },
+              inputs: [
+                { name: "model", type: "STRING" },
+                { name: "model.prompt", type: "STRING" },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    [
+      "DaSiWa stack",
+      "stack_data",
+      {
+        subgraph_of: { node_id: 78, title: "Container" },
+        node_count: 1,
+        nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
+      },
+      undefined,
+    ],
+  ] as const)("keeps a safe %s promoted write successful on the container", async (
+    _name,
+    widget,
+    subgraph,
+    probe,
+  ) => {
+    const stack = widget === "stack_data"
+      ? {
+          stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+          stackDataInnerIdentity: { nodes: [{ id: 76, type: "OtherLoraLoader" }] },
+        }
+      : {};
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget, value: "NEW" },
+      {
+        firstWrite: "ok",
+        subgraph,
+        ...(probe ? { detailById: probe } : {}),
+        ...stack,
+      },
+    );
+    expect(isError).toBe(false);
+    expect(calls.some((c) => c.cmd === "graph_get_subgraph")).toBe(true);
+    if (widget === "stack_data") {
+      expect(calls.map((c) => c.cmd)).toContain("graph_enter_subgraph");
+      expect(calls.map((c) => c.cmd)).toContain("graph_exit_subgraph");
+    } else {
+      expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+      expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
+    }
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({ node_id: 78, widget });
+  });
+
+  it("keeps a successful container write when promotion preflight is unavailable", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: new Error("graph_get_subgraph unavailable"),
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+    ]);
+  });
+
+  it("re-runs the guards for a case-only remapped container widget", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        subgraph: ANIMA_SUBGRAPH,
+        detailById: ANIMA_IDENTITY_BY_ID,
+        preflightSubgraph: new Error("preflight unavailable"),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toContain("animaPrompts");
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({ node_id: 78, widget: "Quality_Prompt" });
+  });
+
 });
 
 describe("parseContradictoryPromotedWidgetRefusal", () => {
@@ -469,12 +705,14 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
         },
+        preflightSubgraph: new Error("preflight unavailable"),
       },
     );
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",
@@ -483,8 +721,8 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
-    expect(calls[2]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(calls[6]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[3]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[7]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
     expect(text).toMatch(/inner widget this promotion lists/);
   });
 
@@ -499,12 +737,14 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "OtherLoraLoader", widgets: { stack_data: "old" } }],
         },
+        preflightSubgraph: new Error("preflight unavailable"),
       },
     );
 
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",
@@ -527,12 +767,14 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
           node_count: 1,
           nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader", widgets: { stack_data: "old" } }],
         },
+        preflightSubgraph: new Error("preflight unavailable"),
       },
     );
 
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
       "graph_get_subgraph",

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -95,27 +95,78 @@ function bridge(opts: {
   remappedWriteError?: string;
   reconnectBeforeWrite?: boolean;
   tabRebindBeforeWrite?: boolean;
-  ownerRebindBeforeWrite?: boolean;
+  authoritativeScopeRead?: boolean;
+  ownerNavigationAfterFinalQuery?: boolean;
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
   let subgraphReads = 0;
+  let postEnterGraphQueries = 0;
+  let authoritativeScopeReads = 0;
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let currentOwnerNodeId = 78;
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
+  let observedPromotedScope: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid?: string;
+  } | { known: false; reason: string } = {
+    known: false,
+    reason: "no current panel graph-scope witness has been observed",
+  };
   const beforeWrite = { mutate: undefined as (() => void) | undefined };
   const currentViewing = () => ({
     scope: inSubgraph ? "subgraph" : "root",
     ...(inSubgraph ? { owner_node_id: currentOwnerNodeId } : {}),
     ...(opts.omitWorkflowUuid ? {} : { workflow_uuid: workflowUuid }),
   });
-  const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> =>
-    Object.prototype.hasOwnProperty.call(value, "viewing")
+  const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> => {
+    const result = Object.prototype.hasOwnProperty.call(value, "viewing")
       ? value
       : { ...value, viewing: currentViewing() };
+    const viewing = result.viewing;
+    if (viewing && typeof viewing === "object" && !Array.isArray(viewing)) {
+      const identity = viewing as Record<string, unknown>;
+      const rawOwner = identity.owner_node_id;
+      const rawWorkflowUuid = identity.workflow_uuid;
+      if (
+        (identity.scope === "root" || identity.scope === "subgraph") &&
+        (rawOwner === undefined || rawOwner === null || typeof rawOwner === "number" || typeof rawOwner === "string") &&
+        (rawWorkflowUuid === undefined || typeof rawWorkflowUuid === "string")
+      ) {
+        observedPromotedScope = {
+          known: true,
+          scope: identity.scope,
+          ownerNodeId: rawOwner == null ? null : String(rawOwner),
+          ...(rawWorkflowUuid !== undefined ? { workflowUuid: rawWorkflowUuid } : {}),
+        };
+      } else {
+        observedPromotedScope = {
+          known: false,
+          reason: "the panel returned malformed current-view metadata",
+        };
+      }
+    }
+    return result;
+  };
+  const afterGraphQuery = (value: Record<string, unknown>, wantId: string | null) => {
+    const result = withCurrentViewing(value);
+    if (
+      inSubgraph &&
+      wantId &&
+      opts.ownerNavigationAfterFinalQuery &&
+      postEnterGraphQueries++ === 2
+    ) {
+      // The final mapping query answered for owner A. Navigation happens before
+      // the handler's fresh authoritative scope read, leaving the cache stale.
+      currentOwnerNodeId = 79;
+    }
+    return result;
+  };
   const b = {
     send: async (
       cmd: Record<string, unknown>,
@@ -191,15 +242,16 @@ function bridge(opts: {
           inSubgraph && wantId ? opts.postEnterGraphQueryById?.[wantId] : undefined;
         if (postEnter !== undefined) {
           if (postEnter instanceof Error) throw postEnter;
-          return withCurrentViewing(postEnter);
+          return afterGraphQuery(postEnter, wantId);
         }
         if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
-          return withCurrentViewing(opts.detailById[wantId]);
+          return afterGraphQuery(opts.detailById[wantId], wantId);
         }
-        if (opts.stackDataIdentity && !inSubgraph) return withCurrentViewing(opts.stackDataIdentity);
+        if (opts.stackDataIdentity && !inSubgraph) return afterGraphQuery(opts.stackDataIdentity, wantId);
         if (opts.stackDataIdentity && inSubgraph) {
-          return withCurrentViewing(
+          return afterGraphQuery(
             opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] },
+            wantId,
           );
         }
         if (inSubgraph && wantId) {
@@ -209,10 +261,10 @@ function bridge(opts: {
             candidate && typeof candidate === "object" && String(candidate.id) === wantId,
           );
           if (node && typeof node.type === "string") {
-            return withCurrentViewing({ nodes: [{ id: node.id, type: node.type }] });
+            return afterGraphQuery({ nodes: [{ id: node.id, type: node.type }] }, wantId);
           }
         }
-        return withCurrentViewing(
+        return afterGraphQuery(
           opts.promotedDetail ?? {
             nodes: [
               {
@@ -224,6 +276,7 @@ function bridge(opts: {
               },
             ],
           },
+          wantId,
         );
       }
       if (cmd.cmd === "refresh_nodes") return opts.refreshNodes ?? { refreshed: true };
@@ -236,12 +289,25 @@ function bridge(opts: {
     resolveActiveTabId: () => TAB,
     tabCanMutateGraph: () => true,
     tabConnectionIdentity: () => connectionIdentity,
-    promotedScopeFor: () => ({
-      known: true,
-      scope: inSubgraph ? "subgraph" : "root",
-      ownerNodeId: inSubgraph ? String(currentOwnerNodeId) : null,
-      ...(opts.omitWorkflowUuid ? {} : { workflowUuid }),
-    }),
+    promotedScopeFor: () => observedPromotedScope,
+    ...(opts.authoritativeScopeRead
+      ? {
+          readPromotedScope: async () => {
+            // This is the test seam for UiBridge.readPromotedScope: unlike the
+            // cached getter above, it samples the live current view after the
+            // race navigation has happened.
+            authoritativeScopeReads += 1;
+            const ownerNodeId = inSubgraph ? String(currentOwnerNodeId) : null;
+            observedPromotedScope = {
+              known: true,
+              scope: inSubgraph ? "subgraph" : "root",
+              ownerNodeId,
+              ...(opts.omitWorkflowUuid ? {} : { workflowUuid }),
+            };
+            return observedPromotedScope;
+          },
+        }
+      : {}),
     tabExpectedNodeTypeFenceCapability: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
@@ -258,22 +324,26 @@ function bridge(opts: {
       // but has a different receiver session.
       connectionIdentity = { generation: 1, tabSessionId: "browser-tab-b" };
     };
-  } else if (opts.ownerRebindBeforeWrite) {
-    beforeWrite.mutate = () => {
-      // Same workflow, same browser-tab session, different open subgraph. The
-      // inner id/type deliberately remain colliding; only the owner witness
-      // distinguishes the receiver at the final dispatch fence.
-      currentOwnerNodeId = 79;
-    };
   }
-  return { b, calls, beforeWrite };
+  return {
+    b,
+    calls,
+    beforeWrite,
+    get authoritativeScopeReads() {
+      return authoritativeScopeReads;
+    },
+    get postEnterGraphQueries() {
+      return postEnterGraphQueries;
+    },
+  };
 }
 
 async function setWidget(
   args: { node_id: number | string; widget: string; value: number | string },
   opts: Parameters<typeof bridge>[0] = {},
 ) {
-  const { b, calls, beforeWrite } = bridge(opts);
+  const harness = bridge(opts);
+  const { b, calls, beforeWrite } = harness;
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
   if (!def) throw new Error("panel_set_widget is not registered");
@@ -282,6 +352,8 @@ async function setWidget(
     text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
     isError: res.isError === true,
     calls,
+    authoritativeScopeReads: harness.authoritativeScopeReads,
+    postEnterGraphQueries: harness.postEnterGraphQueries,
   };
 }
 
@@ -739,20 +811,23 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
-  it("refuses an owner A to owner B navigation at the final dispatch fence", async () => {
-    const { text, isError, calls } = await setWidget(
+  it("refuses owner A to owner B navigation after the final query at the authoritative write fence", async () => {
+    const { text, isError, calls, authoritativeScopeReads, postEnterGraphQueries } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
-        ownerRebindBeforeWrite: true,
+        authoritativeScopeRead: true,
+        ownerNavigationAfterFinalQuery: true,
       },
     );
 
     expect(isError).toBe(true);
     expect(text).toMatch(/current subgraph owner changed|unverifiable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(authoritativeScopeReads).toBe(1);
+    expect(postEnterGraphQueries).toBe(3);
   });
 
   it("keeps a valid same-owner write when workflow_uuid is unavailable", async () => {
@@ -762,6 +837,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         firstWrite: "ok",
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        authoritativeScopeRead: true,
         omitWorkflowUuid: true,
       },
     );

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -95,13 +95,24 @@ function bridge(opts: {
   remappedWriteError?: string;
   reconnectBeforeWrite?: boolean;
   tabRebindBeforeWrite?: boolean;
+  workflowUuid?: string;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
   let subgraphReads = 0;
   let inSubgraph = false;
+  const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
   const beforeWrite = { mutate: undefined as (() => void) | undefined };
+  const currentViewing = () => ({
+    scope: inSubgraph ? "subgraph" : "root",
+    ...(inSubgraph ? { owner_node_id: 78 } : {}),
+    workflow_uuid: workflowUuid,
+  });
+  const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> =>
+    Object.prototype.hasOwnProperty.call(value, "viewing")
+      ? value
+      : { ...value, viewing: currentViewing() };
   const b = {
     send: async (
       cmd: Record<string, unknown>,
@@ -150,15 +161,16 @@ function bridge(opts: {
         subgraphReads += 1;
         if (subgraphReads === 1 && opts.preflightSubgraph !== undefined) {
           if (opts.preflightSubgraph instanceof Error) throw opts.preflightSubgraph;
-          return opts.preflightSubgraph;
+          return withCurrentViewing(opts.preflightSubgraph);
         }
         if (subgraphReads === 2 && opts.recoveryPreflightSubgraph !== undefined) {
           if (opts.recoveryPreflightSubgraph instanceof Error) throw opts.recoveryPreflightSubgraph;
-          return opts.recoveryPreflightSubgraph;
+          return withCurrentViewing(opts.recoveryPreflightSubgraph);
         }
         if (inSubgraph) throw new Error("No node with id 78 in the current graph");
         if (opts.subgraph instanceof Error) throw opts.subgraph;
-        return opts.subgraph ?? SUBGRAPH;
+        const subgraph = opts.subgraph ?? SUBGRAPH;
+        return subgraph instanceof Error ? subgraph : withCurrentViewing(subgraph);
       }
       if (cmd.cmd === "graph_enter_subgraph") {
         if (opts.enterFails) throw new Error("could not enter subgraph 78");
@@ -176,14 +188,16 @@ function bridge(opts: {
           inSubgraph && wantId ? opts.postEnterGraphQueryById?.[wantId] : undefined;
         if (postEnter !== undefined) {
           if (postEnter instanceof Error) throw postEnter;
-          return postEnter;
+          return withCurrentViewing(postEnter);
         }
         if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
-          return opts.detailById[wantId];
+          return withCurrentViewing(opts.detailById[wantId]);
         }
-        if (opts.stackDataIdentity && !inSubgraph) return opts.stackDataIdentity;
+        if (opts.stackDataIdentity && !inSubgraph) return withCurrentViewing(opts.stackDataIdentity);
         if (opts.stackDataIdentity && inSubgraph) {
-          return opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] };
+          return withCurrentViewing(
+            opts.stackDataInnerIdentity ?? { nodes: [{ id: 76, type: "OtherLoraLoader" }] },
+          );
         }
         if (inSubgraph && wantId) {
           const subgraph = opts.subgraph && !(opts.subgraph instanceof Error) ? opts.subgraph : SUBGRAPH;
@@ -192,10 +206,10 @@ function bridge(opts: {
             candidate && typeof candidate === "object" && String(candidate.id) === wantId,
           );
           if (node && typeof node.type === "string") {
-            return { nodes: [{ id: node.id, type: node.type }] };
+            return withCurrentViewing({ nodes: [{ id: node.id, type: node.type }] });
           }
         }
-        return (
+        return withCurrentViewing(
           opts.promotedDetail ?? {
             nodes: [
               {
@@ -206,7 +220,7 @@ function bridge(opts: {
                 ],
               },
             ],
-          }
+          },
         );
       }
       if (cmd.cmd === "refresh_nodes") return opts.refreshNodes ?? { refreshed: true };
@@ -221,6 +235,7 @@ function bridge(opts: {
     tabConnectionIdentity: () => connectionIdentity,
     tabExpectedNodeTypeFenceCapability: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
   } as unknown as PanelToolCtx["bridge"];
   if (opts.reconnectBeforeWrite) {
     beforeWrite.mutate = () => {
@@ -649,6 +664,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
   it.each([
     ["stale owner", { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 79 } }],
     ["wrong node count", { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 }],
+    ["malformed viewing identity", { ...SAFE_ANIMA_SUBGRAPH, viewing: null }],
   ])("refuses a %s envelope before writing the container", async (_name, subgraph) => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
@@ -657,6 +673,49 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(true);
     expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("refuses a same-session subgraph-owner collision even when inner id and type collide", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        postEnterGraphQueryById: {
+          "76": {
+            viewing: { scope: "subgraph", owner_node_id: 79, workflow_uuid: "workflow-a" },
+            nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
+          },
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/current graph scope changed|inner receiver changed|unverifiable/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls).toEqual(expect.arrayContaining([{ cmd: "graph_enter_subgraph", node_id: 78 }]));
+  });
+
+  it("refuses a same-session workflow collision with the same owner, inner id, and type", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        postEnterGraphQueryById: {
+          "76": {
+            viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-b" },
+            nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
+          },
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/current graph scope changed|inner receiver changed|unverifiable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -86,6 +86,10 @@ function bridge(opts: {
   /** #2314: make the first subgraph read unavailable so a recovery test can
    *  continue into the existing post-refusal retry branch. */
   preflightSubgraph?: Record<string, unknown> | Error;
+  recoveryPreflightSubgraph?: Record<string, unknown> | Error;
+  subgraphAfterEnter?: Record<string, unknown> | Error;
+  objectInfoRefusal?: boolean;
+  refreshNodes?: Record<string, unknown>;
   remappedWriteError?: string;
   reconnectBeforeWrite?: boolean;
   tabRebindBeforeWrite?: boolean;
@@ -115,6 +119,9 @@ function bridge(opts: {
         if (writes === 1 && opts.stackDataIdentity && opts.firstWrite !== "ok") {
           throw new Error(STACK_DATA_CONTRADICTORY);
         }
+        if (writes === 1 && opts.objectInfoRefusal) {
+          throw new Error("no usable /object_info was available for this widget write");
+        }
         if (writes === 1 && opts.firstWriteError) throw new Error(opts.firstWriteError);
         if (writes === 2 && opts.remappedWriteError) throw new Error(opts.remappedWriteError);
         if (
@@ -142,6 +149,14 @@ function bridge(opts: {
         if (subgraphReads === 1 && opts.preflightSubgraph !== undefined) {
           if (opts.preflightSubgraph instanceof Error) throw opts.preflightSubgraph;
           return opts.preflightSubgraph;
+        }
+        if (subgraphReads === 2 && opts.recoveryPreflightSubgraph !== undefined) {
+          if (opts.recoveryPreflightSubgraph instanceof Error) throw opts.recoveryPreflightSubgraph;
+          return opts.recoveryPreflightSubgraph;
+        }
+        if (inSubgraph && opts.subgraphAfterEnter !== undefined) {
+          if (opts.subgraphAfterEnter instanceof Error) throw opts.subgraphAfterEnter;
+          return opts.subgraphAfterEnter;
         }
         if (opts.subgraph instanceof Error) throw opts.subgraph;
         return opts.subgraph ?? SUBGRAPH;
@@ -179,6 +194,7 @@ function bridge(opts: {
           }
         );
       }
+      if (cmd.cmd === "refresh_nodes") return opts.refreshNodes ?? { refreshed: true };
       return { ok: true };
     },
     push: () => 1,
@@ -679,8 +695,167 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(isError).toBe(true);
     expect(text).toContain("animaPrompts");
     const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({ node_id: 78, widget: "Quality_Prompt" });
+  });
+
+  it("routes a successful case-only remapped retry through the inner plan", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
+      {
+        firstWrite: "contradict",
+        firstWriteError: ANIMA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(text).toMatch(/validated promoted inner widget/);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
     expect(writes).toHaveLength(2);
     expect(writes[0]).toMatchObject({ node_id: 78, widget: "Quality_Prompt" });
+    expect(writes[1]).toMatchObject({ node_id: 76, widget: "quality_prompt" });
+    expect(calls.filter((c) => c.cmd === "graph_set_widget" && c.node_id === 78)).toHaveLength(1);
+  });
+
+  it("routes a successful scope retry through the promoted inner guards", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 188, widget: "quality_prompt", value: "masterpiece" },
+      {
+        scopeLost: true,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: {
+          ...SAFE_ANIMA_SUBGRAPH,
+          subgraph_of: { node_id: 188, title: "Container" },
+        },
+        detailById: {
+          "188": { nodes: [{ id: 188, type: "SubgraphNode" }] },
+          "76": SAFE_ANIMA_IDENTITY_BY_ID["76"],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toMatchObject({ node_id: 188, widget: "quality_prompt" });
+    expect(writes[1]).toMatchObject({ node_id: 76, widget: "quality_prompt" });
+  });
+
+  it("routes a successful object-info retry through the promoted inner guards", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWriteError: "no usable /object_info was available for this widget write",
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        refreshNodes: { refreshed: true },
+      },
+    );
+
+    expect(isError).toBe(false);
+    const writes = calls.filter((c) => c.cmd === "graph_set_widget");
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toMatchObject({ node_id: 78, widget: "quality_prompt" });
+    expect(writes[1]).toMatchObject({ node_id: 76, widget: "quality_prompt" });
+  });
+
+  it("refuses a known-bad Anima write on an object-info retry", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWriteError: "no usable /object_info was available for this widget write",
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: ANIMA_SUBGRAPH,
+        detailById: ANIMA_IDENTITY_BY_ID,
+        refreshNodes: { refreshed: true },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/animaPrompts/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("refuses a known-bad dynamic child on a scope retry", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 188, widget: "model.prompt", value: "a long prompt" },
+      {
+        scopeLost: true,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: {
+          ...DYNAMIC_SUBGRAPH,
+          subgraph_of: { node_id: 188, title: "Container" },
+        },
+        detailById: {
+          "188": { nodes: [{ id: 188, type: "SubgraphNode" }] },
+          "76": DYNAMIC_DETAIL_BY_ID["76"],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/dynamic-combo/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("refuses a known-bad DaSiWa write on a case-remap retry", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "Stack_Data", value: "NEW" },
+      {
+        firstWriteError: STACK_DATA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: {
+          subgraph_of: { node_id: 78, title: "Container" },
+          node_count: 1,
+          nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader", widgets: { stack_data: "old" } }],
+        },
+        stackDataIdentity: { nodes: [{ id: 78, type: "OtherLoraLoader" }] },
+        stackDataInnerIdentity: { nodes: [{ id: 76, type: "DaSiWa_LTX2LoraLoader" }] },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/DaSiWa_LTX2LoraLoader/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("refuses a promoted retry when the mapping relinks after enter", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWriteError: ANIMA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        subgraphAfterEnter: ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("refuses the legacy recovery when its post-enter mapping relinks", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWriteError: ANIMA_CONTRADICTORY,
+        preflightSubgraph: new Error("preflight unavailable"),
+        recoveryPreflightSubgraph: new Error("recovery preflight unavailable"),
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        subgraphAfterEnter: ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/mapping changed or became unverifiable|type changed after entering/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
   });
 
 });
@@ -808,6 +983,7 @@ describe("resolveInnerPromotedTarget", () => {
     ["wrong node_count", { ...SUBGRAPH, node_count: 1 }],
     ["non-integer node_count", { ...SUBGRAPH, node_count: "2" }],
     ["truncated envelope", { ...SUBGRAPH, truncated: true }],
+    ["malformed inner node id", { ...SUBGRAPH, nodes: [{ ...SUBGRAPH.nodes[0], id: "not-a-node" }, SUBGRAPH.nodes[1]] }],
   ])("rejects a %s instead of trusting its inner mapping", (_name, malformed) => {
     expect(validatePromotedSubgraphEnvelope(malformed, 78)).toBeNull();
     expect(resolveInnerPromotedTarget(malformed, "width", 78)).toBeNull();
@@ -838,12 +1014,14 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
       "graph_query",
+      "graph_get_subgraph",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
     expect(calls[3]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(calls[8]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[10]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
     expect(text).toMatch(/validated promoted inner widget/);
   });
 
@@ -871,6 +1049,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
       "graph_query",
       "graph_exit_subgraph",
     ]);
@@ -902,6 +1081,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
       "graph_query",
       "graph_exit_subgraph",
     ]);
@@ -961,11 +1141,13 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
     expect(calls[0]).toMatchObject({ node_id: 78, widget: "width", value: 1024 });
-    expect(calls[3]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
+    expect(calls[5]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
     expect(text).toMatch(/inner widget this promotion lists: node 76 "width"/);
     expect(text).not.toMatch(/is not a promoted widget/);
   });
@@ -1075,6 +1257,8 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_get_subgraph",
       "graph_enter_subgraph",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -97,7 +97,9 @@ function bridge(opts: {
   tabRebindBeforeWrite?: boolean;
   authoritativeScopeRead?: boolean;
   ownerNavigationAfterFinalQuery?: boolean;
-  ownerNavigationAfterReadBeforeDispatch?: boolean;
+  /** Navigation after MCP's final synchronous callback but before the panel
+   * receiver evaluates the expected_scope envelope. */
+  receiverNavigationAfterMcpFence?: boolean;
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
 }) {
@@ -106,9 +108,6 @@ function bridge(opts: {
   let subgraphReads = 0;
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
-  let authoritativeScopeWitness:
-    | { known: true; scope: "root" | "subgraph"; ownerNodeId: string | null; workflowUuid?: string }
-    | undefined;
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let currentOwnerNodeId = 78;
@@ -179,11 +178,35 @@ function bridge(opts: {
       if (cmd.cmd === "graph_set_widget" && sendOpts?.beforeDispatch) {
         const mutation = beforeWrite.mutate;
         beforeWrite.mutate = undefined;
-        mutation?.();
-        sendOpts.beforeDispatch();
+        if (opts.receiverNavigationAfterMcpFence) {
+          // The MCP callback is the last synchronous server-side check. The
+          // browser can navigate after it returns and before the receiver
+          // handler applies the frame; this is the architectural race the
+          // expected_scope envelope must fence.
+          sendOpts.beforeDispatch();
+          mutation?.();
+        } else {
+          mutation?.();
+          sendOpts.beforeDispatch();
+        }
       }
       calls.push({ ...cmd });
       if (cmd.cmd === "graph_set_widget") {
+        const expectedScope = cmd.expected_scope;
+        if (expectedScope !== undefined) {
+          if (!expectedScope || typeof expectedScope !== "object" || Array.isArray(expectedScope)) {
+            throw new Error("graph_set_widget expected_scope must be a structured subgraph witness");
+          }
+          const expected = expectedScope as Record<string, unknown>;
+          const actualOwner = inSubgraph ? String(currentOwnerNodeId) : null;
+          if (
+            expected.scope !== "subgraph" ||
+            String(expected.owner_node_id) !== actualOwner ||
+            (expected.workflow_uuid !== undefined && expected.workflow_uuid !== workflowUuid)
+          ) {
+            throw new Error("graph_set_widget promoted receiver changed before dispatch: Nothing was applied.");
+          }
+        }
         writes += 1;
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
@@ -310,8 +333,6 @@ function bridge(opts: {
             };
             // Keep the cached reply as a separate value. The live result is
             // the witness the final callback must carry forward.
-            authoritativeScopeWitness = liveWitness;
-            observedPromotedScope = { ...liveWitness };
             return liveWitness;
           },
         }
@@ -332,16 +353,12 @@ function bridge(opts: {
       // but has a different receiver session.
       connectionIdentity = { generation: 1, tabSessionId: "browser-tab-b" };
     };
-  } else if (opts.ownerNavigationAfterReadBeforeDispatch) {
+  } else if (opts.receiverNavigationAfterMcpFence) {
     beforeWrite.mutate = () => {
-      // The live graph_query has already returned owner A. Navigation to owner
-      // B happens in the bridge's final dispatch seam, before the synchronous
-      // callback. Mutate the returned live witness to model the authoritative
-      // receiver token becoming stale in that window; the cached copy remains A.
+      // The live graph_query and MCP-side callback both saw owner A. Navigation
+      // to owner B happens only at the receiver boundary; no returned witness
+      // object is mutated because production navigation cannot do that.
       currentOwnerNodeId = 79;
-      if (authoritativeScopeWitness?.known) {
-        authoritativeScopeWitness.ownerNodeId = String(currentOwnerNodeId);
-      }
     };
   }
   return {
@@ -353,6 +370,9 @@ function bridge(opts: {
     },
     get postEnterGraphQueries() {
       return postEnterGraphQueries;
+    },
+    get writesApplied() {
+      return writes;
     },
   };
 }
@@ -373,6 +393,7 @@ async function setWidget(
     calls,
     authoritativeScopeReads: harness.authoritativeScopeReads,
     postEnterGraphQueries: harness.postEnterGraphQueries,
+    writesApplied: harness.writesApplied,
   };
 }
 
@@ -850,20 +871,21 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
   });
 
   it("uses the live scope witness at the normal final dispatch fence", async () => {
-    const { text, isError, calls, authoritativeScopeReads } = await setWidget(
+    const { text, isError, calls, authoritativeScopeReads, writesApplied } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         authoritativeScopeRead: true,
-        ownerNavigationAfterReadBeforeDispatch: true,
+        receiverNavigationAfterMcpFence: true,
       },
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/current subgraph owner changed|unverifiable/);
-    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(text).toMatch(/promoted receiver changed|Nothing was applied/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(writesApplied).toBe(0);
     expect(authoritativeScopeReads).toBe(1);
   });
 
@@ -983,7 +1005,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
   });
 
   it("refuses legacy recovery navigation after the live read before inner dispatch", async () => {
-    const { text, isError, calls, authoritativeScopeReads } = await setWidget(
+    const { text, isError, calls, authoritativeScopeReads, writesApplied } = await setWidget(
       { node_id: 78, widget: "Quality_Prompt", value: "masterpiece" },
       {
         firstWrite: "contradict",
@@ -992,13 +1014,17 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         subgraph: SAFE_ANIMA_SUBGRAPH,
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
         authoritativeScopeRead: true,
-        ownerNavigationAfterReadBeforeDispatch: true,
+        receiverNavigationAfterMcpFence: true,
       },
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/current subgraph owner changed|unverifiable/);
-    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(text).toMatch(/promoted receiver changed|Nothing was applied/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(2);
+    expect(writesApplied).toBe(1);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")[1]).toMatchObject({
+      expected_scope: { scope: "subgraph", owner_node_id: "78", workflow_uuid: "workflow-a" },
+    });
     expect(authoritativeScopeReads).toBe(1);
   });
 

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -77,7 +77,11 @@ function graphCommandLiteralsInSource(): Set<string> {
       }
       if (!full.endsWith(".ts")) continue;
       const src = stripComments(readFileSync(full, "utf8"));
-      for (const m of src.matchAll(/"(graph_[a-z0-9_]+)"/g)) found.add(m[1]);
+      for (const m of src.matchAll(/"(graph_[a-z0-9_]+)"/g)) {
+        // graph_identity is promoted-scope metadata, not a graph command. Keep
+        // the broad literal scan while excluding this protocol field explicitly.
+        if (m[1] !== "graph_identity") found.add(m[1]);
+      }
     }
   };
   walk(SRC);

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -165,6 +165,7 @@ function connectPanel(
             enforces_expected_node_type_at_write: true,
             enforces_expected_scope_at_write: true,
             enforces_expected_scope_graph_identity_at_write: true,
+            enforces_promoted_parent_rail_at_write: true,
             // The panel's sessionStorage-backed browser-tab identity: unique per
             // browser tab, stable across a reload (#486/#709).
             ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
@@ -3320,6 +3321,60 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       );
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(/graph-identity write fence.*0\.15\.97/i);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    old.close();
+  });
+
+  it("FAILS CLOSED when a witness-capable panel lacks the final parent-rail fence", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:old-promoted-parent-rail",
+            title: "old promoted parent rail fence",
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+            enforces_expected_node_type_at_write: true,
+            enforces_expected_scope_at_write: true,
+            enforces_expected_scope_graph_identity_at_write: true,
+            // Deliberately omit the final parent-rail capability while keeping
+            // the older witness/scope capabilities present.
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-promoted-parent-rail")).toBe(true),
+    );
+    expect(bridge.tabPromotedParentRailFenceCapability("tmp:old-promoted-parent-rail")).toBe(false);
+    const caught = await bridge
+      .send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 76,
+          widget: "quality_prompt",
+          value: "NEW",
+          expected_scope: {
+            scope: "subgraph",
+            owner_node_id: "78",
+            graph_identity: "graph:scope-a",
+            promoted_widget: "quality_prompt",
+            parent_rail: { authoritative: true, widget: "quality_prompt" },
+          },
+        },
+        { tabId: "tmp:old-promoted-parent-rail" },
+      )
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/atomic promoted parent-rail write fence.*0\.15\.97/i);
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -163,6 +163,7 @@ function connectPanel(
             enforces_workflow_stamp: true,
             enforces_workflow_stamp_at_write: true,
             enforces_expected_node_type_at_write: true,
+            enforces_expected_scope_at_write: true,
             // The panel's sessionStorage-backed browser-tab identity: unique per
             // browser tab, stable across a reload (#486/#709).
             ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
@@ -3214,6 +3215,121 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect((caught as Error).message).toMatch(/atomic expected-node-type write fence/);
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
+    modern.close();
+  });
+
+  it("FAILS CLOSED when expected_scope reaches a panel without #2314's receiver fence", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:old-promoted-scope-fence",
+            title: "old promoted scope fence",
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+            enforces_expected_node_type_at_write: true,
+            // Deliberately omit the #2314 receiver-side scope fence. The
+            // panel would otherwise ignore expected_scope and could write a
+            // colliding inner id after navigation.
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-promoted-scope-fence")).toBe(true),
+    );
+    expect(bridge.tabExpectedScopeFenceCapability("tmp:old-promoted-scope-fence")).toBe(false);
+    const caught = await bridge
+      .send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 76,
+          widget: "quality_prompt",
+          value: "NEW",
+          expected_scope: {
+            scope: "subgraph",
+            owner_node_id: "78",
+            workflow_uuid: "workflow-a",
+          },
+        },
+        { tabId: "tmp:old-promoted-scope-fence" },
+      )
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/atomic promoted-scope write fence.*0\.15\.97/i);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    old.close();
+  });
+
+  it("rechecks expected_scope capability after a graph-lane wait and reconnect", async () => {
+    const modern = await connectPanel("tmp:queued-promoted-scope", "queued");
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:queued-promoted-scope")).toBe(true),
+    );
+    const frames: Array<Record<string, unknown>> = [];
+    modern.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.rid && msg.cmd) frames.push(msg);
+    });
+    const predecessor = bridge.send({ cmd: "graph_outline" } as never, {
+      tabId: "tmp:queued-promoted-scope",
+    });
+    await waitFor(() => expect(frames.some((frame) => frame.cmd === "graph_outline")).toBe(true));
+    const fenced = bridge.send(
+      {
+        cmd: "graph_set_widget",
+        node_id: 76,
+        widget: "quality_prompt",
+        value: "NEW",
+        expected_scope: {
+          scope: "subgraph",
+          owner_node_id: "78",
+          workflow_uuid: "workflow-a",
+        },
+      },
+      { tabId: "tmp:queued-promoted-scope" },
+    );
+
+    // A reconnect can re-hello on the same socket while the graph lane waits.
+    // The launch-time capability check must not let the optional envelope reach
+    // a downgraded panel that would ignore it.
+    modern.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "tmp:queued-promoted-scope",
+        title: "old queued promoted-scope panel",
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+        enforces_expected_node_type_at_write: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(bridge.tabExpectedScopeFenceCapability("tmp:queued-promoted-scope")).toBe(false),
+    );
+    const first = frames.find((frame) => frame.cmd === "graph_outline");
+    const firstRid = first?.rid;
+    expect(firstRid).toBeTruthy();
+    if (!firstRid) throw new Error("graph_outline was not dispatched");
+    modern.send(JSON.stringify({ rid: firstRid, ok: true, result: {} }));
+    await predecessor;
+
+    const caught = await fenced.then(
+      () => null,
+      (err) => err,
+    );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/atomic promoted-scope write fence/);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    expect(frames.some((frame) => frame.cmd === "graph_set_widget")).toBe(false);
     modern.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3298,6 +3298,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await waitFor(() =>
       expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-promoted-graph-identity")).toBe(true),
     );
+    expect(bridge.tabExpectedScopeGraphIdentityFenceCapability("tmp:old-promoted-graph-identity")).toBe(false);
     const caught = await bridge
       .send(
         {
@@ -3393,6 +3394,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     autoReply(modern, "modern");
     await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:modern")).toBe(true));
     expect(bridge.tabExpectedNodeTypeFenceCapability("tmp:modern")).toBe(true);
+    expect(bridge.tabExpectedScopeGraphIdentityFenceCapability("tmp:modern")).toBe(true);
     // A graph mutator AND each workflow mutator all dispatch (enforcement + trusted stamp present).
     for (const cmd of [
       { cmd: "graph_add_node", node: "x" },

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -635,6 +635,41 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
     expect(result).toMatchObject({ from: "A" });
     a.close();
   });
+
+  it("records the latest structured current-view owner for promoted-write fences (#2314)", async () => {
+    const a = await connectPanel("tab-scope-2314");
+    a.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_query") {
+        a.send(
+          JSON.stringify({
+            rid: msg.rid,
+            ok: true,
+            result: {
+              viewing: {
+                scope: "subgraph",
+                owner_node_id: 78,
+                workflow_uuid: "11111111-1111-4111-8111-111111111111",
+              },
+              nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
+            },
+          }),
+        );
+      }
+    });
+    await waitFor(() => expect(bridge.connected()).toBe(true));
+    await bridge.send(
+      { cmd: "graph_query", ids: [76], fields: "compact", limit: 1 },
+      { tabId: "tab-scope-2314" },
+    );
+    expect(bridge.promotedScopeFor("tab-scope-2314")).toEqual({
+      known: true,
+      scope: "subgraph",
+      ownerNodeId: "78",
+      workflowUuid: "11111111-1111-4111-8111-111111111111",
+    });
+    a.close();
+  });
 });
 
 describe("UiBridge (multi-tab)", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -670,6 +670,46 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
     });
     a.close();
   });
+
+  it("freshly reads the current promoted owner after the cached owner goes stale (#2314)", async () => {
+    const a = await connectPanel("tab-scope-read-2314");
+    let ownerNodeId = 78;
+    a.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_query") {
+        a.send(
+          JSON.stringify({
+            rid: msg.rid,
+            ok: true,
+            result: {
+              viewing: {
+                scope: "subgraph",
+                owner_node_id: ownerNodeId,
+                workflow_uuid: "11111111-1111-4111-8111-111111111111",
+              },
+              nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
+            },
+          }),
+        );
+      }
+    });
+    await waitFor(() => expect(bridge.connected()).toBe(true));
+    await bridge.send(
+      { cmd: "graph_query", ids: [76], fields: "compact", limit: 1 },
+      { tabId: "tab-scope-read-2314" },
+    );
+    expect(bridge.promotedScopeFor("tab-scope-read-2314")).toMatchObject({ ownerNodeId: "78" });
+
+    ownerNodeId = 79;
+    await expect(bridge.readPromotedScope("tab-scope-read-2314", 76)).resolves.toEqual({
+      known: true,
+      scope: "subgraph",
+      ownerNodeId: "79",
+      workflowUuid: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(bridge.promotedScopeFor("tab-scope-read-2314")).toMatchObject({ ownerNodeId: "79" });
+    a.close();
+  });
 });
 
 describe("UiBridge (multi-tab)", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -164,6 +164,7 @@ function connectPanel(
             enforces_workflow_stamp_at_write: true,
             enforces_expected_node_type_at_write: true,
             enforces_expected_scope_at_write: true,
+            enforces_expected_scope_graph_identity_at_write: true,
             // The panel's sessionStorage-backed browser-tab identity: unique per
             // browser tab, stable across a reload (#486/#709).
             ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
@@ -651,6 +652,7 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
                 scope: "subgraph",
                 owner_node_id: 78,
                 workflow_uuid: "11111111-1111-4111-8111-111111111111",
+                graph_identity: "graph:scope-a",
               },
               nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
             },
@@ -668,6 +670,7 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
       scope: "subgraph",
       ownerNodeId: "78",
       workflowUuid: "11111111-1111-4111-8111-111111111111",
+      graphIdentity: "graph:scope-a",
     });
     a.close();
   });
@@ -687,6 +690,7 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
                 scope: "subgraph",
                 owner_node_id: ownerNodeId,
                 workflow_uuid: "11111111-1111-4111-8111-111111111111",
+                graph_identity: "graph:scope-a",
               },
               nodes: [{ id: 76, type: "PrimitiveStringMultiline" }],
             },
@@ -707,6 +711,7 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
       scope: "subgraph",
       ownerNodeId: "79",
       workflowUuid: "11111111-1111-4111-8111-111111111111",
+      graphIdentity: "graph:scope-a",
     });
     expect(bridge.promotedScopeFor("tab-scope-read-2314")).toMatchObject({ ownerNodeId: "79" });
     a.close();
@@ -3264,6 +3269,56 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       );
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(/atomic promoted-scope write fence.*0\.15\.97/i);
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    old.close();
+  });
+
+  it("FAILS CLOSED when an old promoted fence lacks graph identity enforcement", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:old-promoted-graph-identity",
+            title: "old promoted graph identity fence",
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+            enforces_expected_node_type_at_write: true,
+            enforces_expected_scope_at_write: true,
+            // Deliberately omit the P1 graph-identity capability. The owner id
+            // is graph-local and cannot fence a same-id cross-graph navigation.
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-promoted-graph-identity")).toBe(true),
+    );
+    const caught = await bridge
+      .send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 76,
+          widget: "quality_prompt",
+          value: "NEW",
+          expected_scope: {
+            scope: "subgraph",
+            owner_node_id: "78",
+            graph_identity: "graph:scope-a",
+          },
+        },
+        { tabId: "tmp:old-promoted-graph-identity" },
+      )
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/graph-identity write fence.*0\.15\.97/i);
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();

--- a/src/__tests__/tools/panel-status-latest.test.ts
+++ b/src/__tests__/tools/panel-status-latest.test.ts
@@ -44,9 +44,9 @@ import { requiredPanelVersion } from "../../services/panel-sync.js";
 import { compareSemver } from "../../services/self-update.js";
 import { panelAction } from "../../tools/install-panel.js";
 
-/** A panel above the 0.15.58 capability floor, with a newer published release. */
-const INSTALLED = "0.15.60";
-const LATEST = "0.15.76";
+/** A panel above the 0.15.97 capability floor, with a newer published release. */
+const INSTALLED = "0.15.97";
+const LATEST = "0.16.13";
 
 function status(over: Partial<PanelStatus> = {}): PanelStatus {
   return {
@@ -135,7 +135,7 @@ describe("#1983 — the status tool REACHES the latest-version probe", () => {
 
 describe("#1983 — floor and latest are two answers, never one", () => {
   it("the fixture is still above the floor (input precondition, not an expectation)", () => {
-    // If the derived floor ever rises past 0.15.60 these fixtures stop testing
+    // If the derived floor ever rises past 0.15.97 these fixtures stop testing
     // the reported state. Fail here with a clear reason rather than three tests
     // failing obscurely.
     expect(compareSemver(INSTALLED, requiredPanelVersion())).toBeGreaterThanOrEqual(0);
@@ -147,7 +147,7 @@ describe("#1983 — floor and latest are two answers, never one", () => {
 
     const sync = await statusCall();
 
-    // The floor answer is UNCHANGED — 0.15.60 is not too old to work.
+    // The floor answer is UNCHANGED — 0.15.97 is not too old to work.
     expect(sync.behind).toBe(false);
     expect(sync.decision).toBe("meets-floor");
     // The latest answer is the one that was missing.
@@ -411,7 +411,7 @@ describe("#1983 — boundaries of the ahead-of-published comparison", () => {
   });
 
   it("a higher patch with a prerelease tag IS ahead", async () => {
-    mocks.panelStatus.mockResolvedValue(status({ installedVersion: "0.15.77-rc1" }));
+    mocks.panelStatus.mockResolvedValue(status({ installedVersion: "0.16.14-rc1" }));
     stubFetch(() => new Response(pyproject(LATEST), { status: 200 }));
 
     const sync = await statusCall();
@@ -484,7 +484,7 @@ describe("#1995 gate P1 — every remedy names an action that can succeed from t
     expect(sync.summary).toMatch(SYNC_VERB);
     // And it must not claim a version gap it has no installed version for.
     expect(sync.summary).not.toMatch(/a NEWER panel is published/);
-    expect(sync.summary).toMatch(/newest published panel is 0\.15\.76/);
+    expect(sync.summary).toContain(`newest published panel is ${LATEST}`);
   });
 
   it("ABSENT + pinned → clear the pin, never update", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6271,7 +6271,12 @@ function samePromotedParentRail(
   right: PromotedParentRailWitness | undefined,
 ): boolean {
   if (!left || !right) return left === right;
-  return left.authoritative === true && right.authoritative === true && left.widget === right.widget;
+  return (
+    left.authoritative === true &&
+    right.authoritative === true &&
+    left.widget === right.widget &&
+    left.widgetId === right.widgetId
+  );
 }
 
 /** Run the known-bad set against the node id that is about to be written, then
@@ -6321,6 +6326,8 @@ type PromotedWritePlan = {
 
 type PromotedExpectedScope = PromotedScopeWitness & {
   terminal?: PromotedTerminalWitness;
+  promotedWidget?: string;
+  parentRail?: PromotedParentRailWitness;
 };
 
 type PromotedWritePreflight = PromotedWritePlan | ToolResult | null;
@@ -6750,6 +6757,16 @@ async function preparePromotedWidgetWrite(
     return promotedWriteRefusal(
       widget,
       "the receiving panel lacks the atomic promoted graph-identity write fence",
+    );
+  }
+  // Legacy panels do not publish a parent-rail witness and retain the
+  // established same-name recovery contract. A current witness-capable panel
+  // must advertise the synchronous final rail re-resolution before MCP sends
+  // the inner/shared-subgraph write.
+  if (publishesCompleteTerminalWitness && ctx.tabPromotedParentRailFenceCapability?.() !== true) {
+    return promotedWriteRefusal(
+      widget,
+      "the receiving panel lacks the atomic promoted parent-rail write fence",
     );
   }
 
@@ -12695,6 +12712,7 @@ interface BridgeProbe {
   promotedScopeFor?: (tabId: string) => TabPromotedScopeRead;
   readPromotedScope?: (tabId: string, innerNodeId: number | string) => Promise<TabPromotedScopeRead>;
   tabPromotedTerminalWitnessCapability?: (tabId: string) => boolean;
+  tabPromotedParentRailFenceCapability?: (tabId: string) => boolean;
   lastFenceRefusal?: (tabId: string) => string | undefined;
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
@@ -12831,6 +12849,9 @@ export interface PanelToolCtx {
   /** Whether the currently bound panel publishes the complete renamed-promotion
    * alias -> terminal witness needed for alias-independent preflight (#2314 P1). */
   tabPromotedTerminalWitnessCapability?: () => boolean;
+  /** Whether the currently bound panel re-resolves the promoted parent rail
+   * synchronously at the final graph_set_widget mutation boundary. */
+  tabPromotedParentRailFenceCapability?: () => boolean;
   /**
    * The same question TRI-STATE, for code that must REPORT the answer rather than
    * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
@@ -14256,6 +14277,9 @@ export function makePanelToolCtx(
   ctx.tabPromotedTerminalWitnessCapability = () =>
     typeof bridge.tabPromotedTerminalWitnessCapability === "function" &&
     bridge.tabPromotedTerminalWitnessCapability(ctx.tabId);
+  ctx.tabPromotedParentRailFenceCapability = () =>
+    typeof bridge.tabPromotedParentRailFenceCapability === "function" &&
+    bridge.tabPromotedParentRailFenceCapability(ctx.tabId);
   ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }
@@ -17274,6 +17298,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                           scope: "subgraph",
                           owner_node_id: targetExpectedScope.ownerNodeId,
                           graph_identity: targetExpectedScope.graphIdentity,
+                          ...(targetExpectedScope.promotedWidget && targetExpectedScope.parentRail
+                            ? {
+                                promoted_widget: targetExpectedScope.promotedWidget,
+                                parent_rail: {
+                                  authoritative: true,
+                                  widget: targetExpectedScope.parentRail.widget,
+                                  ...(targetExpectedScope.parentRail.widgetId !== undefined
+                                    ? { widget_id: targetExpectedScope.parentRail.widgetId }
+                                    : {}),
+                                },
+                              }
+                            : {}),
                           ...(targetExpectedScope.workflowUuid !== undefined
                             ? { workflow_uuid: targetExpectedScope.workflowUuid }
                             : {}),
@@ -17508,6 +17544,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               },
               {
                 ...plan.scope,
+                promotedWidget: args.widget as string,
+                parentRail: plan.inner.parentRail,
                 ...(plan.terminal ? { terminal: plan.terminal } : {}),
               },
             );

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -130,6 +130,7 @@ import {
   resolveLegacyInnerPromotedTarget,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
+  type PromotedParentRailWitness,
   type PromotedScopeWitness,
   type PromotedTerminalWitness,
   type UnpromotedControlPersistRemedy,
@@ -6265,6 +6266,14 @@ function samePromotedTerminal(
   );
 }
 
+function samePromotedParentRail(
+  left: PromotedParentRailWitness | undefined,
+  right: PromotedParentRailWitness | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return left.authoritative === true && right.authoritative === true && left.widget === right.widget;
+}
+
 /** Run the known-bad set against the node id that is about to be written, then
  * inspect a uniquely mapped promoted inner node when the addressed node is a
  * subgraph container. Keep promotion handling separate from the direct helper
@@ -6299,7 +6308,11 @@ type PromotedWriteBinding = {
 type PromotedWritePlan = {
   kind: "promoted-write";
   outerNodeId: number | string;
-  inner: { innerNodeId: number | string; widget: string };
+  inner: {
+    innerNodeId: number | string;
+    widget: string;
+    parentRail?: PromotedParentRailWitness;
+  };
   innerNodeType: string;
   terminal?: PromotedTerminalWitness;
   scope: PromotedScopeWitness;
@@ -6699,6 +6712,12 @@ async function preparePromotedWidgetWrite(
         : "the legacy receiver could not prove that this subgraph request was an ordinary widget",
     );
   }
+  if (publishesCompleteTerminalWitness && !inner.parentRail) {
+    return promotedWriteRefusal(
+      widget,
+      "the current promoted-terminal witness did not prove an authoritative parent rail",
+    );
+  }
   const scopeError = currentPromotedScopeError(ctx, scope);
   if (scopeError) return promotedWriteRefusal(widget, scopeError);
 
@@ -6746,7 +6765,11 @@ async function preparePromotedWidgetWrite(
 }
 
 type PromotedMappingProof = {
-  inner: { innerNodeId: number | string; widget: string };
+  inner: {
+    innerNodeId: number | string;
+    widget: string;
+    parentRail?: PromotedParentRailWitness;
+  };
   innerNodeType: string;
   terminal?: PromotedTerminalWitness;
 };
@@ -6759,7 +6782,11 @@ async function recheckPromotedOuterMapping(
   ctx: PanelToolCtx,
   outerNodeId: number | string,
   widget: string,
-  expectedInner: { innerNodeId: number | string; widget: string },
+  expectedInner: {
+    innerNodeId: number | string;
+    widget: string;
+    parentRail?: PromotedParentRailWitness;
+  },
   expectedScope: PromotedScopeWitness,
   expectedTerminal?: PromotedTerminalWitness,
 ): Promise<PromotedMappingProof | ToolResult> {
@@ -6801,6 +6828,7 @@ async function recheckPromotedOuterMapping(
     !inner ||
     canonicalQueriedNodeId(inner.innerNodeId) !== canonicalQueriedNodeId(expectedInner.innerNodeId) ||
     inner.widget !== expectedInner.widget ||
+    !samePromotedParentRail(inner.parentRail, expectedInner.parentRail) ||
     !samePromotedTerminal(inner.terminal, expectedTerminal)
   ) {
     return promotedWriteRefusal(
@@ -6836,7 +6864,11 @@ async function recheckPromotedOuterMapping(
  */
 async function recheckPromotedInnerTarget(
   ctx: PanelToolCtx,
-  expectedInner: { innerNodeId: number | string; widget: string },
+  expectedInner: {
+    innerNodeId: number | string;
+    widget: string;
+    parentRail?: PromotedParentRailWitness;
+  },
   expectedNodeType: string,
   widget: string,
   expectedScope: PromotedScopeWitness,
@@ -6898,7 +6930,11 @@ async function recheckPromotedInnerTarget(
           ctx.tabPromotedTerminalWitnessCapability?.() === true,
         )
       : null;
-    if (!nestedInner?.terminal || !samePromotedTerminal(nestedInner.terminal, expectedTerminal, false)) {
+    if (
+      !nestedInner?.terminal ||
+      (ctx.tabPromotedTerminalWitnessCapability?.() === true && !nestedInner.parentRail) ||
+      !samePromotedTerminal(nestedInner.terminal, expectedTerminal, false)
+    ) {
       return promotedWriteRefusal(
         widget,
         "the nested promoted terminal mapping changed or became unverifiable after entering",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -127,6 +127,7 @@ import {
   parseUnpromotedControlPersistRemedy,
   promotedScopeWitnessFromEnvelope,
   promotedViewingMatchesScope,
+  resolveLegacyInnerPromotedTarget,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
   type PromotedScopeWitness,
@@ -6276,15 +6277,6 @@ async function refuseKnownBadWriteBeforeDispatch(
   return refuseKnownBadWidgetWrite(ctx, nodeId, widget);
 }
 
-function mayHaveKnownBadPromotedWidget(widget: string): boolean {
-  const lower = widget.toLowerCase();
-  return (
-    [...ANIMA_REGIONAL_PROMPT_WIDGETS].some((name) => name.toLowerCase() === lower) ||
-    lower === DASIWA_STACK_WIDGET.toLowerCase() ||
-    widget.includes(".")
-  );
-}
-
 /**
  * #2314 — a promoted write can succeed on the container and propagate to an
  * unsafe inner widget without ever entering the recovery branch. Resolve the
@@ -6375,6 +6367,55 @@ function promotedTerminalAliasCount(
       typeof (entry as Record<string, unknown>).widget === "string" &&
       ((entry as Record<string, unknown>).widget as string).toLowerCase() === widget.toLowerCase(),
   ).length;
+}
+
+/** A capability-skewed receiver's witness array is not authoritative. Any
+ * malformed, duplicate, or unresolved entry also makes the whole successful
+ * subgraph response incomplete: an unrelated requested alias cannot use the
+ * remaining entries as proof that it was ordinary. Do not ignore that evidence
+ * and revive the old same-name scan into an outer write. */
+function promotedTerminalEvidenceError(
+  payload: Record<string, unknown>,
+): string | null {
+  if (!Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")) return null;
+  const entries = payload.promoted_terminals;
+  if (!Array.isArray(entries)) return "the current receiver's promoted-terminal witness was unavailable";
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return "the current receiver's promoted-terminal witness was unavailable";
+    }
+    const witness = entry as Record<string, unknown>;
+    if (typeof witness.widget !== "string" || witness.widget.length === 0) {
+      return "the current receiver's promoted-terminal witness was unavailable";
+    }
+    const key = witness.widget.toLowerCase();
+    if (seen.has(key)) return "the promoted-terminal witness was ambiguous";
+    seen.add(key);
+    if (witness.error) return "the promoted-terminal witness was incomplete or unresolved";
+  }
+  return null;
+}
+
+/** Resolve a requested relation without ever treating an unadvertised
+ * witness miss as ordinary. A valid entry is safe positive evidence for this
+ * alias even during capability skew; the legacy same-name scan remains the
+ * compatibility fallback only when no witness array is present (or when its
+ * requested alias is not represented and the old envelope can positively map
+ * that exact same name). The caller handles every miss as indeterminate. */
+function resolvePromotedWriteTarget(
+  payload: Record<string, unknown> | null | undefined,
+  widget: string,
+  nodeId: number | string,
+  authoritativeWitnesses: boolean,
+) {
+  if (!payload) return null;
+  if (authoritativeWitnesses) return resolveInnerPromotedTarget(payload, widget, nodeId);
+  if (Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")) {
+    const witnessed = resolveInnerPromotedTarget(payload, widget, nodeId);
+    if (witnessed) return witnessed;
+  }
+  return resolveLegacyInnerPromotedTarget(payload, widget, nodeId);
 }
 
 function currentPromotedBindingError(
@@ -6524,15 +6565,27 @@ async function preparePromotedWidgetWrite(
   nodeId: unknown,
   widget: string,
 ): Promise<PromotedWritePreflight> {
+  // Production PanelToolCtx is always backed by UiBridge, which exposes this
+  // per-hello capability getter. A few transport-only forwarding contexts (and
+  // older unit seams) intentionally have no receiver capability API at all;
+  // there is no panel response to authorize or refuse in that case, so leave
+  // their one-hop forwarding contract unchanged. A real connected receiver
+  // reaches the fail-closed `false` branch below when the getter says the
+  // complete witness capability was not advertised.
+  const receiverCapabilityApi = (ctx.bridge as unknown as BridgeProbe | undefined)
+    ?.tabPromotedTerminalWitnessCapability;
+  if (
+    typeof ctx.tabPromotedTerminalWitnessCapability !== "function" ||
+    typeof receiverCapabilityApi !== "function"
+  ) {
+    return null;
+  }
   // The recursive terminal witness is only actionable when the receiver
   // advertises that it publishes that witness. Older panels retain their
   // established known-bad recovery path rather than being mistaken for a
   // bundle that can classify renamed promotion aliases.
   const publishesCompleteTerminalWitness =
     ctx.tabPromotedTerminalWitnessCapability?.() === true;
-  if (!publishesCompleteTerminalWitness && !mayHaveKnownBadPromotedWidget(widget)) {
-    return null;
-  }
 
   const tabBefore = ctx.tabId;
   const hasIdentityApi = typeof ctx.panelConnectionIdentity === "function";
@@ -6570,16 +6623,12 @@ async function preparePromotedWidgetWrite(
     );
   }
   // The recursive alias mapping is the current receiver's proof that this
-  // graph_get_subgraph response can classify renamed promotions. Legacy
-  // envelopes have no terminal relation; leave their established refusal/
-  // recovery path in charge rather than treating a same-name inner hit as a
-  // complete authorization proof.
-  if (
-    !Object.prototype.hasOwnProperty.call(payload, "promoted_terminals") &&
-    !mayHaveKnownBadPromotedWidget(widget)
-  ) {
-    return null;
-  }
+  // graph_get_subgraph response can classify renamed promotions. A legacy
+  // envelope may still positively map an old same-name promotion, but a miss
+  // is not evidence that the request is an ordinary widget on the container.
+  // In particular, do not turn a narrow known-bad-name list into authorization
+  // for an unscoped outer write: renamed Anima, dynamic, DaSiWa, and dotted
+  // aliases are all untrusted shape inputs here.
   if (!hasIdentityApi) {
     return promotedWriteRefusal(widget, "the receiver identity was unavailable while the mapping was read");
   }
@@ -6614,12 +6663,23 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
     );
   }
-  const inner = resolveInnerPromotedTarget(payload, widget, nodeId as number | string);
+  const terminalEvidenceError = promotedTerminalEvidenceError(payload);
+  if (terminalEvidenceError) return promotedWriteRefusal(widget, terminalEvidenceError);
+  const inner = resolvePromotedWriteTarget(
+    payload,
+    widget,
+    nodeId as number | string,
+    publishesCompleteTerminalWitness,
+  );
   if (!inner) {
-    const terminalAliases = publishesCompleteTerminalWitness
-      ? promotedTerminalAliasCount(payload, widget)
-      : 0;
-    if (terminalAliases === null || terminalAliases > 0) {
+    if (publishesCompleteTerminalWitness) {
+      const terminalAliases = promotedTerminalAliasCount(payload, widget);
+      if (terminalAliases === 0) {
+        // A complete current witness is authoritative: an alias absent from it
+        // is an ordinary own-widget, even if an inner node happens to use the
+        // same spelling.
+        return null;
+      }
       return promotedWriteRefusal(
         widget,
         terminalAliases === null
@@ -6627,18 +6687,16 @@ async function preparePromotedWidgetWrite(
           : "the promoted-terminal witness was missing, ambiguous, stale, or unresolved",
       );
     }
-    // A current panel's complete witness array is authoritative: an alias
-    // absent from it is an ordinary own-widget, even if an inner concrete node
-    // happens to use the same spelling. Preserve the original outer write for
-    // that deliberate non-promoted case.
-    if (publishesCompleteTerminalWitness && terminalAliases === 0) return null;
+    // Legacy panels cannot prove that a successful subgraph read has no renamed
+    // relation. Only a definitive non-subgraph error above authorizes the
+    // original outer path; every successful legacy envelope with no positive
+    // same-name mapping is refused before graph_set_widget.
     const matches = promotedMatchCount(payload, widget);
-    if (matches === 0) return null;
     return promotedWriteRefusal(
       widget,
-      matches === 1
-        ? "the terminal promotion endpoint was missing, malformed, or unresolved"
-        : `the envelope mapped it ambiguously to ${matches} inner nodes`,
+      matches > 1
+        ? `the legacy envelope mapped this request ambiguously to ${matches} inner nodes`
+        : "the legacy receiver could not prove that this subgraph request was an ordinary widget",
     );
   }
   const scopeError = currentPromotedScopeError(ctx, scope);
@@ -6728,7 +6786,12 @@ async function recheckPromotedOuterMapping(
   const envelope = validatePromotedSubgraphEnvelope(payload, outerNodeId);
   const observedScope = envelope ? promotedScopeWitnessFromEnvelope(envelope) : null;
   const inner = envelope
-    ? resolveInnerPromotedTarget(payload, widget, outerNodeId)
+    ? resolvePromotedWriteTarget(
+        payload,
+        widget,
+        outerNodeId,
+        ctx.tabPromotedTerminalWitnessCapability?.() === true,
+      )
     : null;
   if (
     !envelope ||
@@ -6828,7 +6891,12 @@ async function recheckPromotedInnerTarget(
       expectedInner.innerNodeId,
     );
     const nestedInner = nestedEnvelope
-      ? resolveInnerPromotedTarget(nestedPayload, expectedInner.widget, expectedInner.innerNodeId)
+      ? resolvePromotedWriteTarget(
+          nestedPayload,
+          expectedInner.widget,
+          expectedInner.innerNodeId,
+          ctx.tabPromotedTerminalWitnessCapability?.() === true,
+        )
       : null;
     if (!nestedInner?.terminal || !samePromotedTerminal(nestedInner.terminal, expectedTerminal, false)) {
       return promotedWriteRefusal(
@@ -12590,6 +12658,7 @@ interface BridgeProbe {
   workflowUuidFor?: (tabId: string) => TabWorkflowUuidRead;
   promotedScopeFor?: (tabId: string) => TabPromotedScopeRead;
   readPromotedScope?: (tabId: string, innerNodeId: number | string) => Promise<TabPromotedScopeRead>;
+  tabPromotedTerminalWitnessCapability?: (tabId: string) => boolean;
   lastFenceRefusal?: (tabId: string) => string | undefined;
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
@@ -17719,10 +17788,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             );
           }
         }
-        const inner = resolveInnerPromotedTarget(
+        const inner = resolvePromotedWriteTarget(
           recoveryPayload,
           refusal.widget,
           args.node_id as number | string,
+          ctx.tabPromotedTerminalWitnessCapability?.() === true,
         );
         if (!inner) {
           return appendToolResultText(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6348,13 +6348,24 @@ function currentPromotedScopeError(
     }
     if (
       requireCurrentSubgraph &&
-      (scopeRead.scope !== "subgraph" || scopeRead.ownerNodeId !== expected.ownerNodeId)
+      (scopeRead.scope !== "subgraph" ||
+        scopeRead.ownerNodeId !== expected.ownerNodeId ||
+        scopeRead.graphIdentity !== expected.graphIdentity)
     ) {
-      return "the receiving panel current subgraph owner changed or became unverifiable";
+      return "the receiving panel current graph/subgraph identity changed or became unverifiable";
+    }
+    // Before graph_enter_subgraph the live query is correctly scoped to the
+    // parent/root graph, while expected.graphIdentity names the target graph
+    // carried in subgraph_of. Compare the graph token only once the receiver
+    // is actually in a subgraph (the authoritative/final fence requires that).
+    if (scopeRead.scope === "subgraph" && scopeRead.graphIdentity !== expected.graphIdentity) {
+      return "the receiving panel current graph identity changed or became unverifiable";
     }
     if (expected.workflowUuid !== undefined && scopeRead.workflowUuid !== expected.workflowUuid) {
       return "the receiving panel workflow scope changed or became unverifiable";
     }
+  } else {
+    return "the receiving panel current graph/subgraph identity became unverifiable";
   }
 
   // The workflow stamp remains an independent receiver fence. Its UUID is
@@ -16953,6 +16964,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                         expected_scope: {
                           scope: "subgraph",
                           owner_node_id: targetExpectedScope.ownerNodeId,
+                          graph_identity: targetExpectedScope.graphIdentity,
                           ...(targetExpectedScope.workflowUuid !== undefined
                             ? { workflow_uuid: targetExpectedScope.workflowUuid }
                             : {}),

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6279,6 +6279,17 @@ function promotedEnvelopeCarriesEvidence(payload: Record<string, unknown> | null
   );
 }
 
+/** The shipped panel's only definitive non-promoted result is its own
+ * `Node <id> (<type>) is not a subgraph` refusal. Every other graph_get_subgraph
+ * error is an indeterminate read: a disconnect, stale route, old panel, or
+ * transport failure can all leave a promoted container unresolved. */
+function isDefinitiveNonPromotedSubgraphRead(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return /^Error:\s*Node\s+\S+(?:\s+\([^)]*\))?\s+is not a subgraph\b/i.test(
+    textOfToolResult(res),
+  );
+}
+
 function promotedMatchCount(payload: Record<string, unknown>, widget: string): number {
   const nodes = payload.nodes;
   if (!Array.isArray(nodes)) return 0;
@@ -6438,9 +6449,10 @@ function promotedWriteRefusal(widget: string, reason: string): ToolResult {
  * checks the receiver again. A later promotion relink therefore cannot redirect
  * an apparently safe container write onto a known-bad inner.
  *
- * An unavailable graph_get_subgraph remains the pre-existing fail-open case: it
- * supplies no promotion classification. A successful response with promotion
- * fields that are malformed, stale, truncated, or ambiguous fails closed.
+ * Only the panel's definitive "is not a subgraph" result supplies a safe
+ * non-promoted classification. An unavailable, malformed, or otherwise
+ * indeterminate read fails closed because the panel can resolve a promoted
+ * container to its unsafe inner node.
  */
 async function preparePromotedWidgetWrite(
   ctx: PanelToolCtx,
@@ -6461,14 +6473,20 @@ async function preparePromotedWidgetWrite(
   }
 
   const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
-  // Preserve #2299's unavailable-preflight fail-open behavior exactly: an
-  // unavailable read does not classify the write as promoted.
-  if (sub.isError) return null;
+  if (sub.isError) {
+    if (isDefinitiveNonPromotedSubgraphRead(sub)) return null;
+    return promotedWriteRefusal(
+      widget,
+      "graph_get_subgraph could not determine whether the addressed node is a promoted container",
+    );
+  }
   const payload = parseToolResultJson(sub);
-  // Some lightweight test seams return the ordinary write envelope for every
-  // command. It carries no subgraph claim, so it is not promotion evidence.
-  if (!promotedEnvelopeCarriesEvidence(payload)) return null;
-  if (!payload) return null;
+  if (!payload || !promotedEnvelopeCarriesEvidence(payload)) {
+    return promotedWriteRefusal(
+      widget,
+      "graph_get_subgraph returned no definitive non-promoted or ownership result",
+    );
+  }
   if (!hasIdentityApi) {
     return promotedWriteRefusal(widget, "the receiver identity was unavailable while the mapping was read");
   }
@@ -6527,6 +6545,12 @@ async function preparePromotedWidgetWrite(
   }
   if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
     return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
+  }
+  if (ctx.tabExpectedScopeGraphIdentityFenceCapability?.() !== true) {
+    return promotedWriteRefusal(
+      widget,
+      "the receiving panel lacks the atomic promoted graph-identity write fence",
+    );
   }
 
   return {
@@ -12527,6 +12551,10 @@ export interface PanelToolCtx {
    * expected_node_type at the synchronous mutation boundary. Real contexts
    * provide this; omitted/false is a fail-closed answer for #2107. */
   tabExpectedNodeTypeFenceCapability?: () => boolean;
+  /** Whether the currently bound panel enforces the stable graph identity in
+   * expected_scope at the synchronous mutation boundary. Real contexts provide
+   * this; omitted/false is a fail-closed answer for promoted writes (#2314 P1). */
+  tabExpectedScopeGraphIdentityFenceCapability?: () => boolean;
   /**
    * The same question TRI-STATE, for code that must REPORT the answer rather than
    * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
@@ -13947,6 +13975,8 @@ export function makePanelToolCtx(
   ctx.tabCanMutateGraph = () => bridge.tabCanMutateGraph(ctx.tabId);
   ctx.tabExpectedNodeTypeFenceCapability = () =>
     bridge.tabExpectedNodeTypeFenceCapability(ctx.tabId);
+  ctx.tabExpectedScopeGraphIdentityFenceCapability = () =>
+    bridge.tabExpectedScopeGraphIdentityFenceCapability(ctx.tabId);
   ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }
@@ -17458,6 +17488,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return appendToolResultText(
               first,
               `\n\n${textOfToolResult(promotedWriteRefusal(refusal.widget, recoveryScopeError))}`,
+            );
+          }
+          if (ctx.tabExpectedScopeGraphIdentityFenceCapability?.() !== true) {
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(
+                promotedWriteRefusal(
+                  refusal.widget,
+                  "the receiving panel lacks the atomic promoted graph-identity write fence",
+                ),
+              )}`,
             );
           }
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6507,7 +6507,16 @@ async function preparePromotedWidgetWrite(
   nodeId: unknown,
   widget: string,
 ): Promise<PromotedWritePreflight> {
-  if (!mayHaveKnownBadPromotedWidget(widget)) return null;
+  // The recursive terminal witness is only actionable when the receiver
+  // advertises that it publishes that witness. Older panels retain their
+  // established known-bad recovery path rather than being mistaken for a
+  // bundle that can classify renamed promotion aliases.
+  if (
+    ctx.tabPromotedTerminalWitnessCapability?.() !== true &&
+    !mayHaveKnownBadPromotedWidget(widget)
+  ) {
+    return null;
+  }
 
   const tabBefore = ctx.tabId;
   const hasIdentityApi = typeof ctx.panelConnectionIdentity === "function";
@@ -6534,6 +6543,17 @@ async function preparePromotedWidgetWrite(
       widget,
       "graph_get_subgraph returned no definitive non-promoted or ownership result",
     );
+  }
+  // The recursive alias mapping is the current receiver's proof that this
+  // graph_get_subgraph response can classify renamed promotions. Legacy
+  // envelopes have no terminal relation; leave their established refusal/
+  // recovery path in charge rather than treating a same-name inner hit as a
+  // complete authorization proof.
+  if (
+    !Object.prototype.hasOwnProperty.call(payload, "promoted_terminals") &&
+    !mayHaveKnownBadPromotedWidget(widget)
+  ) {
+    return null;
   }
   if (!hasIdentityApi) {
     return promotedWriteRefusal(widget, "the receiver identity was unavailable while the mapping was read");
@@ -6569,20 +6589,19 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
     );
   }
-  const scopeError = currentPromotedScopeError(ctx, scope);
-  if (scopeError) return promotedWriteRefusal(widget, scopeError);
   const inner = resolveInnerPromotedTarget(payload, widget, nodeId as number | string);
   if (!inner) {
     const matches = promotedMatchCount(payload, widget);
-    return matches === 0
-      ? null
-      : promotedWriteRefusal(
-          widget,
-          matches === 1
-            ? "the terminal promotion endpoint was missing, malformed, or unresolved"
-            : `the envelope mapped it ambiguously to ${matches} inner nodes`,
-        );
+    if (matches === 0) return null;
+    return promotedWriteRefusal(
+      widget,
+      matches === 1
+        ? "the terminal promotion endpoint was missing, malformed, or unresolved"
+        : `the envelope mapped it ambiguously to ${matches} inner nodes`,
+    );
   }
+  const scopeError = currentPromotedScopeError(ctx, scope);
+  if (scopeError) return promotedWriteRefusal(widget, scopeError);
 
   const targetId = canonicalQueriedNodeId(inner.innerNodeId);
   const innerNode = envelope.nodes.find((candidate) => {
@@ -12654,6 +12673,9 @@ export interface PanelToolCtx {
    * expected_scope at the synchronous mutation boundary. Real contexts provide
    * this; omitted/false is a fail-closed answer for promoted writes (#2314 P1). */
   tabExpectedScopeGraphIdentityFenceCapability?: () => boolean;
+  /** Whether the currently bound panel publishes the complete renamed-promotion
+   * alias -> terminal witness needed for alias-independent preflight (#2314 P1). */
+  tabPromotedTerminalWitnessCapability?: () => boolean;
   /**
    * The same question TRI-STATE, for code that must REPORT the answer rather than
    * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
@@ -14076,6 +14098,9 @@ export function makePanelToolCtx(
     bridge.tabExpectedNodeTypeFenceCapability(ctx.tabId);
   ctx.tabExpectedScopeGraphIdentityFenceCapability = () =>
     bridge.tabExpectedScopeGraphIdentityFenceCapability(ctx.tabId);
+  ctx.tabPromotedTerminalWitnessCapability = () =>
+    typeof bridge.tabPromotedTerminalWitnessCapability === "function" &&
+    bridge.tabPromotedTerminalWitnessCapability(ctx.tabId);
   ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6087,6 +6087,49 @@ function dynamicComboSubWidgetRefusal(
   );
 }
 
+function dynamicComboSubWidgetRefusalFromDetail(
+  detail: QueriedNodeDetail | null,
+  widget: string,
+): ToolResult | null {
+  if (!detail) return null;
+  const dot = widget.indexOf(".");
+  if (dot <= 0 || dot === widget.length - 1) return null;
+
+  const parentInput = widget.slice(0, dot);
+  const childInput = detail.inputs.find(
+    (input) =>
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      (input as Record<string, unknown>).name === widget,
+  );
+  const childExists =
+    childInput !== undefined ||
+    (detail.widgets !== null && Object.prototype.hasOwnProperty.call(detail.widgets, widget));
+  if (!childExists) return null;
+
+  const parent = detail.inputs.find(
+    (input) =>
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      (input as Record<string, unknown>).name === parentInput,
+  );
+  if (!parent || typeof parent !== "object" || Array.isArray(parent)) return null;
+  if ((parent as Record<string, unknown>).type !== COMFY_DYNAMICCOMBO_V3) return null;
+
+  // A dynamic-combo parent is not on its own the #2299 shape. Only a child the
+  // probe PROVES is STRING is refused; a COMBO/INT/FLOAT/BOOLEAN child, or one
+  // whose declared type this row does not carry, keeps the normal setter path.
+  const childType =
+    childInput && typeof childInput === "object" && !Array.isArray(childInput)
+      ? (childInput as Record<string, unknown>).type
+      : undefined;
+  if (childType !== DYNAMIC_COMBO_REFUSED_CHILD_TYPE) return null;
+
+  return dynamicComboSubWidgetRefusal(detail.type, parentInput, widget);
+}
+
 /** Refuse a dotted widget only when the live detail row proves BOTH that its
  * prefix is a COMFY_DYNAMICCOMBO_V3 input and that the addressed child is a
  * STRING (see {@link DYNAMIC_COMBO_REFUSED_CHILD_TYPE} for why the child type is
@@ -6126,39 +6169,7 @@ async function refuseDynamicComboSubWidgetWrite(
   const requestedId = canonicalQueriedNodeId(nodeId);
   if (!detail || !requestedId || detail.id !== requestedId) return null;
 
-  const parentInput = widget.slice(0, dot);
-  const childInput = detail.inputs.find(
-    (input) =>
-      input &&
-      typeof input === "object" &&
-      !Array.isArray(input) &&
-      (input as Record<string, unknown>).name === widget,
-  );
-  const childExists =
-    childInput !== undefined ||
-    (detail.widgets !== null && Object.prototype.hasOwnProperty.call(detail.widgets, widget));
-  if (!childExists) return null;
-
-  const parent = detail.inputs.find(
-    (input) =>
-      input &&
-      typeof input === "object" &&
-      !Array.isArray(input) &&
-      (input as Record<string, unknown>).name === parentInput,
-  );
-  if (!parent || typeof parent !== "object" || Array.isArray(parent)) return null;
-  if ((parent as Record<string, unknown>).type !== COMFY_DYNAMICCOMBO_V3) return null;
-
-  // A dynamic-combo parent is not on its own the #2299 shape. Only a child the
-  // probe PROVES is STRING is refused; a COMBO/INT/FLOAT/BOOLEAN child, or one
-  // whose declared type this row does not carry, keeps the normal setter path.
-  const childType =
-    childInput && typeof childInput === "object" && !Array.isArray(childInput)
-      ? (childInput as Record<string, unknown>).type
-      : undefined;
-  if (childType !== DYNAMIC_COMBO_REFUSED_CHILD_TYPE) return null;
-
-  return dynamicComboSubWidgetRefusal(detail.type, parentInput, widget);
+  return dynamicComboSubWidgetRefusalFromDetail(detail, widget);
 }
 
 /** Refuse the known LC123 regional-canvas prompt widgets. Identity is read
@@ -6180,6 +6191,177 @@ async function refuseAnimaRegionalPromptWrite(
   const type = parseQueriedNodeType(parseToolResultJson(probe));
   if (!type || !ANIMA_REGIONAL_CANVAS_TYPES.has(type)) return null;
   return animaRegionalPromptRefusal(type, widget);
+}
+
+/** Run the complete known-bad widget refusal set for the node that will actually
+ * be written. Keep this as one call site so a new promoted-write path cannot
+ * accidentally re-run only one of the guards. The DaSiWa identity fence remains
+ * a separate final check because it also supplies the expected node type. */
+async function refuseKnownBadWidgetWrite(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<ToolResult | null> {
+  const animaBlocked = await refuseAnimaRegionalPromptWrite(ctx, nodeId, widget);
+  if (animaBlocked) return animaBlocked;
+
+  const dynamicComboBlocked = await refuseDynamicComboSubWidgetWrite(ctx, nodeId, widget);
+  if (dynamicComboBlocked) return dynamicComboBlocked;
+
+  return refuseDaSiWaStackWrite(ctx, nodeId, widget);
+}
+
+/** Run the known-bad set against the node id that is about to be written, then
+ * inspect a uniquely mapped promoted inner node when the addressed node is a
+ * subgraph container. Keep promotion handling separate from the direct helper
+ * so the inner probe cannot recurse into another promotion preflight. */
+async function refuseKnownBadWriteBeforeDispatch(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<ToolResult | null> {
+  const directBlocked = await refuseKnownBadWidgetWrite(ctx, nodeId, widget);
+  if (directBlocked) return directBlocked;
+  return refuseKnownBadPromotedWidgetWrite(ctx, nodeId, widget);
+}
+
+function mayHaveKnownBadPromotedWidget(widget: string): boolean {
+  const lower = widget.toLowerCase();
+  return (
+    [...ANIMA_REGIONAL_PROMPT_WIDGETS].some((name) => name.toLowerCase() === lower) ||
+    lower === DASIWA_STACK_WIDGET.toLowerCase() ||
+    widget.includes(".")
+  );
+}
+
+/**
+ * #2314 — a promoted write can succeed on the container and propagate to an
+ * unsafe inner widget without ever entering the recovery branch. Resolve the
+ * promotion and inspect the live inner-node listing before that first write.
+ * This keeps the caller in its original scope and avoids an enter/exit race
+ * merely to run a read-only guard. In particular, do not replace DaSiWa's live
+ * identity fence with a type copied from a subgraph listing.
+ *
+ * A failed/ambiguous/truncated subgraph read is not evidence of a promotion;
+ * the existing direct guard contracts remain responsible for the addressed
+ * node. A promoted stack candidate is live-verified with the existing DaSiWa
+ * identity fence inside the inner scope; Anima and dynamic-combo retain their
+ * existing fail-open behavior when their specific inner evidence is unavailable.
+ */
+async function refuseKnownBadPromotedWidgetWrite(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<ToolResult | null> {
+  if (!mayHaveKnownBadPromotedWidget(widget)) return null;
+
+  const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+  if (sub.isError) return null;
+  const payload = parseToolResultJson(sub);
+  const inner = resolveInnerPromotedTarget(payload, widget);
+  if (!inner) return null;
+
+  const nodes = payload?.nodes;
+  if (!Array.isArray(nodes)) return null;
+  const targetId = canonicalQueriedNodeId(inner.innerNodeId);
+  const innerNode = nodes.find((candidate) => {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+    const candidateId = canonicalQueriedNodeId((candidate as Record<string, unknown>).id);
+    return candidateId !== null && candidateId === targetId;
+  });
+  if (!innerNode || typeof innerNode !== "object" || Array.isArray(innerNode)) return null;
+
+  // The DaSiWa guard is deliberately stronger than a type classification from
+  // graph_get_subgraph: it authenticates the live node id, tab identity, and the
+  // panel's atomic expected-node-type fence. Preserve that contract for a
+  // promoted stack candidate instead of trusting the listing as a write fence.
+  if (inner.widget === DASIWA_STACK_WIDGET) {
+    return refusePromotedDaSiWaStackWrite(ctx, nodeId, inner.innerNodeId);
+  }
+
+  const identity = parseQueriedNodeIdentityRow(innerNode);
+  if (!identity) {
+    return null;
+  }
+
+  let blocked: ToolResult | null = null;
+  if (isAnimaRegionalPromptWidget(inner.widget)) {
+    if (ANIMA_REGIONAL_CANVAS_TYPES.has(identity.type)) {
+      blocked = animaRegionalPromptRefusal(identity.type, inner.widget);
+    }
+  } else if (inner.widget.includes(".")) {
+    blocked = dynamicComboSubWidgetRefusalFromDetail(
+      parseVerifiedQueriedNodeDetail({ nodes: [innerNode] }),
+      inner.widget,
+    );
+  }
+
+  return blocked
+    ? appendToolResultText(
+        blocked,
+        `\n\n(The addressed widget is promoted from node ${inner.innerNodeId} "${inner.widget}"; ` +
+          `the container write was refused before dispatch. No graph_set_widget was dispatched.)`,
+      )
+    : null;
+}
+
+/** Keep the DaSiWa promoted path on its existing live identity fence. The
+ * subgraph listing only establishes which inner node to inspect; it is never
+ * used as the final type proof for a mutation. */
+async function refusePromotedDaSiWaStackWrite(
+  ctx: PanelToolCtx,
+  containerNodeId: unknown,
+  innerNodeId: number | string,
+): Promise<ToolResult | null> {
+  let entered = false;
+  try {
+    const enter = await ctx.call(
+      { cmd: "graph_enter_subgraph", node_id: containerNodeId },
+      15000,
+    );
+    if (enter.isError) {
+      return daSiWaIdentityRefusal(
+        `the promoted inner node ${innerNodeId} could not be live-verified because ` +
+          `panel_enter_subgraph failed (${textOfToolResult(enter)})`,
+      );
+    }
+    entered = true;
+
+    const blocked = await refuseDaSiWaStackWrite(ctx, innerNodeId, DASIWA_STACK_WIDGET);
+    const exit = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+    entered = false;
+    if (blocked) {
+      return appendToolResultText(
+        blocked,
+        `\n\n(The addressed stack widget is promoted from node ${innerNodeId}; ` +
+          `the container write was refused before dispatch. No graph_set_widget was dispatched.` +
+          (exit.isError
+            ? ` panel_exit_subgraph also FAILED — the caller scope may still be inside ` +
+              `the subgraph. Call panel_exit_subgraph. (${textOfToolResult(exit)})`
+            : ""),
+      );
+    }
+    if (exit.isError) {
+      return daSiWaIdentityRefusal(
+        `the promoted inner node ${innerNodeId} was checked, but panel_exit_subgraph ` +
+          `failed before the container write (${textOfToolResult(exit)})`,
+      );
+    }
+    return null;
+  } catch (error) {
+    return daSiWaIdentityRefusal(
+      `the promoted inner node ${innerNodeId} could not be live-verified before dispatch: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    if (entered) {
+      try {
+        await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+      } catch {
+        // Preserve the refusal. The caller can explicitly recover the scope.
+      }
+    }
+  }
 }
 
 function daSiWaStackRefusal(type: string): ToolResult {
@@ -16429,24 +16611,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // reports success and is overwritten on APPLY. Refuse before the write
         // so the reply is not a lie. Identity is a one-node graph_query; an
         // unreadable probe is fail-open (some other node may own negative_prompt).
-        const blocked = await refuseAnimaRegionalPromptWrite(
+        const blocked = await refuseKnownBadWriteBeforeDispatch(
           ctx,
           args.node_id,
           args.widget as string,
         );
         if (blocked) return blocked;
-        const dynamicComboBlocked = await refuseDynamicComboSubWidgetWrite(
-          ctx,
-          args.node_id,
-          args.widget as string,
-        );
-        if (dynamicComboBlocked) return dynamicComboBlocked;
-        const daSiWaBlocked = await refuseDaSiWaStackWrite(
-          ctx,
-          args.node_id,
-          args.widget as string,
-        );
-        if (daSiWaBlocked) return daSiWaBlocked;
+
         let expectedNodeType: string | undefined;
         if (args.widget === DASIWA_STACK_WIDGET) {
           const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
@@ -16494,6 +16665,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               echoFull,
             ),
           );
+        const guardedWrite = async (
+          nodeId: unknown,
+          widget: string,
+          targetExpectedNodeType: string | undefined = expectedNodeType,
+        ): Promise<ToolResult> => {
+          const blocked = await refuseKnownBadWriteBeforeDispatch(ctx, nodeId, widget);
+          if (blocked) return blocked;
+          return write(nodeId, widget, targetExpectedNodeType);
+        };
         let first = await write(args.node_id, args.widget as string);
         if (!first.isError) {
           markPanelSchemaReady(panelSchemaKey(ctx));
@@ -16577,7 +16757,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             entered.push(ownerNodeId);
           }
 
-          const retried = await write(args.node_id, args.widget as string);
+          const retried = await guardedWrite(args.node_id, args.widget as string);
           if (!retried.isError) {
             const persisted = await persistUnpromotedControlAfterGenerate(
               retried,
@@ -16624,7 +16804,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return appendToolResultText(first, objectInfoWidgetRefreshNote(refreshed));
           }
           markPanelSchemaReady(schemaKey);
-          const retried = await write(args.node_id, args.widget as string);
+          const retried = await guardedWrite(args.node_id, args.widget as string);
           if (!retried.isError) {
             return persistUnpromotedControlAfterGenerate(retried, ctx, args.node_id);
           }
@@ -16648,7 +16828,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (!refusal || String(refusal.nodeId) !== String(args.node_id)) return first;
 
         if (refusal.widget !== args.widget) {
-          const remapped = await write(args.node_id, refusal.widget);
+          const remapped = await guardedWrite(args.node_id, refusal.widget);
           if (!remapped.isError) {
             return persistUnpromotedControlAfterGenerate(remapped, ctx, args.node_id);
           }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -74,7 +74,13 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { UiBridge, PanelVersionReading, UnsupportedShowMediaItem, TabWorkflowUuidRead } from "../services/ui-bridge.js";
+import type {
+  UiBridge,
+  PanelVersionReading,
+  UnsupportedShowMediaItem,
+  TabPromotedScopeRead,
+  TabWorkflowUuidRead,
+} from "../services/ui-bridge.js";
 import {
   requiredPanelVersion,
   SEMVER_RE,
@@ -6319,7 +6325,35 @@ function currentPromotedBindingError(
 function currentPromotedScopeError(
   ctx: PanelToolCtx,
   expected: PromotedScopeWitness,
+  requireCurrentSubgraph = false,
 ): string | null {
+  const readScope = (ctx.bridge as unknown as BridgeProbe).promotedScopeFor;
+  if (typeof readScope === "function") {
+    let observed: TabPromotedScopeRead;
+    try {
+      observed = readScope.call(ctx.bridge, ctx.tabId);
+    } catch {
+      return "the receiving panel current-view scope became unreadable";
+    }
+    if (observed.known !== true) {
+      return "the receiving panel current-view scope became unverifiable";
+    }
+    if (
+      requireCurrentSubgraph &&
+      (observed.scope !== "subgraph" || observed.ownerNodeId !== expected.ownerNodeId)
+    ) {
+      return "the receiving panel current subgraph owner changed or became unverifiable";
+    }
+    if (expected.workflowUuid !== undefined && observed.workflowUuid !== expected.workflowUuid) {
+      return "the receiving panel workflow scope changed or became unverifiable";
+    }
+  }
+
+  // The workflow stamp remains an independent receiver fence. Its UUID is
+  // optional for panels whose structured viewing reply legitimately omits it;
+  // the owner witness above is still required whenever the real bridge provides
+  // one.
+  if (expected.workflowUuid === undefined) return null;
   const read = ctx.bridge.workflowUuidFor;
   if (typeof read !== "function") {
     return "the receiving panel workflow scope was unavailable";
@@ -12312,6 +12346,7 @@ interface BridgeProbe {
   corroborateTabStamp?: (tabId: string, workflowUuid: string) => boolean;
   refreshWorkflowUuid?: (tabId: string, workflowUuid: string) => boolean;
   workflowUuidFor?: (tabId: string) => TabWorkflowUuidRead;
+  promotedScopeFor?: (tabId: string) => TabPromotedScopeRead;
   lastFenceRefusal?: (tabId: string) => string | undefined;
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
@@ -17028,7 +17063,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
                   );
                 }
-                const scopeError = currentPromotedScopeError(ctx, plan.scope);
+                const scopeError = currentPromotedScopeError(ctx, plan.scope, true);
                 if (scopeError) {
                   throw new Error(
                     `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
@@ -17594,7 +17629,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   );
                 }
                 const scopeError = recoveryScope
-                  ? currentPromotedScopeError(ctx, recoveryScope)
+                  ? currentPromotedScopeError(ctx, recoveryScope, true)
                   : "the promoted recovery scope was unavailable";
                 if (scopeError) {
                   throw new Error(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -120,6 +120,7 @@ import {
   parseSubgraphScopeRefusal,
   parseUnpromotedControlPersistRemedy,
   resolveInnerPromotedTarget,
+  validatePromotedSubgraphEnvelope,
   type UnpromotedControlPersistRemedy,
 } from "./promoted-widget.js";
 import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
@@ -6220,9 +6221,7 @@ async function refuseKnownBadWriteBeforeDispatch(
   nodeId: unknown,
   widget: string,
 ): Promise<ToolResult | null> {
-  const directBlocked = await refuseKnownBadWidgetWrite(ctx, nodeId, widget);
-  if (directBlocked) return directBlocked;
-  return refuseKnownBadPromotedWidgetWrite(ctx, nodeId, widget);
+  return refuseKnownBadWidgetWrite(ctx, nodeId, widget);
 }
 
 function mayHaveKnownBadPromotedWidget(widget: string): boolean {
@@ -6248,120 +6247,171 @@ function mayHaveKnownBadPromotedWidget(widget: string): boolean {
  * identity fence inside the inner scope; Anima and dynamic-combo retain their
  * existing fail-open behavior when their specific inner evidence is unavailable.
  */
-async function refuseKnownBadPromotedWidgetWrite(
+type PromotedWriteBinding = {
+  tabId: string;
+  identity: { generation: number; tabSessionId: string };
+};
+
+type PromotedWritePlan = {
+  kind: "promoted-write";
+  outerNodeId: number | string;
+  inner: { innerNodeId: number | string; widget: string };
+  innerNodeType: string;
+  binding: PromotedWriteBinding;
+};
+
+type PromotedWritePreflight = PromotedWritePlan | ToolResult | null;
+
+function promotedEnvelopeCarriesEvidence(payload: Record<string, unknown> | null): boolean {
+  if (!payload) return false;
+  return ["subgraph_of", "node_count", "nodes", "truncated"].some((key) =>
+    Object.prototype.hasOwnProperty.call(payload, key),
+  );
+}
+
+function promotedMatchCount(payload: Record<string, unknown>, widget: string): number {
+  const nodes = payload.nodes;
+  if (!Array.isArray(nodes)) return 0;
+  let matches = 0;
+  for (const raw of nodes) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const widgets = (raw as Record<string, unknown>).widgets;
+    if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) continue;
+    if (
+      Object.keys(widgets as Record<string, unknown>).some(
+        (name) => name === widget || name.toLowerCase() === widget.toLowerCase(),
+      )
+    ) {
+      matches += 1;
+    }
+  }
+  return matches;
+}
+
+function currentPromotedBindingError(
+  ctx: PanelToolCtx,
+  binding: PromotedWriteBinding,
+): string | null {
+  if (ctx.tabId !== binding.tabId) return "the panel tab was rebound";
+  let current: { generation: number; tabSessionId: string } | undefined;
+  try {
+    current = ctx.panelConnectionIdentity?.();
+  } catch {
+    return "the panel connection identity became unreadable";
+  }
+  if (!isUsablePanelConnectionIdentity(current)) {
+    return "the panel connection identity became unavailable";
+  }
+  if (!samePanelConnectionIdentity(binding.identity, current)) {
+    return "the panel session or connection changed";
+  }
+  return null;
+}
+
+function promotedWriteRefusal(widget: string, reason: string): ToolResult {
+  return fail(
+    `panel_set_widget refused the promoted "${widget}" write because ${reason}. ` +
+      `No graph_set_widget was dispatched; retry only after the panel binding and ` +
+      `subgraph mapping are stable.`,
+  );
+}
+
+/**
+ * #2314 — inspect a promoted target before the first write. A valid mapping is
+ * not permission to write the wrapper: the plan carries the receiver identity,
+ * inner node id, and inner type to an inner write whose final dispatch fence
+ * checks the receiver again. A later promotion relink therefore cannot redirect
+ * an apparently safe container write onto a known-bad inner.
+ *
+ * An unavailable graph_get_subgraph remains the pre-existing fail-open case: it
+ * supplies no promotion classification. A successful response with promotion
+ * fields that are malformed, stale, truncated, or ambiguous fails closed.
+ */
+async function preparePromotedWidgetWrite(
   ctx: PanelToolCtx,
   nodeId: unknown,
   widget: string,
-): Promise<ToolResult | null> {
+): Promise<PromotedWritePreflight> {
   if (!mayHaveKnownBadPromotedWidget(widget)) return null;
 
+  const tabBefore = ctx.tabId;
+  const hasIdentityApi = typeof ctx.panelConnectionIdentity === "function";
+  let identityBefore: { generation: number; tabSessionId: string } | undefined;
+  if (hasIdentityApi) {
+    try {
+      identityBefore = ctx.panelConnectionIdentity?.();
+    } catch {
+      return promotedWriteRefusal(widget, "the panel connection identity could not be read");
+    }
+  }
+
   const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+  // Preserve #2299's unavailable-preflight fail-open behavior exactly: an
+  // unavailable read does not classify the write as promoted.
   if (sub.isError) return null;
   const payload = parseToolResultJson(sub);
-  const inner = resolveInnerPromotedTarget(payload, widget);
-  if (!inner) return null;
+  // Some lightweight test seams return the ordinary write envelope for every
+  // command. It carries no subgraph claim, so it is not promotion evidence.
+  if (!promotedEnvelopeCarriesEvidence(payload)) return null;
+  if (!payload) return null;
+  if (!hasIdentityApi) {
+    return promotedWriteRefusal(widget, "the receiver identity was unavailable while the mapping was read");
+  }
+  if (!isUsablePanelConnectionIdentity(identityBefore)) {
+    return promotedWriteRefusal(widget, "the panel connection identity was unavailable");
+  }
 
-  const nodes = payload?.nodes;
-  if (!Array.isArray(nodes)) return null;
+  let identityAfter: { generation: number; tabSessionId: string } | undefined;
+  try {
+    identityAfter = ctx.panelConnectionIdentity?.();
+  } catch {
+    return promotedWriteRefusal(widget, "the panel connection identity became unreadable while the mapping was read");
+  }
+  if (ctx.tabId !== tabBefore || !isUsablePanelConnectionIdentity(identityAfter)) {
+    return promotedWriteRefusal(widget, "the panel tab or connection changed while the mapping was read");
+  }
+  if (!samePanelConnectionIdentity(identityBefore, identityAfter)) {
+    return promotedWriteRefusal(widget, "the panel session or connection changed while the mapping was read");
+  }
+
+  const envelope = validatePromotedSubgraphEnvelope(payload, nodeId as number | string);
+  if (!envelope) {
+    return promotedWriteRefusal(
+      widget,
+      "graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope",
+    );
+  }
+  const inner = resolveInnerPromotedTarget(payload, widget, nodeId as number | string);
+  if (!inner) {
+    const matches = promotedMatchCount(payload, widget);
+    return matches === 0
+      ? null
+      : promotedWriteRefusal(widget, `the envelope mapped it ambiguously to ${matches} inner nodes`);
+  }
+
   const targetId = canonicalQueriedNodeId(inner.innerNodeId);
-  const innerNode = nodes.find((candidate) => {
-    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
-    const candidateId = canonicalQueriedNodeId((candidate as Record<string, unknown>).id);
+  const innerNode = envelope.nodes.find((candidate) => {
+    const candidateId = canonicalQueriedNodeId(candidate.id);
     return candidateId !== null && candidateId === targetId;
   });
-  if (!innerNode || typeof innerNode !== "object" || Array.isArray(innerNode)) return null;
-
-  // The DaSiWa guard is deliberately stronger than a type classification from
-  // graph_get_subgraph: it authenticates the live node id, tab identity, and the
-  // panel's atomic expected-node-type fence. Preserve that contract for a
-  // promoted stack candidate instead of trusting the listing as a write fence.
-  if (inner.widget === DASIWA_STACK_WIDGET) {
-    return refusePromotedDaSiWaStackWrite(ctx, nodeId, inner.innerNodeId);
+  if (!innerNode || !targetId) {
+    return promotedWriteRefusal(widget, "the envelope did not retain the mapped inner node identity");
+  }
+  const innerNodeType = innerNode.type;
+  if (typeof innerNodeType !== "string" || innerNodeType.length === 0) {
+    return promotedWriteRefusal(widget, "the mapped inner node had no verifiable type fence");
+  }
+  if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
+    return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
   }
 
-  const identity = parseQueriedNodeIdentityRow(innerNode);
-  if (!identity) {
-    return null;
-  }
-
-  let blocked: ToolResult | null = null;
-  if (isAnimaRegionalPromptWidget(inner.widget)) {
-    if (ANIMA_REGIONAL_CANVAS_TYPES.has(identity.type)) {
-      blocked = animaRegionalPromptRefusal(identity.type, inner.widget);
-    }
-  } else if (inner.widget.includes(".")) {
-    blocked = dynamicComboSubWidgetRefusalFromDetail(
-      parseVerifiedQueriedNodeDetail({ nodes: [innerNode] }),
-      inner.widget,
-    );
-  }
-
-  return blocked
-    ? appendToolResultText(
-        blocked,
-        `\n\n(The addressed widget is promoted from node ${inner.innerNodeId} "${inner.widget}"; ` +
-          `the container write was refused before dispatch. No graph_set_widget was dispatched.)`,
-      )
-    : null;
-}
-
-/** Keep the DaSiWa promoted path on its existing live identity fence. The
- * subgraph listing only establishes which inner node to inspect; it is never
- * used as the final type proof for a mutation. */
-async function refusePromotedDaSiWaStackWrite(
-  ctx: PanelToolCtx,
-  containerNodeId: unknown,
-  innerNodeId: number | string,
-): Promise<ToolResult | null> {
-  let entered = false;
-  try {
-    const enter = await ctx.call(
-      { cmd: "graph_enter_subgraph", node_id: containerNodeId },
-      15000,
-    );
-    if (enter.isError) {
-      return daSiWaIdentityRefusal(
-        `the promoted inner node ${innerNodeId} could not be live-verified because ` +
-          `panel_enter_subgraph failed (${textOfToolResult(enter)})`,
-      );
-    }
-    entered = true;
-
-    const blocked = await refuseDaSiWaStackWrite(ctx, innerNodeId, DASIWA_STACK_WIDGET);
-    const exit = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
-    entered = false;
-    if (blocked) {
-      return appendToolResultText(
-        blocked,
-        `\n\n(The addressed stack widget is promoted from node ${innerNodeId}; ` +
-          `the container write was refused before dispatch. No graph_set_widget was dispatched.` +
-          (exit.isError
-            ? ` panel_exit_subgraph also FAILED — the caller scope may still be inside ` +
-              `the subgraph. Call panel_exit_subgraph. (${textOfToolResult(exit)})`
-            : ""),
-      );
-    }
-    if (exit.isError) {
-      return daSiWaIdentityRefusal(
-        `the promoted inner node ${innerNodeId} was checked, but panel_exit_subgraph ` +
-          `failed before the container write (${textOfToolResult(exit)})`,
-      );
-    }
-    return null;
-  } catch (error) {
-    return daSiWaIdentityRefusal(
-      `the promoted inner node ${innerNodeId} could not be live-verified before dispatch: ` +
-        `${error instanceof Error ? error.message : String(error)}`,
-    );
-  } finally {
-    if (entered) {
-      try {
-        await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
-      } catch {
-        // Preserve the refusal. The caller can explicitly recover the scope.
-      }
-    }
-  }
+  return {
+    kind: "promoted-write",
+    outerNodeId: nodeId as number | string,
+    inner,
+    innerNodeType,
+    binding: { tabId: tabBefore, identity: identityAfter },
+  };
 }
 
 function daSiWaStackRefusal(type: string): ToolResult {
@@ -12477,10 +12527,16 @@ export function makePanelToolCtx(
     cmd: Record<string, unknown>,
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
+    beforeDispatch?: () => void,
   ): Promise<unknown> => {
     const target = workflowTargets?.get(ctx.tabId);
     const routed = target ? withWorkflowTarget(cmd, target) : cmd;
-    return bridge.send(routed as { cmd: string }, { tabId: ctx.tabId, timeoutMs, onDispatchedRid });
+    return bridge.send(routed as { cmd: string }, {
+      tabId: ctx.tabId,
+      timeoutMs,
+      onDispatchedRid,
+      beforeDispatch,
+    });
   };
 
   const callOnce = async (
@@ -12529,11 +12585,10 @@ export function makePanelToolCtx(
       // so they are dispatched on the bounded budget above instead.
       const blocked = graphCmdBlockedByRunningPrompt(cmd);
       if (blocked) return fail(blocked);
-      // A caller may hold a target/generation fence across the reachability wait.
-      // Run it synchronously in the final gap before sendRouted: an async check here
-      // would reopen the exact retarget window this guard closes.
-      beforeDispatch?.();
-      const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid));
+      // The bridge owns the graph lane and re-resolves the live connection after
+      // waiting. Pass the fence through so it runs at the actual socket dispatch,
+      // not before that retarget window.
+      const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch));
       // panel#1097 — a guard-domain command that SUCCEEDS is the evidence that the
       // switch is over, whichever attempt lands it. Without this an ordinary
       // first-attempt success left the old run in place, and a later unrelated
@@ -12617,8 +12672,7 @@ export function makePanelToolCtx(
           await awaitReachable();
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
-          beforeDispatch?.();
-          const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
+          const retried = ok(await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch));
           // Cleared HERE and nowhere else, and only when the failure this retried
           // was a SWITCH refusal. Clearing on every routed success let an unguarded
           // status read wipe the evidence while graph commands stayed refused
@@ -16618,8 +16672,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         );
         if (blocked) return blocked;
 
+        const promotedPreflight = await preparePromotedWidgetWrite(
+          ctx,
+          args.node_id,
+          args.widget as string,
+        );
+        if (promotedPreflight && "content" in promotedPreflight) return promotedPreflight;
+        const promotedPlan = promotedPreflight && promotedPreflight.kind === "promoted-write"
+          ? promotedPreflight
+          : null;
+
         let expectedNodeType: string | undefined;
-        if (args.widget === DASIWA_STACK_WIDGET) {
+        if (!promotedPlan && args.widget === DASIWA_STACK_WIDGET) {
           const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
           if (daSiWaFence && "content" in daSiWaFence) return daSiWaFence;
           expectedNodeType = daSiWaFence?.expectedNodeType;
@@ -16640,6 +16704,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           nodeId: unknown,
           widget: string,
           targetExpectedNodeType: string | undefined = expectedNodeType,
+          beforeDispatch?: () => void,
         ): Promise<ToolResult> =>
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
@@ -16661,6 +16726,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     : {}),
                 },
                 OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+                undefined,
+                beforeDispatch,
               ),
               echoFull,
             ),
@@ -16674,6 +16741,156 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (blocked) return blocked;
           return write(nodeId, widget, targetExpectedNodeType);
         };
+
+        const writePromotedInner = async (plan: PromotedWritePlan): Promise<ToolResult> => {
+          let entered = false;
+          const leave = async (): Promise<ToolResult> => {
+            const exit = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            entered = false;
+            return exit;
+          };
+          try {
+            const initialBindingError = currentPromotedBindingError(ctx, plan.binding);
+            if (initialBindingError) return promotedWriteRefusal(args.widget as string, initialBindingError);
+
+            // Re-read the ownership envelope immediately before entering. This
+            // catches a promotion relink after the classification read; the
+            // inner write below then addresses the verified node directly.
+            const confirmation = await ctx.call({
+              cmd: "graph_get_subgraph",
+              node_id: plan.outerNodeId,
+            });
+            if (confirmation.isError) {
+              return promotedWriteRefusal(
+                args.widget as string,
+                "the final promoted mapping read was unavailable",
+              );
+            }
+            const confirmedPayload = parseToolResultJson(confirmation);
+            const confirmedEnvelope = validatePromotedSubgraphEnvelope(
+              confirmedPayload,
+              plan.outerNodeId,
+            );
+            const confirmedInner = confirmedEnvelope
+              ? resolveInnerPromotedTarget(
+                  confirmedPayload,
+                  args.widget as string,
+                  plan.outerNodeId,
+                )
+              : null;
+            if (
+              !confirmedEnvelope ||
+              !confirmedInner ||
+              canonicalQueriedNodeId(confirmedInner.innerNodeId) !==
+                canonicalQueriedNodeId(plan.inner.innerNodeId) ||
+              confirmedInner.widget !== plan.inner.widget
+            ) {
+              return promotedWriteRefusal(
+                args.widget as string,
+                "the promoted inner mapping changed or became unverifiable before the write",
+              );
+            }
+            const confirmedNode = confirmedEnvelope.nodes.find(
+              (candidate) =>
+                canonicalQueriedNodeId(candidate.id) ===
+                canonicalQueriedNodeId(plan.inner.innerNodeId),
+            );
+            if (!confirmedNode || confirmedNode.type !== plan.innerNodeType) {
+              return promotedWriteRefusal(
+                args.widget as string,
+                "the promoted inner node type changed before the write",
+              );
+            }
+            const afterMappingError = currentPromotedBindingError(ctx, plan.binding);
+            if (afterMappingError) return promotedWriteRefusal(args.widget as string, afterMappingError);
+
+            const enter = await ctx.call(
+              { cmd: "graph_enter_subgraph", node_id: plan.outerNodeId },
+              15000,
+            );
+            if (enter.isError) {
+              return promotedWriteRefusal(
+                args.widget as string,
+                `panel_enter_subgraph failed (${textOfToolResult(enter)})`,
+              );
+            }
+            entered = true;
+            const afterEnterError = currentPromotedBindingError(ctx, plan.binding);
+            if (afterEnterError) {
+              const exited = await leave();
+              return appendToolResultText(
+                promotedWriteRefusal(args.widget as string, afterEnterError),
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+
+            const innerBlocked = await refuseKnownBadWidgetWrite(
+              ctx,
+              plan.inner.innerNodeId,
+              plan.inner.widget,
+            );
+            if (innerBlocked) {
+              const exited = await leave();
+              return appendToolResultText(
+                innerBlocked,
+                `\n\n(The promoted inner node ${plan.inner.innerNodeId} owns "${plan.inner.widget}"; ` +
+                `the write was refused before dispatch. No inner graph_set_widget was dispatched.` +
+                  (isAnimaRegionalPromptWidget(plan.inner.widget)
+                    ? " This promoted inner widget is an LC123 regional-canvas prompt."
+                    : "") +
+                  (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+              );
+            }
+
+            const written = await write(
+              plan.inner.innerNodeId,
+              plan.inner.widget,
+              plan.innerNodeType,
+              () => {
+                const error = currentPromotedBindingError(ctx, plan.binding);
+                if (error) {
+                  throw new Error(
+                    `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                  );
+                }
+              },
+            );
+            const exited = await leave();
+            if (written.isError) {
+              return appendToolResultText(
+                written,
+                `\n\n(Tried the promoted inner mapping node ${plan.inner.innerNodeId} ` +
+                  `"${plan.inner.widget}" and it FAILED: ${textOfToolResult(written)})`,
+              );
+            }
+            return appendToolResultText(
+              written,
+              `\n\n(Applied via the validated promoted inner widget: node ${plan.inner.innerNodeId} ` +
+                `"${plan.inner.widget}". The container was not written.)` +
+                (exited.isError
+                  ? ` panel_exit_subgraph then FAILED — call panel_exit_subgraph. (${textOfToolResult(exited)})`
+                  : ""),
+            );
+          } catch (error) {
+            if (entered) {
+              try {
+                await leave();
+              } catch {
+                // Preserve the refusal below.
+              }
+            }
+            return promotedWriteRefusal(
+              args.widget as string,
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        };
+
+        if (promotedPlan) {
+          const promotedWritten = await writePromotedInner(promotedPlan);
+          if (!promotedWritten.isError) markPanelSchemaReady(panelSchemaKey(ctx));
+          return promotedWritten;
+        }
         let first = await write(args.node_id, args.widget as string);
         if (!first.isError) {
           markPanelSchemaReady(panelSchemaKey(ctx));
@@ -16842,6 +17059,48 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
 
+        const recoveryPreflight = await preparePromotedWidgetWrite(
+          ctx,
+          args.node_id,
+          refusal.widget,
+        );
+        if (recoveryPreflight && "content" in recoveryPreflight) {
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(recoveryPreflight)}`,
+          );
+        }
+        if (recoveryPreflight && recoveryPreflight.kind === "promoted-write") {
+          const promotedWritten = await writePromotedInner(recoveryPreflight);
+          if (!promotedWritten.isError) {
+            return persistUnpromotedControlAfterGenerate(promotedWritten, ctx, args.node_id);
+          }
+          return appendToolResultText(first, `\n\n${textOfToolResult(promotedWritten)}`);
+        }
+
+        const recoveryTabId = ctx.tabId;
+        let recoveryIdentity: { generation: number; tabSessionId: string } | undefined;
+        const recoveryBinding: PromotedWriteBinding | null =
+          typeof ctx.panelConnectionIdentity === "function"
+            ? (() => {
+                const identity = ctx.panelConnectionIdentity?.();
+                return isUsablePanelConnectionIdentity(identity)
+                  ? { tabId: recoveryTabId, identity }
+                  : null;
+              })()
+            : null;
+        if (typeof ctx.panelConnectionIdentity === "function") {
+          recoveryIdentity = recoveryBinding?.identity;
+          if (!isUsablePanelConnectionIdentity(recoveryIdentity)) {
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(promotedWriteRefusal(
+                refusal.widget,
+                "the panel connection identity was unavailable before the inner mapping read",
+              ))}`,
+            );
+          }
+        }
         const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id });
         if (sub.isError) {
           return appendToolResultText(
@@ -16851,7 +17110,35 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `${textOfToolResult(sub)})`,
           );
         }
-        const inner = resolveInnerPromotedTarget(parseToolResultJson(sub), refusal.widget);
+        if (recoveryIdentity) {
+          const recoveryBindingError = recoveryBinding
+            ? currentPromotedBindingError(ctx, recoveryBinding)
+            : null;
+          if (recoveryBindingError) {
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(promotedWriteRefusal(refusal.widget, recoveryBindingError))}`,
+            );
+          }
+        }
+        const recoveryPayload = parseToolResultJson(sub);
+        const recoveryEnvelope = validatePromotedSubgraphEnvelope(
+          recoveryPayload,
+          args.node_id as number | string,
+        );
+        if (promotedEnvelopeCarriesEvidence(recoveryPayload) && !recoveryEnvelope) {
+          return appendToolResultText(
+            first,
+            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
+              `graph_get_subgraph returned a malformed, stale, or incomplete ownership ` +
+              `envelope, so the inner write was not retried.)`,
+          );
+        }
+        const inner = resolveInnerPromotedTarget(
+          recoveryPayload,
+          refusal.widget,
+          args.node_id as number | string,
+        );
         if (!inner) {
           return appendToolResultText(
             first,
@@ -16871,8 +17158,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             first,
             `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
               `Resolved it to inner node ${inner.innerNodeId} but panel_enter_subgraph FAILED: ` +
-              `${textOfToolResult(entered)})`,
+            `${textOfToolResult(entered)})`,
           );
+        }
+        if (recoveryBinding) {
+          const afterEnterBindingError = currentPromotedBindingError(ctx, recoveryBinding);
+          if (afterEnterBindingError) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(promotedWriteRefusal(refusal.widget, afterEnterBindingError))}` +
+                (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+            );
+          }
         }
 
         let innerExpectedNodeType: string | undefined;
@@ -16988,7 +17286,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
-        const written = await write(inner.innerNodeId, inner.widget, innerExpectedNodeType);
+        const written = await write(
+          inner.innerNodeId,
+          inner.widget,
+          innerExpectedNodeType,
+          recoveryBinding
+            ? () => {
+                const error = currentPromotedBindingError(ctx, recoveryBinding);
+                if (error) {
+                  throw new Error(
+                    `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                  );
+                }
+              }
+            : undefined,
+        );
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
         if (!written.isError) {
           const via =

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -119,8 +119,11 @@ import {
   parseContradictoryPromotedWidgetRefusal,
   parseSubgraphScopeRefusal,
   parseUnpromotedControlPersistRemedy,
+  promotedScopeWitnessFromEnvelope,
+  promotedViewingMatchesScope,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
+  type PromotedScopeWitness,
   type UnpromotedControlPersistRemedy,
 } from "./promoted-widget.js";
 import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
@@ -6257,6 +6260,7 @@ type PromotedWritePlan = {
   outerNodeId: number | string;
   inner: { innerNodeId: number | string; widget: string };
   innerNodeType: string;
+  scope: PromotedScopeWitness;
   binding: PromotedWriteBinding;
 };
 
@@ -6304,6 +6308,33 @@ function currentPromotedBindingError(
   }
   if (!samePanelConnectionIdentity(binding.identity, current)) {
     return "the panel session or connection changed";
+  }
+  return null;
+}
+
+/** The bridge's workflow stamp is the strongest synchronous receiver witness
+ * available at the actual socket send. It complements the panel's structured
+ * `viewing` scope read: the latter proves the graph/subgraph after an await,
+ * while this check catches a workflow rebind in the final dispatch window. */
+function currentPromotedScopeError(
+  ctx: PanelToolCtx,
+  expected: PromotedScopeWitness,
+): string | null {
+  const read = ctx.bridge.workflowUuidFor;
+  if (typeof read !== "function") {
+    return "the receiving panel workflow scope was unavailable";
+  }
+  let observed: TabWorkflowUuidRead;
+  try {
+    observed = read.call(ctx.bridge, ctx.tabId);
+  } catch {
+    return "the receiving panel workflow scope became unreadable";
+  }
+  if (observed.known !== true || typeof observed.uuid !== "string" || observed.uuid.length === 0) {
+    return "the receiving panel workflow scope was unavailable";
+  }
+  if (observed.uuid !== expected.workflowUuid) {
+    return "the receiving panel workflow changed";
   }
   return null;
 }
@@ -6381,6 +6412,15 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope",
     );
   }
+  const scope = promotedScopeWitnessFromEnvelope(envelope);
+  if (!scope) {
+    return promotedWriteRefusal(
+      widget,
+      "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
+    );
+  }
+  const scopeError = currentPromotedScopeError(ctx, scope);
+  if (scopeError) return promotedWriteRefusal(widget, scopeError);
   const inner = resolveInnerPromotedTarget(payload, widget, nodeId as number | string);
   if (!inner) {
     const matches = promotedMatchCount(payload, widget);
@@ -6410,6 +6450,7 @@ async function preparePromotedWidgetWrite(
     outerNodeId: nodeId as number | string,
     inner,
     innerNodeType,
+    scope,
     binding: { tabId: tabBefore, identity: identityAfter },
   };
 }
@@ -6428,6 +6469,7 @@ async function recheckPromotedOuterMapping(
   outerNodeId: number | string,
   widget: string,
   expectedInner: { innerNodeId: number | string; widget: string },
+  expectedScope: PromotedScopeWitness,
 ): Promise<PromotedMappingProof | ToolResult> {
   const confirmation = await ctx.call({
     cmd: "graph_get_subgraph",
@@ -6441,11 +6483,15 @@ async function recheckPromotedOuterMapping(
   }
   const payload = parseToolResultJson(confirmation);
   const envelope = validatePromotedSubgraphEnvelope(payload, outerNodeId);
+  const observedScope = envelope ? promotedScopeWitnessFromEnvelope(envelope) : null;
   const inner = envelope
     ? resolveInnerPromotedTarget(payload, widget, outerNodeId)
     : null;
   if (
     !envelope ||
+    !observedScope ||
+    observedScope.workflowUuid !== expectedScope.workflowUuid ||
+    observedScope.ownerNodeId !== expectedScope.ownerNodeId ||
     !inner ||
     canonicalQueriedNodeId(inner.innerNodeId) !== canonicalQueriedNodeId(expectedInner.innerNodeId) ||
     inner.widget !== expectedInner.widget
@@ -6455,6 +6501,8 @@ async function recheckPromotedOuterMapping(
       "the promoted inner mapping changed or became unverifiable before the write",
     );
   }
+  const scopeError = currentPromotedScopeError(ctx, expectedScope);
+  if (scopeError) return promotedWriteRefusal(widget, scopeError);
   const targetId = canonicalQueriedNodeId(inner.innerNodeId);
   const innerNode = envelope.nodes.find(
     (candidate) => canonicalQueriedNodeId(candidate.id) === targetId,
@@ -6480,6 +6528,7 @@ async function recheckPromotedInnerTarget(
   expectedInner: { innerNodeId: number | string; widget: string },
   expectedNodeType: string,
   widget: string,
+  expectedScope: PromotedScopeWitness,
 ): Promise<PromotedMappingProof | ToolResult> {
   const probe = await ctx.call({
     cmd: "graph_query",
@@ -6493,7 +6542,14 @@ async function recheckPromotedInnerTarget(
       "the promoted inner receiver could not be queried in the entered graph",
     );
   }
-  const identity = parseVerifiedQueriedNodeIdentity(parseToolResultJson(probe));
+  const payload = parseToolResultJson(probe);
+  if (!promotedViewingMatchesScope(payload, expectedScope)) {
+    return promotedWriteRefusal(
+      widget,
+      "the current graph scope changed or became unverifiable in the entered graph",
+    );
+  }
+  const identity = parseVerifiedQueriedNodeIdentity(payload);
   const expectedId = canonicalQueriedNodeId(expectedInner.innerNodeId);
   if (
     !identity ||
@@ -16861,6 +16917,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               plan.outerNodeId,
               args.widget as string,
               plan.inner,
+              plan.scope,
             );
             if ("content" in beforeEnterMapping) return beforeEnterMapping;
             if (beforeEnterMapping.innerNodeType !== plan.innerNodeType) {
@@ -16897,6 +16954,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               plan.inner,
               plan.innerNodeType,
               args.widget as string,
+              plan.scope,
             );
             if ("content" in afterEnterMapping) {
               const exited = await leave();
@@ -16939,6 +16997,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               plan.inner,
               plan.innerNodeType,
               args.widget as string,
+              plan.scope,
             );
             if ("content" in finalMapping) {
               const exited = await leave();
@@ -16967,6 +17026,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 if (error) {
                   throw new Error(
                     `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                  );
+                }
+                const scopeError = currentPromotedScopeError(ctx, plan.scope);
+                if (scopeError) {
+                  throw new Error(
+                    `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
                   );
                 }
               },
@@ -17250,6 +17315,29 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `envelope, so the inner write was not retried.)`,
           );
         }
+        const recoveryScope = recoveryEnvelope
+          ? promotedScopeWitnessFromEnvelope(recoveryEnvelope)
+          : null;
+        if (recoveryEnvelope && !recoveryScope) {
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(
+                refusal.widget,
+                "the recovery envelope did not publish a verifiable workflow and viewing-scope identity",
+              ),
+            )}`,
+          );
+        }
+        if (recoveryScope) {
+          const recoveryScopeError = currentPromotedScopeError(ctx, recoveryScope);
+          if (recoveryScopeError) {
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(promotedWriteRefusal(refusal.widget, recoveryScopeError))}`,
+            );
+          }
+        }
         const inner = resolveInnerPromotedTarget(
           recoveryPayload,
           refusal.widget,
@@ -17314,6 +17402,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           inner,
           recoveryInnerNodeType,
           refusal.widget,
+          recoveryScope!,
         );
         if ("content" in legacyAfterEnterMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -17468,6 +17557,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           inner,
           innerExpectedNodeType ?? recoveryInnerNodeType,
           refusal.widget,
+          recoveryScope!,
         );
         if ("content" in legacyFinalMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -17501,6 +17591,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 if (error) {
                   throw new Error(
                     `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                  );
+                }
+                const scopeError = recoveryScope
+                  ? currentPromotedScopeError(ctx, recoveryScope)
+                  : "the promoted recovery scope was unavailable";
+                if (scopeError) {
+                  throw new Error(
+                    `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
                   );
                 }
               }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6419,11 +6419,11 @@ type PromotedMappingProof = {
   innerNodeType: string;
 };
 
-/** Re-read the ownership envelope for a previously classified promoted write.
- * This is deliberately strict: after entering the subgraph, or immediately
- * before a legacy retry, the old inner id is not permission to trust a relinked
- * wrapper. */
-async function recheckPromotedInnerMapping(
+/** Re-read the ownership envelope for a previously classified promoted write
+ * while the wrapper is still in the current graph. This is deliberately strict:
+ * after entering the subgraph the wrapper id is no longer queryable, so all
+ * post-entry fences must use the captured inner target in the now-current graph. */
+async function recheckPromotedOuterMapping(
   ctx: PanelToolCtx,
   outerNodeId: number | string,
   widget: string,
@@ -6463,6 +6463,50 @@ async function recheckPromotedInnerMapping(
     return promotedWriteRefusal(widget, "the mapped inner node lost its verifiable type fence");
   }
   return { inner, innerNodeType: innerNode.type };
+}
+
+/** Recheck a captured promoted receiver after graph_enter_subgraph.
+ *
+ * graph_get_subgraph resolves ids in the currently viewed graph. Once the
+ * wrapper has been entered, its outer id is intentionally unavailable; using
+ * it here would refuse every valid promoted write in production. The captured
+ * inner id is the production-valid receiver token for the entered graph. A
+ * strict one-row graph_query proves that the current graph still contains that
+ * exact id and type before the known-bad guards and again immediately before
+ * graph_set_widget.
+ */
+async function recheckPromotedInnerTarget(
+  ctx: PanelToolCtx,
+  expectedInner: { innerNodeId: number | string; widget: string },
+  expectedNodeType: string,
+  widget: string,
+): Promise<PromotedMappingProof | ToolResult> {
+  const probe = await ctx.call({
+    cmd: "graph_query",
+    ids: [expectedInner.innerNodeId],
+    fields: "compact",
+    limit: 1,
+  });
+  if (probe.isError) {
+    return promotedWriteRefusal(
+      widget,
+      "the promoted inner receiver could not be queried in the entered graph",
+    );
+  }
+  const identity = parseVerifiedQueriedNodeIdentity(parseToolResultJson(probe));
+  const expectedId = canonicalQueriedNodeId(expectedInner.innerNodeId);
+  if (
+    !identity ||
+    !expectedId ||
+    identity.id !== expectedId ||
+    identity.type !== expectedNodeType
+  ) {
+    return promotedWriteRefusal(
+      widget,
+      "the captured promoted inner receiver changed or became unverifiable in the entered graph",
+    );
+  }
+  return { inner: expectedInner, innerNodeType: identity.type };
 }
 
 function daSiWaStackRefusal(type: string): ToolResult {
@@ -16812,7 +16856,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
 
             // Re-read the ownership envelope immediately before entering. This
             // catches a promotion relink after the classification read.
-            const beforeEnterMapping = await recheckPromotedInnerMapping(
+            const beforeEnterMapping = await recheckPromotedOuterMapping(
               ctx,
               plan.outerNodeId,
               args.widget as string,
@@ -16848,11 +16892,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
 
-            const afterEnterMapping = await recheckPromotedInnerMapping(
+            const afterEnterMapping = await recheckPromotedInnerTarget(
               ctx,
-              plan.outerNodeId,
-              args.widget as string,
               plan.inner,
+              plan.innerNodeType,
+              args.widget as string,
             );
             if ("content" in afterEnterMapping) {
               const exited = await leave();
@@ -16890,11 +16934,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
 
-            const finalMapping = await recheckPromotedInnerMapping(
+            const finalMapping = await recheckPromotedInnerTarget(
               ctx,
-              plan.outerNodeId,
-              args.widget as string,
               plan.inner,
+              plan.innerNodeType,
+              args.widget as string,
             );
             if ("content" in finalMapping) {
               const exited = await leave();
@@ -17265,11 +17309,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
 
-        const legacyAfterEnterMapping = await recheckPromotedInnerMapping(
+        const legacyAfterEnterMapping = await recheckPromotedInnerTarget(
           ctx,
-          args.node_id as number | string,
-          refusal.widget,
           inner,
+          recoveryInnerNodeType,
+          refusal.widget,
         );
         if ("content" in legacyAfterEnterMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -17419,11 +17463,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             );
           }
         }
-        const legacyFinalMapping = await recheckPromotedInnerMapping(
+        const legacyFinalMapping = await recheckPromotedInnerTarget(
           ctx,
-          args.node_id as number | string,
-          refusal.widget,
           inner,
+          innerExpectedNodeType ?? recoveryInnerNodeType,
+          refusal.widget,
         );
         if ("content" in legacyFinalMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -130,6 +130,7 @@ import {
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
   type PromotedScopeWitness,
+  type PromotedTerminalWitness,
   type UnpromotedControlPersistRemedy,
 } from "./promoted-widget.js";
 import { includeRequestedCreateGroupMembers } from "./create-group-membership.js";
@@ -6221,6 +6222,48 @@ async function refuseKnownBadWidgetWrite(
   return refuseDaSiWaStackWrite(ctx, nodeId, widget);
 }
 
+/** Apply the same three known-bad guards to the terminal concrete endpoint
+ * published by the receiver. The terminal is not in MCP's current graph after
+ * entering the outer container, so this decision uses the panel's authenticated
+ * value-free identity/shape witness rather than a second graph_query that could
+ * resolve a graph-local id in the wrong scope. */
+function refuseKnownBadPromotedTerminal(
+  terminal: PromotedTerminalWitness,
+): ToolResult | null {
+  if (ANIMA_REGIONAL_CANVAS_TYPES.has(terminal.nodeType) && isAnimaRegionalPromptWidget(terminal.widget)) {
+    return animaRegionalPromptRefusal(terminal.nodeType, terminal.widget);
+  }
+  const dynamic = dynamicComboSubWidgetRefusalFromDetail(
+    {
+      id: String(terminal.nodeId),
+      type: terminal.nodeType,
+      inputs: terminal.inputs,
+      widgets: null,
+    },
+    terminal.widget,
+  );
+  if (dynamic) return dynamic;
+  if (terminal.nodeType === DASIWA_LTX2_LORA_LOADER && terminal.widget === DASIWA_STACK_WIDGET) {
+    return daSiWaStackRefusal(terminal.nodeType);
+  }
+  return null;
+}
+
+function samePromotedTerminal(
+  left: PromotedTerminalWitness | undefined,
+  right: PromotedTerminalWitness | undefined,
+  includeDepth = true,
+): boolean {
+  if (!left || !right) return left === right;
+  return (
+    canonicalQueriedNodeId(left.nodeId) === canonicalQueriedNodeId(right.nodeId) &&
+    left.nodeType === right.nodeType &&
+    left.widget === right.widget &&
+    (!includeDepth || left.chainDepth === right.chainDepth) &&
+    JSON.stringify(left.inputs) === JSON.stringify(right.inputs)
+  );
+}
+
 /** Run the known-bad set against the node id that is about to be written, then
  * inspect a uniquely mapped promoted inner node when the addressed node is a
  * subgraph container. Keep promotion handling separate from the direct helper
@@ -6266,8 +6309,13 @@ type PromotedWritePlan = {
   outerNodeId: number | string;
   inner: { innerNodeId: number | string; widget: string };
   innerNodeType: string;
+  terminal?: PromotedTerminalWitness;
   scope: PromotedScopeWitness;
   binding: PromotedWriteBinding;
+};
+
+type PromotedExpectedScope = PromotedScopeWitness & {
+  terminal?: PromotedTerminalWitness;
 };
 
 type PromotedWritePreflight = PromotedWritePlan | ToolResult | null;
@@ -6528,7 +6576,12 @@ async function preparePromotedWidgetWrite(
     const matches = promotedMatchCount(payload, widget);
     return matches === 0
       ? null
-      : promotedWriteRefusal(widget, `the envelope mapped it ambiguously to ${matches} inner nodes`);
+      : promotedWriteRefusal(
+          widget,
+          matches === 1
+            ? "the terminal promotion endpoint was missing, malformed, or unresolved"
+            : `the envelope mapped it ambiguously to ${matches} inner nodes`,
+        );
   }
 
   const targetId = canonicalQueriedNodeId(inner.innerNodeId);
@@ -6542,6 +6595,16 @@ async function preparePromotedWidgetWrite(
   const innerNodeType = innerNode.type;
   if (typeof innerNodeType !== "string" || innerNodeType.length === 0) {
     return promotedWriteRefusal(widget, "the mapped inner node had no verifiable type fence");
+  }
+  if (innerNode.is_subgraph === true && !inner.terminal) {
+    return promotedWriteRefusal(
+      widget,
+      "the receiver did not publish a terminal witness for the nested promotion chain",
+    );
+  }
+  if (inner.terminal) {
+    const terminalBlocked = refuseKnownBadPromotedTerminal(inner.terminal);
+    if (terminalBlocked) return terminalBlocked;
   }
   if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
     return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
@@ -6558,6 +6621,7 @@ async function preparePromotedWidgetWrite(
     outerNodeId: nodeId as number | string,
     inner,
     innerNodeType,
+    ...(inner.terminal ? { terminal: inner.terminal } : {}),
     scope,
     binding: { tabId: tabBefore, identity: identityAfter },
   };
@@ -6566,6 +6630,7 @@ async function preparePromotedWidgetWrite(
 type PromotedMappingProof = {
   inner: { innerNodeId: number | string; widget: string };
   innerNodeType: string;
+  terminal?: PromotedTerminalWitness;
 };
 
 /** Re-read the ownership envelope for a previously classified promoted write
@@ -6578,6 +6643,7 @@ async function recheckPromotedOuterMapping(
   widget: string,
   expectedInner: { innerNodeId: number | string; widget: string },
   expectedScope: PromotedScopeWitness,
+  expectedTerminal?: PromotedTerminalWitness,
 ): Promise<PromotedMappingProof | ToolResult> {
   const confirmation = await ctx.call({
     cmd: "graph_get_subgraph",
@@ -6602,7 +6668,8 @@ async function recheckPromotedOuterMapping(
     observedScope.ownerNodeId !== expectedScope.ownerNodeId ||
     !inner ||
     canonicalQueriedNodeId(inner.innerNodeId) !== canonicalQueriedNodeId(expectedInner.innerNodeId) ||
-    inner.widget !== expectedInner.widget
+    inner.widget !== expectedInner.widget ||
+    !samePromotedTerminal(inner.terminal, expectedTerminal)
   ) {
     return promotedWriteRefusal(
       widget,
@@ -6618,7 +6685,11 @@ async function recheckPromotedOuterMapping(
   if (!innerNode || !targetId || typeof innerNode.type !== "string" || innerNode.type.length === 0) {
     return promotedWriteRefusal(widget, "the mapped inner node lost its verifiable type fence");
   }
-  return { inner, innerNodeType: innerNode.type };
+  return {
+    inner,
+    innerNodeType: innerNode.type,
+    ...(inner.terminal ? { terminal: inner.terminal } : {}),
+  };
 }
 
 /** Recheck a captured promoted receiver after graph_enter_subgraph.
@@ -6637,6 +6708,7 @@ async function recheckPromotedInnerTarget(
   expectedNodeType: string,
   widget: string,
   expectedScope: PromotedScopeWitness,
+  expectedTerminal?: PromotedTerminalWitness,
 ): Promise<PromotedMappingProof | ToolResult> {
   const probe = await ctx.call({
     cmd: "graph_query",
@@ -6670,7 +6742,34 @@ async function recheckPromotedInnerTarget(
       "the captured promoted inner receiver changed or became unverifiable in the entered graph",
     );
   }
-  return { inner: expectedInner, innerNodeType: identity.type };
+  if (expectedTerminal && expectedTerminal.chainDepth > 0) {
+    const nested = await ctx.call({
+      cmd: "graph_get_subgraph",
+      node_id: expectedInner.innerNodeId,
+    });
+    if (nested.isError) {
+      return promotedWriteRefusal(
+        widget,
+        "the nested promoted terminal could not be resolved in the entered graph",
+      );
+    }
+    const nestedPayload = parseToolResultJson(nested);
+    const nestedEnvelope = validatePromotedSubgraphEnvelope(
+      nestedPayload,
+      expectedInner.innerNodeId,
+    );
+    const nestedInner = nestedEnvelope
+      ? resolveInnerPromotedTarget(nestedPayload, expectedInner.widget, expectedInner.innerNodeId)
+      : null;
+    if (!nestedInner?.terminal || !samePromotedTerminal(nestedInner.terminal, expectedTerminal, false)) {
+      return promotedWriteRefusal(
+        widget,
+        "the nested promoted terminal mapping changed or became unverifiable after entering",
+      );
+    }
+    return { inner: expectedInner, innerNodeType: identity.type, terminal: expectedTerminal };
+  }
+  return { inner: expectedInner, innerNodeType: identity.type, ...(expectedTerminal ? { terminal: expectedTerminal } : {}) };
 }
 
 function daSiWaStackRefusal(type: string): ToolResult {
@@ -16972,7 +17071,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           widget: string,
           targetExpectedNodeType: string | undefined = expectedNodeType,
           beforeDispatch?: () => void,
-          targetExpectedScope?: PromotedScopeWitness,
+          targetExpectedScope?: PromotedExpectedScope,
         ): Promise<ToolResult> =>
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
@@ -16997,6 +17096,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                           graph_identity: targetExpectedScope.graphIdentity,
                           ...(targetExpectedScope.workflowUuid !== undefined
                             ? { workflow_uuid: targetExpectedScope.workflowUuid }
+                            : {}),
+                          ...(targetExpectedScope.terminal
+                            ? {
+                                terminal: {
+                                  node_id: targetExpectedScope.terminal.nodeId,
+                                  type: targetExpectedScope.terminal.nodeType,
+                                  widget: targetExpectedScope.terminal.widget,
+                                  inputs: targetExpectedScope.terminal.inputs,
+                                  chain_depth: targetExpectedScope.terminal.chainDepth,
+                                },
+                              }
                             : {}),
                         },
                       }
@@ -17047,6 +17157,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               args.widget as string,
               plan.inner,
               plan.scope,
+              plan.terminal,
             );
             if ("content" in beforeEnterMapping) return beforeEnterMapping;
             if (beforeEnterMapping.innerNodeType !== plan.innerNodeType) {
@@ -17084,6 +17195,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               plan.innerNodeType,
               args.widget as string,
               plan.scope,
+              plan.terminal,
             );
             if ("content" in afterEnterMapping) {
               const exited = await leave();
@@ -17101,6 +17213,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 ),
                 exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
               );
+            }
+
+            if (plan.terminal) {
+              const terminalBlocked = refuseKnownBadPromotedTerminal(
+                afterEnterMapping.terminal ?? plan.terminal,
+              );
+              if (terminalBlocked) {
+                const exited = await leave();
+                return appendToolResultText(
+                  terminalBlocked,
+                  exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+                );
+              }
             }
 
             const innerBlocked = await refuseKnownBadWidgetWrite(
@@ -17127,6 +17252,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               plan.innerNodeType,
               args.widget as string,
               plan.scope,
+              plan.terminal,
             );
             if ("content" in finalMapping) {
               const exited = await leave();
@@ -17144,6 +17270,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 ),
                 exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
               );
+            }
+
+            if (plan.terminal) {
+              const terminalBlocked = refuseKnownBadPromotedTerminal(
+                finalMapping.terminal ?? plan.terminal,
+              );
+              if (terminalBlocked) {
+                const exited = await leave();
+                return appendToolResultText(
+                  terminalBlocked,
+                  exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+                );
+              }
             }
 
             // The preceding graph_query updates the bridge's scope cache, but
@@ -17187,7 +17326,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   );
                 }
               },
-              plan.scope,
+              {
+                ...plan.scope,
+                ...(plan.terminal ? { terminal: plan.terminal } : {}),
+              },
             );
             const exited = await leave();
             if (written.isError) {
@@ -17537,6 +17679,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
+        if (recoveryInnerNode?.is_subgraph === true && !inner.terminal) {
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(
+                refusal.widget,
+                "the receiver did not publish a terminal witness for the nested promotion chain",
+              ),
+            )}`,
+          );
+        }
+        if (inner.terminal) {
+          const terminalBlocked = refuseKnownBadPromotedTerminal(inner.terminal);
+          if (terminalBlocked) return appendToolResultText(first, `\n\n${textOfToolResult(terminalBlocked)}`);
+        }
+
         const entered = await ctx.call(
           { cmd: "graph_enter_subgraph", node_id: args.node_id },
           15000,
@@ -17567,6 +17725,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           recoveryInnerNodeType,
           refusal.widget,
           recoveryScope!,
+          inner.terminal,
         );
         if ("content" in legacyAfterEnterMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -17588,6 +17747,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             )}` +
               (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
           );
+        }
+        if (inner.terminal) {
+          const terminalBlocked = refuseKnownBadPromotedTerminal(
+            legacyAfterEnterMapping.terminal ?? inner.terminal,
+          );
+          if (terminalBlocked) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(terminalBlocked)}` +
+                (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+            );
+          }
         }
 
         let innerExpectedNodeType: string | undefined = legacyAfterEnterMapping.innerNodeType;
@@ -17722,6 +17894,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           innerExpectedNodeType ?? recoveryInnerNodeType,
           refusal.widget,
           recoveryScope!,
+          inner.terminal,
         );
         if ("content" in legacyFinalMapping) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -17743,6 +17916,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             )}` +
               (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
           );
+        }
+        if (inner.terminal) {
+          const terminalBlocked = refuseKnownBadPromotedTerminal(
+            legacyFinalMapping.terminal ?? inner.terminal,
+          );
+          if (terminalBlocked) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(terminalBlocked)}` +
+                (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+            );
+          }
         }
 
         const authoritativeRecoveryScope = recoveryScope
@@ -17786,7 +17972,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           inner.widget,
           legacyFinalMapping.innerNodeType,
           recoveryBeforeDispatch,
-          recoveryScope ?? undefined,
+          recoveryScope
+            ? { ...recoveryScope, ...(inner.terminal ? { terminal: inner.terminal } : {}) }
+            : undefined,
         );
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
         if (!written.isError) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6357,6 +6357,26 @@ function promotedMatchCount(payload: Record<string, unknown>, widget: string): n
   return matches;
 }
 
+/** Count the current panel's authoritative alias entries. A complete witness
+ * array is also the distinction between a promoted alias and an ordinary
+ * widget on the same subgraph container; do not infer that distinction from
+ * the inner node's concrete widget names because aliases may be renamed. */
+function promotedTerminalAliasCount(
+  payload: Record<string, unknown>,
+  widget: string,
+): number | null {
+  const entries = payload.promoted_terminals;
+  if (!Array.isArray(entries)) return null;
+  return entries.filter(
+    (entry) =>
+      !!entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      typeof (entry as Record<string, unknown>).widget === "string" &&
+      ((entry as Record<string, unknown>).widget as string).toLowerCase() === widget.toLowerCase(),
+  ).length;
+}
+
 function currentPromotedBindingError(
   ctx: PanelToolCtx,
   binding: PromotedWriteBinding,
@@ -6413,13 +6433,10 @@ function currentPromotedScopeError(
     ) {
       return "the receiving panel current graph/subgraph identity changed or became unverifiable";
     }
-    // Before graph_enter_subgraph the live query is correctly scoped to the
-    // parent/root graph, while expected.graphIdentity names the target graph
-    // carried in subgraph_of. Compare the graph token only once the receiver
-    // is actually in a subgraph (the authoritative/final fence requires that).
-    if (scopeRead.scope === "subgraph" && scopeRead.graphIdentity !== expected.graphIdentity) {
-      return "the receiving panel current graph identity changed or became unverifiable";
-    }
+    // Before graph_enter_subgraph the live query is scoped to the parent/root
+    // graph, while expected.graphIdentity names the child graph carried in
+    // subgraph_of. Never compare those different graph objects. The child
+    // identity is checked only by the post-entry/current-dispatch fences above.
     if (expected.workflowUuid !== undefined && scopeRead.workflowUuid !== expected.workflowUuid) {
       return "the receiving panel workflow scope changed or became unverifiable";
     }
@@ -6511,10 +6528,9 @@ async function preparePromotedWidgetWrite(
   // advertises that it publishes that witness. Older panels retain their
   // established known-bad recovery path rather than being mistaken for a
   // bundle that can classify renamed promotion aliases.
-  if (
-    ctx.tabPromotedTerminalWitnessCapability?.() !== true &&
-    !mayHaveKnownBadPromotedWidget(widget)
-  ) {
+  const publishesCompleteTerminalWitness =
+    ctx.tabPromotedTerminalWitnessCapability?.() === true;
+  if (!publishesCompleteTerminalWitness && !mayHaveKnownBadPromotedWidget(widget)) {
     return null;
   }
 
@@ -6542,6 +6558,15 @@ async function preparePromotedWidgetWrite(
     return promotedWriteRefusal(
       widget,
       "graph_get_subgraph returned no definitive non-promoted or ownership result",
+    );
+  }
+  if (
+    publishesCompleteTerminalWitness &&
+    !Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")
+  ) {
+    return promotedWriteRefusal(
+      widget,
+      "the current receiver advertised complete promoted-terminal witnesses but omitted the witness array",
     );
   }
   // The recursive alias mapping is the current receiver's proof that this
@@ -6591,6 +6616,22 @@ async function preparePromotedWidgetWrite(
   }
   const inner = resolveInnerPromotedTarget(payload, widget, nodeId as number | string);
   if (!inner) {
+    const terminalAliases = publishesCompleteTerminalWitness
+      ? promotedTerminalAliasCount(payload, widget)
+      : 0;
+    if (terminalAliases === null || terminalAliases > 0) {
+      return promotedWriteRefusal(
+        widget,
+        terminalAliases === null
+          ? "the current receiver's promoted-terminal witness was unavailable"
+          : "the promoted-terminal witness was missing, ambiguous, stale, or unresolved",
+      );
+    }
+    // A current panel's complete witness array is authoritative: an alias
+    // absent from it is an ordinary own-widget, even if an inner concrete node
+    // happens to use the same spelling. Preserve the original outer write for
+    // that deliberate non-promoted case.
+    if (publishesCompleteTerminalWitness && terminalAliases === 0) return null;
     const matches = promotedMatchCount(payload, widget);
     if (matches === 0) return null;
     return promotedWriteRefusal(
@@ -6675,6 +6716,15 @@ async function recheckPromotedOuterMapping(
     );
   }
   const payload = parseToolResultJson(confirmation);
+  if (
+    ctx.tabPromotedTerminalWitnessCapability?.() === true &&
+    (!payload || !Object.prototype.hasOwnProperty.call(payload, "promoted_terminals"))
+  ) {
+    return promotedWriteRefusal(
+      widget,
+      "the current receiver advertised complete promoted-terminal witnesses but omitted the witness array",
+    );
+  }
   const envelope = validatePromotedSubgraphEnvelope(payload, outerNodeId);
   const observedScope = envelope ? promotedScopeWitnessFromEnvelope(envelope) : null;
   const inner = envelope

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6326,25 +6326,33 @@ function currentPromotedScopeError(
   ctx: PanelToolCtx,
   expected: PromotedScopeWitness,
   requireCurrentSubgraph = false,
+  observedOverride?: TabPromotedScopeRead,
 ): string | null {
-  const readScope = (ctx.bridge as unknown as BridgeProbe).promotedScopeFor;
-  if (typeof readScope === "function") {
-    let observed: TabPromotedScopeRead;
-    try {
-      observed = readScope.call(ctx.bridge, ctx.tabId);
-    } catch {
-      return "the receiving panel current-view scope became unreadable";
+  let scopeRead = observedOverride;
+  if (scopeRead === undefined) {
+    const readScope = (ctx.bridge as unknown as BridgeProbe).promotedScopeFor;
+    if (typeof readScope === "function") {
+      try {
+        scopeRead = readScope.call(ctx.bridge, ctx.tabId);
+      } catch {
+        scopeRead = {
+          known: false,
+          reason: "the receiving panel current-view scope became unreadable",
+        };
+      }
     }
-    if (observed.known !== true) {
+  }
+  if (scopeRead !== undefined) {
+    if (scopeRead.known !== true) {
       return "the receiving panel current-view scope became unverifiable";
     }
     if (
       requireCurrentSubgraph &&
-      (observed.scope !== "subgraph" || observed.ownerNodeId !== expected.ownerNodeId)
+      (scopeRead.scope !== "subgraph" || scopeRead.ownerNodeId !== expected.ownerNodeId)
     ) {
       return "the receiving panel current subgraph owner changed or became unverifiable";
     }
-    if (expected.workflowUuid !== undefined && observed.workflowUuid !== expected.workflowUuid) {
+    if (expected.workflowUuid !== undefined && scopeRead.workflowUuid !== expected.workflowUuid) {
       return "the receiving panel workflow scope changed or became unverifiable";
     }
   }
@@ -6373,32 +6381,35 @@ function currentPromotedScopeError(
   return null;
 }
 
-/** Perform a fresh current-view read for the promoted receiver. The bridge
- * cache remains useful for the synchronous dispatch callback, but it is not
- * authoritative across the final graph_query -> graph_set_widget window. */
+type PromotedScopeFence = {
+  error: string | null;
+  /** The exact structured result of the live graph_query. Once present, the
+   * synchronous dispatch fence must use this witness rather than the bridge's
+   * cached reply state. */
+  observed?: TabPromotedScopeRead;
+};
+
+/** Perform a fresh current-view read for the promoted receiver. Return the
+ * validated result as part of the fence so the final synchronous callback does
+ * not silently fall back to a stale cached owner. */
 async function authoritativePromotedScopeError(
   ctx: PanelToolCtx,
   expected: PromotedScopeWitness,
   innerNodeId: number | string,
-): Promise<string | null> {
+): Promise<PromotedScopeFence> {
   const readScope = (ctx.bridge as unknown as BridgeProbe).readPromotedScope;
-  if (typeof readScope !== "function") return currentPromotedScopeError(ctx, expected, true);
+  if (typeof readScope !== "function") {
+    return { error: currentPromotedScopeError(ctx, expected, true) };
+  }
 
   let observed: TabPromotedScopeRead;
   try {
     observed = await readScope.call(ctx.bridge, ctx.tabId, innerNodeId);
   } catch {
-    return "the receiving panel current-view scope became unreadable";
+    return { error: "the receiving panel current-view scope became unreadable" };
   }
-  if (
-    observed.known !== true ||
-    observed.scope !== "subgraph" ||
-    observed.ownerNodeId !== expected.ownerNodeId ||
-    (expected.workflowUuid !== undefined && observed.workflowUuid !== expected.workflowUuid)
-  ) {
-    return "the receiving panel current subgraph owner changed or became unverifiable";
-  }
-  return null;
+  const error = currentPromotedScopeError(ctx, expected, true, observed);
+  return { error, observed };
 }
 
 function promotedWriteRefusal(widget: string, reason: string): ToolResult {
@@ -17086,15 +17097,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // before this write is dispatched. Take a fresh authoritative view
             // read at the write boundary so the final synchronous callback is
             // never the first place we discover a stale owner witness.
-            const authoritativeScopeError = await authoritativePromotedScopeError(
+            const authoritativeScope = await authoritativePromotedScopeError(
               ctx,
               plan.scope,
               plan.inner.innerNodeId,
             );
-            if (authoritativeScopeError) {
+            if (authoritativeScope.error) {
               const exited = await leave();
               return appendToolResultText(
-                promotedWriteRefusal(args.widget as string, authoritativeScopeError),
+                promotedWriteRefusal(args.widget as string, authoritativeScope.error),
                 exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
               );
             }
@@ -17110,7 +17121,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
                   );
                 }
-                const scopeError = currentPromotedScopeError(ctx, plan.scope, true);
+                const scopeError = currentPromotedScopeError(
+                  ctx,
+                  plan.scope,
+                  true,
+                  authoritativeScope.observed,
+                );
                 if (scopeError) {
                   throw new Error(
                     `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
@@ -17663,15 +17679,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
-        const authoritativeRecoveryScopeError = recoveryScope
+        const authoritativeRecoveryScope = recoveryScope
           ? await authoritativePromotedScopeError(ctx, recoveryScope, inner.innerNodeId)
-          : "the promoted recovery scope was unavailable";
-        if (authoritativeRecoveryScopeError) {
+          : { error: "the promoted recovery scope was unavailable" };
+        if (authoritativeRecoveryScope.error) {
           const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
           return appendToolResultText(
             first,
             `\n\n${textOfToolResult(
-              promotedWriteRefusal(refusal.widget, authoritativeRecoveryScopeError),
+              promotedWriteRefusal(refusal.widget, authoritativeRecoveryScope.error),
             )}` + (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
           );
         }
@@ -17689,7 +17705,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   );
                 }
                 const scopeError = recoveryScope
-                  ? currentPromotedScopeError(ctx, recoveryScope, true)
+                  ? currentPromotedScopeError(
+                      ctx,
+                      recoveryScope,
+                      true,
+                      authoritativeRecoveryScope.observed,
+                    )
                   : "the promoted recovery scope was unavailable";
                 if (scopeError) {
                   throw new Error(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6414,6 +6414,57 @@ async function preparePromotedWidgetWrite(
   };
 }
 
+type PromotedMappingProof = {
+  inner: { innerNodeId: number | string; widget: string };
+  innerNodeType: string;
+};
+
+/** Re-read the ownership envelope for a previously classified promoted write.
+ * This is deliberately strict: after entering the subgraph, or immediately
+ * before a legacy retry, the old inner id is not permission to trust a relinked
+ * wrapper. */
+async function recheckPromotedInnerMapping(
+  ctx: PanelToolCtx,
+  outerNodeId: number | string,
+  widget: string,
+  expectedInner: { innerNodeId: number | string; widget: string },
+): Promise<PromotedMappingProof | ToolResult> {
+  const confirmation = await ctx.call({
+    cmd: "graph_get_subgraph",
+    node_id: outerNodeId,
+  });
+  if (confirmation.isError) {
+    return promotedWriteRefusal(
+      widget,
+      "the promoted mapping read was unavailable before the write",
+    );
+  }
+  const payload = parseToolResultJson(confirmation);
+  const envelope = validatePromotedSubgraphEnvelope(payload, outerNodeId);
+  const inner = envelope
+    ? resolveInnerPromotedTarget(payload, widget, outerNodeId)
+    : null;
+  if (
+    !envelope ||
+    !inner ||
+    canonicalQueriedNodeId(inner.innerNodeId) !== canonicalQueriedNodeId(expectedInner.innerNodeId) ||
+    inner.widget !== expectedInner.widget
+  ) {
+    return promotedWriteRefusal(
+      widget,
+      "the promoted inner mapping changed or became unverifiable before the write",
+    );
+  }
+  const targetId = canonicalQueriedNodeId(inner.innerNodeId);
+  const innerNode = envelope.nodes.find(
+    (candidate) => canonicalQueriedNodeId(candidate.id) === targetId,
+  );
+  if (!innerNode || !targetId || typeof innerNode.type !== "string" || innerNode.type.length === 0) {
+    return promotedWriteRefusal(widget, "the mapped inner node lost its verifiable type fence");
+  }
+  return { inner, innerNodeType: innerNode.type };
+}
+
 function daSiWaStackRefusal(type: string): ToolResult {
   return fail(
     `panel_set_widget cannot set "${DASIWA_STACK_WIDGET}" on ${type}. ` +
@@ -16732,17 +16783,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               echoFull,
             ),
           );
+        let writePromotedInner: (plan: PromotedWritePlan) => Promise<ToolResult>;
         const guardedWrite = async (
           nodeId: unknown,
           widget: string,
           targetExpectedNodeType: string | undefined = expectedNodeType,
         ): Promise<ToolResult> => {
+          const promotedRetry = await preparePromotedWidgetWrite(ctx, nodeId, widget);
+          if (promotedRetry && "content" in promotedRetry) return promotedRetry;
+          if (promotedRetry && promotedRetry.kind === "promoted-write") {
+            return writePromotedInner(promotedRetry);
+          }
           const blocked = await refuseKnownBadWriteBeforeDispatch(ctx, nodeId, widget);
           if (blocked) return blocked;
           return write(nodeId, widget, targetExpectedNodeType);
         };
 
-        const writePromotedInner = async (plan: PromotedWritePlan): Promise<ToolResult> => {
+        writePromotedInner = async (plan: PromotedWritePlan): Promise<ToolResult> => {
           let entered = false;
           const leave = async (): Promise<ToolResult> => {
             const exit = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
@@ -16754,48 +16811,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             if (initialBindingError) return promotedWriteRefusal(args.widget as string, initialBindingError);
 
             // Re-read the ownership envelope immediately before entering. This
-            // catches a promotion relink after the classification read; the
-            // inner write below then addresses the verified node directly.
-            const confirmation = await ctx.call({
-              cmd: "graph_get_subgraph",
-              node_id: plan.outerNodeId,
-            });
-            if (confirmation.isError) {
-              return promotedWriteRefusal(
-                args.widget as string,
-                "the final promoted mapping read was unavailable",
-              );
-            }
-            const confirmedPayload = parseToolResultJson(confirmation);
-            const confirmedEnvelope = validatePromotedSubgraphEnvelope(
-              confirmedPayload,
+            // catches a promotion relink after the classification read.
+            const beforeEnterMapping = await recheckPromotedInnerMapping(
+              ctx,
               plan.outerNodeId,
+              args.widget as string,
+              plan.inner,
             );
-            const confirmedInner = confirmedEnvelope
-              ? resolveInnerPromotedTarget(
-                  confirmedPayload,
-                  args.widget as string,
-                  plan.outerNodeId,
-                )
-              : null;
-            if (
-              !confirmedEnvelope ||
-              !confirmedInner ||
-              canonicalQueriedNodeId(confirmedInner.innerNodeId) !==
-                canonicalQueriedNodeId(plan.inner.innerNodeId) ||
-              confirmedInner.widget !== plan.inner.widget
-            ) {
-              return promotedWriteRefusal(
-                args.widget as string,
-                "the promoted inner mapping changed or became unverifiable before the write",
-              );
-            }
-            const confirmedNode = confirmedEnvelope.nodes.find(
-              (candidate) =>
-                canonicalQueriedNodeId(candidate.id) ===
-                canonicalQueriedNodeId(plan.inner.innerNodeId),
-            );
-            if (!confirmedNode || confirmedNode.type !== plan.innerNodeType) {
+            if ("content" in beforeEnterMapping) return beforeEnterMapping;
+            if (beforeEnterMapping.innerNodeType !== plan.innerNodeType) {
               return promotedWriteRefusal(
                 args.widget as string,
                 "the promoted inner node type changed before the write",
@@ -16824,6 +16848,30 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
 
+            const afterEnterMapping = await recheckPromotedInnerMapping(
+              ctx,
+              plan.outerNodeId,
+              args.widget as string,
+              plan.inner,
+            );
+            if ("content" in afterEnterMapping) {
+              const exited = await leave();
+              return appendToolResultText(
+                afterEnterMapping,
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+            if (afterEnterMapping.innerNodeType !== plan.innerNodeType) {
+              const exited = await leave();
+              return appendToolResultText(
+                promotedWriteRefusal(
+                  args.widget as string,
+                  "the promoted inner node type changed after entering the subgraph",
+                ),
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+
             const innerBlocked = await refuseKnownBadWidgetWrite(
               ctx,
               plan.inner.innerNodeId,
@@ -16842,10 +16890,34 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
 
+            const finalMapping = await recheckPromotedInnerMapping(
+              ctx,
+              plan.outerNodeId,
+              args.widget as string,
+              plan.inner,
+            );
+            if ("content" in finalMapping) {
+              const exited = await leave();
+              return appendToolResultText(
+                finalMapping,
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+            if (finalMapping.innerNodeType !== plan.innerNodeType) {
+              const exited = await leave();
+              return appendToolResultText(
+                promotedWriteRefusal(
+                  args.widget as string,
+                  "the promoted inner node type changed immediately before the write",
+                ),
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+
             const written = await write(
               plan.inner.innerNodeId,
               plan.inner.widget,
-              plan.innerNodeType,
+              finalMapping.innerNodeType,
               () => {
                 const error = currentPromotedBindingError(ctx, plan.binding);
                 if (error) {
@@ -17148,6 +17220,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `truncated inner list, would target the wrong node.)`,
           );
         }
+        const recoveryInnerId = canonicalQueriedNodeId(inner.innerNodeId);
+        const recoveryInnerNode = recoveryEnvelope?.nodes.find(
+          (candidate) => canonicalQueriedNodeId(candidate.id) === recoveryInnerId,
+        );
+        const recoveryInnerNodeType = recoveryInnerNode?.type;
+        if (
+          !recoveryInnerId ||
+          typeof recoveryInnerNodeType !== "string" ||
+          recoveryInnerNodeType.length === 0
+        ) {
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(
+                refusal.widget,
+                "the recovery envelope did not retain a verifiable inner node type",
+              ),
+            )}`,
+          );
+        }
 
         const entered = await ctx.call(
           { cmd: "graph_enter_subgraph", node_id: args.node_id },
@@ -17158,7 +17250,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             first,
             `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
               `Resolved it to inner node ${inner.innerNodeId} but panel_enter_subgraph FAILED: ` +
-            `${textOfToolResult(entered)})`,
+              `${textOfToolResult(entered)})`,
           );
         }
         if (recoveryBinding) {
@@ -17173,7 +17265,35 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
 
-        let innerExpectedNodeType: string | undefined;
+        const legacyAfterEnterMapping = await recheckPromotedInnerMapping(
+          ctx,
+          args.node_id as number | string,
+          refusal.widget,
+          inner,
+        );
+        if ("content" in legacyAfterEnterMapping) {
+          const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(legacyAfterEnterMapping)}` +
+              (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+          );
+        }
+        if (legacyAfterEnterMapping.innerNodeType !== recoveryInnerNodeType) {
+          const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(
+                refusal.widget,
+                "the promoted inner node type changed after entering the subgraph",
+              ),
+            )}` +
+              (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+          );
+        }
+
+        let innerExpectedNodeType: string | undefined = legacyAfterEnterMapping.innerNodeType;
         if (expectedNodeType !== undefined) {
           // The inner mapping was discovered before an awaited enter. Re-query
           // the addressed inner node after entering so the stack_data write gets
@@ -17286,10 +17406,51 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
+        if (recoveryBinding) {
+          const beforeDispatchBindingError = currentPromotedBindingError(ctx, recoveryBinding);
+          if (beforeDispatchBindingError) {
+            const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+            return appendToolResultText(
+              first,
+              `\n\n${textOfToolResult(
+                promotedWriteRefusal(refusal.widget, beforeDispatchBindingError),
+              )}` +
+                (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+            );
+          }
+        }
+        const legacyFinalMapping = await recheckPromotedInnerMapping(
+          ctx,
+          args.node_id as number | string,
+          refusal.widget,
+          inner,
+        );
+        if ("content" in legacyFinalMapping) {
+          const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(legacyFinalMapping)}` +
+              (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+          );
+        }
+        if (legacyFinalMapping.innerNodeType !== recoveryInnerNodeType) {
+          const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(
+                refusal.widget,
+                "the promoted inner node type changed immediately before the write",
+              ),
+            )}` +
+              (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+          );
+        }
+
         const written = await write(
           inner.innerNodeId,
           inner.widget,
-          innerExpectedNodeType,
+          legacyFinalMapping.innerNodeType,
           recoveryBinding
             ? () => {
                 const error = currentPromotedBindingError(ctx, recoveryBinding);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6373,6 +6373,34 @@ function currentPromotedScopeError(
   return null;
 }
 
+/** Perform a fresh current-view read for the promoted receiver. The bridge
+ * cache remains useful for the synchronous dispatch callback, but it is not
+ * authoritative across the final graph_query -> graph_set_widget window. */
+async function authoritativePromotedScopeError(
+  ctx: PanelToolCtx,
+  expected: PromotedScopeWitness,
+  innerNodeId: number | string,
+): Promise<string | null> {
+  const readScope = (ctx.bridge as unknown as BridgeProbe).readPromotedScope;
+  if (typeof readScope !== "function") return currentPromotedScopeError(ctx, expected, true);
+
+  let observed: TabPromotedScopeRead;
+  try {
+    observed = await readScope.call(ctx.bridge, ctx.tabId, innerNodeId);
+  } catch {
+    return "the receiving panel current-view scope became unreadable";
+  }
+  if (
+    observed.known !== true ||
+    observed.scope !== "subgraph" ||
+    observed.ownerNodeId !== expected.ownerNodeId ||
+    (expected.workflowUuid !== undefined && observed.workflowUuid !== expected.workflowUuid)
+  ) {
+    return "the receiving panel current subgraph owner changed or became unverifiable";
+  }
+  return null;
+}
+
 function promotedWriteRefusal(widget: string, reason: string): ToolResult {
   return fail(
     `panel_set_widget refused the promoted "${widget}" write because ${reason}. ` +
@@ -12347,6 +12375,7 @@ interface BridgeProbe {
   refreshWorkflowUuid?: (tabId: string, workflowUuid: string) => boolean;
   workflowUuidFor?: (tabId: string) => TabWorkflowUuidRead;
   promotedScopeFor?: (tabId: string) => TabPromotedScopeRead;
+  readPromotedScope?: (tabId: string, innerNodeId: number | string) => Promise<TabPromotedScopeRead>;
   lastFenceRefusal?: (tabId: string) => string | undefined;
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
@@ -17052,6 +17081,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
 
+            // The preceding graph_query updates the bridge's scope cache, but
+            // that cache can remain on owner A if the user navigates to owner B
+            // before this write is dispatched. Take a fresh authoritative view
+            // read at the write boundary so the final synchronous callback is
+            // never the first place we discover a stale owner witness.
+            const authoritativeScopeError = await authoritativePromotedScopeError(
+              ctx,
+              plan.scope,
+              plan.inner.innerNodeId,
+            );
+            if (authoritativeScopeError) {
+              const exited = await leave();
+              return appendToolResultText(
+                promotedWriteRefusal(args.widget as string, authoritativeScopeError),
+                exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : "",
+              );
+            }
+
             const written = await write(
               plan.inner.innerNodeId,
               plan.inner.widget,
@@ -17613,6 +17660,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               ),
             )}` +
               (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
+          );
+        }
+
+        const authoritativeRecoveryScopeError = recoveryScope
+          ? await authoritativePromotedScopeError(ctx, recoveryScope, inner.innerNodeId)
+          : "the promoted recovery scope was unavailable";
+        if (authoritativeRecoveryScopeError) {
+          const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+          return appendToolResultText(
+            first,
+            `\n\n${textOfToolResult(
+              promotedWriteRefusal(refusal.widget, authoritativeRecoveryScopeError),
+            )}` + (exited.isError ? ` panel_exit_subgraph also FAILED: ${textOfToolResult(exited)}` : ""),
           );
         }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16931,6 +16931,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           widget: string,
           targetExpectedNodeType: string | undefined = expectedNodeType,
           beforeDispatch?: () => void,
+          targetExpectedScope?: PromotedScopeWitness,
         ): Promise<ToolResult> =>
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
@@ -16946,6 +16947,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   // and supplies that node's own type.
                   ...(targetExpectedNodeType
                     ? { expected_node_type: targetExpectedNodeType }
+                    : {}),
+                  ...(targetExpectedScope
+                    ? {
+                        expected_scope: {
+                          scope: "subgraph",
+                          owner_node_id: targetExpectedScope.ownerNodeId,
+                          ...(targetExpectedScope.workflowUuid !== undefined
+                            ? { workflow_uuid: targetExpectedScope.workflowUuid }
+                            : {}),
+                        },
+                      }
                     : {}),
                   ...(args.defer_until_idle === true
                     ? { defer_until_idle: true, expected_value: args.expected_value }
@@ -17133,6 +17145,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   );
                 }
               },
+              plan.scope,
             );
             const exited = await leave();
             if (written.isError) {
@@ -17692,33 +17705,35 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
 
+        const recoveryBeforeDispatch = recoveryBinding
+          ? () => {
+              const error = currentPromotedBindingError(ctx, recoveryBinding);
+              if (error) {
+                throw new Error(
+                  `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                );
+              }
+              const scopeError = recoveryScope
+                ? currentPromotedScopeError(
+                    ctx,
+                    recoveryScope,
+                    true,
+                    authoritativeRecoveryScope.observed,
+                  )
+                : "the promoted recovery scope was unavailable";
+              if (scopeError) {
+                throw new Error(
+                  `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
+                );
+              }
+            }
+          : undefined;
         const written = await write(
           inner.innerNodeId,
           inner.widget,
           legacyFinalMapping.innerNodeType,
-          recoveryBinding
-            ? () => {
-                const error = currentPromotedBindingError(ctx, recoveryBinding);
-                if (error) {
-                  throw new Error(
-                    `Refusing promoted inner graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
-                  );
-                }
-                const scopeError = recoveryScope
-                  ? currentPromotedScopeError(
-                      ctx,
-                      recoveryScope,
-                      true,
-                      authoritativeRecoveryScope.observed,
-                    )
-                  : "the promoted recovery scope was unavailable";
-                if (scopeError) {
-                  throw new Error(
-                    `Refusing promoted inner graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
-                  );
-                }
-              }
-            : undefined,
+          recoveryBeforeDispatch,
+          recoveryScope ?? undefined,
         );
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
         if (!written.isError) {

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -52,6 +52,10 @@ export type PromotedTerminalWitness = {
 export type PromotedParentRailWitness = {
   authoritative: true;
   widget: string;
+  /** Per-instance host-input identity when the panel exposes it. The final
+   * dispatch still re-resolves the live object, but this catches a relink to
+   * another promoted store entry with the same display name. */
+  widgetId?: string;
 };
 
 type PromotedTerminalEntry = {
@@ -364,7 +368,18 @@ function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] |
       ) {
         return null;
       }
-      parentRail = { authoritative: true, widget: parentRailRaw.widget };
+      const parentRailWidgetId = parentRailRaw.widget_id;
+      if (
+        parentRailWidgetId !== undefined &&
+        (typeof parentRailWidgetId !== "string" || parentRailWidgetId.length === 0)
+      ) {
+        return null;
+      }
+      parentRail = {
+        authoritative: true,
+        widget: parentRailRaw.widget,
+        ...(parentRailWidgetId !== undefined ? { widgetId: parentRailWidgetId } : {}),
+      };
       if (!isNodeId(terminalRaw.terminal_node_id)) return null;
       if (typeof terminalRaw.terminal_node_type !== "string" || terminalRaw.terminal_node_type.length === 0) {
         return null;

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -482,6 +482,23 @@ export function resolveInnerPromotedTarget(
   return hits[0];
 }
 
+/**
+ * Resolve only the legacy same-name relation. A payload from a receiver that
+ * does not advertise `promoted_terminals` is not allowed to use an unadvertised
+ * witness array as an ordinary-write proof: that array may be partial on a
+ * capability-skewed panel. Legacy compatibility is therefore limited to the
+ * old, positive inner-node/name match; a miss remains indeterminate.
+ */
+export function resolveLegacyInnerPromotedTarget(
+  subgraph: Record<string, unknown> | null | undefined,
+  displayedWidget: string,
+  ownerNodeId?: number | string,
+): InnerPromotedTarget | null {
+  if (!isRecord(subgraph)) return null;
+  const { promoted_terminals: _untrustedWitnesses, ...legacyPayload } = subgraph;
+  return resolveInnerPromotedTarget(legacyPayload, displayedWidget, ownerNodeId);
+}
+
 /** True when the refusal listed `requestedWidget` as promoted. */
 export function isContradictoryPromotedWidgetRefusal(
   text: string,

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -28,6 +28,9 @@ export type ContradictoryPromotedWidgetRefusal = {
 export type InnerPromotedTarget = {
   innerNodeId: number | string;
   widget: string;
+  /** Current-panel witnesses must prove the exact local parent rail that
+   * serializes this promoted value. Legacy envelopes omit this proof. */
+  parentRail?: PromotedParentRailWitness;
   /** Terminal concrete endpoint supplied by a receiver that can recursively
    * resolve nested promotion chains. Omitted for legacy one-hop envelopes. */
   terminal?: PromotedTerminalWitness;
@@ -46,8 +49,14 @@ export type PromotedTerminalWitness = {
   chainDepth: number;
 };
 
+export type PromotedParentRailWitness = {
+  authoritative: true;
+  widget: string;
+};
+
 type PromotedTerminalEntry = {
   widget: string;
+  parentRail?: PromotedParentRailWitness;
   immediateNodeId?: number | string;
   immediateWidget?: string;
   terminal?: PromotedTerminalWitness;
@@ -342,9 +351,20 @@ function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] |
     const terminalRaw = raw.terminal_node_id === undefined && raw.terminal_node_type === undefined
       ? undefined
       : raw;
+    const parentRailRaw = raw.parent_rail;
+    let parentRail: PromotedParentRailWitness | undefined;
     let terminal: PromotedTerminalWitness | undefined;
     if (terminalRaw) {
       if (error !== undefined || immediateNodeId === undefined || immediateWidget === undefined) return null;
+      if (
+        !isRecord(parentRailRaw) ||
+        parentRailRaw.authoritative !== true ||
+        typeof parentRailRaw.widget !== "string" ||
+        parentRailRaw.widget.length === 0
+      ) {
+        return null;
+      }
+      parentRail = { authoritative: true, widget: parentRailRaw.widget };
       if (!isNodeId(terminalRaw.terminal_node_id)) return null;
       if (typeof terminalRaw.terminal_node_type !== "string" || terminalRaw.terminal_node_type.length === 0) {
         return null;
@@ -375,6 +395,7 @@ function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] |
     }
     entries.push({
       widget: raw.widget,
+      ...(parentRail ? { parentRail } : {}),
       ...(immediateNodeId !== undefined ? { immediateNodeId } : {}),
       ...(immediateWidget !== undefined ? { immediateWidget } : {}),
       ...(terminal ? { terminal } : {}),
@@ -452,6 +473,7 @@ export function resolveInnerPromotedTarget(
     if (
       entry.error ||
       !entry.terminal ||
+      !entry.parentRail ||
       entry.immediateNodeId === undefined ||
       !entry.immediateWidget
     ) {
@@ -467,6 +489,7 @@ export function resolveInnerPromotedTarget(
     return {
       innerNodeId: entry.immediateNodeId,
       widget: entry.immediateWidget,
+      parentRail: entry.parentRail,
       terminal: entry.terminal,
     };
   }

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -28,6 +28,30 @@ export type ContradictoryPromotedWidgetRefusal = {
 export type InnerPromotedTarget = {
   innerNodeId: number | string;
   widget: string;
+  /** Terminal concrete endpoint supplied by a receiver that can recursively
+   * resolve nested promotion chains. Omitted for legacy one-hop envelopes. */
+  terminal?: PromotedTerminalWitness;
+};
+
+export type PromotedTerminalInput = {
+  name: string;
+  type?: string;
+};
+
+export type PromotedTerminalWitness = {
+  nodeId: number | string;
+  nodeType: string;
+  widget: string;
+  inputs: PromotedTerminalInput[];
+  chainDepth: number;
+};
+
+type PromotedTerminalEntry = {
+  widget: string;
+  immediateNodeId?: number | string;
+  immediateWidget?: string;
+  terminal?: PromotedTerminalWitness;
+  error?: string;
 };
 
 export type PromotedViewingIdentity = {
@@ -53,6 +77,7 @@ export type PromotedSubgraphEnvelope = {
   /** Identity of the target graph reached by entering this wrapper. */
   targetGraphIdentity?: string;
   viewing?: PromotedViewingIdentity;
+  promotedTerminals?: PromotedTerminalEntry[];
 };
 
 export type AmbiguousPromotedWidgetRefusal = {
@@ -285,13 +310,78 @@ export function validatePromotedSubgraphEnvelope(
     if (!isRecord(raw) || innerNodeId(raw) == null) return null;
     normalized.push(raw);
   }
+  const promotedTerminals = Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals")
+    ? parsePromotedTerminalEntries(subgraph.promoted_terminals)
+    : undefined;
+  if (Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals") && !promotedTerminals) {
+    return null;
+  }
   return {
     nodes: normalized,
     nodeId: stripNodeId(String(owner.node_id)),
     nodeCount: nodeCount as number,
     ...(targetGraphIdentity !== undefined ? { targetGraphIdentity } : {}),
     ...(viewing ? { viewing } : {}),
+    ...(promotedTerminals ? { promotedTerminals } : {}),
   };
+}
+
+function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] | null {
+  if (!Array.isArray(value)) return null;
+  const entries: PromotedTerminalEntry[] = [];
+  for (const raw of value) {
+    if (!isRecord(raw) || typeof raw.widget !== "string" || raw.widget.length === 0) return null;
+    const immediateNodeId = raw.immediate_node_id;
+    if (immediateNodeId !== undefined && !isNodeId(immediateNodeId)) return null;
+    const immediateWidget = raw.immediate_widget;
+    if (immediateWidget !== undefined && (typeof immediateWidget !== "string" || immediateWidget.length === 0)) {
+      return null;
+    }
+    const error = raw.error;
+    if (error !== undefined && (typeof error !== "string" || error.length === 0)) return null;
+    const terminalRaw = raw.terminal_node_id === undefined && raw.terminal_node_type === undefined
+      ? undefined
+      : raw;
+    let terminal: PromotedTerminalWitness | undefined;
+    if (terminalRaw) {
+      if (error !== undefined || immediateNodeId === undefined || immediateWidget === undefined) return null;
+      if (!isNodeId(terminalRaw.terminal_node_id)) return null;
+      if (typeof terminalRaw.terminal_node_type !== "string" || terminalRaw.terminal_node_type.length === 0) {
+        return null;
+      }
+      if (typeof terminalRaw.terminal_widget !== "string" || terminalRaw.terminal_widget.length === 0) {
+        return null;
+      }
+      const chainDepth = terminalRaw.chain_depth;
+      if (!Number.isSafeInteger(chainDepth) || (chainDepth as number) < 0 || (chainDepth as number) > 16) {
+        return null;
+      }
+      if (!Array.isArray(terminalRaw.terminal_inputs)) return null;
+      const inputs: PromotedTerminalInput[] = [];
+      for (const input of terminalRaw.terminal_inputs) {
+        if (!isRecord(input) || typeof input.name !== "string" || input.name.length === 0) return null;
+        if (input.type !== undefined && typeof input.type !== "string") return null;
+        inputs.push({ name: input.name, ...(input.type !== undefined ? { type: input.type } : {}) });
+      }
+      terminal = {
+        nodeId: terminalRaw.terminal_node_id,
+        nodeType: terminalRaw.terminal_node_type,
+        widget: terminalRaw.terminal_widget,
+        inputs,
+        chainDepth: chainDepth as number,
+      };
+    } else if (error === undefined) {
+      return null;
+    }
+    entries.push({
+      widget: raw.widget,
+      ...(immediateNodeId !== undefined ? { immediateNodeId } : {}),
+      ...(immediateWidget !== undefined ? { immediateWidget } : {}),
+      ...(terminal ? { terminal } : {}),
+      ...(error !== undefined ? { error } : {}),
+    });
+  }
+  return entries;
 }
 
 /** Extract the target owner and workflow identity from a validated promotion
@@ -354,7 +444,21 @@ export function resolveInnerPromotedTarget(
     const matched = matchListedName(displayedWidget, widgetNamesOnInner(node));
     if (matched) hits.push({ innerNodeId: id, widget: matched });
   }
-  return hits.length === 1 ? hits[0] : null;
+  if (hits.length !== 1) return null;
+  const promotedTerminals =
+    "promotedTerminals" in envelope ? envelope.promotedTerminals : undefined;
+  if (promotedTerminals !== undefined) {
+    const hit = hits[0];
+    const terminalEntries = promotedTerminals.filter(
+      (entry) =>
+        entry.widget.toLowerCase() === displayedWidget.toLowerCase() &&
+        (entry.immediateNodeId === undefined || sameNodeId(entry.immediateNodeId, hit.innerNodeId)) &&
+        (entry.immediateWidget === undefined || entry.immediateWidget.toLowerCase() === hit.widget.toLowerCase()),
+    );
+    if (terminalEntries.length !== 1 || !terminalEntries[0].terminal || terminalEntries[0].error) return null;
+    return { ...hit, terminal: terminalEntries[0].terminal };
+  }
+  return hits[0];
 }
 
 /** True when the refusal listed `requestedWidget` as promoted. */

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -30,10 +30,23 @@ export type InnerPromotedTarget = {
   widget: string;
 };
 
+export type PromotedViewingIdentity = {
+  scope: "root" | "subgraph";
+  ownerNodeId: string | null;
+  workflowUuid: string;
+};
+
+/** The stable scope witness carried from the promotion read to the inner write. */
+export type PromotedScopeWitness = {
+  workflowUuid: string;
+  ownerNodeId: string;
+};
+
 export type PromotedSubgraphEnvelope = {
   nodes: Array<Record<string, unknown>>;
   nodeId: string;
   nodeCount: number;
+  viewing?: PromotedViewingIdentity;
 };
 
 export type AmbiguousPromotedWidgetRefusal = {
@@ -168,6 +181,35 @@ function isNodeId(value: unknown): value is number | string {
   return typeof normalized === "string" || Number.isSafeInteger(normalized);
 }
 
+function canonicalPromotedNodeId(value: unknown): string | null {
+  if (!isNodeId(value)) return null;
+  const normalized = normalizeNodeId(value);
+  return typeof normalized === "number"
+    ? Number.isSafeInteger(normalized)
+      ? String(normalized)
+      : null
+    : normalized;
+}
+
+/** Parse the panel's structured current-graph identity without accepting a
+ * prose/detail fallback. The panel deliberately omits workflow_uuid when the
+ * live workflow identity cannot be read, so that omission is not a usable fence. */
+export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIdentity | null {
+  if (!isRecord(value)) return null;
+  const scope = value.scope;
+  if (scope !== "root" && scope !== "subgraph") return null;
+  const workflowUuid = value.workflow_uuid;
+  if (typeof workflowUuid !== "string" || workflowUuid.length === 0) return null;
+
+  const rawOwner = value.owner_node_id;
+  let ownerNodeId: string | null = null;
+  if (rawOwner !== undefined && rawOwner !== null) {
+    ownerNodeId = canonicalPromotedNodeId(rawOwner);
+    if (!ownerNodeId) return null;
+  }
+  return { scope, ownerNodeId, workflowUuid };
+}
+
 /**
  * Validate the ownership and completeness claims made by graph_get_subgraph.
  * A node list is useful for a promoted write only when it names the wrapper the
@@ -181,6 +223,11 @@ export function validatePromotedSubgraphEnvelope(
 ): PromotedSubgraphEnvelope | null {
   if (!isRecord(subgraph)) return null;
   if (subgraph.truncated !== undefined && subgraph.truncated !== false) return null;
+
+  const viewing = Object.prototype.hasOwnProperty.call(subgraph, "viewing")
+    ? parsePromotedViewingIdentity(subgraph.viewing)
+    : undefined;
+  if (Object.prototype.hasOwnProperty.call(subgraph, "viewing") && !viewing) return null;
 
   const owner = subgraph.subgraph_of;
   if (
@@ -212,7 +259,38 @@ export function validatePromotedSubgraphEnvelope(
     nodes: normalized,
     nodeId: stripNodeId(String(owner.node_id)),
     nodeCount: nodeCount as number,
+    ...(viewing ? { viewing } : {}),
   };
+}
+
+/** Extract the target owner and workflow identity from a validated promotion
+ * envelope. The caller must keep this witness with the resolved inner mapping;
+ * a later inner-id/type match without it is not sufficient because ids are
+ * local to the currently viewed graph. */
+export function promotedScopeWitnessFromEnvelope(
+  envelope: PromotedSubgraphEnvelope | null,
+): PromotedScopeWitness | null {
+  if (!envelope?.viewing) return null;
+  const ownerNodeId = canonicalPromotedNodeId(envelope.nodeId);
+  if (!ownerNodeId) return null;
+  return {
+    workflowUuid: envelope.viewing.workflowUuid,
+    ownerNodeId,
+  };
+}
+
+/** A post-entry graph query must prove that the panel is viewing the exact
+ * subgraph owned by the wrapper that produced the promotion mapping. */
+export function promotedViewingMatchesScope(
+  payload: Record<string, unknown> | null,
+  expected: PromotedScopeWitness,
+): boolean {
+  const viewing = parsePromotedViewingIdentity(payload?.viewing);
+  return (
+    viewing?.scope === "subgraph" &&
+    viewing.workflowUuid === expected.workflowUuid &&
+    viewing.ownerNodeId === expected.ownerNodeId
+  );
 }
 
 /**

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -28,6 +28,12 @@ export type InnerPromotedTarget = {
   widget: string;
 };
 
+export type PromotedSubgraphEnvelope = {
+  nodes: Array<Record<string, unknown>>;
+  nodeId: string;
+  nodeCount: number;
+};
+
 export type AmbiguousPromotedWidgetRefusal = {
   nodeId: string;
   widget: string;
@@ -151,6 +157,64 @@ function innerNodeId(node: Record<string, unknown>): number | string | null {
   return null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNodeId(value: unknown): value is number | string {
+  return (
+    (typeof value === "number" && Number.isFinite(value)) ||
+    (typeof value === "string" && value.trim() !== "")
+  );
+}
+
+/**
+ * Validate the ownership and completeness claims made by graph_get_subgraph.
+ * A node list is useful for a promoted write only when it names the wrapper the
+ * caller asked about and contains exactly the advertised number of inner nodes.
+ * The panel currently emits `truncated:false` for complete reads, but omission
+ * remains accepted for older compatible replies; any asserted truncation is not.
+ */
+export function validatePromotedSubgraphEnvelope(
+  subgraph: Record<string, unknown> | null | undefined,
+  ownerNodeId: number | string,
+): PromotedSubgraphEnvelope | null {
+  if (!isRecord(subgraph)) return null;
+  if (subgraph.truncated !== undefined && subgraph.truncated !== false) return null;
+
+  const owner = subgraph.subgraph_of;
+  if (
+    !isRecord(owner) ||
+    !isNodeId(owner.node_id) ||
+    !isNodeId(ownerNodeId) ||
+    !sameNodeId(owner.node_id, ownerNodeId)
+  ) {
+    return null;
+  }
+
+  const nodeCount = subgraph.node_count;
+  const nodes = subgraph.nodes;
+  if (
+    !Number.isSafeInteger(nodeCount) ||
+    (nodeCount as number) < 0 ||
+    !Array.isArray(nodes) ||
+    nodes.length !== nodeCount
+  ) {
+    return null;
+  }
+
+  const normalized: Array<Record<string, unknown>> = [];
+  for (const raw of nodes) {
+    if (!isRecord(raw) || innerNodeId(raw) == null) return null;
+    normalized.push(raw);
+  }
+  return {
+    nodes: normalized,
+    nodeId: stripNodeId(String(owner.node_id)),
+    nodeCount: nodeCount as number,
+  };
+}
+
 /**
  * Map a displayed promoted name to the unique inner node that owns a widget
  * of that name. `graph_get_subgraph` does not ship a reliable promotion
@@ -160,16 +224,18 @@ function innerNodeId(node: Record<string, unknown>): number | string | null {
 export function resolveInnerPromotedTarget(
   subgraph: Record<string, unknown> | null | undefined,
   displayedWidget: string,
+  ownerNodeId?: number | string,
 ): InnerPromotedTarget | null {
-  if (!subgraph || typeof subgraph !== "object") return null;
-  if (subgraph.truncated === true) return null;
-  const nodes = subgraph.nodes;
-  if (!Array.isArray(nodes)) return null;
+  const envelope =
+    ownerNodeId === undefined
+      ? isRecord(subgraph) && subgraph.truncated !== true && Array.isArray(subgraph.nodes)
+        ? { nodes: subgraph.nodes.filter(isRecord) }
+        : null
+      : validatePromotedSubgraphEnvelope(subgraph, ownerNodeId);
+  if (!envelope) return null;
 
   const hits: InnerPromotedTarget[] = [];
-  for (const raw of nodes) {
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
-    const node = raw as Record<string, unknown>;
+  for (const node of envelope.nodes) {
     const id = innerNodeId(node);
     if (id == null) continue;
     const matched = matchListedName(displayedWidget, widgetNamesOnInner(node));

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -437,6 +437,40 @@ export function resolveInnerPromotedTarget(
       : validatePromotedSubgraphEnvelope(subgraph, ownerNodeId);
   if (!envelope) return null;
 
+  const promotedTerminals =
+    "promotedTerminals" in envelope ? envelope.promotedTerminals : undefined;
+  if (promotedTerminals !== undefined) {
+    // Current panels publish the authoritative alias -> immediate -> terminal
+    // relation. Prefer it over the legacy same-name scan: renamed outer and
+    // intermediate aliases are valid addresses, while the inner node summary
+    // intentionally contains only the concrete widget's programmatic name.
+    const entries = promotedTerminals.filter(
+      (entry) => entry.widget.toLowerCase() === displayedWidget.toLowerCase(),
+    );
+    if (entries.length !== 1) return null;
+    const entry = entries[0];
+    if (
+      entry.error ||
+      !entry.terminal ||
+      entry.immediateNodeId === undefined ||
+      !entry.immediateWidget
+    ) {
+      return null;
+    }
+    const immediateId = canonicalPromotedNodeId(entry.immediateNodeId);
+    if (!immediateId) return null;
+    const immediateNode = envelope.nodes.find((node) => {
+      const candidateId = innerNodeId(node);
+      return candidateId !== null && canonicalPromotedNodeId(candidateId) === immediateId;
+    });
+    if (!immediateNode) return null;
+    return {
+      innerNodeId: entry.immediateNodeId,
+      widget: entry.immediateWidget,
+      terminal: entry.terminal,
+    };
+  }
+
   const hits: InnerPromotedTarget[] = [];
   for (const node of envelope.nodes) {
     const id = innerNodeId(node);
@@ -445,19 +479,6 @@ export function resolveInnerPromotedTarget(
     if (matched) hits.push({ innerNodeId: id, widget: matched });
   }
   if (hits.length !== 1) return null;
-  const promotedTerminals =
-    "promotedTerminals" in envelope ? envelope.promotedTerminals : undefined;
-  if (promotedTerminals !== undefined) {
-    const hit = hits[0];
-    const terminalEntries = promotedTerminals.filter(
-      (entry) =>
-        entry.widget.toLowerCase() === displayedWidget.toLowerCase() &&
-        (entry.immediateNodeId === undefined || sameNodeId(entry.immediateNodeId, hit.innerNodeId)) &&
-        (entry.immediateWidget === undefined || entry.immediateWidget.toLowerCase() === hit.widget.toLowerCase()),
-    );
-    if (terminalEntries.length !== 1 || !terminalEntries[0].terminal || terminalEntries[0].error) return null;
-    return { ...hit, terminal: terminalEntries[0].terminal };
-  }
   return hits[0];
 }
 

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -35,18 +35,23 @@ export type PromotedViewingIdentity = {
   ownerNodeId: string | null;
   /** Older/current panels may omit this while the active workflow identity is unreadable. */
   workflowUuid?: string;
+  /** Object-keyed live graph identity. Required before a promoted write. */
+  graphIdentity?: string;
 };
 
 /** The stable scope witness carried from the promotion read to the inner write. */
 export type PromotedScopeWitness = {
   workflowUuid?: string;
   ownerNodeId: string;
+  graphIdentity: string;
 };
 
 export type PromotedSubgraphEnvelope = {
   nodes: Array<Record<string, unknown>>;
   nodeId: string;
   nodeCount: number;
+  /** Identity of the target graph reached by entering this wrapper. */
+  targetGraphIdentity?: string;
   viewing?: PromotedViewingIdentity;
 };
 
@@ -204,6 +209,13 @@ export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIde
   if (workflowUuid !== undefined && (typeof workflowUuid !== "string" || workflowUuid.length === 0)) {
     return null;
   }
+  const graphIdentity = value.graph_identity;
+  if (
+    graphIdentity !== undefined &&
+    (typeof graphIdentity !== "string" || graphIdentity.length === 0 || graphIdentity.length > 256)
+  ) {
+    return null;
+  }
 
   const rawOwner = value.owner_node_id;
   let ownerNodeId: string | null = null;
@@ -215,6 +227,7 @@ export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIde
     scope,
     ownerNodeId,
     ...(workflowUuid !== undefined ? { workflowUuid } : {}),
+    ...(graphIdentity !== undefined ? { graphIdentity } : {}),
   };
 }
 
@@ -246,6 +259,15 @@ export function validatePromotedSubgraphEnvelope(
   ) {
     return null;
   }
+  const targetGraphIdentity = owner.graph_identity;
+  if (
+    targetGraphIdentity !== undefined &&
+    (typeof targetGraphIdentity !== "string" ||
+      targetGraphIdentity.length === 0 ||
+      targetGraphIdentity.length > 256)
+  ) {
+    return null;
+  }
 
   const nodeCount = subgraph.node_count;
   const nodes = subgraph.nodes;
@@ -267,6 +289,7 @@ export function validatePromotedSubgraphEnvelope(
     nodes: normalized,
     nodeId: stripNodeId(String(owner.node_id)),
     nodeCount: nodeCount as number,
+    ...(targetGraphIdentity !== undefined ? { targetGraphIdentity } : {}),
     ...(viewing ? { viewing } : {}),
   };
 }
@@ -280,12 +303,13 @@ export function promotedScopeWitnessFromEnvelope(
 ): PromotedScopeWitness | null {
   if (!envelope?.viewing) return null;
   const ownerNodeId = canonicalPromotedNodeId(envelope.nodeId);
-  if (!ownerNodeId) return null;
+  if (!ownerNodeId || typeof envelope.targetGraphIdentity !== "string") return null;
   return {
     ...(envelope.viewing.workflowUuid !== undefined
       ? { workflowUuid: envelope.viewing.workflowUuid }
       : {}),
     ownerNodeId,
+    graphIdentity: envelope.targetGraphIdentity,
   };
 }
 
@@ -299,7 +323,8 @@ export function promotedViewingMatchesScope(
   return (
     viewing?.scope === "subgraph" &&
     viewing.ownerNodeId === expected.ownerNodeId &&
-    (expected.workflowUuid === undefined || viewing.workflowUuid === expected.workflowUuid)
+    (expected.workflowUuid === undefined || viewing.workflowUuid === expected.workflowUuid) &&
+    viewing.graphIdentity === expected.graphIdentity
   );
 }
 

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -33,12 +33,13 @@ export type InnerPromotedTarget = {
 export type PromotedViewingIdentity = {
   scope: "root" | "subgraph";
   ownerNodeId: string | null;
-  workflowUuid: string;
+  /** Older/current panels may omit this while the active workflow identity is unreadable. */
+  workflowUuid?: string;
 };
 
 /** The stable scope witness carried from the promotion read to the inner write. */
 export type PromotedScopeWitness = {
-  workflowUuid: string;
+  workflowUuid?: string;
   ownerNodeId: string;
 };
 
@@ -193,13 +194,16 @@ function canonicalPromotedNodeId(value: unknown): string | null {
 
 /** Parse the panel's structured current-graph identity without accepting a
  * prose/detail fallback. The panel deliberately omits workflow_uuid when the
- * live workflow identity cannot be read, so that omission is not a usable fence. */
+ * live workflow identity cannot be read; owner_node_id remains the required
+ * subgraph witness for this promoted mapping. */
 export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIdentity | null {
   if (!isRecord(value)) return null;
   const scope = value.scope;
   if (scope !== "root" && scope !== "subgraph") return null;
   const workflowUuid = value.workflow_uuid;
-  if (typeof workflowUuid !== "string" || workflowUuid.length === 0) return null;
+  if (workflowUuid !== undefined && (typeof workflowUuid !== "string" || workflowUuid.length === 0)) {
+    return null;
+  }
 
   const rawOwner = value.owner_node_id;
   let ownerNodeId: string | null = null;
@@ -207,7 +211,11 @@ export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIde
     ownerNodeId = canonicalPromotedNodeId(rawOwner);
     if (!ownerNodeId) return null;
   }
-  return { scope, ownerNodeId, workflowUuid };
+  return {
+    scope,
+    ownerNodeId,
+    ...(workflowUuid !== undefined ? { workflowUuid } : {}),
+  };
 }
 
 /**
@@ -274,7 +282,9 @@ export function promotedScopeWitnessFromEnvelope(
   const ownerNodeId = canonicalPromotedNodeId(envelope.nodeId);
   if (!ownerNodeId) return null;
   return {
-    workflowUuid: envelope.viewing.workflowUuid,
+    ...(envelope.viewing.workflowUuid !== undefined
+      ? { workflowUuid: envelope.viewing.workflowUuid }
+      : {}),
     ownerNodeId,
   };
 }
@@ -288,8 +298,8 @@ export function promotedViewingMatchesScope(
   const viewing = parsePromotedViewingIdentity(payload?.viewing);
   return (
     viewing?.scope === "subgraph" &&
-    viewing.workflowUuid === expected.workflowUuid &&
-    viewing.ownerNodeId === expected.ownerNodeId
+    viewing.ownerNodeId === expected.ownerNodeId &&
+    (expected.workflowUuid === undefined || viewing.workflowUuid === expected.workflowUuid)
   );
 }
 

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -17,6 +17,8 @@
  * among several inners that share the name, and never from a truncated read.
  */
 
+import { isNodeIdString, normalizeNodeId } from "./node-id.js";
+
 export type ContradictoryPromotedWidgetRefusal = {
   nodeId: string;
   widget: string;
@@ -152,9 +154,7 @@ function widgetNamesOnInner(node: Record<string, unknown>): string[] {
 
 function innerNodeId(node: Record<string, unknown>): number | string | null {
   const id = node.id;
-  if (typeof id === "number" && Number.isFinite(id)) return id;
-  if (typeof id === "string" && id.trim() !== "") return id;
-  return null;
+  return isNodeId(id) ? id : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -162,10 +162,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isNodeId(value: unknown): value is number | string {
-  return (
-    (typeof value === "number" && Number.isFinite(value)) ||
-    (typeof value === "string" && value.trim() !== "")
-  );
+  if (typeof value === "number") return Number.isSafeInteger(value);
+  if (typeof value !== "string" || !isNodeIdString(value)) return false;
+  const normalized = normalizeNodeId(value);
+  return typeof normalized === "string" || Number.isSafeInteger(normalized);
 }
 
 /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -236,6 +236,9 @@ interface Conn {
    * the complete renamed-promotion alias -> terminal witness consumed by the
    * orchestrator before a promoted write. */
   publishesPromotedTerminalWitnesses: boolean;
+  /** True only when THIS hello advertises that graph_set_widget re-resolves the
+   * promoted parent rail through the live owner/input relation at mutation time. */
+  enforcesPromotedParentRailAtWrite: boolean;
   /** True when THIS hello advertises that the panel understands `agent_note` — a frame
    *  delivered to the AGENT ONLY and never rendered as a chat bubble.
    *
@@ -376,6 +379,9 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   // #2314 P1 — the promoted fence additionally validates the object-keyed live
   // graph identity, which is distinct from graph-local owner/node ids.
   enforces_expected_scope_graph_identity_at_write: "0.15.97",
+  // #2314 final-rail race — the promoted inner write re-resolves its live
+  // authoritative parent rail at the synchronous mutation boundary.
+  enforces_promoted_parent_rail_at_write: "0.15.97",
 };
 
 /**
@@ -1583,10 +1589,24 @@ function expectedScopeGraphIdentityFenceRefusal(tabId: string): Error {
   );
 }
 
+function promotedParentRailFenceRefusal(tabId: string): Error {
+  return new Error(
+    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
+      `does not advertise the atomic promoted parent-rail write fence. Update the ` +
+      `panel to 0.15.97+ and hard-refresh the browser tab.`,
+  );
+}
+
 function commandCarriesExpectedGraphIdentity(cmd: BridgeCommand): boolean {
   const scope = cmd.expected_scope;
   return !!scope && typeof scope === "object" && !Array.isArray(scope) &&
     Object.prototype.hasOwnProperty.call(scope, "graph_identity");
+}
+
+function commandCarriesPromotedParentRail(cmd: BridgeCommand): boolean {
+  const scope = cmd.expected_scope;
+  return !!scope && typeof scope === "object" && !Array.isArray(scope) &&
+    Object.prototype.hasOwnProperty.call(scope, "parent_rail");
 }
 
 /** Normalize a syntactically valid HTTP(S) WebSocket handshake `Origin` into a
@@ -3050,6 +3070,9 @@ export class UiBridge {
           publishesPromotedTerminalWitnesses:
             (msg as { publishes_promoted_terminal_witnesses?: unknown })
               .publishes_promoted_terminal_witnesses === true,
+          enforcesPromotedParentRailAtWrite:
+            (msg as { enforces_promoted_parent_rail_at_write?: unknown })
+              .enforces_promoted_parent_rail_at_write === true,
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
@@ -3635,6 +3658,16 @@ export class UiBridge {
   tabPromotedTerminalWitnessCapability(tabId: string): boolean {
     try {
       return this.resolveTarget(tabId).publishesPromotedTerminalWitnesses === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether THIS connected panel re-resolves the promoted parent rail at the
+   * final graph_set_widget mutation boundary. */
+  tabPromotedParentRailFenceCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).enforcesPromotedParentRailAtWrite === true;
     } catch {
       return false;
     }
@@ -5329,6 +5362,17 @@ export class UiBridge {
       );
       return Promise.reject(markCapabilityRefusal(refusal));
     }
+    if (
+      cmd.cmd === "graph_set_widget" &&
+      commandCarriesPromotedParentRail(cmd) &&
+      !conn.enforcesPromotedParentRailAtWrite
+    ) {
+      const refusal = markDispatched(
+        promotedParentRailFenceRefusal(conn.tabId),
+        false,
+      );
+      return Promise.reject(markCapabilityRefusal(refusal));
+    }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
     // panel does NOT enforce the per-command workflow-instance stamp. Such a panel would
@@ -5745,6 +5789,17 @@ export class UiBridge {
         return Promise.reject(
           markCapabilityRefusal(
             markDispatched(expectedScopeGraphIdentityFenceRefusal(live.tabId), false),
+          ),
+        );
+      }
+      if (
+        cmd.cmd === "graph_set_widget" &&
+        commandCarriesPromotedParentRail(cmd) &&
+        !live.enforcesPromotedParentRailAtWrite
+      ) {
+        return Promise.reject(
+          markCapabilityRefusal(
+            markDispatched(promotedParentRailFenceRefusal(live.tabId), false),
           ),
         );
       }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -232,6 +232,10 @@ interface Conn {
    * to a graph, so the older owner/workflow-only fence is insufficient for a
    * same-id cross-graph navigation. */
   enforcesExpectedScopeGraphIdentityAtWrite: boolean;
+  /** True only when THIS hello advertises that graph_get_subgraph publishes
+   * the complete renamed-promotion alias -> terminal witness consumed by the
+   * orchestrator before a promoted write. */
+  publishesPromotedTerminalWitnesses: boolean;
   /** True when THIS hello advertises that the panel understands `agent_note` — a frame
    *  delivered to the AGENT ONLY and never rendered as a chat bubble.
    *
@@ -3043,6 +3047,9 @@ export class UiBridge {
           enforcesExpectedScopeGraphIdentityAtWrite:
             (msg as { enforces_expected_scope_graph_identity_at_write?: unknown })
               .enforces_expected_scope_graph_identity_at_write === true,
+          publishesPromotedTerminalWitnesses:
+            (msg as { publishes_promoted_terminal_witnesses?: unknown })
+              .publishes_promoted_terminal_witnesses === true,
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
@@ -3618,6 +3625,16 @@ export class UiBridge {
   tabExpectedNodeTypeFenceCapability(tabId: string): boolean {
     try {
       return this.resolveTarget(tabId).enforcesExpectedNodeTypeAtWrite === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether THIS connected panel publishes the complete renamed-promotion
+   * terminal witness required for alias-independent promoted-write preflight. */
+  tabPromotedTerminalWitnessCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).publishesPromotedTerminalWitnesses === true;
     } catch {
       return false;
     }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -5060,7 +5060,16 @@ export class UiBridge {
     }
   }
 
-  async send(cmd: BridgeCommand, opts: { tabId?: string; timeoutMs?: number; onDispatchedRid?: (rid: string) => void } = {}): Promise<unknown> {
+  async send(
+    cmd: BridgeCommand,
+    opts: {
+      tabId?: string;
+      timeoutMs?: number;
+      onDispatchedRid?: (rid: string) => void;
+      /** Synchronous fence at the final live-connection dispatch boundary. */
+      beforeDispatch?: () => void;
+    } = {},
+  ): Promise<unknown> {
     // #357: read (idempotent) ops get a more tolerant default so a busy-but-alive
     // panel main thread (e.g. Preview3D loading a large FBX) isn't declared frozen;
     // mutating ops keep the tight default. An explicit opts.timeoutMs always wins.
@@ -5553,6 +5562,18 @@ export class UiBridge {
         }
         return Promise.reject(
           markDispatched(new Error(`Panel tab ${live.tabId.slice(0, 8)} is not open`), false),
+        );
+      }
+      // This is the last synchronous point after the graph lane has waited and
+      // the receiver has been re-resolved. A handler-side callback run before
+      // bridge.send() cannot fence a reconnect or same-workflow tab rebind in
+      // that interval. A throwing callback is a pre-dispatch refusal: no frame
+      // has been written and no mutation can have landed.
+      try {
+        opts.beforeDispatch?.();
+      } catch (err) {
+        return Promise.reject(
+          markDispatched(err instanceof Error ? err : new Error(String(err)), false),
         );
       }
       return new Promise((resolve, reject) => {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3862,6 +3862,35 @@ export class UiBridge {
     );
   }
 
+  /** Read the current panel view from the live graph immediately before a
+   *  promoted write. `promotedScopeFor` is intentionally only a cached witness
+   *  for synchronous dispatch fences; this method performs the authoritative
+   *  current-view probe and never treats that cache as a substitute. */
+  async readPromotedScope(tabId: string, innerNodeId: number | string): Promise<TabPromotedScopeRead> {
+    try {
+      const result = await this.send(
+        {
+          cmd: "graph_query",
+          ids: [innerNodeId],
+          fields: "compact",
+          limit: 1,
+        },
+        { tabId },
+      );
+      return (
+        this.parsePromotedScopeResult(result) ?? {
+          known: false,
+          reason: "the panel current-view query returned no structured scope identity",
+        }
+      );
+    } catch (err) {
+      return {
+        known: false,
+        reason: err instanceof Error ? err.message : String(err ?? "unknown error"),
+      };
+    }
+  }
+
   /** #884 P0 — inject the orchestrator's turn-target pin (see the field doc and
    *  resolveTarget's scope branch). */
   setScopeTargetResolver(fn: (scopeId: string) => string | null | undefined): void {
@@ -5679,24 +5708,29 @@ export class UiBridge {
   /** Record only the panel's structured current-view witness. This is a cache
    * of an authenticated panel reply, not caller-supplied command metadata. */
   private notePromotedScope(tabId: string, result: unknown): void {
-    if (!result || typeof result !== "object" || Array.isArray(result)) return;
+    const parsed = this.parsePromotedScopeResult(result);
+    if (parsed) this.promotedScopes.set(tabId, parsed);
+  }
+
+  /** Parse only structured `viewing` metadata. `undefined` means the command
+   * did not publish a scope witness and must not overwrite the cache. */
+  private parsePromotedScopeResult(result: unknown): TabPromotedScopeRead | undefined {
+    if (!result || typeof result !== "object" || Array.isArray(result)) return undefined;
     const payload = result as Record<string, unknown>;
-    if (!Object.prototype.hasOwnProperty.call(payload, "viewing")) return;
+    if (!Object.prototype.hasOwnProperty.call(payload, "viewing")) return undefined;
     const viewing = payload.viewing;
     if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) {
-      this.promotedScopes.set(tabId, {
+      return {
         known: false,
         reason: "the panel returned malformed current-view metadata",
-      });
-      return;
+      };
     }
     const identity = viewing as Record<string, unknown>;
     if (identity.scope !== "root" && identity.scope !== "subgraph") {
-      this.promotedScopes.set(tabId, {
+      return {
         known: false,
         reason: "the panel returned an unknown current-view scope",
-      });
-      return;
+      };
     }
     const rawOwner = identity.owner_node_id;
     let ownerNodeId: string | null = null;
@@ -5705,11 +5739,10 @@ export class UiBridge {
         (typeof rawOwner !== "number" || !Number.isSafeInteger(rawOwner)) &&
         (typeof rawOwner !== "string" || rawOwner.length === 0)
       ) {
-        this.promotedScopes.set(tabId, {
+        return {
           known: false,
           reason: "the panel returned a malformed current-view owner",
-        });
-        return;
+        };
       }
       ownerNodeId = String(rawOwner);
     }
@@ -5718,18 +5751,17 @@ export class UiBridge {
       rawWorkflowUuid !== undefined &&
       (typeof rawWorkflowUuid !== "string" || rawWorkflowUuid.length === 0)
     ) {
-      this.promotedScopes.set(tabId, {
+      return {
         known: false,
         reason: "the panel returned a malformed current-view workflow identity",
-      });
-      return;
+      };
     }
-    this.promotedScopes.set(tabId, {
+    return {
       known: true,
       scope: identity.scope,
       ownerNodeId,
       ...(rawWorkflowUuid !== undefined ? { workflowUuid: rawWorkflowUuid } : {}),
-    });
+    };
   }
 
   /** Write one attempt of a command to a live socket and arm its reply timer.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -227,6 +227,11 @@ interface Conn {
    * absent: an older panel would silently ignore receiver identity and could
    * write a same-id node after navigation. */
   enforcesExpectedScopeAtWrite: boolean;
+  /** True only when THIS hello advertises that expected_scope also carries and
+   * validates the stable live graph identity. Owner and wrapper ids are local
+   * to a graph, so the older owner/workflow-only fence is insufficient for a
+   * same-id cross-graph navigation. */
+  enforcesExpectedScopeGraphIdentityAtWrite: boolean;
   /** True when THIS hello advertises that the panel understands `agent_note` — a frame
    *  delivered to the AGENT ONLY and never rendered as a chat bubble.
    *
@@ -364,6 +369,9 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   // #2314 — promoted inner writes carry an expected owner/workflow witness that
   // the panel validates immediately before mutating the current graph.
   enforces_expected_scope_at_write: "0.15.97",
+  // #2314 P1 — the promoted fence additionally validates the object-keyed live
+  // graph identity, which is distinct from graph-local owner/node ids.
+  enforces_expected_scope_graph_identity_at_write: "0.15.97",
 };
 
 /**
@@ -1098,6 +1106,7 @@ export type TabPromotedScopeRead =
       scope: "root" | "subgraph";
       ownerNodeId: string | null;
       workflowUuid?: string;
+      graphIdentity?: string;
     }
   | { known: false; reason: string };
 
@@ -1560,6 +1569,20 @@ function expectedScopeFenceRefusal(tabId: string): Error {
       `does not advertise the atomic promoted-scope write fence. Update the ` +
       `panel to 0.15.97+ and hard-refresh the browser tab.`,
   );
+}
+
+function expectedScopeGraphIdentityFenceRefusal(tabId: string): Error {
+  return new Error(
+    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
+      `does not advertise the atomic promoted graph-identity write fence. Update the ` +
+      `panel to 0.15.97+ and hard-refresh the browser tab.`,
+  );
+}
+
+function commandCarriesExpectedGraphIdentity(cmd: BridgeCommand): boolean {
+  const scope = cmd.expected_scope;
+  return !!scope && typeof scope === "object" && !Array.isArray(scope) &&
+    Object.prototype.hasOwnProperty.call(scope, "graph_identity");
 }
 
 /** Normalize a syntactically valid HTTP(S) WebSocket handshake `Origin` into a
@@ -3017,6 +3040,9 @@ export class UiBridge {
             (msg as { enforces_expected_node_type_at_write?: unknown }).enforces_expected_node_type_at_write === true,
           enforcesExpectedScopeAtWrite:
             (msg as { enforces_expected_scope_at_write?: unknown }).enforces_expected_scope_at_write === true,
+          enforcesExpectedScopeGraphIdentityAtWrite:
+            (msg as { enforces_expected_scope_graph_identity_at_write?: unknown })
+              .enforces_expected_scope_graph_identity_at_write === true,
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
@@ -5265,6 +5291,17 @@ export class UiBridge {
       );
       return Promise.reject(markCapabilityRefusal(refusal));
     }
+    if (
+      cmd.cmd === "graph_set_widget" &&
+      commandCarriesExpectedGraphIdentity(cmd) &&
+      !conn.enforcesExpectedScopeGraphIdentityAtWrite
+    ) {
+      const refusal = markDispatched(
+        expectedScopeGraphIdentityFenceRefusal(conn.tabId),
+        false,
+      );
+      return Promise.reject(markCapabilityRefusal(refusal));
+    }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
     // panel does NOT enforce the per-command workflow-instance stamp. Such a panel would
@@ -5673,6 +5710,17 @@ export class UiBridge {
           markCapabilityRefusal(markDispatched(expectedScopeFenceRefusal(live.tabId), false)),
         );
       }
+      if (
+        cmd.cmd === "graph_set_widget" &&
+        commandCarriesExpectedGraphIdentity(cmd) &&
+        !live.enforcesExpectedScopeGraphIdentityAtWrite
+      ) {
+        return Promise.reject(
+          markCapabilityRefusal(
+            markDispatched(expectedScopeGraphIdentityFenceRefusal(live.tabId), false),
+          ),
+        );
+      }
       if (live.sock.readyState !== WebSocket.OPEN) {
         if (opts.tabId && UiBridge.isMailboxable(cmd)) {
           this.storeMailbox(opts.tabId, cmd);
@@ -5811,11 +5859,24 @@ export class UiBridge {
         reason: "the panel returned a malformed current-view workflow identity",
       };
     }
+    const rawGraphIdentity = identity.graph_identity;
+    if (
+      rawGraphIdentity !== undefined &&
+      (typeof rawGraphIdentity !== "string" ||
+        rawGraphIdentity.length === 0 ||
+        rawGraphIdentity.length > 256)
+    ) {
+      return {
+        known: false,
+        reason: "the panel returned a malformed current-view graph identity",
+      };
+    }
     return {
       known: true,
       scope: identity.scope,
       ownerNodeId,
       ...(rawWorkflowUuid !== undefined ? { workflowUuid: rawWorkflowUuid } : {}),
+      ...(rawGraphIdentity !== undefined ? { graphIdentity: rawGraphIdentity } : {}),
     };
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1080,6 +1080,18 @@ export type TabWorkflowUuidRead =
   | { known: true; uuid?: string }
   | { known: false; reason: string };
 
+/** #2314 — the latest structured current-view identity observed from a panel
+ * reply. This is deliberately separate from the workflow stamp: two subgraphs
+ * in one workflow may reuse the same inner node ids and types. */
+export type TabPromotedScopeRead =
+  | {
+      known: true;
+      scope: "root" | "subgraph";
+      ownerNodeId: string | null;
+      workflowUuid?: string;
+    }
+  | { known: false; reason: string };
+
 /**
  * What the orchestrator's fence-adoption validator answers (#1077).
  *
@@ -1930,6 +1942,9 @@ export class UiBridge {
    *  to (the generation-bound-command leak: the server can't retract a frame already
    *  delivered to the browser, but the browser can decline to APPLY a stale one). */
   private resolveTabWorkflowUuid: ((tabId: string) => string | undefined) | null = null;
+  /** #2314 — latest structured current-view witness per routing tab. Cleared on
+   * hello/rebind boundaries; populated only from successful panel replies. */
+  private readonly promotedScopes = new Map<string, TabPromotedScopeRead>();
   /** #1656 — orchestrator-injected: is this tab's CURRENT stamp one that was CARRIED
    *  from a tab id the same socket retired (carryWorkflowCommandStamp), rather than one
    *  the tab itself has proven under this id?
@@ -2948,6 +2963,10 @@ export class UiBridge {
           }
         }
         this.cancelTabGone(tabId, incarnationId);
+        // A hello can keep the route id while replacing the viewed workflow or
+        // subgraph. Do not let a scope witness from the prior canvas authorize
+        // a later promoted write.
+        this.promotedScopes.delete(tabId);
         this.conns.set(tabId, {
           sock,
           tabId,
@@ -3211,6 +3230,7 @@ export class UiBridge {
           // an unrelated tab reusing the id can never be granted the veto.
           const served = this.liveConnForTab(p.ctx.tabId, sock);
           served?.provenSupportedCmds.add(p.cmd);
+          this.notePromotedScope(p.ctx.tabId, msg.result);
           this.noteSiblingSuccess(p.ctx, rid);
           p.resolve(msg.result);
         } else {
@@ -3827,6 +3847,19 @@ export class UiBridge {
     } catch {
       return undefined;
     }
+  }
+
+  /** Return the latest structured current-view owner observed for this tab.
+   * Reads which carry no `viewing` field do not overwrite it; a malformed
+   * structured identity is retained as unknown so a promoted write cannot use
+   * an earlier owner proof after the current-view witness became unreadable. */
+  promotedScopeFor(tabId: string): TabPromotedScopeRead {
+    return (
+      this.promotedScopes.get(tabId) ?? {
+        known: false,
+        reason: "no current panel graph-scope witness has been observed",
+      }
+    );
   }
 
   /** #884 P0 — inject the orchestrator's turn-target pin (see the field doc and
@@ -4962,6 +4995,7 @@ export class UiBridge {
    *  the switch retire branch (with the retired id), and the bridge defers its on-hello
    *  replay/flush/resume until AFTER onPanelMessage so this purge lands first. */
   dropQueuedDeliveries(tabId: string): void {
+    this.promotedScopes.delete(tabId);
     this.missedFrames.delete(tabId);
     this.mailbox.delete(tabId);
     // MIRROR teardown (see above): a viewer must not auto-follow an unproven workflow switch.
@@ -5640,6 +5674,62 @@ export class UiBridge {
       if (p.ctx.tabId !== ctx.tabId) continue;
       p.ctx.siblingReply ??= ctx.command.cmd;
     }
+  }
+
+  /** Record only the panel's structured current-view witness. This is a cache
+   * of an authenticated panel reply, not caller-supplied command metadata. */
+  private notePromotedScope(tabId: string, result: unknown): void {
+    if (!result || typeof result !== "object" || Array.isArray(result)) return;
+    const payload = result as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(payload, "viewing")) return;
+    const viewing = payload.viewing;
+    if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) {
+      this.promotedScopes.set(tabId, {
+        known: false,
+        reason: "the panel returned malformed current-view metadata",
+      });
+      return;
+    }
+    const identity = viewing as Record<string, unknown>;
+    if (identity.scope !== "root" && identity.scope !== "subgraph") {
+      this.promotedScopes.set(tabId, {
+        known: false,
+        reason: "the panel returned an unknown current-view scope",
+      });
+      return;
+    }
+    const rawOwner = identity.owner_node_id;
+    let ownerNodeId: string | null = null;
+    if (rawOwner !== undefined && rawOwner !== null) {
+      if (
+        (typeof rawOwner !== "number" || !Number.isSafeInteger(rawOwner)) &&
+        (typeof rawOwner !== "string" || rawOwner.length === 0)
+      ) {
+        this.promotedScopes.set(tabId, {
+          known: false,
+          reason: "the panel returned a malformed current-view owner",
+        });
+        return;
+      }
+      ownerNodeId = String(rawOwner);
+    }
+    const rawWorkflowUuid = identity.workflow_uuid;
+    if (
+      rawWorkflowUuid !== undefined &&
+      (typeof rawWorkflowUuid !== "string" || rawWorkflowUuid.length === 0)
+    ) {
+      this.promotedScopes.set(tabId, {
+        known: false,
+        reason: "the panel returned a malformed current-view workflow identity",
+      });
+      return;
+    }
+    this.promotedScopes.set(tabId, {
+      known: true,
+      scope: identity.scope,
+      ownerNodeId,
+      ...(rawWorkflowUuid !== undefined ? { workflowUuid: rawWorkflowUuid } : {}),
+    });
   }
 
   /** Write one attempt of a command to a live socket and arm its reply timer.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3905,6 +3905,16 @@ export class UiBridge {
     }
   }
 
+  /** Whether THIS connected panel also enforces the stable graph identity in
+   * an expected promoted scope at the actual mutation boundary (#2314 P1). */
+  tabExpectedScopeGraphIdentityFenceCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).enforcesExpectedScopeGraphIdentityAtWrite === true;
+    } catch {
+      return false;
+    }
+  }
+
   /** Return the latest structured current-view owner observed for this tab.
    * Reads which carry no `viewing` field do not overwrite it; a malformed
    * structured identity is retained as unknown so a promoted write cannot use

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -221,6 +221,12 @@ interface Conn {
    * Re-read per hello and fail closed when absent: an older panel would silently
    * ignore the field and leave the node-replacement fence unenforced. */
   enforcesExpectedNodeTypeAtWrite: boolean;
+  /** True only when THIS hello advertises that the panel validates an optional
+   * expected_scope (promoted owner/workflow witness) at the synchronous
+   * graph_set_widget write boundary. Re-read per hello and fail closed when
+   * absent: an older panel would silently ignore receiver identity and could
+   * write a same-id node after navigation. */
+  enforcesExpectedScopeAtWrite: boolean;
   /** True when THIS hello advertises that the panel understands `agent_note` — a frame
    *  delivered to the AGENT ONLY and never rendered as a chat bubble.
    *
@@ -355,6 +361,9 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   // #2107 — graph_set_widget's optional expected_node_type fence shipped with
   // the panel-side write-boundary check.
   enforces_expected_node_type_at_write: "0.15.58",
+  // #2314 — promoted inner writes carry an expected owner/workflow witness that
+  // the panel validates immediately before mutating the current graph.
+  enforces_expected_scope_at_write: "0.15.97",
 };
 
 /**
@@ -1542,6 +1551,14 @@ function expectedNodeTypeFenceRefusal(tabId: string): Error {
     `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
       `does not advertise the atomic expected-node-type write fence. Update the ` +
       `panel to 0.15.58+ and hard-refresh the browser tab.`,
+  );
+}
+
+function expectedScopeFenceRefusal(tabId: string): Error {
+  return new Error(
+    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
+      `does not advertise the atomic promoted-scope write fence. Update the ` +
+      `panel to 0.15.97+ and hard-refresh the browser tab.`,
   );
 }
 
@@ -2998,6 +3015,8 @@ export class UiBridge {
             (msg as { enforces_workflow_stamp_at_write?: unknown }).enforces_workflow_stamp_at_write === true,
           enforcesExpectedNodeTypeAtWrite:
             (msg as { enforces_expected_node_type_at_write?: unknown }).enforces_expected_node_type_at_write === true,
+          enforcesExpectedScopeAtWrite:
+            (msg as { enforces_expected_scope_at_write?: unknown }).enforces_expected_scope_at_write === true,
           // Re-read per hello like the stamps above: a reconnect can be a different build.
           acceptsAgentNotes:
             (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
@@ -3846,6 +3865,17 @@ export class UiBridge {
       return { generation: conn.helloGeneration, tabSessionId: conn.tabSessionId };
     } catch {
       return undefined;
+    }
+  }
+
+  /** Whether THIS connected panel enforces graph_set_widget's optional
+   * expected promoted owner/workflow witness at the actual mutation boundary
+   * (#2314). */
+  tabExpectedScopeFenceCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).enforcesExpectedScopeAtWrite === true;
+    } catch {
+      return false;
     }
   }
 
@@ -5219,6 +5249,22 @@ export class UiBridge {
       );
       return Promise.reject(markCapabilityRefusal(refusal));
     }
+    // #2314 — an expected_scope is meaningful only when the receiving panel
+    // compares it against its LIVE current graph at the synchronous mutation
+    // boundary. An older panel silently ignoring this optional field could
+    // write a colliding inner node after receiver navigation, so refuse before
+    // dispatch.
+    if (
+      cmd.cmd === "graph_set_widget" &&
+      Object.prototype.hasOwnProperty.call(cmd, "expected_scope") &&
+      !conn.enforcesExpectedScopeAtWrite
+    ) {
+      const refusal = markDispatched(
+        expectedScopeFenceRefusal(conn.tabId),
+        false,
+      );
+      return Promise.reject(markCapabilityRefusal(refusal));
+    }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
     // panel does NOT enforce the per-command workflow-instance stamp. Such a panel would
@@ -5616,6 +5662,15 @@ export class UiBridge {
       ) {
         return Promise.reject(
           markCapabilityRefusal(markDispatched(expectedNodeTypeFenceRefusal(live.tabId), false)),
+        );
+      }
+      if (
+        cmd.cmd === "graph_set_widget" &&
+        Object.prototype.hasOwnProperty.call(cmd, "expected_scope") &&
+        !live.enforcesExpectedScopeAtWrite
+      ) {
+        return Promise.reject(
+          markCapabilityRefusal(markDispatched(expectedScopeFenceRefusal(live.tabId), false)),
         );
       }
       if (live.sock.readyState !== WebSocket.OPEN) {


### PR DESCRIPTION
Fixes #2314\n\nSummary:\n- run the unified known-bad widget guards before the first panel_set_widget dispatch\n- inspect uniquely mapped promoted inner widgets from graph_get_subgraph so successful container writes cannot bypass the Anima or dynamic-combo refusals\n- preserve the existing live DaSiWa identity/fence check for promoted stack_data candidates\n- re-run guards on the canonical same-node remap path\n- keep ambiguous, truncated, or unavailable promotion evidence fail-open, while preserving the existing direct guard contracts\n\nScope:\n- panel_set_widget only; panel_kitchen applyWidget is intentionally left out of this narrow fix\n\nChecks:\n- promoted-widget.test.ts: 39 passed\n- panel-tools.test.ts: 417 passed\n- tsc --noEmit\n- check-tool-vocabulary