### PR TITLE
fix(rate-limit): redact all-alphabetic identifiers

### DIFF
--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -176,9 +176,10 @@ describe("sanitizeDetail", () => {
   });
 
   it("leaves long ordinary prose words readable", () => {
-    for (const word of ["uncharacteristically", "compartmentalization"]) {
-      expect(sanitizeDetail(word)).toBe(word);
-    }
+    expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
+    expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
+      "the user uncharacteristically exceeded the limit",
+    );
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -184,6 +184,24 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("user_id qavexidopulnertiskym is limited")).toBe("user_id <redacted> is limited");
   });
 
+  it("redacts user-labeled identifiers for terminal statuses", () => {
+    for (const status of ["disabled", "blocked", "expired"]) {
+      expect(sanitizeDetail(`user abcdefghijklmnopqrstuv is ${status}`)).toBe(
+        `user <redacted> is ${status}`,
+      );
+    }
+  });
+
+  it("redacts punctuation-wrapped and bracketed labels", () => {
+    expect(sanitizeDetail("account: abcdefghijklmnopqrstuv is limited")).toBe(
+      "account: <redacted> is limited",
+    );
+    expect(sanitizeDetail("account (abcdefghijklmnopqrstuv) is limited")).toBe(
+      "account (<redacted>) is limited",
+    );
+    expect(sanitizeDetail("account_id=[abcdefghijklmnopqrstuv]")).toBe("account_id=[<redacted>]");
+  });
+
   it("redacts a hyphen-attached identifier atomically", () => {
     expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
       "account <redacted> is limited",
@@ -195,6 +213,8 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",
     );
+    expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
+    expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -236,9 +236,27 @@ describe("sanitizeDetail", () => {
 
   it("redacts punctuation, hyphen labels, and composite labels atomically", () => {
     expect(sanitizeDetail("account, abcdefghijklmnopqrstuv")).toBe("account, <redacted>");
+    expect(sanitizeDetail("account.abcdefghijklmnopqrstuv")).toBe("account.<redacted>");
+    expect(sanitizeDetail("account!abcdefghijklmnopqrstuv")).toBe("account!<redacted>");
+    expect(sanitizeDetail("account?abcdefghijklmnopqrstuv")).toBe("account?<redacted>");
     expect(sanitizeDetail("account--abcdefghijklmnopqrstuv")).toBe("account--<redacted>");
+    expect(sanitizeDetail("account-[abcdefghijklmnopqrstuv]")).toBe("account-[<redacted>]");
+    expect(sanitizeDetail("account_[abcdefghijklmnopqrstuv]")).toBe("account_[<redacted>]");
     expect(sanitizeDetail("the-user-abcdefghijklmnopqrstuv")).toBe("the-user-<redacted>");
+    expect(sanitizeDetail("the-user_abcdefghijklmnopqrstuv")).toBe("the-user_<redacted>");
     expect(sanitizeDetail("your-user-abcdefghijklmnopqrstuv")).toBe("your-user-<redacted>");
+    expect(sanitizeDetail("your-user_abcdefghijklmnopqrstuv")).toBe("your-user_<redacted>");
+    expect(sanitizeDetail("account_abcdefghijklmnopqrstuv")).toBe("account_<redacted>");
+    expect(sanitizeDetail("user_abcdefghijklmnopqrstuv")).toBe("user_<redacted>");
+    expect(sanitizeDetail("account_identifier_abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier_<redacted>",
+    );
+    expect(sanitizeDetail("account_identifier_[abcdefghijklmnopqrstuv]")).toBe(
+      "account_identifier_[<redacted>]",
+    );
+    expect(sanitizeDetail("account_identifier-abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier-<redacted>",
+    );
     expect(sanitizeDetail("account_identifier=abcdefghijklmnopqrstuv")).toBe(
       "account_identifier=<redacted>",
     );
@@ -260,6 +278,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
     expect(sanitizeDetail("user_uncharacteristically")).toBe("user_uncharacteristically");
     expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
+    expect(sanitizeDetail("account compartmentalization_v2 is limited")).toBe(
+      "account compartmentalization_v2 is limited",
+    );
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -185,10 +185,12 @@ describe("sanitizeDetail", () => {
   });
 
   it("redacts user-labeled identifiers for terminal statuses", () => {
-    for (const status of ["disabled", "blocked", "expired"]) {
-      expect(sanitizeDetail(`user abcdefghijklmnopqrstuv is ${status}`)).toBe(
-        `user <redacted> is ${status}`,
-      );
+    for (const label of ["user", "the user", "your user"]) {
+      for (const status of ["disabled", "blocked", "expired"]) {
+        expect(sanitizeDetail(`${label} abcdefghijklmnopqrstuv is ${status}`)).toBe(
+          `${label} <redacted> is ${status}`,
+        );
+      }
     }
   });
 
@@ -199,11 +201,18 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account (abcdefghijklmnopqrstuv) is limited")).toBe(
       "account (<redacted>) is limited",
     );
+    expect(sanitizeDetail("account: [abcdefghijklmnopqrstuv] is limited")).toBe(
+      "account: [<redacted>] is limited",
+    );
+    expect(sanitizeDetail("account=[abcdefghijklmnopqrstuv]")).toBe("account=[<redacted>]");
+    expect(sanitizeDetail("user: [abcdefghijklmnopqrstuv] is disabled")).toBe(
+      "user: [<redacted>] is disabled",
+    );
     expect(sanitizeDetail("account_id=[abcdefghijklmnopqrstuv]")).toBe("account_id=[<redacted>]");
   });
 
   it("redacts a hyphen-attached identifier atomically", () => {
-    expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
+    expect(sanitizeDetail("account qavexidopulnertiskym-extra-more is limited")).toBe(
       "account <redacted> is limited",
     );
   });
@@ -212,6 +221,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",
+    );
+    expect(sanitizeDetail("account compartmentalization is limited")).toBe(
+      "account compartmentalization is limited",
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -300,6 +300,25 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("masks prose-looking ids behind quoted JSON-like labels", () => {
+    const proseLookingId = "counterrevolutionary";
+    const cases = [
+      [`{"account_id":"${proseLookingId}"}`, `{"account_id":"<redacted>"}`],
+      [`{"user_id" : "${proseLookingId}"}`, `{"user_id" : "<redacted>"}`],
+      [`{"account_id":${proseLookingId}}`, `{"account_id":<redacted>}`],
+      [`{"outer":{"account_id":"${proseLookingId}"}}`, `{"outer":{"account_id":"<redacted>"}}`],
+      [
+        `{ "payload": { "user_id": [ "${proseLookingId}" ] } }`,
+        `{ "payload": { "user_id": [ "<redacted>" ] } }`,
+      ],
+      [`{"details":{"user_id":("${proseLookingId}")}}`, `{"details":{"user_id":("<redacted>")}}`],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("compartmentalization_v2")).toBe("compartmentalization_v2");
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -218,6 +218,9 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account qavexidopulnertiskymtion is limited")).toBe(
       "account <redacted> is limited",
     );
+    expect(sanitizeDetail("account qavexidopulnertisktion is limited")).toBe(
+      "account <redacted> is limited",
+    );
     expect(sanitizeDetail("account qavexidopulnertiskymaeiotion is limited")).toBe(
       "account <redacted> is limited",
     );
@@ -229,6 +232,16 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("wrapper_qavexidopulnertiskym_suffix")).toBe("wrapper_<redacted>");
     expect(sanitizeDetail("wrapper--qavexidopulnertiskym--suffix")).toBe("wrapper--<redacted>");
+  });
+
+  it("redacts punctuation, hyphen labels, and composite labels atomically", () => {
+    expect(sanitizeDetail("account, abcdefghijklmnopqrstuv")).toBe("account, <redacted>");
+    expect(sanitizeDetail("account--abcdefghijklmnopqrstuv")).toBe("account--<redacted>");
+    expect(sanitizeDetail("the-user-abcdefghijklmnopqrstuv")).toBe("the-user-<redacted>");
+    expect(sanitizeDetail("your-user-abcdefghijklmnopqrstuv")).toBe("your-user-<redacted>");
+    expect(sanitizeDetail("account_identifier=abcdefghijklmnopqrstuv")).toBe(
+      "account_identifier=<redacted>",
+    );
   });
 
   it("leaves long ordinary prose words readable", () => {
@@ -245,6 +258,8 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");
+    expect(sanitizeDetail("user_uncharacteristically")).toBe("user_uncharacteristically");
+    expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
   });
 
   it("leaves an ordinary sentence readable", () => {

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -166,6 +166,12 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("leaves long ordinary prose words readable", () => {
+    for (const word of ["uncharacteristically", "compartmentalization"]) {
+      expect(sanitizeDetail(word)).toBe(word);
+    }
+  });
+
   it("leaves an ordinary sentence readable", () => {
     const out = sanitizeDetail("Rate limit reached for gpt-4o in organization on requests per min (RPM): Limit 500");
     expect(out).toContain("requests per min");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -283,7 +283,25 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("does not let prose exceptions exempt explicit identifier shapes", () => {
+    const proseLookingId = "counterrevolutionary";
+    const cases = [
+      [`account_id=${proseLookingId}`, "account_id=<redacted>"],
+      [`user_id ${proseLookingId} is limited`, "user_id <redacted> is limited"],
+      [`account_${proseLookingId}`, "account_<redacted>"],
+      [`acct-${proseLookingId}`, "acct-<redacted>"],
+      [`wrapper_${proseLookingId}_suffix`, "wrapper_<redacted>"],
+      [`account-[${proseLookingId}]`, "account-[<redacted>]"],
+      [`account (${proseLookingId})`, "account (<redacted>)"],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
+    expect(sanitizeDetail("compartmentalization_v2")).toBe("compartmentalization_v2");
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
       "the user uncharacteristically exceeded the limit",

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -46,6 +46,15 @@ describe("classifyRateLimit", () => {
     expect(v?.retryAfterMs).toBe(1000);
   });
 
+  it("sanitizes a high-vowel labeled bare id in fallback detail", () => {
+    const v = classifyRateLimit(
+      429,
+      h(),
+      JSON.stringify({ error: { message: "account qavexidopulnertiskym is limited" } }),
+    );
+    expect(v?.detail).toBe("account <redacted> is limited");
+  });
+
   it("prefers Retry-After over the prose, in seconds or as a date", () => {
     expect(classifyRateLimit(429, h({ "retry-after": "20" }), KIMI_429)?.retryAfterMs).toBe(20_000);
     const soon = new Date(Date.now() + 30_000).toUTCString();
@@ -223,6 +232,12 @@ describe("sanitizeDetail", () => {
 
   it("redacts an email address", () => {
     expect(sanitizeDetail("quota for art@example.com exhausted")).not.toContain("art@example.com");
+  });
+
+  it("masks a long email local part as one address", () => {
+    expect(sanitizeDetail("quota for abcdefghijklmnopqrstuv@example.com exhausted")).toBe(
+      "quota for <redacted> exhausted",
+    );
   });
 
   // Hyphens defeated both shape rules: the longest unbroken run inside a UUID is 12

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -262,6 +262,27 @@ describe("sanitizeDetail", () => {
     );
   });
 
+  it("uses the explicit alpha-run table across identifier boundaries", () => {
+    const alphaId = "aeiouaeiouaeiouaeiotion";
+    const cases = [
+      [`account ${alphaId} is limited`, "account <redacted> is limited"],
+      [`user ${alphaId} is blocked`, "user <redacted> is blocked"],
+      [`account_id=${alphaId}`, "account_id=<redacted>"],
+      [`user_id ${alphaId} is limited`, "user_id <redacted> is limited"],
+      [`account_${alphaId}`, "account_<redacted>"],
+      [`acct_${alphaId}`, "acct_<redacted>"],
+      [`org-${alphaId}`, "org-<redacted>"],
+      [`wrapper_${alphaId}_suffix`, "wrapper_<redacted>"],
+      [`account-[${alphaId}]`, "account-[<redacted>]"],
+      ["account counterrevolutionary is limited", "account counterrevolutionary is limited"],
+      ["account compartmentalization_v2 is limited", "account compartmentalization_v2 is limited"],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeDetail(input)).toBe(expected);
+    }
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(
@@ -280,6 +301,12 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account_compartmentalization")).toBe("account_compartmentalization");
     expect(sanitizeDetail("account compartmentalization_v2 is limited")).toBe(
       "account compartmentalization_v2 is limited",
+    );
+    expect(sanitizeDetail("account internationalization is limited")).toBe(
+      "account internationalization is limited",
+    );
+    expect(sanitizeDetail("account nondeterministically is limited")).toBe(
+      "account nondeterministically is limited",
     );
   });
 

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -215,6 +215,20 @@ describe("sanitizeDetail", () => {
     expect(sanitizeDetail("account qavexidopulnertiskym-extra-more is limited")).toBe(
       "account <redacted> is limited",
     );
+    expect(sanitizeDetail("account qavexidopulnertiskymtion is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskymaeiotion is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskym_extra_more is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("account qavexidopulnertiskym--extra--more is limited")).toBe(
+      "account <redacted> is limited",
+    );
+    expect(sanitizeDetail("wrapper_qavexidopulnertiskym_suffix")).toBe("wrapper_<redacted>");
+    expect(sanitizeDetail("wrapper--qavexidopulnertiskym--suffix")).toBe("wrapper--<redacted>");
   });
 
   it("leaves long ordinary prose words readable", () => {
@@ -224,6 +238,10 @@ describe("sanitizeDetail", () => {
     );
     expect(sanitizeDetail("account compartmentalization is limited")).toBe(
       "account compartmentalization is limited",
+    );
+    expect(sanitizeDetail("account: compartmentalization policy")).toBe("account: compartmentalization policy");
+    expect(sanitizeDetail("the user: uncharacteristically exceeded")).toBe(
+      "the user: uncharacteristically exceeded",
     );
     expect(sanitizeDetail("user-uncharacteristically")).toBe("user-uncharacteristically");
     expect(sanitizeDetail("account-compartmentalization")).toBe("account-compartmentalization");

--- a/src/__tests__/orchestrator/rate-limit.test.ts
+++ b/src/__tests__/orchestrator/rate-limit.test.ts
@@ -175,6 +175,21 @@ describe("sanitizeDetail", () => {
     }
   });
 
+  it("redacts low-diversity all-alphabetic account identifiers", () => {
+    expect(sanitizeDetail("account aeiouaeiouaeiouaeiou is limited")).toBe("account <redacted> is limited");
+  });
+
+  it("redacts all-alphabetic identifiers with structured labels", () => {
+    expect(sanitizeDetail("account_id=abcdefghijklmnopqrstuv")).toBe("account_id=<redacted>");
+    expect(sanitizeDetail("user_id qavexidopulnertiskym is limited")).toBe("user_id <redacted> is limited");
+  });
+
+  it("redacts a hyphen-attached identifier atomically", () => {
+    expect(sanitizeDetail("account qavexidopulnertiskym-extra is limited")).toBe(
+      "account <redacted> is limited",
+    );
+  });
+
   it("leaves long ordinary prose words readable", () => {
     expect(sanitizeDetail("account compartmentalization policy")).toBe("account compartmentalization policy");
     expect(sanitizeDetail("the user uncharacteristically exceeded the limit")).toBe(

--- a/src/orchestrator/rate-limit.ts
+++ b/src/orchestrator/rate-limit.ts
@@ -189,41 +189,55 @@ const EXPLICIT_ALPHA_IDENTIFIER_LABEL =
   /(?:^|[\s"'([{])(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\b\s*["']?\s*(?:[:=]\s*)?["'([{]?\s*$/i;
 const DIRECT_ALPHA_IDENTIFIER_LABEL =
   /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|acct|user|tenant|plan)\s*(?:[,;.!?:=]\s*[\[({]?|[-_]+\s*[\[({]?|\s+)$/i;
-const GENERIC_ALPHA_IDENTIFIER_CONTEXT = /(?:\b(?:for|from|of|tenant|plan)\s*|[\[({]\s*)$/i;
-const IDENTIFIER_STATUS = /^\s+(?:is|was|has|had|reached|exceeded|exhausted|limited|invalid|expired|blocked|disabled)\b/i;
-const NATURAL_LANGUAGE_ALPHA_RUNS = new Set([
-  "compartmentalization",
-  "counterrevolutionary",
-  "internationalization",
-  "nondeterministically",
-  "uncharacteristically",
+const DIRECT_ALPHA_IDENTIFIER_WRAPPER =
+  /(?:^|[.!?;]\s*|(?:your|the)[\s-]+)(?:account|user)\s*(?:[,;.!?:=]\s*|[-_]+\s*)?[\[({]\s*$/i;
+type AlphaRunClassification = "identifier" | "prose";
+type AlphaRunBoundary = "bare-prose" | "lexical-label-prose";
+
+// There is no reliable morphology or vowel heuristic that can distinguish a
+// minted all-alpha id from an English word. Keep the small prose exception
+// explicit and table-driven; explicit labels and wrappers never use it.
+const ALPHA_RUN_CLASSIFICATION: ReadonlyMap<string, ReadonlySet<AlphaRunBoundary>> = new Map([
+  ["compartmentalization", new Set(["bare-prose", "lexical-label-prose"])],
+  ["counterrevolutionary", new Set(["bare-prose"])],
+  ["internationalization", new Set(["bare-prose"])],
+  ["nondeterministically", new Set(["bare-prose"])],
+  ["uncharacteristically", new Set(["bare-prose", "lexical-label-prose"])],
 ]);
 
-function isNaturalLanguageAlphaRun(run: string): boolean {
-  return NATURAL_LANGUAGE_ALPHA_RUNS.has(run.split(/[-_]+/, 1)[0].toLowerCase());
+function classifyAlphaRun(run: string, boundary: AlphaRunBoundary = "bare-prose"): AlphaRunClassification {
+  const base = run.split(/[-_]+/, 1)[0].toLowerCase();
+  return ALPHA_RUN_CLASSIFICATION.get(base)?.has(boundary) ? "prose" : "identifier";
+}
+
+function isNaturalLanguageAlphaRun(run: string, boundary: AlphaRunBoundary = "bare-prose"): boolean {
+  return classifyAlphaRun(run, boundary) === "prose";
 }
 
 function isExplicitIdentifierValue(run: string): boolean {
   return /^(?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier))[-_]/i.test(run);
 }
 
-function hasAlphaIdentifierContext(input: string, offset: number, run: string): boolean {
+function hasExplicitAlphaIdentifierBoundary(input: string, offset: number): boolean {
   const before = input.slice(Math.max(0, offset - 96), offset);
-  if (EXPLICIT_ALPHA_IDENTIFIER_LABEL.test(before)) return true;
-
-  const after = input.slice(offset + run.length);
-  const afterClosingPunctuation = after.replace(/^\s*[\])}]+/, "");
-  const terminal =
-    !afterClosingPunctuation.trim() ||
-    /^[\s]*[.,;!?]/.test(after) ||
-    IDENTIFIER_STATUS.test(afterClosingPunctuation);
-  if (!terminal) return false;
-
-  return DIRECT_ALPHA_IDENTIFIER_LABEL.test(before) || GENERIC_ALPHA_IDENTIFIER_CONTEXT.test(before);
+  const withoutJsonQuotes = before.replace(/\\?["']/g, "");
+  return (
+    EXPLICIT_ALPHA_IDENTIFIER_LABEL.test(before) ||
+    EXPLICIT_ALPHA_IDENTIFIER_LABEL.test(withoutJsonQuotes) ||
+    DIRECT_ALPHA_IDENTIFIER_WRAPPER.test(before) ||
+    DIRECT_ALPHA_IDENTIFIER_WRAPPER.test(withoutJsonQuotes)
+  );
 }
 
 function firstIdentifierPrefix(run: string): string {
-  const prefix = run.match(/^[A-Za-z][A-Za-z0-9]{0,12}[-_]/)?.[0] ?? "";
+  const explicitLabelPrefix = run.match(
+    /^(?:(?:the|your)[-_])?(?:account|acct|user|workspace|token|key)[-_]+(?:id|identifier)[-_]+/i,
+  )?.[0];
+  if (explicitLabelPrefix) return explicitLabelPrefix;
+  const labelPrefix = run.match(
+    /^(?:(?:the|your)[-_])?(?:account|acct|user|workspace|token|key)(?:[-_]+(?:id|identifier))?[-_]+/i,
+  )?.[0];
+  const prefix = labelPrefix ?? run.match(/^[A-Za-z][A-Za-z0-9]{0,12}[-_]+/)?.[0] ?? "";
   // A UUID glued directly to a vendor word (org550e8400-...) has no safe
   // prefix boundary. Preserving that whole digit-bearing fragment would defeat
   // the atomic UUID replacement, so only retain alphabetic prefix segments.
@@ -232,7 +246,11 @@ function firstIdentifierPrefix(run: string): string {
 
 function preserveNaturalLanguagePrefixedRun(run: string): boolean {
   if (isExplicitIdentifierValue(run)) return false;
-  return isNaturalLanguageAlphaRun(run);
+  const prefix = run.match(
+    /^(?:(?:the|your)[-_])?(?:account|user)[-_]+/i,
+  )?.[0];
+  if (!prefix) return isNaturalLanguageAlphaRun(run);
+  return isNaturalLanguageAlphaRun(run.slice(prefix.length), "lexical-label-prose");
 }
 
 export function sanitizeDetail(raw: string, max = 200): string {
@@ -245,22 +263,27 @@ export function sanitizeDetail(raw: string, max = 200): string {
     // sits in. `\S` has no boundary to be defeated by, so segmented, glued, and
     // multi-prefix forms cannot leave a partial UUID for the next rule.
     .replace(/\S*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\S*/g, "<redacted>")
-    // Prefixed and segmented opaque identifiers: org-…, org_…_…, cak-…, key_…,
-    // and long wrapper/value forms. The entire atom is matched before replacing
-    // it, so no later rule can turn a segmented value into a misleading partial.
-    .replace(
-      /(^|[^A-Za-z0-9])(((?:[A-Za-z][A-Za-z0-9]{0,12}[-_])+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/g,
-      (_m, boundary: string, run: string) =>
-        preserveNaturalLanguagePrefixedRun(run)
-          ? `${boundary}${run}`
-          : `${boundary}${firstIdentifierPrefix(run)}<redacted>`,
-    )
     // Machine-labelled values are identifiers even when their alphabetic
     // payload happens to be an English word. This also handles JSON-like
     // `account_id: "..."` forms that are shorter than the bare-run threshold.
     .replace(
-      /((?:account|acct|user|workspace|token|key)(?:[_-](?:id|identifier)|\s+(?:id|identifier))\b\s*["']?\s*[:=]\s*["'([{]?\s*)([A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/gi,
+      /((?:account|acct|user|workspace|token|key)(?:[_-]+(?:id|identifier)|\s+(?:id|identifier))\s*["']?\s*[:=]\s*["'([{]?\s*)([A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/gi,
       (_m, label: string) => `${label}<redacted>`,
+    )
+    // Prefixed and segmented opaque identifiers: org-…, org_…_…, cak-…, key_…,
+    // and long wrapper/value forms. The entire atom is matched before replacing
+    // it, so no later rule can turn a segmented value into a misleading partial.
+    // The underscore label form can wrap its value directly: account_identifier_[…].
+    .replace(
+      /((?:account|acct|user|workspace|token|key)(?:[_-]+(?:id|identifier))[_-]+)([\[({])\s*[A-Za-z0-9]{10,}(?=\s*[\])}])/gi,
+      (_m, label: string, opening: string) => `${label}${opening}<redacted>`,
+    )
+    .replace(
+      /(^|[^A-Za-z0-9])(?!(?:account|acct|user|workspace|token|key)(?:[_-]+(?:id|identifier))(?=\s*["']?\s*[:=])|(?:account|acct|user|workspace|token|key)(?:[_-]+(?:id|identifier))[_-]+\s*[\[({])(((?:[A-Za-z][A-Za-z0-9]{0,12}[-_])+)[A-Za-z0-9]{10,}(?:[-_]+[A-Za-z0-9]+)*)(?=$|[^A-Za-z0-9])/g,
+      (_m, boundary: string, run: string) =>
+        preserveNaturalLanguagePrefixedRun(run)
+          ? `${boundary}${run}`
+          : `${boundary}${firstIdentifierPrefix(run)}<redacted>`,
     )
     // Long segmented values whose first segment is itself longer than a normal
     // prefix (for example qavexidopulnertiskym_extra) are still one atom.
@@ -269,15 +292,11 @@ export function sanitizeDetail(raw: string, max = 200): string {
       (_m, boundary: string, run: string) =>
         preserveNaturalLanguagePrefixedRun(run) ? `${boundary}${run}` : `${boundary}<redacted>`,
     )
-    // Bare long runs: digits are an opaque shape by themselves. An all-alpha
-    // run is masked only in an identifier/status context, with ordinary prose
-    // words explicitly retained. Explicit machine labels (account_id, user_id,
-    // and their JSON-like forms) are always handled by that context check.
+    // Bare long runs are identifiers unless the explicit prose table recognizes
+    // a bare prose boundary. Structured labels and wrappers override that table.
     .replace(/\b[A-Za-z0-9]{20,}\b/g, (run, offset, input: string) => {
-      if (/\d/.test(run)) return "<redacted>";
-      return !isNaturalLanguageAlphaRun(run) && hasAlphaIdentifierContext(input, offset, run)
-        ? "<redacted>"
-        : run;
+      if (!hasExplicitAlphaIdentifierBoundary(input, offset) && isNaturalLanguageAlphaRun(run)) return run;
+      return "<redacted>";
     });
   return masked.replace(/\s+/g, " ").trim().slice(0, max);
 }


### PR DESCRIPTION
Replacement for closed PR #2315 after base #2294 merged. This rebased child closes all-alphabetic identifier, structured/JSON label, prefix/underscore/wrapper, and prose-boundary sanitizer gaps for issue #2313. Focused sanitizer, Panel rate-limit, and enqueue redaction suites: 68 passed; lint, build, and diff checks pass.