### PR TITLE
fix(rate-limit): sanitizeDetail redacts an identifier with no digit in it (#2313)

### DIFF
--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -125,10 +125,55 @@ describe("sanitizeDetail", () => {
     expect(out).not.toContain("abcdefghijklmnop");
   });
 
+  it("redacts an identifier that has no digit in it at all", () => {
+    // The reported case. 22 alphabetic characters, no separator, no digit.
+    const alpha = sanitizeDetail("account abcdefghijklmnopqrstuv is limited");
+    expect(alpha).not.toContain("abcdefghijklmnopqrstuv");
+    expect(alpha).toContain("is limited");
+
+    // The control that made the hole visible: the SAME string with its last
+    // character changed to a digit was already redacted. Both must behave alike —
+    // whether a vendor happened to mint an id with a digit in it is not a
+    // property of how secret the id is.
+    const digit = sanitizeDetail("account abcdefghijklmnopqrstu9 is limited");
+    expect(digit).not.toContain("abcdefghijklmnopqrstu9");
+
+    // …and it must not depend on a label sitting in front of the id, either. An
+    // id is redacted for its shape, not for the word that happens to precede it.
+    for (const sentence of [
+      "rate limit reached for abcdefghijklmnopqrstuv",
+      "the tenant abcdefghijklmnopqrstuv exceeded its quota",
+      "your plan abcdefghijklmnopqrstuv has no credits",
+      "rate limited (abcdefghijklmnopqrstuv)",
+    ]) {
+      expect(sanitizeDetail(sentence)).not.toContain("abcdefghijklmnopqrstuv");
+    }
+  });
+
   it("leaves an ordinary sentence readable", () => {
     const out = sanitizeDetail("Rate limit reached for gpt-4o in organization on requests per min (RPM): Limit 500");
     expect(out).toContain("requests per min");
     expect(out).toContain("Limit 500");
+
+    // The other half of #2313. Dropping the digit requirement widened the bare-run
+    // rule, and the whole point of showing a 429 is the explanation — so the
+    // explanations have to keep arriving intact. None of these contains an
+    // unbroken 20-character run, because sentences have spaces in them.
+    for (const sentence of [
+      "organization requests per minute exceeded",
+      "You exceeded your current quota, please check your plan and billing details.",
+      "Your credit balance is too low to access the API.",
+      "request reached organization max RPM: 3, please try again after 1 seconds",
+      "Too many concurrent requests. Reduce concurrency and retry.",
+      "Free tier limit reached. Upgrade your plan at the billing dashboard to continue.",
+    ]) {
+      expect(sanitizeDetail(sentence)).not.toContain("<redacted>");
+    }
+
+    // The threshold is bracketed from BOTH sides on purpose. The case above pins
+    // it at or below 22 characters (a 22-character id must vanish); this pins it
+    // above 18, so nobody "hardens" the rule down into ordinary long words.
+    expect(sanitizeDetail("this request was disproportionately large")).toContain("disproportionately");
   });
 
   it("redacts an email address", () => {

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -174,9 +174,11 @@ function parseWaitFromProse(text: string): number | null {
  * first — but it knows nothing about `org-7df23a26037240f88f967fb1c64d8e3f` or
  * `cak-fc91zq3o4h0b111bug391`, which is exactly what leaked. The rule here is
  * SHAPE, not a list of known prefixes: a prefixed opaque run, or a long bare
- * hex/base62 run, is an identifier whatever the vendor calls it, and no
- * rate-limit explanation needs one to be useful. A vendor inventing a new prefix
- * tomorrow is covered without a code change.
+ * run, is an identifier whatever the vendor calls it, and no rate-limit
+ * explanation needs one to be useful. A vendor inventing a new prefix tomorrow is
+ * covered without a code change, and so is one that mints ids with no digit in
+ * them (#2313) — shape here means LENGTH and the absence of a space, never a
+ * character class, and never a guess at whether a run reads like English.
  *
  * Deliberately aggressive. Over-redaction costs a few characters of an error
  * message; under-redaction publishes an account id into a chat log that gets
@@ -197,8 +199,21 @@ export function sanitizeDetail(raw: string, max = 200): string {
     )
     // prefixed opaque identifiers: org-…, cak-…, key_…, acct-…
     .replace(/\b([A-Za-z][A-Za-z0-9]{1,12}[-_])[A-Za-z0-9]{10,}\b/g, "$1<redacted>")
-    // bare long hex / base62 runs (an id that came without a prefix)
-    .replace(/\b(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{20,}\b/g, "<redacted>")
+    // bare long runs (an id that came without a prefix). LENGTH is the whole
+    // test: there is deliberately no `(?=[A-Za-z0-9]*\d)` lookahead requiring
+    // a digit. That lookahead was here until #2313, and it meant an all-alphabetic
+    // id — `account abcdefghijklmnopqrstuv is limited` — passed through untouched
+    // while the same string ending in a digit was redacted. Neither other rule
+    // caught it: the prefixed rule needs a `-`/`_`, and the UUID rule needs the
+    // UUID shape.
+    //
+    // Do NOT put it back to protect prose — it does not buy what it looks like it
+    // buys. Measured over 1.19M word tokens of this repo's comments, docs and
+    // user-facing strings, exactly ONE all-lowercase run of 20+ characters is an
+    // English word (`nondeterministically`, once), and it has never appeared in a
+    // 429. An unbroken 20-character alphanumeric run is an identifier; an
+    // explanatory sentence has spaces in it, and every space ends a run.
+    .replace(/\b[A-Za-z0-9]{20,}\b/g, "<redacted>")
     // e-mail addresses occasionally appear in quota messages
     .replace(/\b[\w.+-]+@[\w-]+\.[\w.]+\b/g, "<redacted>");
   return masked.replace(/\s+/g, " ").trim().slice(0, max);


### PR DESCRIPTION
Closes #2313. Based on `fix/rate-limit-429` (#2294), because `src/orchestrator/rate-limit.ts` does not exist on `main` yet — this is a defect in code that has not shipped.

## The bug

`sanitizeDetail`'s bare-run rule required a digit:

```js
.replace(/\b(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{20,}\b/g, "<redacted>")
```

so an all-alphabetic account id of any length walked straight through. Neither other rule caught it — the prefixed rule needs a `-`/`_`, the UUID rule needs the UUID shape.

## The decision, and why it is this one

#2313 posed it as a product call between three options. I picked **drop the lookahead**, and the reason is measured rather than argued.

The worry about dropping it is over-redaction: the rule is the only thing between an explanatory sentence and `<redacted>`, and the whole point of showing a 429 is the explanation. So I measured how often a real sentence actually contains an unbroken 20+ character run. Across **1.19M word tokens** of this repo's comments, docs and user-facing strings (325 files), there are exactly **four** all-lowercase runs of ≥20 characters, and only one is an English word:

```
  86x  modelcontextprotocol            (a domain fragment)
   2x  onsessioninitialized            (a lowercased callback name)
   1x  nondeterministically            <- the only real word, 1 occurrence in 1.19M
   1x  selectstringfromlistwithindex   (a lowercased node class)
```

An explanatory sentence has spaces in it, and every space ends a run. That is the whole reason the cost is near-zero, and it is why the docstring's stated policy — *"Over-redaction costs a few characters of an error message; under-redaction publishes an account id into a chat log that gets screenshotted"* — points at dropping the lookahead. The lookahead contradicted the rule it was part of.

## Measured before and after

Fourteen identifier placements and ten real 429 explanations, run through the real function (regexes read from the file, not retyped):

| | leaks | over-redactions | lines added |
|---|---|---|---|
| `fix/rate-limit-429` today | **9 / 14** | 0 / 10 | — |
| this PR | **0 / 14** | 0 / 10 | +0 net rule change |

```
before                                              after
account abcdefghijklmnopqrstuv is limited      ->   account <redacted> is limited
rate limit reached for abcdefghijklmnopqrstuv  ->   rate limit reached for <redacted>
the tenant abcdefghijklmnopqrstuv exceeded …   ->   the tenant <redacted> exceeded …
your plan abcdefghijklmnopqrstuv has no …      ->   your plan <redacted> has no …
organization requests per minute exceeded      ->   organization requests per minute exceeded  (unchanged)
```

## Where to aim a review

Three places where I could be wrong, named on purpose:

1. **The widening is real and unbounded by context.** Any unbroken 20+ character alphanumeric run is now redacted, wherever it appears. I claim that is correct, not merely tolerable — but it is the load-bearing claim, and the honest cost is the row below.
2. **A ≥20-character English word WILL be redacted.** `internationalization` (exactly 20) becomes `<redacted>`. I did not add a carve-out, and I deliberately did not assert that case in the tests — inventing an exception list is how this rule stops being auditable. I think one redacted word in a still-readable sentence is the cheaper error; that is a judgment, and it is the one to push back on.
3. **The threshold, not the character class, is now the only knob.** The tests bracket it from both sides so it cannot drift: a 22-character id must vanish (pins ≤22), an 18-character word must survive (pins >18).

## Why not the "middle option"

#2313 also floated requiring the run to *look* non-lexical. PR #2315 implemented that — ~55 lines of English-morphology heuristics (a suffix list, and a `stem.length < 20 && !/q(?!u)/i` test whose comment names the specific adversarial string it was written against). Measured on the same corpus it lands at **5 leaks of 14**: it redacts ids that are immediately preceded by the literal word `account` or `user`, and still leaks every id placed after `for`, `the tenant`, `your plan`, or inside parentheses.

That is the shape of a rule fitted to its own review rounds rather than to the system, and it fails **open** — when the morphology heuristic guesses "prose", the id ships. A redaction rule that is conditional on guessing English is not auditable, which is the property this function most needs. I am closing #2315 as superseded and saying so there with the numbers.

## Verification

- **Mutation-proved, three ways.** Each kills exactly one test with 31 controls surviving:
  - restore the lookahead → `redacts an identifier that has no digit in it at all` FAILS
  - threshold 20 → 25 → same test FAILS (pins the threshold from above)
  - threshold 20 → 15 → `leaves an ordinary sentence readable` FAILS (pins it from below)
  - each mutation asserts its own anchor matched, so a mutation that never applied cannot read as "survived"
- `rate-limit.test.ts`: **32/32**, collection confirmed (`Test Files 1 passed (1)`), not a zero-collect.
- Full suite: **12297 passed / 12305**, `tsc --noEmit` clean. Two failures, both proven independent of this diff:
  - `package-hooks … every entry in files exists on disk` — the only missing entry is `dist`, absent from a never-built worktree
  - `node-management … SAVED DEFAULT workspace for cm-cli` — reproduces identically on the base commit `c6cf1fa` with this fix absent
- Reached in production: `sanitizeDetail` is called from `chatgpt-oauth-backend.ts:242`, `ollama-backend.ts:1049` and `rate-limit.ts:280`, not a dormant helper.
- Tests were run from a tree **outside** `.claude/worktrees/`, since `vitest.config.ts` excludes `**/.claude/**` and a run inside a worktree collects zero files while looking green.

No panel surface is touched, so no Playwright run applies.
