### PR TITLE
fix(2320): Manager v4.2.2 reboot detection

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1513,4 +1513,60 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     // Unknown token → no-op, never throws.
     expect(() => clearRestartDispatch("tok-nope")).not.toThrow();
   });
+
+  it("reboots Manager v4.2.2 via GET /v2/manager/reboot (#2320)", async () => {
+    // Manager v4.2.2 only accepts GET on the /v2/manager/reboot endpoint.
+    // POST returns 405 Method Not Allowed. The probe list must try GET /v2,
+    // and the reboot must fire. The fix adds GET /v2/manager/reboot to REBOOT_ROUTES
+    // so the probe succeeds where it previously failed. When POST /v2 returns
+    // 405 (wrong verb), the fix skips it and continues to the next probe, which
+    // is GET /v2 (added by the fix), and that succeeds.
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    installLiveDesktopSupervisor();
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 500,
+      intervalMs: 5,
+    });
+    const fetchMock = vi.fn(async (url: unknown, opts?: unknown) => {
+      const urlStr = String(url);
+      const method = (opts as any)?.method || "GET";
+      // Manager v4.2.2: POST /v2/manager/reboot → 405 (wrong verb)
+      if (urlStr.includes("/v2/manager/reboot") && method === "POST") {
+        return { status: 405, ok: false } as Response;
+      }
+      // Manager v4.2.2: GET /v2/manager/reboot → connection drop (fires)
+      if (urlStr.includes("/v2/manager/reboot") && method === "GET") {
+        throw new Error("socket hang up"); // connection drop = reboot fired
+      }
+      // /system_stats after reboot comes back
+      if (urlStr.includes("system_stats")) {
+        return { ok: true } as Response;
+      }
+      return { status: 404, ok: false } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.ready).toBe(true);
+    // Desktop reboot: no spawn, so `started` has no evidence. `ready` confirms.
+    // Verify GET /v2/manager/reboot was actually called (the fix being tested)
+    const v2GetCall = fetchMock.mock.calls.find(
+      ([url, opts]) =>
+        String(url).includes("/v2/manager/reboot") &&
+        ((opts as any)?.method || "GET") === "GET"
+    );
+    expect(v2GetCall).toBeDefined();
+  });
 });

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -4720,6 +4720,7 @@ interface RebootResult {
 //     surfaces as 404/405 and we fall through to the next candidate.
 const REBOOT_ROUTES: ReadonlyArray<{ path: string; method: "POST" | "GET" }> = [
   { path: "/v2/manager/reboot", method: "POST" },
+  { path: "/v2/manager/reboot", method: "GET" },
   { path: "/manager/reboot", method: "GET" },
   { path: "/manager/reboot", method: "POST" },
 ];
@@ -4827,8 +4828,13 @@ async function rebootViaManager(base: string): Promise<RebootResult> {
           note: `the request returned HTTP ${res.status}`,
         };
       }
-      // 404 / other non-OK: wrong route for this Manager build — try the next.
-      failures.push(`${method} ${path} → HTTP ${res.status}`);
+      // 405 Method Not Allowed: the route EXISTS but does not accept this verb —
+      // try a different verb on the same path, not a different path. Do not
+      // report it as route-absent (issue #2320). 404 / other non-OK: wrong route
+      // for this Manager build — try the next.
+      if (res.status !== 405) {
+        failures.push(`${method} ${path} → HTTP ${res.status}`);
+      }
     } catch (err) {
       if (isConnectionDrop(err)) {
         return {


### PR DESCRIPTION
## Summary
- Add `GET /v2/manager/reboot` to probe list — ComfyUI-Manager v4 uses this endpoint with GET, not POST
- Stop treating HTTP 405 as "route absent" — 405 proves the route EXISTS, just rejects the verb

## Mutation Testing
**Mutation 1: Remove GET /v2/manager/reboot**
- Result: Test FAILS ❌ (test that proves reachability: "reboots Manager v4.2.2 via GET /v2/manager/reboot (#2320)")
- Tallies: 1 failed, 47 passed

**Mutation 2: Revert 405 handling (treat 405 as route absent)**
- Result: Test PASSES ✓ (GET /v2 succeeds even though POST /v2 returns 405)
- Tallies: 1 passed, 47 skipped
- Note: 405 fix improves message quality but Mutation 1 is load-bearing

## Test Plan
- [x] "reboots Manager v4.2.2 via GET /v2/manager/reboot (#2320)" passes
- [x] All 48 process-control tests pass
- [x] Mutation 1 fails when first fix removed
- [x] Gate review: SHIP (clean pass)
- [x] Suite: 12419 tests passed (1 known-noisy e2e flake unrelated to this change)

Refs #2320