### PR TITLE
fix(2320): stop the reboot give-up path asserting a Manager generation it never probed

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1660,6 +1660,9 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     // blind re-issue, and is given the authoritative way to settle it.
     expect(result.message).toMatch(/MAY have taken effect/);
     expect(result.message).toMatch(/get_system_stats/);
+    // And the report stops asserting unreachability over the top of a 200 it got.
+    expect(result.message).not.toMatch(/No reachable/);
+    expect(result.message).toMatch(/reboot endpoint could be confirmed/);
     expect(result.message).toMatch(/GET \/v2\/manager\/reboot/);
   });
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1666,6 +1666,43 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(result.message).toMatch(/GET \/v2\/manager\/reboot/);
   });
 
+  it("bounds the report-time version read against a stalled host (#2320)", async () => {
+    // The host this runs against is the one comfyuiFetch's 120s default ceiling was
+    // written for: a proxy that accepts the connection and never answers. Without a
+    // budget of its own, the version read would add minutes to a restart call that
+    // has already given up. The version route here settles ONLY on abort, so a probe
+    // that passed no signal would hang this test rather than fall back.
+    installRemoteRebootFixture();
+    let sawSignal = false;
+    const fetchMock = vi.fn(async (url: unknown, opts?: unknown) => {
+      const u = String(url);
+      if (u.includes("/manager/version")) {
+        const signal = (opts as { signal?: AbortSignal } | undefined)?.signal;
+        if (signal) sawSignal = true;
+        // Model real fetch: an ALREADY-aborted signal rejects immediately rather
+        // than waiting for an "abort" event that has already fired. The second
+        // route reuses the one shared budget, so it arrives pre-aborted.
+        if (signal?.aborted) return Promise.reject(new Error("aborted"));
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        });
+      }
+      if (u.includes("/manager/reboot")) return new Response(null, { status: 404 });
+      if (u.includes("system_stats")) return new Response("{}", { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    expect(sawSignal).toBe(true);
+    expect(result.stopped).toBe(false);
+    // The stall costs a clause, not the call.
+    expect(result.message).toMatch(/version could not be read/);
+  });
+
   it("never reads the SPA catchall as a Manager version string (#2320)", async () => {
     // The strict parse shared with node-management.ts is the only thing standing
     // between a 200 page of HTML and a fabricated version claim. Pinned at THIS

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1569,4 +1569,123 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     );
     expect(v2GetCall).toBeDefined();
   });
+  // ---- #2320 remaining half: the REPORT on the give-up path -----------------
+  //
+  // The reboot verdict itself is NOT under test here and must not move: a
+  // catchall 200 and a server that rebooted instantly are indistinguishable from
+  // the HTTP response alone, so `rebooting` stays false. Every test below asserts
+  // that too (`stopped === false`), because the failure mode of the earlier
+  // attempt at this issue was converting the false NEGATIVE into a false
+  // POSITIVE — a phantom reboot the caller then waits on.
+
+  /** Desktop/remote wiring shared by the #2320 report tests. */
+  function installRemoteRebootFixture(): void {
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    installLiveDesktopSupervisor();
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 200,
+      intervalMs: 5,
+    });
+  }
+
+  /** The SPA/proxy catchall: HTTP 200 text/html for any unknown path. */
+  function catchall(): Response {
+    return new Response(
+      '<!doctype html><html lang="en"><head><title>ComfyUI</title>' +
+        '<meta name="version" content="1.45.21"></head><body></body></html>',
+      { status: 200, headers: { "content-type": "text/html" } },
+    );
+  }
+
+  it("does not claim LEGACY Manager 3.x when the Manager reports V4 (#2320)", async () => {
+    // The reported verdict. Every reboot candidate refuses the verb, nothing
+    // succeeds — and the old message concluded "likely runs the LEGACY Manager
+    // 3.x" and prescribed "upgrade to Manager v4+". The server answers the
+    // version question directly, and it says V4.2.2, so both are false.
+    installRemoteRebootFixture();
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/manager/version")) return new Response("V4.2.2", { status: 200 });
+      if (u.includes("/manager/reboot")) return new Response(null, { status: 405 });
+      if (u.includes("system_stats")) return new Response("{}", { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    // The verdict is unchanged — this fix words the failure, it does not invent
+    // a reboot.
+    expect(result.stopped).toBe(false);
+    expect(result.message).toMatch(/reports V4\.x/);
+    expect(result.message).not.toMatch(/LEGACY Manager 3\.x/i);
+    // The useless remedy is gone specifically for a server that already IS v4.
+    expect(result.message).not.toMatch(/upgrade to Manager v4\+/i);
+  });
+
+  it("discloses a catchall-shaped 200 as MAY-have-landed instead of a flat failure (#2320)", async () => {
+    // The reporter's host: the proxy 200s unknown paths, so the GET that really
+    // did reboot the server was written off as "frontend catchall, not a reboot
+    // route" and the caller was told the restart failed — inviting the double
+    // reboot. The version endpoint is behind the same catchall, so it cannot
+    // rescue this case; the disclosure is what does.
+    installRemoteRebootFixture();
+    const fetchMock = vi.fn(async (url: unknown, opts?: unknown) => {
+      const u = String(url);
+      const method = (opts as { method?: string } | undefined)?.method ?? "GET";
+      if (u.includes("/manager/reboot")) {
+        return method === "GET" ? catchall() : new Response(null, { status: 405 });
+      }
+      if (u.includes("/manager/version")) return catchall();
+      if (u.includes("system_stats")) return new Response("{}", { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    // Still NOT a reboot: promoting this is the regression that sank round 1.
+    expect(result.stopped).toBe(false);
+    // But the caller is told a request reached the server and warned off the
+    // blind re-issue, and is given the authoritative way to settle it.
+    expect(result.message).toMatch(/MAY have taken effect/);
+    expect(result.message).toMatch(/get_system_stats/);
+    expect(result.message).toMatch(/GET \/v2\/manager\/reboot/);
+  });
+
+  it("never reads the SPA catchall as a Manager version string (#2320)", async () => {
+    // The strict parse shared with node-management.ts is the only thing standing
+    // between a 200 page of HTML and a fabricated version claim. Pinned at THIS
+    // call site, not just in the helper: the report is built behind exactly the
+    // proxy that serves such a page, and the HTML here carries a version-shaped
+    // number ("1.45.21") that a looser parse would happily lift.
+    installRemoteRebootFixture();
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/manager/version")) return catchall();
+      if (u.includes("/manager/reboot")) return new Response(null, { status: 404 });
+      if (u.includes("system_stats")) return new Response("{}", { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    // No version is claimed at all, and specifically not the one embedded in the
+    // catchall page.
+    expect(result.message).not.toMatch(/reports V/);
+    expect(result.message).not.toMatch(/1\.45/);
+    expect(result.message).toMatch(/version could not be read/);
+  });
 });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1703,6 +1703,38 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(result.message).toMatch(/version could not be read/);
   });
 
+  it("bounds the version read when HEADERS arrive but the BODY stalls (#2320)", async () => {
+    // Codex gate r2, P1: AbortSignal.timeout only cancels the exchange up to
+    // headers. Once they land, res.text() keeps the caller pending for as long as
+    // the body takes — the #1672 failure mode raceAbort exists for. The previous
+    // test stalls BEFORE headers and cannot see this; here the response is fully
+    // formed and only its body never completes.
+    installRemoteRebootFixture();
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/manager/version")) {
+        // Headers are already sent; this stream never enqueues and never closes.
+        return new Response(
+          new ReadableStream({
+            start() {
+              /* deliberately never enqueue, never close */
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (u.includes("/manager/reboot")) return new Response(null, { status: 404 });
+      if (u.includes("system_stats")) return new Response("{}", { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.message).toMatch(/version could not be read/);
+  });
+
   it("never reads the SPA catchall as a Manager version string (#2320)", async () => {
     // The strict parse shared with node-management.ts is the only thing standing
     // between a 200 page of HTML and a fabricated version claim. Pinned at THIS

--- a/src/services/manager-version.ts
+++ b/src/services/manager-version.ts
@@ -1,0 +1,47 @@
+/**
+ * The Manager MAJOR-version parse, shared by every caller that needs to know
+ * which ComfyUI-Manager generation it is talking to.
+ *
+ * Extracted from node-management.ts (#2320) because a SECOND caller — the
+ * remote reboot path in process-control.ts — was drawing the same conclusion
+ * ("this is a legacy Manager 3.x") from probe-shape instead, and got it wrong
+ * against a V4.2.2 server. The probe TRANSPORT differs between the two callers
+ * (node-management goes through `managerFetch`, which adds auth diagnostics and
+ * throws on hard failures; the reboot path uses a bare soft `comfyuiFetch`), so
+ * only the part that actually decides the answer lives here.
+ */
+
+/**
+ * Authoritative Manager MAJOR-version parse (issue #555). The two Manager
+ * generations expose their version string on DISJOINT paths and nowhere else:
+ *   • v4 (pip comfyui-manager) → GET /v2/manager/version   → text "V4.2.2"
+ *   • released 3.x             → GET /manager/version      → text "V3.41"
+ * (v4 registers NO bare /manager/version; 3.x registers NO /v2/* — verified
+ * against both upstream sources.) Both return a BARE version string, so this is
+ * an authoritative version signal that a 405/route-shape is NOT: a 405 means
+ * "wrong method for THIS endpoint", never "old Manager". Returns the major int,
+ * or undefined when neither answers with a plausible version string.
+ *
+ * The parse is deliberately strict (short, `V?<digits>.<digits>…`) so ComfyUI's
+ * SPA catchall — which 200s unknown GETs with a page of HTML — can never be
+ * mistaken for a version string. That strictness is the whole point of sharing
+ * this: it is the one guard standing between a catchall 200 and a false version
+ * claim, and a second hand-rolled copy is how the two drift apart.
+ */
+export function parseManagerMajor(raw: unknown): number | undefined {
+  if (typeof raw !== "string") return undefined;
+  const t = raw.trim();
+  if (t.length === 0 || t.length > 16) return undefined; // reject HTML/SPA bodies
+  const m = t.match(/^v?(\d+)(?:\.\d+)*$/i);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * Version routes in the order they should be tried: v4's `/v2/manager/version`
+ * is the strongest signal (3.x registers no `/v2/*` at all), so a parse there
+ * settles it without consulting the legacy path.
+ */
+export const MANAGER_VERSION_ROUTES: readonly string[] = [
+  "/v2/manager/version",
+  "/manager/version",
+];

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -57,6 +57,7 @@ import {
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { managerBodyClause } from "./manager-error-body.js";
+import { parseManagerMajor } from "./manager-version.js";
 
 // ---------------------------------------------------------------------------
 // Custom-node management — ports `comfy-cli node install|update|reinstall|fix|
@@ -570,29 +571,6 @@ export async function probeManagerQueueAvailability(
   return statuses.length === 2 && statuses.every((status) => status === 404)
     ? "absent"
     : "unreadable";
-}
-
-/**
- * Authoritative Manager MAJOR-version probe (issue #555). The two Manager
- * generations expose their version string on DISJOINT paths and nowhere else:
- *   • v4 (pip comfyui-manager) → GET /v2/manager/version   → text "V4.2.2"
- *   • released 3.x             → GET /manager/version      → text "V3.41"
- * (v4 registers NO bare /manager/version; 3.x registers NO /v2/* — verified
- * against both upstream sources.) Both return a BARE version string, so this is
- * an authoritative version signal that a 405/route-shape is NOT: a 405 means
- * "wrong method for THIS endpoint", never "old Manager". Returns the major int,
- * or undefined when neither answers with a plausible version string.
- *
- * The parse is deliberately strict (short, `V?<digits>.<digits>…`) so ComfyUI's
- * SPA catchall — which 200s unknown GETs with a page of HTML — can never be
- * mistaken for a version string.
- */
-function parseManagerMajor(raw: unknown): number | undefined {
-  if (typeof raw !== "string") return undefined;
-  const t = raw.trim();
-  if (t.length === 0 || t.length > 16) return undefined; // reject HTML/SPA bodies
-  const m = t.match(/^v?(\d+)(?:\.\d+)*$/i);
-  return m ? Number(m[1]) : undefined;
 }
 
 async function probeManagerMajor(base: string): Promise<number | undefined> {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -31,7 +31,7 @@ import {
   isRemoteMode,
   targetIsOnThisMachine,
 } from "../config.js";
-import { comfyuiFetch, describeTargetDrift } from "../comfyui/fetch.js";
+import { comfyuiFetch, describeTargetDrift, raceAbort } from "../comfyui/fetch.js";
 import { scrubLogLines } from "../comfyui/json-guard.js";
 import { errorText } from "../orchestrator/error-text.js";
 import {
@@ -4818,9 +4818,16 @@ async function probeManagerMajorForReport(base: string): Promise<number | undefi
   const signal = AbortSignal.timeout(REPORT_VERSION_PROBE_BUDGET_MS);
   for (const path of MANAGER_VERSION_ROUTES) {
     try {
-      const res = await comfyuiFetch(`${base}${path}`, { method: "GET", signal });
-      if (!res.ok) continue;
-      const major = parseManagerMajor(await res.text());
+      // raceAbort covers the BODY too (codex gate r2, P1). AbortSignal.timeout only
+      // cancels the exchange up to headers — once they arrive, `res.text()` keeps the
+      // caller pending for as long as the body takes, which is the #1672 failure mode
+      // this helper exists for. A host that answers headers and then stalls the body
+      // is the same stalled proxy the budget is here to survive.
+      const major = await raceAbort(signal, async () => {
+        const res = await comfyuiFetch(`${base}${path}`, { method: "GET", signal });
+        if (!res.ok) return undefined;
+        return parseManagerMajor(await res.text());
+      });
       if (major !== undefined) return major;
     } catch {
       // Unreachable/aborted: no version claim. Never fatal — this runs only to

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -4778,17 +4778,12 @@ async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
 }
 
 /**
- * @param base the ALREADY-PINNED target. Not re-read from config here (codex
- * gate P0): the caller resolved which instance it is restarting before its own
- * awaits, and re-reading the mutable base at dispatch time is how a reboot
- * meant for A gets posted to B.
- */
-/**
  * Total budget for the report-time version read (#2320). Generous for a bare
  * version string on a reachable server, and short enough that an unreachable one
  * costs the caller a clause rather than minutes.
  */
 const REPORT_VERSION_PROBE_BUDGET_MS = 3_000;
+
 /**
  * Read the Manager MAJOR version straight from the Manager, for the REPORT only.
  *
@@ -4837,6 +4832,12 @@ async function probeManagerMajorForReport(base: string): Promise<number | undefi
   return undefined;
 }
 
+/**
+ * @param base the ALREADY-PINNED target. Not re-read from config here (codex
+ * gate P0): the caller resolved which instance it is restarting before its own
+ * awaits, and re-reading the mutable base at dispatch time is how a reboot
+ * meant for A gets posted to B.
+ */
 async function rebootViaManager(base: string): Promise<RebootResult> {
   const failures: string[] = [];
   // Candidates that answered 200 but looked like the frontend catchall. They are

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -4784,6 +4784,12 @@ async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
  * meant for A gets posted to B.
  */
 /**
+ * Total budget for the report-time version read (#2320). Generous for a bare
+ * version string on a reachable server, and short enough that an unreachable one
+ * costs the caller a clause rather than minutes.
+ */
+const REPORT_VERSION_PROBE_BUDGET_MS = 3_000;
+/**
  * Read the Manager MAJOR version straight from the Manager, for the REPORT only.
  *
  * Called on one path: after every reboot candidate has failed, to decide whether
@@ -4803,9 +4809,16 @@ async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
  * caller is behind exactly the proxy that serves such a catchall.
  */
 async function probeManagerMajorForReport(base: string): Promise<number | undefined> {
+  // ONE budget for the whole read, shared by both routes. comfyuiFetch otherwise
+  // applies its deliberately generous 120s default ceiling, and that ceiling exists
+  // for exactly the host this runs against: "a stalled reverse proxy … that accepts
+  // the connection and then never answers". Two of those would add four minutes to a
+  // restart call that has ALREADY given up — a worse symptom than the wording this
+  // is here to improve. Losing the read costs only the version clause.
+  const signal = AbortSignal.timeout(REPORT_VERSION_PROBE_BUDGET_MS);
   for (const path of MANAGER_VERSION_ROUTES) {
     try {
-      const res = await comfyuiFetch(`${base}${path}`, { method: "GET" });
+      const res = await comfyuiFetch(`${base}${path}`, { method: "GET", signal });
       if (!res.ok) continue;
       const major = parseManagerMajor(await res.text());
       if (major !== undefined) return major;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -4924,7 +4924,14 @@ async function rebootViaManager(base: string): Promise<RebootResult> {
     rebooting: false,
     reason: "no-endpoint",
     note:
-      `No reachable ComfyUI-Manager reboot endpoint.${generation}${
+      // "No REACHABLE endpoint" is itself a claim, and an ambiguous 200 refutes it:
+      // something answered. Say what was established — nothing could be CONFIRMED —
+      // rather than asserting unreachability over the top of a reply we received.
+      `${
+        ambiguous.length
+          ? "No ComfyUI-Manager reboot endpoint could be confirmed."
+          : "No reachable ComfyUI-Manager reboot endpoint."
+      }${generation}${
         failures.length ? ` Tried: ${failures.join("; ")}.` : ""
       }${maybeLanded} For a LOCAL install, use the headless restart_comfyui tool ` +
       `(kill + relaunch); otherwise restart ComfyUI on the host.`,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -64,6 +64,7 @@ import {
 } from "./listener-ownership.js";
 import { isLoopbackServerUrl } from "./local-vram.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
+import { MANAGER_VERSION_ROUTES, parseManagerMajor } from "./manager-version.js";
 import {
   parseListenerPidFromNetstat,
   findPidByPort,
@@ -4782,8 +4783,48 @@ async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
  * awaits, and re-reading the mutable base at dispatch time is how a reboot
  * meant for A gets posted to B.
  */
+/**
+ * Read the Manager MAJOR version straight from the Manager, for the REPORT only.
+ *
+ * Called on one path: after every reboot candidate has failed, to decide whether
+ * the report may say "legacy Manager 3.x". It never influences `rebooting` — the
+ * reboot has already been given up on by the time this runs — so it cannot
+ * manufacture the phantom-reboot failure mode that sank the earlier attempt at
+ * #2320. Its only job is to stop the report ASSERTING a Manager generation the
+ * probe never established, against a server that answers the question directly.
+ *
+ * Soft in every direction: any throw, any non-2xx, any unparseable body yields
+ * `undefined`, and `undefined` means the report keeps its version-agnostic
+ * wording. A server that went down (because an ambiguous 200 DID reboot it) lands
+ * here too — correctly, since it can no longer answer for itself.
+ *
+ * `parseManagerMajor` is shared with node-management.ts on purpose: its strictness
+ * is what stops the SPA catchall's HTML being read as a version string, and this
+ * caller is behind exactly the proxy that serves such a catchall.
+ */
+async function probeManagerMajorForReport(base: string): Promise<number | undefined> {
+  for (const path of MANAGER_VERSION_ROUTES) {
+    try {
+      const res = await comfyuiFetch(`${base}${path}`, { method: "GET" });
+      if (!res.ok) continue;
+      const major = parseManagerMajor(await res.text());
+      if (major !== undefined) return major;
+    } catch {
+      // Unreachable/aborted: no version claim. Never fatal — this runs only to
+      // word an already-decided failure.
+    }
+  }
+  return undefined;
+}
+
 async function rebootViaManager(base: string): Promise<RebootResult> {
   const failures: string[] = [];
+  // Candidates that answered 200 but looked like the frontend catchall. They are
+  // NOT evidence a reboot fired — that question is unanswerable from response
+  // shape (#2320, three review rounds) and this path still concludes `rebooting:
+  // false`. They ARE evidence a request reached the server, which is the one
+  // thing the old report denied while telling the caller to restart by hand.
+  const ambiguous: string[] = [];
 
   for (const { path, method } of REBOOT_ROUTES) {
     const url = `${base}${path}`;
@@ -4799,7 +4840,7 @@ async function rebootViaManager(base: string): Promise<RebootResult> {
         // reporting a reboot that never fired (which readiness — a still-up
         // server — would then rubber-stamp as success).
         if (await looksLikeSpaCatchall(res)) {
-          failures.push(`${method} ${path} → HTTP 200 (frontend catchall, not a reboot route)`);
+          ambiguous.push(`${method} ${path}`);
           continue;
         }
         // The one path with a real acknowledgement from the Manager itself.
@@ -4851,15 +4892,42 @@ async function rebootViaManager(base: string): Promise<RebootResult> {
     }
   }
 
+  // The generation claim is now READ from the Manager instead of inferred from
+  // which probes failed. The old sentence asserted "likely runs the LEGACY Manager
+  // 3.x" unconditionally — a cause no probe here establishes, and one a V4.2.2
+  // server contradicts on request (#2320). Same discipline the notes above already
+  // follow: state what was observed, not a cause chosen for it.
+  const major = await probeManagerMajorForReport(base);
+  const generation =
+    major !== undefined && major >= 4
+      ? ` ComfyUI-Manager reports V${major}.x, so the legacy-3.x explanation (no HTTP ` +
+        `reboot route at all) does not apply here. Check the Manager security level, ` +
+        `or an access proxy in front of ComfyUI, before assuming the route is absent.`
+      : major !== undefined
+        ? ` ComfyUI-Manager reports V${major}.x; some builds of that generation expose ` +
+          `no HTTP reboot route, and upgrading to Manager v4+ adds one.`
+        : ` The Manager version could not be read, so the build is unknown; a legacy ` +
+          `Manager 3.x without an HTTP reboot route is one possibility, and upgrading ` +
+          `to Manager v4+ would add one.`;
+  // An ambiguous 200 is reported as what it is. It does NOT promote `rebooting`,
+  // because a catchall and an instant reboot are indistinguishable from the
+  // response alone — but the request DID reach the server, so the caller is warned
+  // off the blind re-issue (a double restart mid-render) the old flat-failure
+  // wording invited.
+  const maybeLanded = ambiguous.length
+    ? ` ${ambiguous.join(", ")} answered HTTP 200 with what looks like the ComfyUI ` +
+      `frontend catchall rather than a reboot acknowledgement. That is not proof a ` +
+      `reboot fired, but the request did reach the server and MAY have taken effect — ` +
+      `confirm with get_system_stats (action:"health") before re-issuing a restart.`
+    : "";
   return {
     rebooting: false,
     reason: "no-endpoint",
     note:
-      `No reachable ComfyUI-Manager reboot endpoint (this ComfyUI likely runs the ` +
-      `LEGACY Manager 3.x, which does not expose an HTTP reboot route).${
+      `No reachable ComfyUI-Manager reboot endpoint.${generation}${
         failures.length ? ` Tried: ${failures.join("; ")}.` : ""
-      } For a LOCAL install, use the headless restart_comfyui tool (kill + relaunch); ` +
-      `otherwise restart ComfyUI on the host, or upgrade to Manager v4+.`,
+      }${maybeLanded} For a LOCAL install, use the headless restart_comfyui tool ` +
+      `(kill + relaunch); otherwise restart ComfyUI on the host.`,
   };
 }
 
@@ -5067,7 +5135,11 @@ async function restartViaManagerRebootDispatch(
     return {
       stopped: false,
       started: false,
-      // Nothing was dispatched — this is a refusal, not an uncertain outcome.
+      // No reboot was CONFIRMED dispatched, so there is no restart to wait on and
+      // `not-attempted` stays the honest machine-readable verdict — promoting it on
+      // an ambiguous 200 is the phantom-reboot regression #2320 round 1 reproduced.
+      // Note this is not the same as "no request was sent": when a candidate answered
+      // a catchall-shaped 200, `reboot.note` says so and warns against re-issuing.
       startup: "not-attempted",
       message: reboot.note ?? "ComfyUI-Manager reboot could not be triggered.",
       // The Manager reboot path never spawns a process of ours, so ownership of


### PR DESCRIPTION
Closes the **remaining half** of #2320. The safe half (`GET /v2/manager/reboot`, 405 not treated as absence) shipped in #2330.

## What this deliberately does NOT do

It does not try to decide whether an ambiguous 200 rebooted the server. Three independent NO-SHIP verdicts on #2328 established that a reboot-that-fired and a route-that-does-not-exist are indistinguishable from the HTTP response alone, and every discriminator tried converted the reported false NEGATIVE into a false POSITIVE — a phantom reboot the caller then waits on. **`rebooting` stays `false` on that path.** All five new tests assert `stopped === false` so that property is pinned, not just intended.

What changes is the **report** built on top of that unchanged verdict.

## 1. The give-up path asserted a Manager generation it never probed

The message asserted *"this ComfyUI likely runs the LEGACY Manager 3.x"* and prescribed *"upgrade to Manager v4+"*. Against the reporter's V4.2.2 server both are false and the remedy is useless.

An authoritative version probe already exists in this repo for exactly this — `parseManagerMajor` in `node-management.ts`, added by #555 with the reasoning *"a 405 means 'wrong method for THIS endpoint', never 'old Manager'"*. **The reboot path never adopted it.** It now does.

The parse is lifted into `src/services/manager-version.ts` so both callers share the one guard. Only the parse is shared: the two callers' transports differ for good reasons (`node-management` goes through `managerFetch`, which adds auth diagnostics and throws on hard failures; this path uses a bare soft `comfyuiFetch`), so `node-management`'s own probe is otherwise untouched.

## 2. A catchall-shaped 200 was reported as a flat failure

Such a candidate was folded into `failures`, so the report denied that any request reached the server, and the caller was told to restart by hand. That is the double-reboot the issue reports. It now says the request MAY have taken effect and names `get_system_stats(action:"health")` as the way to settle it.

Relatedly, *"No **reachable** endpoint"* is itself a claim that an ambiguous 200 refutes — something answered. That branch now says no endpoint could be **confirmed**.

## Where the load-bearing claims are — please attack these

- **`probeManagerMajorForReport` is a new network call on a failure path.** It runs only after every reboot candidate has already failed, is soft in every direction (any throw / non-2xx / unparseable body → `undefined` → version-agnostic wording), and its result is used for wording alone. It cannot move `rebooting`.
- **It cannot rescue the reporter's own scenario, and I am not claiming it does.** On that host the version endpoint sits behind the same catchall, so it returns HTML and the version stays unknown. Test 2 models exactly that. For the reporter, change 2 is what helps; change 1 helps the adjacent case (a v4 server whose reboot was refused for another reason — e.g. Manager security level).
- **The `major >= 4` wording rules out one explanation rather than asserting another.** This function has been gated repeatedly for naming causes it had not established, so it says the legacy-3.x reading does not apply and points at the two plausible alternatives without picking one.
- **`ambiguous` entries no longer appear in the `Tried:` list.** They are reported in their own clause instead, so no information is lost — worth checking that reads correctly.

## 3. The version read could have added minutes to an already-failed call

Found in my own review of 1, not by the gate. `comfyuiFetch` applies a deliberately generous **120s** ceiling to callers that bring no budget, and its doc names the exact host this runs against — *"a stalled reverse proxy ... that accepts the connection and then never answers."* Two unbudgeted probes there would add up to four minutes to a restart call that has already given up: a worse symptom than the wording they exist to improve.

One shared 3s `AbortSignal` now covers both routes (`init.signal` always wins over the default). Losing the read costs the version clause only.

## 4. The budget bounded the exchange but not the body

**Codex gate r2, P1 — a real find.** `AbortSignal.timeout` only cancels the HTTP exchange up to headers; once they arrive, `res.text()` keeps the caller pending for as long as the body takes. So change 3's budget bounded the connect but not the read, and a host that answers headers then stalls the body — the same stalled proxy the budget exists to survive — could still hang `restart_comfyui` indefinitely.

`raceAbort` is this repo's existing answer to exactly that (#1672) and now wraps the fetch *and* the body read. My earlier test could not see the gap because it stalls *before* headers; the new one returns a fully-formed response whose body never completes.

## Verification

Full suite in this worktree: **672 files, 12453 passed, 6 skipped, 0 failed.**

Each fix was mutation-checked — every mutant kills exactly its own test and leaves the other two passing as controls:

| mutant | result |
|---|---|
| version probe removed (`major = undefined`) | test 1 fails, 50 pass |
| `ambiguous.push` reverted to `failures.push` | test 2 fails, 50 pass |
| strict parse loosened to first-digits-anywhere | test 3 fails, 50 pass |
| opening sentence reverted to "No reachable" | test 2 fails, 50 pass |
| version probe's `signal` removed | test 4 hangs to the 30s timeout, fails at 30010ms |
| `raceAbort` reverted to signal-only | test 5 hangs to the 30s timeout, fails at 30017ms |

Mutant 3 is the wiring check: the catchall fixture carries a version-shaped `1.45.21` that a looser parse lifts, so it proves the strict parse is reached at *this* call site, not merely that the helper works.

Note `tsc --noEmit` does **not** cover `src/__tests__` (tsconfig excludes it) — the test file is only validated by running it.

**Not browser-verified, and it does not need to be:** nothing here touches panel code. The `via-panel` label reflects how the report was filed. The diff is `process-control.ts`, `node-management.ts`, a new `manager-version.ts`, and one test file.

## Review history

| round | SHA | verdict |
|---|---|---|
| r1 | `b5e75d2` | SHIP — did not carry, head moved for changes 3 and 4 |
| r2 | `618ea15` | **NO-SHIP**, P1 body-stall (fixed in change 4) |
| r3 | `94a138b` | **SHIP** — no P0/P1 found |
| r4 | `b8c383a` | **SHIP** — head moved for a comment-only relocation; re-gated rather than banking r3 |

r4 is the SHA that merges (`b8c383a`); no non-comment line differs from r3. Note codex reported Vitest blocked by `spawn EPERM` in its sandbox in both rounds, so its findings are from reading, not execution — the r2 P1 was correct anyway, and every test result quoted here was run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
